### PR TITLE
docs: add sample game walkthrough

### DIFF
--- a/examples/examples.json
+++ b/examples/examples.json
@@ -1441,6 +1441,25 @@
             "capabilities": [
                 "audio"
             ]
+        },
+        {
+            "slug": "orb-dodge",
+            "path": "showcase/orb-dodge.js",
+            "language": "typescript",
+            "title": "Orb Dodge",
+            "description": "A complete dodge-and-collect loop: move with WASD or arrow keys, collect green orbs for points, avoid red orbs, and restart from the game-over screen.",
+            "backend": "core",
+            "featured": true,
+            "level": "intermediate",
+            "tags": [
+                "game",
+                "input",
+                "collision",
+                "hud"
+            ],
+            "capabilities": [
+                "keyboard"
+            ]
         }
     ],
     "spatial-audio": [
@@ -1737,4 +1756,3 @@
         }
     ]
 }
-

--- a/examples/showcase/orb-dodge.js
+++ b/examples/showcase/orb-dodge.js
@@ -1,0 +1,229 @@
+// Auto-generated from orb-dodge.ts — edit the .ts source, not this file.
+import { Application, Color, Container, Graphics, Keyboard, Scene, Text } from '@codexo/exojs';
+const CANVAS_WIDTH = 800;
+const CANVAS_HEIGHT = 600;
+const PLAYER_RADIUS = 18;
+const PLAYER_SPEED = 260;
+const ORB_RADIUS = 14;
+const SPAWN_INTERVAL = 1.2;
+const ORB_SPEED_MIN = 80;
+const ORB_SPEED_MAX = 200;
+const app = new Application({
+    canvas: {
+        width: CANVAS_WIDTH,
+        height: CANVAS_HEIGHT,
+    },
+    clearColor: new Color(10, 14, 26),
+});
+document.body.append(app.canvas);
+class PlayScene extends Scene {
+    _world;
+    _player;
+    _orbs = [];
+    _px = CANVAS_WIDTH / 2;
+    _py = CANVAS_HEIGHT / 2;
+    _dx = 0;
+    _dy = 0;
+    _score = 0;
+    _elapsed = 0;
+    _spawnTimer = 0;
+    _scoreText;
+    _timeText;
+    init() {
+        this._px = CANVAS_WIDTH / 2;
+        this._py = CANVAS_HEIGHT / 2;
+        this._score = 0;
+        this._elapsed = 0;
+        this._spawnTimer = 0;
+        this._dx = 0;
+        this._dy = 0;
+        this._orbs = [];
+        this._world = new Container();
+        this._player = new Graphics();
+        this._player.fillColor = new Color(80, 160, 255);
+        this._player.drawCircle(0, 0, PLAYER_RADIUS);
+        this._player.setPosition(this._px, this._py);
+        this._world.addChild(this._player);
+        this._scoreText = new Text('Score: 0', { fillColor: Color.white, fontSize: 20 });
+        this._scoreText.setPosition(16, 14);
+        this._timeText = new Text('0.0 s', { fillColor: Color.white, fontSize: 20 });
+        this._timeText.setPosition(CANVAS_WIDTH - 90, 14);
+        this.inputs.onActive(Keyboard.W, () => { this._dy = -1; });
+        this.inputs.onStop(Keyboard.W, () => { if (this._dy < 0)
+            this._dy = 0; });
+        this.inputs.onActive(Keyboard.Up, () => { this._dy = -1; });
+        this.inputs.onStop(Keyboard.Up, () => { if (this._dy < 0)
+            this._dy = 0; });
+        this.inputs.onActive(Keyboard.S, () => { this._dy = 1; });
+        this.inputs.onStop(Keyboard.S, () => { if (this._dy > 0)
+            this._dy = 0; });
+        this.inputs.onActive(Keyboard.Down, () => { this._dy = 1; });
+        this.inputs.onStop(Keyboard.Down, () => { if (this._dy > 0)
+            this._dy = 0; });
+        this.inputs.onActive(Keyboard.A, () => { this._dx = -1; });
+        this.inputs.onStop(Keyboard.A, () => { if (this._dx < 0)
+            this._dx = 0; });
+        this.inputs.onActive(Keyboard.Left, () => { this._dx = -1; });
+        this.inputs.onStop(Keyboard.Left, () => { if (this._dx < 0)
+            this._dx = 0; });
+        this.inputs.onActive(Keyboard.D, () => { this._dx = 1; });
+        this.inputs.onStop(Keyboard.D, () => { if (this._dx > 0)
+            this._dx = 0; });
+        this.inputs.onActive(Keyboard.Right, () => { this._dx = 1; });
+        this.inputs.onStop(Keyboard.Right, () => { if (this._dx > 0)
+            this._dx = 0; });
+    }
+    _spawnOrb() {
+        const danger = Math.random() < 0.4;
+        const side = Math.floor(Math.random() * 4);
+        let ox;
+        let oy;
+        switch (side) {
+            case 0:
+                ox = Math.random() * CANVAS_WIDTH;
+                oy = -ORB_RADIUS;
+                break;
+            case 1:
+                ox = CANVAS_WIDTH + ORB_RADIUS;
+                oy = Math.random() * CANVAS_HEIGHT;
+                break;
+            case 2:
+                ox = Math.random() * CANVAS_WIDTH;
+                oy = CANVAS_HEIGHT + ORB_RADIUS;
+                break;
+            default:
+                ox = -ORB_RADIUS;
+                oy = Math.random() * CANVAS_HEIGHT;
+                break;
+        }
+        const tx = CANVAS_WIDTH / 2 + (Math.random() - 0.5) * 300;
+        const ty = CANVAS_HEIGHT / 2 + (Math.random() - 0.5) * 300;
+        const dist = Math.hypot(tx - ox, ty - oy) || 1;
+        const speed = ORB_SPEED_MIN + Math.random() * (ORB_SPEED_MAX - ORB_SPEED_MIN);
+        const gfx = new Graphics();
+        gfx.fillColor = danger ? new Color(255, 80, 80) : new Color(80, 220, 120);
+        gfx.drawCircle(0, 0, ORB_RADIUS);
+        gfx.setPosition(ox, oy);
+        this._world.addChild(gfx);
+        this._orbs.push({ gfx, vx: ((tx - ox) / dist) * speed, vy: ((ty - oy) / dist) * speed, danger });
+    }
+    update(delta) {
+        this._elapsed += delta.seconds;
+        this._spawnTimer += delta.seconds;
+        if (this._spawnTimer >= SPAWN_INTERVAL) {
+            this._spawnTimer -= SPAWN_INTERVAL;
+            this._spawnOrb();
+        }
+        const mag = Math.hypot(this._dx, this._dy) || 1;
+        if (this._dx !== 0 || this._dy !== 0) {
+            this._px += (this._dx / mag) * PLAYER_SPEED * delta.seconds;
+            this._py += (this._dy / mag) * PLAYER_SPEED * delta.seconds;
+        }
+        this._px = Math.max(PLAYER_RADIUS, Math.min(CANVAS_WIDTH - PLAYER_RADIUS, this._px));
+        this._py = Math.max(PLAYER_RADIUS, Math.min(CANVAS_HEIGHT - PLAYER_RADIUS, this._py));
+        this._player.setPosition(this._px, this._py);
+        let gameEnded = false;
+        const survived = [];
+        for (const orb of this._orbs) {
+            orb.gfx.move(orb.vx * delta.seconds, orb.vy * delta.seconds);
+            if (gameEnded) {
+                this._world.removeChild(orb.gfx);
+                orb.gfx.destroy();
+                continue;
+            }
+            const ox = orb.gfx.x;
+            const oy = orb.gfx.y;
+            if (ox < -80 || ox > CANVAS_WIDTH + 80 || oy < -80 || oy > CANVAS_HEIGHT + 80) {
+                this._world.removeChild(orb.gfx);
+                orb.gfx.destroy();
+                continue;
+            }
+            const dist = Math.hypot(ox - this._px, oy - this._py);
+            if (dist < PLAYER_RADIUS + ORB_RADIUS) {
+                this._world.removeChild(orb.gfx);
+                orb.gfx.destroy();
+                if (orb.danger) {
+                    for (const o of survived) {
+                        this._world.removeChild(o.gfx);
+                        o.gfx.destroy();
+                    }
+                    gameEnded = true;
+                    continue;
+                }
+                this._score++;
+                this._scoreText.text = `Score: ${this._score}`;
+                continue;
+            }
+            survived.push(orb);
+        }
+        this._orbs = gameEnded ? [] : survived;
+        if (gameEnded) {
+            gameOver.setResult(this._score, this._elapsed);
+            void this.app.scene.setScene(gameOver);
+            return;
+        }
+        this._timeText.text = `${this._elapsed.toFixed(1)} s`;
+    }
+    draw(context) {
+        context.backend.clear();
+        context.render(this._world);
+        context.render(this._scoreText);
+        context.render(this._timeText);
+    }
+    destroy() {
+        for (const orb of this._orbs) {
+            orb.gfx.destroy();
+        }
+        this._world?.destroy();
+        super.destroy();
+    }
+}
+class GameOverScene extends Scene {
+    _title;
+    _stats;
+    _hint;
+    _finalScore = 0;
+    _finalTime = 0;
+    setResult(score, time) {
+        this._finalScore = score;
+        this._finalTime = time;
+    }
+    init() {
+        this._title = new Text('GAME OVER', {
+            align: 'center',
+            fillColor: new Color(255, 80, 80),
+            fontSize: 52,
+            fontWeight: 'bold',
+        });
+        this._title.setAnchor(0.5);
+        this._title.setPosition(CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2 - 70);
+        this._stats = new Text(`Score: ${this._finalScore}   Time: ${this._finalTime.toFixed(1)} s`, {
+            align: 'center',
+            fillColor: Color.white,
+            fontSize: 26,
+        });
+        this._stats.setAnchor(0.5);
+        this._stats.setPosition(CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2);
+        this._hint = new Text('Press Space or R to play again', {
+            align: 'center',
+            fillColor: new Color(160, 160, 160),
+            fontSize: 18,
+        });
+        this._hint.setAnchor(0.5);
+        this._hint.setPosition(CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2 + 70);
+        const restart = () => {
+            void this.app.scene.setScene(play);
+        };
+        this.inputs.onTrigger(Keyboard.Space, restart);
+        this.inputs.onTrigger(Keyboard.R, restart);
+    }
+    draw(context) {
+        context.backend.clear();
+        context.render(this._title);
+        context.render(this._stats);
+        context.render(this._hint);
+    }
+}
+const play = new PlayScene();
+const gameOver = new GameOverScene();
+app.start(play);

