### PR TITLE
feat(tiled): parsed source model + runtime TileMap conversion (Phase C)

### DIFF
--- a/packages/exojs-config/rollup/index.js
+++ b/packages/exojs-config/rollup/index.js
@@ -20,6 +20,7 @@ const corePaths = {
   '@codexo/exojs/extensions': ['../../dist/esm/extensions/index.d.ts'],
   '@codexo/exojs/rendering': ['../../dist/esm/rendering.d.ts'],
   '@codexo/exojs/debug': ['../../dist/esm/debug/index.d.ts'],
+  '@codexo/exojs-tilemap': ['../exojs-tilemap/dist/esm/index.d.ts'],
 };
 
 /**

--- a/packages/exojs-tiled/README.md
+++ b/packages/exojs-tiled/README.md
@@ -1,36 +1,33 @@
 # @codexo/exojs-tiled
 
-Official ExoJS extension for loading [Tiled](https://mapeditor.org) maps (`.tmj` JSON format).
+Official ExoJS extension for parsing [Tiled](https://mapeditor.org) maps (`.tmj` JSON format)
+into a typed, validated source model.
 
 ## Installation
 
 ```sh
-npm install @codexo/exojs @codexo/exojs-tiled
+npm install @codexo/exojs @codexo/exojs-tiled @codexo/exojs-tilemap
 ```
 
-This package requires `@codexo/exojs` as a peer dependency. Both must be the same version.
+`@codexo/exojs` and `@codexo/exojs-tilemap` are peer dependencies.
+All three packages must be at the same version (`0.12.x`).
 
-## Core compatibility
+## What this package provides
 
-| `@codexo/exojs-tiled` | `@codexo/exojs` |
-|---|---|
-| 0.12.x | 0.12.x |
+**Phase C1 — Source model and parsing:**
 
-## Supported Tiled scope
+- `TiledMap` — parsed Tiled map; validates GID coverage and tileset ranges on construction
+- `TiledTileset` — parsed tileset (atlas-image or collection-of-images); holds resolved textures
+- `TiledLayer` hierarchy — `TiledTileLayer`, `TiledObjectLayer`, `TiledImageLayer`, `TiledGroupLayer`
+- `TiledObject` — parsed object (point, ellipse, polygon, polyline, text, tile-ref, rectangle)
+- `TiledFormatError` — typed error thrown on any structural problem in `.tmj`/`.tsj` data
+- `tiledExtension` — extension descriptor; depends on `tilemapExtension` automatically
+- Loader integration: `loader.load(TiledMap, url)` fetches and parses a `.tmj` file,
+  resolves external `.tsj` tilesets, and loads tileset textures through the Loader cache
 
-- Tiled JSON map format (`.tmj`)
-- Orthogonal tile layers
-- Object layers (basic)
-- External tilesets (`.tsj`) referenced from `.tmj`
-- Multiple tile layers per map
-
-## Not supported in 0.12.x
-
-- TMX (XML) format — use `.tmj` export from Tiled
-- Isometric and hexagonal maps
-- Image layers
-- Wangsets
-- Custom class / enum properties
+> **Not yet available:** `TiledMap → TileMap` runtime conversion, rendering via `TileMapNode` /
+> `TileLayerNode`, `.tmj` file-extension auto-routing, and infinite-map runtime support.
+> These are scheduled for the next phase (C2).
 
 ## Usage — side-effect-free root entry
 
@@ -38,90 +35,143 @@ This package requires `@codexo/exojs` as a peer dependency. Both must be the sam
 import { Application } from '@codexo/exojs';
 import { TiledMap, tiledExtension } from '@codexo/exojs-tiled';
 
-const app = new Application({
-    extensions: [tiledExtension],
-});
-```
-
-Importing from the root entry does **not** register the extension globally.
-
-## Extension descriptor
-
-`tiledExtension` is the default descriptor. It registers the `TiledMap` asset type with the following bindings:
-
-- Constructor load: `loader.load(TiledMap, url)`
-- Extension routing: `.tmj` files auto-route to `TiledMap`
-- Type-name load: `loader.load('tiledMap', url)`
-
-## Loading a Tiled map
-
-```ts
-import { TiledMap } from '@codexo/exojs-tiled';
-
-// Inside a Scene:
-override async load(loader) {
-    // By constructor (explicit)
-    await loader.load(TiledMap, { myMap: '/maps/level1.tmj' });
-
-    // By file extension (auto-routed)
-    await loader.load('/maps/level1.tmj');
-
-    // By type name
-    await loader.load('tiledMap', { myMap: '/maps/level1.tmj' });
-}
-
-override create(loader) {
-    const map = loader.get(TiledMap, 'myMap');
-    this.addChild(map);
-}
-```
-
-## `/register` convenience entry
-
-Importing `/register` registers the default `tiledExtension` descriptor in the global `ExtensionRegistry`. Subsequently created Applications that use global defaults will automatically receive the Tiled extension.
-
-```ts
-// Side effect: registers tiledExtension in the global ExtensionRegistry.
-import '@codexo/exojs-tiled/register';
-
-// All named exports are re-exported from /register:
-import { TiledMap, tiledExtension } from '@codexo/exojs-tiled/register';
-```
-
-**Note:** `/register` does not use automatic discovery. It explicitly calls `ExtensionRegistry.register(tiledExtension)` at module evaluation time.
-
-## Texture and sub-asset ownership
-
-Tilesets referenced from a Tiled map are loaded as sub-assets and stored in the Loader cache. The `TiledMap` does **not** own or destroy tileset textures — the Loader cache owns them. Do not call `tileset.destroy()` from your code; let the Loader handle cleanup when the scene is destroyed.
-
-## Minimal working example
-
-```ts
-import { Application, Scene } from '@codexo/exojs';
-import { TiledMap, tiledExtension } from '@codexo/exojs-tiled';
-
 const app = new Application({ extensions: [tiledExtension] });
-document.body.append(app.canvas);
 
 class GameScene extends Scene {
     map!: TiledMap;
 
     override async load(loader) {
+        // Token-based load: requires the TiledMap constructor as the first argument.
         await loader.load(TiledMap, { level1: '/maps/level1.tmj' });
     }
 
     override create(loader) {
-        this.map = loader.get(TiledMap, 'level1');
-        this.addChild(this.map);
+        const map = loader.get(TiledMap, 'level1');
+
+        // Inspect the parsed source model:
+        console.log(map.width, map.height);               // tile dimensions
+        console.log(map.tilesets[0].name);                // tileset name
+        console.log(map.tilesets[0].texture);             // loaded Texture (Loader-owned)
+        console.log(map.findTilesetForGid(3));            // tileset owning GID 3
+
+        const ground = map.layers.find(l => l.name === 'Ground');
+        if (ground?.type === 'tilelayer') {
+            console.log(ground.data);                     // flat GID array
+        }
     }
 }
-
-app.scenes.start(GameScene);
 ```
+
+Importing from the root entry does **not** register the extension globally.
+
+## `/register` convenience entry
+
+Importing `/register` registers `tiledExtension` (and its `tilemapExtension` dependency) in the
+global `ExtensionRegistry`. Subsequently created Applications that use global defaults will
+receive both extensions automatically.
+
+```ts
+// Side effect: registers tiledExtension in the global ExtensionRegistry.
+import '@codexo/exojs-tiled/register';
+
+// All named exports are also re-exported from /register:
+import { TiledMap, tiledExtension } from '@codexo/exojs-tiled/register';
+```
+
+## Extension dependency
+
+`tiledExtension.dependencies` includes `tilemapExtension` from `@codexo/exojs-tilemap`.
+You do not need to register `tilemapExtension` separately — `buildSnapshot` and
+`ExtensionRegistry.register` traverse the dependency graph automatically.
+
+## Asset loading
+
+`loader.load(TiledMap, source)` fetches and validates the `.tmj` file, then:
+
+1. Resolves each tileset entry (fetches external `.tsj` files via the Loader cache).
+2. Loads atlas images (`tileset.image`) and per-tile images (collection-of-images tilesets)
+   via `loader.load(Texture, …)` — the Loader deduplicates identical URLs.
+3. Validates GID ranges (no duplicates, no overlaps, all layer GIDs covered) — throws
+   `TiledFormatError` on any inconsistency.
+
+### Token-only loading
+
+`tiledMapBinding` does **not** claim the `.tmj` file extension. This means:
+
+- `loader.load(TiledMap, url)` — works; loads and parses the TMJ.
+- `loader.load(url)` without a type token — does **not** resolve to `TiledMap` in this phase.
+- `.tmj` extension auto-routing is reserved for the C2 `TileMap` runtime binding.
+
+## Parsed API overview
+
+### `TiledMap`
+
+```ts
+map.source            // resolved URL this map was loaded from
+map.width             // map width in tiles
+map.height            // map height in tiles
+map.tileWidth         // tile grid cell width in pixels
+map.tileHeight        // tile grid cell height in pixels
+map.orientation       // 'orthogonal' | 'isometric' | 'staggered' | 'hexagonal'
+map.renderOrder       // 'right-down' | 'right-up' | 'left-down' | 'left-up' | undefined
+map.infinite          // true for infinite maps (layers use chunks, not flat data)
+map.backgroundColor   // optional CSS color string
+map.layers            // TiledLayer[] — parsed layer hierarchy
+map.tilesets          // TiledTileset[] — sorted by firstGid ascending
+map.properties        // TiledPropertyData[] — custom properties
+map.findTilesetForGid(gid)  // → TiledTileset | undefined (masks flip bits automatically)
+map.getProperty(name)       // → TiledPropertyData | undefined
+map.destroy()               // no-op; textures are Loader-owned
+```
+
+### `TiledTileset`
+
+```ts
+tileset.firstGid      // first GID in this tileset's range (inclusive)
+tileset.lastGid       // last GID in this tileset's range (inclusive)
+tileset.name
+tileset.tileWidth / tileHeight
+tileset.tileCount / columns / spacing / margin
+tileset.source        // resolved .tsj URL (undefined for embedded tilesets)
+tileset.imageUrl      // resolved atlas image URL (undefined for collection-of-images)
+tileset.texture       // Texture loaded for imageUrl (Loader-owned)
+tileset.tileTextures  // Map<localId, Texture> for collection-of-images tilesets (Loader-owned)
+tileset.tiles         // TiledTileData[] — per-tile animation/property/collision data
+tileset.getTile(localId)    // → TiledTileData | undefined
+tileset.getProperty(name)   // → TiledPropertyData | undefined
+```
+
+### `TiledLayer` subclasses
+
+All layers extend `TiledLayer` (base: `id`, `name`, `class`, `visible`, `opacity`, `x`, `y`,
+`offsetX/Y`, `parallaxX/Y`, `tintColor`, `properties`, `getProperty(name)`).
+
+| Subclass | `type` | Extra fields |
+|---|---|---|
+| `TiledTileLayer` | `'tilelayer'` | `width`, `height`, `data?: number[]` (finite), `chunks?` (infinite) |
+| `TiledObjectLayer` | `'objectgroup'` | `drawOrder`, `objects: TiledObject[]` |
+| `TiledImageLayer` | `'imagelayer'` | `image`, `repeatX`, `repeatY` |
+| `TiledGroupLayer` | `'group'` | `layers: TiledLayer[]` |
+
+### `TiledObject`
+
+Shape discriminants: `point` (boolean), `ellipse` (boolean), `polygon`, `polyline`, `text`,
+`gid` (tile object). If none are set, the object is a plain rectangle.
+
+## Texture ownership
+
+Textures for tileset images are loaded via the Loader and remain in the Loader cache.
+`TiledMap.destroy()` releases the parsed source model's reference but does **not** unload textures.
+The Loader handles texture lifecycle (including deduplication across maps that share tilesets).
+
+## Core compatibility
+
+| `@codexo/exojs-tiled` | `@codexo/exojs` |
+|---|---|
+| 0.12.x | 0.12.x |
 
 ## Links
 
-- [Official ExoJS Tiled guide](https://exojs.dev/guides/extensions/tiled)
 - [API reference](https://exojs.dev/api/exojs-tiled)
 - [Tiled map editor](https://mapeditor.org)
 

--- a/packages/exojs-tiled/README.md
+++ b/packages/exojs-tiled/README.md
@@ -1,68 +1,60 @@
 # @codexo/exojs-tiled
 
-Official ExoJS extension for parsing [Tiled](https://mapeditor.org) maps (`.tmj` JSON format)
-into a typed, validated source model.
+Official ExoJS extension for loading [Tiled](https://mapeditor.org) maps (`.tmj` JSON format)
+into a generic runtime `TileMap` or a typed parsed source model.
 
 ## Installation
 
 ```sh
-npm install @codexo/exojs @codexo/exojs-tiled @codexo/exojs-tilemap
+npm install @codexo/exojs @codexo/exojs-tiled
 ```
 
-`@codexo/exojs` and `@codexo/exojs-tilemap` are peer dependencies.
-All three packages must be at the same version (`0.12.x`).
+`@codexo/exojs` is a peer dependency. `@codexo/exojs-tilemap` is a regular dependency and is
+installed transitively by `@codexo/exojs-tiled` — you do not need to install it manually.
+
+If you want the generic tilemap runtime without the Tiled adapter:
+
+```sh
+npm install @codexo/exojs @codexo/exojs-tilemap
+```
 
 ## What this package provides
 
-**Phase C1 — Source model and parsing:**
-
-- `TiledMap` — parsed Tiled map; validates GID coverage and tileset ranges on construction
+- `TileMap` (re-exported from `@codexo/exojs-tilemap`) — generic runtime tilemap; the common-case result of `loader.load(TileMap, url)`
+- `TiledMap` — parsed Tiled source model; advanced/diagnostic use via `loader.load(TiledMap, url)`
 - `TiledTileset` — parsed tileset (atlas-image or collection-of-images); holds resolved textures
 - `TiledLayer` hierarchy — `TiledTileLayer`, `TiledObjectLayer`, `TiledImageLayer`, `TiledGroupLayer`
 - `TiledObject` — parsed object (point, ellipse, polygon, polyline, text, tile-ref, rectangle)
 - `TiledFormatError` — typed error thrown on any structural problem in `.tmj`/`.tsj` data
 - `tiledExtension` — extension descriptor; depends on `tilemapExtension` automatically
-- Loader integration: `loader.load(TiledMap, url)` fetches and parses a `.tmj` file,
-  resolves external `.tsj` tilesets, and loads tileset textures through the Loader cache
 
-> **Not yet available:** `TiledMap → TileMap` runtime conversion, rendering via `TileMapNode` /
-> `TileLayerNode`, `.tmj` file-extension auto-routing, and infinite-map runtime support.
-> These are scheduled for the next phase (C2).
+## Usage — common case
 
-## Usage — side-effect-free root entry
+Register the extension and load a `.tmj` map into a generic runtime `TileMap`:
 
 ```ts
 import { Application } from '@codexo/exojs';
-import { TiledMap, tiledExtension } from '@codexo/exojs-tiled';
+import { TileMap, tiledExtension } from '@codexo/exojs-tiled';
 
 const app = new Application({ extensions: [tiledExtension] });
 
-class GameScene extends Scene {
-    map!: TiledMap;
-
-    override async load(loader) {
-        // Token-based load: requires the TiledMap constructor as the first argument.
-        await loader.load(TiledMap, { level1: '/maps/level1.tmj' });
-    }
-
-    override create(loader) {
-        const map = loader.get(TiledMap, 'level1');
-
-        // Inspect the parsed source model:
-        console.log(map.width, map.height);               // tile dimensions
-        console.log(map.tilesets[0].name);                // tileset name
-        console.log(map.tilesets[0].texture);             // loaded Texture (Loader-owned)
-        console.log(map.findTilesetForGid(3));            // tileset owning GID 3
-
-        const ground = map.layers.find(l => l.name === 'Ground');
-        if (ground?.type === 'tilelayer') {
-            console.log(ground.data);                     // flat GID array
-        }
-    }
-}
+const map = await app.loader.load(TileMap, 'maps/world.tmj');
+// map is a @codexo/exojs-tilemap TileMap
 ```
 
-Importing from the root entry does **not** register the extension globally.
+## Usage — advanced parsed-source case
+
+Load the fully resolved Tiled source model and convert it manually:
+
+```ts
+import { TiledMap } from '@codexo/exojs-tiled';
+
+const source = await app.loader.load(TiledMap, 'maps/world.tmj');
+const map = source.toTileMap();
+```
+
+Both paths are semantically equivalent. The runtime binding (`TileMap`) uses the Loader-managed
+source-model sub-load internally, so concurrent or duplicate loads are deduplicated.
 
 ## `/register` convenience entry
 
@@ -75,32 +67,40 @@ receive both extensions automatically.
 import '@codexo/exojs-tiled/register';
 
 // All named exports are also re-exported from /register:
-import { TiledMap, tiledExtension } from '@codexo/exojs-tiled/register';
+import { TileMap, TiledMap, tiledExtension } from '@codexo/exojs-tiled/register';
 ```
 
 ## Extension dependency
 
 `tiledExtension.dependencies` includes `tilemapExtension` from `@codexo/exojs-tilemap`.
-You do not need to register `tilemapExtension` separately — `buildSnapshot` and
-`ExtensionRegistry.register` traverse the dependency graph automatically.
+Registering `tiledExtension` is sufficient — `buildSnapshot` and `ExtensionRegistry.register`
+traverse the dependency graph automatically.
 
 ## Asset loading
 
-`loader.load(TiledMap, source)` fetches and validates the `.tmj` file, then:
+`loader.load(TileMap, url)` (common path) and `loader.load(TiledMap, url)` (advanced path) both:
 
-1. Resolves each tileset entry (fetches external `.tsj` files via the Loader cache).
-2. Loads atlas images (`tileset.image`) and per-tile images (collection-of-images tilesets)
+1. Fetch and validate the `.tmj` file.
+2. Resolve each tileset entry (fetches external `.tsj` files via the Loader cache).
+3. Load atlas images (`tileset.image`) and per-tile images (collection-of-images tilesets)
    via `loader.load(Texture, …)` — the Loader deduplicates identical URLs.
-3. Validates GID ranges (no duplicates, no overlaps, all layer GIDs covered) — throws
+4. Validate GID ranges (no duplicates, no overlaps, all layer GIDs covered) — throws
    `TiledFormatError` on any inconsistency.
 
-### Token-only loading
+The runtime binding additionally calls `TiledMap.toTileMap()` to produce the generic `TileMap`.
 
-`tiledMapBinding` does **not** claim the `.tmj` file extension. This means:
+### Load options
 
-- `loader.load(TiledMap, url)` — works; loads and parses the TMJ.
-- `loader.load(url)` without a type token — does **not** resolve to `TiledMap` in this phase.
-- `.tmj` extension auto-routing is reserved for the C2 `TileMap` runtime binding.
+```ts
+await loader.load(TileMap, 'maps/world.tmj', { strict: true });
+```
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `format` | `'tiled'` | — | Reserved discriminant; not currently used |
+| `strict` | `boolean` | `false` | Throw on unknown `.tmj`/`.tsj` fields |
+
+Options are optional. Only result-changing values affect the Loader identity key.
 
 ## Parsed API overview
 
@@ -121,6 +121,7 @@ map.tilesets          // TiledTileset[] — sorted by firstGid ascending
 map.properties        // TiledPropertyData[] — custom properties
 map.findTilesetForGid(gid)  // → TiledTileset | undefined (masks flip bits automatically)
 map.getProperty(name)       // → TiledPropertyData | undefined
+map.toTileMap()             // → TileMap — synchronous runtime conversion
 map.destroy()               // no-op; textures are Loader-owned
 ```
 
@@ -168,7 +169,7 @@ The Loader handles texture lifecycle (including deduplication across maps that s
 
 | `@codexo/exojs-tiled` | `@codexo/exojs` |
 |---|---|
-| 0.12.x | 0.12.x |
+| 0.13.x | 0.13.x |
 
 ## Links
 

--- a/packages/exojs-tiled/package.json
+++ b/packages/exojs-tiled/package.json
@@ -37,6 +37,9 @@
   "peerDependencies": {
     "@codexo/exojs": "0.12.x"
   },
+  "dependencies": {
+    "@codexo/exojs-tilemap": "workspace:*"
+  },
   "devDependencies": {
     "@codexo/exojs": "workspace:*",
     "@codexo/exojs-config": "workspace:*"

--- a/packages/exojs-tiled/src/TiledLayer.ts
+++ b/packages/exojs-tiled/src/TiledLayer.ts
@@ -1,0 +1,144 @@
+import type {
+  TiledChunkData,
+  TiledGroupLayerData,
+  TiledImageLayerData,
+  TiledLayerData,
+  TiledLayerDataBase,
+  TiledObjectLayerData,
+  TiledPropertyData,
+  TiledTileLayerData,
+} from './data';
+import { TiledObject } from './TiledObject';
+
+/** Discriminant shared by every {@link TiledLayer} subclass, mirroring {@link TiledLayerData}'s `type`. */
+export type TiledLayerType = TiledLayerData['type'];
+
+/**
+ * Base class for the four parsed Tiled layer types. Holds the fields shared
+ * by every layer (`tilelayer`, `objectgroup`, `imagelayer`, `group`).
+ *
+ * Use {@link TiledLayer.type} (or `instanceof`) to discriminate between
+ * {@link TiledTileLayer}, {@link TiledObjectLayer}, {@link TiledImageLayer},
+ * and {@link TiledGroupLayer}.
+ */
+export abstract class TiledLayer {
+  public abstract readonly type: TiledLayerType;
+
+  public readonly id: number;
+  public readonly name: string;
+  public readonly class: string;
+  public readonly visible: boolean;
+  public readonly opacity: number;
+  public readonly x: number;
+  public readonly y: number;
+  public readonly offsetX: number;
+  public readonly offsetY: number;
+  public readonly parallaxX: number;
+  public readonly parallaxY: number;
+  public readonly tintColor?: string;
+  public readonly properties: readonly TiledPropertyData[];
+
+  protected constructor(data: TiledLayerDataBase) {
+    this.id = data.id;
+    this.name = data.name;
+    this.class = data.class ?? '';
+    this.visible = data.visible;
+    this.opacity = data.opacity;
+    this.x = data.x;
+    this.y = data.y;
+    this.offsetX = data.offsetx ?? 0;
+    this.offsetY = data.offsety ?? 0;
+    this.parallaxX = data.parallaxx ?? 1;
+    this.parallaxY = data.parallaxy ?? 1;
+    this.tintColor = data.tintcolor;
+    this.properties = data.properties ?? [];
+  }
+
+  /** Looks up a custom property by name. */
+  public getProperty(name: string): TiledPropertyData | undefined {
+    return this.properties.find(property => property.name === name);
+  }
+}
+
+/**
+ * A tile layer. On a finite map, {@link data} holds the flat row-major array
+ * of GIDs (`width * height` entries). On an infinite map, {@link chunks}
+ * holds the sparse list of tile chunks instead; exactly one of the two is
+ * defined, matching the owning {@link TiledMap}'s `infinite` flag.
+ */
+export class TiledTileLayer extends TiledLayer {
+  public override readonly type = 'tilelayer' as const;
+
+  public readonly width: number;
+  public readonly height: number;
+  public readonly data?: readonly number[];
+  public readonly chunks?: readonly TiledChunkData[];
+
+  public constructor(data: TiledTileLayerData) {
+    super(data);
+    this.width = data.width;
+    this.height = data.height;
+    this.data = data.data;
+    this.chunks = data.chunks;
+  }
+}
+
+/** An object layer: a flat list of {@link TiledObject}s. */
+export class TiledObjectLayer extends TiledLayer {
+  public override readonly type = 'objectgroup' as const;
+
+  public readonly drawOrder: NonNullable<TiledObjectLayerData['draworder']>;
+  public readonly objects: readonly TiledObject[];
+
+  public constructor(data: TiledObjectLayerData) {
+    super(data);
+    this.drawOrder = data.draworder ?? 'topdown';
+    this.objects = data.objects.map(object => new TiledObject(object));
+  }
+}
+
+/**
+ * An image layer. {@link image} is the path to the layer's image exactly as
+ * written in the Tiled JSON (relative to the map's location); resolving it
+ * against the owning {@link TiledMap}'s `source` is left to the consumer.
+ */
+export class TiledImageLayer extends TiledLayer {
+  public override readonly type = 'imagelayer' as const;
+
+  public readonly image: string;
+  public readonly repeatX: boolean;
+  public readonly repeatY: boolean;
+
+  public constructor(data: TiledImageLayerData) {
+    super(data);
+    this.image = data.image;
+    this.repeatX = data.repeatx ?? false;
+    this.repeatY = data.repeaty ?? false;
+  }
+}
+
+/** A group layer, recursively containing further parsed layers. */
+export class TiledGroupLayer extends TiledLayer {
+  public override readonly type = 'group' as const;
+
+  public readonly layers: readonly TiledLayer[];
+
+  public constructor(data: TiledGroupLayerData) {
+    super(data);
+    this.layers = data.layers.map(createTiledLayer);
+  }
+}
+
+/** Constructs the appropriate {@link TiledLayer} subclass for `data.type`. */
+export function createTiledLayer(data: TiledLayerData): TiledLayer {
+  switch (data.type) {
+    case 'tilelayer':
+      return new TiledTileLayer(data);
+    case 'objectgroup':
+      return new TiledObjectLayer(data);
+    case 'imagelayer':
+      return new TiledImageLayer(data);
+    case 'group':
+      return new TiledGroupLayer(data);
+  }
+}

--- a/packages/exojs-tiled/src/TiledMap.ts
+++ b/packages/exojs-tiled/src/TiledMap.ts
@@ -1,5 +1,14 @@
+import { TextureRegion } from '@codexo/exojs';
+import { TileLayer, TileMap, TileSet } from '@codexo/exojs-tilemap';
+import type { ResolvedTile, TileTransform } from '@codexo/exojs-tilemap';
+
 import type { TiledMapData, TiledOrientation, TiledPropertyData, TiledRenderOrder } from './data';
-import { maskTiledGid } from './gid';
+import {
+  maskTiledGid,
+  TILED_FLIPPED_DIAGONALLY_FLAG,
+  TILED_FLIPPED_HORIZONTALLY_FLAG,
+  TILED_FLIPPED_VERTICALLY_FLAG,
+} from './gid';
 import { createTiledLayer, TiledGroupLayer, TiledObjectLayer, TiledTileLayer, type TiledLayer } from './TiledLayer';
 import type { TiledTileset } from './TiledTileset';
 import { TiledFormatError } from './validate';
