### PR TITLE
feat(core): add assert dev diagnostics

### DIFF
--- a/src/core/dev.ts
+++ b/src/core/dev.ts
@@ -7,10 +7,27 @@ const _warned = new Set<string>();
  * Assert `condition` at dev/test time. Throws with `[ExoJS] message` when the
  * condition is falsy and `__DEV__` is true. No-op in production builds.
  */
-export function invariant(condition: boolean, message: string): asserts condition {
+export function assert(condition: boolean, message: string): asserts condition {
   if (__DEV__ && !condition) {
     throw new Error(`[ExoJS] ${message}`);
   }
+}
+
+/**
+ * Assert that `value` is neither `null` nor `undefined`. Returns the value so
+ * it can be used inline in an expression. No-op in production builds (returns
+ * the value cast to `T` without checking).
+ */
+export function assertDefined<T>(value: T | null | undefined, message: string): T {
+  if (__DEV__ && (value === null || value === undefined)) {
+    throw new Error(`[ExoJS] ${message}`);
+  }
+  return value as T;
+}
+
+/** @internal — alias for {@link assert}; kept for backward compatibility. */
+export function invariant(condition: boolean, message: string): asserts condition {
+  assert(condition, message);
 }
 
 /**

--- a/src/rendering/text/BitmapText.ts
+++ b/src/rendering/text/BitmapText.ts
@@ -1,4 +1,4 @@
-import { warnOnce } from '@/core/dev';
+import { assert, warnOnce } from '@/core/dev';
 import type { Texture } from '@/rendering/texture/Texture';
 
 import { AbstractText } from './AbstractText';
@@ -85,6 +85,10 @@ export class BmFontAdapter implements GlyphProvider {
       };
     }
 
+    assert(
+      g.page < this._textures.length,
+      `BitmapText: glyph page index ${g.page} is out of range — font "${this._fontId}" has ${this._textures.length} page(s)`,
+    );
     const texW = this._textures[g.page]?.width ?? 1;
     const texH = this._textures[g.page]?.height ?? 1;
 

--- a/src/rendering/text/BmFont.ts
+++ b/src/rendering/text/BmFont.ts
@@ -1,3 +1,4 @@
+import { assert } from '@/core/dev';
 import type { Texture } from '@/rendering/texture/Texture';
 
 /** Per-character metrics from a BMFont descriptor. */
@@ -51,6 +52,10 @@ export class BmFont {
   public readonly textures: readonly Texture[];
 
   public constructor(fontData: BmFontData, textures: readonly Texture[]) {
+    assert(
+      textures.length === fontData.pages.length,
+      `BmFont: texture count (${textures.length}) must match page count (${fontData.pages.length})`,
+    );
     this.fontData = fontData;
     this.textures = textures;
   }

--- a/src/rendering/texture/RenderTexture.ts
+++ b/src/rendering/texture/RenderTexture.ts
@@ -1,3 +1,4 @@
+import { assert } from '@/core/dev';
 import { isPowerOfTwo } from '@/math/utils';
 import { RenderTarget } from '@/rendering/RenderTarget';
 import type { SamplerOptions } from '@/rendering/texture/Sampler';
@@ -32,6 +33,7 @@ export class RenderTexture extends RenderTarget {
   private _flipY: boolean;
 
   public constructor(width: number, height: number, options?: Partial<SamplerOptions>) {
+    assert(width > 0 && height > 0, `RenderTexture dimensions must be positive (got ${width}×${height})`);
     super(width, height, false);
 
     const { scaleMode, wrapMode, premultiplyAlpha, generateMipMap, flipY } = {
@@ -151,6 +153,7 @@ export class RenderTexture extends RenderTarget {
   }
 
   public setSize(width: number, height: number): this {
+    assert(width > 0 && height > 0, `RenderTexture.setSize() dimensions must be positive (got ${width}×${height})`);
     if (!this._size.equals({ width, height })) {
       this._size.set(width, height);
       this._defaultView.resize(width, height);

--- a/test/core/dev.test.ts
+++ b/test/core/dev.test.ts
@@ -1,7 +1,50 @@
-import { _resetWarnOnce, invariant, warnOnce } from '@/core/dev';
+import { _resetWarnOnce, assert, assertDefined, invariant, warnOnce } from '@/core/dev';
 
 beforeEach(() => {
   _resetWarnOnce();
+});
+
+// ---------------------------------------------------------------------------
+// assert
+// ---------------------------------------------------------------------------
+
+describe('assert', () => {
+  test('does not throw when condition is true', () => {
+    expect(() => assert(true, 'should not throw')).not.toThrow();
+  });
+
+  test('throws with prefixed message when condition is false', () => {
+    expect(() => assert(false, 'test failure')).toThrow('[ExoJS] test failure');
+  });
+
+  test('throws an Error instance', () => {
+    expect(() => assert(false, 'err')).toThrow(Error);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertDefined
+// ---------------------------------------------------------------------------
+
+describe('assertDefined', () => {
+  test('throws when value is null', () => {
+    expect(() => assertDefined(null, 'must not be null')).toThrow('[ExoJS] must not be null');
+  });
+
+  test('throws when value is undefined', () => {
+    expect(() => assertDefined(undefined, 'must not be undefined')).toThrow('[ExoJS] must not be undefined');
+  });
+
+  test('returns the value when it is defined', () => {
+    expect(assertDefined(42, 'unreachable')).toBe(42);
+    expect(assertDefined('hello', 'unreachable')).toBe('hello');
+    expect(assertDefined(0, 'unreachable')).toBe(0);
+    expect(assertDefined(false, 'unreachable')).toBe(false);
+  });
+
+  test('throws an Error instance', () => {
+    expect(() => assertDefined(null, 'err')).toThrow(Error);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/rendering/render-texture.test.ts
+++ b/test/rendering/render-texture.test.ts
@@ -1,0 +1,36 @@
+import { RenderTexture } from '@/rendering/texture/RenderTexture';
+
+describe('RenderTexture dev assertions', () => {
+  test('throws when width is zero', () => {
+    expect(() => new RenderTexture(0, 100)).toThrow('[ExoJS]');
+  });
+
+  test('throws when height is zero', () => {
+    expect(() => new RenderTexture(100, 0)).toThrow('[ExoJS]');
+  });
+
+  test('throws when either dimension is negative', () => {
+    expect(() => new RenderTexture(-1, 100)).toThrow('[ExoJS]');
+    expect(() => new RenderTexture(100, -1)).toThrow('[ExoJS]');
+  });
+
+  test('does not throw for positive dimensions', () => {
+    expect(() => new RenderTexture(1, 1)).not.toThrow();
+    expect(() => new RenderTexture(512, 512)).not.toThrow();
+  });
+
+  test('setSize throws when width is zero', () => {
+    const rt = new RenderTexture(64, 64);
+    expect(() => rt.setSize(0, 64)).toThrow('[ExoJS]');
+  });
+
+  test('setSize throws when height is zero', () => {
+    const rt = new RenderTexture(64, 64);
+    expect(() => rt.setSize(64, 0)).toThrow('[ExoJS]');
+  });
+
+  test('setSize does not throw for positive dimensions', () => {
+    const rt = new RenderTexture(64, 64);
+    expect(() => rt.setSize(128, 128)).not.toThrow();
+  });
+});

--- a/test/rendering/text/bitmap-text.test.ts
+++ b/test/rendering/text/bitmap-text.test.ts
@@ -191,6 +191,39 @@ describe('BitmapText', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Dev assertions — BmFont and BmFontAdapter
+// ---------------------------------------------------------------------------
+
+describe('BmFont dev assertions', () => {
+  test('throws when texture count does not match page count', () => {
+    const fontData = makeFontData({ pages: ['page_0.png', 'page_1.png'] });
+    expect(() => new BmFont(fontData, [makeTex()])).toThrow('[ExoJS]');
+  });
+
+  test('does not throw when texture count matches page count', () => {
+    const fontData = makeFontData({ pages: ['page_0.png'] });
+    expect(() => new BmFont(fontData, [makeTex()])).not.toThrow();
+  });
+});
+
+describe('BmFontAdapter page index assertion', () => {
+  test('throws when a glyph references a page index beyond the texture array', () => {
+    const fontData: BmFontData = {
+      ...makeFontData(),
+      chars: new Map([[65, { x: 0, y: 0, width: 8, height: 12, xOffset: 0, yOffset: 2, xAdvance: 10, page: 1 }]]),
+    };
+    // Only 1 texture provided, but glyph A references page index 1.
+    const adapter = new BmFontAdapter(fontData, [makeTex()], 1);
+    expect(() => adapter.getGlyph('A', 0)).toThrow('[ExoJS]');
+  });
+
+  test('does not throw when glyph page index is valid', () => {
+    const adapter = new BmFontAdapter(makeFontData(), [makeTex()], 1);
+    expect(() => adapter.getGlyph('A', 0)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Missing-glyph diagnostics
 // ---------------------------------------------------------------------------
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
       {
         resolve: { alias: aliasConfig },
         plugins: [shaderPlugin],
+        define: { __DEV__: JSON.stringify(true) },
         test: {
           name: 'browser-webgl-chromium',
           globals: true,
@@ -73,6 +74,7 @@ export default defineConfig({
       {
         resolve: { alias: aliasConfig },
         plugins: [shaderPlugin],
+        define: { __DEV__: JSON.stringify(true) },
         test: {
           name: 'browser-webgl-firefox',
           globals: true,
@@ -91,6 +93,7 @@ export default defineConfig({
       {
         resolve: { alias: aliasConfig },
         plugins: [shaderPlugin],
+        define: { __DEV__: JSON.stringify(true) },
         test: {
           name: 'browser-webgpu',
           globals: true,
@@ -114,6 +117,7 @@ export default defineConfig({
       {
         resolve: { alias: aliasConfig },
         plugins: [shaderPlugin],
+        define: { __DEV__: JSON.stringify(true) },
         test: {
           name: 'browser-webgpu-firefox',
           globals: true,
@@ -133,6 +137,7 @@ export default defineConfig({
       {
         resolve: { alias: aliasConfig },
         plugins: [shaderPlugin],
+        define: { __DEV__: JSON.stringify(true) },
         test: {
           name: 'browser-webgpu-firefox-dark',
           globals: true,


### PR DESCRIPTION
## Summary

- Adds `assert(condition, message)` as the canonical internal dev-check function in `src/core/dev.ts`.
- Adds `assertDefined<T>(value, message)` — an inline narrowing helper that returns `T` and is a no-op passthrough in production.
- Makes `invariant()` a thin alias for `assert()`, preserving backward compatibility for existing usages and tests.
- Adds targeted runtime checks in three critical areas:
  - **RenderTexture**: constructor and `setSize()` assert positive dimensions — a 0×0 render texture is always a bug.
  - **BmFont constructor**: asserts `textures.length === fontData.pages.length` — prevents silent UV corruption from mismatched atlas data.
  - **BmFontAdapter.getGlyph()**: asserts `glyph.page < textures.length` — defense-in-depth after the BmFont check; catches bad font data before it silently produces wrong UVs.

## Why production behavior is unchanged

All checks are gated by `__DEV__`, which is replaced with `false` by the rollup replace plugin in production builds. The resulting dead code (`if (false && ...)`) is fully eliminated. `assertDefined` becomes a passthrough cast.

## Tests added

- `test/core/dev.test.ts` — new `describe` blocks for `assert` (3 cases) and `assertDefined` (4 cases).
- `test/rendering/text/bitmap-text.test.ts` — `BmFont` page-count mismatch assert; `BmFontAdapter` out-of-range page index assert.
- `test/rendering/render-texture.test.ts` (new) — constructor and `setSize()` dimension checks (7 cases).

## Validation

| Check | Result |
|---|---|
| `npm run lint` | ✅ clean |
| `npm run typecheck` | ✅ clean |
| `npm run typecheck:examples` | ✅ clean |
| `npm test -- --project=exojs` | ✅ 1785/1785 |
| `npm run site:build` | ✅ 560 pages |
| `npm run test:examples:smoke` | ✅ 117 passed, 0 failed |