### PR TITLE
style: fix prettier formatting drift

### DIFF
--- a/src/rendering/text/BmFont.ts
+++ b/src/rendering/text/BmFont.ts
@@ -52,10 +52,7 @@ export class BmFont {
   public readonly textures: readonly Texture[];
 
   public constructor(fontData: BmFontData, textures: readonly Texture[]) {
-    assert(
-      textures.length === fontData.pages.length,
-      `BmFont: texture count (${textures.length}) must match page count (${fontData.pages.length})`,
-    );
+    assert(textures.length === fontData.pages.length, `BmFont: texture count (${textures.length}) must match page count (${fontData.pages.length})`);
     this.fontData = fontData;
     this.textures = textures;
   }

--- a/src/rendering/text/GlyphSdf.ts
+++ b/src/rendering/text/GlyphSdf.ts
@@ -147,7 +147,12 @@ export class GlyphSdf {
     ctx.font = this._font;
     ctx.textBaseline = 'alphabetic';
     const m = ctx.measureText('HgjpqyÉÅ');
-    type M = TextMetrics & { fontBoundingBoxAscent?: number; fontBoundingBoxDescent?: number; actualBoundingBoxAscent?: number; actualBoundingBoxDescent?: number };
+    type M = TextMetrics & {
+      fontBoundingBoxAscent?: number;
+      fontBoundingBoxDescent?: number;
+      actualBoundingBoxAscent?: number;
+      actualBoundingBoxDescent?: number;
+    };
     this._fontAscent = Math.max(1, Math.ceil((m as M).fontBoundingBoxAscent ?? (m as M).actualBoundingBoxAscent ?? this._fontSize * 0.8));
     this._fontDescent = Math.max(1, Math.ceil((m as M).fontBoundingBoxDescent ?? (m as M).actualBoundingBoxDescent ?? this._fontSize * 0.2));
     this._metricsReady = true;

--- a/src/rendering/webgpu/WebGpuMeshRenderer.ts
+++ b/src/rendering/webgpu/WebGpuMeshRenderer.ts
@@ -477,7 +477,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
         0,
         resources.indexData.buffer,
         resources.indexData.byteOffset,
-        ((resources.totalIndices * Uint16Array.BYTES_PER_ELEMENT) + 3) & ~3,
+        (resources.totalIndices * Uint16Array.BYTES_PER_ELEMENT + 3) & ~3,
       );
 
       // Build/refresh user uniform UBO from the material (re-built every frame
@@ -493,7 +493,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
         0,
         this._packedIndexData.buffer,
         this._packedIndexData.byteOffset,
-        ((defaultIndices * Uint16Array.BYTES_PER_ELEMENT) + 3) & ~3,
+        (defaultIndices * Uint16Array.BYTES_PER_ELEMENT + 3) & ~3,
       );
     }
     if (defaultUniformData !== null) {
@@ -1230,10 +1230,12 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
     // GPUQueue.writeBuffer requires the byte count to be a multiple of 4.
     // Round up: odd Uint16 counts (e.g. a 3-index triangle) would otherwise
     // produce 6-byte writes which the WebGPU validation layer rejects.
-    const requiredBytes = ((indexCount * Uint16Array.BYTES_PER_ELEMENT) + 3) & ~3;
+    const requiredBytes = (indexCount * Uint16Array.BYTES_PER_ELEMENT + 3) & ~3;
 
     if (this._packedIndexData.length * Uint16Array.BYTES_PER_ELEMENT < requiredBytes) {
-      this._packedIndexData = new Uint16Array(Math.max(requiredBytes / Uint16Array.BYTES_PER_ELEMENT, this._packedIndexData.length === 0 ? 2 : this._packedIndexData.length * 2));
+      this._packedIndexData = new Uint16Array(
+        Math.max(requiredBytes / Uint16Array.BYTES_PER_ELEMENT, this._packedIndexData.length === 0 ? 2 : this._packedIndexData.length * 2),
+      );
     }
 
     if (requiredBytes > this._indexBufferCapacity) {
@@ -1406,7 +1408,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
     }
 
     // Index buffer — capacity must be 4-byte aligned for GPUQueue.writeBuffer.
-    const indexBytes = ((resources.totalIndices * Uint16Array.BYTES_PER_ELEMENT) + 3) & ~3;
+    const indexBytes = (resources.totalIndices * Uint16Array.BYTES_PER_ELEMENT + 3) & ~3;
     if (resources.indexData.length * Uint16Array.BYTES_PER_ELEMENT < indexBytes) {
       resources.indexData = new Uint16Array(Math.max(indexBytes / Uint16Array.BYTES_PER_ELEMENT, resources.indexData.length * 2));
     }

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -1660,12 +1660,7 @@ export class Loader {
   }
 
   private _resolveUrl(path: string): string {
-    if (
-      path.startsWith('http://') ||
-      path.startsWith('https://') ||
-      path.startsWith('//') ||
-      path.startsWith('/')
-    ) {
+    if (path.startsWith('http://') || path.startsWith('https://') || path.startsWith('//') || path.startsWith('/')) {
       return path;
     }
 

--- a/test/rendering/browser/webgpu-graphics-gradient.test.ts
+++ b/test/rendering/browser/webgpu-graphics-gradient.test.ts
@@ -126,7 +126,9 @@ const readCanvas = (backend: WebGpuBackend): ((x: number, y: number) => RgbaTupl
 
 const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 4): void => {
   for (let index = 0; index < 4; index++) {
-    expect(Math.abs(actual[index] - expected[index]), `channel ${index}: got [${actual.join(', ')}] expected [${expected.join(', ')}]`).toBeLessThanOrEqual(tolerance);
+    expect(Math.abs(actual[index] - expected[index]), `channel ${index}: got [${actual.join(', ')}] expected [${expected.join(', ')}]`).toBeLessThanOrEqual(
+      tolerance,
+    );
   }
 };
 

--- a/test/rendering/browser/webgpu-mesh-tint.test.ts
+++ b/test/rendering/browser/webgpu-mesh-tint.test.ts
@@ -97,7 +97,9 @@ const readCanvas = (backend: WebGpuBackend): ((x: number, y: number) => RgbaTupl
 
 const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 4): void => {
   for (let index = 0; index < 4; index++) {
-    expect(Math.abs(actual[index] - expected[index]), `channel ${index}: got [${actual.join(', ')}] expected [${expected.join(', ')}]`).toBeLessThanOrEqual(tolerance);
+    expect(Math.abs(actual[index] - expected[index]), `channel ${index}: got [${actual.join(', ')}] expected [${expected.join(', ')}]`).toBeLessThanOrEqual(
+      tolerance,
+    );
   }
 };
 

--- a/test/rendering/browser/webgpu-sprite-transform.test.ts
+++ b/test/rendering/browser/webgpu-sprite-transform.test.ts
@@ -347,5 +347,4 @@ describe('WebGPU sprite transform storage', () => {
       backend.destroy();
     }
   });
-
 });

