### PR TITLE
feat(docs): overhaul guide experience

### DIFF
--- a/packages/create-exo-app/templates/minimal/src/main.ts
+++ b/packages/create-exo-app/templates/minimal/src/main.ts
@@ -1,3 +1,4 @@
+// #region guide:minimal-main
 import { Application, Color } from '@codexo/exojs';
 import { MainScene } from './scenes/MainScene';
 
@@ -12,3 +13,4 @@ const app = new Application({
 document.body.append(app.canvas);
 
 app.start(new MainScene());
+// #endregion guide:minimal-main

--- a/packages/create-exo-app/templates/minimal/src/scenes/MainScene.ts
+++ b/packages/create-exo-app/templates/minimal/src/scenes/MainScene.ts
@@ -1,3 +1,4 @@
+// #region guide:minimal-scene
 import { Color, Graphics, Scene } from '@codexo/exojs';
 import type { RenderingContext, Time } from '@codexo/exojs';
 
@@ -23,3 +24,4 @@ export class MainScene extends Scene {
     context.render(this.root);
   }
 }
+// #endregion guide:minimal-scene

--- a/site/src/components/Callout.astro
+++ b/site/src/components/Callout.astro
@@ -1,0 +1,129 @@
+---
+/**
+ * Callout — a labelled aside for notes, tips, warnings, and platform hints.
+ *
+ * Usage in MDX:
+ *   import Callout from '../../../components/Callout.astro';
+ *
+ *   <Callout type="tip">
+ *   Start each frame with `context.backend.clear()`.
+ *   </Callout>
+ *
+ *   <Callout type="common-mistake" title="Forgetting the anchor">
+ *   A sprite's default anchor is the top-left corner, not its center.
+ *   </Callout>
+ *
+ * The type is conveyed by a text label and a glyph, never colour alone, so the
+ * meaning survives for colour-blind readers and in high-contrast modes.
+ */
+
+type CalloutType = 'note' | 'tip' | 'important' | 'common-mistake' | 'webgpu' | 'browser';
+
+interface Props {
+    type?: CalloutType;
+    /** Optional heading. Falls back to the type's default label. */
+    title?: string;
+}
+
+const META: Record<CalloutType, { label: string; glyph: string }> = {
+    'note': { label: 'Note', glyph: 'i' },
+    'tip': { label: 'Tip', glyph: '+' },
+    'important': { label: 'Important', glyph: '!' },
+    'common-mistake': { label: 'Common mistake', glyph: '×' },
+    'webgpu': { label: 'WebGPU', glyph: '◆' },
+    'browser': { label: 'Browser behavior', glyph: '◐' },
+};
+
+const { type = 'note', title } = Astro.props;
+const meta = META[type];
+const heading = title ?? meta.label;
+---
+
+<aside class="callout" data-callout={type} role="note">
+    <p class="callout__head">
+        <span class="callout__glyph" aria-hidden="true">{meta.glyph}</span>
+        <span class="callout__label">{heading}</span>
+    </p>
+    <div class="callout__body">
+        <slot />
+    </div>
+</aside>
+
+<style>
+    .callout {
+        --callout-accent: var(--fg-muted);
+        --callout-bg: color-mix(in oklab, var(--bg-elevated), transparent 0%);
+        margin: var(--s-5) 0;
+        padding: var(--s-3) var(--s-4);
+        border: 1px solid var(--line-soft);
+        border-left: 3px solid var(--callout-accent);
+        border-radius: var(--r-3);
+        background: var(--callout-bg);
+    }
+
+    .callout__head {
+        display: flex;
+        align-items: center;
+        gap: var(--s-2);
+        margin: 0 0 var(--s-1);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--callout-accent);
+    }
+
+    .callout__glyph {
+        display: inline-grid;
+        place-items: center;
+        width: 18px;
+        height: 18px;
+        border-radius: var(--r-pill);
+        border: 1px solid var(--callout-accent);
+        font-size: 11px;
+        line-height: 1;
+        font-family: var(--f-mono);
+    }
+
+    .callout__body :global(p) {
+        margin: var(--s-2) 0;
+    }
+
+    .callout__body :global(p:first-child) {
+        margin-top: 0;
+    }
+
+    .callout__body :global(p:last-child) {
+        margin-bottom: 0;
+    }
+
+    .callout[data-callout='note'] {
+        --callout-accent: var(--color-text-muted);
+        --callout-bg: color-mix(in oklab, var(--color-text-muted), transparent 94%);
+    }
+
+    .callout[data-callout='tip'] {
+        --callout-accent: var(--accent);
+        --callout-bg: var(--accent-soft);
+    }
+
+    .callout[data-callout='important'] {
+        --callout-accent: oklch(80% 0.13 85);
+        --callout-bg: color-mix(in oklab, oklch(80% 0.13 85), transparent 90%);
+    }
+
+    .callout[data-callout='common-mistake'] {
+        --callout-accent: oklch(72% 0.16 25);
+        --callout-bg: color-mix(in oklab, oklch(72% 0.16 25), transparent 90%);
+    }
+
+    .callout[data-callout='webgpu'] {
+        --callout-accent: oklch(72% 0.15 290);
+        --callout-bg: color-mix(in oklab, oklch(72% 0.15 290), transparent 90%);
+    }
+
+    .callout[data-callout='browser'] {
+        --callout-accent: oklch(74% 0.12 230);
+        --callout-bg: color-mix(in oklab, oklch(74% 0.12 230), transparent 90%);
+    }
+</style>

--- a/site/src/components/GuideMeta.astro
+++ b/site/src/components/GuideMeta.astro
@@ -1,0 +1,149 @@
+---
+/**
+ * GuideMeta — the metadata block under a chapter's title.
+ *
+ * Rendered by the chapter layout from guide-structure metadata, not authored in
+ * MDX. Shows only the fields that are present: a level badge, an estimated read
+ * time, "What you'll learn", and "Before you start". Nothing renders for an
+ * empty field, so chapters without goals or prerequisites stay clean.
+ */
+
+import type { GuideLevel } from '../lib/guide-structure';
+import { GUIDE_LEVEL_LABEL } from '../lib/guide-structure';
+
+interface Props {
+    level: GuideLevel;
+    readingMinutes?: number;
+    learningGoals?: ReadonlyArray<string>;
+    prerequisites?: ReadonlyArray<{ label: string; href: string }>;
+}
+
+const { level, readingMinutes, learningGoals = [], prerequisites = [] } = Astro.props;
+const hasGoals = learningGoals.length > 0;
+const hasPrerequisites = prerequisites.length > 0;
+---
+
+<div class="guide-meta">
+    <p class="guide-meta__row">
+        <span class="guide-meta__badge" data-level={level}>
+            <span class="guide-meta__badge-dot" aria-hidden="true"></span>
+            {GUIDE_LEVEL_LABEL[level]}
+        </span>
+        {readingMinutes && readingMinutes > 0 && (
+            <span class="guide-meta__read">~{readingMinutes} min read</span>
+        )}
+    </p>
+
+    {hasGoals && (
+        <section class="guide-meta__block" aria-label="What you will learn">
+            <h2 class="guide-meta__heading">What you'll learn</h2>
+            <ul class="guide-meta__goals">
+                {learningGoals.map(goal => (
+                    <li>{goal}</li>
+                ))}
+            </ul>
+        </section>
+    )}
+
+    {hasPrerequisites && (
+        <section class="guide-meta__block" aria-label="Before you start">
+            <h2 class="guide-meta__heading">Before you start</h2>
+            <ul class="guide-meta__prereqs">
+                {prerequisites.map(item => (
+                    <li>
+                        <a href={item.href}>{item.label}</a>
+                    </li>
+                ))}
+            </ul>
+        </section>
+    )}
+</div>
+
+<style>
+    .guide-meta {
+        margin: 0 0 var(--s-7);
+    }
+
+    .guide-meta__row {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: var(--s-3);
+        margin: 0;
+    }
+
+    .guide-meta__badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        border-radius: var(--r-pill);
+        border: 1px solid var(--line-soft);
+        background: var(--bg-elevated);
+        padding: 0.18rem 0.6rem;
+        font-family: var(--f-mono);
+        font-size: 11px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--fg-muted);
+    }
+
+    .guide-meta__badge-dot {
+        width: 7px;
+        height: 7px;
+        border-radius: var(--r-pill);
+        background: var(--fg-faint);
+    }
+
+    .guide-meta__badge[data-level='intro'] .guide-meta__badge-dot {
+        background: oklch(80% 0.14 142);
+    }
+
+    .guide-meta__badge[data-level='intermediate'] .guide-meta__badge-dot {
+        background: oklch(80% 0.13 85);
+    }
+
+    .guide-meta__badge[data-level='advanced'] .guide-meta__badge-dot {
+        background: oklch(72% 0.16 25);
+    }
+
+    .guide-meta__read {
+        font-family: var(--f-mono);
+        font-size: 12px;
+        color: var(--fg-faint);
+    }
+
+    .guide-meta__block {
+        margin-top: var(--s-4);
+        padding: var(--s-3) var(--s-4);
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-3);
+        background: color-mix(in oklab, var(--bg-elevated), transparent 35%);
+    }
+
+    .guide-meta__heading {
+        margin: 0 0 var(--s-2);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--fg-faint);
+        border: 0;
+        padding: 0;
+    }
+
+    .guide-meta__goals,
+    .guide-meta__prereqs {
+        margin: 0;
+        padding-left: var(--s-5);
+        display: flex;
+        flex-direction: column;
+        gap: var(--s-1);
+        font-size: 14px;
+        line-height: 1.5;
+        color: var(--fg);
+    }
+
+    .guide-meta__goals li::marker {
+        color: var(--accent);
+    }
+</style>

--- a/site/src/components/GuidePager.astro
+++ b/site/src/components/GuidePager.astro
@@ -1,0 +1,110 @@
+---
+/**
+ * GuidePager — the structural Previous / Next navigation at the end of a
+ * chapter. Built by the chapter layout from guide ordering; titles come from
+ * the adjacent chapters' frontmatter.
+ */
+
+interface Link {
+    label: string;
+    href: string;
+    context?: string;
+}
+
+interface Props {
+    previous?: Link | null;
+    next?: Link | null;
+}
+
+const { previous = null, next = null } = Astro.props;
+---
+
+<nav class="guide-pager" aria-label="Chapter navigation">
+    {previous ? (
+        <a class="guide-pager__link guide-pager__link--prev" href={previous.href} rel="prev">
+            <span class="guide-pager__dir">← Previous</span>
+            <span class="guide-pager__label">{previous.label}</span>
+            {previous.context && <span class="guide-pager__context">{previous.context}</span>}
+        </a>
+    ) : (
+        <span></span>
+    )}
+    {next ? (
+        <a class="guide-pager__link guide-pager__link--next" href={next.href} rel="next">
+            <span class="guide-pager__dir">Next →</span>
+            <span class="guide-pager__label">{next.label}</span>
+            {next.context && <span class="guide-pager__context">{next.context}</span>}
+        </a>
+    ) : (
+        <span></span>
+    )}
+</nav>
+
+<style>
+    .guide-pager {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--s-3);
+        margin-top: var(--s-9);
+        padding-top: var(--s-6);
+        border-top: 1px solid var(--line-soft);
+    }
+
+    .guide-pager__link {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        padding: var(--s-3) var(--s-4);
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-4);
+        background: var(--bg-elevated);
+        text-decoration: none;
+        color: inherit;
+        transition:
+            border-color var(--transition-fast),
+            transform var(--transition-fast);
+    }
+
+    .guide-pager__link--next {
+        text-align: right;
+    }
+
+    .guide-pager__link:hover {
+        border-color: var(--accent-line);
+        transform: translateY(-1px);
+    }
+
+    .guide-pager__link:focus-visible {
+        outline: 2px solid var(--focus-ring);
+        outline-offset: 2px;
+    }
+
+    .guide-pager__dir {
+        font-family: var(--f-mono);
+        font-size: 11px;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--fg-faint);
+    }
+
+    .guide-pager__label {
+        font-size: 15px;
+        font-weight: 600;
+        color: var(--fg);
+    }
+
+    .guide-pager__context {
+        font-size: 12px;
+        color: var(--fg-muted);
+    }
+
+    @media (max-width: 560px) {
+        .guide-pager {
+            grid-template-columns: 1fr;
+        }
+
+        .guide-pager__link--next {
+            text-align: left;
+        }
+    }
+</style>

--- a/site/src/components/NextStep.astro
+++ b/site/src/components/NextStep.astro
@@ -1,0 +1,101 @@
+---
+/**
+ * NextStep — a single, content-aware "do this next" call to action.
+ *
+ * This is the narrative next step (what to learn next and why), distinct from
+ * the structural Previous/Next pager the chapter layout renders automatically.
+ *
+ * Usage in MDX:
+ *   import NextStep from '../../../components/NextStep.astro';
+ *
+ *   <NextStep href="/ExoJS/en/guide/input/keyboard/" label="Add keyboard input">
+ *   Wire the player to the keyboard so it moves in response to key presses.
+ *   </NextStep>
+ */
+
+interface Props {
+    href: string;
+    label: string;
+    eyebrow?: string;
+}
+
+const { href, label, eyebrow = 'Next' } = Astro.props;
+const hasBody = Astro.slots.has('default');
+---
+
+<a class="next-step" href={href}>
+    <span class="next-step__eyebrow">{eyebrow}</span>
+    <span class="next-step__label">{label}</span>
+    {hasBody && (
+        <span class="next-step__body">
+            <slot />
+        </span>
+    )}
+</a>
+
+<style>
+    .next-step {
+        display: block;
+        margin: var(--s-6) 0 0;
+        padding: var(--s-4) var(--s-5);
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-4);
+        background: var(--bg-elevated);
+        text-decoration: none;
+        color: inherit;
+        transition:
+            border-color var(--transition-fast),
+            transform var(--transition-fast);
+    }
+
+    .next-step:hover {
+        border-color: var(--accent-line);
+        transform: translateY(-1px);
+    }
+
+    .next-step:focus-visible {
+        outline: 2px solid var(--focus-ring);
+        outline-offset: 2px;
+    }
+
+    .next-step__eyebrow {
+        display: block;
+        font-family: var(--f-mono);
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--fg-faint);
+    }
+
+    .next-step__label {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+        margin-top: var(--s-1);
+        font-size: 16px;
+        font-weight: 600;
+        color: var(--fg);
+    }
+
+    .next-step__label::after {
+        content: '→';
+        color: var(--accent);
+        transition: transform var(--transition-fast);
+    }
+
+    .next-step:hover .next-step__label::after {
+        transform: translateX(3px);
+    }
+
+    .next-step__body {
+        display: block;
+        margin-top: var(--s-2);
+        color: var(--fg-muted);
+        font-size: 14px;
+        line-height: 1.55;
+    }
+
+    .next-step__body :global(p) {
+        margin: 0;
+    }
+</style>

