### PR TITLE
fix(playground): stabilize example navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 ### Examples
 
 - New example `geometry-graphics/graphics-gradient.js`: paints `Graphics` shapes with gradients through the canonical `fillStyle` / `strokeStyle` API — a linear-gradient rectangle, a radial-gradient circle, a radial-gradient stroked ring, and a transformed, spinning linear-gradient star.
+- Fixed `performance/backend-comparison.js` importing `DebugOverlay` from the package root. `DebugOverlay` is only exported from `@codexo/exojs/debug`, so the named import was `undefined` and the example threw at runtime; it now imports from the `/debug` subpath like the other debug-layer examples.
+
+### Playground
+
+- The examples sidenav was flattened from the three-level guide structure (Part → Chapter → Example) to a single category level (Category → Example), driven directly by the flat example catalog. Each example now appears exactly once under its home category, ordered and titled by the chapter metadata. The guide/docs navigation is unchanged.
+- Active-link state is now exact and unambiguous. Previously the sidenav reused the guide structure, in which some examples are cross-referenced by multiple chapters (e.g. `getting-started/hello-world`); selecting such an example lit up every copy at once. Matching now runs through a canonical route helper (`isExampleRouteActive`) that ignores a `.js` suffix, leading/trailing slashes, and any query string or hash, so exactly one link is active per example route.
+- Added catalog and nav-model validation tests: catalog entries resolve to real source files, routes and per-category slugs are unique, the catalog category set matches the chapter metadata, the nav model is one level deep with no duplicated example, and active-link matching is exact (never prefix-based).
 
 ## [0.10.0] - 2026-05-31
 