--- a/test/rendering/gradient.test.ts
+++ b/test/rendering/gradient.test.ts
@@ -134,12 +134,29 @@ describe('Gradient value-object semantics', () => {
 
   test('exposes a type discriminant', () => {
     expect(makeLinear().type).toBe('linear');
-    expect(new RadialGradient([{ offset: 0, color: Color.white }, { offset: 1, color: Color.black }]).type).toBe('radial');
+    expect(
+      new RadialGradient([
+        { offset: 0, color: Color.white },
+        { offset: 1, color: Color.black },
+      ]).type,
+    ).toBe('radial');
   });
 
   test('rejects non-finite stop offsets', () => {
-    expect(() => new LinearGradient([{ offset: Number.NaN, color: Color.red }, { offset: 1, color: Color.blue }])).toThrow('Gradient stop offset must be a finite number.');
-    expect(() => new LinearGradient([{ offset: 0, color: Color.red }, { offset: Number.POSITIVE_INFINITY, color: Color.blue }])).toThrow('Gradient stop offset must be a finite number.');
+    expect(
+      () =>
+        new LinearGradient([
+          { offset: Number.NaN, color: Color.red },
+          { offset: 1, color: Color.blue },
+        ]),
+    ).toThrow('Gradient stop offset must be a finite number.');
+    expect(
+      () =>
+        new LinearGradient([
+          { offset: 0, color: Color.red },
+          { offset: Number.POSITIVE_INFINITY, color: Color.blue },
+        ]),
+    ).toThrow('Gradient stop offset must be a finite number.');
   });
 
   test('geometry getters expose constructor values without leaking internals', () => {
@@ -152,7 +169,14 @@ describe('Gradient value-object semantics', () => {
     linear.start[0] = 99;
     expect(linear.start).toEqual([0, 0]);
 
-    const radial = new RadialGradient([{ offset: 0, color: Color.white }, { offset: 1, color: Color.black }], [0.25, 0.75], 0.4);
+    const radial = new RadialGradient(
+      [
+        { offset: 0, color: Color.white },
+        { offset: 1, color: Color.black },
+      ],
+      [0.25, 0.75],
+      0.4,
+    );
 
     expect(radial.center).toEqual([0.25, 0.75]);
     expect(radial.radius).toBe(0.4);
@@ -198,16 +222,52 @@ describe('Gradient value-object semantics', () => {
     expect(base.equals(makeLinear())).toBe(true);
 
     // Different stop color.
-    expect(base.equals(new LinearGradient([{ offset: 0, color: Color.red }, { offset: 1, color: Color.green }], [0, 0], [1, 0]))).toBe(false);
+    expect(
+      base.equals(
+        new LinearGradient(
+          [
+            { offset: 0, color: Color.red },
+            { offset: 1, color: Color.green },
+          ],
+          [0, 0],
+          [1, 0],
+        ),
+      ),
+    ).toBe(false);
 
     // Different stop offset.
-    expect(base.equals(new LinearGradient([{ offset: 0, color: Color.red }, { offset: 0.5, color: Color.blue }], [0, 0], [1, 0]))).toBe(false);
+    expect(
+      base.equals(
+        new LinearGradient(
+          [
+            { offset: 0, color: Color.red },
+            { offset: 0.5, color: Color.blue },
+          ],
+          [0, 0],
+          [1, 0],
+        ),
+      ),
+    ).toBe(false);
 
     // Different geometry.
-    expect(base.equals(new LinearGradient([{ offset: 0, color: Color.red }, { offset: 1, color: Color.blue }], [0, 0], [0, 1]))).toBe(false);
+    expect(
+      base.equals(
+        new LinearGradient(
+          [
+            { offset: 0, color: Color.red },
+            { offset: 1, color: Color.blue },
+          ],
+          [0, 0],
+          [0, 1],
+        ),
+      ),
+    ).toBe(false);
 
     // Different type.
-    const radial = new RadialGradient([{ offset: 0, color: Color.red }, { offset: 1, color: Color.blue }]);
+    const radial = new RadialGradient([
+      { offset: 0, color: Color.red },
+      { offset: 1, color: Color.blue },
+    ]);
 
     expect(base.equals(radial)).toBe(false);
     expect(radial.equals(base)).toBe(false);

--- a/test/rendering/render-plan-grouping-key-audit.test.ts
+++ b/test/rendering/render-plan-grouping-key-audit.test.ts
@@ -176,9 +176,9 @@ const createPlan = (entries: object[]) => {
 };
 
 const getGroupIndices = (plan: ReturnType<typeof createPlan>) =>
-  plan.passes[0].root.entries.filter((e: unknown) => (e as { kind: RenderEntryKind }).kind === RenderEntryKind.Draw).map(
-    (e: unknown) => ((e as { command: DrawCommand }).command.groupIndex ?? 0),
-  );
+  plan.passes[0].root.entries
+    .filter((e: unknown) => (e as { kind: RenderEntryKind }).kind === RenderEntryKind.Draw)
+    .map((e: unknown) => (e as { command: DrawCommand }).command.groupIndex ?? 0);
 
 const minimalGlsl = {
   vertex: '#version 300 es\nvoid main(){gl_Position=vec4(0.0);}',
@@ -217,10 +217,7 @@ describe('render plan grouping key audit', () => {
       const a = new AuditDrawable();
       const b = new AuditDrawable();
 
-      const plan = createPlan([
-        createDrawEntry(a, 100, 200),
-        createDrawEntry(b, 999, 200),
-      ]);
+      const plan = createPlan([createDrawEntry(a, 100, 200), createDrawEntry(b, 999, 200)]);
 
       RenderPlanOptimizer.optimize(plan);
 
@@ -233,10 +230,7 @@ describe('render plan grouping key audit', () => {
       const a = new AuditDrawable();
       const b = new AuditDrawable();
 
-      const plan = createPlan([
-        createDrawEntry(a, 100, 200),
-        createDrawEntry(b, 100, 999),
-      ]);
+      const plan = createPlan([createDrawEntry(a, 100, 200), createDrawEntry(b, 100, 999)]);
 
       RenderPlanOptimizer.optimize(plan);
 
@@ -543,10 +537,7 @@ describe('render plan grouping key audit', () => {
       const a = new AuditDrawable();
       const b = new AuditDrawable();
 
-      const plan = createPlan([
-        createDrawEntry(a, 100, 200, { zIndex: 0 }),
-        createDrawEntry(b, 100, 200, { zIndex: 5 }),
-      ]);
+      const plan = createPlan([createDrawEntry(a, 100, 200, { zIndex: 0 }), createDrawEntry(b, 100, 200, { zIndex: 5 })]);
 
       RenderPlanOptimizer.optimize(plan);
 
@@ -559,10 +550,7 @@ describe('render plan grouping key audit', () => {
       const a = new AuditDrawable();
       const b = new AuditDrawable();
 
-      const plan = createPlan([
-        createDrawEntry(a, 100, 200, { zIndex: 3 }),
-        createDrawEntry(b, 100, 200, { zIndex: 3 }),
-      ]);
+      const plan = createPlan([createDrawEntry(a, 100, 200, { zIndex: 3 }), createDrawEntry(b, 100, 200, { zIndex: 3 })]);
 
       RenderPlanOptimizer.optimize(plan);
 
@@ -597,11 +585,7 @@ describe('render plan grouping key audit', () => {
         },
       };
 
-      const plan = createPlan([
-        createDrawEntry(a, 100, 200),
-        barrier,
-        createDrawEntry(b, 100, 200),
-      ]);
+      const plan = createPlan([createDrawEntry(a, 100, 200), barrier, createDrawEntry(b, 100, 200)]);
 
       RenderPlanOptimizer.optimize(plan);
 
@@ -609,8 +593,8 @@ describe('render plan grouping key audit', () => {
 
       expect(drawEntries).toHaveLength(2);
 
-      const gi0 = ((drawEntries[0] as { command: DrawCommand }).command).groupIndex;
-      const gi1 = ((drawEntries[1] as { command: DrawCommand }).command).groupIndex;
+      const gi0 = (drawEntries[0] as { command: DrawCommand }).command.groupIndex;
+      const gi1 = (drawEntries[1] as { command: DrawCommand }).command.groupIndex;
 
       // Barrier separates the two segments; neither is undefined.
       expect(gi0).toBeDefined();
@@ -635,11 +619,7 @@ describe('render plan grouping key audit', () => {
         },
       };
 
-      const plan = createPlan([
-        createDrawEntry(a, 100, 200),
-        groupEntry,
-        createDrawEntry(b, 100, 200),
-      ]);
+      const plan = createPlan([createDrawEntry(a, 100, 200), groupEntry, createDrawEntry(b, 100, 200)]);
 
       RenderPlanOptimizer.optimize(plan);
 
@@ -678,10 +658,7 @@ describe('render plan grouping key audit', () => {
       const a = new AuditDrawable();
       const b = new AuditDrawable();
 
-      const plan = createPlan([
-        createDrawEntry(a, 100, 200),
-        createDrawEntry(b, 100, 200),
-      ]);
+      const plan = createPlan([createDrawEntry(a, 100, 200), createDrawEntry(b, 100, 200)]);
 
       RenderPlanOptimizer.optimize(plan);
 

--- a/test/rendering/render-plan-player.test.ts
+++ b/test/rendering/render-plan-player.test.ts
@@ -21,12 +21,7 @@ const material = (id: number): MaterialKey => ({
   bindKey: id,
 });
 
-const createDrawCommand = (
-  drawable: Drawable,
-  seq: number,
-  groupIndex: number | undefined,
-  key: number,
-): DrawCommand => ({
+const createDrawCommand = (drawable: Drawable, seq: number, groupIndex: number | undefined, key: number): DrawCommand => ({
   kind: RenderEntryKind.Draw,
   drawable,
   nodeIndex: seq,
@@ -158,26 +153,12 @@ describe('render plan player', () => {
   test('undefined groupIndex draws remain singleton groups', () => {
     const a = new BoxDrawable('a');
     const b = new BoxDrawable('b');
-    const root = groupScope([
-      drawEntry(createDrawCommand(a, 0, undefined, 1)),
-      drawEntry(createDrawCommand(b, 1, undefined, 1)),
-    ]);
+    const root = groupScope([drawEntry(createDrawCommand(a, 0, undefined, 1)), drawEntry(createDrawCommand(b, 1, undefined, 1))]);
     const spy = createPlaybackSpy();
 
     RenderPlanPlayer.playScope(root, spy.backend);
 
-    expect(spy.events).toEqual([
-      'begin:a',
-      'upload:a:1:0:0:0',
-      'prepare:a',
-      'draw:a',
-      'end:a',
-      'begin:b',
-      'upload:b:1:1:1:1',
-      'prepare:b',
-      'draw:b',
-      'end:b',
-    ]);
+    expect(spy.events).toEqual(['begin:a', 'upload:a:1:0:0:0', 'prepare:a', 'draw:a', 'end:a', 'begin:b', 'upload:b:1:1:1:1', 'prepare:b', 'draw:b', 'end:b']);
     expect(spy.slots).toEqual(['a:0:0', 'b:0:1']);
     expect(spy.uploads).toEqual(['a:1:0:0:0', 'b:1:1:1:1']);
   });

--- a/test/rendering/transform-storage-filter.test.ts
+++ b/test/rendering/transform-storage-filter.test.ts
@@ -252,11 +252,7 @@ describe('render-group upload records transform write stats', () => {
     const t1 = new NonConsumingDrawable(10, 20, new Color());
     const t2 = new NonConsumingDrawable(30, 40, new Color());
     const t3 = new NonConsumingDrawable(50, 60, new Color());
-    const scope = groupScope([
-      drawEntry(createDrawCommand(t1, 0, 1, 1)),
-      drawEntry(createDrawCommand(t2, 1, 1, 1)),
-      drawEntry(createDrawCommand(t3, 2, 1, 1)),
-    ]);
+    const scope = groupScope([drawEntry(createDrawCommand(t1, 0, 1, 1)), drawEntry(createDrawCommand(t2, 1, 1, 1)), drawEntry(createDrawCommand(t3, 2, 1, 1))]);
 
     const { buffer } = playFiltered(scope);
 

--- a/test/rendering/webgpu-transform-group-upload.test.ts
+++ b/test/rendering/webgpu-transform-group-upload.test.ts
@@ -241,11 +241,7 @@ describe('WebGPU group-upload: draw order is unchanged', () => {
     const t1 = new NonConsumingDrawable(10, 20, new Color());
     const t2 = new NonConsumingDrawable(30, 40, new Color());
     const t3 = new NonConsumingDrawable(50, 60, new Color());
-    const scope = groupScope([
-      drawEntry(createDrawCommand(t1, 0, 1, 1)),
-      drawEntry(createDrawCommand(t2, 1, 1, 1)),
-      drawEntry(createDrawCommand(t3, 2, 1, 1)),
-    ]);
+    const scope = groupScope([drawEntry(createDrawCommand(t1, 0, 1, 1)), drawEntry(createDrawCommand(t2, 1, 1, 1)), drawEntry(createDrawCommand(t3, 2, 1, 1))]);
 
     const { drawOrder } = playGroupUpload(scope);
 
@@ -258,10 +254,7 @@ describe('WebGPU group-upload: nodeIndex slot contract', () => {
     const floatsPerSlot = 12;
     const a = new ConsumingDrawable(11, 22, new Color());
     const b = new ConsumingDrawable(33, 44, new Color());
-    const scope = groupScope([
-      drawEntry(createDrawCommand(a, 5, 1, 1)),
-      drawEntry(createDrawCommand(b, 7, 1, 1)),
-    ]);
+    const scope = groupScope([drawEntry(createDrawCommand(a, 5, 1, 1)), drawEntry(createDrawCommand(b, 7, 1, 1))]);
 
     const storage2 = new WebGpuTransformStorage();
 

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -48,6 +48,13 @@
       "@assets": ["./examples/shared/assets-catalog.d.ts"]
     }
   },
-  "include": ["examples/**/*.js", "examples/**/*.ts", "examples/shared/runtime.d.ts", "examples/shared/assets-catalog.d.ts", "src/typings.d.ts", "src/build-constants.d.ts"],
+  "include": [
+    "examples/**/*.js",
+    "examples/**/*.ts",
+    "examples/shared/runtime.d.ts",
+    "examples/shared/assets-catalog.d.ts",
+    "src/typings.d.ts",
+    "src/build-constants.d.ts"
+  ],
   "exclude": ["examples/shared/editor-support.d.ts"]
 }


### PR DESCRIPTION
## Summary

Fixes accumulated Prettier formatting drift in 13 files that broke
`pnpm verify:release` at the `format:check` gate.

- 4 `src/` files, 8 `test/` files, `tsconfig.examples.json`
- Mechanical `prettier --write` only — no logic or behavior change
  (verified against the largest diff; long single-line expressions
  wrap to the canonical multi-line form under `printWidth: 160`)

## Root cause

`format:check` is not part of the PR CI gate (only `lint` / `typecheck` /
`test` run there), and the `eslint-config-prettier` setup does not enforce
formatting — so the drift landed unnoticed across several PRs.

## Validation

Full release gate green with this change applied:

- `typecheck` · `lint:strict` · `format:check` · `test` (1785) · `build` · `verify:exports`
- `test:browser:webgl` (84)

## Follow-up (separate PR)

Add `format:check` to the PR CI gate so formatting drift can't land
unnoticed again.
