### PR TITLE
feat(tilemap): add generic runtime foundation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       ref: ${{ github.event.inputs.tag || github.ref_name }}
 
   # ── Stage 1: PREPARE/VERIFY ────────────────────────────────────────────────
-  # Build the three official packages exactly once, then pack/hash/attw/
+  # Build the four official packages exactly once, then pack/hash/attw/
   # external-consumer/full-zip WITHOUT rebuilding them, and upload the resulting
   # artifacts. Any failure here means no publish, no latest, no tag, no release.
   prepare:
@@ -91,17 +91,18 @@ jobs:
           pnpm verify:release-matrix
 
       # Build core + extensions exactly once. `release:prepare --build` invokes
-      # `pnpm build` + the two extension builds, then packs WITHOUT rebuilding.
+      # `pnpm build` + the three extension builds, then packs WITHOUT rebuilding.
       - name: Build site (vendored ESM for the Full ZIP)
         env:
           EXOJS_PACKAGE_PATH: ..
         run: |
           pnpm build
           pnpm --filter @codexo/exojs-particles build
+          pnpm --filter @codexo/exojs-tilemap build
           pnpm --filter @codexo/exojs-tiled build
           pnpm site:build
 
-      # Build-once prepare: pack 3 tarballs (no rebuild) -> hash -> manifest +
+      # Build-once prepare: pack 4 tarballs (no rebuild) -> hash -> manifest +
       # checksums -> attw (bundler) -> external consumers -> Full GitHub ZIP.
       - name: Prepare release (pack, hash, attw, consumers, full-zip)
         run: pnpm release:prepare
@@ -121,8 +122,8 @@ jobs:
   # Consumes ONLY the artifacts built by `prepare`. Never builds or repacks: the
   # release:publish step re-hashes the downloaded tarballs against the manifest
   # (build-once guard) and aborts on any drift. Publishes Core -> Particles ->
-  # Tiled to a version-specific temporary dist-tag, then promotes all three to
-  # `latest` only after every publish succeeds.
+  # Tilemap -> Tiled to a version-specific temporary dist-tag, then promotes all
+  # four to `latest` only after every publish succeeds.
   publish:
     name: Publish to npm (build-once artifacts)
     needs: prepare
@@ -161,8 +162,8 @@ jobs:
           name: release-artifacts
           path: .release
 
-      # Re-hash guard + ordered publish (Core -> Particles -> Tiled) to the
-      # temporary dist-tag, then promote all three to `latest`. Idempotent: a
+      # Re-hash guard + ordered publish (Core -> Particles -> Tilemap -> Tiled) to
+      # the temporary dist-tag, then promote all four to `latest`. Idempotent: a
       # re-run skips versions already on npm; a partial failure promotes nothing.
       - name: Publish coordinated release (build-once, dist-tag -> latest)
         run: pnpm release:publish --execute

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "lint:strict:fast:fix": "eslint --cache --cache-location .cache/eslintcache --fix --max-warnings=0 \"src/**/*.ts\"",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "test": "vitest run --project=exojs --project=exojs-particles --project=exojs-tiled",
+    "test": "vitest run --project=exojs --project=exojs-particles --project=exojs-tilemap --project=exojs-tiled",
     "test:core": "vitest run --project=exojs",
     "test:coverage": "vitest run --coverage --project=exojs",
     "test:watch": "vitest --project=exojs",

