### PR TITLE
fix(docs): align guides with generated api

### DIFF
--- a/site/src/components/SourceSnippet.astro
+++ b/site/src/components/SourceSnippet.astro
@@ -25,13 +25,16 @@
 import { Code } from 'astro:components';
 import { extractSnippetRegion } from '../lib/source-snippets';
 
+/** The syntax-highlighting language union accepted by Astro's <Code> component. */
+type CodeLang = NonNullable<Parameters<typeof Code>[0]['lang']>;
+
 interface Props {
     /** Path to the source file, relative to the repo root. */
     source: string;
     /** Name of the region to extract (without the "guide:" prefix). */
     region: string;
     /** Language for syntax highlighting. Defaults to "ts". */
-    language?: string;
+    language?: CodeLang;
     /** Optional caption shown above the code block. */
     title?: string;
 }
@@ -42,9 +45,9 @@ let code: string;
 try {
     code = extractSnippetRegion(source, region);
 } catch (err) {
-    // Re-throw with additional context so Astro reports the source MDX file too.
+    // Re-throw with additional context so Astro reports the consuming page too.
     throw new Error(
-        `SourceSnippet build error in ${Astro.self.moduleId ?? 'unknown'}\n` +
+        `SourceSnippet build error while rendering ${Astro.url.pathname}\n` +
         String(err instanceof Error ? err.message : err),
     );
 }

--- a/site/src/content/api/bitmap-text.mdx
+++ b/site/src/content/api/bitmap-text.mdx
@@ -9,7 +9,7 @@ memberCount: 81
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/rendering/text/BitmapText.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/text/BitmapText.ts#L136"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/text/BitmapText.ts#L149"
 ---
 ## Import
 
@@ -130,4 +130,4 @@ label.style.align  = 'center';     // immediate rebuild
 
 ## Source
 
