### PR TITLE
fix(dx): add create-exo-app prepack

### DIFF
--- a/packages/create-exo-app/package.json
+++ b/packages/create-exo-app/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "tsc && node --input-type=module --eval \"import{readFileSync,writeFileSync}from'node:fs';const f='dist/index.js';writeFileSync(f,'#!/usr/bin/env node\\n'+readFileSync(f,'utf-8'));\"",
     "dev": "tsc --watch",
+    "prepack": "pnpm build",
     "start": "tsx src/index.ts"
   },
   "publishConfig": {


### PR DESCRIPTION
## Problem

`create-exo-app` was merged without its publishability fix.

The package points `bin` at `./dist/index.js`, but `dist/` is not committed. Without a `prepack` script, `npm pack` / `npm publish` would produce a package without the built CLI entrypoint.

## Solution

Add:

```json
"prepack": "pnpm build"
```

to `packages/create-exo-app/package.json`.

## Scope

Publishability fix only. No template, CLI, docs, or engine changes.

## Validation

- ✅ `pnpm verify:create-exo-app` (45/45)
- ✅ `pnpm typecheck`
- ✅ `pnpm typecheck:guides`
- ✅ `pnpm typecheck:examples`
- ✅ `pnpm test` (1785 tests)
- ✅ `pnpm build`
- ✅ `pnpm verify:package`
- ✅ `pnpm --filter create-exo-app pack --dry-run` — `prepack` ran, `dist/index.js` present in tarball