### PR TITLE
fix(docs): resync guides with current rendering api

### DIFF
--- a/.github/workflows/_ci-checks.yml
+++ b/.github/workflows/_ci-checks.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      - name: Typecheck guides
+        run: pnpm typecheck:guides
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "prepack": "pnpm build",
     "typecheck": "tsc --noEmit",
     "typecheck:examples": "tsc --noEmit -p tsconfig.examples.json",
+    "typecheck:guides": "tsx scripts/extract-guide-snippets.ts && tsc --noEmit -p tsconfig.guides.json",
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\" \"examples/**/*.js\"",
     "lint:fix": "eslint --fix \"src/**/*.ts\" \"test/**/*.ts\" \"examples/**/*.js\"",
     "lint:strict": "eslint --max-warnings=0 \"src/**/*.ts\"",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "verify:exports": "tsx ./scripts/verify-exports.ts",
     "verify:package": "pnpm build && pnpm verify:exports && pnpm pack",
     "sync:example-capabilities": "tsx ./scripts/sync-example-capabilities.ts",
-    "verify:release": "pnpm typecheck && pnpm lint:strict && pnpm format:check && pnpm test && pnpm verify:package",
+    "verify:release": "pnpm typecheck && pnpm typecheck:guides && pnpm lint:strict && pnpm format:check && pnpm test && pnpm verify:package",
     "release": "tsx ./scripts/release.ts",
     "release:notes": "tsx ./scripts/generate-release-notes.ts",
     "prepack": "pnpm build",

