### PR TITLE
docs(examples): add graphics gradient example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 - WebGPU mesh tint is now normalized to 0..1 before the shader multiply. The default- and custom-material mesh paths packed the per-mesh tint `Color`'s RGB in the 0..255 range while the WGSL shaders multiply `sample * color * tint` expecting 0..1; with the default white tint this scaled every sampled texel channel by 255 and clamped it, so textures with intermediate colors (gradients, grays, photos) rendered fully saturated while pure 0/255 colors looked correct. This makes WebGPU `DataTexture`-backed and canvas-sourced textured meshes — including rasterized `Gradient` fills — sample pixel-correct, matching WebGL2. The instanced mesh and sprite paths were already correct (they source the tint from the normalized shared `TransformBuffer`). No public API change.
 
+### Examples
+
+- New example `geometry-graphics/graphics-gradient.js`: paints `Graphics` shapes with gradients through the canonical `fillStyle` / `strokeStyle` API — a linear-gradient rectangle, a radial-gradient circle, a radial-gradient stroked ring, and a transformed, spinning linear-gradient star.
+
 ## [0.10.0] - 2026-05-31
 
 ### Breaking — RenderingContext and Scene.draw migration

--- a/examples/examples.json
+++ b/examples/examples.json
@@ -534,6 +534,19 @@
             ]
         },
         {
+            "slug": "graphics-gradient",
+            "path": "geometry-graphics/graphics-gradient.js",
+            "title": "Graphics Gradient",
+            "description": "Paint Graphics shapes with gradients through the fillStyle / strokeStyle API: a linear-gradient rectangle, a radial-gradient circle, a radial-gradient stroked ring, and a spinning linear-gradient star.",
+            "backend": "core",
+            "tags": [
+                "graphics",
+                "gradient",
+                "fillStyle",
+                "strokeStyle"
+            ]
+        },
+        {
             "slug": "gradient",
             "path": "geometry-graphics/gradient.js",
             "title": "Gradient",

--- a/examples/geometry-graphics/graphics-gradient.js
+++ b/examples/geometry-graphics/graphics-gradient.js
@@ -1,0 +1,97 @@
+import { Application, Color, Container, Graphics, LinearGradient, RadialGradient, Scene } from '@codexo/exojs';
+
+const app = new Application({
+    canvas: {
+        width: 800,
+        height: 600,
+    },
+    clearColor: Color.midnightBlue,
+});
+
+document.body.append(app.canvas);
+
+app.start(
+    new (class extends Scene {
+        init() {
+            const { width, height } = this.app.canvas;
+
+            this._sceneRoot = new Container();
+            this._sceneRoot.setPosition(width / 2, height / 2);
+
+            // Rectangle filled with a diagonal linear gradient.
+            this._panel = new Graphics();
+            this._panel.fillStyle = new LinearGradient(
+                [
+                    { offset: 0, color: new Color(255, 90, 40, 1) },
+                    { offset: 0.5, color: new Color(255, 210, 70, 1) },
+                    { offset: 1, color: new Color(70, 120, 255, 1) },
+                ],
+                [0, 0],
+                [1, 1]
+            );
+            this._panel.drawRectangle(-190, -130, 380, 260);
+
+            // Circle filled with a radial gradient (bright core fading outward).
+            this._orb = new Graphics();
+            this._orb.fillStyle = new RadialGradient(
+                [
+                    { offset: 0, color: new Color(255, 255, 255, 1) },
+                    { offset: 0.4, color: new Color(120, 220, 255, 1) },
+                    { offset: 1, color: new Color(20, 40, 90, 1) },
+                ],
+                [0.5, 0.5],
+                0.5
+            );
+            this._orb.drawCircle(-96, -8, 56);
+
+            // Outline stroked with a radial gradient — no fill, just the ring.
+            this._ring = new Graphics();
+            this._ring.lineWidth = 12;
+            this._ring.strokeStyle = new RadialGradient(
+                [
+                    { offset: 0, color: new Color(255, 240, 180, 1) },
+                    { offset: 1, color: new Color(255, 80, 160, 1) },
+                ],
+                [0.5, 0.5],
+                0.5
+            );
+            this._ring.drawArc(104, 8, 52, 0, Math.PI * 2);
+
+            // Star with a linear-gradient fill, spun on its own pivot below.
+            this._badge = new Graphics();
+            this._badge.fillStyle = new LinearGradient([
+                { offset: 0, color: new Color(180, 255, 200, 1) },
+                { offset: 1, color: new Color(40, 160, 120, 1) },
+            ]);
+            this._badge.drawStar(0, 116, 5, 46, 20);
+
+            this._sceneRoot.addChild(this._panel, this._orb, this._ring, this._badge);
+        }
+        update(delta) {
+            // The whole group is a transformed Graphics container.
+            this._sceneRoot.rotate(delta.seconds * 8);
+            this._badge.rotate(delta.seconds * 60);
+            this._orb.setScale(1 + Math.sin(this.app.activeTime.seconds * 2) * 0.06);
+        }
+        draw(context) {
+            context.backend.clear();
+            context.render(this._sceneRoot);
+        }
+        unload() {
+            this._sceneRoot?.destroy();
+            this._sceneRoot = null;
+            this._panel = null;
+            this._orb = null;
+            this._ring = null;
+            this._badge = null;
+        }
+        destroy() {
+            this.unload();
+        }
+    })()
+).catch(error => {
+    app.canvas.remove();
+    app.destroy();
+
+    throw error;
+});


### PR DESCRIPTION
## Summary

Adds one concise, runnable example demonstrating `Graphics` gradient paints through the **final** `fillStyle` / `strokeStyle` API. Placed in the cataloged `geometry-graphics` chapter next to the existing `graphics-primitives.js` and `gradient.js`, since that is where Graphics examples live and where the examples catalog wires them (there is no `rendering` chapter in `examples.json`).

No renderer or public API change — this is documentation/example material only.

## Example API usage

```js
// Linear-gradient rectangle fill
graphics.fillStyle = new LinearGradient(stops, [0, 0], [1, 1]);
graphics.drawRectangle(-190, -130, 380, 260);

// Radial-gradient circle fill
graphics.fillStyle = new RadialGradient(stops, [0.5, 0.5], 0.5);
graphics.drawCircle(-96, -8, 56);

// Radial-gradient stroked ring (no fill)
graphics.lineWidth = 12;
graphics.strokeStyle = new RadialGradient(stops, [0.5, 0.5], 0.5);
graphics.drawArc(104, 8, 52, 0, Math.PI * 2);

// Transformed, spinning linear-gradient star (rotated each frame)
graphics.fillStyle = new LinearGradient(stops);
graphics.drawStar(0, 116, 5, 46, 20);
```

The four required demonstrations are covered: linear-gradient rectangle fill, radial-gradient circle fill, gradient stroke (`strokeStyle` + `lineWidth`), and a transformed Graphics object (the whole `Container` scene root rotates and the star spins on its own pivot).

Only the canonical API is used: `fillStyle`, `strokeStyle`, `lineWidth`. No `fillGradient` / `lineGradient` (repo-wide grep confirms none remain).

## Files changed

- `examples/geometry-graphics/graphics-gradient.js` — new example (new file).
- `examples/examples.json` — catalog entry (section `geometry-graphics`, slug `graphics-gradient`); `capabilities` left empty by the `sync:example-capabilities` deriver (no explicit backend).
- `CHANGELOG.md` — concise `[Unreleased] → Examples` note.

## Validation

| Check | Result |
| --- | --- |
| `npm run lint` | pass |
| `npm run typecheck` | pass |
| `npm test -- --reporter=dot` | pass (131 files, 1705 tests) |
| `npm run verify:exports` | pass (6 entry targets) |
| `npm run build` | pass |
| `npm run site:build` | pass (560 pages) |
| `prettier --check` (changed files) | pass |
| `sync:example-capabilities` | no-op (0 changed) |

Browser tests (`test:browser:*`) were not required: the example adds no `.test.ts`, and catalog wiring does not depend on the browser suites.

## CHANGELOG / roadmap status

- **CHANGELOG**: added a concise bullet under a new `### Examples` subsection in `[Unreleased]` (examples are historically tracked in the changelog).
- **Roadmap**: `.workspace/roadmap-0.10-0.12.md` exists but is **gitignored** (local-only, not committed). It has no dedicated "Graphics gradient example" line item; the closest entries are the Graphics-gradient API work (#6, already done) and a broad examples overhaul (#2, still open). A local note marking this example done was added under #6.

## No renderer / API changes

- No changes to rendering behavior, public API, `Sprite`/`Mesh`/`TransformBuffer`/`RenderPassCoordinator`/stencil, CI, Firefox lanes, or release config.
- Did not reintroduce `fillGradient` / `lineGradient`.
- Regenerated `site/src/content/api/*.mdx` files (pre-existing API-doc drift on `main`, surfaced by `site:build`) were intentionally reverted to keep this PR scoped to the example.
