### PR TITLE
fix(webgpu): normalize mesh tint to 0-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 - `Gradient` (and `LinearGradient` / `RadialGradient`) are now full value objects alongside `Color`: they implement `Cloneable` (`clone()` / `copy()`), gained structural `equals()`, a `type` discriminant (`GradientType` `'linear' | 'radial'`), and read-only geometry getters (`start` / `end`, `center` / `radius`). Stop construction now rejects non-finite offsets. No rendering or Drawable behavior changed — these remain texture-first paint values consumed via `toTexture()`.
 - RenderPlanOptimizer grouping key audit: documented that optimizer group boundaries are already aligned with Sprite/Mesh renderer batch boundaries. Key findings: (1) Sprite renderers do not consume `groupIndex` — they batch via their own state machine; (2) Mesh static-batch uses `groupIndex` as a gate, and the optimizer's `pipelineKey:bindKey` grouping correctly covers all conditions the mesh renderer checks; (3) texture-slot coalescing for default-path sprites is correctly renderer-owned; (4) custom-sprite base texture and sprite-level blend-mode override are renderer-owned boundaries not captured in `groupIndex`. Tests were added to prove each invariant.
 
+### Fixed
+
+- WebGPU mesh tint is now normalized to 0..1 before the shader multiply. The default- and custom-material mesh paths packed the per-mesh tint `Color`'s RGB in the 0..255 range while the WGSL shaders multiply `sample * color * tint` expecting 0..1; with the default white tint this scaled every sampled texel channel by 255 and clamped it, so textures with intermediate colors (gradients, grays, photos) rendered fully saturated while pure 0/255 colors looked correct. This makes WebGPU `DataTexture`-backed and canvas-sourced textured meshes — including rasterized `Gradient` fills — sample pixel-correct, matching WebGL2. The instanced mesh and sprite paths were already correct (they source the tint from the normalized shared `TransformBuffer`). No public API change.
+
 ## [0.10.0] - 2026-05-31
 
 ### Breaking — RenderingContext and Scene.draw migration

--- a/src/rendering/webgpu/WebGpuMeshRenderer.ts
+++ b/src/rendering/webgpu/WebGpuMeshRenderer.ts
@@ -413,14 +413,18 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
           }
         }
 