-[src/rendering/text/BitmapText.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/text/BitmapText.ts#L136)
+[src/rendering/text/BitmapText.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/text/BitmapText.ts#L149)

--- a/site/src/content/api/bm-font.mdx
+++ b/site/src/content/api/bm-font.mdx
@@ -9,7 +9,7 @@ memberCount: 3
 tier: "stable"
 sections: ["Import", "Constructors", "Properties", "Source"]
 sourcePath: "src/rendering/text/BmFont.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/text/BmFont.ts#L49"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/text/BmFont.ts#L50"
 ---
 ## Import
 
@@ -37,4 +37,4 @@ const label = new BitmapText('Score: 0', font);
 
 ## Source
 
-[src/rendering/text/BmFont.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/text/BmFont.ts#L49)
+[src/rendering/text/BmFont.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/text/BmFont.ts#L50)

--- a/site/src/content/api/gradient.mdx
+++ b/site/src/content/api/gradient.mdx
@@ -1,21 +1,28 @@
 ---
 title: "Gradient"
-description: "CPU-rasterized gradient base that can be converted into a DataTexture."
+description: "CPU-rasterized gradient base. A Color-like paint value (not a Drawable): it owns a normalized list of color stops plus subclass geometry and supports the value-object contract — Gradient.clone, Gradient.copy, and Gradient.equals. Stops are cloned on the way in, clamped to `0..1`, and kept sorted by offset. Convert a gradient into a sampleable DataTexture with Gradient.toTexture; wrap that texture in a `Sprite`/`Mesh` to draw it."
 symbol: "Gradient"
 kind: "class"
 subsystem: "rendering"
 importPath: "@codexo/exojs"
-memberCount: 6
+memberCount: 12
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/rendering/gradient/Gradient.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/gradient/Gradient.ts#L26"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/gradient/Gradient.ts#L37"
 ---
 ## Import
 
 `import { Gradient } from '@codexo/exojs'`
 
-CPU-rasterized gradient base that can be converted into a DataTexture.
+CPU-rasterized gradient base. A Color-like paint value (not a
+Drawable): it owns a normalized list of color stops plus subclass
+geometry and supports the value-object contract — Gradient.clone,
+Gradient.copy, and Gradient.equals. Stops are cloned on the
+way in, clamped to `0..1`, and kept sorted by offset.
+
+Convert a gradient into a sampleable DataTexture with
+Gradient.toTexture; wrap that texture in a `Sprite`/`Mesh` to draw it.
 
 ## Constructors
 
@@ -23,7 +30,12 @@ CPU-rasterized gradient base that can be converted into a DataTexture.
 
 ## Methods
 
+- `_copyGeometry(source: this): void`
+- `_geometryEquals(other: Gradient): boolean`
+- `clone(): this`
+- `copy(source: this): this`
 - `destroy(): void`
+- `equals(other: Gradient): boolean`
 - `resolveT(u: number, v: number): number`
 - `sampleAt(t: number, out: Float32Array): void`
 - `toTexture(width: number, height: number, options?: GradientToTextureOptions & object): DataTexture<"rgba8">`
@@ -31,8 +43,9 @@ CPU-rasterized gradient base that can be converted into a DataTexture.
 
 ## Properties
 
+- `type: GradientType`
 - `stops: readonly GradientStop[]`
 
 ## Source
 
-[src/rendering/gradient/Gradient.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/gradient/Gradient.ts#L26)
+[src/rendering/gradient/Gradient.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/gradient/Gradient.ts#L37)

--- a/site/src/content/api/graphics.mdx
+++ b/site/src/content/api/graphics.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Graphics"
-description: "Immediate-mode 2D shape API backed by Mesh children. Each draw call (e.g. `drawCircle`, `drawRectangle`, `drawLine`) appends a new Mesh child colored with the current `fillColor` or `lineColor`. The active `lineWidth` controls stroke thickness for path and outline draws. Path commands (`moveTo`, `lineTo`, `quadraticCurveTo`, etc.) track a cursor point and flush a Mesh on each segment. Call clear to remove all child meshes and reset pen state. Because each shape is a separate Mesh, `Graphics` inherits full filter, blend, tint, and mask support from Container."
+description: "Immediate-mode 2D shape API backed by Mesh children. Each draw call (e.g. `drawCircle`, `drawRectangle`, `drawLine`) appends a new Mesh child painted with the active fill or stroke style. A style is either a solid Color or a Gradient, assigned through fillStyle / strokeStyle. The fillColor / lineColor accessors are color-only conveniences over those styles. The active `lineWidth` controls stroke thickness for path and outline draws. Path commands (`moveTo`, `lineTo`, `quadraticCurveTo`, etc.) track a cursor point and flush a Mesh on each segment. Gradient styles are rasterized once to a DataTexture via Gradient.toTexture and sampled across each shape's local bounding box, so LinearGradient and RadialGradient render through the same texture path as a textured Mesh. The textures are owned by the Graphics and released on clear / destroy. Call clear to remove all child meshes and reset pen state. Because each shape is a separate Mesh, `Graphics` inherits full filter, blend, tint, and mask support from Container."
 symbol: "Graphics"
 kind: "class"
 subsystem: "rendering"
 importPath: "@codexo/exojs"
-memberCount: 100
+memberCount: 102
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/rendering/primitives/Graphics.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/primitives/Graphics.ts#L23"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/primitives/Graphics.ts#L42"
 ---
 ## Import
 
@@ -18,10 +18,19 @@ sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/primitives
 Immediate-mode 2D shape API backed by Mesh children.
 
 Each draw call (e.g. `drawCircle`, `drawRectangle`, `drawLine`) appends a
-new Mesh child colored with the current `fillColor` or `lineColor`.
+new Mesh child painted with the active fill or stroke style. A style
+is either a solid Color or a Gradient, assigned through
+fillStyle / strokeStyle. The fillColor /
+lineColor accessors are color-only conveniences over those styles.
 The active `lineWidth` controls stroke thickness for path and outline draws.
 Path commands (`moveTo`, `lineTo`, `quadraticCurveTo`, etc.) track a cursor
 point and flush a Mesh on each segment.
+
+Gradient styles are rasterized once to a DataTexture via
+Gradient.toTexture and sampled across each shape's local bounding
+box, so LinearGradient and RadialGradient render through the
+same texture path as a textured Mesh. The textures are owned by the Graphics
+and released on clear / destroy.
 
 Call clear to remove all child meshes and reset pen state. Because
 each shape is a separate Mesh, `Graphics` inherits full filter, blend,
@@ -104,6 +113,7 @@ tint, and mask support from Container.
 - `cullable: boolean`
 - `currentPoint: Vector`
 - `fillColor: Color`
+- `fillStyle: Color | Gradient`
 - `filters: readonly Filter[]`
 - `height: number`
 - `interactive: boolean`
@@ -120,6 +130,7 @@ tint, and mask support from Container.
 - `scale: ObservableVector`
 - `skewX: number`
 - `skewY: number`
+- `strokeStyle: Color | Gradient`
 - `top: number`
 - `visible: boolean`
 - `width: number`
@@ -141,4 +152,4 @@ tint, and mask support from Container.
 
 ## Source
 
-[src/rendering/primitives/Graphics.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/primitives/Graphics.ts#L23)
+[src/rendering/primitives/Graphics.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/primitives/Graphics.ts#L42)

--- a/site/src/content/api/linear-gradient.mdx
+++ b/site/src/content/api/linear-gradient.mdx
@@ -5,7 +5,7 @@ symbol: "LinearGradient"
 kind: "class"
 subsystem: "rendering"
 importPath: "@codexo/exojs"
-memberCount: 6
+memberCount: 14
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/rendering/gradient/LinearGradient.ts"
@@ -23,7 +23,12 @@ Linear gradient in UV space projected from `start` to `end`.
 
 ## Methods
 
+- `_copyGeometry(source: LinearGradient): void`
+- `_geometryEquals(other: Gradient): boolean`
+- `clone(): this`
+- `copy(source: this): this`
 - `destroy(): void`
+- `equals(other: Gradient): boolean`
 - `resolveT(u: number, v: number): number`
 - `sampleAt(t: number, out: Float32Array): void`
 - `toTexture(width: number, height: number, options?: GradientToTextureOptions & object): DataTexture<"rgba8">`
@@ -31,6 +36,9 @@ Linear gradient in UV space projected from `start` to `end`.
 
 ## Properties
 
+- `type: GradientType`
+- `end: readonly [number, number]`
+- `start: readonly [number, number]`
 - `stops: readonly GradientStop[]`
 
 ## Source

--- a/site/src/content/api/radial-gradient.mdx
+++ b/site/src/content/api/radial-gradient.mdx
@@ -5,7 +5,7 @@ symbol: "RadialGradient"
 kind: "class"
 subsystem: "rendering"
 importPath: "@codexo/exojs"
-memberCount: 6
+memberCount: 14
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/rendering/gradient/RadialGradient.ts"
@@ -23,7 +23,12 @@ Radial gradient in UV space around `center` with normalized radius.
 
 ## Methods
 
+- `_copyGeometry(source: RadialGradient): void`
+- `_geometryEquals(other: Gradient): boolean`
+- `clone(): this`
+- `copy(source: this): this`
 - `destroy(): void`
+- `equals(other: Gradient): boolean`
 - `resolveT(u: number, v: number): number`
 - `sampleAt(t: number, out: Float32Array): void`
 - `toTexture(width: number, height: number, options?: GradientToTextureOptions & object): DataTexture<"rgba8">`
@@ -31,6 +36,9 @@ Radial gradient in UV space around `center` with normalized radius.
 
 ## Properties
 
+- `type: GradientType`
+- `center: readonly [number, number]`
+- `radius: number`
 - `stops: readonly GradientStop[]`
 
 ## Source

--- a/site/src/content/api/render-texture.mdx
+++ b/site/src/content/api/render-texture.mdx
@@ -9,7 +9,7 @@ memberCount: 33
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/rendering/texture/RenderTexture.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/texture/RenderTexture.ts#L17"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/texture/RenderTexture.ts#L18"
 ---
 ## Import
 
@@ -69,4 +69,4 @@ updated every frame and mip generation is expensive.
 
 ## Source
 
-[src/rendering/texture/RenderTexture.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/texture/RenderTexture.ts#L17)
+[src/rendering/texture/RenderTexture.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/texture/RenderTexture.ts#L18)

--- a/site/src/content/api/text-style.mdx
+++ b/site/src/content/api/text-style.mdx
@@ -9,7 +9,7 @@ memberCount: 23
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/rendering/text/TextStyle.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/text/TextStyle.ts#L118"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/text/TextStyle.ts#L123"
 ---
 ## Import
 
@@ -63,4 +63,4 @@ hint and clear the flag.
 
 ## Source
 
-[src/rendering/text/TextStyle.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/text/TextStyle.ts#L118)
+[src/rendering/text/TextStyle.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/text/TextStyle.ts#L123)

--- a/site/src/content/api/web-gl2-backend.mdx
+++ b/site/src/content/api/web-gl2-backend.mdx
@@ -9,7 +9,7 @@ memberCount: 32
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/rendering/webgl2/WebGl2Backend.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/webgl2/WebGl2Backend.ts#L135"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/webgl2/WebGl2Backend.ts#L136"
 ---
 ## Import
 
@@ -73,4 +73,4 @@ GPU-side state as needed on the next draw.
 
 ## Source
 
-[src/rendering/webgl2/WebGl2Backend.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/webgl2/WebGl2Backend.ts#L135)
+[src/rendering/webgl2/WebGl2Backend.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/webgl2/WebGl2Backend.ts#L136)

--- a/site/src/content/api/web-gl2-sprite-renderer.mdx
+++ b/site/src/content/api/web-gl2-sprite-renderer.mdx
@@ -9,7 +9,7 @@ memberCount: 11
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/rendering/webgl2/WebGl2SpriteRenderer.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/webgl2/WebGl2SpriteRenderer.ts#L65"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/webgl2/WebGl2SpriteRenderer.ts#L70"
 ---
 ## Import
 
@@ -48,4 +48,4 @@ Subclasses must implement:
 
 ## Source
 
-[src/rendering/webgl2/WebGl2SpriteRenderer.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/webgl2/WebGl2SpriteRenderer.ts#L65)
+[src/rendering/webgl2/WebGl2SpriteRenderer.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/webgl2/WebGl2SpriteRenderer.ts#L70)

--- a/site/src/content/api/web-gpu-backend.mdx
+++ b/site/src/content/api/web-gpu-backend.mdx
@@ -9,7 +9,7 @@ memberCount: 39
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/rendering/webgpu/WebGpuBackend.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/webgpu/WebGpuBackend.ts#L81"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/webgpu/WebGpuBackend.ts#L82"
 ---
 ## Import
 
@@ -87,4 +87,4 @@ acquisition fails on `'auto'`.
 
 ## Source
 
-[src/rendering/webgpu/WebGpuBackend.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/webgpu/WebGpuBackend.ts#L81)
+[src/rendering/webgpu/WebGpuBackend.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/webgpu/WebGpuBackend.ts#L82)

--- a/site/src/content/api/web-gpu-sprite-renderer.mdx
+++ b/site/src/content/api/web-gpu-sprite-renderer.mdx
@@ -9,7 +9,7 @@ memberCount: 12
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/rendering/webgpu/WebGpuSpriteRenderer.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/webgpu/WebGpuSpriteRenderer.ts#L179"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/webgpu/WebGpuSpriteRenderer.ts#L192"
 ---
 ## Import
 
@@ -49,4 +49,4 @@ Subclasses must implement:
 
 ## Source
 
-[src/rendering/webgpu/WebGpuSpriteRenderer.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/webgpu/WebGpuSpriteRenderer.ts#L179)
+[src/rendering/webgpu/WebGpuSpriteRenderer.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/webgpu/WebGpuSpriteRenderer.ts#L192)

--- a/site/src/content/guide/advanced/backend-comparison.mdx
+++ b/site/src/content/guide/advanced/backend-comparison.mdx
@@ -36,7 +36,7 @@ Where differences exist, they are performance characteristics or rendering-path 
 |------|--------|--------|
 | Sprite batching | Multi-texture batched (up to 8) | Multi-texture batched (up to 8) |
 | Particle simulation | CPU | CPU (default); optional GPU compute update path when all update modules implement `wgsl()` |
-| MeshShader | GLSL ES 3.00 | WGSL |
+| MeshMaterial | GLSL ES 3.00 | WGSL |
 | ShaderFilter | `WebGl2ShaderFilter` (GLSL) | `WebGpuShaderFilter` (WGSL) |
 | GPU compute | Not available | Raw `backend.device` access for compute + custom pipelines |
 | Engine-emitted debug pass labels | Not currently emitted | Emitted on key passes (e.g. `WebGpuShaderFilter pass`) |
@@ -53,7 +53,7 @@ On WebGL2, or when any update module lacks `wgsl()`, the system runs on CPU. The
 
 ## Custom shaders
 
-`MeshShader` accepts both `glsl: { vertex, fragment }` and `wgsl` source. The renderer picks the appropriate language for the active backend. Provide both for cross-backend portability. [`detectUniformDrift()`](/ExoJS/en/api/mesh-shader/#detectuniformdrift) compares declared uniforms across languages for CI-style verification.
+A [`ShaderSource`](/ExoJS/en/api/shader-source/) accepts both `glsl: { vertex, fragment }` and `wgsl` source; wrap it in a [`MeshMaterial`](/ExoJS/en/api/mesh-material/) to bind uniforms and attach it to a `Mesh`. The renderer picks the appropriate language for the active backend. Provide both for cross-backend portability. [`ShaderSource.detectUniformDrift()`](/ExoJS/en/api/shader-source/#methods) compares declared uniforms across languages for CI-style verification.
 
 For screen-space effects, use `WebGl2ShaderFilter` on WebGL2 and `WebGpuShaderFilter` on WebGPU. Both accept the same uniform-value types — only the shader language differs. For cross-backend filters, construct the appropriate variant based on `app.backend.backendType` at init time.
 

--- a/site/src/content/guide/advanced/custom-renderers.mdx
+++ b/site/src/content/guide/advanced/custom-renderers.mdx
@@ -7,9 +7,9 @@ import ExamplePreview from '../../../components/ExamplePreview.astro';
 
 # Custom renderers
 
-"Custom rendering" in ExoJS means inserting your own draw logic into the frame — either as a pass between normal draws, or as direct GPU work that bypasses the engine's renderer system entirely. The extension surface is intentionally small: two public mechanisms, plus the existing `Mesh`/`MeshShader`/custom shader filter primitives covered in earlier chapters.
+"Custom rendering" in ExoJS means inserting your own draw logic into the frame — either as a pass between normal draws, or as direct GPU work that bypasses the engine's renderer system entirely. The extension surface is intentionally small: two public mechanisms, plus the existing `Mesh`/`MeshMaterial`/custom shader filter primitives covered in earlier chapters.
 
-The distinction: a custom renderer controls *when* and *how* things are drawn. A [`MeshShader`](/ExoJS/en/api/mesh-shader/) controls *what shader* an existing `Mesh` uses. A custom shader filter ([`WebGl2ShaderFilter`](/ExoJS/en/api/web-gl2-shader-filter/) or [`WebGpuShaderFilter`](/ExoJS/en/api/web-gpu-shader-filter/)) controls a screen-space post-render effect on a drawable's output. You reach for custom renderers when none of those primitives fit — you need to issue draw calls at a specific point in the frame, or you need to bypass ExoJS drawable types entirely.
+The distinction: a custom renderer controls *when* and *how* things are drawn. A [`MeshMaterial`](/ExoJS/en/api/mesh-material/) controls *what shader* an existing `Mesh` uses. A custom shader filter ([`WebGl2ShaderFilter`](/ExoJS/en/api/web-gl2-shader-filter/) or [`WebGpuShaderFilter`](/ExoJS/en/api/web-gpu-shader-filter/)) controls a screen-space post-render effect on a drawable's output. You reach for custom renderers when none of those primitives fit — you need to issue draw calls at a specific point in the frame, or you need to bypass ExoJS drawable types entirely.
 
 ## CallbackRenderPass
 
@@ -87,7 +87,7 @@ class CustomTriangleRenderer {
 
 The scene's `draw` method would call `this._triangleRenderer.draw()` instead of `context.backend.clear()` / `context.render(sprite)`. The custom renderer owns the entire render pass and does not interact with ExoJS drawables.
 
-Direct backend access is deliberately unabstracted — you are writing raw WebGPU code. On WebGL2 backends, a different renderer class would use `backend.context` (`WebGL2RenderingContext`) and branch by `backend.backendType`. For most projects, `MeshShader` + `CallbackRenderPass` + custom shader filters (`WebGl2ShaderFilter` / `WebGpuShaderFilter`) cover custom rendering needs without reaching for raw GPU APIs.
+Direct backend access is deliberately unabstracted — you are writing raw WebGPU code. On WebGL2 backends, a different renderer class would use `backend.context` (`WebGL2RenderingContext`) and branch by `backend.backendType`. For most projects, `MeshMaterial` + `CallbackRenderPass` + custom shader filters (`WebGl2ShaderFilter` / `WebGpuShaderFilter`) cover custom rendering needs without reaching for raw GPU APIs.
 
 ## Renderer registration
 
@@ -100,7 +100,7 @@ Registering a custom renderer is an advanced extension point. For most custom re
 | Mechanism | Use when |
 |---|---|
 | [`Mesh`](/ExoJS/en/api/mesh/) | You need custom vertex geometry with the standard pipeline |
-| [`MeshShader`](/ExoJS/en/api/mesh-shader/) | You need a custom vertex/fragment shader on a `Mesh` |
+| [`MeshMaterial`](/ExoJS/en/api/mesh-material/) | You need a custom vertex/fragment shader on a `Mesh` |
 | Custom shader filter (`WebGl2ShaderFilter` / `WebGpuShaderFilter`) | You need a screen-space post-render effect on a drawable |
 | `CallbackRenderPass` | You need to issue draw calls at a specific point in the frame between other draws |
 | Direct backend access | You need to bypass ExoJS entirely and work at the GPU API level |

--- a/site/src/content/guide/advanced/render-pipeline-debugging.mdx
+++ b/site/src/content/guide/advanced/render-pipeline-debugging.mdx
@@ -129,7 +129,7 @@ For that level of detail, use external capture tools:
 On WebGPU, ExoJS emits labels on key passes so capture tools display meaningful names rather than generic calls. Look for labels such as:
 
 - `WebGpuShaderFilter pass` — a `WebGpuShaderFilter` executing
-- `MeshShader (custom)` — a `Mesh` with an attached `MeshShader` drawing inside the main render pass
+- `MeshMaterial (custom)` — a `Mesh` with an attached `MeshMaterial` drawing inside the main render pass
 - `WebGpuMaskCompositor pass` — mask composition for a drawable with an active `mask`
 
 These labels are visible in tools that surface WebGPU pass labels (for example, Chrome's WebGPU tooling).

--- a/site/src/content/guide/core-concepts/application.mdx
+++ b/site/src/content/guide/core-concepts/application.mdx
@@ -38,10 +38,10 @@ const app = new Application({
 
 Options are organised into groups:
 
-- `canvas` — canvas element, size, pixel ratio, and rendering hints. See [`CanvasApplicationOptions`](/ExoJS/en/api/canvas-application-options/).
-- `loader` — base path, fetch options, caching. See [`LoaderOptions`](/ExoJS/en/api/loader-options/).
-- `rendering` — WebGL2 debug, context attributes, batch sizes. See [`RenderingApplicationOptions`](/ExoJS/en/api/rendering-application-options/).
-- `input` — gamepad definitions, slot strategy, pointer threshold. See [`InputApplicationOptions`](/ExoJS/en/api/input-application-options/).
+- `canvas` — canvas element, size, pixel ratio, and rendering hints (`CanvasApplicationOptions`).
+- `loader` — base path, fetch options, caching (`LoaderOptions`).
+- `rendering` — WebGL2 debug, context attributes, batch sizes (`RenderingApplicationOptions`).
+- `input` — gamepad definitions, slot strategy, pointer threshold (`InputApplicationOptions`).
 - `clearColor` — what `context.backend.clear()` paints each frame.
 - `backend` — `{ type: 'auto' }` (default), or pin to `'webgl2'` / `'webgpu'`.
 

--- a/site/src/content/guide/effects/custom-mesh-shaders.mdx
+++ b/site/src/content/guide/effects/custom-mesh-shaders.mdx
@@ -1,120 +1,122 @@
 ---
 title: 'Custom mesh shaders'
-description: 'Attach custom GLSL or WGSL shaders to a Mesh for backend-portable visual effects.'
+description: 'Attach a custom GLSL or WGSL shader to a Mesh through a MeshMaterial for backend-portable visual effects.'
 ---
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 
 # Custom mesh shaders
 
-A [`Mesh`](/ExoJS/en/api/mesh/) normally renders with the engine's built-in batch shader — textured or untextured, vertex-colored or uniform-tinted, lit with the mesh's own tint and blend mode. That covers most use cases. When you need something the default shader does not do — procedural displacement, custom lighting, multi-texture mixing, a Shadertoy-style effect mapped onto geometry — you attach a [`MeshShader`](/ExoJS/en/api/mesh-shader/).
+A [`Mesh`](/ExoJS/en/api/mesh/) normally renders with the engine's built-in batch shader — textured or untextured, vertex-colored or uniform-tinted, lit with the mesh's own tint and blend mode. That covers most use cases. When you need something the default shader does not do — procedural displacement, custom lighting, multi-texture mixing, a Shadertoy-style effect mapped onto geometry — you attach a custom [`MeshMaterial`](/ExoJS/en/api/mesh-material/).
 
-`MeshShader` holds a pair of shader programs (one for WebGL2, one for WebGPU) and a map of uniform values. One `MeshShader` instance can be shared across multiple meshes; the renderer caches compiled programs and pipelines per-instance.
+A custom look is two objects. A [`ShaderSource`](/ExoJS/en/api/shader-source/) holds the immutable shader text — one program for WebGL2 (GLSL), one for WebGPU (WGSL). A `MeshMaterial` wraps that `ShaderSource` together with a map of uniform values, extra textures, and a blend mode. One `ShaderSource` can back many materials, and one `MeshMaterial` can be shared across multiple meshes; the renderer caches the compiled program/pipeline per shader source and reuses it for every material that references it.
 
-## When to use a MeshShader vs. a filter
+## When to use a mesh material vs. a filter
 
-A custom shader filter ([`WebGl2ShaderFilter`](/ExoJS/en/api/web-gl2-shader-filter/) or [`WebGpuShaderFilter`](/ExoJS/en/api/web-gpu-shader-filter/)) applies a post-processing effect to a drawable's final rendered output — it works in screen space on the full viewport or on the drawable's rendered texture. A `MeshShader` replaces the drawable's vertex and fragment stages entirely. The distinction matters:
+A custom shader filter ([`WebGl2ShaderFilter`](/ExoJS/en/api/web-gl2-shader-filter/) or [`WebGpuShaderFilter`](/ExoJS/en/api/web-gpu-shader-filter/)) applies a post-processing effect to a drawable's final rendered output — it works in screen space on the full viewport or on the drawable's rendered texture. A `MeshMaterial` replaces the drawable's vertex and fragment stages entirely. The distinction matters:
 
 - Use a filter when the effect is screen-space — blur, color grade, CRT scanlines, vignette.
-- Use a `MeshShader` when the effect is geometry-space — vertex displacement, per-vertex animation, custom UV mapping, or when the fragment shader needs to compute its own world position from interpolated attributes.
-- Use both together: a `MeshShader` on the mesh for geometry effects, plus a filter on its parent container for post-processing.
+- Use a `MeshMaterial` when the effect is geometry-space — vertex displacement, per-vertex animation, custom UV mapping, or when the fragment shader needs to compute its own world position from interpolated attributes.
+- Use both together: a `MeshMaterial` on the mesh for geometry effects, plus a filter on its parent container for post-processing.
 
 ## Construction
 
-At least one language source is required. Pass `glsl` for WebGL2, `wgsl` for WebGPU, or both for cross-backend meshes:
+Build a `ShaderSource` from the shader text, then wrap it in a `MeshMaterial` with the initial uniform values. At least one language source is required on the `ShaderSource`. Pass `glsl` for WebGL2, `wgsl` for WebGPU, or both for cross-backend meshes:
 
-```js no-check
-import { MeshShader } from '@codexo/exojs';
+```js
+import { MeshMaterial, ShaderSource } from '@codexo/exojs';
 
-const waveShader = new MeshShader({
-    glsl: {
-        vertex: `
-            #version 300 es
-            layout(location = 0) in vec2 a_position;
-            layout(location = 1) in vec2 a_texcoord;
-            layout(location = 2) in vec4 a_color;
+const waveMaterial = new MeshMaterial({
+    shader: new ShaderSource({
+        glsl: {
+            vertex: `
+                #version 300 es
+                layout(location = 0) in vec2 a_position;
+                layout(location = 1) in vec2 a_texcoord;
+                layout(location = 2) in vec4 a_color;
 
-            uniform mat3 u_projection;
-            uniform mat3 u_translation;
-            uniform float u_time;
+                uniform mat3 u_projection;
+                uniform mat3 u_translation;
+                uniform float u_time;
 
-            out vec2 v_texcoord;
-            out vec4 v_color;
+                out vec2 v_texcoord;
+                out vec4 v_color;
 
-            void main() {
-                vec2 pos = a_position;
-                pos.y += sin(pos.x * 0.05 + u_time) * 10.0;
+                void main() {
+                    vec2 pos = a_position;
+                    pos.y += sin(pos.x * 0.05 + u_time) * 10.0;
 
-                gl_Position = vec4((u_projection * u_translation * vec3(pos, 1.0)).xy, 0.0, 1.0);
-                v_texcoord = a_texcoord;
-                v_color = a_color;
+                    gl_Position = vec4((u_projection * u_translation * vec3(pos, 1.0)).xy, 0.0, 1.0);
+                    v_texcoord = a_texcoord;
+                    v_color = a_color;
+                }
+            `,
+            fragment: `
+                #version 300 es
+                precision mediump float;
+
+                in vec2 v_texcoord;
+                in vec4 v_color;
+
+                uniform vec4 u_tint;
+                uniform sampler2D u_texture;
+
+                out vec4 fragColor;
+
+                void main() {
+                    vec4 texColor = texture(u_texture, v_texcoord);
+                    fragColor = texColor * v_color * u_tint;
+                }
+            `,
+        },
+        wgsl: `
+            struct VertexInput {
+                @location(0) position: vec2<f32>,
+                @location(1) texcoord: vec2<f32>,
+                @location(2) color: vec4<f32>,
+            };
+
+            struct VertexOutput {
+                @builtin(position) position: vec4<f32>,
+                @location(0) texcoord: vec2<f32>,
+                @location(1) color: vec4<f32>,
+            };
+
+            struct MeshUniforms {
+                projection: mat3x3<f32>,
+                translation: mat3x3<f32>,
+                tint: vec4<f32>,
+            };
+
+            struct UserUniforms {
+                time: f32,
+            };
+
+            @group(0) @binding(0) var<uniform> u_mesh: MeshUniforms;
+            @group(1) @binding(0) var u_texture: texture_2d<f32>;
+            @group(1) @binding(1) var u_sampler: sampler;
+            @group(2) @binding(0) var<uniform> u_user: UserUniforms;
+
+            @vertex
+            fn vertexMain(in: VertexInput) -> VertexOutput {
+                var out: VertexOutput;
+                var pos = in.position;
+                pos.y += sin(pos.x * 0.05 + u_user.time) * 10.0;
+
+                let clip = u_mesh.projection * u_mesh.translation * vec3<f32>(pos, 1.0);
+                out.position = vec4<f32>(clip.xy, 0.0, 1.0);
+                out.texcoord = in.texcoord;
+                out.color = in.color;
+                return out;
+            }
+
+            @fragment
+            fn fragmentMain(in: VertexOutput) -> @location(0) vec4<f32> {
+                let tex = textureSample(u_texture, u_sampler, in.texcoord);
+                return tex * in.color * u_mesh.tint;
             }
         `,
-        fragment: `
-            #version 300 es
-            precision mediump float;
-
-            in vec2 v_texcoord;
-            in vec4 v_color;
-
-            uniform vec4 u_tint;
-            uniform sampler2D u_texture;
-
-            out vec4 fragColor;
-
-            void main() {
-                vec4 texColor = texture(u_texture, v_texcoord);
-                fragColor = texColor * v_color * u_tint;
-            }
-        `,
-    },
-    wgsl: `
-        struct VertexInput {
-            @location(0) position: vec2<f32>,
-            @location(1) texcoord: vec2<f32>,
-            @location(2) color: vec4<f32>,
-        };
-
-        struct VertexOutput {
-            @builtin(position) position: vec4<f32>,
-            @location(0) texcoord: vec2<f32>,
-            @location(1) color: vec4<f32>,
-        };
-
-        struct MeshUniforms {
-            projection: mat3x3<f32>,
-            translation: mat3x3<f32>,
-            tint: vec4<f32>,
-        };
-
-        struct UserUniforms {
-            time: f32,
-        };
-
-        @group(0) @binding(0) var<uniform> u_mesh: MeshUniforms;
-        @group(1) @binding(0) var u_texture: texture_2d<f32>;
-        @group(1) @binding(1) var u_sampler: sampler;
-        @group(2) @binding(0) var<uniform> u_user: UserUniforms;
-
-        @vertex
-        fn vertexMain(in: VertexInput) -> VertexOutput {
-            var out: VertexOutput;
-            var pos = in.position;
-            pos.y += sin(pos.x * 0.05 + u_user.time) * 10.0;
-
-            let clip = u_mesh.projection * u_mesh.translation * vec3<f32>(pos, 1.0);
-            out.position = vec4<f32>(clip.xy, 0.0, 1.0);
-            out.texcoord = in.texcoord;
-            out.color = in.color;
-            return out;
-        }
-
-        @fragment
-        fn fragmentMain(in: VertexOutput) -> @location(0) vec4<f32> {
-            let tex = textureSample(u_texture, u_sampler, in.texcoord);
-            return tex * in.color * u_mesh.tint;
-        }
-    `,
+    }),
     uniforms: { u_time: 0 },
 });
 ```
@@ -145,7 +147,7 @@ The renderer supplies the vertex stream from `mesh.vertices`, `mesh.uvs`, and `m
 
 ## Auto-bound uniforms
 
-The renderer automatically sets four uniforms when the shader declares them. You do not need to supply them in `MeshShader.uniforms`:
+The renderer automatically sets four uniforms when the shader declares them. You do not need to supply them in `MeshMaterial.uniforms`:
 
 | Uniform | GLSL declaration | WGSL binding | Source |
 |---------|------------------|--------------|--------|
@@ -158,12 +160,12 @@ You can omit any of them. If your fragment shader ignores the texture and sample
 
 ## User uniforms
 
-Anything you put in `MeshShader.uniforms` is set after the auto-binds. Mutate the `uniforms` map between frames to drive animated effects:
+Anything you put in `MeshMaterial.uniforms` is set after the auto-binds. Mutate the `uniforms` map between frames to drive animated effects:
 
 ```js
 update(delta) {
-    this.waveShader.uniforms.u_time = this.clock.elapsedSeconds;
-    this.waveShader.uniforms.u_waveAmp = 10 + this.detector.pulse * 15;
+    this.waveMaterial.uniforms.u_time = this.clock.elapsedSeconds;
+    this.waveMaterial.uniforms.u_waveAmp = 10 + this.detector.pulse * 15;
 }
 ```
 
@@ -178,18 +180,39 @@ In WGSL, user uniforms belong to `@group(2)`. Scalar/vector/matrix uniforms decl
 
 ## Attaching to a Mesh
 
-Pass a `MeshShader` in the mesh constructor's `shader` option:
+Pass a `MeshMaterial` in the mesh constructor's `material` option:
 
-```js no-check
-import { Mesh, MeshShader } from '@codexo/exojs';
+```js
+import { Mesh, MeshMaterial, ShaderSource } from '@codexo/exojs';
 
-const shader = new MeshShader({
-    glsl: { vertex: vertSrc, fragment: fragSrc },
+// A minimal stand-in material — see the Construction section for the full
+// cross-backend shader. Only the wiring into `Mesh` matters here.
+const material = new MeshMaterial({
+    shader: new ShaderSource({
+        glsl: {
+            vertex: `
+                #version 300 es
+                layout(location = 0) in vec2 a_position;
+                uniform mat3 u_projection;
+                uniform mat3 u_translation;
+                void main() {
+                    gl_Position = vec4((u_projection * u_translation * vec3(a_position, 1.0)).xy, 0.0, 1.0);
+                }
+            `,
+            fragment: `
+                #version 300 es
+                precision mediump float;
+                uniform vec4 u_tint;
+                out vec4 fragColor;
+                void main() { fragColor = u_tint; }
+            `,
+        },
+    }),
     uniforms: { u_time: 0 },
 });
 
 const mesh = new Mesh({
-    shader,
+    material,
     vertices: new Float32Array([
          0,   0,
        100,   0,
@@ -200,26 +223,25 @@ const mesh = new Mesh({
         1, 0,
         0, 1,
     ]),
-    texture: myTexture,
 });
 ```
 
-The mesh renders with the same transform, tint, blend mode, filters, masks, and `cacheAsBitmap` behavior as a default mesh. Only the GPU program changes.
+The mesh's `material` is set at construction and is read-only afterward. It renders with the same transform, tint, blend mode, filters, masks, and `cacheAsBitmap` behavior as a default mesh. Only the GPU program changes.
 
 ## Sharing and lifecycle
 
-One `MeshShader` can be attached to many meshes. The renderer compiles one program (WebGL2) or pipeline (WebGPU) per unique `MeshShader` instance, then reuses it across all meshes that reference it.
+One `MeshMaterial` can be attached to many meshes, and one `ShaderSource` can back many materials. The renderer compiles one program (WebGL2) or pipeline (WebGPU) per unique `ShaderSource`, then reuses it across every material that references that source.
 
-Call `shader.destroy()` to release cached GPU resources on every backend the shader was used on. After `destroy`, the shader can still be reused — renderers will recompile on the next draw — but the typical pattern is to drop the reference.
+Call `material.destroy()` to release cached GPU resources on every backend the material was used on. After `destroy`, the material can still be reused — renderers will recompile on the next draw — but the typical pattern is to drop the reference.
 
-When a mesh is destroyed, its `MeshShader` is left untouched. The shader outlives the mesh unless you destroy it explicitly. This means a single shader can survive scene transitions.
+When a mesh is destroyed, its `MeshMaterial` is left untouched. The material outlives the mesh unless you destroy it explicitly. This means a single material can survive scene transitions.
 
 ## Detecting uniform drift
 
-When you write shaders for both GLSL and WGSL, keeping uniform names synchronized across languages becomes a manual task. `getDeclaredUniforms()` reflects uniform declarations from each language's source via lightweight regex parsing. Companion method `detectUniformDrift()` compares the two and reports names that appear in only one language:
+When you write shaders for both GLSL and WGSL, keeping uniform names synchronized across languages becomes a manual task. The reflection helpers live on the `ShaderSource`, reachable through `material.shader`. `getDeclaredUniforms()` reflects uniform declarations from each language's source via lightweight regex parsing. Companion method `detectUniformDrift()` compares the two and reports names that appear in only one language:
 
 ```js
-const drift = shader.detectUniformDrift();
+const drift = waveMaterial.shader.detectUniformDrift();
 // drift.onlyInGlsl → ['u_waveAmp']
 // drift.onlyInWgsl → ['u_displacement']
 ```
@@ -229,7 +251,7 @@ Auto-bound uniforms (`u_projection`, `u_translation`, `u_tint`, `u_texture`, `u_
 ```js no-check
 import assert from 'node:assert';
 
-const drift = shader.detectUniformDrift();
+const drift = waveMaterial.shader.detectUniformDrift();
 assert.deepStrictEqual(drift.onlyInGlsl, [], 'GLSL-only uniforms found');
 assert.deepStrictEqual(drift.onlyInWgsl, [], 'WGSL-only uniforms found');
 ```

--- a/site/src/content/guide/effects/filters.mdx
+++ b/site/src/content/guide/effects/filters.mdx
@@ -131,15 +131,15 @@ Filters on individual children inside an unfiltered container each get their own
 
 For static subtrees that don't change every frame, set `container.cacheAsBitmap = true`. The filter chain bakes once and subsequent frames skip the per-frame re-rendering — one texture draw instead of the full subtree + filters.
 
-## Filters vs. MeshShader
+## Filters vs. mesh materials
 
-A filter transforms a drawable's rendered pixels — it operates on the 2D output, in screen texture space. A `MeshShader` replaces the drawable's vertex and fragment stages entirely — it operates in geometry space. The distinction matters:
+A filter transforms a drawable's rendered pixels — it operates on the 2D output, in screen texture space. A `MeshMaterial` replaces the drawable's vertex and fragment stages entirely — it operates in geometry space. The distinction matters:
 
 - Use a filter for post-render effects: blur, tint, color grade, CRT scanlines, vignette.
-- Use a `MeshShader` for per-vertex effects: displacement, custom lighting, procedural geometry.
-- Use both together: a `MeshShader` on the mesh, plus a filter on the mesh's parent container.
+- Use a `MeshMaterial` for per-vertex effects: displacement, custom lighting, procedural geometry.
+- Use both together: a `MeshMaterial` on the mesh, plus a filter on the mesh's parent container.
 
-The next chapter, [Custom mesh shaders](/ExoJS/en/guide/effects/custom-mesh-shaders/), covers `MeshShader` in detail.
+The next chapter, [Custom mesh shaders](/ExoJS/en/guide/effects/custom-mesh-shaders/), covers attaching a `MeshMaterial` in detail.
 
 ## Examples
 

--- a/site/src/pages/en/guide/[part]/[chapter]/index.astro
+++ b/site/src/pages/en/guide/[part]/[chapter]/index.astro
@@ -6,6 +6,7 @@ import DocsSidebar from '../../../../../components/DocsSidebar.astro';
 import GuideMeta from '../../../../../components/GuideMeta.astro';
 import GuidePager from '../../../../../components/GuidePager.astro';
 import { GUIDE_PARTS, GUIDE_CHAPTER_BY_PATH, getAdjacentChapters } from '../../../../../lib/guide-structure';
+import { toApiHref } from '../../../../../lib/api-reference';
 
 export function getStaticPaths() {
     return GUIDE_PARTS.flatMap(part =>
@@ -71,6 +72,22 @@ const previousLink = previous
 const nextLink = next
     ? { label: titleByPath(next.path), href: guideHref(next.path), context: next.partTitle }
     : null;
+
+// Surface the chapter's curated spine apiLinks as a compact "Related API"
+// section. Slugs resolve against the generated api collection, so a stale slug
+// fails the build (and the guide-structure test) rather than shipping a dead
+// link — the same contract TryIt uses.
+const apiEntries = await getCollection('api');
+const apiEntryById = new Map<string, CollectionEntry<'api'>>(
+    apiEntries.map((item: CollectionEntry<'api'>) => [item.id, item] as [string, CollectionEntry<'api'>]),
+);
+const relatedApi = chapterMeta.apiLinks.map(slug => {
+    const apiEntry = apiEntryById.get(slug);
+    if (!apiEntry) {
+        throw new Error(`Unknown API page "${slug}" referenced by guide chapter ${chapterPath}`);
+    }
+    return { label: apiEntry.data.symbol || apiEntry.data.title, href: toApiHref(import.meta.env.BASE_URL, slug) };
+});
 
 const getFirstChapterHref = (part: (typeof GUIDE_PARTS)[number]) => {
     const firstChapter = part.chapters[0];
@@ -142,6 +159,19 @@ const sidebarParts = GUIDE_PARTS.map(part => ({
         <div class="chapter-content">
             <Content />
         </div>
+
+        {relatedApi.length > 0 && (
+            <nav class="related-api" aria-label="Related API">
+                <p class="related-api__heading">Related API</p>
+                <ul class="related-api__list">
+                    {relatedApi.map(link => (
+                        <li>
+                            <a href={link.href}><code>{link.label}</code></a>
+                        </li>
+                    ))}
+                </ul>
+            </nav>
+        )}
 
         <GuidePager previous={previousLink} next={nextLink} />
     </article>
@@ -359,5 +389,83 @@ const sidebarParts = GUIDE_PARTS.map(part => ({
         margin-top: 1.5rem;
         padding-top: 0.75rem;
         border-top: 1px solid var(--line-soft);
+    }
+
+    /* Spine-curated apiLinks, surfaced as a compact chip row below the chapter
+       body. Selectors are nested under .related-api so the prose link/code rules
+       above do not bleed in. */
+    .related-api {
+        margin: var(--s-9) 0 0;
+        padding-top: var(--s-5);
+        border-top: 1px solid var(--line-soft);
+    }
+
+    .related-api .related-api__heading {
+        margin: 0 0 var(--s-3);
+        padding: 0;
+        border: 0;
+        font-family: var(--f-mono);
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--fg-faint);
+    }
+
+    .related-api .related-api__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--s-2);
+    }
+
+    .related-api .related-api__list li {
+        margin: 0;
+    }
+
+    .related-api .related-api__list a {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.25rem 0.65rem;
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-pill);
+        background: var(--bg-elevated);
+        color: var(--fg-muted);
+        text-decoration: none;
+        font-size: 13px;
+        line-height: 1.4;
+        transition: color 0.15s ease, border-color 0.15s ease;
+    }
+
+    .related-api .related-api__list a::before {
+        content: '↗';
+        color: var(--fg-faint);
+        font-size: 11px;
+    }
+
+    .related-api .related-api__list a:hover {
+        color: var(--accent);
+        border-color: var(--accent-line);
+    }
+
+    .related-api .related-api__list a:hover::before {
+        color: var(--accent);
+    }
+
+    .related-api .related-api__list a:focus-visible {
+        outline: 2px solid var(--focus-ring);
+        outline-offset: 2px;
+        color: var(--accent);
+    }
+
+    .related-api .related-api__list code {
+        border: 0;
+        background: transparent;
+        padding: 0;
+        font-size: 13px;
+        color: inherit;
     }
 </style>

--- a/test/site/guide-prose-links.test.ts
+++ b/test/site/guide-prose-links.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Validates internal links that live directly in guide MDX — the surface the
+ * spine test (guide-structure.test.ts, which checks guide-structure.ts metadata)
+ * does not cover. A markdown link to a renamed or deleted API page, a dead
+ * `/api/mesh-shader/` reference, an invalid `NextStep` target, or a bad `TryIt`
+ * slug fails here rather than shipping a broken link.
+ *
+ * Scope: internal `/api/...` and `/guide/...` links only, plus `TryIt`
+ * api/examples props. External URLs are never fetched. Links are normalized for
+ * the optional `/ExoJS/` base, an optional `en`/`de` locale segment, trailing
+ * slashes, hash fragments, and query strings before resolution.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { EXAMPLES_CATALOG } from '../../site/src/lib/examples-catalog';
+import { GUIDE_CHAPTER_BY_PATH, GUIDE_PARTS } from '../../site/src/lib/guide-structure';
+
+const ROOT = process.cwd();
+const GUIDE_DIR = join(ROOT, 'site', 'src', 'content', 'guide');
+const API_DIR = join(ROOT, 'site', 'src', 'content', 'api');
+
+// Non-symbol API routes that exist as pages (en/api/index.astro, en/api/all.astro)
+// rather than as a generated api/<slug>.mdx entry.
+const API_INDEX_SLUGS = new Set(['', 'all']);
+
+// Part slugs back the /guide/<part>/ index route (en/guide/[part]/index.astro).
+const PART_SLUGS = new Set(GUIDE_PARTS.map(part => part.slug));
+
+// API pages that were removed/renamed and must never reappear as a guide link.
+// `mesh-shader` → `mesh-material` + `shader-source`; the *-application-options /
+// loader-options interfaces are not generated (the generator documents classes
+// and enums only), so their option-page links were dropped.
+const REMOVED_API_SLUGS = ['mesh-shader', 'canvas-application-options', 'loader-options', 'rendering-application-options', 'input-application-options'];
+
+function walkMdx(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walkMdx(full));
+    else if (full.endsWith('.mdx') || full.endsWith('.md')) out.push(full);
+  }
+  return out;
+}
+
+const guideFiles = walkMdx(GUIDE_DIR);
+const rel = (file: string): string => file.slice(GUIDE_DIR.length + 1).replace(/\\/g, '/');
+
+/**
+ * Normalize an href to a locale-/base-/slash-agnostic internal path, or return
+ * `null` for external, protocol-relative, anchor-only, or non-rootabsolute links
+ * (none of which this test resolves).
+ */
+function normalizeInternal(href: string): string | null {
+  let h = href.trim();
+  // Drop an optional markdown link title: [x](/path "Title").
+  const space = h.search(/\s/);
+  if (space >= 0) h = h.slice(0, space);
+  // External, protocol-relative, mailto, anchor-only, or query-only — not ours.
+  if (/^(https?:)?\/\//i.test(h) || h.startsWith('mailto:')) return null;
+  if (h.startsWith('#') || h.startsWith('?')) return null;
+  // Strip hash + query.
+  h = h.split('#')[0].split('?')[0];
+  if (!h) return null;
+  // Strip the optional GitHub Pages base prefix.
+  h = h.replace(/^\/ExoJS\//, '/');
+  if (!h.startsWith('/')) return null; // relative link — none exist in the guides
+  // Strip leading slashes, an optional locale segment, and the trailing slash.
+  const path = h
+    .replace(/^\/+/, '')
+    .replace(/^(en|de)\//, '')
+    .replace(/\/+$/, '');
+  return path;
+}
+
+interface Resolution {
+  kind: 'api' | 'guide' | 'other';
+  ok: boolean;
+  target: string;
+}
+
+function resolveInternal(path: string): Resolution {
+  const seg = path.split('/');
+  if (seg[0] === 'api') {
+    const slug = seg.slice(1).join('/');
+    const ok = API_INDEX_SLUGS.has(slug) || existsSync(join(API_DIR, `${slug}.mdx`));
+    return { kind: 'api', ok, target: slug };
+  }
+  if (seg[0] === 'guide') {
+    const chapterPath = seg.slice(1).join('/');
+    const ok = chapterPath === '' || PART_SLUGS.has(chapterPath) || GUIDE_CHAPTER_BY_PATH.has(chapterPath);
+    return { kind: 'guide', ok, target: chapterPath };
+  }
+  // Playground and other internal routes are validated by their own embeds.
+  return { kind: 'other', ok: true, target: path };
+}
+
+const MD_LINK_RE = /\]\(([^)]+)\)/g;
+const NEXTSTEP_HREF_RE = /<NextStep\b[\s\S]*?\shref=["']([^"']+)["']/g;
+const TRYIT_TAG_RE = /<TryIt\b[\s\S]*?\/>/g;
+const STRING_LITERAL_RE = /['"]([^'"]+)['"]/g;
+
+/** Collect every internal (api|guide) link in a file with its raw form. */
+function collectLinks(body: string): { raw: string; path: string; res: Resolution }[] {
+  const found: { raw: string; path: string; res: Resolution }[] = [];
+  const add = (raw: string): void => {
+    const path = normalizeInternal(raw);
+    if (path === null) return;
+    const res = resolveInternal(path);
+    if (res.kind === 'other') return;
+    found.push({ raw, path, res });
+  };
+
+  for (const m of body.matchAll(MD_LINK_RE)) add(m[1]);
+  for (const m of body.matchAll(NEXTSTEP_HREF_RE)) add(m[1]);
+  return found;
+}
+
+const exampleExists = (ref: string): boolean => {
+  const slash = ref.indexOf('/');
+  if (slash < 0) return false;
+  const category = ref.slice(0, slash);
+  const slug = ref.slice(slash + 1);
+  return (EXAMPLES_CATALOG[category] ?? []).some(entry => entry.slug === slug);
+};
+
+function collectTryItRefs(body: string): { api: string[]; examples: string[] } {
+  const api: string[] = [];
+  const examples: string[] = [];
+  for (const tag of body.matchAll(TRYIT_TAG_RE)) {
+    const block = tag[0];
+    const apiArr = /api=\{\[([^\]]*)\]\}/.exec(block);
+    const exArr = /examples=\{\[([^\]]*)\]\}/.exec(block);
+    if (apiArr) for (const s of apiArr[1].matchAll(STRING_LITERAL_RE)) api.push(s[1]);
+    if (exArr) for (const s of exArr[1].matchAll(STRING_LITERAL_RE)) examples.push(s[1]);
+  }
+  return { api, examples };
+}
+
+describe('guide prose links', () => {
+  it('actually collects internal links (guards against a vacuous regex)', () => {
+    let api = 0;
+    let guide = 0;
+    for (const file of guideFiles) {
+      for (const link of collectLinks(readFileSync(file, 'utf8'))) {
+        if (link.res.kind === 'api') api++;
+        else if (link.res.kind === 'guide') guide++;
+      }
+    }
+    // Conservative floors well below the real counts (~80 API, ~40 guide): high
+    // enough that a broken collector trips this, low enough to survive edits.
+    expect(api).toBeGreaterThan(50);
+    expect(guide).toBeGreaterThan(20);
+  });
+
+  it('resolves every internal API link to an existing API page', () => {
+    const broken: string[] = [];
+    for (const file of guideFiles) {
+      const body = readFileSync(file, 'utf8');
+      for (const link of collectLinks(body)) {
+        if (link.res.kind === 'api' && !link.res.ok) broken.push(`${rel(file)} → ${link.raw}`);
+      }
+    }
+    expect(broken).toEqual([]);
+  });
+
+  it('resolves every internal guide link to a known chapter, part, or landing', () => {
+    const broken: string[] = [];
+    for (const file of guideFiles) {
+      const body = readFileSync(file, 'utf8');
+      for (const link of collectLinks(body)) {
+        if (link.res.kind === 'guide' && !link.res.ok) broken.push(`${rel(file)} → ${link.raw}`);
+      }
+    }
+    expect(broken).toEqual([]);
+  });
+
+  it('never links to a removed or renamed API page', () => {
+    const removed = new Set(REMOVED_API_SLUGS);
+    const offenders: string[] = [];
+    for (const file of guideFiles) {
+      const body = readFileSync(file, 'utf8');
+      for (const link of collectLinks(body)) {
+        if (link.res.kind === 'api' && removed.has(link.res.target)) {
+          offenders.push(`${rel(file)} → ${link.raw}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('teaches MeshMaterial, never the removed MeshShader symbol', () => {
+    // `custom-mesh-shaders` is a valid chapter slug, so match the symbol and the
+    // dead API route precisely rather than the substring "mesh-shader".
+    const offenders: string[] = [];
+    for (const file of guideFiles) {
+      const body = readFileSync(file, 'utf8');
+      if (/\bMeshShader\b/.test(body)) offenders.push(`${rel(file)} (MeshShader symbol)`);
+      if (body.includes('/api/mesh-shader/')) offenders.push(`${rel(file)} (/api/mesh-shader/ link)`);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('resolves every TryIt api slug and example ref', () => {
+    const brokenApi: string[] = [];
+    const brokenExamples: string[] = [];
+    for (const file of guideFiles) {
+      const body = readFileSync(file, 'utf8');
+      const { api, examples } = collectTryItRefs(body);
+      for (const slug of api) {
+        if (!existsSync(join(API_DIR, `${slug}.mdx`))) brokenApi.push(`${rel(file)} → ${slug}`);
+      }
+      for (const ref of examples) {
+        if (!exampleExists(ref)) brokenExamples.push(`${rel(file)} → ${ref}`);
+      }
+    }
+    expect(brokenApi).toEqual([]);
+    expect(brokenExamples).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

Guides and committed API docs carried pre-existing naming/link drift that PR #94 made highly visible:

- Guides taught a `MeshShader` class the engine no longer exports — the current API is `ShaderSource` + `MeshMaterial`.
- Four prose links pointed at the non-existent `/api/mesh-shader/` page.
- `core-concepts/application.mdx` linked four options interfaces that get no generated API pages.
- `SourceSnippet.astro` had two pre-existing `astro check` type errors.
- Running the API generator changed ~12 committed API MDX files (committed output had drifted from source).
- The spine's curated `apiLinks` were validated but never shown in the chapter UI.

## Solution

- **MeshShader → MeshMaterial migration.** Reworked the canonical `custom-mesh-shaders` chapter onto the real `ShaderSource` + `MeshMaterial` + `new Mesh({ material })` API (its construction/attach blocks are now standalone-typechecked instead of `no-check`), and fixed every prose/table/label reference in `custom-mesh-shaders`, `backend-comparison`, `custom-renderers`, `filters`, and `render-pipeline-debugging` (the WebGPU debug label now matches the real `MeshMaterial (custom)`). Prose now distinguishes shader source / material / renderer correctly; `detectUniformDrift()` is attributed to `ShaderSource`.
- **API link strategy.** Dead `/api/mesh-shader/` links now resolve to `/api/mesh-material/` (and `ShaderSource.detectUniformDrift()` → `/api/shader-source/#methods`). The four `*ApplicationOptions` / `LoaderOptions` links are demoted to inline code: the generator documents only classes/enums, so interfaces never get pages, and a four-type generator special case is explicitly out of scope (Option C).
- **Astro typecheck cleanup.** `SourceSnippet.astro` derives the `language` prop from the `<Code>` component's own `lang` type (no `any`, no deep import) and uses `Astro.url.pathname` for error context instead of the untyped `Astro.self.moduleId`. `astro check` is now 0 errors.
- **Deterministic API regeneration.** Ran the official generator; the ~12-file diff is real source drift (corrected source-line anchors plus new `Gradient` value-object members and `Graphics` fill/stroke styles), is byte-identical across runs, and is committed so a fresh build leaves the tree clean.
- **Visible spine API links.** The chapter layout now renders a compact, keyboard-accessible, focus-visible "Related API" chip row from `apiLinks` (build-validated against the api collection, only when present); curated `TryIt` blocks stay for playground + API combos.
- **Stronger link validation.** New `test/site/guide-prose-links.test.ts` validates internal `/api/` and `/guide/` links in MDX prose, `NextStep` hrefs, and `TryIt` slugs — with locale / base / trailing-slash / hash / query normalization — and guards against the removed `mesh-shader` and options-interface pages.

## Scope

Docs / site / tooling only. No runtime features, no API changes, no new examples or templates, no playground redesign, no versioning or release.

## Validation

All green from a clean tree, **and the tree stays clean after API regeneration + build + site build**:

- `pnpm typecheck` · `typecheck:guides` (28 extracted / 20 no-check, up from 26 / 22) · `typecheck:examples` — pass
- `pnpm lint:strict` — pass
- `pnpm test` — 1846 pass (incl. the new link-drift test)
- `pnpm build` · `verify:exports` · `verify:package` · `verify:create-exo-app` (45 pass) — pass
- `pnpm site:build` (572 pages) · `test:examples:smoke` (118 pass) · `astro check` (0 errors) — pass
- API regeneration is deterministic; `git status --short` is clean after generate + build + site:build (only the intended 21 files)
- ⚠️ `pnpm format:check` flags 6 files (`rollup.config.ts`, `scripts/extract-guide-snippets.ts`, `scripts/verify-create-exo-app.ts`, `test/site/example-search.test.ts`, `test/site/source-snippets.test.ts`, `tsconfig.guides.json`) — **all unmodified by this PR and pre-existing on `main`** (prettier drift). Left untouched to avoid mixing unrelated reformatting into a docs PR; recommend a dedicated formatting/prettier-pin PR.

## Release note

Release preparation must be recreated fresh from `main` after this PR. The stale release-prep PR #93 is superseded by #94 and this PR and can then be closed. This PR intentionally does not touch versioning or the changelog.