--- a/examples/showcase/orb-dodge.ts
+++ b/examples/showcase/orb-dodge.ts
@@ -1,0 +1,254 @@
+import { Application, Color, Container, Graphics, Keyboard, Scene, Text } from '@codexo/exojs';
+
+const CANVAS_WIDTH = 800;
+const CANVAS_HEIGHT = 600;
+const PLAYER_RADIUS = 18;
+const PLAYER_SPEED = 260;
+const ORB_RADIUS = 14;
+const SPAWN_INTERVAL = 1.2;
+const ORB_SPEED_MIN = 80;
+const ORB_SPEED_MAX = 200;
+
+const app = new Application({
+    canvas: {
+        width: CANVAS_WIDTH,
+        height: CANVAS_HEIGHT,
+    },
+    clearColor: new Color(10, 14, 26),
+});
+
+document.body.append(app.canvas);
+
+interface OrbData {
+    gfx: Graphics;
+    vx: number;
+    vy: number;
+    danger: boolean;
+}
+
+class PlayScene extends Scene {
+    private _world!: Container;
+    private _player!: Graphics;
+    private _orbs: OrbData[] = [];
+    private _px = CANVAS_WIDTH / 2;
+    private _py = CANVAS_HEIGHT / 2;
+    private _dx = 0;
+    private _dy = 0;
+    private _score = 0;
+    private _elapsed = 0;
+    private _spawnTimer = 0;
+    private _scoreText!: Text;
+    private _timeText!: Text;
+
+    override init(): void {
+        this._px = CANVAS_WIDTH / 2;
+        this._py = CANVAS_HEIGHT / 2;
+        this._score = 0;
+        this._elapsed = 0;
+        this._spawnTimer = 0;
+        this._dx = 0;
+        this._dy = 0;
+        this._orbs = [];
+
+        this._world = new Container();
+
+        this._player = new Graphics();
+        this._player.fillColor = new Color(80, 160, 255);
+        this._player.drawCircle(0, 0, PLAYER_RADIUS);
+        this._player.setPosition(this._px, this._py);
+        this._world.addChild(this._player);
+
+        this._scoreText = new Text('Score: 0', { fillColor: Color.white, fontSize: 20 });
+        this._scoreText.setPosition(16, 14);
+
+        this._timeText = new Text('0.0 s', { fillColor: Color.white, fontSize: 20 });
+        this._timeText.setPosition(CANVAS_WIDTH - 90, 14);
+
+        this.inputs.onActive(Keyboard.W, () => { this._dy = -1; });
+        this.inputs.onStop(Keyboard.W, () => { if (this._dy < 0) this._dy = 0; });
+        this.inputs.onActive(Keyboard.Up, () => { this._dy = -1; });
+        this.inputs.onStop(Keyboard.Up, () => { if (this._dy < 0) this._dy = 0; });
+
+        this.inputs.onActive(Keyboard.S, () => { this._dy = 1; });
+        this.inputs.onStop(Keyboard.S, () => { if (this._dy > 0) this._dy = 0; });
+        this.inputs.onActive(Keyboard.Down, () => { this._dy = 1; });
+        this.inputs.onStop(Keyboard.Down, () => { if (this._dy > 0) this._dy = 0; });
+
+        this.inputs.onActive(Keyboard.A, () => { this._dx = -1; });
+        this.inputs.onStop(Keyboard.A, () => { if (this._dx < 0) this._dx = 0; });
+        this.inputs.onActive(Keyboard.Left, () => { this._dx = -1; });
+        this.inputs.onStop(Keyboard.Left, () => { if (this._dx < 0) this._dx = 0; });
+
+        this.inputs.onActive(Keyboard.D, () => { this._dx = 1; });
+        this.inputs.onStop(Keyboard.D, () => { if (this._dx > 0) this._dx = 0; });
+        this.inputs.onActive(Keyboard.Right, () => { this._dx = 1; });
+        this.inputs.onStop(Keyboard.Right, () => { if (this._dx > 0) this._dx = 0; });
+    }
+
+    private _spawnOrb(): void {
+        const danger = Math.random() < 0.4;
+        const side = Math.floor(Math.random() * 4);
+        let ox: number;
+        let oy: number;
+        switch (side) {
+            case 0: ox = Math.random() * CANVAS_WIDTH; oy = -ORB_RADIUS; break;
+            case 1: ox = CANVAS_WIDTH + ORB_RADIUS; oy = Math.random() * CANVAS_HEIGHT; break;
+            case 2: ox = Math.random() * CANVAS_WIDTH; oy = CANVAS_HEIGHT + ORB_RADIUS; break;
+            default: ox = -ORB_RADIUS; oy = Math.random() * CANVAS_HEIGHT; break;
+        }
+        const tx = CANVAS_WIDTH / 2 + (Math.random() - 0.5) * 300;
+        const ty = CANVAS_HEIGHT / 2 + (Math.random() - 0.5) * 300;
+        const dist = Math.hypot(tx - ox, ty - oy) || 1;
+        const speed = ORB_SPEED_MIN + Math.random() * (ORB_SPEED_MAX - ORB_SPEED_MIN);
+
+        const gfx = new Graphics();
+        gfx.fillColor = danger ? new Color(255, 80, 80) : new Color(80, 220, 120);
+        gfx.drawCircle(0, 0, ORB_RADIUS);
+        gfx.setPosition(ox, oy);
+        this._world.addChild(gfx);
+        this._orbs.push({ gfx, vx: ((tx - ox) / dist) * speed, vy: ((ty - oy) / dist) * speed, danger });
+    }
+
+    override update(delta): void {
+        this._elapsed += delta.seconds;
+        this._spawnTimer += delta.seconds;
+
+        if (this._spawnTimer >= SPAWN_INTERVAL) {
+            this._spawnTimer -= SPAWN_INTERVAL;
+            this._spawnOrb();
+        }
+
+        const mag = Math.hypot(this._dx, this._dy) || 1;
+        if (this._dx !== 0 || this._dy !== 0) {
+            this._px += (this._dx / mag) * PLAYER_SPEED * delta.seconds;
+            this._py += (this._dy / mag) * PLAYER_SPEED * delta.seconds;
+        }
+        this._px = Math.max(PLAYER_RADIUS, Math.min(CANVAS_WIDTH - PLAYER_RADIUS, this._px));
+        this._py = Math.max(PLAYER_RADIUS, Math.min(CANVAS_HEIGHT - PLAYER_RADIUS, this._py));
+        this._player.setPosition(this._px, this._py);
+
+        let gameEnded = false;
+        const survived: OrbData[] = [];
+
+        for (const orb of this._orbs) {
+            orb.gfx.move(orb.vx * delta.seconds, orb.vy * delta.seconds);
+
+            if (gameEnded) {
+                this._world.removeChild(orb.gfx);
+                orb.gfx.destroy();
+                continue;
+            }
+
+            const ox = orb.gfx.x;
+            const oy = orb.gfx.y;
+
+            if (ox < -80 || ox > CANVAS_WIDTH + 80 || oy < -80 || oy > CANVAS_HEIGHT + 80) {
+                this._world.removeChild(orb.gfx);
+                orb.gfx.destroy();
+                continue;
+            }
+
+            const dist = Math.hypot(ox - this._px, oy - this._py);
+            if (dist < PLAYER_RADIUS + ORB_RADIUS) {
+                this._world.removeChild(orb.gfx);
+                orb.gfx.destroy();
+                if (orb.danger) {
+                    for (const o of survived) {
+                        this._world.removeChild(o.gfx);
+                        o.gfx.destroy();
+                    }
+                    gameEnded = true;
+                    continue;
+                }
+                this._score++;
+                this._scoreText.text = `Score: ${this._score}`;
+                continue;
+            }
+
+            survived.push(orb);
+        }
+
+        this._orbs = gameEnded ? [] : survived;
+
+        if (gameEnded) {
+            gameOver.setResult(this._score, this._elapsed);
+            void this.app.scene.setScene(gameOver);
+            return;
+        }
+
+        this._timeText.text = `${this._elapsed.toFixed(1)} s`;
+    }
+
+    override draw(context): void {
+        context.backend.clear();
+        context.render(this._world);
+        context.render(this._scoreText);
+        context.render(this._timeText);
+    }
+
+    override destroy(): void {
+        for (const orb of this._orbs) {
+            orb.gfx.destroy();
+        }
+        this._world?.destroy();
+        super.destroy();
+    }
+}
+
+class GameOverScene extends Scene {
+    private _title!: Text;
+    private _stats!: Text;
+    private _hint!: Text;
+    private _finalScore = 0;
+    private _finalTime = 0;
+
+    setResult(score: number, time: number): void {
+        this._finalScore = score;
+        this._finalTime = time;
+    }
+
+    override init(): void {
+        this._title = new Text('GAME OVER', {
+            align: 'center',
+            fillColor: new Color(255, 80, 80),
+            fontSize: 52,
+            fontWeight: 'bold',
+        });
+        this._title.setAnchor(0.5);
+        this._title.setPosition(CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2 - 70);
+
+        this._stats = new Text(`Score: ${this._finalScore}   Time: ${this._finalTime.toFixed(1)} s`, {
+            align: 'center',
+            fillColor: Color.white,
+            fontSize: 26,
+        });
+        this._stats.setAnchor(0.5);
+        this._stats.setPosition(CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2);
+
+        this._hint = new Text('Press Space or R to play again', {
+            align: 'center',
+            fillColor: new Color(160, 160, 160),
+            fontSize: 18,
+        });
+        this._hint.setAnchor(0.5);
+        this._hint.setPosition(CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2 + 70);
+
+        const restart = (): void => {
+            void this.app.scene.setScene(play);
+        };
+        this.inputs.onTrigger(Keyboard.Space, restart);
+        this.inputs.onTrigger(Keyboard.R, restart);
+    }
+
+    override draw(context): void {
+        context.backend.clear();
+        context.render(this._title);
+        context.render(this._stats);
+        context.render(this._hint);
+    }
+}
+
+const play = new PlayScene();
+const gameOver = new GameOverScene();
+
+app.start(play);