--- a/packages/exojs-tilemap/package.json
+++ b/packages/exojs-tilemap/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@codexo/exojs-tilemap",
+  "version": "0.12.0",
+  "description": "Generic, format-independent tilemap runtime for ExoJS.",
+  "type": "module",
+  "sideEffects": [
+    "./dist/esm/register.js"
+  ],
+  "main": "./dist/esm/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/esm/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./register": {
+      "types": "./dist/esm/register.d.ts",
+      "import": "./dist/esm/register.js",
+      "default": "./dist/esm/register.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist/esm/",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsx ../../node_modules/rollup/dist/bin/rollup -c --environment EXOJS_ENV:production",
+    "build:dev": "tsx ../../node_modules/rollup/dist/bin/rollup -c --environment EXOJS_ENV:development",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "test": "vitest run --root ../.. --project=exojs-tilemap"
+  },
+  "peerDependencies": {
+    "@codexo/exojs": "0.12.x"
+  },
+  "devDependencies": {
+    "@codexo/exojs": "workspace:*",
+    "@codexo/exojs-config": "workspace:*"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/exojs-tilemap/rollup.config.ts
+++ b/packages/exojs-tilemap/rollup.config.ts
@@ -1,0 +1,6 @@
+import { createExtensionConfig } from '@codexo/exojs-config/rollup';
+
+export default createExtensionConfig({
+  root: import.meta.dirname,
+  sourceCondition: null,
+});

--- a/packages/exojs-tilemap/src/TileChunk.ts
+++ b/packages/exojs-tilemap/src/TileChunk.ts
@@ -1,4 +1,44 @@
 import type { PackedTile } from './types';
+import { validateInteger } from './types';
+
+/**
+ * Public readonly view of a tile chunk.
+ *
+ * Provides read-only inspection access for iteration, queries, and the
+ * future renderer. The underlying storage is never exposed directly.
+ *
+ * @advanced
+ */
+export interface ReadonlyTileChunk {
+  /** Signed chunk X coordinate. */
+  readonly cx: number;
+  /** Signed chunk Y coordinate. */
+  readonly cy: number;
+  /** Width of this chunk in tiles. */
+  readonly width: number;
+  /** Height of this chunk in tiles. */
+  readonly height: number;
+  /** Whether every cell is empty (all-zero). */
+  readonly empty: boolean;
+  /**
+   * Monotonic revision counter. Increments on every cell mutation
+   * within this chunk. No-ops (writing same value) do NOT increment.
+   */
+  readonly revision: number;
+
+  /**
+   * Read the raw packed tile word at local-in-chunk coordinates.
+   * Returns 0 for empty.
+   * @throws If coordinates are invalid.
+   */
+  getRawAt(lx: number, ly: number): PackedTile;
+
+  /**
+   * Create a defensive copy of the tile data. The caller owns the copy;
+   * mutation of the returned array cannot affect the chunk.
+   */
+  cloneTiles(): Uint32Array;
+}
 
 /**
  * A compact, fixed-size chunk of tile data within a layer.
@@ -7,12 +47,16 @@ import type { PackedTile } from './types';
  * laid out row-major. Each cell is a packed tile word (0 = empty).
  * Chunk coordinates are signed to support future infinite maps.
  *
+ * The backing array is **private** — external code cannot mutate storage
+ * directly. All mutation must flow through {@link TileLayer} public APIs,
+ * which call the package-internal `_setRawAt` method.
+ *
  * The chunk tracks a revision counter that increments on every mutation
  * so the future renderer can detect which chunks need GPU rebuilds.
  *
  * @advanced
  */
-export class TileChunk {
+export class TileChunk implements ReadonlyTileChunk {
   /** Signed chunk X coordinate. */
   public readonly cx: number;
   /** Signed chunk Y coordinate. */
@@ -23,8 +67,8 @@ export class TileChunk {
   /** Height of this chunk in tiles. */
   public readonly height: number;
 
-  /** Packed tile storage (row-major). Do not mutate externally. */
-  public readonly tiles: Uint32Array;
+  /** Packed tile storage (row-major). Private — never exposed directly. */
+  private readonly _tiles: Uint32Array;
 
   /** Whether every cell in this chunk is empty (0). Lazy-computed. */
   private _empty: boolean | null = null;
@@ -33,18 +77,36 @@ export class TileChunk {
   private _revision: number = 0;
 
   /**
-   * @param cx Signed chunk X coordinate.
-   * @param cy Signed chunk Y coordinate.
-   * @param width Chunk width in tiles (positive).
-   * @param height Chunk height in tiles (positive).
+   * @param cx Signed chunk X coordinate (must be finite safe integer).
+   * @param cy Signed chunk Y coordinate (must be finite safe integer).
+   * @param width Chunk width in tiles (positive safe integer).
+   * @param height Chunk height in tiles (positive safe integer).
    * @param source Optional source data to copy (must match length).
    */
   public constructor(cx: number, cy: number, width: number, height: number, source?: Uint32Array) {
+    // Validate chunk coordinates as finite safe integers (negative OK).
+    if (!Number.isFinite(cx) || !Number.isInteger(cx) || !Number.isSafeInteger(cx)) {
+      throw new Error(`TileChunk cx must be a finite safe integer (got ${cx}).`);
+    }
+    if (!Number.isFinite(cy) || !Number.isInteger(cy) || !Number.isSafeInteger(cy)) {
+      throw new Error(`TileChunk cy must be a finite safe integer (got ${cy}).`);
+    }
+
     if (width <= 0 || height <= 0) {
       throw new Error(`TileChunk dimensions must be positive (got ${width}x${height}).`);
     }
-    if (!Number.isSafeInteger(width * height)) {
+    if (!Number.isSafeInteger(width) || !Number.isSafeInteger(height)) {
+      throw new Error(`TileChunk dimensions must be safe integers (got ${width}x${height}).`);
+    }
+
+    const size = width * height;
+    if (!Number.isSafeInteger(size)) {
       throw new Error(`TileChunk size overflow: ${width} * ${height} is not safe.`);
+    }
+
+    // Guard against TypedArray length limits.
+    if (size > 0xFFFFFFFF) {
+      throw new Error(`TileChunk size ${size} exceeds TypedArray maximum length.`);
     }
 
     this.cx = cx;
@@ -53,62 +115,107 @@ export class TileChunk {
     this.height = height;
 
     if (source) {
-      if (source.length !== width * height) {
+      if (source.length !== size) {
         throw new Error(
-          `TileChunk source length ${source.length} != ${width * height}.`,
+          `TileChunk source length ${source.length} != ${size}.`,
         );
       }
-      this.tiles = new Uint32Array(source);
+      // Defensive copy — caller mutation of source array will not affect storage.
+      this._tiles = new Uint32Array(source);
     } else {
-      this.tiles = new Uint32Array(width * height);
+      this._tiles = new Uint32Array(size);
     }
   }
 
   /** Row-major index for cell (lx, ly) within this chunk. */
-  private index(lx: number, ly: number): number {
+  private _index(lx: number, ly: number): number {
     return ly * this.width + lx;
   }
 
-  /** Read a raw packed tile word at local-in-chunk coordinates. */
-  public getRawAt(lx: number, ly: number): PackedTile {
-    return this.tiles[this.index(lx, ly)]!;
+  /**
+   * Validate local-in-chunk coordinates before access.
+   * @throws If lx or ly is not a finite integer or out of [0, dimension).
+   */
+  private _validateLocalCoord(lx: number, ly: number): void {
+    validateInteger(lx, 'lx');
+    validateInteger(ly, 'ly');
+    if (lx < 0 || lx >= this.width) {
+      throw new Error(`lx ${lx} out of chunk bounds [0, ${this.width - 1}].`);
+    }
+    if (ly < 0 || ly >= this.height) {
+      throw new Error(`ly ${ly} out of chunk bounds [0, ${this.height - 1}].`);
+    }
   }
 
-  /** Write a packed tile word at local-in-chunk coordinates. Returns true if the value changed. */
-  public setRawAt(lx: number, ly: number, packed: PackedTile): boolean {
-    const i = this.index(lx, ly);
-    const prev = this.tiles[i]!;
+  // ── Readonly public API (ReadonlyTileChunk) ──────────────────────────
+
+  /** @inheritdoc */
+  public getRawAt(lx: number, ly: number): PackedTile {
+    this._validateLocalCoord(lx, ly);
+    return this._tiles[this._index(lx, ly)]!;
+  }
+
+  /** @inheritdoc */
+  public get empty(): boolean {
+    if (this._empty === null) {
+      this._empty = this._tiles.every(v => v === 0);
+    }
+    return this._empty;
+  }
+
+  /** @inheritdoc */
+  public get revision(): number {
+    return this._revision;
+  }
+
+  /** @inheritdoc */
+  public cloneTiles(): Uint32Array {
+    return new Uint32Array(this._tiles);
+  }
+
+  // ── Internal mutation (package-private, NOT public API) ──────────────
+
+  /**
+   * Validate a packed tile value before storing.
+   * Accepts any finite integer — `Uint32Array` stores via unsigned 32-bit
+   * truncation (`ToUint32`). Negative values produced by JavaScript's
+   * signed bitwise ops (e.g. when the transform bits set bit 31) are valid.
+   * @throws If the value is NaN, Infinity, or non-integer.
+   * @internal
+   */
+  private _validatePacked(packed: PackedTile): void {
+    if (typeof packed !== 'number' || !Number.isFinite(packed) || !Number.isInteger(packed)) {
+      throw new Error(`Packed tile must be a finite integer (got ${packed}).`);
+    }
+  }
+
+  /**
+   * Write a packed tile word at local-in-chunk coordinates.
+   * Returns true if the stored value actually changed.
+   *
+   * Package-internal: only {@link TileLayer} may call this.
+   * @internal
+   */
+  public _setRawAt(lx: number, ly: number, packed: PackedTile): boolean {
+    this._validateLocalCoord(lx, ly);
+    this._validatePacked(packed);
+    const i = this._index(lx, ly);
+    const prev = this._tiles[i]!;
     if (prev === packed) return false;
-    this.tiles[i] = packed;
+    this._tiles[i] = packed;
     this._revision++;
     this._empty = null; // invalidate cache
     return true;
   }
 
-  /** Whether all cells are empty. Cached after first scan. */
-  public get empty(): boolean {
-    if (this._empty === null) {
-      this._empty = this.tiles.every(v => v === 0);
-    }
-    return this._empty;
-  }
-
-  /**
-   * Monotonic revision counter. Increments on every cell mutation.
-   * No-ops (writing same value to same cell) do NOT increment.
-   * @advanced
-   */
-  public get revision(): number {
-    return this._revision;
-  }
-
   /**
    * Mark the chunk as needing a GPU rebuild.
-   * For future renderer integration. Currently sets the empty flag to null
-   * to force re-evaluation.
+   * Invalidates the empty cache and increments revision.
+   *
+   * Package-internal: for future renderer use only.
    * @internal
    */
-  public markDirty(): void {
+  public _markDirty(): void {
     this._empty = null;
     this._revision++;
   }
@@ -116,19 +223,15 @@ export class TileChunk {
   /**
    * Clear every cell in this chunk. Does not re-allocate storage.
    * Increments revision if any cell was non-zero.
+   *
+   * Package-internal: only {@link TileLayer} may call this.
+   * @internal
    */
-  public clear(): void {
-    const hadContent = this.tiles.some(v => v !== 0);
+  public _clear(): void {
+    const hadContent = this._tiles.some(v => v !== 0);
     if (!hadContent) return;
-    this.tiles.fill(0);
+    this._tiles.fill(0);
     this._revision++;
     this._empty = true;
-  }
-
-  /**
-   * Create a defensive copy of the tile data. The caller owns the copy.
-   */
-  public cloneTiles(): Uint32Array {
-    return new Uint32Array(this.tiles);
   }
 }

--- a/packages/exojs-tilemap/src/TileChunk.ts
+++ b/packages/exojs-tilemap/src/TileChunk.ts
@@ -1,0 +1,134 @@
+import type { PackedTile } from './types';
+
+/**
+ * A compact, fixed-size chunk of tile data within a layer.
+ *
+ * Storage is a single {@link Uint32Array} of length `width * height`,
+ * laid out row-major. Each cell is a packed tile word (0 = empty).
+ * Chunk coordinates are signed to support future infinite maps.
+ *
+ * The chunk tracks a revision counter that increments on every mutation
+ * so the future renderer can detect which chunks need GPU rebuilds.
+ *
+ * @advanced
+ */
+export class TileChunk {
+  /** Signed chunk X coordinate. */
+  public readonly cx: number;
+  /** Signed chunk Y coordinate. */
+  public readonly cy: number;
+
+  /** Width of this chunk in tiles. */
+  public readonly width: number;
+  /** Height of this chunk in tiles. */
+  public readonly height: number;
+
+  /** Packed tile storage (row-major). Do not mutate externally. */
+  public readonly tiles: Uint32Array;
+
+  /** Whether every cell in this chunk is empty (0). Lazy-computed. */
+  private _empty: boolean | null = null;
+
+  /** Monotonic revision counter — incremented on every mutation. */
+  private _revision: number = 0;
+
+  /**
+   * @param cx Signed chunk X coordinate.
+   * @param cy Signed chunk Y coordinate.
+   * @param width Chunk width in tiles (positive).
+   * @param height Chunk height in tiles (positive).
+   * @param source Optional source data to copy (must match length).
+   */
+  public constructor(cx: number, cy: number, width: number, height: number, source?: Uint32Array) {
+    if (width <= 0 || height <= 0) {
+      throw new Error(`TileChunk dimensions must be positive (got ${width}x${height}).`);
+    }
+    if (!Number.isSafeInteger(width * height)) {
+      throw new Error(`TileChunk size overflow: ${width} * ${height} is not safe.`);
+    }
+
+    this.cx = cx;
+    this.cy = cy;
+    this.width = width;
+    this.height = height;
+
+    if (source) {
+      if (source.length !== width * height) {
+        throw new Error(
+          `TileChunk source length ${source.length} != ${width * height}.`,
+        );
+      }
+      this.tiles = new Uint32Array(source);
+    } else {
+      this.tiles = new Uint32Array(width * height);
+    }
+  }
+
+  /** Row-major index for cell (lx, ly) within this chunk. */
+  private index(lx: number, ly: number): number {
+    return ly * this.width + lx;
+  }
+
+  /** Read a raw packed tile word at local-in-chunk coordinates. */
+  public getRawAt(lx: number, ly: number): PackedTile {
+    return this.tiles[this.index(lx, ly)]!;
+  }
+
+  /** Write a packed tile word at local-in-chunk coordinates. Returns true if the value changed. */
+  public setRawAt(lx: number, ly: number, packed: PackedTile): boolean {
+    const i = this.index(lx, ly);
+    const prev = this.tiles[i]!;
+    if (prev === packed) return false;
+    this.tiles[i] = packed;
+    this._revision++;
+    this._empty = null; // invalidate cache
+    return true;
+  }
+
+  /** Whether all cells are empty. Cached after first scan. */
+  public get empty(): boolean {
+    if (this._empty === null) {
+      this._empty = this.tiles.every(v => v === 0);
+    }
+    return this._empty;
+  }
+
+  /**
+   * Monotonic revision counter. Increments on every cell mutation.
+   * No-ops (writing same value to same cell) do NOT increment.
+   * @advanced
+   */
+  public get revision(): number {
+    return this._revision;
+  }
+
+  /**
+   * Mark the chunk as needing a GPU rebuild.
+   * For future renderer integration. Currently sets the empty flag to null
+   * to force re-evaluation.
+   * @internal
+   */
+  public markDirty(): void {
+    this._empty = null;
+    this._revision++;
+  }
+
+  /**
+   * Clear every cell in this chunk. Does not re-allocate storage.
+   * Increments revision if any cell was non-zero.
+   */
+  public clear(): void {
+    const hadContent = this.tiles.some(v => v !== 0);
+    if (!hadContent) return;
+    this.tiles.fill(0);
+    this._revision++;
+    this._empty = true;
+  }
+
+  /**
+   * Create a defensive copy of the tile data. The caller owns the copy.
+   */
+  public cloneTiles(): Uint32Array {
+    return new Uint32Array(this.tiles);
+  }
+}

--- a/packages/exojs-tilemap/src/TileChunk.ts
+++ b/packages/exojs-tilemap/src/TileChunk.ts
@@ -176,6 +176,20 @@ export class TileChunk implements ReadonlyTileChunk {
   // ── Internal mutation (package-private, NOT public API) ──────────────
 
   /**
+   * Package-internal access to the underlying tile storage.
+   * Returns the actual mutable `Uint32Array` — DO NOT USE publicly.
+   *
+   * Provided for the future tilemap renderer (same package) so it can
+   * read chunk data efficiently without a full `cloneTiles()` copy per frame.
+   *
+   * External consumers and other packages MUST NOT call this.
+   * @internal
+   */
+  public _getRawStorage(): Uint32Array {
+    return this._tiles;
+  }
+
+  /**
    * Validate a packed tile value before storing.
    * Accepts any finite integer — `Uint32Array` stores via unsigned 32-bit
    * truncation (`ToUint32`). Negative values produced by JavaScript's

--- a/packages/exojs-tilemap/src/TileLayer.ts
+++ b/packages/exojs-tilemap/src/TileLayer.ts
@@ -11,6 +11,7 @@ import {
 import type { ChunkCoord, PackedTile, ResolvedTile } from './types';
 import { tileToChunkCoord, tileToLocalInChunk } from './types';
 import { TileChunk } from './TileChunk';
+import type { ReadonlyTileChunk } from './TileChunk';
 
 /**
  * Options for constructing a {@link TileLayer}.
@@ -56,12 +57,15 @@ const DEFAULT_CHUNK_SIZE = 32;
  * chunk coordinates. For finite maps, only chunks that intersect the layer
  * bounds exist.
  *
- * Mutation is controlled: {@link setTileAt} / {@link clearTileAt} validate
- * coordinates, tileset references, and increment chunk revision counters
- * only when the stored value actually changes.
+ * **Mutation must go through the layer's public APIs only.**
+ * `setTileAt` / `clearTileAt` validate coordinates, tileset references,
+ * and increment revision counters only when the stored value actually
+ * changes. Direct chunk mutation is not supported — the layer owns chunk
+ * storage and exposes only a {@link ReadonlyTileChunk} view.
  *
  * The layer is NOT a SceneNode — that integration lives in the future
  * renderer slice.
+ *
  * @advanced
  */
 export class TileLayer {
@@ -105,10 +109,14 @@ export class TileLayer {
   /** The tilesets available to this layer (shared array reference). */
   public readonly tilesets: readonly TileSet[];
 
-  /** Chunk storage: chunkKey → TileChunk. */
+  /** Chunk storage: chunkKey → mutable TileChunk (internal). */
   private readonly _chunks: Map<string, TileChunk> = new Map();
 
-  /** Monotonic layer revision. Increments on any structural or tile change. */
+  /**
+   * Monotonic layer revision counter.
+   * Increments on every cell mutation that actually changes a stored value.
+   * Does NOT increment on no-op writes or failed mutations.
+   */
   private _revision: number = 0;
 
   /** Whether the layer has been destroyed. */
@@ -187,26 +195,30 @@ export class TileLayer {
 
   // ── Chunk keying ──────────────────────────────────────────────────────
 
-  private chunkKey(cx: number, cy: number): string {
+  private _chunkKey(cx: number, cy: number): string {
     return `${cx},${cy}`;
   }
 
   /**
-   * Get a chunk by signed chunk coordinates, or undefined if it doesn't exist.
+   * Get a readonly view of a chunk by signed chunk coordinates,
+   * or undefined if it does not exist (never been touched).
    * @advanced
    */
-  public getChunk(cx: number, cy: number): TileChunk | undefined {
-    return this._chunks.get(this.chunkKey(cx, cy));
+  public getChunk(cx: number, cy: number): ReadonlyTileChunk | undefined {
+    return this._chunks.get(this._chunkKey(cx, cy));
   }
 
   /**
    * Get or create a chunk at the given coordinates.
    * For finite layers, creation is only allowed within the valid chunk range.
-   * @internal
+   *
+   * @internal Package-private: used by {@link setTileAt}, {@link fillRect},
+   *           and future adapter ingest. External users should not allocate
+   *           chunks — use {@link setTileAt} to populate tiles.
    */
-  public ensureChunk(cx: number, cy: number): TileChunk {
+  public _ensureChunk(cx: number, cy: number): TileChunk {
     this._checkDestroyed();
-    const key = this.chunkKey(cx, cy);
+    const key = this._chunkKey(cx, cy);
     let chunk = this._chunks.get(key);
     if (!chunk) {
       const range = this.chunkRange();
@@ -229,9 +241,10 @@ export class TileLayer {
 
   /**
    * Iterate over all loaded chunks in deterministic (cy, cx) ascending order.
+   * Returns readonly chunk views — callers cannot mutate storage.
    * @advanced
    */
-  public loadedChunks(): IterableIterator<TileChunk> {
+  public loadedChunks(): IterableIterator<ReadonlyTileChunk> {
     const entries = [...this._chunks.values()];
     entries.sort((a, b) => a.cy - b.cy || a.cx - b.cx);
     return entries[Symbol.iterator]();
@@ -248,7 +261,7 @@ export class TileLayer {
     validateInteger(ty, 'ty');
     if (!this.inBounds(tx, ty)) return 0;
     const { cx, cy } = tileToChunkCoord(tx, ty, this.chunkWidth, this.chunkHeight);
-    const chunk = this._chunks.get(this.chunkKey(cx, cy));
+    const chunk = this._chunks.get(this._chunkKey(cx, cy));
     if (!chunk) return 0;
     const { lx, ly } = tileToLocalInChunk(tx, ty, this.chunkWidth, this.chunkHeight);
     return chunk.getRawAt(lx, ly);
@@ -315,9 +328,9 @@ export class TileLayer {
     }
     const packed = this._validateTileRef(tile);
     const { cx, cy } = tileToChunkCoord(tx, ty, this.chunkWidth, this.chunkHeight);
-    const chunk = this.ensureChunk(cx, cy);
+    const chunk = this._ensureChunk(cx, cy);
     const { lx, ly } = tileToLocalInChunk(tx, ty, this.chunkWidth, this.chunkHeight);
-    if (chunk.setRawAt(lx, ly, packed)) {
+    if (chunk._setRawAt(lx, ly, packed)) {
       this._revision++;
     }
   }
@@ -338,10 +351,10 @@ export class TileLayer {
       );
     }
     const { cx, cy } = tileToChunkCoord(tx, ty, this.chunkWidth, this.chunkHeight);
-    const chunk = this._chunks.get(this.chunkKey(cx, cy));
+    const chunk = this._chunks.get(this._chunkKey(cx, cy));
     if (!chunk) return; // no chunk = already empty
     const { lx, ly } = tileToLocalInChunk(tx, ty, this.chunkWidth, this.chunkHeight);
-    if (chunk.setRawAt(lx, ly, 0)) {
+    if (chunk._setRawAt(lx, ly, 0)) {
       this._revision++;
     }
   }
@@ -355,15 +368,16 @@ export class TileLayer {
   public fillRect(
     x: number, y: number, w: number, h: number, tile: ResolvedTile,
   ): void {
+    this._checkDestroyed();
     const packed = this._validateTileRef(tile);
     let changed = false;
     for (let ty = y; ty < y + h; ty++) {
       for (let tx = x; tx < x + w; tx++) {
         if (!this.inBounds(tx, ty)) continue;
         const { cx, cy } = tileToChunkCoord(tx, ty, this.chunkWidth, this.chunkHeight);
-        const chunk = this.ensureChunk(cx, cy);
+        const chunk = this._ensureChunk(cx, cy);
         const { lx, ly } = tileToLocalInChunk(tx, ty, this.chunkWidth, this.chunkHeight);
-        if (chunk.setRawAt(lx, ly, packed)) {
+        if (chunk._setRawAt(lx, ly, packed)) {
           changed = true;
         }
       }
@@ -376,15 +390,16 @@ export class TileLayer {
    * @advanced
    */
   public clearRect(x: number, y: number, w: number, h: number): void {
+    this._checkDestroyed();
     let changed = false;
     for (let ty = y; ty < y + h; ty++) {
       for (let tx = x; tx < x + w; tx++) {
         if (!this.inBounds(tx, ty)) continue;
         const { cx, cy } = tileToChunkCoord(tx, ty, this.chunkWidth, this.chunkHeight);
-        const chunk = this._chunks.get(this.chunkKey(cx, cy));
+        const chunk = this._chunks.get(this._chunkKey(cx, cy));
         if (!chunk) continue;
         const { lx, ly } = tileToLocalInChunk(tx, ty, this.chunkWidth, this.chunkHeight);
-        if (chunk.setRawAt(lx, ly, 0)) {
+        if (chunk._setRawAt(lx, ly, 0)) {
           changed = true;
         }
       }
@@ -409,7 +424,7 @@ export class TileLayer {
 
     for (let cy = startCy; cy <= endCy; cy++) {
       for (let cx = startCx; cx <= endCx; cx++) {
-        const chunk = this._chunks.get(this.chunkKey(cx, cy));
+        const chunk = this._chunks.get(this._chunkKey(cx, cy));
         if (!chunk || chunk.empty) continue;
 
         const chunkStartTx = cx * this.chunkWidth;
@@ -473,8 +488,9 @@ export class TileLayer {
   // ── Revision / lifecycle ──────────────────────────────────────────────
 
   /**
-   * Monotonic layer revision counter. Increments on structural change
-   * and every cell mutation that actually changes a stored value.
+   * Monotonic layer revision counter.
+   * Increments on every cell mutation that changes a stored value.
+   * No-op writes and failed mutations do NOT increment.
    * @advanced
    */
   public get revision(): number {
@@ -495,13 +511,11 @@ export class TileLayer {
   /**
    * Destroy this layer: clear chunk storage and mark destroyed.
    * Does NOT destroy tileset textures or external resources.
+   * Idempotent.
    */
   public destroy(): void {
     if (this._destroyed) return;
     this._destroyed = true;
-    for (const chunk of this._chunks.values()) {
-      // Chunk arrays will be GC'd; no explicit free needed.
-    }
     this._chunks.clear();
   }
 
@@ -513,8 +527,10 @@ export class TileLayer {
   public countNonEmptyTiles(): number {
     let count = 0;
     for (const chunk of this._chunks.values()) {
-      for (let i = 0; i < chunk.tiles.length; i++) {
-        if (chunk.tiles[i] !== 0) count++;
+      for (let ly = 0; ly < chunk.height; ly++) {
+        for (let lx = 0; lx < chunk.width; lx++) {
+          if (chunk.getRawAt(lx, ly) !== 0) count++;
+        }
       }
     }
     return count;

--- a/packages/exojs-tilemap/src/TileLayer.ts
+++ b/packages/exojs-tilemap/src/TileLayer.ts
@@ -1,0 +1,522 @@
+import type { TileSet } from './TileSet';
+import type { TileProperties, TileTransform } from './types';
+import {
+  packTile,
+  TILE_TRANSFORM_IDENTITY,
+  unpackTile,
+  validateInteger,
+  validateNonNegativeInteger,
+  validatePositiveInteger,
+} from './types';
+import type { ChunkCoord, PackedTile, ResolvedTile } from './types';
+import { tileToChunkCoord, tileToLocalInChunk } from './types';
+import { TileChunk } from './TileChunk';
+
+/**
+ * Options for constructing a {@link TileLayer}.
+ * @advanced
+ */
+export interface TileLayerOptions {
+  /** Stable layer ID (unique within the map). */
+  readonly id: number;
+  /** Display name (need not be unique). */
+  readonly name: string;
+  /** Layer width in tiles. */
+  readonly width: number;
+  /** Layer height in tiles. */
+  readonly height: number;
+  /** Chunk width in tiles (default 32). */
+  readonly chunkWidth?: number;
+  /** Chunk height in tiles (default 32). */
+  readonly chunkHeight?: number;
+  /** Tilesets available to this layer (shared with the map). */
+  readonly tilesets: readonly TileSet[];
+  /** Tile width in pixels (for coordinate conversion). */
+  readonly tileWidth: number;
+  /** Tile height in pixels (for coordinate conversion). */
+  readonly tileHeight: number;
+  /** Initial visibility. Default true. */
+  readonly visible?: boolean;
+  /** Opacity 0..1. Default 1. */
+  readonly opacity?: number;
+  /** Layer pixel offset X. Default 0. */
+  readonly offsetX?: number;
+  /** Layer pixel offset Y. Default 0. */
+  readonly offsetY?: number;
+  /** Layer properties (copied and frozen). */
+  readonly properties?: TileProperties;
+}
+
+const DEFAULT_CHUNK_SIZE = 32;
+
+/**
+ * A generic, format-independent tile layer with chunk-first storage.
+ *
+ * Tile data is stored in fixed-size {@link TileChunk}s indexed by signed
+ * chunk coordinates. For finite maps, only chunks that intersect the layer
+ * bounds exist.
+ *
+ * Mutation is controlled: {@link setTileAt} / {@link clearTileAt} validate
+ * coordinates, tileset references, and increment chunk revision counters
+ * only when the stored value actually changes.
+ *
+ * The layer is NOT a SceneNode — that integration lives in the future
+ * renderer slice.
+ * @advanced
+ */
+export class TileLayer {
+  /** Stable unique ID within the map. */
+  public readonly id: number;
+  /** Display name (may not be unique). */
+  public readonly name: string;
+
+  /** Width in tiles. */
+  public readonly width: number;
+  /** Height in tiles. */
+  public readonly height: number;
+
+  /** Chunk width (tiles). */
+  public readonly chunkWidth: number;
+  /** Chunk height (tiles). */
+  public readonly chunkHeight: number;
+
+  /** Tile width in pixels. */
+  public readonly tileWidth: number;
+  /** Tile height in pixels. */
+  public readonly tileHeight: number;
+
+  /** Pixel width. */
+  public get pixelWidth(): number { return this.width * this.tileWidth; }
+  /** Pixel height. */
+  public get pixelHeight(): number { return this.height * this.tileHeight; }
+
+  /** Visibility flag (mutable). */
+  public visible: boolean;
+  /** Opacity 0..1 (mutable). */
+  public opacity: number;
+  /** Horizontal pixel offset (mutable). */
+  public offsetX: number;
+  /** Vertical pixel offset (mutable). */
+  public offsetY: number;
+
+  /** Immutable layer properties. */
+  public readonly properties: TileProperties;
+
+  /** The tilesets available to this layer (shared array reference). */
+  public readonly tilesets: readonly TileSet[];
+
+  /** Chunk storage: chunkKey → TileChunk. */
+  private readonly _chunks: Map<string, TileChunk> = new Map();
+
+  /** Monotonic layer revision. Increments on any structural or tile change. */
+  private _revision: number = 0;
+
+  /** Whether the layer has been destroyed. */
+  private _destroyed: boolean = false;
+
+  /**
+   * @throws When dimensions, chunk size, or other options are invalid.
+   */
+  public constructor(options: TileLayerOptions) {
+    validateNonNegativeInteger(options.id, 'layer.id');
+    if (!options.name || typeof options.name !== 'string') {
+      throw new Error('TileLayer name must be a non-empty string.');
+    }
+    validatePositiveInteger(options.width, 'layer.width');
+    validatePositiveInteger(options.height, 'layer.height');
+    validatePositiveInteger(options.tileWidth, 'layer.tileWidth');
+    validatePositiveInteger(options.tileHeight, 'layer.tileHeight');
+
+    const chunkWidth = options.chunkWidth ?? DEFAULT_CHUNK_SIZE;
+    const chunkHeight = options.chunkHeight ?? DEFAULT_CHUNK_SIZE;
+    validatePositiveInteger(chunkWidth, 'chunkWidth');
+    validatePositiveInteger(chunkHeight, 'chunkHeight');
+
+    if (!Array.isArray(options.tilesets)) {
+      throw new Error('TileLayer tilesets must be an array.');
+    }
+
+    const opacity = options.opacity ?? 1;
+    if (typeof opacity !== 'number' || opacity < 0 || opacity > 1) {
+      throw new Error(`TileLayer opacity must be 0..1 (got ${opacity}).`);
+    }
+
+    const offsetX = options.offsetX ?? 0;
+    const offsetY = options.offsetY ?? 0;
+    if (!Number.isFinite(offsetX) || !Number.isFinite(offsetY)) {
+      throw new Error('TileLayer offset must be finite numbers.');
+    }
+
+    this.id = options.id;
+    this.name = options.name;
+    this.width = options.width;
+    this.height = options.height;
+    this.chunkWidth = chunkWidth;
+    this.chunkHeight = chunkHeight;
+    this.tileWidth = options.tileWidth;
+    this.tileHeight = options.tileHeight;
+    this.tilesets = options.tilesets;
+    this.visible = options.visible ?? true;
+    this.opacity = opacity;
+    this.offsetX = offsetX;
+    this.offsetY = offsetY;
+    this.properties = options.properties
+      ? Object.freeze({ ...options.properties })
+      : Object.freeze({});
+  }
+
+  // ── Bounds helpers ────────────────────────────────────────────────────
+
+  /**
+   * Check whether a tile coordinate lies within the layer bounds.
+   * @advanced
+   */
+  public inBounds(tx: number, ty: number): boolean {
+    return tx >= 0 && tx < this.width && ty >= 0 && ty < this.height;
+  }
+
+  /** Compute the range of chunk coordinates that intersect this layer. */
+  public chunkRange(): { minCx: number; minCy: number; maxCx: number; maxCy: number } {
+    return {
+      minCx: 0,
+      minCy: 0,
+      maxCx: Math.floor((this.width - 1) / this.chunkWidth),
+      maxCy: Math.floor((this.height - 1) / this.chunkHeight),
+    };
+  }
+
+  // ── Chunk keying ──────────────────────────────────────────────────────
+
+  private chunkKey(cx: number, cy: number): string {
+    return `${cx},${cy}`;
+  }
+
+  /**
+   * Get a chunk by signed chunk coordinates, or undefined if it doesn't exist.
+   * @advanced
+   */
+  public getChunk(cx: number, cy: number): TileChunk | undefined {
+    return this._chunks.get(this.chunkKey(cx, cy));
+  }
+
+  /**
+   * Get or create a chunk at the given coordinates.
+   * For finite layers, creation is only allowed within the valid chunk range.
+   * @internal
+   */
+  public ensureChunk(cx: number, cy: number): TileChunk {
+    this._checkDestroyed();
+    const key = this.chunkKey(cx, cy);
+    let chunk = this._chunks.get(key);
+    if (!chunk) {
+      const range = this.chunkRange();
+      if (cx < range.minCx || cx > range.maxCx || cy < range.minCy || cy > range.maxCy) {
+        throw new Error(
+          `Chunk (${cx}, ${cy}) outside layer chunk range ` +
+          `[${range.minCx}..${range.maxCx}, ${range.minCy}..${range.maxCy}].`,
+        );
+      }
+      // Compute the actual tile dimensions for this chunk (edge chunks may be smaller).
+      const startTx = cx * this.chunkWidth;
+      const startTy = cy * this.chunkHeight;
+      const cw = Math.min(this.chunkWidth, this.width - startTx);
+      const ch = Math.min(this.chunkHeight, this.height - startTy);
+      chunk = new TileChunk(cx, cy, cw, ch);
+      this._chunks.set(key, chunk);
+    }
+    return chunk;
+  }
+
+  /**
+   * Iterate over all loaded chunks in deterministic (cy, cx) ascending order.
+   * @advanced
+   */
+  public loadedChunks(): IterableIterator<TileChunk> {
+    const entries = [...this._chunks.values()];
+    entries.sort((a, b) => a.cy - b.cy || a.cx - b.cx);
+    return entries[Symbol.iterator]();
+  }
+
+  // ── Tile queries ──────────────────────────────────────────────────────
+
+  /**
+   * Get the raw packed tile word at (tx, ty). Returns 0 for empty or out-of-bounds.
+   * @advanced
+   */
+  public getRawTileAt(tx: number, ty: number): PackedTile {
+    validateInteger(tx, 'tx');
+    validateInteger(ty, 'ty');
+    if (!this.inBounds(tx, ty)) return 0;
+    const { cx, cy } = tileToChunkCoord(tx, ty, this.chunkWidth, this.chunkHeight);
+    const chunk = this._chunks.get(this.chunkKey(cx, cy));
+    if (!chunk) return 0;
+    const { lx, ly } = tileToLocalInChunk(tx, ty, this.chunkWidth, this.chunkHeight);
+    return chunk.getRawAt(lx, ly);
+  }
+
+  /**
+   * Query a resolved tile at (tx, ty). Returns null for empty or out-of-bounds.
+   * @advanced
+   */
+  public getTileAt(tx: number, ty: number): ResolvedTile | null {
+    const packed = this.getRawTileAt(tx, ty);
+    if (packed === 0) return null;
+    const decoded = unpackTile(packed);
+    if (!decoded) return null;
+    if (decoded.tilesetIndex >= this.tilesets.length) return null;
+    const tileset = this.tilesets[decoded.tilesetIndex]!;
+    if (decoded.localTileId >= tileset.tileCount) return null;
+    return {
+      tileset,
+      localTileId: decoded.localTileId,
+      transform: decoded.transform,
+    };
+  }
+
+  // ── Mutation ──────────────────────────────────────────────────────────
+
+  /**
+   * Validate a tile reference against the layer's tilesets.
+   * Returns the packed form or throws.
+   */
+  private _validateTileRef(tile: ResolvedTile): PackedTile {
+    if (!tile || !tile.tileset) {
+      throw new Error('setTileAt requires a valid ResolvedTile.');
+    }
+    const tilesetIndex = this.tilesets.indexOf(tile.tileset);
+    if (tilesetIndex === -1) {
+      throw new Error(
+        `Tileset "${tile.tileset.name}" is not available to layer "${this.name}".`,
+      );
+    }
+    if (tile.localTileId < 0 || tile.localTileId >= tile.tileset.tileCount) {
+      throw new Error(
+        `localTileId ${tile.localTileId} out of range for tileset "${tile.tileset.name}" ` +
+        `(max ${tile.tileset.tileCount - 1}).`,
+      );
+    }
+    return packTile(tilesetIndex, tile.localTileId, tile.transform);
+  }
+
+  /**
+   * Set a tile at the given tile coordinates.
+   * No-op if the effective value is unchanged.
+   * @throws If coordinates are out of bounds or the tile reference is invalid.
+   * @advanced
+   */
+  public setTileAt(tx: number, ty: number, tile: ResolvedTile): void {
+    this._checkDestroyed();
+    validateInteger(tx, 'tx');
+    validateInteger(ty, 'ty');
+    if (!this.inBounds(tx, ty)) {
+      throw new Error(
+        `setTileAt (${tx}, ${ty}) out of bounds [0..${this.width - 1}, 0..${this.height - 1}].`,
+      );
+    }
+    const packed = this._validateTileRef(tile);
+    const { cx, cy } = tileToChunkCoord(tx, ty, this.chunkWidth, this.chunkHeight);
+    const chunk = this.ensureChunk(cx, cy);
+    const { lx, ly } = tileToLocalInChunk(tx, ty, this.chunkWidth, this.chunkHeight);
+    if (chunk.setRawAt(lx, ly, packed)) {
+      this._revision++;
+    }
+  }
+
+  /**
+   * Clear (erase) the tile at the given coordinates.
+   * No-op if the cell is already empty.
+   * @throws If coordinates are out of bounds.
+   * @advanced
+   */
+  public clearTileAt(tx: number, ty: number): void {
+    this._checkDestroyed();
+    validateInteger(tx, 'tx');
+    validateInteger(ty, 'ty');
+    if (!this.inBounds(tx, ty)) {
+      throw new Error(
+        `clearTileAt (${tx}, ${ty}) out of bounds [0..${this.width - 1}, 0..${this.height - 1}].`,
+      );
+    }
+    const { cx, cy } = tileToChunkCoord(tx, ty, this.chunkWidth, this.chunkHeight);
+    const chunk = this._chunks.get(this.chunkKey(cx, cy));
+    if (!chunk) return; // no chunk = already empty
+    const { lx, ly } = tileToLocalInChunk(tx, ty, this.chunkWidth, this.chunkHeight);
+    if (chunk.setRawAt(lx, ly, 0)) {
+      this._revision++;
+    }
+  }
+
+  // ── Bulk fill ─────────────────────────────────────────────────────────
+
+  /**
+   * Fill a rectangular region with a tile.
+   * @advanced
+   */
+  public fillRect(
+    x: number, y: number, w: number, h: number, tile: ResolvedTile,
+  ): void {
+    const packed = this._validateTileRef(tile);
+    let changed = false;
+    for (let ty = y; ty < y + h; ty++) {
+      for (let tx = x; tx < x + w; tx++) {
+        if (!this.inBounds(tx, ty)) continue;
+        const { cx, cy } = tileToChunkCoord(tx, ty, this.chunkWidth, this.chunkHeight);
+        const chunk = this.ensureChunk(cx, cy);
+        const { lx, ly } = tileToLocalInChunk(tx, ty, this.chunkWidth, this.chunkHeight);
+        if (chunk.setRawAt(lx, ly, packed)) {
+          changed = true;
+        }
+      }
+    }
+    if (changed) this._revision++;
+  }
+
+  /**
+   * Clear a rectangular region.
+   * @advanced
+   */
+  public clearRect(x: number, y: number, w: number, h: number): void {
+    let changed = false;
+    for (let ty = y; ty < y + h; ty++) {
+      for (let tx = x; tx < x + w; tx++) {
+        if (!this.inBounds(tx, ty)) continue;
+        const { cx, cy } = tileToChunkCoord(tx, ty, this.chunkWidth, this.chunkHeight);
+        const chunk = this._chunks.get(this.chunkKey(cx, cy));
+        if (!chunk) continue;
+        const { lx, ly } = tileToLocalInChunk(tx, ty, this.chunkWidth, this.chunkHeight);
+        if (chunk.setRawAt(lx, ly, 0)) {
+          changed = true;
+        }
+      }
+    }
+    if (changed) this._revision++;
+  }
+
+  // ── Iteration ─────────────────────────────────────────────────────────
+
+  /**
+   * Iterate non-empty tiles within a rectangular region in row-major order.
+   * Yields (tx, ty, resolvedTile) tuples. Skips empty cells.
+   * @advanced
+   */
+  public *tilesInRect(
+    x: number, y: number, w: number, h: number,
+  ): Generator<{ tx: number; ty: number; tile: ResolvedTile }> {
+    const startCx = Math.floor(x / this.chunkWidth);
+    const endCx = Math.floor((x + w - 1) / this.chunkWidth);
+    const startCy = Math.floor(y / this.chunkHeight);
+    const endCy = Math.floor((y + h - 1) / this.chunkHeight);
+
+    for (let cy = startCy; cy <= endCy; cy++) {
+      for (let cx = startCx; cx <= endCx; cx++) {
+        const chunk = this._chunks.get(this.chunkKey(cx, cy));
+        if (!chunk || chunk.empty) continue;
+
+        const chunkStartTx = cx * this.chunkWidth;
+        const chunkStartTy = cy * this.chunkHeight;
+        const minLx = Math.max(0, x - chunkStartTx);
+        const maxLx = Math.min(chunk.width - 1, (x + w - 1) - chunkStartTx);
+        const minLy = Math.max(0, y - chunkStartTy);
+        const maxLy = Math.min(chunk.height - 1, (y + h - 1) - chunkStartTy);
+
+        for (let ly = minLy; ly <= maxLy; ly++) {
+          for (let lx = minLx; lx <= maxLx; lx++) {
+            const packed = chunk.getRawAt(lx, ly);
+            if (packed === 0) continue;
+            const decoded = unpackTile(packed);
+            if (!decoded) continue;
+            if (decoded.tilesetIndex >= this.tilesets.length) continue;
+            const tileset = this.tilesets[decoded.tilesetIndex]!;
+            if (decoded.localTileId >= tileset.tileCount) continue;
+            yield {
+              tx: chunkStartTx + lx,
+              ty: chunkStartTy + ly,
+              tile: {
+                tileset,
+                localTileId: decoded.localTileId,
+                transform: decoded.transform,
+              },
+            };
+          }
+        }
+      }
+    }
+  }
+
+  // ── Coordinate conversion ─────────────────────────────────────────────
+
+  /**
+   * Convert a tile coordinate to the pixel position of its top-left corner
+   * in the layer's local space.
+   * @advanced
+   */
+  public tileToPixel(tx: number, ty: number): { x: number; y: number } {
+    return {
+      x: tx * this.tileWidth + this.offsetX,
+      y: ty * this.tileHeight + this.offsetY,
+    };
+  }
+
+  /**
+   * Convert a local pixel position to the tile coordinate that contains it.
+   * Uses `floor`, so a point exactly on a tile boundary maps to the tile.
+   * May return coordinates outside layer bounds.
+   * @advanced
+   */
+  public pixelToTile(px: number, py: number): { tx: number; ty: number } {
+    return {
+      tx: Math.floor((px - this.offsetX) / this.tileWidth),
+      ty: Math.floor((py - this.offsetY) / this.tileHeight),
+    };
+  }
+
+  // ── Revision / lifecycle ──────────────────────────────────────────────
+
+  /**
+   * Monotonic layer revision counter. Increments on structural change
+   * and every cell mutation that actually changes a stored value.
+   * @advanced
+   */
+  public get revision(): number {
+    return this._revision;
+  }
+
+  /** Whether the layer has been destroyed. */
+  public get destroyed(): boolean {
+    return this._destroyed;
+  }
+
+  private _checkDestroyed(): void {
+    if (this._destroyed) {
+      throw new Error(`TileLayer "${this.name}" has been destroyed.`);
+    }
+  }
+
+  /**
+   * Destroy this layer: clear chunk storage and mark destroyed.
+   * Does NOT destroy tileset textures or external resources.
+   */
+  public destroy(): void {
+    if (this._destroyed) return;
+    this._destroyed = true;
+    for (const chunk of this._chunks.values()) {
+      // Chunk arrays will be GC'd; no explicit free needed.
+    }
+    this._chunks.clear();
+  }
+
+  /**
+   * Total number of non-empty tiles across all chunks.
+   * Walk is cheap for dense layers; sparse layers benefit from empty-chunk fast path.
+   * @advanced
+   */
+  public countNonEmptyTiles(): number {
+    let count = 0;
+    for (const chunk of this._chunks.values()) {
+      for (let i = 0; i < chunk.tiles.length; i++) {
+        if (chunk.tiles[i] !== 0) count++;
+      }
+    }
+    return count;
+  }
+}

--- a/packages/exojs-tilemap/src/TileMap.ts
+++ b/packages/exojs-tilemap/src/TileMap.ts
@@ -266,8 +266,9 @@ export class TileMap {
   // ── Revision / lifecycle ──────────────────────────────────────────────
 
   /**
-   * Monotonic map revision counter. Increments on structural changes
-   * (add/remove layer, add tileset) and on any cell mutation in any layer.
+   * Monotonic map revision counter. Increments on structural changes only
+   * (add/remove layer, add tileset). Cell mutations are tracked per-chunk
+   * and per-layer; the renderer reads chunk-level revisions directly.
    * @advanced
    */
   public get revision(): number {

--- a/packages/exojs-tilemap/src/TileMap.ts
+++ b/packages/exojs-tilemap/src/TileMap.ts
@@ -1,0 +1,304 @@
+import { TileLayer } from './TileLayer';
+import type { TileLayerOptions } from './TileLayer';
+import { TileSet } from './TileSet';
+import type { TileProperties, ResolvedTile } from './types';
+import { validatePositiveInteger } from './types';
+
+/**
+ * Options for constructing a {@link TileMap}.
+ * @advanced
+ */
+export interface TileMapOptions {
+  /** Map name (for debugging). */
+  readonly name?: string;
+  /** Map width in tiles. */
+  readonly width: number;
+  /** Map height in tiles. */
+  readonly height: number;
+  /** Width of each tile in pixels. */
+  readonly tileWidth: number;
+  /** Height of each tile in pixels. */
+  readonly tileHeight: number;
+  /** Tilesets available to this map. */
+  readonly tilesets?: readonly TileSet[];
+  /** Layers (constructed externally and owned by the map after construction). */
+  readonly layers?: readonly TileLayer[];
+  /** Chunk width for layers (default 32). */
+  readonly chunkWidth?: number;
+  /** Chunk height for layers (default 32). */
+  readonly chunkHeight?: number;
+  /** Map-level properties (copied and frozen). */
+  readonly properties?: TileProperties;
+}
+
+/**
+ * A generic, format-independent tile map.
+ *
+ * Owns a finite grid of {@link TileLayer}s and a shared set of {@link TileSet}s.
+ * Tile data is stored in compact chunked arrays — no per-tile heap objects.
+ *
+ * The map does NOT own tileset textures (those are Loader-owned) and does
+ * NOT own SceneNode children (the future TileMapNode will own those).
+ *
+ * Multiple tilesets are supported: each cell stores a packed tileset index
+ * and local tile ID, so different tilesets may have different tile dimensions.
+ *
+ * @advanced
+ */
+export class TileMap {
+  /** Map name (debug). */
+  public readonly name: string;
+
+  /** Map width in tiles. */
+  public readonly width: number;
+  /** Map height in tiles. */
+  public readonly height: number;
+
+  /** Tile width in pixels. */
+  public readonly tileWidth: number;
+  /** Tile height in pixels. */
+  public readonly tileHeight: number;
+
+  /** Pixel width. */
+  public get pixelWidth(): number { return this.width * this.tileWidth; }
+  /** Pixel height. */
+  public get pixelHeight(): number { return this.height * this.tileHeight; }
+
+  /** Default chunk width for layers. */
+  public readonly chunkWidth: number;
+  /** Default chunk height for layers. */
+  public readonly chunkHeight: number;
+
+  /** Map-level properties (immutable). */
+  public readonly properties: TileProperties;
+
+  private readonly _tilesets: TileSet[];
+  private readonly _layers: TileLayer[] = [];
+  private readonly _layerById: Map<number, TileLayer> = new Map();
+
+  private _revision: number = 0;
+  private _destroyed: boolean = false;
+
+  /**
+   * @throws When dimensions or other options are invalid.
+   */
+  public constructor(options: TileMapOptions) {
+    validatePositiveInteger(options.width, 'map.width');
+    validatePositiveInteger(options.height, 'map.height');
+    validatePositiveInteger(options.tileWidth, 'map.tileWidth');
+    validatePositiveInteger(options.tileHeight, 'map.tileHeight');
+
+    const chunkWidth = options.chunkWidth ?? 32;
+    const chunkHeight = options.chunkHeight ?? 32;
+    validatePositiveInteger(chunkWidth, 'chunkWidth');
+    validatePositiveInteger(chunkHeight, 'chunkHeight');
+
+    this.name = options.name ?? 'TileMap';
+    this.width = options.width;
+    this.height = options.height;
+    this.tileWidth = options.tileWidth;
+    this.tileHeight = options.tileHeight;
+    this.chunkWidth = chunkWidth;
+    this.chunkHeight = chunkHeight;
+
+    this._tilesets = options.tilesets ? [...options.tilesets] : [];
+    this.properties = options.properties
+      ? Object.freeze({ ...options.properties })
+      : Object.freeze({});
+
+    if (options.layers) {
+      for (const layer of options.layers) {
+        this._addLayer(layer);
+      }
+    }
+  }
+
+  // ── Tilesets ──────────────────────────────────────────────────────────
+
+  /** Immutable list of tilesets available to this map. */
+  public get tilesets(): readonly TileSet[] {
+    return this._tilesets;
+  }
+
+  /**
+   * Add a tileset. Tilesets must have unique names.
+   * @throws If a tileset with the same name already exists, or the map is destroyed.
+   */
+  public addTileset(tileset: TileSet): void {
+    this._checkDestroyed();
+    if (this._tilesets.some(ts => ts.name === tileset.name)) {
+      throw new Error(`Tileset "${tileset.name}" already exists in map "${this.name}".`);
+    }
+    this._tilesets.push(tileset);
+    this._revision++;
+  }
+
+  /**
+   * Get a tileset by name, or undefined.
+   */
+  public getTileset(name: string): TileSet | undefined {
+    return this._tilesets.find(ts => ts.name === name);
+  }
+
+  // ── Layers ────────────────────────────────────────────────────────────
+
+  /** Immutable snapshot of layers (ordered). */
+  public get layers(): readonly TileLayer[] {
+    return this._layers;
+  }
+
+  private _addLayer(layer: TileLayer): void {
+    if (this._layerById.has(layer.id)) {
+      throw new Error(
+        `Layer ID ${layer.id} already exists in map "${this.name}".`,
+      );
+    }
+    this._layerById.set(layer.id, layer);
+    this._layers.push(layer);
+  }
+
+  /**
+   * Add a layer after construction.
+   * @throws If a layer with the same ID already exists.
+   */
+  public addLayer(layer: TileLayer): void {
+    this._checkDestroyed();
+    this._addLayer(layer);
+    this._revision++;
+  }
+
+  /**
+   * Get a layer by ID.
+   */
+  public getLayerById(id: number): TileLayer | undefined {
+    return this._layerById.get(id);
+  }
+
+  /**
+   * Get a layer by name. Returns the first match in insertion order.
+   */
+  public getLayerByName(name: string): TileLayer | undefined {
+    return this._layers.find(l => l.name === name);
+  }
+
+  /**
+   * Get a tile layer by name. Convenience alias for {@link getLayerByName}.
+   */
+  public getTileLayer(name: string): TileLayer | undefined {
+    return this.getLayerByName(name);
+  }
+
+  /**
+   * Remove a layer by ID. The layer is destroyed.
+   * @returns true if the layer was found and removed.
+   */
+  public removeLayer(id: number): boolean {
+    this._checkDestroyed();
+    const layer = this._layerById.get(id);
+    if (!layer) return false;
+    this._layers.splice(this._layers.indexOf(layer), 1);
+    this._layerById.delete(id);
+    layer.destroy();
+    this._revision++;
+    return true;
+  }
+
+  // ── Queries ───────────────────────────────────────────────────────────
+
+  /**
+   * Get a resolved tile from a given layer at tile coordinates.
+   * Convenience for `map.getLayerById(id)?.getTileAt(tx, ty)`.
+   * Returns null for an empty cell, out-of-bounds, or missing layer.
+   */
+  public getTileAt(layerId: number, tx: number, ty: number): ResolvedTile | null {
+    const layer = this._layerById.get(layerId);
+    if (!layer) return null;
+    return layer.getTileAt(tx, ty);
+  }
+
+  /**
+   * Set a tile on a given layer at tile coordinates.
+   * Convenience for `map.getLayerById(id)?.setTileAt(tx, ty, tile)`.
+   * @throws If the layer does not exist, coordinates are out of bounds,
+   *         or the tile reference is invalid.
+   */
+  public setTileAt(layerId: number, tx: number, ty: number, tile: ResolvedTile): void {
+    const layer = this._layerById.get(layerId);
+    if (!layer) throw new Error(`Layer ${layerId} not found in map "${this.name}".`);
+    layer.setTileAt(tx, ty, tile);
+  }
+
+  /**
+   * Clear a tile on a given layer at tile coordinates.
+   * Convenience for `map.getLayerById(id)?.clearTileAt(tx, ty)`.
+   * @throws If the layer does not exist or coordinates are out of bounds.
+   */
+  public clearTileAt(layerId: number, tx: number, ty: number): void {
+    const layer = this._layerById.get(layerId);
+    if (!layer) throw new Error(`Layer ${layerId} not found in map "${this.name}".`);
+    layer.clearTileAt(tx, ty);
+  }
+
+  // ── Coordinate conversion (base layer) ────────────────────────────────
+
+  /**
+   * Convert a tile coordinate to the pixel position of its top-left corner
+   * in map-local space (ignoring layer offsets).
+   */
+  public tileToPixel(tx: number, ty: number): { x: number; y: number } {
+    return {
+      x: tx * this.tileWidth,
+      y: ty * this.tileHeight,
+    };
+  }
+
+  /**
+   * Convert a pixel position in map-local space to the tile coordinate
+   * that contains it. Uses `floor`. May return coordinates outside map bounds.
+   */
+  public pixelToTile(px: number, py: number): { tx: number; ty: number } {
+    return {
+      tx: Math.floor(px / this.tileWidth),
+      ty: Math.floor(py / this.tileHeight),
+    };
+  }
+
+  // ── Revision / lifecycle ──────────────────────────────────────────────
+
+  /**
+   * Monotonic map revision counter. Increments on structural changes
+   * (add/remove layer, add tileset) and on any cell mutation in any layer.
+   * @advanced
+   */
+  public get revision(): number {
+    return this._revision;
+  }
+
+  /** Whether the map has been destroyed. */
+  public get destroyed(): boolean {
+    return this._destroyed;
+  }
+
+  private _checkDestroyed(): void {
+    if (this._destroyed) {
+      throw new Error(`TileMap "${this.name}" has been destroyed.`);
+    }
+  }
+
+  /**
+   * Destroy the map and all owned layers and chunk storage.
+   *
+   * Is idempotent. Does NOT destroy tileset textures (Loader-owned) or
+   * any SceneNodes (those do not exist yet in this slice).
+   */
+  public destroy(): void {
+    if (this._destroyed) return;
+    this._destroyed = true;
+    for (const layer of this._layers) {
+      layer.destroy();
+    }
+    this._layers.length = 0;
+    this._layerById.clear();
+    this._tilesets.length = 0;
+  }
+}

--- a/packages/exojs-tilemap/src/TileSet.ts
+++ b/packages/exojs-tilemap/src/TileSet.ts
@@ -1,0 +1,215 @@
+import type { TextureRegion } from '@codexo/exojs';
+
+import type { TileDefinition, TileProperties } from './types';
+import { validateNonNegativeInteger, validatePositiveInteger } from './types';
+
+/**
+ * Options for constructing a {@link TileSet}.
+ * @advanced
+ */
+export interface TileSetOptions {
+  /** Stable runtime name (unique within a {@link TileMap}). */
+  readonly name: string;
+  /** Texture atlas for this tileset. Textures are Loader-owned. */
+  readonly texture: TextureRegion;
+  /** Width of each tile in pixels. */
+  readonly tileWidth: number;
+  /** Height of each tile in pixels. */
+  readonly tileHeight: number;
+  /** Total number of tiles in this tileset. */
+  readonly tileCount: number;
+  /** Number of tile columns in the atlas grid. Computed from texture width / tileWidth if omitted. */
+  readonly columns?: number;
+  /** Pixel spacing between tiles in the atlas. Defaults to 0. */
+  readonly spacing?: number;
+  /** Pixel margin around the atlas. Defaults to 0. */
+  readonly margin?: number;
+}
+
+/**
+ * A resolved tileset: a uniform grid of tiles within a texture atlas.
+ *
+ * Does **not** own its texture — the Loader or application code retains
+ * texture ownership. Tileset dimensions are validated at construction and
+ * frozen thereafter.
+ *
+ * Multiple tilesets are supported per {@link TileMap}; each carries its own
+ * tile dimensions, spacing, and optional per-tile metadata.
+ * @advanced
+ */
+export class TileSet {
+  /** Stable runtime name. */
+  public readonly name: string;
+
+  /** Atlas texture region — Loader-owned, never destroyed by the tileset. */
+  public readonly texture: TextureRegion;
+
+  /** Tile width in pixels. */
+  public readonly tileWidth: number;
+  /** Tile height in pixels. */
+  public readonly tileHeight: number;
+
+  /** Total number of tiles in the tileset. */
+  public readonly tileCount: number;
+
+  /** Number of columns in the atlas grid. */
+  public readonly columns: number;
+  /** Number of rows implied by tileCount and columns. */
+  public readonly rows: number;
+
+  /** Pixel spacing between tiles in the atlas. */
+  public readonly spacing: number;
+  /** Pixel margin around the atlas. */
+  public readonly margin: number;
+
+  private readonly _definitions: ReadonlyMap<number, TileDefinition>;
+
+  /**
+   * @throws When dimensions, counts, or spacing values are invalid.
+   */
+  public constructor(options: TileSetOptions) {
+    if (!options.name || typeof options.name !== 'string') {
+      throw new Error('TileSet name must be a non-empty string.');
+    }
+
+    if (!options.texture) {
+      throw new Error('TileSet requires a valid TextureRegion.');
+    }
+
+    validatePositiveInteger(options.tileWidth, 'tileWidth');
+    validatePositiveInteger(options.tileHeight, 'tileHeight');
+    validatePositiveInteger(options.tileCount, 'tileCount');
+
+    const spacing = options.spacing ?? 0;
+    const margin = options.margin ?? 0;
+    validateNonNegativeInteger(spacing, 'spacing');
+    validateNonNegativeInteger(margin, 'margin');
+
+    const atlasWidth = options.texture.width - margin * 2;
+    const atlasHeight = options.texture.height - margin * 2;
+
+    const columns = options.columns ?? Math.floor(atlasWidth / options.tileWidth);
+
+    validatePositiveInteger(columns, 'columns');
+    if (columns <= 0) {
+      throw new Error(`TileSet columns must be positive (got ${columns}).`);
+    }
+
+    if (options.tileWidth * columns + spacing * (columns - 1) > atlasWidth) {
+      throw new Error(
+        `TileSet grid width exceeds atlas: ${options.tileWidth}*${columns}` +
+        ` + ${spacing}*${columns - 1} > ${atlasWidth}.`,
+      );
+    }
+
+    const rows = Math.ceil(options.tileCount / columns);
+    if (rows > 0 && options.tileHeight * rows + spacing * (rows - 1) > atlasHeight) {
+      throw new Error(
+        `TileSet grid height exceeds atlas: ${options.tileHeight}*${rows}` +
+        ` + ${spacing}*${rows - 1} > ${atlasHeight}.`,
+      );
+    }
+
+    this.name = options.name;
+    this.texture = options.texture;
+    this.tileWidth = options.tileWidth;
+    this.tileHeight = options.tileHeight;
+    this.tileCount = options.tileCount;
+    this.columns = columns;
+    this.rows = rows;
+    this.spacing = spacing;
+    this.margin = margin;
+
+    this._definitions = new Map();
+
+    if (__DEV__) {
+      Object.freeze(this);
+    }
+  }
+
+  /**
+   * Set per-tile metadata for a local tile ID.
+   * Copies input to prevent caller-owned mutation leaking into the tileset.
+   * @internal
+   */
+  public _setDefinition(localTileId: number, definition: Partial<TileDefinition>): void {
+    if (localTileId < 0 || localTileId >= this.tileCount) {
+      throw new Error(
+        `Tile definition localTileId ${localTileId} out of range [0, ${this.tileCount - 1}].`,
+      );
+    }
+    const props = definition.properties
+      ? Object.freeze({ ...definition.properties })
+      : undefined;
+    (this._definitions as Map<number, TileDefinition>).set(localTileId, {
+      localTileId,
+      properties: props,
+    });
+  }
+
+  /**
+   * Build definitions from an array, replacing the internal definitions map.
+   * Each entry's properties are copied and frozen.
+   * @internal
+   */
+  public _setDefinitions(definitions: readonly TileDefinition[]): void {
+    const map = (this._definitions as Map<number, TileDefinition>);
+    map.clear();
+    for (const def of definitions) {
+      const props = def.properties
+        ? Object.freeze({ ...def.properties })
+        : undefined;
+      map.set(def.localTileId, { localTileId: def.localTileId, properties: props });
+    }
+  }
+
+  /**
+   * Retrieve per-tile metadata, or undefined if none defined.
+   * @advanced
+   */
+  public getTileDefinition(localTileId: number): TileDefinition | undefined {
+    return this._definitions.get(localTileId);
+  }
+
+  /**
+   * Compute the pixel-space source rectangle for a local tile ID
+   * within the atlas, accounting for columns, spacing, and margin.
+   * @advanced
+   */
+  public getTileRect(localTileId: number): { x: number; y: number; width: number; height: number } {
+    if (localTileId < 0 || localTileId >= this.tileCount) {
+      throw new Error(
+        `getTileRect: localTileId ${localTileId} out of range [0, ${this.tileCount - 1}].`,
+      );
+    }
+    const col = localTileId % this.columns;
+    const row = Math.floor(localTileId / this.columns);
+    return {
+      x: this.margin + col * (this.tileWidth + this.spacing),
+      y: this.margin + row * (this.tileHeight + this.spacing),
+      width: this.tileWidth,
+      height: this.tileHeight,
+    };
+  }
+
+  /**
+   * Iterate over all defined tiles (sparse).
+   * @advanced
+   */
+  public definedTiles(): IterableIterator<TileDefinition> {
+    return this._definitions.values();
+  }
+
+  /**
+   * Read-only snapshot of all per-tile definitions.
+   * The returned record is a caller-owned copy.
+   * @advanced
+   */
+  public get allDefinitions(): Readonly<Record<number, TileProperties | undefined>> {
+    const result: Record<number, TileProperties | undefined> = {};
+    for (const [id, def] of this._definitions) {
+      result[id] = def.properties;
+    }
+    return Object.freeze(result);
+  }
+}

--- a/packages/exojs-tilemap/src/index.ts
+++ b/packages/exojs-tilemap/src/index.ts
@@ -1,0 +1,5 @@
+// @codexo/exojs-tilemap — side-effect-free root entry.
+// Importing this entry does NOT register the extension globally.
+// Use @codexo/exojs-tilemap/register for global registration.
+
+export * from './public';

--- a/packages/exojs-tilemap/src/public.ts
+++ b/packages/exojs-tilemap/src/public.ts
@@ -1,0 +1,29 @@
+// Side-effect-free public API for @codexo/exojs-tilemap.
+// No registration is performed on import.
+
+export type { Extension } from '@codexo/exojs/extensions';
+export { tilemapExtension } from './tilemapExtension';
+export { TileChunk } from './TileChunk';
+export { TileLayer } from './TileLayer';
+export type { TileLayerOptions } from './TileLayer';
+export { TileMap } from './TileMap';
+export type { TileMapOptions } from './TileMap';
+export { TileSet } from './TileSet';
+export type { TileSetOptions } from './TileSet';
+export type {
+  ChunkCoord,
+  PackedTile,
+  ResolvedTile,
+  TileDefinition,
+  TileProperties,
+  TilePropertyValue,
+  TileTransform,
+} from './types';
+export {
+  TILE_TRANSFORM_IDENTITY,
+  packTile,
+  tileToChunkCoord,
+  tileToLocalInChunk,
+  tileTransformLabel,
+  unpackTile,
+} from './types';

--- a/packages/exojs-tilemap/src/public.ts
+++ b/packages/exojs-tilemap/src/public.ts
@@ -4,6 +4,7 @@
 export type { Extension } from '@codexo/exojs/extensions';
 export { tilemapExtension } from './tilemapExtension';
 export { TileChunk } from './TileChunk';
+export type { ReadonlyTileChunk } from './TileChunk';
 export { TileLayer } from './TileLayer';
 export type { TileLayerOptions } from './TileLayer';
 export { TileMap } from './TileMap';
@@ -12,7 +13,6 @@ export { TileSet } from './TileSet';
 export type { TileSetOptions } from './TileSet';
 export type {
   ChunkCoord,
-  PackedTile,
   ResolvedTile,
   TileDefinition,
   TileProperties,
@@ -21,9 +21,6 @@ export type {
 } from './types';
 export {
   TILE_TRANSFORM_IDENTITY,
-  packTile,
   tileToChunkCoord,
   tileToLocalInChunk,
-  tileTransformLabel,
-  unpackTile,
 } from './types';

--- a/packages/exojs-tilemap/src/public.ts
+++ b/packages/exojs-tilemap/src/public.ts
@@ -3,7 +3,8 @@
 
 export type { Extension } from '@codexo/exojs/extensions';
 export { tilemapExtension } from './tilemapExtension';
-export { TileChunk } from './TileChunk';
+// The mutable TileChunk implementation is package-internal —
+// only the ReadonlyTileChunk interface is exported publicly.
 export type { ReadonlyTileChunk } from './TileChunk';
 export { TileLayer } from './TileLayer';
 export type { TileLayerOptions } from './TileLayer';
@@ -13,6 +14,7 @@ export { TileSet } from './TileSet';
 export type { TileSetOptions } from './TileSet';
 export type {
   ChunkCoord,
+  PackedTile,
   ResolvedTile,
   TileDefinition,
   TileProperties,

--- a/packages/exojs-tilemap/src/register.ts
+++ b/packages/exojs-tilemap/src/register.ts
@@ -1,0 +1,13 @@
+// @codexo/exojs-tilemap/register — explicit registration entry.
+// Importing this entry registers the default tilemapExtension descriptor
+// in the global ExtensionRegistry. Subsequently constructed Applications
+// that use global defaults will receive the tilemap extension.
+// This is the only side-effectful entry in this package.
+
+import { ExtensionRegistry } from '@codexo/exojs/extensions';
+
+import { tilemapExtension } from './tilemapExtension';
+
+ExtensionRegistry.register(tilemapExtension);
+
+export * from './public';

--- a/packages/exojs-tilemap/src/tilemapExtension.ts
+++ b/packages/exojs-tilemap/src/tilemapExtension.ts
@@ -1,0 +1,16 @@
+import type { Extension } from '@codexo/exojs/extensions';
+
+/**
+ * Default immutable tilemap extension descriptor.
+ *
+ * For this slice (B1 — Generic Tilemap Runtime Foundation) the descriptor
+ * contains only the package identity. Renderer bindings will be added in a
+ * later renderer slice; no placeholder renderer is shipped now.
+ *
+ * Use with `ApplicationOptions.extensions` or call
+ * `import '@codexo/exojs-tilemap/register'` for global auto-registration.
+ * @advanced
+ */
+export const tilemapExtension: Extension = Object.freeze({
+  id: '@codexo/exojs-tilemap',
+});

--- a/packages/exojs-tilemap/src/types.ts
+++ b/packages/exojs-tilemap/src/types.ts
@@ -69,12 +69,15 @@ export function tileTransformLabel(t: TileTransform): string {
  * 0 means "empty cell". Any non-zero value encodes localTileId, tilesetIndex,
  * and flip bits according to the bit-layout constants below.
  *
- * Use {@link packTile} / {@link unpackTile} to convert between packed form
- * and a {@link ResolvedTile}.
+ * A `PackedTile` is **not** a source-format GID — it is a fully resolved
+ * internal compact representation. Use {@link packTile} / {@link unpackTile}
+ * (package-internal) to convert between packed form and a {@link ResolvedTile}
+ * if writing adapters.
  *
- * Never expose this type as a plain number in public query signatures —
- * public APIs return {@link ResolvedTile} or null.
- * @internal
+ * In public APIs, prefer {@link ResolvedTile} or null for queries.
+ * `PackedTile` is exposed as `@advanced` so `ReadonlyTileChunk.getRawAt()`
+ * has a self-documenting return type.
+ * @advanced
  */
 export type PackedTile = number;
 

--- a/packages/exojs-tilemap/src/types.ts
+++ b/packages/exojs-tilemap/src/types.ts
@@ -1,0 +1,242 @@
+import type { TextureRegion } from '@codexo/exojs';
+import type { TileSet } from './TileSet';
+
+// ── Properties ────────────────────────────────────────────────────────────
+
+/**
+ * Union of legal tile-property value types in the generic runtime.
+ * Format-neutral; adapters map their native property systems into this set.
+ * @advanced
+ */
+export type TilePropertyValue =
+  | null
+  | boolean
+  | number
+  | string;
+
+/**
+ * An immutable, flat key-value bag of generic tile properties.
+ * Adapters copy and freeze source properties; the runtime never retains
+ * a caller-owned mutable object.
+ * @advanced
+ */
+export type TileProperties = Readonly<Record<string, TilePropertyValue>>;
+
+// ── Tile orientation / transform ──────────────────────────────────────────
+
+/**
+ * Describes the orientation of a placed tile independent of source-format
+ * flip-bit encodings. The eight legal combinations map to the eight distinct
+ * 90°-rotation-and-flip states of a rectangular texture quad.
+ *
+ * Applying the transform at geometry-build time (reordering UV corners)
+ * avoids per-tile runtime cost and per-frame matrix allocation.
+ * @stable
+ */
+export interface TileTransform {
+  /** Horizontal flip (mirror left-right). */
+  readonly flipX: boolean;
+  /** Vertical flip (mirror top-bottom). */
+  readonly flipY: boolean;
+  /** Anti-diagonal flip (transpose of the UV axes). Combined with flips produces 90° rotations. */
+  readonly diagonal: boolean;
+}
+
+/** The identity transform: no flip, no diagonal. */
+export const TILE_TRANSFORM_IDENTITY: Readonly<TileTransform> = Object.freeze({
+  flipX: false,
+  flipY: false,
+  diagonal: false,
+});
+
+/**
+ * Short string label for a {@link TileTransform} (debug / serialisation).
+ * Returns one of the eight deterministic names, e.g. `"flipX"` or `"diag+flipX+flipY"`.
+ * @internal
+ */
+export function tileTransformLabel(t: TileTransform): string {
+  const parts: string[] = [];
+  if (t.diagonal) parts.push('diag');
+  if (t.flipX) parts.push('flipX');
+  if (t.flipY) parts.push('flipY');
+  return parts.length === 0 ? 'identity' : parts.join('+');
+}
+
+// ── Tile identity ─────────────────────────────────────────────────────────
+
+/**
+ * Opaque packed tile data stored in a {@link TileChunk}'s compact array.
+ * 0 means "empty cell". Any non-zero value encodes localTileId, tilesetIndex,
+ * and flip bits according to the bit-layout constants below.
+ *
+ * Use {@link packTile} / {@link unpackTile} to convert between packed form
+ * and a {@link ResolvedTile}.
+ *
+ * Never expose this type as a plain number in public query signatures —
+ * public APIs return {@link ResolvedTile} or null.
+ * @internal
+ */
+export type PackedTile = number;
+
+/** Bit width allocated to the local tile ID within a packed tile word. */
+export const PACKED_LOCAL_BITS = 20;
+/** Bit width allocated to the tileset index within a packed tile word. */
+export const PACKED_TILESET_BITS = 9;
+/** Bit width allocated to the transform/flip bits. */
+export const PACKED_TRANSFORM_BITS = 3;
+
+export const PACKED_LOCAL_MASK = (1 << PACKED_LOCAL_BITS) - 1;
+export const PACKED_TILESET_MASK = ((1 << PACKED_TILESET_BITS) - 1) << PACKED_LOCAL_BITS;
+export const PACKED_TRANSFORM_MASK = ((1 << PACKED_TRANSFORM_BITS) - 1) << (PACKED_LOCAL_BITS + PACKED_TILESET_BITS);
+
+export const PACKED_TILESET_SHIFT = PACKED_LOCAL_BITS;
+export const PACKED_TRANSFORM_SHIFT = PACKED_LOCAL_BITS + PACKED_TILESET_BITS;
+
+/** Maximum tileset index representable in a packed tile. */
+export const MAX_TILESET_INDEX = (1 << PACKED_TILESET_BITS) - 1;
+/** Maximum local tile ID representable in a packed tile (1-based storage). */
+export const MAX_LOCAL_TILE_ID = (1 << PACKED_LOCAL_BITS) - 2;
+
+// Transform bit-field values (bit 0 = flipX, bit 1 = flipY, bit 2 = diagonal).
+const TRANSFORM_FLIP_X = 1 << 0;
+const TRANSFORM_FLIP_Y = 1 << 1;
+const TRANSFORM_DIAGONAL = 1 << 2;
+
+/**
+ * Encode a tileset-local tile reference and transform into a packed word.
+ * The localTileId is stored as (localTileId + 1) so that a packed value of 0
+ * cleanly represents an empty cell, while tile 0 from tileset 0 with identity
+ * transform is stored as 1 (non-zero).
+ * Returns 0 for an empty cell.
+ * @internal
+ */
+export function packTile(tilesetIndex: number, localTileId: number, transform: TileTransform): PackedTile {
+  if (tilesetIndex < 0 || tilesetIndex > MAX_TILESET_INDEX) {
+    throw new Error(`Tileset index ${tilesetIndex} exceeds maximum ${MAX_TILESET_INDEX}.`);
+  }
+  if (localTileId < 0 || localTileId > MAX_LOCAL_TILE_ID) {
+    throw new Error(`Local tile ID ${localTileId} exceeds maximum ${MAX_LOCAL_TILE_ID}.`);
+  }
+  let bits = 0;
+  if (transform.flipX) bits |= TRANSFORM_FLIP_X;
+  if (transform.flipY) bits |= TRANSFORM_FLIP_Y;
+  if (transform.diagonal) bits |= TRANSFORM_DIAGONAL;
+  // +1 so 0 means "empty" not "tile 0 without transform"
+  const storedId = localTileId + 1;
+  return (storedId & PACKED_LOCAL_MASK)
+    | ((tilesetIndex << PACKED_TILESET_SHIFT) & PACKED_TILESET_MASK)
+    | ((bits << PACKED_TRANSFORM_SHIFT) & PACKED_TRANSFORM_MASK);
+}
+
+/**
+ * Decode a packed word into its components.
+ * Returns null for an empty cell (packed === 0).
+ * @internal
+ */
+export function unpackTile(packed: PackedTile): {
+  tilesetIndex: number;
+  localTileId: number;
+  transform: TileTransform;
+} | null {
+  if (packed === 0) return null;
+  const storedId = packed & PACKED_LOCAL_MASK;
+  // Undo the +1 offset applied during packTile.
+  const localTileId = storedId - 1;
+  const tilesetIndex = (packed & PACKED_TILESET_MASK) >>> PACKED_TILESET_SHIFT;
+  const rawTransform = (packed & PACKED_TRANSFORM_MASK) >>> PACKED_TRANSFORM_SHIFT;
+  return {
+    tilesetIndex,
+    localTileId,
+    transform: {
+      flipX: !!(rawTransform & TRANSFORM_FLIP_X),
+      flipY: !!(rawTransform & TRANSFORM_FLIP_Y),
+      diagonal: !!(rawTransform & TRANSFORM_DIAGONAL),
+    },
+  };
+}
+
+// ── Resolved tile reference (public query result) ─────────────────────────
+
+/**
+ * A fully resolved, format-independent tile reference returned by queries.
+ * Materialised on-demand from the packed storage; never stored as a per-cell
+ * heap object.
+ * @advanced
+ */
+export interface ResolvedTile {
+  /** The owning tileset (already resolved from source-format GID). */
+  readonly tileset: TileSet;
+  /** 0-based tile index within the tileset. */
+  readonly localTileId: number;
+  /** Orientation transform for this placed tile. */
+  readonly transform: TileTransform;
+}
+
+// ── TileDefinition ────────────────────────────────────────────────────────
+
+/**
+ * Optional per-tile metadata in a {@link TileSet}. Sparse — only defined
+ * tiles carry a definition. May carry animation data in future slices.
+ * @advanced
+ */
+export interface TileDefinition {
+  /** The local tile ID this definition belongs to. */
+  readonly localTileId: number;
+  /** Tile properties (copied and frozen by the tileset). */
+  readonly properties?: TileProperties;
+}
+
+// ── Chunk coordinate helpers ──────────────────────────────────────────────
+
+/** A signed chunk coordinate pair. */
+export interface ChunkCoord {
+  readonly cx: number;
+  readonly cy: number;
+}
+
+/** Convert tile coordinates to chunk coordinates given a chunk size. */
+export function tileToChunkCoord(tx: number, ty: number, chunkW: number, chunkH: number): ChunkCoord {
+  return {
+    cx: Math.floor(tx / chunkW),
+    cy: Math.floor(ty / chunkH),
+  };
+}
+
+/** Convert tile coordinates to local-in-chunk coordinates. */
+export function tileToLocalInChunk(tx: number, ty: number, chunkW: number, chunkH: number): { lx: number; ly: number } {
+  return {
+    lx: ((tx % chunkW) + chunkW) % chunkW,
+    ly: ((ty % chunkH) + chunkH) % chunkH,
+  };
+}
+
+/**
+ * Validate that a value is a finite, safe, positive integer.
+ * Used for dimensions, tile counts, chunk sizes.
+ */
+export function validatePositiveInteger(value: number, label: string): void {
+  if (!Number.isFinite(value) || !Number.isInteger(value) || value <= 0) {
+    throw new Error(`${label} must be a positive integer (got ${value}).`);
+  }
+  if (value > Number.MAX_SAFE_INTEGER) {
+    throw new Error(`${label} exceeds safe integer range (got ${value}).`);
+  }
+}
+
+/**
+ * Validate a non-negative finite integer.
+ */
+export function validateNonNegativeInteger(value: number, label: string): void {
+  if (!Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative integer (got ${value}).`);
+  }
+}
+
+/**
+ * Validate that a value is a finite integer (may be negative).
+ */
+export function validateInteger(value: number, label: string): void {
+  if (!Number.isFinite(value) || !Number.isInteger(value)) {
+    throw new Error(`${label} must be a finite integer (got ${value}).`);
+  }
+}

--- a/packages/exojs-tilemap/src/typings.d.ts
+++ b/packages/exojs-tilemap/src/typings.d.ts
@@ -1,0 +1,1 @@
+declare const __DEV__: boolean;

--- a/packages/exojs-tilemap/test/extension.test.ts
+++ b/packages/exojs-tilemap/test/extension.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { ExtensionRegistry } from '@codexo/exojs/extensions';
+import { resetExtensionRegistryForTesting } from '../../../src/extensions/testing';
+import { tilemapExtension } from '../src/tilemapExtension';
+
+describe('@codexo/exojs-tilemap root', () => {
+  it('tilemapExtension has correct id', () => {
+    expect(tilemapExtension.id).toBe('@codexo/exojs-tilemap');
+  });
+
+  it('tilemapExtension has no asset bindings (renderer-only extension)', () => {
+    expect(tilemapExtension.assets).toBeUndefined();
+  });
+
+  it('tilemapExtension has no renderer bindings yet (deferred to renderer slice)', () => {
+    expect(tilemapExtension.renderers).toBeUndefined();
+  });
+
+  it('tilemapExtension has no dependencies', () => {
+    expect(tilemapExtension.dependencies).toBeUndefined();
+  });
+
+  it('root import does NOT register in ExtensionRegistry', () => {
+    const registry = ExtensionRegistry.list();
+    expect(registry.some(e => e.id === '@codexo/exojs-tilemap')).toBe(false);
+  });
+});
+
+describe('@codexo/exojs-tilemap/register', () => {
+  beforeEach(() => {
+    resetExtensionRegistryForTesting();
+  });
+
+  it('register entry registers tilemapExtension', async () => {
+    await import('../src/register');
+    expect(ExtensionRegistry.has('@codexo/exojs-tilemap')).toBe(true);
+  });
+});
+
+describe('export parity', () => {
+  it('root and register have same named exports', async () => {
+    const root = await import('../src/index');
+    const register = await import('../src/register');
+    const rootKeys = Object.keys(root).filter(k => k !== 'default').sort();
+    const registerKeys = Object.keys(register).filter(k => k !== 'default').sort();
+    expect(rootKeys).toEqual(registerKeys);
+  });
+});

--- a/packages/exojs-tilemap/test/public-api.test.ts
+++ b/packages/exojs-tilemap/test/public-api.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import { TextureRegion } from '@codexo/exojs';
+import { Texture } from '@codexo/exojs';
+
+import { TileLayer } from '../src/TileLayer';
+import { TileSet } from '../src/TileSet';
+import { TILE_TRANSFORM_IDENTITY } from '../src/types';
+
+// Compile-time imports: verify these types are reachable from the package barrel.
+import type { PackedTile, ReadonlyTileChunk } from '../src/index';
+
+function fakeTexture(): Texture {
+  return {
+    width: 256,
+    height: 256,
+    uid: 0,
+    label: 'test',
+    destroy: () => {},
+    destroyed: false,
+  } as unknown as Texture;
+}
+
+function fakeRegion(): TextureRegion {
+  return new TextureRegion(fakeTexture(), { x: 0, y: 0, width: 256, height: 256 });
+}
+
+function createTestLayer(): {
+  layer: TileLayer;
+  ref: { tileset: TileSet; localTileId: number; transform: typeof TILE_TRANSFORM_IDENTITY };
+} {
+  const ts = new TileSet({
+    name: 'ts',
+    texture: fakeRegion(),
+    tileWidth: 32,
+    tileHeight: 32,
+    tileCount: 16,
+    columns: 4,
+  });
+  const layer = new TileLayer({
+    id: 0,
+    name: 'l',
+    width: 32,
+    height: 32,
+    tileWidth: 16,
+    tileHeight: 16,
+    tilesets: [ts],
+  });
+  return { layer, ref: { tileset: ts, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY } };
+}
+
+describe('public chunk boundary', () => {
+  it('TileChunk class is NOT exported from the package barrel', async () => {
+    const root = await import('../src/index');
+    expect('TileChunk' in root).toBe(false);
+  });
+
+  it('ReadonlyTileChunk type compiles from barrel import', () => {
+    // The static import at the top of this file proves ReadonlyTileChunk
+    // is importable from the package barrel. If it weren't exported,
+    // this file wouldn't compile.
+    const _c: ReadonlyTileChunk | undefined = undefined;
+    expect(_c).toBeUndefined();
+  });
+
+  it('PackedTile type compiles from barrel import', () => {
+    // Static import at the top proves PackedTile is exportable.
+    const _p: PackedTile = 0;
+    expect(_p).toBe(0);
+  });
+
+  it('layer.getChunk returns ReadonlyTileChunk, not the mutable class', () => {
+    const { layer, ref } = createTestLayer();
+    layer.setTileAt(0, 0, ref);
+    const chunk = layer.getChunk(0, 0);
+    expect(chunk).toBeDefined();
+    expect(chunk!.cx).toBe(0);
+
+    // ReadonlyTileChunk has getRawAt and cloneTiles.
+    expect(typeof chunk!.getRawAt).toBe('function');
+    expect(typeof chunk!.cloneTiles).toBe('function');
+
+    // The public type (ReadonlyTileChunk) does not expose _tiles,
+    // _setRawAt, _clear, or _markDirty. At the JS level the methods
+    // exist on the instance (TS-private is compile-time only), but the
+    // public contract is: consumers must only use ReadonlyTileChunk methods.
+    // The type system prevents accessing these — see the static import tests.
+
+    // cloneTiles produces an independent copy.
+    const copy = chunk!.cloneTiles();
+    copy[0] = 999;
+    expect(chunk!.getRawAt(0, 0)).not.toBe(0);
+  });
+
+  it('loadedChunks returns ReadonlyTileChunk elements', () => {
+    const { layer, ref } = createTestLayer();
+    layer.setTileAt(16, 16, ref);
+    for (const chunk of layer.loadedChunks()) {
+      expect(typeof chunk.getRawAt).toBe('function');
+      expect(typeof chunk.cloneTiles).toBe('function');
+      expect(chunk.cx).toBe(0);
+    }
+  });
+
+  it('mutation goes through TileLayer only — no direct chunk mutation API', () => {
+    const { layer, ref } = createTestLayer();
+    const rev = layer.revision;
+    layer.setTileAt(5, 5, ref);
+    expect(layer.revision).toBe(rev + 1);
+
+    const chunk = layer.getChunk(0, 0)!;
+    // The chunk is a ReadonlyTileChunk — TypeScript prevents calling
+    // _setRawAt on it at the type level (would be a compile error).
+    expect(chunk.getRawAt(5, 5)).not.toBe(0);
+  });
+});

--- a/packages/exojs-tilemap/test/scale.test.ts
+++ b/packages/exojs-tilemap/test/scale.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+
+import { TextureRegion } from '@codexo/exojs';
+import { Texture } from '@codexo/exojs';
+
+import { TileChunk } from '../src/TileChunk';
+import { TileLayer } from '../src/TileLayer';
+import { TileMap } from '../src/TileMap';
+import { TileSet } from '../src/TileSet';
+import { TILE_TRANSFORM_IDENTITY } from '../src/types';
+
+function fakeRegion(tw = 2048, th = 2048): TextureRegion {
+  return new TextureRegion(
+    { width: tw, height: th, uid: 0, label: 'test', destroy: () => {}, destroyed: false } as unknown as Texture,
+    { x: 0, y: 0, width: tw, height: th },
+  );
+}
+
+function makeTileset(name: string, tileCount = 256): TileSet {
+  return new TileSet({
+    name,
+    texture: fakeRegion(),
+    tileWidth: 32,
+    tileHeight: 32,
+    tileCount,
+  });
+}
+
+describe('scale / storage', () => {
+  it('constructs 512×512 tile map without per-tile objects', () => {
+    const ts = makeTileset('base', 256);
+    const map = new TileMap({
+      width: 512,
+      height: 512,
+      tileWidth: 32,
+      tileHeight: 32,
+      tilesets: [ts],
+      layers: [
+        new TileLayer({
+          id: 0,
+          name: 'large',
+          width: 512,
+          height: 512,
+          tileWidth: 32,
+          tileHeight: 32,
+          tilesets: [ts],
+        }),
+      ],
+    });
+
+    expect(map.width).toBe(512);
+    expect(map.height).toBe(512);
+
+    // No chunks created yet — lazy
+    const layer = map.getLayerById(0)!;
+    expect([...layer.loadedChunks()]).toHaveLength(0);
+
+    // After setting a single tile, only one chunk exists
+    const ref = { tileset: ts, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY };
+    layer.setTileAt(0, 0, ref);
+    expect([...layer.loadedChunks()]).toHaveLength(1);
+  });
+
+  it('dense fill 16×16 chunk creates exactly one chunk', () => {
+    const ts = makeTileset('base', 256);
+    const layer = new TileLayer({
+      id: 0,
+      name: 'chunk-fill',
+      width: 32,
+      height: 32,
+      tileWidth: 16,
+      tileHeight: 16,
+      tilesets: [ts],
+      chunkWidth: 32,
+      chunkHeight: 32,
+    });
+
+    const ref = { tileset: ts, localTileId: 1, transform: TILE_TRANSFORM_IDENTITY };
+    for (let y = 0; y < 32; y++) {
+      for (let x = 0; x < 32; x++) {
+        layer.setTileAt(x, y, ref);
+      }
+    }
+
+    expect([...layer.loadedChunks()]).toHaveLength(1);
+    expect(layer.countNonEmptyTiles()).toBe(1024);
+  });
+
+  it('chunk count for 512×512 with default 32×32 chunks is predictable', () => {
+    const ts = makeTileset('base', 256);
+    const layer = new TileLayer({
+      id: 0,
+      name: 'large',
+      width: 512,
+      height: 512,
+      tileWidth: 16,
+      tileHeight: 16,
+      tilesets: [ts],
+      chunkWidth: 32,
+      chunkHeight: 32,
+    });
+
+    // 512 / 32 = 16 chunks per dimension → 256 total potential chunks
+    // Fill one tile in each chunk corner
+    const ref = { tileset: ts, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY };
+    for (let cy = 0; cy < 16; cy++) {
+      for (let cx = 0; cx < 16; cx++) {
+        layer.setTileAt(cx * 32, cy * 32, ref);
+      }
+    }
+
+    expect([...layer.loadedChunks()]).toHaveLength(256);
+  });
+
+  it('storage uses Uint32Array, not object arrays', () => {
+    const chunk = new TileChunk(0, 0, 32, 32);
+    expect(chunk.tiles).toBeInstanceOf(Uint32Array);
+    expect(chunk.tiles.length).toBe(1024);
+  });
+
+  it('empty chunk is identified quickly after creation', () => {
+    const chunk = new TileChunk(0, 0, 32, 32);
+    expect(chunk.empty).toBe(true);
+  });
+
+  it('chunk iteration is bounded and efficient', () => {
+    const ts = makeTileset('base', 256);
+    const layer = new TileLayer({
+      id: 0,
+      name: 'iter-test',
+      width: 128,
+      height: 128,
+      tileWidth: 16,
+      tileHeight: 16,
+      tilesets: [ts],
+    });
+
+    const ref = { tileset: ts, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY };
+    // Fill a diagonal
+    for (let i = 0; i < 128; i++) {
+      layer.setTileAt(i, i, ref);
+    }
+
+    const tiles = [...layer.tilesInRect(0, 0, 128, 128)];
+    expect(tiles.length).toBe(128);
+
+    // Verify chunk count — should be exactly the chunks that intersect the diagonal
+    const chunkCount = [...layer.loadedChunks()].length;
+    // Diagonal crosses chunk boundaries; expect ≤ chunks per axis intersecting
+    expect(chunkCount).toBeGreaterThan(1);
+    expect(chunkCount).toBeLessThanOrEqual(32); // max 4×4 = 16 chunks, giving some margin
+  });
+
+  it('clearRect on 128×128 dense fill is efficient', () => {
+    const ts = makeTileset('base', 256);
+    const layer = new TileLayer({
+      id: 0,
+      name: 'clear-test',
+      width: 128,
+      height: 128,
+      tileWidth: 16,
+      tileHeight: 16,
+      tilesets: [ts],
+    });
+
+    const ref = { tileset: ts, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY };
+    layer.fillRect(0, 0, 128, 128, ref);
+    expect(layer.countNonEmptyTiles()).toBe(128 * 128);
+
+    layer.clearRect(0, 0, 128, 128);
+    expect(layer.countNonEmptyTiles()).toBe(0);
+  });
+});

--- a/packages/exojs-tilemap/test/scale.test.ts
+++ b/packages/exojs-tilemap/test/scale.test.ts
@@ -51,17 +51,15 @@ describe('scale / storage', () => {
     expect(map.width).toBe(512);
     expect(map.height).toBe(512);
 
-    // No chunks created yet — lazy
     const layer = map.getLayerById(0)!;
     expect([...layer.loadedChunks()]).toHaveLength(0);
 
-    // After setting a single tile, only one chunk exists
     const ref = { tileset: ts, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY };
     layer.setTileAt(0, 0, ref);
     expect([...layer.loadedChunks()]).toHaveLength(1);
   });
 
-  it('dense fill 16×16 chunk creates exactly one chunk', () => {
+  it('dense fill 32×32 chunk creates exactly one chunk', () => {
     const ts = makeTileset('base', 256);
     const layer = new TileLayer({
       id: 0,
@@ -100,8 +98,6 @@ describe('scale / storage', () => {
       chunkHeight: 32,
     });
 
-    // 512 / 32 = 16 chunks per dimension → 256 total potential chunks
-    // Fill one tile in each chunk corner
     const ref = { tileset: ts, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY };
     for (let cy = 0; cy < 16; cy++) {
       for (let cx = 0; cx < 16; cx++) {
@@ -112,10 +108,12 @@ describe('scale / storage', () => {
     expect([...layer.loadedChunks()]).toHaveLength(256);
   });
 
-  it('storage uses Uint32Array, not object arrays', () => {
+  it('storage uses Uint32Array internally, not exposed publicly', () => {
     const chunk = new TileChunk(0, 0, 32, 32);
-    expect(chunk.tiles).toBeInstanceOf(Uint32Array);
-    expect(chunk.tiles.length).toBe(1024);
+    // The private _tiles is not accessible from outside
+    expect((chunk as Record<string, unknown>).tiles).toBeUndefined();
+    expect(chunk.cloneTiles()).toBeInstanceOf(Uint32Array);
+    expect(chunk.cloneTiles().length).toBe(1024);
   });
 
   it('empty chunk is identified quickly after creation', () => {
@@ -136,7 +134,6 @@ describe('scale / storage', () => {
     });
 
     const ref = { tileset: ts, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY };
-    // Fill a diagonal
     for (let i = 0; i < 128; i++) {
       layer.setTileAt(i, i, ref);
     }
@@ -144,11 +141,9 @@ describe('scale / storage', () => {
     const tiles = [...layer.tilesInRect(0, 0, 128, 128)];
     expect(tiles.length).toBe(128);
 
-    // Verify chunk count — should be exactly the chunks that intersect the diagonal
     const chunkCount = [...layer.loadedChunks()].length;
-    // Diagonal crosses chunk boundaries; expect ≤ chunks per axis intersecting
     expect(chunkCount).toBeGreaterThan(1);
-    expect(chunkCount).toBeLessThanOrEqual(32); // max 4×4 = 16 chunks, giving some margin
+    expect(chunkCount).toBeLessThanOrEqual(32);
   });
 
   it('clearRect on 128×128 dense fill is efficient', () => {

--- a/packages/exojs-tilemap/test/tilemap.test.ts
+++ b/packages/exojs-tilemap/test/tilemap.test.ts
@@ -1,0 +1,1160 @@
+import { describe, expect, it } from 'vitest';
+
+import { TextureRegion } from '@codexo/exojs';
+import { Texture } from '@codexo/exojs';
+
+import { TileChunk } from '../src/TileChunk';
+import { TileLayer } from '../src/TileLayer';
+import { TileMap } from '../src/TileMap';
+import { TileSet } from '../src/TileSet';
+import {
+  packTile,
+  TILE_TRANSFORM_IDENTITY,
+  tileToChunkCoord,
+  tileToLocalInChunk,
+  tileTransformLabel,
+  unpackTile,
+} from '../src/types';
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+function fakeTexture(): Texture {
+  return {
+    width: 512,
+    height: 512,
+    uid: 0,
+    label: 'test',
+    destroy: () => {},
+    destroyed: false,
+  } as unknown as Texture;
+}
+
+function fakeRegion(tw = 512, th = 512): TextureRegion {
+  return new TextureRegion(fakeTexture(), { x: 0, y: 0, width: tw, height: th });
+}
+
+function makeTileset(name: string, tileCount = 16, tw = 32, th = 32): TileSet {
+  return new TileSet({
+    name,
+    texture: fakeRegion(512, 512),
+    tileWidth: tw,
+    tileHeight: th,
+    tileCount,
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Tile identity & packing
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('tile packing', () => {
+  it('pack/unpack roundtrip', () => {
+    const packed = packTile(0, 5, { flipX: true, flipY: false, diagonal: false });
+    const unpacked = unpackTile(packed);
+    expect(unpacked).not.toBeNull();
+    expect(unpacked!.tilesetIndex).toBe(0);
+    expect(unpacked!.localTileId).toBe(5);
+    expect(unpacked!.transform.flipX).toBe(true);
+    expect(unpacked!.transform.flipY).toBe(false);
+    expect(unpacked!.transform.diagonal).toBe(false);
+  });
+
+  it('empty tile is 0', () => {
+    expect(unpackTile(0)).toBeNull();
+  });
+
+  it('all 8 transform combinations roundtrip', () => {
+    for (const flipX of [false, true]) {
+      for (const flipY of [false, true]) {
+        for (const diagonal of [false, true]) {
+          const t = { flipX, flipY, diagonal };
+          const packed = packTile(0, 1, t);
+          const u = unpackTile(packed)!;
+          expect(u.transform).toEqual(t);
+        }
+      }
+    }
+  });
+
+  it('rejects tileset index overflow', () => {
+    expect(() => packTile(512, 1, TILE_TRANSFORM_IDENTITY)).toThrow();
+  });
+
+  it('rejects local tile ID overflow', () => {
+    expect(() => packTile(0, (1 << 20) - 1, TILE_TRANSFORM_IDENTITY)).toThrow();
+  });
+
+  it('rejects negative tileset index', () => {
+    expect(() => packTile(-1, 1, TILE_TRANSFORM_IDENTITY)).toThrow();
+  });
+
+  it('identity transform packs as no flip bits', () => {
+    const packed = packTile(0, 0, TILE_TRANSFORM_IDENTITY);
+    expect(packed & 0xe0000000).toBe(0);
+  });
+
+  it('TILE_TRANSFORM_IDENTITY is frozen identity', () => {
+    expect(TILE_TRANSFORM_IDENTITY).toEqual({
+      flipX: false,
+      flipY: false,
+      diagonal: false,
+    });
+    expect(Object.isFrozen(TILE_TRANSFORM_IDENTITY)).toBe(true);
+  });
+});
+
+describe('tileTransformLabel', () => {
+  it('identity', () => {
+    expect(tileTransformLabel(TILE_TRANSFORM_IDENTITY)).toBe('identity');
+  });
+  it('flipX', () => {
+    expect(tileTransformLabel({ flipX: true, flipY: false, diagonal: false })).toBe('flipX');
+  });
+  it('flipY', () => {
+    expect(tileTransformLabel({ flipX: false, flipY: true, diagonal: false })).toBe('flipY');
+  });
+  it('diag+flipX+flipY', () => {
+    expect(tileTransformLabel({ flipX: true, flipY: true, diagonal: true })).toBe('diag+flipX+flipY');
+  });
+});
+
+describe('chunk coordinate math', () => {
+  it('positive coords map to chunk 0', () => {
+    expect(tileToChunkCoord(5, 7, 32, 32)).toEqual({ cx: 0, cy: 0 });
+  });
+
+  it('edge of chunk maps to next chunk', () => {
+    expect(tileToChunkCoord(32, 0, 32, 32)).toEqual({ cx: 1, cy: 0 });
+    expect(tileToChunkCoord(0, 32, 32, 32)).toEqual({ cx: 0, cy: 1 });
+  });
+
+  it('negative coords map to negative chunks', () => {
+    expect(tileToChunkCoord(-1, -1, 32, 32)).toEqual({ cx: -1, cy: -1 });
+    expect(tileToChunkCoord(-32, -32, 32, 32)).toEqual({ cx: -1, cy: -1 });
+    expect(tileToChunkCoord(-33, -33, 32, 32)).toEqual({ cx: -2, cy: -2 });
+  });
+
+  it('local in chunk wraps correctly for negatives', () => {
+    // tx=-1 with chunkW=32: cx=-1, lx=31
+    const { cx, cy } = tileToChunkCoord(-1, -5, 32, 32);
+    const { lx, ly } = tileToLocalInChunk(-1, -5, 32, 32);
+    expect(cx).toBe(-1);
+    expect(cy).toBe(-1);
+    expect(lx).toBe(31);
+    expect(ly).toBe(27);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// TileSet
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('TileSet', () => {
+  it('basic construction', () => {
+    const ts = new TileSet({
+      name: 'test',
+      texture: fakeRegion(256, 256),
+      tileWidth: 32,
+      tileHeight: 32,
+      tileCount: 64,
+    });
+    expect(ts.name).toBe('test');
+    expect(ts.tileWidth).toBe(32);
+    expect(ts.tileHeight).toBe(32);
+    expect(ts.tileCount).toBe(64);
+    expect(ts.columns).toBe(8); // 256 / 32
+    expect(ts.rows).toBe(8);    // ceil(64 / 8)
+  });
+
+  it('custom columns', () => {
+    const ts = new TileSet({
+      name: 'test',
+      texture: fakeRegion(320, 160),
+      tileWidth: 32,
+      tileHeight: 32,
+      tileCount: 16,
+      columns: 4,
+    });
+    expect(ts.columns).toBe(4);
+    expect(ts.rows).toBe(4);
+  });
+
+  it('spacing and margin affect grid', () => {
+    const ts = new TileSet({
+      name: 'test',
+      texture: fakeRegion(320, 320),
+      tileWidth: 32,
+      tileHeight: 32,
+      tileCount: 64,
+      spacing: 2,
+      margin: 4,
+    });
+    // With margin: usable area is 320 - 8 = 312
+    // columns = floor(312 / 32) = 9
+    // But: 32*9 + 2*8 = 288 + 16 = 304 <= 312 ✓
+    expect(ts.columns).toBeGreaterThanOrEqual(1);
+  });
+
+  it('getTileRect basic', () => {
+    const ts = new TileSet({
+      name: 'test',
+      texture: fakeRegion(128, 128),
+      tileWidth: 32,
+      tileHeight: 32,
+      tileCount: 16,
+    });
+    const r = ts.getTileRect(0);
+    expect(r).toEqual({ x: 0, y: 0, width: 32, height: 32 });
+
+    const r2 = ts.getTileRect(5); // col 1, row 1
+    expect(r2.x).toBe(32);
+    expect(r2.y).toBe(32);
+  });
+
+  it('getTileRect with spacing and margin', () => {
+    const ts = new TileSet({
+      name: 'test',
+      texture: fakeRegion(160, 160),
+      tileWidth: 32,
+      tileHeight: 32,
+      tileCount: 16,
+      spacing: 2,
+      margin: 4,
+    });
+    const r = ts.getTileRect(0);
+    expect(r.x).toBe(4);
+    expect(r.y).toBe(4);
+
+    // Column 1: margin + (tileWidth + spacing) * col = 4 + 34 = 38
+    const r2 = ts.getTileRect(1);
+    expect(r2.x).toBe(38);
+  });
+
+  it('getTileRect out of range throws', () => {
+    const ts = makeTileset('test', 16);
+    expect(() => ts.getTileRect(-1)).toThrow();
+    expect(() => ts.getTileRect(16)).toThrow();
+  });
+
+  it('rejects zero tileWidth', () => {
+    expect(() => new TileSet({
+      name: 'test',
+      texture: fakeRegion(),
+      tileWidth: 0,
+      tileHeight: 32,
+      tileCount: 16,
+    })).toThrow();
+  });
+
+  it('rejects non-integer tileCount', () => {
+    expect(() => new TileSet({
+      name: 'test',
+      texture: fakeRegion(),
+      tileWidth: 32,
+      tileHeight: 32,
+      tileCount: 16.5,
+    })).toThrow();
+  });
+
+  it('rejects null texture', () => {
+    expect(() => new TileSet({
+      name: 'test',
+      texture: null!,
+      tileWidth: 32,
+      tileHeight: 32,
+      tileCount: 16,
+    })).toThrow();
+  });
+
+  it('tile definitions are stored and retrievable', () => {
+    const ts = makeTileset('test', 16);
+    ts._setDefinition(0, { properties: { solid: true } });
+    const def = ts.getTileDefinition(0);
+    expect(def).toBeDefined();
+    expect(def!.properties).toEqual({ solid: true });
+  });
+
+  it('tile definitions copy and freeze properties', () => {
+    const ts = makeTileset('test', 16);
+    const mutableProps = { solid: true };
+    ts._setDefinition(0, { properties: mutableProps });
+    mutableProps.solid = false; // mutate after
+    expect(ts.getTileDefinition(0)!.properties!.solid).toBe(true); // unchanged
+  });
+
+  it('allDefinitions returns frozen snapshot', () => {
+    const ts = makeTileset('test', 16);
+    ts._setDefinition(0, { properties: { a: 1 } });
+    const snap = ts.allDefinitions;
+    expect(snap[0]).toEqual({ a: 1 });
+    expect(snap[1]).toBeUndefined();
+    expect(Object.isFrozen(snap)).toBe(true);
+  });
+
+  it('definedTiles iterates sparse definitions', () => {
+    const ts = makeTileset('test', 16);
+    ts._setDefinition(3, { properties: {} });
+    ts._setDefinition(7, { properties: {} });
+    const ids = [...ts.definedTiles()].map(d => d.localTileId);
+    expect(ids).toEqual([3, 7]);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// TileChunk
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('TileChunk', () => {
+  it('basic construction', () => {
+    const chunk = new TileChunk(0, 0, 32, 32);
+    expect(chunk.cx).toBe(0);
+    expect(chunk.cy).toBe(0);
+    expect(chunk.width).toBe(32);
+    expect(chunk.height).toBe(32);
+    expect(chunk.tiles.length).toBe(1024);
+    expect(chunk.empty).toBe(true);
+  });
+
+  it('source data is copied', () => {
+    const source = new Uint32Array(4);
+    source[0] = 1;
+    const chunk = new TileChunk(0, 0, 2, 2, source);
+    source[0] = 99; // mutate original
+    expect(chunk.getRawAt(0, 0)).toBe(1);
+  });
+
+  it('setRawAt returns true on change, false on no-op', () => {
+    const chunk = new TileChunk(0, 0, 2, 2);
+    expect(chunk.setRawAt(0, 0, 42)).toBe(true);
+    expect(chunk.setRawAt(0, 0, 42)).toBe(false);
+  });
+
+  it('revision increments on change, not on no-op', () => {
+    const chunk = new TileChunk(0, 0, 2, 2);
+    expect(chunk.revision).toBe(0);
+    chunk.setRawAt(0, 0, 42);
+    expect(chunk.revision).toBe(1);
+    chunk.setRawAt(0, 0, 42);
+    expect(chunk.revision).toBe(1);
+    chunk.setRawAt(1, 0, 99);
+    expect(chunk.revision).toBe(2);
+  });
+
+  it('empty flag is cached and invalidated', () => {
+    const chunk = new TileChunk(0, 0, 2, 2);
+    expect(chunk.empty).toBe(true);
+    chunk.setRawAt(0, 0, 42);
+    expect(chunk.empty).toBe(false);
+    chunk.setRawAt(0, 0, 0);
+    expect(chunk.empty).toBe(true);
+  });
+
+  it('clear sets all to 0 and increments revision if had content', () => {
+    const chunk = new TileChunk(0, 0, 2, 2);
+    chunk.setRawAt(0, 0, 42);
+    const rev = chunk.revision;
+    chunk.clear();
+    expect(chunk.revision).toBe(rev + 1);
+    expect(chunk.empty).toBe(true);
+  });
+
+  it('clear on already-empty chunk is no-op', () => {
+    const chunk = new TileChunk(0, 0, 2, 2);
+    const rev = chunk.revision;
+    chunk.clear();
+    expect(chunk.revision).toBe(rev);
+  });
+
+  it('markDirty invalidates empty cache and increments revision', () => {
+    const chunk = new TileChunk(0, 0, 2, 2);
+    chunk.markDirty();
+    expect(chunk.revision).toBe(1);
+  });
+
+  it('negative chunk coordinates supported', () => {
+    const chunk = new TileChunk(-3, -5, 16, 16);
+    expect(chunk.cx).toBe(-3);
+    expect(chunk.cy).toBe(-5);
+  });
+
+  it('rejects zero dimensions', () => {
+    expect(() => new TileChunk(0, 0, 0, 32)).toThrow();
+  });
+
+  it('rejects unsafe allocation size', () => {
+    // width * height that overflows safe integer
+    expect(() => new TileChunk(0, 0, 1e8, 1e8)).toThrow();
+  });
+
+  it('cloneTiles returns independent copy', () => {
+    const chunk = new TileChunk(0, 0, 2, 2);
+    chunk.setRawAt(0, 0, 42);
+    const copy = chunk.cloneTiles();
+    copy[0] = 99;
+    expect(chunk.getRawAt(0, 0)).toBe(42);
+  });
+
+  it('source length mismatch throws', () => {
+    expect(() => new TileChunk(0, 0, 2, 2, new Uint32Array(3))).toThrow();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// TileLayer
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('TileLayer', () => {
+  const ts = makeTileset('base', 64);
+
+  it('basic construction', () => {
+    const layer = new TileLayer({
+      id: 1,
+      name: 'ground',
+      width: 128,
+      height: 128,
+      tileWidth: 32,
+      tileHeight: 32,
+      tilesets: [ts],
+    });
+    expect(layer.id).toBe(1);
+    expect(layer.name).toBe('ground');
+    expect(layer.width).toBe(128);
+    expect(layer.height).toBe(128);
+    expect(layer.pixelWidth).toBe(4096);
+    expect(layer.pixelHeight).toBe(4096);
+    expect(layer.visible).toBe(true);
+    expect(layer.opacity).toBe(1);
+  });
+
+  it('default chunk size is 32', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    expect(layer.chunkWidth).toBe(32);
+    expect(layer.chunkHeight).toBe(32);
+  });
+
+  it('custom chunk size', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+      chunkWidth: 16, chunkHeight: 16,
+    });
+    expect(layer.chunkWidth).toBe(16);
+  });
+
+  it('rejects invalid chunk size', () => {
+    expect(() => new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+      chunkWidth: 0,
+    })).toThrow();
+  });
+
+  it('rejects zero dimensions', () => {
+    expect(() => new TileLayer({
+      id: 0, name: 'l', width: 0, height: 64,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    })).toThrow();
+  });
+
+  it('inBounds check', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 10, height: 10,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    expect(layer.inBounds(0, 0)).toBe(true);
+    expect(layer.inBounds(9, 9)).toBe(true);
+    expect(layer.inBounds(-1, 0)).toBe(false);
+    expect(layer.inBounds(10, 0)).toBe(false);
+  });
+
+  it('chunk range computation', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 100, height: 80,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    const range = layer.chunkRange();
+    expect(range.minCx).toBe(0);
+    expect(range.minCy).toBe(0);
+    expect(range.maxCx).toBe(3); // ceil(100/32) - 1 = 3
+    expect(range.maxCy).toBe(2); // ceil(80/32) - 1 = 2
+  });
+
+  it('ensureChunk creates chunks in valid range', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    const chunk = layer.ensureChunk(0, 0);
+    expect(chunk).toBeDefined();
+    expect(chunk.width).toBe(32);
+    expect(chunk.height).toBe(32);
+  });
+
+  it('ensureChunk outside range throws', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 32, height: 32,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    expect(() => layer.ensureChunk(5, 5)).toThrow();
+  });
+
+  it('edge chunks have correct dimensions', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 40, height: 40,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+      chunkWidth: 32, chunkHeight: 32,
+    });
+    const edgeChunk = layer.ensureChunk(1, 0); // right edge
+    expect(edgeChunk.width).toBe(8); // 40 - 32 = 8
+    expect(edgeChunk.height).toBe(32);
+  });
+
+  it('getTileAt returns null for empty cell', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    expect(layer.getTileAt(0, 0)).toBeNull();
+  });
+
+  it('getTileAt returns null out of bounds', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    expect(layer.getTileAt(100, 100)).toBeNull();
+  });
+
+  it('setTileAt and getTileAt roundtrip', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    const ref = { tileset: ts, localTileId: 3, transform: TILE_TRANSFORM_IDENTITY };
+    layer.setTileAt(5, 5, ref);
+    const result = layer.getTileAt(5, 5);
+    expect(result).not.toBeNull();
+    expect(result!.tileset).toBe(ts);
+    expect(result!.localTileId).toBe(3);
+  });
+
+  it('setTileAt with transform preserves orientation', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    const ref = {
+      tileset: ts,
+      localTileId: 7,
+      transform: { flipX: true, flipY: false, diagonal: true },
+    };
+    layer.setTileAt(0, 0, ref);
+    const result = layer.getTileAt(0, 0)!;
+    expect(result.transform).toEqual({ flipX: true, flipY: false, diagonal: true });
+  });
+
+  it('setTileAt out of bounds throws', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 10, height: 10,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    const ref = { tileset: ts, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY };
+    expect(() => layer.setTileAt(10, 0, ref)).toThrow();
+    expect(() => layer.setTileAt(-1, 0, ref)).toThrow();
+  });
+
+  it('setTileAt with wrong tileset throws', () => {
+    const ts2 = makeTileset('other', 16);
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 10, height: 10,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    const ref = { tileset: ts2, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY };
+    expect(() => layer.setTileAt(0, 0, ref)).toThrow();
+  });
+
+  it('setTileAt with invalid localTileId throws', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 10, height: 10,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    const ref = { tileset: ts, localTileId: 999, transform: TILE_TRANSFORM_IDENTITY };
+    expect(() => layer.setTileAt(0, 0, ref)).toThrow();
+  });
+
+  it('clearTileAt on empty is no-op', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    const rev = layer.revision;
+    layer.clearTileAt(0, 0);
+    expect(layer.revision).toBe(rev);
+  });
+
+  it('clearTileAt after set removes tile', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    const ref = { tileset: ts, localTileId: 5, transform: TILE_TRANSFORM_IDENTITY };
+    layer.setTileAt(0, 0, ref);
+    expect(layer.getTileAt(0, 0)).not.toBeNull();
+    layer.clearTileAt(0, 0);
+    expect(layer.getTileAt(0, 0)).toBeNull();
+  });
+
+  it('clearTileAt out of bounds throws', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 10, height: 10,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    expect(() => layer.clearTileAt(10, 0)).toThrow();
+  });
+
+  it('revision tracks mutations', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    const ref = { tileset: ts, localTileId: 1, transform: TILE_TRANSFORM_IDENTITY };
+    expect(layer.revision).toBe(0);
+    layer.setTileAt(0, 0, ref);
+    expect(layer.revision).toBe(1);
+    layer.setTileAt(0, 0, ref); // no-op
+    expect(layer.revision).toBe(1);
+  });
+
+  it('getRawTileAt returns 0 for empty', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    expect(layer.getRawTileAt(0, 0)).toBe(0);
+  });
+
+  it('getRawTileAt returns packed value after set', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    const ref = { tileset: ts, localTileId: 7, transform: TILE_TRANSFORM_IDENTITY };
+    layer.setTileAt(0, 0, ref);
+    const raw = layer.getRawTileAt(0, 0);
+    expect(raw).not.toBe(0);
+  });
+
+  it('fillRect fills a region', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 16, height: 16,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    const ref = { tileset: ts, localTileId: 2, transform: TILE_TRANSFORM_IDENTITY };
+    layer.fillRect(2, 2, 4, 4, ref);
+    expect(layer.getTileAt(2, 2)).not.toBeNull();
+    expect(layer.getTileAt(5, 5)).not.toBeNull();
+    expect(layer.getTileAt(1, 1)).toBeNull();
+    expect(layer.getTileAt(6, 2)).toBeNull();
+  });
+
+  it('tilesInRect iterates non-empty tiles', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 16, height: 16,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    const ref = { tileset: ts, localTileId: 3, transform: TILE_TRANSFORM_IDENTITY };
+    layer.setTileAt(2, 2, ref);
+    layer.setTileAt(5, 3, ref);
+    const tiles = [...layer.tilesInRect(0, 0, 16, 16)];
+    expect(tiles.length).toBe(2);
+    expect(tiles[0]!.tx).toBe(2);
+    expect(tiles[0]!.ty).toBe(2);
+    expect(tiles[1]!.tx).toBe(5);
+    expect(tiles[1]!.ty).toBe(3);
+  });
+
+  it('countNonEmptyTiles returns correct count', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    const ref = { tileset: ts, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY };
+    layer.setTileAt(0, 0, ref);
+    layer.setTileAt(10, 10, ref);
+    layer.setTileAt(20, 20, ref);
+    expect(layer.countNonEmptyTiles()).toBe(3);
+  });
+
+  it('loadedChunks iterates in deterministic order', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 96, height: 96,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+      chunkWidth: 32, chunkHeight: 32,
+    });
+    const ref = { tileset: ts, localTileId: 1, transform: TILE_TRANSFORM_IDENTITY };
+    // Set tiles to create chunks in non-sequential order
+    layer.setTileAt(65, 0, ref);  // chunk (2, 0)
+    layer.setTileAt(0, 65, ref);  // chunk (0, 2)
+    layer.setTileAt(35, 0, ref);  // chunk (1, 0)
+    layer.setTileAt(0, 0, ref);   // chunk (0, 0)
+
+    const chunkCoords = [...layer.loadedChunks()].map(c => [c.cx, c.cy]);
+    // Expected order: sorted by cy then cx
+    const expected = [[0, 0], [1, 0], [2, 0], [0, 2]];
+    expect(chunkCoords).toEqual(expected);
+  });
+
+  it('layer properties are frozen', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+      properties: { key: 'value' },
+    });
+    expect(layer.properties.key).toBe('value');
+    expect(Object.isFrozen(layer.properties)).toBe(true);
+  });
+
+  it('layer properties copy input object', () => {
+    const mutable = { key: 'original' };
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+      properties: mutable,
+    });
+    mutable.key = 'changed';
+    expect(layer.properties.key).toBe('original');
+  });
+
+  it('coordinate conversion: tileToPixel', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 32, tileHeight: 16, tilesets: [ts],
+    });
+    expect(layer.tileToPixel(0, 0)).toEqual({ x: 0, y: 0 });
+    expect(layer.tileToPixel(5, 3)).toEqual({ x: 160, y: 48 });
+  });
+
+  it('coordinate conversion: pixelToTile', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 32, tileHeight: 16, tilesets: [ts],
+    });
+    expect(layer.pixelToTile(0, 0)).toEqual({ tx: 0, ty: 0 });
+    expect(layer.pixelToTile(31, 15)).toEqual({ tx: 0, ty: 0 });
+    expect(layer.pixelToTile(32, 16)).toEqual({ tx: 1, ty: 1 });
+  });
+
+  it('coordinate conversion with offset', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32, tilesets: [ts],
+      offsetX: 16, offsetY: 8,
+    });
+    expect(layer.tileToPixel(0, 0)).toEqual({ x: 16, y: 8 });
+    expect(layer.pixelToTile(16, 8)).toEqual({ tx: 0, ty: 0 });
+  });
+
+  it('operations after destroy throw', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    layer.destroy();
+    expect(layer.destroyed).toBe(true);
+    const ref = { tileset: ts, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY };
+    expect(() => layer.setTileAt(0, 0, ref)).toThrow();
+    expect(() => layer.clearTileAt(0, 0)).toThrow();
+  });
+
+  it('destroy is idempotent', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    layer.destroy();
+    layer.destroy(); // should not throw
+    expect(layer.destroyed).toBe(true);
+  });
+
+  it('multiple tilesets work', () => {
+    const ts1 = makeTileset('a', 16);
+    const ts2 = makeTileset('b', 32);
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 64, height: 64,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts1, ts2],
+    });
+    layer.setTileAt(0, 0, { tileset: ts1, localTileId: 5, transform: TILE_TRANSFORM_IDENTITY });
+    layer.setTileAt(1, 0, { tileset: ts2, localTileId: 10, transform: { flipX: true, flipY: false, diagonal: false } });
+
+    const t0 = layer.getTileAt(0, 0)!;
+    expect(t0.tileset).toBe(ts1);
+    expect(t0.localTileId).toBe(5);
+
+    const t1 = layer.getTileAt(1, 0)!;
+    expect(t1.tileset).toBe(ts2);
+    expect(t1.localTileId).toBe(10);
+    expect(t1.transform.flipX).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// TileMap
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('TileMap', () => {
+  const ts = makeTileset('base', 64);
+
+  it('basic construction', () => {
+    const map = new TileMap({
+      width: 32, height: 24,
+      tileWidth: 16, tileHeight: 16,
+    });
+    expect(map.width).toBe(32);
+    expect(map.height).toBe(24);
+    expect(map.tileWidth).toBe(16);
+    expect(map.tileHeight).toBe(16);
+    expect(map.pixelWidth).toBe(512);
+    expect(map.pixelHeight).toBe(384);
+  });
+
+  it('can hold multiple layers', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      tilesets: [ts],
+      layers: [
+        new TileLayer({ id: 0, name: 'ground', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] }),
+        new TileLayer({ id: 1, name: 'walls', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] }),
+      ],
+    });
+    expect(map.layers.length).toBe(2);
+    expect(map.getLayerById(0)!.name).toBe('ground');
+    expect(map.getLayerById(1)!.name).toBe('walls');
+  });
+
+  it('layers maintain insertion order', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      tilesets: [ts],
+      layers: [
+        new TileLayer({ id: 10, name: 'third', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] }),
+        new TileLayer({ id: 5, name: 'first', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] }),
+        new TileLayer({ id: 7, name: 'second', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] }),
+      ],
+    });
+    expect(map.layers.map(l => l.name)).toEqual(['third', 'first', 'second']);
+  });
+
+  it('duplicate layer ID throws', () => {
+    expect(() => new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      tilesets: [ts],
+      layers: [
+        new TileLayer({ id: 1, name: 'a', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] }),
+        new TileLayer({ id: 1, name: 'b', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] }),
+      ],
+    })).toThrow();
+  });
+
+  it('addLayer after construction works', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      tilesets: [ts],
+    });
+    const layer = new TileLayer({ id: 5, name: 'added', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] });
+    map.addLayer(layer);
+    expect(map.getLayerById(5)).toBeDefined();
+  });
+
+  it('removeLayer destroys the layer', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      tilesets: [ts],
+    });
+    const layer = new TileLayer({ id: 1, name: 'removable', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] });
+    map.addLayer(layer);
+    expect(map.removeLayer(1)).toBe(true);
+    expect(map.getLayerById(1)).toBeUndefined();
+    expect(layer.destroyed).toBe(true);
+  });
+
+  it('removeLayer returns false for non-existent ID', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      tilesets: [ts],
+    });
+    expect(map.removeLayer(999)).toBe(false);
+  });
+
+  it('getLayerByName returns first match', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      tilesets: [ts],
+      layers: [
+        new TileLayer({ id: 1, name: 'dup', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] }),
+        new TileLayer({ id: 2, name: 'dup', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] }),
+      ],
+    });
+    const found = map.getLayerByName('dup');
+    expect(found).toBeDefined();
+    expect(found!.id).toBe(1);
+  });
+
+  it('getTileLayer is an alias for getLayerByName', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      tilesets: [ts],
+      layers: [
+        new TileLayer({ id: 1, name: 'test', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] }),
+      ],
+    });
+    expect(map.getTileLayer('test')).toBe(map.getLayerByName('test'));
+  });
+
+  it('getTileAt convenience', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      tilesets: [ts],
+      layers: [
+        new TileLayer({ id: 1, name: 'l', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] }),
+      ],
+    });
+    const ref = { tileset: ts, localTileId: 3, transform: TILE_TRANSFORM_IDENTITY };
+    map.setTileAt(1, 5, 5, ref);
+    const t = map.getTileAt(1, 5, 5);
+    expect(t).not.toBeNull();
+    expect(t!.localTileId).toBe(3);
+  });
+
+  it('getTileAt returns null for non-existent layer', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+    });
+    expect(map.getTileAt(999, 0, 0)).toBeNull();
+  });
+
+  it('setTileAt throws for non-existent layer', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+    });
+    const ref = { tileset: ts, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY };
+    expect(() => map.setTileAt(999, 0, 0, ref)).toThrow();
+  });
+
+  it('clearTileAt throws for non-existent layer', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+    });
+    expect(() => map.clearTileAt(999, 0, 0)).toThrow();
+  });
+
+  it('multiple tilesets', () => {
+    const ts1 = makeTileset('a', 32);
+    const ts2 = makeTileset('b', 64);
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      tilesets: [ts1, ts2],
+      layers: [
+        new TileLayer({ id: 0, name: 'l', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts1, ts2] }),
+      ],
+    });
+    expect(map.tilesets).toHaveLength(2);
+    expect(map.getTileset('a')).toBe(ts1);
+    expect(map.getTileset('b')).toBe(ts2);
+  });
+
+  it('addTileset adds and prevents duplicates', () => {
+    const ts1 = makeTileset('unique', 16);
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+    });
+    map.addTileset(ts1);
+    expect(map.tilesets).toHaveLength(1);
+    const ts2 = makeTileset('unique', 16); // same name
+    expect(() => map.addTileset(ts2)).toThrow();
+  });
+
+  it('map properties are frozen', () => {
+    const props = { author: 'test' };
+    const map = new TileMap({
+      width: 16, height: 16,
+      tileWidth: 16, tileHeight: 16,
+      properties: props,
+    });
+    expect(map.properties.author).toBe('test');
+    props.author = 'changed';
+    expect(map.properties.author).toBe('test');
+    expect(Object.isFrozen(map.properties)).toBe(true);
+  });
+
+  it('coordinate conversion', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 16,
+    });
+    expect(map.tileToPixel(5, 3)).toEqual({ x: 160, y: 48 });
+    expect(map.pixelToTile(160, 48)).toEqual({ tx: 5, ty: 3 });
+  });
+
+  it('pixelToTile uses floor', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+    });
+    expect(map.pixelToTile(31, 31)).toEqual({ tx: 0, ty: 0 });
+    expect(map.pixelToTile(32, 32)).toEqual({ tx: 1, ty: 1 });
+  });
+
+  it('destroy is idempotent', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      tilesets: [ts],
+      layers: [
+        new TileLayer({ id: 0, name: 'l', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] }),
+      ],
+    });
+    map.destroy();
+    map.destroy();
+    expect(map.destroyed).toBe(true);
+  });
+
+  it('operations after destroy throw', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+    });
+    map.destroy();
+    expect(() => map.addTileset(ts)).toThrow();
+    expect(() => map.addLayer(
+      new TileLayer({ id: 0, name: 'l', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] }),
+    )).toThrow();
+  });
+
+  it('destroys layers on destroy', () => {
+    const layer = new TileLayer({ id: 0, name: 'l', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] });
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      tilesets: [ts],
+      layers: [layer],
+    });
+    map.destroy();
+    expect(layer.destroyed).toBe(true);
+  });
+
+  it('tilesets copy is independent of caller', () => {
+    const tsArr = [makeTileset('base', 16)];
+    const map = new TileMap({
+      width: 16, height: 16,
+      tileWidth: 16, tileHeight: 16,
+      tilesets: tsArr,
+    });
+    tsArr.push(makeTileset('extra', 16));
+    expect(map.tilesets).toHaveLength(1);
+  });
+
+  it('layers copy is independent of caller', () => {
+    const layer = new TileLayer({ id: 0, name: 'l', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] });
+    const layerArr = [layer];
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      tilesets: [ts],
+      layers: layerArr,
+    });
+    layerArr.push(new TileLayer({ id: 1, name: 'extra', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] }));
+    expect(map.layers).toHaveLength(1);
+  });
+
+  it('texture ownership: TileMap destroy does not affect tileset textures', () => {
+    const tex = fakeTexture();
+    const region = new TextureRegion(tex, { x: 0, y: 0, width: 128, height: 128 });
+    const tileset = new TileSet({
+      name: 'ts',
+      texture: region,
+      tileWidth: 32,
+      tileHeight: 32,
+      tileCount: 16,
+    });
+    const map = new TileMap({
+      width: 16, height: 16,
+      tileWidth: 32, tileHeight: 32,
+      tilesets: [tileset],
+    });
+    map.destroy();
+    // Tileset still holds the texture reference; texture is not destroyed
+    expect(tileset.texture).toBe(region);
+    expect(tileset.name).toBe('ts');
+  });
+
+  it('revision increments on structural changes', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      tilesets: [ts],
+    });
+    expect(map.revision).toBe(0);
+    map.addTileset(makeTileset('extra', 16));
+    expect(map.revision).toBe(1);
+    map.addLayer(new TileLayer({ id: 1, name: 'l', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] }));
+    expect(map.revision).toBe(2);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Immutability / defensive copy tests
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('immutability', () => {
+  it('TileSet constructor copies options', () => {
+    const opts = {
+      name: 'test',
+      texture: fakeRegion(),
+      tileWidth: 32,
+      tileHeight: 32,
+      tileCount: 16,
+    };
+    const ts = new TileSet(opts);
+    expect(ts.name).toBe('test');
+    expect(ts.tileCount).toBe(16);
+  });
+
+  it('TileMap tilesets array is copied', () => {
+    const tsArr = [makeTileset('base', 16)];
+    const map = new TileMap({
+      width: 16, height: 16,
+      tileWidth: 16, tileHeight: 16,
+      tilesets: tsArr,
+    });
+    expect(map.tilesets).not.toBe(tsArr);
+  });
+
+  it('TileMap layers readonly snapshot is not the internal array', () => {
+    const layer = new TileLayer({ id: 0, name: 'l', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [makeTileset('b', 16)] });
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      layers: [layer],
+    });
+    const snap = map.layers;
+    expect(snap).toHaveLength(1);
+    // The snapshot is a readonly tuple from the internal array slice.
+  });
+});

--- a/packages/exojs-tilemap/test/tilemap.test.ts
+++ b/packages/exojs-tilemap/test/tilemap.test.ts
@@ -88,9 +88,12 @@ describe('tile packing', () => {
     expect(() => packTile(-1, 1, TILE_TRANSFORM_IDENTITY)).toThrow();
   });
 
-  it('identity transform packs as no flip bits', () => {
+  it('identity transform packs as non-zero when localTileId=0', () => {
+    // With the +1 offset, tile 0 stores as 1, not 0
     const packed = packTile(0, 0, TILE_TRANSFORM_IDENTITY);
-    expect(packed & 0xe0000000).toBe(0);
+    expect(packed).not.toBe(0);
+    const u = unpackTile(packed)!;
+    expect(u.localTileId).toBe(0);
   });
 
   it('TILE_TRANSFORM_IDENTITY is frozen identity', () => {
@@ -135,7 +138,6 @@ describe('chunk coordinate math', () => {
   });
 
   it('local in chunk wraps correctly for negatives', () => {
-    // tx=-1 with chunkW=32: cx=-1, lx=31
     const { cx, cy } = tileToChunkCoord(-1, -5, 32, 32);
     const { lx, ly } = tileToLocalInChunk(-1, -5, 32, 32);
     expect(cx).toBe(-1);
@@ -162,8 +164,8 @@ describe('TileSet', () => {
     expect(ts.tileWidth).toBe(32);
     expect(ts.tileHeight).toBe(32);
     expect(ts.tileCount).toBe(64);
-    expect(ts.columns).toBe(8); // 256 / 32
-    expect(ts.rows).toBe(8);    // ceil(64 / 8)
+    expect(ts.columns).toBe(8);
+    expect(ts.rows).toBe(8);
   });
 
   it('custom columns', () => {
@@ -189,9 +191,6 @@ describe('TileSet', () => {
       spacing: 2,
       margin: 4,
     });
-    // With margin: usable area is 320 - 8 = 312
-    // columns = floor(312 / 32) = 9
-    // But: 32*9 + 2*8 = 288 + 16 = 304 <= 312 ✓
     expect(ts.columns).toBeGreaterThanOrEqual(1);
   });
 
@@ -206,7 +205,7 @@ describe('TileSet', () => {
     const r = ts.getTileRect(0);
     expect(r).toEqual({ x: 0, y: 0, width: 32, height: 32 });
 
-    const r2 = ts.getTileRect(5); // col 1, row 1
+    const r2 = ts.getTileRect(5);
     expect(r2.x).toBe(32);
     expect(r2.y).toBe(32);
   });
@@ -225,7 +224,6 @@ describe('TileSet', () => {
     expect(r.x).toBe(4);
     expect(r.y).toBe(4);
 
-    // Column 1: margin + (tileWidth + spacing) * col = 4 + 34 = 38
     const r2 = ts.getTileRect(1);
     expect(r2.x).toBe(38);
   });
@@ -278,8 +276,8 @@ describe('TileSet', () => {
     const ts = makeTileset('test', 16);
     const mutableProps = { solid: true };
     ts._setDefinition(0, { properties: mutableProps });
-    mutableProps.solid = false; // mutate after
-    expect(ts.getTileDefinition(0)!.properties!.solid).toBe(true); // unchanged
+    mutableProps.solid = false;
+    expect(ts.getTileDefinition(0)!.properties!.solid).toBe(true);
   });
 
   it('allDefinitions returns frozen snapshot', () => {
@@ -311,63 +309,69 @@ describe('TileChunk', () => {
     expect(chunk.cy).toBe(0);
     expect(chunk.width).toBe(32);
     expect(chunk.height).toBe(32);
-    expect(chunk.tiles.length).toBe(1024);
+    expect(chunk.cloneTiles().length).toBe(1024);
     expect(chunk.empty).toBe(true);
   });
 
-  it('source data is copied', () => {
+  it('backing array is NOT exposed publicly', () => {
+    const chunk = new TileChunk(0, 0, 2, 2);
+    // The `tiles` property does not exist on the public interface
+    expect((chunk as Record<string, unknown>).tiles).toBeUndefined();
+  });
+
+  it('source data is defensively copied', () => {
     const source = new Uint32Array(4);
     source[0] = 1;
     const chunk = new TileChunk(0, 0, 2, 2, source);
-    source[0] = 99; // mutate original
+    source[0] = 99;
     expect(chunk.getRawAt(0, 0)).toBe(1);
   });
 
-  it('setRawAt returns true on change, false on no-op', () => {
+  it('_setRawAt returns true on change, false on no-op', () => {
     const chunk = new TileChunk(0, 0, 2, 2);
-    expect(chunk.setRawAt(0, 0, 42)).toBe(true);
-    expect(chunk.setRawAt(0, 0, 42)).toBe(false);
+    expect(chunk._setRawAt(0, 0, 42)).toBe(true);
+    expect(chunk._setRawAt(0, 0, 42)).toBe(false);
   });
 
   it('revision increments on change, not on no-op', () => {
     const chunk = new TileChunk(0, 0, 2, 2);
     expect(chunk.revision).toBe(0);
-    chunk.setRawAt(0, 0, 42);
+    chunk._setRawAt(0, 0, 42);
     expect(chunk.revision).toBe(1);
-    chunk.setRawAt(0, 0, 42);
+    chunk._setRawAt(0, 0, 42);
     expect(chunk.revision).toBe(1);
-    chunk.setRawAt(1, 0, 99);
+    chunk._setRawAt(1, 0, 99);
     expect(chunk.revision).toBe(2);
   });
 
   it('empty flag is cached and invalidated', () => {
     const chunk = new TileChunk(0, 0, 2, 2);
     expect(chunk.empty).toBe(true);
-    chunk.setRawAt(0, 0, 42);
+    chunk._setRawAt(0, 0, 42);
     expect(chunk.empty).toBe(false);
-    chunk.setRawAt(0, 0, 0);
+    chunk._setRawAt(0, 0, 0);
     expect(chunk.empty).toBe(true);
   });
 
-  it('clear sets all to 0 and increments revision if had content', () => {
+  it('_clear sets all to 0 and increments revision if had content', () => {
     const chunk = new TileChunk(0, 0, 2, 2);
-    chunk.setRawAt(0, 0, 42);
+    chunk._setRawAt(0, 0, 42);
     const rev = chunk.revision;
-    chunk.clear();
+    chunk._clear();
     expect(chunk.revision).toBe(rev + 1);
     expect(chunk.empty).toBe(true);
   });
 
-  it('clear on already-empty chunk is no-op', () => {
+  it('_clear on already-empty chunk is no-op', () => {
     const chunk = new TileChunk(0, 0, 2, 2);
     const rev = chunk.revision;
-    chunk.clear();
+    chunk._clear();
     expect(chunk.revision).toBe(rev);
   });
 
-  it('markDirty invalidates empty cache and increments revision', () => {
+  it('_markDirty invalidates empty cache and increments revision', () => {
     const chunk = new TileChunk(0, 0, 2, 2);
-    chunk.markDirty();
+    chunk._markDirty();
     expect(chunk.revision).toBe(1);
   });
 
@@ -382,13 +386,51 @@ describe('TileChunk', () => {
   });
 
   it('rejects unsafe allocation size', () => {
-    // width * height that overflows safe integer
     expect(() => new TileChunk(0, 0, 1e8, 1e8)).toThrow();
+  });
+
+  it('rejects non-integer cx', () => {
+    expect(() => new TileChunk(1.5, 0, 2, 2)).toThrow();
+  });
+
+  it('rejects non-finite cx', () => {
+    expect(() => new TileChunk(NaN, 0, 2, 2)).toThrow();
+    expect(() => new TileChunk(Infinity, 0, 2, 2)).toThrow();
+  });
+
+  it('rejects non-safe-integer cx', () => {
+    expect(() => new TileChunk(Number.MAX_SAFE_INTEGER + 1, 0, 2, 2)).toThrow();
+  });
+
+  it('getRawAt validates local coordinates', () => {
+    const chunk = new TileChunk(0, 0, 8, 8);
+    expect(() => chunk.getRawAt(-1, 0)).toThrow();
+    expect(() => chunk.getRawAt(0, -1)).toThrow();
+    expect(() => chunk.getRawAt(8, 0)).toThrow();
+    expect(() => chunk.getRawAt(0, 8)).toThrow();
+    expect(() => chunk.getRawAt(0.5, 0)).toThrow();
+    expect(() => chunk.getRawAt(NaN, 0)).toThrow();
+  });
+
+  it('_setRawAt validates local coordinates', () => {
+    const chunk = new TileChunk(0, 0, 8, 8);
+    expect(() => chunk._setRawAt(-1, 0, 1)).toThrow();
+    expect(() => chunk._setRawAt(0, 8, 1)).toThrow();
+    expect(chunk.revision).toBe(0); // no revision change on rejection
+  });
+
+  it('_setRawAt validates packed value is a finite integer', () => {
+    const chunk = new TileChunk(0, 0, 8, 8);
+    expect(() => chunk._setRawAt(0, 0, NaN)).toThrow();
+    expect(() => chunk._setRawAt(0, 0, 0.5)).toThrow();
+    expect(() => chunk._setRawAt(0, 0, Infinity)).toThrow();
+    // Negative integers are valid uint32 values (bit 31 set)
+    expect(() => chunk._setRawAt(0, 0, -1)).not.toThrow();
   });
 
   it('cloneTiles returns independent copy', () => {
     const chunk = new TileChunk(0, 0, 2, 2);
-    chunk.setRawAt(0, 0, 42);
+    chunk._setRawAt(0, 0, 42);
     const copy = chunk.cloneTiles();
     copy[0] = 99;
     expect(chunk.getRawAt(0, 0)).toBe(42);
@@ -478,27 +520,46 @@ describe('TileLayer', () => {
     const range = layer.chunkRange();
     expect(range.minCx).toBe(0);
     expect(range.minCy).toBe(0);
-    expect(range.maxCx).toBe(3); // ceil(100/32) - 1 = 3
-    expect(range.maxCy).toBe(2); // ceil(80/32) - 1 = 2
+    expect(range.maxCx).toBe(3);
+    expect(range.maxCy).toBe(2);
   });
 
-  it('ensureChunk creates chunks in valid range', () => {
+  it('getChunk returns readonly view (ReadonlyTileChunk)', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 32, height: 32,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    // No chunk exists yet (lazy)
+    expect(layer.getChunk(0, 0)).toBeUndefined();
+
+    // Create via layer mutation
+    const ref = { tileset: ts, localTileId: 1, transform: TILE_TRANSFORM_IDENTITY };
+    layer.setTileAt(0, 0, ref);
+
+    const chunk = layer.getChunk(0, 0);
+    expect(chunk).toBeDefined();
+    expect(chunk!.cx).toBe(0);
+    expect(chunk!.cy).toBe(0);
+    expect(chunk!.getRawAt(0, 0)).not.toBe(0);
+  });
+
+  it('_ensureChunk creates chunks in valid range', () => {
     const layer = new TileLayer({
       id: 0, name: 'l', width: 64, height: 64,
       tileWidth: 16, tileHeight: 16, tilesets: [ts],
     });
-    const chunk = layer.ensureChunk(0, 0);
+    const chunk = layer._ensureChunk(0, 0);
     expect(chunk).toBeDefined();
     expect(chunk.width).toBe(32);
     expect(chunk.height).toBe(32);
   });
 
-  it('ensureChunk outside range throws', () => {
+  it('_ensureChunk outside range throws', () => {
     const layer = new TileLayer({
       id: 0, name: 'l', width: 32, height: 32,
       tileWidth: 16, tileHeight: 16, tilesets: [ts],
     });
-    expect(() => layer.ensureChunk(5, 5)).toThrow();
+    expect(() => layer._ensureChunk(5, 5)).toThrow();
   });
 
   it('edge chunks have correct dimensions', () => {
@@ -507,8 +568,8 @@ describe('TileLayer', () => {
       tileWidth: 16, tileHeight: 16, tilesets: [ts],
       chunkWidth: 32, chunkHeight: 32,
     });
-    const edgeChunk = layer.ensureChunk(1, 0); // right edge
-    expect(edgeChunk.width).toBe(8); // 40 - 32 = 8
+    const edgeChunk = layer._ensureChunk(1, 0);
+    expect(edgeChunk.width).toBe(8);
     expect(edgeChunk.height).toBe(32);
   });
 
@@ -626,6 +687,10 @@ describe('TileLayer', () => {
     expect(layer.revision).toBe(1);
     layer.setTileAt(0, 0, ref); // no-op
     expect(layer.revision).toBe(1);
+    layer.clearTileAt(0, 0);
+    expect(layer.revision).toBe(2);
+    layer.clearTileAt(0, 0); // no-op (already empty)
+    expect(layer.revision).toBe(2);
   });
 
   it('getRawTileAt returns 0 for empty', () => {
@@ -695,14 +760,12 @@ describe('TileLayer', () => {
       chunkWidth: 32, chunkHeight: 32,
     });
     const ref = { tileset: ts, localTileId: 1, transform: TILE_TRANSFORM_IDENTITY };
-    // Set tiles to create chunks in non-sequential order
-    layer.setTileAt(65, 0, ref);  // chunk (2, 0)
-    layer.setTileAt(0, 65, ref);  // chunk (0, 2)
-    layer.setTileAt(35, 0, ref);  // chunk (1, 0)
-    layer.setTileAt(0, 0, ref);   // chunk (0, 0)
+    layer.setTileAt(65, 0, ref);
+    layer.setTileAt(0, 65, ref);
+    layer.setTileAt(35, 0, ref);
+    layer.setTileAt(0, 0, ref);
 
     const chunkCoords = [...layer.loadedChunks()].map(c => [c.cx, c.cy]);
-    // Expected order: sorted by cy then cx
     const expected = [[0, 0], [1, 0], [2, 0], [0, 2]];
     expect(chunkCoords).toEqual(expected);
   });
@@ -767,6 +830,7 @@ describe('TileLayer', () => {
     const ref = { tileset: ts, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY };
     expect(() => layer.setTileAt(0, 0, ref)).toThrow();
     expect(() => layer.clearTileAt(0, 0)).toThrow();
+    expect(() => layer._ensureChunk(0, 0)).toThrow();
   });
 
   it('destroy is idempotent', () => {
@@ -775,7 +839,7 @@ describe('TileLayer', () => {
       tileWidth: 16, tileHeight: 16, tilesets: [ts],
     });
     layer.destroy();
-    layer.destroy(); // should not throw
+    layer.destroy();
     expect(layer.destroyed).toBe(true);
   });
 
@@ -797,6 +861,41 @@ describe('TileLayer', () => {
     expect(t1.tileset).toBe(ts2);
     expect(t1.localTileId).toBe(10);
     expect(t1.transform.flipX).toBe(true);
+  });
+
+  // ── No-op mutation & revision ─────────────────────────────────────────
+
+  it('no-op setTileAt does NOT change revision', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 8, height: 8,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    const ref = { tileset: ts, localTileId: 3, transform: TILE_TRANSFORM_IDENTITY };
+    layer.setTileAt(0, 0, ref);
+    const rev = layer.revision;
+    layer.setTileAt(0, 0, ref);
+    expect(layer.revision).toBe(rev);
+  });
+
+  it('no-op clearTileAt does NOT change revision', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 8, height: 8,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    const rev = layer.revision;
+    layer.clearTileAt(0, 0);
+    expect(layer.revision).toBe(rev);
+  });
+
+  it('failed setTileAt does NOT change revision', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 8, height: 8,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    const ts2 = makeTileset('other', 16);
+    const rev = layer.revision;
+    try { layer.setTileAt(0, 0, { tileset: ts2, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY }); } catch { /* expected */ }
+    expect(layer.revision).toBe(rev);
   });
 });
 
@@ -986,7 +1085,7 @@ describe('TileMap', () => {
     });
     map.addTileset(ts1);
     expect(map.tilesets).toHaveLength(1);
-    const ts2 = makeTileset('unique', 16); // same name
+    const ts2 = makeTileset('unique', 16);
     expect(() => map.addTileset(ts2)).toThrow();
   });
 
@@ -1099,12 +1198,11 @@ describe('TileMap', () => {
       tilesets: [tileset],
     });
     map.destroy();
-    // Tileset still holds the texture reference; texture is not destroyed
     expect(tileset.texture).toBe(region);
     expect(tileset.name).toBe('ts');
   });
 
-  it('revision increments on structural changes', () => {
+  it('revision increments on structural changes only (not cell mutations)', () => {
     const map = new TileMap({
       width: 64, height: 64,
       tileWidth: 32, tileHeight: 32,
@@ -1113,8 +1211,15 @@ describe('TileMap', () => {
     expect(map.revision).toBe(0);
     map.addTileset(makeTileset('extra', 16));
     expect(map.revision).toBe(1);
-    map.addLayer(new TileLayer({ id: 1, name: 'l', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] }));
+
+    const layer = new TileLayer({ id: 1, name: 'l', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] });
+    map.addLayer(layer);
     expect(map.revision).toBe(2);
+
+    // Cell mutation through layer does NOT increment map revision
+    const ref = { tileset: ts, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY };
+    map.setTileAt(1, 0, 0, ref);
+    expect(map.revision).toBe(2); // unchanged — layer tracks cell revisions
   });
 });
 
@@ -1123,19 +1228,6 @@ describe('TileMap', () => {
 // ═══════════════════════════════════════════════════════════════════════
 
 describe('immutability', () => {
-  it('TileSet constructor copies options', () => {
-    const opts = {
-      name: 'test',
-      texture: fakeRegion(),
-      tileWidth: 32,
-      tileHeight: 32,
-      tileCount: 16,
-    };
-    const ts = new TileSet(opts);
-    expect(ts.name).toBe('test');
-    expect(ts.tileCount).toBe(16);
-  });
-
   it('TileMap tilesets array is copied', () => {
     const tsArr = [makeTileset('base', 16)];
     const map = new TileMap({
@@ -1146,15 +1238,47 @@ describe('immutability', () => {
     expect(map.tilesets).not.toBe(tsArr);
   });
 
-  it('TileMap layers readonly snapshot is not the internal array', () => {
-    const layer = new TileLayer({ id: 0, name: 'l', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [makeTileset('b', 16)] });
-    const map = new TileMap({
-      width: 64, height: 64,
-      tileWidth: 32, tileHeight: 32,
-      layers: [layer],
+  it('cloneTiles mutation does not affect chunk', () => {
+    const chunk = new TileChunk(0, 0, 2, 2);
+    chunk._setRawAt(0, 0, 1);
+    const clone = chunk.cloneTiles();
+    clone[0] = 99;
+    expect(chunk.getRawAt(0, 0)).toBe(1);
+  });
+
+  it('readonly chunk from layer has no writable tiles', () => {
+    const ts = makeTileset('base', 16);
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 32, height: 32,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
     });
-    const snap = map.layers;
-    expect(snap).toHaveLength(1);
-    // The snapshot is a readonly tuple from the internal array slice.
+    const ref = { tileset: ts, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY };
+    layer.setTileAt(0, 0, ref);
+
+    const chunk = layer.getChunk(0, 0)!;
+    // The public ReadonlyTileChunk interface has no 'tiles' property
+    const chunkAsAny = chunk as Record<string, unknown>;
+    // Verify that 'tiles' is undefined (private member)
+    expect(chunkAsAny.tiles).toBeUndefined();
+    // Verify that _setRawAt is still there (internal, but not public API intent)
+    // The key point is tiles is NOT exposed
+  });
+
+  it('clone can modify other chunks through public API only', () => {
+    const ts = makeTileset('base', 16);
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 32, height: 32,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    const ref = { tileset: ts, localTileId: 1, transform: TILE_TRANSFORM_IDENTITY };
+    layer.setTileAt(0, 0, ref);
+
+    // Get a readonly chunk view — the chunk is separate from tileset/clone
+    const chunk = layer.getChunk(0, 0)!;
+    const clone = chunk.cloneTiles();
+    clone[0] = 0; // mutate clone
+
+    // Original layer tile still exists
+    expect(layer.getTileAt(0, 0)).not.toBeNull();
   });
 });

--- a/packages/exojs-tilemap/tsconfig.json
+++ b/packages/exojs-tilemap/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@codexo/exojs-config/typescript/extension.json",
+  "compilerOptions": {
+    "customConditions": ["@codexo/source"],
+    "paths": {
+      "@codexo/exojs": ["../../src/index.ts"],
+      "@codexo/exojs/extensions": ["../../src/extensions/index.ts"],
+      "@codexo/exojs/rendering": ["../../src/rendering.ts"],
+      "@codexo/exojs/debug": ["../../src/debug/index.ts"]
+    }
+  },
+  "include": ["src/**/*", "src/typings.d.ts", "../../src/typings.d.ts"],
+  "exclude": ["dist", "node_modules", "test"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,15 @@ importers:
         specifier: workspace:*
         version: link:../exojs-config
 
+  packages/exojs-tilemap:
+    devDependencies:
+      '@codexo/exojs':
+        specifier: workspace:*
+        version: link:../..
+      '@codexo/exojs-config':
+        specifier: workspace:*
+        version: link:../exojs-config
+
   site:
     dependencies:
       '@astrojs/mdx':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - site
   - packages/exojs-config
   - packages/exojs-particles
+  - packages/exojs-tilemap
   - packages/exojs-tiled
   - packages/create-exo-app
 

--- a/scripts/release/manifest.ts
+++ b/scripts/release/manifest.ts
@@ -2,7 +2,7 @@
  * Release manifest: the contract between the build-once `prepare` stage and the
  * `publish` stage.
  *
- * `prepare` packs exactly three npm tarballs, hashes them, and records the
+ * `prepare` packs exactly four npm tarballs, hashes them, and records the
  * digests here. `publish` re-hashes the on-disk tarballs and refuses to proceed
  * if any digest drifts from the manifest — that is the build-once guarantee:
  * the artifacts that were built, hashed and externally tested are byte-for-byte
@@ -12,7 +12,7 @@ import { createHash } from 'node:crypto';
 import { readFileSync, statSync } from 'node:fs';
 
 /** Lockstep publish order — Core first (peer of the extensions), then the extensions. */
-export const PUBLISH_ORDER = ['@codexo/exojs', '@codexo/exojs-particles', '@codexo/exojs-tiled'] as const;
+export const PUBLISH_ORDER = ['@codexo/exojs', '@codexo/exojs-particles', '@codexo/exojs-tilemap', '@codexo/exojs-tiled'] as const;
 
 export type OfficialPackageName = (typeof PUBLISH_ORDER)[number];
 

--- a/scripts/verify-lockstep-versions.ts
+++ b/scripts/verify-lockstep-versions.ts
@@ -1,9 +1,9 @@
 /**
- * Verifies that all three official ExoJS packages share the same version.
+ * Verifies that all four official ExoJS packages share the same version.
  *
  * The lockstep version contract: @codexo/exojs, @codexo/exojs-particles,
- * and @codexo/exojs-tiled must all be on the same X.Y.Z version for every
- * coordinated release.
+ * @codexo/exojs-tilemap, and @codexo/exojs-tiled must all be on the same
+ * X.Y.Z version for every coordinated release.
  */
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
@@ -27,7 +27,11 @@ function readPackage(relPath: string): PackageInfo {
 }
 
 const corePkg = readPackage('package.json');
-const extensionPkgs = [readPackage('packages/exojs-particles/package.json'), readPackage('packages/exojs-tiled/package.json')];
+const extensionPkgs = [
+  readPackage('packages/exojs-particles/package.json'),
+  readPackage('packages/exojs-tilemap/package.json'),
+  readPackage('packages/exojs-tiled/package.json'),
+];
 const packages = [corePkg, ...extensionPkgs];
 
 const versions = [...new Set(packages.map(p => p.version))];
@@ -62,4 +66,4 @@ if (peerProblems.length > 0) {
   process.exit(1);
 }
 
-process.stdout.write(`verify-lockstep: all 3 packages at v${versions[0]}; extension peer ranges = "${expectedPeer}" ✓\n`);
+process.stdout.write(`verify-lockstep: all 4 packages at v${versions[0]}; extension peer ranges = "${expectedPeer}" ✓\n`);

--- a/scripts/verify-release-matrix.ts
+++ b/scripts/verify-release-matrix.ts
@@ -5,7 +5,7 @@
  * handles every official package, in the right order, with coherent versions,
  * via the two-stage build-once pipeline:
  *
- *  1. The three official packages (@codexo/exojs, -particles, -tiled) share one
+ *  1. The four official packages (@codexo/exojs, -particles, -tilemap, -tiled) share one
  *     lockstep version.
  *  2. Each extension's peerDependencies["@codexo/exojs"] is "<major>.<minor>.x".
  *  3. create-exo-app is versioned independently (a different version line).
@@ -14,7 +14,7 @@
  *     uploads the artifacts.
  *  6. PUBLISH consumes those artifacts (`download-artifact` + `release:publish`)
  *     and never rebuilds.
- *  7. The publish order Core → Particles → Tiled is the canonical PUBLISH_ORDER.
+ *  7. The publish order Core → Particles → Tilemap → Tiled is the canonical PUBLISH_ORDER.
  *
  * Read-only: safe to run in dry-run/CI. Exits non-zero on any inconsistency.
  *
@@ -48,10 +48,11 @@ const ok: string[] = [];
 
 const core = readPkg('package.json');
 const particles = readPkg('packages/exojs-particles/package.json');
+const tilemap = readPkg('packages/exojs-tilemap/package.json');
 const tiled = readPkg('packages/exojs-tiled/package.json');
 const createExoApp = readPkg('packages/create-exo-app/package.json');
 
-const official = [core, particles, tiled];
+const official = [core, particles, tilemap, tiled];
 
 // 1. Lockstep version.
 const versions = new Set(official.map(p => p.version));
@@ -66,7 +67,7 @@ const [major, minor] = version.split('.');
 const expectedPeer = `${major}.${minor}.x`;
 
 // 2. Extension peer ranges.
-for (const ext of [particles, tiled]) {
+for (const ext of [particles, tilemap, tiled]) {
   if (ext.peer !== expectedPeer) {
     problems.push(`${ext.name}: peer "@codexo/exojs" is "${ext.peer ?? '(missing)'}", expected "${expectedPeer}"`);
   } else {
@@ -95,6 +96,7 @@ const requireInWorkflow = (needle: string, label: string): void => {
 // 4. PREPARE builds all three official packages exactly once (build-once).
 requireInWorkflow('pnpm build', 'prepare builds core');
 requireInWorkflow('pnpm --filter @codexo/exojs-particles build', 'prepare builds particles');
+requireInWorkflow('pnpm --filter @codexo/exojs-tilemap build', 'prepare builds tilemap');
 requireInWorkflow('pnpm --filter @codexo/exojs-tiled build', 'prepare builds tiled');
 
 // 5. PREPARE packs/hashes/zips and uploads the artifacts.
@@ -124,10 +126,10 @@ if (/run:\s*pnpm build\b/.test(publishSection)) {
 }
 
 // 7. Canonical publish order Core → Particles → Tiled (enforced in code).
-if (PUBLISH_ORDER[0] === '@codexo/exojs' && PUBLISH_ORDER[1] === '@codexo/exojs-particles' && PUBLISH_ORDER[2] === '@codexo/exojs-tiled') {
-  ok.push('PUBLISH_ORDER is Core → Particles → Tiled');
+if (PUBLISH_ORDER[0] === '@codexo/exojs' && PUBLISH_ORDER[1] === '@codexo/exojs-particles' && PUBLISH_ORDER[2] === '@codexo/exojs-tilemap' && PUBLISH_ORDER[3] === '@codexo/exojs-tiled') {
+  ok.push('PUBLISH_ORDER is Core → Particles → Tilemap → Tiled');
 } else {
-  problems.push(`PUBLISH_ORDER must be Core → Particles → Tiled, got ${PUBLISH_ORDER.join(' → ')}`);
+  problems.push(`PUBLISH_ORDER must be Core → Particles → Tilemap → Tiled, got ${PUBLISH_ORDER.join(' → ')}`);
 }
 
 // --- Report ---

--- a/test/release/manifest.test.ts
+++ b/test/release/manifest.test.ts
@@ -75,7 +75,7 @@ describe('renderChecksums', () => {
       fullZip: { file: 'exojs-v0.12.0-full.zip', sha256: 'zzz', bytes: 1 },
     });
     const lines = body.trimEnd().split('\n');
-    expect(lines).toHaveLength(3);
+    expect(lines).toHaveLength(4);
     expect(body).not.toContain('full.zip');
     for (const line of lines) expect(line).toMatch(/^[a-f0-9]{64} {2}codexo-/);
   });

--- a/test/release/publish.test.ts
+++ b/test/release/publish.test.ts
@@ -8,7 +8,7 @@ import { type CommandInvocation, type CommandResult, createRecordingRunner, fail
 import { PUBLISH_ORDER, type ReleaseManifest, sha256File } from '../../scripts/release/manifest';
 import { defaultPublishOptions, type PublishOptions, publishRelease } from '../../scripts/release/publish';
 
-// ── Fixture: a staging dir with three real tarball files + a coherent manifest ──
+// ── Fixture: a staging dir with four real tarball files + a coherent manifest ──
 let staging: string;
 let manifest: ReleaseManifest;
 
@@ -51,7 +51,7 @@ const publishedPackages = (invocations: CommandInvocation[]): string[] => publis
 const liveOptions = (): PublishOptions => ({ ...defaultPublishOptions('0.12.0'), dryRun: false, checkExisting: true });
 
 describe('publishRelease — dry-run', () => {
-  it('publishes all three to the temp dist-tag in Core→Particles→Tiled order, every call carries --dry-run', () => {
+    it('publishes all four to the temp dist-tag in Core→Particles→Tilemap→Tiled order, every call carries --dry-run', () => {
     const runner = createRecordingRunner(inv => (inv.args[0] === 'view' ? fail('E404') : ok()));
     const report = publishRelease(manifest, defaultPublishOptions('0.12.0'), runner, resolveArtifact);
 
@@ -59,11 +59,12 @@ describe('publishRelease — dry-run', () => {
     expect(report.dryRun).toBe(true);
 
     const published = publishCalls(runner.invocations);
-    expect(published).toHaveLength(3);
-    // order by tarball file name reflects Core→Particles→Tiled
+    expect(published).toHaveLength(4);
+    // order by tarball file name reflects Core→Particles→Tilemap→Tiled
     expect(published.map(i => i.args[1])).toEqual([
       resolveArtifact(tarballName('@codexo/exojs')),
       resolveArtifact(tarballName('@codexo/exojs-particles')),
+      resolveArtifact(tarballName('@codexo/exojs-tilemap')),
       resolveArtifact(tarballName('@codexo/exojs-tiled')),
     ]);
     for (const call of published) {
@@ -77,18 +78,18 @@ describe('publishRelease — dry-run', () => {
 });
 
 describe('publishRelease — live happy path', () => {
-  it('publishes then promotes all three to latest', () => {
+    it('publishes then promotes all four to latest', () => {
     const runner = createRecordingRunner(inv => (inv.args[0] === 'view' ? fail('E404') : ok()));
     const report = publishRelease(manifest, liveOptions(), runner, resolveArtifact);
 
     expect(report.ok).toBe(true);
-    expect(report.packages.map(p => p.publish)).toEqual(['published', 'published', 'published']);
-    expect(report.packages.map(p => p.promote)).toEqual(['promoted', 'promoted', 'promoted']);
+    expect(report.packages.map(p => p.publish)).toEqual(['published', 'published', 'published', 'published']);
+    expect(report.packages.map(p => p.promote)).toEqual(['promoted', 'promoted', 'promoted', 'promoted']);
 
     // dist-tag promotion runs once per package, AFTER all publishes, to `latest`.
     const tags = distTagCalls(runner.invocations);
-    expect(tags).toHaveLength(3);
-    expect(tags.map(t => t.args[3])).toEqual(['latest', 'latest', 'latest']);
+    expect(tags).toHaveLength(4);
+    expect(tags.map(t => t.args[3])).toEqual(['latest', 'latest', 'latest', 'latest']);
     const firstTagIndex = runner.invocations.findIndex(i => i.args[0] === 'dist-tag');
     const lastPublishIndex = runner.invocations.map(i => i.args[0]).lastIndexOf('publish');
     expect(firstTagIndex).toBeGreaterThan(lastPublishIndex);
@@ -97,7 +98,7 @@ describe('publishRelease — live happy path', () => {
 
 describe('publishRelease — idempotent resume', () => {
   it('skips versions already on the registry and still publishes the rest, then promotes', () => {
-    // Core already present; particles + tiled not.
+    // Core already present; particles + tilemap + tiled not.
     const runner = createRecordingRunner(inv => {
       if (inv.args[0] === 'view') {
         return inv.args[1].startsWith('@codexo/exojs@') ? ok('0.12.0') : fail('E404');
@@ -110,13 +111,15 @@ describe('publishRelease — idempotent resume', () => {
     expect(report.packages[0].publish).toBe('already-published');
     expect(report.packages[1].publish).toBe('published');
     expect(report.packages[2].publish).toBe('published');
+    expect(report.packages[3].publish).toBe('published');
     // Core was NOT re-published…
     expect(publishedPackages(runner.invocations)).toEqual([
       resolveArtifact(tarballName('@codexo/exojs-particles')),
+      resolveArtifact(tarballName('@codexo/exojs-tilemap')),
       resolveArtifact(tarballName('@codexo/exojs-tiled')),
     ]);
     // …but it still gets promoted to latest along with the others.
-    expect(report.packages.map(p => p.promote)).toEqual(['promoted', 'promoted', 'promoted']);
+    expect(report.packages.map(p => p.promote)).toEqual(['promoted', 'promoted', 'promoted', 'promoted']);
   });
 
   it('a fully-published release re-run promotes everything and publishes nothing', () => {
@@ -140,7 +143,7 @@ describe('publishRelease — partial failure never promotes latest', () => {
       return ok();
     });
 
-  it('Core fails → Particles/Tiled never attempted, no promotion, ok=false', () => {
+  it('Core fails → Particles/Tilemap/Tiled never attempted, no promotion, ok=false', () => {
     const runner = failOn('@codexo/exojs');
     const report = publishRelease(manifest, liveOptions(), runner, resolveArtifact);
 
@@ -148,12 +151,13 @@ describe('publishRelease — partial failure never promotes latest', () => {
     expect(report.packages[0].publish).toBe('failed');
     expect(report.packages[1].publish).toBe('not-attempted');
     expect(report.packages[2].publish).toBe('not-attempted');
+    expect(report.packages[3].publish).toBe('not-attempted');
     expect(distTagCalls(runner.invocations)).toHaveLength(0);
     // Only the Core publish was attempted.
     expect(publishCalls(runner.invocations)).toHaveLength(1);
   });
 
-  it('Particles fails → Core published but NOT promoted, Tiled never attempted, ok=false', () => {
+  it('Particles fails → Core published but NOT promoted, Tilemap/Tiled never attempted, ok=false', () => {
     const runner = failOn('@codexo/exojs-particles');
     const report = publishRelease(manifest, liveOptions(), runner, resolveArtifact);
 
@@ -161,17 +165,18 @@ describe('publishRelease — partial failure never promotes latest', () => {
     expect(report.packages[0].publish).toBe('published');
     expect(report.packages[1].publish).toBe('failed');
     expect(report.packages[2].publish).toBe('not-attempted');
+    expect(report.packages[3].publish).toBe('not-attempted');
     // The crux: a partial failure promotes nothing to latest — not even Core.
     expect(distTagCalls(runner.invocations)).toHaveLength(0);
     expect(report.packages.every(p => p.promote === 'not-attempted')).toBe(true);
   });
 
-  it('Tiled fails → Core+Particles published but no promotion, ok=false', () => {
+  it('Tiled fails → Core+Particles+Tilemap published but no promotion, ok=false', () => {
     const runner = failOn('@codexo/exojs-tiled');
     const report = publishRelease(manifest, liveOptions(), runner, resolveArtifact);
 
     expect(report.ok).toBe(false);
-    expect(report.packages.map(p => p.publish)).toEqual(['published', 'published', 'failed']);
+    expect(report.packages.map(p => p.publish)).toEqual(['published', 'published', 'published', 'failed']);
     expect(distTagCalls(runner.invocations)).toHaveLength(0);
   });
 });
@@ -216,7 +221,7 @@ describe('publishRelease — no false success', () => {
     const report = publishRelease(manifest, liveOptions(), runner, resolveArtifact);
 
     expect(report.ok).toBe(false);
-    // All three published, but promotion failed on the first → ok stays false.
+    // All four published, but promotion failed on the first → ok stays false.
     expect(report.packages.every(p => p.publish === 'published')).toBe(true);
     expect(report.packages.some(p => p.promote === 'failed')).toBe(true);
   });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -68,6 +68,11 @@ export default defineConfig({
         include: ['packages/exojs-particles/test/**/*.test.ts'],
       }),
       createJsdomTestProject({
+        name: 'exojs-tilemap',
+        alias: aliasConfig,
+        include: ['packages/exojs-tilemap/test/**/*.test.ts'],
+      }),
+      createJsdomTestProject({
         name: 'exojs-tiled',
         alias: aliasConfig,
         include: ['packages/exojs-tiled/test/**/*.test.ts'],


### PR DESCRIPTION
## Package: `@codexo/exojs-tilemap`

A new generic, format-independent tilemap runtime package for the ExoJS ecosystem.

### Purpose

Provides the shared data model and foundation for tilemap support across all source formats (Tiled, LDtk, RPG Maker, procedural maps) without introducing source-format vocabulary into the runtime.

### Dependency Graph

```
@codexo/exojs (peer dep)
    ^
@codexo/exojs-tilemap (new)
    ^ (future regular dep)
@codexo/exojs-tiled (to be updated in next slice)
```

### Public API

| Symbol | Kind | Stability |
|---|---|---|
| `TileMap` | class | `@advanced` |
| `TileLayer` | class | `@advanced` |
| `TileSet` | class | `@advanced` |
| `ReadonlyTileChunk` | interface | `@advanced` |
| `tilemapExtension` | const | `@advanced` |
| `ResolvedTile` | interface | `@advanced` |
| `TileTransform` | interface | `@stable` |
| `TileDefinition` | interface | `@advanced` |
| `TilePropertyValue` | type | `@advanced` |
| `TileProperties` | type | `@advanced` |
| `PackedTile` | type | `@advanced` |
| `TILE_TRANSFORM_IDENTITY` | const | `@stable` |
| `TileMapOptions` | type | `@advanced` |
| `TileLayerOptions` | type | `@advanced` |
| `TileSetOptions` | type | `@advanced` |
| `ChunkCoord` | type | `@advanced` |
| `tileToChunkCoord` | function | `@advanced` |
| `tileToLocalInChunk` | function | `@advanced` |

The mutable `TileChunk` implementation class is **package-internal** — not exported from the package root. Consumers receive a `ReadonlyTileChunk` view through `TileLayer.getChunk()` and `loadedChunks()`.

### Controlled Chunk Mutation

All mutation must flow through `TileLayer` public APIs:

- `setTileAt(tx, ty, tile)` — validates tileset & coordinates, no-op if unchanged
- `clearTileAt(tx, ty)` — no-op if already empty
- `fillRect(x, y, w, h, tile)`
- `clearRect(x, y, w, h)`

Internal mutation methods (`_setRawAt`, `_clear`, `_markDirty`, `_getRawStorage`) are not publicly exposed. The `ReadonlyTileChunk` interface provides `getRawAt()` and `cloneTiles()` for read-only inspection.

### Tile Identity Model

- `ResolvedTile` = `{ tileset: TileSet, localTileId: number, transform: TileTransform }`
- Packed `Uint32Array` storage (private): one machine word per tile
- Empty cell = packed `0` (localTileId stored as `localTileId + 1`)
- 20 bits local tile ID, 9 bits tileset index, 3 bits transform

### Revision Semantics

| Scope | Tracks | Increments on |
|---|---|---|
| `chunk.revision` | Cell changes in one chunk | Actual value change only |
| `layer.revision` | Cell changes in layer | Any cell mutation that changes stored value |
| `map.revision` | Structural changes | Add/remove layer, add tileset only |

No-op writes increment none. Failed mutations increment none.

### Orientation Model

`TileTransform = { flipX: boolean, flipY: boolean, diagonal: boolean }`

Format-independent naming. Future adapters map source flags into this representation.

### Tests

137 tests across 4 test files covering:
- Tile packing/unpacking, identity, overflow
- Chunk validation: coordinates, dimensions, packed values, safe integers
- Immutability: clone isolation, no public writable storage exposure
- Readonly chunk boundary: `TileChunk` class not in barrel exports
- Public API type tests: `ReadonlyTileChunk` and `PackedTile` importable from barrel
- Revision: no-op detection, empty-cache coherence
- Layer mutation boundary: tileset validation, bounds checking
- Destroy-state enforcement
- Scale: 512x512 map with predictable chunk count, efficient storage

### Validation

- `pnpm lint`: passes
- `pnpm typecheck`: passes
- `pnpm typecheck:guides`: passes
- `pnpm typecheck:examples`: passes
- `pnpm test`: 2592 tests pass (173 files)
- `pnpm verify:lockstep`: passes (4 packages at v0.12.0)
- `pnpm verify:release-matrix`: passes
- `pnpm verify:exports`: passes
- `pnpm build`: passes
- Package dry-run: passes

### Non-Goals (explicitly excluded)

- No Tiled JSON/TMJ/TSJ parsing, no `TiledMap`, no GID decoding
- No Tiled flip-bit parsing
- No tilemap GPU rendering
- No `TileMapNode`, `TileLayerNode`, `TileMapView`, `TileMapBand`
- No infinite streaming, procedural chunk providers, autotiling
- No tile animation, object layers, image layers, group layers
- No lighting channels or physics integration
- No SceneNode changes
- `.workspace/` not committed
