### PR TITLE
feat(build): add debug bundle entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "dist/esm/",
     "dist/exo.esm.js",
     "dist/exo.esm.js.map",
+    "dist/exo.debug.esm.js",
+    "dist/exo.debug.esm.js.map",
     "README.md",
     "CHANGELOG.md"
   ],

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -63,10 +63,15 @@ const bundled: RollupOptions = {
 
 const debugBundled: RollupOptions = {
   input: 'src/debug/index.ts',
+  // All @/ imports are core dependencies — mark them external so the debug
+  // bundle contains only debug code and imports from @codexo/exojs at runtime.
+  external: (id) => id.startsWith('@/'),
   output: {
     file: 'dist/exo.debug.esm.js',
     format: 'es',
     sourcemap: true,
+    // Remap all @/ external IDs to the package name in the output.
+    paths: (id) => (id.startsWith('@/') ? '@codexo/exojs' : id),
   },
   plugins: [
     constantReplacementPlugin,

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -61,6 +61,24 @@ const bundled: RollupOptions = {
   ],
 };
 
+const debugBundled: RollupOptions = {
+  input: 'src/debug/index.ts',
+  output: {
+    file: 'dist/exo.debug.esm.js',
+    format: 'es',
+    sourcemap: true,
+  },
+  plugins: [
+    constantReplacementPlugin,
+    resolve({ mainFields: ['browser', 'module', 'main'] }),
+    glslPlugin,
+    typescript({
+      compilerOptions: { incremental: false },
+      outputToFilesystem: false,
+    }),
+  ],
+};
+
 const modules: RollupOptions = {
   input: ['src/index.ts', 'src/debug/index.ts'],
   output: {
@@ -85,4 +103,4 @@ const modules: RollupOptions = {
   ],
 };
 
-export default [bundled, modules];
+export default [bundled, debugBundled, modules];

--- a/site/src/content/guide/advanced/debug-layer.mdx
+++ b/site/src/content/guide/advanced/debug-layer.mdx
@@ -12,7 +12,7 @@ import ExamplePreview from '../../../components/ExamplePreview.astro';
 
 # 7.2 Debug layer
 
-ExoJS ships five diagnostic layers in the `@codexo/exojs/debug` subpath. Four are managed by `DebugOverlay` (performance, bounding boxes, hit-test, pointer stack), and `RenderPassInspectorLayer` is a standalone layer covered below. These tools render as overlays on top of your running scene — no scene-logic changes, no special draw-call instrumentation, no build flags.
+ExoJS ships five diagnostic layers in the `@codexo/exojs/debug` optional entrypoint. Four are managed by `DebugOverlay` (performance, bounding boxes, hit-test, pointer stack), and `RenderPassInspectorLayer` is a standalone layer covered below. These tools render as overlays on top of your running scene — no scene-logic changes, no special draw-call instrumentation, no build flags.
 
 ## DebugOverlay
 

--- a/site/src/content/guide/advanced/render-pipeline-debugging.mdx
+++ b/site/src/content/guide/advanced/render-pipeline-debugging.mdx
@@ -11,7 +11,7 @@ import ExamplePreview from '../../../components/ExamplePreview.astro';
 
 Every filter attached to a drawable costs at least one extra render pass. A stack of three filters on a container means the container renders to an off-screen target, the first filter reads and writes a target, the second does the same, and the third composites the result — four passes for one element. When your frame budget tightens, knowing who is adding passes and why matters.
 
-[`RenderPassInspectorLayer`](/ExoJS/en/api/render-pass-inspector-layer/) shows you that information live, in a compact text panel overlaid on the canvas. It ships in the `@codexo/exojs/debug` subpath alongside the other debug layers.
+[`RenderPassInspectorLayer`](/ExoJS/en/api/render-pass-inspector-layer/) shows you that information live, in a compact text panel overlaid on the canvas. It ships in the `@codexo/exojs/debug` optional entrypoint alongside the other debug layers.
 
 ## What the layer reveals
 
@@ -28,7 +28,7 @@ The panel does not show drawables with zero filters — they are invisible to th
 
 `RenderPassInspectorLayer` extends `DebugLayer` and is designed to be driven via `app.onFrame` — the same pattern used by `DebugOverlay` for the other debug layers. It is not pushed onto the scene stack. The inspector walks `scene.currentScene?.root` each frame, so it sees whichever scene is currently active.
 
-Import from the debug subpath, construct against the application, subscribe to `app.onFrame`, and toggle visibility:
+Import from the debug entrypoint, construct against the application, subscribe to `app.onFrame`, and toggle visibility:
 
 ```js
 import { Scene, View } from '@codexo/exojs';
@@ -142,7 +142,7 @@ These labels are visible in tools that surface WebGPU pass labels (for example, 
 - **During profiling** — when a scene's frame time is higher than expected, enable the inspector to rule out (or confirm) filter pass overhead as the cause.
 - **In CI** — snapshot `inspector.entries` and `inspector.totalPasses` on a known scene to catch regressions. A PR that accidentally enables `cacheAsBitmap: false` or adds an unintended filter won't change visual output but will show up as a pass-count increase.
 
-For live FPS, frame time, and draw call counts, use [`PerformanceLayer`](/ExoJS/en/api/performance-layer/) from the same debug subpath. For bounding-box and transform visualization, use [`BoundingBoxesLayer`](/ExoJS/en/api/bounding-boxes-layer/).
+For live FPS, frame time, and draw call counts, use [`PerformanceLayer`](/ExoJS/en/api/performance-layer/) from the same `@codexo/exojs/debug` entrypoint. For bounding-box and transform visualization, use [`BoundingBoxesLayer`](/ExoJS/en/api/bounding-boxes-layer/).
 
 ## Where to go next
 

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -44,6 +44,7 @@
     "forceConsistentCasingInFileNames": true,
     "paths": {
       "@codexo/exojs": ["./src/index.ts"],
+      "@codexo/exojs/debug": ["./src/debug/index.ts"],
       "@/*": ["./src/*"],
       "@assets": ["./examples/shared/assets-catalog.d.ts"]
     }


### PR DESCRIPTION
## Problem

Debug tools live in the `@codexo/exojs/debug` optional entrypoint, but release-bundle and CDN-style users need a dedicated debug artifact that can be loaded next to the core ESM bundle.

A debug bundle that includes its own copy of ExoJS core would duplicate runtime classes when loaded together with `dist/exo.esm.js`. That can break class identity checks such as `instanceof`.

## Solution

Keep `@codexo/exojs` as the single runtime package with `@codexo/exojs/debug` as the official optional debug entrypoint, and add a dedicated external-core debug extension bundle:

- `dist/exo.debug.esm.js` — external-core ESM debug extension bundle built from `src/debug/index.ts`; imports core runtime APIs from `@codexo/exojs`
- `dist/exo.debug.esm.js.map` — source map
- both included in the npm tarball via `files[]`

`dist/exo.debug.esm.js` contains the debug layers and `DebugOverlay`, but imports core runtime APIs from `@codexo/exojs` instead of bundling a second copy of the core.

For npm consumers nothing changes:

```ts
import { DebugOverlay } from '@codexo/exojs/debug';
```

For release-zip/CDN-style usage, use an import map that maps `@codexo/exojs` to `./dist/exo.esm.js`, then import `DebugOverlay` from `./dist/exo.debug.esm.js`.

Example:

```html
<script type="importmap">
  {
    "imports": {
      "@codexo/exojs": "./dist/exo.esm.js"
    }
  }
</script>

<script type="module">
  import { Application } from '@codexo/exojs';
  import { DebugOverlay } from './dist/exo.debug.esm.js';
</script>
```

## Compatibility

`@codexo/exojs/debug` remains the official npm entrypoint.

No separate `@codexo/exojs-debug` npm package is introduced in this PR.

No breaking changes.

## Scope

Build/docs/tooling only.

No new engine features.
No separate npm package.
No particles migration.

## Changes

* `rollup.config.ts`: adds an external-core debug bundle entry from `src/debug/index.ts` to `dist/exo.debug.esm.js`
* `package.json` `files[]`: includes `dist/exo.debug.esm.js` and `dist/exo.debug.esm.js.map`
* `tsconfig.examples.json`: maps `@codexo/exojs/debug` to `src/debug/index.ts` for example typecheck
* guides: use "optional entrypoint" wording for debug imports

## Validation

| Check                     | Result                                                                                            |
| ------------------------- | ------------------------------------------------------------------------------------------------- |
| `pnpm typecheck`          | ✅                                                                                                 |
| `pnpm typecheck:guides`   | ✅                                                                                                 |
| `pnpm typecheck:examples` | ✅                                                                                                 |
| `pnpm test`               | ✅                                                                                                 |
| `pnpm build`              | ✅ — produces `dist/exo.esm.js`, external-core `dist/exo.debug.esm.js` (~32 KB), and `dist/esm/**` |
| `pnpm verify:exports`     | ✅                                                                                                 |
| `pnpm verify:package`     | ✅ — tarball includes `dist/exo.debug.esm.js` and `.map`                                           |
| `pnpm site:build`         | ✅                                                                                                 |
