### PR TITLE
perf(webgpu): reserve transform storage before playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 - Internal transform write/upload counters and a micro-benchmark were added to guard the optimization.
 - WebGPU transform writes now use the same RenderGroup upload boundary as WebGL2: transforms are packed once per group before the first draw, instead of once per draw command.
 - Adjacent compatible Sprite batches across render-group boundaries (e.g. sprites at different z-indices) are already coalesced into a single instanced draw call — the sprite renderer tracks blend-mode, texture, and material, not group-index boundaries. Tests and documentation were added to prove this behaviour and define the compatibility predicate (same blend mode, texture set, and material; no intervening barrier/filter/render-target switch). No public API change.
+- WebGPU TransformStorage now reserves per-plan capacity before render-plan playback to avoid mid-frame storage-buffer reallocations across multiple sprite/mesh flushes (e.g. different blend-mode groups).
 
 ## [0.10.0] - 2026-05-31
 

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -238,7 +238,18 @@ export class WebGpuBackend implements RenderBackend {
 
   /** @internal */
   public _beginDrawPlan(nodeCount: number): void {
-    this._getTransformStorage().begin(nodeCount);
+    const storage = this._getTransformStorage();
+
+    storage.begin(nodeCount);
+
+    // Pre-allocate the GPU storage buffer for the full plan before any group
+    // flush runs. Without this, a later flush with a higher maxNodeIndex would
+    // destroy and replace the buffer mid-frame while earlier command buffers
+    // may still reference the old allocation.
+    if (nodeCount > 0 && this._device !== null && !this._deviceLost) {
+      storage.reserve(this._device, nodeCount);
+    }
+
     this._activeDrawCommand = null;
     this._drawPlanDepth++;
   }

--- a/src/rendering/webgpu/WebGpuTransformStorage.ts
+++ b/src/rendering/webgpu/WebGpuTransformStorage.ts
@@ -50,39 +50,46 @@ export class WebGpuTransformStorage {
     return this._buffer.push(drawable.getGlobalTransform(), drawable.tint);
   }
 
+  /**
+   * Pre-allocate (or grow) the GPU storage buffer to hold at least
+   * `recordCount` transform slots. Called once before render-plan playback so
+   * that later per-group flushes never trigger a mid-frame reallocation.
+   *
+   * If the buffer already covers `recordCount` this is a no-op — no GPU
+   * objects are destroyed or re-created. Capacity only grows, never shrinks.
+   * @internal
+   */
+  public reserve(device: GPUDevice, recordCount: number): void {
+    const minCount = Math.max(1, recordCount);
+    const requiredBytes = minCount * slotFloatCount * Float32Array.BYTES_PER_ELEMENT;
+
+    if (this._storageBuffer !== null && requiredBytes <= this._storageCapacity) {
+      return;
+    }
+
+    this._growBuffer(device, requiredBytes);
+  }
+
   public getBuffer(device: GPUDevice, minCount: number): { readonly buffer: GPUBuffer; readonly count: number } {
     const requiredCount = Math.max(1, minCount);
     const requiredBytes = requiredCount * slotFloatCount * Float32Array.BYTES_PER_ELEMENT;
     const snapshot = this._buffer.commitSnapshot(requiredCount);
 
     if (this._storageBuffer === null || requiredBytes > this._storageCapacity) {
-      let nextCapacity = Math.max(this._storageCapacity, slotFloatCount * Float32Array.BYTES_PER_ELEMENT);
-
-      while (nextCapacity < requiredBytes) {
-        nextCapacity *= 2;
-      }
-
-      this._storageBuffer?.destroy();
-      this._storageBuffer = device.createBuffer({
-        size: nextCapacity,
-        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
-      });
-      this._storageCapacity = nextCapacity;
-      this._storageHash = 0;
-      this._storageCount = -1;
+      this._growBuffer(device, requiredBytes);
     }
 
     if (snapshot.changed || snapshot.hash !== this._storageHash || snapshot.count !== this._storageCount) {
       const bytes = snapshot.count * slotFloatCount * Float32Array.BYTES_PER_ELEMENT;
 
-      device.queue.writeBuffer(this._storageBuffer, 0, this._buffer.data.buffer, this._buffer.data.byteOffset, bytes);
+      device.queue.writeBuffer(this._storageBuffer!, 0, this._buffer.data.buffer, this._buffer.data.byteOffset, bytes);
       this._buffer.recordUpload(snapshot.count);
       this._storageHash = snapshot.hash;
       this._storageCount = snapshot.count;
     }
 
     return {
-      buffer: this._storageBuffer,
+      buffer: this._storageBuffer!,
       count: snapshot.count,
     };
   }
@@ -91,6 +98,23 @@ export class WebGpuTransformStorage {
     this._storageBuffer?.destroy();
     this._storageBuffer = null;
     this._storageCapacity = 0;
+    this._storageHash = 0;
+    this._storageCount = -1;
+  }
+
+  private _growBuffer(device: GPUDevice, requiredBytes: number): void {
+    let nextCapacity = Math.max(this._storageCapacity, slotFloatCount * Float32Array.BYTES_PER_ELEMENT);
+
+    while (nextCapacity < requiredBytes) {
+      nextCapacity *= 2;
+    }
+
+    this._storageBuffer?.destroy();
+    this._storageBuffer = device.createBuffer({
+      size: nextCapacity,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    });
+    this._storageCapacity = nextCapacity;
     this._storageHash = 0;
     this._storageCount = -1;
   }

--- a/test/rendering/browser/webgpu-sprite-transform.test.ts
+++ b/test/rendering/browser/webgpu-sprite-transform.test.ts
@@ -26,6 +26,7 @@ import { Container } from '@/rendering/Container';
 import type { RenderNode } from '@/rendering/RenderNode';
 import { Sprite } from '@/rendering/sprite/Sprite';
 import { Texture } from '@/rendering/texture/Texture';
+import { BlendModes } from '@/rendering/types';
 import { WebGpuBackend } from '@/rendering/webgpu/WebGpuBackend';
 
 import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
@@ -249,6 +250,63 @@ describe('WebGPU sprite transform storage', () => {
     } finally {
       root.destroy();
       texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('sprites with different blend modes produce separate draw calls without mid-frame buffer reallocation', async ctx => {
+    // Sprites with different blend modes cannot batch together and trigger
+    // separate renderer flushes. Before transform-storage pre-reservation, the
+    // second flush could allocate a larger GPU buffer while the first flush's
+    // command buffer still referenced the old one, causing WebGPU validation
+    // errors. With reserve() called in _beginDrawPlan the buffer is sized for
+    // the full plan once, so no reallocation happens between flushes.
+    const backend = await setupBackend(ctx);
+    const textureA = createSolidTexture('#ff0000', 12);
+    const textureB = createSolidTexture('#0000ff', 12);
+    const root = new Container();
+    const a = new Sprite(textureA);
+    const b = new Sprite(textureB);
+    const c = new Sprite(textureA);
+    const d = new Sprite(textureB);
+
+    try {
+      // Two pairs — each pair shares a texture but has a distinct blend mode,
+      // forcing at least two renderer flushes: Normal group and Additive group.
+      // The Additive sprites carry higher nodeIndices so the second flush
+      // requests a buffer sized for max(nodeIndex)+1. Pre-reservation ensures
+      // the buffer was already large enough from the start.
+      a.setPosition(4, 4);
+      a.blendMode = BlendModes.Normal;
+      b.setPosition(20, 4);
+      b.blendMode = BlendModes.Normal;
+      c.setPosition(4, 20);
+      c.blendMode = BlendModes.Additive;
+      d.setPosition(20, 20);
+      d.blendMode = BlendModes.Additive;
+      root.addChild(a, b, c, d);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      // Sprites with different blend modes must NOT coalesce.
+      expect(backend.stats.drawCalls).toBeGreaterThanOrEqual(2);
+
+      const readPixel = readCanvas(backend);
+
+      // Normal sprites (top row): red at (8, 8) and blue at (24, 8).
+      expectPixelNear(readPixel(8, 8), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(24, 8), [0, 0, 255, 255]);
+
+      // Additive sprites (bottom row): red at (8, 24) and blue at (24, 24).
+      // Additive over black == same colour (black + colour = colour).
+      expectPixelNear(readPixel(8, 24), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(24, 24), [0, 0, 255, 255]);
+    } finally {
+      root.destroy();
+      textureA.destroy();
+      textureB.destroy();
       backend.destroy();
     }
   });

--- a/test/rendering/webgpu-transform-storage-reserve.test.ts
+++ b/test/rendering/webgpu-transform-storage-reserve.test.ts
@@ -1,0 +1,400 @@
+import { Drawable } from '@/rendering/Drawable';
+import { type DrawCommand, type MaterialKey, RenderEntryKind } from '@/rendering/plan/RenderCommand';
+import { WebGpuTransformStorage } from '@/rendering/webgpu/WebGpuTransformStorage';
+
+// Minimal WebGPU device mock sufficient for storage-buffer creation/destruction.
+interface MockBuffer {
+  readonly id: number;
+  destroy: MockInstance;
+}
+
+interface MockDevice {
+  readonly createBuffer: MockInstance;
+  readonly buffers: MockBuffer[];
+  queue: {
+    writeBuffer: MockInstance;
+  };
+}
+
+let bufferIdCounter = 0;
+
+const createMockDevice = (): MockDevice => {
+  const buffers: MockBuffer[] = [];
+
+  return {
+    createBuffer: vi.fn(() => {
+      const buf: MockBuffer = {
+        id: ++bufferIdCounter,
+        destroy: vi.fn(),
+      };
+
+      buffers.push(buf);
+
+      return buf as unknown as GPUBuffer;
+    }),
+    buffers,
+    queue: {
+      writeBuffer: vi.fn(),
+    },
+  };
+};
+
+// Restore GPUBufferUsage after tests that define it.
+const setupGpuBufferUsage = (): (() => void) => {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, 'GPUBufferUsage');
+
+  Object.defineProperty(globalThis, 'GPUBufferUsage', {
+    configurable: true,
+    value: { STORAGE: 128, COPY_DST: 8 },
+  });
+
+  return () => {
+    if (previous) {
+      Object.defineProperty(globalThis, 'GPUBufferUsage', previous);
+    } else {
+      Object.defineProperty(globalThis, 'GPUBufferUsage', {
+        configurable: true,
+        value: undefined,
+      });
+    }
+  };
+};
+
+const material = (): MaterialKey => ({
+  rendererId: 1,
+  blendMode: 0,
+  textureId: -1,
+  shaderId: -1,
+  pipelineKey: 1,
+  bindKey: 1,
+});
+
+class TestDrawable extends Drawable {
+  public constructor() {
+    super();
+    this.getLocalBounds().set(0, 0, 8, 8);
+  }
+}
+
+const makeCommand = (nodeIndex: number): DrawCommand => ({
+  kind: RenderEntryKind.Draw,
+  drawable: new TestDrawable(),
+  nodeIndex,
+  seq: nodeIndex,
+  zIndex: 0,
+  material: material(),
+  groupIndex: 1,
+  minX: 0,
+  minY: 0,
+  maxX: 8,
+  maxY: 8,
+});
+
+describe('WebGpuTransformStorage.reserve', () => {
+  let restore: () => void;
+
+  beforeEach(() => {
+    restore = setupGpuBufferUsage();
+    bufferIdCounter = 0;
+  });
+
+  afterEach(() => {
+    restore();
+  });
+
+  test('reserve allocates a GPU buffer on a fresh storage', () => {
+    const device = createMockDevice();
+    const storage = new WebGpuTransformStorage();
+
+    storage.begin(4);
+    storage.reserve(device as unknown as GPUDevice, 4);
+
+    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+    expect(device.buffers.length).toBe(1);
+  });
+
+  test('reserve with sufficient capacity is a no-op (same buffer, no extra allocations)', () => {
+    const device = createMockDevice();
+    const storage = new WebGpuTransformStorage();
+
+    storage.begin(8);
+    storage.reserve(device as unknown as GPUDevice, 8);
+
+    const firstBuffer = device.buffers[0];
+
+    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+
+    // A second reserve with ≤ the original count must not create a new buffer.
+    storage.reserve(device as unknown as GPUDevice, 4);
+    storage.reserve(device as unknown as GPUDevice, 8);
+
+    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+    expect(firstBuffer.destroy).not.toHaveBeenCalled();
+  });
+
+  test('getBuffer with count ≤ reserve count reuses the pre-allocated buffer', () => {
+    const device = createMockDevice();
+    const storage = new WebGpuTransformStorage();
+
+    storage.begin(16);
+    storage.reserve(device as unknown as GPUDevice, 16);
+
+    const reservedBuffer = device.buffers[0];
+
+    // Write a command so getBuffer has data to upload.
+    storage.writeCommand(makeCommand(0));
+
+    const result = storage.getBuffer(device as unknown as GPUDevice, 4);
+
+    // No additional buffer should have been created.
+    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+    expect(result.buffer).toBe(reservedBuffer);
+  });
+
+  test('getBuffer with count larger than reserve still grows correctly', () => {
+    const device = createMockDevice();
+    const storage = new WebGpuTransformStorage();
+
+    storage.begin(4);
+    storage.reserve(device as unknown as GPUDevice, 4);
+
+    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+
+    const firstBuffer = device.buffers[0];
+
+    // Request a much larger buffer than reserved.
+    storage.writeCommand(makeCommand(0));
+    storage.getBuffer(device as unknown as GPUDevice, 64);
+
+    expect(device.createBuffer).toHaveBeenCalledTimes(2);
+    expect(firstBuffer.destroy).toHaveBeenCalledTimes(1);
+    expect(device.buffers.length).toBe(2);
+  });
+
+  test('reserve with recordCount = 0 still allocates at least one slot', () => {
+    const device = createMockDevice();
+    const storage = new WebGpuTransformStorage();
+
+    storage.begin(0);
+    storage.reserve(device as unknown as GPUDevice, 0);
+
+    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+  });
+
+  test('write/skip/upload counters are unaffected by reserve', () => {
+    const device = createMockDevice();
+    const storage = new WebGpuTransformStorage();
+
+    storage.begin(4);
+    storage.reserve(device as unknown as GPUDevice, 4);
+    storage.writeCommand(makeCommand(0));
+    storage.writeCommand(makeCommand(1));
+    storage.recordSkippedWrite();
+
+    expect(storage.buffer.writeCount).toBe(2);
+    expect(storage.buffer.skippedWriteCount).toBe(1);
+    expect(storage.buffer.uploadCount).toBe(0);
+  });
+
+  test('upload counters increment correctly after getBuffer following reserve', () => {
+    const device = createMockDevice();
+    const storage = new WebGpuTransformStorage();
+
+    storage.begin(4);
+    storage.reserve(device as unknown as GPUDevice, 4);
+    storage.writeCommand(makeCommand(0));
+    storage.writeCommand(makeCommand(2));
+
+    storage.getBuffer(device as unknown as GPUDevice, 3);
+
+    expect(storage.buffer.uploadCount).toBe(1);
+    expect(storage.buffer.uploadedRecordCount).toBe(3);
+  });
+
+  test('reserve after begin does not reset write counters', () => {
+    const device = createMockDevice();
+    const storage = new WebGpuTransformStorage();
+
+    storage.begin(4);
+    storage.writeCommand(makeCommand(0));
+
+    expect(storage.buffer.writeCount).toBe(1);
+
+    storage.reserve(device as unknown as GPUDevice, 4);
+
+    // Reserve must not call begin() or reset stats.
+    expect(storage.buffer.writeCount).toBe(1);
+  });
+
+  test('destroy cleans up a pre-reserved buffer', () => {
+    const device = createMockDevice();
+    const storage = new WebGpuTransformStorage();
+
+    storage.begin(4);
+    storage.reserve(device as unknown as GPUDevice, 4);
+
+    const buf = device.buffers[0];
+
+    storage.destroy();
+
+    expect(buf.destroy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('WebGpuTransformStorage.reserve: no reallocation across multiple getBuffer calls', () => {
+  let restore: () => void;
+
+  beforeEach(() => {
+    restore = setupGpuBufferUsage();
+    bufferIdCounter = 0;
+  });
+
+  afterEach(() => {
+    restore();
+  });
+
+  test('simulated multi-group plan: reserve once, multiple getBuffer calls share the same buffer', () => {
+    // Simulates a render plan with two sprite groups of different blend modes.
+    // Group A has nodes 0-2, Group B has nodes 3-5. Without pre-reservation the
+    // second flush (nodeIndex 5+1=6) would reallocate if the first flush only
+    // sized the buffer for 3 slots. With reserve(6) the buffer is large enough
+    // from the start.
+    const device = createMockDevice();
+    const storage = new WebGpuTransformStorage();
+    const planNodeCount = 6;
+
+    storage.begin(planNodeCount);
+    storage.reserve(device as unknown as GPUDevice, planNodeCount);
+
+    const reservedBuffer = device.buffers[0];
+
+    // Group A: nodes 0-2 written before flush.
+    storage.writeCommand(makeCommand(0));
+    storage.writeCommand(makeCommand(1));
+    storage.writeCommand(makeCommand(2));
+
+    const flush1 = storage.getBuffer(device as unknown as GPUDevice, 3);
+
+    expect(flush1.buffer).toBe(reservedBuffer);
+    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+
+    // Group B: nodes 3-5 written before second flush.
+    storage.writeCommand(makeCommand(3));
+    storage.writeCommand(makeCommand(4));
+    storage.writeCommand(makeCommand(5));
+
+    const flush2 = storage.getBuffer(device as unknown as GPUDevice, 6);
+
+    expect(flush2.buffer).toBe(reservedBuffer);
+    // Still only the one buffer from reserve — no mid-frame reallocation.
+    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+    expect(reservedBuffer.destroy).not.toHaveBeenCalled();
+  });
+
+  test('without reserve, second getBuffer with larger count triggers reallocation', () => {
+    // This documents the pre-fix behaviour: without reserve(), a second flush
+    // that needs more capacity destroys and replaces the buffer.
+    const device = createMockDevice();
+    const storage = new WebGpuTransformStorage();
+
+    storage.begin(6);
+
+    // First flush sizes for 3 slots.
+    storage.writeCommand(makeCommand(0));
+    storage.getBuffer(device as unknown as GPUDevice, 3);
+
+    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+
+    const firstBuffer = device.buffers[0];
+
+    // Second flush needs 6 slots — old buffer is too small, reallocation happens.
+    storage.writeCommand(makeCommand(5));
+    storage.getBuffer(device as unknown as GPUDevice, 6);
+
+    expect(device.createBuffer).toHaveBeenCalledTimes(2);
+    expect(firstBuffer.destroy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('WebGpuTransformStorage.reserve: Color/tint correctness after multi-flush', () => {
+  let restore: () => void;
+
+  beforeEach(() => {
+    restore = setupGpuBufferUsage();
+  });
+
+  afterEach(() => {
+    restore();
+  });
+
+  test('data written across two groups is intact after both flushes complete', () => {
+    const device = createMockDevice();
+    const storage = new WebGpuTransformStorage();
+    const floatsPerSlot = 12;
+
+    storage.begin(4);
+    storage.reserve(device as unknown as GPUDevice, 4);
+
+    const cmd0 = makeCommand(0);
+
+    (cmd0.drawable as Drawable).setPosition(10, 20);
+    storage.writeCommand(cmd0);
+
+    const cmd3 = makeCommand(3);
+
+    (cmd3.drawable as Drawable).setPosition(70, 80);
+    storage.writeCommand(cmd3);
+
+    storage.getBuffer(device as unknown as GPUDevice, 4);
+
+    // Node 0: tx=10, ty=20
+    expect(storage.buffer.data[floatsPerSlot * 0 + 4]).toBe(10);
+    expect(storage.buffer.data[floatsPerSlot * 0 + 5]).toBe(20);
+
+    // Node 3: tx=70, ty=80
+    expect(storage.buffer.data[floatsPerSlot * 3 + 4]).toBe(70);
+    expect(storage.buffer.data[floatsPerSlot * 3 + 5]).toBe(80);
+  });
+});
+
+// Regression guard: ensure begin() still resets counters even when a reserved
+// buffer is already present (buffer must NOT be re-created on begin).
+describe('WebGpuTransformStorage.reserve: begin across frames', () => {
+  let restore: () => void;
+
+  beforeEach(() => {
+    restore = setupGpuBufferUsage();
+  });
+
+  afterEach(() => {
+    restore();
+  });
+
+  test('begin on frame N+1 resets counters but keeps the reserved GPU buffer', () => {
+    const device = createMockDevice();
+    const storage = new WebGpuTransformStorage();
+
+    // Frame 1.
+    storage.begin(4);
+    storage.reserve(device as unknown as GPUDevice, 4);
+    storage.writeCommand(makeCommand(0));
+    storage.getBuffer(device as unknown as GPUDevice, 1);
+
+    expect(storage.buffer.uploadCount).toBe(1);
+    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+
+    const buf = device.buffers[0];
+
+    // Frame 2: same capacity.
+    storage.begin(4);
+
+    expect(storage.buffer.writeCount).toBe(0);
+    expect(storage.buffer.uploadCount).toBe(0);
+
+    // Reserve again — buffer is already large enough; no new allocation.
+    storage.reserve(device as unknown as GPUDevice, 4);
+
+    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+    expect(buf.destroy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `WebGpuTransformStorage.reserve(device, recordCount)` — a pre-allocation method that grows the GPU storage buffer once to hold at least `recordCount` transform slots and is a no-op if capacity is already sufficient.
- `WebGpuBackend._beginDrawPlan()` now calls `reserve(plan.nodeCount)` before render-plan playback begins, ensuring every subsequent per-group flush reuses the same buffer.
- The internal doubling logic is factored into a shared `_growBuffer(device, requiredBytes)` private method, used by both `reserve()` and `getBuffer()`.

## Why mid-frame reallocation was risky

`WebGpuTransformStorage.getBuffer(maxNodeIndex + 1)` is called at each renderer flush. When a scene contains sprites in two separate blend-mode groups (Normal and Additive), the renderer flushes twice per frame — once for each group. If the first flush sized the buffer for, say, 3 slots and the second flush needed 6 (because it held the higher `nodeIndex` values), `getBuffer` would call `device.createBuffer` for a larger buffer and `destroy()` the old one **while the first flush's command buffer may still reference it**. This is a WebGPU validation error and a use-after-free hazard.

## Capacity / reserve strategy

`plan.nodeCount` (set by `RenderPlanBuilder` to the total number of draw commands) equals the maximum `nodeIndex + 1` across all groups. It is already passed into `_beginDrawPlan(nodeCount)` by the plan player. We reserve that count once before the first group is processed, so every later `getBuffer(k)` call where `k ≤ nodeCount` finds the buffer large enough and skips allocation entirely.

Direct/synthetic draws (a `backend.draw(drawable)` outside the plan player, e.g. `_pushTransform`) still grow on demand via `getBuffer()` as before — no change to that path.

## Tests added / re-enabled

**Unit (jsdom) — `test/rendering/webgpu-transform-storage-reserve.test.ts`** (12 tests):
- `reserve` allocates a GPU buffer on a fresh storage instance.
- A second `reserve` with sufficient capacity is a no-op (same buffer, no extra `createBuffer` call).
- `getBuffer` with count ≤ reserved count reuses the pre-allocated buffer.
- `getBuffer` with count larger than reserved still grows correctly (second allocation).
- `reserve(0)` allocates at least one slot.
- Write/skip/upload counters are unaffected by `reserve`.
- Upload counters increment correctly after `getBuffer` following a `reserve`.
- `reserve` does not reset write counters (must not call `begin`).
- `destroy` cleans up a pre-reserved buffer.
- Multi-group simulation: two `getBuffer` calls after a single `reserve` share the same buffer with zero reallocations.
- Without `reserve`: documents the pre-fix behaviour where the second flush triggers reallocation (regression guard).
- Data written across two groups is intact after both flushes.
- Cross-frame: `begin()` on frame N+1 resets counters but keeps the reserved GPU buffer alive; re-`reserve`-ing with same capacity is a no-op.

**Browser (WebGPU Chromium) — `test/rendering/browser/webgpu-sprite-transform.test.ts`** (1 new test):
- Four sprites in two blend-mode groups (Normal + Additive) are rendered through the real plan path inside a `pushErrorScope('validation')`. Asserts: (1) no validation errors, (2) ≥ 2 draw calls (blend modes cannot batch), (3) all four sprites appear at their expected pixel positions. Previously omitted because the storage-buffer reallocation triggered a WebGPU validation error inside the scope; with pre-reservation the test passes cleanly.

## Validation

```
npm run lint          ✅ no errors
npm run typecheck     ✅ no errors
npm test              ✅ 1671/1671 unit tests passed
npm run test:browser:webgl  ✅ 54/54 passed
npm run test:browser:webgpu ✅ 41/41 passed (includes new blend-mode test)
npm run verify:exports      ✅ 6 entry targets OK
npm run build               ✅ dist/exo.esm.js + dist/esm/ generated
```

## CHANGELOG

`[Unreleased]` updated:
> WebGPU TransformStorage now reserves per-plan capacity before render-plan playback to avoid mid-frame storage-buffer reallocations across multiple sprite/mesh flushes (e.g. different blend-mode groups).

## Roadmap

`.workspace/roadmap-0.10-0.12.md` — §1 TransformBuffer/Batch Instancing: pre-reservation item added to "Erledigt" list.

## No public API / no shader contract / no CI changes

`reserve()` is `@internal`. No shader bindings, no layout changes, no WebGL2 touches, no CI configuration changes.