### PR TITLE
fix(dx): address 0.12 onboarding review notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ class HelloScene extends Scene {
   }
 
   public override draw(context: RenderingContext): void {
+    context.backend.clear();
     context.render(this.root);
   }
 }

--- a/site/src/pages/en/index.astro
+++ b/site/src/pages/en/index.astro
@@ -37,9 +37,9 @@ class PlayerScene extends Scene {
     );
   }
 
-  draw(backend) {
-    backend.clear();
-    this.hero.render(backend);
+  draw(context) {
+    context.backend.clear();
+    context.render(this.hero);
   }
 }
 
@@ -56,12 +56,12 @@ await app.start(new PlayerScene());`;
 const quickstartSnippet = `import { Application, Scene } from '@codexo/exojs';
 
 class HelloScene extends Scene {
-  draw(backend) {
-    backend.clear();
+  draw(context) {
+    context.backend.clear();
   }
 }
 
-const app = new Application();
+const app = new Application({ canvas: { width: 800, height: 600 } });
 app.start(new HelloScene());`;
 
 const examples = [


### PR DESCRIPTION
## Problem

The 0.12 post-merge onboarding review found stale API snippets in user-facing onboarding surfaces.

`site/src/pages/en/index.astro` still showed old v0.8.x-style snippets such as `draw(backend)`, `backend.clear()`, and `node.render(backend)`.

The README quickstart snippet also missed `context.backend.clear()`.

## Solution

Update the onboarding snippets to the current rendering API:

- `draw(context)`
- `context.backend.clear()`
- `context.render(node)`

## Scope

DX/docs snippet fix only. No engine, template, playground, or runtime changes.

## Validation

- `pnpm typecheck` — passed (0 errors)
- `pnpm typecheck:guides` — passed (32 extracted, 22 no-check, 217 partial)
- `pnpm test` — passed (139 test files, 1810 tests)
- `pnpm site:build` — passed (568 pages built, no errors)