--- a/examples/performance/backend-comparison.js
+++ b/examples/performance/backend-comparison.js
@@ -1,4 +1,5 @@
-import { Application, Color, DebugOverlay, Keyboard, Scene, Sprite, Texture } from '@codexo/exojs';
+import { Application, Color, Keyboard, Scene, Sprite, Texture } from '@codexo/exojs';
+import { DebugOverlay } from '@codexo/exojs/debug';
 
 const options = {
     canvas: {

--- a/site/src/components/Navigation.scss
+++ b/site/src/components/Navigation.scss
@@ -136,41 +136,6 @@ nav {
     padding: 0.45rem 0.38rem;
 }
 
-.chapter {
-    border-top: 1px solid color-mix(in oklab, var(--line-soft), transparent 42%);
-}
-
-.chapter__toggle {
-    appearance: none;
-    width: 100%;
-    border: 0;
-    background: transparent;
-    color: inherit;
-    min-height: 33px;
-    padding: 0 0.54rem 0 0.74rem;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    cursor: pointer;
-    text-align: left;
-    border-radius: var(--r-2);
-}
-
-.chapter__toggle:hover {
-    background: color-mix(in oklab, var(--bg-panel), transparent 10%);
-}
-
-.chapter__toggle:focus-visible {
-    outline: none;
-    box-shadow: inset 0 0 0 2px var(--accent-line);
-}
-
-@media (max-width: 1119px) {
-    .chapter__toggle {
-        min-height: 44px;
-    }
-}
-
 @media (max-width: 760px) {
     .search kbd {
         display: none;
@@ -179,35 +144,6 @@ nav {
     .search {
         height: 40px;
     }
-}
-
-.chapter__title {
-    flex: 1 1 auto;
-    min-width: 0;
-    font-size: 0.68rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    font-weight: 600;
-    color: var(--fg-muted);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.chapter__chevron {
-    width: 7px;
-    height: 7px;
-    border-right: 1.5px solid var(--fg-faint);
-    border-bottom: 1.5px solid var(--fg-faint);
-    transform: rotate(45deg);
-}
-
-.chapter__chevron[data-expanded] {
-    transform: rotate(225deg);
-}
-
-.chapter__examples {
-    padding: 0.2rem 0 0.28rem;
 }
 
 .error {

--- a/site/src/components/Navigation.ts
+++ b/site/src/components/Navigation.ts
@@ -1,36 +1,17 @@
 import { LitElement, html, nothing, unsafeCSS } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { GUIDE_PARTS } from '../lib/guide-structure';
 import { getExampleAvailability } from '../lib/runtime-support';
 import type { Example, ExamplesMap } from '../lib/types';
 import type { VersionInfo } from '../lib/versions';
 import { buildExampleHref } from '../lib/url-state';
+import { buildPlaygroundNavModel, isExampleRouteActive, type PlaygroundNavCategory } from '../lib/playground-nav';
 import componentStyles from './Navigation.scss?inline';
 import './LoadingSpinner';
 import './NavigationLink';
 import './NavigationSection';
 
-interface ChapterGroup {
-    key: string;
-    title: string;
-    examples: Array<Example>;
-}
-
-interface PartGroup {
-    key: string;
-    title: string;
-    chapters: Array<ChapterGroup>;
-}
-
 const TAG_PRIORITY = ['scene', 'input', 'audio', 'fx', 'effects', 'particles', 'rendering', 'debug', 'advanced'] as const;
 const MAX_DEFAULT_TAGS = 9;
-
-function normalizeExampleRef(value: string): string {
-    return value
-        .trim()
-        .replace(/^\/+/, '')
-        .replace(/\.js$/i, '');
-}
 
 @customElement('exo-navigation')
 export class Navigation extends LitElement {
@@ -46,13 +27,11 @@ export class Navigation extends LitElement {
     @state() private _searchQuery = '';
     @state() private _activeTagFilter: string | null = null;
     @state() private _showAllTags = false;
-    @state() private _overriddenParts: Map<string, boolean> = new Map();
-    @state() private _overriddenChapters: Map<string, boolean> = new Map();
+    @state() private _overriddenCategories: Map<string, boolean> = new Map();
 
     protected override willUpdate(changedProperties: Map<PropertyKey, unknown>): void {
-        if (changedProperties.has('activeExample') && (this._overriddenParts.size > 0 || this._overriddenChapters.size > 0)) {
-            this._overriddenParts = new Map();
-            this._overriddenChapters = new Map();
+        if (changedProperties.has('activeExample') && this._overriddenCategories.size > 0) {
+            this._overriddenCategories = new Map();
         }
 
         if (changedProperties.has('availableTags')) {
@@ -166,96 +145,55 @@ export class Navigation extends LitElement {
         if (this.loadError) return html`<p class="error">${this.loadError}</p>`;
         if (!this.loaded) return html`<exo-spinner centered></exo-spinner>`;
 
-        const groups = this._buildGroups();
-        return html`${groups.map(group => this._renderPart(group))}`;
+        const categories = this._buildCategories();
+        return html`${categories.map(category => this._renderCategory(category))}`;
     }
 
-    private _buildGroups(): Array<PartGroup> {
-        const allExamples = Array.from(this.examples.values()).flat();
-        const examplesByPath = new Map<string, Example>();
-
-        for (const example of allExamples) {
-            examplesByPath.set(normalizeExampleRef(example.path), example);
-            examplesByPath.set(normalizeExampleRef(example.slug), example);
-        }
-
-        return GUIDE_PARTS.map(part => {
-            const chapters: Array<ChapterGroup> = part.chapters
-                .map(chapter => {
-                    const mapped = chapter.examples
-                        .map(path => examplesByPath.get(normalizeExampleRef(path)))
-                        .filter((example): example is Example => Boolean(example))
-                        .filter(example => (this._activeTagFilter ? (example.tags ?? []).includes(this._activeTagFilter) : true))
-                        .filter(example => {
-                            if (!this._searchQuery.trim()) return true;
-                            const query = this._searchQuery.trim().toLowerCase();
-                            return (
-                                example.title.toLowerCase().includes(query) ||
-                                example.path.toLowerCase().includes(query) ||
-                                example.description.toLowerCase().includes(query)
-                            );
-                        });
-
-                    return {
-                        key: chapter.path,
-                        title: chapter.title,
-                        examples: mapped,
-                    };
-                })
-                .filter(chapter => chapter.examples.length > 0);
-
-            return {
-                key: part.slug,
-                title: part.title,
-                chapters,
-            };
-        }).filter(part => part.chapters.length > 0);
+    // The playground sidenav is the flat catalog: one category level, examples
+    // directly underneath. Each example appears exactly once (under its own
+    // `section`), so the active-link state can never light up two links at once.
+    private _buildCategories(): Array<PlaygroundNavCategory> {
+        return buildPlaygroundNavModel(this._filterExamples(Array.from(this.examples.values()).flat()));
     }
 
-    private _isPartExpanded(group: PartGroup): boolean {
-        if (this._overriddenParts.has(group.key)) return this._overriddenParts.get(group.key)!;
-        return group.chapters.some(chapter => chapter.examples.some(example => example.path === this.activeExample?.path));
+    private _filterExamples(examples: Array<Example>): Array<Example> {
+        const query = this._searchQuery.trim().toLowerCase();
+
+        return examples.filter(example => {
+            if (this._activeTagFilter && !(example.tags ?? []).includes(this._activeTagFilter)) {
+                return false;
+            }
+
+            if (query) {
+                return (
+                    example.title.toLowerCase().includes(query) ||
+                    example.path.toLowerCase().includes(query) ||
+                    example.description.toLowerCase().includes(query)
+                );
+            }
+
+            return true;
+        });
     }
 
-    private _isChapterExpanded(chapter: ChapterGroup): boolean {
-        if (this._overriddenChapters.has(chapter.key)) return this._overriddenChapters.get(chapter.key)!;
-        return chapter.examples.some(example => example.path === this.activeExample?.path);
+    private _isCategoryExpanded(category: PlaygroundNavCategory): boolean {
+        if (this._overriddenCategories.has(category.slug)) return this._overriddenCategories.get(category.slug)!;
+        return category.examples.some(example => isExampleRouteActive(example.path, this.activeExample?.path));
     }
 
-    private _renderPart(group: PartGroup): ReturnType<LitElement['render']> {
-        const expanded = this._isPartExpanded(group);
-        const unavailableCount = group.chapters
-            .flatMap(chapter => chapter.examples)
-            .filter(example => !getExampleAvailability(example).available).length;
+    private _renderCategory(category: PlaygroundNavCategory): ReturnType<LitElement['render']> {
+        const expanded = this._isCategoryExpanded(category);
+        const unavailableCount = category.examples.filter(example => !getExampleAvailability(example).available).length;
 
         return html`
             <exo-nav-section
-                headline=${group.title}
+                headline=${category.title}
                 .expanded=${expanded}
                 .unavailableCount=${unavailableCount}
-                @toggle-section=${() => this._onTogglePart(group.key)}
+                @toggle-section=${() => this._onToggleCategory(category.slug)}
             >
-                ${group.chapters.map(chapter => this._renderChapter(chapter))}
+                ${category.examples.map(example => this._renderLink(example))}
             </exo-nav-section>
-        `;
-    }
-
-    private _renderChapter(chapter: ChapterGroup): ReturnType<LitElement['render']> {
-        const expanded = this._isChapterExpanded(chapter);
-        return html`
-            <section class="chapter">
-                <button class="chapter__toggle" type="button" aria-expanded=${String(expanded)} @click=${() => this._onToggleChapter(chapter.key)}>
-                    <span class="chapter__title">${chapter.title}</span>
-                    <span class="chapter__chevron" ?data-expanded=${expanded}></span>
-                </button>
-                ${expanded
-                    ? html`
-                          <div class="chapter__examples">
-                              ${chapter.examples.map(example => this._renderLink(example))}
-                          </div>
-                      `
-                    : nothing}
-            </section>
         `;
     }
 
@@ -269,7 +207,7 @@ export class Navigation extends LitElement {
                 path=${example.path}
                 title=${example.title}
                 description=${example.description}
-                ?active=${this.activeExample?.path === example.path}
+                ?active=${isExampleRouteActive(example.path, this.activeExample?.path)}
                 ?unavailable=${!availability.available}
                 unavailableReason=${availability.reason ?? ''}
             ></exo-nav-link>
@@ -288,23 +226,13 @@ export class Navigation extends LitElement {
         this._showAllTags = !this._showAllTags;
     }
 
-    private _onTogglePart(key: string): void {
-        const next = new Map(this._overriddenParts);
-        const group = this._buildGroups().find(entry => entry.key === key);
-        if (!group) return;
-        const current = next.get(key) ?? this._isPartExpanded(group);
-        next.set(key, !current);
-        this._overriddenParts = next;
-    }
-
-    private _onToggleChapter(key: string): void {
-        const next = new Map(this._overriddenChapters);
-        const groups = this._buildGroups();
-        const chapter = groups.flatMap(group => group.chapters).find(entry => entry.key === key);
-        if (!chapter) return;
-        const current = next.get(key) ?? this._isChapterExpanded(chapter);
-        next.set(key, !current);
-        this._overriddenChapters = next;
+    private _onToggleCategory(slug: string): void {
+        const next = new Map(this._overriddenCategories);
+        const category = this._buildCategories().find(entry => entry.slug === slug);
+        if (!category) return;
+        const current = next.get(slug) ?? this._isCategoryExpanded(category);
+        next.set(slug, !current);
+        this._overriddenCategories = next;
     }
 }
 

--- a/site/src/lib/playground-nav.ts
+++ b/site/src/lib/playground-nav.ts
@@ -1,0 +1,98 @@
+// Pure, DOM-free helpers for the playground sidenav.
+//
+// The playground browser shows the *flat* example catalog: one category level
+// (the `examples.json` directory / `CHAPTERS` slug) with the examples of that
+// category directly underneath — never the guide's Part → Chapter → Example
+// nesting. Keeping these helpers free of Lit/DOM imports lets them be unit
+// tested directly (see `test/site/playground-nav.test.ts`).
+
+import { CHAPTER_BY_SLUG } from './chapters';
+import type { Example } from './types';
+
+export interface PlaygroundNavCategory {
+    /** Catalog category slug, e.g. `"particles"` (matches the `examples.json` key). */
+    slug: string;
+    /** Display label, taken from `CHAPTERS` when available. */
+    title: string;
+    /** Sort key from `CHAPTERS`; unknown categories sort last. */
+    order: number;
+    examples: Array<Example>;
+}
+
+// Title-cases an unknown category slug as a last resort. Known categories use
+// their curated `CHAPTERS` title instead.
+function humanizeSlug(slug: string): string {
+    return slug
+        .split(/[-/]/)
+        .map(word => (word ? word[0].toUpperCase() + word.slice(1) : word))
+        .join(' ');
+}
+
+/**
+ * Reduces an example path or route to its canonical slug form so two
+ * references to the same example compare equal regardless of how they were
+ * written. Strips, in order: a query string or hash fragment, leading and
+ * trailing slashes, and a `.js` suffix.
+ *
+ *   normalizeExamplePath('/particles/bonfire.js?x=1#frag') === 'particles/bonfire'
+ */
+export function normalizeExamplePath(value: string | null | undefined): string {
+    if (!value) return '';
+
+    let path = value.trim();
+
+    const queryOrHash = path.search(/[?#]/);
+    if (queryOrHash !== -1) {
+        path = path.slice(0, queryOrHash);
+    }
+
+    return path
+        .replace(/^\/+/, '')
+        .replace(/\/+$/, '')
+        .replace(/\.js$/i, '');
+}
+
+/**
+ * Exact, unambiguous active-route match: true only when `candidatePath` and
+ * `activePath` resolve to the same canonical example slug. This is a full-path
+ * equality check, never a prefix match, so sibling routes like
+ * `input/keyboard` and `input/keyboard-extra` never both match.
+ */
+export function isExampleRouteActive(candidatePath: string, activePath: string | null | undefined): boolean {
+    if (!activePath) return false;
+    return normalizeExamplePath(candidatePath) === normalizeExamplePath(activePath);
+}
+
+/**
+ * Groups a flat list of examples into one nav level — category → examples —
+ * ordered and titled by `CHAPTERS`. Each example appears exactly once (under
+ * its own `section`), which is what makes the active-link state unambiguous.
+ * Categories that end up empty (e.g. after search/tag filtering upstream) are
+ * not produced.
+ */
+export function buildPlaygroundNavModel(examples: ReadonlyArray<Example>): Array<PlaygroundNavCategory> {
+    const bySection = new Map<string, Array<Example>>();
+
+    for (const example of examples) {
+        const existing = bySection.get(example.section);
+        if (existing) {
+            existing.push(example);
+        } else {
+            bySection.set(example.section, [example]);
+        }
+    }
+
+    const categories: Array<PlaygroundNavCategory> = [];
+    for (const [slug, sectionExamples] of bySection) {
+        const meta = CHAPTER_BY_SLUG.get(slug);
+        categories.push({
+            slug,
+            title: meta?.title ?? humanizeSlug(slug),
+            order: meta?.order ?? Number.MAX_SAFE_INTEGER,
+            examples: sectionExamples,
+        });
+    }
+
+    categories.sort((a, b) => a.order - b.order || a.slug.localeCompare(b.slug));
+    return categories;
+}

--- a/test/site/examples-catalog.test.ts
+++ b/test/site/examples-catalog.test.ts
@@ -1,0 +1,50 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { CHAPTERS } from '../../site/src/lib/chapters';
+import { EXAMPLES_CATALOG } from '../../site/src/lib/examples-catalog';
+
+// Vitest runs with the repository root as the working directory; the example
+// sources live in `<root>/examples`. `import.meta.url` is an http URL under
+// Vite, so it can't be used to resolve a filesystem path here.
+const examplesDir = join(process.cwd(), 'examples');
+
+const entries = Object.entries(EXAMPLES_CATALOG).flatMap(([category, list]) => list.map(entry => ({ ...entry, category })));
+
+describe('examples catalog integrity', () => {
+  it('points every catalog entry at a source file that exists', () => {
+    const missing = entries.filter(entry => !existsSync(join(examplesDir, entry.path)));
+    expect(missing.map(entry => entry.path)).toEqual([]);
+  });
+
+  it('keeps every path consistent with "<category>/<slug>.js"', () => {
+    const mismatched = entries.filter(entry => entry.path !== `${entry.category}/${entry.slug}.js`);
+    expect(mismatched.map(entry => entry.path)).toEqual([]);
+  });
+
+  it('has no duplicate routes (full paths)', () => {
+    const paths = entries.map(entry => entry.path);
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+
+  it('has no duplicate slug within a category', () => {
+    for (const [category, list] of Object.entries(EXAMPLES_CATALOG)) {
+      const slugs = list.map(entry => entry.slug);
+      expect(new Set(slugs).size, `duplicate slug in "${category}"`).toBe(slugs.length);
+    }
+  });
+
+  it('matches the CHAPTERS category set exactly (no orphan category metadata)', () => {
+    const catalogCategories = Object.keys(EXAMPLES_CATALOG).sort();
+    const chapterSlugs = CHAPTERS.map(chapter => chapter.slug).sort();
+    expect(catalogCategories).toEqual(chapterSlugs);
+  });
+
+  it('assigns every example to a known chapter', () => {
+    const known = new Set(CHAPTERS.map(chapter => chapter.slug));
+    const orphaned = entries.filter(entry => !known.has(entry.category));
+    expect(orphaned.map(entry => entry.path)).toEqual([]);
+  });
+});

--- a/test/site/playground-nav.test.ts
+++ b/test/site/playground-nav.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+
+import { CHAPTERS } from '../../site/src/lib/chapters';
+import { EXAMPLES_CATALOG } from '../../site/src/lib/examples-catalog';
+import { buildPlaygroundNavModel, isExampleRouteActive, normalizeExamplePath } from '../../site/src/lib/playground-nav';
+import type { Example } from '../../site/src/lib/types';
+
+function ex(section: string, slug: string, extra: Partial<Example> = {}): Example {
+  return {
+    section,
+    slug,
+    path: `${section}/${slug}.js`,
+    title: slug,
+    description: '',
+    backend: 'core',
+    ...extra,
+  };
+}
+
+// A flat list synthesised from the real catalog, exactly how the live store
+// hands examples to the nav (each entry once, carrying its `section`).
+function catalogExamples(): Example[] {
+  return Object.entries(EXAMPLES_CATALOG).flatMap(([section, entries]) =>
+    entries.map(entry => ex(section, entry.slug, { path: entry.path, title: entry.title })),
+  );
+}
+
+describe('normalizeExamplePath', () => {
+  it('strips a .js suffix', () => {
+    expect(normalizeExamplePath('particles/bonfire.js')).toBe('particles/bonfire');
+  });
+
+  it('returns an already-canonical slug unchanged', () => {
+    expect(normalizeExamplePath('particles/bonfire')).toBe('particles/bonfire');
+  });
+
+  it('strips leading and trailing slashes', () => {
+    expect(normalizeExamplePath('/particles/bonfire.js')).toBe('particles/bonfire');
+    expect(normalizeExamplePath('particles/bonfire.js/')).toBe('particles/bonfire');
+  });
+
+  it('drops a query string or hash fragment', () => {
+    expect(normalizeExamplePath('particles/bonfire.js?version=current')).toBe('particles/bonfire');
+    expect(normalizeExamplePath('particles/bonfire.js#section')).toBe('particles/bonfire');
+    expect(normalizeExamplePath('particles/bonfire?x=1#y')).toBe('particles/bonfire');
+  });
+
+  it('is case-insensitive about the suffix and trims whitespace', () => {
+    expect(normalizeExamplePath('  particles/bonfire.JS  ')).toBe('particles/bonfire');
+  });
+
+  it('treats empty / nullish input as empty', () => {
+    expect(normalizeExamplePath('')).toBe('');
+    expect(normalizeExamplePath(null)).toBe('');
+    expect(normalizeExamplePath(undefined)).toBe('');
+  });
+});
+
+describe('isExampleRouteActive', () => {
+  it('matches identical canonical routes', () => {
+    expect(isExampleRouteActive('particles/bonfire.js', 'particles/bonfire.js')).toBe(true);
+  });
+
+  it('matches across .js / slash / query / hash differences', () => {
+    expect(isExampleRouteActive('particles/bonfire.js', 'particles/bonfire')).toBe(true);
+    expect(isExampleRouteActive('/particles/bonfire', 'particles/bonfire.js?version=current#x')).toBe(true);
+  });
+
+  it('is false when there is no active example', () => {
+    expect(isExampleRouteActive('particles/bonfire.js', null)).toBe(false);
+    expect(isExampleRouteActive('particles/bonfire.js', undefined)).toBe(false);
+    expect(isExampleRouteActive('particles/bonfire.js', '')).toBe(false);
+  });
+
+  it('does not prefix-match sibling routes', () => {
+    expect(isExampleRouteActive('input/keyboard.js', 'input/keyboard-extra.js')).toBe(false);
+    expect(isExampleRouteActive('input/key.js', 'input/keyboard.js')).toBe(false);
+    expect(isExampleRouteActive('input/keyboard.js', 'input/key.js')).toBe(false);
+  });
+
+  it('is false for a genuinely different example', () => {
+    expect(isExampleRouteActive('particles/bonfire.js', 'particles/fireworks.js')).toBe(false);
+  });
+});
+
+describe('buildPlaygroundNavModel', () => {
+  it('produces exactly one category level (category -> flat example list)', () => {
+    const model = buildPlaygroundNavModel([ex('particles', 'bonfire'), ex('particles', 'fireworks')]);
+
+    expect(model).toHaveLength(1);
+    expect(model[0].slug).toBe('particles');
+    expect(model[0].examples.map(e => e.slug)).toEqual(['bonfire', 'fireworks']);
+    // The examples are plain Example objects, not nested sub-categories.
+    expect(model[0].examples.every(e => typeof e.path === 'string' && !('chapters' in e))).toBe(true);
+  });
+
+  it('titles categories from CHAPTERS and orders them by the curated order', () => {
+    // Deliberately reversed input order.
+    const model = buildPlaygroundNavModel([ex('particles', 'bonfire'), ex('getting-started', 'hello-world')]);
+
+    expect(model.map(c => c.slug)).toEqual(['getting-started', 'particles']);
+    expect(model[0].title).toBe('Getting Started');
+    expect(model[1].title).toBe('Particles');
+  });
+
+  it('falls back to a humanised title and last-place order for unknown categories', () => {
+    const model = buildPlaygroundNavModel([ex('rendering', 'camera-basic'), ex('getting-started', 'hello-world')]);
+
+    expect(model.map(c => c.slug)).toEqual(['getting-started', 'rendering']);
+    const rendering = model.find(c => c.slug === 'rendering')!;
+    expect(rendering.title).toBe('Rendering');
+    expect(rendering.order).toBeGreaterThan(CHAPTERS.length);
+  });
+
+  it('returns an empty model for empty input', () => {
+    expect(buildPlaygroundNavModel([])).toEqual([]);
+  });
+
+  it('covers the whole catalog with no example appearing twice', () => {
+    const model = buildPlaygroundNavModel(catalogExamples());
+
+    // One category per catalog directory.
+    expect(model).toHaveLength(Object.keys(EXAMPLES_CATALOG).length);
+
+    const total = model.reduce((sum, category) => sum + category.examples.length, 0);
+    const catalogTotal = Object.values(EXAMPLES_CATALOG).reduce((sum, entries) => sum + entries.length, 0);
+    expect(total).toBe(catalogTotal);
+
+    // Every example route is unique across the entire rendered model — this is
+    // the property the old GUIDE_PARTS model violated (hello-world appeared in
+    // two parts), which lit up multiple active links at once.
+    const allPaths = model.flatMap(category => category.examples.map(e => e.path));
+    expect(new Set(allPaths).size).toBe(allPaths.length);
+
+    // First category is Getting Started (curated order).
+    expect(model[0].slug).toBe('getting-started');
+  });
+
+  it('keeps a previously-duplicated example in exactly one category', () => {
+    const model = buildPlaygroundNavModel(catalogExamples());
+    const hits = model.filter(category => category.examples.some(e => e.path === 'getting-started/hello-world.js'));
+
+    expect(hits).toHaveLength(1);
+    expect(hits[0].slug).toBe('getting-started');
+  });
+});


### PR DESCRIPTION
## Summary

Stabilizes the playground/examples experience in one focused pass: the examples sidenav is flattened from a three-level guide structure to a single category level, the active-link state is made exact (only one link active per example route), and the one genuinely broken example import is fixed. No rendering-engine behavior changes.

The sidenav was rendering `GUIDE_PARTS` (the pedagogical **Part → Chapter → Example** guide structure, in which the same example legitimately illustrates several chapters) and matched the active link with a plain `path === path` check — so any cross-referenced example lit up **every** copy at once. The fix drives the sidenav from the flat example catalog (`examples.json` + `CHAPTERS`) instead, where each example appears exactly once.

## Example audit results

Full local report: `.workspace/reports/playground-audit.md` (gitignored). Headlines:

- **19 categories, 115 catalog entries, 117 `.js` files on disk.**
- Catalog integrity is **clean**: 0 missing files (catalog→disk), 0 `path` vs `<category>/<slug>.js` mismatches, 0 duplicate routes, 0 duplicate slugs (cross-category), catalog category keys == `CHAPTERS` exactly.
- **2 orphan files** (on disk, not in catalog): `examples/shared/runtime.js` (intentional preview-harness infra) and `examples/rendering/camera-basic.js` (a stray from the old Camera-facade work, in a `rendering/` dir that is not a catalog category — left untouched, documented for follow-up).
- **Static import validity** (every named import checked against the 344 root + 7 `/debug` bundle exports): **1 real bug** found and fixed; 0 remaining.
- **11 examples were referenced by 2 guide chapters each** — the root cause of the multi-active-link bug (e.g. `getting-started/hello-world` in Part 1 *and* Part 2).

## Broken examples: fixed / removed / left

- **Fixed:** `performance/backend-comparison.js` imported `DebugOverlay` from the package root, but it is only exported from `@codexo/exojs/debug`. The named import resolved to `undefined`, so `new DebugOverlay(app)` threw at runtime. Now imported from the `/debug` subpath, matching the other `debug-layer/*` examples.
- **Left (documented):** `examples/rendering/camera-basic.js` — an orphan file not exposed in the playground; not deleted (not introduced here) and flagged in the audit + roadmap for a follow-up decision.
- No catalog entries were removed — the catalog is internally consistent, so nothing needed temporary removal.

## Sidenav flattening behavior

- New shape: **Category → Example** (one collapsible level), e.g. `Particles > Bonfire` instead of `06 Effects > 6.2 Particles > Bonfire`.
- Categories come straight from `examples.json`, titled and ordered by `CHAPTERS` (Getting Started first). Each example appears exactly once under its home category. Empty categories (after search/tag filtering) are not shown.
- Routes are unchanged (`#/<version>/<example-path>`), so existing shareable links keep working. The guide/docs navigation (`GUIDE_PARTS`, `DocsSidebar`) is untouched.
- Dead `.chapter*` styles were removed from `Navigation.scss`.

## Active-link fix

- Matching now goes through a canonical `isExampleRouteActive(candidate, active)` helper that normalizes both sides (ignores a `.js` suffix, leading/trailing slashes, and any query string or hash) and compares the **full** path — never a prefix. Sibling routes like `input/keyboard` and `input/keyboard-extra` can no longer both match.
- Because each example now renders once, selecting an example highlights exactly one link.
- Other prefix-based active states (the `ExoHeader` Guide/Playground/API tabs, the `DocsSidebar` part highlight) are intentional section/parent highlighting with exact child matching and were left as-is.

## Tests added

Pure helpers extracted to `site/src/lib/playground-nav.ts` and unit-tested under the existing root `exojs` vitest project (same pattern as `test/site/url-state.test.ts`):

- `test/site/playground-nav.test.ts` — `normalizeExamplePath` (`.js`/slash/query/hash/case), `isExampleRouteActive` (exact match, no prefix match, null-safe), `buildPlaygroundNavModel` (one level deep, CHAPTERS order/titles, unknown-category fallback, whole-catalog coverage with no duplicated example, previously-duplicated example appears in exactly one category).
- `test/site/examples-catalog.test.ts` — catalog→file existence, `path` consistency, unique routes, unique slug per category, catalog category set == `CHAPTERS`.

## Validation

| Step | Result |
| --- | --- |
| `npm run lint` | pass |
| `npm run typecheck` | pass |
| `npm test -- --reporter=dot` | pass — 1728 tests / 133 files (incl. 26 site tests) |
| `npm run verify:exports` | pass |
| `npm run build` | pass |
| `npm run site:build` | pass — 560 pages built (incl. `/en/playground/`, `/de/playground/`) |

Browser tests (`test:browser:webgl` / `webgpu`) were **not** run: the changes are confined to site navigation + one example import and do not touch any engine rendering path covered by `test/rendering/browser/**`.

> Note: `site:build` (`build:api`) regenerated several `site/src/content/api/*.mdx` files — pre-existing generated API-doc drift, unrelated to this work. Per scope, those regenerated files were reverted and are **not** part of this PR.

## CHANGELOG / roadmap

- `CHANGELOG.md` `[Unreleased]` updated: new **Playground** section (sidenav flattening, exact active-link, validation tests) and an **Examples** entry for the `backend-comparison.js` import fix.
- `.workspace/roadmap-0.10-0.12.md` (local, gitignored) section *2. Examples Assets Overhaul + Site-Fixes* marked 🔶 teilweise with a dated status note.

## No rendering engine behavior changes

`src/` is untouched. Changes are limited to `site/` (playground nav + helper), `examples/performance/backend-comparison.js` (import path only), `test/site/`, and `CHANGELOG.md`.