### PR TITLE
chore(release): prepare 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,77 @@ merged pull requests and commits since the previous tag (each with its commit /
 PR link); `pnpm release:notes` then renders that section into the published
 GitHub release with a `PREVIOUS_TAG...CURRENT_TAG` compare link.
 
+## [0.12.0] - 2026-06-05
+
+This release has no new engine features. The focus is entirely on developer
+experience, onboarding, documentation, and the playground.
+
+### Onboarding
+
+- **`create-exo-app` scaffolding CLI.** `npm create exo-app@latest` scaffolds a
+  new ExoJS project in one command. Supports three starter templates: `minimal`,
+  `game-starter`, and `audio-reactive`. (#86, #87, #91)
+
+- **`minimal` template.** A bare-bones Vite + TypeScript project with a single
+  `MainScene`, ready to run with `npm run dev`. (#86)
+
+- **`game-starter` template.** A structured starter with `GameScene`,
+  `GameOverScene`, and a `Player` object — a solid foundation for a game loop.
+  (#86)
+
+- **`audio-reactive` template.** A starter wired for beat-detection and
+  audio-driven visuals via `AudioReactiveScene`. (#86)
+
+### Guides
+
+- **Rendering API resync.** All guide code blocks updated to the current
+  `RenderingContext` API introduced in 0.10: `context.render()`, `app.rendering`,
+  and `Application.renderTo()`. (#83)
+
+- **Guide code typecheck gate.** All guide code snippets are extracted and
+  type-checked via `pnpm typecheck:guides`. Snippets that intentionally opt out
+  of type-checking use the `// no-check` convention. (#91)
+
+- **Source-backed guide snippets.** Key snippets in the introduction and Orb
+  Dodge walkthrough are now rendered from live source files (`examples/`) via
+  `<SourceSnippet>`, eliminating drift between guide prose and tested code. (#92)
+
+- **Troubleshooting guide.** New guide covering common setup issues, WebGL2/WebGPU
+  fallback behaviour, asset loading pitfalls, and performance gotchas. (#89)
+
+- **Deployment guide.** New guide covering Vite-based production builds, static
+  hosting (GitHub Pages, Netlify, Vercel), base-path configuration, and
+  import-map requirements for direct CDN usage. (#89)
+
+- **Orb Dodge sample game walkthrough.** Step-by-step guide through the complete
+  `orb-dodge` showcase example: scene setup, player movement, collision detection,
+  game-over flow, and score display. (#90)
+
+### Playground
+
+- **Start Here and Featured sections.** The playground landing page now surfaces
+  a curated "Start Here" category for first-time visitors and a "Featured" section
+  highlighting high-quality showcase examples. (#88)
+
+- **Search and filter.** The playground supports full-text search across example
+  titles and descriptions, plus category filtering. (#88)
+
+- **Improved catalog descriptions.** All 100+ example entries were reviewed and
+  updated with accurate, concise descriptions to improve discoverability. (#88)
+
+### Distribution / Debug
+
+- **Official `@codexo/exojs/debug` entrypoint.** The debug subpath is now the
+  supported way to access debug utilities:
+  `import { ... } from '@codexo/exojs/debug'`. The former
+  `@codexo/exojs-debug` package name is not supported. (#85)
+
+- **`dist/exo.debug.esm.js` external-core bundle.** A pre-built debug bundle
+  is distributed alongside the main bundle. It imports its core from
+  `@codexo/exojs` via an import map, so no second copy of the runtime is
+  included. Direct CDN/bundle usage requires an import map that resolves
+  `@codexo/exojs`. (#85)
+
 ## [0.11.0] - 2026-06-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@codexo/exojs",
   "description": "A TypeScript-first browser 2D runtime for games and interactive apps.",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "type": "module",
   "packageManager": "pnpm@11.4.0",
   "files": [
@@ -53,7 +53,7 @@
     "verify:package": "pnpm build && pnpm verify:exports && pnpm pack",
     "verify:create-exo-app": "tsx ./scripts/verify-create-exo-app.ts",
     "sync:example-capabilities": "tsx ./scripts/sync-example-capabilities.ts",
-    "verify:release": "pnpm typecheck && pnpm typecheck:guides && pnpm lint:strict && pnpm format:check && pnpm test && pnpm verify:package && pnpm verify:create-exo-app",
+    "verify:release": "pnpm typecheck && pnpm typecheck:guides && pnpm typecheck:examples && pnpm lint:strict && pnpm format:check && pnpm test && pnpm verify:package && pnpm verify:create-exo-app && pnpm site:build",
     "release": "tsx ./scripts/release.ts",
     "release:notes": "tsx ./scripts/generate-release-notes.ts",
     "prepack": "pnpm build",

--- a/packages/create-exo-app/templates/audio-reactive/package.json
+++ b/packages/create-exo-app/templates/audio-reactive/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@codexo/exojs": "^0.11.0"
+    "@codexo/exojs": "^0.12.0"
   },
   "devDependencies": {
     "typescript": "^5.8.0",

--- a/packages/create-exo-app/templates/game-starter/package.json
+++ b/packages/create-exo-app/templates/game-starter/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@codexo/exojs": "^0.11.0"
+    "@codexo/exojs": "^0.12.0"
   },
   "devDependencies": {
     "typescript": "^5.8.0",

--- a/packages/create-exo-app/templates/minimal/package.json
+++ b/packages/create-exo-app/templates/minimal/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@codexo/exojs": "^0.11.0"
+    "@codexo/exojs": "^0.12.0"
   },
   "devDependencies": {
     "typescript": "^5.8.0",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -65,13 +65,13 @@ const debugBundled: RollupOptions = {
   input: 'src/debug/index.ts',
   // All @/ imports are core dependencies — mark them external so the debug
   // bundle contains only debug code and imports from @codexo/exojs at runtime.
-  external: (id) => id.startsWith('@/'),
+  external: id => id.startsWith('@/'),
   output: {
     file: 'dist/exo.debug.esm.js',
     format: 'es',
     sourcemap: true,
     // Remap all @/ external IDs to the package name in the output.
-    paths: (id) => (id.startsWith('@/') ? '@codexo/exojs' : id),
+    paths: id => (id.startsWith('@/') ? '@codexo/exojs' : id),
   },
   plugins: [
     constantReplacementPlugin,

--- a/scripts/extract-guide-snippets.ts
+++ b/scripts/extract-guide-snippets.ts
@@ -156,9 +156,7 @@ for (const file of files) {
 
     // Derive a unique output file name from the guide path and block index.
     // Double underscores separate path segments.
-    const slug = rel
-      .replace(/\.(mdx?|tsx?)$/, '')
-      .replaceAll('/', '__');
+    const slug = rel.replace(/\.(mdx?|tsx?)$/, '').replaceAll('/', '__');
     // ts/typescript/tsx blocks → .ts (full TypeScript syntax allowed).
     // js/javascript blocks    → .js (allowJs mode; class properties inferred
     //                               from assignments, no false positives).
@@ -174,6 +172,4 @@ for (const file of files) {
 }
 
 const total = extracted + skippedMeta + skippedPartial;
-console.log(
-  `guide-snippets: ${extracted} extracted, ${skippedMeta} no-check, ${skippedPartial} partial (${total} total blocks)`
-);
+console.log(`guide-snippets: ${extracted} extracted, ${skippedMeta} no-check, ${skippedPartial} partial (${total} total blocks)`);

--- a/scripts/verify-create-exo-app.ts
+++ b/scripts/verify-create-exo-app.ts
@@ -9,18 +9,14 @@ const tmpRoot = join(rootDir, '.workspace', 'tmp', 'create-exo-app');
 const cliSrc = join(rootDir, 'packages', 'create-exo-app', 'src', 'index.ts');
 const templatesDir = join(rootDir, 'packages', 'create-exo-app', 'templates');
 
+const rootPkg = JSON.parse(readFileSync(join(rootDir, 'package.json'), 'utf-8')) as { version: string };
+const EXPECTED_EXOJS_VERSION = `^${rootPkg.version}`;
+
 const TEMPLATES = ['minimal', 'game-starter', 'audio-reactive'] as const;
 type TemplateName = (typeof TEMPLATES)[number];
 
 const EXPECTED_FILES: Record<TemplateName, string[]> = {
-  'minimal': [
-    'index.html',
-    'package.json',
-    'tsconfig.json',
-    'vite.config.ts',
-    'src/main.ts',
-    'src/scenes/MainScene.ts',
-  ],
+  minimal: ['index.html', 'package.json', 'tsconfig.json', 'vite.config.ts', 'src/main.ts', 'src/scenes/MainScene.ts'],
   'game-starter': [
     'index.html',
     'package.json',
@@ -31,14 +27,7 @@ const EXPECTED_FILES: Record<TemplateName, string[]> = {
     'src/scenes/GameOverScene.ts',
     'src/objects/Player.ts',
   ],
-  'audio-reactive': [
-    'index.html',
-    'package.json',
-    'tsconfig.json',
-    'vite.config.ts',
-    'src/main.ts',
-    'src/scenes/AudioReactiveScene.ts',
-  ],
+  'audio-reactive': ['index.html', 'package.json', 'tsconfig.json', 'vite.config.ts', 'src/main.ts', 'src/scenes/AudioReactiveScene.ts'],
 };
 
 // Patterns that indicate stale API usage
@@ -80,11 +69,7 @@ check(existsSync(cliSrc), 'src/index.ts found', 'src/index.ts missing');
 // 2. All templates present
 console.log('\n2. Template directories');
 for (const t of TEMPLATES) {
-  check(
-    existsSync(join(templatesDir, t)),
-    `templates/${t}/ exists`,
-    `templates/${t}/ missing`,
-  );
+  check(existsSync(join(templatesDir, t)), `templates/${t}/ exists`, `templates/${t}/ missing`);
 }
 
 // 3. Scaffold each template
@@ -96,10 +81,7 @@ for (const t of TEMPLATES) {
   }
 
   try {
-    execSync(
-      `node --import tsx/esm "${cliSrc}" "${destDir}" --template ${t} --force`,
-      { stdio: 'pipe', env: { ...process.env, FORCE_COLOR: '0' } },
-    );
+    execSync(`node --import tsx/esm "${cliSrc}" "${destDir}" --template ${t} --force`, { stdio: 'pipe', env: { ...process.env, FORCE_COLOR: '0' } });
     ok(`scaffold ${t} → .workspace/tmp/create-exo-app/${t}`);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -112,11 +94,7 @@ console.log('\n4. Expected files in scaffolded projects');
 for (const t of TEMPLATES) {
   const destDir = join(tmpRoot, t);
   for (const file of EXPECTED_FILES[t]) {
-    check(
-      existsSync(join(destDir, file)),
-      `${t}/${file}`,
-      `${t}/${file} missing`,
-    );
+    check(existsSync(join(destDir, file)), `${t}/${file}`, `${t}/${file} missing`);
   }
 }
 
@@ -169,6 +147,26 @@ for (const t of TEMPLATES) {
     } catch {
       ok(`${t}: no "${label}"`);
     }
+  }
+}
+
+// 7. Template ExoJS dependency version
+console.log('\n7. Template ExoJS dependency versions');
+for (const t of TEMPLATES) {
+  const pkgPath = join(templatesDir, t, 'package.json');
+  try {
+    const raw = readFileSync(pkgPath, 'utf-8');
+    const pkg = JSON.parse(raw) as { dependencies?: Record<string, string> };
+    const actual = pkg.dependencies?.['@codexo/exojs'];
+    check(
+      actual === EXPECTED_EXOJS_VERSION,
+      `${t}: @codexo/exojs="${actual}" matches expected "${EXPECTED_EXOJS_VERSION}"`,
+      `${t}: @codexo/exojs="${actual ?? '(missing)'}" — expected "${EXPECTED_EXOJS_VERSION}"`,
+    );
+    const hasWorkspaceDep = Object.values(pkg.dependencies ?? {}).some(v => v.startsWith('workspace:'));
+    check(!hasWorkspaceDep, `${t}: no workspace: dependency`, `${t}: contains a workspace: dependency — templates must not reference workspace packages`);
+  } catch {
+    fail(`${t}/package.json could not be read for version check`);
   }
 }
 

--- a/test/site/example-search.test.ts
+++ b/test/site/example-search.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { FEATURED_FILTER,filterExamples } from '../../site/src/lib/example-search';
+import { FEATURED_FILTER, filterExamples } from '../../site/src/lib/example-search';
 import { EXAMPLES_CATALOG } from '../../site/src/lib/examples-catalog';
 import type { Example } from '../../site/src/lib/types';
 
@@ -167,9 +167,7 @@ describe('filterExamples', () => {
 // ---------------------------------------------------------------------------
 
 describe('catalog featured metadata', () => {
-  const entries = Object.entries(EXAMPLES_CATALOG).flatMap(([section, list]) =>
-    list.map(entry => ({ ...entry, section })),
-  );
+  const entries = Object.entries(EXAMPLES_CATALOG).flatMap(([section, list]) => list.map(entry => ({ ...entry, section })));
 
   it('has at least one featured example', () => {
     const featured = entries.filter(e => e.featured === true);
@@ -190,9 +188,7 @@ describe('catalog featured metadata', () => {
   });
 
   it('start-here examples cover getting-started, sprites, input, audio, debug, and performance', () => {
-    const featuredSections = new Set(
-      entries.filter(e => e.featured === true).map(e => e.section),
-    );
+    const featuredSections = new Set(entries.filter(e => e.featured === true).map(e => e.section));
     // These are the key sections we promised to cover.
     for (const section of ['getting-started', 'sprites-textures', 'input', 'audio-basics', 'debug-layer']) {
       expect(featuredSections.has(section), `expected a featured example in "${section}"`).toBe(true);

--- a/test/site/source-snippets.test.ts
+++ b/test/site/source-snippets.test.ts
@@ -27,22 +27,22 @@ let TMP_DIR: string;
 let TMP_REL: string; // relative to repo root (== process.cwd() in vitest)
 
 beforeAll(() => {
-    // Create a temp directory under .workspace so it is gitignored.
-    const base = join(process.cwd(), '.workspace', 'test-snippets');
-    mkdirSync(base, { recursive: true });
-    TMP_DIR = mkdtempSync(join(base, 'tmp-'));
-    // Relative path from repo root to our temp dir.
-    TMP_REL = TMP_DIR.slice(process.cwd().length).replace(/\\/g, '/').replace(/^\//, '');
+  // Create a temp directory under .workspace so it is gitignored.
+  const base = join(process.cwd(), '.workspace', 'test-snippets');
+  mkdirSync(base, { recursive: true });
+  TMP_DIR = mkdtempSync(join(base, 'tmp-'));
+  // Relative path from repo root to our temp dir.
+  TMP_REL = TMP_DIR.slice(process.cwd().length).replace(/\\/g, '/').replace(/^\//, '');
 });
 
 afterAll(() => {
-    rmSync(TMP_DIR, { recursive: true, force: true });
+  rmSync(TMP_DIR, { recursive: true, force: true });
 });
 
 function writeFixture(name: string, content: string): string {
-    const abs = join(TMP_DIR, name);
-    writeFileSync(abs, content, 'utf8');
-    return `${TMP_REL}/${name}`;
+  const abs = join(TMP_DIR, name);
+  writeFileSync(abs, content, 'utf8');
+  return `${TMP_REL}/${name}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -50,136 +50,100 @@ function writeFixture(name: string, content: string): string {
 // ---------------------------------------------------------------------------
 
 describe('extractSnippetRegion', () => {
-    describe('happy path', () => {
-        test('extracts lines between markers', () => {
-            const rel = writeFixture('basic.ts', [
-                'const a = 1;',
-                '// #region guide:my-region',
-                'const b = 2;',
-                'const c = 3;',
-                '// #endregion guide:my-region',
-                'const d = 4;',
-            ].join('\n'));
+  describe('happy path', () => {
+    test('extracts lines between markers', () => {
+      const rel = writeFixture(
+        'basic.ts',
+        ['const a = 1;', '// #region guide:my-region', 'const b = 2;', 'const c = 3;', '// #endregion guide:my-region', 'const d = 4;'].join('\n'),
+      );
 
-            const result = extractSnippetRegion(rel, 'my-region');
-            expect(result).toBe('const b = 2;\nconst c = 3;');
-        });
-
-        test('marker lines are not included in the output', () => {
-            const rel = writeFixture('markers.ts', [
-                '// #region guide:zone',
-                'doSomething();',
-                '// #endregion guide:zone',
-            ].join('\n'));
-
-            const result = extractSnippetRegion(rel, 'zone');
-            expect(result).not.toContain('#region');
-            expect(result).not.toContain('#endregion');
-        });
-
-        test('dedent: common leading whitespace is removed', () => {
-            const rel = writeFixture('indented.ts', [
-                'class Foo {',
-                '    // #region guide:method',
-                '    override init(): void {',
-                '        this.x = 1;',
-                '    }',
-                '    // #endregion guide:method',
-                '}',
-            ].join('\n'));
-
-            const result = extractSnippetRegion(rel, 'method');
-            expect(result).toBe('override init(): void {\n    this.x = 1;\n}');
-        });
-
-        test('preserves relative indentation within the region', () => {
-            const rel = writeFixture('relative-indent.ts', [
-                '// #region guide:block',
-                '    if (x) {',
-                '        y = 1;',
-                '    }',
-                '// #endregion guide:block',
-            ].join('\n'));
-
-            const result = extractSnippetRegion(rel, 'block');
-            // 4-space indent stripped; inner block retains 4 spaces of relative indent
-            expect(result).toBe('if (x) {\n    y = 1;\n}');
-        });
-
-        test('trailing empty lines are stripped', () => {
-            const rel = writeFixture('trailing.ts', [
-                '// #region guide:r',
-                'foo();',
-                '',
-                '',
-                '// #endregion guide:r',
-            ].join('\n'));
-
-            const result = extractSnippetRegion(rel, 'r');
-            expect(result).toBe('foo();');
-        });
+      const result = extractSnippetRegion(rel, 'my-region');
+      expect(result).toBe('const b = 2;\nconst c = 3;');
     });
 
-    describe('error cases', () => {
-        test('throws for a missing file', () => {
-            expect(() =>
-                extractSnippetRegion('does/not/exist.ts', 'any-region'),
-            ).toThrow('[SourceSnippet] File not found');
-        });
+    test('marker lines are not included in the output', () => {
+      const rel = writeFixture('markers.ts', ['// #region guide:zone', 'doSomething();', '// #endregion guide:zone'].join('\n'));
 
-        test('throws for a missing file and includes path in message', () => {
-            expect(() =>
-                extractSnippetRegion('does/not/exist.ts', 'any-region'),
-            ).toThrow('does/not/exist.ts');
-        });
-
-        test('throws for a region not found, with region name in message', () => {
-            const rel = writeFixture('no-region.ts', 'const x = 1;\n');
-
-            expect(() =>
-                extractSnippetRegion(rel, 'missing-region'),
-            ).toThrow('missing-region');
-        });
-
-        test('throws for a duplicate region', () => {
-            const rel = writeFixture('duplicate.ts', [
-                '// #region guide:dup',
-                'first();',
-                '// #endregion guide:dup',
-                '// #region guide:dup',
-                'second();',
-                '// #endregion guide:dup',
-            ].join('\n'));
-
-            expect(() =>
-                extractSnippetRegion(rel, 'dup'),
-            ).toThrow('Duplicate region');
-        });
-
-        test('throws for an empty region', () => {
-            const rel = writeFixture('empty.ts', [
-                '// #region guide:empty',
-                '   ',
-                '// #endregion guide:empty',
-            ].join('\n'));
-
-            expect(() =>
-                extractSnippetRegion(rel, 'empty'),
-            ).toThrow('empty');
-        });
-
-        test('does not confuse regions with similar names', () => {
-            const rel = writeFixture('similar.ts', [
-                '// #region guide:foo',
-                'inFoo();',
-                '// #endregion guide:foo',
-                '// #region guide:foo-bar',
-                'inFooBar();',
-                '// #endregion guide:foo-bar',
-            ].join('\n'));
-
-            expect(extractSnippetRegion(rel, 'foo')).toBe('inFoo();');
-            expect(extractSnippetRegion(rel, 'foo-bar')).toBe('inFooBar();');
-        });
+      const result = extractSnippetRegion(rel, 'zone');
+      expect(result).not.toContain('#region');
+      expect(result).not.toContain('#endregion');
     });
+
+    test('dedent: common leading whitespace is removed', () => {
+      const rel = writeFixture(
+        'indented.ts',
+        [
+          'class Foo {',
+          '    // #region guide:method',
+          '    override init(): void {',
+          '        this.x = 1;',
+          '    }',
+          '    // #endregion guide:method',
+          '}',
+        ].join('\n'),
+      );
+
+      const result = extractSnippetRegion(rel, 'method');
+      expect(result).toBe('override init(): void {\n    this.x = 1;\n}');
+    });
+
+    test('preserves relative indentation within the region', () => {
+      const rel = writeFixture(
+        'relative-indent.ts',
+        ['// #region guide:block', '    if (x) {', '        y = 1;', '    }', '// #endregion guide:block'].join('\n'),
+      );
+
+      const result = extractSnippetRegion(rel, 'block');
+      // 4-space indent stripped; inner block retains 4 spaces of relative indent
+      expect(result).toBe('if (x) {\n    y = 1;\n}');
+    });
+
+    test('trailing empty lines are stripped', () => {
+      const rel = writeFixture('trailing.ts', ['// #region guide:r', 'foo();', '', '', '// #endregion guide:r'].join('\n'));
+
+      const result = extractSnippetRegion(rel, 'r');
+      expect(result).toBe('foo();');
+    });
+  });
+
+  describe('error cases', () => {
+    test('throws for a missing file', () => {
+      expect(() => extractSnippetRegion('does/not/exist.ts', 'any-region')).toThrow('[SourceSnippet] File not found');
+    });
+
+    test('throws for a missing file and includes path in message', () => {
+      expect(() => extractSnippetRegion('does/not/exist.ts', 'any-region')).toThrow('does/not/exist.ts');
+    });
+
+    test('throws for a region not found, with region name in message', () => {
+      const rel = writeFixture('no-region.ts', 'const x = 1;\n');
+
+      expect(() => extractSnippetRegion(rel, 'missing-region')).toThrow('missing-region');
+    });
+
+    test('throws for a duplicate region', () => {
+      const rel = writeFixture(
+        'duplicate.ts',
+        ['// #region guide:dup', 'first();', '// #endregion guide:dup', '// #region guide:dup', 'second();', '// #endregion guide:dup'].join('\n'),
+      );
+
+      expect(() => extractSnippetRegion(rel, 'dup')).toThrow('Duplicate region');
+    });
+
+    test('throws for an empty region', () => {
+      const rel = writeFixture('empty.ts', ['// #region guide:empty', '   ', '// #endregion guide:empty'].join('\n'));
+
+      expect(() => extractSnippetRegion(rel, 'empty')).toThrow('empty');
+    });
+
+    test('does not confuse regions with similar names', () => {
+      const rel = writeFixture(
+        'similar.ts',
+        ['// #region guide:foo', 'inFoo();', '// #endregion guide:foo', '// #region guide:foo-bar', 'inFooBar();', '// #endregion guide:foo-bar'].join('\n'),
+      );
+
+      expect(extractSnippetRegion(rel, 'foo')).toBe('inFoo();');
+      expect(extractSnippetRegion(rel, 'foo-bar')).toBe('inFooBar();');
+    });
+  });
 });

--- a/tsconfig.guides.json
+++ b/tsconfig.guides.json
@@ -36,10 +36,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": [
-    ".workspace/generated/guide-typecheck/**/*.ts",
-    ".workspace/generated/guide-typecheck/**/*.js",
-    "src/typings.d.ts",
-    "src/build-constants.d.ts"
-  ]
+  "include": [".workspace/generated/guide-typecheck/**/*.ts", ".workspace/generated/guide-typecheck/**/*.js", "src/typings.d.ts", "src/build-constants.d.ts"]
 }


### PR DESCRIPTION
## Scope

ExoJS **0.12.0** ist ein reiner DX-/Docs-/Onboarding-/Playground-Release. Keine neuen Engine-Features.

Dieser PR bereitet Versionen, Release Notes und Packaging-Verifikation vor. Er veröffentlicht nichts — kein npm publish, kein Git-Tag, kein GitHub Release.

---

## Versionierungsentscheidung

| Package          | Version | Begründung |
|------------------|---------|------------|
| `@codexo/exojs`  | 0.12.0  | Hauptpaket, reguläre Minor-Version |
| `create-exo-app` | 0.1.0   | Unabhängig versioniert; erstes öffentliches Release. Der Workflow veröffentlicht nur `@codexo/exojs`; `create-exo-app` muss bei Bedarf separat publiziert werden. |

---

## Release Notes — 0.12.0

### Onboarding
- `npm create exo-app@latest` scaffolding CLI mit drei Templates: `minimal`, `game-starter`, `audio-reactive`

### Guides
- Resync der Guide-Code-Blöcke auf aktuelle `RenderingContext`-API
- Guide-Code-Typecheck-Gate (`pnpm typecheck:guides`)
- Source-backed Guide-Snippets via `<SourceSnippet>` aus `examples/`
- Troubleshooting-Guide
- Deployment-Guide
- Orb Dodge Sample-Game-Walkthrough

### Playground
- Start Here / Featured Sektionen
- Suche + Filter
- Überarbeitete Katalogbeschreibungen (100+ Einträge)

### Distribution / Debug
- Offizieller `@codexo/exojs/debug` Entrypoint
- `dist/exo.debug.esm.js` als external-core Extension-Bundle
- Import-Map-Anforderung bei direkter CDN-Nutzung dokumentiert

---

## Pack-Verifikation

| Artefakt                    | Größe        | Status |
|-----------------------------|--------------|--------|
| `codexo-exojs-0.12.0.tgz`  | ~1.36 MB     | ✓      |
| `create-exo-app-0.1.0.tgz` | ~5.7 KB      | ✓      |

- `dist/exo.esm.js`, `dist/exo.debug.esm.js`, `dist/esm/**`, Typ-Deklarationen — alle im Core-Tarball enthalten ✓
- Debug-Bundle importiert `@codexo/exojs` extern (keine zweite Core-Runtime) ✓
- Alle 3 Templates im create-exo-app-Tarball mit `^0.12.0` ✓
- Shebang in `dist/index.js` vorhanden ✓
- Scaffold-Test aus gepacktem CLI erfolgreich ✓

---

## Vollständige Checkliste

- [x] `pnpm typecheck`
- [x] `pnpm typecheck:guides` (29 extracted, 22 no-check)
- [x] `pnpm typecheck:examples`
- [x] `pnpm lint:strict`
- [x] `pnpm format:check`
- [x] `pnpm test` (1821/1821, 140 Dateien)
- [x] `pnpm build`
- [x] `pnpm verify:exports` (6 Targets)
- [x] `pnpm verify:package` (pack + exports)
- [x] `pnpm verify:create-exo-app` (51/51, inkl. neuer Versions-Check)
- [x] `pnpm site:build` (568 Seiten)
- [x] `pnpm test:examples:smoke` (118/0/0)
- [x] `pnpm verify:release` (alles oben inkl. site:build)

---

## Geänderte Dateien

| Datei | Änderung |
|-------|----------|
| `package.json` | version 0.11.0 → 0.12.0; `verify:release` um `typecheck:examples` + `site:build` erweitert |
| `CHANGELOG.md` | `[0.12.0] - 2026-06-05` Eintrag |
| `packages/create-exo-app/templates/*/package.json` | `^0.11.0` → `^0.12.0` |
| `scripts/verify-create-exo-app.ts` | Schritt 7: Template-Versions-Check gegen Root-Package-Version |
| `rollup.config.ts`, `scripts/extract-guide-snippets.ts`, `test/site/*.test.ts`, `tsconfig.guides.json` | Prettier-Formatierungsfixes |

---

> **Kein npm Publish. Kein Git-Tag. Kein GitHub Release. Kein Push auf main. Kein Merge durch diesen PR.**