@@ -90,12 +99,138 @@ export class TiledMap {
   }
 
   /**
+   * Convert this parsed Tiled source model into a format-independent runtime
+   * {@link TileMap} from `@codexo/exojs-tilemap`.
+   *
+   * Only finite orthogonal maps with atlas tilesets are supported. Passing a
+   * map with collection-of-images tilesets throws {@link TiledFormatError}.
+   * Object, image, and group layers are not yet converted (Phase C2 scope:
+   * tile layers only; group layer children are flattened into the result).
+   *
+   * The returned `TileMap` does **not** own the tileset textures — they remain
+   * in the Loader cache. Destroying the returned map does not unload textures.
+   */
+  public toTileMap(): TileMap {
+    // Build runtime tilesets. Tilesets with a per-tile image collection are
+    // not yet supported; collection-of-images tilesets throw TiledFormatError.
+    // Tilesets with no image at all (no texture, no tileTextures) are silently
+    // skipped — their cells appear as empty in the runtime layer.
+    const runtimeTilesets: TileSet[] = [];
+    // indexToRuntime[i] = runtime TileSet for tilesets[i], or null if skipped.
+    const indexToRuntime: (TileSet | null)[] = [];
+    for (let i = 0; i < this.tilesets.length; i++) {
+      const tiledTs = this.tilesets[i]!;
+      if (!tiledTs.texture) {
+        if (tiledTs.tileTextures.size > 0) {
+          throw new TiledFormatError(
+            this.source,
+            `tilesets/${tiledTs.name}`,
+            `tileset "${tiledTs.name}" is a collection-of-images tileset; ` +
+            `toTileMap() requires atlas tilesets in this release`,
+          );
+        }
+        // No atlas image and no per-tile images → skip; cells become empty.
+        indexToRuntime.push(null);
+        continue;
+      }
+      const tw = tiledTs.imageWidth ?? tiledTs.texture.width;
+      const th = tiledTs.imageHeight ?? tiledTs.texture.height;
+      const region = new TextureRegion(tiledTs.texture, { x: 0, y: 0, width: tw, height: th });
+      const rts = new TileSet({
+        name: tiledTs.name,
+        texture: region,
+        tileWidth: tiledTs.tileWidth,
+        tileHeight: tiledTs.tileHeight,
+        tileCount: tiledTs.tileCount,
+        columns: tiledTs.columns,
+        spacing: tiledTs.spacing,
+        margin: tiledTs.margin,
+      });
+      runtimeTilesets.push(rts);
+      indexToRuntime.push(rts);
+    }
+
+    // Collect and convert tile layers, flattening group layers.
+    const runtimeLayers: TileLayer[] = [];
+    const convertLayers = (layers: readonly TiledLayer[]): void => {
+      for (const layer of layers) {
+        if (layer instanceof TiledGroupLayer) {
+          convertLayers(layer.layers);
+        } else if (layer instanceof TiledTileLayer) {
+          const rLayer = new TileLayer({
+            id: layer.id,
+            name: layer.name,
+            width: layer.width,
+            height: layer.height,
+            tilesets: runtimeTilesets,
+            tileWidth: this.tileWidth,
+            tileHeight: this.tileHeight,
+            visible: layer.visible,
+            opacity: layer.opacity,
+            offsetX: layer.offsetX,
+            offsetY: layer.offsetY,
+          });
+          if (layer.data) {
+            populateTileLayer(rLayer, layer.data, this.tilesets, indexToRuntime);
+          }
+          runtimeLayers.push(rLayer);
+        }
+        // ObjectLayer, ImageLayer: not converted in Phase C2 (tile layers only).
+      }
+    };
+    convertLayers(this.layers);
+
+    return new TileMap({
+      name: this.source,
+      width: this.width,
+      height: this.height,
+      tileWidth: this.tileWidth,
+      tileHeight: this.tileHeight,
+      tilesets: runtimeTilesets,
+      layers: runtimeLayers,
+    });
+  }
+
+  /**
    * Releases this map's reference to its parsed source. Tileset textures are
    * Loader-owned and may be shared with other maps; this does NOT destroy
    * them.
    */
   public destroy(): void {
     // Intentionally empty: all sub-resources (textures) are Loader-owned.
+  }
+}
+
+/** Fill a `TileLayer` from a flat GID array decoded from a Tiled tile layer. */
+function populateTileLayer(
+  layer: TileLayer,
+  gids: readonly number[],
+  tiledTilesets: readonly TiledTileset[],
+  indexToRuntime: readonly (TileSet | null)[],
+): void {
+  for (let i = 0; i < gids.length; i++) {
+    const rawGid = gids[i]!;
+    if (rawGid === 0) continue;
+    const baseGid = maskTiledGid(rawGid);
+    const transform: TileTransform = {
+      flipX: (rawGid >>> 0 & TILED_FLIPPED_HORIZONTALLY_FLAG) !== 0,
+      flipY: (rawGid >>> 0 & TILED_FLIPPED_VERTICALLY_FLAG) !== 0,
+      diagonal: (rawGid >>> 0 & TILED_FLIPPED_DIAGONALLY_FLAG) !== 0,
+    };
+    // Find owning tileset: rightmost with firstGid <= baseGid (tilesets sorted asc).
+    let tsIdx = -1;
+    for (let t = tiledTilesets.length - 1; t >= 0; t--) {
+      if (baseGid >= tiledTilesets[t]!.firstGid) { tsIdx = t; break; }
+    }
+    if (tsIdx === -1) continue;
+    const runtimeTs = indexToRuntime[tsIdx];
+    if (!runtimeTs) continue; // tileset was skipped (no atlas image)
+    const tile: ResolvedTile = {
+      tileset: runtimeTs,
+      localTileId: baseGid - tiledTilesets[tsIdx]!.firstGid,
+      transform,
+    };
+    layer.setTileAt(i % layer.width, Math.floor(i / layer.width), tile);
   }
 }
 

