### PR TITLE
feat(playground): add TypeScript example pilot

### DIFF
--- a/examples/examples.json
+++ b/examples/examples.json
@@ -626,6 +626,7 @@
         {
             "slug": "game-loop",
             "path": "getting-started/game-loop.js",
+            "language": "typescript",
             "title": "Game Loop",
             "description": "Example: Game Loop.",
             "backend": "core",
@@ -637,6 +638,7 @@
         {
             "slug": "hello-world",
             "path": "getting-started/hello-world.js",
+            "language": "typescript",
             "title": "Hello World",
             "description": "Example: Hello World.",
             "backend": "core",
@@ -648,6 +650,7 @@
         {
             "slug": "resize-and-dpr",
             "path": "getting-started/resize-and-dpr.js",
+            "language": "typescript",
             "title": "Resize And Dpr",
             "description": "Example: Resize And Dpr.",
             "backend": "core",

--- a/examples/getting-started/game-loop.js
+++ b/examples/getting-started/game-loop.js
@@ -1,5 +1,5 @@
+// Auto-generated from game-loop.ts — edit the .ts source, not this file.
 import { Application, Color, Scene, Sprite, Texture } from '@codexo/exojs';
-
 const app = new Application({
     canvas: {
         width: 800,
@@ -10,27 +10,23 @@ const app = new Application({
         basePath: 'assets/',
     },
 });
-
 document.body.append(app.canvas);
-
-app.start(
-    new (class extends Scene {
-        async load(loader) {
-            await loader.load(Texture, { bunny: 'image/ship-a.png' });
-        }
-        init(loader) {
-            const { width, height } = this.app.canvas;
-
-            this._sprite = new Sprite(loader.get(Texture, 'bunny'));
-            this._sprite.setAnchor(0.5);
-            this._sprite.setPosition(width / 2, height / 2);
-        }
-        update(delta) {
-            this._sprite.rotate(delta.seconds * 120);
-        }
-        draw(context) {
-            context.backend.clear();
-            context.render(this._sprite);
-        }
-    })()
-);
+class GameLoopScene extends Scene {
+    _sprite;
+    async load(loader) {
+        this._sprite = new Sprite(await loader.load(Texture, 'image/ship-a.png'));
+    }
+    init() {
+        const { width, height } = this.app.canvas;
+        this._sprite.setAnchor(0.5);
+        this._sprite.setPosition(width / 2, height / 2);
+    }
+    update(delta) {
+        this._sprite.rotate(delta.seconds * 120);
+    }
+    draw(context) {
+        context.backend.clear();
+        context.render(this._sprite);
+    }
+}
+app.start(new GameLoopScene());

--- a/examples/getting-started/game-loop.ts
+++ b/examples/getting-started/game-loop.ts
@@ -1,5 +1,5 @@
-// Auto-generated from hello-world.ts — edit the .ts source, not this file.
 import { Application, Color, Scene, Sprite, Texture } from '@codexo/exojs';
+
 const app = new Application({
     canvas: {
         width: 800,
@@ -10,20 +10,31 @@ const app = new Application({
         basePath: 'assets/',
     },
 });
+
 document.body.append(app.canvas);
-class HelloWorldScene extends Scene {
-    _sprite;
-    async load(loader) {
+
+class GameLoopScene extends Scene {
+    private _sprite!: Sprite;
+
+    override async load(loader): Promise<void> {
         this._sprite = new Sprite(await loader.load(Texture, 'image/ship-a.png'));
     }
-    init() {
+
+    override init(): void {
         const { width, height } = this.app.canvas;
+
         this._sprite.setAnchor(0.5);
         this._sprite.setPosition(width / 2, height / 2);
     }
-    draw(context) {
+
+    override update(delta): void {
+        this._sprite.rotate(delta.seconds * 120);
+    }
+
+    override draw(context): void {
         context.backend.clear();
         context.render(this._sprite);
     }
 }
-app.start(new HelloWorldScene());
+
+app.start(new GameLoopScene());

--- a/examples/getting-started/hello-world.ts
+++ b/examples/getting-started/hello-world.ts
@@ -1,5 +1,5 @@
-// Auto-generated from hello-world.ts — edit the .ts source, not this file.
 import { Application, Color, Scene, Sprite, Texture } from '@codexo/exojs';
+
 const app = new Application({
     canvas: {
         width: 800,
@@ -10,20 +10,27 @@ const app = new Application({
         basePath: 'assets/',
     },
 });
+
 document.body.append(app.canvas);
+
 class HelloWorldScene extends Scene {
-    _sprite;
-    async load(loader) {
+    private _sprite!: Sprite;
+
+    override async load(loader): Promise<void> {
         this._sprite = new Sprite(await loader.load(Texture, 'image/ship-a.png'));
     }
-    init() {
+
+    override init(): void {
         const { width, height } = this.app.canvas;
+
         this._sprite.setAnchor(0.5);
         this._sprite.setPosition(width / 2, height / 2);
     }
-    draw(context) {
+
+    override draw(context): void {
         context.backend.clear();
         context.render(this._sprite);
     }
 }
+
 app.start(new HelloWorldScene());

--- a/examples/getting-started/resize-and-dpr.ts
+++ b/examples/getting-started/resize-and-dpr.ts
@@ -1,5 +1,5 @@
-// Auto-generated from resize-and-dpr.ts — edit the .ts source, not this file.
 import { Application, Color, Scene, Sprite, Text, Texture } from '@codexo/exojs';
+
 const app = new Application({
     canvas: {
         width: 800,
@@ -11,38 +11,51 @@ const app = new Application({
         basePath: 'assets/',
     },
 });
+
 document.body.style.margin = '0';
 document.body.append(app.canvas);
+
 window.addEventListener('resize', () => {
     app.resize(window.innerWidth, window.innerHeight);
 });
+
 app.resize(window.innerWidth, window.innerHeight);
+
 class ResizeScene extends Scene {
-    _sprite;
-    _info;
-    async load(loader) {
+    private _sprite!: Sprite;
+    private _info!: Text;
+
+    override async load(loader): Promise<void> {
         this._sprite = new Sprite(await loader.load(Texture, 'image/ship-a.png'));
     }
-    init() {
+
+    override init(): void {
         this._sprite.setAnchor(0.5);
+
         this._info = new Text('', { fillColor: Color.white, fontSize: 16 });
         this._info.setAnchor(0.5, 0);
+
         this._layout();
     }
-    update() {
+
+    override update(): void {
         this._layout();
     }
-    draw(context) {
+
+    override draw(context): void {
         context.backend.clear();
         context.render(this._sprite);
         context.render(this._info);
     }
-    _layout() {
+
+    private _layout(): void {
         const { width, height } = this.app.canvas;
         const dpr = Math.max(1, window.devicePixelRatio || 1);
+
         this._sprite.setPosition(width / 2, height / 2);
         this._info.setPosition(width / 2, 12);
         this._info.text = `${width}x${height} @ DPR ${dpr.toFixed(2)}`;
     }
 }
+
 app.start(new ResizeScene());

--- a/site/scripts/sync-examples-static.ts
+++ b/site/scripts/sync-examples-static.ts
@@ -2,6 +2,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import ts from 'typescript';
+
 import { rawAssets } from '../../packages/assets/src/catalog.js';
 import { resolveAssetCatalog } from '../../packages/assets/src/resolver.js';
 
@@ -35,11 +37,72 @@ const copyRecursive = (sourceDir: string, targetDir: string): void => {
     fs.cpSync(sourceDir, targetDir, { recursive: true, force: true });
 };
 
+// Walks a directory tree and returns all files matching the predicate.
+const findFiles = (dir: string, predicate: (file: string) => boolean): string[] => {
+    const results: string[] = [];
+
+    const walk = (current: string): void => {
+        for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+            const fullPath = path.join(current, entry.name);
+            if (entry.isDirectory()) {
+                walk(fullPath);
+            } else if (entry.isFile() && predicate(entry.name)) {
+                results.push(fullPath);
+            }
+        }
+    };
+
+    walk(dir);
+    return results;
+};
+
+// Transpiles TypeScript example sources to JavaScript in-place within
+// sourceExamplesDir. Each .ts file (excluding .d.ts declarations) produces a
+// sibling .js file that the playground iframe and smoke harness can execute.
+// These generated .js files are committed alongside their .ts sources so the
+// rest of the toolchain (import.meta.glob, guide embeds, typecheck) can treat
+// the examples directory as a normal JS-and-TS tree without a mandatory
+// build step.
+const transpileTypescriptExamples = (dir: string): number => {
+    const tsFiles = findFiles(dir, name => name.endsWith('.ts') && !name.endsWith('.d.ts'));
+    let count = 0;
+
+    for (const tsFile of tsFiles) {
+        const source = fs.readFileSync(tsFile, 'utf8');
+
+        const { outputText } = ts.transpileModule(source, {
+            compilerOptions: {
+                module: ts.ModuleKind.ESNext,
+                target: ts.ScriptTarget.ES2022,
+                removeComments: false,
+                declaration: false,
+                sourceMap: false,
+            },
+        });
+
+        // Prepend a generated-file notice so editors and linters know not to
+        // treat this as the authoritative source.
+        const header = `// Auto-generated from ${path.basename(tsFile)} — edit the .ts source, not this file.\n`;
+        const jsFile = tsFile.replace(/\.ts$/, '.js');
+        fs.writeFileSync(jsFile, header + outputText, 'utf8');
+        count++;
+    }
+
+    return count;
+};
+
 const run = (): void => {
     ensureSource(sourceExamplesDir);
     ensureSource(sourceAssetsDir);
     ensureSource(sourceCatalogDemoDir);
     ensureSource(sourceCatalogTechnicalDir);
+
+    // Transpile TypeScript examples to JavaScript before copying so the
+    // generated .js files are included in the public/examples snapshot.
+    const transpiled = transpileTypescriptExamples(sourceExamplesDir);
+    if (transpiled > 0) {
+        console.log(`[examples:sync] Transpiled ${transpiled} TypeScript example(s) to JavaScript`);
+    }
 
     resetDir(targetExamplesDir);
     resetDir(targetAssetsDir);

--- a/site/src/components/Editor.ts
+++ b/site/src/components/Editor.ts
@@ -28,6 +28,8 @@ export class Editor extends LitElement {
 
     @state() private _sourceCode: string | null = null;
     @state() private _originalSourceCode: string | null = null;
+    @state() private _executionCode: string | null = null;
+    @state() private _originalExecutionCode: string | null = null;
     @state() private _sourceLoadError: PreviewErrorEntry | null = null;
     @state() private _previewErrors: Array<PreviewErrorEntry> = [];
     @state() private _canvasWidth = 0;
@@ -71,6 +73,8 @@ export class Editor extends LitElement {
     private async _loadSourceCode(example: Example | null): Promise<void> {
         this._sourceCode = null;
         this._originalSourceCode = null;
+        this._executionCode = null;
+        this._originalExecutionCode = null;
         this._sourceLoadError = null;
         this._previewErrors = [];
         this._diagnostics = [];
@@ -85,9 +89,25 @@ export class Editor extends LitElement {
         }
 
         try {
-            const sourceCode = await loadExampleSource(this.selectedVersionId, example.path);
-            this._sourceCode = sourceCode;
-            this._originalSourceCode = sourceCode;
+            if (example.language === 'typescript') {
+                // Load TypeScript source for editor display and generated
+                // JavaScript for iframe execution separately.
+                const tsPath = example.path.replace(/\.js$/, '.ts');
+                const [tsSource, jsSource] = await Promise.all([
+                    loadExampleSource(this.selectedVersionId, tsPath),
+                    loadExampleSource(this.selectedVersionId, example.path),
+                ]);
+                this._sourceCode = tsSource;
+                this._originalSourceCode = tsSource;
+                this._executionCode = jsSource;
+                this._originalExecutionCode = jsSource;
+            } else {
+                const sourceCode = await loadExampleSource(this.selectedVersionId, example.path);
+                this._sourceCode = sourceCode;
+                this._originalSourceCode = sourceCode;
+                this._executionCode = null;
+                this._originalExecutionCode = null;
+            }
         } catch (error) {
             this._sourceLoadError = {
                 summary: 'Failed to load example source',
@@ -121,7 +141,7 @@ export class Editor extends LitElement {
                 ></exo-preview-toolbar>
                 <div class="preview-surface">
                     <exo-preview
-                        .sourceCode=${this._sourceCode}
+                        .sourceCode=${this._executionCode ?? this._sourceCode}
                         .exampleMeta=${activeExample}
                         .selectedVersionId=${this.selectedVersionId}
                         @preview-errors=${this._onPreviewErrors}
@@ -146,7 +166,8 @@ export class Editor extends LitElement {
             <section class="editor-frame" aria-label="Source editor">
                 <exo-code-editor
                     .sourceCode=${this._sourceCode}
-                    .sourcePath=${activeExample?.path ?? null}
+                    .sourcePath=${this._getDisplayPath(activeExample)}
+                    .language=${activeExample?.language === 'typescript' ? 'typescript' : 'javascript'}
                     .canReset=${!!this._originalSourceCode && this._sourceCode !== this._originalSourceCode}
                     .exampleTitle=${activeExample?.title ?? 'Loading...'}
                     .selectedVersionId=${this.selectedVersionId}
@@ -161,7 +182,7 @@ export class Editor extends LitElement {
                     .column=${this._cursorColumn}
                     .selectionLength=${this._selectionLength}
                     .dirty=${this._dirty}
-                    language="JavaScript"
+                    .language=${activeExample?.language === 'typescript' ? 'TypeScript' : 'JavaScript'}
                 ></exo-editor-status-bar>
             </section>
         `;
@@ -169,12 +190,26 @@ export class Editor extends LitElement {
 
     private _onUpdateCode(event: CustomEvent<UpdateCodeEvent>): void {
         this._sourceCode = event.detail.code;
+        if (event.detail.executionCode !== undefined) {
+            this._executionCode = event.detail.executionCode;
+        } else {
+            this._executionCode = null;
+        }
     }
 
     private _onResetCode(_event: CustomEvent<ResetCodeEvent>): void {
         if (this._originalSourceCode === null) return;
         this._previewErrors = [];
         this._sourceCode = this._originalSourceCode;
+        this._executionCode = this._originalExecutionCode;
+    }
+
+    private _getDisplayPath(example: Example | null): string | null {
+        if (!example) return null;
+        if (example.language === 'typescript') {
+            return example.path.replace(/\.js$/, '.ts');
+        }
+        return example.path;
     }
 
     private _onPreviewErrors(event: CustomEvent<{ errors: Array<PreviewErrorEntry> }>): void {

--- a/site/src/components/EditorCode.ts
+++ b/site/src/components/EditorCode.ts
@@ -13,6 +13,7 @@ import './LoadingSpinner';
 
 export interface UpdateCodeEvent {
     code: string;
+    executionCode?: string;
 }
 
 export interface ResetCodeEvent {
@@ -105,6 +106,7 @@ const _typingsCache = new Map<string, Promise<ReadonlyArray<ExtraLib>>>();
 
 let _monacoConfiguredPromise: Promise<void> | null = null;
 let _jsHoverProviderRegistered = false;
+let _tsHoverProviderRegistered = false;
 let _assetCompletionProviderRegistered = false;
 let _showInlineErrorCommandId: string | null = null;
 let _pendingViewErrorLine: number | null = null;
@@ -220,6 +222,7 @@ export class EditorCode extends LitElement {
 
     @property({ type: String }) public sourceCode: string | null = null;
     @property({ type: String }) public sourcePath: string | null = null;
+    @property({ type: String }) public language: 'javascript' | 'typescript' = 'javascript';
     @property({ type: Boolean }) public canReset = false;
     @property({ type: String }) public exampleTitle = 'Loading...';
     @property({ type: String }) public selectedVersionId = '';
@@ -427,7 +430,7 @@ export class EditorCode extends LitElement {
                 }
                 this._autoRefreshTimer = setTimeout(() => {
                     this._autoRefreshTimer = null;
-                    if (this._autoRefresh) this._triggerRefreshPreview();
+                    if (this._autoRefresh) void this._triggerRefreshPreview();
                 }, 800);
             }
         });
@@ -447,10 +450,10 @@ export class EditorCode extends LitElement {
 
         this._attachCtrlSHandler();
 
-        this.editorView.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => this._triggerRefreshPreview());
+        this.editorView.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => void this._triggerRefreshPreview());
 
         if (typeof monaco.KeyCode.KeyS === 'number') {
-            this.editorView.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => this._triggerRefreshPreview());
+            this.editorView.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => void this._triggerRefreshPreview());
         }
 
         // MONACO UPDATE CHECKLIST — verify all of the following after a version bump:
@@ -563,38 +566,45 @@ export class EditorCode extends LitElement {
                 }
             }) ?? null;
 
+        const buildInlineErrorHoverProvider = (): monaco.languages.HoverProvider => ({
+            provideHover: (model, position) => {
+                const cmdId = _showInlineErrorCommandId;
+                if (!cmdId) return null;
+
+                const markers = monaco.editor
+                    .getModelMarkers({ resource: model.uri })
+                    .filter(m => m.severity >= 4 && m.startLineNumber <= position.lineNumber && m.endLineNumber >= position.lineNumber);
+
+                if (!markers.length) return null;
+
+                _pendingViewErrorLine = position.lineNumber;
+                const m = markers[0];
+                return {
+                    contents: [
+                        {
+                            value: `[$(arrow-right) View Error Inline](command:${cmdId})`,
+                            isTrusted: true,
+                            supportThemeIcons: true,
+                        },
+                    ],
+                    range: {
+                        startLineNumber: m.startLineNumber,
+                        startColumn: m.startColumn,
+                        endLineNumber: m.endLineNumber,
+                        endColumn: m.endColumn,
+                    },
+                };
+            },
+        });
+
         if (!_jsHoverProviderRegistered) {
             _jsHoverProviderRegistered = true;
-            monaco.languages.registerHoverProvider('javascript', {
-                provideHover: (model, position) => {
-                    const cmdId = _showInlineErrorCommandId;
-                    if (!cmdId) return null;
+            monaco.languages.registerHoverProvider('javascript', buildInlineErrorHoverProvider());
+        }
 
-                    const markers = monaco.editor
-                        .getModelMarkers({ resource: model.uri })
-                        .filter(m => m.severity >= 4 && m.startLineNumber <= position.lineNumber && m.endLineNumber >= position.lineNumber);
-
-                    if (!markers.length) return null;
-
-                    _pendingViewErrorLine = position.lineNumber;
-                    const m = markers[0];
-                    return {
-                        contents: [
-                            {
-                                value: `[$(arrow-right) View Error Inline](command:${cmdId})`,
-                                isTrusted: true,
-                                supportThemeIcons: true,
-                            },
-                        ],
-                        range: {
-                            startLineNumber: m.startLineNumber,
-                            startColumn: m.startColumn,
-                            endLineNumber: m.endLineNumber,
-                            endColumn: m.endColumn,
-                        },
-                    };
-                },
-            });
+        if (!_tsHoverProviderRegistered) {
+            _tsHoverProviderRegistered = true;
+            monaco.languages.registerHoverProvider('typescript', buildInlineErrorHoverProvider());
         }
 
         this._remeasureEditorFonts();
@@ -637,7 +647,7 @@ export class EditorCode extends LitElement {
     }
 
     private _createModel(sourceCode: string, sourcePath: string | null): monaco.editor.ITextModel {
-        return monaco.editor.createModel(sourceCode, 'javascript', monaco.Uri.parse(this._getModelUrl(sourcePath)));
+        return monaco.editor.createModel(sourceCode, this.language, monaco.Uri.parse(this._getModelUrl(sourcePath)));
     }
 
     private _ensureMonacoStyles(): void {
@@ -835,7 +845,8 @@ export class EditorCode extends LitElement {
     }
 
     private _getModelUrl(sourcePath: string | null): string {
-        const normalizedPath = (sourcePath ?? 'examples/active-example.js').replace(/^\/+/, '');
+        const defaultExt = this.language === 'typescript' ? '.ts' : '.js';
+        const normalizedPath = (sourcePath ?? `examples/active-example${defaultExt}`).replace(/^\/+/, '');
         return `file:///${normalizedPath}`;
     }
 
@@ -1162,12 +1173,18 @@ export class EditorCode extends LitElement {
         api.remeasureFonts?.();
     }
 
-    private _triggerRefreshPreview(): void {
+    private async _triggerRefreshPreview(): Promise<void> {
         if (this.editorView === null) return;
+
+        const code = this.editorView.getValue();
+        const executionCode = await this._getExecutionCode(code);
 
         this.dispatchEvent(
             new CustomEvent<UpdateCodeEvent>('update-code', {
-                detail: { code: this.editorView.getValue() },
+                detail: {
+                    code,
+                    executionCode: this._isTypescriptModel() ? executionCode : undefined,
+                },
             })
         );
         this._setDirty(false);
@@ -1177,7 +1194,37 @@ export class EditorCode extends LitElement {
     // to route their Reload action through the same code path as the in-editor
     // Refresh button and the Ctrl+Enter / Ctrl+S keyboard shortcuts.
     public triggerRefresh(): void {
-        this._triggerRefreshPreview();
+        void this._triggerRefreshPreview();
+    }
+
+    private _isTypescriptModel(): boolean {
+        return this._editorModel?.getLanguageId() === 'typescript';
+    }
+
+    // For TypeScript models: asks Monaco's TypeScript language service worker
+    // to emit the current model source as JavaScript. Falls back to the raw
+    // source if the worker is unavailable or emit fails (e.g. network error).
+    private async _getExecutionCode(source: string): Promise<string> {
+        if (!this._isTypescriptModel() || !this._editorModel) return source;
+
+        try {
+            type TsWorkerClient = {
+                getEmitOutput(uri: string): Promise<{ outputFiles: Array<{ name: string; text: string }> }>;
+            };
+            type TsWorkerFactory = (...uris: monaco.Uri[]) => Promise<TsWorkerClient>;
+            type MonacoTs = { getTypeScriptWorker(): Promise<TsWorkerFactory> };
+
+            const monacoTs = (monaco.languages as unknown as { typescript: MonacoTs }).typescript;
+            const workerFactory = await monacoTs.getTypeScriptWorker();
+            const worker = await workerFactory(this._editorModel.uri);
+            const output = await worker.getEmitOutput(this._editorModel.uri.toString());
+            const jsFile = output.outputFiles.find(f => f.name.endsWith('.js'));
+            if (jsFile?.text) return jsFile.text;
+        } catch {
+            // Emit failed — return the raw source so the preview stays usable.
+        }
+
+        return source;
     }
 
     // Moves the caret to the requested position and reveals the line in view.
@@ -1348,7 +1395,7 @@ export class EditorCode extends LitElement {
         this._editorKeydownHandler = (event: KeyboardEvent) => {
             if (!(event.ctrlKey || event.metaKey) || event.key.toLowerCase() !== 's') return;
             event.preventDefault();
-            this._triggerRefreshPreview();
+            void this._triggerRefreshPreview();
         };
         this._editorHostElement.addEventListener('keydown', this._editorKeydownHandler);
     }

--- a/site/src/components/ExamplePreview.astro
+++ b/site/src/components/ExamplePreview.astro
@@ -1,7 +1,7 @@
 ---
 import type { Capability } from '../lib/examples-catalog';
 import { getExamplesForChapter } from '../lib/examples-catalog';
-import { getExampleSource } from '../lib/example-sources';
+import { getExampleExecutionSource, getExampleSource } from '../lib/example-sources';
 
 interface Props {
     chapter: string;
@@ -24,11 +24,13 @@ const CAPABILITY_LABELS: Record<Capability, string> = {
 
 const { chapter, slug } = Astro.props;
 const example = getExamplesForChapter(chapter).find(entry => entry.slug === slug);
-const sourceCode = getExampleSource(chapter, slug);
+const displaySource = getExampleSource(chapter, slug);
+const executionSource = getExampleExecutionSource(chapter, slug);
 const exampleTitle = example?.title ?? slug;
 const capabilities = example?.capabilities ?? [];
 const capabilitiesAttr = JSON.stringify(capabilities);
-const sourceHref = `${import.meta.env.BASE_URL}examples/${chapter}/${slug}.js`;
+const sourceExt = example?.language === 'typescript' ? 'ts' : 'js';
+const sourceHref = `${import.meta.env.BASE_URL}examples/${chapter}/${slug}.${sourceExt}`;
 const locale = Astro.currentLocale === 'de' ? 'de' : 'en';
 ---
 
@@ -51,10 +53,10 @@ const locale = Astro.currentLocale === 'de' ? 'de' : 'en';
     </header>
     <div class="embed-body">
         <div class="embed-preview">
-            <guide-example-preview chapter={chapter} slug={slug} title={exampleTitle} sourcecode={sourceCode} capabilities={capabilitiesAttr}></guide-example-preview>
+            <guide-example-preview chapter={chapter} slug={slug} title={exampleTitle} sourcecode={executionSource} capabilities={capabilitiesAttr}></guide-example-preview>
         </div>
         <div class="embed-source">
-            <pre><code>{sourceCode}</code></pre>
+            <pre><code>{displaySource}</code></pre>
         </div>
     </div>
 </section>

--- a/site/src/lib/example-sources.ts
+++ b/site/src/lib/example-sources.ts
@@ -1,4 +1,5 @@
-const modules = import.meta.glob<string>('~examples/**/*.js', { query: '?raw', import: 'default', eager: true });
+const jsModules = import.meta.glob<string>('~examples/**/*.js', { query: '?raw', import: 'default', eager: true });
+const tsModules = import.meta.glob<string>('~examples/**/*.ts', { query: '?raw', import: 'default', eager: true });
 
 const normalizeToCatalogPath = (key: string): string => {
     const normalized = key.split('\\').join('/');
@@ -10,10 +11,34 @@ const normalizeToCatalogPath = (key: string): string => {
     return normalized.slice(idx + marker.length);
 };
 
-const SOURCE_BY_PATH = new Map<string, string>();
+// Execution source: always JavaScript (runs in browser module scripts).
+const EXEC_SOURCE_BY_PATH = new Map<string, string>();
 
-for (const [key, sourceCode] of Object.entries(modules)) {
-    SOURCE_BY_PATH.set(normalizeToCatalogPath(key), sourceCode);
+// Display source: TypeScript if available, otherwise JavaScript.
+const DISPLAY_SOURCE_BY_PATH = new Map<string, string>();
+
+for (const [key, sourceCode] of Object.entries(jsModules)) {
+    const catalogPath = normalizeToCatalogPath(key);
+    EXEC_SOURCE_BY_PATH.set(catalogPath, sourceCode);
+    DISPLAY_SOURCE_BY_PATH.set(catalogPath, sourceCode);
 }
 
-export const getExampleSource = (chapter: string, slug: string): string => SOURCE_BY_PATH.get(`${chapter}/${slug}.js`) ?? `// Missing source: ${chapter}/${slug}.js`;
+for (const [key, sourceCode] of Object.entries(tsModules)) {
+    if (key.endsWith('.d.ts')) continue;
+    // TS sources are keyed by the equivalent .js catalog path.
+    const catalogPath = normalizeToCatalogPath(key).replace(/\.ts$/, '.js');
+    DISPLAY_SOURCE_BY_PATH.set(catalogPath, sourceCode);
+}
+
+// Returns the display source for an example: TypeScript when available (for
+// code blocks in guide pages), otherwise the JavaScript source.
+export const getExampleSource = (chapter: string, slug: string): string =>
+    DISPLAY_SOURCE_BY_PATH.get(`${chapter}/${slug}.js`) ?? `// Missing source: ${chapter}/${slug}.js`;
+
+// Returns the execution source for an example: always JavaScript so it can be
+// injected directly as a browser module script (used by guide preview embeds
+// and the smoke harness).
+export const getExampleExecutionSource = (chapter: string, slug: string): string =>
+    EXEC_SOURCE_BY_PATH.get(`${chapter}/${slug}.js`) ??
+    DISPLAY_SOURCE_BY_PATH.get(`${chapter}/${slug}.js`) ??
+    `// Missing source: ${chapter}/${slug}.js`;

--- a/site/src/lib/examples-catalog.ts
+++ b/site/src/lib/examples-catalog.ts
@@ -19,6 +19,7 @@ export interface CatalogEntry {
     title: string;
     description: string;
     backend: string;
+    language?: string;
     capabilities?: Array<Capability>;
     tags?: Array<string>;
 }

--- a/site/src/lib/types.ts
+++ b/site/src/lib/types.ts
@@ -12,6 +12,7 @@ export interface ExampleDefinition {
     title: string;
     description: string;
     backend: ExampleBackend;
+    language?: string;
     capabilities?: Array<Capability>;
     notes?: Array<string>;
     unsupportedNote?: string;

--- a/src/core/dev.ts
+++ b/src/core/dev.ts
@@ -7,10 +7,27 @@ const _warned = new Set<string>();
  * Assert `condition` at dev/test time. Throws with `[ExoJS] message` when the
  * condition is falsy and `__DEV__` is true. No-op in production builds.
  */
-export function invariant(condition: boolean, message: string): asserts condition {
+export function assert(condition: boolean, message: string): asserts condition {
   if (__DEV__ && !condition) {
     throw new Error(`[ExoJS] ${message}`);
   }
+}
+
+/**
+ * Assert that `value` is neither `null` nor `undefined`. Returns the value so
+ * it can be used inline in an expression. No-op in production builds (returns
+ * the value cast to `T` without checking).
+ */
+export function assertDefined<T>(value: T | null | undefined, message: string): T {
+  if (__DEV__ && (value === null || value === undefined)) {
+    throw new Error(`[ExoJS] ${message}`);
+  }
+  return value as T;
+}
+
+/** @internal — alias for {@link assert}; kept for backward compatibility. */
+export function invariant(condition: boolean, message: string): asserts condition {
+  assert(condition, message);
 }
 
 /**

--- a/src/rendering/text/BitmapText.ts
+++ b/src/rendering/text/BitmapText.ts
@@ -1,4 +1,4 @@
-import { warnOnce } from '@/core/dev';
+import { assert, warnOnce } from '@/core/dev';
 import type { Texture } from '@/rendering/texture/Texture';
 
 import { AbstractText } from './AbstractText';
@@ -85,6 +85,10 @@ export class BmFontAdapter implements GlyphProvider {
       };
     }
 
+    assert(
+      g.page < this._textures.length,
+      `BitmapText: glyph page index ${g.page} is out of range — font "${this._fontId}" has ${this._textures.length} page(s)`,
+    );
     const texW = this._textures[g.page]?.width ?? 1;
     const texH = this._textures[g.page]?.height ?? 1;
 

--- a/src/rendering/text/BmFont.ts
+++ b/src/rendering/text/BmFont.ts
@@ -1,3 +1,4 @@
+import { assert } from '@/core/dev';
 import type { Texture } from '@/rendering/texture/Texture';
 
 /** Per-character metrics from a BMFont descriptor. */
@@ -51,6 +52,10 @@ export class BmFont {
   public readonly textures: readonly Texture[];
 
   public constructor(fontData: BmFontData, textures: readonly Texture[]) {
+    assert(
+      textures.length === fontData.pages.length,
+      `BmFont: texture count (${textures.length}) must match page count (${fontData.pages.length})`,
+    );
     this.fontData = fontData;
     this.textures = textures;
   }

--- a/src/rendering/texture/RenderTexture.ts
+++ b/src/rendering/texture/RenderTexture.ts
@@ -1,3 +1,4 @@
+import { assert } from '@/core/dev';
 import { isPowerOfTwo } from '@/math/utils';
 import { RenderTarget } from '@/rendering/RenderTarget';
 import type { SamplerOptions } from '@/rendering/texture/Sampler';
@@ -32,6 +33,7 @@ export class RenderTexture extends RenderTarget {
   private _flipY: boolean;
 
   public constructor(width: number, height: number, options?: Partial<SamplerOptions>) {
+    assert(width > 0 && height > 0, `RenderTexture dimensions must be positive (got ${width}×${height})`);
     super(width, height, false);
 
     const { scaleMode, wrapMode, premultiplyAlpha, generateMipMap, flipY } = {
@@ -151,6 +153,7 @@ export class RenderTexture extends RenderTarget {
   }
 
   public setSize(width: number, height: number): this {
+    assert(width > 0 && height > 0, `RenderTexture.setSize() dimensions must be positive (got ${width}×${height})`);
     if (!this._size.equals({ width, height })) {
       this._size.set(width, height);
       this._defaultView.resize(width, height);

--- a/test/core/dev.test.ts
+++ b/test/core/dev.test.ts
@@ -1,7 +1,50 @@
-import { _resetWarnOnce, invariant, warnOnce } from '@/core/dev';
+import { _resetWarnOnce, assert, assertDefined, invariant, warnOnce } from '@/core/dev';
 
 beforeEach(() => {
   _resetWarnOnce();
+});
+
+// ---------------------------------------------------------------------------
+// assert
+// ---------------------------------------------------------------------------
+
+describe('assert', () => {
+  test('does not throw when condition is true', () => {
+    expect(() => assert(true, 'should not throw')).not.toThrow();
+  });
+
+  test('throws with prefixed message when condition is false', () => {
+    expect(() => assert(false, 'test failure')).toThrow('[ExoJS] test failure');
+  });
+
+  test('throws an Error instance', () => {
+    expect(() => assert(false, 'err')).toThrow(Error);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertDefined
+// ---------------------------------------------------------------------------
+
+describe('assertDefined', () => {
+  test('throws when value is null', () => {
+    expect(() => assertDefined(null, 'must not be null')).toThrow('[ExoJS] must not be null');
+  });
+
+  test('throws when value is undefined', () => {
+    expect(() => assertDefined(undefined, 'must not be undefined')).toThrow('[ExoJS] must not be undefined');
+  });
+
+  test('returns the value when it is defined', () => {
+    expect(assertDefined(42, 'unreachable')).toBe(42);
+    expect(assertDefined('hello', 'unreachable')).toBe('hello');
+    expect(assertDefined(0, 'unreachable')).toBe(0);
+    expect(assertDefined(false, 'unreachable')).toBe(false);
+  });
+
+  test('throws an Error instance', () => {
+    expect(() => assertDefined(null, 'err')).toThrow(Error);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/rendering/render-texture.test.ts
+++ b/test/rendering/render-texture.test.ts
@@ -1,0 +1,36 @@
+import { RenderTexture } from '@/rendering/texture/RenderTexture';
+
+describe('RenderTexture dev assertions', () => {
+  test('throws when width is zero', () => {
+    expect(() => new RenderTexture(0, 100)).toThrow('[ExoJS]');
+  });
+
+  test('throws when height is zero', () => {
+    expect(() => new RenderTexture(100, 0)).toThrow('[ExoJS]');
+  });
+
+  test('throws when either dimension is negative', () => {
+    expect(() => new RenderTexture(-1, 100)).toThrow('[ExoJS]');
+    expect(() => new RenderTexture(100, -1)).toThrow('[ExoJS]');
+  });
+
+  test('does not throw for positive dimensions', () => {
+    expect(() => new RenderTexture(1, 1)).not.toThrow();
+    expect(() => new RenderTexture(512, 512)).not.toThrow();
+  });
+
+  test('setSize throws when width is zero', () => {
+    const rt = new RenderTexture(64, 64);
+    expect(() => rt.setSize(0, 64)).toThrow('[ExoJS]');
+  });
+
+  test('setSize throws when height is zero', () => {
+    const rt = new RenderTexture(64, 64);
+    expect(() => rt.setSize(64, 0)).toThrow('[ExoJS]');
+  });
+
+  test('setSize does not throw for positive dimensions', () => {
+    const rt = new RenderTexture(64, 64);
+    expect(() => rt.setSize(128, 128)).not.toThrow();
+  });
+});

--- a/test/rendering/text/bitmap-text.test.ts
+++ b/test/rendering/text/bitmap-text.test.ts
@@ -191,6 +191,39 @@ describe('BitmapText', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Dev assertions — BmFont and BmFontAdapter
+// ---------------------------------------------------------------------------
+
+describe('BmFont dev assertions', () => {
+  test('throws when texture count does not match page count', () => {
+    const fontData = makeFontData({ pages: ['page_0.png', 'page_1.png'] });
+    expect(() => new BmFont(fontData, [makeTex()])).toThrow('[ExoJS]');
+  });
+
+  test('does not throw when texture count matches page count', () => {
+    const fontData = makeFontData({ pages: ['page_0.png'] });
+    expect(() => new BmFont(fontData, [makeTex()])).not.toThrow();
+  });
+});
+
+describe('BmFontAdapter page index assertion', () => {
+  test('throws when a glyph references a page index beyond the texture array', () => {
+    const fontData: BmFontData = {
+      ...makeFontData(),
+      chars: new Map([[65, { x: 0, y: 0, width: 8, height: 12, xOffset: 0, yOffset: 2, xAdvance: 10, page: 1 }]]),
+    };
+    // Only 1 texture provided, but glyph A references page index 1.
+    const adapter = new BmFontAdapter(fontData, [makeTex()], 1);
+    expect(() => adapter.getGlyph('A', 0)).toThrow('[ExoJS]');
+  });
+
+  test('does not throw when glyph page index is valid', () => {
+    const adapter = new BmFontAdapter(makeFontData(), [makeTex()], 1);
+    expect(() => adapter.getGlyph('A', 0)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Missing-glyph diagnostics
 // ---------------------------------------------------------------------------
 

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -48,6 +48,6 @@
       "@assets": ["./examples/shared/assets-catalog.d.ts"]
     }
   },
-  "include": ["examples/**/*.js", "examples/shared/runtime.d.ts", "examples/shared/assets-catalog.d.ts", "src/typings.d.ts", "src/build-constants.d.ts"],
-  "exclude": []
+  "include": ["examples/**/*.js", "examples/**/*.ts", "examples/shared/runtime.d.ts", "examples/shared/assets-catalog.d.ts", "src/typings.d.ts", "src/build-constants.d.ts"],
+  "exclude": ["examples/shared/editor-support.d.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
       {
         resolve: { alias: aliasConfig },
         plugins: [shaderPlugin],
+        define: { __DEV__: JSON.stringify(true) },
         test: {
           name: 'browser-webgl-chromium',
           globals: true,
@@ -73,6 +74,7 @@ export default defineConfig({
       {
         resolve: { alias: aliasConfig },
         plugins: [shaderPlugin],
+        define: { __DEV__: JSON.stringify(true) },
         test: {
           name: 'browser-webgl-firefox',
           globals: true,
@@ -91,6 +93,7 @@ export default defineConfig({
       {
         resolve: { alias: aliasConfig },
         plugins: [shaderPlugin],
+        define: { __DEV__: JSON.stringify(true) },
         test: {
           name: 'browser-webgpu',
           globals: true,
@@ -114,6 +117,7 @@ export default defineConfig({
       {
         resolve: { alias: aliasConfig },
         plugins: [shaderPlugin],
+        define: { __DEV__: JSON.stringify(true) },
         test: {
           name: 'browser-webgpu-firefox',
           globals: true,
@@ -133,6 +137,7 @@ export default defineConfig({
       {
         resolve: { alias: aliasConfig },
         plugins: [shaderPlugin],
+        define: { __DEV__: JSON.stringify(true) },
         test: {
           name: 'browser-webgpu-firefox-dark',
           globals: true,


### PR DESCRIPTION
## Summary

- Converts `examples/getting-started/` (3 examples) to TypeScript as a pilot for the TS-first playground pipeline. The `.ts` files are the authoritative source; sibling `.js` files are generated by `examples:sync` and committed so the full toolchain works without an extra build step.
- Adds a minimal TS transpile path to the Playground: Monaco creates a TypeScript model for TS examples (full diagnostics/IntelliSense), then emits JavaScript via the Monaco TS worker on save/refresh, and passes it separately to the iframe.
- Guide page embeds for TS examples now show TypeScript in the code block and run the generated JavaScript in the live preview.

## Architecture

```
examples/getting-started/*.ts  ←  source of truth (committed)
examples/getting-started/*.js  ←  generated by examples:sync via ts.transpileModule (committed)
catalog path                   ←  still *.js (smoke, iframe unchanged)
Editor._sourceCode             ←  TypeScript (fetched at *.ts URL; shown in Monaco)
Editor._executionCode          ←  JavaScript (fetched at *.js URL; injected into iframe)
on save/refresh                ←  Monaco TS worker emits JS → update-code { code, executionCode }
```

## Style improvements in converted examples

- Named classes (`HelloWorldScene`, `GameLoopScene`, `ResizeScene`) instead of anonymous class expressions
- Direct `await loader.load(Texture, path)` — no alias/get split for simple single assets
- Private typed fields with definite-assignment (`!:`)
- `override` keyword on all lifecycle methods
- Multiline canvas config, blank lines between logical blocks
- `resize-and-dpr` extracts layout into a named `_layout()` method

## Files changed

| Area | Files |
|------|-------|
| TS examples (new) | `examples/getting-started/*.ts` |
| Generated JS (replaced) | `examples/getting-started/*.js` |
| Catalog | `examples/examples.json` (adds `language: "typescript"`) |
| Sync script | `site/scripts/sync-examples-static.ts` |
| Type declarations | `site/src/lib/examples-catalog.ts`, `site/src/lib/types.ts` |
| Source loading | `site/src/lib/example-sources.ts` |
| Playground editor | `site/src/components/Editor.ts`, `EditorCode.ts`, `ExamplePreview.astro` |
| Typecheck | `tsconfig.examples.json` |

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:examples` — clean (all TS examples type-check against engine source)
- [x] `npm test -- --reporter=dot` — 1785 tests, all passed
- [x] `npm run site:build` — 560 pages, no errors
- [x] Smoke tests for getting-started: **3/3 passed** (hello-world, game-loop, resize-and-dpr)