### PR TITLE
feat(assets): type declarative handler options

### DIFF
--- a/src/extensions/Extension.ts
+++ b/src/extensions/Extension.ts
@@ -69,19 +69,17 @@ export interface RendererBinding<Target extends Drawable = Drawable> {
  * an {@link AssetHandler} instance that the Loader owns for its entire lifetime.
  * The handler may hold loader-local state (Workers, WASM modules, parsed caches).
  *
- * `Type` is the asset constructor (e.g. `typeof TileMap`); the result type is
- * derived automatically as `InstanceType<Type>`. `Options` is the typed options
- * object, defaulting to `undefined` (no options).
+ * `Result` is the produced asset instance type (e.g. `TileMap`). `Options` is the
+ * typed options object, defaulting to `undefined` (no options). The runtime `type`
+ * field must be a constructor that produces `Result`; the handler returned by
+ * `create` must also produce `Result` — both relationships are enforced by TypeScript.
  *
- * Use `satisfies AssetBinding<typeof MyAsset, MyLoadOptions>` on an object literal
- * to get typed options in the handler and enforce the result type without repeating it.
+ * Use `satisfies AssetBinding<MyAsset, MyLoadOptions>` on an object literal to get
+ * typed options in the handler and enforce the result type without repeating it.
  * @advanced
  */
-export interface AssetBinding<
-  Type extends AssetConstructor = AssetConstructor,
-  Options = undefined,
-> {
-  readonly type: Type;
+export interface AssetBinding<Result = unknown, Options = undefined> {
+  readonly type: AssetConstructor<Result>;
   /**
    * Config-map type names that resolve to this handler, e.g. `['tiledMap']`.
    * Most bindings declare exactly one name; a binding may declare several when a
@@ -90,7 +88,7 @@ export interface AssetBinding<
    */
   readonly typeNames?: readonly string[];
   readonly extensions?: readonly string[];
-  create(loader: Loader): AssetHandler<InstanceType<Type>, Options>;
+  create(loader: Loader): AssetHandler<Result, Options>;
 }
 
 /**

--- a/src/extensions/Extension.ts
+++ b/src/extensions/Extension.ts
@@ -5,12 +5,17 @@ import type { AssetConstructor } from '#resources/FactoryRegistry';
 import type { AssetLoaderContext, Loader } from '#resources/Loader';
 
 /**
- * Per-load request passed to {@link AssetHandler.load}.
+ * Per-load request passed to {@link AssetHandler.load} and
+ * {@link AssetHandler.getIdentityKey}.
+ *
+ * `Options` is `undefined` by default — a handler without typed options receives
+ * `request.options: undefined`. A handler with typed options receives
+ * `request.options: Options | undefined` (options remain optional even when typed).
  * @advanced
  */
-export interface AssetLoadRequest {
+export interface AssetLoadRequest<Options = undefined> {
   readonly source: string;
-  readonly options?: Readonly<Record<string, unknown>>;
+  readonly options?: Options;
 }
 
 /**
@@ -20,8 +25,26 @@ export interface AssetLoadRequest {
  * NOT by this handler or the asset returned by `load`.
  * @advanced
  */
-export interface AssetHandler<Result = unknown> {
-  load(request: AssetLoadRequest, context: AssetLoaderContext): Promise<Result>;
+export interface AssetHandler<Result = unknown, Options = undefined> {
+  /**
+   * Returns the deterministic identity key used for in-flight deduplication and
+   * loaded-resource reuse (and cache/resource-store identity where applicable).
+   *
+   * Include every option that **changes the produced resource** (format, locale,
+   * variant, color space, decoding mode, strictness when it affects output).
+   * Exclude control-only values that do not alter the resource (callbacks,
+   * `AbortSignal`, logger, request priority, timeout).
+   *
+   * Do **not** use `JSON.stringify(request.options)` — property-order instability,
+   * control-only field inclusion, and unbounded key size make it unsuitable.
+   * Explicitly select the identity-relevant fields instead.
+   *
+   * The Loader namespaces the key with the asset type, so the returned string may
+   * be type-local. Omit this hook to use the default (source-only) identity.
+   * @advanced
+   */
+  getIdentityKey?(request: AssetLoadRequest<Options>): string;
+  load(request: AssetLoadRequest<Options>, context: AssetLoaderContext): Promise<Result>;
   destroy?(): void;
 }
 
@@ -45,10 +68,20 @@ export interface RendererBinding<Target extends Drawable = Drawable> {
  * `create(loader)` is called once per Loader at Application construction, producing
  * an {@link AssetHandler} instance that the Loader owns for its entire lifetime.
  * The handler may hold loader-local state (Workers, WASM modules, parsed caches).
+ *
+ * `Type` is the asset constructor (e.g. `typeof TileMap`); the result type is
+ * derived automatically as `InstanceType<Type>`. `Options` is the typed options
+ * object, defaulting to `undefined` (no options).
+ *
+ * Use `satisfies AssetBinding<typeof MyAsset, MyLoadOptions>` on an object literal
+ * to get typed options in the handler and enforce the result type without repeating it.
  * @advanced
  */
-export interface AssetBinding<Result = unknown> {
-  readonly type: AssetConstructor<Result>;
+export interface AssetBinding<
+  Type extends AssetConstructor = AssetConstructor,
+  Options = undefined,
+> {
+  readonly type: Type;
   /**
    * Config-map type names that resolve to this handler, e.g. `['tiledMap']`.
    * Most bindings declare exactly one name; a binding may declare several when a
@@ -57,7 +90,7 @@ export interface AssetBinding<Result = unknown> {
    */
   readonly typeNames?: readonly string[];
   readonly extensions?: readonly string[];
-  create(loader: Loader): AssetHandler<Result>;
+  create(loader: Loader): AssetHandler<InstanceType<Type>, Options>;
 }
 
 /**

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -1058,14 +1058,14 @@ export class Loader {
    * Validates all keys BEFORE mutating any map. Any already-registered key
    * throws before any mutation (no override in 0.12).
    *
-   * `Type` and `Options` are inferred from the binding's `AssetBinding<Type, Options>`
+   * `Result` and `Options` are inferred from the binding's `AssetBinding<Result, Options>`
    * contract. A declarative handler's optional `getIdentityKey` is forwarded into
    * the internal {@link HandlerEntry} so it participates in in-flight deduplication.
    * @internal
    */
-  public bindAsset<Type extends AssetConstructor = AssetConstructor, Options = undefined>(
-    keys: { type: Type; typeNames?: readonly string[]; extensions?: readonly string[] },
-    handler: AssetHandler<InstanceType<Type>, Options>,
+  public bindAsset<Result = unknown, Options = undefined>(
+    keys: { type: AssetConstructor<Result>; typeNames?: readonly string[]; extensions?: readonly string[] },
+    handler: AssetHandler<Result, Options>,
   ): void {
     const normalizedExts: string[] = [];
     const resolvedNames: string[] = keys.typeNames !== undefined ? [...keys.typeNames] : [];
@@ -1109,7 +1109,7 @@ export class Loader {
     // `{ source, ...fields }`. The public AssetHandler<Result, Options> interface
     // uses `AssetLoadRequest<Options> = { source, options? }`. This single `toRequest`
     // helper is the only place where the erased flat config is cast to the typed
-    // request — justified by the `AssetBinding<Type, Options>` contract that
+    // request — justified by the `AssetBinding<Result, Options>` contract that
     // associates this handler's Options with the registered constructor.
     //
     // `options` is intentionally omitted (not set to `undefined`) when the flat

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -1,5 +1,5 @@
 import { Signal } from '#core/Signal';
-import type { AssetHandler } from '#extensions/Extension';
+import type { AssetHandler, AssetLoadRequest } from '#extensions/Extension';
 import { type BmFont } from '#rendering/text/BmFont';
 
 import { Asset, AssetImpl } from './Asset';
@@ -1057,9 +1057,16 @@ export class Loader {
    * Atomically bind all keys for one AssetBinding to a pre-created handler.
    * Validates all keys BEFORE mutating any map. Any already-registered key
    * throws before any mutation (no override in 0.12).
+   *
+   * `Type` and `Options` are inferred from the binding's `AssetBinding<Type, Options>`
+   * contract. A declarative handler's optional `getIdentityKey` is forwarded into
+   * the internal {@link HandlerEntry} so it participates in in-flight deduplication.
    * @internal
    */
-  public bindAsset(keys: { type: AssetConstructor; typeNames?: readonly string[]; extensions?: readonly string[] }, handler: AssetHandler): void {
+  public bindAsset<Type extends AssetConstructor = AssetConstructor, Options = undefined>(
+    keys: { type: Type; typeNames?: readonly string[]; extensions?: readonly string[] },
+    handler: AssetHandler<InstanceType<Type>, Options>,
+  ): void {
     const normalizedExts: string[] = [];
     const resolvedNames: string[] = keys.typeNames !== undefined ? [...keys.typeNames] : [];
 
@@ -1097,17 +1104,34 @@ export class Loader {
     }
 
     // All validation passed — install atomically.
-    // Internally the loader builds a flat config `{ source, ...fields }` (the
-    // shape the advanced `registerAssetType` handler form receives). Extension
-    // AssetHandlers are typed against the public `AssetLoadRequest`
-    // (`{ source, options? }`), so reshape the flat config here: pull `source`
-    // out and nest the remaining per-load fields under `options`.
+    //
+    // Localized type-erasure boundary: the internal Loader uses a flat config
+    // `{ source, ...fields }`. The public AssetHandler<Result, Options> interface
+    // uses `AssetLoadRequest<Options> = { source, options? }`. This single `toRequest`
+    // helper is the only place where the erased flat config is cast to the typed
+    // request — justified by the `AssetBinding<Type, Options>` contract that
+    // associates this handler's Options with the registered constructor.
+    //
+    // `options` is intentionally omitted (not set to `undefined`) when the flat
+    // config carries no extra fields, keeping the object compatible with a future
+    // `exactOptionalPropertyTypes` migration.
+    const toRequest = (config: unknown): AssetLoadRequest<Options> => {
+      const { source, ...rest } = config as { source: string } & Record<string, unknown>;
+
+      if (Object.keys(rest).length === 0) {
+        return { source };
+      }
+
+      return { source, options: rest as Options };
+    };
+
+    const boundIdentityKey = handler.getIdentityKey?.bind(handler);
+
     this._handlerFunctions.set(keys.type, {
-      load: (config, ctx) => {
-        const { source, ...rest } = config as { source: string } & Record<string, unknown>;
-        const options = Object.keys(rest).length > 0 ? (rest as Readonly<Record<string, unknown>>) : undefined;
-        return handler.load({ source, options }, ctx);
-      },
+      load: (config, ctx) => handler.load(toRequest(config), ctx),
+      getIdentityKey: boundIdentityKey
+        ? (config) => boundIdentityKey(toRequest(config))
+        : undefined,
     });
 
     for (const name of resolvedNames) {
@@ -1118,8 +1142,10 @@ export class Loader {
       this._extensionMap.set(ext, keys.type);
     }
 
-    // Own this handler for lifecycle management
-    this._boundHandlers.push(handler);
+    // Own this handler for lifecycle management.
+    // Cast to the erased AssetHandler for storage; destroy() is the only method
+    // called on entries in this array.
+    this._boundHandlers.push(handler as AssetHandler);
   }
 
   /**

--- a/test/resources/asset-handler-options.test.ts
+++ b/test/resources/asset-handler-options.test.ts
@@ -1,0 +1,455 @@
+/**
+ * Phase 0B — Typed Declarative Asset Handlers & Identity
+ *
+ * Type-level tests: verify that AssetLoadRequest, AssetHandler, and AssetBinding
+ * generics behave as specified (options typing, result derivation, satisfies pattern).
+ *
+ * Runtime tests: verify that a declarative handler's getIdentityKey propagates
+ * through the full Extension → AssetBinding → materializeAssetBindings →
+ * Loader.bindAsset → identity resolution path.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import type { AssetBinding, AssetHandler, AssetLoadRequest } from '#extensions/Extension';
+import { materializeAssetBindings } from '#extensions/materialize';
+import { Asset } from '#resources/Asset';
+import type { AssetLoaderContext } from '#resources/Loader';
+import { Loader } from '#resources/Loader';
+
+// ---------------------------------------------------------------------------
+// Minimal test asset types
+// ---------------------------------------------------------------------------
+
+class ExampleAsset {}
+class OtherAsset {}
+
+interface ExampleLoadOptions {
+  readonly format?: 'example' | 'alt';
+  readonly strict?: boolean;
+  /** Control-only: does not change the produced resource. */
+  readonly trace?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Shared normalization helper (used by both getIdentityKey and load to stay aligned)
+// ---------------------------------------------------------------------------
+
+interface ResolvedExampleOptions {
+  readonly format: 'example' | 'alt';
+  readonly strict: boolean;
+}
+
+function resolveExampleOptions(opts: ExampleLoadOptions | undefined): ResolvedExampleOptions {
+  return {
+    format: opts?.format ?? 'example',
+    strict: opts?.strict ?? true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Type-level tests
+// ---------------------------------------------------------------------------
+
+describe('AssetHandler type contracts', () => {
+  it('handler without options: request.options is undefined', () => {
+    const handler: AssetHandler<ExampleAsset> = {
+      async load(request) {
+        expectTypeOf(request.options).toEqualTypeOf<undefined>();
+        return new ExampleAsset();
+      },
+    };
+
+    expectTypeOf(handler).toMatchTypeOf<AssetHandler<ExampleAsset>>();
+  });
+
+  it('handler with options: request.options is typed and optional', () => {
+    const handler: AssetHandler<ExampleAsset, ExampleLoadOptions> = {
+      getIdentityKey(request) {
+        expectTypeOf(request.options).toEqualTypeOf<ExampleLoadOptions | undefined>();
+        void request.options?.format;
+        void request.options?.strict;
+        return request.source;
+      },
+
+      async load(request) {
+        expectTypeOf(request.options).toEqualTypeOf<ExampleLoadOptions | undefined>();
+        void request.options?.format;
+        void request.options?.strict;
+        return new ExampleAsset();
+      },
+    };
+
+    expectTypeOf(handler).toMatchTypeOf<AssetHandler<ExampleAsset, ExampleLoadOptions>>();
+  });
+
+  it('getIdentityKey and load receive the same request type', () => {
+    type RequestInGetIdentity = Parameters<NonNullable<AssetHandler<ExampleAsset, ExampleLoadOptions>['getIdentityKey']>>[0];
+    type RequestInLoad = Parameters<AssetHandler<ExampleAsset, ExampleLoadOptions>['load']>[0];
+
+    expectTypeOf<RequestInGetIdentity>().toEqualTypeOf<RequestInLoad>();
+  });
+
+  it('handler without options cannot access typed option properties', () => {
+    const handler: AssetHandler<ExampleAsset> = {
+      async load(request) {
+        // @ts-expect-error — options is undefined, no .format property
+        void request.options?.format;
+        return new ExampleAsset();
+      },
+    };
+
+    void handler;
+  });
+
+  it('handler with options rejects unknown option properties', () => {
+    const handler: AssetHandler<ExampleAsset, ExampleLoadOptions> = {
+      async load(request) {
+        // @ts-expect-error — unknownField is not part of ExampleLoadOptions
+        void request.options?.unknownField;
+        return new ExampleAsset();
+      },
+    };
+
+    void handler;
+  });
+});
+
+describe('AssetBinding type contracts', () => {
+  it('binding derives result from constructor via satisfies', () => {
+    const binding = {
+      type: ExampleAsset,
+      typeNames: ['example' as const],
+
+      create() {
+        return {
+          getIdentityKey(request: AssetLoadRequest<ExampleLoadOptions>) {
+            const o = resolveExampleOptions(request.options);
+            return [request.source, o.format, String(o.strict)].join('|');
+          },
+
+          async load(request: AssetLoadRequest<ExampleLoadOptions>) {
+            resolveExampleOptions(request.options);
+            return new ExampleAsset();
+          },
+        };
+      },
+    } satisfies AssetBinding<typeof ExampleAsset, ExampleLoadOptions>;
+
+    expectTypeOf(binding.type).toEqualTypeOf<typeof ExampleAsset>();
+  });
+
+  it('binding rejects wrong result type', () => {
+    const _binding = {
+      type: ExampleAsset,
+
+      create() {
+        return {
+          // @ts-expect-error — OtherAsset is not assignable to ExampleAsset
+          async load(_request: AssetLoadRequest<ExampleLoadOptions>): Promise<OtherAsset> {
+            return new OtherAsset();
+          },
+        };
+      },
+    } satisfies AssetBinding<typeof ExampleAsset, ExampleLoadOptions>;
+
+    void _binding;
+  });
+
+  it('no-options binding: options in handler request is undefined', () => {
+    const _binding = {
+      type: ExampleAsset,
+
+      create() {
+        return {
+          async load(request: AssetLoadRequest) {
+            expectTypeOf(request.options).toEqualTypeOf<undefined>();
+            return new ExampleAsset();
+          },
+        };
+      },
+    } satisfies AssetBinding<typeof ExampleAsset>;
+
+    void _binding;
+  });
+
+  it('no-options binding: handler cannot access typed option values', () => {
+    const _binding = {
+      type: ExampleAsset,
+
+      create() {
+        return {
+          async load(request: AssetLoadRequest) {
+            // @ts-expect-error — options is undefined, no .format property
+            void request.options?.format;
+            return new ExampleAsset();
+          },
+        };
+      },
+    } satisfies AssetBinding<typeof ExampleAsset>;
+
+    void _binding;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runtime identity tests
+// ---------------------------------------------------------------------------
+
+describe('declarative bindAsset identity propagation', () => {
+  let loader: Loader;
+
+  beforeEach(() => {
+    loader = new Loader();
+  });
+
+  function buildExampleBinding(
+    onLoad: (opts: ResolvedExampleOptions) => void,
+  ): AssetBinding<typeof ExampleAsset, ExampleLoadOptions> {
+    return {
+      type: ExampleAsset,
+      typeNames: ['example'],
+
+      create() {
+        return {
+          getIdentityKey(request) {
+            const o = resolveExampleOptions(request.options);
+            return [request.source, o.format, String(o.strict)].join('|');
+          },
+
+          async load(request) {
+            const o = resolveExampleOptions(request.options);
+            onLoad(o);
+            return new ExampleAsset();
+          },
+        };
+      },
+    };
+  }
+
+  it('getIdentityKey is forwarded through bindAsset into the internal HandlerEntry', async () => {
+    let loadCount = 0;
+    materializeAssetBindings(loader, [buildExampleBinding(() => loadCount++)]);
+
+    // Both assets have identical source + options — same identity → single load
+    const a1 = new Asset({ type: 'example', source: 'file.dat', format: 'example', strict: true });
+    const a2 = new Asset({ type: 'example', source: 'file.dat', format: 'example', strict: true });
+
+    await Promise.all([loader.load(a1), loader.load(a2)]);
+
+    expect(loadCount).toBe(1);
+    loader.destroy();
+  });
+
+  it('same request loaded twice returns the same in-flight promise (deduplication)', async () => {
+    const calls: ResolvedExampleOptions[] = [];
+    materializeAssetBindings(loader, [buildExampleBinding(o => calls.push(o))]);
+
+    const a1 = new Asset({ type: 'example', source: 'world.dat', format: 'example', strict: true });
+    const a2 = new Asset({ type: 'example', source: 'world.dat', format: 'example', strict: true });
+
+    const [r1, r2] = await Promise.all([loader.load(a1), loader.load(a2)]);
+
+    expect(calls).toHaveLength(1);
+    expect(r1).toBe(r2);
+    loader.destroy();
+  });
+
+  it('different result-changing options produce separate identities', async () => {
+    const calls: boolean[] = [];
+    materializeAssetBindings(loader, [buildExampleBinding(o => calls.push(o.strict))]);
+
+    // strict: true and strict: false produce different resources
+    const strict = new Asset({ type: 'example', source: 'data.dat', strict: true });
+    const lenient = new Asset({ type: 'example', source: 'data.dat', strict: false });
+
+    const [r1, r2] = await Promise.all([loader.load(strict), loader.load(lenient)]);
+
+    expect(calls).toHaveLength(2);
+    // Results are separate instances
+    expect(r1).not.toBe(r2);
+    loader.destroy();
+  });
+
+  it('default normalization: omitted options and explicit defaults produce same identity', async () => {
+    let loadCount = 0;
+    materializeAssetBindings(loader, [buildExampleBinding(() => loadCount++)]);
+
+    // load with no options — handler normalizes to { format: 'example', strict: true }
+    const noOpts = new Asset({ type: 'example', source: 'map.dat' });
+    // load with explicit defaults — same normalized result
+    const explicitDefaults = new Asset({ type: 'example', source: 'map.dat', format: 'example', strict: true });
+
+    await Promise.all([loader.load(noOpts), loader.load(explicitDefaults)]);
+
+    expect(loadCount).toBe(1);
+    loader.destroy();
+  });
+
+  it('control-only option (trace) does not affect identity', async () => {
+    let loadCount = 0;
+
+    const bindingWithTrace: AssetBinding<typeof ExampleAsset, ExampleLoadOptions> = {
+      type: ExampleAsset,
+      typeNames: ['traceExample'],
+
+      create() {
+        return {
+          getIdentityKey(request) {
+            // Intentionally excludes `trace` — it is control-only
+            const o = resolveExampleOptions(request.options);
+            return [request.source, o.format, String(o.strict)].join('|');
+          },
+
+          async load(request) {
+            const o = resolveExampleOptions(request.options);
+            void o;
+            loadCount++;
+            return new ExampleAsset();
+          },
+        };
+      },
+    };
+
+    materializeAssetBindings(loader, [bindingWithTrace]);
+
+    const withTrace = new Asset({ type: 'traceExample', source: 'asset.dat', trace: true });
+    const withoutTrace = new Asset({ type: 'traceExample', source: 'asset.dat', trace: false });
+
+    await Promise.all([loader.load(withTrace), loader.load(withoutTrace)]);
+
+    // Same identity despite differing trace values
+    expect(loadCount).toBe(1);
+    loader.destroy();
+  });
+
+  it('handler without getIdentityKey preserves source-based identity', async () => {
+    let loadCount = 0;
+
+    const noIdentityBinding: AssetBinding<typeof ExampleAsset> = {
+      type: ExampleAsset,
+      typeNames: ['simpleExample'],
+
+      create() {
+        return {
+          async load(_request) {
+            loadCount++;
+            return new ExampleAsset();
+          },
+        };
+      },
+    };
+
+    materializeAssetBindings(loader, [noIdentityBinding]);
+
+    const a1 = new Asset({ type: 'simpleExample', source: 'shared.dat' });
+    const a2 = new Asset({ type: 'simpleExample', source: 'shared.dat' });
+
+    await Promise.all([loader.load(a1), loader.load(a2)]);
+
+    // Source-only deduplication — both have same source, so single load
+    expect(loadCount).toBe(1);
+    loader.destroy();
+  });
+
+  it('handler lifecycle: destroy() is called on loader.destroy()', async () => {
+    let destroyed = false;
+
+    const destroyableBinding: AssetBinding<typeof ExampleAsset> = {
+      type: ExampleAsset,
+      typeNames: ['destroyable'],
+
+      create() {
+        return {
+          async load(_request) {
+            return new ExampleAsset();
+          },
+          destroy() {
+            destroyed = true;
+          },
+        };
+      },
+    };
+
+    materializeAssetBindings(loader, [destroyableBinding]);
+    loader.destroy();
+
+    expect(destroyed).toBe(true);
+  });
+
+  it('handler receives options nested under request.options via declarative path', async () => {
+    let seenRequest: AssetLoadRequest<ExampleLoadOptions> | undefined;
+
+    const capturingBinding: AssetBinding<typeof ExampleAsset, ExampleLoadOptions> = {
+      type: ExampleAsset,
+      typeNames: ['captureExample'],
+
+      create() {
+        return {
+          async load(request) {
+            seenRequest = request;
+            return new ExampleAsset();
+          },
+        };
+      },
+    };
+
+    materializeAssetBindings(loader, [capturingBinding]);
+
+    await loader.load(ExampleAsset, 'thing.dat', { format: 'alt', strict: false } as ExampleLoadOptions).catch(() => undefined);
+
+    expect(seenRequest?.source).toBe('thing.dat');
+    expect(seenRequest?.options).toEqual({ format: 'alt', strict: false });
+    loader.destroy();
+  });
+
+  it('handler receives no options key when none are passed (declarative path)', async () => {
+    let seenRequest: AssetLoadRequest<ExampleLoadOptions> | undefined;
+
+    const capturingBinding: AssetBinding<typeof ExampleAsset, ExampleLoadOptions> = {
+      type: ExampleAsset,
+      typeNames: ['captureNoOpts'],
+
+      create() {
+        return {
+          async load(request) {
+            seenRequest = request;
+            return new ExampleAsset();
+          },
+        };
+      },
+    };
+
+    materializeAssetBindings(loader, [capturingBinding]);
+
+    await loader.load(ExampleAsset, 'thing.dat').catch(() => undefined);
+
+    expect(seenRequest?.source).toBe('thing.dat');
+    expect(seenRequest?.options).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(seenRequest, 'options')).toBe(false);
+    loader.destroy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Module-augmentation test: AssetDefinitions and ExtensionTypeMap are still augmentable
+// ---------------------------------------------------------------------------
+
+// Verify that external packages can augment AssetDefinitions without touching core.
+// This is a compile-time-only test — no runtime assertions needed.
+declare module '#resources/AssetDefinitions' {
+  interface AssetDefinitions {
+    example: {
+      resource: ExampleAsset;
+      config: { source: string; format?: 'example' | 'alt'; strict?: boolean };
+    };
+  }
+}
+
+describe('module augmentation', () => {
+  it('augmented AssetDefinitions type compiles without error', () => {
+    // Type-only validation: AssetLoaderContext is still accessible
+    type _CtxCheck = AssetLoaderContext;
+    expect(true).toBe(true);
+  });
+});

--- a/test/resources/asset-handler-options.test.ts
+++ b/test/resources/asset-handler-options.test.ts
@@ -116,7 +116,7 @@ describe('AssetHandler type contracts', () => {
 });
 
 describe('AssetBinding type contracts', () => {
-  it('binding derives result from constructor via satisfies', () => {
+  it('binding with result-typed satisfies compiles and preserves constructor type', () => {
     const binding = {
       type: ExampleAsset,
       typeNames: ['example' as const],
@@ -134,7 +134,7 @@ describe('AssetBinding type contracts', () => {
           },
         };
       },
-    } satisfies AssetBinding<typeof ExampleAsset, ExampleLoadOptions>;
+    } satisfies AssetBinding<ExampleAsset, ExampleLoadOptions>;
 
     expectTypeOf(binding.type).toEqualTypeOf<typeof ExampleAsset>();
   });
@@ -151,7 +151,24 @@ describe('AssetBinding type contracts', () => {
           },
         };
       },
-    } satisfies AssetBinding<typeof ExampleAsset, ExampleLoadOptions>;
+    } satisfies AssetBinding<ExampleAsset, ExampleLoadOptions>;
+
+    void _binding;
+  });
+
+  it('binding rejects mismatched constructor (type field produces wrong result type)', () => {
+    const _binding = {
+      // @ts-expect-error — OtherAsset constructor produces OtherAsset instances, not ExampleAsset
+      type: OtherAsset,
+
+      create() {
+        return {
+          async load(_request: AssetLoadRequest): Promise<ExampleAsset> {
+            return new ExampleAsset();
+          },
+        };
+      },
+    } satisfies AssetBinding<ExampleAsset>;
 
     void _binding;
   });
@@ -168,7 +185,7 @@ describe('AssetBinding type contracts', () => {
           },
         };
       },
-    } satisfies AssetBinding<typeof ExampleAsset>;
+    } satisfies AssetBinding<ExampleAsset>;
 
     void _binding;
   });
@@ -186,7 +203,7 @@ describe('AssetBinding type contracts', () => {
           },
         };
       },
-    } satisfies AssetBinding<typeof ExampleAsset>;
+    } satisfies AssetBinding<ExampleAsset>;
 
     void _binding;
   });
@@ -205,7 +222,7 @@ describe('declarative bindAsset identity propagation', () => {
 
   function buildExampleBinding(
     onLoad: (opts: ResolvedExampleOptions) => void,
-  ): AssetBinding<typeof ExampleAsset, ExampleLoadOptions> {
+  ): AssetBinding<ExampleAsset, ExampleLoadOptions> {
     return {
       type: ExampleAsset,
       typeNames: ['example'],
@@ -289,7 +306,7 @@ describe('declarative bindAsset identity propagation', () => {
   it('control-only option (trace) does not affect identity', async () => {
     let loadCount = 0;
 
-    const bindingWithTrace: AssetBinding<typeof ExampleAsset, ExampleLoadOptions> = {
+    const bindingWithTrace: AssetBinding<ExampleAsset, ExampleLoadOptions> = {
       type: ExampleAsset,
       typeNames: ['traceExample'],
 
@@ -326,7 +343,7 @@ describe('declarative bindAsset identity propagation', () => {
   it('handler without getIdentityKey preserves source-based identity', async () => {
     let loadCount = 0;
 
-    const noIdentityBinding: AssetBinding<typeof ExampleAsset> = {
+    const noIdentityBinding: AssetBinding<ExampleAsset> = {
       type: ExampleAsset,
       typeNames: ['simpleExample'],
 
@@ -355,7 +372,7 @@ describe('declarative bindAsset identity propagation', () => {
   it('handler lifecycle: destroy() is called on loader.destroy()', async () => {
     let destroyed = false;
 
-    const destroyableBinding: AssetBinding<typeof ExampleAsset> = {
+    const destroyableBinding: AssetBinding<ExampleAsset> = {
       type: ExampleAsset,
       typeNames: ['destroyable'],
 
@@ -380,7 +397,7 @@ describe('declarative bindAsset identity propagation', () => {
   it('handler receives options nested under request.options via declarative path', async () => {
     let seenRequest: AssetLoadRequest<ExampleLoadOptions> | undefined;
 
-    const capturingBinding: AssetBinding<typeof ExampleAsset, ExampleLoadOptions> = {
+    const capturingBinding: AssetBinding<ExampleAsset, ExampleLoadOptions> = {
       type: ExampleAsset,
       typeNames: ['captureExample'],
 
@@ -396,7 +413,9 @@ describe('declarative bindAsset identity propagation', () => {
 
     materializeAssetBindings(loader, [capturingBinding]);
 
-    await loader.load(ExampleAsset, 'thing.dat', { format: 'alt', strict: false } as ExampleLoadOptions).catch(() => undefined);
+    await expect(
+      loader.load(ExampleAsset, 'thing.dat', { format: 'alt', strict: false } as ExampleLoadOptions),
+    ).resolves.toBeInstanceOf(ExampleAsset);
 
     expect(seenRequest?.source).toBe('thing.dat');
     expect(seenRequest?.options).toEqual({ format: 'alt', strict: false });
@@ -406,7 +425,7 @@ describe('declarative bindAsset identity propagation', () => {
   it('handler receives no options key when none are passed (declarative path)', async () => {
     let seenRequest: AssetLoadRequest<ExampleLoadOptions> | undefined;
 
-    const capturingBinding: AssetBinding<typeof ExampleAsset, ExampleLoadOptions> = {
+    const capturingBinding: AssetBinding<ExampleAsset, ExampleLoadOptions> = {
       type: ExampleAsset,
       typeNames: ['captureNoOpts'],
 
@@ -422,7 +441,7 @@ describe('declarative bindAsset identity propagation', () => {
 
     materializeAssetBindings(loader, [capturingBinding]);
 
-    await loader.load(ExampleAsset, 'thing.dat').catch(() => undefined);
+    await expect(loader.load(ExampleAsset, 'thing.dat')).resolves.toBeInstanceOf(ExampleAsset);
 
     expect(seenRequest?.source).toBe('thing.dat');
     expect(seenRequest?.options).toBeUndefined();


### PR DESCRIPTION
## Motivation

The declarative `Extension → AssetBinding → AssetHandler → Loader.bindAsset()` path had two gaps compared to the lower-level `registerAssetType()` path:

1. **Options were untyped.** Handler methods received `options?: Readonly<Record<string, unknown>>`, providing no autocomplete, no excess-property rejection, and no type inference for callers.
2. **Declarative handlers could not declare `getIdentityKey`.** The hook existed in the internal `HandlerEntry` and was forwarded from `registerAssetType()`, but `bindAsset()` never forwarded it from the public `AssetHandler`. Declarative extension handlers were permanently limited to source-only identity, making option-sensitive caching (e.g. format-aware TileMap loading) impossible through the Extension system.

This PR closes both gaps. It is a prerequisite for the typed Tiled adapter (Phase C).

---

## Public type changes

### `AssetLoadRequest<Options = undefined>`

```ts
export interface AssetLoadRequest<Options = undefined> {
  readonly source: string;
  readonly options?: Options;
}
```

- **Before:** `options?: Readonly<Record<string, unknown>>`
- **After:** `options?: Options` — typed, optional, default `undefined`

### `AssetHandler<Result = unknown, Options = undefined>`

```ts
export interface AssetHandler<Result = unknown, Options = undefined> {
  getIdentityKey?(request: AssetLoadRequest<Options>): string;
  load(request: AssetLoadRequest<Options>, context: AssetLoaderContext): Promise<Result>;
  destroy?(): void;
}
```

- Adds `Options` generic with default `undefined`
- Adds optional `getIdentityKey?` hook

### `AssetBinding<Result = unknown, Options = undefined>`

```ts
export interface AssetBinding<Result = unknown, Options = undefined> {
  readonly type: AssetConstructor<Result>;
  readonly typeNames?: readonly string[];
  readonly extensions?: readonly string[];
  create(loader: Loader): AssetHandler<Result, Options>;
}
```

- **Before:** `AssetBinding<Result = unknown>` with untyped options
- **After:** `Result` is the produced instance type (e.g. `TiledMap`); `Options` is the typed options object
- The runtime `type` field must be a constructor that produces `Result`; `create()` must return a handler that also produces `Result` — both enforced by TypeScript

Authors use `satisfies AssetBinding<MyAsset, MyLoadOptions>` on object literals for typed options and result enforcement:

```ts
const myBinding = {
  type: MyAsset,
  typeNames: ['myAsset'],
  create(loader) {
    return {
      getIdentityKey(request) { return request.source; },
      async load(request) { return new MyAsset(); },
    };
  },
} satisfies AssetBinding<MyAsset, MyLoadOptions>;
```

---

## Final generic signatures

```
AssetLoadRequest<Options = undefined>
AssetHandler<Result = unknown, Options = undefined>
AssetBinding<Result = unknown, Options = undefined>
```

---

## Why `Options = undefined`

`undefined` is the correct default for "no options declared":

- `AssetHandler<Texture>` → `request.options: undefined` — cannot read `.foo`, no spurious error on use, callers never need to pass `{}`
- `AssetHandler<TileMap, TiledLoadOptions>` → `request.options: TiledLoadOptions | undefined` — typed but still optional

`unknown` was rejected because it would force every handler to narrow before use and would not reject bogus property access. `never` was not needed since `undefined` creates no overload/assignability problems.

---

## Options remain optional

`loader.load(TileMap, 'world.tmj')` compiles without passing `{}`. Tested via compile-time assertion and runtime test "handler receives no options key when none are passed".

---

## `getIdentityKey` contract

- **Name:** `getIdentityKey` (canonical, unchanged)
- **Purpose:** deterministic identity key for in-flight deduplication and loaded-resource reuse
- **Include:** options that change the produced resource (format, locale, variant, color space, strictness when it affects output)
- **Exclude:** control-only values (callbacks, AbortSignal, logger, priority, timeout when it does not affect the result)
- **Not** `JSON.stringify(request.options)` — property-order instability, control-only inclusion, unbounded key size
- **Scope:** type-local; Loader prepends `id:<typeId>:`
- **Omit** to fall back to source-only identity (existing behavior)

---

## `Loader.bindAsset()` propagation

`bindAsset<Result, Options>()` is now generic and forwards `getIdentityKey` into the internal `HandlerEntry`:

```ts
const boundIdentityKey = handler.getIdentityKey?.bind(handler);
const toRequest = (config: unknown): AssetLoadRequest<Options> => {
  const { source, ...rest } = config as { source: string } & Record<string, unknown>;
  if (Object.keys(rest).length === 0) return { source };
  return { source, options: rest as Options };
};

this._handlerFunctions.set(keys.type, {
  load: (config, ctx) => handler.load(toRequest(config), ctx),
  getIdentityKey: boundIdentityKey
    ? (config) => boundIdentityKey(toRequest(config))
    : undefined,
});
```

`options` is intentionally **omitted** (not set to `undefined`) when the config carries no extra fields — compatible with a future `exactOptionalPropertyTypes` migration.

---

## Localized type-erasure boundary

The single `toRequest()` helper inside `bindAsset()` is the only place where the flat internal config is cast to `AssetLoadRequest<Options>`. The cast is:

- **Confined** to `Loader.bindAsset()` (one private helper)
- **Invisible** to Extension authors — they write a plain object literal + `satisfies`
- **Justified** by the `AssetBinding<Result, Options>` contract that ties the constructor, result type, and options type together
- **Covered** by compile-time and runtime tests

---

## Type tests added (`test/resources/asset-handler-options.test.ts`)

- Handler without options: `request.options` is `undefined`
- Handler with options: `request.options?.format`, `request.options?.strict` typed; same type in `getIdentityKey` and `load` (verified via `Parameters<>`)
- No-options handler: access attempt on `options?.format` is `@ts-expect-error`
- With-options handler: unknown property access is `@ts-expect-error`
- Binding inference: `satisfies AssetBinding<ExampleAsset, ExampleLoadOptions>` compiles
- Invalid result: `OtherAsset` returned from `ExampleAsset` binding is `@ts-expect-error`
- Constructor mismatch: `type: OtherAsset` on `satisfies AssetBinding<ExampleAsset>` is `@ts-expect-error`
- No-options binding: `options` is `undefined`, access attempt is `@ts-expect-error`

---

## Runtime identity tests added (`test/resources/asset-handler-options.test.ts`)

All use the declarative `Extension → AssetBinding → materializeAssetBindings → bindAsset` path:

- `getIdentityKey` forwarded through `bindAsset` into internal `HandlerEntry`
- Same request (same source + options) → single load (dedup)
- Different `strict` values → separate identities, separate loads
- Default normalization: omitted options and explicit defaults produce the same identity key (shared private `resolveExampleOptions` helper used by both `getIdentityKey` and `load`)
- Control-only field (`trace`) excluded from identity → same identity despite different values
- Handler without `getIdentityKey` → source-based identity preserved
- Handler lifecycle: `destroy()` called on `loader.destroy()`
- Options correctly nested under `request.options` in declarative path

---

## Validation results

| Step | Result |
|------|--------|
| `pnpm lint` | 0 errors, 0 warnings |
| `pnpm typecheck` | 0 errors |
| `pnpm typecheck:guides` | 0 errors (39 extracted, 282 total blocks) |
| `pnpm test` | 163 files, 2116 tests passed |
| `pnpm verify:exports` | 10 entry targets checked |
| `pnpm build` | all bundles generated |

---

## No runtime helpers added

No `defineAssetBinding()`, `defineAssetHandler()`, `createAssetBinding()` or similar. Bindings remain plain object literals validated by `satisfies`.

## No central defaults system added

No `defaultOptions`, `mergeOptions`, `resolveDefaults` on `AssetBinding`, `AssetHandler`, or `Loader`. Handlers normalize defaults locally (e.g. `request.options?.strict ?? true` or a private resolver).

## No Tilemap/Tiled implementation included

This PR touches only `src/extensions/Extension.ts`, `src/resources/Loader.ts`, and `test/resources/asset-handler-options.test.ts`. No TileMap runtime, Tiled adapter, `.tmj`, scalable sprites, or package scaffolding.

---

## Go/No-Go gate mapping

| Gate | Test |
|------|------|
| G-ASSET-BOUND-HANDLER-IDENTITY | `getIdentityKey forwarded through bindAsset into the internal HandlerEntry` |
| G-ASSET-TYPED-OPTIONS | `handler with options: request.options is typed and optional` |
| G-ASSET-OPTIONS-OPTIONAL | `handler receives no options key when none are passed` + options-omitted compile test |
| G-ASSET-BINDING-INFERENCE | `binding with result-typed satisfies compiles and preserves constructor type` |
| G-ASSET-IDENTITY-NORMALIZATION | `default normalization: omitted options and explicit defaults produce same identity` |
| G-ASSET-NO-RUNTIME-HELPER | no `defineAssetBinding` etc. added (code review) |
| G-ASSET-NO-CENTRAL-DEFAULTS | no `defaultOptions`/`mergeOptions` added (code review) |