--- a/site/src/content/guide/recipes/build-orb-dodge.mdx
+++ b/site/src/content/guide/recipes/build-orb-dodge.mdx
@@ -1,0 +1,306 @@
+---
+title: '8.9 Build Orb Dodge'
+description: 'Build a complete small game from scratch: player movement, spawning orbs, collision, scoring, a HUD, and a game-over screen — all without external assets.'
+part: 8
+chapter: 9
+examples:
+  - showcase/orb-dodge
+---
+
+import ExamplePreview from '../../../components/ExamplePreview.astro';
+
+# 8.9 Build Orb Dodge
+
+This chapter builds a small, complete game end-to-end. You will see how several ExoJS concepts fit together in one project: a scene that runs every frame, keyboard input, `Graphics` primitives for all visuals, a HUD with live score and time, and a separate game-over scene that transitions back into the game on restart.
+
+No external assets are needed. Every shape is drawn in code.
+
+The finished result is playable in the playground at the bottom of this page.
+
+## What you need
+
+Start from a `create-exo-app` project using the `game-starter` or `minimal` template:
+
+```bash
+npx create-exo-app my-orb-dodge
+```
+
+If you already have a project, the only package you need is `@codexo/exojs`.
+
+## Application setup
+
+Every ExoJS project starts with an `Application`. For a fixed-size game canvas:
+
+```ts
+import { Application, Color } from '@codexo/exojs';
+
+const app = new Application({
+    canvas: {
+        width: 800,
+        height: 600,
+    },
+    clearColor: new Color(10, 14, 26),
+});
+
+document.body.append(app.canvas);
+```
+
+`clearColor` sets the background that `context.backend.clear()` paints at the start of each frame. A dark near-black makes the colored orbs stand out clearly.
+
+## Scene structure
+
+The game uses two scenes: `PlayScene` drives the active game loop, `GameOverScene` shows the result and offers a restart.
+
+Define a constant set for canvas dimensions and game parameters at the top so both scenes can reference them:
+
+```ts no-check
+const CANVAS_WIDTH = 800;
+const CANVAS_HEIGHT = 600;
+const PLAYER_RADIUS = 18;
+const PLAYER_SPEED = 260;
+const ORB_RADIUS = 14;
+const SPAWN_INTERVAL = 1.2;
+```
+
+A scene has four lifecycle hooks — override the ones you need:
+
+- `init()` — set up state; called once per activation
+- `update(delta)` — per-frame logic; `delta.seconds` carries elapsed time
+- `draw(context)` — per-frame rendering; start with `context.backend.clear()`
+
+## Player and keyboard movement
+
+The player is a filled circle drawn with `Graphics`. Keyboard movement uses `this.inputs.onActive` (fires every frame while the key is held) and `this.inputs.onStop` (fires when the key is released) to track a directional velocity:
+
+```js
+init() {
+    this._world = new Container();
+
+    this._player = new Graphics();
+    this._player.fillColor = new Color(80, 160, 255);
+    this._player.drawCircle(0, 0, PLAYER_RADIUS);
+    this._player.setPosition(this._px, this._py);
+    this._world.addChild(this._player);
+
+    this.inputs.onActive(Keyboard.W, () => { this._dy = -1; });
+    this.inputs.onStop(Keyboard.W,  () => { if (this._dy < 0) this._dy = 0; });
+    this.inputs.onActive(Keyboard.Up, () => { this._dy = -1; });
+    this.inputs.onStop(Keyboard.Up,  () => { if (this._dy < 0) this._dy = 0; });
+    // ... A/D and Left/Right similarly
+}
+```
+
+In `update`, normalize the direction vector so diagonal movement is not faster than cardinal movement, then clamp the position inside the canvas:
+
+```js
+update(delta) {
+    const mag = Math.hypot(this._dx, this._dy) || 1;
+    if (this._dx !== 0 || this._dy !== 0) {
+        this._px += (this._dx / mag) * PLAYER_SPEED * delta.seconds;
+        this._py += (this._dy / mag) * PLAYER_SPEED * delta.seconds;
+    }
+    this._px = Math.max(PLAYER_RADIUS, Math.min(CANVAS_WIDTH - PLAYER_RADIUS, this._px));
+    this._py = Math.max(PLAYER_RADIUS, Math.min(CANVAS_HEIGHT - PLAYER_RADIUS, this._py));
+    this._player.setPosition(this._px, this._py);
+}
+```
+
+`this.inputs` is scene-bound: all bindings registered through it are automatically released when the scene is destroyed. No manual cleanup is needed.
+
+## Spawning orbs
+
+Orbs are created dynamically during `update` on a timer. Each orb spawns just outside one of the four edges and moves toward the center area with a small random offset:
+
+```js
+_spawnOrb() {
+    const danger = Math.random() < 0.4;
+    // pick a random edge (0=top, 1=right, 2=bottom, 3=left)
+    const side = Math.floor(Math.random() * 4);
+    let ox, oy;
+    switch (side) {
+        case 0: ox = Math.random() * CANVAS_WIDTH; oy = -ORB_RADIUS;              break;
+        case 1: ox = CANVAS_WIDTH + ORB_RADIUS;    oy = Math.random() * CANVAS_HEIGHT; break;
+        case 2: ox = Math.random() * CANVAS_WIDTH; oy = CANVAS_HEIGHT + ORB_RADIUS; break;
+        default: ox = -ORB_RADIUS;                 oy = Math.random() * CANVAS_HEIGHT; break;
+    }
+    // aim at a random point near center
+    const tx = CANVAS_WIDTH / 2  + (Math.random() - 0.5) * 300;
+    const ty = CANVAS_HEIGHT / 2 + (Math.random() - 0.5) * 300;
+    const dist = Math.hypot(tx - ox, ty - oy) || 1;
+    const speed = 80 + Math.random() * 120;
+
+    const gfx = new Graphics();
+    gfx.fillColor = danger ? new Color(255, 80, 80) : new Color(80, 220, 120);
+    gfx.drawCircle(0, 0, ORB_RADIUS);
+    gfx.setPosition(ox, oy);
+    this._world.addChild(gfx);
+    this._orbs.push({ gfx, vx: ((tx - ox) / dist) * speed, vy: ((ty - oy) / dist) * speed, danger });
+}
+```
+
+Orbs are stored in an array of `{ gfx, vx, vy, danger }` objects. Danger orbs are red; collectible orbs are green.
+
+## Collision and scoring
+
+Each frame, move every orb and check its distance to the player. Distance collision is reliable for circles because it captures overlap without axis-aligned assumptions:
+
+```js
+const dist = Math.hypot(ox - this._px, oy - this._py);
+if (dist < PLAYER_RADIUS + ORB_RADIUS) {
+    this._world.removeChild(orb.gfx);
+    orb.gfx.destroy();
+    if (orb.danger) {
+        // clean up remaining orbs, switch to game over
+        for (const o of survived) {
+            this._world.removeChild(o.gfx);
+            o.gfx.destroy();
+        }
+        gameEnded = true;
+        continue;
+    }
+    this._score++;
+    this._scoreText.text = `Score: ${this._score}`;
+    continue;
+}
+```
+
+Orbs that leave the canvas are also removed. After the loop, if `gameEnded` is true, call `setScene` to switch to the game-over screen. Use a flag instead of breaking early so all remaining orbs are cleaned up in the same loop pass.
+
+## HUD text
+
+Score and elapsed time sit on top of the world as plain `Text` nodes — rendered after `context.render(this._world)` so they always appear in front:
+
+```js
+draw(context) {
+    context.backend.clear();
+    context.render(this._world);
+    context.render(this._scoreText);
+    context.render(this._timeText);
+}
+```
+
+`Text` content is updated by assigning to `.text`:
+
+```js
+this._scoreText.text = `Score: ${this._score}`;
+this._timeText.text  = `${this._elapsed.toFixed(1)} s`;
+```
+
+## Game-over scene and restart
+
+`GameOverScene` receives the final score and time via a `setResult` method called just before `setScene`. This decouples data transfer from scene initialization — `init` always reads from `_finalScore` / `_finalTime`, whatever they were set to:
+
+```ts
+import { Application, Color, Keyboard, Scene, Text } from '@codexo/exojs';
+
+const app = new Application({
+    canvas: { width: 800, height: 600 },
+    clearColor: new Color(10, 14, 26),
+});
+
+document.body.append(app.canvas);
+
+class GameOverScene extends Scene {
+    private _title!: Text;
+    private _stats!: Text;
+    private _hint!: Text;
+    private _finalScore = 0;
+    private _finalTime = 0;
+
+    setResult(score: number, time: number): void {
+        this._finalScore = score;
+        this._finalTime = time;
+    }
+
+    override init(): void {
+        this._title = new Text('GAME OVER', {
+            align: 'center',
+            fillColor: new Color(255, 80, 80),
+            fontSize: 52,
+            fontWeight: 'bold',
+        });
+        this._title.setAnchor(0.5);
+        this._title.setPosition(400, 230);
+
+        this._stats = new Text(
+            `Score: ${this._finalScore}   Time: ${this._finalTime.toFixed(1)} s`,
+            { align: 'center', fillColor: Color.white, fontSize: 26 },
+        );
+        this._stats.setAnchor(0.5);
+        this._stats.setPosition(400, 300);
+
+        this._hint = new Text('Press Space or R to play again', {
+            align: 'center',
+            fillColor: new Color(160, 160, 160),
+            fontSize: 18,
+        });
+        this._hint.setAnchor(0.5);
+        this._hint.setPosition(400, 370);
+
+        const restart = (): void => {
+            void this.app.scene.setScene(play);
+        };
+        this.inputs.onTrigger(Keyboard.Space, restart);
+        this.inputs.onTrigger(Keyboard.R, restart);
+    }
+
+    override draw(context): void {
+        context.backend.clear();
+        context.render(this._title);
+        context.render(this._stats);
+        context.render(this._hint);
+    }
+}
+
+// Forward declarations so both scenes can reference each other.
+declare const play: Scene;
+
+const gameOver = new GameOverScene();
+```
+
+When the player restarts, `setScene(play)` switches back to `PlayScene`. `SceneManager` calls `init()` on `play` again — the scene reinitializes from scratch, so no manual reset is needed. Input bindings registered in `init` via `this.inputs` are disposed and recreated automatically with each scene activation.
+
+## How scenes reference each other
+
+Both scenes reference the same two instances at module level:
+
+```js
+const play     = new PlayScene();
+const gameOver = new GameOverScene();
+
+app.start(play);
+```
+
+`PlayScene` calls `gameOver.setResult(...)` then `void this.app.scene.setScene(gameOver)`. `GameOverScene` calls `void this.app.scene.setScene(play)`. The forward reference is safe because both scenes exist before `app.start` is called.
+
+## Cleanup in destroy
+
+When `SceneManager` switches scenes it calls `destroy()` on the outgoing scene. For `PlayScene`, override it to release orb graphics that were created dynamically:
+
+```js
+override destroy() {
+    for (const orb of this._orbs) {
+        orb.gfx.destroy();
+    }
+    this._world?.destroy();
+    super.destroy();
+}
+```
+
+Static nodes created in `init` are recreated on every activation, so they are always fresh when `init` is called again.
+
+## Complete example
+
+The full, playable game is in the playground. Open it to read the complete source, run it, or fork it as a starting point:
+
+<ExamplePreview chapter="showcase" slug="orb-dodge" />
+
+## Where to go next
+
+From here you can extend Orb Dodge in several directions:
+
+- **Keyboard guide** — [4.1 Keyboard](/ExoJS/en/guide/input/keyboard/) — rebindable actions, action mapping
+- **HUD overlay** — [8.1 HUD overlay](/ExoJS/en/guide/recipes/hud-overlay/) — push a dedicated overlay scene on top instead of rendering HUD inside the game scene
+- **Game feel** — [8.6 Game feel](/ExoJS/en/guide/recipes/game-feel/) — add a screen shake or color flash when a danger orb is collected
+- **Deployment** — [10.2 Deployment](/ExoJS/en/guide/reference/deployment/) — build and host the finished game
+- **Troubleshooting** — [10.1 Troubleshooting](/ExoJS/en/guide/reference/troubleshooting/) — blank canvas, input not firing, and other common issues

