### PR TITLE
feat(tilemap): add chunk renderer and nodes

### DIFF
--- a/packages/exojs-tiled/README.md
+++ b/packages/exojs-tiled/README.md
@@ -21,6 +21,7 @@ npm install @codexo/exojs @codexo/exojs-tilemap
 ## What this package provides
 
 - `TileMap` (re-exported from `@codexo/exojs-tilemap`) — generic runtime tilemap; the common-case result of `loader.load(TileMap, url)`
+- `TileMapNode` / `TileLayerNode` (re-exported from `@codexo/exojs-tilemap`) — scene nodes that render a loaded `TileMap` on WebGL2/WebGPU
 - `TiledMap` — parsed Tiled source model; advanced/diagnostic use via `loader.load(TiledMap, url)`
 - `TiledTileset` — parsed tileset (atlas-image or collection-of-images); holds resolved textures
 - `TiledLayer` hierarchy — `TiledTileLayer`, `TiledObjectLayer`, `TiledImageLayer`, `TiledGroupLayer`
@@ -30,17 +31,26 @@ npm install @codexo/exojs @codexo/exojs-tilemap
 
 ## Usage — common case
 
-Register the extension and load a `.tmj` map into a generic runtime `TileMap`:
+Register the extension, load a `.tmj` map into a generic runtime `TileMap`, and render it. One
+extension enables **both** loading and rendering — `tiledExtension` depends on `tilemapExtension`,
+so the tile chunk renderer bindings are materialised automatically (no manual `tilemapExtension`
+registration):
 
 ```ts
 import { Application } from '@codexo/exojs';
-import { TileMap, tiledExtension } from '@codexo/exojs-tiled';
+import { TileMap, TileMapNode, tiledExtension } from '@codexo/exojs-tiled';
 
 const app = new Application({ extensions: [tiledExtension] });
 
 const map = await app.loader.load(TileMap, 'maps/world.tmj');
 // map is a @codexo/exojs-tilemap TileMap
+
+app.scene.root.addChild(new TileMapNode(map));
 ```