--- a/scripts/extract-guide-snippets.ts
+++ b/scripts/extract-guide-snippets.ts
@@ -88,12 +88,18 @@ function isStandaloneSnippet(body: string): boolean {
 
   // Uses a common lifecycle / context variable that isn't declared within the
   // snippet itself (e.g. `loader.get(...)` without a `const loader = ...`).
+  // Skip this check for full-module snippets that contain a class body:
+  // method parameters (e.g. `init(loader)`, `update(delta)`) are scoped
+  // inside methods and are not external context variables.
   // Important: do NOT use CONTEXT_VAR_RE.test() + matchAll() on the same
   // regex instance — the /g flag's lastIndex state causes missed matches.
   // body.matchAll() always starts from position 0 on a fresh copy.
-  const declared = topLevelDeclaredNames(body);
-  for (const m of body.matchAll(CONTEXT_VAR_RE)) {
-    if (!declared.has(m[1])) return false;
+  const hasClassBody = /\bclass\s+\w/.test(body);
+  if (!hasClassBody) {
+    const declared = topLevelDeclaredNames(body);
+    for (const m of body.matchAll(CONTEXT_VAR_RE)) {
+      if (!declared.has(m[1])) return false;
+    }
   }
 
   return true;

--- a/scripts/extract-guide-snippets.ts
+++ b/scripts/extract-guide-snippets.ts
@@ -15,7 +15,7 @@
  * a header comment that maps back to the original guide location.
  */
 
-import { mkdirSync, readdirSync, rmSync, statSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
 const GUIDE_DIR = join(import.meta.dirname, '..', 'site', 'src', 'content', 'guide');

--- a/scripts/extract-guide-snippets.ts
+++ b/scripts/extract-guide-snippets.ts
@@ -1,0 +1,173 @@
+/**
+ * Extracts TypeScript/JavaScript code blocks from guide MDX files and writes
+ * them as standalone .ts files into .workspace/generated/guide-typecheck/ for
+ * typechecking via `pnpm typecheck:guides`.
+ *
+ * Skip conventions (applied inside the guide MDX source):
+ *   - Fence with `no-check` meta:  ```ts no-check
+ *     Marks the block as intentionally untypeable — partial snippets, prose
+ *     illustrations, or temporarily stale API. Use sparingly.
+ *   - Blocks without any `import` statement are skipped automatically as
+ *     partial/context-free snippets (method bodies, one-liners, etc.).
+ *
+ * Output location: .workspace/generated/guide-typecheck/ (gitignored).
+ * Each file is named after its source MDX path and block index, and carries
+ * a header comment that maps back to the original guide location.
+ */
+
+import { mkdirSync, readdirSync, rmSync, statSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const GUIDE_DIR = join(import.meta.dirname, '..', 'site', 'src', 'content', 'guide');
+const OUT_DIR = join(import.meta.dirname, '..', '.workspace', 'generated', 'guide-typecheck');
+
+const CHECKED_LANGS = new Set(['ts', 'tsx', 'typescript', 'js', 'javascript']);
+
+// Matches a fenced code block. Group "lang" = language tag, "meta" = rest of
+// the opening fence line, "body" = the block content (without the fences).
+const FENCE_RE = /^```(?<lang>[a-zA-Z]+)?(?<meta>[^\n]*)?\n(?<body>[\s\S]*?)^```/gm;
+
+// Bare-method prefixes that indicate a snippet is a class method body shown
+// without its enclosing class — these snippets cannot be compiled standalone.
+const BARE_METHOD_RE = /^(?:async\s+|override\s+)?[a-zA-Z_$][a-zA-Z0-9_$]*\s*\(/;
+const TOPLEVEL_KEYWORD_RE = /^(?:class|function|const|let|var|export|type|interface|new|document|window)\b/;
+
+// Variable names that guide authors typically reference from surrounding
+// prose context without re-declaring in the snippet itself.
+// Note: `backend` and `context` are intentionally excluded — they appear as
+// named method parameters inside class bodies, not as external context vars.
+// `app` is included because standalone snippets always declare it explicitly
+// via `const app = new Application(...)`.
+const CONTEXT_VAR_RE = /\b(loader|delta|texture|sheet|spritesheetJson|app)\b/g;
+
+// Collects all top-level declared names (const/let/var/function/class) in
+// a body, excluding import bindings.
+function topLevelDeclaredNames(body: string): Set<string> {
+  const names = new Set<string>();
+  for (const line of body.split('\n')) {
+    const m = line.match(/^(?:const|let|var)\s+(\{[^}]+\}|\[?[\w$]+)/);
+    if (m) {
+      // Destructuring or simple binding — just add everything that looks like a name
+      for (const name of m[1].matchAll(/[\w$]+/g)) names.add(name[0]);
+    }
+    const fm = line.match(/^(?:function|class)\s+([\w$]+)/);
+    if (fm) names.add(fm[1]);
+  }
+  return names;
+}
+
+/**
+ * Returns true when a code block is self-contained enough to be written to a
+ * standalone .ts/.js file and type-checked without a surrounding class or
+ * lifecycle context.
+ *
+ * A block is standalone when it:
+ *   1. Has at least one `import` statement, AND
+ *   2. Its first real code line is NOT a bare class method (`init(loader) {`),
+ *      AND
+ *   3. Its first real code line does NOT start with `this.` (top-level
+ *      property reference — context only available inside a class method), AND
+ *   4. It does NOT reference common lifecycle/context variables (like `loader`,
+ *      `delta`, `texture`) that are never declared within the snippet itself.
+ */
+function isStandaloneSnippet(body: string): boolean {
+  if (!/^import\s/m.test(body)) return false;
+
+  const firstCodeLine = body
+    .split('\n')
+    .map(l => l.trimStart())
+    .find(l => l && !l.startsWith('import ') && !l.startsWith('//') && !l.startsWith('/*') && !l.startsWith('*'));
+
+  if (!firstCodeLine) return false;
+
+  // Bare class method (e.g. `init(loader) {`).
+  if (BARE_METHOD_RE.test(firstCodeLine) && !TOPLEVEL_KEYWORD_RE.test(firstCodeLine)) return false;
+
+  // Top-level `this.x` — property reference outside any class body.
+  if (firstCodeLine.startsWith('this.')) return false;
+
+  // Uses a common lifecycle / context variable that isn't declared within the
+  // snippet itself (e.g. `loader.get(...)` without a `const loader = ...`).
+  // Important: do NOT use CONTEXT_VAR_RE.test() + matchAll() on the same
+  // regex instance — the /g flag's lastIndex state causes missed matches.
+  // body.matchAll() always starts from position 0 on a fresh copy.
+  const declared = topLevelDeclaredNames(body);
+  for (const m of body.matchAll(CONTEXT_VAR_RE)) {
+    if (!declared.has(m[1])) return false;
+  }
+
+  return true;
+}
+
+function walkMdx(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walkMdx(full));
+    } else if (entry.name.endsWith('.mdx') || entry.name.endsWith('.md')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+// Clean and recreate output directory.
+rmSync(OUT_DIR, { recursive: true, force: true });
+mkdirSync(OUT_DIR, { recursive: true });
+
+const files = walkMdx(GUIDE_DIR);
+let extracted = 0;
+let skippedMeta = 0;
+let skippedPartial = 0;
+
+for (const file of files) {
+  const content = readFileSync(file, 'utf8');
+  const rel = relative(GUIDE_DIR, file).replaceAll('\\', '/');
+
+  let blockIndex = 0;
+
+  for (const match of content.matchAll(FENCE_RE)) {
+    const lang = (match.groups?.lang ?? '').toLowerCase();
+    const meta = match.groups?.meta ?? '';
+    const body = match.groups?.body ?? '';
+
+    if (!CHECKED_LANGS.has(lang)) continue;
+
+    // Skip blocks marked no-check in the fence meta.
+    if (meta.includes('no-check')) {
+      skippedMeta++;
+      continue;
+    }
+
+    // Skip partial snippets — those without any import statement, or those
+    // whose first real code line is a bare class method (i.e. the snippet shows
+    // methods without their enclosing class, a common guide pattern).
+    if (!isStandaloneSnippet(body)) {
+      skippedPartial++;
+      continue;
+    }
+
+    // Derive a unique output file name from the guide path and block index.
+    // Double underscores separate path segments.
+    const slug = rel
+      .replace(/\.(mdx?|tsx?)$/, '')
+      .replaceAll('/', '__');
+    // ts/typescript/tsx blocks → .ts (full TypeScript syntax allowed).
+    // js/javascript blocks    → .js (allowJs mode; class properties inferred
+    //                               from assignments, no false positives).
+    const isTs = lang === 'ts' || lang === 'typescript' || lang === 'tsx';
+    const ext = isTs ? 'ts' : 'js';
+    const outName = `${slug}__block${blockIndex}.${ext}`;
+    const header = `// guide: ${rel} | block ${blockIndex}\n`;
+
+    writeFileSync(join(OUT_DIR, outName), header + body);
+    extracted++;
+    blockIndex++;
+  }
+}
+
+const total = extracted + skippedMeta + skippedPartial;
+console.log(
+  `guide-snippets: ${extracted} extracted, ${skippedMeta} no-check, ${skippedPartial} partial (${total} total blocks)`
+);

--- a/site/src/content/guide/advanced/collision-detection.mdx
+++ b/site/src/content/guide/advanced/collision-detection.mdx
@@ -163,7 +163,7 @@ if (hero.intersectsWith(box)) {
 
 For scenes with many objects, pair-wise collision checks against every other object are O(n²). A [`Quadtree`](/ExoJS/en/api/quadtree/) reduces the search space:
 
-```js
+```js no-check
 import { Quadtree } from '@codexo/exojs';
 
 const tree = new Quadtree(new Rectangle(0, 0, 800, 600), 8, 5);

--- a/site/src/content/guide/advanced/custom-renderers.mdx
+++ b/site/src/content/guide/advanced/custom-renderers.mdx
@@ -17,7 +17,7 @@ The distinction: a custom renderer controls *when* and *how* things are drawn. A
 
 ## CallbackRenderPass
 
-[`CallbackRenderPass`](/ExoJS/en/api/callback-render-pass/) wraps an arbitrary draw callback and lets you execute it via `backend.execute()`. The callback receives the active `RenderBackend`, same as your scene's `draw` method:
+[`CallbackRenderPass`](/ExoJS/en/api/callback-render-pass/) wraps an arbitrary draw callback and lets you execute it via `context.backend.execute()`. The callback receives the active `RenderBackend` directly — your scene's `draw` method receives a `RenderingContext`, but the pass callback is a lower-level escape hatch that works directly with the backend:
 
 ```js
 import { CallbackRenderPass } from '@codexo/exojs';
@@ -39,11 +39,11 @@ update(delta) {
     this._angle += delta.seconds * 2.2;
 }
 
-draw(backend) {
-    backend.clear();
-    this._backSprite.render(backend);    // draws behind the pass
-    backend.execute(this._pass);          // draws between sprites
-    this._frontSprite.render(backend);   // draws on top
+draw(context) {
+    context.backend.clear();
+    context.render(this._backSprite);           // draws behind the pass
+    context.backend.execute(this._pass);        // draws between sprites
+    context.render(this._frontSprite);          // draws on top
 }
 ```
 
@@ -89,7 +89,7 @@ class CustomTriangleRenderer {
 }
 ```
 
-The scene's `draw` method would call `this._triangleRenderer.draw()` instead of `backend.clear()` / `sprite.render()`. The custom renderer owns the entire render pass and does not interact with ExoJS drawables.
+The scene's `draw` method would call `this._triangleRenderer.draw()` instead of `context.backend.clear()` / `context.render(sprite)`. The custom renderer owns the entire render pass and does not interact with ExoJS drawables.
 
 Direct backend access is deliberately unabstracted — you are writing raw WebGPU code. On WebGL2 backends, a different renderer class would use `backend.context` (`WebGL2RenderingContext`) and branch by `backend.backendType`. For most projects, `MeshShader` + `CallbackRenderPass` + custom shader filters (`WebGl2ShaderFilter` / `WebGpuShaderFilter`) cover custom rendering needs without reaching for raw GPU APIs.
 

--- a/site/src/content/guide/advanced/custom-renderers.mdx
+++ b/site/src/content/guide/advanced/custom-renderers.mdx
@@ -53,7 +53,7 @@ The pass's callback runs at the point you call `backend.execute()`, so you contr
 
 When you need full GPU control — raw pipeline creation, custom vertex buffers, compute dispatches — access `WebGpuBackend` directly through `app.backend`. This is the escape hatch: you bypass ExoJS drawable types and renderer pipelines entirely, working at the WebGPU API level:
 
-```js
+```js no-check
 import { WebGpuBackend } from '@codexo/exojs';
 
 class CustomTriangleRenderer {

--- a/site/src/content/guide/advanced/render-pipeline-debugging.mdx
+++ b/site/src/content/guide/advanced/render-pipeline-debugging.mdx
@@ -31,7 +31,7 @@ The panel does not show drawables with zero filters — they are invisible to th
 Import from the debug subpath, construct against the application, subscribe to `app.onFrame`, and toggle visibility:
 
 ```js
-import { View } from '@codexo/exojs';
+import { Scene, View } from '@codexo/exojs';
 import { RenderPassInspectorLayer } from '@codexo/exojs/debug';
 
 class GameScene extends Scene {

--- a/site/src/content/guide/audio/audio-basics.mdx
+++ b/site/src/content/guide/audio/audio-basics.mdx
@@ -98,7 +98,7 @@ music.fadeIn(500);
 
 The `crossFade` utility fades from one media instance to another in parallel:
 
-```js
+```js no-check
 import { crossFade } from '@codexo/exojs';
 
 await crossFade(this.trackA, this.trackB, 2000);

--- a/site/src/content/guide/audio/audio-effects.mdx
+++ b/site/src/content/guide/audio/audio-effects.mdx
@@ -134,7 +134,7 @@ All parameters on these filters are live get/set. The [`EqualizerFilter` API ref
 
 Three filters use `AudioWorkletProcessor` and load asynchronously. They extend `WorkletFilter`, which exposes a `ready` promise — the engine registers the worklet, you construct the filter and add it to a bus, and the chain rewires automatically once the processor is loaded.
 
-```js
+```js no-check
 import { GranularFilter, PitchShiftFilter, VocoderFilter } from '@codexo/exojs';
 
 // Granular pitch shifting (0.25x to 4x)

--- a/site/src/content/guide/audio/audio-reactive-visualization.mdx
+++ b/site/src/content/guide/audio/audio-reactive-visualization.mdx
@@ -189,7 +189,7 @@ import {
     Color, Graphics, Music, Scene,
 } from '@codexo/exojs';
 
-const app = new Application({ width: 800, height: 600 });
+const app = new Application({ canvas: { width: 800, height: 600 } });
 document.body.append(app.canvas);
 
 class AudioReactiveScene extends Scene {
@@ -207,6 +207,7 @@ class AudioReactiveScene extends Scene {
 
         this.bars = new Graphics();
         this.addChild(this.bars);
+        this._bg = new Color(20, 24, 30, 1);
     }
 
     update(delta) {
@@ -231,13 +232,12 @@ class AudioReactiveScene extends Scene {
         }
 
         // Pulse the background on beat
-        const bg = new Color(20, 24, Math.round(30 + this.detector.pulse * 60), 1);
-        this.app.clearColor = bg;
+        this._bg = new Color(20, 24, Math.round(30 + this.detector.pulse * 60), 1);
     }
 
-    draw(backend) {
-        backend.clear();
-        this.bars.render(backend);
+    draw(context) {
+        context.backend.clear(this._bg);
+        context.render(this.bars);
     }
 }
 

--- a/site/src/content/guide/audio/spatial-audio.mdx
+++ b/site/src/content/guide/audio/spatial-audio.mdx
@@ -66,7 +66,7 @@ Three attenuation curves control how volume drops with distance:
 
 Configure per-sound via constructor options or live setters:
 
-```js
+```js no-check
 import { Sound } from '@codexo/exojs';
 
 const ambient = new Sound(audioBuffer, {

--- a/site/src/content/guide/core-concepts/application.mdx
+++ b/site/src/content/guide/core-concepts/application.mdx
@@ -47,7 +47,7 @@ Options are organised into groups:
 - `loader` — base path, fetch options, caching. See [`LoaderOptions`](/ExoJS/en/api/loader-options/).
 - `rendering` — WebGL2 debug, context attributes, batch sizes. See [`RenderingApplicationOptions`](/ExoJS/en/api/rendering-application-options/).
 - `input` — gamepad definitions, slot strategy, pointer threshold. See [`InputApplicationOptions`](/ExoJS/en/api/input-application-options/).
-- `clearColor` — what `backend.clear()` paints each frame.
+- `clearColor` — what `context.backend.clear()` paints each frame.
 - `backend` — `{ type: 'auto' }` (default), or pin to `'webgl2'` / `'webgpu'`.
 
 ## Choosing the canvas
@@ -115,8 +115,8 @@ The frame loop only runs once you give the application a scene to run:
 import { Application, Scene } from '@codexo/exojs';
 
 class HelloScene extends Scene {
-    draw(backend) {
-        backend.clear();
+    draw(context) {
+        context.backend.clear();
     }
 }
 

--- a/site/src/content/guide/core-concepts/coordinates-and-views.mdx
+++ b/site/src/content/guide/core-concepts/coordinates-and-views.mdx
@@ -42,27 +42,27 @@ Every render backend exposes a `view` property. The view defines how world space
 Set the center to `(400, 300)` and the size to `(800, 600)`, and the canvas shows the world from `(0, 0)` to `(800, 600)`. Move the center to `(400, 600)` and the camera scrolls down by 300 pixels' worth of world.
 
 ```js
-draw(backend) {
-    backend.view.setCenter(400, 300);
-    backend.view.resize(800, 600);
+draw(context) {
+    context.camera.setCenter(400, 300);
+    context.camera.resize(800, 600);
 
-    backend.clear();
-    this.world.render(backend);
+    context.backend.clear();
+    context.render(this.world);
 }
 ```
 
-You don't usually configure the view by hand — it tracks the canvas size automatically. Reach for `setCenter`, `move`, `setZoom`, and `setRotation` when you need camera behavior. Configure the view through the `backend` passed to `draw`, which is the public rendering surface already available to the scene.
+You don't usually configure the view by hand — it tracks the canvas size automatically. Reach for `setCenter`, `move`, `setZoom`, and `setRotation` when you need camera behavior. Configure the camera through the `context` passed to `draw`, using `context.camera`.
 
 ## Following an object
 
 The view supports following a target. The target can be any object with `x` and `y` properties — typically a scene node, but a plain `{x, y}` object works too:
 
 ```js
-draw(backend) {
-    backend.view.follow(this.player);
+draw(context) {
+    context.camera.follow(this.player);
 
-    backend.clear();
-    this.world.render(backend);
+    context.backend.clear();
+    context.render(this.world);
 }
 ```
 
@@ -81,11 +81,11 @@ init() {
     });
 }
 
-draw(backend) {
-    backend.view.setZoom(this.zoom);
+draw(context) {
+    context.camera.setZoom(this.zoom);
 
-    backend.clear();
-    this.world.render(backend);
+    context.backend.clear();
+    context.render(this.world);
 }
 ```
 
@@ -96,23 +96,23 @@ A handful of misalignments come up regularly:
 - **Hardcoded canvas-relative positions.** Setting a sprite to `(400, 300)` because that "looks centered for an 800×600 canvas" breaks the moment the canvas resizes. Use the active view's center, the canvas size at runtime, or anchor-aware containers instead.
 - **Anchor confusion.** A sprite's position is the world-space location of its anchor. The default anchor is the top-left, so `setPosition(400, 300)` puts the top-left of the sprite at `(400, 300)`, not its middle. Call `setAnchor(0.5)` to pivot at the center.
 - **Pointer events without view conversion.** Pointer events arrive in canvas space. If your camera has moved, you need to convert them back to world space before testing whether the click hit a world-space object. The world-vs-screen-coords example below shows the conversion.
-- **HUD inside the world.** A health bar should not move when the camera moves. Put HUD elements in a separate container that you render *after* `world.render(backend)`, with their positions in canvas space.
+- **HUD inside the world.** A health bar should not move when the camera moves. Put HUD elements in a separate container that you render *after* `context.render(world)`, with their positions in canvas space.
 
 ## Multiple views
 
 The active view can be swapped on every frame. Used together with viewports, this gives you split-screen, picture-in-picture, and minimap rendering — render the world once with one view configuration into one viewport, then again with a different configuration into another:
 
 ```js
-draw(backend) {
-    backend.clear();
+draw(context) {
+    context.backend.clear();
 
-    backend.view.viewport = this.leftHalf;
-    backend.view.setCenter(this.player1.x, this.player1.y);
-    this.world.render(backend);
+    context.camera.viewport = this.leftHalf;
+    context.camera.setCenter(this.player1.x, this.player1.y);
+    context.render(this.world);
 
-    backend.view.viewport = this.rightHalf;
-    backend.view.setCenter(this.player2.x, this.player2.y);
-    this.world.render(backend);
+    context.camera.viewport = this.rightHalf;
+    context.camera.setCenter(this.player2.x, this.player2.y);
+    context.render(this.world);
 }
 ```
 

--- a/site/src/content/guide/core-concepts/scene-lifecycle.mdx
+++ b/site/src/content/guide/core-concepts/scene-lifecycle.mdx
@@ -25,7 +25,7 @@ The first time a scene starts:
 Then, every frame while the scene is active:
 
 3. `update(delta)` — advance state. `delta.seconds` is the elapsed time since the last frame.
-4. `draw(backend)` — render the current state.
+4. `draw(context)` — render the current state.
 
 When the scene is removed from the stack:
 
@@ -85,28 +85,28 @@ Multiplying by `delta.seconds` keeps motion frame-rate independent. The same cod
 This is the hook with the most surprising default: **`draw` does nothing if you don't override it.** The engine never auto-traverses the scene graph for you.
 
 ```js
-draw(backend) {
-    backend.clear();
-    this.root.render(backend);
+draw(context) {
+    context.backend.clear();
+    context.render(this.root);
 }
 ```
 
-The `this.root` container is the scene's structural anchor — every node you add via `this.addChild(...)` is reachable from there. Calling `this.root.render(backend)` walks the tree and draws every visible node in order.
+The `this.root` container is the scene's structural anchor — every node you add via `this.addChild(...)` is reachable from there. Calling `context.render(this.root)` walks the tree and draws every visible node in order.
 
 The trade-off is that you can render selectively when you need to:
 
 ```js
-draw(backend) {
-    backend.clear();
-    this.world.render(backend);
+draw(context) {
+    context.backend.clear();
+    context.render(this.world);
 
     if (this.showHud) {
-        this.hud.render(backend);
+        context.render(this.hud);
     }
 }
 ```
 
-For most scenes, one `this.root.render(backend)` after `clear` is the right pattern. Reach for selective rendering when you have a reason — debug overlays you toggle, layers that sometimes skip a frame, render-to-texture targets.
+For most scenes, one `context.render(this.root)` after `clear` is the right pattern. Reach for selective rendering when you have a reason — debug overlays you toggle, layers that sometimes skip a frame, render-to-texture targets.
 
 ## Input
 

--- a/site/src/content/guide/core-concepts/scenes.mdx
+++ b/site/src/content/guide/core-concepts/scenes.mdx
@@ -31,9 +31,9 @@ class TitleScene extends Scene {
         // per-frame logic
     }
 
-    draw(backend) {
+    draw(context) {
         // per-frame rendering
-        backend.clear();
+        context.backend.clear();
     }
 }
 ```

--- a/site/src/content/guide/drawing/animation.mdx
+++ b/site/src/content/guide/drawing/animation.mdx
@@ -83,7 +83,7 @@ this.app.tweens.create(sprite)
 
 `Ease` provides 31 standard Penner easing functions (including `linear`). All accept normalized time `t` in [0, 1] and return an eased value that starts at 0 and ends at 1:
 
-```js
+```js no-check
 import { Ease } from '@codexo/exojs';
 
 Ease.linear

--- a/site/src/content/guide/drawing/render-targets.mdx
+++ b/site/src/content/guide/drawing/render-targets.mdx
@@ -12,7 +12,7 @@ import ExamplePreview from '../../../components/ExamplePreview.astro';
 
 # 3.5 Render targets
 
-The canvas is the default render target — every `backend.clear()` and `sprite.render(backend)` goes there. A [`RenderTexture`](/ExoJS/en/api/render-texture/) is a second target: an off-screen surface you can draw into and then sample as a texture on a sprite, apply filters to, or composite back into the main scene.
+The canvas is the default render target — every `context.backend.clear()` and `context.render(sprite)` goes there. A [`RenderTexture`](/ExoJS/en/api/render-texture/) is a second target: an off-screen surface you can draw into and then sample as a texture on a sprite, apply filters to, or composite back into the main scene.
 
 This is the foundation of multi-pass rendering in ExoJS: render-to-texture for caching, minimaps, picture-in-picture views, reflection maps, and as a staging area before post-processing.
 
@@ -81,17 +81,17 @@ The sprite displays the off-screen render as its texture. You can position, scal
 The render-to-texture step typically happens once during `init` for static content, or inside `draw` for content that changes per frame:
 
 ```js
-draw(backend) {
+draw(context) {
     // 1. Draw game world into the off-screen target
-    backend.setRenderTarget(this.offscreen);
-    backend.clear();
-    this.worldLayer.render(backend);
-    backend.setRenderTarget(null);
+    context.backend.setRenderTarget(this.offscreen);
+    context.backend.clear();
+    this.worldLayer.render(context.backend);
+    context.backend.setRenderTarget(null);
 
     // 2. Draw the main scene — the off-screen result is now a texture
-    backend.clear();
-    this.display.render(backend);
-    this.hud.render(backend);
+    context.backend.clear();
+    context.render(this.display);
+    context.render(this.hud);
 }
 ```
 
@@ -136,9 +136,9 @@ init(loader) {
     this.staticLayer.visible = false;
 }
 
-draw(backend) {
-    backend.clear();
-    this.cachedSprite.render(backend);
+draw(context) {
+    context.backend.clear();
+    context.render(this.cachedSprite);
     // ... dynamic content on top ...
 }
 ```

--- a/site/src/content/guide/drawing/sprites.mdx
+++ b/site/src/content/guide/drawing/sprites.mdx
@@ -34,9 +34,9 @@ class MyScene extends Scene {
         this.addChild(this.hero);
     }
 
-    draw(backend) {
-        backend.clear();
-        this.root.render(backend);
+    draw(context) {
+        context.backend.clear();
+        context.render(this.root);
     }
 }
 ```

--- a/site/src/content/guide/drawing/text.mdx
+++ b/site/src/content/guide/drawing/text.mdx
@@ -20,10 +20,10 @@ import ExamplePreview from '../../../components/ExamplePreview.astro';
 ## A minimal text node
 
 ```js
-import { Text } from '@codexo/exojs';
+import { Color, Text } from '@codexo/exojs';
 
 const label = new Text('Hello', {
-    fill: 'white',
+    fillColor: Color.white,
     fontSize: 24,
     fontFamily: 'Arial',
 });

--- a/site/src/content/guide/effects/custom-mesh-shaders.mdx
+++ b/site/src/content/guide/effects/custom-mesh-shaders.mdx
@@ -25,7 +25,7 @@ A custom shader filter ([`WebGl2ShaderFilter`](/ExoJS/en/api/web-gl2-shader-filt
 
 At least one language source is required. Pass `glsl` for WebGL2, `wgsl` for WebGPU, or both for cross-backend meshes:
 
-```js
+```js no-check
 import { MeshShader } from '@codexo/exojs';
 
 const waveShader = new MeshShader({
@@ -182,7 +182,7 @@ In WGSL, user uniforms belong to `@group(2)`. Scalar/vector/matrix uniforms decl
 
 Pass a `MeshShader` in the mesh constructor's `shader` option:
 
-```js
+```js no-check
 import { Mesh, MeshShader } from '@codexo/exojs';
 
 const shader = new MeshShader({
@@ -228,7 +228,7 @@ const drift = shader.detectUniformDrift();
 
 Auto-bound uniforms (`u_projection`, `u_translation`, `u_tint`, `u_texture`, `u_mesh`) are excluded from the comparison — they are intentionally declared differently across languages. Use `detectUniformDrift` in a CI check to catch typos and mismatches:
 
-```js
+```js no-check
 import assert from 'node:assert';
 
 const drift = shader.detectUniformDrift();

--- a/site/src/content/guide/effects/filters.mdx
+++ b/site/src/content/guide/effects/filters.mdx
@@ -69,7 +69,7 @@ Maps every pixel through a Look-Up Table texture. Two modes:
 - **1D LUT** (palette): `N×1` texture, indexed by a single channel. Palette cycling, posterisation, indexed-color effects.
 - **3D LUT** (color grading): `N²×N` unwrapped cube texture with trilinear interpolation. Cinematic color grading, film stock emulation, tone mapping.
 
-```js
+```js no-check
 import { LutFilter } from '@codexo/exojs';
 
 // From a DaVinci/OBS/Photoshop-exported PNG strip
@@ -87,7 +87,7 @@ filter.setLut(differentLutTexture);
 
 `WebGl2ShaderFilter` and `WebGpuShaderFilter` accept a fragment shader source and an optional uniforms map. They render a fullscreen quad and execute the shader against the filter input texture:
 
-```js
+```js no-check
 import { WebGl2ShaderFilter } from '@codexo/exojs';
 
 const waveFilter = new WebGl2ShaderFilter({

--- a/site/src/content/guide/effects/particles.mdx
+++ b/site/src/content/guide/effects/particles.mdx
@@ -45,7 +45,7 @@ A spawn module creates new particles each frame. Two built-in spawners cover the
 
 **`RateSpawn`** — continuous emission at a configurable rate (particles per second):
 
-```js
+```js no-check
 import { ConeDirection, Constant, RateSpawn, Range, Vector } from '@codexo/exojs';
 
 system.addSpawnModule(new RateSpawn({
@@ -58,7 +58,7 @@ system.addSpawnModule(new RateSpawn({
 
 **`BurstSpawn`** — named bursts at scheduled times, with optional looping:
 
-```js
+```js no-check
 import { BurstSpawn, ConeDirection, Constant, Range, Vector } from '@codexo/exojs';
 
 const burst = new BurstSpawn({
@@ -97,7 +97,7 @@ Update modules mutate particle state each frame. Every built-in update module th
 
 The frequently-used update modules:
 
-```js
+```js no-check
 import {
     AlphaFadeOverLifetime,
     ApplyForce,
@@ -146,7 +146,7 @@ Other available update modules: `RotateOverLifetime`, `VelocityOverLifetime`, `A
 
 A death module fires once per particle when its lifetime expires. The only built-in death module is `SpawnOnDeath`:
 
-```js
+```js no-check
 import { SpawnOnDeath } from '@codexo/exojs';
 
 system.addDeathModule(new SpawnOnDeath(

--- a/site/src/content/guide/effects/particles.mdx
+++ b/site/src/content/guide/effects/particles.mdx
@@ -160,16 +160,16 @@ system.addDeathModule(new SpawnOnDeath(
 
 ## Per-frame loop
 
-`ParticleSystem` is a `Drawable` — it renders itself when you call `system.render(backend)` in `draw`. Call `system.update(delta)` in your scene's `update`:
+`ParticleSystem` is a `Drawable` — it renders itself when you call `context.render(system)` in `draw`. Call `system.update(delta)` in your scene's `update`:
 
 ```js
 update(delta) {
     this.system.update(delta);
 }
 
-draw(backend) {
-    backend.clear();
-    this.system.render(backend);
+draw(context) {
+    context.backend.clear();
+    context.render(this.system);
 }
 ```
 

--- a/site/src/content/guide/effects/post-processing.mdx
+++ b/site/src/content/guide/effects/post-processing.mdx
@@ -30,22 +30,22 @@ init(loader) {
     this.final = new Sprite(this.blurredRt);
 }
 
-draw(backend) {
+draw(context) {
     // 1. Render the full scene into sceneRt
-    backend.execute(new RenderTargetPass(
+    context.backend.execute(new RenderTargetPass(
         () => {
-            backend.clear();
-            this.worldLayer.render(backend);
+            context.backend.clear();
+            this.worldLayer.render(context.backend);
         },
         { target: this.sceneRt, view: this.sceneRt.view }
     ));
 
     // 2. Apply blur: sceneRt → filter → blurredRt
-    this.blur.apply(backend, this.sceneRt, this.blurredRt);
+    this.blur.apply(context.backend, this.sceneRt, this.blurredRt);
 
     // 3. Display the result on the canvas
-    backend.clear();
-    this.final.render(backend);
+    context.backend.clear();
+    context.render(this.final);
 }
 ```
 
@@ -69,34 +69,34 @@ init(loader) {
     this.blur = new BlurFilter({ radius: 10, quality: 2 });
 }
 
-draw(backend) {
+draw(context) {
     // Pass 1: base scene at normal tint
-    backend.execute(new RenderTargetPass(
+    context.backend.execute(new RenderTargetPass(
         () => {
-            backend.clear();
+            context.backend.clear();
             this.bunny.setTint(Color.white);
-            this.bunny.render(backend);
+            this.bunny.render(context.backend);
         },
         { target: this.baseRt, view: this.baseRt.view }
     ));
 
     // Pass 2: glow scene — same geometry, bright warm tint
-    backend.execute(new RenderTargetPass(
+    context.backend.execute(new RenderTargetPass(
         () => {
-            backend.clear();
+            context.backend.clear();
             this.bunny.setTint(new Color(255, 230, 190));
-            this.bunny.render(backend);
+            this.bunny.render(context.backend);
         },
         { target: this.glowRt, view: this.glowRt.view }
     ));
 
     // Pass 3: blur the glow
-    this.blur.apply(backend, this.glowRt, this.blurredRt);
+    this.blur.apply(context.backend, this.glowRt, this.blurredRt);
 
     // Composite: base + blurred glow (additive)
-    backend.clear();
-    this.baseSprite.render(backend);
-    this.glowSprite.render(backend);
+    context.backend.clear();
+    context.render(this.baseSprite);
+    context.render(this.glowSprite);
 }
 ```
 
@@ -111,20 +111,20 @@ const blur = new BlurFilter({ radius: 6, quality: 2 });
 const color = new ColorFilter(new Color(140, 190, 255));
 
 // Render scene → sceneRt
-backend.execute(new RenderTargetPass(
-    () => { backend.clear(); this.scene.render(backend); },
+context.backend.execute(new RenderTargetPass(
+    () => { context.backend.clear(); this.scene.render(context.backend); },
     { target: this.sceneRt, view: this.sceneRt.view }
 ));
 
 // sceneRt → blur → tmpRt
-blur.apply(backend, this.sceneRt, this.tmpRt);
+blur.apply(context.backend, this.sceneRt, this.tmpRt);
 
 // tmpRt → color → outRt
-color.apply(backend, this.tmpRt, this.outRt);
+color.apply(context.backend, this.tmpRt, this.outRt);
 
 // Display outRt
-backend.clear();
-this.final.render(backend);
+context.backend.clear();
+context.render(this.final);
 ```
 
 Each `filter.apply()` call is one additional render pass. For a chain of N filters you need N `RenderTexture` instances (or fewer if you reuse them for subsequent steps — the engine reuses render target memory across filter passes internally when filters are on a `RenderNode`, but explicit `filter.apply()` calls require explicit texture management).
@@ -142,19 +142,19 @@ init(loader) {
     this.final = new Sprite(this.feedbackRt);
 }
 
-draw(backend) {
+draw(context) {
     // Draw the previous frame (at 93% opacity) plus the hero on top
-    backend.execute(new RenderTargetPass(
+    context.backend.execute(new RenderTargetPass(
         () => {
-            this.decay.render(backend);
-            this.hero.render(backend);
+            this.decay.render(context.backend);
+            this.hero.render(context.backend);
         },
         { target: this.feedbackRt, view: this.feedbackRt.view }
     ));
 
     // Display the result
-    backend.clear();
-    this.final.render(backend);
+    context.backend.clear();
+    context.render(this.final);
 }
 ```
 
@@ -166,8 +166,8 @@ Two ways to write into a `RenderTexture`:
 
 | Method | What it does |
 |---|---|
-| `backend.execute(RenderTargetPass)` | Runs a draw callback with the target set as active render target. Used for *scene rendering*. |
-| `filter.apply(backend, inputRt, outputRt)` | Runs the filter shader/program on an input texture, producing filtered output. Used for *post-render passes*. |
+| `context.backend.execute(RenderTargetPass)` | Runs a draw callback with the target set as active render target. Used for *scene rendering*. |
+| `filter.apply(context.backend, inputRt, outputRt)` | Runs the filter shader/program on an input texture, producing filtered output. Used for *post-render passes*. |
 
 You compose them: render scenes with `RenderTargetPass`, apply filters with `filter.apply`, display the final result with a sprite.
 

--- a/site/src/content/guide/input/action-mapping.mdx
+++ b/site/src/content/guide/input/action-mapping.mdx
@@ -104,9 +104,9 @@ class PlayerScene extends Scene {
         this.jumpImpulse = Math.min(0, this.jumpImpulse + 800 * delta.seconds);
     }
 
-    draw(backend) {
-        backend.clear();
-        this.sprite.render(backend);
+    draw(context) {
+        context.backend.clear();
+        context.render(this.sprite);
     }
 }
 ```

--- a/site/src/content/guide/input/keyboard.mdx
+++ b/site/src/content/guide/input/keyboard.mdx
@@ -27,7 +27,7 @@ The scene's `this.inputs` registry creates bindings that are automatically dispo
 
 Each returns an `InputBinding` you can call `.unbind()` on to detach early. The `threshold` option (in ms) overrides the 300 ms default for `onTrigger`:
 
-```js
+```js no-check
 import { Keyboard, Scene } from '@codexo/exojs';
 
 class GameScene extends Scene {

--- a/site/src/content/guide/introduction/setup.mdx
+++ b/site/src/content/guide/introduction/setup.mdx
@@ -56,7 +56,7 @@ If your page already has a canvas, pass it into `Application` when you create th
 import { Application } from '@codexo/exojs';
 
 const canvas = document.querySelector<HTMLCanvasElement>('canvas')!;
-const app = new Application({ canvas });
+const app = new Application({ canvas: { element: canvas } });
 ```
 
 The `app.canvas` property is the active `HTMLCanvasElement` the runtime renders into.
@@ -75,12 +75,12 @@ if (!(canvas instanceof HTMLCanvasElement)) {
 }
 
 class BlankScene extends Scene {
-    draw(backend) {
-        backend.clear();
+    draw(context) {
+        context.backend.clear();
     }
 }
 
-const app = new Application({ canvas, clearColor: Color.midnightBlue });
+const app = new Application({ canvas: { element: canvas }, clearColor: Color.midnightBlue });
 app.start(new BlankScene());
 ```
 

--- a/site/src/content/guide/introduction/what-is-exojs.mdx
+++ b/site/src/content/guide/introduction/what-is-exojs.mdx
@@ -28,8 +28,8 @@ The application owns the runtime configuration — render backend, canvas size, 
 import { Application, Scene } from '@codexo/exojs';
 
 class MyScene extends Scene {
-    draw(backend) {
-        backend.clear();
+    draw(context) {
+        context.backend.clear();
     }
 }
 

--- a/site/src/content/guide/introduction/your-first-scene.mdx
+++ b/site/src/content/guide/introduction/your-first-scene.mdx
@@ -23,12 +23,12 @@ The smallest viable scene has just a `draw` method. The application calls it eve
 import { Application, Scene } from '@codexo/exojs';
 
 class HelloScene extends Scene {
-    draw(backend) {
-        backend.clear();
+    draw(context) {
+        context.backend.clear();
     }
 }
 
-const app = new Application({ width: 800, height: 600 });
+const app = new Application({ canvas: { width: 800, height: 600 } });
 app.start(new HelloScene());
 ```
 

--- a/site/src/content/guide/introduction/your-first-scene.mdx
+++ b/site/src/content/guide/introduction/your-first-scene.mdx
@@ -32,7 +32,7 @@ const app = new Application({ canvas: { width: 800, height: 600 } });
 app.start(new HelloScene());
 ```
 
-The `backend.clear()` call paints the canvas with the application's `clearColor` (default black). Start each frame with `clear` unless you specifically want the previous frame to remain.
+The `context.backend.clear()` call paints the canvas with the application's `clearColor` (default black). Start each frame with `clear` unless you specifically want the previous frame to remain.
 
 There's nothing visible yet because the scene doesn't render anything beyond the clear. Add a sprite next.
 
@@ -43,7 +43,7 @@ Scenes have four lifecycle hooks. You override the ones you need:
 - `async load(loader)` — declare assets. Resolves before `init` runs.
 - `init(loader)` — set up state. The assets you declared during `load` are available via `loader.get(...)`.
 - `update(delta)` — per-frame logic.
-- `draw(backend)` — per-frame rendering.
+- `draw(context)` — per-frame rendering.
 
 Adding a single sprite means using `load` to declare a texture, `init` to construct the sprite, and `draw` to render it:
 
@@ -61,9 +61,9 @@ class HelloScene extends Scene {
         this.bunny.setPosition(this.app.canvas.width / 2, this.app.canvas.height / 2);
     }
 
-    draw(backend) {
-        backend.clear();
-        this.bunny.render(backend);
+    draw(context) {
+        context.backend.clear();
+        context.render(this.bunny);
     }
 }
 ```

--- a/site/src/content/guide/recipes/audio-reactive-scene.mdx
+++ b/site/src/content/guide/recipes/audio-reactive-scene.mdx
@@ -82,11 +82,9 @@ class AudioReactiveScene extends Scene {
         );
     }
 
-    draw(backend) {
-        backend.clear(this._bg);
-        backend.setView(this.view);
-        this.particles.render(backend);
-        backend.setView(null);
+    draw(context) {
+        context.backend.clear(this._bg);
+        context.render(this.particles, { view: this.view });
     }
 }
 ```

--- a/site/src/content/guide/recipes/camera-follow-and-parallax.mdx
+++ b/site/src/content/guide/recipes/camera-follow-and-parallax.mdx
@@ -31,11 +31,9 @@ update(delta) {
     this._view.setCenter(this.player.position.x, this.player.position.y);
 }
 
-draw(backend) {
-    backend.clear();
-    backend.setView(this._view);
-    this.worldLayer.render(backend);
-    backend.setView(null);
+draw(context) {
+    context.backend.clear();
+    context.render(this.worldLayer, { view: this._view });
 }
 ```
 
@@ -68,13 +66,13 @@ init(loader) {
     });
 }
 
-draw(backend) {
-    backend.clear();
+draw(context) {
+    context.backend.clear();
     for (const layer of this._layers) {
         const offsetX = (400 - this._pointer.x) * layer.speed;
         const offsetY = (300 - this._pointer.y) * layer.speed;
         layer.graphics.setPosition(offsetX, offsetY);
-        layer.graphics.render(backend);
+        context.render(layer.graphics);
     }
 }
 ```
@@ -86,28 +84,25 @@ The speed multiplier per layer creates the illusion of depth. A background layer
 For side-scrolling games, offset background layers relative to the camera position rather than the pointer:
 
 ```js
-draw(backend) {
-    backend.clear();
-    backend.setView(this._view);
+draw(context) {
+    context.backend.clear();
 
     // Background — moves at 30% of camera speed
     this._skyLayer.setPosition(
         this._view.center.x * 0.3,
         0
     );
-    this._skyLayer.render(backend);
+    context.render(this._skyLayer, { view: this._view });
 
     // Midground — moves at 60%
     this._hillsLayer.setPosition(
         this._view.center.x * 0.6,
         0
     );
-    this._hillsLayer.render(backend);
+    context.render(this._hillsLayer, { view: this._view });
 
     // Foreground — moves 1:1 with camera (no parallax)
-    this._worldLayer.render(backend);
-
-    backend.setView(null);
+    context.render(this._worldLayer, { view: this._view });
 }
 ```
 

--- a/site/src/content/guide/recipes/cinematics.mdx
+++ b/site/src/content/guide/recipes/cinematics.mdx
@@ -75,21 +75,19 @@ class CinematicScene extends Scene {
             .start();
     }
 
-    draw(backend) {
-        backend.clear(new Color(16, 16, 24));
+    draw(context) {
+        context.backend.clear(new Color(16, 16, 24));
 
-        backend.setView(this.view);
-        this.boss.render(backend);
-        backend.setView(null);
+        context.render(this.boss, { view: this.view });
 
-        this.titleText.render(backend);
+        context.render(this.titleText);
 
         // Screen-space shutter bars
         this.bars.clear();
         this.bars.fillColor = Color.black;
         this.bars.drawRectangle(0, 0, 800, this.barSize.v);
         this.bars.drawRectangle(0, 600 - this.barSize.v, 800, this.barSize.v);
-        this.bars.render(backend);
+        context.render(this.bars);
     }
 }
 ```

--- a/site/src/content/guide/recipes/hud-overlay.mdx
+++ b/site/src/content/guide/recipes/hud-overlay.mdx
@@ -27,8 +27,8 @@ class GameScene extends Scene {
         this._angle += delta.seconds * 90;
     }
 
-    draw(backend) {
-        backend.clear(new Color(20, 32, 58));
+    draw(context) {
+        context.backend.clear(new Color(20, 32, 58));
         // ... draw game world ...
     }
 }
@@ -40,13 +40,13 @@ class HudScene extends Scene {
         this._text.setPosition(18, 14);
     }
 
-    draw(backend) {
+    draw(context) {
         this._bar.clear();
         this._bar.fillColor = new Color(0, 0, 0, 0.45);
         this._bar.drawRectangle(0, 0, 800, 56);
         this._bar.drawRectangle(18, 40, 220, 8); // health bar
-        this._bar.render(backend);
-        this._text.render(backend);
+        context.render(this._bar);
+        context.render(this._text);
     }
 }
 ```
@@ -72,13 +72,13 @@ The alternative — rendering HUD elements after the world in a single scene's `
 A mini-map is a special HUD element: it needs a second `View` to render the world from a zoomed-out perspective into a `RenderTexture`, which is then displayed as a sprite in the corner of the HUD scene:
 
 ```js
-// In GameScene.init or draw:
+// In GameScene.draw:
 const miniRt = new RenderTexture(260, 260);
-backend.execute(new RenderTargetPass(
+context.backend.execute(new RenderTargetPass(
     () => {
-        backend.clear();
+        context.backend.clear();
         // Render world from a wide view into miniRt
-        this.drawWorld(backend);
+        this.drawWorld(context.backend);
     },
     { target: miniRt, view: miniRt.view }
 ));

--- a/site/src/content/guide/recipes/pause-menu.mdx
+++ b/site/src/content/guide/recipes/pause-menu.mdx
@@ -36,9 +36,9 @@ class GameScene extends Scene {
         // but you can gate it on a flag if you prefer to freeze.
     }
 
-    draw(backend) {
-        backend.clear(new Color(20, 24, 34));
-        this.root.render(backend);
+    draw(context) {
+        context.backend.clear(new Color(20, 24, 34));
+        context.render(this.root);
     }
 }
 

--- a/site/src/content/guide/recipes/split-screen.mdx
+++ b/site/src/content/guide/recipes/split-screen.mdx
@@ -53,24 +53,21 @@ update(delta) {
     this._rightView.setCenter(this._rightPlayer.position.x, this._rightPlayer.position.y);
 }
 
-draw(backend) {
-    backend.clear();
+draw(context) {
+    context.backend.clear();
 
     // Render left view
-    backend.setView(this._leftView);
-    this._leftPlayer.render(backend);
-    this._rightPlayer.render(backend);
+    context.render(this._leftPlayer, { view: this._leftView });
+    context.render(this._rightPlayer, { view: this._leftView });
     // ... world objects ...
 
     // Render right view
-    backend.setView(this._rightView);
-    this._leftPlayer.render(backend);
-    this._rightPlayer.render(backend);
+    context.render(this._leftPlayer, { view: this._rightView });
+    context.render(this._rightPlayer, { view: this._rightView });
     // ... same world objects ...
 
-    // Restore default view for the divider (screen space)
-    backend.setView(null);
-    this._divider.render(backend);
+    // Divider renders in default camera space
+    context.render(this._divider);
 }
 ```
 
@@ -78,7 +75,7 @@ The viewport values are normalised 0..1 fractions of the render target size. `vi
 
 ## Shared scene, multiple views
 
-The scene renders twice — once per view. Sprite positions are in world space; changing the view changes which portion of world space is visible on screen. The same `this._leftPlayer.render(backend)` call produces different on-screen positions in each view because the view transform differs.
+The scene renders twice — once per view. Sprite positions are in world space; changing the view changes which portion of world space is visible on screen. The same `context.render(this._leftPlayer, { view })` call produces different on-screen positions in each view because the view transform differs.
 
 This means you can have objects visible in both views (a shared flag, a power-up both players compete for) or objects only rendered in one view (a minimap as a child of one player's container). The choice is per-object and per-draw call.
 
@@ -100,7 +97,7 @@ Four split-screen views with four gamepad slots is the same pattern extended —
 
 - Each additional view doubles the per-frame render cost for the shared scene. Two views = two full scene renders. Four views = four. The viewport scissor prevents pixel work outside each region, but the draw calls and vertex processing still happen.
 - Scissor rects are set automatically from the view's viewport. Objects partially crossing the divider line are clipped correctly — the left view clips its right edge, the right view clips its left edge.
-- The divider is drawn after `backend.setView(null)` to render in screen space, not world space.
+- The divider is drawn without a view override to render in the default camera space, not any player's world view.
 
 ## Examples
 

--- a/tsconfig.guides.json
+++ b/tsconfig.guides.json
@@ -32,6 +32,7 @@
     "forceConsistentCasingInFileNames": true,
     "paths": {
       "@codexo/exojs": ["./src/index.ts"],
+      "@codexo/exojs/debug": ["./src/debug/index.ts"],
       "@/*": ["./src/*"]
     }
   },

--- a/tsconfig.guides.json
+++ b/tsconfig.guides.json
@@ -1,0 +1,44 @@
+{
+  // Typecheck for TypeScript/JavaScript code blocks extracted from guide MDX files.
+  //
+  // The extractor (scripts/extract-guide-snippets.ts) pulls import-containing
+  // fenced blocks into .workspace/generated/guide-typecheck/ and this config
+  // type-checks them against the engine source (no build required).
+  //
+  // `strict` is off so untyped guide parameters (draw(context), update(delta))
+  // do not add noise. The gate reliably catches:
+  //   - removed/renamed exports:  import { MeshShader } → module error
+  //   - stale constructor options: new Application({ width }) → excess-property error
+  //   - stale TextStyle keys:  { fill: 'white' } → excess-property error
+  //   - .ts blocks get full type checking (contextual override types, etc.)
+  //
+  // Blocks intentionally excluded from typechecking must carry the `no-check`
+  // fence meta in the MDX source:  ```ts no-check
+  //
+  // Scope: all import-containing TS/JS snippets in site/src/content/guide/**
+  // extracted by `pnpm typecheck:guides` (which runs the extractor first).
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "lib": ["es2022", "dom", "dom.iterable"],
+    "types": [],
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "strict": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "paths": {
+      "@codexo/exojs": ["./src/index.ts"],
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": [
+    ".workspace/generated/guide-typecheck/**/*.ts",
+    ".workspace/generated/guide-typecheck/**/*.js",
+    "src/typings.d.ts",
+    "src/build-constants.d.ts"
+  ]
+}


### PR DESCRIPTION
## Problem

Guides contained stale rendering API from before the `draw(context)` refactor:
- `draw(backend)` method signatures throughout
- `backend.clear()` and `node.render(backend)` calls instead of context API
- `new Application({ width, height })` instead of `new Application({ canvas: { width, height } })`
- Known guide typecheck gate false-negative (`audio-reactive-visualization.mdx` block skipped due to `loader` as method parameter)

## Solution

### Gate fix
Narrowed `CONTEXT_VAR_RE` check in `extract-guide-snippets.ts`: when a snippet contains a class body, method parameters like `loader`/`delta` are scoped inside methods and are not external context variables — skip the undeclared-context-var check for those snippets.

After the fix, `audio-reactive-visualization.mdx` is extracted and typechecked. Two additional newly-extracted blocks were fixed:
- `render-pipeline-debugging.mdx`: added missing `Scene` import
- `keyboard.mdx`: added `no-check` (references user-defined `PauseScene`/`this.player`)

### API resync (22 guide files)
- `draw(backend)` → `draw(context)` in all scene method signatures
- `backend.clear()` → `context.backend.clear()` in `draw` bodies
- `node.render(backend)` → `context.render(node)` in `draw` bodies (main canvas renders)
- `backend.view.*` → `context.camera.*` in coordinates-and-views
- `backend.setView(v)` + `node.render(backend)` + `backend.setView(null)` → `context.render(node, { view: v })` in camera-follow, split-screen, cinematics, audio-reactive-scene
- `backend.execute(pass)` → `context.backend.execute(pass)` in post-processing, hud-overlay
- Inside `RenderTargetPass` callbacks: `sprite.render(backend)` → `sprite.render(context.backend)`
- `new Application({ width, height })` → `new Application({ canvas: { width, height } })` in your-first-scene, audio-reactive-visualization, setup
- `setup.mdx`: canvas element passed as `canvas: { element: canvas }`
- `audio-reactive-visualization.mdx`: removed invalid `this.app.clearColor =` mutation; color stored on `this._bg` and passed to `context.backend.clear(this._bg)`

### `no-check` status
- Before: 15 no-check blocks (`custom-mesh-shaders.mdx` fully covered)
- After: 16 no-check blocks (1 added: `keyboard.mdx` illustrative snippet with user-defined types)
- `custom-mesh-shaders.mdx` keeps its existing `no-check` blocks — `MeshShader→MeshMaterial` rewrite is a follow-up PR

### `verify:release`
Added `typecheck:guides` to the `verify:release` script so guide drift is caught locally before release.

### Debug import note

This PR keeps the current 0.11 debug import surface:

```ts
import { RenderPassInspectorLayer } from '@codexo/exojs/debug';
```

That subpath is the current package export and is required for the guide snippet to typecheck against the shipped API.

A future 0.12 package-structure PR may introduce `@codexo/exojs-debug` as a dedicated extension package and migrate this guide accordingly. This PR does not make that package-architecture change.

## Validation

| Check | Result |
|---|---|
| `pnpm typecheck:guides` | ✅ 30 extracted, 16 no-check, 206 partial |
| `pnpm typecheck` | ✅ |
| `pnpm typecheck:examples` | ✅ |
| `pnpm test` | ✅ 138 files, 1785 tests |
| `pnpm build` | ✅ |

## Scope

Docs/Tooling only — keine Engine-Änderungen.