--- a/site/src/components/TryIt.astro
+++ b/site/src/components/TryIt.astro
@@ -1,0 +1,180 @@
+---
+/**
+ * TryIt — the Guide → Playground → API bridge.
+ *
+ * Renders a compact "Try it" panel that turns a concept into action: open the
+ * runnable example in the playground, then jump to the API it uses.
+ *
+ * Usage in MDX:
+ *   import TryIt from '../../../components/TryIt.astro';
+ *
+ *   <TryIt
+ *     examples={['input/keyboard', 'input/key-rebinding']}
+ *     api={['keyboard', 'input-manager']}
+ *   />
+ *
+ * `examples` are "<category>/<slug>" playground refs; `api` are content slugs
+ * under site/src/content/api. Both are resolved at build time — an unknown ref
+ * fails the build with a clear message rather than shipping a dead link.
+ */
+
+import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
+import { getExamplesForChapter } from '../lib/examples-catalog';
+import { toApiHref } from '../lib/api-reference';
+
+interface Props {
+    examples?: ReadonlyArray<string>;
+    api?: ReadonlyArray<string>;
+    title?: string;
+}
+
+const { examples = [], api = [], title = 'Try it' } = Astro.props;
+const base = import.meta.env.BASE_URL;
+const locale = Astro.currentLocale === 'de' ? 'de' : 'en';
+
+const exampleLinks = examples.map(ref => {
+    const slash = ref.indexOf('/');
+    const category = ref.slice(0, slash);
+    const slug = ref.slice(slash + 1);
+    const entry = getExamplesForChapter(category).find(item => item.slug === slug);
+    if (!entry) {
+        throw new Error(`[TryIt] Unknown playground example "${ref}" — no matching entry in examples.json`);
+    }
+    return {
+        label: entry.title,
+        href: `${base}${locale}/playground/?example=${category}/${slug}`,
+    };
+});
+
+let apiLinks: Array<{ label: string; href: string }> = [];
+if (api.length > 0) {
+    const apiEntries = await getCollection('api');
+    const byId = new Map<string, CollectionEntry<'api'>>(
+        apiEntries.map((entry: CollectionEntry<'api'>) => [entry.id, entry] as [string, CollectionEntry<'api'>]),
+    );
+    apiLinks = api.map(slug => {
+        const entry = byId.get(slug);
+        if (!entry) {
+            throw new Error(`[TryIt] Unknown API page "${slug}" — no matching page under src/content/api`);
+        }
+        return { label: entry.data.symbol || entry.data.title, href: toApiHref(base, slug) };
+    });
+}
+---
+
+<aside class="tryit" aria-label={title}>
+    <p class="tryit__title">{title}</p>
+    <div class="tryit__cols">
+        {exampleLinks.length > 0 && (
+            <div class="tryit__col">
+                <p class="tryit__heading">Playground</p>
+                <ul>
+                    {exampleLinks.map(link => (
+                        <li>
+                            <a href={link.href}>{link.label}</a>
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        )}
+        {apiLinks.length > 0 && (
+            <div class="tryit__col">
+                <p class="tryit__heading">API</p>
+                <ul>
+                    {apiLinks.map(link => (
+                        <li>
+                            <a href={link.href}><code>{link.label}</code></a>
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        )}
+    </div>
+</aside>
+
+<style>
+    .tryit {
+        margin: var(--s-6) 0;
+        padding: var(--s-4) var(--s-5);
+        border: 1px solid var(--accent-line);
+        border-radius: var(--r-4);
+        background: var(--accent-soft);
+    }
+
+    .tryit__title {
+        margin: 0 0 var(--s-3);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--accent);
+    }
+
+    .tryit__cols {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--s-5);
+    }
+
+    .tryit__heading {
+        margin: 0 0 var(--s-2);
+        font-family: var(--f-mono);
+        font-size: 11px;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--fg-faint);
+    }
+
+    .tryit ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--s-1);
+    }
+
+    .tryit li {
+        margin: 0;
+    }
+
+    .tryit a {
+        display: inline-flex;
+        align-items: baseline;
+        gap: 0.35rem;
+        color: var(--fg);
+        text-decoration: none;
+        font-size: 14px;
+        line-height: 1.45;
+    }
+
+    .tryit a::before {
+        content: '→';
+        color: var(--accent);
+    }
+
+    .tryit a:hover {
+        color: var(--accent);
+    }
+
+    .tryit a:focus-visible {
+        outline: 2px solid var(--focus-ring);
+        outline-offset: 2px;
+        border-radius: var(--r-1);
+    }
+
+    .tryit code {
+        border: 0;
+        background: transparent;
+        padding: 0;
+        font-size: 13px;
+    }
+
+    @media (max-width: 560px) {
+        .tryit__cols {
+            grid-template-columns: 1fr;
+            gap: var(--s-4);
+        }
+    }
+</style>

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,14 +1,15 @@
 import { defineCollection, z } from 'astro:content';
 import { glob } from 'astro/loaders';
 
+// Guide ordering, grouping, and learning metadata live in
+// src/lib/guide-structure.ts (the single source of truth, reconciled with these
+// files by test/site/guide-structure.test.ts). Frontmatter only carries the
+// prose that belongs next to the content: a title and a one-line description.
 const guide = defineCollection({
     loader: glob({ base: './src/content/guide', pattern: '**/*.{md,mdx}' }),
     schema: z.object({
-        title: z.string(),
-        description: z.string(),
-        part: z.number().int().min(1).max(10),
-        chapter: z.number().int().positive(),
-        examples: z.array(z.string()).default([]),
+        title: z.string().min(1),
+        description: z.string().min(1),
     }),
 });
 

--- a/site/src/content/guide/advanced/backend-comparison.mdx
+++ b/site/src/content/guide/advanced/backend-comparison.mdx
@@ -1,15 +1,11 @@
 ---
-title: '7.4 Backend comparison'
+title: 'Backend comparison'
 description: 'Compare backend behavior and decide what to ship.'
-part: 7
-chapter: 4
-examples:
-  - performance/backend-comparison
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 7.4 Backend comparison
+# Backend comparison
 
 ExoJS renders through one of two backends: WebGL2 or WebGPU. The choice is automatic by default — the engine picks WebGPU when `navigator.gpu` is available, WebGL2 otherwise. You can override this with `backend: { type: 'webgpu' }` or `backend: { type: 'webgl2' }` in `ApplicationOptions`.
 

--- a/site/src/content/guide/advanced/collision-detection.mdx
+++ b/site/src/content/guide/advanced/collision-detection.mdx
@@ -1,15 +1,11 @@
 ---
-title: '7.5 Collision detection'
+title: 'Collision detection'
 description: 'Validate collision flow and response with interactive shapes.'
-part: 7
-chapter: 5
-examples:
-  - showcase/rectangles-collision
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 7.5 Collision detection
+# Collision detection
 
 ExoJS provides a geometry-based collision system built on shape primitives and the Separating Axis Theorem (SAT). Every shape implements the `Collidable` interface, giving you three levels of collision query: boolean overlap (`intersectsWith`), penetration response (`collidesWith`), and point containment (`contains`). A [`Quadtree`](/ExoJS/en/api/quadtree/) provides spatial partitioning for broad-phase culling when you have many objects.
 

--- a/site/src/content/guide/advanced/custom-renderers.mdx
+++ b/site/src/content/guide/advanced/custom-renderers.mdx
@@ -1,15 +1,11 @@
 ---
-title: '7.1 Custom renderers'
+title: 'Custom renderers'
 description: 'Extend rendering with custom passes and backend-specific logic.'
-part: 7
-chapter: 1
-examples:
-  - custom-renderers/custom-render-pass
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 7.1 Custom renderers
+# Custom renderers
 
 "Custom rendering" in ExoJS means inserting your own draw logic into the frame — either as a pass between normal draws, or as direct GPU work that bypasses the engine's renderer system entirely. The extension surface is intentionally small: two public mechanisms, plus the existing `Mesh`/`MeshShader`/custom shader filter primitives covered in earlier chapters.
 

--- a/site/src/content/guide/advanced/debug-layer.mdx
+++ b/site/src/content/guide/advanced/debug-layer.mdx
@@ -72,7 +72,7 @@ The pointer-stack panel shows up to 10 nodes under the cursor sorted by `zIndex`
 
 ## Render-pass inspector
 
-The [`RenderPassInspectorLayer`](/ExoJS/en/api/render-pass-inspector-layer/) (added in v0.8.3) is covered in detail in [7.6 Render pipeline debugging](/ExoJS/en/guide/advanced/render-pipeline-debugging/). It lists every `RenderNode` with an active filter chain each frame, showing total pass count, per-drawable filter sequences, bounding-box dimensions, and mask/cache flags.
+The [`RenderPassInspectorLayer`](/ExoJS/en/api/render-pass-inspector-layer/) (added in v0.8.3) is covered in detail in [Render pipeline debugging](/ExoJS/en/guide/advanced/render-pipeline-debugging/). It lists every `RenderNode` with an active filter chain each frame, showing total pass count, per-drawable filter sequences, bounding-box dimensions, and mask/cache flags.
 
 ## Lifecycle
 

--- a/site/src/content/guide/advanced/debug-layer.mdx
+++ b/site/src/content/guide/advanced/debug-layer.mdx
@@ -1,16 +1,12 @@
 ---
-title: '7.2 Debug layer'
+title: 'Debug layer'
 description: 'Inspect scene state and runtime behavior while a scene is running.'
-part: 7
-chapter: 2
-examples:
-  - debug-layer/bounding-boxes
-  - debug-layer/performance-overlay
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
+import TryIt from '../../../components/TryIt.astro';
 
-# 7.2 Debug layer
+# Debug layer
 
 ExoJS ships five diagnostic layers in the `@codexo/exojs/debug` optional entrypoint. Four are managed by `DebugOverlay` (performance, bounding boxes, hit-test, pointer stack), and `RenderPassInspectorLayer` is a standalone layer covered below. These tools render as overlays on top of your running scene — no scene-logic changes, no special draw-call instrumentation, no build flags.
 
@@ -95,6 +91,11 @@ Rotating sprites with bounding-box outlines — the fastest way to check that tr
 <ExamplePreview chapter="debug-layer" slug="performance-overlay" />
 
 1600 bouncing sprites with live FPS, frame time, draw-call count, and sparkline.
+
+<TryIt
+  examples={['debug-layer/performance-overlay', 'debug-layer/bounding-boxes']}
+  api={['debug-overlay', 'performance-layer']}
+/>
 
 ## Where to go next
 

--- a/site/src/content/guide/advanced/performance.mdx
+++ b/site/src/content/guide/advanced/performance.mdx
@@ -1,16 +1,12 @@
 ---
-title: '7.3 Performance'
+title: 'Performance'
 description: 'Measure scene limits with focused stress examples.'
-part: 7
-chapter: 3
-examples:
-  - performance/sprite-stress
-  - performance/particle-stress
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
+import TryIt from '../../../components/TryIt.astro';
 
-# 7.3 Performance
+# Performance
 
 Performance in ExoJS is about three things: how many drawables you push per frame, how many render passes they cost, and how much state change happens between draws. The engine does a lot automatically — batching sprites that share a texture, reusing render-target memory across filter passes, culling nodes outside the view — but the decisions that matter most are yours: how many sprites, how many textures, how many filters, how many particle systems.
 
@@ -91,6 +87,11 @@ A 34×20 grid of sprites (680 total) from a single texture atlas, each with anim
 <ExamplePreview chapter="performance" slug="particle-stress" />
 
 Three particle systems emitting 240–320 particles per second each, with custom tint-cycling, scale-over-lifetime, alpha-fade, and force-based velocity. Demonstrates particle system throughput with a non-GPU-eligible custom update module.
+
+<TryIt
+  examples={['performance/sprite-stress', 'performance/particle-stress']}
+  api={['performance-layer']}
+/>
 
 ## Where to go next
 

--- a/site/src/content/guide/advanced/render-pipeline-debugging.mdx
+++ b/site/src/content/guide/advanced/render-pipeline-debugging.mdx
@@ -1,13 +1,11 @@
 ---
-title: '7.6 Render pipeline debugging'
+title: 'Render pipeline debugging'
 description: 'Inspect filter chains, render passes, and intermediate render targets with the in-engine inspector layer and external capture tools.'
-part: 7
-chapter: 6
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 7.6 Render pipeline debugging
+# Render pipeline debugging
 
 Every filter attached to a drawable costs at least one extra render pass. A stack of three filters on a container means the container renders to an off-screen target, the first filter reads and writes a target, the second does the same, and the third composites the result — four passes for one element. When your frame budget tightens, knowing who is adding passes and why matters.
 

--- a/site/src/content/guide/audio/audio-basics.mdx
+++ b/site/src/content/guide/audio/audio-basics.mdx
@@ -1,16 +1,13 @@
 ---
-title: '5.1 Audio basics'
+title: 'Audio basics'
 description: 'Play sounds and music with reliable runtime controls.'
-part: 5
-chapter: 1
-examples:
-  - audio-basics/play-sound
-  - audio-basics/crossfade-tracks
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
+import TryIt from '../../../components/TryIt.astro';
+import Callout from '../../../components/Callout.astro';
 
-# 5.1 Audio basics
+# Audio basics
 
 ExoJS audio is built on two media types: [`Sound`](/ExoJS/en/api/sound/) for short, pooled, decoded-buffer playback and [`Music`](/ExoJS/en/api/music/) for long, streamed, seekable tracks. Both extend `AbstractMedia` and share the same volume, loop, playback rate, mute, bus, and fade controls. The difference is how the browser handles the underlying data.
 
@@ -57,6 +54,10 @@ Browsers require a user gesture before Web Audio starts. ExoJS handles this auto
 For `Sound`, `play()` requests queue until the context is ready. `Music` uses `HTMLAudioElement` playback and is still subject to browser autoplay policy, so starting music from a user gesture remains the safest pattern.
 
 If you need to know when the context is ready, import `isAudioContextReady` from `@codexo/exojs` and poll it.
+
+<Callout type="browser" title="Audio needs a user gesture">
+Browsers won't start audio until the user interacts with the page. Trigger the first sound or music from a click, tap, or key press — the embedded examples below ask for a click for exactly this reason.
+</Callout>
 
 ## Playback controls
 
@@ -171,6 +172,11 @@ Click the canvas to play a loaded `Sound` — the minimal audio example.
 <ExamplePreview chapter="audio-basics" slug="crossfade-tracks" />
 
 Two looping music tracks crossfading back and forth with `crossFade()`.
+
+<TryIt
+  examples={['audio-basics/play-sound', 'audio-basics/crossfade-tracks']}
+  api={['sound', 'music', 'audio-manager']}
+/>
 
 ## Where to go next
 

--- a/site/src/content/guide/audio/audio-effects.mdx
+++ b/site/src/content/guide/audio/audio-effects.mdx
@@ -1,16 +1,11 @@
 ---
-title: '5.3 Audio effects'
+title: 'Audio effects'
 description: 'Shape sound with filters and bus-level processing.'
-part: 5
-chapter: 3
-examples:
-  - audio-fx/compressor
-  - audio-fx/reverb-and-delay
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 5.3 Audio effects
+# Audio effects
 
 Every bus in ExoJS carries a filter chain — an ordered list of [`AudioFilter`](/ExoJS/en/api/audio-filter/) instances that process audio in series. Filters are applied at the bus level, which means adding a filter to `app.audio.music` affects every `Music` instance routing through the music bus. You can also create custom buses for isolated effect chains.
 

--- a/site/src/content/guide/audio/audio-reactive-visualization.mdx
+++ b/site/src/content/guide/audio/audio-reactive-visualization.mdx
@@ -1,16 +1,11 @@
 ---
-title: '5.5 Audio-reactive visualization'
+title: 'Audio-reactive visualization'
 description: 'Bridge audio analysis and beat-detection state into the render pipeline via DataTexture and BeatDetector polling.'
-part: 5
-chapter: 5
-examples:
-  - showcase/audio-visualisation
-  - beat-detection/beat-sync-pulse
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 5.5 Audio-reactive visualization
+# Audio-reactive visualization
 
 An audio-reactive scene is one where visuals move, change color, or trigger effects in response to the music or sound currently playing. ExoJS gives you two building blocks for this: [`AudioAnalyser`](/ExoJS/en/api/audio-analyser/) for per-frame spectrum data, and [`BeatDetector`](/ExoJS/en/api/beat-detector/) for rhythmic timing. You combine them inside `update` — sample what you need, map it to visual properties, and let the renderer handle the rest.
 

--- a/site/src/content/guide/audio/beat-detection.mdx
+++ b/site/src/content/guide/audio/beat-detection.mdx
@@ -7,7 +7,7 @@ import ExamplePreview from '../../../components/ExamplePreview.astro';
 
 # Beat detection
 
-The [`BeatDetector`](/ExoJS/en/api/beat-detector/) analyses an audio signal in real time using a self-contained `AudioWorkletProcessor`. It detects tempo, beat positions, and bar/downbeat structure, then reports results back to the main thread as both discrete events (`onBeat`, `onDownbeat`, `onBarStart`, `onTempoChange`) and per-frame polling getters. You use the events for one-shot triggers and the getters for continuous animation — both are covered in detail in [5.5 Audio-reactive visualization](/ExoJS/en/guide/audio/audio-reactive-visualization/).
+The [`BeatDetector`](/ExoJS/en/api/beat-detector/) analyses an audio signal in real time using a self-contained `AudioWorkletProcessor`. It detects tempo, beat positions, and bar/downbeat structure, then reports results back to the main thread as both discrete events (`onBeat`, `onDownbeat`, `onBarStart`, `onTempoChange`) and per-frame polling getters. You use the events for one-shot triggers and the getters for continuous animation — both are covered in detail in [Audio-reactive visualization](/ExoJS/en/guide/audio/audio-reactive-visualization/).
 
 This chapter covers what the detector does and the events it fires. The next chapter covers what you do with that information.
 
@@ -128,7 +128,7 @@ const detector = new BeatDetector({
 
 `BeatDetector` uses an `AudioWorkletProcessor` that runs entirely in the Web Audio rendering thread. It applies a Hann window, runs a radix-2 FFT, computes mel-band energies, detects onsets via spectral flux, builds a tempogram with autocorrelation, and tracks beat phase with a dynamic-programming grid. All of this is internal — the public API is the events and getters listed above.
 
-Beat/state messages are posted from the worklet and handled asynchronously on the main thread. They are not locked to your scene's `update` timing, and worklet timing can be finer than `requestAnimationFrame`. For frame-stable visual animation, prefer polling getters in `update` (see [5.5 Audio-reactive visualization](/ExoJS/en/guide/audio/audio-reactive-visualization/)).
+Beat/state messages are posted from the worklet and handled asynchronously on the main thread. They are not locked to your scene's `update` timing, and worklet timing can be finer than `requestAnimationFrame`. For frame-stable visual animation, prefer polling getters in `update` (see [Audio-reactive visualization](/ExoJS/en/guide/audio/audio-reactive-visualization/)).
 
 ## Configuring the detector
 

--- a/site/src/content/guide/audio/beat-detection.mdx
+++ b/site/src/content/guide/audio/beat-detection.mdx
@@ -1,16 +1,11 @@
 ---
-title: '5.4 Beat detection'
+title: 'Beat detection'
 description: 'Drive visuals from beat and frequency information.'
-part: 5
-chapter: 4
-examples:
-  - beat-detection/beat-sync-pulse
-  - beat-detection/tempo-tracking
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 5.4 Beat detection
+# Beat detection
 
 The [`BeatDetector`](/ExoJS/en/api/beat-detector/) analyses an audio signal in real time using a self-contained `AudioWorkletProcessor`. It detects tempo, beat positions, and bar/downbeat structure, then reports results back to the main thread as both discrete events (`onBeat`, `onDownbeat`, `onBarStart`, `onTempoChange`) and per-frame polling getters. You use the events for one-shot triggers and the getters for continuous animation — both are covered in detail in [5.5 Audio-reactive visualization](/ExoJS/en/guide/audio/audio-reactive-visualization/).
 

--- a/site/src/content/guide/audio/spatial-audio.mdx
+++ b/site/src/content/guide/audio/spatial-audio.mdx
@@ -1,16 +1,11 @@
 ---
-title: '5.2 Spatial audio'
+title: 'Spatial audio'
 description: 'Place listener and sources in space for directional sound behavior.'
-part: 5
-chapter: 2
-examples:
-  - spatial-audio/listener-and-source
-  - spatial-audio/falloff-curves
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 5.2 Spatial audio
+# Spatial audio
 
 Spatial audio in ExoJS is 2D: a single shared listener and any number of sound sources, each with a world-space position. The engine maps the 2D coordinates to the Web Audio API's 3D panner behind the scenes — you work in the same pixel coordinates your sprites and containers use, and the audio system pans and attenuates accordingly.
 

--- a/site/src/content/guide/core-concepts/application.mdx
+++ b/site/src/content/guide/core-concepts/application.mdx
@@ -1,11 +1,6 @@
 ---
-title: '2.1 Application'
+title: 'Application'
 description: 'How the application owns canvas, render backend, resources, input, scene management, and the frame loop.'
-part: 2
-chapter: 1
-examples:
-  - getting-started/hello-world
-  - getting-started/resize-and-dpr
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';

--- a/site/src/content/guide/core-concepts/coordinates-and-views.mdx
+++ b/site/src/content/guide/core-concepts/coordinates-and-views.mdx
@@ -1,13 +1,6 @@
 ---
-title: '2.5 Coordinates and views'
+title: 'Coordinates and views'
 description: 'World space, canvas space, and how the active view maps between them — plus camera movement, zoom, and split rendering.'
-part: 2
-chapter: 5
-examples:
-  - application-scenes/camera-and-view
-  - application-scenes/multi-view-split-screen
-  - application-scenes/picture-in-picture
-  - application-scenes/world-vs-screen-coords
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';

--- a/site/src/content/guide/core-concepts/loading-and-resources.mdx
+++ b/site/src/content/guide/core-concepts/loading-and-resources.mdx
@@ -1,10 +1,6 @@
 ---
-title: '2.6 Loading and resources'
+title: 'Loading and resources'
 description: 'The asset pipeline — how the loader registers, fetches, and resolves resources before your scene starts updating.'
-part: 2
-chapter: 6
-examples:
-  - sprites-textures/texture-loader
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';

--- a/site/src/content/guide/core-concepts/loading-and-resources.mdx
+++ b/site/src/content/guide/core-concepts/loading-and-resources.mdx
@@ -417,4 +417,4 @@ The minimum loader workflow — register textures during `load`, retrieve them d
 
 ## Where to go next
 
-That closes Part 2. The next part, [Drawing](/ExoJS/en/guide/drawing/), covers what you can put on screen — graphics primitives, sprites, text, animation, and render targets.
+That closes Core Concepts. The next part, [Drawing](/ExoJS/en/guide/drawing/), covers what you can put on screen — graphics primitives, sprites, text, animation, and render targets.

--- a/site/src/content/guide/core-concepts/scene-graph.mdx
+++ b/site/src/content/guide/core-concepts/scene-graph.mdx
@@ -1,15 +1,6 @@
 ---
-title: '2.4 Scene graph'
+title: 'Scene graph'
 description: 'Parent-child structure, transform inheritance, render order, masks, and how the tree stays composable.'
-part: 2
-chapter: 4
-examples:
-  - scene-graph/containers
-  - scene-graph/nested-transforms
-  - scene-graph/local-vs-global-transform
-  - scene-graph/pivot-and-anchor
-  - scene-graph/z-ordering
-  - scene-graph/masks
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';

--- a/site/src/content/guide/core-concepts/scene-graph.mdx
+++ b/site/src/content/guide/core-concepts/scene-graph.mdx
@@ -11,7 +11,7 @@ A scene's drawables form a tree: every renderable node has zero or one parent an
 
 ## Containers and nodes
 
-Two key types: [`RenderNode`](/ExoJS/en/api/rendernode/) is the abstract base for everything that can be drawn. [`Container`](/ExoJS/en/api/container/) is a `RenderNode` that holds children. Sprites, text, graphics, and meshes are all render nodes; containers are how you group them.
+Two key types: [`RenderNode`](/ExoJS/en/api/render-node/) is the abstract base for everything that can be drawn. [`Container`](/ExoJS/en/api/container/) is a `RenderNode` that holds children. Sprites, text, graphics, and meshes are all render nodes; containers are how you group them.
 
 Every scene starts with one container already in place — `this.root`. Adding a node via `this.addChild(...)` is shorthand for `this.root.addChild(...)`:
 

--- a/site/src/content/guide/core-concepts/scene-lifecycle.mdx
+++ b/site/src/content/guide/core-concepts/scene-lifecycle.mdx
@@ -1,15 +1,10 @@
 ---
-title: '2.3 Scene lifecycle'
+title: 'Scene lifecycle'
 description: 'The order scene hooks run in, what each one is for, and the rule about explicit drawing.'
-part: 2
-chapter: 3
-examples:
-  - application-scenes/scene-lifecycle
-  - application-scenes/pause-and-resume
-  - getting-started/game-loop
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
+import TryIt from '../../../components/TryIt.astro';
 
 # Scene lifecycle
 
@@ -147,6 +142,11 @@ The `update` hook is gated; `draw` keeps running. Demonstrates that the loop con
 <ExamplePreview chapter="getting-started" slug="game-loop" />
 
 The minimum lifecycle that produces motion: `init` builds the sprite, `update` rotates it, `draw` renders.
+
+<TryIt
+  examples={['application-scenes/scene-lifecycle', 'getting-started/game-loop']}
+  api={['scene', 'loader']}
+/>
 
 ## Where to go next
 

--- a/site/src/content/guide/core-concepts/scenes.mdx
+++ b/site/src/content/guide/core-concepts/scenes.mdx
@@ -1,13 +1,10 @@
 ---
-title: '2.2 Scenes'
+title: 'Scenes'
 description: 'How scenes split runtime work, hold game state, and compose into a stack via the scene manager.'
-part: 2
-chapter: 2
-examples:
-  - application-scenes/multiple-scenes
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
+import TryIt from '../../../components/TryIt.astro';
 
 # Scenes
 
@@ -93,6 +90,11 @@ await app.scene.pushScene(pause);
 <ExamplePreview chapter="application-scenes" slug="multiple-scenes" />
 
 Switching between two scenes — a menu and a game — using the scene manager.
+
+<TryIt
+  examples={['application-scenes/multiple-scenes']}
+  api={['scene']}
+/>
 
 ## Where to go next
 

--- a/site/src/content/guide/drawing/animation.mdx
+++ b/site/src/content/guide/drawing/animation.mdx
@@ -1,21 +1,11 @@
 ---
-title: '3.4 Animation'
+title: 'Animation'
 description: 'Animate transforms and values with tweens and frame updates.'
-part: 3
-chapter: 4
-examples:
-  - tweens-animation/easing-curves
-  - tweens-animation/frame-animation
-  - tweens-animation/interrupt-and-replace
-  - tweens-animation/tween-basics
-  - tweens-animation/tween-chains
-  - tweens-animation/tween-from-array
-  - tweens-animation/tween-with-yoyo
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 3.4 Animation
+# Animation
 
 ExoJS gives you three layers of animation control, each suited to a different kind of motion:
 

--- a/site/src/content/guide/drawing/graphics.mdx
+++ b/site/src/content/guide/drawing/graphics.mdx
@@ -1,19 +1,12 @@
 ---
-title: '3.1 Graphics'
+title: 'Graphics'
 description: 'Draw procedural shapes and mesh-based geometry.'
-part: 3
-chapter: 1
-examples:
-  - geometry-graphics/graphics-primitives
-  - geometry-graphics/infinite-grid
-  - geometry-graphics/mesh-triangle
-  - geometry-graphics/mesh-textured-quad
-  - geometry-graphics/mesh-deformed-grid
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
+import TryIt from '../../../components/TryIt.astro';
 
-# 3.1 Graphics
+# Graphics
 
 [`Graphics`](/ExoJS/en/api/graphics/) is a `Container` that builds vector shapes and filled meshes procedurally at runtime. Each call to `drawCircle`, `drawRectangle`, `drawLine`, or any of the path commands appends a new colored [`Mesh`](/ExoJS/en/api/mesh/) child. `Graphics` inherits full filter, blend, tint, and mask support from `Container`, so every shape you draw participates in the scene graph the same way a `Sprite` would.
 
@@ -167,6 +160,11 @@ All seven shape primitives on one canvas, each animated differently.
 <ExamplePreview chapter="geometry-graphics" slug="mesh-deformed-grid" />
 
 Animated vertex deformation on a `Mesh` — the lower-level primitive `Graphics` builds on.
+
+<TryIt
+  examples={['geometry-graphics/graphics-primitives', 'geometry-graphics/mesh-deformed-grid']}
+  api={['graphics', 'color']}
+/>
 
 ## Where to go next
 

--- a/site/src/content/guide/drawing/render-targets.mdx
+++ b/site/src/content/guide/drawing/render-targets.mdx
@@ -1,16 +1,11 @@
 ---
-title: '3.5 Render targets'
+title: 'Render targets'
 description: 'Render into intermediate textures and reuse those outputs in scene composition.'
-part: 3
-chapter: 5
-examples:
-  - render-targets/render-to-texture
-  - render-targets/mini-map
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 3.5 Render targets
+# Render targets
 
 The canvas is the default render target — every `context.backend.clear()` and `context.render(sprite)` goes there. A [`RenderTexture`](/ExoJS/en/api/render-texture/) is a second target: an off-screen surface you can draw into and then sample as a texture on a sprite, apply filters to, or composite back into the main scene.
 

--- a/site/src/content/guide/drawing/sprites.mdx
+++ b/site/src/content/guide/drawing/sprites.mdx
@@ -1,19 +1,12 @@
 ---
-title: '3.2 Sprites'
+title: 'Sprites'
 description: 'Render image-based content from textures, sheets, SVG, and video.'
-part: 3
-chapter: 2
-examples:
-  - sprites-textures/sprite-basics
-  - sprites-textures/blendmodes
-  - sprites-textures/spritesheet-frames
-  - sprites-textures/svg-drawable
-  - sprites-textures/video-drawable
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
+import TryIt from '../../../components/TryIt.astro';
 
-# 3.2 Sprites
+# Sprites
 
 A [`Sprite`](/ExoJS/en/api/sprite/) is the primary drawable for textured quads — rectangles that display an image, a sub-region of an image, or a rendered-to-texture surface. Most visible content in a 2D scene passes through sprites.
 
@@ -177,6 +170,11 @@ A single sprite in the center of the canvas, rotating and cycling through tints.
 <ExamplePreview chapter="sprites-textures" slug="spritesheet-frames" />
 
 Navigating a spritesheet's frames by name — the texture-frame mechanism in practice.
+
+<TryIt
+  examples={['sprites-textures/sprite-basics', 'sprites-textures/spritesheet-frames']}
+  api={['sprite', 'spritesheet', 'texture']}
+/>
 
 ## Where to go next
 

--- a/site/src/content/guide/drawing/text.mdx
+++ b/site/src/content/guide/drawing/text.mdx
@@ -1,19 +1,11 @@
 ---
-title: '3.3 Text'
+title: 'Text'
 description: 'Control layout, styling, and visual effects for runtime text.'
-part: 3
-chapter: 3
-examples:
-  - text-fonts/basic-text
-  - text-fonts/multiline-and-wrap
-  - text-fonts/stroke-and-shadow
-  - text-fonts/web-fonts
-  - text-fonts/text-glitch
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 3.3 Text
+# Text
 
 [`Text`](/ExoJS/en/api/text/) renders GPU-accelerated text strings as nodes in the scene graph. Each `Text` instance rasterizes its glyphs into the engine's shared glyph atlas and draws them as a single `Mesh` — one draw call per text node, regardless of string length. The node extends `Container` and inherits full transform, filter, blend, and mask support.
 

--- a/site/src/content/guide/effects/custom-mesh-shaders.mdx
+++ b/site/src/content/guide/effects/custom-mesh-shaders.mdx
@@ -1,13 +1,11 @@
 ---
-title: '6.4 Custom mesh shaders'
+title: 'Custom mesh shaders'
 description: 'Attach custom GLSL or WGSL shaders to a Mesh for backend-portable visual effects.'
-part: 6
-chapter: 4
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 6.4 Custom mesh shaders
+# Custom mesh shaders
 
 A [`Mesh`](/ExoJS/en/api/mesh/) normally renders with the engine's built-in batch shader — textured or untextured, vertex-colored or uniform-tinted, lit with the mesh's own tint and blend mode. That covers most use cases. When you need something the default shader does not do — procedural displacement, custom lighting, multi-texture mixing, a Shadertoy-style effect mapped onto geometry — you attach a [`MeshShader`](/ExoJS/en/api/mesh-shader/).
 

--- a/site/src/content/guide/effects/filters.mdx
+++ b/site/src/content/guide/effects/filters.mdx
@@ -1,16 +1,11 @@
 ---
-title: '6.1 Filters'
+title: 'Filters'
 description: 'Stack shader and color effects to control final image style.'
-part: 6
-chapter: 1
-examples:
-  - filters/blur-filter
-  - filters/filter-stack
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 6.1 Filters
+# Filters
 
 A [`Filter`](/ExoJS/en/api/filter/) is a post-render effect applied to a single drawable's output. Every `RenderNode` — sprites, containers, graphics, meshes, text — carries a `filters` array. Each filter in that array transforms the node's rendered pixels before the result composites into the parent.
 

--- a/site/src/content/guide/effects/particles.mdx
+++ b/site/src/content/guide/effects/particles.mdx
@@ -1,16 +1,11 @@
 ---
-title: '6.2 Particles'
+title: 'Particles'
 description: 'Spawn and tune particle systems for environmental and reactive effects.'
-part: 6
-chapter: 2
-examples:
-  - particles/emitter-basics
-  - particles/bonfire
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 6.2 Particles
+# Particles
 
 A [`ParticleSystem`](/ExoJS/en/api/particle-system/) is a `Drawable` that manages thousands of animated sprites with data-oriented performance. Instead of creating and destroying individual `Sprite` instances per particle, the system stores particle state in parallel typed arrays (Struct-of-Arrays) and mutates them in bulk. This keeps the work per-particle extremely lean — no allocations, no GC pressure, no per-sprite transform tree overhead.
 

--- a/site/src/content/guide/effects/post-processing.mdx
+++ b/site/src/content/guide/effects/post-processing.mdx
@@ -1,16 +1,11 @@
 ---
-title: '6.3 Post-processing'
+title: 'Post-processing'
 description: 'Build multi-pass render flows for bloom, trails, and mirror effects.'
-part: 6
-chapter: 3
-examples:
-  - render-targets/bloom-lite
-  - render-targets/post-processing-chain
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 6.3 Post-processing
+# Post-processing
 
 Post-processing means rendering a scene — or parts of one — into off-screen [`RenderTexture`](/ExoJS/en/api/render-texture/) targets, running filters on those targets, and compositing the results back onto the canvas. This is the pattern behind bloom, color grading, motion trails, screen-wide shader effects, and any multi-pass render flow where a filter treats the whole scene as one image.
 

--- a/site/src/content/guide/effects/post-processing.mdx
+++ b/site/src/content/guide/effects/post-processing.mdx
@@ -172,7 +172,7 @@ You compose them: render scenes with `RenderTargetPass`, apply filters with `fil
 - Post-processing: Filter affects the entire scene rendered into a target. Good for screen-wide effects — bloom, color grading, CRT simulation.
 - Both together: Per-node filters for individual effects, post-processing chain for scene-wide compositing.
 
-The cost is in passes. A post-processing chain with 3 RTS and 2 filters costs at least 4 passes (scene render + filter A + filter B + final composite). Per-node filters cost 1 pass per filtered node per frame. The render pipeline debugger ([7.6 Render pipeline debugging](/ExoJS/en/guide/advanced/render-pipeline-debugging/)) helps you count these.
+The cost is in passes. A post-processing chain with 3 RTS and 2 filters costs at least 4 passes (scene render + filter A + filter B + final composite). Per-node filters cost 1 pass per filtered node per frame. The render pipeline debugger ([Render pipeline debugging](/ExoJS/en/guide/advanced/render-pipeline-debugging/)) helps you count these.
 
 ## Examples
 

--- a/site/src/content/guide/input/action-mapping.mdx
+++ b/site/src/content/guide/input/action-mapping.mdx
@@ -1,15 +1,11 @@
 ---
-title: '4.4 Action mapping'
+title: 'Action mapping'
 description: 'Map multiple devices to the same intent-driven input actions.'
-part: 4
-chapter: 4
-examples:
-  - input/action-mapping
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 4.4 Action mapping
+# Action mapping
 
 Hard-coding `Keyboard.Space` for jump works until someone picks up a controller. Hard-coding `GamepadButton.South` works until someone prefers the keyboard. Action mapping means naming what the player intends to do — "jump", "move right", "pause" — and binding each intent to one or more input channels regardless of device.
 

--- a/site/src/content/guide/input/gamepad.mdx
+++ b/site/src/content/guide/input/gamepad.mdx
@@ -1,16 +1,12 @@
 ---
-title: '4.3 Gamepad'
+title: 'Gamepad'
 description: 'Read controller input and support multiple connected gamepads.'
-part: 4
-chapter: 3
-examples:
-  - input/gamepad
-  - input/multi-gamepad
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
+import TryIt from '../../../components/TryIt.astro';
 
-# 4.3 Gamepad
+# Gamepad
 
 ExoJS manages gamepads through four stable slot mailboxes. Each slot is a [`Gamepad`](/ExoJS/en/api/gamepad/) instance that lives for the application's full lifetime — a physical controller moves in when connected, moves out when disconnected, and your listeners stay attached through both transitions. Address pads by slot (0–3, stable across reconnect) rather than by browser index (which the browser may reassign).
 
@@ -235,6 +231,11 @@ Visual gamepad state display: buttons, sticks, D-pad, and triggers mapped to on-
 <ExamplePreview chapter="input" slug="multi-gamepad" />
 
 Four sprites, each controlled by a separate gamepad slot via aggregate signed stick axes.
+
+<TryIt
+  examples={['input/gamepad', 'input/multi-gamepad']}
+  api={['gamepad', 'input-manager']}
+/>
 
 ## Where to go next
 

--- a/site/src/content/guide/input/keyboard.mdx
+++ b/site/src/content/guide/input/keyboard.mdx
@@ -1,16 +1,12 @@
 ---
-title: '4.1 Keyboard'
+title: 'Keyboard'
 description: 'Capture keys and support configurable bindings.'
-part: 4
-chapter: 1
-examples:
-  - input/keyboard
-  - input/key-rebinding
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
+import TryIt from '../../../components/TryIt.astro';
 
-# 4.1 Keyboard
+# Keyboard
 
 ExoJS maps keys to numeric channels via the [`Keyboard`](/ExoJS/en/api/keyboard/) enum. `Keyboard.Space` is channel 32, `Keyboard.A` is 65, `Keyboard.Left` is 37. Values follow the browser's legacy `KeyboardEvent.keyCode` mapping. Keys only fire while the canvas has focus; when focus leaves, all held keys are released automatically.
 
@@ -174,6 +170,11 @@ WASD movement with `onActive`/`onStop` — the standard held-key pattern.
 <ExamplePreview chapter="input" slug="key-rebinding" />
 
 Press J to enter rebind mode, then press any key to reassign the jump action.
+
+<TryIt
+  examples={['input/keyboard', 'input/key-rebinding']}
+  api={['keyboard', 'input-manager']}
+/>
 
 ## Where to go next
 

--- a/site/src/content/guide/input/mouse-and-pointer.mdx
+++ b/site/src/content/guide/input/mouse-and-pointer.mdx
@@ -1,16 +1,11 @@
 ---
-title: '4.2 Mouse and pointer'
+title: 'Mouse and pointer'
 description: 'Work with pointer events across mouse and touch-compatible devices.'
-part: 4
-chapter: 2
-examples:
-  - input/mouse-and-pointer
-  - input/pointer-to-world
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 4.2 Mouse and pointer
+# Mouse and pointer
 
 ExoJS unifies mouse, touch, and pen input under a single pointer system built on the browser's Pointer Events API. Every pointer is represented by a [`Pointer`](/ExoJS/en/api/pointer/) instance with a canvas-pixel position, button state, pressure, tilt, and a slot index. The [`InputManager`](/ExoJS/en/api/input-manager/) tracks up to 16 simultaneous pointers — enough for ten-finger multitouch, plus a mouse, plus a pen — with no additional configuration.
 

--- a/site/src/content/guide/introduction/project-structure.mdx
+++ b/site/src/content/guide/introduction/project-structure.mdx
@@ -1,0 +1,73 @@
+---
+title: 'Project structure'
+description: 'Find your way around a create-exo-app project: the entry point, scenes, assets, and how main.ts wires an Application to a Scene.'
+---
+
+import SourceSnippet from '../../../components/SourceSnippet.astro';
+import NextStep from '../../../components/NextStep.astro';
+
+# Project structure
+
+A `create-exo-app` project is a standard Vite + TypeScript app. The `minimal` template gives you the smallest layout that still separates startup from scene code:
+
+```txt
+my-game/
+├─ index.html          # mounts the app, loads src/main.ts
+├─ package.json        # @codexo/exojs + Vite scripts
+├─ tsconfig.json       # strict TypeScript config
+├─ vite.config.ts      # dev server and build config
+├─ public/
+│  └─ assets/          # static files served as-is (images, audio, fonts)
+└─ src/
+   ├─ main.ts          # entry point: create the Application, start a Scene
+   └─ scenes/
+      └─ MainScene.ts  # your first scene
+```
+
+Two files hold the code you will edit most: `main.ts` and the scene under `src/scenes/`.
+
+## The entry point
+
+`src/main.ts` is where the app starts. It creates one [`Application`](/ExoJS/en/api/application/), mounts its canvas, and starts a [`Scene`](/ExoJS/en/api/scene/):
+
+<SourceSnippet
+  source="packages/create-exo-app/templates/minimal/src/main.ts"
+  region="minimal-main"
+  language="ts"
+  title="src/main.ts"
+/>
+
+The application owns runtime configuration — canvas size, clear color, render backend, and the frame loop. `app.start(scene)` hands control to a scene and begins ticking. `document.body.append(app.canvas)` mounts the canvas; in a real layout you place it wherever your page needs it.
+
+## The scene
+
+`src/scenes/MainScene.ts` is the scene `main.ts` starts. It sets up state in its constructor, updates it each frame, and draws it:
+
+<SourceSnippet
+  source="packages/create-exo-app/templates/minimal/src/scenes/MainScene.ts"
+  region="minimal-scene"
+  language="ts"
+  title="src/scenes/MainScene.ts"
+/>
+
+`update(delta)` advances state — here, rotating a box — and `draw(context)` renders it. `delta.seconds` carries the elapsed time since the last frame, so motion stays frame-rate independent. The [Your first scene](/ExoJS/en/guide/introduction/your-first-scene/) chapter builds a scene like this from scratch.
+
+## Where assets go
+
+Files under `public/assets/` are served as-is and addressed by path at runtime — for example `loader.load(Texture, { hero: 'assets/hero.png' })`. The [Loading and resources](/ExoJS/en/guide/core-concepts/loading-and-resources/) chapter covers the loader in detail.
+
+## Scripts
+
+The template's `package.json` defines the standard Vite scripts:
+
+```sh
+npm run dev      # start the dev server with hot reload
+npm run build    # produce a production build in dist/
+npm run preview  # serve the production build locally
+```
+
+The other templates add more structure on top of this same shape: `game-starter` splits player logic into `src/objects/` and adds a game-over scene, and `audio-reactive` adds an analyser-driven scene. The entry point and scene model stay the same.
+
+<NextStep href="/ExoJS/en/guide/introduction/your-first-scene/" label="Build your first scene">
+Start from an empty scene and add a texture, a sprite, and per-frame motion.
+</NextStep>

--- a/site/src/content/guide/introduction/setup.mdx
+++ b/site/src/content/guide/introduction/setup.mdx
@@ -1,91 +1,84 @@
 ---
 title: 'Setup'
-description: 'Install ExoJS, create an application, choose a canvas, and verify the runtime before writing scene code.'
-part: 1
-chapter: 2
-examples: []
+description: 'Create a typed ExoJS project with create-exo-app, run the dev server, and produce a production build.'
 ---
+
+import Callout from '../../../components/Callout.astro';
+import NextStep from '../../../components/NextStep.astro';
 
 # Setup
 
-This page covers the practical setup before writing scene code: installing the runtime, creating an app, choosing a canvas, and confirming everything works.
+The fastest way to start is `create-exo-app`. It scaffolds a Vite + TypeScript project that already imports `@codexo/exojs`, runs a scene, and is ready for `dev` and `build`.
 
-## Install
+## Create a project
+
+Run the scaffolder and follow the prompts:
+
+```sh
+npm create exo-app@latest my-game
+```
+
+Then install dependencies and start the dev server:
+
+```sh
+cd my-game
+npm install
+npm run dev
+```
+
+The dev server prints a local URL. Open it and you'll see a running scene with hot reload.
+
+## Choose a template
+
+`create-exo-app` ships three templates. Pass one with `--template`, or pick it interactively:
+
+| Template | Starts with |
+|----------|-------------|
+| `minimal` | One scene drawing and animating a single shape — the smallest real project. |
+| `game-starter` | A player object, a game scene, and a game-over scene with restart. |
+| `audio-reactive` | An analyser-driven scene that turns sound into a live spectrum. |
+
+```sh
+npm create exo-app@latest my-game -- --template game-starter
+```
+
+The [Project structure](/ExoJS/en/guide/introduction/project-structure/) chapter walks through what each file does.
+
+## Build for production
+
+Vite produces a static bundle you can host anywhere:
+
+```sh
+npm run build     # output in dist/
+npm run preview   # serve the production build locally
+```
+
+The [Deployment](/ExoJS/en/guide/reference/deployment/) chapter covers hosting, base paths, and assets.
+
+## Add ExoJS to an existing project
+
+If you already have a bundler-based project, install the runtime directly:
 
 ```sh
 npm install @codexo/exojs
 ```
 
-The package ships as ESM with TypeScript declarations. Any modern bundler (Vite, esbuild, Rollup, webpack, Parcel, …) picks both up automatically.
-
-## A minimal HTML page
-
-ExoJS renders into a regular `HTMLCanvasElement`. For a small test page, defining one canvas in the page is enough:
-
-```html
-<!doctype html>
-<html lang="en">
-    <head>
-        <meta charset="utf-8" />
-        <title>ExoJS</title>
-        <style>
-            body { margin: 0; }
-            #scene { display: block; }
-        </style>
-    </head>
-    <body>
-        <canvas id="scene" width="800" height="600"></canvas>
-        <script type="module" src="./main.js"></script>
-    </body>
-</html>
-```
-
-## Create the application
-
-The `Application` can create a canvas automatically:
-
-```js
-import { Application } from '@codexo/exojs';
-
-const app = new Application();
-```
-
-If your page already has a canvas, pass it into `Application` when you create the app:
+The package ships as ESM with TypeScript declarations, so any modern bundler (Vite, esbuild, Rollup, webpack, Parcel) picks up both the code and the types. ExoJS renders into a regular `HTMLCanvasElement`; create one yourself or let `Application` create it for you:
 
 ```ts
 import { Application } from '@codexo/exojs';
 
-const canvas = document.querySelector<HTMLCanvasElement>('canvas')!;
+// Pass an existing canvas...
+const canvas = document.querySelector<HTMLCanvasElement>('#scene')!;
 const app = new Application({ canvas: { element: canvas } });
+
+// ...or let the application create one and mount app.canvas yourself.
 ```
 
-The `app.canvas` property is the active `HTMLCanvasElement` the runtime renders into.
+<Callout type="tip">
+`app.canvas` is the active `HTMLCanvasElement` the runtime renders into. Append it wherever your layout needs it.
+</Callout>
 
-## Verify the runtime
-
-Before adding game logic, confirm the runtime starts cleanly:
-
-```js
-import { Application, Color, Scene } from '@codexo/exojs';
-
-const canvas = document.querySelector('#scene');
-
-if (!(canvas instanceof HTMLCanvasElement)) {
-    throw new Error('Expected #scene canvas element.');
-}
-
-class BlankScene extends Scene {
-    draw(context) {
-        context.backend.clear();
-    }
-}
-
-const app = new Application({ canvas: { element: canvas }, clearColor: Color.midnightBlue });
-app.start(new BlankScene());
-```
-
-Open the page; the canvas paints solid midnight blue every frame. If you see that, the runtime is wired correctly.
-
-## Where to go next
-
-You have a working page with a running app. The next chapter, [Your first scene](/ExoJS/en/guide/introduction/your-first-scene/), builds on this scaffold to load assets, position a sprite, and animate it.
+<NextStep href="/ExoJS/en/guide/introduction/project-structure/" label="Tour the project structure">
+See where the entry point, scenes, and assets live in a generated project.
+</NextStep>

--- a/site/src/content/guide/introduction/what-is-exojs.mdx
+++ b/site/src/content/guide/introduction/what-is-exojs.mdx
@@ -1,10 +1,10 @@
 ---
-title: '1.1 What is ExoJS?'
+title: 'What is ExoJS?'
 description: 'A short tour of what ExoJS is, where it fits, how a project is shaped, and how to read this guide.'
-part: 1
-chapter: 1
-examples: []
 ---
+
+import Callout from '../../../components/Callout.astro';
+import NextStep from '../../../components/NextStep.astro';
 
 # What is ExoJS?
 
@@ -45,14 +45,18 @@ ExoJS ships as ESM with TypeScript declarations. JavaScript projects can use the
 
 ## Browser support
 
-ExoJS targets evergreen browsers: current Chrome, Firefox, Edge, and Safari. On startup, the runtime auto-selects the strongest available render backend (WebGPU when present, WebGL2 otherwise).
+ExoJS targets evergreen browsers: current Chrome, Firefox, Edge, and Safari. Some examples in this guide need browser features beyond rendering — audio playback, gamepad APIs, or multi-touch input. Capability badges above each example list what it expects; when a feature is missing, the embedded preview shows a clear overlay instead of failing silently.
 
-Some examples in this guide require browser features beyond rendering, such as audio playback, gamepad APIs, or multi-touch input. Capability badges above each example list what it expects; when a feature is missing, the embedded preview shows a clear overlay instead of failing silently.
+<Callout type="browser">
+On startup the runtime auto-selects the strongest available backend — WebGPU when present, WebGL2 otherwise. You write the same scene code either way.
+</Callout>
 
 ## How to read this guide
 
-Read the first two parts in order — Introduction and Core Concepts. They build the mental model the rest of the guide assumes. After that, jump by topic.
+Read Getting Started and Core Concepts in order — they build the mental model the rest of the guide assumes. After that, jump by topic.
 
-The [API reference](/ExoJS/en/api/) covers exact constructor options, method signatures, and return types. The [playground](/ExoJS/en/playground/) lets you change any embedded example and see what happens.
+Three resources work together: the **guide** explains concepts and workflows, the [**playground**](/ExoJS/en/playground/) runs and edits every example live, and the [**API reference**](/ExoJS/en/api/) documents exact constructor options, method signatures, and return types.
 
-Capability badges over each example show which browser features it expects (audio, gamepad, WebGPU, …). When a feature is unavailable in the current browser, the preview shows an overlay listing what's missing rather than silently breaking.
+<NextStep href="/ExoJS/en/guide/introduction/setup/" label="Create a project">
+Scaffold a typed project with create-exo-app and run it in the browser.
+</NextStep>

--- a/site/src/content/guide/introduction/your-first-scene.mdx
+++ b/site/src/content/guide/introduction/your-first-scene.mdx
@@ -1,14 +1,13 @@
 ---
-title: '1.3 Your first scene'
+title: 'Your first scene'
 description: 'Build a working scene from scratch — load a texture, position a sprite, draw it, and animate it across frames.'
-part: 1
-chapter: 3
-examples:
-  - getting-started/hello-world
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 import SourceSnippet from '../../../components/SourceSnippet.astro';
+import Callout from '../../../components/Callout.astro';
+import TryIt from '../../../components/TryIt.astro';
+import NextStep from '../../../components/NextStep.astro';
 
 # Your first scene
 
@@ -60,6 +59,10 @@ A few things worth pointing out:
 - `loader.load(Texture, { bunny: 'image/bunny.png' })` declares one asset under the name `bunny`. Inside `init`, `loader.get(Texture, 'bunny')` returns the loaded texture instance. Names are stable; paths can change later without touching the rest of the code.
 - The default sprite anchor is `(0, 0)` — the top-left. With `setAnchor(0.5)`, the sprite's center becomes its pivot point, so `setPosition(width / 2, height / 2)` places the sprite at the canvas center rather than offset to one corner.
 
+<Callout type="common-mistake" title="A sprite that won't center">
+A sprite's default anchor is its top-left corner. `setPosition(width / 2, height / 2)` then places the corner — not the center — at the middle of the canvas. Call `setAnchor(0.5)` first.
+</Callout>
+
 ## Adding motion
 
 Override `update` to advance state once per frame. The `delta` argument carries the elapsed time since the previous frame; multiplying transforms by `delta.seconds` makes motion frame-rate independent:
@@ -86,8 +89,15 @@ For the smallest possible test page, appending to `document.body` is fine. Eithe
 
 <ExamplePreview chapter="getting-started" slug="hello-world" />
 
+<TryIt
+  examples={['getting-started/hello-world']}
+  api={['scene', 'sprite', 'texture', 'loader']}
+/>
+
 ## Where to go next
 
-The pieces shown here — `Application`, `Scene`, `Loader`, `Sprite`, `Texture` — each have their own chapter. [Core Concepts](/ExoJS/en/guide/core-concepts/application/) walks through the engine plumbing in order: how applications and scenes fit together, how the scene graph composes drawables, how the view transform handles cameras and resolutions.
+The pieces shown here — `Application`, `Scene`, `Loader`, `Sprite`, `Texture` — each have their own chapter. [Core Concepts](/ExoJS/en/guide/core-concepts/application/) walks through the runtime model in order: how applications and scenes fit together, how the scene graph composes drawables, and how the view transform handles cameras and resolutions.
 
-If you'd rather poke at the live example first, the playground link above opens it in an editable editor.
+<NextStep href="/ExoJS/en/guide/core-concepts/scene-lifecycle/" label="Understand the scene lifecycle">
+See how load, init, update, and draw work together as one repeatable loop.
+</NextStep>

--- a/site/src/content/guide/migration/v0-8-x-to-v0-9-0.mdx
+++ b/site/src/content/guide/migration/v0-8-x-to-v0-9-0.mdx
@@ -1,9 +1,6 @@
 ---
-title: '9.1 v0.8.x to v0.9.0'
+title: 'v0.8.x to v0.9.0'
 description: 'Migrate ExoJS projects from v0.8.x to v0.9.0 with mechanical API rename and cleanup steps.'
-part: 9
-chapter: 1
-examples: []
 ---
 
 # v0.8.x to v0.9.0

--- a/site/src/content/guide/recipes/audio-reactive-scene.mdx
+++ b/site/src/content/guide/recipes/audio-reactive-scene.mdx
@@ -1,16 +1,11 @@
 ---
-title: '8.5 Audio reactive scene'
+title: 'Audio reactive scene'
 description: 'Map audio analysis to movement, particles, and camera response.'
-part: 8
-chapter: 5
-examples:
-  - showcase/audio-reactive-particles
-  - showcase/low-band-camera-shake
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 8.5 Audio reactive scene
+# Audio reactive scene
 
 This recipe combines `BeatDetector`, `ParticleSystem`, tween-driven camera shake, and audio-triggered visual effects into one scene. It builds on [Beat detection](/ExoJS/en/guide/audio/beat-detection/) for analysis and [Audio-reactive visualization](/ExoJS/en/guide/audio/audio-reactive-visualization/) for the visual patterns — this chapter is about orchestration, not re-teaching the individual APIs.
 

--- a/site/src/content/guide/recipes/build-orb-dodge.mdx
+++ b/site/src/content/guide/recipes/build-orb-dodge.mdx
@@ -1,16 +1,13 @@
 ---
-title: '8.9 Build Orb Dodge'
+title: 'Build Orb Dodge'
 description: 'Build a complete small game from scratch: player movement, spawning orbs, collision, scoring, a HUD, and a game-over screen — all without external assets.'
-part: 8
-chapter: 9
-examples:
-  - showcase/orb-dodge
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 import SourceSnippet from '../../../components/SourceSnippet.astro';
+import TryIt from '../../../components/TryIt.astro';
 
-# 8.9 Build Orb Dodge
+# Build Orb Dodge
 
 This chapter builds a small, complete game end-to-end. You will see how several ExoJS concepts fit together in one project: a scene that runs every frame, keyboard input, `Graphics` primitives for all visuals, a HUD with live score and time, and a separate game-over scene that transitions back into the game on restart.
 
@@ -228,12 +225,17 @@ The full, playable game is in the playground. Open it to read the complete sourc
 
 <ExamplePreview chapter="showcase" slug="orb-dodge" />
 
+<TryIt
+  examples={['showcase/orb-dodge']}
+  api={['scene', 'graphics', 'keyboard', 'text']}
+/>
+
 ## Where to go next
 
 From here you can extend Orb Dodge in several directions:
 
-- **Keyboard guide** — [4.1 Keyboard](/ExoJS/en/guide/input/keyboard/) — rebindable actions, action mapping
-- **HUD overlay** — [8.1 HUD overlay](/ExoJS/en/guide/recipes/hud-overlay/) — push a dedicated overlay scene on top instead of rendering HUD inside the game scene
-- **Game feel** — [8.6 Game feel](/ExoJS/en/guide/recipes/game-feel/) — add a screen shake or color flash when a danger orb is collected
-- **Deployment** — [10.2 Deployment](/ExoJS/en/guide/reference/deployment/) — build and host the finished game
-- **Troubleshooting** — [10.1 Troubleshooting](/ExoJS/en/guide/reference/troubleshooting/) — blank canvas, input not firing, and other common issues
+- **Keyboard** — [Keyboard](/ExoJS/en/guide/input/keyboard/) — rebindable actions, action mapping
+- **HUD overlay** — [HUD overlay](/ExoJS/en/guide/recipes/hud-overlay/) — push a dedicated overlay scene on top instead of rendering HUD inside the game scene
+- **Game feel** — [Game feel](/ExoJS/en/guide/recipes/game-feel/) — add a screen shake or color flash when a danger orb is collected
+- **Deployment** — [Deployment](/ExoJS/en/guide/reference/deployment/) — build and host the finished game
+- **Troubleshooting** — [Troubleshooting](/ExoJS/en/guide/reference/troubleshooting/) — blank canvas, input not firing, and other common issues

--- a/site/src/content/guide/recipes/build-orb-dodge.mdx
+++ b/site/src/content/guide/recipes/build-orb-dodge.mdx
@@ -20,7 +20,7 @@ The finished result is playable in the playground at the bottom of this page.
 Start from a `create-exo-app` project using the `game-starter` or `minimal` template:
 
 ```bash
-npx create-exo-app my-orb-dodge
+npm create exo-app@latest my-orb-dodge
 ```
 
 If you already have a project, the only package you need is `@codexo/exojs`.

--- a/site/src/content/guide/recipes/camera-follow-and-parallax.mdx
+++ b/site/src/content/guide/recipes/camera-follow-and-parallax.mdx
@@ -1,16 +1,11 @@
 ---
-title: '8.2 Camera follow & parallax'
+title: 'Camera follow & parallax'
 description: 'Create depth and motion parallax from camera and pointer movement.'
-part: 8
-chapter: 2
-examples:
-  - scene-graph/parallax-starfield
-  - showcase/mouse-parallax
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 8.2 Camera follow & parallax
+# Camera follow & parallax
 
 Parallax means layers at different depths move at different rates relative to the camera. In 2D, you create it by moving background layers slower than foreground layers when the camera or pointer shifts. No depth buffer, no z-axis — just scaled position offsets applied per layer each frame.
 

--- a/site/src/content/guide/recipes/cinematics.mdx
+++ b/site/src/content/guide/recipes/cinematics.mdx
@@ -1,15 +1,11 @@
 ---
-title: '8.8 Cinematics'
+title: 'Cinematics'
 description: 'Coordinate timing, camera, and audio for scripted scene beats.'
-part: 8
-chapter: 8
-examples:
-  - showcase/boss-intro-cinematic
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 8.8 Cinematics
+# Cinematics
 
 A cinematic (or cutscene) is a choreographed sequence where the camera moves, dialogue appears, characters animate, music swells, and the player's input is temporarily suspended — all driven by timing, not by gameplay logic. ExoJS does not ship a timeline or cutscene system, but you can build one from the primitives that already exist: tweens (for timed animation), `View` (for camera movement), `Music` (for audio), and scene-stack management (for input gating).
 

--- a/site/src/content/guide/recipes/game-feel.mdx
+++ b/site/src/content/guide/recipes/game-feel.mdx
@@ -1,16 +1,11 @@
 ---
-title: '8.6 Game feel'
+title: 'Game feel'
 description: 'Add feedback cues that make interaction feel responsive.'
-part: 8
-chapter: 6
-examples:
-  - showcase/damage-flash
-  - showcase/screen-shake-on-explosion
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 8.6 Game feel
+# Game feel
 
 Game feel is the layer of feedback that makes actions feel tangible: a flash when the player takes damage, a shake when something explodes, a sound that clicks with each tween step, particles that trail behind a moving object. In ExoJS, these effects are compositions of primitives you already know — tweens, filters, particles, view manipulation, audio — applied at the moment of an event.
 

--- a/site/src/content/guide/recipes/hud-overlay.mdx
+++ b/site/src/content/guide/recipes/hud-overlay.mdx
@@ -1,15 +1,11 @@
 ---
-title: '8.1 HUD overlay'
+title: 'HUD overlay'
 description: 'Compose gameplay and UI layers without coupling scene logic.'
-part: 8
-chapter: 1
-examples:
-  - application-scenes/hud-overlay-scene
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 8.1 HUD overlay
+# HUD overlay
 
 A HUD (heads-up display) renders UI elements on top of the game world — health bars, score text, mini-maps, debug readouts — without those elements moving or scaling with the game camera. The recipe separates world-space content from screen-space content by using two scenes on the stack.
 

--- a/site/src/content/guide/recipes/pause-menu.mdx
+++ b/site/src/content/guide/recipes/pause-menu.mdx
@@ -1,15 +1,11 @@
 ---
-title: '8.3 Pause menu'
+title: 'Pause menu'
 description: 'Pause scene updates while keeping clear visual context for players.'
-part: 8
-chapter: 3
-examples:
-  - showcase/pause-blur
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 8.3 Pause menu
+# Pause menu
 
 A pause menu can freeze the game, display a menu overlay, and resume cleanly when dismissed. In ExoJS, this is a scene-stack operation: push a `PauseScene` on top of the game scene with `'overlay'` mode so the game remains visible.
 

--- a/site/src/content/guide/recipes/split-screen.mdx
+++ b/site/src/content/guide/recipes/split-screen.mdx
@@ -1,15 +1,11 @@
 ---
-title: '8.4 Split screen'
+title: 'Split screen'
 description: 'Render multiple viewpoints in a shared scene timeline.'
-part: 8
-chapter: 4
-examples:
-  - application-scenes/multi-view-split-screen
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 8.4 Split screen
+# Split screen
 
 Split screen renders the same scene from two (or more) camera viewpoints into separate regions of the canvas. The recipe uses multiple `View` instances with different viewport rectangles, renders the shared scene contents once per view, and draws a divider between the regions.
 

--- a/site/src/content/guide/recipes/ui-patterns.mdx
+++ b/site/src/content/guide/recipes/ui-patterns.mdx
@@ -1,16 +1,11 @@
 ---
-title: '8.7 UI patterns'
+title: 'UI patterns'
 description: 'Build reusable dialog and text-flow UI behavior in-scene.'
-part: 8
-chapter: 7
-examples:
-  - showcase/dialog-system
-  - showcase/typewriter-text
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 8.7 UI patterns
+# UI patterns
 
 In-canvas UI means text boxes, dialog panels, progress indicators, and interactive elements built from ExoJS primitives — `Text`, `Graphics`, `Sprite`, `Container` — and rendered inside the scene. This recipe covers two patterns (dialog system with typewriter reveal, tween-driven progress) and explains when DOM UI is a better choice.
 

--- a/site/src/content/guide/reference/deployment.mdx
+++ b/site/src/content/guide/reference/deployment.mdx
@@ -1,12 +1,9 @@
 ---
-title: '10.2 Deployment'
+title: 'Deployment'
 description: 'Build and host an ExoJS app: local production build, Vite base path, static hosting, assets, CDN bundles, and browser support.'
-part: 10
-chapter: 2
-examples: []
 ---
 
-# 10.2 Deployment
+# Deployment
 
 ExoJS apps built with `create-exo-app` use Vite and produce a fully static output. The build step compiles, bundles, and copies all required files into a `dist/` directory. That directory is everything you need to host.
 

--- a/site/src/content/guide/reference/troubleshooting.mdx
+++ b/site/src/content/guide/reference/troubleshooting.mdx
@@ -1,18 +1,11 @@
 ---
-title: '10.1 Troubleshooting'
+title: 'Troubleshooting'
 description: 'Diagnose and fix the most common ExoJS problems: blank canvas, API errors, missing assets, audio, input, and performance.'
-part: 10
-chapter: 1
-examples:
-  - debug-layer/performance-overlay
-  - input/keyboard
-  - input/gamepad
-  - audio-basics/play-sound
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
-# 10.1 Troubleshooting
+# Troubleshooting
 
 This chapter covers the issues that come up most often when starting with ExoJS or upgrading from an older snippet. Work through the relevant section, check the linked guides for more detail, and open the playground examples to see the correct pattern in action.
 

--- a/site/src/lib/guide-structure.ts
+++ b/site/src/lib/guide-structure.ts
@@ -1,14 +1,67 @@
+/**
+ * Guide information architecture — the single source of truth for guide
+ * ordering, grouping, learning metadata, and cross-references (playground
+ * examples and API pages).
+ *
+ * Per-chapter prose (title, description) lives in the MDX frontmatter so it
+ * stays next to the content it describes. This module owns everything that the
+ * navigation, landing page, and learning path need without parsing MDX:
+ *   - part grouping and order
+ *   - chapter order within a part (chapter numbers are positional)
+ *   - level, learning goals, and prerequisites
+ *   - related playground examples ("<category>/<slug>")
+ *   - related API pages (API slugs, resolved against site/src/content/api)
+ *
+ * Chapter numbers are derived from array position, so reordering a part never
+ * requires renumbering titles by hand. A node test reconciles this module with
+ * the MDX files (every chapter has a file, no orphans) and validates every
+ * cross-reference, so a typo fails the test suite rather than shipping a dead
+ * link.
+ */
+
+export type GuideLevel = 'intro' | 'intermediate' | 'advanced';
+
+export const GUIDE_LEVELS: ReadonlyArray<GuideLevel> = ['intro', 'intermediate', 'advanced'];
+
+export const GUIDE_LEVEL_LABEL: Record<GuideLevel, string> = {
+    intro: 'Intro',
+    intermediate: 'Intermediate',
+    advanced: 'Advanced',
+};
+
+/** Authoring shape — only the fields a chapter actually sets. */
+interface RawChapter {
+    slug: string;
+    level: GuideLevel;
+    /** Concrete, scannable outcomes. Set on the core onboarding chapters. */
+    learningGoals?: ReadonlyArray<string>;
+    /** Guide paths ("<partSlug>/<chapterSlug>") the reader should do first. */
+    prerequisites?: ReadonlyArray<string>;
+    /** Related playground examples as "<category>/<slug>". */
+    examples?: ReadonlyArray<string>;
+    /** Related API pages as content slugs under site/src/content/api. */
+    apiLinks?: ReadonlyArray<string>;
+}
+
+interface RawPart {
+    slug: string;
+    title: string;
+    description: string;
+    chapters: ReadonlyArray<RawChapter>;
+}
+
 export interface GuideChapterMeta {
     part: number;
     chapter: number;
     partSlug: string;
     partTitle: string;
-    partDescription: string;
     slug: string;
-    title: string;
-    description: string;
     path: string;
+    level: GuideLevel;
+    learningGoals: ReadonlyArray<string>;
+    prerequisites: ReadonlyArray<string>;
     examples: ReadonlyArray<string>;
+    apiLinks: ReadonlyArray<string>;
 }
 
 export interface GuidePartMeta {
@@ -19,779 +72,573 @@ export interface GuidePartMeta {
     chapters: ReadonlyArray<GuideChapterMeta>;
 }
 
-const PARTS: ReadonlyArray<GuidePartMeta> = [
+const RAW_PARTS: ReadonlyArray<RawPart> = [
     {
-        part: 1,
-        slug: "introduction",
-        title: "01 Introduction",
-        description: "Start here to understand what ExoJS is and how to move through this guide.",
+        slug: 'introduction',
+        title: 'Getting Started',
+        description: 'Understand what ExoJS is, create a project, and render your first scene.',
         chapters: [
             {
-                part: 1,
-                chapter: 1,
-                partSlug: "introduction",
-                partTitle: "01 Introduction",
-                partDescription: "Start here to understand what ExoJS is and how to move through this guide.",
-                slug: "what-is-exojs",
-                title: "1.1 What is ExoJS?",
-                description: "Understand where ExoJS fits and what kind of projects it is built for.",
-                path: "introduction/what-is-exojs",
-                examples: []
+                slug: 'what-is-exojs',
+                level: 'intro',
+                learningGoals: [
+                    'know what ExoJS is and the kind of projects it targets',
+                    'recognise where ExoJS fits next to your UI framework',
+                    'know how the guide, playground, and API reference work together',
+                ],
+                apiLinks: ['application', 'scene'],
             },
             {
-                part: 1,
-                chapter: 2,
-                partSlug: "introduction",
-                partTitle: "01 Introduction",
-                partDescription: "Start here to understand what ExoJS is and how to move through this guide.",
-                slug: "setup",
-                title: "1.2 Setup",
-                description: "Install ExoJS, create an application, choose a canvas, and verify the runtime before writing scene code.",
-                path: "introduction/setup",
-                examples: []
+                slug: 'setup',
+                level: 'intro',
+                learningGoals: [
+                    'create a typed project with create-exo-app',
+                    'choose between the minimal, game-starter, and audio-reactive templates',
+                    'run the dev server and a production build',
+                ],
+                prerequisites: ['introduction/what-is-exojs'],
+                apiLinks: ['application'],
             },
             {
-                part: 1,
-                chapter: 3,
-                partSlug: "introduction",
-                partTitle: "01 Introduction",
-                partDescription: "Start here to understand what ExoJS is and how to move through this guide.",
-                slug: "your-first-scene",
-                title: "1.3 Your first scene",
-                description: "Build a first scene and see the frame loop in action.",
-                path: "introduction/your-first-scene",
-                examples: [
-                    "getting-started/hello-world"
-                ]
-            }
-        ]
+                slug: 'project-structure',
+                level: 'intro',
+                learningGoals: [
+                    'find your way around a create-exo-app project',
+                    'know where the entry point, scenes, and assets live',
+                    'understand how main.ts wires an Application to a Scene',
+                ],
+                prerequisites: ['introduction/setup'],
+                examples: ['getting-started/hello-world'],
+                apiLinks: ['application', 'scene'],
+            },
+            {
+                slug: 'your-first-scene',
+                level: 'intro',
+                learningGoals: [
+                    'load a texture and draw a sprite',
+                    'center a sprite with an anchor',
+                    'animate state each frame with delta time',
+                ],
+                prerequisites: ['introduction/setup'],
+                examples: ['getting-started/hello-world'],
+                apiLinks: ['application', 'scene', 'sprite', 'texture', 'loader'],
+            },
+        ],
     },
     {
-        part: 2,
-        slug: "core-concepts",
-        title: "02 Core Concepts",
-        description: "These chapters explain the runtime model that most ExoJS projects rely on.",
+        slug: 'core-concepts',
+        title: 'Core Concepts',
+        description: 'The runtime model most ExoJS projects rely on: applications, scenes, the frame loop, and coordinates.',
         chapters: [
             {
-                part: 2,
-                chapter: 1,
-                partSlug: "core-concepts",
-                partTitle: "02 Core Concepts",
-                partDescription: "These chapters explain the runtime model that most ExoJS projects rely on.",
-                slug: "application",
-                title: "2.1 Application",
-                description: "How the application owns canvas lifecycle, sizing, and startup.",
-                path: "core-concepts/application",
-                examples: [
-                    "getting-started/hello-world",
-                    "getting-started/resize-and-dpr"
-                ]
+                slug: 'application',
+                level: 'intro',
+                learningGoals: [
+                    'create and configure an Application',
+                    'understand how the application owns canvas, sizing, and the frame loop',
+                ],
+                prerequisites: ['introduction/your-first-scene'],
+                examples: ['getting-started/hello-world', 'getting-started/resize-and-dpr'],
+                apiLinks: ['application'],
             },
             {
-                part: 2,
-                chapter: 2,
-                partSlug: "core-concepts",
-                partTitle: "02 Core Concepts",
-                partDescription: "These chapters explain the runtime model that most ExoJS projects rely on.",
-                slug: "scenes",
-                title: "2.2 Scenes",
-                description: "How scenes split responsibilities and keep projects composable.",
-                path: "core-concepts/scenes",
-                examples: [
-                    "application-scenes/multiple-scenes"
-                ]
+                slug: 'scenes',
+                level: 'intro',
+                learningGoals: [
+                    'split a project into focused scenes',
+                    'switch between scenes at runtime',
+                ],
+                prerequisites: ['introduction/your-first-scene'],
+                examples: ['application-scenes/multiple-scenes'],
+                apiLinks: ['scene'],
             },
             {
-                part: 2,
-                chapter: 3,
-                partSlug: "core-concepts",
-                partTitle: "02 Core Concepts",
-                partDescription: "These chapters explain the runtime model that most ExoJS projects rely on.",
-                slug: "scene-lifecycle",
-                title: "2.3 Scene lifecycle",
-                description: "How load, init, update, and draw work together as one repeatable loop.",
-                path: "core-concepts/scene-lifecycle",
-                examples: [
-                    "application-scenes/scene-lifecycle",
-                    "application-scenes/pause-and-resume",
-                    "getting-started/game-loop"
-                ]
+                slug: 'scene-lifecycle',
+                level: 'intro',
+                learningGoals: [
+                    'order work across load, init, update, and draw',
+                    'separate state updates from rendering',
+                    'release resources in destroy',
+                ],
+                prerequisites: ['core-concepts/scenes'],
+                examples: ['application-scenes/scene-lifecycle', 'application-scenes/pause-and-resume', 'getting-started/game-loop'],
+                apiLinks: ['scene', 'loader', 'time'],
             },
             {
-                part: 2,
-                chapter: 4,
-                partSlug: "core-concepts",
-                partTitle: "02 Core Concepts",
-                partDescription: "These chapters explain the runtime model that most ExoJS projects rely on.",
-                slug: "scene-graph",
-                title: "2.4 Scene graph",
-                description: "How transforms, hierarchy, masks, and draw order shape what you see.",
-                path: "core-concepts/scene-graph",
+                slug: 'scene-graph',
+                level: 'intermediate',
+                learningGoals: [
+                    'compose drawables with containers',
+                    'reason about transforms, draw order, and masks',
+                ],
+                prerequisites: ['core-concepts/scenes'],
                 examples: [
-                    "scene-graph/containers",
-                    "scene-graph/nested-transforms",
-                    "scene-graph/local-vs-global-transform",
-                    "scene-graph/pivot-and-anchor",
-                    "scene-graph/z-ordering",
-                    "scene-graph/masks"
-                ]
+                    'scene-graph/containers',
+                    'scene-graph/nested-transforms',
+                    'scene-graph/local-vs-global-transform',
+                    'scene-graph/pivot-and-anchor',
+                    'scene-graph/z-ordering',
+                    'scene-graph/masks',
+                ],
+                apiLinks: ['container', 'drawable'],
             },
             {
-                part: 2,
-                chapter: 5,
-                partSlug: "core-concepts",
-                partTitle: "02 Core Concepts",
-                partDescription: "These chapters explain the runtime model that most ExoJS projects rely on.",
-                slug: "coordinates-and-views",
-                title: "2.5 Coordinates and views",
-                description: "How world space, screen space, and camera views map onto each other.",
-                path: "core-concepts/coordinates-and-views",
+                slug: 'coordinates-and-views',
+                level: 'intermediate',
+                learningGoals: [
+                    'map world space to screen space',
+                    'move and zoom a camera view',
+                ],
+                prerequisites: ['core-concepts/scene-graph'],
                 examples: [
-                    "application-scenes/camera-and-view",
-                    "application-scenes/multi-view-split-screen",
-                    "application-scenes/picture-in-picture",
-                    "application-scenes/world-vs-screen-coords"
-                ]
+                    'application-scenes/camera-and-view',
+                    'application-scenes/multi-view-split-screen',
+                    'application-scenes/picture-in-picture',
+                    'application-scenes/world-vs-screen-coords',
+                ],
+                apiLinks: ['view', 'camera'],
             },
             {
-                part: 2,
-                chapter: 6,
-                partSlug: "core-concepts",
-                partTitle: "02 Core Concepts",
-                partDescription: "These chapters explain the runtime model that most ExoJS projects rely on.",
-                slug: "loading-and-resources",
-                title: "2.6 Loading and resources",
-                description: "How to load resources predictably and keep asset access consistent.",
-                path: "core-concepts/loading-and-resources",
-                examples: [
-                    "sprites-textures/texture-loader"
-                ]
-            }
-        ]
+                slug: 'loading-and-resources',
+                level: 'intermediate',
+                learningGoals: [
+                    'declare and load assets predictably',
+                    'access loaded resources by name',
+                ],
+                prerequisites: ['core-concepts/scene-lifecycle'],
+                examples: ['sprites-textures/texture-loader'],
+                apiLinks: ['loader', 'texture'],
+            },
+        ],
     },
     {
-        part: 3,
-        slug: "drawing",
-        title: "03 Drawing",
-        description: "Use ExoJS drawing primitives, sprites, text, and animation to build a scene.",
+        slug: 'drawing',
+        title: 'Drawing',
+        description: 'Build a scene with shapes, sprites, text, and animation.',
         chapters: [
             {
-                part: 3,
-                chapter: 1,
-                partSlug: "drawing",
-                partTitle: "03 Drawing",
-                partDescription: "Use ExoJS drawing primitives, sprites, text, and animation to build a scene.",
-                slug: "graphics",
-                title: "3.1 Graphics",
-                description: "Draw procedural shapes and mesh-based geometry.",
-                path: "drawing/graphics",
+                slug: 'graphics',
+                level: 'intro',
+                learningGoals: [
+                    'draw procedural shapes with Graphics',
+                    'fill, stroke, and position drawn geometry',
+                ],
+                prerequisites: ['introduction/your-first-scene'],
                 examples: [
-                    "geometry-graphics/graphics-primitives",
-                    "geometry-graphics/infinite-grid",
-                    "geometry-graphics/mesh-triangle",
-                    "geometry-graphics/mesh-textured-quad",
-                    "geometry-graphics/mesh-deformed-grid"
-                ]
+                    'geometry-graphics/graphics-primitives',
+                    'geometry-graphics/infinite-grid',
+                    'geometry-graphics/mesh-triangle',
+                    'geometry-graphics/mesh-textured-quad',
+                    'geometry-graphics/mesh-deformed-grid',
+                ],
+                apiLinks: ['graphics', 'color'],
             },
             {
-                part: 3,
-                chapter: 2,
-                partSlug: "drawing",
-                partTitle: "03 Drawing",
-                partDescription: "Use ExoJS drawing primitives, sprites, text, and animation to build a scene.",
-                slug: "sprites",
-                title: "3.2 Sprites",
-                description: "Render image-based content from textures, sheets, SVG, and video.",
-                path: "drawing/sprites",
+                slug: 'sprites',
+                level: 'intro',
+                learningGoals: [
+                    'render textures, sheets, SVG, and video as sprites',
+                    'control anchor, blend mode, and frames',
+                ],
+                prerequisites: ['introduction/your-first-scene'],
                 examples: [
-                    "sprites-textures/sprite-basics",
-                    "sprites-textures/blendmodes",
-                    "sprites-textures/spritesheet-frames",
-                    "sprites-textures/svg-drawable",
-                    "sprites-textures/video-drawable"
-                ]
+                    'sprites-textures/sprite-basics',
+                    'sprites-textures/blendmodes',
+                    'sprites-textures/spritesheet-frames',
+                    'sprites-textures/svg-drawable',
+                    'sprites-textures/video-drawable',
+                ],
+                apiLinks: ['sprite', 'spritesheet', 'texture'],
             },
             {
-                part: 3,
-                chapter: 3,
-                partSlug: "drawing",
-                partTitle: "03 Drawing",
-                partDescription: "Use ExoJS drawing primitives, sprites, text, and animation to build a scene.",
-                slug: "text",
-                title: "3.3 Text",
-                description: "Control layout, styling, and visual effects for runtime text.",
-                path: "drawing/text",
+                slug: 'text',
+                level: 'intro',
+                learningGoals: [
+                    'render and style runtime text',
+                    'lay out multiline and wrapped text',
+                ],
                 examples: [
-                    "text-fonts/basic-text",
-                    "text-fonts/multiline-and-wrap",
-                    "text-fonts/stroke-and-shadow",
-                    "text-fonts/web-fonts",
-                    "text-fonts/text-glitch"
-                ]
+                    'text-fonts/basic-text',
+                    'text-fonts/multiline-and-wrap',
+                    'text-fonts/stroke-and-shadow',
+                    'text-fonts/web-fonts',
+                    'text-fonts/text-glitch',
+                ],
+                apiLinks: ['text', 'bitmap-text', 'text-style'],
             },
             {
-                part: 3,
-                chapter: 4,
-                partSlug: "drawing",
-                partTitle: "03 Drawing",
-                partDescription: "Use ExoJS drawing primitives, sprites, text, and animation to build a scene.",
-                slug: "animation",
-                title: "3.4 Animation",
-                description: "Animate transforms and values with tweens and frame updates.",
-                path: "drawing/animation",
+                slug: 'animation',
+                level: 'intermediate',
+                learningGoals: [
+                    'tween transforms and values over time',
+                    'chain, yoyo, and interrupt tweens',
+                ],
                 examples: [
-                    "tweens-animation/easing-curves",
-                    "tweens-animation/frame-animation",
-                    "tweens-animation/interrupt-and-replace",
-                    "tweens-animation/tween-basics",
-                    "tweens-animation/tween-chains",
-                    "tweens-animation/tween-from-array",
-                    "tweens-animation/tween-with-yoyo"
-                ]
+                    'tweens-animation/easing-curves',
+                    'tweens-animation/frame-animation',
+                    'tweens-animation/interrupt-and-replace',
+                    'tweens-animation/tween-basics',
+                    'tweens-animation/tween-chains',
+                    'tweens-animation/tween-from-array',
+                    'tweens-animation/tween-with-yoyo',
+                ],
+                apiLinks: ['tween', 'tween-manager', 'animated-sprite'],
             },
             {
-                part: 3,
-                chapter: 5,
-                partSlug: "drawing",
-                partTitle: "03 Drawing",
-                partDescription: "Use ExoJS drawing primitives, sprites, text, and animation to build a scene.",
-                slug: "render-targets",
-                title: "3.5 Render targets",
-                description: "Render into intermediate textures and reuse those outputs in scene composition.",
-                path: "drawing/render-targets",
-                examples: [
-                    "render-targets/render-to-texture",
-                    "render-targets/mini-map"
-                ]
-            }
-        ]
+                slug: 'render-targets',
+                level: 'advanced',
+                learningGoals: [
+                    'render a scene into an intermediate texture',
+                    'reuse render-target output in composition',
+                ],
+                prerequisites: ['drawing/sprites'],
+                examples: ['render-targets/render-to-texture', 'render-targets/mini-map'],
+                apiLinks: ['render-target', 'render-texture'],
+            },
+        ],
     },
     {
-        part: 4,
-        slug: "input",
-        title: "04 Input",
-        description: "Handle keyboard, pointer, touch, and gamepad with predictable input flow.",
+        slug: 'input',
+        title: 'Input',
+        description: 'Handle keyboard, pointer, touch, and gamepad with predictable input flow.',
         chapters: [
             {
-                part: 4,
-                chapter: 1,
-                partSlug: "input",
-                partTitle: "04 Input",
-                partDescription: "Handle keyboard, pointer, touch, and gamepad with predictable input flow.",
-                slug: "keyboard",
-                title: "4.1 Keyboard",
-                description: "Capture keys and support configurable bindings.",
-                path: "input/keyboard",
-                examples: [
-                    "input/keyboard",
-                    "input/key-rebinding"
-                ]
+                slug: 'keyboard',
+                level: 'intro',
+                learningGoals: [
+                    'capture keys with scene-scoped bindings',
+                    'handle taps, holds, and rebinding',
+                ],
+                prerequisites: ['introduction/your-first-scene'],
+                examples: ['input/keyboard', 'input/key-rebinding'],
+                apiLinks: ['keyboard', 'input-manager'],
             },
             {
-                part: 4,
-                chapter: 2,
-                partSlug: "input",
-                partTitle: "04 Input",
-                partDescription: "Handle keyboard, pointer, touch, and gamepad with predictable input flow.",
-                slug: "mouse-and-pointer",
-                title: "4.2 Mouse and pointer",
-                description: "Work with pointer events across mouse and touch-compatible devices.",
-                path: "input/mouse-and-pointer",
-                examples: [
-                    "input/mouse-and-pointer",
-                    "input/multitouch",
-                    "input/pointer-to-world"
-                ]
+                slug: 'mouse-and-pointer',
+                level: 'intro',
+                learningGoals: [
+                    'read unified pointer events across mouse and touch',
+                    'translate pointer position into world space',
+                ],
+                prerequisites: ['input/keyboard'],
+                examples: ['input/mouse-and-pointer', 'input/multitouch', 'input/pointer-to-world'],
+                apiLinks: ['pointer', 'input-manager'],
             },
             {
-                part: 4,
-                chapter: 3,
-                partSlug: "input",
-                partTitle: "04 Input",
-                partDescription: "Handle keyboard, pointer, touch, and gamepad with predictable input flow.",
-                slug: "gamepad",
-                title: "4.3 Gamepad",
-                description: "Read controller input and support multiple connected gamepads.",
-                path: "input/gamepad",
-                examples: [
-                    "input/gamepad",
-                    "input/multi-gamepad"
-                ]
+                slug: 'gamepad',
+                level: 'intermediate',
+                learningGoals: [
+                    'read controller buttons and axes',
+                    'support multiple connected gamepads',
+                ],
+                prerequisites: ['input/keyboard'],
+                examples: ['input/gamepad', 'input/multi-gamepad'],
+                apiLinks: ['gamepad', 'input-manager'],
             },
             {
-                part: 4,
-                chapter: 4,
-                partSlug: "input",
-                partTitle: "04 Input",
-                partDescription: "Handle keyboard, pointer, touch, and gamepad with predictable input flow.",
-                slug: "action-mapping",
-                title: "4.4 Action mapping",
-                description: "Map multiple devices to the same intent-driven input actions.",
-                path: "input/action-mapping",
-                examples: [
-                    "input/action-mapping"
-                ]
-            }
-        ]
+                slug: 'action-mapping',
+                level: 'intermediate',
+                learningGoals: [
+                    'map several devices to one intent',
+                    'keep gameplay code device-agnostic',
+                ],
+                prerequisites: ['input/keyboard'],
+                examples: ['input/action-mapping'],
+                apiLinks: ['input-manager'],
+            },
+        ],
     },
     {
-        part: 5,
-        slug: "audio",
-        title: "05 Audio",
-        description: "Build complete audio behavior from playback to effects and analysis.",
+        slug: 'audio',
+        title: 'Audio',
+        description: 'Play sound and music, place it in space, shape it with effects, and react to it.',
         chapters: [
             {
-                part: 5,
-                chapter: 1,
-                partSlug: "audio",
-                partTitle: "05 Audio",
-                partDescription: "Build complete audio behavior from playback to effects and analysis.",
-                slug: "audio-basics",
-                title: "5.1 Audio basics",
-                description: "Play sounds and music with reliable runtime controls.",
-                path: "audio/audio-basics",
+                slug: 'audio-basics',
+                level: 'intro',
+                learningGoals: [
+                    'load and play Sound and Music',
+                    'control volume, looping, and fades',
+                    'handle the browser autoplay gesture',
+                ],
+                prerequisites: ['introduction/your-first-scene'],
                 examples: [
-                    "audio-basics/audio-buses",
-                    "audio-basics/crossfade-tracks",
-                    "audio-basics/music-loop",
-                    "audio-basics/play-sound",
-                    "audio-basics/random-pitch-pool",
-                    "audio-basics/sound-pool"
-                ]
+                    'audio-basics/play-sound',
+                    'audio-basics/music-loop',
+                    'audio-basics/crossfade-tracks',
+                    'audio-basics/sound-pool',
+                    'audio-basics/random-pitch-pool',
+                    'audio-basics/audio-buses',
+                ],
+                apiLinks: ['sound', 'music', 'audio-manager'],
             },
             {
-                part: 5,
-                chapter: 2,
-                partSlug: "audio",
-                partTitle: "05 Audio",
-                partDescription: "Build complete audio behavior from playback to effects and analysis.",
-                slug: "spatial-audio",
-                title: "5.2 Spatial audio",
-                description: "Place listener and sources in space for directional sound behavior.",
-                path: "audio/spatial-audio",
-                examples: [
-                    "spatial-audio/listener-and-source",
-                    "spatial-audio/moving-source",
-                    "spatial-audio/falloff-curves"
-                ]
+                slug: 'spatial-audio',
+                level: 'intermediate',
+                learningGoals: [
+                    'place a listener and sources in space',
+                    'tune directional falloff',
+                ],
+                prerequisites: ['audio/audio-basics'],
+                examples: ['spatial-audio/listener-and-source', 'spatial-audio/moving-source', 'spatial-audio/falloff-curves'],
+                apiLinks: ['audio-listener', 'audio-manager'],
             },
             {
-                part: 5,
-                chapter: 3,
-                partSlug: "audio",
-                partTitle: "05 Audio",
-                partDescription: "Build complete audio behavior from playback to effects and analysis.",
-                slug: "audio-effects",
-                title: "5.3 Audio effects",
-                description: "Shape sound with filters and bus-level processing.",
-                path: "audio/audio-effects",
-                examples: [
-                    "audio-fx/compressor",
-                    "audio-fx/ducking",
-                    "audio-fx/reverb-and-delay",
-                    "audio-fx/vocoder"
-                ]
+                slug: 'audio-effects',
+                level: 'intermediate',
+                learningGoals: [
+                    'shape sound with bus filters',
+                    'apply reverb, delay, and ducking',
+                ],
+                prerequisites: ['audio/audio-basics'],
+                examples: ['audio-fx/compressor', 'audio-fx/ducking', 'audio-fx/reverb-and-delay', 'audio-fx/vocoder'],
+                apiLinks: ['audio-bus', 'audio-filter'],
             },
             {
-                part: 5,
-                chapter: 4,
-                partSlug: "audio",
-                partTitle: "05 Audio",
-                partDescription: "Build complete audio behavior from playback to effects and analysis.",
-                slug: "beat-detection",
-                title: "5.4 Beat detection",
-                description: "Drive visuals from beat and frequency information.",
-                path: "audio/beat-detection",
-                examples: [
-                    "beat-detection/beat-sync-pulse",
-                    "beat-detection/frequency-bands",
-                    "beat-detection/tempo-tracking"
-                ]
-            }
-        ]
+                slug: 'beat-detection',
+                level: 'intermediate',
+                learningGoals: [
+                    'read beat and frequency information',
+                    'drive timing from audio analysis',
+                ],
+                prerequisites: ['audio/audio-basics'],
+                examples: ['beat-detection/beat-sync-pulse', 'beat-detection/frequency-bands', 'beat-detection/tempo-tracking'],
+                apiLinks: ['beat-detector', 'audio-analyser'],
+            },
+            {
+                slug: 'audio-reactive-visualization',
+                level: 'intermediate',
+                learningGoals: [
+                    'map audio analysis to visuals',
+                    'build a responsive audio-reactive scene',
+                ],
+                prerequisites: ['audio/beat-detection'],
+                examples: ['showcase/audio-visualisation', 'showcase/audio-reactive-particles'],
+                apiLinks: ['audio-analyser', 'beat-detector'],
+            },
+        ],
     },
     {
-        part: 6,
-        slug: "effects",
-        title: "06 Effects",
-        description: "Layer visual effects to build mood, motion, and feedback.",
+        slug: 'effects',
+        title: 'Effects',
+        description: 'Layer filters, particles, post-processing, and custom shaders for mood and motion.',
         chapters: [
             {
-                part: 6,
-                chapter: 1,
-                partSlug: "effects",
-                partTitle: "06 Effects",
-                partDescription: "Layer visual effects to build mood, motion, and feedback.",
-                slug: "filters",
-                title: "6.1 Filters",
-                description: "Stack shader and color effects to control final image style.",
-                path: "effects/filters",
+                slug: 'filters',
+                level: 'intermediate',
                 examples: [
-                    "filters/blur-filter",
-                    "filters/chromatic-aberration",
-                    "filters/color-filter",
-                    "filters/crt-scanlines",
-                    "filters/custom-fragment-shader",
-                    "filters/filter-stack",
-                    "filters/metaballs",
-                    "filters/noise-vignette",
-                    "filters/palette-cycling",
-                    "showcase/color-grading"
-                ]
+                    'filters/blur-filter',
+                    'filters/chromatic-aberration',
+                    'filters/color-filter',
+                    'filters/crt-scanlines',
+                    'filters/custom-fragment-shader',
+                    'filters/filter-stack',
+                    'filters/metaballs',
+                    'filters/noise-vignette',
+                    'filters/palette-cycling',
+                    'showcase/color-grading',
+                ],
+                apiLinks: ['filter', 'color-filter', 'blur-filter'],
             },
             {
-                part: 6,
-                chapter: 2,
-                partSlug: "effects",
-                partTitle: "06 Effects",
-                partDescription: "Layer visual effects to build mood, motion, and feedback.",
-                slug: "particles",
-                title: "6.2 Particles",
-                description: "Spawn and tune particle systems for environmental and reactive effects.",
-                path: "effects/particles",
+                slug: 'particles',
+                level: 'intermediate',
                 examples: [
-                    "particles/bonfire",
-                    "particles/cursor-attractor-particles",
-                    "particles/custom-wgsl-module",
-                    "particles/emitter-basics",
-                    "particles/fireworks",
-                    "particles/gpu-particles"
-                ]
+                    'particles/emitter-basics',
+                    'particles/bonfire',
+                    'particles/fireworks',
+                    'particles/cursor-attractor-particles',
+                    'particles/gpu-particles',
+                    'particles/custom-wgsl-module',
+                ],
+                apiLinks: ['particle-system'],
             },
             {
-                part: 6,
-                chapter: 3,
-                partSlug: "effects",
-                partTitle: "06 Effects",
-                partDescription: "Layer visual effects to build mood, motion, and feedback.",
-                slug: "post-processing",
-                title: "6.3 Post-processing",
-                description: "Build multi-pass render flows for bloom, trails, and mirror effects.",
-                path: "effects/post-processing",
+                slug: 'post-processing',
+                level: 'advanced',
+                prerequisites: ['drawing/render-targets'],
                 examples: [
-                    "render-targets/bloom-lite",
-                    "render-targets/post-processing-chain",
-                    "render-targets/trail-feedback",
-                    "render-targets/water-mirror"
-                ]
+                    'render-targets/bloom-lite',
+                    'render-targets/post-processing-chain',
+                    'render-targets/trail-feedback',
+                    'render-targets/water-mirror',
+                ],
+                apiLinks: ['render-target', 'filter'],
             },
             {
-                part: 6,
-                chapter: 4,
-                partSlug: "effects",
-                partTitle: "06 Effects",
-                partDescription: "Layer visual effects to build mood, motion, and feedback.",
-                slug: "custom-mesh-shaders",
-                title: "6.4 Custom mesh shaders",
-                description: "Attach custom GLSL or WGSL programs to meshes for geometry-space effects.",
-                path: "effects/custom-mesh-shaders",
-                examples: [
-                    "geometry-graphics/mesh-triangle",
-                    "geometry-graphics/mesh-textured-quad",
-                    "geometry-graphics/mesh-deformed-grid"
-                ]
-            }
-        ]
+                slug: 'custom-mesh-shaders',
+                level: 'advanced',
+                prerequisites: ['drawing/graphics'],
+                examples: ['geometry-graphics/mesh-triangle', 'geometry-graphics/mesh-textured-quad', 'geometry-graphics/mesh-deformed-grid'],
+                apiLinks: ['mesh'],
+            },
+        ],
     },
     {
-        part: 7,
-        slug: "advanced",
-        title: "07 Advanced",
-        description: "Go deeper when you need custom pipelines, tooling, and profiling data.",
+        slug: 'advanced',
+        title: 'Debugging & Performance',
+        description: 'Inspect a running scene, profile it, debug the render pipeline, and choose a backend.',
         chapters: [
             {
-                part: 7,
-                chapter: 1,
-                partSlug: "advanced",
-                partTitle: "07 Advanced",
-                partDescription: "Go deeper when you need custom pipelines, tooling, and profiling data.",
-                slug: "custom-renderers",
-                title: "7.1 Custom renderers",
-                description: "Extend rendering with custom passes and backend-specific logic.",
-                path: "advanced/custom-renderers",
-                examples: [
-                    "custom-renderers/custom-render-pass",
-                    "custom-renderers/custom-triangle-renderer"
-                ]
+                slug: 'debug-layer',
+                level: 'intermediate',
+                learningGoals: [
+                    'overlay performance, bounds, and hit-test layers',
+                    'toggle debug layers without changing scene code',
+                ],
+                prerequisites: ['introduction/your-first-scene'],
+                examples: ['debug-layer/performance-overlay', 'debug-layer/bounding-boxes', 'debug-layer/pointer-and-hittest', 'debug-layer/signal-bus-inspector'],
+                apiLinks: ['debug-overlay', 'performance-layer', 'bounding-boxes-layer', 'hit-test-layer'],
             },
             {
-                part: 7,
-                chapter: 2,
-                partSlug: "advanced",
-                partTitle: "07 Advanced",
-                partDescription: "Go deeper when you need custom pipelines, tooling, and profiling data.",
-                slug: "debug-layer",
-                title: "7.2 Debug layer",
-                description: "Inspect scene state and runtime behavior while a scene is running.",
-                path: "advanced/debug-layer",
-                examples: [
-                    "debug-layer/bounding-boxes",
-                    "debug-layer/performance-overlay",
-                    "debug-layer/pointer-and-hittest",
-                    "debug-layer/signal-bus-inspector"
-                ]
+                slug: 'performance',
+                level: 'intermediate',
+                learningGoals: [
+                    'measure scene limits with stress examples',
+                    'read the performance overlay to find bottlenecks',
+                ],
+                prerequisites: ['advanced/debug-layer'],
+                examples: ['performance/sprite-stress', 'performance/multi-texture-stress', 'performance/particle-stress'],
+                apiLinks: ['performance-layer'],
             },
             {
-                part: 7,
-                chapter: 3,
-                partSlug: "advanced",
-                partTitle: "07 Advanced",
-                partDescription: "Go deeper when you need custom pipelines, tooling, and profiling data.",
-                slug: "performance",
-                title: "7.3 Performance",
-                description: "Measure scene limits with focused stress examples.",
-                path: "advanced/performance",
-                examples: [
-                    "performance/sprite-stress",
-                    "performance/multi-texture-stress",
-                    "performance/particle-stress"
-                ]
+                slug: 'render-pipeline-debugging',
+                level: 'advanced',
+                prerequisites: ['advanced/debug-layer'],
+                examples: ['render-targets/post-processing-chain', 'render-targets/bloom-lite'],
+                apiLinks: ['render-pass-inspector-layer'],
             },
             {
-                part: 7,
-                chapter: 4,
-                partSlug: "advanced",
-                partTitle: "07 Advanced",
-                partDescription: "Go deeper when you need custom pipelines, tooling, and profiling data.",
-                slug: "backend-comparison",
-                title: "7.4 Backend comparison",
-                description: "Compare backend behavior and decide what to ship.",
-                path: "advanced/backend-comparison",
-                examples: [
-                    "performance/backend-comparison"
-                ]
+                slug: 'backend-comparison',
+                level: 'advanced',
+                examples: ['performance/backend-comparison'],
+                apiLinks: ['capabilities'],
             },
             {
-                part: 7,
-                chapter: 5,
-                partSlug: "advanced",
-                partTitle: "07 Advanced",
-                partDescription: "Go deeper when you need custom pipelines, tooling, and profiling data.",
-                slug: "collision-detection",
-                title: "7.5 Collision detection",
-                description: "Validate collision flow and response with interactive shapes.",
-                path: "advanced/collision-detection",
-                examples: [
-                    "showcase/rectangles-collision"
-                ]
+                slug: 'custom-renderers',
+                level: 'advanced',
+                examples: ['custom-renderers/custom-render-pass', 'custom-renderers/custom-triangle-renderer'],
             },
             {
-                part: 7,
-                chapter: 6,
-                partSlug: "advanced",
-                partTitle: "07 Advanced",
-                partDescription: "Go deeper when you need custom pipelines, tooling, and profiling data.",
-                slug: "render-pipeline-debugging",
-                title: "7.6 Render pipeline debugging",
-                description: "Inspect filter chains and pass counts with the render-pass inspector.",
-                path: "advanced/render-pipeline-debugging",
-                examples: [
-                    "render-targets/post-processing-chain",
-                    "render-targets/bloom-lite"
-                ]
-            }
-        ]
+                slug: 'collision-detection',
+                level: 'advanced',
+                examples: ['showcase/rectangles-collision'],
+                apiLinks: ['bounds', 'circle'],
+            },
+        ],
     },
     {
-        part: 8,
-        slug: "recipes",
-        title: "08 Recipes",
-        description: "Use practical scene patterns you can adapt directly in production.",
+        slug: 'recipes',
+        title: 'Recipes',
+        description: 'Practical scene patterns you can adapt directly, ending with a complete small game.',
         chapters: [
             {
-                part: 8,
-                chapter: 1,
-                partSlug: "recipes",
-                partTitle: "08 Recipes",
-                partDescription: "Use practical scene patterns you can adapt directly in production.",
-                slug: "hud-overlay",
-                title: "8.1 HUD overlay",
-                description: "Compose gameplay and UI layers without coupling scene logic.",
-                path: "recipes/hud-overlay",
-                examples: [
-                    "application-scenes/hud-overlay-scene",
-                    "showcase/minimap-with-mask"
-                ]
+                slug: 'hud-overlay',
+                level: 'intermediate',
+                examples: ['application-scenes/hud-overlay-scene', 'showcase/minimap-with-mask'],
             },
             {
-                part: 8,
-                chapter: 2,
-                partSlug: "recipes",
-                partTitle: "08 Recipes",
-                partDescription: "Use practical scene patterns you can adapt directly in production.",
-                slug: "camera-follow-and-parallax",
-                title: "8.2 Camera follow & parallax",
-                description: "Create depth and motion parallax from camera and pointer movement.",
-                path: "recipes/camera-follow-and-parallax",
-                examples: [
-                    "showcase/mouse-parallax",
-                    "scene-graph/parallax-starfield"
-                ]
+                slug: 'camera-follow-and-parallax',
+                level: 'intermediate',
+                examples: ['showcase/mouse-parallax', 'scene-graph/parallax-starfield'],
             },
             {
-                part: 8,
-                chapter: 3,
-                partSlug: "recipes",
-                partTitle: "08 Recipes",
-                partDescription: "Use practical scene patterns you can adapt directly in production.",
-                slug: "pause-menu",
-                title: "8.3 Pause menu",
-                description: "Pause scene updates while keeping clear visual context for players.",
-                path: "recipes/pause-menu",
-                examples: [
-                    "showcase/pause-blur"
-                ]
+                slug: 'pause-menu',
+                level: 'intermediate',
+                examples: ['showcase/pause-blur'],
             },
             {
-                part: 8,
-                chapter: 4,
-                partSlug: "recipes",
-                partTitle: "08 Recipes",
-                partDescription: "Use practical scene patterns you can adapt directly in production.",
-                slug: "split-screen",
-                title: "8.4 Split screen",
-                description: "Render multiple viewpoints in a shared scene timeline.",
-                path: "recipes/split-screen",
-                examples: [
-                    "application-scenes/multi-view-split-screen"
-                ]
+                slug: 'split-screen',
+                level: 'intermediate',
+                examples: ['application-scenes/multi-view-split-screen'],
             },
             {
-                part: 8,
-                chapter: 5,
-                partSlug: "recipes",
-                partTitle: "08 Recipes",
-                partDescription: "Use practical scene patterns you can adapt directly in production.",
-                slug: "audio-reactive-scene",
-                title: "8.5 Audio reactive scene",
-                description: "Map audio analysis to movement, particles, and camera response.",
-                path: "recipes/audio-reactive-scene",
-                examples: [
-                    "showcase/audio-reactive-particles",
-                    "showcase/audio-visualisation",
-                    "showcase/low-band-camera-shake",
-                    "showcase/vinyl-record"
-                ]
+                slug: 'audio-reactive-scene',
+                level: 'intermediate',
+                examples: ['showcase/audio-reactive-particles', 'showcase/audio-visualisation', 'showcase/low-band-camera-shake', 'showcase/vinyl-record'],
             },
             {
-                part: 8,
-                chapter: 6,
-                partSlug: "recipes",
-                partTitle: "08 Recipes",
-                partDescription: "Use practical scene patterns you can adapt directly in production.",
-                slug: "game-feel",
-                title: "8.6 Game feel",
-                description: "Add feedback cues that make interaction feel responsive.",
-                path: "recipes/game-feel",
-                examples: [
-                    "showcase/damage-flash",
-                    "showcase/screen-shake-on-explosion",
-                    "showcase/gamepad-spaceship"
-                ]
+                slug: 'game-feel',
+                level: 'intermediate',
+                examples: ['showcase/damage-flash', 'showcase/screen-shake-on-explosion', 'showcase/gamepad-spaceship'],
             },
             {
-                part: 8,
-                chapter: 7,
-                partSlug: "recipes",
-                partTitle: "08 Recipes",
-                partDescription: "Use practical scene patterns you can adapt directly in production.",
-                slug: "ui-patterns",
-                title: "8.7 UI patterns",
-                description: "Build reusable dialog and text-flow UI behavior in-scene.",
-                path: "recipes/ui-patterns",
-                examples: [
-                    "showcase/dialog-system",
-                    "showcase/typewriter-text"
-                ]
+                slug: 'ui-patterns',
+                level: 'intermediate',
+                examples: ['showcase/dialog-system', 'showcase/typewriter-text'],
             },
             {
-                part: 8,
-                chapter: 8,
-                partSlug: "recipes",
-                partTitle: "08 Recipes",
-                partDescription: "Use practical scene patterns you can adapt directly in production.",
-                slug: "cinematics",
-                title: "8.8 Cinematics",
-                description: "Coordinate timing, camera, and audio for scripted scene beats.",
-                path: "recipes/cinematics",
-                examples: [
-                    "showcase/boss-intro-cinematic"
-                ]
+                slug: 'cinematics',
+                level: 'intermediate',
+                examples: ['showcase/boss-intro-cinematic'],
             },
             {
-                part: 8,
-                chapter: 9,
-                partSlug: "recipes",
-                partTitle: "08 Recipes",
-                partDescription: "Use practical scene patterns you can adapt directly in production.",
-                slug: "build-orb-dodge",
-                title: "8.9 Build Orb Dodge",
-                description: "Build a complete small game: player movement, orb spawning, collision, scoring, HUD, and a game-over scene.",
-                path: "recipes/build-orb-dodge",
-                examples: [
-                    "showcase/orb-dodge"
-                ]
-            }
-        ]
+                slug: 'build-orb-dodge',
+                level: 'intermediate',
+                learningGoals: [
+                    'wire a complete game from scenes, input, and graphics',
+                    'spawn, move, and collide objects each frame',
+                    'transition to a game-over scene and restart',
+                ],
+                prerequisites: ['core-concepts/scene-lifecycle', 'input/keyboard', 'drawing/graphics'],
+                examples: ['showcase/orb-dodge'],
+                apiLinks: ['scene', 'graphics', 'keyboard', 'text', 'color'],
+            },
+        ],
     },
     {
-        part: 9,
-        slug: "migration",
-        title: "09 Migration",
-        description: "Upgrade guidance for pre-1.0 API changes between ExoJS minor versions.",
+        slug: 'migration',
+        title: 'Migration',
+        description: 'Upgrade guidance for pre-1.0 API changes between ExoJS minor versions.',
         chapters: [
             {
-                part: 9,
-                chapter: 1,
-                partSlug: "migration",
-                partTitle: "09 Migration",
-                partDescription: "Upgrade guidance for pre-1.0 API changes between ExoJS minor versions.",
-                slug: "v0-8-x-to-v0-9-0",
-                title: "9.1 v0.8.x to v0.9.0",
-                description: "Mechanical migration steps for the v0.9.0 API consolidation release.",
-                path: "migration/v0-8-x-to-v0-9-0",
-                examples: []
-            }
-        ]
+                slug: 'v0-8-x-to-v0-9-0',
+                level: 'intermediate',
+            },
+        ],
     },
     {
-        part: 10,
-        slug: "reference",
-        title: "10 Reference",
-        description: "Practical guides for diagnosing problems and shipping ExoJS apps to production.",
+        slug: 'reference',
+        title: 'Reference & Deployment',
+        description: 'Diagnose common problems and ship an ExoJS app to production.',
         chapters: [
             {
-                part: 10,
-                chapter: 1,
-                partSlug: "reference",
-                partTitle: "10 Reference",
-                partDescription: "Practical guides for diagnosing problems and shipping ExoJS apps to production.",
-                slug: "troubleshooting",
-                title: "10.1 Troubleshooting",
-                description: "Diagnose and fix the most common ExoJS problems: blank canvas, API errors, missing assets, audio, input, and performance.",
-                path: "reference/troubleshooting",
-                examples: [
-                    "debug-layer/performance-overlay",
-                    "input/keyboard",
-                    "input/gamepad",
-                    "audio-basics/play-sound"
-                ]
+                slug: 'troubleshooting',
+                level: 'intro',
+                examples: ['debug-layer/performance-overlay', 'input/keyboard', 'input/gamepad', 'audio-basics/play-sound'],
             },
             {
-                part: 10,
-                chapter: 2,
-                partSlug: "reference",
-                partTitle: "10 Reference",
-                partDescription: "Practical guides for diagnosing problems and shipping ExoJS apps to production.",
-                slug: "deployment",
-                title: "10.2 Deployment",
-                description: "Build and host an ExoJS app: local production build, Vite base path, static hosting, assets, CDN bundles, and browser support.",
-                path: "reference/deployment",
-                examples: []
-            }
-        ]
-    }
+                slug: 'deployment',
+                level: 'intermediate',
+                prerequisites: ['recipes/build-orb-dodge'],
+            },
+        ],
+    },
 ];
+
+const PARTS: ReadonlyArray<GuidePartMeta> = RAW_PARTS.map((rawPart, partIndex) => {
+    const part = partIndex + 1;
+    const partMeta: GuidePartMeta = {
+        part,
+        slug: rawPart.slug,
+        title: rawPart.title,
+        description: rawPart.description,
+        chapters: rawPart.chapters.map((rawChapter, chapterIndex) => ({
+            part,
+            chapter: chapterIndex + 1,
+            partSlug: rawPart.slug,
+            partTitle: rawPart.title,
+            slug: rawChapter.slug,
+            path: `${rawPart.slug}/${rawChapter.slug}`,
+            level: rawChapter.level,
+            learningGoals: rawChapter.learningGoals ?? [],
+            prerequisites: rawChapter.prerequisites ?? [],
+            examples: rawChapter.examples ?? [],
+            apiLinks: rawChapter.apiLinks ?? [],
+        })),
+    };
+    return partMeta;
+});
 
 export const GUIDE_PARTS: ReadonlyArray<GuidePartMeta> = PARTS;
 
@@ -799,3 +646,74 @@ export const GUIDE_CHAPTERS: ReadonlyArray<GuideChapterMeta> = PARTS.flatMap(par
 
 export const GUIDE_CHAPTER_BY_PATH = new Map(GUIDE_CHAPTERS.map(chapter => [chapter.path, chapter]));
 
+export const GUIDE_PART_BY_SLUG = new Map(GUIDE_PARTS.map(part => [part.slug, part]));
+
+export interface LearningPathStep {
+    /** Guide chapter path ("<partSlug>/<chapterSlug>"). */
+    path: string;
+    /** One concrete outcome for this step. */
+    goal: string;
+    /** Optional related playground example ("<category>/<slug>"). */
+    example?: string;
+}
+
+/**
+ * The recommended onboarding journey, shown on the guide landing page. Each step
+ * links to a real chapter; the landing reconciliation test keeps every path and
+ * example valid.
+ */
+export const GUIDE_LEARNING_PATH: ReadonlyArray<LearningPathStep> = [
+    { path: 'introduction/what-is-exojs', goal: 'See what ExoJS is and how its pieces fit together.' },
+    { path: 'introduction/setup', goal: 'Scaffold a typed project and run the dev server.' },
+    { path: 'introduction/your-first-scene', goal: 'Load a texture, draw a sprite, and animate it.', example: 'getting-started/hello-world' },
+    { path: 'core-concepts/scene-lifecycle', goal: 'Update state and render each frame.', example: 'getting-started/game-loop' },
+    { path: 'input/keyboard', goal: 'Move something in response to key presses.', example: 'input/keyboard' },
+    { path: 'audio/audio-basics', goal: 'Play sound and music with reliable controls.', example: 'audio-basics/play-sound' },
+    { path: 'recipes/build-orb-dodge', goal: 'Combine it all into a complete small game.', example: 'showcase/orb-dodge' },
+    { path: 'reference/deployment', goal: 'Build and host the finished project.' },
+];
+
+export interface GuideTopic {
+    title: string;
+    description: string;
+    /** Guide chapter path the topic opens. */
+    path: string;
+}
+
+/** Topic-based entry points on the guide landing page. */
+export const GUIDE_TOPICS: ReadonlyArray<GuideTopic> = [
+    { title: 'Build games', description: 'Scenes, input, collision, and a full game walkthrough.', path: 'recipes/build-orb-dodge' },
+    { title: 'Create visuals', description: 'Graphics, sprites, text, filters, and particles.', path: 'drawing/graphics' },
+    { title: 'Work with audio', description: 'Playback, spatial audio, effects, and beat detection.', path: 'audio/audio-basics' },
+    { title: 'Debug & optimize', description: 'Overlays, profiling, and render-pipeline inspection.', path: 'advanced/debug-layer' },
+];
+
+/** The core onboarding chapters that must carry full pedagogical metadata. */
+export const CORE_ONBOARDING_PATHS: ReadonlyArray<string> = [
+    'introduction/what-is-exojs',
+    'introduction/setup',
+    'introduction/project-structure',
+    'introduction/your-first-scene',
+    'core-concepts/scene-lifecycle',
+    'input/keyboard',
+    'audio/audio-basics',
+    'recipes/build-orb-dodge',
+];
+
+/** Returns the chapters immediately before and after the given guide path. */
+export function getAdjacentChapters(path: string): {
+    previous: GuideChapterMeta | null;
+    next: GuideChapterMeta | null;
+} {
+    const index = GUIDE_CHAPTERS.findIndex(chapter => chapter.path === path);
+    if (index === -1) return { previous: null, next: null };
+    return {
+        previous: index > 0 ? GUIDE_CHAPTERS[index - 1] : null,
+        next: index < GUIDE_CHAPTERS.length - 1 ? GUIDE_CHAPTERS[index + 1] : null,
+    };
+}
+
+/** True when the value matches a known guide chapter path. */
+export function isGuidePath(path: string): boolean {
+    return GUIDE_CHAPTER_BY_PATH.has(path);
+}

--- a/site/src/pages/de/guide/[part]/[chapter]/index.astro
+++ b/site/src/pages/de/guide/[part]/[chapter]/index.astro
@@ -1,4 +1,6 @@
 ---
+import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
 import DocsLayout from '../../../../../layouts/DocsLayout.astro';
 import TranslationNotice from '../../../../../components/TranslationNotice.astro';
 import { GUIDE_PARTS, GUIDE_CHAPTER_BY_PATH } from '../../../../../lib/guide-structure';
@@ -22,11 +24,15 @@ const chapterMeta = GUIDE_CHAPTER_BY_PATH.get(chapterPath);
 if (!chapterMeta) {
     throw new Error(`Unknown guide chapter: ${chapterPath}`);
 }
+
+const guideEntries = await getCollection('guide');
+const entry = guideEntries.find((item: CollectionEntry<'guide'>) => item.id.replace(/\.(md|mdx)$/, '') === chapterPath);
+const chapterTitle = entry?.data.title ?? chapterSlug;
 ---
 
-<DocsLayout title={`${chapterMeta.title} (DE)`} description="German localization placeholder for this guide chapter.">
+<DocsLayout title={`${chapterTitle} (DE)`} description="German localization placeholder for this guide chapter.">
     <section class="de-guide-chapter">
-        <h1>{chapterMeta.title}</h1>
+        <h1>{chapterTitle}</h1>
         <p>This chapter is not translated to German yet.</p>
         <TranslationNotice englishHref={`${import.meta.env.BASE_URL}en/guide/${partSlug}/${chapterSlug}/`} />
     </section>

--- a/site/src/pages/de/guide/[part]/index.astro
+++ b/site/src/pages/de/guide/[part]/index.astro
@@ -1,4 +1,6 @@
 ---
+import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
 import { GUIDE_PARTS } from '../../../../lib/guide-structure';
 
 export function getStaticPaths() {
@@ -17,6 +19,11 @@ if (!firstChapter) {
     throw new Error(`Guide part has no chapters: ${partSlug}`);
 }
 
+const guideEntries = await getCollection('guide');
+const firstChapterTitle =
+    guideEntries.find((entry: CollectionEntry<'guide'>) => entry.id.replace(/\.(md|mdx)$/, '') === firstChapter.path)?.data
+        .title ?? firstChapter.slug;
+
 const targetHref = `${import.meta.env.BASE_URL}de/guide/${part.slug}/${firstChapter.slug}/`;
 ---
 
@@ -34,6 +41,6 @@ const targetHref = `${import.meta.env.BASE_URL}de/guide/${part.slug}/${firstChap
         </noscript>
     </head>
     <body>
-        <p>Weiterleitung zu <a href={targetHref}>{firstChapter.title}</a>...</p>
+        <p>Weiterleitung zu <a href={targetHref}>{firstChapterTitle}</a>...</p>
     </body>
 </html>

--- a/site/src/pages/en/guide/[part]/[chapter]/index.astro
+++ b/site/src/pages/en/guide/[part]/[chapter]/index.astro
@@ -3,7 +3,9 @@ import { getCollection, render } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
 import DocsLayout from '../../../../../layouts/DocsLayout.astro';
 import DocsSidebar from '../../../../../components/DocsSidebar.astro';
-import { GUIDE_PARTS, GUIDE_CHAPTER_BY_PATH } from '../../../../../lib/guide-structure';
+import GuideMeta from '../../../../../components/GuideMeta.astro';
+import GuidePager from '../../../../../components/GuidePager.astro';
+import { GUIDE_PARTS, GUIDE_CHAPTER_BY_PATH, getAdjacentChapters } from '../../../../../lib/guide-structure';
 
 export function getStaticPaths() {
     return GUIDE_PARTS.flatMap(part =>
@@ -20,11 +22,6 @@ const partSlug = (Astro.params as Record<string, string | undefined>).part ?? ''
 const chapterSlug = (Astro.params as Record<string, string | undefined>).chapter ?? '';
 const chapterPath = `${partSlug}/${chapterSlug}`;
 const chapterMeta = GUIDE_CHAPTER_BY_PATH.get(chapterPath);
-const parseIndexedLabel = (value: string) => {
-    const match = /^([0-9]+(?:\.[0-9]+)?)\s+(.+)$/.exec(value.trim());
-    if (!match) return { index: null, label: value };
-    return { index: match[1], label: match[2] };
-};
 
 if (!chapterMeta) {
     throw new Error(`Unknown guide chapter: ${chapterPath}`);
@@ -40,12 +37,40 @@ if (!entry) {
     throw new Error(`Missing guide content entry: ${chapterPath}`);
 }
 
+const titleByPath = (path: string): string => entryByPath.get(path)?.data.title ?? path;
+const guideHref = (path: string): string => `${import.meta.env.BASE_URL}en/guide/${path}/`;
+
+// Reading-time estimate from the prose: strip code fences and component tags so
+// the number reflects what a reader actually reads, then 200 words/minute.
+const proseWords = entry.body
+    ? entry.body
+        .replace(/```[\s\S]*?```/g, ' ')
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/[#>*_`|-]/g, ' ')
+        .split(/\s+/)
+        .filter(Boolean).length
+    : 0;
+const readingMinutes = proseWords > 0 ? Math.max(1, Math.round(proseWords / 200)) : undefined;
+
+const prerequisites = chapterMeta.prerequisites.map(path => ({
+    label: titleByPath(path),
+    href: guideHref(path),
+}));
+
 type TocHeading = { depth: number; slug: string; text: string };
 const { Content, headings } = await render(entry);
 const tocItems = (headings as TocHeading[]).filter((heading: TocHeading) => heading.depth >= 2 && heading.depth <= 3);
 const primaryExample = chapterMeta.examples[0] ?? null;
-const partLabel = parseIndexedLabel(chapterMeta.partTitle).label;
-const chapterLabel = parseIndexedLabel(chapterMeta.title).label;
+const partTitle = chapterMeta.partTitle;
+const chapterTitle = entry.data.title;
+
+const { previous, next } = getAdjacentChapters(chapterPath);
+const previousLink = previous
+    ? { label: titleByPath(previous.path), href: guideHref(previous.path), context: previous.partTitle }
+    : null;
+const nextLink = next
+    ? { label: titleByPath(next.path), href: guideHref(next.path), context: next.partTitle }
+    : null;
 
 const getFirstChapterHref = (part: (typeof GUIDE_PARTS)[number]) => {
     const firstChapter = part.chapters[0];
@@ -60,13 +85,13 @@ const sidebarParts = GUIDE_PARTS.map(part => ({
     baseHref: `${import.meta.env.BASE_URL}en/guide/${part.slug}/`,
     chapters: part.chapters.map(chapter => ({
         slug: chapter.slug,
-        title: chapter.title,
+        title: titleByPath(chapter.path),
         href: `${import.meta.env.BASE_URL}en/guide/${part.slug}/${chapter.slug}/`,
     })),
 }));
 ---
 
-<DocsLayout title={`${chapterLabel} | ExoJS Guide`} description={chapterMeta.description} variant="guide">
+<DocsLayout title={`${chapterTitle} | ExoJS Guide`} description={entry.data.description} variant="guide">
     <DocsSidebar slot="sidebar" parts={sidebarParts} />
     <aside slot="rail" class="toc" aria-label="On this page">
         <h6>On this page</h6>
@@ -100,14 +125,25 @@ const sidebarParts = GUIDE_PARTS.map(part => ({
         <div class="crumbs">
                 <a href={`${import.meta.env.BASE_URL}en/guide/`}>Guide</a>
                 <span class="sep" aria-hidden="true">/</span>
-                <a href={`${import.meta.env.BASE_URL}en/guide/${chapterMeta.partSlug}/`}>{partLabel}</a>
+                <a href={`${import.meta.env.BASE_URL}en/guide/${chapterMeta.partSlug}/`}>{partTitle}</a>
                 <span class="sep" aria-hidden="true">/</span>
-                <span>{chapterLabel}</span>
+                <span>{chapterTitle}</span>
         </div>
-        <h1>{chapterLabel}</h1>
-        <p class="lead">{chapterMeta.description}</p>
+        <h1>{chapterTitle}</h1>
+        <p class="lead">{entry.data.description}</p>
 
-        <Content />
+        <GuideMeta
+            level={chapterMeta.level}
+            readingMinutes={readingMinutes}
+            learningGoals={chapterMeta.learningGoals}
+            prerequisites={prerequisites}
+        />
+
+        <div class="chapter-content">
+            <Content />
+        </div>
+
+        <GuidePager previous={previousLink} next={nextLink} />
     </article>
 </DocsLayout>
 
@@ -166,6 +202,7 @@ const sidebarParts = GUIDE_PARTS.map(part => ({
         font-size: 12.5px;
         color: var(--fg-faint);
         font-family: var(--f-mono);
+        flex-wrap: wrap;
     }
 
     .chapter-prose .crumbs .sep {
@@ -185,14 +222,16 @@ const sidebarParts = GUIDE_PARTS.map(part => ({
     }
 
     .chapter-prose .lead {
-        margin: 0 0 var(--s-7);
+        margin: 0 0 var(--s-6);
         font-size: 17px;
         color: var(--fg-muted);
         line-height: 1.55;
         text-wrap: pretty;
     }
 
-    .chapter-prose :global(h1:first-child) {
+    /* The MDX body repeats the title as a leading H1; the layout already renders
+       the title above, so hide the in-content one. */
+    .chapter-prose :global(.chapter-content > h1:first-child) {
         display: none;
     }
 
@@ -254,13 +293,20 @@ const sidebarParts = GUIDE_PARTS.map(part => ({
         margin: var(--s-9) 0;
     }
 
-    .chapter-prose :global(a) {
+    /* Underline prose links only — component links (TryIt, NextStep, pager,
+       example/source embeds) keep their own styling. */
+    .chapter-prose :global(p a),
+    .chapter-prose :global(li a) {
         color: var(--fg);
-        text-decoration: none;
+        text-decoration: underline;
+        text-decoration-color: color-mix(in oklab, var(--accent), transparent 55%);
+        text-underline-offset: 0.2em;
     }
 
-    .chapter-prose :global(a:hover) {
+    .chapter-prose :global(p a:hover),
+    .chapter-prose :global(li a:hover) {
         color: var(--accent);
+        text-decoration-color: var(--accent);
     }
 
     .toc h6 {

--- a/site/src/pages/en/guide/[part]/index.astro
+++ b/site/src/pages/en/guide/[part]/index.astro
@@ -1,4 +1,6 @@
 ---
+import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
 import { GUIDE_PARTS } from '../../../../lib/guide-structure';
 
 export function getStaticPaths() {
@@ -17,6 +19,11 @@ if (!firstChapter) {
     throw new Error(`Guide part has no chapters: ${partSlug}`);
 }
 
+const guideEntries = await getCollection('guide');
+const firstChapterTitle =
+    guideEntries.find((entry: CollectionEntry<'guide'>) => entry.id.replace(/\.(md|mdx)$/, '') === firstChapter.path)?.data
+        .title ?? firstChapter.slug;
+
 const targetHref = `${import.meta.env.BASE_URL}en/guide/${part.slug}/${firstChapter.slug}/`;
 ---
 
@@ -34,6 +41,6 @@ const targetHref = `${import.meta.env.BASE_URL}en/guide/${part.slug}/${firstChap
         </noscript>
     </head>
     <body>
-        <p>Redirecting to <a href={targetHref}>{firstChapter.title}</a>...</p>
+        <p>Redirecting to <a href={targetHref}>{firstChapterTitle}</a>...</p>
     </body>
 </html>

--- a/site/src/pages/en/guide/index.astro
+++ b/site/src/pages/en/guide/index.astro
@@ -1,107 +1,150 @@
 ---
+import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
 import DocsLayout from '../../../layouts/DocsLayout.astro';
 import DocsSidebar from '../../../components/DocsSidebar.astro';
-import { GUIDE_PARTS } from '../../../lib/guide-structure';
+import { GUIDE_PARTS, GUIDE_LEARNING_PATH, GUIDE_TOPICS } from '../../../lib/guide-structure';
+
+const base = import.meta.env.BASE_URL;
+const guideHref = (path: string): string => `${base}en/guide/${path}/`;
+const playgroundHref = (example: string): string => `${base}en/playground/?example=${example}`;
+
+const guideEntries = await getCollection('guide');
+const dataByPath = new Map<string, CollectionEntry<'guide'>['data']>(
+    guideEntries.map((entry: CollectionEntry<'guide'>) => [entry.id.replace(/\.(md|mdx)$/, ''), entry.data]),
+);
+const titleOf = (path: string): string => dataByPath.get(path)?.title ?? path;
+const descriptionOf = (path: string): string => dataByPath.get(path)?.description ?? '';
 
 const chapterCount = GUIDE_PARTS.reduce((sum, part) => sum + part.chapters.length, 0);
-const exampleCount = GUIDE_PARTS.reduce((sum, part) => sum + part.chapters.reduce((inner, chapter) => inner + chapter.examples.length, 0), 0);
-const chapterTopics = (chapterSlug: string) =>
-    chapterSlug
-        .replace(/-/g, ' ')
-        .split(' ')
-        .filter(Boolean)
-        .slice(0, 2);
+
+const learningPath = GUIDE_LEARNING_PATH;
+const topics = GUIDE_TOPICS;
+
 const getFirstChapterHref = (part: (typeof GUIDE_PARTS)[number]) => {
     const firstChapter = part.chapters[0];
-    return firstChapter
-        ? `${import.meta.env.BASE_URL}en/guide/${part.slug}/${firstChapter.slug}/`
-        : `${import.meta.env.BASE_URL}en/guide/${part.slug}/`;
+    return firstChapter ? guideHref(`${part.slug}/${firstChapter.slug}`) : `${base}en/guide/${part.slug}/`;
 };
 const sidebarParts = GUIDE_PARTS.map(part => ({
     slug: part.slug,
     title: part.title,
     href: getFirstChapterHref(part),
-    baseHref: `${import.meta.env.BASE_URL}en/guide/${part.slug}/`,
+    baseHref: `${base}en/guide/${part.slug}/`,
     chapters: part.chapters.map(chapter => ({
         slug: chapter.slug,
-        title: chapter.title,
-        href: `${import.meta.env.BASE_URL}en/guide/${part.slug}/${chapter.slug}/`,
+        title: titleOf(chapter.path),
+        href: guideHref(chapter.path),
     })),
 }));
 ---
 
-<DocsLayout title="ExoJS Guide" description="Structured ExoJS guide from introduction to advanced recipes." variant="guide">
+<DocsLayout title="ExoJS Guide" description="Learn ExoJS from your first project to a complete, deployable game." variant="guide">
     <DocsSidebar slot="sidebar" parts={sidebarParts} />
     <aside slot="rail" class="toc" aria-label="Guide index shortcuts">
         <h6>On this page</h6>
         <ul>
-            {GUIDE_PARTS.map(part => (
-                <li>
-                    <a href={`#part-${part.slug}`}>{part.title.replace(/^[0-9]+\s+/, '')}</a>
-                </li>
-            ))}
+            <li><a href="#start">Start here</a></li>
+            <li><a href="#path">Learning path</a></li>
+            <li><a href="#topics">Browse by topic</a></li>
+            <li><a href="#all">All chapters</a></li>
         </ul>
         <div class="toc__resources">
             <h6>Resources</h6>
             <ul>
-                <li>
-                    <a href={`${import.meta.env.BASE_URL}en/api/`}>API reference</a>
-                </li>
-                <li>
-                    <a href={`${import.meta.env.BASE_URL}en/playground/`}>Playground</a>
-                </li>
+                <li><a href={`${base}en/api/`}>API reference</a></li>
+                <li><a href={`${base}en/playground/`}>Playground</a></li>
             </ul>
         </div>
     </aside>
 
     <div class="prose guide-index-prose">
-    <section class="guide-hero">
-        <h1>Guide</h1>
-        <p>
-            Start with Introduction if you are new to ExoJS. Move into Core Concepts for the runtime model, then jump by topic for drawing, input, audio, effects, and production recipes.
-        </p>
-        <div class="stats">
-            <div class="stat">
-                <div class="n">{chapterCount}</div>
-                <div class="l">chapters</div>
+        <section class="guide-hero" id="start">
+            <h1>Build your first ExoJS project</h1>
+            <p>
+                Start with a TypeScript project, learn the Scene and rendering model, then move into input, audio,
+                effects, debugging, and deployment.
+            </p>
+            <div class="guide-hero__cmd">
+                <code>npm create exo-app@latest my-game</code>
             </div>
-            <div class="stat">
-                <div class="n">{exampleCount}</div>
-                <div class="l">examples</div>
+            <div class="guide-hero__actions">
+                <a class="act act--primary" href={guideHref('introduction/setup')}>Create a project</a>
+                <a class="act" href={guideHref('introduction/what-is-exojs')}>Start the first guide</a>
+                <a class="act" href={`${base}en/playground/`}>Open the Playground</a>
             </div>
-            <div class="stat">
-                <div class="n">~3h</div>
-                <div class="l">read time</div>
-            </div>
-        </div>
-    </section>
+        </section>
 
-    <section aria-label="Guide parts">
-        {GUIDE_PARTS.map(part => (
-            <section id={`part-${part.slug}`}>
-                <h2 class="guide-index-section-title">
-                    <span>{String(part.part).padStart(2, '0')}</span>
-                    <span>{part.title.replace(/^[0-9]+\s+/, '').toUpperCase()}</span>
-                </h2>
-                <div class="chapter-grid">
-                    {part.chapters.map(chapter => (
-                        <a class="chapter-card" href={`${import.meta.env.BASE_URL}en/guide/${part.slug}/${chapter.slug}/`}>
-                            <div class="head">
-                                <span class="num">{String(part.part).padStart(2, '0')}</span>
-                                <h3>{chapter.title.replace(/^[0-9]+\.[0-9]+\s+/, '')}</h3>
-                            </div>
-                            <p>{chapter.description}</p>
-                            <div class="topics">
-                                {chapterTopics(chapter.slug).map(topic => (
-                                    <span class="topic">{topic}</span>
-                                ))}
-                            </div>
-                        </a>
-                    ))}
+        <section class="guide-section" id="path" aria-labelledby="path-title">
+            <h2 class="guide-section__title" id="path-title">Recommended learning path</h2>
+            <p class="guide-section__lead">Follow these in order to go from an empty folder to a deployable game.</p>
+            <ol class="path">
+                {learningPath.map((step, index) => (
+                    <li class="path__step">
+                        <span class="path__num" aria-hidden="true">{index + 1}</span>
+                        <div class="path__body">
+                            <a class="path__title" href={guideHref(step.path)}>{titleOf(step.path)}</a>
+                            <p class="path__goal">{step.goal}</p>
+                            {step.example && (
+                                <a class="path__example" href={playgroundHref(step.example)}>Open example ↗</a>
+                            )}
+                        </div>
+                    </li>
+                ))}
+            </ol>
+        </section>
+
+        <section class="guide-section" id="topics" aria-labelledby="topics-title">
+            <h2 class="guide-section__title" id="topics-title">Browse by topic</h2>
+            <div class="topic-grid">
+                {topics.map(topic => (
+                    <a class="topic-card" href={guideHref(topic.path)}>
+                        <h3>{topic.title}</h3>
+                        <p>{topic.description}</p>
+                    </a>
+                ))}
+            </div>
+        </section>
+
+        <section class="guide-section orient" aria-labelledby="orient-title">
+            <h2 class="guide-section__title" id="orient-title">Guides, Playground, and API</h2>
+            <div class="orient-grid">
+                <div class="orient-card">
+                    <p class="orient-card__k">Guides</p>
+                    <p class="orient-card__v">Explain concepts and workflows, step by step.</p>
                 </div>
-            </section>
-        ))}
-    </section>
+                <span class="orient-arrow" aria-hidden="true">→</span>
+                <div class="orient-card">
+                    <p class="orient-card__k">Playground</p>
+                    <p class="orient-card__v">Run and edit every example live in the browser.</p>
+                </div>
+                <span class="orient-arrow" aria-hidden="true">→</span>
+                <div class="orient-card">
+                    <p class="orient-card__k">API reference</p>
+                    <p class="orient-card__v">Documents every class, method, and option.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="guide-section" id="all" aria-labelledby="all-title">
+            <h2 class="guide-section__title" id="all-title">All chapters</h2>
+            <p class="guide-section__lead">{chapterCount} chapters across {GUIDE_PARTS.length} parts.</p>
+            {GUIDE_PARTS.map(part => (
+                <section class="part-block" id={`part-${part.slug}`}>
+                    <h3 class="part-block__title">
+                        <span>{String(part.part).padStart(2, '0')}</span>
+                        <span>{part.title}</span>
+                    </h3>
+                    <div class="chapter-grid">
+                        {part.chapters.map(chapter => (
+                            <a class="chapter-card" href={guideHref(chapter.path)}>
+                                <h4>{titleOf(chapter.path)}</h4>
+                                <p>{descriptionOf(chapter.path)}</p>
+                            </a>
+                        ))}
+                    </div>
+                </section>
+            ))}
+        </section>
     </div>
 </DocsLayout>
 
@@ -117,7 +160,7 @@ const sidebarParts = GUIDE_PARTS.map(part => ({
         border-radius: var(--r-5);
         padding: var(--s-9) var(--s-7);
         background: var(--bg-elevated);
-        margin-bottom: var(--s-7);
+        margin-bottom: var(--s-8);
     }
 
     .guide-hero::before {
@@ -146,69 +189,270 @@ const sidebarParts = GUIDE_PARTS.map(part => ({
 
     .guide-hero p {
         margin: 0.75rem 0 0;
-        max-width: 580px;
+        max-width: 56ch;
         color: var(--fg-muted);
+        line-height: 1.6;
     }
 
-    .guide-hero .stats {
-        margin-top: var(--s-6);
-        display: flex;
-        gap: var(--s-7);
+    .guide-hero__cmd {
+        margin-top: var(--s-5);
     }
 
-    .guide-hero .stat .n {
+    .guide-hero__cmd code {
+        display: inline-block;
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-2);
+        background: var(--bg-canvas);
+        padding: 0.5rem 0.8rem;
         font-family: var(--f-mono);
-        font-size: 22px;
-        color: var(--accent);
+        font-size: 13.5px;
+        color: var(--fg);
+    }
+
+    .guide-hero__actions {
+        margin-top: var(--s-5);
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--s-3);
+    }
+
+    .act {
+        display: inline-flex;
+        align-items: center;
+        min-height: 40px;
+        padding: 0 var(--s-4);
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-2);
+        background: var(--bg-canvas);
+        color: var(--fg);
+        text-decoration: none;
+        font-size: 14px;
         font-weight: 600;
     }
 
-    .guide-hero .stat .l {
-        font-size: 12px;
+    .act--primary {
+        border-color: var(--accent-line);
+        background: var(--accent-soft);
+    }
+
+    .act:hover {
+        border-color: var(--accent-line);
+        color: var(--accent);
+    }
+
+    .act:focus-visible {
+        outline: 2px solid var(--focus-ring);
+        outline-offset: 2px;
+    }
+
+    .guide-section {
+        margin-top: var(--s-8);
+    }
+
+    .guide-section__title {
+        display: flex;
+        align-items: baseline;
+        gap: 0.6rem;
+        margin: 0 0 var(--s-2);
+        font-size: 20px;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+        border: 0;
+        padding: 0;
+    }
+
+    .guide-section__lead {
+        margin: 0 0 var(--s-5);
         color: var(--fg-muted);
+        max-width: 64ch;
+    }
+
+    .path {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: var(--s-3);
+    }
+
+    .path__step {
+        display: flex;
+        gap: var(--s-4);
+        align-items: flex-start;
+        padding: var(--s-4);
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-4);
+        background: var(--bg-elevated);
+    }
+
+    .path__num {
+        flex: none;
+        display: inline-grid;
+        place-items: center;
+        width: 28px;
+        height: 28px;
+        border-radius: var(--r-pill);
+        border: 1px solid var(--accent-line);
+        background: var(--accent-soft);
+        color: var(--accent);
+        font-family: var(--f-mono);
+        font-size: 13px;
+        font-weight: 600;
+    }
+
+    .path__body {
+        min-width: 0;
+    }
+
+    .path__title {
+        font-size: 16px;
+        font-weight: 600;
+        color: var(--fg);
+        text-decoration: none;
+    }
+
+    .path__title:hover {
+        color: var(--accent);
+    }
+
+    .path__goal {
+        margin: 4px 0 0;
+        color: var(--fg-muted);
+        font-size: 14px;
+        line-height: 1.5;
+        max-width: none;
+    }
+
+    .path__example {
+        display: inline-block;
+        margin-top: var(--s-2);
+        font-family: var(--f-mono);
+        font-size: 12px;
+        color: var(--fg-faint);
+        text-decoration: none;
+    }
+
+    .path__example:hover {
+        color: var(--accent);
+    }
+
+    .topic-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: var(--s-3);
+    }
+
+    .topic-card {
+        display: block;
+        padding: var(--s-5);
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-4);
+        background: var(--bg-elevated);
+        text-decoration: none;
+        color: inherit;
+        transition:
+            border-color var(--transition-fast),
+            transform var(--transition-fast);
+    }
+
+    .topic-card:hover {
+        border-color: var(--accent-line);
+        transform: translateY(-2px);
+    }
+
+    .topic-card:focus-visible {
+        outline: 2px solid var(--focus-ring);
+        outline-offset: 2px;
+    }
+
+    .topic-card h3 {
+        margin: 0;
+        font-size: 16px;
+        color: var(--fg);
+    }
+
+    .topic-card p {
+        margin: var(--s-2) 0 0;
+        font-size: 13.5px;
+        line-height: 1.5;
+        color: var(--fg-muted);
+        max-width: none;
+    }
+
+    .orient-grid {
+        display: flex;
+        align-items: stretch;
+        gap: var(--s-3);
+    }
+
+    .orient-card {
+        flex: 1;
+        padding: var(--s-4);
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-4);
+        background: var(--bg-elevated);
+    }
+
+    .orient-card__k {
+        margin: 0;
+        font-family: var(--f-mono);
+        font-size: 12px;
+        letter-spacing: 0.04em;
         text-transform: uppercase;
-        letter-spacing: 0.06em;
+        color: var(--accent);
     }
 
-    .guide-index-prose > section + section {
-        margin-top: 2rem;
+    .orient-card__v {
+        margin: var(--s-2) 0 0;
+        font-size: 13.5px;
+        line-height: 1.5;
+        color: var(--fg-muted);
+        max-width: none;
     }
 
-    .guide-index-section-title {
-        margin: 0 0 1rem;
+    .orient-arrow {
+        display: flex;
+        align-items: center;
+        color: var(--fg-faint);
+        font-family: var(--f-mono);
+    }
+
+    .part-block + .part-block {
+        margin-top: var(--s-6);
+    }
+
+    .part-block__title {
         display: inline-flex;
         align-items: baseline;
         gap: 0.6rem;
-        font-size: 18px;
-        letter-spacing: 0.08em;
+        margin: 0 0 var(--s-3);
+        font-family: var(--f-mono);
+        font-size: 14px;
+        letter-spacing: 0.06em;
         text-transform: uppercase;
         border: 0;
         padding: 0;
     }
 
-    .guide-index-section-title span:first-child {
-        font-family: var(--f-mono);
-        font-size: 18px;
+    .part-block__title span:first-child {
         color: var(--accent);
     }
 
-    .guide-index-section-title span:last-child {
-        font-family: var(--f-mono);
-        font-size: 18px;
+    .part-block__title span:last-child {
         color: var(--fg-muted);
     }
 
     .chapter-grid {
         display: grid;
         grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: var(--s-4);
+        gap: var(--s-3);
     }
 
     .chapter-card {
         display: flex;
         flex-direction: column;
-        gap: var(--s-3);
-        padding: var(--s-5);
+        gap: var(--s-2);
+        padding: var(--s-4);
         border: 1px solid var(--line-soft);
         border-radius: var(--r-4);
         background: var(--bg-elevated);
@@ -229,61 +473,18 @@ const sidebarParts = GUIDE_PARTS.map(part => ({
         outline-offset: 2px;
     }
 
-    .chapter-card .head {
-        display: flex;
-        align-items: center;
-        gap: var(--s-3);
-    }
-
-    .chapter-card .num {
-        display: inline-grid;
-        place-items: center;
-        min-width: 28px;
-        height: 28px;
-        padding: 0 0.46rem;
-        border-radius: var(--r-2);
-        border: 1px solid var(--line-soft);
-        background: var(--bg-canvas);
-        font-family: var(--f-mono);
-        font-size: 12px;
-        color: var(--fg-muted);
-        white-space: nowrap;
-    }
-
-    .chapter-card h3 {
+    .chapter-card h4 {
         margin: 0;
-        font-size: 16px;
+        font-size: 15px;
         color: var(--fg);
     }
 
     .chapter-card p {
         margin: 0;
-        font-size: 13.5px;
+        font-size: 13px;
         line-height: 1.5;
         color: var(--fg-muted);
         max-width: none;
-    }
-
-    .chapter-card .topics {
-        margin-top: auto;
-        padding-top: var(--s-2);
-        display: flex;
-        gap: 4px;
-        flex-wrap: wrap;
-    }
-
-    .chapter-card .topic {
-        display: inline-flex;
-        align-items: center;
-        border-radius: var(--r-pill);
-        border: 1px solid var(--line-soft);
-        background: var(--bg-canvas);
-        padding: 0.12rem 0.45rem;
-        font-family: var(--f-mono);
-        font-size: 0.7rem;
-        color: var(--fg-muted);
-        letter-spacing: 0.04em;
-        text-transform: uppercase;
     }
 
     .toc h6 {
@@ -332,9 +533,19 @@ const sidebarParts = GUIDE_PARTS.map(part => ({
         border-top: 1px solid var(--line-soft);
     }
 
-    @media (max-width: 1100px) {
+    @media (max-width: 900px) {
+        .topic-grid,
         .chapter-grid {
             grid-template-columns: 1fr;
+        }
+
+        .orient-grid {
+            flex-direction: column;
+        }
+
+        .orient-arrow {
+            transform: rotate(90deg);
+            justify-content: center;
         }
     }
 </style>

--- a/test/site/guide-structure.test.ts
+++ b/test/site/guide-structure.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Validates the guide information architecture in
+ * site/src/lib/guide-structure.ts against the real content tree and the
+ * playground / API catalogs. A typo in a slug, a missing prerequisite, an
+ * orphaned MDX file, or a broken landing reference fails here rather than
+ * shipping a dead link.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { EXAMPLES_CATALOG } from '../../site/src/lib/examples-catalog';
+import {
+  CORE_ONBOARDING_PATHS,
+  getAdjacentChapters,
+  GUIDE_CHAPTER_BY_PATH,
+  GUIDE_CHAPTERS,
+  GUIDE_LEARNING_PATH,
+  GUIDE_LEVELS,
+  GUIDE_PARTS,
+  GUIDE_TOPICS,
+} from '../../site/src/lib/guide-structure';
+
+const GUIDE_DIR = join(process.cwd(), 'site', 'src', 'content', 'guide');
+const API_DIR = join(process.cwd(), 'site', 'src', 'content', 'api');
+
+function walkMdx(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walkMdx(full));
+    else if (full.endsWith('.mdx') || full.endsWith('.md')) out.push(full);
+  }
+  return out;
+}
+
+/** Minimal frontmatter reader for the controlled `title` / `description` scalars. */
+function readFrontmatter(file: string): { title: string; description: string } {
+  const raw = readFileSync(file, 'utf8');
+  const match = /^---\n([\s\S]*?)\n---/.exec(raw);
+  const block = match?.[1] ?? '';
+  const scalar = (key: string): string => {
+    const line = new RegExp(`^${key}:\\s*(.+)$`, 'm').exec(block);
+    if (!line) return '';
+    return line[1]
+      .trim()
+      .replace(/^['"]|['"]$/g, '')
+      .trim();
+  };
+  return { title: scalar('title'), description: scalar('description') };
+}
+
+const exampleExists = (ref: string): boolean => {
+  const slash = ref.indexOf('/');
+  if (slash < 0) return false;
+  const category = ref.slice(0, slash);
+  const slug = ref.slice(slash + 1);
+  return (EXAMPLES_CATALOG[category] ?? []).some(entry => entry.slug === slug);
+};
+
+const guideFiles = walkMdx(GUIDE_DIR);
+const guidePathsOnDisk = guideFiles.map(file =>
+  file
+    .slice(GUIDE_DIR.length + 1)
+    .replace(/\\/g, '/')
+    .replace(/\.(md|mdx)$/, ''),
+);
+
+describe('guide structure ↔ content reconciliation', () => {
+  it('points every chapter at an existing MDX file', () => {
+    const missing = GUIDE_CHAPTERS.filter(chapter => !existsSync(join(GUIDE_DIR, `${chapter.path}.mdx`)));
+    expect(missing.map(chapter => chapter.path)).toEqual([]);
+  });
+
+  it('has no orphan MDX files outside the structure', () => {
+    const orphans = guidePathsOnDisk.filter(path => !GUIDE_CHAPTER_BY_PATH.has(path));
+    expect(orphans).toEqual([]);
+  });
+
+  it('has no duplicate chapter paths', () => {
+    const paths = GUIDE_CHAPTERS.map(chapter => chapter.path);
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+
+  it('gives every guide file a non-empty title and description', () => {
+    const bad = guideFiles.filter(file => {
+      const fm = readFrontmatter(file);
+      return !fm.title || !fm.description;
+    });
+    expect(bad).toEqual([]);
+  });
+});
+
+describe('guide metadata', () => {
+  it('uses only valid level values', () => {
+    const invalid = GUIDE_CHAPTERS.filter(chapter => !GUIDE_LEVELS.includes(chapter.level));
+    expect(invalid.map(chapter => chapter.path)).toEqual([]);
+  });
+
+  it('numbers parts sequentially from 1', () => {
+    expect(GUIDE_PARTS.map(part => part.part)).toEqual(GUIDE_PARTS.map((_, index) => index + 1));
+  });
+
+  it('numbers chapters sequentially within each part', () => {
+    for (const part of GUIDE_PARTS) {
+      expect(part.chapters.map(chapter => chapter.chapter)).toEqual(part.chapters.map((_, index) => index + 1));
+    }
+  });
+
+  it('resolves every prerequisite to a known chapter', () => {
+    const broken = GUIDE_CHAPTERS.flatMap(chapter =>
+      chapter.prerequisites.filter(path => !GUIDE_CHAPTER_BY_PATH.has(path)).map(path => `${chapter.path} → ${path}`),
+    );
+    expect(broken).toEqual([]);
+  });
+
+  it('never lists a chapter as its own prerequisite', () => {
+    const selfRefs = GUIDE_CHAPTERS.filter(chapter => chapter.prerequisites.includes(chapter.path));
+    expect(selfRefs.map(chapter => chapter.path)).toEqual([]);
+  });
+
+  it('resolves every playground example to the catalog', () => {
+    const broken = GUIDE_CHAPTERS.flatMap(chapter => chapter.examples.filter(ref => !exampleExists(ref)).map(ref => `${chapter.path} → ${ref}`));
+    expect(broken).toEqual([]);
+  });
+
+  it('resolves every API link to an existing API page', () => {
+    const broken = GUIDE_CHAPTERS.flatMap(chapter =>
+      chapter.apiLinks.filter(slug => !existsSync(join(API_DIR, `${slug}.mdx`))).map(slug => `${chapter.path} → ${slug}`),
+    );
+    expect(broken).toEqual([]);
+  });
+
+  it('gives core onboarding chapters a level and learning goals', () => {
+    for (const path of CORE_ONBOARDING_PATHS) {
+      const chapter = GUIDE_CHAPTER_BY_PATH.get(path);
+      expect(chapter, `missing core chapter ${path}`).toBeDefined();
+      expect(GUIDE_LEVELS.includes(chapter!.level)).toBe(true);
+      expect(chapter!.learningGoals.length, `no learning goals for ${path}`).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('previous / next navigation', () => {
+  it('starts with no previous and ends with no next', () => {
+    const first = GUIDE_CHAPTERS[0];
+    const last = GUIDE_CHAPTERS[GUIDE_CHAPTERS.length - 1];
+    expect(getAdjacentChapters(first.path).previous).toBeNull();
+    expect(getAdjacentChapters(last.path).next).toBeNull();
+  });
+
+  it('forms one linear chain with no gaps or cycles', () => {
+    const visited = new Set<string>();
+    let cursor: string | null = GUIDE_CHAPTERS[0].path;
+    let steps = 0;
+    while (cursor && steps <= GUIDE_CHAPTERS.length) {
+      expect(visited.has(cursor), `cycle at ${cursor}`).toBe(false);
+      visited.add(cursor);
+      cursor = getAdjacentChapters(cursor).next?.path ?? null;
+      steps++;
+    }
+    expect(visited.size).toBe(GUIDE_CHAPTERS.length);
+  });
+
+  it('keeps previous and next consistent with each other', () => {
+    for (const chapter of GUIDE_CHAPTERS) {
+      const { next } = getAdjacentChapters(chapter.path);
+      if (next) {
+        expect(getAdjacentChapters(next.path).previous?.path).toBe(chapter.path);
+      }
+    }
+  });
+
+  it('returns nulls for an unknown path', () => {
+    expect(getAdjacentChapters('does/not-exist')).toEqual({ previous: null, next: null });
+  });
+});
+
+describe('guide landing references', () => {
+  it('points every learning-path step at a real chapter', () => {
+    const broken = GUIDE_LEARNING_PATH.filter(step => !GUIDE_CHAPTER_BY_PATH.has(step.path));
+    expect(broken.map(step => step.path)).toEqual([]);
+  });
+
+  it('points every learning-path example at the catalog', () => {
+    const broken = GUIDE_LEARNING_PATH.filter(step => step.example && !exampleExists(step.example));
+    expect(broken.map(step => step.example)).toEqual([]);
+  });
+
+  it('points every topic at a real chapter', () => {
+    const broken = GUIDE_TOPICS.filter(topic => !GUIDE_CHAPTER_BY_PATH.has(topic.path));
+    expect(broken.map(topic => topic.path)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

The guide infrastructure (typecheck gate, source-backed snippets) is reliable, but onboarding and navigation still require too much prior knowledge. Chapters had no Previous/Next, no learning metadata, no visible Guide → Playground → API path, the landing page was a flat chapter list, titles/numbers were duplicated across the structure and frontmatter (and had drifted), and one chapter was orphaned and unreachable.

## Solution

A focused redesign of the guide *experience* on top of that infrastructure:

- **Information architecture** — `site/src/lib/guide-structure.ts` is now the single source of truth for ordering, grouping, and learning metadata (level, learning goals, prerequisites, playground examples, API links). Chapter numbers are positional, so reordering never means renumbering by hand. MDX frontmatter is slimmed to `{ title, description }`. Part renames: *Getting Started*, *Debugging & Performance*, *Reference & Deployment*. The orphaned `audio-reactive-visualization` chapter is reattached under Audio. New `introduction/project-structure` chapter.
- **Landing / Start here** — hero with the `create-exo-app` command and primary actions, a numbered recommended learning path (What is ExoJS → Setup → First scene → Frame loop → Input → Audio → Orb Dodge → Deploy), topic entry cards, and a Guide → Playground → API orientation strip.
- **Page UX** — chapter header with a level badge, auto-computed read time, "What you'll learn", and "Before you start"; a structural Previous/Next pager at the end of every chapter; the redundant in-content H1 is hidden.
- **Reusable components** — `Callout` (note / tip / important / common-mistake / webgpu / browser — label + glyph, never colour alone), `TryIt` (compact Playground + API bridge, slugs validated at build time), `NextStep`, `GuideMeta`, `GuidePager`.
- **Critical onboarding rewrites** — What is ExoJS?, Setup (create-exo-app first), Project structure (source-backed from the minimal template), Your first scene, Scene lifecycle, Keyboard, Audio basics, Debug layer, Performance, Build Orb Dodge.
- **Guide → Playground → API flow** — `TryIt` added to Your first scene, Scenes, Scene lifecycle, Graphics, Sprites, Keyboard, Gamepad, Audio basics, Debug layer, Performance, and Orb Dodge.
- **Source-backed snippets** — minimal template `main.ts` / `MainScene.ts` get `guide:` regions, consumed by the new Project structure chapter.

## Scope

Docs / site / DX only. No engine features, no runtime API changes, no new packages, no versioning, no release notes.

## Validation

| Check | Result |
|-------|--------|
| `pnpm typecheck` | ✅ |
| `pnpm typecheck:guides` | ✅ 27 extracted, 22 no-check, 217 partial |
| `pnpm typecheck:examples` | ✅ |
| `pnpm lint:strict` | ✅ |
| `pnpm test` | ✅ 141 files, 1840 tests |
| new `test/site/guide-structure.test.ts` | ✅ 19 tests (structure↔content reconciliation, metadata + cross-ref validation, prev/next linearity, landing refs) |
| `pnpm build` + `pnpm verify:exports` | ✅ |
| `pnpm verify:create-exo-app` | ✅ 45/0 |
| `pnpm site:build` | ✅ 572 pages |
| `pnpm test:examples:smoke` | ✅ 118/0 |

`pnpm format:check` reports 6 pre-existing offenders unrelated to this PR (`rollup.config.ts`, `scripts/extract-guide-snippets.ts`, `scripts/verify-create-exo-app.ts`, `test/site/example-search.test.ts`, `test/site/source-snippets.test.ts`, `tsconfig.guides.json` — all unchanged here); every file touched by this PR is prettier-clean.

**Visually reviewed** (desktop 1440×1000 + mobile 390×844, dark + light): guide landing, What is ExoJS?, Setup, Project structure, Your first scene, Keyboard, Audio basics, Debug layer, Performance, Build Orb Dodge, Troubleshooting, Deployment.

## Release note

Release preparation (PR #93) remains postponed and must be re-created or updated after this overhaul lands. This PR contains no version or changelog changes.