-        // Pack tint+flags for default path.
+        // Pack tint+flags for default path. Color RGB channels are 0..255; the
+        // shader multiplies the sampled texel by this tint, so normalize to
+        // 0..1 (matching TransformBuffer and the WebGL2 mesh shader). Leaving
+        // them at 0..255 scales every non-zero texel channel past 1.0, which
+        // clamps intermediate colors (gradients, photos) to full saturation.
         if (defaultUniformF32 !== null) {
           const offsetWords = (defaultUniformIndex * this._uniformAlignment) / Float32Array.BYTES_PER_ELEMENT;
           const tint = dc.mesh.tint;
 
-          defaultUniformF32[offsetWords + 0] = tint.r;
-          defaultUniformF32[offsetWords + 1] = tint.g;
-          defaultUniformF32[offsetWords + 2] = tint.b;
+          defaultUniformF32[offsetWords + 0] = tint.r / 255;
+          defaultUniformF32[offsetWords + 1] = tint.g / 255;
+          defaultUniformF32[offsetWords + 2] = tint.b / 255;
           defaultUniformF32[offsetWords + 3] = tint.a;
           defaultUniformF32[offsetWords + 4] = dc.premultiplySample ? 1 : 0;
           defaultUniformF32[offsetWords + 5] = 0;
@@ -1495,11 +1499,12 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
     data[off + 11] = 0;
     off += 12;
 
-    // tint (vec4)
+    // tint (vec4). RGB are 0..255; normalize to 0..1 for the shader multiply
+    // (u_mesh.tint is documented as 0..1, matching the default path above).
     const tint = mesh.tint;
-    data[off + 0] = tint.r;
-    data[off + 1] = tint.g;
-    data[off + 2] = tint.b;
+    data[off + 0] = tint.r / 255;
+    data[off + 1] = tint.g / 255;
+    data[off + 2] = tint.b / 255;
     data[off + 3] = tint.a;
 
     this._device!.queue.writeBuffer(resources.meshUniformBuffer!, drawCursor * slotBytes, data);

--- a/test/rendering/browser/webgpu-mesh-tint.test.ts
+++ b/test/rendering/browser/webgpu-mesh-tint.test.ts
@@ -1,0 +1,297 @@
+/**
+ * WebGPU mesh tint / texture-sampling browser tests — opt-in, capability-aware.
+ *
+ * Regression coverage for a WebGPU mesh-renderer bug where the per-mesh tint
+ * Color was packed into the tint uniform in the engine's 0..255 range while the
+ * WGSL mesh shaders multiply `sample * color * tint` expecting 0..1. With the
+ * default white tint (255,255,255) every sampled texel channel was scaled by
+ * 255 and clamped, so pure 0/255 colors survived but intermediate values
+ * (gradients, grays, photos) saturated to full white/primary. The fix
+ * normalizes the tint to 0..1 (matching TransformBuffer and the WebGL2 mesh
+ * shader), so intermediate texture colors now render pixel-correct.
+ *
+ * The defect was not specific to DataTexture: it affected every textured mesh.
+ * These tests therefore cover DataTexture, canvas-sourced Texture, a rasterized
+ * Gradient, and a fractional tint, all through the default mesh path.
+ *
+ * All tests skip gracefully when WebGPU is unavailable.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import type { Application } from '@/core/Application';
+import { Color } from '@/core/Color';
+import { LinearGradient } from '@/rendering/gradient/LinearGradient';
+import { Mesh } from '@/rendering/mesh/Mesh';
+import { DataTexture } from '@/rendering/texture/DataTexture';
+import { Texture } from '@/rendering/texture/Texture';
+import { ScaleModes } from '@/rendering/types';
+import { WebGpuBackend } from '@/rendering/webgpu/WebGpuBackend';
+
+import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: {
+      canvas: { width: canvasSize, height: canvasSize },
+      clearColor: Color.black,
+    },
+  }) as unknown as Application;
+
+const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<WebGpuBackend> => {
+  if (!navigator.gpu) {
+    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
+  }
+
+  const adapter = await navigator.gpu.requestAdapter();
+
+  if (!adapter) {
+    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
+  }
+
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  await backend.initialize();
+
+  return backend;
+};
+
+// A full-canvas quad in pixel space with UVs spanning the whole texture.
+const fullQuadVertices = (): Float32Array => new Float32Array([0, 0, canvasSize, 0, canvasSize, canvasSize, 0, 0, canvasSize, canvasSize, 0, canvasSize]);
+const fullQuadUvs = (): Float32Array => new Float32Array([0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1]);
+
+// Read the presented WebGPU canvas back through a 2D canvas. drawImage accepts a
+// WebGPU-configured canvas as an image source, giving CPU-side pixel access
+// without touching the backend's managed GPU textures.
+const readCanvas = (backend: WebGpuBackend): ((x: number, y: number) => RgbaTuple) => {
+  const source = backend.context.canvas as HTMLCanvasElement;
+  const readback = document.createElement('canvas');
+
+  readback.width = canvasSize;
+  readback.height = canvasSize;
+
+  const ctx = readback.getContext('2d');
+
+  if (!ctx) {
+    throw new Error('2D context is required for canvas readback.');
+  }
+
+  ctx.drawImage(source, 0, 0);
+
+  return (x: number, y: number): RgbaTuple => {
+    const { data } = ctx.getImageData(Math.floor(x), Math.floor(y), 1, 1);
+
+    return [data[0], data[1], data[2], data[3]];
+  };
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 4): void => {
+  for (let index = 0; index < 4; index++) {
+    expect(Math.abs(actual[index] - expected[index]), `channel ${index}: got [${actual.join(', ')}] expected [${expected.join(', ')}]`).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+// On the software (swiftshader) adapter the WebGPU device can drop mid-test;
+// treat that as an unavailable-adapter skip rather than a failure.
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+// Render a single mesh through the real flush path inside a validation error
+// scope. Returns false when the device dropped mid-test (caller should bail).
+const renderMesh = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, mesh: Mesh): Promise<boolean> => {
+  const device = getBackendDeviceOrSkip(ctx, backend);
+
+  if (!device) {
+    return false;
+  }
+
+  device.pushErrorScope('validation');
+
+  let validationError: GPUError | null;
+
+  try {
+    backend.resetStats();
+    backend.clear(Color.black);
+    mesh.render(backend);
+    backend.flush();
+    validationError = await device.popErrorScope();
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+
+  expect(validationError).toBeNull();
+  expect(backend.stats.drawCalls).toBeGreaterThan(0);
+
+  return true;
+};
+
+describe('WebGPU mesh tint and texture sampling', () => {
+  test('samples intermediate DataTexture grayscale levels without saturating', async ctx => {
+    const backend = await setupBackend(ctx);
+    const levels = [32, 96, 160, 224];
+    const width = levels.length;
+    const data = new Uint8Array(width * 4);
+
+    for (let i = 0; i < width; i++) {
+      data.set([levels[i], levels[i], levels[i], 255], i * 4);
+    }
+
+    const texture = new DataTexture({ width, height: 1, format: 'rgba8', data, samplerOptions: { scaleMode: ScaleModes.Nearest } });
+    const mesh = new Mesh({ vertices: fullQuadVertices(), uvs: fullQuadUvs(), texture });
+
+    try {
+      if (!(await renderMesh(ctx, backend, mesh))) {
+        return;
+      }
+
+      const readPixel = readCanvas(backend);
+
+      levels.forEach((level, i) => {
+        const x = Math.floor(((i + 0.5) * canvasSize) / width);
+
+        expectPixelNear(readPixel(x, 32), [level, level, level, 255]);
+      });
+    } finally {
+      mesh.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('samples a 2x2 rgba8 DataTexture into the correct quadrants', async ctx => {
+    const backend = await setupBackend(ctx);
+    // Row-major, top-left origin: row 0 = red, green; row 1 = blue, white.
+    const texture = new DataTexture({
+      width: 2,
+      height: 2,
+      format: 'rgba8',
+      data: new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 255, 255]),
+      samplerOptions: { scaleMode: ScaleModes.Nearest },
+    });
+    const mesh = new Mesh({ vertices: fullQuadVertices(), uvs: fullQuadUvs(), texture });
+
+    try {
+      if (!(await renderMesh(ctx, backend, mesh))) {
+        return;
+      }
+
+      const readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(16, 16), [255, 0, 0, 255]); // top-left
+      expectPixelNear(readPixel(48, 16), [0, 255, 0, 255]); // top-right
+      expectPixelNear(readPixel(16, 48), [0, 0, 255, 255]); // bottom-left
+      expectPixelNear(readPixel(48, 48), [255, 255, 255, 255]); // bottom-right
+    } finally {
+      mesh.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('samples an intermediate canvas-sourced Texture without saturating', async ctx => {
+    const backend = await setupBackend(ctx);
+    const source = document.createElement('canvas');
+
+    source.width = 2;
+    source.height = 1;
+
+    const context = source.getContext('2d');
+
+    if (!context) {
+      throw new Error('2D context is required to create the test texture.');
+    }
+
+    context.fillStyle = 'rgb(96, 96, 96)';
+    context.fillRect(0, 0, 2, 1);
+
+    const texture = new Texture(source, { scaleMode: ScaleModes.Nearest });
+    const mesh = new Mesh({ vertices: fullQuadVertices(), uvs: fullQuadUvs(), texture });
+
+    try {
+      if (!(await renderMesh(ctx, backend, mesh))) {
+        return;
+      }
+
+      expectPixelNear(readCanvas(backend)(32, 32), [96, 96, 96, 255]);
+    } finally {
+      mesh.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('renders a rasterized linear gradient DataTexture across the quad', async ctx => {
+    const backend = await setupBackend(ctx);
+    const gradient = new LinearGradient(
+      [
+        { offset: 0, color: Color.red },
+        { offset: 1, color: Color.blue },
+      ],
+      [0, 0],
+      [1, 0],
+    );
+    const texture = gradient.toTexture(256, 256, { samplerOptions: { scaleMode: ScaleModes.Linear } });
+    const mesh = new Mesh({ vertices: fullQuadVertices(), uvs: fullQuadUvs(), texture });
+
+    try {
+      if (!(await renderMesh(ctx, backend, mesh))) {
+        return;
+      }
+
+      const readPixel = readCanvas(backend);
+
+      // Endpoints resolve near the pure stops; the middle is the blend (magenta).
+      expectPixelNear(readPixel(2, 32), [255, 0, 0, 255], 20); // left ≈ red
+      expectPixelNear(readPixel(32, 32), [128, 0, 128, 255], 20); // middle ≈ magenta
+      expectPixelNear(readPixel(62, 32), [0, 0, 255, 255], 20); // right ≈ blue
+    } finally {
+      mesh.destroy();
+      gradient.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('applies a fractional mesh tint to a white texture without saturating', async ctx => {
+    const backend = await setupBackend(ctx);
+    const texture = new DataTexture({
+      width: 1,
+      height: 1,
+      format: 'rgba8',
+      data: new Uint8Array([255, 255, 255, 255]),
+      samplerOptions: { scaleMode: ScaleModes.Nearest },
+    });
+    const mesh = new Mesh({ vertices: fullQuadVertices(), uvs: fullQuadUvs(), texture });
+
+    // Tint RGB is stored 0..255; the renderer must normalize it to 0..1 before
+    // the shader multiply, otherwise 96 → 96× saturates the white texel.
+    mesh.tint = new Color(96, 160, 224);
+
+    try {
+      if (!(await renderMesh(ctx, backend, mesh))) {
+        return;
+      }
+
+      expectPixelNear(readCanvas(backend)(32, 32), [96, 160, 224, 255]);
+    } finally {
+      mesh.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

WebGPU textured meshes rendered intermediate texel colors fully saturated: a rasterized `Gradient.toTexture()` `DataTexture` read back as flat magenta, grays blew out to white, etc. This PR fixes the root cause — a missing tint normalization in the WebGPU mesh renderer — so `DataTexture`-backed and canvas-sourced textured meshes (including `Graphics` gradient fills) sample pixel-correct, matching WebGL2.

The original task framed this as a "WebGPU `DataTexture` upload/sampling" bug. Isolation proved that was **not** the cause (see below); the fix and PR were re-framed accordingly with approval.

## Root cause

`Color.r/g/b` are stored in the engine's `0..255` range (only `Color.a` is `0..1`). The WebGPU mesh renderer packed the per-mesh tint into its tint uniform **raw**:

- default path — `WebGpuMeshRenderer.flush()`
- custom path — `WebGpuMeshRenderer._writeCustomMeshUniform()`

The WGSL mesh shaders compute `modulated = sample * color * tint`. With the default white tint `(255,255,255)` every sampled texel channel was multiplied by 255, so `clamp(x*255, 0, 1)` mapped `0 → 0` and **every** non-zero value `→ 1.0`. Pure `0/255` colors are fixed points (so existing pixel tests, which only used pure colors, looked correct), while intermediate values (gradients, grays, photos) saturated.

This was **not** DataTexture-specific and **not** an upload bug:
- A raw `queue.writeTexture` → `copyTextureToBuffer` roundtrip with the backend's exact parameters is byte-correct for both 256-aligned and non-aligned row strides.
- A canvas-sourced `Texture` with gray `(100,100,100)` showed the identical defect through the same mesh path.
- A white texture + fractional tint `(100,100,100)` reproduced the saturation with no intermediate texel involved — pinning the cause to the tint uniform.

The WebGL2 default mesh path and the WebGPU **instanced** mesh + sprite paths were already correct: they source the tint from the shared `TransformBuffer`, which normalizes (`tint.r / 255`).

## Fix

Normalize the tint RGB to `0..1` (`/255`) when packing it in both WebGPU mesh uniform paths (default + custom); alpha is already `0..1`. 6 lines in `WebGpuMeshRenderer.ts`. The WGSL shaders, WebGL2, sprite/particle, TransformBuffer, RenderPassCoordinator, and stencil paths are untouched.

## WebGPU pixel coverage

New `test/rendering/browser/webgpu-mesh-tint.test.ts` (5 tests) asserts pixel-correct sampling through the default mesh path:
- intermediate-value `DataTexture` grayscale levels (the core regression)
- a 2×2 `DataTexture` resolving into the correct quadrants
- an intermediate-value canvas-sourced `Texture`
- a rasterized linear-gradient `DataTexture` (left ≈ red, middle ≈ magenta, right ≈ blue)
- a fractional mesh tint on a white texture

Upgrading the **Graphics** gradient tests (`webgpu-graphics-gradient.test.ts`) from validation-only to pixel assertions is intentionally out of scope here: that file and the `Graphics.fillGradient`/`lineGradient` API live only on the unmerged PR #53, not on `main`. The sampling blocker is now removed, so those pixel tests can be activated once #53 merges.

## Validation

- `npm run lint` ✓
- `npm run typecheck` ✓
- `npm test` — 1693 passed ✓
- `npm run test:browser:webgl` — 54 passed ✓
- `npm run test:browser:webgpu` — 46 passed (incl. 5 new) ✓
- `npm run verify:exports` ✓
- `npm run build` ✓
- `site:build`: skipped (no tracked docs/site files changed)

## CHANGELOG / roadmap

- CHANGELOG `[Unreleased]` → added `### Fixed` entry for the WebGPU mesh tint normalization.
- Local `.workspace/roadmap-0.10-0.12.md` (gitignored) updated: WebGPU gradient follow-up marked fixed with the corrected root cause; the Graphics-gradient pixel-test activation noted as blocked on PR #53.

## Scope

No public API change. No WebGL2 change. No CI / Firefox / release-config / sprite / particle / transform / stencil change.
