### PR TITLE
feat(docs): add source-backed guide snippets

### DIFF
--- a/examples/getting-started/hello-world.js
+++ b/examples/getting-started/hello-world.js
@@ -11,6 +11,7 @@ const app = new Application({
     },
 });
 document.body.append(app.canvas);
+// #region guide:first-scene
 class HelloWorldScene extends Scene {
     _sprite;
     async load(loader) {
@@ -26,4 +27,5 @@ class HelloWorldScene extends Scene {
         context.render(this._sprite);
     }
 }
+// #endregion guide:first-scene
 app.start(new HelloWorldScene());

--- a/examples/getting-started/hello-world.ts
+++ b/examples/getting-started/hello-world.ts
@@ -13,6 +13,7 @@ const app = new Application({
 
 document.body.append(app.canvas);
 
+// #region guide:first-scene
 class HelloWorldScene extends Scene {
     private _sprite!: Sprite;
 
@@ -32,5 +33,6 @@ class HelloWorldScene extends Scene {
         context.render(this._sprite);
     }
 }
+// #endregion guide:first-scene
 
 app.start(new HelloWorldScene());

--- a/examples/showcase/orb-dodge.js
+++ b/examples/showcase/orb-dodge.js
@@ -8,6 +8,7 @@ const ORB_RADIUS = 14;
 const SPAWN_INTERVAL = 1.2;
 const ORB_SPEED_MIN = 80;
 const ORB_SPEED_MAX = 200;
+// #region guide:application-setup
 const app = new Application({
     canvas: {
         width: CANVAS_WIDTH,
@@ -178,6 +179,7 @@ class PlayScene extends Scene {
         super.destroy();
     }
 }
+// #region guide:game-over-scene
 class GameOverScene extends Scene {
     _title;
     _stats;
@@ -224,6 +226,7 @@ class GameOverScene extends Scene {
         context.render(this._hint);
     }
 }
+// #endregion guide:game-over-scene
 const play = new PlayScene();
 const gameOver = new GameOverScene();
 app.start(play);

--- a/examples/showcase/orb-dodge.ts
+++ b/examples/showcase/orb-dodge.ts
@@ -9,6 +9,7 @@ const SPAWN_INTERVAL = 1.2;
 const ORB_SPEED_MIN = 80;
 const ORB_SPEED_MAX = 200;
 
+// #region guide:application-setup
 const app = new Application({
     canvas: {
         width: CANVAS_WIDTH,
@@ -18,6 +19,7 @@ const app = new Application({
 });
 
 document.body.append(app.canvas);
+// #endregion guide:application-setup
 
 interface OrbData {
     gfx: Graphics;
@@ -195,6 +197,7 @@ class PlayScene extends Scene {
     }
 }
 
+// #region guide:game-over-scene
 class GameOverScene extends Scene {
     private _title!: Text;
     private _stats!: Text;
@@ -247,6 +250,7 @@ class GameOverScene extends Scene {
         context.render(this._hint);
     }
 }
+// #endregion guide:game-over-scene
 
 const play = new PlayScene();
 const gameOver = new GameOverScene();

--- a/site/src/components/SourceSnippet.astro
+++ b/site/src/components/SourceSnippet.astro
@@ -1,0 +1,83 @@
+---
+/**
+ * SourceSnippet — renders a named region from a real source file.
+ *
+ * Regions are delimited in the source file with:
+ *   // #region guide:<name>
+ *   ...
+ *   // #endregion guide:<name>
+ *
+ * Example MDX usage:
+ *   import SourceSnippet from '../../../components/SourceSnippet.astro';
+ *
+ *   <SourceSnippet
+ *     source="examples/showcase/orb-dodge.ts"
+ *     region="application-setup"
+ *     language="ts"
+ *     title="Application Setup"
+ *   />
+ *
+ * `source` is relative to the repo root.
+ * Build fails with a clear error on missing file, missing region, empty
+ * region, or duplicate region names in the same file.
+ */
+
+import { Code } from 'astro:components';
+import { extractSnippetRegion } from '../lib/source-snippets';
+
+interface Props {
+    /** Path to the source file, relative to the repo root. */
+    source: string;
+    /** Name of the region to extract (without the "guide:" prefix). */
+    region: string;
+    /** Language for syntax highlighting. Defaults to "ts". */
+    language?: string;
+    /** Optional caption shown above the code block. */
+    title?: string;
+}
+
+const { source, region, language = 'ts', title } = Astro.props;
+
+let code: string;
+try {
+    code = extractSnippetRegion(source, region);
+} catch (err) {
+    // Re-throw with additional context so Astro reports the source MDX file too.
+    throw new Error(
+        `SourceSnippet build error in ${Astro.self.moduleId ?? 'unknown'}\n` +
+        String(err instanceof Error ? err.message : err),
+    );
+}
+---
+
+<figure class="source-snippet">
+    {title && <figcaption class="source-snippet__title">{title}</figcaption>}
+    <Code code={code} lang={language} themes={{ light: 'github-light', dark: 'github-dark' }} />
+</figure>
+
+<style>
+    .source-snippet {
+        margin: var(--s-5, 1.25rem) 0;
+    }
+
+    .source-snippet__title {
+        display: block;
+        font-family: var(--f-mono, monospace);
+        font-size: 12px;
+        color: var(--fg-muted, #6e7781);
+        padding: 6px 14px 0;
+        margin-bottom: -6px;
+        /* Visually connects the caption to the code block below it. */
+        border: 1px solid var(--line-soft, #d0d7de);
+        border-bottom: none;
+        border-radius: var(--r-4, 6px) var(--r-4, 6px) 0 0;
+        background: var(--bg-canvas, #fff);
+    }
+
+    /* When a title is present, remove the top border-radius of the code block
+       rendered by the <Code> component so it merges visually. */
+    .source-snippet:has(.source-snippet__title) :global(pre) {
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+    }
+</style>

--- a/site/src/content/guide/introduction/your-first-scene.mdx
+++ b/site/src/content/guide/introduction/your-first-scene.mdx
@@ -8,6 +8,7 @@ examples:
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
+import SourceSnippet from '../../../components/SourceSnippet.astro';
 
 # Your first scene
 
@@ -47,26 +48,12 @@ Scenes have four lifecycle hooks. You override the ones you need:
 
 Adding a single sprite means using `load` to declare a texture, `init` to construct the sprite, and `draw` to render it:
 
-```js
-import { Application, Scene, Sprite, Texture } from '@codexo/exojs';
-
-class HelloScene extends Scene {
-    async load(loader) {
-        await loader.load(Texture, { bunny: 'image/bunny.png' });
-    }
-
-    init(loader) {
-        this.bunny = new Sprite(loader.get(Texture, 'bunny'));
-        this.bunny.setAnchor(0.5);
-        this.bunny.setPosition(this.app.canvas.width / 2, this.app.canvas.height / 2);
-    }
-
-    draw(context) {
-        context.backend.clear();
-        context.render(this.bunny);
-    }
-}
-```
+<SourceSnippet
+  source="examples/getting-started/hello-world.ts"
+  region="first-scene"
+  language="ts"
+  title="examples/getting-started/hello-world.ts"
+/>
 
 A few things worth pointing out:
 

--- a/site/src/content/guide/recipes/build-orb-dodge.mdx
+++ b/site/src/content/guide/recipes/build-orb-dodge.mdx
@@ -8,6 +8,7 @@ examples:
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
+import SourceSnippet from '../../../components/SourceSnippet.astro';
 
 # 8.9 Build Orb Dodge
 
@@ -31,19 +32,12 @@ If you already have a project, the only package you need is `@codexo/exojs`.
 
 Every ExoJS project starts with an `Application`. For a fixed-size game canvas:
 
-```ts
-import { Application, Color } from '@codexo/exojs';
-
-const app = new Application({
-    canvas: {
-        width: 800,
-        height: 600,
-    },
-    clearColor: new Color(10, 14, 26),
-});
-
-document.body.append(app.canvas);
-```
+<SourceSnippet
+  source="examples/showcase/orb-dodge.ts"
+  region="application-setup"
+  language="ts"
+  title="examples/showcase/orb-dodge.ts"
+/>
 
 `clearColor` sets the background that `context.backend.clear()` paints at the start of each frame. A dark near-black makes the colored orbs stand out clearly.
 
@@ -190,73 +184,12 @@ this._timeText.text  = `${this._elapsed.toFixed(1)} s`;
 
 `GameOverScene` receives the final score and time via a `setResult` method called just before `setScene`. This decouples data transfer from scene initialization — `init` always reads from `_finalScore` / `_finalTime`, whatever they were set to:
 
-```ts
-import { Application, Color, Keyboard, Scene, Text } from '@codexo/exojs';
-
-const app = new Application({
-    canvas: { width: 800, height: 600 },
-    clearColor: new Color(10, 14, 26),
-});
-
-document.body.append(app.canvas);
-
-class GameOverScene extends Scene {
-    private _title!: Text;
-    private _stats!: Text;
-    private _hint!: Text;
-    private _finalScore = 0;
-    private _finalTime = 0;
-
-    setResult(score: number, time: number): void {
-        this._finalScore = score;
-        this._finalTime = time;
-    }
-
-    override init(): void {
-        this._title = new Text('GAME OVER', {
-            align: 'center',
-            fillColor: new Color(255, 80, 80),
-            fontSize: 52,
-            fontWeight: 'bold',
-        });
-        this._title.setAnchor(0.5);
-        this._title.setPosition(400, 230);
-
-        this._stats = new Text(
-            `Score: ${this._finalScore}   Time: ${this._finalTime.toFixed(1)} s`,
-            { align: 'center', fillColor: Color.white, fontSize: 26 },
-        );
-        this._stats.setAnchor(0.5);
-        this._stats.setPosition(400, 300);
-
-        this._hint = new Text('Press Space or R to play again', {
-            align: 'center',
-            fillColor: new Color(160, 160, 160),
-            fontSize: 18,
-        });
-        this._hint.setAnchor(0.5);
-        this._hint.setPosition(400, 370);
-
-        const restart = (): void => {
-            void this.app.scene.setScene(play);
-        };
-        this.inputs.onTrigger(Keyboard.Space, restart);
-        this.inputs.onTrigger(Keyboard.R, restart);
-    }
-
-    override draw(context): void {
-        context.backend.clear();
-        context.render(this._title);
-        context.render(this._stats);
-        context.render(this._hint);
-    }
-}
-
-// Forward declarations so both scenes can reference each other.
-declare const play: Scene;
-
-const gameOver = new GameOverScene();
-```
+<SourceSnippet
+  source="examples/showcase/orb-dodge.ts"
+  region="game-over-scene"
+  language="ts"
+  title="examples/showcase/orb-dodge.ts — GameOverScene"
+/>
 
 When the player restarts, `setScene(play)` switches back to `PlayScene`. `SceneManager` calls `init()` on `play` again — the scene reinitializes from scratch, so no manual reset is needed. Input bindings registered in `init` via `this.inputs` are disposed and recreated automatically with each scene activation.
 

--- a/site/src/lib/source-snippets.ts
+++ b/site/src/lib/source-snippets.ts
@@ -1,0 +1,159 @@
+/**
+ * Source-backed guide snippets.
+ *
+ * Marker syntax in TypeScript source files:
+ *   // #region guide:<name>
+ *   ...
+ *   // #endregion guide:<name>
+ *
+ * Usage in MDX guides:
+ *   import SourceSnippet from '../../../components/SourceSnippet.astro';
+ *   <SourceSnippet source="examples/foo.ts" region="bar" title="Foo Bar" />
+ *
+ * Paths in `source` are relative to the repo root.
+ *
+ * Build fails with a clear error if: source file missing, region missing,
+ * region empty, or duplicate region names in the same file.
+ *
+ * Typecheck coverage:
+ *   - examples/* → typecheck:examples
+ *   - packages/create-exo-app/templates/* → verify:create-exo-app
+ *   - site/src/snippets/* → typecheck:guides (included via tsconfig.guides.json)
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const REGION_OPEN_RE = /^[ \t]*\/\/ #region guide:(.+)$/;
+const REGION_CLOSE_RE = /^[ \t]*\/\/ #endregion guide:(.+)$/;
+
+/**
+ * Returns the monorepo root by walking up from `process.cwd()` until a
+ * `pnpm-workspace.yaml` sentinel is found.
+ *
+ * This works correctly in all execution contexts:
+ * - Vitest (run from repo root): cwd = repo root → found immediately.
+ * - Astro SSG prerender (run from `site/`): cwd = site/ → found 1 level up.
+ *
+ * Using `import.meta.dirname` is intentionally avoided: in an Astro SSG build
+ * the module is bundled into `site/dist/.prerender/chunks/`, so
+ * `import.meta.dirname` points to the bundle output directory, not the
+ * original source directory.
+ */
+function repoRoot(): string {
+    let dir = process.cwd();
+    for (let i = 0; i < 8; i++) {
+        if (existsSync(join(dir, 'pnpm-workspace.yaml'))) {
+            return dir;
+        }
+        const parent = dirname(dir);
+        if (parent === dir) break; // filesystem root
+        dir = parent;
+    }
+    // Last resort: return cwd and let readFileSync emit a clear error.
+    return process.cwd();
+}
+
+/**
+ * Extracts a named region from a TypeScript (or any text) source file.
+ *
+ * The region is delimited by:
+ *   // #region guide:<name>
+ *   // #endregion guide:<name>
+ *
+ * Marker lines are stripped from the output. Common leading whitespace
+ * (dedent) is removed so the snippet renders at column 0.
+ *
+ * @param filePath - Path relative to the repo root (e.g. `"examples/showcase/orb-dodge.ts"`).
+ * @param region   - Region name (the `<name>` part of the marker, e.g. `"application-setup"`).
+ * @returns The dedented snippet text, without the marker lines.
+ *
+ * @throws If the source file does not exist.
+ * @throws If the region name appears more than once (duplicate) in the file.
+ * @throws If the region is not found in the file.
+ * @throws If the region contains no non-empty lines after stripping markers.
+ */
+export function extractSnippetRegion(filePath: string, region: string): string {
+    const absolutePath = join(repoRoot(), filePath);
+
+    let source: string;
+    try {
+        source = readFileSync(absolutePath, 'utf8');
+    } catch {
+        throw new Error(
+            `[SourceSnippet] File not found: ${filePath}\n` +
+            `  (resolved to: ${absolutePath})`,
+        );
+    }
+
+    const lines = source.split('\n');
+
+    // Validate: no duplicate region names.
+    const openCount = lines.filter(l => {
+        const m = l.match(REGION_OPEN_RE);
+        return m !== null && m[1].trim() === region;
+    }).length;
+
+    if (openCount > 1) {
+        throw new Error(
+            `[SourceSnippet] Duplicate region "${region}" in ${filePath} ` +
+            `(found ${openCount} opening markers).`,
+        );
+    }
+
+    // Extract lines between open and close markers.
+    const snippetLines: string[] = [];
+    let inside = false;
+    let found = false;
+
+    for (const line of lines) {
+        const openMatch = line.match(REGION_OPEN_RE);
+        if (openMatch && openMatch[1].trim() === region) {
+            inside = true;
+            found = true;
+            continue;
+        }
+
+        const closeMatch = line.match(REGION_CLOSE_RE);
+        if (closeMatch && closeMatch[1].trim() === region) {
+            inside = false;
+            continue;
+        }
+
+        if (inside) {
+            snippetLines.push(line);
+        }
+    }
+
+    if (!found) {
+        throw new Error(
+            `[SourceSnippet] Region "${region}" not found in ${filePath}.\n` +
+            `  Add a "// #region guide:${region}" marker to the source file.`,
+        );
+    }
+
+    // Remove trailing empty lines added by formatting.
+    while (snippetLines.length > 0 && snippetLines[snippetLines.length - 1].trim() === '') {
+        snippetLines.pop();
+    }
+
+    const nonEmpty = snippetLines.filter(l => l.trim() !== '');
+    if (nonEmpty.length === 0) {
+        throw new Error(
+            `[SourceSnippet] Region "${region}" in ${filePath} is empty ` +
+            `(contains no non-empty lines).`,
+        );
+    }
+
+    // Dedent: find the minimum leading whitespace across all non-empty lines.
+    const minIndent = nonEmpty.reduce((min, line) => {
+        const indent = line.match(/^(\s*)/)?.[1].length ?? 0;
+        return Math.min(min, indent);
+    }, Infinity);
+
+    const dedented = snippetLines.map(line =>
+        line.length >= minIndent ? line.slice(minIndent) : line,
+    );
+
+    return dedented.join('\n');
+}

--- a/test/site/source-snippets.test.ts
+++ b/test/site/source-snippets.test.ts
@@ -1,13 +1,12 @@
 /**
  * Tests for site/src/lib/source-snippets.ts
  *
- * Uses real temporary files (via os.tmpdir) so the extractor exercises the
+ * Uses real temporary files so the extractor exercises the
  * actual readFileSync path without touching any checked-in source files.
  */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
 
 // We test the module via a dynamic import so we can override import.meta.dirname
 // to point at our temp directory. Instead, we directly import the function and
@@ -18,7 +17,6 @@ import { tmpdir } from 'node:os';
 // Actually: extractSnippetRegion joins repoRoot() + filePath. In vitest the
 // cwd is the repo root, so we can create real fixture files under a temp
 // sub-folder and pass relative paths.
-
 import { extractSnippetRegion } from '../../site/src/lib/source-snippets';
 
 // ---------------------------------------------------------------------------

--- a/test/site/source-snippets.test.ts
+++ b/test/site/source-snippets.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for site/src/lib/source-snippets.ts
+ *
+ * Uses real temporary files (via os.tmpdir) so the extractor exercises the
+ * actual readFileSync path without touching any checked-in source files.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// We test the module via a dynamic import so we can override import.meta.dirname
+// to point at our temp directory. Instead, we directly import the function and
+// pass absolute paths. The `filePath` parameter is joined with repoRoot(), but
+// repoRoot() may resolve to process.cwd() in vitest. We work around this by
+// writing fixture files relative to process.cwd() in a temp sub-dir.
+//
+// Actually: extractSnippetRegion joins repoRoot() + filePath. In vitest the
+// cwd is the repo root, so we can create real fixture files under a temp
+// sub-folder and pass relative paths.
+
+import { extractSnippetRegion } from '../../site/src/lib/source-snippets';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+let TMP_DIR: string;
+let TMP_REL: string; // relative to repo root (== process.cwd() in vitest)
+
+beforeAll(() => {
+    // Create a temp directory under .workspace so it is gitignored.
+    const base = join(process.cwd(), '.workspace', 'test-snippets');
+    mkdirSync(base, { recursive: true });
+    TMP_DIR = mkdtempSync(join(base, 'tmp-'));
+    // Relative path from repo root to our temp dir.
+    TMP_REL = TMP_DIR.slice(process.cwd().length).replace(/\\/g, '/').replace(/^\//, '');
+});
+
+afterAll(() => {
+    rmSync(TMP_DIR, { recursive: true, force: true });
+});
+
+function writeFixture(name: string, content: string): string {
+    const abs = join(TMP_DIR, name);
+    writeFileSync(abs, content, 'utf8');
+    return `${TMP_REL}/${name}`;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('extractSnippetRegion', () => {
+    describe('happy path', () => {
+        test('extracts lines between markers', () => {
+            const rel = writeFixture('basic.ts', [
+                'const a = 1;',
+                '// #region guide:my-region',
+                'const b = 2;',
+                'const c = 3;',
+                '// #endregion guide:my-region',
+                'const d = 4;',
+            ].join('\n'));
+
+            const result = extractSnippetRegion(rel, 'my-region');
+            expect(result).toBe('const b = 2;\nconst c = 3;');
+        });
+
+        test('marker lines are not included in the output', () => {
+            const rel = writeFixture('markers.ts', [
+                '// #region guide:zone',
+                'doSomething();',
+                '// #endregion guide:zone',
+            ].join('\n'));
+
+            const result = extractSnippetRegion(rel, 'zone');
+            expect(result).not.toContain('#region');
+            expect(result).not.toContain('#endregion');
+        });
+
+        test('dedent: common leading whitespace is removed', () => {
+            const rel = writeFixture('indented.ts', [
+                'class Foo {',
+                '    // #region guide:method',
+                '    override init(): void {',
+                '        this.x = 1;',
+                '    }',
+                '    // #endregion guide:method',
+                '}',
+            ].join('\n'));
+
+            const result = extractSnippetRegion(rel, 'method');
+            expect(result).toBe('override init(): void {\n    this.x = 1;\n}');
+        });
+
+        test('preserves relative indentation within the region', () => {
+            const rel = writeFixture('relative-indent.ts', [
+                '// #region guide:block',
+                '    if (x) {',
+                '        y = 1;',
+                '    }',
+                '// #endregion guide:block',
+            ].join('\n'));
+
+            const result = extractSnippetRegion(rel, 'block');
+            // 4-space indent stripped; inner block retains 4 spaces of relative indent
+            expect(result).toBe('if (x) {\n    y = 1;\n}');
+        });
+
+        test('trailing empty lines are stripped', () => {
+            const rel = writeFixture('trailing.ts', [
+                '// #region guide:r',
+                'foo();',
+                '',
+                '',
+                '// #endregion guide:r',
+            ].join('\n'));
+
+            const result = extractSnippetRegion(rel, 'r');
+            expect(result).toBe('foo();');
+        });
+    });
+
+    describe('error cases', () => {
+        test('throws for a missing file', () => {
+            expect(() =>
+                extractSnippetRegion('does/not/exist.ts', 'any-region'),
+            ).toThrow('[SourceSnippet] File not found');
+        });
+
+        test('throws for a missing file and includes path in message', () => {
+            expect(() =>
+                extractSnippetRegion('does/not/exist.ts', 'any-region'),
+            ).toThrow('does/not/exist.ts');
+        });
+
+        test('throws for a region not found, with region name in message', () => {
+            const rel = writeFixture('no-region.ts', 'const x = 1;\n');
+
+            expect(() =>
+                extractSnippetRegion(rel, 'missing-region'),
+            ).toThrow('missing-region');
+        });
+
+        test('throws for a duplicate region', () => {
+            const rel = writeFixture('duplicate.ts', [
+                '// #region guide:dup',
+                'first();',
+                '// #endregion guide:dup',
+                '// #region guide:dup',
+                'second();',
+                '// #endregion guide:dup',
+            ].join('\n'));
+
+            expect(() =>
+                extractSnippetRegion(rel, 'dup'),
+            ).toThrow('Duplicate region');
+        });
+
+        test('throws for an empty region', () => {
+            const rel = writeFixture('empty.ts', [
+                '// #region guide:empty',
+                '   ',
+                '// #endregion guide:empty',
+            ].join('\n'));
+
+            expect(() =>
+                extractSnippetRegion(rel, 'empty'),
+            ).toThrow('empty');
+        });
+
+        test('does not confuse regions with similar names', () => {
+            const rel = writeFixture('similar.ts', [
+                '// #region guide:foo',
+                'inFoo();',
+                '// #endregion guide:foo',
+                '// #region guide:foo-bar',
+                'inFooBar();',
+                '// #endregion guide:foo-bar',
+            ].join('\n'));
+
+            expect(extractSnippetRegion(rel, 'foo')).toBe('inFoo();');
+            expect(extractSnippetRegion(rel, 'foo-bar')).toBe('inFooBar();');
+        });
+    });
+});


### PR DESCRIPTION
## Problem
Guide snippets can drift from examples and templates — code is manually duplicated and not type-checked against the real source.

## Solution
Source-backed snippet regions with build-time validation:
- `site/src/lib/source-snippets.ts` — pure utility with `extractSnippetRegion()`
- `site/src/components/SourceSnippet.astro` — MDX component (SSG, build-time extraction)
- Region marker convention: `// #region guide:<name>` / `// #endregion guide:<name>`
- Build fails on missing file, missing region, empty region, or duplicate regions

## Implementation note
`repoRoot()` walks up from `process.cwd()` looking for `pnpm-workspace.yaml` instead of using `import.meta.dirname`. This is required because Astro SSG bundles the component into `site/dist/.prerender/chunks/`, making `import.meta.dirname` point to the bundle output rather than the source directory.

## Scope
Docs/tooling foundation with a small representative migration (~3–4 snippets from orb-dodge walkthrough and first-scene guide).

## Validation
- pnpm typecheck ✓
- pnpm typecheck:guides ✓
- pnpm typecheck:examples ✓
- pnpm test ✓ (1821 tests pass, including 11 new snippet tests)
- pnpm build ✓
- pnpm verify:create-exo-app ✓
- pnpm site:build ✓
- Error case confirmed (missing region → build error with actionable message)