+
+`TileMapNode` and `TileLayerNode` are the same classes exported by `@codexo/exojs-tilemap` (see its
+[README](https://www.npmjs.com/package/@codexo/exojs-tilemap) for the rendering/culling model and
+actor interleaving). `instanceof TileMap` holds across both import paths.
 
 ## Usage — advanced parsed-source case
 

--- a/packages/exojs-tiled/src/public.ts
+++ b/packages/exojs-tiled/src/public.ts
@@ -9,7 +9,9 @@ export { type TiledLoadOptions } from './tiledOptions';
 // holds whether the class was imported from @codexo/exojs-tilemap or here.
 export {
   TileLayer,
+  TileLayerNode,
   TileMap,
+  TileMapNode,
   TileSet,
   tilemapExtension,
   TILE_TRANSFORM_IDENTITY,
@@ -20,7 +22,9 @@ export type {
   ReadonlyTileChunk,
   ResolvedTile,
   TileDefinition,
+  TileLayerNodeOptions,
   TileLayerOptions,
+  TileMapNodeOptions,
   TileMapOptions,
   TileProperties,
   TilePropertyValue,

--- a/packages/exojs-tiled/test/extension.test.ts
+++ b/packages/exojs-tiled/test/extension.test.ts
@@ -69,9 +69,11 @@ describe('@codexo/exojs-tiled extension descriptor', () => {
     expect(snapshot.assets).toContain(tiledMapBinding);
   });
 
-  it('buildSnapshot has no renderer bindings (rendering not yet implemented)', () => {
+  it('buildSnapshot([tiledExtension]) pulls in the tilemap renderer binding (one-extension rendering)', () => {
     const snapshot = buildSnapshot([tiledExtension]);
-    expect(snapshot.renderers).toHaveLength(0);
+    // The tilemap dependency contributes its tile chunk renderer binding, so a
+    // Tiled-only setup can both load AND render without manual registration.
+    expect(snapshot.renderers).toHaveLength(1);
   });
 });
 

--- a/packages/exojs-tiled/test/facade.test.ts
+++ b/packages/exojs-tiled/test/facade.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { TileLayer, TileLayerNode, TileMap, TileMapNode, TileSet } from '@codexo/exojs-tilemap';
+
+import * as tiled from '../src/public';
+
+// G-PKG-IDENTITY / G-PKG-FACADE: the Tiled package re-exports the *same* runtime
+// class bindings as @codexo/exojs-tilemap (not copies), so `instanceof` and
+// renderer registration hold across both import paths.
+describe('@codexo/exojs-tiled runtime facade', () => {
+  it('re-exports the same class identities as @codexo/exojs-tilemap', () => {
+    expect(tiled.TileMap).toBe(TileMap);
+    expect(tiled.TileMapNode).toBe(TileMapNode);
+    expect(tiled.TileLayerNode).toBe(TileLayerNode);
+    expect(tiled.TileLayer).toBe(TileLayer);
+    expect(tiled.TileSet).toBe(TileSet);
+  });
+
+  it('an instance built through the facade is instanceof the canonical class', () => {
+    const map = new tiled.TileMap({ name: 'm', width: 2, height: 2, tileWidth: 16, tileHeight: 16 });
+    const node = new tiled.TileMapNode(map);
+
+    expect(map).toBeInstanceOf(TileMap);
+    expect(node).toBeInstanceOf(TileMapNode);
+
+    node.destroy();
+  });
+
+  it('the Tiled extension depends on the tilemap extension (one-extension rendering)', () => {
+    expect(tiled.tiledExtension.dependencies).toContain(tiled.tilemapExtension);
+    expect(tiled.tilemapExtension.renderers).toBeDefined();
+  });
+});

--- a/packages/exojs-tilemap/README.md
+++ b/packages/exojs-tilemap/README.md
@@ -1,0 +1,145 @@
+# @codexo/exojs-tilemap
+
+Generic, format-independent tilemap runtime **and** WebGL2/WebGPU chunk renderer for
+[ExoJS](https://exojs.dev). No Tiled (or any other on-disk format) vocabulary leaks into this
+package — adapters such as [`@codexo/exojs-tiled`](https://www.npmjs.com/package/@codexo/exojs-tiled)
+parse their format and hand this runtime fully-resolved tiles.
+
+## Installation
+
+```sh
+npm install @codexo/exojs @codexo/exojs-tilemap
+```
+
+`@codexo/exojs` is a peer dependency. Most users load Tiled maps and get this package
+transitively through `@codexo/exojs-tiled` — install it directly only for procedural or
+custom-format maps.
+
+## What this package provides
+
+**Runtime (data model)** — pure data, no scene graph:
+
+- `TileMap` — a finite, chunk-first map: dimensions, tile size, `tilesets`, ordered `layers`.
+- `TileLayer` — one tile layer; packed `Uint32Array` chunk storage, `visible` / `opacity` /
+  `offsetX/Y`, queries, and revision tracking.
+- `TileSet` — a resolved tileset grid over a Core `TextureRegion` (Loader-owned texture).
+- `ResolvedTile` / `TileTransform` — value-typed tile references with `flipX` / `flipY` /
+  `diagonal` orientation.
+
+**Scene / rendering (`@advanced`)**:
+
+- `TileMapNode` — convenience root that renders a whole `TileMap`.
+- `TileLayerNode` — renders one `TileLayer`; place these yourself to interleave actors.
+- `tilemapExtension` — extension descriptor carrying the WebGL2/WebGPU renderer bindings.
+
+## Usage — procedural map
+
+```ts
+import { Application, Texture, TextureRegion } from '@codexo/exojs';
+import {
+  TileLayer,
+  TileMap,
+  TileMapNode,
+  TileSet,
+  tilemapExtension,
+  TILE_TRANSFORM_IDENTITY,
+} from '@codexo/exojs-tilemap';
+
+const app = new Application({ extensions: [tilemapExtension] /* canvas, … */ });
+
+// Tileset over a Loader-owned atlas texture (the runtime never destroys it).
+const atlas = await app.loader.load(Texture, 'tiles.png');
+const terrain = new TileSet({
+  name: 'terrain',
+  texture: new TextureRegion(atlas, { x: 0, y: 0, width: atlas.width, height: atlas.height }),
+  tileWidth: 16,
+  tileHeight: 16,
+  tileCount: 256,
+});
+
+const ground = new TileLayer({
+  id: 1,
+  name: 'ground',
+  width: 64,
+  height: 64,
+  tileWidth: 16,
+  tileHeight: 16,
+  tilesets: [terrain],
+});
+ground.setTileAt(0, 0, { tileset: terrain, localTileId: 5, transform: TILE_TRANSFORM_IDENTITY });
+
+const map = new TileMap({
+  name: 'world',
+  width: 64,
+  height: 64,
+  tileWidth: 16,
+  tileHeight: 16,
+  tilesets: [terrain],
+  layers: [ground],
+});
+
+// Render the whole map.
+app.scene.root.addChild(new TileMapNode(map));
+```
+
+### Interleaving actors between layers
+
+`TileMapNode` owns **only** the map's layer nodes. To place actors *between* layers, build the
+layer nodes yourself and parent them in your own scene graph:
+
+```ts
+const background = new TileLayerNode(map.getTileLayer('background')!);
+const foreground = new TileLayerNode(map.getTileLayer('foreground')!);
+
+world.addChild(background);
+world.addChild(player);      // app-owned actor, drawn between the two layers
+world.addChild(foreground);
+```
+
+## `/register` convenience entry
+
+```ts
+// Side effect: registers tilemapExtension in the global ExtensionRegistry.
+import '@codexo/exojs-tilemap/register';
+```
+
+## Renderer model
+
+- **Chunk-first.** A `TileLayerNode` is a container of per-chunk `TileChunkNode` drawables (one
+  per non-empty loaded chunk). The renderer batches tiles by `(shader, tileset texture)` and
+  issues one instanced draw per batch — draw calls scale with *visible chunks × layers*, not
+  total tile count.
+- **Revision-cached geometry.** Each chunk's quad geometry is built once and cached against the
+  source chunk's `revision`. Unchanged chunks never rebuild; a camera pan rebuilds nothing —
+  off-screen chunks are culled by their local bounds before any geometry is touched.
+- **Orientation.** `flipX` / `flipY` / `diagonal` are baked into the chunk geometry / resolved in
+  the shader (all 8 combinations), with no per-tile matrix or per-frame cost.
+- **Multiple tilesets** with differing tile sizes are first-class; tiles taller than the map grid
+  are bottom-left aligned (Tiled orthogonal convention).
+- **WebGL2 and WebGPU** share one CPU geometry builder and produce identical output (golden
+  parity tested on both backends).
+
+## Ownership & lifecycle
+
+- Tileset **textures are Loader-owned**. The runtime and renderer never destroy them.
+- `TileMapNode` / `TileLayerNode` reference — but never own — the `TileMap`. Destroying a map
+  node frees its layer/chunk nodes and their cached geometry; the `TileMap` data and textures
+  survive. Free those via `TileMap.destroy()` and `Loader.destroy()` respectively.
+- A `TileMapNode` reflects the layer set at construction time. After structural changes (layers
+  added/removed, or tiles written into previously-empty chunks) call `node.refreshLayers()` /
+  `layerNode.refresh()`. In-place edits to existing chunks are picked up automatically.
+
+## Core compatibility
+
+| `@codexo/exojs-tilemap` | `@codexo/exojs` |
+|---|---|
+| 0.x | matching `0.x` |
+
+## Links
+
+- [API reference](https://exojs.dev/api/exojs-tilemap)
+- [`@codexo/exojs-tiled`](https://www.npmjs.com/package/@codexo/exojs-tiled) — load Tiled `.tmj` maps into this runtime
+
+## License
+
+MIT

--- a/packages/exojs-tilemap/src/TileChunkNode.ts
+++ b/packages/exojs-tilemap/src/TileChunkNode.ts
@@ -1,0 +1,115 @@
+import type { Rectangle } from '@codexo/exojs';
+import { Drawable } from '@codexo/exojs/rendering';
+
+import type { ChunkPage } from './chunkGeometry';
+import { buildChunkPages } from './chunkGeometry';
+import type { ReadonlyTileChunk } from './TileChunk';
+import type { TileSet } from './TileSet';
+
+/**
+ * A single renderable tile chunk. One `TileChunkNode` is a {@link Drawable}
+ * that owns the batched quad geometry for exactly one {@link ReadonlyTileChunk}
+ * of one {@link import('./TileLayer').TileLayer}, positioned at the chunk's
+ * pixel origin within the owning {@link TileLayerNode}.
+ *
+ * Geometry is built lazily and cached against the source chunk's `revision`:
+ * the renderer reads {@link TileChunkNode.pages} on each visible frame, but a
+ * rebuild only happens when the underlying chunk actually changed. Off-screen
+ * chunks are culled by their accurate {@link getLocalBounds} before `render`
+ * is ever called, so a camera pan rebuilds nothing.
+ *
+ * The node references — but never owns — the runtime chunk, tilesets, and
+ * tileset textures. Destroying it releases only its cached CPU geometry; the
+ * `TileMap`/`TileLayer` data and Loader-owned textures are untouched.
+ *
+ * @internal Package-internal render node; the renderer is registered for this
+ * class. Applications use {@link TileMapNode} / {@link TileLayerNode}.
+ */
+export class TileChunkNode extends Drawable {
+  private readonly _chunk: ReadonlyTileChunk;
+  private readonly _tilesets: readonly TileSet[];
+  private readonly _tileWidth: number;
+  private readonly _tileHeight: number;
+  private readonly _pixelWidth: number;
+  private readonly _pixelHeight: number;
+
+  private _pages: ChunkPage[] = [];
+  private _builtRevision = -1;
+
+  /**
+   * @param chunk          The readonly chunk this node renders.
+   * @param tilesets       The owning layer's tileset array.
+   * @param tileWidth      Map/layer tile cell width in pixels.
+   * @param tileHeight     Map/layer tile cell height in pixels.
+   * @param chunkWidthTiles  The layer's (unclamped) chunk width in tiles, used
+   *                         to compute the chunk's pixel origin. Edge chunks
+   *                         report a smaller `chunk.width`, but always start at
+   *                         `cx * chunkWidthTiles`.
+   * @param chunkHeightTiles The layer's (unclamped) chunk height in tiles.
+   */
+  public constructor(
+    chunk: ReadonlyTileChunk,
+    tilesets: readonly TileSet[],
+    tileWidth: number,
+    tileHeight: number,
+    chunkWidthTiles: number,
+    chunkHeightTiles: number,
+  ) {
+    super();
+
+    this._chunk = chunk;
+    this._tilesets = tilesets;
+    this._tileWidth = tileWidth;
+    this._tileHeight = tileHeight;
+    this._pixelWidth = chunk.width * tileWidth;
+    this._pixelHeight = chunk.height * tileHeight;
+
+    this.setPosition(
+      chunk.cx * chunkWidthTiles * tileWidth,
+      chunk.cy * chunkHeightTiles * tileHeight,
+    );
+  }
+
+  /** The signed chunk coordinates this node renders. */
+  public get chunkX(): number {
+    return this._chunk.cx;
+  }
+
+  public get chunkY(): number {
+    return this._chunk.cy;
+  }
+
+  /**
+   * The revision-cached per-tileset page geometry. Rebuilt only when the source
+   * chunk's `revision` advances; otherwise the same arrays are returned.
+   * @internal Read by the per-backend tile chunk renderer.
+   */
+  public get pages(): readonly ChunkPage[] {
+    if (this._builtRevision !== this._chunk.revision) {
+      this._pages = buildChunkPages(this._chunk, this._tilesets, this._tileWidth, this._tileHeight);
+      this._builtRevision = this._chunk.revision;
+    }
+
+    return this._pages;
+  }
+
+  /** `true` when the chunk has no drawable tiles (no geometry, no draw calls). */
+  public get isEmpty(): boolean {
+    return this.pages.length === 0;
+  }
+
+  public override getLocalBounds(): Rectangle {
+    const bounds = super.getLocalBounds();
+
+    bounds.set(0, 0, this._pixelWidth, this._pixelHeight);
+
+    return bounds;
+  }
+
+  public override destroy(): void {
+    this._pages = [];
+    this._builtRevision = -1;
+
+    super.destroy();
+  }
+}

--- a/packages/exojs-tilemap/src/TileLayerNode.ts
+++ b/packages/exojs-tilemap/src/TileLayerNode.ts
@@ -1,0 +1,160 @@
+import type { Rectangle } from '@codexo/exojs';
+import { Container } from '@codexo/exojs';
+import type { RenderPlanBuilder } from '@codexo/exojs/rendering';
+
+import type { TileLayer } from './TileLayer';
+import { TileChunkNode } from './TileChunkNode';
+
+/**
+ * Options for a {@link TileLayerNode}. All optional; reserved for forward
+ * compatibility.
+ * @advanced
+ */
+export interface TileLayerNodeOptions {
+  /**
+   * Whether the layer's chunk nodes participate in per-chunk view culling.
+   * Defaults to `true`. Disable only for tiny, always-on-screen layers where
+   * the per-chunk bounds test is pure overhead.
+   */
+  readonly cullable?: boolean;
+}
+
+/**
+ * A scene node that renders one generic {@link TileLayer} as a
+ * {@link Container} of per-chunk {@link TileChunkNode} drawables.
+ *
+ * Each non-empty loaded chunk becomes one child positioned at its pixel
+ * origin, so the engine's existing per-node culling drops individual chunks and
+ * the render-plan optimiser batches them by tileset texture. The layer's pixel
+ * `offset` is applied to this node's transform; `visible` and `opacity` are
+ * read live from the runtime layer on every frame (no rebuild required).
+ *
+ * The node references — but never owns — the {@link TileLayer}: destroying it
+ * frees its chunk nodes and their cached geometry but leaves the layer, map,
+ * and Loader-owned textures intact.
+ *
+ * Structural changes to the layer (tiles written into previously-empty chunks)
+ * are reflected only after {@link TileLayerNode.refresh}; in-place edits to
+ * existing chunks are picked up automatically via chunk revisions.
+ *
+ * @advanced
+ */
+export class TileLayerNode extends Container {
+  private readonly _layer: TileLayer;
+  private readonly _cullChunks: boolean;
+  private readonly _chunkNodes: TileChunkNode[] = [];
+  private _syncedOpacity = -1;
+
+  public constructor(layer: TileLayer, options?: TileLayerNodeOptions) {
+    super();
+
+    this._layer = layer;
+    this._cullChunks = options?.cullable ?? true;
+
+    this.setPosition(layer.offsetX, layer.offsetY);
+    this._buildChunkNodes();
+  }
+
+  /** The runtime layer this node renders. */
+  public get layer(): TileLayer {
+    return this._layer;
+  }
+
+  /**
+   * Rebuild the chunk-node children from the layer's current loaded chunks.
+   * Call after structural mutation that creates or empties chunks. In-place
+   * tile edits to existing chunks do not need a refresh.
+   */
+  public refresh(): this {
+    const previous = [...this._chunkNodes];
+
+    this.removeChildren();
+    this._chunkNodes.length = 0;
+
+    for (const child of previous) {
+      child.destroy();
+    }
+
+    this._syncedOpacity = -1;
+    this._buildChunkNodes();
+
+    return this;
+  }
+
+  /** The chunk render nodes owned by this layer node, in build order. @internal */
+  public get chunkNodes(): readonly TileChunkNode[] {
+    return this._chunkNodes;
+  }
+
+  public override getLocalBounds(): Rectangle {
+    const bounds = super.getLocalBounds();
+
+    bounds.set(0, 0, this._layer.pixelWidth, this._layer.pixelHeight);
+
+    return bounds;
+  }
+
+  /** @internal */
+  protected override _collectContent(builder: RenderPlanBuilder): void {
+    if (!this._layer.visible) {
+      return;
+    }
+
+    this._syncOpacity();
+
+    super._collectContent(builder);
+  }
+
+  public override destroy(): void {
+    const children = [...this._chunkNodes];
+
+    this._chunkNodes.length = 0;
+
+    super.destroy();
+
+    for (const child of children) {
+      child.destroy();
+    }
+  }
+
+  private _buildChunkNodes(): void {
+    const layer = this._layer;
+
+    for (const chunk of layer.loadedChunks()) {
+      if (chunk.empty) {
+        continue;
+      }
+
+      const node = new TileChunkNode(
+        chunk,
+        layer.tilesets,
+        layer.tileWidth,
+        layer.tileHeight,
+        layer.chunkWidth,
+        layer.chunkHeight,
+      );
+
+      node.cullable = this._cullChunks;
+
+      this._chunkNodes.push(node);
+      this.addChild(node);
+    }
+
+    this._syncOpacity();
+  }
+
+  /** Propagate the layer's live opacity onto the chunk tints if it changed. */
+  private _syncOpacity(): void {
+    const opacity = this._layer.opacity;
+
+    if (opacity === this._syncedOpacity) {
+      return;
+    }
+
+    for (const child of this._chunkNodes) {
+      child.tint.a = opacity;
+    }
+
+    this._syncedOpacity = opacity;
+  }
+}

--- a/packages/exojs-tilemap/src/TileMapNode.ts
+++ b/packages/exojs-tilemap/src/TileMapNode.ts
@@ -1,0 +1,115 @@
+import type { Rectangle } from '@codexo/exojs';
+import { Container } from '@codexo/exojs';
+
+import type { TileMap } from './TileMap';
+import { TileLayerNode } from './TileLayerNode';
+
+/**
+ * Options for a {@link TileMapNode}.
+ * @advanced
+ */
+export interface TileMapNodeOptions {
+  /**
+   * Whether the map's chunk nodes participate in per-chunk view culling.
+   * Forwarded to every {@link TileLayerNode}. Defaults to `true`.
+   */
+  readonly cullable?: boolean;
+}
+
+/**
+ * A convenience scene node that renders a whole {@link TileMap} as a
+ * {@link Container} of one {@link TileLayerNode} per tile layer, in map layer
+ * order (back-to-front by document order).
+ *
+ * `TileMapNode` owns **only** its layer nodes — never application actors. Use
+ * it for the simple, non-interleaved case (no actors between layers); for
+ * actor interleaving, place individual `TileLayerNode`s into your own scene
+ * graph instead.
+ *
+ * The node references — but never owns — the {@link TileMap}: destroying the
+ * node frees its layer/chunk nodes and their cached GPU geometry, while the
+ * `TileMap` data and Loader-owned tileset textures survive (free them via
+ * `TileMap.destroy()` / `Loader.destroy()` respectively).
+ *
+ * Layers added to or removed from the map after construction are reflected only
+ * after {@link TileMapNode.refreshLayers}.
+ *
+ * @advanced
+ */
+export class TileMapNode extends Container {
+  private readonly _map: TileMap;
+  private readonly _cullChunks: boolean;
+  private readonly _layerNodes: TileLayerNode[] = [];
+
+  public constructor(map: TileMap, options?: TileMapNodeOptions) {
+    super();
+
+    this._map = map;
+    this._cullChunks = options?.cullable ?? true;
+
+    this._buildLayerNodes();
+  }
+
+  /** The runtime map this node renders. */
+  public get map(): TileMap {
+    return this._map;
+  }
+
+  /** The layer render nodes, in map layer order. */
+  public get layerNodes(): readonly TileLayerNode[] {
+    return this._layerNodes;
+  }
+
+  /** Find the layer node rendering the named layer, or `undefined`. */
+  public getLayerNode(name: string): TileLayerNode | undefined {
+    return this._layerNodes.find(node => node.layer.name === name);
+  }
+
+  /**
+   * Rebuild the layer-node children from the map's current layers. Call after
+   * layers are structurally added to or removed from the map.
+   */
+  public refreshLayers(): this {
+    const previous = [...this._layerNodes];
+
+    this.removeChildren();
+    this._layerNodes.length = 0;
+
+    for (const node of previous) {
+      node.destroy();
+    }
+
+    this._buildLayerNodes();
+
+    return this;
+  }
+
+  public override getLocalBounds(): Rectangle {
+    const bounds = super.getLocalBounds();
+
+    bounds.set(0, 0, this._map.pixelWidth, this._map.pixelHeight);
+
+    return bounds;
+  }
+
+  public override destroy(): void {
+    const layerNodes = [...this._layerNodes];
+
+    this._layerNodes.length = 0;
+
+    super.destroy();
+
+    for (const node of layerNodes) {
+      node.destroy();
+    }
+  }
+
+  private _buildLayerNodes(): void {
+    for (const layer of this._map.layers) {
+      const node = new TileLayerNode(layer, { cullable: this._cullChunks });
+
+      this._layerNodes.push(node);
+      this.addChild(node);
+    }
+  }
+}

--- a/packages/exojs-tilemap/src/chunkGeometry.ts
+++ b/packages/exojs-tilemap/src/chunkGeometry.ts
@@ -1,0 +1,160 @@
+import type { Texture } from '@codexo/exojs';
+
+import type { ReadonlyTileChunk } from './TileChunk';
+import type { TileSet } from './TileSet';
+import type { TileTransform } from './types';
+import { unpackTile } from './types';
+
+/**
+ * One textured tile quad in chunk-local pixel space.
+ *
+ * `u0/v0/u1/v1` are the raw (min/max) source UV bounds of the tile within its
+ * tileset texture — flip/orientation is **not** baked here; it travels in
+ * {@link TileQuad.orient} and is applied by the per-backend renderer (flipX/Y
+ * via UV-corner swap, diagonal via an axis swap in the shader). Keeping the
+ * geometry orientation-neutral lets both backends share one CPU builder.
+ * @internal
+ */
+export interface TileQuad {
+  /** Local destination rect, left/top (chunk-local pixels). */
+  readonly x0: number;
+  readonly y0: number;
+  /** Local destination rect, right/bottom (chunk-local pixels). */
+  readonly x1: number;
+  readonly y1: number;
+  /** Normalised source UV bounds (always min ≤ max). */
+  readonly u0: number;
+  readonly v0: number;
+  readonly u1: number;
+  readonly v1: number;
+  /** Orientation code: bit0 = flipX, bit1 = flipY, bit2 = diagonal. */
+  readonly orient: number;
+}
+
+/**
+ * Geometry for one tileset "page" within a chunk: every tile in the chunk that
+ * draws from a single tileset texture, grouped so the renderer can batch by
+ * `(shader, texture)`.
+ * @internal
+ */
+export interface ChunkPage {
+  /** The tileset all quads in this page draw from. */
+  readonly tileset: TileSet;
+  /** The underlying GPU texture (the tileset's atlas), bound once per page. */
+  readonly texture: Texture;
+  /** The tile quads for this page, in deterministic row-major order. */
+  readonly quads: readonly TileQuad[];
+}
+
+/** Pack a {@link TileTransform} into a 3-bit orientation code. @internal */
+export function orientCode(transform: TileTransform): number {
+  return (transform.flipX ? 1 : 0) | (transform.flipY ? 2 : 0) | (transform.diagonal ? 4 : 0);
+}
+
+/**
+ * Build per-tileset page geometry for a single chunk.
+ *
+ * Iterates the chunk's packed cells in deterministic row-major order, skipping
+ * empties, out-of-range tilesets, and out-of-range local tile ids (all treated
+ * as empty — this is the renderer's half of the G-GID contract). Each surviving
+ * cell is resolved to its source UV rect (from `tileset.getTileRect` + the
+ * tileset `TextureRegion`) and a chunk-local destination rect (bottom-left
+ * aligned per Tiled orthogonal semantics, so tilesets whose tiles are taller
+ * than the map grid extend upward).
+ *
+ * Allocation happens here only — the result is cached on the owning
+ * {@link import('./TileChunkNode').TileChunkNode} keyed by `chunk.revision`, so
+ * unchanged chunks never rebuild and the per-frame path stays allocation-free.
+ *
+ * @param chunk      The readonly chunk view to build from.
+ * @param tilesets   The layer's tileset array (packed `tilesetIndex` selects one).
+ * @param tileWidth  Map/layer tile cell width in pixels.
+ * @param tileHeight Map/layer tile cell height in pixels.
+ * @internal
+ */
+export function buildChunkPages(
+  chunk: ReadonlyTileChunk,
+  tilesets: readonly TileSet[],
+  tileWidth: number,
+  tileHeight: number,
+): ChunkPage[] {
+  if (chunk.empty) {
+    return [];
+  }
+
+  const buckets = new Map<TileSet, TileQuad[]>();
+  const width = chunk.width;
+  const height = chunk.height;
+
+  for (let ly = 0; ly < height; ly++) {
+    for (let lx = 0; lx < width; lx++) {
+      const packed = chunk.getRawAt(lx, ly);
+
+      if (packed === 0) {
+        continue;
+      }
+
+      const decoded = unpackTile(packed);
+
+      if (decoded === null) {
+        continue;
+      }
+
+      const tileset = tilesets[decoded.tilesetIndex];
+
+      // Out-of-range tileset or local id → treat as empty (G-GID). getTileRect
+      // throws on an out-of-range id, so the bounds check must precede it.
+      if (tileset === undefined || decoded.localTileId >= tileset.tileCount) {
+        continue;
+      }
+
+      const region = tileset.texture;
+      const texture = region.texture;
+      const textureWidth = texture.width;
+      const textureHeight = texture.height;
+
+      if (textureWidth <= 0 || textureHeight <= 0) {
+        continue;
+      }
+
+      const rect = tileset.getTileRect(decoded.localTileId);
+
+      // Absolute source pixel rect = tileset-region offset + in-atlas tile rect.
+      const sx = region.x + rect.x;
+      const sy = region.y + rect.y;
+      const u0 = sx / textureWidth;
+      const v0 = sy / textureHeight;
+      const u1 = (sx + rect.width) / textureWidth;
+      const v1 = (sy + rect.height) / textureHeight;
+
+      // Bottom-left aligned destination (Tiled orthogonal). Uniform tiles
+      // (rect.height === tileHeight) collapse to a plain cell rect.
+      const x0 = lx * tileWidth;
+      const y0 = ly * tileHeight + tileHeight - rect.height;
+      const x1 = x0 + rect.width;
+      const y1 = y0 + rect.height;
+
+      let bucket = buckets.get(tileset);
+
+      if (bucket === undefined) {
+        bucket = [];
+        buckets.set(tileset, bucket);
+      }
+
+      bucket.push({ x0, y0, x1, y1, u0, v0, u1, v1, orient: orientCode(decoded.transform) });
+    }
+  }
+
+  // Emit pages in tileset-array order for deterministic, reproducible builds.
+  const pages: ChunkPage[] = [];
+
+  for (const tileset of tilesets) {
+    const quads = buckets.get(tileset);
+
+    if (quads !== undefined && quads.length > 0) {
+      pages.push({ tileset, texture: tileset.texture.texture, quads });
+    }
+  }
+
+  return pages;
+}

--- a/packages/exojs-tilemap/src/public.ts
+++ b/packages/exojs-tilemap/src/public.ts
@@ -12,6 +12,12 @@ export { TileMap } from './TileMap';
 export type { TileMapOptions } from './TileMap';
 export { TileSet } from './TileSet';
 export type { TileSetOptions } from './TileSet';
+// Scene/rendering nodes (advanced). The per-chunk drawable and the
+// per-backend renderers stay package-internal.
+export { TileMapNode } from './TileMapNode';
+export type { TileMapNodeOptions } from './TileMapNode';
+export { TileLayerNode } from './TileLayerNode';
+export type { TileLayerNodeOptions } from './TileLayerNode';
 export type {
   ChunkCoord,
   PackedTile,

--- a/packages/exojs-tilemap/src/tilemapExtension.ts
+++ b/packages/exojs-tilemap/src/tilemapExtension.ts
@@ -1,11 +1,50 @@
-import type { Extension } from '@codexo/exojs/extensions';
+import type { Extension, RendererBinding } from '@codexo/exojs/extensions';
+import type { RenderBackend } from '@codexo/exojs/rendering';
+import { RenderBackendType } from '@codexo/exojs/rendering';
+
+import { TileChunkNode } from './TileChunkNode';
+import { WebGl2TileChunkRenderer } from './webgl2/WebGl2TileChunkRenderer';
+import { WebGpuTileChunkRenderer } from './webgpu/WebGpuTileChunkRenderer';
+
+/** Per-tile instance batch size for the WebGL2 tile chunk renderer. */
+const tileRendererBatchSize = 4096;
+
+/**
+ * Build the renderer binding that wires the per-backend
+ * {@link import('./TileChunkNode').TileChunkNode} renderers. The binding targets
+ * the internal chunk drawable; applications never construct it directly — they
+ * build {@link import('./TileMapNode').TileMapNode} /
+ * {@link import('./TileLayerNode').TileLayerNode}, whose chunk children resolve
+ * to this renderer through the registry prototype walk.
+ */
+function buildTileChunkRendererBinding(batchSize: number): RendererBinding {
+  return {
+    targets: [TileChunkNode],
+    create(backend: RenderBackend) {
+      if (backend.backendType === RenderBackendType.WebGl2) {
+        return new WebGl2TileChunkRenderer(batchSize);
+      }
+
+      if (backend.backendType === RenderBackendType.WebGpu) {
+        return new WebGpuTileChunkRenderer();
+      }
+
+      return undefined;
+    },
+  };
+}
 
 /**
  * Default immutable tilemap extension descriptor.
  *
- * For this slice (B1 — Generic Tilemap Runtime Foundation) the descriptor
- * contains only the package identity. Renderer bindings will be added in a
- * later renderer slice; no placeholder renderer is shipped now.
+ * Registers the WebGL2/WebGPU tile chunk renderers (`renderers`); it carries no
+ * asset bindings — there is no generic on-disk tilemap format in this slice, so
+ * format adapters (e.g. `@codexo/exojs-tiled`) own loading and depend on this
+ * descriptor to pull in rendering.
+ *
+ * Install + register directly for procedural / hand-built maps
+ * (`extensions: [tilemapExtension]` plus a `TileMap` built via the runtime), or
+ * receive it transitively through a format adapter's `dependencies`.
  *
  * Use with `ApplicationOptions.extensions` or call
  * `import '@codexo/exojs-tilemap/register'` for global auto-registration.
@@ -13,4 +52,5 @@ import type { Extension } from '@codexo/exojs/extensions';
  */
 export const tilemapExtension: Extension = Object.freeze({
   id: '@codexo/exojs-tilemap',
+  renderers: [buildTileChunkRendererBinding(tileRendererBatchSize)],
 });

--- a/packages/exojs-tilemap/src/webgl2/WebGl2TileChunkRenderer.ts
+++ b/packages/exojs-tilemap/src/webgl2/WebGl2TileChunkRenderer.ts
@@ -1,0 +1,434 @@
+import type { Texture, View, WebGl2Backend, WebGl2RenderBufferRuntime, WebGl2VertexArrayObjectRuntime } from '@codexo/exojs/rendering';
+import {
+  AbstractWebGl2Renderer,
+  type BlendModes,
+  BufferTypes,
+  BufferUsage,
+  createWebGl2ShaderProgram,
+  RenderingPrimitives,
+  Shader,
+  WebGl2RenderBuffer,
+  WebGl2VertexArrayObject,
+} from '@codexo/exojs/rendering';
+
+import type { TileQuad } from '../chunkGeometry';
+import type { TileChunkNode } from '../TileChunkNode';
+
+// One instance = one tile quad. Layout matches the engine's instanced-quad
+// convention (NineSlice/Repeating): float32x4 local rect, unorm16x4 UV bounds,
+// unorm8x4 tint, uint32 tile word (transform row + diagonal bit).
+const instanceStrideBytes = 32;
+const wordsPerInstance = instanceStrideBytes / Uint32Array.BYTES_PER_ELEMENT;
+const transformTextureUnit = 1;
+
+// Tile word packing: transform-buffer row in the low 29 bits, diagonal flip in
+// bit 29. flipX/flipY are baked into the UV bounds at write time; the shader
+// only needs the diagonal axis swap.
+const TILE_ROW_MASK = 0x1fffffff;
+const TILE_DIAGONAL_BIT = 0x20000000;
+
+const tileVertexSource = `#version 300 es
+precision highp float;
+precision highp int;
+
+// Per-instance attributes (divisor = 1). One entry per tile quad.
+// gl_VertexID 0..3 selects which corner of the quad this invocation computes.
+layout(location = 0) in vec4 a_quadBounds;   // x0, y0, x1, y1 (chunk-local)
+layout(location = 1) in vec4 a_uvBounds;     // uMin, vMin, uMax, vMax (flipX/Y + texture flipY baked)
+layout(location = 2) in vec4 a_color;        // RGBA tint (layer opacity in alpha)
+layout(location = 3) in uint a_tileWord;     // transform row (bits 0..28) | diagonal (bit 29)
+
+uniform mat3 u_projection;
+uniform sampler2D u_transforms;              // shared per-frame transform buffer (2 texels/row)
+
+out vec2 v_texcoord;
+out vec4 v_color;
+
+void main(void) {
+    // gl_VertexID 0..3 -> corner: 0=TL, 1=TR, 2=BL, 3=BR (TRIANGLE_STRIP order)
+    int vid = gl_VertexID;
+    int cornerX = vid & 1;
+    int cornerY = (vid >> 1) & 1;
+
+    float localX = (cornerX == 0) ? a_quadBounds.x : a_quadBounds.z;
+    float localY = (cornerY == 0) ? a_quadBounds.y : a_quadBounds.w;
+
+    int row = int(a_tileWord & ${TILE_ROW_MASK}u);
+    bool diagonal = (a_tileWord & ${TILE_DIAGONAL_BIT}u) != 0u;
+
+    vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0); // a, b, c, d
+    vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0); // tx, ty, 0, 0
+
+    float worldX = (m0.x * localX) + (m0.y * localY) + m1.x;
+    float worldY = (m0.z * localX) + (m0.w * localY) + m1.y;
+
+    gl_Position = vec4((u_projection * vec3(worldX, worldY, 1.0)).xy, 0.0, 1.0);
+
+    // Tile orientation: the diagonal flip transposes the corner-coordinate axes
+    // before the UV corner is selected; flipX/flipY are already baked into the
+    // (uMin,uMax)/(vMin,vMax) ordering by the CPU writer.
+    int su = cornerX;
+    int sv = cornerY;
+    if (diagonal) { int t = su; su = sv; sv = t; }
+
+    float u = (su == 0) ? a_uvBounds.x : a_uvBounds.z;
+    float v = (sv == 0) ? a_uvBounds.y : a_uvBounds.w;
+    v_texcoord = vec2(u, v);
+
+    v_color = vec4(a_color.rgb * a_color.a, a_color.a);
+}`;
+
+const tileFragmentSource = `#version 300 es
+precision highp float;
+
+uniform sampler2D u_texture;
+
+in vec2 v_texcoord;
+in vec4 v_color;
+
+layout(location = 0) out vec4 fragColor;
+
+void main(void) {
+    vec4 sampleColor = texture(u_texture, v_texcoord);
+    fragColor = sampleColor * v_color;
+}`;
+
+interface TileRendererConnection {
+  readonly gl: WebGL2RenderingContext;
+  readonly buffers: Map<WebGl2RenderBuffer, { handle: WebGLBuffer; dataByteLength: number }>;
+  readonly vaoHandle: WebGLVertexArrayObject;
+}
+
+/**
+ * Instanced WebGL2 renderer for {@link TileChunkNode}. Each tile is one
+ * instanced quad; tiles are batched by `(shader, tileset texture)` and one
+ * `drawArraysInstanced` is issued per batch. Per-chunk transforms ride on the
+ * shared transform buffer (one row per chunk node), so the chunk geometry is
+ * orientation-neutral and never re-uploaded for a camera pan.
+ * @internal
+ */
+export class WebGl2TileChunkRenderer extends AbstractWebGl2Renderer<TileChunkNode> {
+  private readonly _shader: Shader;
+  private readonly _batchSize: number;
+  private readonly _instanceData: ArrayBuffer;
+  private readonly _instanceFloat32: Float32Array;
+  private readonly _instanceUint32: Uint32Array;
+
+  private readonly _transformUnitScratch: Int32Array = new Int32Array([transformTextureUnit]);
+
+  private _quadIndex = 0;
+  private _maxNodeIndex = 0;
+  private _currentBlendMode: BlendModes | null = null;
+  private _currentTexture: Texture | null = null;
+  private _currentView: View | null = null;
+  private _currentViewId = -1;
+
+  private _instanceBuffer: WebGl2RenderBuffer | null = null;
+  private _vao: WebGl2VertexArrayObject | null = null;
+  private _connection: TileRendererConnection | null = null;
+
+  public constructor(batchSize: number) {
+    super();
+
+    this._batchSize = batchSize;
+    this._shader = new Shader(tileVertexSource, tileFragmentSource);
+    this._instanceData = new ArrayBuffer(batchSize * instanceStrideBytes);
+    this._instanceFloat32 = new Float32Array(this._instanceData);
+    this._instanceUint32 = new Uint32Array(this._instanceData);
+  }
+
+  public render(node: TileChunkNode): void {
+    const pages = node.pages;
+
+    if (pages.length === 0) {
+      return;
+    }
+
+    const backend = this.getBackend();
+    const blendMode = node.blendMode;
+    const tintRgba = node.tint.toRgba();
+
+    const command = backend.activeDrawCommand;
+    const nodeIndex = command !== null ? command.nodeIndex : backend._pushTransform(node);
+
+    for (const page of pages) {
+      this._renderPage(backend, page.texture, page.quads, blendMode, tintRgba, nodeIndex);
+    }
+  }
+
+  private _renderPage(
+    backend: WebGl2Backend,
+    texture: Texture,
+    quads: readonly TileQuad[],
+    blendMode: BlendModes,
+    tintRgba: number,
+    nodeIndex: number,
+  ): void {
+    if (quads.length === 0) {
+      return;
+    }
+
+    const textureChanged = this._currentTexture !== null && texture !== this._currentTexture;
+    const blendModeChanged = blendMode !== this._currentBlendMode;
+
+    if (this._quadIndex > 0 && (blendModeChanged || textureChanged || this._quadIndex + quads.length > this._batchSize)) {
+      this.flush();
+    }
+
+    if (this._currentBlendMode === null || this._currentBlendMode !== blendMode) {
+      this._currentBlendMode = blendMode;
+      backend.setBlendMode(blendMode);
+    }
+
+    if (this._currentTexture !== texture) {
+      this._currentTexture = texture;
+      backend.bindTexture(texture, 0);
+    }
+
+    const flipY = texture.flipY;
+
+    // A chunk page may hold more tiles than the fixed batch buffer; write in
+    // batch-sized runs, flushing (and re-establishing state) between runs.
+    let offset = 0;
+
+    while (offset < quads.length) {
+      const remaining = quads.length - offset;
+      const runSize = Math.min(remaining, this._batchSize);
+
+      this._writeRun(quads, offset, runSize, flipY, tintRgba, nodeIndex);
+
+      offset += runSize;
+
+      if (offset < quads.length) {
+        this.flush();
+        this._currentBlendMode = blendMode;
+        backend.setBlendMode(blendMode);
+        this._currentTexture = texture;
+        backend.bindTexture(texture, 0);
+      }
+    }
+  }
+
+  private _writeRun(
+    quads: readonly TileQuad[],
+    offset: number,
+    count: number,
+    flipY: boolean,
+    tintRgba: number,
+    nodeIndex: number,
+  ): void {
+    const f32 = this._instanceFloat32;
+    const u32 = this._instanceUint32;
+    const baseWord = nodeIndex & TILE_ROW_MASK;
+
+    for (let i = 0; i < count; i++) {
+      const q = quads[offset + i];
+      const idx = this._quadIndex * wordsPerInstance;
+
+      f32[idx + 0] = q.x0;
+      f32[idx + 1] = q.y0;
+      f32[idx + 2] = q.x1;
+      f32[idx + 3] = q.y1;
+
+      // Bake flipX/flipY into the UV corner ordering; the diagonal axis swap is
+      // resolved in the shader. Texture flipY (uploaded-flipped atlases) is an
+      // additional vertical swap that composes with the tile flipY.
+      const flipX = (q.orient & 1) !== 0;
+      const tileFlipY = (q.orient & 2) !== 0;
+      const diagonal = (q.orient & 4) !== 0;
+
+      const uA = flipX ? q.u1 : q.u0;
+      const uB = flipX ? q.u0 : q.u1;
+      let vA = tileFlipY ? q.v1 : q.v0;
+      let vB = tileFlipY ? q.v0 : q.v1;
+
+      if (flipY) {
+        const swap = vA;
+        vA = vB;
+        vB = swap;
+      }
+
+      const uMin = (uA * 0xffff) & 0xffff;
+      const vMin = (vA * 0xffff) & 0xffff;
+      const uMax = (uB * 0xffff) & 0xffff;
+      const vMax = (vB * 0xffff) & 0xffff;
+
+      u32[idx + 4] = uMin | (vMin << 16);
+      u32[idx + 5] = uMax | (vMax << 16);
+      u32[idx + 6] = tintRgba;
+      u32[idx + 7] = (diagonal ? baseWord | TILE_DIAGONAL_BIT : baseWord) >>> 0;
+
+      this._quadIndex++;
+    }
+
+    if (nodeIndex > this._maxNodeIndex) {
+      this._maxNodeIndex = nodeIndex;
+    }
+  }
+
+  public flush(): void {
+    const backend = this.getBackendOrNull();
+    const instanceBuffer = this._instanceBuffer;
+    const vao = this._vao;
+
+    if (this._quadIndex === 0 || backend === null || instanceBuffer === null || vao === null) {
+      this._quadIndex = 0;
+      this._maxNodeIndex = 0;
+      return;
+    }
+
+    const view = backend.view;
+
+    if (this._currentView !== view || this._currentViewId !== view.updateId) {
+      this._currentView = view;
+      this._currentViewId = view.updateId;
+      this._shader.getUniform('u_projection').setValue(view.getTransform().toArray(false));
+    }
+
+    if (this._currentTexture !== null) {
+      this._shader.getUniform('u_texture').setValue(new Int32Array([0]));
+    }
+
+    backend.bindTransformBufferTexture(transformTextureUnit, this._maxNodeIndex + 1);
+    this._shader.getUniform('u_transforms').setValue(this._transformUnitScratch);
+
+    this._shader.sync();
+    backend.bindVertexArrayObject(vao);
+    instanceBuffer.upload(this._instanceFloat32.subarray(0, this._quadIndex * wordsPerInstance));
+    vao.drawInstanced(4, 0, this._quadIndex, RenderingPrimitives.TriangleStrip);
+    backend.stats.batches++;
+    backend.stats.drawCalls++;
+
+    this._quadIndex = 0;
+    this._maxNodeIndex = 0;
+  }
+
+  protected onConnect(backend: WebGl2Backend): void {
+    const gl = backend.context;
+
+    this._shader.connect(createWebGl2ShaderProgram(gl));
+    this._connection = this._createConnection(gl);
+    this._instanceBuffer = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, this._instanceData, BufferUsage.DynamicDraw).connect(
+      this._createBufferRuntime(this._connection),
+    );
+    this._shader.sync();
+
+    this._vao = new WebGl2VertexArrayObject(RenderingPrimitives.TriangleStrip)
+      .addAttribute(this._instanceBuffer, this._shader.getAttribute('a_quadBounds'), gl.FLOAT, false, instanceStrideBytes, 0, false, 1)
+      .addAttribute(this._instanceBuffer, this._shader.getAttribute('a_uvBounds'), gl.UNSIGNED_SHORT, true, instanceStrideBytes, 16, false, 1)
+      .addAttribute(this._instanceBuffer, this._shader.getAttribute('a_color'), gl.UNSIGNED_BYTE, true, instanceStrideBytes, 24, false, 1)
+      .addAttribute(this._instanceBuffer, this._shader.getAttribute('a_tileWord'), gl.UNSIGNED_INT, false, instanceStrideBytes, 28, true, 1)
+      .connect(this._createVaoRuntime(this._connection));
+  }
+
+  protected onDisconnect(): void {
+    this._shader.disconnect();
+    this._instanceBuffer?.destroy();
+    this._instanceBuffer = null;
+    this._vao?.destroy();
+    this._vao = null;
+    this._connection = null;
+    this._currentBlendMode = null;
+    this._currentTexture = null;
+    this._currentView = null;
+    this._currentViewId = -1;
+    this._quadIndex = 0;
+    this._maxNodeIndex = 0;
+  }
+
+  public destroy(): void {
+    this.disconnect();
+    this._shader.destroy();
+  }
+
+  private _createConnection(gl: WebGL2RenderingContext): TileRendererConnection {
+    const vaoHandle = gl.createVertexArray();
+
+    if (vaoHandle === null) {
+      throw new Error('WebGl2TileChunkRenderer: could not create vertex array object.');
+    }
+
+    return { gl, buffers: new Map(), vaoHandle };
+  }
+
+  private _createBufferRuntime(connection: TileRendererConnection): WebGl2RenderBufferRuntime {
+    const handle = connection.gl.createBuffer();
+
+    if (handle === null) {
+      throw new Error('WebGl2TileChunkRenderer: could not create render buffer.');
+    }
+
+    return {
+      bind: (buffer): void => {
+        connection.gl.bindBuffer(buffer.type, handle);
+      },
+      upload: (buffer, offset): void => {
+        const gl = connection.gl;
+        const data = buffer.data;
+        const state = connection.buffers.get(buffer);
+
+        gl.bindBuffer(buffer.type, handle);
+
+        if (state && state.dataByteLength >= data.byteLength) {
+          gl.bufferSubData(buffer.type, offset, data);
+          state.dataByteLength = data.byteLength;
+        } else {
+          gl.bufferData(buffer.type, data, buffer.usage);
+          connection.buffers.set(buffer, { handle, dataByteLength: data.byteLength });
+        }
+      },
+      destroy: (buffer): void => {
+        connection.gl.deleteBuffer(handle);
+        connection.buffers.delete(buffer);
+        buffer.disconnect();
+      },
+    };
+  }
+
+  private _createVaoRuntime(connection: TileRendererConnection): WebGl2VertexArrayObjectRuntime {
+    let appliedVersion = -1;
+
+    return {
+      bind: (vao): void => {
+        const gl = connection.gl;
+
+        gl.bindVertexArray(connection.vaoHandle);
+
+        if (appliedVersion !== vao.version) {
+          let lastBuffer: WebGl2RenderBuffer | null = null;
+
+          for (const attribute of vao.attributes) {
+            if (lastBuffer !== attribute.buffer) {
+              attribute.buffer.bind();
+              lastBuffer = attribute.buffer;
+            }
+
+            if (attribute.integer) {
+              gl.vertexAttribIPointer(attribute.location, attribute.size, attribute.type, attribute.stride, attribute.start);
+            } else {
+              gl.vertexAttribPointer(attribute.location, attribute.size, attribute.type, attribute.normalized, attribute.stride, attribute.start);
+            }
+
+            gl.enableVertexAttribArray(attribute.location);
+            gl.vertexAttribDivisor(attribute.location, attribute.divisor);
+          }
+
+          appliedVersion = vao.version;
+        }
+      },
+      unbind: (): void => {
+        connection.gl.bindVertexArray(null);
+      },
+      draw: (_vao, size, start, type): void => {
+        connection.gl.drawArrays(type, start, size);
+      },
+      drawInstanced: (_vao, count, start, instanceCount, type): void => {
+        connection.gl.drawArraysInstanced(type, start, count, instanceCount);
+      },
+      destroy: (vao): void => {
+        connection.gl.deleteVertexArray(connection.vaoHandle);
+        vao.disconnect();
+      },
+    };
+  }
+}

--- a/packages/exojs-tilemap/src/webgpu/WebGpuTileChunkRenderer.ts
+++ b/packages/exojs-tilemap/src/webgpu/WebGpuTileChunkRenderer.ts
@@ -1,0 +1,472 @@
+/// <reference types="@webgpu/types" />
+
+import type { BlendModes, WebGpuBackend } from '@codexo/exojs/rendering';
+import { AbstractWebGpuRenderer, getWebGpuBlendState, stencilContentDepthStencilState, Texture } from '@codexo/exojs/rendering';
+
+import type { TileQuad } from '../chunkGeometry';
+import type { TileChunkNode } from '../TileChunkNode';
+
+const instanceStrideBytes = 32;
+const wordsPerInstance = instanceStrideBytes / Uint32Array.BYTES_PER_ELEMENT; // = 8
+const projectionByteLength = 64;
+const initialBatchCapacity = 256;
+const indicesPerInstance = 6;
+const quadIndices = new Uint16Array([0, 1, 2, 0, 2, 3]);
+
+const TILE_ROW_MASK = 0x1fffffff;
+const TILE_DIAGONAL_BIT = 0x20000000;
+
+const tileShaderSource = `
+struct ProjectionUniforms {
+    matrix: mat4x4<f32>,
+};
+
+struct TransformSlot {
+    m0: vec4<f32>,
+    m1: vec4<f32>,
+    m2: vec4<f32>,
+};
+
+@group(0) @binding(0)
+var<uniform> projection: ProjectionUniforms;
+@group(0) @binding(1)
+var<storage, read> transforms: array<TransformSlot>;
+
+@group(1) @binding(0)
+var tileTexture: texture_2d<f32>;
+@group(1) @binding(1)
+var tileSampler: sampler;
+
+struct VertexInput {
+    @location(0) quadBounds: vec4<f32>,   // x0, y0, x1, y1
+    @location(1) uvBounds: vec4<f32>,     // uMin, vMin, uMax, vMax (flipX/Y + texture flipY baked)
+    @location(2) color: vec4<f32>,        // RGBA tint (layer opacity in alpha)
+    @location(3) tileWord: u32,           // transform row (bits 0..28) | diagonal (bit 29)
+};
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) texcoord: vec2<f32>,
+    @location(1) color: vec4<f32>,
+};
+
+@vertex
+fn vertexMain(input: VertexInput, @builtin(vertex_index) vid: u32) -> VertexOutput {
+    var output: VertexOutput;
+
+    // vid 0..3 → TL, TR, BR, BL (matches static index buffer [0,1,2,0,2,3])
+    let cornerX = ((vid + 1u) >> 1u) & 1u;
+    let cornerY = vid >> 1u;
+
+    let localX = select(input.quadBounds.x, input.quadBounds.z, cornerX == 1u);
+    let localY = select(input.quadBounds.y, input.quadBounds.w, cornerY == 1u);
+
+    let row = input.tileWord & ${TILE_ROW_MASK}u;
+    let diagonal = (input.tileWord & ${TILE_DIAGONAL_BIT}u) != 0u;
+
+    let slot = transforms[row];
+    let worldX = slot.m0.x * localX + slot.m0.y * localY + slot.m1.x;
+    let worldY = slot.m0.z * localX + slot.m0.w * localY + slot.m1.y;
+
+    output.position = projection.matrix * vec4<f32>(worldX, worldY, 0.0, 1.0);
+
+    // Tile orientation: diagonal transposes the corner-coordinate axes; flipX/Y
+    // are baked into the UV corner ordering by the CPU writer.
+    var su = cornerX;
+    var sv = cornerY;
+    if (diagonal) {
+        let t = su;
+        su = sv;
+        sv = t;
+    }
+
+    let u = select(input.uvBounds.x, input.uvBounds.z, su == 1u);
+    let v = select(input.uvBounds.y, input.uvBounds.w, sv == 1u);
+    output.texcoord = vec2<f32>(u, v);
+
+    output.color = vec4(input.color.rgb * input.color.a, input.color.a);
+
+    return output;
+}
+
+@fragment
+fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+    let sample = textureSample(tileTexture, tileSampler, input.texcoord);
+    return sample * input.color;
+}
+`;
+
+/**
+ * Instanced WebGPU renderer for {@link TileChunkNode}, the parity counterpart of
+ * the WebGL2 renderer. Same instance layout and orientation handling; per-chunk
+ * transforms ride on the backend's shared transform storage buffer, and the
+ * instance buffer grows on demand rather than flushing in fixed runs.
+ * @internal
+ */
+export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNode> {
+  private readonly _projectionData = new Float32Array(projectionByteLength / Float32Array.BYTES_PER_ELEMENT);
+
+  private _device: GPUDevice | null = null;
+  private _shaderModule: GPUShaderModule | null = null;
+  private _uniformBindGroupLayout: GPUBindGroupLayout | null = null;
+  private _textureBindGroupLayout: GPUBindGroupLayout | null = null;
+  private _pipelineLayout: GPUPipelineLayout | null = null;
+  private _uniformBuffer: GPUBuffer | null = null;
+  private _transformBindGroup: GPUBindGroup | null = null;
+  private _transformStorageBuffer: GPUBuffer | null = null;
+  private _indexBuffer: GPUBuffer | null = null;
+  private _instanceBuffer: GPUBuffer | null = null;
+  private _instanceCapacity = 0;
+  private _instanceData: ArrayBuffer = new ArrayBuffer(0);
+  private _instanceFloat32 = new Float32Array(this._instanceData);
+  private _instanceUint32 = new Uint32Array(this._instanceData);
+  private readonly _pipelines = new Map<string, GPURenderPipeline>();
+
+  private _quadIndex = 0;
+  private _maxNodeIndex = 0;
+  private _currentBlendMode: BlendModes | null = null;
+  private _currentTexture: Texture | null = null;
+
+  protected onConnect(backend: WebGpuBackend): void {
+    if (this._device) {
+      return;
+    }
+
+    this._device = backend.device;
+    this._shaderModule = this._device.createShaderModule({ code: tileShaderSource });
+
+    this._uniformBindGroupLayout = this._device.createBindGroupLayout({
+      entries: [
+        { binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform' } },
+        { binding: 1, visibility: GPUShaderStage.VERTEX, buffer: { type: 'read-only-storage' } },
+      ],
+    });
+
+    this._textureBindGroupLayout = this._device.createBindGroupLayout({
+      entries: [
+        { binding: 0, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } },
+        { binding: 1, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' } },
+      ],
+    });
+
+    this._pipelineLayout = this._device.createPipelineLayout({
+      bindGroupLayouts: [this._uniformBindGroupLayout, this._textureBindGroupLayout],
+    });
+
+    this._uniformBuffer = this._device.createBuffer({
+      size: projectionByteLength,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+
+    this._indexBuffer = this._device.createBuffer({
+      size: quadIndices.byteLength,
+      usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
+    });
+    this._device.queue.writeBuffer(this._indexBuffer, 0, quadIndices.buffer, quadIndices.byteOffset, quadIndices.byteLength);
+  }
+
+  protected onDisconnect(): void {
+    this._instanceBuffer?.destroy();
+    this._indexBuffer?.destroy();
+    this._uniformBuffer?.destroy();
+    this._pipelines.clear();
+    this._instanceBuffer = null;
+    this._indexBuffer = null;
+    this._transformBindGroup = null;
+    this._transformStorageBuffer = null;
+    this._uniformBuffer = null;
+    this._pipelineLayout = null;
+    this._textureBindGroupLayout = null;
+    this._uniformBindGroupLayout = null;
+    this._shaderModule = null;
+    this._device = null;
+    this._backend = null;
+    this._instanceCapacity = 0;
+    this._instanceData = new ArrayBuffer(0);
+    this._instanceFloat32 = new Float32Array(this._instanceData);
+    this._instanceUint32 = new Uint32Array(this._instanceData);
+    this._quadIndex = 0;
+    this._maxNodeIndex = 0;
+    this._currentBlendMode = null;
+    this._currentTexture = null;
+  }
+
+  public render(node: TileChunkNode): void {
+    const backend = this._backend;
+
+    if (backend === null) {
+      return;
+    }
+
+    const pages = node.pages;
+
+    if (pages.length === 0) {
+      return;
+    }
+
+    const blendMode = node.blendMode;
+    const tintRgba = node.tint.toRgba();
+
+    const command = backend.activeDrawCommand;
+    const nodeIndex = command !== null ? command.nodeIndex : backend._pushTransform(node);
+
+    for (const page of pages) {
+      this._renderPage(backend, page.texture, page.quads, blendMode, tintRgba, nodeIndex);
+    }
+  }
+
+  private _renderPage(
+    backend: WebGpuBackend,
+    texture: Texture,
+    quads: readonly TileQuad[],
+    blendMode: BlendModes,
+    tintRgba: number,
+    nodeIndex: number,
+  ): void {
+    if (quads.length === 0) {
+      return;
+    }
+
+    if (texture.width === 0 || texture.height === 0) {
+      return;
+    }
+
+    if (texture instanceof Texture && texture.source === null) {
+      return;
+    }
+
+    const blendModeChanged = this._currentBlendMode !== null && blendMode !== this._currentBlendMode;
+    const textureChanged = this._currentTexture !== null && texture !== this._currentTexture;
+    const willExceed = this._quadIndex + quads.length > this._instanceCapacity && this._instanceCapacity > 0;
+
+    if ((blendModeChanged || textureChanged || willExceed) && this._quadIndex > 0) {
+      this.flush();
+    }
+
+    this._currentBlendMode = blendMode;
+    this._currentTexture = texture;
+    backend.setBlendMode(blendMode);
+
+    this._ensureInstanceCapacity(this._quadIndex + quads.length);
+
+    const f32 = this._instanceFloat32;
+    const u32 = this._instanceUint32;
+    const flipYTexture = texture.flipY;
+    const baseWord = nodeIndex & TILE_ROW_MASK;
+
+    for (const q of quads) {
+      const idx = this._quadIndex * wordsPerInstance;
+
+      f32[idx + 0] = q.x0;
+      f32[idx + 1] = q.y0;
+      f32[idx + 2] = q.x1;
+      f32[idx + 3] = q.y1;
+
+      const flipX = (q.orient & 1) !== 0;
+      const tileFlipY = (q.orient & 2) !== 0;
+      const diagonal = (q.orient & 4) !== 0;
+
+      const uA = flipX ? q.u1 : q.u0;
+      const uB = flipX ? q.u0 : q.u1;
+      let vA = tileFlipY ? q.v1 : q.v0;
+      let vB = tileFlipY ? q.v0 : q.v1;
+
+      if (flipYTexture) {
+        const swap = vA;
+        vA = vB;
+        vB = swap;
+      }
+
+      const uMin = (uA * 0xffff) & 0xffff;
+      const vMin = (vA * 0xffff) & 0xffff;
+      const uMax = (uB * 0xffff) & 0xffff;
+      const vMax = (vB * 0xffff) & 0xffff;
+
+      u32[idx + 4] = uMin | (vMin << 16);
+      u32[idx + 5] = uMax | (vMax << 16);
+      u32[idx + 6] = tintRgba;
+      u32[idx + 7] = (diagonal ? baseWord | TILE_DIAGONAL_BIT : baseWord) >>> 0;
+
+      this._quadIndex++;
+    }
+
+    if (nodeIndex > this._maxNodeIndex) {
+      this._maxNodeIndex = nodeIndex;
+    }
+  }
+
+  public flush(): void {
+    const backend = this._backend;
+    const device = this._device;
+    const uniformBuffer = this._uniformBuffer;
+
+    if (!backend || !device || !uniformBuffer) {
+      return;
+    }
+
+    if (this._quadIndex === 0 && !backend.clearRequested) {
+      return;
+    }
+
+    const viewMatrix = backend.view.getTransform();
+
+    this._projectionData.set([viewMatrix.a, viewMatrix.c, 0, 0, viewMatrix.b, viewMatrix.d, 0, 0, 0, 0, 1, 0, viewMatrix.x, viewMatrix.y, 0, viewMatrix.z]);
+    device.queue.writeBuffer(uniformBuffer, 0, this._projectionData.buffer, this._projectionData.byteOffset, this._projectionData.byteLength);
+
+    const scissor = backend.getScissorRect();
+    const maskClipsAll = scissor !== null && (scissor.width <= 0 || scissor.height <= 0);
+
+    const pass = backend._passCoordinator.acquirePass().pass;
+
+    if (this._quadIndex > 0 && !maskClipsAll && this._instanceBuffer !== null && this._indexBuffer !== null && this._currentBlendMode !== null && this._currentTexture !== null) {
+      device.queue.writeBuffer(this._instanceBuffer, 0, this._instanceData, 0, this._quadIndex * instanceStrideBytes);
+
+      const storage = backend.getTransformStorageBuffer(this._maxNodeIndex + 1);
+      const transformBindGroup = this._getOrCreateTransformBindGroup(device, uniformBuffer, storage.buffer);
+      const textureBindGroup = this._createTextureBindGroup(device, backend, this._currentTexture);
+
+      const stencil = backend._passCoordinator.stencilActive;
+      const pipeline = this._getPipeline(this._currentBlendMode, backend.renderTargetFormat, stencil);
+
+      pass.setPipeline(pipeline);
+      pass.setBindGroup(0, transformBindGroup);
+      pass.setBindGroup(1, textureBindGroup);
+      pass.setVertexBuffer(0, this._instanceBuffer);
+      pass.setIndexBuffer(this._indexBuffer, 'uint16');
+      pass.drawIndexed(indicesPerInstance, this._quadIndex, 0, 0, 0);
+
+      backend.stats.batches++;
+      backend.stats.drawCalls++;
+    }
+
+    backend._passCoordinator.endPass();
+
+    this._quadIndex = 0;
+    this._maxNodeIndex = 0;
+    this._currentBlendMode = null;
+    this._currentTexture = null;
+  }
+
+  public destroy(): void {
+    this.disconnect();
+  }
+
+  private _getOrCreateTransformBindGroup(device: GPUDevice, uniformBuffer: GPUBuffer, storageBuffer: GPUBuffer): GPUBindGroup {
+    if (this._transformBindGroup !== null && this._transformStorageBuffer === storageBuffer) {
+      return this._transformBindGroup;
+    }
+
+    this._transformStorageBuffer = storageBuffer;
+    this._transformBindGroup = device.createBindGroup({
+      layout: this._uniformBindGroupLayout!,
+      entries: [
+        { binding: 0, resource: { buffer: uniformBuffer } },
+        { binding: 1, resource: { buffer: storageBuffer } },
+      ],
+    });
+
+    return this._transformBindGroup;
+  }
+
+  private _createTextureBindGroup(device: GPUDevice, backend: WebGpuBackend, texture: Texture): GPUBindGroup {
+    const binding = backend.getTextureBinding(texture);
+
+    return device.createBindGroup({
+      layout: this._textureBindGroupLayout!,
+      entries: [
+        { binding: 0, resource: binding.view },
+        { binding: 1, resource: binding.sampler },
+      ],
+    });
+  }
+
+  private _getPipeline(blendMode: BlendModes, format: GPUTextureFormat, stencil: boolean): GPURenderPipeline {
+    const key = `${blendMode}:${format}:${stencil ? 's' : 'n'}`;
+    const existing = this._pipelines.get(key);
+
+    if (existing) {
+      return existing;
+    }
+
+    if (!this._device || !this._shaderModule || !this._pipelineLayout) {
+      throw new Error('WebGpuTileChunkRenderer: renderer must be connected first.');
+    }
+
+    const descriptor: GPURenderPipelineDescriptor = {
+      layout: this._pipelineLayout,
+      vertex: {
+        module: this._shaderModule,
+        entryPoint: 'vertexMain',
+        buffers: [
+          {
+            arrayStride: instanceStrideBytes,
+            stepMode: 'instance',
+            attributes: [
+              { shaderLocation: 0, offset: 0, format: 'float32x4' },
+              { shaderLocation: 1, offset: 16, format: 'unorm16x4' },
+              { shaderLocation: 2, offset: 24, format: 'unorm8x4' },
+              { shaderLocation: 3, offset: 28, format: 'uint32' },
+            ],
+          },
+        ],
+      },
+      fragment: {
+        module: this._shaderModule,
+        entryPoint: 'fragmentMain',
+        targets: [
+          {
+            format,
+            blend: getWebGpuBlendState(blendMode),
+            writeMask: GPUColorWrite.ALL,
+          },
+        ],
+      },
+      primitive: {
+        topology: 'triangle-list',
+      },
+    };
+
+    if (stencil) {
+      descriptor.depthStencil = stencilContentDepthStencilState();
+    }
+
+    const pipeline = this._device.createRenderPipeline(descriptor);
+
+    this._pipelines.set(key, pipeline);
+
+    return pipeline;
+  }
+
+  private _ensureInstanceCapacity(instanceCount: number): void {
+    if (!this._device || instanceCount <= this._instanceCapacity) {
+      return;
+    }
+
+    let nextCapacity = Math.max(this._instanceCapacity, initialBatchCapacity);
+
+    while (nextCapacity < instanceCount) {
+      nextCapacity *= 2;
+    }
+
+    const oldData = this._instanceData;
+    const carryBytes = Math.min(this._quadIndex * instanceStrideBytes, oldData.byteLength);
+    const instanceData = new ArrayBuffer(nextCapacity * instanceStrideBytes);
+
+    if (carryBytes > 0) {
+      new Uint8Array(instanceData).set(new Uint8Array(oldData, 0, carryBytes));
+    }
+
+    const instanceBuffer = this._device.createBuffer({
+      size: instanceData.byteLength,
+      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+    });
+
+    this._instanceBuffer?.destroy();
+
+    this._instanceCapacity = nextCapacity;
+    this._instanceData = instanceData;
+    this._instanceFloat32 = new Float32Array(instanceData);
+    this._instanceUint32 = new Uint32Array(instanceData);
+    this._instanceBuffer = instanceBuffer;
+  }
+}

--- a/packages/exojs-tilemap/test/chunkGeometry.test.ts
+++ b/packages/exojs-tilemap/test/chunkGeometry.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest';
+
+import { TextureRegion } from '@codexo/exojs';
+import { Texture } from '@codexo/exojs';
+
+import { buildChunkPages, orientCode } from '../src/chunkGeometry';
+import { TileLayer } from '../src/TileLayer';
+import { TileSet } from '../src/TileSet';
+import type { ReadonlyTileChunk } from '../src/TileChunk';
+import { packTile, TILE_TRANSFORM_IDENTITY } from '../src/types';
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+function fakeTexture(width = 512, height = 512): Texture {
+  return {
+    width,
+    height,
+    flipY: false,
+    uid: 0,
+    label: 'test',
+    destroy: () => {},
+    destroyed: false,
+  } as unknown as Texture;
+}
+
+function makeTileset(name = 'tiles', tileCount = 16, tw = 32, th = 32, texW = 512, texH = 512): TileSet {
+  return new TileSet({
+    name,
+    texture: new TextureRegion(fakeTexture(texW, texH), { x: 0, y: 0, width: texW, height: texH }),
+    tileWidth: tw,
+    tileHeight: th,
+    tileCount,
+  });
+}
+
+function makeLayer(tilesets: TileSet[], width = 4, height = 4): TileLayer {
+  return new TileLayer({
+    id: 1,
+    name: 'ground',
+    width,
+    height,
+    tileWidth: 32,
+    tileHeight: 32,
+    tilesets,
+  });
+}
+
+/** Minimal fixed-content chunk stub for the defensive out-of-range paths. */
+function stubChunk(raw: number): ReadonlyTileChunk {
+  return {
+    cx: 0,
+    cy: 0,
+    width: 1,
+    height: 1,
+    empty: false,
+    revision: 1,
+    getRawAt: () => raw,
+    cloneTiles: () => new Uint32Array([raw]),
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('orientCode', () => {
+  it('maps the 8 transform combinations to 0..7', () => {
+    expect(orientCode({ flipX: false, flipY: false, diagonal: false })).toBe(0);
+    expect(orientCode({ flipX: true, flipY: false, diagonal: false })).toBe(1);
+    expect(orientCode({ flipX: false, flipY: true, diagonal: false })).toBe(2);
+    expect(orientCode({ flipX: true, flipY: true, diagonal: false })).toBe(3);
+    expect(orientCode({ flipX: false, flipY: false, diagonal: true })).toBe(4);
+    expect(orientCode({ flipX: true, flipY: true, diagonal: true })).toBe(7);
+  });
+});
+
+describe('buildChunkPages', () => {
+  it('returns no pages for an empty chunk', () => {
+    const tileset = makeTileset();
+    const layer = makeLayer([tileset]);
+    // No tiles set → the chunk never materialises.
+    const chunk = layer.getChunk(0, 0);
+    expect(chunk).toBeUndefined();
+  });
+
+  it('builds one page with one quad and correct UVs for a single tile', () => {
+    const tileset = makeTileset('tiles', 16, 32, 32, 512, 512);
+    const layer = makeLayer([tileset]);
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+
+    const chunk = layer.getChunk(0, 0)!;
+    const pages = buildChunkPages(chunk, [tileset], 32, 32);
+
+    expect(pages).toHaveLength(1);
+    expect(pages[0].tileset).toBe(tileset);
+    expect(pages[0].quads).toHaveLength(1);
+
+    const quad = pages[0].quads[0];
+    // Tile 0 of a 32px grid in a 512px texture → [0, 0]..[0.0625, 0.0625].
+    expect(quad.u0).toBeCloseTo(0, 6);
+    expect(quad.v0).toBeCloseTo(0, 6);
+    expect(quad.u1).toBeCloseTo(32 / 512, 6);
+    expect(quad.v1).toBeCloseTo(32 / 512, 6);
+    // Destination rect is the chunk-local cell.
+    expect(quad.x0).toBe(0);
+    expect(quad.y0).toBe(0);
+    expect(quad.x1).toBe(32);
+    expect(quad.y1).toBe(32);
+    expect(quad.orient).toBe(0);
+  });
+
+  it('uses the second column UVs for local tile id 1', () => {
+    const tileset = makeTileset('tiles', 16, 32, 32, 512, 512);
+    const layer = makeLayer([tileset]);
+    layer.setTileAt(1, 0, { tileset, localTileId: 1, transform: TILE_TRANSFORM_IDENTITY });
+
+    const pages = buildChunkPages(layer.getChunk(0, 0)!, [tileset], 32, 32);
+    const quad = pages[0].quads[0];
+
+    expect(quad.u0).toBeCloseTo(32 / 512, 6);
+    expect(quad.u1).toBeCloseTo(64 / 512, 6);
+    // Cell (1,0) → local x starts at 32.
+    expect(quad.x0).toBe(32);
+    expect(quad.x1).toBe(64);
+  });
+
+  it('carries the per-tile orientation code through to the quad', () => {
+    const tileset = makeTileset();
+    const layer = makeLayer([tileset]);
+    layer.setTileAt(0, 0, { tileset, localTileId: 2, transform: { flipX: true, flipY: false, diagonal: true } });
+
+    const pages = buildChunkPages(layer.getChunk(0, 0)!, [tileset], 32, 32);
+
+    expect(pages[0].quads[0].orient).toBe(orientCode({ flipX: true, flipY: false, diagonal: true }));
+  });
+
+  it('bottom-left aligns tiles taller than the map cell', () => {
+    // 32×48 tiles drawn on a 32px grid extend 16px upward.
+    const tileset = makeTileset('tall', 8, 32, 48, 256, 256);
+    const layer = makeLayer([tileset]);
+    layer.setTileAt(0, 1, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+
+    const pages = buildChunkPages(layer.getChunk(0, 0)!, [tileset], 32, 32);
+    const quad = pages[0].quads[0];
+
+    // Cell (0,1): bottom edge at y = 2*32 = 64; a 48px tile starts at 64-48 = 16.
+    expect(quad.y1).toBe(64);
+    expect(quad.y0).toBe(16);
+    expect(quad.x0).toBe(0);
+    expect(quad.x1).toBe(32);
+  });
+
+  it('groups tiles by tileset in tileset-array order (multiple tilesets)', () => {
+    const tsA = makeTileset('a', 16, 32, 32, 512, 512);
+    const tsB = makeTileset('b', 16, 32, 32, 512, 512);
+    const layer = makeLayer([tsA, tsB]);
+    // Interleave: A, B, A across the row.
+    layer.setTileAt(0, 0, { tileset: tsA, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+    layer.setTileAt(1, 0, { tileset: tsB, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+    layer.setTileAt(2, 0, { tileset: tsA, localTileId: 1, transform: TILE_TRANSFORM_IDENTITY });
+
+    const pages = buildChunkPages(layer.getChunk(0, 0)!, [tsA, tsB], 32, 32);
+
+    expect(pages).toHaveLength(2);
+    expect(pages[0].tileset).toBe(tsA);
+    expect(pages[0].quads).toHaveLength(2);
+    expect(pages[1].tileset).toBe(tsB);
+    expect(pages[1].quads).toHaveLength(1);
+  });
+
+  it('skips cells whose packed tileset index is out of range (treated as empty)', () => {
+    const tileset = makeTileset();
+    // tilesetIndex 5, but only one tileset is available.
+    const pages = buildChunkPages(stubChunk(packTile(5, 0, TILE_TRANSFORM_IDENTITY)), [tileset], 32, 32);
+    expect(pages).toHaveLength(0);
+  });
+
+  it('skips cells whose local tile id is out of range (treated as empty)', () => {
+    const tileset = makeTileset('tiles', 16);
+    // localTileId 20 exceeds tileCount 16.
+    const pages = buildChunkPages(stubChunk(packTile(0, 20, TILE_TRANSFORM_IDENTITY)), [tileset], 32, 32);
+    expect(pages).toHaveLength(0);
+  });
+});

--- a/packages/exojs-tilemap/test/extension.test.ts
+++ b/packages/exojs-tilemap/test/extension.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach } from 'vitest';
 import { ExtensionRegistry } from '@codexo/exojs/extensions';
 import { resetExtensionRegistryForTesting } from '../../../src/extensions/testing';
 import { tilemapExtension } from '../src/tilemapExtension';
+import { TileChunkNode } from '../src/TileChunkNode';
 
 describe('@codexo/exojs-tilemap root', () => {
   it('tilemapExtension has correct id', () => {
@@ -12,8 +13,10 @@ describe('@codexo/exojs-tilemap root', () => {
     expect(tilemapExtension.assets).toBeUndefined();
   });
 
-  it('tilemapExtension has no renderer bindings yet (deferred to renderer slice)', () => {
-    expect(tilemapExtension.renderers).toBeUndefined();
+  it('tilemapExtension exposes exactly one tile chunk renderer binding', () => {
+    expect(tilemapExtension.renderers).toBeDefined();
+    expect(tilemapExtension.renderers).toHaveLength(1);
+    expect(tilemapExtension.renderers![0].targets).toContain(TileChunkNode);
   });
 
   it('tilemapExtension has no dependencies', () => {

--- a/packages/exojs-tilemap/test/nodes.test.ts
+++ b/packages/exojs-tilemap/test/nodes.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { TextureRegion } from '@codexo/exojs';
+import { Texture } from '@codexo/exojs';
+
+import { TileLayer } from '../src/TileLayer';
+import { TileLayerNode } from '../src/TileLayerNode';
+import { TileMap } from '../src/TileMap';
+import { TileMapNode } from '../src/TileMapNode';
+import { TileSet } from '../src/TileSet';
+import { TILE_TRANSFORM_IDENTITY } from '../src/types';
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+function fakeTexture(width = 512, height = 512): Texture {
+  return {
+    width,
+    height,
+    flipY: false,
+    uid: 0,
+    label: 'test',
+    destroy: vi.fn(),
+    destroyed: false,
+  } as unknown as Texture;
+}
+
+function makeTileset(name = 'tiles'): TileSet {
+  return new TileSet({
+    name,
+    texture: new TextureRegion(fakeTexture(), { x: 0, y: 0, width: 512, height: 512 }),
+    tileWidth: 32,
+    tileHeight: 32,
+    tileCount: 16,
+  });
+}
+
+interface LayerOpts {
+  readonly id?: number;
+  readonly name?: string;
+  readonly width?: number;
+  readonly height?: number;
+  readonly visible?: boolean;
+  readonly opacity?: number;
+  readonly offsetX?: number;
+  readonly offsetY?: number;
+}
+
+function makeLayer(tileset: TileSet, opts: LayerOpts = {}): TileLayer {
+  const layer = new TileLayer({
+    id: opts.id ?? 1,
+    name: opts.name ?? 'ground',
+    width: opts.width ?? 4,
+    height: opts.height ?? 4,
+    tileWidth: 32,
+    tileHeight: 32,
+    tilesets: [tileset],
+    visible: opts.visible,
+    opacity: opts.opacity,
+    offsetX: opts.offsetX,
+    offsetY: opts.offsetY,
+  });
+  return layer;
+}
+
+function fillLayer(layer: TileLayer, tileset: TileSet): TileLayer {
+  for (let ty = 0; ty < layer.height; ty++) {
+    for (let tx = 0; tx < layer.width; tx++) {
+      layer.setTileAt(tx, ty, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+    }
+  }
+  return layer;
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// TileLayerNode
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('TileLayerNode', () => {
+  it('builds one chunk node per non-empty loaded chunk', () => {
+    const tileset = makeTileset();
+    // 40×40 map, chunk size 32 → chunks (0,0) and (1,1) once both are touched.
+    const layer = new TileLayer({ id: 1, name: 'l', width: 40, height: 40, tileWidth: 32, tileHeight: 32, tilesets: [tileset] });
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+    layer.setTileAt(33, 33, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+
+    const node = new TileLayerNode(layer);
+
+    expect(node.chunkNodes).toHaveLength(2);
+    expect(node.children).toHaveLength(2);
+  });
+
+  it('skips empty chunks', () => {
+    const tileset = makeTileset();
+    const layer = makeLayer(tileset);
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+    layer.clearTileAt(0, 0); // chunk materialised but now empty
+
+    const node = new TileLayerNode(layer);
+
+    expect(node.chunkNodes).toHaveLength(0);
+  });
+
+  it('positions the node at the layer pixel offset', () => {
+    const tileset = makeTileset();
+    const layer = makeLayer(tileset, { offsetX: 64, offsetY: -32 });
+    const node = new TileLayerNode(layer);
+
+    expect(node.x).toBe(64);
+    expect(node.y).toBe(-32);
+  });
+
+  it('reports local bounds as the layer pixel rect (even when empty)', () => {
+    const tileset = makeTileset();
+    const layer = makeLayer(tileset, { width: 5, height: 3 });
+    const node = new TileLayerNode(layer);
+
+    const bounds = node.getLocalBounds();
+    expect(bounds.width).toBe(5 * 32);
+    expect(bounds.height).toBe(3 * 32);
+  });
+
+  it('synchronises the layer opacity onto chunk tints at construction', () => {
+    const tileset = makeTileset();
+    const layer = fillLayer(makeLayer(tileset, { opacity: 0.5 }), tileset);
+    const node = new TileLayerNode(layer);
+
+    expect(node.chunkNodes.length).toBeGreaterThan(0);
+    for (const chunk of node.chunkNodes) {
+      expect(chunk.tint.a).toBeCloseTo(0.5, 6);
+    }
+  });
+
+  it('refresh() picks up chunks created after construction', () => {
+    const tileset = makeTileset();
+    // 40-wide map so a second chunk can appear later.
+    const layer = new TileLayer({ id: 1, name: 'l', width: 40, height: 8, tileWidth: 32, tileHeight: 32, tilesets: [tileset] });
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+
+    const node = new TileLayerNode(layer);
+    expect(node.chunkNodes).toHaveLength(1);
+
+    layer.setTileAt(33, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+    expect(node.chunkNodes).toHaveLength(1); // not auto-reflected
+
+    node.refresh();
+    expect(node.chunkNodes).toHaveLength(2);
+  });
+
+  it('destroy() frees chunk nodes but not the layer', () => {
+    const tileset = makeTileset();
+    const layer = fillLayer(makeLayer(tileset), tileset);
+    const node = new TileLayerNode(layer);
+
+    node.destroy();
+
+    expect(node.chunkNodes).toHaveLength(0);
+    expect(node.children).toHaveLength(0);
+    expect(layer.destroyed).toBe(false);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// TileChunkNode revision cache + culling bounds
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('TileChunkNode geometry cache', () => {
+  it('returns the same page geometry until the chunk revision changes', () => {
+    const tileset = makeTileset();
+    const layer = makeLayer(tileset);
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+
+    const node = new TileLayerNode(layer).chunkNodes[0];
+
+    const first = node.pages;
+    expect(node.pages).toBe(first); // cached, no rebuild
+
+    layer.setTileAt(1, 1, { tileset, localTileId: 1, transform: TILE_TRANSFORM_IDENTITY });
+
+    const second = node.pages;
+    expect(second).not.toBe(first); // rebuilt after revision bump
+    expect(second[0].quads).toHaveLength(2);
+  });
+
+  it('does not rebuild geometry on a no-op tile write', () => {
+    const tileset = makeTileset();
+    const layer = makeLayer(tileset);
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+
+    const node = new TileLayerNode(layer).chunkNodes[0];
+    const first = node.pages;
+
+    // Writing the identical value is a no-op → revision unchanged → no rebuild.
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+
+    expect(node.pages).toBe(first);
+  });
+
+  it('does not rebuild geometry when only the node transform changes', () => {
+    const tileset = makeTileset();
+    const layer = makeLayer(tileset);
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+
+    const node = new TileLayerNode(layer).chunkNodes[0];
+    const first = node.pages;
+
+    node.setPosition(123, 456);
+
+    expect(node.pages).toBe(first); // geometry is transform-independent
+  });
+
+  it('exposes accurate local bounds for culling (clamped edge chunk)', () => {
+    const tileset = makeTileset();
+    // 3×3 map, single chunk clamped to 3×3 tiles.
+    const layer = makeLayer(tileset, { width: 3, height: 3 });
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+
+    const node = new TileLayerNode(layer).chunkNodes[0];
+    const bounds = node.getLocalBounds();
+
+    expect(bounds.width).toBe(3 * 32);
+    expect(bounds.height).toBe(3 * 32);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// TileMapNode
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('TileMapNode', () => {
+  function makeMap(): { map: TileMap; tileset: TileSet } {
+    const tileset = makeTileset();
+    const background = fillLayer(makeLayer(tileset, { id: 1, name: 'background' }), tileset);
+    const foreground = fillLayer(makeLayer(tileset, { id: 2, name: 'foreground' }), tileset);
+    const map = new TileMap({
+      name: 'm',
+      width: 4,
+      height: 4,
+      tileWidth: 32,
+      tileHeight: 32,
+      tilesets: [tileset],
+      layers: [background, foreground],
+    });
+    return { map, tileset };
+  }
+
+  it('builds one layer node per map layer, preserving order', () => {
+    const { map } = makeMap();
+    const node = new TileMapNode(map);
+
+    expect(node.layerNodes).toHaveLength(2);
+    expect(node.layerNodes[0].layer.name).toBe('background');
+    expect(node.layerNodes[1].layer.name).toBe('foreground');
+    expect(node.children).toHaveLength(2);
+  });
+
+  it('resolves layer nodes by name', () => {
+    const { map } = makeMap();
+    const node = new TileMapNode(map);
+
+    expect(node.getLayerNode('foreground')).toBe(node.layerNodes[1]);
+    expect(node.getLayerNode('missing')).toBeUndefined();
+  });
+
+  it('reports local bounds covering the whole map (including an empty map)', () => {
+    const { map } = makeMap();
+    expect(new TileMapNode(map).getLocalBounds().width).toBe(4 * 32);
+
+    const emptyMap = new TileMap({ name: 'e', width: 6, height: 2, tileWidth: 32, tileHeight: 32 });
+    const emptyBounds = new TileMapNode(emptyMap).getLocalBounds();
+    expect(emptyBounds.width).toBe(6 * 32);
+    expect(emptyBounds.height).toBe(2 * 32);
+  });
+
+  it('destroy() frees layer/chunk nodes but never the map or its textures', () => {
+    const { map, tileset } = makeMap();
+    const node = new TileMapNode(map);
+
+    node.destroy();
+
+    expect(node.layerNodes).toHaveLength(0);
+    expect(node.children).toHaveLength(0);
+    expect(map.destroyed).toBe(false);
+    expect(map.layers[0].destroyed).toBe(false);
+    expect(tileset.texture.texture.destroy).not.toHaveBeenCalled();
+  });
+
+  it('does not own the map lifetime — the map survives node disposal', () => {
+    const { map } = makeMap();
+    const node = new TileMapNode(map);
+    node.destroy();
+
+    // The map is still fully usable.
+    expect(map.getTileAt(1, 0, 0)).not.toBeNull();
+  });
+});

--- a/test/rendering/browser/_tilemapScene.ts
+++ b/test/rendering/browser/_tilemapScene.ts
@@ -1,0 +1,91 @@
+import { tiledExtension } from '@codexo/exojs-tiled';
+import type { TileTransform } from '@codexo/exojs-tilemap';
+import { TILE_TRANSFORM_IDENTITY, TileLayer, TileMap, tilemapExtension,TileSet } from '@codexo/exojs-tilemap';
+
+import { materializeRendererBindings } from '#extensions/materialize';
+import { buildSnapshot } from '#extensions/snapshot';
+import type { RenderBackend } from '#rendering/RenderBackend';
+import { Texture } from '#rendering/texture/Texture';
+import { TextureRegion } from '#rendering/texture/TextureRegion';
+
+/**
+ * Shared helpers for the WebGL2/WebGPU tilemap browser tests. The tilemap nodes
+ * only emit `TileChunkNode` drawables, so the tests wire just the tilemap
+ * renderer binding — no core renderers and therefore no shader-file mocks.
+ */
+
+/** Materialise the tilemap renderer binding directly into a bare test backend. */
+export function wireTilemapRenderers(backend: RenderBackend): void {
+  materializeRendererBindings(backend, tilemapExtension.renderers ?? []);
+}
+
+/**
+ * Wire renderers the way an Application would for `extensions: [tiledExtension]`:
+ * resolve the extension dependency snapshot (which pulls in `tilemapExtension`)
+ * and materialise its renderer bindings. Proves the one-extension Tiled path —
+ * loading is unit-tested in the Tiled package; this exercises rendering.
+ */
+export function wireViaTiledExtension(backend: RenderBackend): void {
+  materializeRendererBindings(backend, buildSnapshot([tiledExtension]).renderers);
+}
+
+/** A `size`×`size` solid-colour texture. */
+export function createSolidTexture(color: string, size = 16): Texture {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = size;
+  canvas.height = size;
+
+  const ctx = canvas.getContext('2d')!;
+
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, size, size);
+
+  return new Texture(canvas);
+}
+
+/**
+ * A 16×16 four-quadrant atlas: top-left red, top-right green, bottom-left blue,
+ * bottom-right white. Rendered as one 16×16 tile, every flip/rotation
+ * orientation produces a distinct, observable quadrant arrangement.
+ */
+export function createQuadrantTexture(): Texture {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = 16;
+  canvas.height = 16;
+
+  const ctx = canvas.getContext('2d')!;
+
+  ctx.fillStyle = '#ff0000';
+  ctx.fillRect(0, 0, 8, 8); // top-left
+  ctx.fillStyle = '#00ff00';
+  ctx.fillRect(8, 0, 8, 8); // top-right
+  ctx.fillStyle = '#0000ff';
+  ctx.fillRect(0, 8, 8, 8); // bottom-left
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(8, 8, 8, 8); // bottom-right
+
+  return new Texture(canvas);
+}
+
+/** A single 16×16 tile tileset over a texture (`tileCount` covering the grid). */
+export function makeTileset(texture: Texture, name = 'tiles', tileCount = 1): TileSet {
+  return new TileSet({
+    name,
+    texture: new TextureRegion(texture, { x: 0, y: 0, width: texture.width, height: texture.height }),
+    tileWidth: 16,
+    tileHeight: 16,
+    tileCount,
+  });
+}
+
+/** Build a 1×1 map containing a single tile with the given orientation. */
+export function singleTileMap(texture: Texture, transform: TileTransform = TILE_TRANSFORM_IDENTITY): TileMap {
+  const tileset = makeTileset(texture);
+  const layer = new TileLayer({ id: 1, name: 'ground', width: 1, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tileset] });
+
+  layer.setTileAt(0, 0, { tileset, localTileId: 0, transform });
+
+  return new TileMap({ name: 'm', width: 1, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tileset], layers: [layer] });
+}

--- a/test/rendering/browser/webgl2-tilemap.test.ts
+++ b/test/rendering/browser/webgl2-tilemap.test.ts
@@ -1,0 +1,376 @@
+/**
+ * WebGL2 tilemap chunk renderer browser tests.
+ *
+ * Exercises the @codexo/exojs-tilemap renderer end-to-end on a real WebGL2
+ * backend: single/multi-tileset rendering, all 8 tile orientations, chunk
+ * boundaries, chunk-level culling, layer opacity, and the one-extension Tiled
+ * wiring (`extensions: [tiledExtension]` pulls in the renderer transitively).
+ *
+ * The renderer uses inline GLSL, so no shader-file mocks are required, and the
+ * scene only emits TileChunkNode drawables, so no core renderers are wired.
+ *
+ * Run via:  pnpm test:browser:webgl2
+ */
+
+import { TILE_TRANSFORM_IDENTITY,TileLayer, TileMap, TileMapNode, TileSet } from '@codexo/exojs-tilemap';
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import type { RenderNode } from '#rendering/RenderNode';
+import type { Texture } from '#rendering/texture/Texture';
+import { TextureRegion } from '#rendering/texture/TextureRegion';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import {
+  createQuadrantTexture,
+  createSolidTexture,
+  makeTileset,
+  singleTileMap,
+  wireTilemapRenderers,
+  wireViaTiledExtension,
+} from './_tilemapScene';
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const createBackend = async (wire: (backend: WebGl2Backend) => void = wireTilemapRenderers): Promise<WebGl2Backend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const app: Application = {
+    canvas,
+    options: {
+      clearColor: Color.black,
+      canvas: { width: canvasSize, height: canvasSize },
+      rendering: {
+        debug: false,
+        webglAttributes: {
+          alpha: false,
+          antialias: false,
+          premultipliedAlpha: false,
+          preserveDrawingBuffer: true,
+          stencil: false,
+          depth: false,
+        },
+      },
+    },
+  } as unknown as Application;
+
+  const backend = new WebGl2Backend(app);
+
+  await backend.initialize();
+  wire(backend);
+
+  return backend;
+};
+
+const render = (backend: WebGl2Backend, node: RenderNode): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+  node.render(backend);
+  backend.flush();
+};
+
+const readPixel = (backend: WebGl2Backend, x: number, y: number): RgbaTuple => {
+  const buf = new Uint8Array(4);
+  const gl = backend.context;
+
+  gl.readPixels(Math.floor(x), backend.renderTarget.height - Math.floor(y) - 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+
+  return [buf[0], buf[1], buf[2], buf[3]];
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 12): void => {
+  for (let i = 0; i < 4; i++) {
+    expect(Math.abs(actual[i] - expected[i])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+// ── basic rendering ─────────────────────────────────────────────────────
+
+describe('WebGL2 tilemap — single tile', () => {
+  test('renders one tile at the node position', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ff0000');
+    const node = new TileMapNode(singleTileMap(texture));
+
+    try {
+      node.setPosition(16, 16); // tile spans screen (16,16)..(32,32)
+      render(backend, node);
+
+      expectPixelNear(readPixel(backend, 24, 24), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(backend, 4, 4), [0, 0, 0, 255]);
+      expect(backend.stats.drawCalls).toBeGreaterThan(0);
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});
+
+describe('WebGL2 tilemap — multiple tilesets', () => {
+  test('renders adjacent tiles from two different tileset textures', async () => {
+    const backend = await createBackend();
+    const red = createSolidTexture('#ff0000');
+    const blue = createSolidTexture('#0000ff');
+    const tsRed = makeTileset(red, 'red');
+    const tsBlue = makeTileset(blue, 'blue');
+
+    const layer = new TileLayer({ id: 1, name: 'l', width: 2, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tsRed, tsBlue] });
+    layer.setTileAt(0, 0, { tileset: tsRed, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+    layer.setTileAt(1, 0, { tileset: tsBlue, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+
+    const map = new TileMap({ name: 'm', width: 2, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tsRed, tsBlue], layers: [layer] });
+    const node = new TileMapNode(map);
+
+    try {
+      node.setPosition(0, 0);
+      render(backend, node);
+
+      expectPixelNear(readPixel(backend, 8, 8), [255, 0, 0, 255]); // first cell red
+      expectPixelNear(readPixel(backend, 24, 8), [0, 0, 255, 255]); // second cell blue
+    } finally {
+      node.destroy();
+      red.destroy();
+      blue.destroy();
+      backend.destroy();
+    }
+  });
+});
+
+// ── orientation (G-FLIP) ─────────────────────────────────────────────────
+
+describe('WebGL2 tilemap — tile orientation', () => {
+  // Quadrant centres on screen for a tile placed at (16,16): corner (cx,cy)
+  // maps to screen (cx ? 28 : 20, cy ? 28 : 20).
+  const readQuadrants = (backend: WebGl2Backend, texture: Texture, transform = TILE_TRANSFORM_IDENTITY): RgbaTuple[][] => {
+    const node = new TileMapNode(singleTileMap(texture, transform));
+    node.setPosition(16, 16);
+    render(backend, node);
+    const read = (cx: number, cy: number): RgbaTuple => readPixel(backend, cx ? 28 : 20, cy ? 28 : 20);
+    const result = [
+      [read(0, 0), read(0, 1)],
+      [read(1, 0), read(1, 1)],
+    ];
+    node.destroy();
+    return result;
+  };
+
+  test('all 8 flip/diagonal orientations permute the source quadrants correctly (G-FLIP)', async () => {
+    const backend = await createBackend();
+    const texture = createQuadrantTexture();
+
+    try {
+      // Identity establishes the on-screen source-corner → colour mapping
+      // (absorbing any texture flipY), so the assertions stay flipY-agnostic.
+      const identity = readQuadrants(backend, texture);
+
+      for (const flipX of [false, true]) {
+        for (const flipY of [false, true]) {
+          for (const diagonal of [false, true]) {
+            const measured = readQuadrants(backend, texture, { flipX, flipY, diagonal });
+
+            for (const cx of [0, 1]) {
+              for (const cy of [0, 1]) {
+                let su = cx;
+                let sv = cy;
+                if (diagonal) {
+                  const t = su;
+                  su = sv;
+                  sv = t;
+                }
+                if (flipX) su = 1 - su;
+                if (flipY) sv = 1 - sv;
+
+                expectPixelNear(measured[cx][cy], identity[su][sv]);
+              }
+            }
+          }
+        }
+      }
+    } finally {
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});
+
+// ── chunk boundary ───────────────────────────────────────────────────────
+
+describe('WebGL2 tilemap — chunk boundary', () => {
+  test('renders tiles spanning two chunks with no gap at the seam', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ff0000');
+    const tileset = makeTileset(texture);
+    // chunkWidth 2 → cells (0,1) and (2,3) live in different chunks.
+    const layer = new TileLayer({ id: 1, name: 'l', width: 4, height: 1, tileWidth: 16, tileHeight: 16, chunkWidth: 2, chunkHeight: 2, tilesets: [tileset] });
+    for (let tx = 0; tx < 4; tx++) {
+      layer.setTileAt(tx, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+    }
+    const map = new TileMap({ name: 'm', width: 4, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tileset], layers: [layer] });
+    const node = new TileMapNode(map);
+
+    try {
+      node.setPosition(0, 0);
+      render(backend, node);
+
+      // Chunk boundary is at tile x=2 → screen x=32. No seam: both sides red.
+      expectPixelNear(readPixel(backend, 24, 8), [255, 0, 0, 255]); // chunk 0
+      expectPixelNear(readPixel(backend, 32, 8), [255, 0, 0, 255]); // seam
+      expectPixelNear(readPixel(backend, 40, 8), [255, 0, 0, 255]); // chunk 1
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});
+
+// ── culling ──────────────────────────────────────────────────────────────
+
+describe('WebGL2 tilemap — chunk culling', () => {
+  test('culls off-screen chunks and draws on-screen ones', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ff0000');
+    const tileset = makeTileset(texture);
+    // 8 tiles wide, chunkWidth 2 → 4 chunks at screen x 0,32,64,96.
+    const layer = new TileLayer({ id: 1, name: 'l', width: 8, height: 1, tileWidth: 16, tileHeight: 16, chunkWidth: 2, chunkHeight: 2, tilesets: [tileset] });
+    for (let tx = 0; tx < 8; tx++) {
+      layer.setTileAt(tx, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+    }
+    const map = new TileMap({ name: 'm', width: 8, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tileset], layers: [layer] });
+    const node = new TileMapNode(map);
+
+    try {
+      // Fully off-screen → all 4 chunks culled, nothing drawn.
+      node.setPosition(1000, 1000);
+      render(backend, node);
+      expect(backend.stats.culledNodes).toBeGreaterThan(0);
+      expect(backend.stats.drawCalls).toBe(0);
+      expectPixelNear(readPixel(backend, 8, 8), [0, 0, 0, 255]);
+
+      // On-screen → chunks at x≥64 are off the 64px canvas and culled, but the
+      // visible chunks render.
+      node.setPosition(0, 0);
+      render(backend, node);
+      expect(backend.stats.drawCalls).toBeGreaterThan(0);
+      expect(backend.stats.culledNodes).toBeGreaterThan(0); // chunks 2 & 3 off-screen
+      expectPixelNear(readPixel(backend, 8, 8), [255, 0, 0, 255]);
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});
+
+// ── layer opacity ────────────────────────────────────────────────────────
+
+describe('WebGL2 tilemap — layer opacity', () => {
+  test('applies layer opacity to the rendered tile', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ffffff');
+    const tileset = makeTileset(texture);
+    const layer = new TileLayer({ id: 1, name: 'l', width: 1, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tileset], opacity: 0.5 });
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+    const map = new TileMap({ name: 'm', width: 1, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tileset], layers: [layer] });
+    const node = new TileMapNode(map);
+
+    try {
+      node.setPosition(16, 16);
+      render(backend, node);
+
+      // White tile at opacity 0.5 over black ≈ mid grey.
+      const pixel = readPixel(backend, 24, 24);
+      expect(pixel[0]).toBeGreaterThan(96);
+      expect(pixel[0]).toBeLessThan(160);
+      expect(pixel[1]).toBeGreaterThan(96);
+      expect(pixel[2]).toBeGreaterThan(96);
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('an invisible layer renders nothing', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ff0000');
+    const tileset = makeTileset(texture);
+    const layer = new TileLayer({ id: 1, name: 'l', width: 1, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tileset], visible: false });
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+    const map = new TileMap({ name: 'm', width: 1, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tileset], layers: [layer] });
+    const node = new TileMapNode(map);
+
+    try {
+      node.setPosition(16, 16);
+      render(backend, node);
+
+      expectPixelNear(readPixel(backend, 24, 24), [0, 0, 0, 255]);
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});
+
+// ── capacity overflow ────────────────────────────────────────────────────
+
+describe('WebGL2 tilemap — batch capacity overflow', () => {
+  test('renders a single chunk whose tile count exceeds the batch buffer', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ff0000', 1);
+    const tileset = new TileSet({
+      name: 'big',
+      texture: new TextureRegion(texture, { x: 0, y: 0, width: 1, height: 1 }),
+      tileWidth: 1,
+      tileHeight: 1,
+      tileCount: 1,
+    });
+    // One 128×128 chunk → 16384 tiles in a single page, far beyond the 4096
+    // instance batch → the renderer must flush in runs without overflowing.
+    const layer = new TileLayer({ id: 1, name: 'l', width: 128, height: 128, tileWidth: 1, tileHeight: 1, chunkWidth: 128, chunkHeight: 128, tilesets: [tileset] });
+    layer.fillRect(0, 0, 128, 128, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+    const map = new TileMap({ name: 'm', width: 128, height: 128, tileWidth: 1, tileHeight: 1, tilesets: [tileset], layers: [layer] });
+    const node = new TileMapNode(map);
+
+    try {
+      node.setPosition(0, 0);
+
+      expect(() => render(backend, node)).not.toThrow();
+      // The visible portion is fully covered — no gaps from the run boundaries.
+      expectPixelNear(readPixel(backend, 16, 16), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(backend, 48, 48), [255, 0, 0, 255]);
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});
+
+// ── one-extension Tiled wiring (G-TILED-ONE-EXTENSION) ────────────────────
+
+describe('WebGL2 tilemap — one-extension Tiled wiring', () => {
+  test('extensions: [tiledExtension] makes TileMapNode render via the tilemap dependency', async () => {
+    const backend = await createBackend(wireViaTiledExtension);
+    const texture = createSolidTexture('#00ff00');
+    const node = new TileMapNode(singleTileMap(texture));
+
+    try {
+      node.setPosition(16, 16);
+      render(backend, node);
+
+      expectPixelNear(readPixel(backend, 24, 24), [0, 255, 0, 255]);
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgpu-tilemap.test.ts
+++ b/test/rendering/browser/webgpu-tilemap.test.ts
@@ -1,0 +1,377 @@
+/**
+ * WebGPU tilemap chunk renderer browser tests — opt-in, capability-aware.
+ *
+ * The parity counterpart of `webgl2-tilemap.test.ts`: single/multi-tileset
+ * rendering, all 8 tile orientations, culling, layer opacity, and one-extension
+ * Tiled wiring on a real WebGPU backend. All WebGPU renderers use inline WGSL —
+ * no shader mocks. Tests skip gracefully when WebGPU is unavailable (no adapter)
+ * or the software adapter is lost mid-test.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import { TILE_TRANSFORM_IDENTITY,TileLayer, TileMap, TileMapNode } from '@codexo/exojs-tilemap';
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import type { RenderNode } from '#rendering/RenderNode';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import {
+  createQuadrantTexture,
+  createSolidTexture,
+  makeTileset,
+  singleTileMap,
+  wireTilemapRenderers,
+  wireViaTiledExtension,
+} from './_tilemapScene';
+import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: { canvas: { width: canvasSize, height: canvasSize }, clearColor: Color.black },
+  }) as unknown as Application;
+
+const setupBackend = async (
+  ctx: { skip: (reason: string) => void },
+  wire: (backend: WebGpuBackend) => void = wireTilemapRenderers,
+): Promise<WebGpuBackend | null> => {
+  if (!navigator.gpu) {
+    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
+
+    return null;
+  }
+
+  const adapter = await navigator.gpu.requestAdapter();
+
+  if (!adapter) {
+    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
+
+    return null;
+  }
+
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  await backend.initialize();
+  wire(backend);
+
+  return backend;
+};
+
+const readCanvas = (backend: WebGpuBackend): ((x: number, y: number) => RgbaTuple) => {
+  const source = backend.context.canvas as HTMLCanvasElement;
+  const readback = document.createElement('canvas');
+
+  readback.width = canvasSize;
+  readback.height = canvasSize;
+
+  const ctx = readback.getContext('2d')!;
+
+  ctx.drawImage(source, 0, 0);
+
+  return (x: number, y: number): RgbaTuple => {
+    const { data } = ctx.getImageData(Math.floor(x), Math.floor(y), 1, 1);
+
+    return [data[0], data[1], data[2], data[3]];
+  };
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 18): void => {
+  for (let i = 0; i < 4; i++) {
+    expect(Math.abs(actual[i] - expected[i])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+const isDeviceLoss = (error: unknown): boolean =>
+  error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+const renderScene = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
+  const device = getBackendDeviceOrSkip(ctx, backend);
+
+  if (!device) {
+    return false;
+  }
+
+  device.pushErrorScope('validation');
+
+  let validationError: GPUError | null;
+
+  try {
+    backend.resetStats();
+    backend.clear(Color.black);
+    root.render(backend);
+    backend.flush();
+    validationError = await device.popErrorScope();
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+
+  expect(validationError).toBeNull();
+
+  return true;
+};
+
+// ── basic rendering ─────────────────────────────────────────────────────
+
+describe('WebGPU tilemap — single tile', () => {
+  test('renders one tile at the node position', async ctx => {
+    const backend = await setupBackend(ctx);
+
+    if (!backend) {
+      return;
+    }
+
+    const texture = createSolidTexture('#ff0000');
+    const node = new TileMapNode(singleTileMap(texture));
+
+    try {
+      node.setPosition(16, 16);
+
+      if (!(await renderScene(ctx, backend, node))) {
+        return;
+      }
+
+      const read = readCanvas(backend);
+      expectPixelNear(read(24, 24), [255, 0, 0, 255]);
+      expectPixelNear(read(4, 4), [0, 0, 0, 255]);
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});
+
+describe('WebGPU tilemap — multiple tilesets', () => {
+  test('renders adjacent tiles from two different tileset textures', async ctx => {
+    const backend = await setupBackend(ctx);
+
+    if (!backend) {
+      return;
+    }
+
+    const red = createSolidTexture('#ff0000');
+    const blue = createSolidTexture('#0000ff');
+    const tsRed = makeTileset(red, 'red');
+    const tsBlue = makeTileset(blue, 'blue');
+    const layer = new TileLayer({ id: 1, name: 'l', width: 2, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tsRed, tsBlue] });
+    layer.setTileAt(0, 0, { tileset: tsRed, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+    layer.setTileAt(1, 0, { tileset: tsBlue, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+    const map = new TileMap({ name: 'm', width: 2, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tsRed, tsBlue], layers: [layer] });
+    const node = new TileMapNode(map);
+
+    try {
+      node.setPosition(0, 0);
+
+      if (!(await renderScene(ctx, backend, node))) {
+        return;
+      }
+
+      const read = readCanvas(backend);
+      expectPixelNear(read(8, 8), [255, 0, 0, 255]);
+      expectPixelNear(read(24, 8), [0, 0, 255, 255]);
+    } finally {
+      node.destroy();
+      red.destroy();
+      blue.destroy();
+      backend.destroy();
+    }
+  });
+});
+
+// ── orientation (G-FLIP / G-PARITY) ──────────────────────────────────────
+
+describe('WebGPU tilemap — tile orientation', () => {
+  test('all 8 flip/diagonal orientations permute the source quadrants correctly', async ctx => {
+    const backend = await setupBackend(ctx);
+
+    if (!backend) {
+      return;
+    }
+
+    const texture = createQuadrantTexture();
+
+    const readQuadrants = async (transform = TILE_TRANSFORM_IDENTITY): Promise<RgbaTuple[][] | null> => {
+      const node = new TileMapNode(singleTileMap(texture, transform));
+      node.setPosition(16, 16);
+
+      if (!(await renderScene(ctx, backend, node))) {
+        node.destroy();
+        return null;
+      }
+
+      const read = readCanvas(backend);
+      const at = (cx: number, cy: number): RgbaTuple => read(cx ? 28 : 20, cy ? 28 : 20);
+      const result = [
+        [at(0, 0), at(0, 1)],
+        [at(1, 0), at(1, 1)],
+      ];
+      node.destroy();
+      return result;
+    };
+
+    try {
+      const identity = await readQuadrants();
+
+      if (!identity) {
+        return;
+      }
+
+      for (const flipX of [false, true]) {
+        for (const flipY of [false, true]) {
+          for (const diagonal of [false, true]) {
+            const measured = await readQuadrants({ flipX, flipY, diagonal });
+
+            if (!measured) {
+              return;
+            }
+
+            for (const cx of [0, 1]) {
+              for (const cy of [0, 1]) {
+                let su = cx;
+                let sv = cy;
+                if (diagonal) {
+                  const t = su;
+                  su = sv;
+                  sv = t;
+                }
+                if (flipX) su = 1 - su;
+                if (flipY) sv = 1 - sv;
+
+                expectPixelNear(measured[cx][cy], identity[su][sv]);
+              }
+            }
+          }
+        }
+      }
+    } finally {
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});
+
+// ── culling ──────────────────────────────────────────────────────────────
+
+describe('WebGPU tilemap — chunk culling', () => {
+  test('culls off-screen chunks and draws on-screen ones', async ctx => {
+    const backend = await setupBackend(ctx);
+
+    if (!backend) {
+      return;
+    }
+
+    const texture = createSolidTexture('#ff0000');
+    const tileset = makeTileset(texture);
+    const layer = new TileLayer({ id: 1, name: 'l', width: 8, height: 1, tileWidth: 16, tileHeight: 16, chunkWidth: 2, chunkHeight: 2, tilesets: [tileset] });
+    for (let tx = 0; tx < 8; tx++) {
+      layer.setTileAt(tx, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+    }
+    const map = new TileMap({ name: 'm', width: 8, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tileset], layers: [layer] });
+    const node = new TileMapNode(map);
+
+    try {
+      node.setPosition(1000, 1000);
+
+      if (!(await renderScene(ctx, backend, node))) {
+        return;
+      }
+
+      expect(backend.stats.culledNodes).toBeGreaterThan(0);
+      expect(backend.stats.drawCalls).toBe(0);
+
+      node.setPosition(0, 0);
+
+      if (!(await renderScene(ctx, backend, node))) {
+        return;
+      }
+
+      expect(backend.stats.drawCalls).toBeGreaterThan(0);
+      expectPixelNear(readCanvas(backend)(8, 8), [255, 0, 0, 255]);
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});
+
+// ── layer opacity ────────────────────────────────────────────────────────
+
+describe('WebGPU tilemap — layer opacity', () => {
+  test('applies layer opacity to the rendered tile', async ctx => {
+    const backend = await setupBackend(ctx);
+
+    if (!backend) {
+      return;
+    }
+
+    const texture = createSolidTexture('#ffffff');
+    const tileset = makeTileset(texture);
+    const layer = new TileLayer({ id: 1, name: 'l', width: 1, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tileset], opacity: 0.5 });
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+    const map = new TileMap({ name: 'm', width: 1, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tileset], layers: [layer] });
+    const node = new TileMapNode(map);
+
+    try {
+      node.setPosition(16, 16);
+
+      if (!(await renderScene(ctx, backend, node))) {
+        return;
+      }
+
+      const pixel = readCanvas(backend)(24, 24);
+      expect(pixel[0]).toBeGreaterThan(80);
+      expect(pixel[0]).toBeLessThan(176);
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});
+
+// ── one-extension Tiled wiring (G-TILED-ONE-EXTENSION) ────────────────────
+
+describe('WebGPU tilemap — one-extension Tiled wiring', () => {
+  test('extensions: [tiledExtension] makes TileMapNode render via the tilemap dependency', async ctx => {
+    const backend = await setupBackend(ctx, wireViaTiledExtension);
+
+    if (!backend) {
+      return;
+    }
+
+    const texture = createSolidTexture('#00ff00');
+    const node = new TileMapNode(singleTileMap(texture));
+
+    try {
+      node.setPosition(16, 16);
+
+      if (!(await renderScene(ctx, backend, node))) {
+        return;
+      }
+
+      expectPixelNear(readCanvas(backend)(24, 24), [0, 255, 0, 255]);
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,7 @@ const aliasConfig = [
   // @codexo/exojs-tiled depends on @codexo/exojs-tilemap; neither package
   // exports a `@codexo/source` condition, so alias to source for in-repo tests.
   { find: '@codexo/exojs-tilemap', replacement: fileURLToPath(new URL('./packages/exojs-tilemap/src/index.ts', import.meta.url)) },
+  { find: '@codexo/exojs-tiled', replacement: fileURLToPath(new URL('./packages/exojs-tiled/src/index.ts', import.meta.url)) },
 ] as const;
 
 // Shared resolution/plugin wiring for the repository-local browser projects.


### PR DESCRIPTION
## Summary

Phase D of the v0.13 tilemap spine: the first production-quality tilemap **rendering** vertical slice. Building on the generic runtime from #112 and the Tiled adapter from #113, this adds a chunk-first WebGL2/WebGPU renderer plus the `TileMapNode` / `TileLayerNode` scene nodes, and wires them through `tilemapExtension` so that `extensions: [tiledExtension]` alone both **loads and renders** Tiled maps.

Spec 03 (`.workspace/specs/v0.13-tilemap-and-scalable-sprites/03-tilemap-renderer.md`) is authoritative for this slice.

## Packages / API surface

`@codexo/exojs-tilemap` new **public** exports (`@advanced`):

- `TileMapNode`, `TileMapNodeOptions`
- `TileLayerNode`, `TileLayerNodeOptions`
- `tilemapExtension` now carries `renderers: [tileChunkRendererBinding]`

Kept **internal** (not exported): `TileChunkNode` (the registered renderer target), `WebGl2TileChunkRenderer`, `WebGpuTileChunkRenderer`, `chunkGeometry` helpers.

`@codexo/exojs-tiled` facade additionally re-exports `TileMapNode` / `TileLayerNode` (same class identity as the canonical package).

## `TileMapNode` / `TileLayerNode` API

```ts
const node = new TileMapNode(map);            // one TileLayerNode per map layer, in order
scene.root.addChild(node);

const layerNode = new TileLayerNode(layer);   // render one layer; place to interleave actors
```

- `TileMapNode` is a `Container` of `TileLayerNode`s — the convenience root for the simple, non-interleaved case. It owns **only** its layer nodes (`.layerNodes`, `.getLayerNode(name)`), never application actors or the `TileMap` itself.
- `TileLayerNode` is a `Container` of per-chunk `TileChunkNode` drawables (`.chunkNodes`), positioned at the layer's pixel offset. `visible` and `opacity` are read live from the runtime layer each frame.
- Both accept `{ cullable?: boolean }` (forwarded to chunk nodes; default `true`).
- Structural changes are reflected via `node.refreshLayers()` / `layerNode.refresh()`; in-place tile edits to existing chunks are picked up automatically via chunk revisions.
- Local bounds: `TileLayerNode` = `(0, 0, layerPixelW, layerPixelH)`; `TileMapNode` = `(0, 0, mapPixelW, mapPixelH)` (well-defined even for empty maps), unioned with child bounds for offset/over-tall tiles.

## Renderer architecture

Chunk-first, modelled on the engine's instanced-quad renderers (NineSlice/Repeating):

- `TileLayerNode` → one `TileChunkNode` per **non-empty loaded chunk** → per-tileset "pages" of tile quads.
- A `TileChunkNode` is a `Drawable`; the registry resolves it to the per-backend renderer via the prototype walk. Its accurate local bounds give **free per-chunk culling** through the existing `RenderNode._collect` path.
- One shared CPU quad builder (`chunkGeometry.ts`) feeds both backends → identical geometry.
- Per-chunk transform rides the **shared transform buffer** (one row per chunk node); tile quads are chunk-local and orientation-neutral.

### Chunk cache / revision behavior

Geometry is built lazily and cached on the `TileChunkNode` keyed by the source chunk's `revision`. The renderer is stateless w.r.t. per-chunk caches (no strong refs that would pin GC). Consequences (all tested): unchanged chunks never rebuild; a no-op tile write does not rebuild; one changed chunk rebuilds only itself; a node transform change rebuilds nothing; a camera pan rebuilds nothing (off-screen chunks are culled before geometry is touched).

### Culling

Per-chunk AABB vs view bounds via the node's local bounds. Off-screen chunks are not uploaded or drawn (`drawCalls == 0` for a fully off-screen map; `culledNodes > 0`); visible/edge chunks draw correctly. Verified on both backends.

### Multiple tilesets

First-class via the packed `tilesetIndex`. Tiles are grouped into pages by tileset (deterministic tileset-array order) and batched by `(shader, tileset texture)`. Tilesets with differing tile sizes are supported; tiles taller than the map grid are bottom-left aligned (Tiled orthogonal convention). Out-of-range tileset/local-tile ids are treated as empty (G-GID).

### Transform / orientation

`flipX` / `flipY` are baked into the UV corner ordering at write time; the **diagonal** flip is resolved as an axis swap in the shader. All 8 `(flipX, flipY, diagonal)` combinations render correctly and **identically on WebGL2 and WebGPU**, verified against an asymmetric four-quadrant texture (G-FLIP / G-PARITY).

## WebGL2 implementation

`WebGl2TileChunkRenderer` — inline GLSL (no `.vert`/`.frag` imports), instanced quads (`drawArraysInstanced`, TRIANGLE_STRIP, `gl_VertexID` corners), 32-byte instance layout (`float32x4` local rect, `unorm16x4` UVs, `unorm8x4` tint, `uint32` tile word = transform row + diagonal bit), shared transform-buffer texture, fixed batch with chunked-flush capacity overflow handling.

## WebGPU implementation

`WebGpuTileChunkRenderer` — inline WGSL, indexed instanced quads, identical 32-byte layout, transform storage buffer, blend/format/stencil pipeline cache, dynamic instance-buffer growth. Parity with WebGL2 (same orientation/UV math).

## One-extension Tiled integration

`tiledExtension.dependencies = [tilemapExtension]` (already from #113) means `buildSnapshot([tiledExtension])` now materialises the tile chunk renderer binding. Verified by unit test (snapshot has 1 renderer binding) **and** by WebGL2 + WebGPU browser tests that wire renderers purely via `buildSnapshot([tiledExtension])` and render a `TileMapNode`. `extensions: [tilemapExtension, tiledExtension]` deduplicates to the same snapshot. No manual `tilemapExtension` registration is required for Tiled usage.

## Package facade / re-exports

`@codexo/exojs-tiled` re-exports `TileMapNode` / `TileLayerNode` from `@codexo/exojs-tilemap` (same live binding). A new `facade.test.ts` asserts `tiled.TileMapNode === tilemap.TileMapNode` (G-PKG-IDENTITY) and `instanceof` across both import paths. Canonical docs remain owned by `@codexo/exojs-tilemap` (new README).

## Texture ownership

Tileset textures are Loader-owned. Neither the runtime, the nodes, nor the renderers destroy them. Destroying a map/layer node frees its node tree + cached geometry; the `TileMap` and textures survive (G-DESTROY / G-OWNERSHIP).

## Tests

- **Unit** (`@codexo/exojs-tilemap`, jsdom): `chunkGeometry.test.ts` (UVs, bottom-align, multi-tileset grouping, out-of-range→empty, orientation codes), `nodes.test.ts` (construction, ordering, empty-chunk skip, bounds, offset, opacity sync, refresh, revision cache, no-op/transform invalidation, ownership/destruction). Updated `extension.test.ts` (renderer binding present).
- **Facade** (`@codexo/exojs-tiled`): class-identity + one-extension dependency. Updated `extension.test.ts` (snapshot now carries the renderer binding).
- **Browser** (`test/rendering/browser/webgl2-tilemap.test.ts`, `webgpu-tilemap.test.ts`): single tile, multiple tilesets, all-8 orientations, chunk boundary, culling, layer opacity + invisibility, capacity overflow (WebGL2), and one-extension Tiled render. Inline shaders → no shader mocks; nodes emit only `TileChunkNode` → no core renderers wired. WebGPU uses the mandatory double-skip (`getBackendDeviceOrSkip` + device-loss).

## Browser results (local)

- Chromium WebGL2: **9/9** (full lane 15 files / 114 tests green).
- Chromium WebGPU: **6/6** (full lane 12 files / 66 tests green).
- Firefox WebGL2: **9/9**.

## Validation (local)

`pnpm --filter @codexo/exojs-tilemap {typecheck,test (162),build}`, `pnpm --filter @codexo/exojs-tiled {typecheck,test (249),build}`, `pnpm typecheck`, `pnpm lint`, `pnpm test` (2856), `pnpm build`, `pnpm verify:exports`, `pnpm verify:lockstep`, `pnpm verify:release-matrix`, `pnpm typecheck:guides`, `pnpm typecheck:examples` — all green. No package versions bumped; no `.workspace/`, `dist/`, or `coverage/` committed.

## Non-goals (explicitly out of scope)

Infinite/procedural streaming; runtime autotiling; public lighting/material channels; object/image/group layer rendering; tile animation runtime; broad pixel snapping; physics; UI/layout; editor tooling; generic renderer redesign. `TileMapView` / interleaving bands are left for the follow-up layer-interleaving slice (Spec 03 keeps them design-only). Atlas bleed handling is minimal (exact UVs + nearest filtering for tile atlases) — a half-texel/extrusion inset for tilemaps is a follow-up.