--- a/site/src/lib/guide-structure.ts
+++ b/site/src/lib/guide-structure.ts
@@ -717,6 +717,20 @@ const PARTS: ReadonlyArray<GuidePartMeta> = [
                 examples: [
                     "showcase/boss-intro-cinematic"
                 ]
+            },
+            {
+                part: 8,
+                chapter: 9,
+                partSlug: "recipes",
+                partTitle: "08 Recipes",
+                partDescription: "Use practical scene patterns you can adapt directly in production.",
+                slug: "build-orb-dodge",
+                title: "8.9 Build Orb Dodge",
+                description: "Build a complete small game: player movement, orb spawning, collision, scoring, HUD, and a game-over scene.",
+                path: "recipes/build-orb-dodge",
+                examples: [
+                    "showcase/orb-dodge"
+                ]
             }
         ]
     },


### PR DESCRIPTION
## Summary

- ExoJS has starter templates but no complete sample project with a walkthrough — this PR adds both
- Adds **Orb Dodge** (`examples/showcase/orb-dodge.ts`): a playable dodge-and-collect game built entirely from `Graphics` primitives, no external assets
- Adds **Guide 8.9 Build Orb Dodge** (`site/src/content/guide/recipes/build-orb-dodge.mdx`): step-by-step walkthrough covering Application setup, player movement, orb spawning, collision/scoring, HUD text, scene switching, and game-over/restart
- Updates playground catalog (`examples/examples.json`) with `featured: true`, `level: intermediate`, tags `[game, input, collision, hud]`
- Registers chapter 8.9 in `guide-structure.ts`

## Scope

Docs/Examples/DX only — no engine features, no runtime API changes, no new packages.

## Concepts demonstrated

`Application` · `Scene` · `update(delta)` · `draw(context)` · `context.backend.clear()` · `context.render()` · `Container` · `Graphics` · `Text` · `Keyboard` input · scene switching (`setScene`) · distance collision · HUD rendering · game-over/restart flow

## Validation

| Check | Result |
|---|---|
| `pnpm typecheck` | ✅ pass |
| `pnpm typecheck:examples` | ✅ pass |
| `pnpm typecheck:guides` | ✅ pass (2 blocks extracted from new guide, both valid) |
| `pnpm test` | ✅ 1810 tests pass |
| `pnpm build` | ✅ pass |
| `pnpm verify:exports` | ✅ pass |
| `pnpm verify:package` | ✅ pass |
| `pnpm verify:create-exo-app` | ✅ 45 checks pass |
| `pnpm sync:example-capabilities` | ✅ 0 changed (keyboard capability already correct) |
| `pnpm test:examples:smoke` | ✅ 118 passed / 0 failed — `showcase/orb-dodge.js` ✅ |
| `pnpm site:build` | ✅ 568 pages built including `/en/guide/recipes/build-orb-dodge/` |