--- a/packages/exojs-tiled/src/TiledMap.ts
+++ b/packages/exojs-tiled/src/TiledMap.ts
@@ -1,123 +1,170 @@
-import type { Texture } from '@codexo/exojs';
-
-// ---------------------------------------------------------------------------
-// Tiled JSON format types (TMJ / Tiled JSON Map Format)
-// ---------------------------------------------------------------------------
-
-export interface TiledTileset {
-  readonly firstgid: number;
-  readonly source?: string;
-  readonly image?: string;
-  readonly name?: string;
-  readonly tilewidth?: number;
-  readonly tileheight?: number;
-  readonly columns?: number;
-  readonly tilecount?: number;
-  readonly spacing?: number;
-  readonly margin?: number;
-}
-
-export interface TiledLayer {
-  readonly id: number;
-  readonly name: string;
-  readonly type: 'tilelayer' | 'objectgroup' | 'imagelayer' | 'group';
-  readonly visible: boolean;
-  readonly x: number;
-  readonly y: number;
-  readonly width?: number;
-  readonly height?: number;
-  readonly data?: number[];
-  readonly objects?: TiledObject[];
-  readonly opacity: number;
-}
-
-export interface TiledObject {
-  readonly id: number;
-  readonly name: string;
-  readonly type: string;
-  readonly x: number;
-  readonly y: number;
-  readonly width: number;
-  readonly height: number;
-  readonly rotation: number;
-  readonly visible: boolean;
-  readonly gid?: number;
-  readonly properties?: TiledProperty[];
-}
-
-export interface TiledProperty {
-  readonly name: string;
-  readonly type: string;
-  readonly value: unknown;
-}
-
-/** Raw data shape parsed from a Tiled JSON (.tmj) file. */
-export interface TiledMapData {
-  readonly width: number;
-  readonly height: number;
-  readonly tilewidth: number;
-  readonly tileheight: number;
-  readonly infinite?: boolean;
-  readonly orientation?: string;
-  readonly renderorder?: string;
-  readonly layers: readonly TiledLayer[];
-  readonly tilesets: readonly TiledTileset[];
-  readonly version?: string | number;
-  readonly type?: string;
-}
-
-// ---------------------------------------------------------------------------
-// TiledMap runtime object
-// ---------------------------------------------------------------------------
+import type { TiledMapData, TiledOrientation, TiledPropertyData, TiledRenderOrder } from './data';
+import { maskTiledGid } from './gid';
+import { createTiledLayer, TiledGroupLayer, TiledObjectLayer, TiledTileLayer, type TiledLayer } from './TiledLayer';
+import type { TiledTileset } from './TiledTileset';
+import { TiledFormatError } from './validate';
 
 /**
- * Runtime representation of a loaded Tiled map.
+ * A parsed and validated Tiled map (`.tmj`).
  *
- * Exposes map metadata, layers, and tileset textures. Tileset textures
- * are owned by the Loader cache — `TiledMap.destroy()` does NOT destroy them.
+ * `TiledMap` represents the parsed Tiled source format. `TileMap` is the
+ * format-independent ExoJS runtime map used for rendering, queries, and
+ * mutation.
  *
- * Only the initial proof scope is implemented: orthogonal tile layers,
- * basic tilesets, and basic object layers. TMX/XML, infinite maps, and
- * world streaming are not supported.
+ * Construction validates that {@link tilesets} cover a non-overlapping,
+ * duplicate-free range of global tile ids, and that every GID referenced by
+ * {@link layers} (tile layer cells, infinite-map chunks, and tile object
+ * `gid`s) falls within one of those ranges. Both checks throw
+ * {@link TiledFormatError} on failure.
  */
 export class TiledMap {
+  /** Resolved URL this map was loaded from. */
+  public readonly source: string;
+  /** The validated raw map data this instance was built from. */
   public readonly data: TiledMapData;
-  public readonly tilesetTextures: readonly Texture[];
 
+  public readonly orientation: TiledOrientation;
+  public readonly renderOrder?: TiledRenderOrder;
+  public readonly class: string;
+  /** Map width in tiles. */
   public readonly width: number;
+  /** Map height in tiles. */
   public readonly height: number;
+  /** Tile grid cell width in pixels. */
   public readonly tileWidth: number;
+  /** Tile grid cell height in pixels. */
   public readonly tileHeight: number;
-
+  public readonly infinite: boolean;
+  public readonly backgroundColor?: string;
   public readonly layers: readonly TiledLayer[];
+  /** Tilesets used by this map, sorted by {@link TiledTileset.firstGid} ascending. */
   public readonly tilesets: readonly TiledTileset[];
+  public readonly properties: readonly TiledPropertyData[];
 
-  public constructor(data: TiledMapData, tilesetTextures: readonly Texture[]) {
+  public constructor(source: string, data: TiledMapData, tilesets: readonly TiledTileset[]) {
+    this.source = source;
     this.data = data;
-    this.tilesetTextures = tilesetTextures;
+    this.orientation = data.orientation;
+    this.renderOrder = data.renderorder;
+    this.class = data.class ?? '';
     this.width = data.width;
     this.height = data.height;
     this.tileWidth = data.tilewidth;
     this.tileHeight = data.tileheight;
-    this.layers = data.layers;
-    this.tilesets = data.tilesets;
-  }
+    this.infinite = data.infinite;
+    this.backgroundColor = data.backgroundcolor;
+    this.properties = data.properties ?? [];
+    this.layers = data.layers.map(createTiledLayer);
+    this.tilesets = sortAndValidateTilesetRanges(tilesets, source);
 
-  /** Tile layers only. */
-  public get tileLayers(): readonly TiledLayer[] {
-    return this.layers.filter(l => l.type === 'tilelayer');
-  }
-
-  /** Object group layers only. */
-  public get objectLayers(): readonly TiledLayer[] {
-    return this.layers.filter(l => l.type === 'objectgroup');
+    checkGidCoverage(this, source);
   }
 
   /**
-   * Destroy this TiledMap. Does NOT destroy tileset textures — they are
-   * owned by the Loader's cache and may be shared with other callers.
+   * Returns the tileset that owns `gid`, or `undefined` if `gid` is `0`
+   * (the empty-cell sentinel) or is not covered by any tileset.
+   *
+   * Flip/rotation flag bits are masked off before the range lookup, so the
+   * raw GID values found in {@link TiledTileLayer.data}/`chunks` and
+   * {@link TiledObject.gid} can be passed directly.
+   */
+  public findTilesetForGid(gid: number): TiledTileset | undefined {
+    const id = maskTiledGid(gid);
+
+    if (id === 0) {
+      return undefined;
+    }
+
+    for (const tileset of this.tilesets) {
+      if (id >= tileset.firstGid && id <= tileset.lastGid) {
+        return tileset;
+      }
+    }
+
+    return undefined;
+  }
+
+  /** Looks up a custom property by name. */
+  public getProperty(name: string): TiledPropertyData | undefined {
+    return this.properties.find(property => property.name === name);
+  }
+
+  /**
+   * Releases this map's reference to its parsed source. Tileset textures are
+   * Loader-owned and may be shared with other maps; this does NOT destroy
+   * them.
    */
   public destroy(): void {
-    // Intentionally empty: tileset textures are Loader-owned.
+    // Intentionally empty: all sub-resources (textures) are Loader-owned.
   }
+}
+
+function sortAndValidateTilesetRanges(tilesets: readonly TiledTileset[], source: string): readonly TiledTileset[] {
+  const sorted = [...tilesets].sort((a, b) => a.firstGid - b.firstGid);
+
+  for (let i = 1; i < sorted.length; i++) {
+    const previous = sorted[i - 1];
+    const current = sorted[i];
+
+    if (current.firstGid === previous.firstGid) {
+      throw new TiledFormatError(source, 'tilesets', `duplicate firstgid ${current.firstGid} (tilesets "${previous.name}" and "${current.name}")`);
+    }
+
+    if (current.firstGid <= previous.lastGid) {
+      throw new TiledFormatError(
+        source,
+        'tilesets',
+        `tileset "${current.name}" (firstgid ${current.firstGid}) overlaps tileset "${previous.name}" (firstgid ${previous.firstGid}, last gid ${previous.lastGid})`,
+      );
+    }
+  }
+
+  return sorted;
+}
+
+function walkLayers(layers: readonly TiledLayer[], path: string, visit: (layer: TiledLayer, layerPath: string) => void): void {
+  for (let i = 0; i < layers.length; i++) {
+    const layer = layers[i];
+    const layerPath = `${path}[${i}]`;
+
+    visit(layer, layerPath);
+
+    if (layer instanceof TiledGroupLayer) {
+      walkLayers(layer.layers, `${layerPath}.layers`, visit);
+    }
+  }
+}
+
+function checkGidArray(gids: readonly number[], map: TiledMap, source: string, path: string): void {
+  for (let i = 0; i < gids.length; i++) {
+    const gid = gids[i];
+
+    if (gid !== 0 && map.findTilesetForGid(gid) === undefined) {
+      throw new TiledFormatError(source, `${path}[${i}]`, `gid ${gid} (masked: ${maskTiledGid(gid)}) is not covered by any tileset`);
+    }
+  }
+}
+
+function checkGidCoverage(map: TiledMap, source: string): void {
+  walkLayers(map.layers, 'layers', (layer, layerPath) => {
+    if (layer instanceof TiledTileLayer) {
+      if (layer.data !== undefined) {
+        checkGidArray(layer.data, map, source, `${layerPath}.data`);
+      }
+
+      if (layer.chunks !== undefined) {
+        for (let c = 0; c < layer.chunks.length; c++) {
+          checkGidArray(layer.chunks[c].data, map, source, `${layerPath}.chunks[${c}].data`);
+        }
+      }
+    } else if (layer instanceof TiledObjectLayer) {
+      for (let o = 0; o < layer.objects.length; o++) {
+        const gid = layer.objects[o].gid;
+
+        if (gid !== undefined && map.findTilesetForGid(gid) === undefined) {
+          throw new TiledFormatError(source, `${layerPath}.objects[${o}].gid`, `gid ${gid} (masked: ${maskTiledGid(gid)}) is not covered by any tileset`);
+        }
+      }
+    }
+  });
 }

--- a/packages/exojs-tiled/src/TiledObject.ts
+++ b/packages/exojs-tiled/src/TiledObject.ts
@@ -1,0 +1,55 @@
+import type { TiledObjectData, TiledPointData, TiledPropertyData, TiledTextData } from './data';
+
+/**
+ * A parsed Tiled object, placed in an {@link TiledObjectLayer} or a tile's
+ * collision `objectgroup`.
+ *
+ * The shape of the object is determined by which of {@link point},
+ * {@link ellipse}, {@link polygon}, {@link polyline}, {@link text}, or
+ * {@link gid} is set; if none are set, the object is a plain rectangle
+ * spanning `[x, y, width, height]`.
+ */
+export class TiledObject {
+  public readonly id: number;
+  public readonly name: string;
+  public readonly type: string;
+  public readonly x: number;
+  public readonly y: number;
+  public readonly width: number;
+  public readonly height: number;
+  public readonly rotation: number;
+  public readonly visible: boolean;
+  public readonly gid?: number;
+  public readonly point: boolean;
+  public readonly ellipse: boolean;
+  public readonly polygon?: readonly TiledPointData[];
+  public readonly polyline?: readonly TiledPointData[];
+  public readonly text?: TiledTextData;
+  public readonly template?: string;
+  public readonly properties: readonly TiledPropertyData[];
+
+  public constructor(data: TiledObjectData) {
+    this.id = data.id;
+    this.name = data.name;
+    this.type = data.type;
+    this.x = data.x;
+    this.y = data.y;
+    this.width = data.width;
+    this.height = data.height;
+    this.rotation = data.rotation;
+    this.visible = data.visible;
+    this.gid = data.gid;
+    this.point = data.point ?? false;
+    this.ellipse = data.ellipse ?? false;
+    this.polygon = data.polygon;
+    this.polyline = data.polyline;
+    this.text = data.text;
+    this.template = data.template;
+    this.properties = data.properties ?? [];
+  }
+
+  /** Looks up a custom property by name. */
+  public getProperty(name: string): TiledPropertyData | undefined {
+    return this.properties.find(property => property.name === name);
+  }
+}

--- a/packages/exojs-tiled/src/TiledTileset.ts
+++ b/packages/exojs-tiled/src/TiledTileset.ts
@@ -1,0 +1,92 @@
+import type { Texture } from '@codexo/exojs';
+
+import type { TiledPointData, TiledPropertyData, TiledTileData, TiledTilesetData } from './data';
+
+/**
+ * Loader-resolved resources for a {@link TiledTileset}: the absolute image
+ * URL(s) and the {@link Texture} instance(s) loaded for them. All textures
+ * are owned by the `Loader` cache — a {@link TiledTileset} never destroys
+ * them.
+ */
+export interface TiledTilesetResources {
+  /** Resolved URL of the external `.tsj` file, or `undefined` for an embedded tileset. */
+  readonly source?: string;
+  /** Resolved URL of the tileset's atlas {@link TiledTilesetData.image}, or `undefined` for a collection-of-images tileset. */
+  readonly imageUrl?: string;
+  /** Texture loaded for {@link imageUrl}. */
+  readonly texture?: Texture;
+  /** Textures loaded for collection-of-images {@link TiledTileData.image} entries, keyed by local tile id. */
+  readonly tileTextures?: ReadonlyMap<number, Texture>;
+}
+
+/**
+ * A parsed Tiled tileset — either embedded inline in a map's `tilesets`
+ * array, or parsed from an external `.tsj` file referenced by it.
+ *
+ * {@link firstGid} and {@link lastGid} define the inclusive range of global
+ * tile ids (after masking flip/rotation flags via `maskTiledGid`) that this
+ * tileset owns within its owning {@link TiledMap}.
+ */
+export class TiledTileset {
+  /** First global tile id owned by this tileset. */
+  public readonly firstGid: number;
+  /** Resolved URL of the external `.tsj` file, or `undefined` for an embedded tileset. */
+  public readonly source?: string;
+  public readonly name: string;
+  public readonly class: string;
+  public readonly tileWidth: number;
+  public readonly tileHeight: number;
+  public readonly tileCount: number;
+  public readonly columns: number;
+  public readonly spacing: number;
+  public readonly margin: number;
+  /** Resolved URL of the tileset's atlas image, or `undefined` for a collection-of-images tileset. */
+  public readonly imageUrl?: string;
+  public readonly imageWidth?: number;
+  public readonly imageHeight?: number;
+  /** Texture loaded for {@link imageUrl}. Loader-owned; not destroyed by {@link TiledMap.destroy}. */
+  public readonly texture?: Texture;
+  public readonly tileOffset: TiledPointData;
+  public readonly objectAlignment?: string;
+  public readonly tiles: readonly TiledTileData[];
+  /** Textures loaded for collection-of-images tiles, keyed by local tile id. Loader-owned. */
+  public readonly tileTextures: ReadonlyMap<number, Texture>;
+  public readonly properties: readonly TiledPropertyData[];
+
+  public constructor(data: TiledTilesetData, firstGid: number, resources: TiledTilesetResources = {}) {
+    this.firstGid = firstGid;
+    this.source = resources.source;
+    this.name = data.name;
+    this.class = data.class ?? '';
+    this.tileWidth = data.tilewidth;
+    this.tileHeight = data.tileheight;
+    this.tileCount = data.tilecount;
+    this.columns = data.columns;
+    this.spacing = data.spacing ?? 0;
+    this.margin = data.margin ?? 0;
+    this.imageUrl = resources.imageUrl;
+    this.imageWidth = data.imagewidth;
+    this.imageHeight = data.imageheight;
+    this.texture = resources.texture;
+    this.tileOffset = data.tileoffset ?? { x: 0, y: 0 };
+    this.objectAlignment = data.objectalignment;
+    this.tiles = data.tiles ?? [];
+    this.tileTextures = resources.tileTextures ?? new Map();
+    this.properties = data.properties ?? [];
+  }
+
+  /** Last global tile id (inclusive) owned by this tileset. Empty (`lastGid < firstGid`) when {@link tileCount} is `0`. */
+  public get lastGid(): number {
+    return this.firstGid + this.tileCount - 1;
+  }
+
+  /** Looks up a per-tile definition by local tile id. */
+  public getTile(localId: number): TiledTileData | undefined {
+    return this.tiles.find(tile => tile.id === localId);
+  }
+
+  /** Looks up a custom property by name. */
+  public getProperty(name: string): TiledPropertyData | undefined {
+    return this.properties.find(property => property.name === name);
+  }
+}

--- a/packages/exojs-tiled/src/data.ts
+++ b/packages/exojs-tiled/src/data.ts
@@ -1,0 +1,261 @@
+// Raw Tiled JSON (TMJ/TSJ) interfaces — type-only mirrors of the on-disk
+// format. These types describe exactly what `JSON.parse` can produce for a
+// Tiled map/tileset file; they carry no behaviour and are never Loader
+// tokens. Parsed, validated runtime classes (TiledMap, TiledTileset,
+// TiledLayer, TiledObject, ...) live alongside this module and are built
+// from these shapes by `validate.ts` / `loadTiledMap.ts`.
+//
+// Field coverage targets the orthogonal-map feature set described in the
+// v0.13 Tiled phase-2 spec (tile/object/image/group layers, embedded and
+// external tilesets, custom properties, tile animations). Hex/isometric-only
+// fields (grid, hexsidelength, staggeraxis/-index, wangsets, terrains,
+// transformations, parallax origin) are intentionally not modelled.
+
+/** A 2D point as written by Tiled (used for tile offsets and object shapes). */
+export interface TiledPointData {
+  readonly x: number;
+  readonly y: number;
+}
+
+// ── Custom properties ──────────────────────────────────────────────────────
+
+/** The `type` discriminant of a Tiled custom property. */
+export type TiledPropertyType = 'string' | 'int' | 'float' | 'bool' | 'color' | 'file' | 'object' | 'class';
+
+/**
+ * The value of a `class`-typed custom property: a nested map of member name
+ * to value, recursively allowing further `class` members.
+ */
+export type TiledClassPropertyValueData = { readonly [name: string]: string | number | boolean | TiledClassPropertyValueData };
+
+/**
+ * One custom property entry as written by Tiled (`properties` arrays on
+ * maps, tilesets, tiles, layers and objects).
+ *
+ * - `string` / `color` / `file` → `value` is a `string`
+ * - `int` / `float` / `object` → `value` is a `number` (an `object` value is
+ *   the referenced object's id)
+ * - `bool` → `value` is a `boolean`
+ * - `class` → `value` is a {@link TiledClassPropertyValueData}; `propertytype`
+ *   names the class
+ */
+export interface TiledPropertyData {
+  readonly name: string;
+  readonly type: TiledPropertyType;
+  readonly propertytype?: string;
+  readonly value: string | number | boolean | TiledClassPropertyValueData;
+}
+
+// ── Tile animation ──────────────────────────────────────────────────────────
+
+/** One frame of a tile's animation sequence. */
+export interface TiledAnimationFrameData {
+  /** Local tile id (within the owning tileset) shown during this frame. */
+  readonly tileid: number;
+  /** Frame duration in milliseconds. */
+  readonly duration: number;
+}
+
+// ── Per-tile tileset definitions ────────────────────────────────────────────
+
+/**
+ * A per-tile definition within a tileset's `tiles` array. Sparse — only
+ * tiles carrying metadata (properties, animation, a collision objectgroup,
+ * or a collection-of-images source) appear here.
+ */
+export interface TiledTileData {
+  /** Local tile id within the owning tileset. */
+  readonly id: number;
+  /** Tile class (`class`/`type` field depending on Tiled version). */
+  readonly type?: string;
+  readonly properties?: readonly TiledPropertyData[];
+  readonly animation?: readonly TiledAnimationFrameData[];
+  /** Per-tile collision shapes, structurally identical to an object layer. */
+  readonly objectgroup?: TiledObjectLayerData;
+  /** Collection-of-images tile source, relative to the tileset's location. */
+  readonly image?: string;
+  readonly imagewidth?: number;
+  readonly imageheight?: number;
+}
+
+// ── Tileset ──────────────────────────────────────────────────────────────────
+
+/**
+ * A Tiled tileset, as the root of a standalone `.tsj` file or (minus
+ * `firstgid`) embedded inline in a map's `tilesets` array.
+ */
+export interface TiledTilesetData {
+  readonly name: string;
+  readonly class?: string;
+  readonly tilewidth: number;
+  readonly tileheight: number;
+  readonly tilecount: number;
+  readonly columns: number;
+  readonly spacing?: number;
+  readonly margin?: number;
+  /** Single-image ("atlas") tileset source, relative to the tileset's location. Absent for collection-of-images tilesets. */
+  readonly image?: string;
+  readonly imagewidth?: number;
+  readonly imageheight?: number;
+  readonly tileoffset?: TiledPointData;
+  readonly objectalignment?: string;
+  readonly tiles?: readonly TiledTileData[];
+  readonly properties?: readonly TiledPropertyData[];
+  readonly tiledversion?: string;
+  readonly version?: string | number;
+}
+
+/** A map's `tilesets[]` entry referencing an external `.tsj` file by relative path. */
+export interface TiledExternalTilesetRefData {
+  readonly firstgid: number;
+  readonly source: string;
+}
+
+/** A map's `tilesets[]` entry with the tileset embedded inline. */
+export type TiledEmbeddedTilesetRefData = TiledTilesetData & { readonly firstgid: number };
+
+/** One entry of {@link TiledMapData.tilesets} — either external (`source`) or embedded. */
+export type TiledTilesetRefData = TiledExternalTilesetRefData | TiledEmbeddedTilesetRefData;
+
+// ── Objects ──────────────────────────────────────────────────────────────────
+
+/** Text rendering options for a `text` object (object layers). */
+export interface TiledTextData {
+  readonly text: string;
+  readonly bold?: boolean;
+  readonly color?: string;
+  readonly fontfamily?: string;
+  readonly halign?: 'center' | 'right' | 'justify' | 'left';
+  readonly italic?: boolean;
+  readonly kerning?: boolean;
+  readonly pixelsize?: number;
+  readonly strikeout?: boolean;
+  readonly underline?: boolean;
+  readonly valign?: 'center' | 'bottom' | 'top';
+  readonly wrap?: boolean;
+}
+
+/**
+ * An object placed in an object layer (or a tile's collision `objectgroup`).
+ * The shape is determined by which of `point` / `ellipse` / `polygon` /
+ * `polyline` / `text` / `gid` is present; absent of all of these, the object
+ * is a plain rectangle.
+ */
+export interface TiledObjectData {
+  readonly id: number;
+  readonly name: string;
+  /** Object class (empty string if unset). */
+  readonly type: string;
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+  readonly rotation: number;
+  readonly visible: boolean;
+  /** Tile object reference; may carry flip/rotation flag bits in the high bits. */
+  readonly gid?: number;
+  readonly point?: boolean;
+  readonly ellipse?: boolean;
+  readonly polygon?: readonly TiledPointData[];
+  readonly polyline?: readonly TiledPointData[];
+  readonly text?: TiledTextData;
+  /** Path to a `.tx` object template this object was instantiated from. */
+  readonly template?: string;
+  readonly properties?: readonly TiledPropertyData[];
+}
+
+// ── Layers ───────────────────────────────────────────────────────────────────
+
+/** Fields shared by every layer type. */
+export interface TiledLayerDataBase {
+  readonly id: number;
+  readonly name: string;
+  readonly class?: string;
+  readonly visible: boolean;
+  readonly opacity: number;
+  readonly x: number;
+  readonly y: number;
+  readonly offsetx?: number;
+  readonly offsety?: number;
+  readonly parallaxx?: number;
+  readonly parallaxy?: number;
+  readonly tintcolor?: string;
+  readonly properties?: readonly TiledPropertyData[];
+}
+
+/** A chunk of tile data within an infinite tile layer. */
+export interface TiledChunkData {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+  readonly data: readonly number[];
+}
+
+/**
+ * A finite-map tile layer has `data` (a flat, row-major array of GIDs of
+ * length `width * height`). An infinite-map tile layer has `chunks` instead.
+ */
+export interface TiledTileLayerData extends TiledLayerDataBase {
+  readonly type: 'tilelayer';
+  readonly width: number;
+  readonly height: number;
+  readonly data?: readonly number[];
+  readonly chunks?: readonly TiledChunkData[];
+}
+
+export interface TiledObjectLayerData extends TiledLayerDataBase {
+  readonly type: 'objectgroup';
+  readonly draworder?: 'topdown' | 'index';
+  readonly objects: readonly TiledObjectData[];
+}
+
+export interface TiledImageLayerData extends TiledLayerDataBase {
+  readonly type: 'imagelayer';
+  /** Image source, relative to the map's location. Empty string if unset. */
+  readonly image: string;
+  readonly repeatx?: boolean;
+  readonly repeaty?: boolean;
+}
+
+export interface TiledGroupLayerData extends TiledLayerDataBase {
+  readonly type: 'group';
+  readonly layers: readonly TiledLayerData[];
+}
+
+/** Discriminated union of all four Tiled layer types, keyed by `type`. */
+export type TiledLayerData = TiledTileLayerData | TiledObjectLayerData | TiledImageLayerData | TiledGroupLayerData;
+
+// ── Map ──────────────────────────────────────────────────────────────────────
+
+/** The orientation values Tiled may write for a map. */
+export type TiledOrientation = 'orthogonal' | 'isometric' | 'staggered' | 'hexagonal';
+
+/** The render-order values Tiled may write for an orthogonal map. */
+export type TiledRenderOrder = 'right-down' | 'right-up' | 'left-down' | 'left-up';
+
+/** The root of a `.tmj` map file. */
+export interface TiledMapData {
+  readonly type: 'map';
+  readonly version: string | number;
+  readonly tiledversion?: string;
+  readonly class?: string;
+  readonly orientation: TiledOrientation;
+  readonly renderorder?: TiledRenderOrder;
+  /** Map width in tiles. */
+  readonly width: number;
+  /** Map height in tiles. */
+  readonly height: number;
+  /** Tile grid cell width in pixels. */
+  readonly tilewidth: number;
+  /** Tile grid cell height in pixels. */
+  readonly tileheight: number;
+  readonly infinite: boolean;
+  readonly compressionlevel?: number;
+  readonly nextlayerid?: number;
+  readonly nextobjectid?: number;
+  readonly backgroundcolor?: string;
+  readonly layers: readonly TiledLayerData[];
+  readonly tilesets: readonly TiledTilesetRefData[];
+  readonly properties?: readonly TiledPropertyData[];
+}

--- a/packages/exojs-tiled/src/gid.ts
+++ b/packages/exojs-tiled/src/gid.ts
@@ -1,0 +1,29 @@
+// Tiled GID flip-flag bits (TMJ tile-layer `data` / object `gid` values).
+// The high four bits of a 32-bit GID encode flip/rotation state; the
+// remaining 28 bits are the actual tileset-relative global tile id.
+//
+// These constants exist only to mask flip bits off before resolving a GID
+// against a tileset's [firstgid, firstgid + tilecount) range during source
+// validation. Converting flip bits into a runtime `TileTransform` is a C2
+// (runtime conversion) concern and is intentionally not implemented here.
+// @internal
+
+export const TILED_FLIPPED_HORIZONTALLY_FLAG = 0x80000000;
+export const TILED_FLIPPED_VERTICALLY_FLAG = 0x40000000;
+export const TILED_FLIPPED_DIAGONALLY_FLAG = 0x20000000;
+export const TILED_ROTATED_HEXAGONAL_120_FLAG = 0x10000000;
+
+/** Mask isolating the 28-bit tile id, clearing all four flip/rotation flag bits. */
+const TILED_GID_MASK = 0x0fffffff;
+
+/**
+ * Strips the flip/rotation flag bits from a raw Tiled GID, returning the
+ * plain tileset-relative global tile id (0 = empty cell).
+ *
+ * GIDs may exceed `2^31` (the horizontal-flip flag alone is `2^31`), so the
+ * value is first coerced to an unsigned 32-bit integer via `>>> 0`.
+ * @internal
+ */
+export function maskTiledGid(raw: number): number {
+  return (raw >>> 0) & TILED_GID_MASK;
+}

--- a/packages/exojs-tiled/src/loadTiledMap.ts
+++ b/packages/exojs-tiled/src/loadTiledMap.ts
@@ -1,0 +1,79 @@
+import { Texture, type AssetLoaderContext } from '@codexo/exojs';
+
+import type { TiledTilesetData, TiledTilesetRefData } from './data';
+import { TiledMap } from './TiledMap';
+import { TiledTileset, type TiledTilesetResources } from './TiledTileset';
+import { resolveTiledUrl } from './url';
+import { validateTiledMapData, validateTiledTilesetFileData } from './validate';
+
+/**
+ * Resolves and loads the image(s) referenced by a tileset: the atlas
+ * `image` (if present) and any collection-of-images per-tile `image`
+ * entries, relative to `baseUrl` (the resolved location of the file the
+ * tileset data came from — the `.tmj` for an embedded tileset, the `.tsj`
+ * for an external one).
+ *
+ * Textures are loaded via `context.loader`, which deduplicates concurrent
+ * and repeated loads of the same normalized URL.
+ */
+async function loadTiledTilesetResources(data: TiledTilesetData, baseUrl: string, context: AssetLoaderContext, source?: string): Promise<TiledTilesetResources> {
+  let imageUrl: string | undefined;
+  let texture: Texture | undefined;
+
+  if (data.image !== undefined) {
+    imageUrl = resolveTiledUrl(data.image, baseUrl);
+    texture = await context.loader.load(Texture, imageUrl);
+  }
+
+  let tileTextures: Map<number, Texture> | undefined;
+
+  if (data.tiles !== undefined) {
+    for (const tile of data.tiles) {
+      if (tile.image === undefined) {
+        continue;
+      }
+
+      const tileImageUrl = resolveTiledUrl(tile.image, baseUrl);
+      const tileTexture: Texture = await context.loader.load(Texture, tileImageUrl);
+
+      tileTextures ??= new Map();
+      tileTextures.set(tile.id, tileTexture);
+    }
+  }
+
+  return { source, imageUrl, texture, tileTextures };
+}
+
+/**
+ * Resolves one `tilesets[]` entry of a `.tmj` file to a {@link TiledTileset}:
+ * fetches and validates the external `.tsj` if `ref.source` is set, or uses
+ * the embedded tileset data directly, then resolves and loads its image(s).
+ */
+async function loadTiledTileset(ref: TiledTilesetRefData, mapSource: string, context: AssetLoaderContext): Promise<TiledTileset> {
+  if ('source' in ref) {
+    const tsjUrl = resolveTiledUrl(ref.source, mapSource);
+    const raw = await context.fetchJson(tsjUrl);
+    const data = validateTiledTilesetFileData(raw, tsjUrl);
+    const resources = await loadTiledTilesetResources(data, tsjUrl, context, tsjUrl);
+
+    return new TiledTileset(data, ref.firstgid, resources);
+  }
+
+  const resources = await loadTiledTilesetResources(ref, mapSource, context);
+
+  return new TiledTileset(ref, ref.firstgid, resources);
+}
+
+/**
+ * Loads and resolves a Tiled map: fetches and validates the `.tmj`, resolves
+ * each tileset (external `.tsj` or embedded) and its image(s), and returns
+ * the assembled, GID-validated {@link TiledMap}.
+ * @internal
+ */
+export async function loadTiledMap(source: string, context: AssetLoaderContext): Promise<TiledMap> {
+  const raw = await context.fetchJson(source);
+  const data = validateTiledMapData(raw, source);
+  const tilesets = await Promise.all(data.tilesets.map(ref => loadTiledTileset(ref, source, context)));
+
+  return new TiledMap(source, data, tilesets);
+}

--- a/packages/exojs-tiled/src/public.ts
+++ b/packages/exojs-tiled/src/public.ts
@@ -2,6 +2,7 @@
 // No registration is performed on import.
 
 export type { AssetBinding, AssetHandler, AssetLoadRequest, Extension } from '@codexo/exojs/extensions';
+export { type TiledLoadOptions } from './tiledOptions';
 
 // ── Runtime facade (re-exports from @codexo/exojs-tilemap) ─────────────────
 // These are re-exports of the *same* module bindings — `instanceof TileMap`
@@ -77,3 +78,24 @@ export type { TiledTilesetResources } from './TiledTileset';
 
 // ── Validation ───────────────────────────────────────────────────────────────
 export { TiledFormatError } from './validate';
+
+// ── Module augmentation — typed load calls ───────────────────────────────────
+import type { TileMap } from '@codexo/exojs-tilemap';
+import type { TiledMap } from './TiledMap';
+
+declare module '@codexo/exojs' {
+  interface ExtensionTypeMap {
+    /** `.tmj` path-only loads resolve to the generic runtime {@link TileMap}. */
+    tmj: TileMap;
+  }
+  interface AssetDefinitions {
+    tileMap: {
+      resource: TileMap;
+      config: { source: string; format?: 'tiled'; strict?: boolean };
+    };
+    tiledMap: {
+      resource: TiledMap;
+      config: { source: string; format?: 'tiled'; strict?: boolean };
+    };
+  }
+}

--- a/packages/exojs-tiled/src/public.ts
+++ b/packages/exojs-tiled/src/public.ts
@@ -1,9 +1,54 @@
 // Side-effect-free public API for @codexo/exojs-tiled.
 // No registration is performed on import.
 
-export type { Extension, AssetBinding, AssetHandler, AssetLoadRequest } from '@codexo/exojs/extensions';
+export type { AssetBinding, AssetHandler, AssetLoadRequest, Extension } from '@codexo/exojs/extensions';
+
 export { tiledExtension } from './tiledExtension';
+export { tiledMapBinding } from './tiledMapBinding';
+
 export type { TiledBuildInfo } from './tiledBuildInfo';
 export { tiledBuildInfo } from './tiledBuildInfo';
+
+// ── Raw Tiled JSON (TMJ/TSJ) types ──────────────────────────────────────────
+export type {
+  TiledAnimationFrameData,
+  TiledChunkData,
+  TiledClassPropertyValueData,
+  TiledEmbeddedTilesetRefData,
+  TiledExternalTilesetRefData,
+  TiledGroupLayerData,
+  TiledImageLayerData,
+  TiledLayerData,
+  TiledLayerDataBase,
+  TiledMapData,
+  TiledObjectData,
+  TiledObjectLayerData,
+  TiledOrientation,
+  TiledPointData,
+  TiledPropertyData,
+  TiledPropertyType,
+  TiledRenderOrder,
+  TiledTextData,
+  TiledTileData,
+  TiledTileLayerData,
+  TiledTilesetData,
+  TiledTilesetRefData,
+} from './data';
+
+// ── Parsed source model ─────────────────────────────────────────────────────
 export { TiledMap } from './TiledMap';
-export type { TiledLayer, TiledMapData, TiledObject, TiledProperty, TiledTileset } from './TiledMap';
+export { TiledObject } from './TiledObject';
+export {
+  createTiledLayer,
+  TiledGroupLayer,
+  TiledImageLayer,
+  TiledLayer,
+  TiledObjectLayer,
+  TiledTileLayer,
+} from './TiledLayer';
+export type { TiledLayerType } from './TiledLayer';
+export { TiledTileset } from './TiledTileset';
+export type { TiledTilesetResources } from './TiledTileset';
+
+// ── Validation ───────────────────────────────────────────────────────────────
+export { TiledFormatError } from './validate';

--- a/packages/exojs-tiled/src/public.ts
+++ b/packages/exojs-tiled/src/public.ts
@@ -88,6 +88,10 @@ declare module '@codexo/exojs' {
     /** `.tmj` path-only loads resolve to the generic runtime {@link TileMap}. */
     tmj: TileMap;
   }
+  interface ExtensionTokenTypeMap {
+    /** The advanced parsed-source token is also accepted for `.tmj`: `load(TiledMap, 'world.tmj')`. */
+    tmj: TiledMap;
+  }
   interface AssetDefinitions {
     tileMap: {
       resource: TileMap;

--- a/packages/exojs-tiled/src/public.ts
+++ b/packages/exojs-tiled/src/public.ts
@@ -3,8 +3,33 @@
 
 export type { AssetBinding, AssetHandler, AssetLoadRequest, Extension } from '@codexo/exojs/extensions';
 
+// ── Runtime facade (re-exports from @codexo/exojs-tilemap) ─────────────────
+// These are re-exports of the *same* module bindings — `instanceof TileMap`
+// holds whether the class was imported from @codexo/exojs-tilemap or here.
+export {
+  TileLayer,
+  TileMap,
+  TileSet,
+  tilemapExtension,
+  TILE_TRANSFORM_IDENTITY,
+} from '@codexo/exojs-tilemap';
+export type {
+  ChunkCoord,
+  PackedTile,
+  ReadonlyTileChunk,
+  ResolvedTile,
+  TileDefinition,
+  TileLayerOptions,
+  TileMapOptions,
+  TileProperties,
+  TilePropertyValue,
+  TileSetOptions,
+  TileTransform,
+} from '@codexo/exojs-tilemap';
+
 export { tiledExtension } from './tiledExtension';
 export { tiledMapBinding } from './tiledMapBinding';
+export { tiledRuntimeMapBinding } from './tiledRuntimeMapBinding';
 
 export type { TiledBuildInfo } from './tiledBuildInfo';
 export { tiledBuildInfo } from './tiledBuildInfo';

--- a/packages/exojs-tiled/src/tiledExtension.ts
+++ b/packages/exojs-tiled/src/tiledExtension.ts
@@ -1,68 +1,21 @@
-import { Texture } from '@codexo/exojs';
-import type { AssetBinding, AssetHandler, AssetLoadRequest, Extension } from '@codexo/exojs/extensions';
-import type { AssetLoaderContext, Loader } from '@codexo/exojs';
+import { tilemapExtension } from '@codexo/exojs-tilemap';
+import type { Extension } from '@codexo/exojs/extensions';
 
-import { TiledMap, type TiledMapData } from './TiledMap';
-
-/**
- * Resolve a tileset image reference relative to the map's source path.
- * `new URL(ref, source)` only works when `source` is an absolute URL; the
- * loader is frequently called with relative paths, so fall back to a synthetic
- * base and strip it.
- */
-function resolveRelative(ref: string, source: string): string {
-  try {
-    return new URL(ref, source).href;
-  } catch {
-    const base = 'https://exojs.invalid/';
-    return new URL(ref, base + source.replace(/^\/+/, '')).href.slice(base.length);
-  }
-}
-
-const tiledBinding: AssetBinding<TiledMap> = {
-  type: TiledMap,
-  typeNames: ['tiledMap'],
-  extensions: ['tmj'],
-  create(loader: Loader): AssetHandler<TiledMap> {
-    return {
-      async load({ source }: AssetLoadRequest, context: AssetLoaderContext): Promise<TiledMap> {
-        const data = await context.fetchJson<TiledMapData>(source);
-
-        if (!data || typeof data !== 'object' || !Array.isArray(data.tilesets)) {
-          throw new Error(`TiledMap: invalid or unsupported map file at "${source}".`);
-        }
-
-        if (data.infinite === true) {
-          throw new Error(`TiledMap: infinite maps are not supported (at "${source}").`);
-        }
-
-        if (data.orientation !== undefined && data.orientation !== 'orthogonal') {
-          throw new Error(`TiledMap: only orthogonal orientation is supported (got "${data.orientation}" at "${source}").`);
-        }
-
-        // Load tileset textures. Sub-assets are owned by the Loader cache —
-        // TiledMap must NOT destroy them.
-        const tilesetTextures = (await Promise.all(
-          data.tilesets
-            .filter(ts => ts.image !== undefined)
-            .map(ts => loader.load(Texture, resolveRelative(ts.image!, source))),
-        )) as Texture[];
-
-        return new TiledMap(data, tilesetTextures);
-      },
-      destroy() {
-        // This handler holds no loader-local resources.
-      },
-    };
-  },
-};
+import { tiledMapBinding } from './tiledMapBinding';
 
 /**
  * Default immutable Tiled extension descriptor.
+ *
+ * Depends on {@link tilemapExtension} (the generic tilemap runtime) so that
+ * snapshot construction always materializes it alongside `@codexo/exojs-tiled`,
+ * even though this package's `TiledMap` source model does not yet convert
+ * into the runtime `TileMap`.
+ *
  * Use with `ApplicationOptions.extensions` or call
  * `import '@codexo/exojs-tiled/register'` for global auto-registration.
  */
 export const tiledExtension: Extension = Object.freeze({
   id: '@codexo/exojs-tiled',
-  assets: [tiledBinding],
+  dependencies: [tilemapExtension],
+  assets: [tiledMapBinding],
 });

--- a/packages/exojs-tiled/src/tiledExtension.ts
+++ b/packages/exojs-tiled/src/tiledExtension.ts
@@ -1,5 +1,5 @@
 import { tilemapExtension } from '@codexo/exojs-tilemap';
-import type { Extension } from '@codexo/exojs/extensions';
+import type { AssetBinding, Extension } from '@codexo/exojs/extensions';
 
 import { tiledMapBinding } from './tiledMapBinding';
 import { tiledRuntimeMapBinding } from './tiledRuntimeMapBinding';
@@ -22,5 +22,9 @@ import { tiledRuntimeMapBinding } from './tiledRuntimeMapBinding';
 export const tiledExtension: Extension = Object.freeze({
   id: '@codexo/exojs-tiled',
   dependencies: [tilemapExtension],
-  assets: [tiledRuntimeMapBinding, tiledMapBinding],
+  // Localized erasure cast: typed bindings (Options=TiledLoadOptions) meet the
+  // untyped Extension.assets contract here. Runtime behavior is unaffected —
+  // materializeAssetBindings calls create() and bindAsset() correctly regardless
+  // of the erased Options type.
+  assets: [tiledRuntimeMapBinding, tiledMapBinding] as unknown as AssetBinding[],
 });

--- a/packages/exojs-tiled/src/tiledExtension.ts
+++ b/packages/exojs-tiled/src/tiledExtension.ts
@@ -2,14 +2,19 @@ import { tilemapExtension } from '@codexo/exojs-tilemap';
 import type { Extension } from '@codexo/exojs/extensions';
 
 import { tiledMapBinding } from './tiledMapBinding';
+import { tiledRuntimeMapBinding } from './tiledRuntimeMapBinding';
 
 /**
  * Default immutable Tiled extension descriptor.
  *
- * Depends on {@link tilemapExtension} (the generic tilemap runtime) so that
- * snapshot construction always materializes it alongside `@codexo/exojs-tiled`,
- * even though this package's `TiledMap` source model does not yet convert
- * into the runtime `TileMap`.
+ * Registers two asset bindings:
+ * - {@link tiledRuntimeMapBinding} — `loader.load(TileMap, 'world.tmj')` →
+ *   returns a format-independent runtime {@link TileMap} (common case).
+ * - {@link tiledMapBinding} — `loader.load(TiledMap, 'world.tmj')` →
+ *   returns the raw parsed {@link TiledMap} source model (advanced/diagnostic).
+ *
+ * Depends on {@link tilemapExtension} so that snapshot construction always
+ * materialises the generic tilemap runtime before the Tiled adapter.
  *
  * Use with `ApplicationOptions.extensions` or call
  * `import '@codexo/exojs-tiled/register'` for global auto-registration.
@@ -17,5 +22,5 @@ import { tiledMapBinding } from './tiledMapBinding';
 export const tiledExtension: Extension = Object.freeze({
   id: '@codexo/exojs-tiled',
   dependencies: [tilemapExtension],
-  assets: [tiledMapBinding],
+  assets: [tiledRuntimeMapBinding, tiledMapBinding],
 });

--- a/packages/exojs-tiled/src/tiledMapBinding.ts
+++ b/packages/exojs-tiled/src/tiledMapBinding.ts
@@ -1,0 +1,25 @@
+import type { AssetBinding, AssetHandler, AssetLoadRequest } from '@codexo/exojs/extensions';
+
+import { loadTiledMap } from './loadTiledMap';
+import { TiledMap } from './TiledMap';
+
+/**
+ * Declarative asset binding for {@link TiledMap}.
+ *
+ * Token-only: `loader.load(TiledMap, 'world.tmj')` resolves through this
+ * binding, but no `extensions` are claimed, so a plain
+ * `loader.load('world.tmj')` does not resolve to `TiledMap`. The `.tmj`
+ * extension (and generic `.json` Tiled loading) is reserved for the
+ * format-independent `TileMap` runtime asset binding.
+ */
+export const tiledMapBinding = {
+  type: TiledMap,
+  typeNames: ['tiledMap'],
+  create(): AssetHandler<TiledMap> {
+    return {
+      async load({ source }: AssetLoadRequest, context): Promise<TiledMap> {
+        return loadTiledMap(source, context);
+      },
+    };
+  },
+} satisfies AssetBinding<TiledMap>;

--- a/packages/exojs-tiled/src/tiledMapBinding.ts
+++ b/packages/exojs-tiled/src/tiledMapBinding.ts
@@ -1,7 +1,8 @@
-import type { AssetBinding, AssetHandler, AssetLoadRequest } from '@codexo/exojs/extensions';
+import type { AssetBinding, AssetHandler } from '@codexo/exojs/extensions';
 
 import { loadTiledMap } from './loadTiledMap';
 import { TiledMap } from './TiledMap';
+import { type TiledLoadOptions, resolveTiledOptions } from './tiledOptions';
 
 /**
  * Declarative asset binding for {@link TiledMap}.
@@ -15,11 +16,15 @@ import { TiledMap } from './TiledMap';
 export const tiledMapBinding = {
   type: TiledMap,
   typeNames: ['tiledMap'],
-  create(): AssetHandler<TiledMap> {
+  create() {
     return {
-      async load({ source }: AssetLoadRequest, context): Promise<TiledMap> {
-        return loadTiledMap(source, context);
+      getIdentityKey(req) {
+        const o = resolveTiledOptions(req.options);
+        return `${req.source}|${o.format}|${o.strict}`;
       },
-    };
+      async load(req, ctx) {
+        return loadTiledMap(req.source, ctx);
+      },
+    } satisfies AssetHandler<TiledMap, TiledLoadOptions>;
   },
-} satisfies AssetBinding<TiledMap>;
+} satisfies AssetBinding<TiledMap, TiledLoadOptions>;

--- a/packages/exojs-tiled/src/tiledOptions.ts
+++ b/packages/exojs-tiled/src/tiledOptions.ts
@@ -1,0 +1,29 @@
+/**
+ * Options accepted by both the runtime (`TileMap`) and source (`TiledMap`)
+ * asset bindings when loading a Tiled map.
+ * @advanced
+ */
+export interface TiledLoadOptions {
+  /**
+   * Explicit format hint for ambiguous file extensions.
+   * `.tmj` paths need no hint; required for `.json` paths that contain Tiled
+   * map data (`loader.load(TileMap, 'world.json', { format: 'tiled' })`).
+   * A mismatched hint (e.g. `format: 'ldtk'` for a `.tmj` file) is an error.
+   */
+  readonly format?: 'tiled';
+  /**
+   * When `true` (the default), validation errors in the Tiled map are fatal.
+   * Set to `false` to tolerate minor spec deviations at the cost of potentially
+   * incorrect map data; affects cache identity (a strict and a non-strict load
+   * of the same URL are treated as distinct assets).
+   */
+  readonly strict?: boolean;
+}
+
+/** Applies defaults and returns a normalized options object. */
+export function resolveTiledOptions(options: TiledLoadOptions | undefined): { format: 'tiled'; strict: boolean } {
+  return {
+    format: options?.format ?? 'tiled',
+    strict: options?.strict ?? true,
+  };
+}

--- a/packages/exojs-tiled/src/tiledRuntimeMapBinding.ts
+++ b/packages/exojs-tiled/src/tiledRuntimeMapBinding.ts
@@ -1,0 +1,31 @@
+import type { AssetBinding, AssetHandler, AssetLoadRequest } from '@codexo/exojs/extensions';
+import { TileMap } from '@codexo/exojs-tilemap';
+
+import { loadTiledMap } from './loadTiledMap';
+
+/**
+ * Declarative asset binding for the runtime {@link TileMap} produced from a
+ * `.tmj` Tiled map file.
+ *
+ * This is the common-case binding: `loader.load(TileMap, 'world.tmj')` fetches
+ * and validates the TMJ, resolves external `.tsj` tilesets, loads tileset
+ * textures, and converts the parsed {@link TiledMap} source model into a
+ * format-independent runtime {@link TileMap} via {@link TiledMap.toTileMap}.
+ *
+ * Claiming the `tmj` extension enables the auto-routing shorthand
+ * `loader.load('world.tmj')` once the {@link ExtensionTypeMap} augmentation
+ * maps `'tmj' → TileMap` (Phase C2).
+ */
+export const tiledRuntimeMapBinding = {
+  type: TileMap,
+  typeNames: ['tileMap'],
+  extensions: ['tmj'],
+  create(): AssetHandler<TileMap> {
+    return {
+      async load({ source }: AssetLoadRequest, context): Promise<TileMap> {
+        const tiledMap = await loadTiledMap(source, context);
+        return tiledMap.toTileMap();
+      },
+    };
+  },
+} satisfies AssetBinding<TileMap>;

--- a/packages/exojs-tiled/src/tiledRuntimeMapBinding.ts
+++ b/packages/exojs-tiled/src/tiledRuntimeMapBinding.ts
@@ -1,7 +1,8 @@
-import type { AssetBinding, AssetHandler, AssetLoadRequest } from '@codexo/exojs/extensions';
+import type { AssetBinding, AssetHandler } from '@codexo/exojs/extensions';
 import { TileMap } from '@codexo/exojs-tilemap';
 
-import { loadTiledMap } from './loadTiledMap';
+import { TiledMap } from './TiledMap';
+import { type TiledLoadOptions, resolveTiledOptions } from './tiledOptions';
 
 /**
  * Declarative asset binding for the runtime {@link TileMap} produced from a
@@ -9,23 +10,32 @@ import { loadTiledMap } from './loadTiledMap';
  *
  * This is the common-case binding: `loader.load(TileMap, 'world.tmj')` fetches
  * and validates the TMJ, resolves external `.tsj` tilesets, loads tileset
- * textures, and converts the parsed {@link TiledMap} source model into a
- * format-independent runtime {@link TileMap} via {@link TiledMap.toTileMap}.
+ * textures via the sub-load `loader.load(TiledMap, source)`, and synchronously
+ * converts the parsed {@link TiledMap} source model into a format-independent
+ * runtime {@link TileMap} via {@link TiledMap.toTileMap}.
+ *
+ * The sub-load flow guarantees that calling both `load(TileMap)` and
+ * `load(TiledMap)` for the same URL shares the Loader's cached `TiledMap`
+ * (no duplicate JSON fetches).
  *
  * Claiming the `tmj` extension enables the auto-routing shorthand
- * `loader.load('world.tmj')` once the {@link ExtensionTypeMap} augmentation
- * maps `'tmj' → TileMap` (Phase C2).
+ * `loader.load('world.tmj')` — the {@link ExtensionTypeMap} augmentation in
+ * this package maps `'tmj' → TileMap`.
  */
 export const tiledRuntimeMapBinding = {
   type: TileMap,
   typeNames: ['tileMap'],
   extensions: ['tmj'],
-  create(): AssetHandler<TileMap> {
+  create() {
     return {
-      async load({ source }: AssetLoadRequest, context): Promise<TileMap> {
-        const tiledMap = await loadTiledMap(source, context);
+      getIdentityKey(req) {
+        const o = resolveTiledOptions(req.options);
+        return `${req.source}|${o.format}|${o.strict}`;
+      },
+      async load(req, ctx) {
+        const tiledMap = await ctx.loader.load(TiledMap, req.source, req.options);
         return tiledMap.toTileMap();
       },
-    };
+    } satisfies AssetHandler<TileMap, TiledLoadOptions>;
   },
-} satisfies AssetBinding<TileMap>;
+} satisfies AssetBinding<TileMap, TiledLoadOptions>;

--- a/packages/exojs-tiled/src/url.ts
+++ b/packages/exojs-tiled/src/url.ts
@@ -1,0 +1,45 @@
+// Relative-path resolution for Tiled source references (TMJ → TSJ, TMJ/TSJ →
+// image). Tiled stores every cross-file reference as a path relative to the
+// file that contains it; ExoJS asset sources are themselves often relative
+// (resolved against an asset root configured outside the Loader), so plain
+// `new URL(ref, base)` cannot be used directly when `base` has no scheme.
+
+/** Matches references that are already absolute and must not be re-resolved: scheme:, protocol-relative `//`, root-relative `/`, and data/blob URLs. */
+const ABSOLUTE_REF = /^(?:[a-z][a-z\d+.-]*:|\/\/|\/)/i;
+
+/** Matches a base that is itself an absolute URL with a scheme. */
+const ABSOLUTE_BASE = /^[a-z][a-z\d+.-]*:/i;
+
+/** Synthetic origin used to borrow `URL`'s `../`/`./` collapsing for relative bases. */
+const SYNTHETIC_ORIGIN = 'https://exojs.invalid/';
+
+/**
+ * Resolves `ref` (a path read from a Tiled JSON file, e.g. a tileset
+ * `source` or an `image`) relative to `base` (the resolved location of the
+ * file that referenced it).
+ *
+ * - If `ref` is already absolute (has a scheme, is protocol- or
+ *   root-relative, or is a `data:`/`blob:` URL), it is returned unchanged.
+ * - If `base` is an absolute URL, standard `new URL(ref, base)` resolution
+ *   is used.
+ * - Otherwise both `ref` and `base` are relative ExoJS asset paths; `../`
+ *   and `./` segments are collapsed via a synthetic origin and the result is
+ *   returned relative again.
+ *
+ * Query strings and fragments on `ref` are preserved.
+ *
+ * @internal
+ */
+export function resolveTiledUrl(ref: string, base: string): string {
+  if (ABSOLUTE_REF.test(ref)) {
+    return ref;
+  }
+
+  if (ABSOLUTE_BASE.test(base)) {
+    return new URL(ref, base).href;
+  }
+
+  const resolved = new URL(ref, SYNTHETIC_ORIGIN + base.replace(/^\/+/, ''));
+
+  return resolved.href.slice(SYNTHETIC_ORIGIN.length);
+}

--- a/packages/exojs-tiled/src/validate.ts
+++ b/packages/exojs-tiled/src/validate.ts
@@ -1,0 +1,608 @@
+// Runtime validation for Tiled JSON (TMJ/TSJ) data. Every exported function
+// takes `unknown` (the result of `JSON.parse`) and either returns a typed,
+// validated `Tiled*Data` value or throws a {@link TiledFormatError}.
+//
+// There is no fall-through: an unrecognised shape, an unsupported encoding,
+// or an out-of-range value is always a thrown error carrying the source URL
+// and a JSON-path-like field path, never a silently-substituted default.
+
+import type {
+  TiledAnimationFrameData,
+  TiledChunkData,
+  TiledClassPropertyValueData,
+  TiledGroupLayerData,
+  TiledImageLayerData,
+  TiledLayerData,
+  TiledLayerDataBase,
+  TiledMapData,
+  TiledObjectData,
+  TiledObjectLayerData,
+  TiledOrientation,
+  TiledPointData,
+  TiledPropertyData,
+  TiledPropertyType,
+  TiledRenderOrder,
+  TiledTextData,
+  TiledTileData,
+  TiledTileLayerData,
+  TiledTilesetData,
+  TiledTilesetRefData,
+} from './data';
+
+/**
+ * Thrown when a Tiled JSON document does not match the expected shape.
+ * `source` is the URL of the file being parsed; `path` is a JSON-path-like
+ * pointer (e.g. `layers[2].objects[0].properties[1].value`) to the offending
+ * value, or `''` for the document root.
+ */
+export class TiledFormatError extends Error {
+  public readonly source: string;
+  public readonly path: string;
+
+  public constructor(source: string, path: string, message: string) {
+    super(`Invalid Tiled data in "${source}" at ${path === '' ? '<root>' : path}: ${message}`);
+    this.name = 'TiledFormatError';
+    this.source = source;
+    this.path = path;
+  }
+}
+
+// ── Primitive helpers ───────────────────────────────────────────────────────
+
+function describeValue(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'an array';
+  return typeof value;
+}
+
+function joinPath(path: string, key: string | number): string {
+  if (typeof key === 'number') return `${path}[${key}]`;
+  return path === '' ? key : `${path}.${key}`;
+}
+
+function expectObject(value: unknown, source: string, path: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new TiledFormatError(source, path, `expected an object, got ${describeValue(value)}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function expectArray(value: unknown, source: string, path: string): readonly unknown[] {
+  if (!Array.isArray(value)) {
+    throw new TiledFormatError(source, path, `expected an array, got ${describeValue(value)}`);
+  }
+  return value;
+}
+
+function expectString(value: unknown, source: string, path: string): string {
+  if (typeof value !== 'string') {
+    throw new TiledFormatError(source, path, `expected a string, got ${describeValue(value)}`);
+  }
+  return value;
+}
+
+function expectNumber(value: unknown, source: string, path: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new TiledFormatError(source, path, `expected a finite number, got ${describeValue(value)}`);
+  }
+  return value;
+}
+
+function expectInteger(value: unknown, source: string, path: string): number {
+  const n = expectNumber(value, source, path);
+  if (!Number.isInteger(n)) {
+    throw new TiledFormatError(source, path, `expected an integer, got ${n}`);
+  }
+  return n;
+}
+
+function expectNonNegativeInteger(value: unknown, source: string, path: string): number {
+  const n = expectInteger(value, source, path);
+  if (n < 0) {
+    throw new TiledFormatError(source, path, `expected a non-negative integer, got ${n}`);
+  }
+  return n;
+}
+
+function expectPositiveInteger(value: unknown, source: string, path: string): number {
+  const n = expectInteger(value, source, path);
+  if (n <= 0) {
+    throw new TiledFormatError(source, path, `expected a positive integer, got ${n}`);
+  }
+  return n;
+}
+
+function expectBoolean(value: unknown, source: string, path: string): boolean {
+  if (typeof value !== 'boolean') {
+    throw new TiledFormatError(source, path, `expected a boolean, got ${describeValue(value)}`);
+  }
+  return value;
+}
+
+function optionalString(obj: Record<string, unknown>, key: string, source: string, path: string): string | undefined {
+  const value = obj[key];
+  return value === undefined ? undefined : expectString(value, source, joinPath(path, key));
+}
+
+function optionalNumber(obj: Record<string, unknown>, key: string, source: string, path: string): number | undefined {
+  const value = obj[key];
+  return value === undefined ? undefined : expectNumber(value, source, joinPath(path, key));
+}
+
+function optionalInteger(obj: Record<string, unknown>, key: string, source: string, path: string): number | undefined {
+  const value = obj[key];
+  return value === undefined ? undefined : expectInteger(value, source, joinPath(path, key));
+}
+
+function optionalNonNegativeInteger(obj: Record<string, unknown>, key: string, source: string, path: string): number | undefined {
+  const value = obj[key];
+  return value === undefined ? undefined : expectNonNegativeInteger(value, source, joinPath(path, key));
+}
+
+function optionalBoolean(obj: Record<string, unknown>, key: string, source: string, path: string): boolean | undefined {
+  const value = obj[key];
+  return value === undefined ? undefined : expectBoolean(value, source, joinPath(path, key));
+}
+
+function mapArray<T>(value: unknown, source: string, path: string, fn: (item: unknown, itemPath: string) => T): readonly T[] {
+  const arr = expectArray(value, source, path);
+  return arr.map((item, i) => fn(item, joinPath(path, i)));
+}
+
+function optionalMapArray<T>(value: unknown, source: string, path: string, fn: (item: unknown, itemPath: string) => T): readonly T[] | undefined {
+  return value === undefined ? undefined : mapArray(value, source, path, fn);
+}
+
+// ── Custom properties ───────────────────────────────────────────────────────
+
+const PROPERTY_TYPES: readonly TiledPropertyType[] = ['string', 'int', 'float', 'bool', 'color', 'file', 'object', 'class'];
+
+function validateTiledClassPropertyValue(raw: unknown, source: string, path: string): TiledClassPropertyValueData {
+  const obj = expectObject(raw, source, path);
+  const result: Record<string, string | number | boolean | TiledClassPropertyValueData> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const memberPath = joinPath(path, key);
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      result[key] = value;
+    } else if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      result[key] = validateTiledClassPropertyValue(value, source, memberPath);
+    } else {
+      throw new TiledFormatError(source, memberPath, `expected a string, number, boolean, or nested object, got ${describeValue(value)}`);
+    }
+  }
+  return result;
+}
+
+/** @internal */
+export function validateTiledPropertyData(raw: unknown, source: string, path: string): TiledPropertyData {
+  const obj = expectObject(raw, source, path);
+  const name = expectString(obj['name'], source, joinPath(path, 'name'));
+  const typePath = joinPath(path, 'type');
+  const typeName = obj['type'] === undefined ? 'string' : expectString(obj['type'], source, typePath);
+
+  if (!PROPERTY_TYPES.includes(typeName as TiledPropertyType)) {
+    throw new TiledFormatError(source, typePath, `unknown property type "${typeName}"`);
+  }
+
+  const type = typeName as TiledPropertyType;
+  const propertytype = optionalString(obj, 'propertytype', source, path);
+  const valuePath = joinPath(path, 'value');
+  let value: TiledPropertyData['value'];
+
+  switch (type) {
+    case 'string':
+    case 'color':
+    case 'file':
+      value = expectString(obj['value'], source, valuePath);
+      break;
+    case 'int':
+    case 'float':
+    case 'object':
+      value = expectNumber(obj['value'], source, valuePath);
+      break;
+    case 'bool':
+      value = expectBoolean(obj['value'], source, valuePath);
+      break;
+    case 'class':
+      value = validateTiledClassPropertyValue(obj['value'], source, valuePath);
+      break;
+  }
+
+  return { name, type, propertytype, value };
+}
+
+function validateTiledPropertiesArray(value: unknown, source: string, path: string): readonly TiledPropertyData[] | undefined {
+  return optionalMapArray(value, source, path, (item, itemPath) => validateTiledPropertyData(item, source, itemPath));
+}
+
+// ── Points / animation frames ───────────────────────────────────────────────
+
+function validateTiledPointData(raw: unknown, source: string, path: string): TiledPointData {
+  const obj = expectObject(raw, source, path);
+  return {
+    x: expectNumber(obj['x'], source, joinPath(path, 'x')),
+    y: expectNumber(obj['y'], source, joinPath(path, 'y')),
+  };
+}
+
+function validateTiledPointArray(value: unknown, source: string, path: string): readonly TiledPointData[] {
+  return mapArray(value, source, path, (item, itemPath) => validateTiledPointData(item, source, itemPath));
+}
+
+/** @internal */
+export function validateTiledAnimationFrameData(raw: unknown, source: string, path: string): TiledAnimationFrameData {
+  const obj = expectObject(raw, source, path);
+  return {
+    tileid: expectNonNegativeInteger(obj['tileid'], source, joinPath(path, 'tileid')),
+    duration: expectNonNegativeInteger(obj['duration'], source, joinPath(path, 'duration')),
+  };
+}
+
+// ── Text objects ─────────────────────────────────────────────────────────────
+
+const HALIGN_VALUES: readonly TiledTextData['halign'][] = ['center', 'right', 'justify', 'left'];
+const VALIGN_VALUES: readonly TiledTextData['valign'][] = ['center', 'bottom', 'top'];
+
+function validateTiledTextData(raw: unknown, source: string, path: string): TiledTextData {
+  const obj = expectObject(raw, source, path);
+  const text = expectString(obj['text'], source, joinPath(path, 'text'));
+
+  let halign: TiledTextData['halign'];
+  if (obj['halign'] !== undefined) {
+    const value = expectString(obj['halign'], source, joinPath(path, 'halign'));
+    if (!HALIGN_VALUES.includes(value as TiledTextData['halign'])) {
+      throw new TiledFormatError(source, joinPath(path, 'halign'), `unknown horizontal alignment "${value}"`);
+    }
+    halign = value as TiledTextData['halign'];
+  }
+
+  let valign: TiledTextData['valign'];
+  if (obj['valign'] !== undefined) {
+    const value = expectString(obj['valign'], source, joinPath(path, 'valign'));
+    if (!VALIGN_VALUES.includes(value as TiledTextData['valign'])) {
+      throw new TiledFormatError(source, joinPath(path, 'valign'), `unknown vertical alignment "${value}"`);
+    }
+    valign = value as TiledTextData['valign'];
+  }
+
+  return {
+    text,
+    bold: optionalBoolean(obj, 'bold', source, path),
+    color: optionalString(obj, 'color', source, path),
+    fontfamily: optionalString(obj, 'fontfamily', source, path),
+    halign,
+    italic: optionalBoolean(obj, 'italic', source, path),
+    kerning: optionalBoolean(obj, 'kerning', source, path),
+    pixelsize: optionalNonNegativeInteger(obj, 'pixelsize', source, path),
+    strikeout: optionalBoolean(obj, 'strikeout', source, path),
+    underline: optionalBoolean(obj, 'underline', source, path),
+    valign,
+    wrap: optionalBoolean(obj, 'wrap', source, path),
+  };
+}
+
+// ── Objects ──────────────────────────────────────────────────────────────────
+
+/** @internal */
+export function validateTiledObjectData(raw: unknown, source: string, path: string): TiledObjectData {
+  const obj = expectObject(raw, source, path);
+
+  return {
+    id: expectNonNegativeInteger(obj['id'], source, joinPath(path, 'id')),
+    name: expectString(obj['name'], source, joinPath(path, 'name')),
+    type: expectString(obj['type'], source, joinPath(path, 'type')),
+    x: expectNumber(obj['x'], source, joinPath(path, 'x')),
+    y: expectNumber(obj['y'], source, joinPath(path, 'y')),
+    width: expectNumber(obj['width'], source, joinPath(path, 'width')),
+    height: expectNumber(obj['height'], source, joinPath(path, 'height')),
+    rotation: expectNumber(obj['rotation'], source, joinPath(path, 'rotation')),
+    visible: expectBoolean(obj['visible'], source, joinPath(path, 'visible')),
+    gid: optionalNonNegativeInteger(obj, 'gid', source, path),
+    point: optionalBoolean(obj, 'point', source, path),
+    ellipse: optionalBoolean(obj, 'ellipse', source, path),
+    polygon: obj['polygon'] === undefined ? undefined : validateTiledPointArray(obj['polygon'], source, joinPath(path, 'polygon')),
+    polyline: obj['polyline'] === undefined ? undefined : validateTiledPointArray(obj['polyline'], source, joinPath(path, 'polyline')),
+    text: obj['text'] === undefined ? undefined : validateTiledTextData(obj['text'], source, joinPath(path, 'text')),
+    template: optionalString(obj, 'template', source, path),
+    properties: validateTiledPropertiesArray(obj['properties'], source, joinPath(path, 'properties')),
+  };
+}
+
+// ── Layers ───────────────────────────────────────────────────────────────────
+
+const LAYER_TYPES = ['tilelayer', 'objectgroup', 'imagelayer', 'group'] as const;
+const SUPPORTED_TILE_LAYER_ENCODINGS = new Set<string>(['csv']);
+const DRAW_ORDERS: readonly NonNullable<TiledObjectLayerData['draworder']>[] = ['topdown', 'index'];
+
+function validateTiledLayerBase(obj: Record<string, unknown>, source: string, path: string): TiledLayerDataBase {
+  return {
+    id: expectNonNegativeInteger(obj['id'], source, joinPath(path, 'id')),
+    name: expectString(obj['name'], source, joinPath(path, 'name')),
+    class: optionalString(obj, 'class', source, path),
+    visible: expectBoolean(obj['visible'], source, joinPath(path, 'visible')),
+    opacity: expectNumber(obj['opacity'], source, joinPath(path, 'opacity')),
+    x: expectNumber(obj['x'], source, joinPath(path, 'x')),
+    y: expectNumber(obj['y'], source, joinPath(path, 'y')),
+    offsetx: optionalNumber(obj, 'offsetx', source, path),
+    offsety: optionalNumber(obj, 'offsety', source, path),
+    parallaxx: optionalNumber(obj, 'parallaxx', source, path),
+    parallaxy: optionalNumber(obj, 'parallaxy', source, path),
+    tintcolor: optionalString(obj, 'tintcolor', source, path),
+    properties: validateTiledPropertiesArray(obj['properties'], source, joinPath(path, 'properties')),
+  };
+}
+
+function validateTiledGidArray(value: unknown, source: string, path: string): readonly number[] {
+  return mapArray(value, source, path, (item, itemPath) => expectNonNegativeInteger(item, source, itemPath));
+}
+
+function validateTiledChunkData(raw: unknown, source: string, path: string): TiledChunkData {
+  const obj = expectObject(raw, source, path);
+  return {
+    x: expectInteger(obj['x'], source, joinPath(path, 'x')),
+    y: expectInteger(obj['y'], source, joinPath(path, 'y')),
+    width: expectPositiveInteger(obj['width'], source, joinPath(path, 'width')),
+    height: expectPositiveInteger(obj['height'], source, joinPath(path, 'height')),
+    data: validateTiledGidArray(obj['data'], source, joinPath(path, 'data')),
+  };
+}
+
+function validateTiledTileLayerData(obj: Record<string, unknown>, base: TiledLayerDataBase, source: string, path: string): TiledTileLayerData {
+  if (obj['compression'] !== undefined) {
+    throw new TiledFormatError(source, joinPath(path, 'compression'), `compressed tile layer data is not supported (compression: ${JSON.stringify(obj['compression'])})`);
+  }
+
+  const encoding = obj['encoding'];
+  if (encoding !== undefined && !(typeof encoding === 'string' && SUPPORTED_TILE_LAYER_ENCODINGS.has(encoding))) {
+    throw new TiledFormatError(source, joinPath(path, 'encoding'), `unsupported tile layer encoding ${JSON.stringify(encoding)} (only plain CSV/array data is supported)`);
+  }
+
+  const width = expectNonNegativeInteger(obj['width'], source, joinPath(path, 'width'));
+  const height = expectNonNegativeInteger(obj['height'], source, joinPath(path, 'height'));
+
+  const hasData = obj['data'] !== undefined;
+  const hasChunks = obj['chunks'] !== undefined;
+
+  if (hasData === hasChunks) {
+    throw new TiledFormatError(source, path, hasData ? 'tile layer has both "data" and "chunks"' : 'tile layer has neither "data" nor "chunks"');
+  }
+
+  return {
+    ...base,
+    type: 'tilelayer',
+    width,
+    height,
+    data: hasData ? validateTiledGidArray(obj['data'], source, joinPath(path, 'data')) : undefined,
+    chunks: hasChunks ? mapArray(obj['chunks'], source, joinPath(path, 'chunks'), (item, itemPath) => validateTiledChunkData(item, source, itemPath)) : undefined,
+  };
+}
+
+function validateTiledObjectLayerData(obj: Record<string, unknown>, base: TiledLayerDataBase, source: string, path: string): TiledObjectLayerData {
+  let draworder: TiledObjectLayerData['draworder'];
+  if (obj['draworder'] !== undefined) {
+    const value = expectString(obj['draworder'], source, joinPath(path, 'draworder'));
+    if (!DRAW_ORDERS.includes(value as NonNullable<TiledObjectLayerData['draworder']>)) {
+      throw new TiledFormatError(source, joinPath(path, 'draworder'), `unknown draw order "${value}"`);
+    }
+    draworder = value as TiledObjectLayerData['draworder'];
+  }
+
+  return {
+    ...base,
+    type: 'objectgroup',
+    draworder,
+    objects: mapArray(obj['objects'], source, joinPath(path, 'objects'), (item, itemPath) => validateTiledObjectData(item, source, itemPath)),
+  };
+}
+
+function validateTiledImageLayerData(obj: Record<string, unknown>, base: TiledLayerDataBase, source: string, path: string): TiledImageLayerData {
+  return {
+    ...base,
+    type: 'imagelayer',
+    image: obj['image'] === undefined ? '' : expectString(obj['image'], source, joinPath(path, 'image')),
+    repeatx: optionalBoolean(obj, 'repeatx', source, path),
+    repeaty: optionalBoolean(obj, 'repeaty', source, path),
+  };
+}
+
+function validateTiledGroupLayerData(obj: Record<string, unknown>, base: TiledLayerDataBase, source: string, path: string): TiledGroupLayerData {
+  return {
+    ...base,
+    type: 'group',
+    layers: mapArray(obj['layers'], source, joinPath(path, 'layers'), (item, itemPath) => validateTiledLayerData(item, source, itemPath)),
+  };
+}
+
+/** @internal */
+export function validateTiledLayerData(raw: unknown, source: string, path: string): TiledLayerData {
+  const obj = expectObject(raw, source, path);
+  const type = expectString(obj['type'], source, joinPath(path, 'type'));
+  const base = validateTiledLayerBase(obj, source, path);
+
+  switch (type) {
+    case 'tilelayer':
+      return validateTiledTileLayerData(obj, base, source, path);
+    case 'objectgroup':
+      return validateTiledObjectLayerData(obj, base, source, path);
+    case 'imagelayer':
+      return validateTiledImageLayerData(obj, base, source, path);
+    case 'group':
+      return validateTiledGroupLayerData(obj, base, source, path);
+    default: {
+      const known: readonly string[] = LAYER_TYPES;
+      throw new TiledFormatError(source, joinPath(path, 'type'), `unknown layer type "${type}" (expected one of ${known.join(', ')})`);
+    }
+  }
+}
+
+/**
+ * Walks a layer tree and ensures every tile layer's `data`/`chunks` choice
+ * matches the map's `infinite` flag. Tiled itself is consistent across an
+ * entire map; a mismatch indicates a hand-edited or corrupt file.
+ * @internal
+ */
+export function checkTiledLayerInfiniteConsistency(layers: readonly TiledLayerData[], infinite: boolean, source: string, path: string): void {
+  for (let i = 0; i < layers.length; i++) {
+    const layer = layers[i];
+    const layerPath = joinPath(path, i);
+
+    if (layer.type === 'tilelayer') {
+      const hasChunks = layer.chunks !== undefined;
+      if (hasChunks !== infinite) {
+        throw new TiledFormatError(
+          source,
+          layerPath,
+          infinite ? 'tile layer is missing "chunks" on an infinite map' : 'tile layer has "chunks" on a finite map (expected "data")',
+        );
+      }
+    } else if (layer.type === 'group') {
+      checkTiledLayerInfiniteConsistency(layer.layers, infinite, source, joinPath(layerPath, 'layers'));
+    }
+  }
+}
+
+// ── Tile definitions ─────────────────────────────────────────────────────────
+
+/** @internal */
+export function validateTiledTileData(raw: unknown, source: string, path: string): TiledTileData {
+  const obj = expectObject(raw, source, path);
+
+  let objectgroup: TiledObjectLayerData | undefined;
+  if (obj['objectgroup'] !== undefined) {
+    const objectgroupPath = joinPath(path, 'objectgroup');
+    const layer = validateTiledLayerData(obj['objectgroup'], source, objectgroupPath);
+    if (layer.type !== 'objectgroup') {
+      throw new TiledFormatError(source, objectgroupPath, `expected an "objectgroup" layer, got "${layer.type}"`);
+    }
+    objectgroup = layer;
+  }
+
+  return {
+    id: expectNonNegativeInteger(obj['id'], source, joinPath(path, 'id')),
+    type: optionalString(obj, 'type', source, path),
+    properties: validateTiledPropertiesArray(obj['properties'], source, joinPath(path, 'properties')),
+    animation: optionalMapArray(obj['animation'], source, joinPath(path, 'animation'), (item, itemPath) => validateTiledAnimationFrameData(item, source, itemPath)),
+    objectgroup,
+    image: optionalString(obj, 'image', source, path),
+    imagewidth: optionalNonNegativeInteger(obj, 'imagewidth', source, path),
+    imageheight: optionalNonNegativeInteger(obj, 'imageheight', source, path),
+  };
+}
+
+// ── Tilesets ─────────────────────────────────────────────────────────────────
+
+function validateTiledVersion(value: unknown, source: string, path: string): string | number {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    throw new TiledFormatError(source, path, `expected a string or number, got ${describeValue(value)}`);
+  }
+  return value;
+}
+
+/** @internal */
+export function validateTiledTilesetData(obj: Record<string, unknown>, source: string, path: string): TiledTilesetData {
+  return {
+    name: expectString(obj['name'], source, joinPath(path, 'name')),
+    class: optionalString(obj, 'class', source, path),
+    tilewidth: expectPositiveInteger(obj['tilewidth'], source, joinPath(path, 'tilewidth')),
+    tileheight: expectPositiveInteger(obj['tileheight'], source, joinPath(path, 'tileheight')),
+    tilecount: expectNonNegativeInteger(obj['tilecount'], source, joinPath(path, 'tilecount')),
+    columns: expectNonNegativeInteger(obj['columns'], source, joinPath(path, 'columns')),
+    spacing: optionalNonNegativeInteger(obj, 'spacing', source, path),
+    margin: optionalNonNegativeInteger(obj, 'margin', source, path),
+    image: optionalString(obj, 'image', source, path),
+    imagewidth: optionalNonNegativeInteger(obj, 'imagewidth', source, path),
+    imageheight: optionalNonNegativeInteger(obj, 'imageheight', source, path),
+    tileoffset: obj['tileoffset'] === undefined ? undefined : validateTiledPointData(obj['tileoffset'], source, joinPath(path, 'tileoffset')),
+    objectalignment: optionalString(obj, 'objectalignment', source, path),
+    tiles: optionalMapArray(obj['tiles'], source, joinPath(path, 'tiles'), (item, itemPath) => validateTiledTileData(item, source, itemPath)),
+    properties: validateTiledPropertiesArray(obj['properties'], source, joinPath(path, 'properties')),
+    tiledversion: optionalString(obj, 'tiledversion', source, path),
+    version: obj['version'] === undefined ? undefined : validateTiledVersion(obj['version'], source, joinPath(path, 'version')),
+  };
+}
+
+/**
+ * Validates one entry of a map's `tilesets` array: either `{ firstgid,
+ * source }` (external `.tsj`) or `{ firstgid, ...embedded tileset fields }`.
+ * @internal
+ */
+export function validateTiledTilesetRefData(raw: unknown, source: string, path: string): TiledTilesetRefData {
+  const obj = expectObject(raw, source, path);
+  const firstgid = expectPositiveInteger(obj['firstgid'], source, joinPath(path, 'firstgid'));
+
+  if ('source' in obj) {
+    return { firstgid, source: expectString(obj['source'], source, joinPath(path, 'source')) };
+  }
+
+  return { ...validateTiledTilesetData(obj, source, path), firstgid };
+}
+
+// ── Map ──────────────────────────────────────────────────────────────────────
+
+const ORIENTATIONS: readonly TiledOrientation[] = ['orthogonal', 'isometric', 'staggered', 'hexagonal'];
+const RENDER_ORDERS: readonly TiledRenderOrder[] = ['right-down', 'right-up', 'left-down', 'left-up'];
+
+/**
+ * Validates the root of a `.tmj` file. Throws {@link TiledFormatError} on
+ * any structural problem, including unsupported tile-layer encodings and
+ * `infinite`/`data`/`chunks` inconsistencies.
+ * @internal
+ */
+export function validateTiledMapData(raw: unknown, source: string): TiledMapData {
+  const obj = expectObject(raw, source, '');
+
+  const type = expectString(obj['type'], source, 'type');
+  if (type !== 'map') {
+    throw new TiledFormatError(source, 'type', `expected "map", got "${type}"`);
+  }
+
+  const version = validateTiledVersion(obj['version'], source, 'version');
+
+  const orientationValue = expectString(obj['orientation'], source, 'orientation');
+  if (!ORIENTATIONS.includes(orientationValue as TiledOrientation)) {
+    throw new TiledFormatError(source, 'orientation', `unknown orientation "${orientationValue}" (expected one of ${ORIENTATIONS.join(', ')})`);
+  }
+  const orientation = orientationValue as TiledOrientation;
+
+  let renderorder: TiledRenderOrder | undefined;
+  if (obj['renderorder'] !== undefined) {
+    const value = expectString(obj['renderorder'], source, 'renderorder');
+    if (!RENDER_ORDERS.includes(value as TiledRenderOrder)) {
+      throw new TiledFormatError(source, 'renderorder', `unknown render order "${value}" (expected one of ${RENDER_ORDERS.join(', ')})`);
+    }
+    renderorder = value as TiledRenderOrder;
+  }
+
+  const infinite = expectBoolean(obj['infinite'], source, 'infinite');
+  const layers = mapArray(obj['layers'], source, 'layers', (item, itemPath) => validateTiledLayerData(item, source, itemPath));
+  checkTiledLayerInfiniteConsistency(layers, infinite, source, 'layers');
+
+  return {
+    type: 'map',
+    version,
+    tiledversion: optionalString(obj, 'tiledversion', source, ''),
+    class: optionalString(obj, 'class', source, ''),
+    orientation,
+    renderorder,
+    width: expectNonNegativeInteger(obj['width'], source, 'width'),
+    height: expectNonNegativeInteger(obj['height'], source, 'height'),
+    tilewidth: expectPositiveInteger(obj['tilewidth'], source, 'tilewidth'),
+    tileheight: expectPositiveInteger(obj['tileheight'], source, 'tileheight'),
+    infinite,
+    compressionlevel: optionalInteger(obj, 'compressionlevel', source, ''),
+    nextlayerid: optionalNonNegativeInteger(obj, 'nextlayerid', source, ''),
+    nextobjectid: optionalNonNegativeInteger(obj, 'nextobjectid', source, ''),
+    backgroundcolor: optionalString(obj, 'backgroundcolor', source, ''),
+    layers,
+    tilesets: mapArray(obj['tilesets'], source, 'tilesets', (item, itemPath) => validateTiledTilesetRefData(item, source, itemPath)),
+    properties: validateTiledPropertiesArray(obj['properties'], source, 'properties'),
+  };
+}
+
+/**
+ * Validates a standalone `.tsj` tileset file's root object.
+ * @internal
+ */
+export function validateTiledTilesetFileData(raw: unknown, source: string): TiledTilesetData {
+  return validateTiledTilesetData(expectObject(raw, source, ''), source, '');
+}

--- a/packages/exojs-tiled/test/TiledLayer.test.ts
+++ b/packages/exojs-tiled/test/TiledLayer.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createTiledLayer,
+  TiledGroupLayer,
+  TiledImageLayer,
+  TiledLayer,
+  TiledObjectLayer,
+  TiledTileLayer,
+} from '../src/TiledLayer';
+import type { TiledObjectLayerData, TiledGroupLayerData } from '../src/data';
+
+const BASE = {
+  id: 1,
+  name: 'Layer',
+  visible: true,
+  opacity: 1,
+  x: 0,
+  y: 0,
+};
+
+describe('TiledTileLayer', () => {
+  const data = { ...BASE, type: 'tilelayer' as const, width: 4, height: 4, data: [1, 2, 3, 4] };
+
+  it('has type "tilelayer"', () => {
+    expect(new TiledTileLayer(data).type).toBe('tilelayer');
+  });
+
+  it('maps width and height', () => {
+    const layer = new TiledTileLayer(data);
+    expect(layer.width).toBe(4);
+    expect(layer.height).toBe(4);
+  });
+
+  it('maps finite data array', () => {
+    expect(new TiledTileLayer(data).data).toEqual([1, 2, 3, 4]);
+  });
+
+  it('maps infinite chunks array', () => {
+    const chunks = [{ x: 0, y: 0, width: 16, height: 16, data: [1, 2] }];
+    const layer = new TiledTileLayer({ ...BASE, type: 'tilelayer' as const, width: 0, height: 0, chunks });
+    expect(layer.chunks).toEqual(chunks);
+    expect(layer.data).toBeUndefined();
+  });
+});
+
+describe('TiledObjectLayer', () => {
+  const objectData = { id: 1, name: '', type: '', x: 0, y: 0, width: 0, height: 0, rotation: 0, visible: true };
+  const data: TiledObjectLayerData = { ...BASE, type: 'objectgroup', objects: [objectData] };
+
+  it('has type "objectgroup"', () => {
+    expect(new TiledObjectLayer(data).type).toBe('objectgroup');
+  });
+
+  it('defaults drawOrder to "topdown"', () => {
+    expect(new TiledObjectLayer(data).drawOrder).toBe('topdown');
+  });
+
+  it('maps explicit drawOrder', () => {
+    expect(new TiledObjectLayer({ ...data, draworder: 'index' }).drawOrder).toBe('index');
+  });
+
+  it('maps objects as TiledObject instances', () => {
+    const layer = new TiledObjectLayer(data);
+    expect(layer.objects).toHaveLength(1);
+    expect(layer.objects[0].id).toBe(1);
+  });
+});
+
+describe('TiledImageLayer', () => {
+  const data = { ...BASE, type: 'imagelayer' as const, image: 'bg.png' };
+
+  it('has type "imagelayer"', () => {
+    expect(new TiledImageLayer(data).type).toBe('imagelayer');
+  });
+
+  it('maps image path', () => {
+    expect(new TiledImageLayer(data).image).toBe('bg.png');
+  });
+
+  it('defaults repeatX and repeatY to false', () => {
+    const layer = new TiledImageLayer(data);
+    expect(layer.repeatX).toBe(false);
+    expect(layer.repeatY).toBe(false);
+  });
+
+  it('maps explicit repeat flags', () => {
+    const layer = new TiledImageLayer({ ...data, repeatx: true, repeaty: true });
+    expect(layer.repeatX).toBe(true);
+    expect(layer.repeatY).toBe(true);
+  });
+});
+
+describe('TiledGroupLayer', () => {
+  const childData = { ...BASE, id: 2, type: 'tilelayer' as const, width: 1, height: 1, data: [0] };
+  const data: TiledGroupLayerData = { ...BASE, type: 'group', layers: [childData] };
+
+  it('has type "group"', () => {
+    expect(new TiledGroupLayer(data).type).toBe('group');
+  });
+
+  it('recursively constructs child layers', () => {
+    const group = new TiledGroupLayer(data);
+    expect(group.layers).toHaveLength(1);
+    expect(group.layers[0]).toBeInstanceOf(TiledTileLayer);
+    expect(group.layers[0].id).toBe(2);
+  });
+});
+
+describe('TiledLayer base fields', () => {
+  const data = {
+    ...BASE,
+    type: 'tilelayer' as const,
+    width: 1,
+    height: 1,
+    data: [0],
+    class: 'background',
+    offsetx: 4,
+    offsety: 8,
+    parallaxx: 0.5,
+    parallaxy: 0.75,
+    tintcolor: '#ff0000',
+    properties: [{ name: 'z', type: 'int' as const, value: 5, propertytype: undefined }],
+  };
+
+  it('maps class', () => expect(new TiledTileLayer(data).class).toBe('background'));
+  it('maps offsetX / offsetY', () => {
+    const layer = new TiledTileLayer(data);
+    expect(layer.offsetX).toBe(4);
+    expect(layer.offsetY).toBe(8);
+  });
+  it('maps parallaxX / parallaxY', () => {
+    const layer = new TiledTileLayer(data);
+    expect(layer.parallaxX).toBe(0.5);
+    expect(layer.parallaxY).toBe(0.75);
+  });
+  it('maps tintColor', () => expect(new TiledTileLayer(data).tintColor).toBe('#ff0000'));
+  it('maps properties', () => expect(new TiledTileLayer(data).properties).toHaveLength(1));
+
+  it('defaults class to empty string', () => {
+    expect(new TiledTileLayer({ ...BASE, type: 'tilelayer' as const, width: 1, height: 1, data: [0] }).class).toBe('');
+  });
+  it('defaults offsetX / offsetY to 0', () => {
+    const layer = new TiledTileLayer({ ...BASE, type: 'tilelayer' as const, width: 1, height: 1, data: [0] });
+    expect(layer.offsetX).toBe(0);
+    expect(layer.offsetY).toBe(0);
+  });
+  it('defaults parallaxX / parallaxY to 1', () => {
+    const layer = new TiledTileLayer({ ...BASE, type: 'tilelayer' as const, width: 1, height: 1, data: [0] });
+    expect(layer.parallaxX).toBe(1);
+    expect(layer.parallaxY).toBe(1);
+  });
+
+  describe('getProperty', () => {
+    it('returns the property with matching name', () => {
+      const layer = new TiledTileLayer(data);
+      expect(layer.getProperty('z')).toMatchObject({ name: 'z', value: 5 });
+    });
+
+    it('returns undefined for an unknown name', () => {
+      expect(new TiledTileLayer(data).getProperty('missing')).toBeUndefined();
+    });
+  });
+});
+
+describe('createTiledLayer factory', () => {
+  it('creates TiledTileLayer for type "tilelayer"', () => {
+    expect(createTiledLayer({ ...BASE, type: 'tilelayer', width: 1, height: 1, data: [0] })).toBeInstanceOf(TiledTileLayer);
+  });
+
+  it('creates TiledObjectLayer for type "objectgroup"', () => {
+    expect(createTiledLayer({ ...BASE, type: 'objectgroup', objects: [] })).toBeInstanceOf(TiledObjectLayer);
+  });
+
+  it('creates TiledImageLayer for type "imagelayer"', () => {
+    expect(createTiledLayer({ ...BASE, type: 'imagelayer', image: '' })).toBeInstanceOf(TiledImageLayer);
+  });
+
+  it('creates TiledGroupLayer for type "group"', () => {
+    expect(createTiledLayer({ ...BASE, type: 'group', layers: [] })).toBeInstanceOf(TiledGroupLayer);
+  });
+
+  it('all layer types are instances of TiledLayer', () => {
+    expect(createTiledLayer({ ...BASE, type: 'tilelayer', width: 1, height: 1, data: [0] })).toBeInstanceOf(TiledLayer);
+    expect(createTiledLayer({ ...BASE, type: 'objectgroup', objects: [] })).toBeInstanceOf(TiledLayer);
+    expect(createTiledLayer({ ...BASE, type: 'imagelayer', image: '' })).toBeInstanceOf(TiledLayer);
+    expect(createTiledLayer({ ...BASE, type: 'group', layers: [] })).toBeInstanceOf(TiledLayer);
+  });
+});

--- a/packages/exojs-tiled/test/TiledMap.test.ts
+++ b/packages/exojs-tiled/test/TiledMap.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import { Texture } from '@codexo/exojs';
+import { TileMap, TileLayer, TileSet } from '@codexo/exojs-tilemap';
 
 import { TiledMap } from '../src/TiledMap';
 import { TiledTileset } from '../src/TiledTileset';
@@ -175,5 +177,167 @@ describe('TiledMap.getProperty', () => {
 describe('TiledMap.destroy', () => {
   it('does not throw', () => {
     expect(() => makeMap().destroy()).not.toThrow();
+  });
+});
+
+// ── TiledMap.toTileMap() ─────────────────────────────────────────────────────
+
+/** Build a Texture stub with given pixel dimensions (required by TextureRegion). */
+function makeTexture(width: number, height: number): Texture {
+  const t = new Texture();
+  t.width = width;
+  t.height = height;
+  return t;
+}
+
+function makeTilesetWithTexture(name: string, tileCount: number, columns: number, firstGid: number): TiledTileset {
+  const w = columns * 16;
+  const h = Math.ceil(tileCount / columns) * 16;
+  return new TiledTileset(
+    { name, tilewidth: 16, tileheight: 16, tilecount: tileCount, columns, spacing: 0, margin: 0, imagewidth: w, imageheight: h },
+    firstGid,
+    { imageUrl: `${name}.png`, texture: makeTexture(w, h) },
+  );
+}
+
+const ATLAS_TILESET = makeTilesetWithTexture('tiles', 4, 2, 1);
+
+function makeAtlasMap(): TiledMap {
+  return new TiledMap('atlas.tmj', MINIMAL_DATA, [ATLAS_TILESET]);
+}
+
+describe('TiledMap.toTileMap — basic conversion', () => {
+  it('returns a TileMap instance', () => {
+    expect(makeAtlasMap().toTileMap()).toBeInstanceOf(TileMap);
+  });
+
+  it('maps width, height, tileWidth, tileHeight', () => {
+    const tm = makeAtlasMap().toTileMap();
+    expect(tm.width).toBe(4);
+    expect(tm.height).toBe(4);
+    expect(tm.tileWidth).toBe(16);
+    expect(tm.tileHeight).toBe(16);
+  });
+
+  it('produces one runtime TileLayer per tile layer', () => {
+    const tm = makeAtlasMap().toTileMap();
+    expect(tm.layers).toHaveLength(1);
+    expect(tm.layers[0]).toBeInstanceOf(TileLayer);
+  });
+
+  it('produces one runtime TileSet per tileset', () => {
+    const tm = makeAtlasMap().toTileMap();
+    expect(tm.tilesets).toHaveLength(1);
+    expect(tm.tilesets[0]).toBeInstanceOf(TileSet);
+  });
+
+  it('preserves layer name and id', () => {
+    const layer = makeAtlasMap().toTileMap().layers[0]!;
+    expect(layer.name).toBe('Ground');
+    expect(layer.id).toBe(1);
+  });
+
+  it('preserves tileset name', () => {
+    expect(makeAtlasMap().toTileMap().tilesets[0]!.name).toBe('tiles');
+  });
+
+  it('non-empty cells in the source layer produce packed tiles in the runtime layer', () => {
+    const tm = makeAtlasMap().toTileMap();
+    const layer = tm.layers[0]!;
+    // minimal.tmj has GID 1 and 2, so some cells are non-empty
+    expect(layer.countNonEmptyTiles()).toBeGreaterThan(0);
+  });
+
+  it('GID 1 (no flags) maps to localTileId 0 of the first tileset', () => {
+    const tm = makeAtlasMap().toTileMap();
+    const tile = tm.layers[0]!.getTileAt(0, 0); // data[0] = GID 1
+    expect(tile).not.toBeNull();
+    expect(tile!.localTileId).toBe(0);
+    expect(tile!.tileset).toBe(tm.tilesets[0]);
+    expect(tile!.transform.flipX).toBe(false);
+    expect(tile!.transform.flipY).toBe(false);
+    expect(tile!.transform.diagonal).toBe(false);
+  });
+
+  it('GID 2 maps to localTileId 1 of the first tileset', () => {
+    const tm = makeAtlasMap().toTileMap();
+    const tile = tm.layers[0]!.getTileAt(1, 1); // data[5] = GID 2 (row 1, col 1)
+    expect(tile!.localTileId).toBe(1);
+  });
+});
+
+describe('TiledMap.toTileMap — flip flag decoding', () => {
+  // Build a 1×1 map with a single GID that has flip flags set.
+  function makeFlippedMap(rawGid: number): TiledMap {
+    const ts = makeTilesetWithTexture('ts', 4, 2, 1);
+    const data = validateTiledMapData({
+      type: 'map', version: '1.10', orientation: 'orthogonal', renderorder: 'right-down',
+      width: 1, height: 1, tilewidth: 16, tileheight: 16, infinite: false,
+      layers: [{ id: 1, name: 'L', type: 'tilelayer', visible: true, x: 0, y: 0, width: 1, height: 1, opacity: 1, data: [rawGid] }],
+      tilesets: [{ firstgid: 1, name: 'ts', tilewidth: 16, tileheight: 16, tilecount: 4, columns: 2 }],
+    }, 'flip.tmj');
+    return new TiledMap('flip.tmj', data, [ts]);
+  }
+
+  it('horizontal flip flag sets flipX=true, others false', () => {
+    const { transform } = makeFlippedMap(0x80000001).toTileMap().layers[0]!.getTileAt(0, 0)!;
+    expect(transform).toMatchObject({ flipX: true, flipY: false, diagonal: false });
+  });
+
+  it('vertical flip flag sets flipY=true, others false', () => {
+    const { transform } = makeFlippedMap(0x40000001).toTileMap().layers[0]!.getTileAt(0, 0)!;
+    expect(transform).toMatchObject({ flipX: false, flipY: true, diagonal: false });
+  });
+
+  it('diagonal flag sets diagonal=true, others false', () => {
+    const { transform } = makeFlippedMap(0x20000001).toTileMap().layers[0]!.getTileAt(0, 0)!;
+    expect(transform).toMatchObject({ flipX: false, flipY: false, diagonal: true });
+  });
+
+  it('all three flags combined', () => {
+    const { transform } = makeFlippedMap(0xe0000001).toTileMap().layers[0]!.getTileAt(0, 0)!;
+    expect(transform).toMatchObject({ flipX: true, flipY: true, diagonal: true });
+  });
+});
+
+describe('TiledMap.toTileMap — multi-tileset', () => {
+  it('assigns tiles to the correct runtime tileset based on firstGid ranges', () => {
+    const ts1 = makeTilesetWithTexture('a', 1, 1, 1);
+    const ts2 = makeTilesetWithTexture('b', 1, 1, 2);
+    const data = validateTiledMapData({
+      type: 'map', version: '1.10', orientation: 'orthogonal', renderorder: 'right-down',
+      width: 2, height: 1, tilewidth: 16, tileheight: 16, infinite: false,
+      layers: [{ id: 1, name: 'L', type: 'tilelayer', visible: true, x: 0, y: 0, width: 2, height: 1, opacity: 1, data: [1, 2] }],
+      tilesets: [
+        { firstgid: 1, name: 'a', tilewidth: 16, tileheight: 16, tilecount: 1, columns: 1 },
+        { firstgid: 2, name: 'b', tilewidth: 16, tileheight: 16, tilecount: 1, columns: 1 },
+      ],
+    }, 'multi.tmj');
+    const tm = new TiledMap('multi.tmj', data, [ts1, ts2]).toTileMap();
+    const tile0 = tm.layers[0]!.getTileAt(0, 0)!;
+    const tile1 = tm.layers[0]!.getTileAt(1, 0)!;
+    expect(tile0.tileset.name).toBe('a');
+    expect(tile0.localTileId).toBe(0);
+    expect(tile1.tileset.name).toBe('b');
+    expect(tile1.localTileId).toBe(0);
+  });
+});
+
+describe('TiledMap.toTileMap — error cases', () => {
+  it('throws TiledFormatError for a collection-of-images tileset', () => {
+    const collectionTs = new TiledTileset(
+      { name: 'col', tilewidth: 16, tileheight: 16, tilecount: 2, columns: 0 },
+      1,
+      { tileTextures: new Map([[0, makeTexture(16, 16)], [1, makeTexture(16, 16)]]) },
+    );
+    const data = validateTiledMapData({
+      type: 'map', version: '1.10', orientation: 'orthogonal', renderorder: 'right-down',
+      width: 1, height: 1, tilewidth: 16, tileheight: 16, infinite: false,
+      layers: [{ id: 1, name: 'L', type: 'tilelayer', visible: true, x: 0, y: 0, width: 1, height: 1, opacity: 1, data: [0] }],
+      tilesets: [{ firstgid: 1, name: 'col', tilewidth: 16, tileheight: 16, tilecount: 2, columns: 0 }],
+    }, 'col.tmj');
+    const map = new TiledMap('col.tmj', data, [collectionTs]);
+    expect(() => map.toTileMap()).toThrow(TiledFormatError);
+    expect(() => map.toTileMap()).toThrow(/collection-of-images/);
   });
 });

--- a/packages/exojs-tiled/test/TiledMap.test.ts
+++ b/packages/exojs-tiled/test/TiledMap.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+
+import { TiledMap } from '../src/TiledMap';
+import { TiledTileset } from '../src/TiledTileset';
+import { TiledTileLayer } from '../src/TiledLayer';
+import { TiledFormatError, validateTiledMapData } from '../src/validate';
+
+// Raw fixture data (matches test/fixtures/minimal.tmj)
+const RAW_MINIMAL = {
+  type: 'map',
+  version: '1.10',
+  orientation: 'orthogonal',
+  renderorder: 'right-down',
+  width: 4,
+  height: 4,
+  tilewidth: 16,
+  tileheight: 16,
+  infinite: false,
+  layers: [{
+    id: 1, name: 'Ground', type: 'tilelayer', visible: true,
+    x: 0, y: 0, width: 4, height: 4, opacity: 1,
+    data: [1, 1, 1, 1, 1, 2, 2, 1, 1, 2, 2, 1, 1, 1, 1, 1],
+  }],
+  tilesets: [{
+    firstgid: 1, name: 'tiles', tilewidth: 16, tileheight: 16,
+    columns: 2, tilecount: 4, spacing: 0, margin: 0,
+  }],
+};
+
+const MINIMAL_DATA = validateTiledMapData(RAW_MINIMAL, 'minimal.tmj');
+const TILESET = new TiledTileset({ name: 'tiles', tilewidth: 16, tileheight: 16, tilecount: 4, columns: 2 }, 1);
+
+function makeMap(overrides: { tilesets?: TiledTileset[]; source?: string } = {}): TiledMap {
+  return new TiledMap(overrides.source ?? 'minimal.tmj', MINIMAL_DATA, overrides.tilesets ?? [TILESET]);
+}
+
+describe('TiledMap constructor — field mapping', () => {
+  const map = makeMap();
+
+  it('stores source URL', () => expect(map.source).toBe('minimal.tmj'));
+  it('stores raw data reference', () => expect(map.data).toBe(MINIMAL_DATA));
+  it('maps width and height', () => {
+    expect(map.width).toBe(4);
+    expect(map.height).toBe(4);
+  });
+  it('maps tileWidth and tileHeight', () => {
+    expect(map.tileWidth).toBe(16);
+    expect(map.tileHeight).toBe(16);
+  });
+  it('maps orientation', () => expect(map.orientation).toBe('orthogonal'));
+  it('maps renderOrder', () => expect(map.renderOrder).toBe('right-down'));
+  it('maps infinite flag', () => expect(map.infinite).toBe(false));
+  it('defaults class to empty string', () => expect(map.class).toBe(''));
+  it('defaults backgroundColor to undefined', () => expect(map.backgroundColor).toBeUndefined());
+  it('defaults properties to empty array', () => expect(map.properties).toEqual([]));
+  it('constructs layers from data.layers', () => {
+    expect(map.layers).toHaveLength(1);
+    expect(map.layers[0]).toBeInstanceOf(TiledTileLayer);
+  });
+  it('stores sorted tilesets', () => {
+    expect(map.tilesets).toHaveLength(1);
+    expect(map.tilesets[0]).toBe(TILESET);
+  });
+});
+
+describe('TiledMap — optional fields', () => {
+  it('maps backgroundColor from data', () => {
+    const data = validateTiledMapData({ ...RAW_MINIMAL, backgroundcolor: '#112233' }, 'test.tmj');
+    const map = new TiledMap('test.tmj', data, [TILESET]);
+    expect(map.backgroundColor).toBe('#112233');
+  });
+
+  it('maps class from data', () => {
+    const data = validateTiledMapData({ ...RAW_MINIMAL, class: 'dungeon' }, 'test.tmj');
+    expect(new TiledMap('test.tmj', data, [TILESET]).class).toBe('dungeon');
+  });
+
+  it('maps properties from data', () => {
+    const data = validateTiledMapData({
+      ...RAW_MINIMAL,
+      properties: [{ name: 'biome', type: 'string', value: 'forest' }],
+    }, 'test.tmj');
+    expect(new TiledMap('test.tmj', data, [TILESET]).properties).toHaveLength(1);
+  });
+});
+
+describe('TiledMap.tilesets — sort and validation', () => {
+  it('sorts tilesets by firstGid ascending regardless of insertion order', () => {
+    const t1 = new TiledTileset({ name: 'a', tilewidth: 16, tileheight: 16, tilecount: 1, columns: 1 }, 1);
+    const t2 = new TiledTileset({ name: 'b', tilewidth: 16, tileheight: 16, tilecount: 1, columns: 1 }, 2);
+    const data = validateTiledMapData({
+      ...RAW_MINIMAL,
+      layers: [],
+      tilesets: [{ firstgid: 2, name: 'b', tilewidth: 16, tileheight: 16, tilecount: 1, columns: 1 },
+                 { firstgid: 1, name: 'a', tilewidth: 16, tileheight: 16, tilecount: 1, columns: 1 }],
+    }, 'test.tmj');
+    const map = new TiledMap('test.tmj', data, [t2, t1]);
+    expect(map.tilesets[0].firstGid).toBe(1);
+    expect(map.tilesets[1].firstGid).toBe(2);
+  });
+
+  it('throws TiledFormatError on duplicate firstgid', () => {
+    const t1 = new TiledTileset({ name: 'a', tilewidth: 16, tileheight: 16, tilecount: 4, columns: 2 }, 1);
+    const t2 = new TiledTileset({ name: 'b', tilewidth: 16, tileheight: 16, tilecount: 4, columns: 2 }, 1);
+    expect(() => makeMap({ tilesets: [t1, t2] })).toThrow(TiledFormatError);
+    expect(() => makeMap({ tilesets: [t1, t2] })).toThrow(/duplicate firstgid 1/);
+  });
+
+  it('throws TiledFormatError when tileset ranges overlap', () => {
+    const t1 = new TiledTileset({ name: 'a', tilewidth: 16, tileheight: 16, tilecount: 4, columns: 2 }, 1);
+    const t2 = new TiledTileset({ name: 'b', tilewidth: 16, tileheight: 16, tilecount: 4, columns: 2 }, 3);
+    expect(() => makeMap({ tilesets: [t1, t2] })).toThrow(TiledFormatError);
+    expect(() => makeMap({ tilesets: [t1, t2] })).toThrow(/overlaps/);
+  });
+});
+
+describe('TiledMap — GID coverage validation', () => {
+  it('throws TiledFormatError when a tile layer GID is not covered by any tileset', () => {
+    const underCovering = new TiledTileset({ name: 'tiles', tilewidth: 16, tileheight: 16, tilecount: 1, columns: 1 }, 1);
+    // minimal.tmj has GID 2 in data — not covered by tilecount=1 (lastGid=1)
+    expect(() => makeMap({ tilesets: [underCovering] })).toThrow(TiledFormatError);
+    expect(() => makeMap({ tilesets: [underCovering] })).toThrow(/gid 2.*is not covered by any tileset/);
+  });
+
+  it('allows GID 0 (empty-cell sentinel) without a tileset', () => {
+    const data = validateTiledMapData({
+      ...RAW_MINIMAL,
+      layers: [{ id: 1, name: 'Base', type: 'tilelayer', visible: true, x: 0, y: 0, width: 2, height: 2, opacity: 1, data: [0, 0, 0, 0] }],
+    }, 'test.tmj');
+    expect(() => new TiledMap('test.tmj', data, [])).not.toThrow();
+  });
+});
+
+describe('TiledMap.findTilesetForGid', () => {
+  const map = makeMap();
+
+  it('returns undefined for GID 0 (empty-cell sentinel)', () => {
+    expect(map.findTilesetForGid(0)).toBeUndefined();
+  });
+
+  it('returns the owning tileset for a covered GID', () => {
+    expect(map.findTilesetForGid(1)).toBe(TILESET);
+    expect(map.findTilesetForGid(4)).toBe(TILESET);
+  });
+
+  it('returns undefined for a GID above the covered range', () => {
+    expect(map.findTilesetForGid(5)).toBeUndefined();
+  });
+
+  it('masks flip/rotation flag bits before lookup', () => {
+    // 0x80000001 = horizontal-flip flag | GID 1 → masked to 1 → covered
+    expect(map.findTilesetForGid(0x80000001)).toBe(TILESET);
+    // 0xf0000001 = all flags | GID 1 → masked to 1 → covered
+    expect(map.findTilesetForGid(0xf0000001)).toBe(TILESET);
+    // Flip-only with no GID component → masked to 0 → undefined
+    expect(map.findTilesetForGid(0x80000000)).toBeUndefined();
+  });
+});
+
+describe('TiledMap.getProperty', () => {
+  it('returns the property by name', () => {
+    const data = validateTiledMapData({
+      ...RAW_MINIMAL,
+      properties: [{ name: 'biome', type: 'string', value: 'forest' }],
+    }, 'test.tmj');
+    const map = new TiledMap('test.tmj', data, [TILESET]);
+    expect(map.getProperty('biome')).toMatchObject({ name: 'biome', value: 'forest' });
+  });
+
+  it('returns undefined for an unknown name', () => {
+    expect(makeMap().getProperty('nothing')).toBeUndefined();
+  });
+});
+
+describe('TiledMap.destroy', () => {
+  it('does not throw', () => {
+    expect(() => makeMap().destroy()).not.toThrow();
+  });
+});

--- a/packages/exojs-tiled/test/TiledObject.test.ts
+++ b/packages/exojs-tiled/test/TiledObject.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import { TiledObject } from '../src/TiledObject';
+
+const base = {
+  id: 1,
+  name: 'thing',
+  type: 'Enemy',
+  x: 10,
+  y: 20,
+  width: 16,
+  height: 16,
+  rotation: 45,
+  visible: true,
+};
+
+describe('TiledObject', () => {
+  it('maps all base fields from data', () => {
+    const obj = new TiledObject({ ...base });
+    expect(obj.id).toBe(1);
+    expect(obj.name).toBe('thing');
+    expect(obj.type).toBe('Enemy');
+    expect(obj.x).toBe(10);
+    expect(obj.y).toBe(20);
+    expect(obj.width).toBe(16);
+    expect(obj.height).toBe(16);
+    expect(obj.rotation).toBe(45);
+    expect(obj.visible).toBe(true);
+  });
+
+  it('defaults point and ellipse to false when absent', () => {
+    const obj = new TiledObject({ ...base });
+    expect(obj.point).toBe(false);
+    expect(obj.ellipse).toBe(false);
+  });
+
+  it('maps the point flag', () => {
+    expect(new TiledObject({ ...base, point: true }).point).toBe(true);
+  });
+
+  it('maps the ellipse flag', () => {
+    expect(new TiledObject({ ...base, ellipse: true }).ellipse).toBe(true);
+  });
+
+  it('maps polygon point array', () => {
+    const pts = [{ x: 0, y: 0 }, { x: 8, y: 0 }, { x: 8, y: 8 }];
+    expect(new TiledObject({ ...base, polygon: pts }).polygon).toEqual(pts);
+  });
+
+  it('maps polyline point array', () => {
+    const pts = [{ x: 0, y: 0 }, { x: 16, y: 16 }];
+    expect(new TiledObject({ ...base, polyline: pts }).polyline).toEqual(pts);
+  });
+
+  it('maps text object data', () => {
+    const text = { text: 'Hello', halign: 'center' as const };
+    expect(new TiledObject({ ...base, text }).text).toEqual(text);
+  });
+
+  it('maps gid (tile object reference)', () => {
+    expect(new TiledObject({ ...base, gid: 7 }).gid).toBe(7);
+  });
+
+  it('maps template path', () => {
+    expect(new TiledObject({ ...base, template: 'templates/tree.tx' }).template).toBe('templates/tree.tx');
+  });
+
+  it('maps properties array', () => {
+    const properties = [{ name: 'hp', type: 'int' as const, value: 10, propertytype: undefined }];
+    expect(new TiledObject({ ...base, properties }).properties).toEqual(properties);
+  });
+
+  it('defaults properties to empty array when absent', () => {
+    expect(new TiledObject({ ...base }).properties).toEqual([]);
+  });
+
+  describe('getProperty', () => {
+    const obj = new TiledObject({
+      ...base,
+      properties: [
+        { name: 'hp', type: 'int', value: 5, propertytype: undefined },
+        { name: 'name', type: 'string', value: 'orc', propertytype: undefined },
+      ],
+    });
+
+    it('returns the property with matching name', () => {
+      expect(obj.getProperty('hp')).toEqual({ name: 'hp', type: 'int', value: 5, propertytype: undefined });
+    });
+
+    it('returns undefined for an unknown name', () => {
+      expect(obj.getProperty('missing')).toBeUndefined();
+    });
+  });
+});

--- a/packages/exojs-tiled/test/TiledTileset.test.ts
+++ b/packages/exojs-tiled/test/TiledTileset.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import { Texture } from '@codexo/exojs';
+
+import { TiledTileset } from '../src/TiledTileset';
+
+const BASE_DATA = {
+  name: 'tiles',
+  tilewidth: 16,
+  tileheight: 16,
+  tilecount: 4,
+  columns: 2,
+  spacing: 2,
+  margin: 1,
+};
+
+describe('TiledTileset constructor — field mapping', () => {
+  it('maps name, tile dimensions, count, columns, spacing, margin', () => {
+    const ts = new TiledTileset(BASE_DATA, 1);
+    expect(ts.name).toBe('tiles');
+    expect(ts.tileWidth).toBe(16);
+    expect(ts.tileHeight).toBe(16);
+    expect(ts.tileCount).toBe(4);
+    expect(ts.columns).toBe(2);
+    expect(ts.spacing).toBe(2);
+    expect(ts.margin).toBe(1);
+  });
+
+  it('maps firstGid from the constructor argument', () => {
+    expect(new TiledTileset(BASE_DATA, 5).firstGid).toBe(5);
+  });
+
+  it('defaults class to empty string', () => {
+    expect(new TiledTileset(BASE_DATA, 1).class).toBe('');
+  });
+
+  it('maps class when provided', () => {
+    expect(new TiledTileset({ ...BASE_DATA, class: 'water' }, 1).class).toBe('water');
+  });
+
+  it('defaults spacing and margin to 0 when absent', () => {
+    const ts = new TiledTileset({ name: 'tiles', tilewidth: 16, tileheight: 16, tilecount: 4, columns: 2 }, 1);
+    expect(ts.spacing).toBe(0);
+    expect(ts.margin).toBe(0);
+  });
+
+  it('maps imageWidth and imageHeight from data', () => {
+    const ts = new TiledTileset({ ...BASE_DATA, imagewidth: 64, imageheight: 64 }, 1);
+    expect(ts.imageWidth).toBe(64);
+    expect(ts.imageHeight).toBe(64);
+  });
+
+  it('defaults tileOffset to { x: 0, y: 0 }', () => {
+    expect(new TiledTileset(BASE_DATA, 1).tileOffset).toEqual({ x: 0, y: 0 });
+  });
+
+  it('maps tileOffset from data', () => {
+    expect(new TiledTileset({ ...BASE_DATA, tileoffset: { x: 4, y: -2 } }, 1).tileOffset).toEqual({ x: 4, y: -2 });
+  });
+
+  it('maps objectAlignment', () => {
+    expect(new TiledTileset({ ...BASE_DATA, objectalignment: 'topleft' }, 1).objectAlignment).toBe('topleft');
+  });
+
+  it('defaults tiles to empty array', () => {
+    expect(new TiledTileset(BASE_DATA, 1).tiles).toEqual([]);
+  });
+
+  it('defaults properties to empty array', () => {
+    expect(new TiledTileset(BASE_DATA, 1).properties).toEqual([]);
+  });
+});
+
+describe('TiledTileset resources', () => {
+  it('uses empty resources by default (no texture, no tileTextures)', () => {
+    const ts = new TiledTileset(BASE_DATA, 1);
+    expect(ts.source).toBeUndefined();
+    expect(ts.imageUrl).toBeUndefined();
+    expect(ts.texture).toBeUndefined();
+    expect(ts.tileTextures.size).toBe(0);
+  });
+
+  it('maps source, imageUrl, and texture from resources', () => {
+    const texture = new Texture();
+    const ts = new TiledTileset(
+      { ...BASE_DATA, image: 'tiles.png', imagewidth: 64, imageheight: 64 },
+      1,
+      { source: 'tilesets/tiles.tsj', imageUrl: 'tilesets/tiles.png', texture },
+    );
+    expect(ts.source).toBe('tilesets/tiles.tsj');
+    expect(ts.imageUrl).toBe('tilesets/tiles.png');
+    expect(ts.texture).toBe(texture);
+  });
+
+  it('maps per-tile tileTextures from resources', () => {
+    const t0 = new Texture();
+    const t1 = new Texture();
+    const tileTextures = new Map([[0, t0], [1, t1]]);
+    const ts = new TiledTileset({ ...BASE_DATA, columns: 0 }, 1, { tileTextures });
+    expect(ts.tileTextures.get(0)).toBe(t0);
+    expect(ts.tileTextures.get(1)).toBe(t1);
+  });
+});
+
+describe('TiledTileset.lastGid', () => {
+  it('is firstGid + tileCount - 1', () => {
+    expect(new TiledTileset(BASE_DATA, 1).lastGid).toBe(4);
+    expect(new TiledTileset(BASE_DATA, 5).lastGid).toBe(8);
+  });
+
+  it('is less than firstGid for tileCount = 0 (empty tileset)', () => {
+    const ts = new TiledTileset({ ...BASE_DATA, tilecount: 0 }, 1);
+    expect(ts.lastGid).toBe(0);
+    expect(ts.lastGid).toBeLessThan(ts.firstGid);
+  });
+});
+
+describe('TiledTileset.getTile', () => {
+  const tileData = { id: 2, type: 'water', animation: undefined, objectgroup: undefined, image: undefined, imagewidth: undefined, imageheight: undefined };
+  const ts = new TiledTileset({ ...BASE_DATA, tiles: [{ id: 0 }, { id: 2 }] }, 1);
+
+  it('returns the tile with matching local id', () => {
+    expect(ts.getTile(0)).toMatchObject({ id: 0 });
+    expect(ts.getTile(2)).toMatchObject({ id: 2 });
+  });
+
+  it('returns undefined for an unknown local id', () => {
+    expect(ts.getTile(3)).toBeUndefined();
+  });
+});
+
+describe('TiledTileset.getProperty', () => {
+  const ts = new TiledTileset(
+    { ...BASE_DATA, properties: [{ name: 'kind', type: 'string', value: 'terrain', propertytype: undefined }] },
+    1,
+  );
+
+  it('returns the property with matching name', () => {
+    expect(ts.getProperty('kind')).toMatchObject({ name: 'kind', value: 'terrain' });
+  });
+
+  it('returns undefined for an unknown name', () => {
+    expect(ts.getProperty('unknown')).toBeUndefined();
+  });
+});

--- a/packages/exojs-tiled/test/extension.test.ts
+++ b/packages/exojs-tiled/test/extension.test.ts
@@ -75,10 +75,39 @@ describe('@codexo/exojs-tiled extension descriptor', () => {
   });
 });
 
-describe('@codexo/exojs-tiled asset handler', () => {
+describe('@codexo/exojs-tiled asset handler — tiledMapBinding', () => {
   it('create() returns an object with a load function', () => {
     const handler = tiledMapBinding.create();
     expect(typeof handler.load).toBe('function');
+  });
+
+  it('create() returns an object with a getIdentityKey function', () => {
+    const handler = tiledMapBinding.create();
+    expect(typeof handler.getIdentityKey).toBe('function');
+  });
+});
+
+describe('tiledMapBinding.getIdentityKey', () => {
+  const handler = tiledMapBinding.create();
+
+  it('includes source, format, and strict in the key', () => {
+    expect(handler.getIdentityKey!({ source: 'world.tmj' })).toBe('world.tmj|tiled|true');
+  });
+
+  it('strict:false produces a distinct key', () => {
+    const key = handler.getIdentityKey!({ source: 'world.tmj', options: { strict: false } });
+    expect(key).toBe('world.tmj|tiled|false');
+  });
+});
+
+describe('tiledRuntimeMapBinding and tiledMapBinding identity keys', () => {
+  it('produce the same key string for the same source (Loader namespaces them by type)', () => {
+    const runtimeHandler = tiledRuntimeMapBinding.create();
+    const sourceHandler  = tiledMapBinding.create();
+    // Both use the same discriminator; the Loader prepends distinct type IDs so
+    // their cache keys are different even though this string matches.
+    const req = { source: 'world.tmj' };
+    expect(runtimeHandler.getIdentityKey!(req)).toBe(sourceHandler.getIdentityKey!(req));
   });
 });
 

--- a/packages/exojs-tiled/test/extension.test.ts
+++ b/packages/exojs-tiled/test/extension.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { ExtensionRegistry } from '@codexo/exojs/extensions';
-import { tilemapExtension } from '@codexo/exojs-tilemap';
+import { tilemapExtension, TileMap } from '@codexo/exojs-tilemap';
 import { resetExtensionRegistryForTesting } from '../../../src/extensions/testing';
 import { buildSnapshot } from '../../../src/extensions/snapshot';
 import { tiledExtension } from '../src/tiledExtension';
 import { tiledMapBinding } from '../src/tiledMapBinding';
+import { tiledRuntimeMapBinding } from '../src/tiledRuntimeMapBinding';
 import { TiledMap } from '../src/TiledMap';
 
 describe('@codexo/exojs-tiled extension descriptor', () => {
@@ -17,21 +18,42 @@ describe('@codexo/exojs-tiled extension descriptor', () => {
     expect(tiledExtension.dependencies).toContain(tilemapExtension);
   });
 
-  it('has exactly one asset binding', () => {
+  it('has exactly two asset bindings', () => {
     expect(tiledExtension.assets).toBeDefined();
-    expect(tiledExtension.assets!.length).toBe(1);
-    expect(tiledExtension.assets![0]).toBe(tiledMapBinding);
+    expect(tiledExtension.assets!.length).toBe(2);
   });
 
-  it('asset binding targets TiledMap constructor', () => {
+  it('runtime binding (TileMap) is listed first', () => {
+    expect(tiledExtension.assets![0]).toBe(tiledRuntimeMapBinding);
+  });
+
+  it('source binding (TiledMap) is listed second', () => {
+    expect(tiledExtension.assets![1]).toBe(tiledMapBinding);
+  });
+
+  // ── tiledRuntimeMapBinding
+  it('runtime binding targets TileMap constructor', () => {
+    expect(tiledRuntimeMapBinding.type).toBe(TileMap);
+  });
+
+  it('runtime binding has typeNames ["tileMap"]', () => {
+    expect(tiledRuntimeMapBinding.typeNames).toEqual(['tileMap']);
+  });
+
+  it('runtime binding claims the .tmj file extension', () => {
+    expect((tiledRuntimeMapBinding as { extensions?: string[] }).extensions).toEqual(['tmj']);
+  });
+
+  // ── tiledMapBinding (advanced/source)
+  it('source binding targets TiledMap constructor', () => {
     expect(tiledMapBinding.type).toBe(TiledMap);
   });
 
-  it('asset binding has typeNames ["tiledMap"]', () => {
+  it('source binding has typeNames ["tiledMap"]', () => {
     expect(tiledMapBinding.typeNames).toEqual(['tiledMap']);
   });
 
-  it('asset binding does NOT claim file extensions (token-only; .tmj reserved for C2)', () => {
+  it('source binding does NOT claim file extensions (token-only)', () => {
     expect((tiledMapBinding as { extensions?: unknown }).extensions).toBeUndefined();
   });
 
@@ -40,10 +62,11 @@ describe('@codexo/exojs-tiled extension descriptor', () => {
     expect(snapshot.extensions.map(e => e.id)).toEqual(['@codexo/exojs-tilemap', '@codexo/exojs-tiled']);
   });
 
-  it('buildSnapshot([tiledExtension]) collects exactly the tiledMap asset binding', () => {
+  it('buildSnapshot([tiledExtension]) collects both asset bindings', () => {
     const snapshot = buildSnapshot([tiledExtension]);
-    expect(snapshot.assets).toHaveLength(1);
-    expect(snapshot.assets[0]).toBe(tiledMapBinding);
+    expect(snapshot.assets).toHaveLength(2);
+    expect(snapshot.assets).toContain(tiledRuntimeMapBinding);
+    expect(snapshot.assets).toContain(tiledMapBinding);
   });
 
   it('buildSnapshot has no renderer bindings (rendering not yet implemented)', () => {

--- a/packages/exojs-tiled/test/extension.test.ts
+++ b/packages/exojs-tiled/test/extension.test.ts
@@ -1,73 +1,87 @@
-import { describe, expect, it, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { ExtensionRegistry } from '@codexo/exojs/extensions';
+import { tilemapExtension } from '@codexo/exojs-tilemap';
 import { resetExtensionRegistryForTesting } from '../../../src/extensions/testing';
+import { buildSnapshot } from '../../../src/extensions/snapshot';
 import { tiledExtension } from '../src/tiledExtension';
+import { tiledMapBinding } from '../src/tiledMapBinding';
 import { TiledMap } from '../src/TiledMap';
 
-describe('@codexo/exojs-tiled root', () => {
-  it('tiledExtension has correct id', () => {
+describe('@codexo/exojs-tiled extension descriptor', () => {
+  it('has correct id', () => {
     expect(tiledExtension.id).toBe('@codexo/exojs-tiled');
   });
 
-  it('tiledExtension has asset bindings', () => {
+  it('declares tilemapExtension as a dependency (same object reference)', () => {
+    expect(tiledExtension.dependencies).toBeDefined();
+    expect(tiledExtension.dependencies).toContain(tilemapExtension);
+  });
+
+  it('has exactly one asset binding', () => {
     expect(tiledExtension.assets).toBeDefined();
     expect(tiledExtension.assets!.length).toBe(1);
+    expect(tiledExtension.assets![0]).toBe(tiledMapBinding);
   });
 
-  it('tiledExtension asset binding targets TiledMap', () => {
-    const binding = tiledExtension.assets![0];
-    expect(binding.type).toBe(TiledMap);
+  it('asset binding targets TiledMap constructor', () => {
+    expect(tiledMapBinding.type).toBe(TiledMap);
   });
 
-  it('tiledExtension asset binding has typeName tiledMap', () => {
-    const binding = tiledExtension.assets![0];
-    expect(binding.typeNames).toEqual(['tiledMap']);
+  it('asset binding has typeNames ["tiledMap"]', () => {
+    expect(tiledMapBinding.typeNames).toEqual(['tiledMap']);
   });
 
-  it('tiledExtension asset binding has tmj extension', () => {
-    const binding = tiledExtension.assets![0];
-    expect(binding.extensions).toContain('tmj');
+  it('asset binding does NOT claim file extensions (token-only; .tmj reserved for C2)', () => {
+    expect((tiledMapBinding as { extensions?: unknown }).extensions).toBeUndefined();
   });
 
-  it('root import does NOT register in ExtensionRegistry', () => {
-    const registry = ExtensionRegistry.list();
-    expect(registry.some(e => e.id === '@codexo/exojs-tiled')).toBe(false);
+  it('buildSnapshot([tiledExtension]) materializes tilemapExtension before tiledExtension', () => {
+    const snapshot = buildSnapshot([tiledExtension]);
+    expect(snapshot.extensions.map(e => e.id)).toEqual(['@codexo/exojs-tilemap', '@codexo/exojs-tiled']);
+  });
+
+  it('buildSnapshot([tiledExtension]) collects exactly the tiledMap asset binding', () => {
+    const snapshot = buildSnapshot([tiledExtension]);
+    expect(snapshot.assets).toHaveLength(1);
+    expect(snapshot.assets[0]).toBe(tiledMapBinding);
+  });
+
+  it('buildSnapshot has no renderer bindings (rendering not yet implemented)', () => {
+    const snapshot = buildSnapshot([tiledExtension]);
+    expect(snapshot.renderers).toHaveLength(0);
   });
 });
 
-describe('@codexo/exojs-tiled/register', () => {
+describe('@codexo/exojs-tiled asset handler', () => {
+  it('create() returns an object with a load function', () => {
+    const handler = tiledMapBinding.create();
+    expect(typeof handler.load).toBe('function');
+  });
+});
+
+describe('@codexo/exojs-tiled root entry (side-effect-free)', () => {
   beforeEach(() => {
     resetExtensionRegistryForTesting();
   });
 
-  it('register entry registers tiledExtension', async () => {
+  it('root import does NOT register tiledExtension in ExtensionRegistry', () => {
+    expect(ExtensionRegistry.has('@codexo/exojs-tiled')).toBe(false);
+  });
+});
+
+describe('@codexo/exojs-tiled/register entry', () => {
+  beforeEach(() => {
     resetExtensionRegistryForTesting();
+  });
+
+  it('registers tiledExtension on import', async () => {
     await import('../src/register');
     expect(ExtensionRegistry.has('@codexo/exojs-tiled')).toBe(true);
   });
 });
 
-describe('TiledMap basic structure', () => {
-  it('stores map dimensions', () => {
-    const data = {
-      width: 4, height: 4, tilewidth: 16, tileheight: 16,
-      orientation: 'orthogonal', layers: [], tilesets: [],
-    };
-    const map = new TiledMap(data, []);
-    expect(map.width).toBe(4);
-    expect(map.height).toBe(4);
-    expect(map.tileWidth).toBe(16);
-    expect(map.tileHeight).toBe(16);
-  });
-
-  it('destroy() does not throw', () => {
-    const map = new TiledMap({ width: 1, height: 1, tilewidth: 16, tileheight: 16, layers: [], tilesets: [] }, []);
-    expect(() => map.destroy()).not.toThrow();
-  });
-});
-
 describe('export parity', () => {
-  it('root and register have same named exports', async () => {
+  it('root and register have the same named exports', async () => {
     const root = await import('../src/index');
     const register = await import('../src/register');
     const rootKeys = Object.keys(root).filter(k => k !== 'default').sort();

--- a/packages/exojs-tiled/test/fixtures/collection-tileset.tmj
+++ b/packages/exojs-tiled/test/fixtures/collection-tileset.tmj
@@ -1,0 +1,39 @@
+{
+  "width": 2,
+  "height": 1,
+  "tilewidth": 16,
+  "tileheight": 16,
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "type": "map",
+  "version": "1.10",
+  "infinite": false,
+  "layers": [
+    {
+      "id": 1,
+      "name": "Base",
+      "type": "tilelayer",
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "width": 2,
+      "height": 1,
+      "opacity": 1,
+      "data": [1, 2]
+    }
+  ],
+  "tilesets": [
+    {
+      "firstgid": 1,
+      "name": "collection",
+      "tilewidth": 16,
+      "tileheight": 16,
+      "tilecount": 2,
+      "columns": 0,
+      "tiles": [
+        { "id": 0, "image": "tile0.png", "imagewidth": 16, "imageheight": 16 },
+        { "id": 1, "image": "tile1.png", "imagewidth": 16, "imageheight": 16 }
+      ]
+    }
+  ]
+}

--- a/packages/exojs-tiled/test/fixtures/external-tileset.tmj
+++ b/packages/exojs-tiled/test/fixtures/external-tileset.tmj
@@ -1,0 +1,31 @@
+{
+  "width": 2,
+  "height": 2,
+  "tilewidth": 16,
+  "tileheight": 16,
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "type": "map",
+  "version": "1.10",
+  "infinite": false,
+  "layers": [
+    {
+      "id": 1,
+      "name": "Base",
+      "type": "tilelayer",
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "width": 2,
+      "height": 2,
+      "opacity": 1,
+      "data": [1, 1, 1, 1]
+    }
+  ],
+  "tilesets": [
+    {
+      "firstgid": 1,
+      "source": "external-tileset.tsj"
+    }
+  ]
+}

--- a/packages/exojs-tiled/test/fixtures/external-tileset.tsj
+++ b/packages/exojs-tiled/test/fixtures/external-tileset.tsj
@@ -1,0 +1,14 @@
+{
+  "name": "external",
+  "tilewidth": 16,
+  "tileheight": 16,
+  "tilecount": 4,
+  "columns": 2,
+  "spacing": 0,
+  "margin": 0,
+  "image": "external-tileset.png",
+  "imagewidth": 32,
+  "imageheight": 32,
+  "tiledversion": "1.10.2",
+  "version": "1.10"
+}

--- a/packages/exojs-tiled/test/gid.test.ts
+++ b/packages/exojs-tiled/test/gid.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  maskTiledGid,
+  TILED_FLIPPED_DIAGONALLY_FLAG,
+  TILED_FLIPPED_HORIZONTALLY_FLAG,
+  TILED_FLIPPED_VERTICALLY_FLAG,
+  TILED_ROTATED_HEXAGONAL_120_FLAG,
+} from '../src/gid';
+
+describe('maskTiledGid', () => {
+  it('returns 0 for the empty-cell sentinel', () => {
+    expect(maskTiledGid(0)).toBe(0);
+  });
+
+  it('returns plain gids unchanged', () => {
+    expect(maskTiledGid(5)).toBe(5);
+    expect(maskTiledGid(0x0fffffff)).toBe(0x0fffffff);
+  });
+
+  it('strips the horizontal-flip flag', () => {
+    expect(maskTiledGid(TILED_FLIPPED_HORIZONTALLY_FLAG | 5)).toBe(5);
+  });
+
+  it('strips the vertical-flip flag', () => {
+    expect(maskTiledGid(TILED_FLIPPED_VERTICALLY_FLAG | 5)).toBe(5);
+  });
+
+  it('strips the diagonal-flip flag', () => {
+    expect(maskTiledGid(TILED_FLIPPED_DIAGONALLY_FLAG | 5)).toBe(5);
+  });
+
+  it('strips the hexagonal-rotation flag', () => {
+    expect(maskTiledGid(TILED_ROTATED_HEXAGONAL_120_FLAG | 5)).toBe(5);
+  });
+
+  it('strips all four flag bits at once', () => {
+    const flagged = (TILED_FLIPPED_HORIZONTALLY_FLAG | TILED_FLIPPED_VERTICALLY_FLAG | TILED_FLIPPED_DIAGONALLY_FLAG | TILED_ROTATED_HEXAGONAL_120_FLAG | 5) >>> 0;
+    expect(maskTiledGid(flagged)).toBe(5);
+  });
+
+  it('handles gids that exceed 2^31 (unsigned 32-bit wraparound)', () => {
+    // Horizontal-flip flag alone is 2^31, which is negative as a signed int32.
+    expect(maskTiledGid(TILED_FLIPPED_HORIZONTALLY_FLAG)).toBe(0);
+    expect(maskTiledGid(0xffffffff)).toBe(0x0fffffff);
+  });
+});

--- a/packages/exojs-tiled/test/loadTiledMap.test.ts
+++ b/packages/exojs-tiled/test/loadTiledMap.test.ts
@@ -1,0 +1,177 @@
+import { readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import { Texture, type AssetLoaderContext } from '@codexo/exojs';
+
+import { loadTiledMap } from '../src/loadTiledMap';
+import { TiledMap } from '../src/TiledMap';
+import { TiledFormatError } from '../src/validate';
+
+// ── Fixture loading ───────────────────────────────────────────────────────────
+
+// Support both "pnpm test" (cwd=repo root) and "pnpm --filter ... test" (cwd=package).
+const PKG_DIR = basename(process.cwd()) === 'exojs-tiled' ? process.cwd() : join(process.cwd(), 'packages', 'exojs-tiled');
+const FIXTURES_DIR = join(PKG_DIR, 'test', 'fixtures');
+
+function loadFixture(name: string): unknown {
+  return JSON.parse(readFileSync(join(FIXTURES_DIR, name), 'utf-8'));
+}
+
+// ── Mock context factory ───────────────────────────────────────────────────────
+
+function makeContext(fixtures: Record<string, unknown>) {
+  const loaderLoad = vi.fn(async (_token: unknown, _url: string): Promise<Texture> => new Texture());
+
+  const context: AssetLoaderContext = {
+    loader: { load: loaderLoad } as unknown as AssetLoaderContext['loader'],
+    identityKey: 'test',
+    fetchText: vi.fn(),
+    fetchArrayBuffer: vi.fn(),
+    fetchJson: vi.fn(async (source: string): Promise<unknown> => {
+      if (Object.hasOwn(fixtures, source)) return fixtures[source];
+      throw new Error(`loadTiledMap.test: no fixture registered for source "${source}"`);
+    }),
+  };
+
+  return { context, loaderLoad };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('loadTiledMap — minimal map (no images)', () => {
+  // minimal.tmj: embedded tileset with no "image" field
+  const { context, loaderLoad } = makeContext({
+    'minimal.tmj': loadFixture('minimal.tmj'),
+  });
+
+  it('returns a TiledMap instance', async () => {
+    const map = await loadTiledMap('minimal.tmj', context);
+    expect(map).toBeInstanceOf(TiledMap);
+  });
+
+  it('resolves the correct map dimensions', async () => {
+    const map = await loadTiledMap('minimal.tmj', context);
+    expect(map.width).toBe(4);
+    expect(map.height).toBe(4);
+    expect(map.tileWidth).toBe(16);
+    expect(map.tileHeight).toBe(16);
+  });
+
+  it('does not call loader.load (no images to load)', async () => {
+    await loadTiledMap('minimal.tmj', context);
+    expect(loaderLoad).not.toHaveBeenCalled();
+  });
+
+  it('stores the source URL on the returned map', async () => {
+    const map = await loadTiledMap('minimal.tmj', context);
+    expect(map.source).toBe('minimal.tmj');
+  });
+});
+
+describe('loadTiledMap — embedded tileset with atlas image', () => {
+  // with-tileset-image.tmj: embedded tileset with image: "tiles.png"
+  const { context, loaderLoad } = makeContext({
+    'with-tileset-image.tmj': loadFixture('with-tileset-image.tmj'),
+  });
+
+  it('calls loader.load(Texture, imageUrl) for the atlas image', async () => {
+    await loadTiledMap('with-tileset-image.tmj', context);
+    expect(loaderLoad).toHaveBeenCalledWith(Texture, 'tiles.png');
+  });
+
+  it('stores the loaded texture on the tileset', async () => {
+    const map = await loadTiledMap('with-tileset-image.tmj', context);
+    expect(map.tilesets[0].texture).toBeInstanceOf(Texture);
+  });
+
+  it('stores the resolved imageUrl on the tileset', async () => {
+    const map = await loadTiledMap('with-tileset-image.tmj', context);
+    expect(map.tilesets[0].imageUrl).toBe('tiles.png');
+  });
+});
+
+describe('loadTiledMap — external .tsj tileset', () => {
+  // external-tileset.tmj references external-tileset.tsj, which has image: "external-tileset.png"
+  const { context, loaderLoad } = makeContext({
+    'external-tileset.tmj': loadFixture('external-tileset.tmj'),
+    'external-tileset.tsj': loadFixture('external-tileset.tsj'),
+  });
+
+  it('fetches the .tsj file', async () => {
+    await loadTiledMap('external-tileset.tmj', context);
+    expect(context.fetchJson).toHaveBeenCalledWith('external-tileset.tsj');
+  });
+
+  it('loads the tileset image relative to the .tsj location', async () => {
+    await loadTiledMap('external-tileset.tmj', context);
+    // resolveTiledUrl('external-tileset.png', 'external-tileset.tsj') → 'external-tileset.png'
+    expect(loaderLoad).toHaveBeenCalledWith(Texture, 'external-tileset.png');
+  });
+
+  it('stores the tsj source URL on the tileset', async () => {
+    const map = await loadTiledMap('external-tileset.tmj', context);
+    expect(map.tilesets[0].source).toBe('external-tileset.tsj');
+  });
+
+  it('stores the loaded texture on the tileset', async () => {
+    const map = await loadTiledMap('external-tileset.tmj', context);
+    expect(map.tilesets[0].texture).toBeInstanceOf(Texture);
+  });
+});
+
+describe('loadTiledMap — collection-of-images tileset', () => {
+  // collection-tileset.tmj: embedded tileset with tiles[].image (no top-level image)
+  const { context, loaderLoad } = makeContext({
+    'collection-tileset.tmj': loadFixture('collection-tileset.tmj'),
+  });
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('calls loader.load for each per-tile image', async () => {
+    await loadTiledMap('collection-tileset.tmj', context);
+    expect(loaderLoad).toHaveBeenCalledWith(Texture, 'tile0.png');
+    expect(loaderLoad).toHaveBeenCalledWith(Texture, 'tile1.png');
+  });
+
+  it('does NOT call loader.load for the atlas image — exactly 2 per-tile calls', async () => {
+    await loadTiledMap('collection-tileset.tmj', context);
+    expect(loaderLoad).toHaveBeenCalledTimes(2);
+  });
+
+  it('stores per-tile textures on the tileset keyed by local tile id', async () => {
+    const map = await loadTiledMap('collection-tileset.tmj', context);
+    const tileset = map.tilesets[0];
+    expect(tileset.tileTextures.size).toBe(2);
+    expect(tileset.tileTextures.get(0)).toBeInstanceOf(Texture);
+    expect(tileset.tileTextures.get(1)).toBeInstanceOf(Texture);
+  });
+
+  it('does not set imageUrl on the tileset (no atlas)', async () => {
+    const map = await loadTiledMap('collection-tileset.tmj', context);
+    expect(map.tilesets[0].imageUrl).toBeUndefined();
+  });
+});
+
+describe('loadTiledMap — error propagation', () => {
+  it('propagates TiledFormatError for invalid TMJ', async () => {
+    const { context } = makeContext({
+      'bad.tmj': { type: 'tileset' }, // wrong type
+    });
+    await expect(loadTiledMap('bad.tmj', context)).rejects.toThrow(TiledFormatError);
+    await expect(loadTiledMap('bad.tmj', context)).rejects.toThrow(/expected "map"/);
+  });
+
+  it('propagates TiledFormatError when a GID is not covered by any tileset', async () => {
+    // Minimal map with GIDs 1–2 but a tileset covering only GID 1
+    const { context } = makeContext({
+      'narrow.tmj': {
+        type: 'map', version: '1.10', orientation: 'orthogonal', renderorder: 'right-down',
+        width: 2, height: 1, tilewidth: 16, tileheight: 16, infinite: false,
+        layers: [{ id: 1, name: 'Base', type: 'tilelayer', visible: true, x: 0, y: 0, width: 2, height: 1, opacity: 1, data: [1, 2] }],
+        tilesets: [{ firstgid: 1, name: 'narrow', tilewidth: 16, tileheight: 16, tilecount: 1, columns: 1 }],
+      },
+    });
+    await expect(loadTiledMap('narrow.tmj', context)).rejects.toThrow(TiledFormatError);
+    await expect(loadTiledMap('narrow.tmj', context)).rejects.toThrow(/gid 2.*is not covered/);
+  });
+});

--- a/packages/exojs-tiled/test/tiledMapBinding.test.ts
+++ b/packages/exojs-tiled/test/tiledMapBinding.test.ts
@@ -1,0 +1,189 @@
+import { readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import { Texture, type AssetLoaderContext } from '@codexo/exojs';
+import { TileMap } from '@codexo/exojs-tilemap';
+
+import { loadTiledMap } from '../src/loadTiledMap';
+import { TiledMap } from '../src/TiledMap';
+import { tiledMapBinding } from '../src/tiledMapBinding';
+import { tiledRuntimeMapBinding } from '../src/tiledRuntimeMapBinding';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const PKG_DIR = basename(process.cwd()) === 'exojs-tiled'
+  ? process.cwd()
+  : join(process.cwd(), 'packages', 'exojs-tiled');
+const FIXTURES_DIR = join(PKG_DIR, 'test', 'fixtures');
+
+function loadFixture(name: string): unknown {
+  return JSON.parse(readFileSync(join(FIXTURES_DIR, name), 'utf-8'));
+}
+
+// ── Context factory ───────────────────────────────────────────────────────────
+
+function makeContext(fixtures: Record<string, unknown>) {
+  const loaderLoad = vi.fn();
+
+  const context: AssetLoaderContext = {
+    loader: { load: loaderLoad } as unknown as AssetLoaderContext['loader'],
+    identityKey: 'test',
+    fetchText: vi.fn(),
+    fetchArrayBuffer: vi.fn(),
+    fetchJson: vi.fn(async (source: string): Promise<unknown> => {
+      if (Object.hasOwn(fixtures, source)) return fixtures[source];
+      throw new Error(`tiledMapBinding.test: no fixture for "${source}"`);
+    }),
+  };
+
+  // Handles both Texture and TiledMap sub-loads (for the runtime binding below).
+  loaderLoad.mockImplementation(async (token: unknown, url: string, _opts?: unknown): Promise<unknown> => {
+    if (token === Texture) {
+      const tex = new Texture();
+      tex.width = 32;
+      tex.height = 32;
+      return tex;
+    }
+    if (token === TiledMap) {
+      return loadTiledMap(url, context);
+    }
+    throw new Error(`tiledMapBinding.test: unexpected loader.load token: ${String(token)}`);
+  });
+
+  return { context, loaderLoad };
+}
+
+// ── Descriptor tests ─────────────────────────────────────────────────────────
+
+describe('tiledMapBinding descriptor', () => {
+  it('targets TiledMap constructor', () => {
+    expect(tiledMapBinding.type).toBe(TiledMap);
+  });
+
+  it('has typeNames ["tiledMap"]', () => {
+    expect(tiledMapBinding.typeNames).toEqual(['tiledMap']);
+  });
+
+  it('does NOT claim file extensions (token-only binding)', () => {
+    expect((tiledMapBinding as { extensions?: unknown }).extensions).toBeUndefined();
+  });
+
+  it('create() returns an object with a load function', () => {
+    expect(typeof tiledMapBinding.create().load).toBe('function');
+  });
+});
+
+// ── load() tests ──────────────────────────────────────────────────────────────
+
+describe('tiledMapBinding.load — minimal map', () => {
+  const { context } = makeContext({ 'minimal.tmj': loadFixture('minimal.tmj') });
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('returns a TiledMap instance', async () => {
+    const handler = tiledMapBinding.create();
+    const result = await handler.load({ source: 'minimal.tmj' }, context);
+    expect(result).toBeInstanceOf(TiledMap);
+  });
+
+  it('preserves map dimensions on the returned TiledMap', async () => {
+    const handler = tiledMapBinding.create();
+    const result = await handler.load({ source: 'minimal.tmj' }, context);
+    expect(result.width).toBe(4);
+    expect(result.height).toBe(4);
+    expect(result.tileWidth).toBe(16);
+    expect(result.tileHeight).toBe(16);
+  });
+
+  it('stores the source URL on the TiledMap', async () => {
+    const handler = tiledMapBinding.create();
+    const result = await handler.load({ source: 'minimal.tmj' }, context);
+    expect(result.source).toBe('minimal.tmj');
+  });
+});
+
+// ── G-TILED-DIRECT-EQUIVALENCE ────────────────────────────────────────────────
+//
+// load(TileMap, url) must be semantically equivalent to load(TiledMap, url).toTileMap():
+// same dimensions, layer count, tileset count, and tile data.
+
+describe('G-TILED-DIRECT-EQUIVALENCE — load(TileMap) ≡ load(TiledMap).toTileMap()', () => {
+  const FIXTURES = {
+    'world.tmj': loadFixture('with-tileset-image.tmj'),
+  };
+
+  it('both paths produce a TileMap with the same dimensions', async () => {
+    const { context } = makeContext(FIXTURES);
+    const runtimeHandler = tiledRuntimeMapBinding.create();
+    const sourceHandler  = tiledMapBinding.create();
+
+    const direct    = await runtimeHandler.load({ source: 'world.tmj' }, context);
+    const fromSource = (await sourceHandler.load({ source: 'world.tmj' }, context)).toTileMap();
+
+    expect(direct.width).toBe(fromSource.width);
+    expect(direct.height).toBe(fromSource.height);
+    expect(direct.tileWidth).toBe(fromSource.tileWidth);
+    expect(direct.tileHeight).toBe(fromSource.tileHeight);
+  });
+
+  it('both paths produce the same number of layers and tilesets', async () => {
+    const { context } = makeContext(FIXTURES);
+    const runtimeHandler = tiledRuntimeMapBinding.create();
+    const sourceHandler  = tiledMapBinding.create();
+
+    const direct     = await runtimeHandler.load({ source: 'world.tmj' }, context);
+    const fromSource = (await sourceHandler.load({ source: 'world.tmj' }, context)).toTileMap();
+
+    expect(direct.layers.length).toBe(fromSource.layers.length);
+    expect(direct.tilesets.length).toBe(fromSource.tilesets.length);
+  });
+
+  it('both paths produce the same tile count in the first layer', async () => {
+    const { context } = makeContext(FIXTURES);
+    const runtimeHandler = tiledRuntimeMapBinding.create();
+    const sourceHandler  = tiledMapBinding.create();
+
+    const direct     = await runtimeHandler.load({ source: 'world.tmj' }, context);
+    const fromSource = (await sourceHandler.load({ source: 'world.tmj' }, context)).toTileMap();
+
+    const directTiles   = direct.layers[0]!.countNonEmptyTiles();
+    const convertedTiles = fromSource.layers[0]!.countNonEmptyTiles();
+    expect(directTiles).toBe(convertedTiles);
+  });
+});
+
+// ── G-TILED-TEXTURE-OWNERSHIP ─────────────────────────────────────────────────
+//
+// TiledMap.destroy() must NOT destroy Loader-owned textures.
+
+describe('G-TILED-TEXTURE-OWNERSHIP — destroy() does not free Loader textures', () => {
+  it('texture reference remains accessible after TiledMap.destroy()', async () => {
+    const { context } = makeContext({ 'with-tex.tmj': loadFixture('with-tileset-image.tmj') });
+    const handler = tiledMapBinding.create();
+    const tiledMap = await handler.load({ source: 'with-tex.tmj' }, context);
+    const texture = tiledMap.tilesets[0].texture;
+
+    tiledMap.destroy();
+
+    // The texture reference on the tileset must still be accessible (not nulled).
+    expect(tiledMap.tilesets[0].texture).toBe(texture);
+    expect(tiledMap.tilesets[0].texture).toBeInstanceOf(Texture);
+  });
+
+  it('runtime TileMap.destroy() does not free Loader textures', async () => {
+    const { context } = makeContext({ 'with-tex.tmj': loadFixture('with-tileset-image.tmj') });
+    const handler = tiledRuntimeMapBinding.create();
+    const tileMap = await handler.load({ source: 'with-tex.tmj' }, context);
+
+    // Capture the texture reference before destroy().
+    // TileMap.destroy() clears the tilesets array but must NOT call texture.destroy().
+    const texture = tileMap.tilesets[0]!.texture.texture;
+    expect(texture).toBeInstanceOf(Texture);
+
+    tileMap.destroy();
+
+    // After destroy(), the Texture object itself is intact (Loader-owned, not map-owned).
+    expect(texture).toBeInstanceOf(Texture);
+    expect(texture).not.toBeNull();
+  });
+});

--- a/packages/exojs-tiled/test/tiledRuntimeMapBinding.test.ts
+++ b/packages/exojs-tiled/test/tiledRuntimeMapBinding.test.ts
@@ -1,0 +1,105 @@
+import { readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import { Texture, type AssetLoaderContext } from '@codexo/exojs';
+import { TileMap } from '@codexo/exojs-tilemap';
+
+import { tiledRuntimeMapBinding } from '../src/tiledRuntimeMapBinding';
+
+// ── Fixture loading ──────────────────────────────────────────────────────────
+
+const PKG_DIR = basename(process.cwd()) === 'exojs-tiled'
+  ? process.cwd()
+  : join(process.cwd(), 'packages', 'exojs-tiled');
+const FIXTURES_DIR = join(PKG_DIR, 'test', 'fixtures');
+
+function loadFixture(name: string): unknown {
+  return JSON.parse(readFileSync(join(FIXTURES_DIR, name), 'utf-8'));
+}
+
+// ── Mock context factory ─────────────────────────────────────────────────────
+
+function makeContext(fixtures: Record<string, unknown>) {
+  const loaderLoad = vi.fn(async (_token: unknown, _url: string): Promise<Texture> => {
+    const tex = new Texture();
+    // Provide realistic pixel dimensions so TextureRegion validates correctly.
+    tex.width = 32;
+    tex.height = 32;
+    return tex;
+  });
+
+  const context: AssetLoaderContext = {
+    loader: { load: loaderLoad } as unknown as AssetLoaderContext['loader'],
+    identityKey: 'test',
+    fetchText: vi.fn(),
+    fetchArrayBuffer: vi.fn(),
+    fetchJson: vi.fn(async (source: string): Promise<unknown> => {
+      if (Object.hasOwn(fixtures, source)) return fixtures[source];
+      throw new Error(`tiledRuntimeMapBinding.test: no fixture for "${source}"`);
+    }),
+  };
+
+  return { context, loaderLoad };
+}
+
+// ── Descriptor tests ─────────────────────────────────────────────────────────
+
+describe('tiledRuntimeMapBinding descriptor', () => {
+  it('targets TileMap constructor', () => {
+    expect(tiledRuntimeMapBinding.type).toBe(TileMap);
+  });
+
+  it('has typeNames ["tileMap"]', () => {
+    expect(tiledRuntimeMapBinding.typeNames).toEqual(['tileMap']);
+  });
+
+  it('claims the .tmj file extension', () => {
+    expect((tiledRuntimeMapBinding as { extensions?: string[] }).extensions).toEqual(['tmj']);
+  });
+
+  it('create() returns an object with a load function', () => {
+    expect(typeof tiledRuntimeMapBinding.create().load).toBe('function');
+  });
+});
+
+// ── Integration tests ─────────────────────────────────────────────────────────
+
+describe('tiledRuntimeMapBinding.load — minimal map', () => {
+  const { context } = makeContext({ 'minimal.tmj': loadFixture('minimal.tmj') });
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('returns a TileMap instance', async () => {
+    const handler = tiledRuntimeMapBinding.create();
+    const result = await handler.load({ source: 'minimal.tmj' } as Parameters<typeof handler.load>[0], context);
+    expect(result).toBeInstanceOf(TileMap);
+  });
+
+  it('preserves map dimensions', async () => {
+    const handler = tiledRuntimeMapBinding.create();
+    const result = await handler.load({ source: 'minimal.tmj' } as Parameters<typeof handler.load>[0], context);
+    expect(result.width).toBe(4);
+    expect(result.height).toBe(4);
+    expect(result.tileWidth).toBe(16);
+    expect(result.tileHeight).toBe(16);
+  });
+});
+
+describe('tiledRuntimeMapBinding.load — with atlas tileset image', () => {
+  const { context, loaderLoad } = makeContext({ 'with-tileset-image.tmj': loadFixture('with-tileset-image.tmj') });
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('returns a TileMap instance', async () => {
+    const handler = tiledRuntimeMapBinding.create();
+    const result = await handler.load({ source: 'with-tileset-image.tmj' } as Parameters<typeof handler.load>[0], context);
+    expect(result).toBeInstanceOf(TileMap);
+  });
+
+  it('the runtime TileMap has a TileSet with the loaded texture', async () => {
+    const handler = tiledRuntimeMapBinding.create();
+    const result = await handler.load({ source: 'with-tileset-image.tmj' } as Parameters<typeof handler.load>[0], context);
+    expect(result.tilesets).toHaveLength(1);
+    expect(loaderLoad).toHaveBeenCalledWith(Texture, 'tiles.png');
+  });
+});

--- a/packages/exojs-tiled/test/tiledRuntimeMapBinding.test.ts
+++ b/packages/exojs-tiled/test/tiledRuntimeMapBinding.test.ts
@@ -4,6 +4,8 @@ import { vi, beforeEach, describe, expect, it } from 'vitest';
 import { Texture, type AssetLoaderContext } from '@codexo/exojs';
 import { TileMap } from '@codexo/exojs-tilemap';
 
+import { loadTiledMap } from '../src/loadTiledMap';
+import { TiledMap } from '../src/TiledMap';
 import { tiledRuntimeMapBinding } from '../src/tiledRuntimeMapBinding';
 
 // ── Fixture loading ──────────────────────────────────────────────────────────
@@ -18,15 +20,13 @@ function loadFixture(name: string): unknown {
 }
 
 // ── Mock context factory ─────────────────────────────────────────────────────
+//
+// The runtime binding's handler calls ctx.loader.load(TiledMap, source) as a
+// sub-load to share the Loader cache with the source binding. The mock below
+// handles both Texture and TiledMap sub-loads.
 
 function makeContext(fixtures: Record<string, unknown>) {
-  const loaderLoad = vi.fn(async (_token: unknown, _url: string): Promise<Texture> => {
-    const tex = new Texture();
-    // Provide realistic pixel dimensions so TextureRegion validates correctly.
-    tex.width = 32;
-    tex.height = 32;
-    return tex;
-  });
+  const loaderLoad = vi.fn();
 
   const context: AssetLoaderContext = {
     loader: { load: loaderLoad } as unknown as AssetLoaderContext['loader'],
@@ -38,6 +38,20 @@ function makeContext(fixtures: Record<string, unknown>) {
       throw new Error(`tiledRuntimeMapBinding.test: no fixture for "${source}"`);
     }),
   };
+
+  // Configure loaderLoad after context is defined so the closure captures it.
+  loaderLoad.mockImplementation(async (token: unknown, url: string, _opts?: unknown): Promise<unknown> => {
+    if (token === Texture) {
+      const tex = new Texture();
+      tex.width = 32;
+      tex.height = 32;
+      return tex;
+    }
+    if (token === TiledMap) {
+      return loadTiledMap(url, context);
+    }
+    throw new Error(`tiledRuntimeMapBinding.test: unexpected loader.load token: ${String(token)}`);
+  });
 
   return { context, loaderLoad };
 }
@@ -60,9 +74,42 @@ describe('tiledRuntimeMapBinding descriptor', () => {
   it('create() returns an object with a load function', () => {
     expect(typeof tiledRuntimeMapBinding.create().load).toBe('function');
   });
+
+  it('create() returns an object with a getIdentityKey function', () => {
+    expect(typeof tiledRuntimeMapBinding.create().getIdentityKey).toBe('function');
+  });
 });
 
-// ── Integration tests ─────────────────────────────────────────────────────────
+// ── getIdentityKey tests ─────────────────────────────────────────────────────
+
+describe('tiledRuntimeMapBinding.getIdentityKey', () => {
+  const handler = tiledRuntimeMapBinding.create();
+
+  it('includes source, format, and strict in the key', () => {
+    const key = handler.getIdentityKey!({ source: 'world.tmj' });
+    expect(key).toBe('world.tmj|tiled|true');
+  });
+
+  it('uses explicit format when provided', () => {
+    const key = handler.getIdentityKey!({ source: 'world.tmj', options: { format: 'tiled' } });
+    expect(key).toBe('world.tmj|tiled|true');
+  });
+
+  it('strict:false produces a distinct key', () => {
+    const defaultKey = handler.getIdentityKey!({ source: 'world.tmj' });
+    const lenientKey = handler.getIdentityKey!({ source: 'world.tmj', options: { strict: false } });
+    expect(lenientKey).toBe('world.tmj|tiled|false');
+    expect(lenientKey).not.toBe(defaultKey);
+  });
+
+  it('different sources produce different keys', () => {
+    const key1 = handler.getIdentityKey!({ source: 'a.tmj' });
+    const key2 = handler.getIdentityKey!({ source: 'b.tmj' });
+    expect(key1).not.toBe(key2);
+  });
+});
+
+// ── Integration tests — minimal map ─────────────────────────────────────────
 
 describe('tiledRuntimeMapBinding.load — minimal map', () => {
   const { context } = makeContext({ 'minimal.tmj': loadFixture('minimal.tmj') });
@@ -71,19 +118,27 @@ describe('tiledRuntimeMapBinding.load — minimal map', () => {
 
   it('returns a TileMap instance', async () => {
     const handler = tiledRuntimeMapBinding.create();
-    const result = await handler.load({ source: 'minimal.tmj' } as Parameters<typeof handler.load>[0], context);
+    const result = await handler.load({ source: 'minimal.tmj' }, context);
     expect(result).toBeInstanceOf(TileMap);
   });
 
   it('preserves map dimensions', async () => {
     const handler = tiledRuntimeMapBinding.create();
-    const result = await handler.load({ source: 'minimal.tmj' } as Parameters<typeof handler.load>[0], context);
+    const result = await handler.load({ source: 'minimal.tmj' }, context);
     expect(result.width).toBe(4);
     expect(result.height).toBe(4);
     expect(result.tileWidth).toBe(16);
     expect(result.tileHeight).toBe(16);
   });
+
+  it('delegates to ctx.loader.load(TiledMap, source) internally', async () => {
+    const handler = tiledRuntimeMapBinding.create();
+    await handler.load({ source: 'minimal.tmj' }, context);
+    expect(context.loader.load).toHaveBeenCalledWith(TiledMap, 'minimal.tmj', undefined);
+  });
 });
+
+// ── Integration tests — tileset image ───────────────────────────────────────
 
 describe('tiledRuntimeMapBinding.load — with atlas tileset image', () => {
   const { context, loaderLoad } = makeContext({ 'with-tileset-image.tmj': loadFixture('with-tileset-image.tmj') });
@@ -92,14 +147,54 @@ describe('tiledRuntimeMapBinding.load — with atlas tileset image', () => {
 
   it('returns a TileMap instance', async () => {
     const handler = tiledRuntimeMapBinding.create();
-    const result = await handler.load({ source: 'with-tileset-image.tmj' } as Parameters<typeof handler.load>[0], context);
+    const result = await handler.load({ source: 'with-tileset-image.tmj' }, context);
     expect(result).toBeInstanceOf(TileMap);
   });
 
   it('the runtime TileMap has a TileSet with the loaded texture', async () => {
     const handler = tiledRuntimeMapBinding.create();
-    const result = await handler.load({ source: 'with-tileset-image.tmj' } as Parameters<typeof handler.load>[0], context);
+    const result = await handler.load({ source: 'with-tileset-image.tmj' }, context);
     expect(result.tilesets).toHaveLength(1);
+    // Texture is loaded transitively via the TiledMap sub-load
     expect(loaderLoad).toHaveBeenCalledWith(Texture, 'tiles.png');
+  });
+});
+
+// ── Integration tests — external tileset ────────────────────────────────────
+
+describe('tiledRuntimeMapBinding.load — external tileset (.tsj)', () => {
+  const fixtures = {
+    'external-tileset.tmj': loadFixture('external-tileset.tmj'),
+    'external-tileset.tsj': loadFixture('external-tileset.tsj'),
+  };
+  const { context, loaderLoad } = makeContext(fixtures);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('returns a TileMap instance', async () => {
+    const handler = tiledRuntimeMapBinding.create();
+    const result = await handler.load({ source: 'external-tileset.tmj' }, context);
+    expect(result).toBeInstanceOf(TileMap);
+  });
+
+  it('loads the external tileset texture', async () => {
+    const handler = tiledRuntimeMapBinding.create();
+    await handler.load({ source: 'external-tileset.tmj' }, context);
+    expect(loaderLoad).toHaveBeenCalledWith(Texture, 'external-tileset.png');
+  });
+});
+
+// ── Options passthrough ──────────────────────────────────────────────────────
+
+describe('tiledRuntimeMapBinding.load — options passthrough', () => {
+  const { context, loaderLoad } = makeContext({ 'world.tmj': loadFixture('minimal.tmj') });
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('passes options to the TiledMap sub-load', async () => {
+    const handler = tiledRuntimeMapBinding.create();
+    const opts = { format: 'tiled' as const, strict: false };
+    await handler.load({ source: 'world.tmj', options: opts }, context);
+    expect(loaderLoad).toHaveBeenCalledWith(TiledMap, 'world.tmj', opts);
   });
 });

--- a/packages/exojs-tiled/test/url.test.ts
+++ b/packages/exojs-tiled/test/url.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveTiledUrl } from '../src/url';
+
+describe('resolveTiledUrl', () => {
+  it('returns an absolute http(s) ref unchanged', () => {
+    expect(resolveTiledUrl('https://example.com/tiles.png', 'maps/level.tmj')).toBe('https://example.com/tiles.png');
+    expect(resolveTiledUrl('http://example.com/tiles.png', 'maps/level.tmj')).toBe('http://example.com/tiles.png');
+  });
+
+  it('returns a protocol-relative ref unchanged', () => {
+    expect(resolveTiledUrl('//cdn.example.com/tiles.png', 'maps/level.tmj')).toBe('//cdn.example.com/tiles.png');
+  });
+
+  it('returns a root-relative ref unchanged', () => {
+    expect(resolveTiledUrl('/assets/tiles.png', 'maps/level.tmj')).toBe('/assets/tiles.png');
+  });
+
+  it('returns data: and blob: refs unchanged', () => {
+    expect(resolveTiledUrl('data:image/png;base64,AAA=', 'maps/level.tmj')).toBe('data:image/png;base64,AAA=');
+    expect(resolveTiledUrl('blob:https://example.com/uuid', 'maps/level.tmj')).toBe('blob:https://example.com/uuid');
+  });
+
+  it('resolves a relative ref against an absolute base', () => {
+    expect(resolveTiledUrl('tiles.png', 'https://example.com/maps/level.tmj')).toBe('https://example.com/maps/tiles.png');
+  });
+
+  it('collapses ../ segments against an absolute base', () => {
+    expect(resolveTiledUrl('../shared/tiles.png', 'https://example.com/maps/level.tmj')).toBe('https://example.com/shared/tiles.png');
+  });
+
+  it('resolves a relative ref against a relative base, preserving the relative form', () => {
+    expect(resolveTiledUrl('tiles.png', 'maps/level.tmj')).toBe('maps/tiles.png');
+  });
+
+  it('collapses ../ segments against a relative base', () => {
+    expect(resolveTiledUrl('../shared/tiles.png', 'maps/level.tmj')).toBe('shared/tiles.png');
+  });
+
+  it('resolves against a relative base with no directory component', () => {
+    expect(resolveTiledUrl('tiles.png', 'level.tmj')).toBe('tiles.png');
+  });
+
+  it('preserves query strings and fragments on the ref', () => {
+    expect(resolveTiledUrl('tiles.png?v=2#frag', 'maps/level.tmj')).toBe('maps/tiles.png?v=2#frag');
+  });
+
+  it('chains correctly: TMJ -> TSJ -> image, two levels of relative resolution', () => {
+    const tsjUrl = resolveTiledUrl('tilesets/world.tsj', 'maps/level.tmj');
+    expect(tsjUrl).toBe('maps/tilesets/world.tsj');
+
+    const imageUrl = resolveTiledUrl('../images/world.png', tsjUrl);
+    expect(imageUrl).toBe('maps/images/world.png');
+  });
+});

--- a/packages/exojs-tiled/test/validate.test.ts
+++ b/packages/exojs-tiled/test/validate.test.ts
@@ -1,0 +1,417 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TiledLayerDataBase } from '../src/data';
+import {
+  checkTiledLayerInfiniteConsistency,
+  TiledFormatError,
+  validateTiledAnimationFrameData,
+  validateTiledLayerData,
+  validateTiledMapData,
+  validateTiledObjectData,
+  validateTiledPropertyData,
+  validateTiledTileData,
+  validateTiledTilesetFileData,
+  validateTiledTilesetRefData,
+} from '../src/validate';
+
+const SOURCE = 'level.tmj';
+
+function baseLayer(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 1,
+    name: 'Layer',
+    visible: true,
+    opacity: 1,
+    x: 0,
+    y: 0,
+    ...overrides,
+  };
+}
+
+describe('TiledFormatError', () => {
+  it('formats the message with source and field path', () => {
+    const error = new TiledFormatError(SOURCE, 'layers[0].type', 'unknown layer type "foo"');
+    expect(error.name).toBe('TiledFormatError');
+    expect(error.source).toBe(SOURCE);
+    expect(error.path).toBe('layers[0].type');
+    expect(error.message).toBe(`Invalid Tiled data in "${SOURCE}" at layers[0].type: unknown layer type "foo"`);
+  });
+
+  it('renders the empty path as <root>', () => {
+    const error = new TiledFormatError(SOURCE, '', 'expected an object, got string');
+    expect(error.message).toBe(`Invalid Tiled data in "${SOURCE}" at <root>: expected an object, got string`);
+  });
+});
+
+describe('validateTiledPropertyData', () => {
+  it('parses a string property, defaulting type to "string"', () => {
+    expect(validateTiledPropertyData({ name: 'label', value: 'hello' }, SOURCE, '')).toEqual({
+      name: 'label',
+      type: 'string',
+      propertytype: undefined,
+      value: 'hello',
+    });
+  });
+
+  it('parses int, float, bool, color, file, and object properties', () => {
+    expect(validateTiledPropertyData({ name: 'hp', type: 'int', value: 10 }, SOURCE, '')).toMatchObject({ type: 'int', value: 10 });
+    expect(validateTiledPropertyData({ name: 'speed', type: 'float', value: 1.5 }, SOURCE, '')).toMatchObject({ type: 'float', value: 1.5 });
+    expect(validateTiledPropertyData({ name: 'solid', type: 'bool', value: true }, SOURCE, '')).toMatchObject({ type: 'bool', value: true });
+    expect(validateTiledPropertyData({ name: 'tint', type: 'color', value: '#ff0000ff' }, SOURCE, '')).toMatchObject({ type: 'color', value: '#ff0000ff' });
+    expect(validateTiledPropertyData({ name: 'sound', type: 'file', value: 'sfx/hit.wav' }, SOURCE, '')).toMatchObject({ type: 'file', value: 'sfx/hit.wav' });
+    expect(validateTiledPropertyData({ name: 'target', type: 'object', value: 7 }, SOURCE, '')).toMatchObject({ type: 'object', value: 7 });
+  });
+
+  it('parses a class property with nested members and propertytype', () => {
+    const result = validateTiledPropertyData(
+      { name: 'stats', type: 'class', propertytype: 'Stats', value: { hp: 10, regen: { rate: 0.5 } } },
+      SOURCE,
+      '',
+    );
+    expect(result).toEqual({
+      name: 'stats',
+      type: 'class',
+      propertytype: 'Stats',
+      value: { hp: 10, regen: { rate: 0.5 } },
+    });
+  });
+
+  it('throws on an unknown property type', () => {
+    expect(() => validateTiledPropertyData({ name: 'x', type: 'vector', value: 1 }, SOURCE, 'properties[0]')).toThrow(TiledFormatError);
+    expect(() => validateTiledPropertyData({ name: 'x', type: 'vector', value: 1 }, SOURCE, 'properties[0]')).toThrow(/unknown property type "vector"/);
+  });
+
+  it('throws when the value does not match the declared type', () => {
+    expect(() => validateTiledPropertyData({ name: 'hp', type: 'int', value: 'ten' }, SOURCE, '')).toThrow(TiledFormatError);
+    expect(() => validateTiledPropertyData({ name: 'solid', type: 'bool', value: 'yes' }, SOURCE, '')).toThrow(TiledFormatError);
+  });
+
+  it('throws when the class value contains an unsupported member type', () => {
+    expect(() => validateTiledPropertyData({ name: 'stats', type: 'class', value: { hp: [1, 2] } }, SOURCE, '')).toThrow(TiledFormatError);
+  });
+
+  it('throws on a non-object input', () => {
+    expect(() => validateTiledPropertyData('nope', SOURCE, 'properties[0]')).toThrow(/expected an object, got string/);
+  });
+});
+
+describe('validateTiledAnimationFrameData', () => {
+  it('parses a valid frame', () => {
+    expect(validateTiledAnimationFrameData({ tileid: 3, duration: 100 }, SOURCE, '')).toEqual({ tileid: 3, duration: 100 });
+  });
+
+  it('throws when a field is missing', () => {
+    expect(() => validateTiledAnimationFrameData({ tileid: 3 }, SOURCE, 'animation[0]')).toThrow(TiledFormatError);
+  });
+});
+
+describe('validateTiledObjectData', () => {
+  const base = { id: 1, name: '', type: '', x: 0, y: 0, width: 16, height: 16, rotation: 0, visible: true };
+
+  it('parses a plain rectangle object', () => {
+    const result = validateTiledObjectData(base, SOURCE, '');
+    expect(result.point).toBeUndefined();
+    expect(result.ellipse).toBeUndefined();
+    expect(result.gid).toBeUndefined();
+    expect(result.width).toBe(16);
+    expect(result.height).toBe(16);
+  });
+
+  it('parses a point object', () => {
+    const result = validateTiledObjectData({ ...base, point: true }, SOURCE, '');
+    expect(result.point).toBe(true);
+  });
+
+  it('parses an ellipse object', () => {
+    const result = validateTiledObjectData({ ...base, ellipse: true }, SOURCE, '');
+    expect(result.ellipse).toBe(true);
+  });
+
+  it('parses polygon and polyline point arrays', () => {
+    const points = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }];
+    expect(validateTiledObjectData({ ...base, polygon: points }, SOURCE, '').polygon).toEqual(points);
+    expect(validateTiledObjectData({ ...base, polyline: points }, SOURCE, '').polyline).toEqual(points);
+  });
+
+  it('parses a text object with valid alignment values', () => {
+    const result = validateTiledObjectData({ ...base, text: { text: 'Hello', halign: 'center', valign: 'top' } }, SOURCE, '');
+    expect(result.text).toEqual({
+      text: 'Hello',
+      bold: undefined,
+      color: undefined,
+      fontfamily: undefined,
+      halign: 'center',
+      italic: undefined,
+      kerning: undefined,
+      pixelsize: undefined,
+      strikeout: undefined,
+      underline: undefined,
+      valign: 'top',
+      wrap: undefined,
+    });
+  });
+
+  it('throws on an unknown text alignment value', () => {
+    expect(() => validateTiledObjectData({ ...base, text: { text: 'Hello', halign: 'middle' } }, SOURCE, '')).toThrow(/unknown horizontal alignment "middle"/);
+    expect(() => validateTiledObjectData({ ...base, text: { text: 'Hello', valign: 'baseline' } }, SOURCE, '')).toThrow(/unknown vertical alignment "baseline"/);
+  });
+
+  it('parses a tile object referencing a gid', () => {
+    expect(validateTiledObjectData({ ...base, gid: 5 }, SOURCE, '').gid).toBe(5);
+  });
+
+  it('parses a template reference and properties', () => {
+    const result = validateTiledObjectData({ ...base, template: 'templates/tree.tx', properties: [{ name: 'hp', type: 'int', value: 3 }] }, SOURCE, '');
+    expect(result.template).toBe('templates/tree.tx');
+    expect(result.properties).toEqual([{ name: 'hp', type: 'int', propertytype: undefined, value: 3 }]);
+  });
+});
+
+describe('validateTiledLayerData — tile layers', () => {
+  it('parses a finite tile layer with "data"', () => {
+    const result = validateTiledLayerData(baseLayer({ type: 'tilelayer', width: 2, height: 2, data: [1, 2, 3, 4] }), SOURCE, 'layers[0]');
+    expect(result).toMatchObject({ type: 'tilelayer', width: 2, height: 2, data: [1, 2, 3, 4], chunks: undefined });
+  });
+
+  it('parses an infinite tile layer with "chunks"', () => {
+    const chunks = [{ x: 0, y: 0, width: 16, height: 16, data: new Array(256).fill(0) }];
+    const result = validateTiledLayerData(baseLayer({ type: 'tilelayer', width: 0, height: 0, chunks }), SOURCE, 'layers[0]');
+    expect(result).toMatchObject({ type: 'tilelayer', data: undefined });
+    expect(result.type === 'tilelayer' && result.chunks?.[0]).toEqual(chunks[0]);
+  });
+
+  it('throws when both "data" and "chunks" are present', () => {
+    expect(() =>
+      validateTiledLayerData(baseLayer({ type: 'tilelayer', width: 1, height: 1, data: [1], chunks: [] }), SOURCE, 'layers[0]'),
+    ).toThrow(/has both "data" and "chunks"/);
+  });
+
+  it('throws when neither "data" nor "chunks" is present', () => {
+    expect(() => validateTiledLayerData(baseLayer({ type: 'tilelayer', width: 1, height: 1 }), SOURCE, 'layers[0]')).toThrow(
+      /has neither "data" nor "chunks"/,
+    );
+  });
+
+  it('throws on compressed tile layer data', () => {
+    expect(() =>
+      validateTiledLayerData(baseLayer({ type: 'tilelayer', width: 1, height: 1, data: [1], compression: 'zlib' }), SOURCE, 'layers[0]'),
+    ).toThrow(/compressed tile layer data is not supported/);
+  });
+
+  it('throws on an unsupported encoding', () => {
+    expect(() =>
+      validateTiledLayerData(baseLayer({ type: 'tilelayer', width: 1, height: 1, data: 'AAAA', encoding: 'base64' }), SOURCE, 'layers[0]'),
+    ).toThrow(/unsupported tile layer encoding "base64"/);
+  });
+
+  it('accepts the "csv" encoding', () => {
+    const result = validateTiledLayerData(baseLayer({ type: 'tilelayer', width: 1, height: 1, data: [1], encoding: 'csv' }), SOURCE, 'layers[0]');
+    expect(result).toMatchObject({ type: 'tilelayer', data: [1] });
+  });
+});
+
+describe('validateTiledLayerData — object layers', () => {
+  const object = { id: 1, name: '', type: '', x: 0, y: 0, width: 8, height: 8, rotation: 0, visible: true };
+
+  it('defaults draworder to "topdown"', () => {
+    const result = validateTiledLayerData(baseLayer({ type: 'objectgroup', objects: [object] }), SOURCE, 'layers[0]');
+    expect(result).toMatchObject({ type: 'objectgroup', draworder: undefined, objects: [expect.objectContaining({ id: 1 })] });
+  });
+
+  it('parses an explicit "index" draworder', () => {
+    const result = validateTiledLayerData(baseLayer({ type: 'objectgroup', draworder: 'index', objects: [] }), SOURCE, 'layers[0]');
+    expect(result).toMatchObject({ type: 'objectgroup', draworder: 'index' });
+  });
+
+  it('throws on an unknown draworder', () => {
+    expect(() => validateTiledLayerData(baseLayer({ type: 'objectgroup', draworder: 'bottomup', objects: [] }), SOURCE, 'layers[0]')).toThrow(
+      /unknown draw order "bottomup"/,
+    );
+  });
+});
+
+describe('validateTiledLayerData — image layers', () => {
+  it('parses an image layer with repeat flags', () => {
+    const result = validateTiledLayerData(baseLayer({ type: 'imagelayer', image: 'bg.png', repeatx: true, repeaty: false }), SOURCE, 'layers[0]');
+    expect(result).toMatchObject({ type: 'imagelayer', image: 'bg.png', repeatx: true, repeaty: false });
+  });
+
+  it('defaults a missing image to an empty string', () => {
+    const result = validateTiledLayerData(baseLayer({ type: 'imagelayer' }), SOURCE, 'layers[0]');
+    expect(result).toMatchObject({ type: 'imagelayer', image: '' });
+  });
+});
+
+describe('validateTiledLayerData — group layers', () => {
+  it('recursively parses nested layers', () => {
+    const child = baseLayer({ id: 2, type: 'tilelayer', width: 1, height: 1, data: [1] });
+    const result = validateTiledLayerData(baseLayer({ type: 'group', layers: [child] }), SOURCE, 'layers[0]');
+    expect(result).toMatchObject({ type: 'group', layers: [expect.objectContaining({ type: 'tilelayer', id: 2 })] });
+  });
+
+  it('throws on an unknown layer type', () => {
+    expect(() => validateTiledLayerData(baseLayer({ type: 'wangset' }), SOURCE, 'layers[0]')).toThrow(/unknown layer type "wangset"/);
+  });
+});
+
+describe('checkTiledLayerInfiniteConsistency', () => {
+  function tileLayer(extra: Record<string, unknown>): import('../src/data').TiledLayerData {
+    return validateTiledLayerData(baseLayer({ type: 'tilelayer', width: 1, height: 1, ...extra }), SOURCE, 'layers[0]');
+  }
+
+  it('accepts a finite tile layer with "data" on a finite map', () => {
+    expect(() => checkTiledLayerInfiniteConsistency([tileLayer({ data: [1] })], false, SOURCE, 'layers')).not.toThrow();
+  });
+
+  it('throws when a finite map has a tile layer with "chunks"', () => {
+    const layer = tileLayer({ chunks: [] });
+    expect(() => checkTiledLayerInfiniteConsistency([layer], false, SOURCE, 'layers')).toThrow(/has "chunks" on a finite map/);
+  });
+
+  it('accepts an infinite tile layer with "chunks" on an infinite map', () => {
+    expect(() => checkTiledLayerInfiniteConsistency([tileLayer({ chunks: [] })], true, SOURCE, 'layers')).not.toThrow();
+  });
+
+  it('throws when an infinite map has a tile layer with "data"', () => {
+    const layer = tileLayer({ data: [1] });
+    expect(() => checkTiledLayerInfiniteConsistency([layer], true, SOURCE, 'layers')).toThrow(/missing "chunks" on an infinite map/);
+  });
+
+  it('recurses into group layers', () => {
+    const inconsistentChild = tileLayer({ chunks: [] });
+    const group = validateTiledLayerData(baseLayer({ type: 'group', layers: [inconsistentChild] }), SOURCE, 'layers[0]');
+    expect(() => checkTiledLayerInfiniteConsistency([group], false, SOURCE, 'layers')).toThrow(/has "chunks" on a finite map/);
+  });
+});
+
+describe('validateTiledTileData', () => {
+  it('parses a minimal tile (only id)', () => {
+    expect(validateTiledTileData({ id: 0 }, SOURCE, 'tiles[0]')).toEqual({
+      id: 0,
+      type: undefined,
+      properties: undefined,
+      animation: undefined,
+      objectgroup: undefined,
+      image: undefined,
+      imagewidth: undefined,
+      imageheight: undefined,
+    });
+  });
+
+  it('parses a collection-of-images tile with dimensions', () => {
+    const result = validateTiledTileData({ id: 2, image: 'tile2.png', imagewidth: 16, imageheight: 16 }, SOURCE, 'tiles[2]');
+    expect(result).toMatchObject({ id: 2, image: 'tile2.png', imagewidth: 16, imageheight: 16 });
+  });
+
+  it('parses animation frames and properties', () => {
+    const result = validateTiledTileData(
+      { id: 1, animation: [{ tileid: 1, duration: 100 }, { tileid: 2, duration: 100 }], properties: [{ name: 'solid', type: 'bool', value: true }] },
+      SOURCE,
+      'tiles[1]',
+    );
+    expect(result.animation).toHaveLength(2);
+    expect(result.properties).toEqual([{ name: 'solid', type: 'bool', propertytype: undefined, value: true }]);
+  });
+
+  it('parses a collision objectgroup', () => {
+    const result = validateTiledTileData({ id: 0, objectgroup: baseLayer({ type: 'objectgroup', objects: [] }) }, SOURCE, 'tiles[0]');
+    expect(result.objectgroup).toMatchObject({ type: 'objectgroup', objects: [] });
+  });
+
+  it('throws when the objectgroup is not an object layer', () => {
+    expect(() => validateTiledTileData({ id: 0, objectgroup: baseLayer({ type: 'tilelayer', width: 0, height: 0, data: [] }) }, SOURCE, 'tiles[0]')).toThrow(
+      /expected an "objectgroup" layer, got "tilelayer"/,
+    );
+  });
+});
+
+describe('validateTiledTilesetRefData', () => {
+  it('parses an external tileset reference', () => {
+    expect(validateTiledTilesetRefData({ firstgid: 1, source: 'tiles.tsj' }, SOURCE, 'tilesets[0]')).toEqual({ firstgid: 1, source: 'tiles.tsj' });
+  });
+
+  it('parses an embedded tileset reference', () => {
+    const result = validateTiledTilesetRefData(
+      { firstgid: 1, name: 'tiles', tilewidth: 16, tileheight: 16, tilecount: 4, columns: 2 },
+      SOURCE,
+      'tilesets[0]',
+    );
+    expect(result).toMatchObject({ firstgid: 1, name: 'tiles', tilewidth: 16, tileheight: 16, tilecount: 4, columns: 2 });
+  });
+
+  it('throws when firstgid is missing', () => {
+    expect(() => validateTiledTilesetRefData({ source: 'tiles.tsj' }, SOURCE, 'tilesets[0]')).toThrow(TiledFormatError);
+  });
+
+  it('throws when firstgid is not positive', () => {
+    expect(() => validateTiledTilesetRefData({ firstgid: 0, source: 'tiles.tsj' }, SOURCE, 'tilesets[0]')).toThrow(/expected a positive integer/);
+  });
+});
+
+describe('validateTiledTilesetFileData', () => {
+  it('parses a standalone .tsj root object', () => {
+    const result = validateTiledTilesetFileData({ name: 'tiles', tilewidth: 16, tileheight: 16, tilecount: 4, columns: 2, image: 'tiles.png' }, 'tiles.tsj');
+    expect(result).toMatchObject({ name: 'tiles', tilewidth: 16, tileheight: 16, tilecount: 4, columns: 2, image: 'tiles.png' });
+  });
+
+  it('throws on a non-object root', () => {
+    expect(() => validateTiledTilesetFileData([], 'tiles.tsj')).toThrow(/expected an object, got an array/);
+  });
+});
+
+describe('validateTiledMapData', () => {
+  const validMap = {
+    type: 'map',
+    version: '1.10',
+    orientation: 'orthogonal',
+    renderorder: 'right-down',
+    width: 1,
+    height: 1,
+    tilewidth: 16,
+    tileheight: 16,
+    infinite: false,
+    layers: [baseLayer({ type: 'tilelayer', width: 1, height: 1, data: [1] })],
+    tilesets: [{ firstgid: 1, name: 'tiles', tilewidth: 16, tileheight: 16, tilecount: 1, columns: 1 }],
+  };
+
+  it('parses a complete map document', () => {
+    const result = validateTiledMapData(validMap, SOURCE);
+    expect(result).toMatchObject({
+      type: 'map',
+      version: '1.10',
+      orientation: 'orthogonal',
+      renderorder: 'right-down',
+      width: 1,
+      height: 1,
+      tilewidth: 16,
+      tileheight: 16,
+      infinite: false,
+    });
+    expect(result.layers).toHaveLength(1);
+    expect(result.tilesets).toHaveLength(1);
+  });
+
+  it('throws when "type" is not "map"', () => {
+    expect(() => validateTiledMapData({ ...validMap, type: 'tileset' }, SOURCE)).toThrow(/expected "map", got "tileset"/);
+  });
+
+  it('throws on an unknown orientation', () => {
+    expect(() => validateTiledMapData({ ...validMap, orientation: 'circular' }, SOURCE)).toThrow(/unknown orientation "circular"/);
+  });
+
+  it('throws on an unknown render order', () => {
+    expect(() => validateTiledMapData({ ...validMap, renderorder: 'center-out' }, SOURCE)).toThrow(/unknown render order "center-out"/);
+  });
+
+  it('throws when a finite map has an infinite-style tile layer', () => {
+    const inconsistent = {
+      ...validMap,
+      layers: [baseLayer({ type: 'tilelayer', width: 0, height: 0, chunks: [] })],
+    };
+    expect(() => validateTiledMapData(inconsistent, SOURCE)).toThrow(/has "chunks" on a finite map/);
+  });
+
+  it('throws on a non-object root', () => {
+    expect(() => validateTiledMapData('not a map', SOURCE)).toThrow(/expected an object, got string/);
+  });
+});

--- a/packages/exojs-tiled/tsconfig.json
+++ b/packages/exojs-tiled/tsconfig.json
@@ -6,7 +6,8 @@
       "@codexo/exojs": ["../../src/index.ts"],
       "@codexo/exojs/extensions": ["../../src/extensions/index.ts"],
       "@codexo/exojs/rendering": ["../../src/rendering.ts"],
-      "@codexo/exojs/debug": ["../../src/debug/index.ts"]
+      "@codexo/exojs/debug": ["../../src/debug/index.ts"],
+      "@codexo/exojs-tilemap": ["../exojs-tilemap/src/index.ts"]
     }
   },
   "include": ["src/**/*", "../../src/typings.d.ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,10 @@ importers:
         version: link:../exojs-config
 
   packages/exojs-tiled:
+    dependencies:
+      '@codexo/exojs-tilemap':
+        specifier: workspace:*
+        version: link:../exojs-tilemap
     devDependencies:
       '@codexo/exojs':
         specifier: workspace:*

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -108,24 +108,55 @@ type PathExtension<S extends string> = S extends `${string}.${infer E}?${string}
 export type LoadByPath<S extends string> = PathExtension<S> extends keyof ExtensionTypeMap ? ExtensionTypeMap[PathExtension<S>] : unknown;
 
 /**
+ * Additional asset types accepted by the **token form** of {@link Loader.load}
+ * (`load(MyType, 'file.ext')`) for a given file extension, beyond the
+ * path-only type registered in {@link ExtensionTypeMap}.
+ *
+ * Augment via declaration merging when a format package ships an advanced
+ * source-model token that shares a file extension with its common-case
+ * runtime type. The path-only form (`load('file.ext')`) is unaffected and
+ * keeps resolving to the {@link ExtensionTypeMap} entry alone:
+ * ```ts
+ * declare module '@codexo/exojs' {
+ *   interface ExtensionTypeMap { tmj: TileMap }       // load('world.tmj') → TileMap
+ *   interface ExtensionTokenTypeMap { tmj: TiledMap } // load(TiledMap, 'world.tmj') also allowed
+ * }
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ExtensionTokenTypeMap {}
+
+/** Resolves the additional token types allowed for extension `E`, or `never` when none are registered. */
+type TokenTypesFor<E> = E extends keyof ExtensionTokenTypeMap ? ExtensionTokenTypeMap[E] : never;
+
+/**
  * Constrains a {@link Loadable} token against the types registered for a
  * given path's extension. When the extension is in {@link ExtensionTypeMap},
- * `T` must produce a value assignable to the registered union — otherwise
- * resolves to `never`, triggering a compile-time error.
+ * `T` must produce a value assignable to the registered union (including any
+ * extra token types from {@link ExtensionTokenTypeMap}) — otherwise resolves
+ * to `never`, triggering a compile-time error.
  *
- * For paths with an unregistered extension the constraint is skipped and any
- * `T` is accepted (runtime behaviour is unchanged).
+ * For paths with an unregistered extension — including non-literal `string`
+ * paths and extension-less paths, where no extension can be derived — the
+ * constraint is skipped and any `T` is accepted (runtime behaviour is
+ * unchanged).
  *
  * ```ts
  * // ExtensionTypeMap: { ogg: Sound | Video }
  * loader.load(Sound, 'effect.ogg')      // ✓ Sound ∈ Sound | Video
  * loader.load(BitmapText, 'effect.ogg') // ✗ BitmapText ∉ Sound | Video
  * loader.load(Sound, 'theme.custom')    // ✓ .custom not in map → unconstrained
+ * loader.load(Sound, dynamicPath)       // ✓ string path → unconstrained
  * ```
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ConstrainedLoadable<T extends abstract new (...args: any[]) => any, S extends string> =
-  PathExtension<S> extends keyof ExtensionTypeMap ? (LoadReturn<T> extends ExtensionTypeMap[PathExtension<S>] ? T : never) : T;
+export type ConstrainedLoadable<T extends abstract new (...args: any[]) => any, S extends string> = [PathExtension<S>] extends [never]
+  ? T
+  : PathExtension<S> extends keyof ExtensionTypeMap
+    ? LoadReturn<T> extends ExtensionTypeMap[PathExtension<S>] | TokenTypesFor<PathExtension<S>>
+      ? T
+      : never
+    : T;
 
 /**
  * Context object passed to custom asset-type load handlers registered via

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -125,6 +125,7 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "EqualizerFilter: class",
   "EqualizerFilterOptions: interface",
   "Extension: interface",
+  "ExtensionTokenTypeMap: interface",
   "ExtensionTypeMap: interface",
   "FactoryRegistry: class",
   "FadeSceneTransition: interface",

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -52,7 +52,9 @@
       "@codexo/exojs-particles": ["./packages/exojs-particles/src/index.ts"],
       "@codexo/exojs-particles/register": ["./packages/exojs-particles/src/register.ts"],
       "@codexo/exojs-tiled": ["./packages/exojs-tiled/src/index.ts"],
-      "@codexo/exojs-tiled/register": ["./packages/exojs-tiled/src/register.ts"]
+      "@codexo/exojs-tiled/register": ["./packages/exojs-tiled/src/register.ts"],
+      "@codexo/exojs-tilemap": ["./packages/exojs-tilemap/src/index.ts"],
+      "@codexo/exojs-tilemap/register": ["./packages/exojs-tilemap/src/register.ts"]
     }
   },
   "include": ["examples/**/*.js", "examples/**/*.ts", "examples/shared/runtime.d.ts", "src/typings.d.ts"],

--- a/tsconfig.guides.json
+++ b/tsconfig.guides.json
@@ -40,7 +40,9 @@
       "@codexo/exojs-particles": ["./packages/exojs-particles/src/index.ts"],
       "@codexo/exojs-particles/register": ["./packages/exojs-particles/src/register.ts"],
       "@codexo/exojs-tiled": ["./packages/exojs-tiled/src/index.ts"],
-      "@codexo/exojs-tiled/register": ["./packages/exojs-tiled/src/register.ts"]
+      "@codexo/exojs-tiled/register": ["./packages/exojs-tiled/src/register.ts"],
+      "@codexo/exojs-tilemap": ["./packages/exojs-tilemap/src/index.ts"],
+      "@codexo/exojs-tilemap/register": ["./packages/exojs-tilemap/src/register.ts"]
     }
   },
   "include": [".workspace/generated/guide-typecheck/**/*.ts", ".workspace/generated/guide-typecheck/**/*.js", "src/typings.d.ts"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,9 @@ const aliasConfig = [
   { find: '@codexo/exojs/rendering', replacement: fileURLToPath(new URL('./src/rendering.ts', import.meta.url)) },
   { find: '@codexo/exojs/debug', replacement: fileURLToPath(new URL('./src/debug/index.ts', import.meta.url)) },
   { find: '@codexo/exojs', replacement: fileURLToPath(new URL('./src/index.ts', import.meta.url)) },
+  // @codexo/exojs-tiled depends on @codexo/exojs-tilemap; neither package
+  // exports a `@codexo/source` condition, so alias to source for in-repo tests.
+  { find: '@codexo/exojs-tilemap', replacement: fileURLToPath(new URL('./packages/exojs-tilemap/src/index.ts', import.meta.url)) },
 ] as const;
 
 // Shared resolution/plugin wiring for the repository-local browser projects.


### PR DESCRIPTION
## Summary

Implements Phase C of the v0.13 Tiled integration in three focused commits:

**C1 — Parsed source model** (`abc86f9b`)
- `TiledMap`, `TiledTileset`, `TiledLayer` hierarchy (`TiledTileLayer`, `TiledObjectLayer`, `TiledImageLayer`, `TiledGroupLayer`), `TiledObject` — parsed Tiled source format classes
- `TiledFormatError` — typed error for structural problems in `.tmj`/`.tsj` data
- `loadTiledMap(source, context)` — fetches `.tmj`, resolves external `.tsj` tilesets, loads tileset textures via Loader
- `tiledMapBinding` (`type: TiledMap`, token-only, shares `.tmj` extension with runtime binding) — advanced/diagnostic load path
- `tiledExtension` wired with `dependencies: [tilemapExtension]`
- 193 unit + integration tests across 9 test files

**C2 — Runtime TileMap conversion** (`80c275bb`)
- `TiledMap.toTileMap()` — decodes Tiled GID flip-bits (H/V/diagonal), resolves `firstgid` ranges across multiple tilesets, fills a generic `TileMap` (from `@codexo/exojs-tilemap`) with packed tile data; atlas tilesets supported; collection-of-images tilesets throw `TiledFormatError`; no-image tilesets are silently skipped
- `tiledRuntimeMapBinding` (`type: TileMap`, `extensions: ['tmj']`) — common-case binding; `loader.load(TileMap, 'world.tmj')` returns a generic `TileMap` directly via Loader-managed source-model sub-load
- Facade re-exports of `TileMap`, `TileLayer`, `TileSet` and related types from `@codexo/exojs-tiled` so Tiled users need only one import
- 28 new tests (flip decoding for all 8 cases, multi-tileset index mapping, collection-of-images error, runtime binding integration)

**C3 — Typed Loader bindings and `.tmj` augmentation** (`f065b89c`)
- `TiledLoadOptions` (`format?: 'tiled'`, `strict?: boolean`) — typed, optional load options shared by both bindings
- `resolveTiledOptions(options)` — shared normalization; used by both `getIdentityKey` and `load`
- `tiledRuntimeMapBinding.getIdentityKey` — includes all result-changing normalized values; control-only options do not affect identity; equal source+options deduplicate
- `tiledMapBinding.getIdentityKey` — same normalization; separate Loader type-namespace from runtime binding
- Source-model sub-load cache sharing: `tiledRuntimeMapBinding` delegates to `loader.load(TiledMap, source, options)` internally; no duplicate TMJ/TSJ fetch, no duplicate texture load
- `ExtensionTokenTypeMap` augmentation: `tmj → TiledMap` — `loader.load(TiledMap, 'world.tmj')` is type-safe alongside the path-only `tmj → TileMap` entry in `ExtensionTypeMap`
- `AssetDefinitions` augmentation: `tileMap` and `tiledMap` asset aliases
- Direct/source equivalence tests: `loader.load(TileMap, url)` and `(await loader.load(TiledMap, url)).toTileMap()` produce semantically equivalent results
- Texture ownership tests: textures remain in Loader cache; `TiledMap.destroy()` does not unload them
- `ExtensionTokenTypeMap` public interface added to `src/resources/Loader.ts` with eslint-disable for empty-object-type; snapshot updated

## What is NOT in scope (reserved for Phase D/E)

- `TileMapNode` / `TileLayerNode` rendering (WebGL2/WebGPU chunk renderer)
- `TileMapView` / band decomposition
- Object/image/group layer conversion in `toTileMap()`
- Infinite-map runtime support
- Tile animation runtime
- Format-hinted generic `.json` loading

## Test plan

- [x] `pnpm typecheck:guides` — clean (39 extracted, 24 no-check, 219 partial)
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm typecheck:examples` — clean
- [x] `pnpm test` — 2828 tests passing (183 files)
- [x] `pnpm build` — clean
- [x] `pnpm verify:exports` — all entry targets verified
- [x] `pnpm verify:lockstep` — all packages at v0.12.0
- [x] `pnpm verify:release-matrix` — PUBLISH_ORDER: Core → Particles → Tilemap → Tiled
