### PR TITLE
feat(rendering): add render-only pixel snapping

### DIFF
--- a/packages/exojs-tilemap/src/TileLayerNode.ts
+++ b/packages/exojs-tilemap/src/TileLayerNode.ts
@@ -1,8 +1,9 @@
 import type { Rectangle } from '@codexo/exojs';
 import { Container } from '@codexo/exojs';
-import type { RenderPlanBuilder } from '@codexo/exojs/rendering';
+import type { PixelSnapMode, RenderPlanBuilder } from '@codexo/exojs/rendering';
 
 import type { TileLayer } from './TileLayer';
+import { assertPixelSnapMode } from './pixelSnap';
 import { TileChunkNode } from './TileChunkNode';
 
 /**
@@ -44,6 +45,7 @@ export class TileLayerNode extends Container {
   private readonly _cullChunks: boolean;
   private readonly _chunkNodes: TileChunkNode[] = [];
   private _syncedOpacity = -1;
+  private _pixelSnapMode: PixelSnapMode = 'none';
 
   public constructor(layer: TileLayer, options?: TileLayerNodeOptions) {
     super();
@@ -58,6 +60,39 @@ export class TileLayerNode extends Container {
   /** The runtime layer this node renders. */
   public get layer(): TileLayer {
     return this._layer;
+  }
+
+  /**
+   * Render-only pixel-snap mode applied to every chunk node in this layer (and
+   * to chunks rebuilt later by {@link refresh}). Each chunk's rendered origin is
+   * snapped to the active render target's device-pixel grid; because chunk
+   * origins are integer multiples of the integer tile pitch from the same layer
+   * origin, the whole grid stays exact and adjacent chunks cannot drift apart.
+   *
+   * Purely visual: tile data, the layer offset, chunk content revisions, and
+   * culling bounds are never changed. `'geometry'` and `'position'` both resolve
+   * to coherent origin snapping for tile chunks (chunk quads are already on the
+   * integer pixel grid by construction). Setting the current value is a no-op;
+   * an invalid value throws and leaves the prior mode unchanged.
+   *
+   * @default 'none'
+   * @stable
+   */
+  public get pixelSnapMode(): PixelSnapMode {
+    return this._pixelSnapMode;
+  }
+
+  public set pixelSnapMode(mode: PixelSnapMode) {
+    if (mode === this._pixelSnapMode) {
+      return;
+    }
+
+    assertPixelSnapMode(mode);
+    this._pixelSnapMode = mode;
+
+    for (const chunk of this._chunkNodes) {
+      chunk.pixelSnapMode = mode;
+    }
   }
 
   /**
@@ -135,6 +170,10 @@ export class TileLayerNode extends Container {
       );
 
       node.cullable = this._cullChunks;
+
+      if (this._pixelSnapMode !== 'none') {
+        node.pixelSnapMode = this._pixelSnapMode;
+      }
 
       this._chunkNodes.push(node);
       this.addChild(node);

--- a/packages/exojs-tilemap/src/TileMapNode.ts
+++ b/packages/exojs-tilemap/src/TileMapNode.ts
@@ -1,7 +1,9 @@
 import type { Rectangle } from '@codexo/exojs';
 import { Container } from '@codexo/exojs';
+import type { PixelSnapMode } from '@codexo/exojs/rendering';
 
 import type { TileMap } from './TileMap';
+import { assertPixelSnapMode } from './pixelSnap';
 import { TileLayerNode } from './TileLayerNode';
 
 /**
@@ -40,6 +42,7 @@ export class TileMapNode extends Container {
   private readonly _map: TileMap;
   private readonly _cullChunks: boolean;
   private readonly _layerNodes: TileLayerNode[] = [];
+  private _pixelSnapMode: PixelSnapMode = 'none';
 
   public constructor(map: TileMap, options?: TileMapNodeOptions) {
     super();
@@ -53,6 +56,35 @@ export class TileMapNode extends Container {
   /** The runtime map this node renders. */
   public get map(): TileMap {
     return this._map;
+  }
+
+  /**
+   * Render-only pixel-snap mode applied to every layer (and forwarded to every
+   * chunk node, current and rebuilt). Snaps tile chunk origins to the active
+   * render target's device-pixel grid for crisp tiles; with integer tile pitch
+   * the grid stays exact and adjacent chunks/layers cannot drift apart. Purely
+   * visual — tile data, layer offsets, chunk revisions, and culling are
+   * unchanged. Setting the current value is a no-op; an invalid value throws and
+   * leaves the prior mode unchanged.
+   *
+   * @default 'none'
+   * @stable
+   */
+  public get pixelSnapMode(): PixelSnapMode {
+    return this._pixelSnapMode;
+  }
+
+  public set pixelSnapMode(mode: PixelSnapMode) {
+    if (mode === this._pixelSnapMode) {
+      return;
+    }
+
+    assertPixelSnapMode(mode);
+    this._pixelSnapMode = mode;
+
+    for (const node of this._layerNodes) {
+      node.pixelSnapMode = mode;
+    }
   }
 
   /** The layer render nodes, in map layer order. */
@@ -107,6 +139,10 @@ export class TileMapNode extends Container {
   private _buildLayerNodes(): void {
     for (const layer of this._map.layers) {
       const node = new TileLayerNode(layer, { cullable: this._cullChunks });
+
+      if (this._pixelSnapMode !== 'none') {
+        node.pixelSnapMode = this._pixelSnapMode;
+      }
 
       this._layerNodes.push(node);
       this.addChild(node);

--- a/packages/exojs-tilemap/src/TileMapView.ts
+++ b/packages/exojs-tilemap/src/TileMapView.ts
@@ -1,3 +1,6 @@
+import type { PixelSnapMode } from '@codexo/exojs/rendering';
+
+import { assertPixelSnapMode } from './pixelSnap';
 import type { TileLayer } from './TileLayer';
 import { TileLayerNode } from './TileLayerNode';
 import type { TileMap } from './TileMap';
@@ -103,6 +106,7 @@ export class TileMapView {
   private readonly _directLayerNodes: TileLayerNode[] = [];
 
   private _destroyed = false;
+  private _pixelSnapMode: PixelSnapMode = 'none';
 
   /**
    * @param map     The runtime map to compose. Referenced, never owned.
@@ -152,6 +156,36 @@ export class TileMapView {
   /** Whether this view has been destroyed. */
   public get destroyed(): boolean {
     return this._destroyed;
+  }
+
+  /**
+   * Render-only pixel-snap mode applied to every layer node this view owns (and
+   * forwarded to every chunk drawable, current and rebuilt by
+   * {@link refreshLayers}). Snaps tile chunk origins to the active render
+   * target's device-pixel grid for crisp tiles; with integer tile pitch the grid
+   * stays exact and adjacent chunks cannot drift apart. Purely visual — tile
+   * data, layer offsets, chunk revisions, and culling are unchanged. Setting the
+   * current value is a no-op; an invalid value throws and leaves the prior mode
+   * unchanged.
+   *
+   * @default 'none'
+   * @stable
+   */
+  public get pixelSnapMode(): PixelSnapMode {
+    return this._pixelSnapMode;
+  }
+
+  public set pixelSnapMode(mode: PixelSnapMode) {
+    if (mode === this._pixelSnapMode) {
+      return;
+    }
+
+    assertPixelSnapMode(mode);
+    this._pixelSnapMode = mode;
+
+    for (const node of this._layerNodes) {
+      node.pixelSnapMode = mode;
+    }
   }
 
   /**
@@ -242,6 +276,11 @@ export class TileMapView {
 
       if (!node) {
         node = new TileLayerNode(layer, { cullable: this._cullable });
+
+        if (this._pixelSnapMode !== 'none') {
+          node.pixelSnapMode = this._pixelSnapMode;
+        }
+
         this._layerNodeById.set(layer.id, node);
         this._assignNewNode(node, layer);
       }

--- a/packages/exojs-tilemap/src/pixelSnap.ts
+++ b/packages/exojs-tilemap/src/pixelSnap.ts
@@ -1,0 +1,19 @@
+import type { PixelSnapMode } from '@codexo/exojs/rendering';
+
+const validPixelSnapModes: ReadonlySet<string> = new Set<string>(['none', 'position', 'geometry']);
+
+/**
+ * Throw a deterministic error when `mode` is not a valid {@link PixelSnapMode}.
+ *
+ * Mirrors the core `Drawable` setter's guard so the tilemap node passthroughs
+ * (`TileMapView` / `TileMapNode` / `TileLayerNode`) reject JavaScript-invalid
+ * values atomically — even for an empty layer that has no chunk drawable to
+ * delegate the validation to. Kept local because the core guard is not part of
+ * the public API surface.
+ * @internal
+ */
+export function assertPixelSnapMode(mode: PixelSnapMode): void {
+  if (typeof mode !== 'string' || !validPixelSnapModes.has(mode)) {
+    throw new Error(`pixelSnapMode must be 'none', 'position', or 'geometry' (got ${String(mode)}).`);
+  }
+}

--- a/packages/exojs-tilemap/test/pixel-snap-types.test.ts
+++ b/packages/exojs-tilemap/test/pixel-snap-types.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Compile-time type contracts for the render-only pixel-snapping API.
+ *
+ * Uses Vitest's built-in `expectTypeOf` (the same convention as
+ * test/core/type-assertions.test.ts and the type-contract blocks in
+ * view.test.ts): the assertions are validated by the TypeScript compiler,
+ * not at runtime. Imports go through the PUBLIC package specifiers so the
+ * contracts cover exactly what consumers see.
+ */
+
+import { describe, expectTypeOf, it } from 'vitest';
+
+import type { Drawable, NineSliceSprite, PixelSnapMode, Sprite } from '@codexo/exojs';
+import type { TileLayerNode, TileMapNode, TileMapView } from '@codexo/exojs-tilemap';
+
+describe('PixelSnapMode type contracts', () => {
+  it('is exactly the three documented literal modes', () => {
+    expectTypeOf<PixelSnapMode>().toEqualTypeOf<'none' | 'position' | 'geometry'>();
+  });
+
+  it('core drawables expose pixelSnapMode as PixelSnapMode', () => {
+    expectTypeOf<Drawable['pixelSnapMode']>().toEqualTypeOf<PixelSnapMode>();
+    expectTypeOf<Sprite['pixelSnapMode']>().toEqualTypeOf<PixelSnapMode>();
+    expectTypeOf<NineSliceSprite['pixelSnapMode']>().toEqualTypeOf<PixelSnapMode>();
+  });
+
+  it('tilemap composition nodes expose pixelSnapMode as PixelSnapMode', () => {
+    expectTypeOf<TileMapView['pixelSnapMode']>().toEqualTypeOf<PixelSnapMode>();
+    expectTypeOf<TileMapNode['pixelSnapMode']>().toEqualTypeOf<PixelSnapMode>();
+    expectTypeOf<TileLayerNode['pixelSnapMode']>().toEqualTypeOf<PixelSnapMode>();
+  });
+
+  it('valid literals are assignable; arbitrary strings are not', () => {
+    expectTypeOf<'none'>().toMatchTypeOf<PixelSnapMode>();
+    expectTypeOf<'position'>().toMatchTypeOf<PixelSnapMode>();
+    expectTypeOf<'geometry'>().toMatchTypeOf<PixelSnapMode>();
+    expectTypeOf<'bogus'>().not.toMatchTypeOf<PixelSnapMode>();
+    expectTypeOf<string>().not.toMatchTypeOf<PixelSnapMode>();
+  });
+
+  it('assigning an invalid literal to pixelSnapMode is a compile error', () => {
+    // Shape-only stand-ins: assignments run against plain objects, so the
+    // setter checks below stay compile-time-only (no runtime construction).
+    const sprite = {} as Sprite;
+    const nineSlice = {} as NineSliceSprite;
+    const drawable = {} as Drawable;
+    const view = {} as TileMapView;
+    const mapNode = {} as TileMapNode;
+    const layerNode = {} as TileLayerNode;
+
+    // Valid literals compile on every carrier …
+    sprite.pixelSnapMode = 'none';
+    drawable.pixelSnapMode = 'position';
+    view.pixelSnapMode = 'position';
+    mapNode.pixelSnapMode = 'geometry';
+    layerNode.pixelSnapMode = 'geometry';
+
+    // … invalid ones do not.
+    // @ts-expect-error — 'crisp' is not a PixelSnapMode
+    sprite.pixelSnapMode = 'crisp';
+    // @ts-expect-error — 'Geometry' (wrong case) is not a PixelSnapMode
+    nineSlice.pixelSnapMode = 'Geometry';
+    // @ts-expect-error — a widened string is not narrowable to PixelSnapMode
+    drawable.pixelSnapMode = String('none');
+    // @ts-expect-error — 'bogus' is not a PixelSnapMode
+    view.pixelSnapMode = 'bogus';
+    // @ts-expect-error — 'snap' is not a PixelSnapMode
+    mapNode.pixelSnapMode = 'snap';
+    // @ts-expect-error — numbers are not PixelSnapMode
+    layerNode.pixelSnapMode = 0;
+  });
+});

--- a/packages/exojs-tilemap/test/pixel-snap.test.ts
+++ b/packages/exojs-tilemap/test/pixel-snap.test.ts
@@ -1,0 +1,481 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PixelSnapMode } from '@codexo/exojs';
+import { TextureRegion } from '@codexo/exojs';
+import { Texture } from '@codexo/exojs';
+
+import { TileLayer } from '../src/TileLayer';
+import { TileLayerNode } from '../src/TileLayerNode';
+import { TileMap } from '../src/TileMap';
+import { TileMapNode } from '../src/TileMapNode';
+import { TileMapView } from '../src/TileMapView';
+import { TileSet } from '../src/TileSet';
+import { TILE_TRANSFORM_IDENTITY } from '../src/types';
+
+// ── helpers (conventions shared with nodes.test.ts / view.test.ts) ─────
+
+function fakeTexture(width = 512, height = 512): Texture {
+  return {
+    width,
+    height,
+    flipY: false,
+    uid: 0,
+    label: 'test',
+    destroy: vi.fn(),
+    destroyed: false,
+  } as unknown as Texture;
+}
+
+function makeTileset(name = 'tiles'): TileSet {
+  return new TileSet({
+    name,
+    texture: new TextureRegion(fakeTexture(), { x: 0, y: 0, width: 512, height: 512 }),
+    tileWidth: 32,
+    tileHeight: 32,
+    tileCount: 16,
+  });
+}
+
+interface BoundaryLayerOpts {
+  readonly id?: number;
+  readonly name?: string;
+  readonly offsetX?: number;
+  readonly offsetY?: number;
+}
+
+/**
+ * A 40×8 layer (default 32-tile chunks) with tiles written on BOTH sides of
+ * the chunk-x boundary: chunks (0,0) and (1,0) are non-empty and loaded, and
+ * the tiles at x = 31 / x = 32 are direct neighbours across the seam.
+ */
+function makeBoundaryLayer(tileset: TileSet, opts: BoundaryLayerOpts = {}): TileLayer {
+  const layer = new TileLayer({
+    id: opts.id ?? 1,
+    name: opts.name ?? 'ground',
+    width: 40,
+    height: 8,
+    tileWidth: 32,
+    tileHeight: 32,
+    tilesets: [tileset],
+    offsetX: opts.offsetX,
+    offsetY: opts.offsetY,
+  });
+  const ref = { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY };
+
+  layer.setTileAt(31, 0, ref); // last column of chunk (0,0)
+  layer.setTileAt(32, 0, ref); // first column of chunk (1,0) — across the seam
+  layer.setTileAt(0, 7, ref);
+  layer.setTileAt(39, 7, ref);
+
+  return layer;
+}
+
+/** An empty 4×4 layer — constructible, but produces zero chunk nodes. */
+function makeEmptyLayer(tileset: TileSet, id = 1, name = 'empty'): TileLayer {
+  return new TileLayer({ id, name, width: 4, height: 4, tileWidth: 32, tileHeight: 32, tilesets: [tileset] });
+}
+
+/** A 40×8 map with two boundary-spanning layers: background (1), ground (2). */
+function makeBoundaryMap(): { map: TileMap; tileset: TileSet } {
+  const tileset = makeTileset();
+  const map = new TileMap({
+    name: 'world',
+    width: 40,
+    height: 8,
+    tileWidth: 32,
+    tileHeight: 32,
+    tilesets: [tileset],
+    layers: [
+      makeBoundaryLayer(tileset, { id: 1, name: 'background' }),
+      makeBoundaryLayer(tileset, { id: 2, name: 'ground' }),
+    ],
+  });
+  return { map, tileset };
+}
+
+/** The pixel-snap mode of every chunk drawable, in build order. */
+function chunkModes(node: TileLayerNode): PixelSnapMode[] {
+  return node.chunkNodes.map(chunk => chunk.pixelSnapMode);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Defaults
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('pixelSnapMode defaults', () => {
+  it('defaults to none on a fresh TileLayerNode and its chunk drawables', () => {
+    const node = new TileLayerNode(makeBoundaryLayer(makeTileset()));
+
+    expect(node.pixelSnapMode).toBe('none');
+    expect(node.chunkNodes).toHaveLength(2); // sanity: spans a chunk boundary
+    expect(chunkModes(node)).toEqual(['none', 'none']);
+  });
+
+  it('defaults to none on a fresh TileMapNode and all descendants', () => {
+    const { map } = makeBoundaryMap();
+    const node = new TileMapNode(map);
+
+    expect(node.pixelSnapMode).toBe('none');
+    expect(node.layerNodes).toHaveLength(2);
+    for (const layerNode of node.layerNodes) {
+      expect(layerNode.pixelSnapMode).toBe('none');
+      expect(chunkModes(layerNode)).toEqual(['none', 'none']);
+    }
+  });
+
+  it('defaults to none on a fresh TileMapView and all descendants', () => {
+    const { map } = makeBoundaryMap();
+    const view = map.createView();
+
+    expect(view.pixelSnapMode).toBe('none');
+    expect(view.layers).toHaveLength(2);
+    for (const layerNode of view.layers) {
+      expect(layerNode.pixelSnapMode).toBe('none');
+      expect(chunkModes(layerNode)).toEqual(['none', 'none']);
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// TileLayerNode
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('TileLayerNode.pixelSnapMode', () => {
+  it('cascades geometry and position to every chunk node across the chunk boundary', () => {
+    const node = new TileLayerNode(makeBoundaryLayer(makeTileset()));
+
+    expect(node.chunkNodes).toHaveLength(2);
+
+    for (const mode of ['geometry', 'position'] as const) {
+      node.pixelSnapMode = mode;
+
+      expect(node.pixelSnapMode).toBe(mode);
+      expect(chunkModes(node)).toEqual([mode, mode]);
+    }
+  });
+
+  it('throws on an invalid value and atomically keeps the prior mode', () => {
+    const node = new TileLayerNode(makeBoundaryLayer(makeTileset()));
+
+    expect(() => {
+      node.pixelSnapMode = 'bogus' as PixelSnapMode;
+    }).toThrow(/pixelSnapMode/);
+    expect(node.pixelSnapMode).toBe('none');
+    expect(chunkModes(node)).toEqual(['none', 'none']);
+
+    node.pixelSnapMode = 'geometry';
+
+    expect(() => {
+      node.pixelSnapMode = 'bogus' as PixelSnapMode;
+    }).toThrow(/pixelSnapMode/);
+    expect(node.pixelSnapMode).toBe('geometry');
+    expect(chunkModes(node)).toEqual(['geometry', 'geometry']);
+  });
+
+  it('validates even for an empty layer with no chunk drawables to delegate to', () => {
+    const node = new TileLayerNode(makeEmptyLayer(makeTileset()));
+
+    expect(node.chunkNodes).toHaveLength(0);
+    expect(node.pixelSnapMode).toBe('none');
+
+    expect(() => {
+      node.pixelSnapMode = 'bogus' as PixelSnapMode;
+    }).toThrow(/pixelSnapMode/);
+    expect(node.pixelSnapMode).toBe('none');
+
+    node.pixelSnapMode = 'geometry';
+    expect(node.pixelSnapMode).toBe('geometry');
+  });
+
+  it('setting the same value twice is a no-op (no throw, no re-propagation)', () => {
+    const node = new TileLayerNode(makeBoundaryLayer(makeTileset()));
+
+    expect(() => {
+      node.pixelSnapMode = 'none'; // same as the default
+    }).not.toThrow();
+    expect(node.pixelSnapMode).toBe('none');
+
+    node.pixelSnapMode = 'geometry';
+
+    // Diverge one chunk on purpose, then re-set the same node value: the
+    // no-op must not touch the chunk drawables again.
+    node.chunkNodes[0].pixelSnapMode = 'none';
+    node.pixelSnapMode = 'geometry';
+
+    expect(node.pixelSnapMode).toBe('geometry');
+    expect(chunkModes(node)).toEqual(['none', 'geometry']);
+
+    // A real change re-propagates to every chunk.
+    node.pixelSnapMode = 'position';
+    expect(chunkModes(node)).toEqual(['position', 'position']);
+  });
+
+  it('refresh() applies the mode to newly built chunk nodes', () => {
+    const tileset = makeTileset();
+    const layer = new TileLayer({ id: 1, name: 'l', width: 40, height: 8, tileWidth: 32, tileHeight: 32, tilesets: [tileset] });
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+
+    const node = new TileLayerNode(layer);
+
+    node.pixelSnapMode = 'geometry';
+    expect(node.chunkNodes).toHaveLength(1);
+
+    // A tile in a previously-empty chunk is reflected only after refresh().
+    layer.setTileAt(32, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+    node.refresh();
+
+    expect(node.chunkNodes).toHaveLength(2);
+    expect(node.pixelSnapMode).toBe('geometry');
+    expect(chunkModes(node)).toEqual(['geometry', 'geometry']);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// TileMapNode
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('TileMapNode.pixelSnapMode', () => {
+  it('cascades to every layer node and every chunk drawable', () => {
+    const { map } = makeBoundaryMap();
+    const node = new TileMapNode(map);
+
+    expect(node.layerNodes).toHaveLength(2);
+
+    for (const mode of ['geometry', 'position'] as const) {
+      node.pixelSnapMode = mode;
+
+      expect(node.pixelSnapMode).toBe(mode);
+      for (const layerNode of node.layerNodes) {
+        expect(layerNode.pixelSnapMode).toBe(mode);
+        expect(chunkModes(layerNode)).toEqual([mode, mode]);
+      }
+    }
+  });
+
+  it('throws on an invalid value and atomically keeps the prior mode', () => {
+    const { map } = makeBoundaryMap();
+    const node = new TileMapNode(map);
+
+    node.pixelSnapMode = 'position';
+
+    expect(() => {
+      node.pixelSnapMode = 'bogus' as PixelSnapMode;
+    }).toThrow(/pixelSnapMode/);
+    expect(node.pixelSnapMode).toBe('position');
+    for (const layerNode of node.layerNodes) {
+      expect(layerNode.pixelSnapMode).toBe('position');
+      expect(chunkModes(layerNode)).toEqual(['position', 'position']);
+    }
+  });
+
+  it('validates on a map with no layers', () => {
+    const map = new TileMap({ name: 'empty', width: 4, height: 4, tileWidth: 32, tileHeight: 32 });
+    const node = new TileMapNode(map);
+
+    expect(node.layerNodes).toHaveLength(0);
+
+    expect(() => {
+      node.pixelSnapMode = 'bogus' as PixelSnapMode;
+    }).toThrow(/pixelSnapMode/);
+    expect(node.pixelSnapMode).toBe('none');
+
+    node.pixelSnapMode = 'geometry';
+    expect(node.pixelSnapMode).toBe('geometry');
+  });
+
+  it('setting the same value twice is a no-op', () => {
+    const { map } = makeBoundaryMap();
+    const node = new TileMapNode(map);
+
+    node.pixelSnapMode = 'geometry';
+
+    expect(() => {
+      node.pixelSnapMode = 'geometry';
+    }).not.toThrow();
+    expect(node.pixelSnapMode).toBe('geometry');
+  });
+
+  it('refreshLayers() re-applies the mode to rebuilt and newly added layers', () => {
+    const { map, tileset } = makeBoundaryMap();
+    const node = new TileMapNode(map);
+
+    node.pixelSnapMode = 'geometry';
+
+    map.addLayer(makeBoundaryLayer(tileset, { id: 3, name: 'roofs' }));
+    node.refreshLayers();
+
+    expect(node.layerNodes).toHaveLength(3);
+    for (const layerNode of node.layerNodes) {
+      expect(layerNode.pixelSnapMode).toBe('geometry');
+      expect(chunkModes(layerNode)).toEqual(['geometry', 'geometry']);
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// TileMapView
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('TileMapView.pixelSnapMode', () => {
+  it('cascades to every layer node and chunk drawable, banded or not', () => {
+    const { map } = makeBoundaryMap();
+    // 'background' is banded; 'ground' stays view-owned (unbanded).
+    const view = map.createView({ bands: { lower: ['background'] } });
+
+    view.pixelSnapMode = 'geometry';
+
+    expect(view.pixelSnapMode).toBe('geometry');
+    expect(view.layers).toHaveLength(2);
+    for (const layerNode of view.layers) {
+      expect(layerNode.pixelSnapMode).toBe('geometry');
+      expect(chunkModes(layerNode)).toEqual(['geometry', 'geometry']);
+    }
+
+    view.pixelSnapMode = 'position';
+    for (const layerNode of view.layers) {
+      expect(chunkModes(layerNode)).toEqual(['position', 'position']);
+    }
+  });
+
+  it('throws on an invalid value and atomically keeps the prior mode', () => {
+    const { map } = makeBoundaryMap();
+    const view = map.createView();
+
+    view.pixelSnapMode = 'geometry';
+
+    expect(() => {
+      view.pixelSnapMode = 'bogus' as PixelSnapMode;
+    }).toThrow(/pixelSnapMode/);
+    expect(view.pixelSnapMode).toBe('geometry');
+    for (const layerNode of view.layers) {
+      expect(layerNode.pixelSnapMode).toBe('geometry');
+      expect(chunkModes(layerNode)).toEqual(['geometry', 'geometry']);
+    }
+  });
+
+  it('validates on a view over a map with no layers', () => {
+    const map = new TileMap({ name: 'empty', width: 4, height: 4, tileWidth: 32, tileHeight: 32 });
+    const view = new TileMapView(map);
+
+    expect(view.layers).toHaveLength(0);
+
+    expect(() => {
+      view.pixelSnapMode = 'bogus' as PixelSnapMode;
+    }).toThrow(/pixelSnapMode/);
+    expect(view.pixelSnapMode).toBe('none');
+
+    view.pixelSnapMode = 'position';
+    expect(view.pixelSnapMode).toBe('position');
+  });
+
+  it('setting the same value twice is a no-op', () => {
+    const { map } = makeBoundaryMap();
+    const view = map.createView();
+
+    view.pixelSnapMode = 'geometry';
+
+    expect(() => {
+      view.pixelSnapMode = 'geometry';
+    }).not.toThrow();
+    expect(view.pixelSnapMode).toBe('geometry');
+  });
+
+  it('refreshLayers() applies the mode to nodes built for added layers', () => {
+    const { map, tileset } = makeBoundaryMap();
+    const view = map.createView();
+    const existing = view.getLayerNodeById(1)!;
+
+    view.pixelSnapMode = 'geometry';
+
+    map.addLayer(makeBoundaryLayer(tileset, { id: 9, name: 'extra' }));
+    view.refreshLayers();
+
+    const added = view.getLayerNodeById(9)!;
+
+    expect(view.getLayerNodeById(1)).toBe(existing); // identity retained
+    expect(added.pixelSnapMode).toBe('geometry');
+    expect(chunkModes(added)).toEqual(['geometry', 'geometry']);
+    for (const layerNode of view.layers) {
+      expect(layerNode.pixelSnapMode).toBe('geometry');
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Render-only contract — purely visual, never a data/geometry mutation
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('pixelSnapMode render-only contract', () => {
+  it('toggling never rebuilds chunk geometry: pages keep the same reference', () => {
+    const node = new TileLayerNode(makeBoundaryLayer(makeTileset()));
+    const [first, second] = [node.chunkNodes[0], node.chunkNodes[1]];
+    const firstPages = first.pages; // builds + caches against the chunk revision
+    const secondPages = second.pages;
+    const revisionBefore = node.layer.revision;
+
+    node.pixelSnapMode = 'geometry';
+
+    expect(first.pages).toBe(firstPages);
+    expect(second.pages).toBe(secondPages);
+
+    node.pixelSnapMode = 'position';
+    node.pixelSnapMode = 'none';
+
+    expect(first.pages).toBe(firstPages);
+    expect(second.pages).toBe(secondPages);
+    expect(node.layer.revision).toBe(revisionBefore); // no revision bump
+  });
+
+  it('leaves layer offsets, node transforms, tile data, and bounds untouched', () => {
+    const tileset = makeTileset();
+    const layer = makeBoundaryLayer(tileset, { offsetX: 64, offsetY: -32 });
+    const map = new TileMap({
+      name: 'm',
+      width: 40,
+      height: 8,
+      tileWidth: 32,
+      tileHeight: 32,
+      tilesets: [tileset],
+      layers: [layer],
+    });
+    const view = map.createView();
+    const node = view.getLayerNodeById(1)!;
+    const seamChunk = node.chunkNodes[1]; // chunk (1,0), origin x = 32 tiles
+    const pagesBefore = seamChunk.pages;
+    const tileBefore = layer.getTileAt(32, 0)!;
+    const rawBefore = layer.getRawTileAt(31, 0);
+    const revisionBefore = layer.revision;
+
+    view.pixelSnapMode = 'geometry';
+
+    // Layer data and offsets are untouched …
+    expect(layer.offsetX).toBe(64);
+    expect(layer.offsetY).toBe(-32);
+    expect(layer.getRawTileAt(31, 0)).toBe(rawBefore);
+    expect(layer.revision).toBe(revisionBefore);
+
+    const tileAfter = layer.getTileAt(32, 0)!;
+
+    expect(tileAfter.tileset).toBe(tileBefore.tileset);
+    expect(tileAfter.localTileId).toBe(tileBefore.localTileId);
+
+    // … logical node transforms stay logical …
+    expect(node.x).toBe(64);
+    expect(node.y).toBe(-32);
+    expect(seamChunk.x).toBe(1024); // 1 chunk × 32 tiles × 32 px
+    expect(seamChunk.y).toBe(0);
+
+    // … and the cached geometry plus culling bounds are unchanged.
+    expect(seamChunk.pages).toBe(pagesBefore);
+
+    const layerBounds = node.getLocalBounds();
+
+    expect(layerBounds.width).toBe(40 * 32);
+    expect(layerBounds.height).toBe(8 * 32);
+
+    const chunkBounds = seamChunk.getLocalBounds();
+
+    expect(chunkBounds.width).toBe(8 * 32); // clamped edge chunk: 8 tiles wide
+    expect(chunkBounds.height).toBe(8 * 32);
+  });
+});

--- a/site/src/content/guide/rendering/pixel-snapping.mdx
+++ b/site/src/content/guide/rendering/pixel-snapping.mdx
@@ -1,0 +1,101 @@
+---
+title: 'Pixel snapping'
+description: 'Keep sprites, panels, and tilemaps crisp by snapping rendered output to the device-pixel grid — render-only, camera- and DPR-aware.'
+---
+
+# Pixel snapping
+
+When a drawable lands between device pixels — a camera at a fractional offset, a tween easing to rest, a 1.25× zoom on a high-DPR display — texel edges fall across pixel boundaries and crisp art starts to shimmer and blur. Every [`Drawable`](/ExoJS/en/api/drawable/) carries a `pixelSnapMode` property that fixes this at render time:
+
+```ts
+import type { NineSliceSprite, Sprite } from '@codexo/exojs';
+import type { TileMapNode } from '@codexo/exojs-tilemap';
+
+declare const sprite: Sprite;
+declare const panel: NineSliceSprite;
+declare const mapNode: TileMapNode;
+
+sprite.pixelSnapMode = 'position';  // snap the rendered origin
+panel.pixelSnapMode = 'geometry';   // panel is a NineSliceSprite — also snap its slice edges
+mapNode.pixelSnapMode = 'geometry'; // mapNode is a TileMapNode (or TileMapView) — cascades to chunks
+```
+
+The value is the `PixelSnapMode` union exported from `@codexo/exojs` — `'none' | 'position' | 'geometry'` — and defaults to `'none'` (existing behaviour). Setting the current value is a no-op; setting anything outside the union throws and leaves the prior mode unchanged.
+
+## Render-only, by contract
+
+Snapping adjusts only the per-frame data handed to the GPU. It never mutates logical state:
+
+- position, scale, and `getGlobalTransform()` keep their exact fractional values
+- collision tests and `getBounds()` are unchanged
+- tween and physics state never see snapped values
+
+A tween moving a snapped sprite still animates its logical position smoothly — only the rendered quad steps in whole device pixels. You can toggle modes at any time without feedback loops or drift.
+
+## The two snapping modes
+
+`'position'` snaps the drawable's rendered origin to the nearest device pixel. Only the translation of the uploaded world matrix is adjusted — the linear part is untouched — so it is safe under **any** transform: rotation, skew, and non-uniform scale included.
+
+`'geometry'` does that and additionally snaps the drawable's shared boundary plan: nine-slice edges, repeat-segment boundaries, the sprite quad, tilemap chunk and layer origins. Every boundary goes through the same pure rounding function, so two neighbours that share a boundary value snap to the same result — seams cannot open between adjacent slices, segments, or chunks.
+
+```ts
+import { NineSliceSprite, RepeatingSprite, Texture } from '@codexo/exojs';
+
+declare const uiTexture: Texture;
+
+const panel = new NineSliceSprite(uiTexture, { slices: 12, width: 240, height: 96 });
+panel.pixelSnapMode = 'geometry'; // slice edges land on whole device pixels
+
+const backdrop = new RepeatingSprite(uiTexture, { width: 640, height: 360 });
+backdrop.pixelSnapMode = 'geometry'; // repeat boundaries stay seam-free
+```
+
+## Device pixels, not world units
+
+Snapping targets the **device-pixel grid of the active render target** — world position × [`View`](/ExoJS/en/api/view/) scale × pixel ratio — not integer world units. One world unit only equals one device pixel when the camera zoom and `pixelRatio` are both 1; under zoom or a high-DPR backbuffer the engine projects into device space, rounds there, and projects back. The result is camera- and DPR-aware by construction, and stays correct inside `RenderTexture` targets and split-screen viewport rectangles. See [Resize, DPR, and canvas](/ExoJS/en/guide/getting-started/resize-dpr-and-canvas/) and [Coordinates and views](/ExoJS/en/guide/runtime/coordinates-and-views/) for the underlying mapping.
+
+## Rotation downgrades `geometry` — no errors
+
+`'geometry'` is guaranteed only while the combined node + view transform is **axis-aligned**. Under rotation or skew (on the node, any ancestor, or the camera) it automatically downgrades to `'position'` for the affected frames — no error, no throw; dev builds log a one-time console warning. Axis-aligned non-uniform scale is fully supported: snapping is computed per axis.
+
+## Supported drawables
+
+| Type             | `'position'` | `'geometry'`                                                                                                |
+| ---------------- | ------------ | ----------------------------------------------------------------------------------------------------------- |
+| `Sprite`         | yes          | snaps the textured quad's edges                                                                              |
+| `NineSliceSprite` | yes         | snaps every slice boundary; corners stay pixel-exact                                                         |
+| `RepeatingSprite` | yes         | snaps repeat-segment boundaries (atlas-region sources); bare-`Texture` sources snap the destination quad while repetition stays shader-based |
+| Tilemap nodes    | yes          | snaps chunk/layer origins; integer tile pitch keeps every tile edge exact across chunks                      |
+
+`'position'` is honoured by **every** drawable — it is applied once at the backend's transform-upload seam, identically on WebGL2 and WebGPU. `'geometry'` adds boundary snapping only for the types above; on other drawables it currently behaves like `'position'`.
+
+## Tilemaps
+
+`@codexo/exojs-tilemap` exposes the same property on its scene nodes — `TileMapNode`, `TileMapView`, and `TileLayerNode`. Setting it cascades to every chunk node, current and rebuilt:
+
+```ts
+import { TileLayerNode, TileMap, TileMapNode, TileMapView } from '@codexo/exojs-tilemap';
+
+declare const map: TileMap;
+
+const mapNode = new TileMapNode(map);
+mapNode.pixelSnapMode = 'geometry'; // forwarded to every TileLayerNode and chunk
+
+declare const mapView: TileMapView;
+declare const groundLayer: TileLayerNode;
+
+mapView.pixelSnapMode = 'geometry';     // same property on a composed view (bands)
+groundLayer.pixelSnapMode = 'position'; // or per individual layer node
+```
+
+Chunk origins snap on the shared device grid, and a chunk's internal tile geometry uses integer tile pitch — so snapping the origin keeps every tile edge exact, and adjacent chunks and layers cannot drift apart. Tile data, layer offsets, chunk revisions, and culling are unaffected.
+
+## Limitations and non-goals
+
+- **Not a layout system.** There is no screen-space/UI layout rounding — logical widths, heights, and positions are never rounded for you.
+- **No shader-based snapping.** Snapping happens on the CPU during render-data preparation, with one deterministic rounding policy (`Math.round` to the nearest device pixel) shared by both backends.
+- **Logical bounds stay logical.** `getBounds()` reports unsnapped values; the rasterised result may differ from them by less than one device pixel.
+
+## Where to go next
+
+The next section, [Effects](/ExoJS/en/guide/effects/filters/), builds directly on the rendering chapters — filters, particles, and post-processing chains that layer mood and motion onto a scene.

--- a/site/src/content/guide/rendering/render-targets.mdx
+++ b/site/src/content/guide/rendering/render-targets.mdx
@@ -166,4 +166,4 @@ A zoomed-out view of a tile map rendered into a small `RenderTexture` and displa
 
 ## Where to go next
 
-The next section, [Effects](/ExoJS/en/guide/effects/filters/), builds directly on render targets — filters, particles, and post-processing chains that layer mood and motion onto a scene. In particular, [Post-processing](/ExoJS/en/guide/effects/post-processing/) extends the render-to-texture pattern into multi-pass filtering and screen-space effects.
+The next chapter, [Pixel snapping](/ExoJS/en/guide/rendering/pixel-snapping/), shows how to keep sprites, panels, and tilemaps crisp on the device-pixel grid without touching logical state. After that, the [Effects](/ExoJS/en/guide/effects/filters/) section builds directly on render targets — in particular, [Post-processing](/ExoJS/en/guide/effects/post-processing/) extends the render-to-texture pattern into multi-pass filtering and screen-space effects.

--- a/site/src/lib/guide-structure.ts
+++ b/site/src/lib/guide-structure.ts
@@ -320,6 +320,17 @@ const RAW_PARTS: ReadonlyArray<RawPart> = [
                 examples: ['render-targets/render-to-texture', 'render-targets/mini-map'],
                 apiLinks: ['render-target', 'render-texture'],
             },
+            {
+                slug: 'pixel-snapping',
+                level: 'intermediate',
+                learningGoals: [
+                    'snap rendered sprites, panels, and tilemaps to the device-pixel grid',
+                    'choose between position and geometry snapping',
+                    'rely on the render-only contract: logical state never changes',
+                ],
+                prerequisites: ['rendering/sprites'],
+                apiLinks: ['drawable', 'sprite', 'view'],
+            },
         ],
     },
     {

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -3,6 +3,7 @@
 // extension packages. Prefer the root barrel for ordinary application code.
 
 export { Drawable } from '#rendering/Drawable';
+export type { PixelSnapMode } from '#rendering/pixelSnap';
 export type { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
 export type { RenderBackend } from '#rendering/RenderBackend';
 export { RenderBackendType } from '#rendering/RenderBackendType';

--- a/src/rendering/Drawable.ts
+++ b/src/rendering/Drawable.ts
@@ -1,6 +1,7 @@
 import { Color } from '#core/Color';
 import type { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
 
+import { isPixelSnapMode, type PixelSnapMode } from './pixelSnap';
 import { RenderNode } from './RenderNode';
 import { BlendModes } from './types';
 
@@ -14,6 +15,7 @@ import { BlendModes } from './types';
 export class Drawable extends RenderNode {
   private _tint: Color = Color.white.clone();
   private _blendMode: BlendModes = BlendModes.Normal;
+  private _pixelSnapMode: PixelSnapMode = 'none';
 
   public get tint(): Color {
     return this._tint;
@@ -29,6 +31,42 @@ export class Drawable extends RenderNode {
 
   public set blendMode(blendMode: BlendModes) {
     this.setBlendMode(blendMode);
+  }
+
+  /**
+   * Render-only pixel-snapping policy for this drawable. Aligns the rendered
+   * origin (`'position'`) or origin plus shared geometry boundaries
+   * (`'geometry'`) to the active render target's device-pixel grid. Purely
+   * visual: logical `x`/`y`, transforms, bounds, collision, tween and physics
+   * state are never affected, and {@link getBounds}/{@link getGlobalTransform}
+   * keep returning logical values.
+   *
+   * `'geometry'` is guaranteed only for axis-aligned transforms; rotation or
+   * skew (on this node, an ancestor, or the view) downgrade it to `'position'`
+   * for the affected frame, with no logical-state change. Snapping targets
+   * device pixels (× view scale × pixel ratio), not integer world units.
+   *
+   * Setting the current value is a no-op. Setting a value outside the
+   * {@link PixelSnapMode} union throws and leaves the prior mode unchanged.
+   *
+   * @default 'none'
+   * @stable
+   */
+  public get pixelSnapMode(): PixelSnapMode {
+    return this._pixelSnapMode;
+  }
+
+  public set pixelSnapMode(mode: PixelSnapMode) {
+    if (mode === this._pixelSnapMode) {
+      return;
+    }
+
+    if (!isPixelSnapMode(mode)) {
+      throw new Error(`Drawable.pixelSnapMode must be 'none', 'position', or 'geometry' (got ${String(mode)}).`);
+    }
+
+    this._pixelSnapMode = mode;
+    this.invalidateCache();
   }
 
   /**

--- a/src/rendering/index.ts
+++ b/src/rendering/index.ts
@@ -7,6 +7,7 @@ export type { CameraOptions } from './Camera';
 export { Camera } from './Camera';
 export { Container } from './Container';
 export { Drawable } from './Drawable';
+export type { PixelSnapMode } from './pixelSnap';
 export type { RenderBackend } from './RenderBackend';
 export { RenderBackendType } from './RenderBackendType';
 export type { DrawableConstructor, Renderer } from './Renderer';

--- a/src/rendering/pixelSnap.ts
+++ b/src/rendering/pixelSnap.ts
@@ -1,0 +1,384 @@
+import type { Matrix } from '#math/Matrix';
+import type { Rectangle } from '#math/Rectangle';
+
+import type { Drawable } from './Drawable';
+import type { View } from './View';
+
+/**
+ * Render-only pixel snapping.
+ *
+ * ## Coordinate spaces
+ *
+ * A drawable travels through these spaces before it lands on the screen:
+ *
+ * ```
+ * local space      quad / boundary coordinates relative to the node origin
+ *   │  × node world matrix (a, b, c, d, x, y)  — logical, NEVER mutated here
+ *   ▼
+ * world space      the scene's logical coordinate system
+ *   │  × View.getTransform()                   — the camera (center, zoom, rotation)
+ *   ▼
+ * clip space       OpenGL/WebGPU normalised device coordinates, [-1, 1]
+ *   │  × viewport (fraction) × target device pixels
+ *   ▼
+ * device space     actual pixels of the active render target
+ *                  (root canvas = css × pixelRatio; RenderTexture = its own size)
+ * ```
+ *
+ * Pixel snapping aligns rendered geometry to **device pixels** — not to integer
+ * world units. One world unit only equals one device pixel when the view scale
+ * and pixel ratio are both `1`; under zoom or a high-DPR backbuffer the device
+ * grid is finer or coarser, so we always project into device space, round there,
+ * and project back. The full world↔device mapping is provided by the existing,
+ * tested {@link View.worldToScreen} / {@link View.screenToWorld} helpers — we
+ * pass the **active render target's device-pixel dimensions** so the result is
+ * device-correct for both the main canvas and offscreen render targets, and
+ * correct under viewport rectangles (split-screen).
+ *
+ * ## Render-only contract
+ *
+ * Snapping happens on the CPU during render-data preparation and affects only
+ * the values handed to the GPU for that frame. It never mutates logical
+ * position, world/local matrices used for queries, collision data, tween or
+ * physics state, or {@link SceneNode.getBounds} results. {@link snapWorldTranslationInto}
+ * writes into a caller-owned scratch matrix; the node's cached global transform
+ * is left untouched.
+ *
+ * ## Modes
+ *
+ * - `position` — snap the node's rendered origin (the world translation) only.
+ *   Touches the matrix translation `(x, y)` exclusively, leaving the linear part
+ *   `(a, b, c, d)` intact, so it is safe under any transform (rotation, skew,
+ *   non-uniform scale) — the origin is a single point with a well-defined device
+ *   position.
+ * - `geometry` — additionally snap shared geometry boundaries (NineSlice edges,
+ *   repeat-segment boundaries, the sprite quad). Each unique boundary is snapped
+ *   by the **same** pure function {@link snapLocalBoundary}, so adjacent quads
+ *   that share a boundary value snap to the same result — seams cannot open.
+ *   Guaranteed only for **axis-aligned** transforms; rotation / skew (in the
+ *   node or the view) downgrade it to `position` (see
+ *   {@link resolveEffectivePixelSnapMode}).
+ *
+ * ## Rounding policy
+ *
+ * Nearest device pixel via `Math.round` (ties toward +∞). One deterministic
+ * policy used everywhere, so CPU debug values, WebGL2 and WebGPU all agree.
+ *
+ * @module
+ */
+
+/**
+ * Render-only pixel-snapping policy for a {@link Drawable}.
+ *
+ * - `'none'` — no snapping; rendered transform and geometry use existing behaviour.
+ * - `'position'` — snap the rendered origin to the nearest device pixel. Logical
+ *   `x`/`y`, matrices, bounds and collision are unchanged.
+ * - `'geometry'` — snap a single coherent shared-boundary plan (origin + boundaries)
+ *   so neighbouring quads stay seam-free. Falls back to `'position'` automatically
+ *   when the transform is not axis-aligned (rotation / skew).
+ *
+ * Snapping targets device pixels (× view scale × pixel ratio), not integer world
+ * units, and never alters logical state.
+ *
+ * @default 'none'
+ * @stable
+ */
+export type PixelSnapMode = 'none' | 'position' | 'geometry';
+
+const pixelSnapModes: ReadonlySet<string> = new Set<string>(['none', 'position', 'geometry']);
+
+/**
+ * Runtime guard for the {@link PixelSnapMode} union. Used by the public setter to
+ * reject JavaScript-invalid values atomically.
+ * @internal
+ */
+export function isPixelSnapMode(value: unknown): value is PixelSnapMode {
+  return typeof value === 'string' && pixelSnapModes.has(value);
+}
+
+/** Below this magnitude an axis is treated as collapsed / cross-coupled. @internal */
+const epsilon = 1e-6;
+
+/**
+ * Axis-aligned device-pixel mapping for one drawable in the active pass. Built
+ * from the node world matrix, the pass {@link View}, and the active render
+ * target's device-pixel dimensions. Distances/positions are in device pixels;
+ * `worldX`/`worldY` are back in world space.
+ * @internal
+ */
+export interface PixelSnapContext {
+  /** Device-pixel position of the node's local origin, before snapping. */
+  readonly originX: number;
+  readonly originY: number;
+  /** Device-pixel position of the local origin after snapping to the nearest pixel. */
+  readonly snappedOriginX: number;
+  readonly snappedOriginY: number;
+  /** World translation that places the local origin exactly on the snapped device pixel. */
+  readonly worldX: number;
+  readonly worldY: number;
+  /** Signed device pixels per local unit along X / Y (node scale × view scale × DPR). */
+  readonly scaleX: number;
+  readonly scaleY: number;
+  /** `true` when local axes map cleanly to device axes (no rotation/skew in node or view). */
+  readonly axisAligned: boolean;
+}
+
+/**
+ * Build the device-pixel snap context for `world` (a node's global transform)
+ * under `view`, targeting a surface of `targetPxWidth` × `targetPxHeight` device
+ * pixels. Pure — does not mutate `world` or `view`. Falls back to a no-op context
+ * (snapped origin = original origin) when the target size or projection is
+ * degenerate, so callers can always use the result safely.
+ * @internal
+ */
+export function buildPixelSnapContext(world: Matrix, view: View, targetPxWidth: number, targetPxHeight: number): PixelSnapContext {
+  const ox = world.x;
+  const oy = world.y;
+
+  if (!(targetPxWidth > 0) || !(targetPxHeight > 0)) {
+    return noopContext(ox, oy);
+  }
+
+  // Forward projection only (world → device). The view's inverse is deliberately
+  // avoided; instead the origin plus two world-unit axis tips give the exact
+  // world→device Jacobian, which we invert ourselves (a 2×2) to map the snapped
+  // device origin back to world space. This stays exact for any affine view.
+  const origin = view.worldToScreen(ox, oy, targetPxWidth, targetPxHeight);
+
+  if (!Number.isFinite(origin.x) || !Number.isFinite(origin.y)) {
+    return noopContext(ox, oy);
+  }
+
+  const tipWorldX = view.worldToScreen(ox + 1, oy, targetPxWidth, targetPxHeight);
+  const tipWorldY = view.worldToScreen(ox, oy + 1, targetPxWidth, targetPxHeight);
+
+  // Columns of the world→device Jacobian J = [[jxx, jyx], [jxy, jyy]].
+  const jxx = tipWorldX.x - origin.x;
+  const jxy = tipWorldX.y - origin.y;
+  const jyx = tipWorldY.x - origin.x;
+  const jyy = tipWorldY.y - origin.y;
+
+  // Local axes in device pixels: apply the node's linear part to the Jacobian —
+  // local (1,0)→world (a,c), local (0,1)→world (b,d).
+  const scaleX = world.a * jxx + world.c * jyx; // device-x per local-x unit
+  const crossXy = world.a * jxy + world.c * jyy; // device-y per local-x unit
+  const crossYx = world.b * jxx + world.d * jyx; // device-x per local-y unit
+  const scaleY = world.b * jxy + world.d * jyy; // device-y per local-y unit
+
+  const axisAligned = Math.abs(crossXy) < epsilon && Math.abs(crossYx) < epsilon;
+
+  const snappedOriginX = Math.round(origin.x);
+  const snappedOriginY = Math.round(origin.y);
+
+  // Map the snapped device origin back to world via J⁻¹ so that, re-projected
+  // through the (unchanged) view, the rendered origin lands on the device pixel.
+  let worldX = ox;
+  let worldY = oy;
+  const det = jxx * jyy - jyx * jxy;
+
+  if (Math.abs(det) > epsilon) {
+    const ddx = snappedOriginX - origin.x;
+    const ddy = snappedOriginY - origin.y;
+
+    worldX = ox + (jyy * ddx - jyx * ddy) / det;
+    worldY = oy + (jxx * ddy - jxy * ddx) / det;
+  }
+
+  return {
+    originX: origin.x,
+    originY: origin.y,
+    snappedOriginX,
+    snappedOriginY,
+    worldX,
+    worldY,
+    scaleX,
+    scaleY,
+    axisAligned,
+  };
+}
+
+function noopContext(ox: number, oy: number): PixelSnapContext {
+  return {
+    originX: ox,
+    originY: oy,
+    snappedOriginX: ox,
+    snappedOriginY: oy,
+    worldX: ox,
+    worldY: oy,
+    scaleX: 0,
+    scaleY: 0,
+    axisAligned: false,
+  };
+}
+
+/**
+ * Copy `world` into `out`, replacing only the translation with the snapped world
+ * origin from `ctx`. The linear part `(a, b, c, d)` and homogeneous row are
+ * preserved, so rotation / scale / skew are untouched — position snapping is safe
+ * under any transform. The source `world` matrix is never mutated.
+ * @internal
+ */
+export function snapWorldTranslationInto(out: Matrix, world: Matrix, ctx: PixelSnapContext): Matrix {
+  out.copy(world);
+  out.x = ctx.worldX;
+  out.y = ctx.worldY;
+
+  return out;
+}
+
+/**
+ * Snap a single local boundary coordinate to the device-pixel grid along an axis
+ * whose local→device scale is `scale`. Returns the local value whose device
+ * position (relative to the already-snapped origin) lands on an integer device
+ * pixel: `round(L · scale) / scale`.
+ *
+ * The function is pure, so two boundaries with the same input value snap to the
+ * same output — shared boundaries stay shared and seams cannot open. It is also
+ * monotonic non-decreasing in `L` for any non-zero `scale` (including negative
+ * scale from a flip), so boundary order is preserved and snapped spans never go
+ * negative. Degenerate scales (`|scale| < epsilon`) and non-finite inputs return
+ * the value unchanged.
+ * @internal
+ */
+export function snapLocalBoundary(localValue: number, scale: number): number {
+  if (!Number.isFinite(localValue) || Math.abs(scale) < epsilon) {
+    return localValue;
+  }
+
+  return Math.round(localValue * scale) / scale;
+}
+
+/** A local-space quad with UVs — the content-cache shape shared by NineSlice / RepeatingSprite. @internal */
+export interface BoundaryQuad {
+  readonly x0: number;
+  readonly y0: number;
+  readonly x1: number;
+  readonly y1: number;
+  readonly u0: number;
+  readonly v0: number;
+  readonly u1: number;
+  readonly v1: number;
+}
+
+/** Mutable quad produced by {@link snapQuadsInto}; consumed by the batched sprite renderers. @internal */
+export interface RenderQuad {
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+  u0: number;
+  v0: number;
+  u1: number;
+  v1: number;
+}
+
+/**
+ * Snap every quad's local X/Y boundaries to the device grid using the per-axis
+ * scale in `ctx`, writing the result into the reusable `out` buffer (grown /
+ * truncated to match `source`, never reallocated per frame once warm). UVs are
+ * copied verbatim — sampling is unchanged. Because {@link snapLocalBoundary} is
+ * pure, quads sharing a boundary value stay seam-free without any explicit
+ * de-duplication.
+ * @internal
+ */
+export function snapQuadsInto(source: readonly BoundaryQuad[], ctx: PixelSnapContext, out: RenderQuad[]): RenderQuad[] {
+  const { scaleX, scaleY } = ctx;
+
+  out.length = source.length;
+
+  for (let i = 0; i < source.length; i++) {
+    const q = source[i];
+    let t = out[i];
+
+    if (t === undefined) {
+      t = out[i] = { x0: 0, y0: 0, x1: 0, y1: 0, u0: 0, v0: 0, u1: 0, v1: 0 };
+    }
+
+    t.x0 = snapLocalBoundary(q.x0, scaleX);
+    t.x1 = snapLocalBoundary(q.x1, scaleX);
+    t.y0 = snapLocalBoundary(q.y0, scaleY);
+    t.y1 = snapLocalBoundary(q.y1, scaleY);
+    t.u0 = q.u0;
+    t.v0 = q.v0;
+    t.u1 = q.u1;
+    t.v1 = q.v1;
+  }
+
+  return out;
+}
+
+/**
+ * Resolve the world transform to upload for `drawable` at the transform-buffer
+ * write seam. Returns the drawable's live global transform unchanged when its
+ * mode is `'none'` (zero overhead), otherwise a snapped copy written into the
+ * caller-owned `scratch` matrix — the logical global transform is never mutated.
+ *
+ * Both backends call this at their single transform-write boundary, so position
+ * snapping (and tilemap chunk/layer origin snapping) is applied once, backend-
+ * neutrally, to every drawable. `view` and the target device-pixel dimensions
+ * come from the active pass.
+ * @internal
+ */
+export function resolveUploadTransform(drawable: Drawable, view: View, targetPxWidth: number, targetPxHeight: number, scratch: Matrix): Matrix {
+  const world = drawable.getGlobalTransform();
+
+  if (drawable.pixelSnapMode === 'none') {
+    return world;
+  }
+
+  const ctx = buildPixelSnapContext(world, view, targetPxWidth, targetPxHeight);
+
+  return snapWorldTranslationInto(scratch, world, ctx);
+}
+
+/**
+ * Snap a single local-space bounds rectangle (e.g. a sprite quad) to the device
+ * grid using the per-axis scale in `ctx`, writing the result into `out`. Each of
+ * the four edges is snapped by {@link snapLocalBoundary}, so combined with the
+ * device-snapped origin every corner lands on a whole device pixel. `out` may be
+ * the same instance across frames (no allocation). UV/texture mapping is the
+ * caller's concern and is unaffected.
+ * @internal
+ */
+export function snapBoundsInto(base: Rectangle, ctx: PixelSnapContext, out: Rectangle): Rectangle {
+  const left = snapLocalBoundary(base.left, ctx.scaleX);
+  const top = snapLocalBoundary(base.top, ctx.scaleY);
+  const right = snapLocalBoundary(base.right, ctx.scaleX);
+  const bottom = snapLocalBoundary(base.bottom, ctx.scaleY);
+
+  return out.set(left, top, right - left, bottom - top);
+}
+
+/** Reason a requested `geometry` snap was downgraded. @internal */
+export type PixelSnapDowngradeReason = 'non-axis-aligned' | null;
+
+/**
+ * Resolve the effective snap mode from the requested mode and whether the
+ * combined node+view transform is axis-aligned. `geometry` downgrades to
+ * `position` when the transform is not axis-aligned (rotation or skew, in the
+ * node itself or any ancestor or the view); `none` and `position` pass through
+ * unchanged. Pure and stateless — never stores an effective mode, so it always
+ * reflects the current world transform.
+ * @internal
+ */
+export function resolveEffectivePixelSnapMode(requested: PixelSnapMode, axisAligned: boolean): PixelSnapMode {
+  if (requested === 'geometry' && !axisAligned) {
+    return 'position';
+  }
+
+  return requested;
+}
+
+/**
+ * Diagnostic companion to {@link resolveEffectivePixelSnapMode}: returns why a
+ * `geometry` request was downgraded, or `null` when no downgrade occurred. Not a
+ * stable public API — exposed for tests and dev warnings only.
+ * @internal
+ */
+export function getPixelSnapDowngradeReason(requested: PixelSnapMode, axisAligned: boolean): PixelSnapDowngradeReason {
+  if (requested === 'geometry' && !axisAligned) {
+    return 'non-axis-aligned';
+  }
+
+  return null;
+}

--- a/src/rendering/sprite/NineSliceSprite.ts
+++ b/src/rendering/sprite/NineSliceSprite.ts
@@ -1,7 +1,10 @@
+import { warnOnce } from '#core/dev';
 import type { Rectangle } from '#math/Rectangle';
 import { Drawable } from '#rendering/Drawable';
+import { buildPixelSnapContext, type RenderQuad, snapQuadsInto } from '#rendering/pixelSnap';
 import type { Texture } from '#rendering/texture/Texture';
 import { TextureRegion } from '#rendering/texture/TextureRegion';
+import type { View } from '#rendering/View';
 
 import type { NineSliceInsets, NineSliceModes, NineSliceOptions, NineSliceQuad } from './nineSlice';
 import {
@@ -43,6 +46,7 @@ export class NineSliceSprite extends Drawable {
 
   private _quads: NineSliceQuad[] = [];
   private _geometryDirty = true;
+  private readonly _renderQuads: RenderQuad[] = [];
 
   public constructor(texture: Texture | TextureRegion, options: NineSliceOptions) {
     super();
@@ -220,6 +224,36 @@ export class NineSliceSprite extends Drawable {
     }
 
     return this._quads;
+  }
+
+  /**
+   * Render-time quads for the active pass. In `'geometry'` pixel-snap mode (and
+   * only when the combined node+view transform is axis-aligned) the shared
+   * boundary plan is snapped to the render target's device-pixel grid via the
+   * common {@link snapQuadsInto} helper, so every corner/edge/center quad reuses
+   * the exact same snapped boundary value and no seams can open. The content
+   * quad cache ({@link quads}) is never rebuilt by snapping — camera movement
+   * reuses it — and snapped quads are written into a reused buffer. Returns the
+   * unsnapped content quads for `'none'`/`'position'` or under a rotation/skew
+   * downgrade.
+   * @internal
+   */
+  public getRenderQuads(view: View, targetPxWidth: number, targetPxHeight: number): readonly NineSliceQuad[] {
+    const base = this.quads;
+
+    if (base.length === 0) {
+      return base;
+    }
+
+    const ctx = buildPixelSnapContext(this.getGlobalTransform(), view, targetPxWidth, targetPxHeight);
+
+    if (!ctx.axisAligned) {
+      warnOnce('pixel-snap:geometry-downgrade', 'pixelSnapMode "geometry" downgraded to "position" for a rotated/skewed transform; rendered geometry is not boundary-snapped this frame.');
+
+      return base;
+    }
+
+    return snapQuadsInto(base, ctx, this._renderQuads);
   }
 
   // -----------------------------------------------------------------------

--- a/src/rendering/sprite/RepeatingSprite.ts
+++ b/src/rendering/sprite/RepeatingSprite.ts
@@ -1,8 +1,11 @@
+import { warnOnce } from '#core/dev';
 import type { Rectangle } from '#math/Rectangle';
 import { Drawable } from '#rendering/Drawable';
+import { buildPixelSnapContext, type RenderQuad, snapBoundsInto, snapQuadsInto } from '#rendering/pixelSnap';
 import type { RepeatFit, RepeatMode } from '#rendering/texture/repeat';
 import type { Texture } from '#rendering/texture/Texture';
 import { TextureRegion } from '#rendering/texture/TextureRegion';
+import type { View } from '#rendering/View';
 
 import type { RepeatingSpriteOptions, RepeatingSpriteQuad } from './repeatingSpritePlan';
 import {
@@ -46,6 +49,7 @@ export class RepeatingSprite extends Drawable {
 
   private _quads: RepeatingSpriteQuad[] = [];
   private _geometryDirty = true;
+  private readonly _renderQuads: RenderQuad[] = [];
 
   public constructor(source: Texture | TextureRegion, options?: RepeatingSpriteOptions) {
     super();
@@ -279,6 +283,57 @@ export class RepeatingSprite extends Drawable {
       this._rebuildGeometry();
     }
     return this._quads;
+  }
+
+  /**
+   * Render-time quads for the **geometry strategy**, device-pixel-snapped in
+   * `'geometry'` pixel-snap mode (axis-aligned only). Like NineSlice, every
+   * shared repeat-segment boundary is snapped once by {@link snapQuadsInto}, so
+   * adjacent segments stay gap-free; the content cache ({@link quads}) is never
+   * rebuilt by snapping. Returns the unsnapped quads otherwise.
+   * @internal
+   */
+  public getRenderQuads(view: View, targetPxWidth: number, targetPxHeight: number): readonly RepeatingSpriteQuad[] {
+    const base = this.quads;
+
+    if (this.pixelSnapMode !== 'geometry' || base.length === 0) {
+      return base;
+    }
+
+    const ctx = buildPixelSnapContext(this.getGlobalTransform(), view, targetPxWidth, targetPxHeight);
+
+    if (!ctx.axisAligned) {
+      warnOnce('pixel-snap:geometry-downgrade', 'pixelSnapMode "geometry" downgraded to "position" for a rotated/skewed transform; rendered geometry is not boundary-snapped this frame.');
+
+      return base;
+    }
+
+    return snapQuadsInto(base, ctx, this._renderQuads);
+  }
+
+  /**
+   * Render-time destination bounds for the **shader strategy**, written into
+   * `out`. In `'geometry'` pixel-snap mode (axis-aligned only) the destination
+   * quad edges are snapped to the device grid; repetition stays shader-based, so
+   * only the outer rectangle moves. Returns the logical local bounds otherwise.
+   * @internal
+   */
+  public getRenderBounds(view: View, targetPxWidth: number, targetPxHeight: number, out: Rectangle): Rectangle {
+    const base = this.getLocalBounds();
+
+    if (this.pixelSnapMode !== 'geometry') {
+      return base;
+    }
+
+    const ctx = buildPixelSnapContext(this.getGlobalTransform(), view, targetPxWidth, targetPxHeight);
+
+    if (!ctx.axisAligned) {
+      warnOnce('pixel-snap:geometry-downgrade', 'pixelSnapMode "geometry" downgraded to "position" for a rotated/skewed transform; rendered geometry is not boundary-snapped this frame.');
+
+      return base;
+    }
+
+    return snapBoundsInto(base, ctx, out);
   }
 
   // -----------------------------------------------------------------------

--- a/src/rendering/sprite/Sprite.ts
+++ b/src/rendering/sprite/Sprite.ts
@@ -1,12 +1,15 @@
+import { warnOnce } from '#core/dev';
 import { Interval } from '#math/Interval';
 import { Rectangle } from '#math/Rectangle';
 import { Vector } from '#math/Vector';
 import { Drawable } from '#rendering/Drawable';
 import type { Material } from '#rendering/material/Material';
 import type { SpriteMaterial } from '#rendering/material/SpriteMaterial';
+import { buildPixelSnapContext, snapBoundsInto } from '#rendering/pixelSnap';
 import { RenderNode } from '#rendering/RenderNode';
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { Texture } from '#rendering/texture/Texture';
+import type { View } from '#rendering/View';
 
 /**
  * Internal dirty-flag bitmask used by {@link Sprite} to lazily recompute
@@ -142,6 +145,35 @@ export class Sprite extends Drawable {
     }
 
     return this._vertices;
+  }
+
+  /**
+   * Local-space quad bounds for the active pass, written into `out`. In
+   * `'geometry'` pixel-snap mode (and only when the combined node+view transform
+   * is axis-aligned) the quad edges are snapped to the render target's
+   * device-pixel grid via the shared {@link snapLocalBoundary} helper — combined
+   * with the device-snapped origin from the transform seam, all four corners
+   * land on whole device pixels. The logical local bounds (used by collision /
+   * `getBounds`) are never changed. Returns the unsnapped local bounds for
+   * `'none'`/`'position'` or under a rotation/skew downgrade.
+   * @internal
+   */
+  public getRenderBounds(view: View, targetPxWidth: number, targetPxHeight: number, out: Rectangle): Rectangle {
+    const base = this.getLocalBounds();
+
+    if (this.pixelSnapMode !== 'geometry') {
+      return base;
+    }
+
+    const ctx = buildPixelSnapContext(this.getGlobalTransform(), view, targetPxWidth, targetPxHeight);
+
+    if (!ctx.axisAligned) {
+      warnOnce('pixel-snap:geometry-downgrade', 'pixelSnapMode "geometry" downgraded to "position" for a rotated/skewed transform; rendered geometry is not boundary-snapped this frame.');
+
+      return base;
+    }
+
+    return snapBoundsInto(base, ctx, out);
   }
 
   /**

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -7,6 +7,7 @@ import { Vector } from '#math/Vector';
 import type { BackendRenderPass } from '#rendering/BackendRenderPass';
 import type { Drawable } from '#rendering/Drawable';
 import type { Geometry } from '#rendering/geometry/Geometry';
+import { resolveUploadTransform } from '#rendering/pixelSnap';
 import { type DrawCommand, drawCommandUsesSharedTransform } from '#rendering/plan/RenderCommand';
 import type { RenderGroup } from '#rendering/plan/RenderInstruction';
 import type { RenderBackend } from '#rendering/RenderBackend';
@@ -153,6 +154,7 @@ export class WebGl2Backend implements RenderBackend {
   private _canvas: HTMLCanvasElement;
   private _contextLost: boolean;
   private _renderTarget: RenderTarget;
+  private readonly _snapTransform: Matrix = new Matrix();
   private _renderer: Renderer | null = null;
   private _shader: Shader | null = null;
   private _blendMode: BlendModes | null = null;
@@ -310,7 +312,38 @@ export class WebGl2Backend implements RenderBackend {
   public _writeTransformCommand(command: DrawCommand): void {
     const drawable = command.drawable;
 
-    this._transformBuffer.write(command.nodeIndex, drawable.getGlobalTransform(), drawable.tint);
+    this._transformBuffer.write(command.nodeIndex, this._resolveSnapTransform(drawable), drawable.tint);
+  }
+
+  /**
+   * Resolve the world transform to upload for `drawable`, applying render-only
+   * pixel snapping against the active render target's device-pixel grid when the
+   * drawable opts in. Returns the live (unsnapped) global transform for the
+   * `'none'` default; never mutates logical state.
+   * @internal
+   */
+  private _resolveSnapTransform(drawable: Drawable): Matrix {
+    const target = this._renderTarget;
+    const width = target.root ? this._canvas.width : target.width;
+    const height = target.root ? this._canvas.height : target.height;
+
+    return resolveUploadTransform(drawable, target.view, width, height, this._snapTransform);
+  }
+
+  /**
+   * Device-pixel dimensions of the active render target — `canvas.width/height`
+   * (css × pixelRatio) for the root, or the target's own size for an offscreen
+   * {@link RenderTexture}. Used by batched renderers to snap shared geometry
+   * boundaries to the same device grid the transform seam snaps the origin to.
+   * @internal
+   */
+  public _getSnapPixelSize(): { readonly width: number; readonly height: number } {
+    const target = this._renderTarget;
+
+    return {
+      width: target.root ? this._canvas.width : target.width,
+      height: target.root ? this._canvas.height : target.height,
+    };
   }
 
   /**
@@ -324,7 +357,7 @@ export class WebGl2Backend implements RenderBackend {
    * @internal
    */
   public _pushTransform(drawable: Drawable): number {
-    return this._transformBuffer.push(drawable.getGlobalTransform(), drawable.tint);
+    return this._transformBuffer.push(this._resolveSnapTransform(drawable), drawable.tint);
   }
 
   /** @internal */

--- a/src/rendering/webgl2/WebGl2NineSliceSpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2NineSliceSpriteRenderer.ts
@@ -111,13 +111,19 @@ export class WebGl2NineSliceSpriteRenderer extends AbstractWebGl2Renderer<NineSl
   }
 
   public render(sprite: NineSliceSprite): void {
-    const quads = sprite.quads;
+    const backend = this.getBackend();
+    let quads: readonly NineSliceQuad[] = sprite.quads;
+
+    if (sprite.pixelSnapMode === 'geometry') {
+      const snap = backend._getSnapPixelSize();
+
+      quads = sprite.getRenderQuads(backend.view, snap.width, snap.height);
+    }
 
     if (quads.length === 0) {
       return;
     }
 
-    const backend = this.getBackend();
     const texture = sprite.texture;
     const blendMode = sprite.blendMode;
     const tintRgba = sprite.tint.toRgba();

--- a/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
@@ -1,6 +1,7 @@
+import { Rectangle } from '#math/Rectangle';
 import { Shader } from '#rendering/shader/Shader';
 import type { RepeatingSprite } from '#rendering/sprite/RepeatingSprite';
-import { computeShaderTiling } from '#rendering/sprite/repeatingSpritePlan';
+import { computeShaderTiling, type RepeatingSpriteQuad } from '#rendering/sprite/repeatingSpritePlan';
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { RepeatMode } from '#rendering/texture/repeat';
 import { Texture } from '#rendering/texture/Texture';
@@ -186,6 +187,7 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
   private _connection: RendererConnection | null = null;
 
   private readonly _transformUnitScratch = new Int32Array([transformTextureUnit]);
+  private readonly _snapBounds = new Rectangle();
   private _currentView: unknown = null;
   private _currentViewId = -1;
 
@@ -259,9 +261,21 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
     const texture = sprite.texture;
     const srcW    = sprite.region.width;
     const srcH    = sprite.region.height;
-    const destW   = sprite.width;
-    const destH   = sprite.height;
+    let   destW   = sprite.width;
+    let   destH   = sprite.height;
     const flipY   = texture instanceof Texture && texture.flipY;
+
+    // 'geometry' mode: snap the destination quad to the device grid. Repetition
+    // stays shader-based; only the outer rectangle (and the tiling derived from
+    // it) moves. Position/none leave the destination unchanged.
+    if (sprite.pixelSnapMode === 'geometry') {
+      const backend = this.getBackend();
+      const snap = backend._getSnapPixelSize();
+      const rb = sprite.getRenderBounds(backend.view, snap.width, snap.height, this._snapBounds);
+
+      destW = rb.width;
+      destH = rb.height;
+    }
 
     const tilingX = computeShaderTiling(srcW, destW, sprite.modeX, sprite.fitX);
     const tilingY = computeShaderTiling(srcH, destH, sprite.modeY, sprite.fitY);
@@ -295,7 +309,16 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
   }
 
   private _writeGeoQuads(sprite: RepeatingSprite, nodeIndex: number): void {
-    const quads  = sprite.quads;
+    let quads: readonly RepeatingSpriteQuad[] = sprite.quads;
+
+    // 'geometry' mode: snap shared segment boundaries once (gap-free), like NineSlice.
+    if (sprite.pixelSnapMode === 'geometry') {
+      const backend = this.getBackend();
+      const snap = backend._getSnapPixelSize();
+
+      quads = sprite.getRenderQuads(backend.view, snap.width, snap.height);
+    }
+
     const flipY  = (sprite.texture instanceof Texture) && sprite.texture.flipY;
     const tint   = sprite.tint.toRgba();
 

--- a/src/rendering/webgl2/WebGl2SpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2SpriteRenderer.ts
@@ -1,3 +1,4 @@
+import { Rectangle } from '#math/Rectangle';
 import type { UniformValue } from '#rendering/material/Material';
 import type { SpriteMaterial } from '#rendering/material/SpriteMaterial';
 import { Shader } from '#rendering/shader/Shader';
@@ -88,6 +89,10 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> {
   private readonly _transformUnitScratch: Int32Array = new Int32Array([transformTextureUnit]);
   private _currentMaterial: SpriteMaterial | null = null;
   private _currentBaseTexture: Texture | RenderTexture | null = null;
+  // Reusable scratch for device-snapped local bounds ('geometry' mode), and the
+  // bounds resolved for the sprite currently being packed (snapped or logical).
+  private readonly _snapBounds: Rectangle = new Rectangle();
+  private _activeBounds: Rectangle | null = null;
 
   private _instanceCount = 0;
   // Highest transform-buffer row referenced by the pending batch; drives the
@@ -128,6 +133,8 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> {
     const command = backend.activeDrawCommand;
     const nodeIndex = command !== null ? command.nodeIndex : backend._pushTransform(sprite);
 
+    this._activeBounds = this._resolveBounds(sprite, backend);
+
     if (material === null) {
       this._renderDefault(sprite, texture, backend, nodeIndex);
     } else {
@@ -135,6 +142,22 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> {
     }
 
     return this;
+  }
+
+  /**
+   * Local bounds to upload for `sprite` this draw: device-pixel-snapped in
+   * `'geometry'` pixel-snap mode (axis-aligned only), otherwise the sprite's
+   * logical local bounds. Reuses a scratch rectangle and never mutates logical
+   * state. Consumed synchronously by {@link _packInstance}.
+   */
+  private _resolveBounds(sprite: Sprite, backend: WebGl2Backend): Rectangle {
+    if (sprite.pixelSnapMode !== 'geometry') {
+      return sprite.getLocalBounds();
+    }
+
+    const snap = backend._getSnapPixelSize();
+
+    return sprite.getRenderBounds(backend.view, snap.width, snap.height, this._snapBounds);
   }
 
   public flush(): void {
@@ -319,8 +342,9 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> {
     const f32 = this._instanceFloat32;
     const u32 = this._instanceUint32;
 
-    // localBounds: left, top, right, bottom (offset 0..3)
-    const bounds = sprite.getLocalBounds();
+    // localBounds: left, top, right, bottom (offset 0..3) — device-snapped in
+    // 'geometry' pixel-snap mode, otherwise the logical local bounds.
+    const bounds = this._activeBounds ?? sprite.getLocalBounds();
 
     f32[offset + 0] = bounds.left;
     f32[offset + 1] = bounds.top;

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -4,12 +4,13 @@
 import type { Application } from '#core/Application';
 import { Color } from '#core/Color';
 import { Signal } from '#core/Signal';
-import type { Matrix } from '#math/Matrix';
+import { Matrix } from '#math/Matrix';
 import type { Rectangle } from '#math/Rectangle';
 import { Vector } from '#math/Vector';
 import type { BackendRenderPass } from '#rendering/BackendRenderPass';
 import type { Drawable } from '#rendering/Drawable';
 import type { Geometry } from '#rendering/geometry/Geometry';
+import { resolveUploadTransform } from '#rendering/pixelSnap';
 import { type DrawCommand, drawCommandUsesSharedTransform } from '#rendering/plan/RenderCommand';
 import type { RenderGroup } from '#rendering/plan/RenderInstruction';
 import type { RenderBackend } from '#rendering/RenderBackend';
@@ -105,6 +106,7 @@ export class WebGpuBackend implements RenderBackend {
   private _format: GPUTextureFormat | null = null;
   private _initializePromise: Promise<this> | null = null;
   private _renderTarget: RenderTarget;
+  private readonly _snapTransform: Matrix = new Matrix();
   private _renderer: Renderer | null = null;
   private _texture: Texture | RenderTexture | null = null;
   private _clearRequested = false;
@@ -258,7 +260,7 @@ export class WebGpuBackend implements RenderBackend {
       const command = instructions[i];
 
       if (drawCommandUsesSharedTransform(command, this)) {
-        storage.writeCommand(command);
+        storage.writeCommand(command, this._resolveSnapTransform(command.drawable));
       } else {
         storage.recordSkippedWrite();
       }
@@ -686,7 +688,34 @@ export class WebGpuBackend implements RenderBackend {
    * @internal
    */
   public _pushTransform(drawable: Drawable): number {
-    return this._getTransformStorage().push(drawable);
+    return this._getTransformStorage().push(drawable, this._resolveSnapTransform(drawable));
+  }
+
+  /**
+   * Resolve the world transform to upload for `drawable`, applying render-only
+   * pixel snapping against the active render target's device-pixel grid when the
+   * drawable opts in. Returns the live (unsnapped) global transform for the
+   * `'none'` default; never mutates logical state.
+   * @internal
+   */
+  private _resolveSnapTransform(drawable: Drawable): Matrix {
+    const target = this._renderTarget;
+    const root = target === this._rootRenderTarget;
+    const width = root ? this._canvas.width : target.width;
+    const height = root ? this._canvas.height : target.height;
+
+    return resolveUploadTransform(drawable, target.view, width, height, this._snapTransform);
+  }
+
+  /**
+   * Device-pixel dimensions of the active render target — `canvas.width/height`
+   * (css × pixelRatio) for the root, or the target's own size for an offscreen
+   * {@link RenderTexture}. Used by batched renderers to snap shared geometry
+   * boundaries to the same device grid the transform seam snaps the origin to.
+   * @internal
+   */
+  public _getSnapPixelSize(): { readonly width: number; readonly height: number } {
+    return this._getAttachmentPixelSize(this._renderTarget);
   }
 
   private _setActiveRenderer(renderer: Renderer | null): void {

--- a/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
@@ -1,5 +1,6 @@
 /// <reference types="@webgpu/types" />
 
+import type { NineSliceQuad } from '#rendering/sprite/nineSlice';
 import type { NineSliceSprite } from '#rendering/sprite/NineSliceSprite';
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
 import { Texture } from '#rendering/texture/Texture';
@@ -180,7 +181,13 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
       return;
     }
 
-    const quads = sprite.quads;
+    let quads: readonly NineSliceQuad[] = sprite.quads;
+
+    if (sprite.pixelSnapMode === 'geometry') {
+      const snap = backend._getSnapPixelSize();
+
+      quads = sprite.getRenderQuads(backend.view, snap.width, snap.height);
+    }
 
     if (quads.length === 0) {
       return;

--- a/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
@@ -1,7 +1,8 @@
 /// <reference types="@webgpu/types" />
 
+import { Rectangle } from '#math/Rectangle';
 import type { RepeatingSprite } from '#rendering/sprite/RepeatingSprite';
-import { computeShaderTiling } from '#rendering/sprite/repeatingSpritePlan';
+import { computeShaderTiling, type RepeatingSpriteQuad } from '#rendering/sprite/repeatingSpritePlan';
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { RepeatMode } from '#rendering/texture/repeat';
 import { Texture } from '#rendering/texture/Texture';
@@ -178,6 +179,8 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
   private _currentModeX: RepeatMode | null = null;
   private _currentModeY: RepeatMode | null = null;
   private _currentPath: 'shader' | 'geometry' | null = null;
+  // Reusable scratch for device-snapped bounds ('geometry' mode).
+  private readonly _snapBounds = new Rectangle();
 
   protected onConnect(backend: WebGpuBackend): void {
     if (this._device) return;
@@ -301,9 +304,21 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     const texture = sprite.texture;
     const srcW    = sprite.region.width;
     const srcH    = sprite.region.height;
-    const destW   = sprite.width;
-    const destH   = sprite.height;
+    let   destW   = sprite.width;
+    let   destH   = sprite.height;
     const flipY   = texture instanceof Texture && texture.flipY;
+
+    // 'geometry' mode: snap the destination quad to the device grid. Repetition
+    // stays shader-based; only the outer rectangle (and the tiling derived from
+    // it) moves. Position/none leave the destination unchanged.
+    if (sprite.pixelSnapMode === 'geometry') {
+      const backend = this.getBackend();
+      const snap = backend._getSnapPixelSize();
+      const rb = sprite.getRenderBounds(backend.view, snap.width, snap.height, this._snapBounds);
+
+      destW = rb.width;
+      destH = rb.height;
+    }
 
     const tilingX = computeShaderTiling(srcW, destW, sprite.modeX, sprite.fitX);
     const tilingY = computeShaderTiling(srcH, destH, sprite.modeY, sprite.fitY);
@@ -334,7 +349,16 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
   }
 
   private _writeGeoQuads(sprite: RepeatingSprite, nodeIndex: number): void {
-    const quads = sprite.quads;
+    let quads: readonly RepeatingSpriteQuad[] = sprite.quads;
+
+    // 'geometry' mode: snap shared segment boundaries once (gap-free), like NineSlice.
+    if (sprite.pixelSnapMode === 'geometry') {
+      const backend = this.getBackend();
+      const snap = backend._getSnapPixelSize();
+
+      quads = sprite.getRenderQuads(backend.view, snap.width, snap.height);
+    }
+
     if (quads.length === 0) return;
 
     const flipY = (sprite.texture instanceof Texture) && sprite.texture.flipY;

--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -1,5 +1,6 @@
 /// <reference types="@webgpu/types" />
 
+import { Rectangle } from '#math/Rectangle';
 import type { UniformValue } from '#rendering/material/Material';
 import type { SpriteMaterial } from '#rendering/material/SpriteMaterial';
 import type { Sprite } from '#rendering/sprite/Sprite';
@@ -225,6 +226,10 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
   private _customBaseTextureLayout: GPUBindGroupLayout | null = null;
   private _currentMaterial: SpriteMaterial | null = null;
   private _currentBaseTexture: Texture | RenderTexture | null = null;
+  // Reusable scratch for device-snapped local bounds ('geometry' mode), and the
+  // bounds resolved for the sprite currently being packed (snapped or logical).
+  private readonly _snapBounds: Rectangle = new Rectangle();
+  private _activeBounds: Rectangle | null = null;
 
   protected onConnect(backend: WebGpuBackend): void {
     if (this._device) {
@@ -359,11 +364,29 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     const command = backend.activeDrawCommand;
     const nodeIndex = command !== null ? command.nodeIndex : backend._pushTransform(sprite);
 
+    this._activeBounds = this._resolveBounds(sprite, backend);
+
     if (material === null) {
       this._renderDefault(sprite, texture, backend, nodeIndex);
     } else {
       this._renderCustom(sprite, texture, material, backend, nodeIndex);
     }
+  }
+
+  /**
+   * Local bounds to upload for `sprite` this draw: device-pixel-snapped in
+   * `'geometry'` pixel-snap mode (axis-aligned only), otherwise the sprite's
+   * logical local bounds. Reuses a scratch rectangle and never mutates logical
+   * state. Consumed synchronously by {@link _packInstance}.
+   */
+  private _resolveBounds(sprite: Sprite, backend: WebGpuBackend): Rectangle {
+    if (sprite.pixelSnapMode !== 'geometry') {
+      return sprite.getLocalBounds();
+    }
+
+    const snap = backend._getSnapPixelSize();
+
+    return sprite.getRenderBounds(backend.view, snap.width, snap.height, this._snapBounds);
   }
 
   /** Default multi-texture path: rotate the base texture through 8 slots. */
@@ -587,8 +610,9 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     const f32 = this._instanceFloat32;
     const u32 = this._instanceUint32;
 
-    // localBounds: left, top, right, bottom (words 0..3, offset 0)
-    const bounds = sprite.getLocalBounds();
+    // localBounds: left, top, right, bottom (words 0..3, offset 0) — device-snapped in
+    // 'geometry' pixel-snap mode, otherwise the logical local bounds.
+    const bounds = this._activeBounds ?? sprite.getLocalBounds();
 
     f32[offset + 0] = bounds.left;
     f32[offset + 1] = bounds.top;

--- a/src/rendering/webgpu/WebGpuTransformStorage.ts
+++ b/src/rendering/webgpu/WebGpuTransformStorage.ts
@@ -1,3 +1,4 @@
+import type { Matrix } from '#math/Matrix';
 import type { Drawable } from '#rendering/Drawable';
 import type { DrawCommand } from '#rendering/plan/RenderCommand';
 import { TransformBuffer } from '#rendering/TransformBuffer';
@@ -25,10 +26,10 @@ export class WebGpuTransformStorage {
     this._buffer.begin(nodeCount);
   }
 
-  public writeCommand(command: DrawCommand): void {
+  public writeCommand(command: DrawCommand, transform?: Matrix): void {
     const drawable = command.drawable;
 
-    this._buffer.write(command.nodeIndex, drawable.getGlobalTransform(), drawable.tint);
+    this._buffer.write(command.nodeIndex, transform ?? drawable.getGlobalTransform(), drawable.tint);
   }
 
   /**
@@ -46,8 +47,8 @@ export class WebGpuTransformStorage {
    * `nodeIndex` — a direct `backend.draw(drawable)` outside the plan player —
    * so a batch of synthetic draws does not collide on a single row.
    */
-  public push(drawable: Drawable): number {
-    return this._buffer.push(drawable.getGlobalTransform(), drawable.tint);
+  public push(drawable: Drawable, transform?: Matrix): number {
+    return this._buffer.push(transform ?? drawable.getGlobalTransform(), drawable.tint);
   }
 
   /**

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -246,6 +246,7 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "OscillatorType: type alias",
   "PitchShiftFilter: class",
   "PitchShiftFilterOptions: interface",
+  "PixelSnapMode: type alias",
   "PlayOptions: interface",
   "PlayStationGamepadMapping: class",
   "PlaybackOptions: interface",

--- a/test/rendering/browser/webgl2-pixel-snap.test.ts
+++ b/test/rendering/browser/webgl2-pixel-snap.test.ts
@@ -1,0 +1,369 @@
+/**
+ * WebGL2 render-only pixel-snapping browser tests.
+ *
+ * The exact snapping math (device-pixel mapping, rounding, shared-boundary
+ * snapping, downgrade) is proven by `test/rendering/pixel-snap.test.ts`. These
+ * end-to-end tests verify that snapping flows through the real WebGL2 pipeline
+ * without breaking rendering, keeps logical state untouched, produces seam-free
+ * geometry, stays deterministic, and downgrades gracefully under rotation.
+ *
+ * Note on single-frame pixel assertions: a solid quad's rasterised coverage is
+ * already quantised to the device grid (pixel-centre rule), so a static
+ * solid-colour frame cannot distinguish snapped from unsnapped — the snapping
+ * benefit is sampling stability under motion. We therefore assert render
+ * correctness, the render-only contract, and seam-freeness rather than a
+ * snapped-vs-unsnapped solid-pixel diff.
+ *
+ * Run via:  pnpm test:browser:webgl2
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import type { RenderNode } from '#rendering/RenderNode';
+import { NineSliceSprite } from '#rendering/sprite/NineSliceSprite';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+
+const shaderSources = vi.hoisted(() => ({
+  spriteVert: `#version 300 es
+precision mediump float;
+in vec4 a_localBounds;
+in vec4 a_uvBounds;
+in vec4 a_color;
+in uint a_textureSlot;
+in uint a_nodeIndex;
+uniform mat3 u_projection;
+uniform sampler2D u_transforms;
+out vec2 v_uv;
+out vec4 v_color;
+flat out uint v_textureSlot;
+void main() {
+  vec2 local;
+  if (gl_VertexID == 0) local = vec2(a_localBounds.x, a_localBounds.y);
+  else if (gl_VertexID == 1) local = vec2(a_localBounds.z, a_localBounds.y);
+  else if (gl_VertexID == 2) local = vec2(a_localBounds.x, a_localBounds.w);
+  else local = vec2(a_localBounds.z, a_localBounds.w);
+  vec2 uv;
+  if (gl_VertexID == 0) uv = vec2(a_uvBounds.x, a_uvBounds.y);
+  else if (gl_VertexID == 1) uv = vec2(a_uvBounds.z, a_uvBounds.y);
+  else if (gl_VertexID == 2) uv = vec2(a_uvBounds.x, a_uvBounds.w);
+  else uv = vec2(a_uvBounds.z, a_uvBounds.w);
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
+  vec3 clip = u_projection * vec3(world, 1.0);
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = uv; v_color = a_color; v_textureSlot = a_textureSlot;
+}`,
+  spriteFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv;
+in vec4 v_color;
+flat in uint v_textureSlot;
+uniform sampler2D u_texture0;
+uniform sampler2D u_texture1;
+uniform sampler2D u_texture2;
+uniform sampler2D u_texture3;
+uniform sampler2D u_texture4;
+uniform sampler2D u_texture5;
+uniform sampler2D u_texture6;
+uniform sampler2D u_texture7;
+out vec4 outColor;
+vec4 sampleTexture(uint slot, vec2 uv) {
+  if (slot == uint(0)) return texture(u_texture0, uv);
+  if (slot == uint(1)) return texture(u_texture1, uv);
+  if (slot == uint(2)) return texture(u_texture2, uv);
+  if (slot == uint(3)) return texture(u_texture3, uv);
+  if (slot == uint(4)) return texture(u_texture4, uv);
+  if (slot == uint(5)) return texture(u_texture5, uv);
+  if (slot == uint(6)) return texture(u_texture6, uv);
+  return texture(u_texture7, uv);
+}
+void main() { outColor = sampleTexture(v_textureSlot, v_uv) * v_color; }`,
+  meshVert: `#version 300 es
+precision mediump float;
+in vec2 a_position;
+in vec2 a_texcoord;
+in vec4 a_color;
+in uint a_nodeIndex;
+uniform mat3 u_projection;
+uniform sampler2D u_transforms;
+out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
+void main() {
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  mat3 t = mat3(m0.x,m0.z,0.0, m0.y,m0.w,0.0, m1.x,m1.y,1.0);
+  vec3 world = t * vec3(a_position, 1.0);
+  vec3 clip = u_projection * world;
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = a_texcoord; v_color = a_color;
+  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+}`,
+  meshFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv; in vec4 v_color; in vec4 v_tint;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() { outColor = texture(u_texture, v_uv) * v_color * v_tint; }`,
+  textVert: `#version 300 es
+precision mediump float;
+in vec2 a_position; in vec2 a_texcoord; in float a_nodeIndex;
+uniform mat3 u_projection;
+out vec2 v_uv;
+void main() {
+  float ni = a_nodeIndex;
+  vec3 clip = u_projection * vec3(a_position + vec2(ni * 0.0), 1.0);
+  gl_Position = vec4(clip.xy, 0.0, 1.0); v_uv = a_texcoord;
+}`,
+  textFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() { outColor = texture(u_texture, v_uv); }`,
+}));
+
+vi.mock('#rendering/webgl2/glsl/sprite.vert', () => ({ default: shaderSources.spriteVert }));
+vi.mock('#rendering/webgl2/glsl/sprite.frag', () => ({ default: shaderSources.spriteFrag }));
+vi.mock('#rendering/webgl2/glsl/mesh.vert', () => ({ default: shaderSources.meshVert }));
+vi.mock('#rendering/webgl2/glsl/mesh.frag', () => ({ default: shaderSources.meshFrag }));
+vi.mock('#rendering/webgl2/glsl/text.vert', () => ({ default: shaderSources.textVert }));
+vi.mock('#rendering/webgl2/glsl/text-color.frag', () => ({ default: shaderSources.textFrag }));
+vi.mock('#rendering/webgl2/glsl/text-msdf.frag', () => ({ default: shaderSources.textFrag }));
+vi.mock('#rendering/webgl2/glsl/text-sdf.frag', () => ({ default: shaderSources.textFrag }));
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const createBackend = async (): Promise<WebGl2Backend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const app: Application = {
+    canvas,
+    options: {
+      clearColor: Color.black,
+      canvas: { width: canvasSize, height: canvasSize },
+      rendering: {
+        debug: false,
+        webglAttributes: {
+          alpha: false,
+          antialias: false,
+          premultipliedAlpha: false,
+          preserveDrawingBuffer: true,
+          stencil: false,
+          depth: false,
+        },
+        spriteRendererBatchSize: 1024,
+        particleRendererBatchSize: 1024,
+      },
+    },
+  } as unknown as Application;
+
+  const backend = new WebGl2Backend(app);
+
+  await backend.initialize();
+  wireCoreRenderers(backend, app.options.rendering);
+
+  return backend;
+};
+
+const render = (backend: WebGl2Backend, node: RenderNode): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+  node.render(backend);
+  backend.flush();
+};
+
+const readPixel = (backend: WebGl2Backend, x: number, y: number): RgbaTuple => {
+  const buf = new Uint8Array(4);
+  const gl = backend.context;
+
+  gl.readPixels(Math.floor(x), backend.renderTarget.height - Math.floor(y) - 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+
+  return [buf[0], buf[1], buf[2], buf[3]];
+};
+
+const readAll = (backend: WebGl2Backend): Uint8Array => {
+  const buf = new Uint8Array(canvasSize * canvasSize * 4);
+  const gl = backend.context;
+
+  gl.readPixels(0, 0, canvasSize, canvasSize, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+
+  return buf;
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 8): void => {
+  for (let i = 0; i < 4; i++) {
+    expect(Math.abs(actual[i] - expected[i])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+const createSolidTexture = (color: string, width = 16, height = 16): Texture => {
+  const src = document.createElement('canvas');
+
+  src.width = width;
+  src.height = height;
+
+  const ctx = src.getContext('2d')!;
+
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, width, height);
+
+  return new Texture(src);
+};
+
+// ---------------------------------------------------------------------------
+// Sprite — position snapping is render-only
+// ---------------------------------------------------------------------------
+
+describe('WebGL2 pixel snapping — Sprite position mode', () => {
+  test('renders correctly at a fractional position and leaves logical state untouched', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ff0000', 16, 16);
+    const root = new Container();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.setPosition(12.37, 14.83);
+      sprite.pixelSnapMode = 'position';
+      root.addChild(sprite);
+
+      const worldBefore = sprite.getGlobalTransform().clone();
+
+      render(backend, root);
+
+      // Renders through the snap pipeline (interior covered, exterior clear).
+      expectPixelNear(readPixel(backend, 20, 22), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(backend, 2, 2), [0, 0, 0, 255]);
+
+      // Render-only: logical position and world transform are unchanged.
+      expect(sprite.x).toBe(12.37);
+      expect(sprite.y).toBe(14.83);
+      expect(sprite.getGlobalTransform().equals(worldBefore)).toBe(true);
+
+      worldBefore.destroy();
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('unsnapped baseline renders the same interior color', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ff0000', 16, 16);
+    const root = new Container();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.setPosition(12.37, 14.83);
+      sprite.pixelSnapMode = 'none';
+      root.addChild(sprite);
+
+      render(backend, root);
+
+      expectPixelNear(readPixel(backend, 20, 22), [255, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('snapped rendering is deterministic across frames', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#00ff00', 16, 16);
+    const root = new Container();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.setPosition(9.6, 5.2);
+      sprite.pixelSnapMode = 'geometry';
+      root.addChild(sprite);
+
+      render(backend, root);
+      const first = readAll(backend);
+
+      render(backend, root);
+      const second = readAll(backend);
+
+      expect(Array.from(second)).toEqual(Array.from(first));
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NineSlice — geometry snapping is seam-free and downgrades under rotation
+// ---------------------------------------------------------------------------
+
+describe('WebGL2 pixel snapping — NineSlice geometry mode', () => {
+  test('produces no interior seams at a fractional placement', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ff0000', 32, 32);
+    const root = new Container();
+    const panel = new NineSliceSprite(texture, { slices: 8, width: 41, height: 41 });
+
+    try {
+      panel.setPosition(6.3, 6.3);
+      panel.pixelSnapMode = 'geometry';
+      root.addChild(panel);
+
+      render(backend, root);
+
+      // Scan a horizontal line well inside the panel: every pixel must be the
+      // solid panel colour — a snapping-induced seam would show as black.
+      for (let x = 10; x <= 44; x++) {
+        const pixel = readPixel(backend, x, 26);
+
+        expect(pixel[0]).toBeGreaterThan(200); // red present → no gap
+      }
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('geometry mode under rotation downgrades without error and keeps logical transform', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#0000ff', 32, 32);
+    const root = new Container();
+    const panel = new NineSliceSprite(texture, { slices: 8, width: 30, height: 30 });
+
+    try {
+      panel.setPosition(32, 32);
+      panel.setRotation(25);
+      panel.pixelSnapMode = 'geometry';
+      root.addChild(panel);
+
+      const worldBefore = panel.getGlobalTransform().clone();
+
+      expect(() => render(backend, root)).not.toThrow();
+
+      // Logical transform untouched by the (downgraded) snap.
+      expect(panel.getGlobalTransform().equals(worldBefore)).toBe(true);
+      // Still drew something blue near the centre.
+      expect(readPixel(backend, 32, 32)[2]).toBeGreaterThan(128);
+
+      worldBefore.destroy();
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgl2-tilemap-snap.test.ts
+++ b/test/rendering/browser/webgl2-tilemap-snap.test.ts
@@ -1,0 +1,256 @@
+/**
+ * WebGL2 tilemap pixel-snapping browser tests.
+ *
+ * Verifies that setting `pixelSnapMode = 'geometry'` on a {@link TileMapNode}
+ * placed at a fractional world position produces no background/clear-colour
+ * gaps across a chunk boundary in the rendered output. The snapping benefit is
+ * that tile chunk origins are snapped to the device-pixel grid, keeping
+ * adjacent chunks exactly contiguous even when the map's anchor lands on a
+ * sub-pixel boundary.
+ *
+ * The tilemap renderer uses inline GLSL, so no shader-file mocks are required.
+ * Only the tilemap renderer binding is wired (no core renderers needed).
+ *
+ * Run via:  pnpm test:browser:webgl2
+ */
+
+import { TILE_TRANSFORM_IDENTITY, TileLayer, TileMap, TileMapNode } from '@codexo/exojs-tilemap';
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import type { RenderNode } from '#rendering/RenderNode';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import { createSolidTexture, makeTileset, wireTilemapRenderers } from './_tilemapScene';
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const createBackend = async (): Promise<WebGl2Backend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const app: Application = {
+    canvas,
+    options: {
+      clearColor: Color.black,
+      canvas: { width: canvasSize, height: canvasSize },
+      rendering: {
+        debug: false,
+        webglAttributes: {
+          alpha: false,
+          antialias: false,
+          premultipliedAlpha: false,
+          preserveDrawingBuffer: true,
+          stencil: false,
+          depth: false,
+        },
+      },
+    },
+  } as unknown as Application;
+
+  const backend = new WebGl2Backend(app);
+
+  await backend.initialize();
+  wireTilemapRenderers(backend);
+
+  return backend;
+};
+
+const render = (backend: WebGl2Backend, node: RenderNode): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+  node.render(backend);
+  backend.flush();
+};
+
+const readPixel = (backend: WebGl2Backend, x: number, y: number): RgbaTuple => {
+  const buf = new Uint8Array(4);
+  const gl = backend.context;
+
+  gl.readPixels(Math.floor(x), backend.renderTarget.height - Math.floor(y) - 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+
+  return [buf[0], buf[1], buf[2], buf[3]];
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 12): void => {
+  for (let i = 0; i < 4; i++) {
+    expect(Math.abs(actual[i] - expected[i])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+/**
+ * Build a 4×1 tile map with chunkWidth=2 so the chunk seam falls at tile x=2
+ * (screen x = node.x + 2*tileWidth). All tiles use a solid-colour tileset.
+ * Tile pitch is 16px; the canvas is 64px wide, leaving room for the seam at
+ * screen x≈32 when the node is near the origin.
+ */
+function buildSeamMap(texture: ReturnType<typeof createSolidTexture>): { map: TileMap; tileset: ReturnType<typeof makeTileset> } {
+  const tileset = makeTileset(texture);
+  const layer = new TileLayer({
+    id: 1,
+    name: 'ground',
+    width: 4,
+    height: 1,
+    tileWidth: 16,
+    tileHeight: 16,
+    chunkWidth: 2,
+    chunkHeight: 2,
+    tilesets: [tileset],
+  });
+
+  for (let tx = 0; tx < 4; tx++) {
+    layer.setTileAt(tx, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+  }
+
+  const map = new TileMap({
+    name: 'm',
+    width: 4,
+    height: 1,
+    tileWidth: 16,
+    tileHeight: 16,
+    tilesets: [tileset],
+    layers: [layer],
+  });
+
+  return { map, tileset };
+}
+
+// ── pixel-snap seam tests ────────────────────────────────────────────────
+
+describe('WebGL2 tilemap pixel snapping — chunk seam', () => {
+  test('geometry mode: no clear-colour gap across chunk boundary at fractional position', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ff0000');
+    const { map } = buildSeamMap(texture);
+    const node = new TileMapNode(map);
+
+    try {
+      // Fractional placement: the node's world position is not on the device-pixel
+      // grid, so without snapping floating-point rounding can open a 1-pixel gap
+      // at the chunk seam. With 'geometry' mode each chunk's origin is snapped,
+      // keeping all four tiles contiguous.
+      node.setPosition(0.7, 0.7);
+      node.pixelSnapMode = 'geometry';
+
+      render(backend, node);
+
+      // The chunk seam is between tile x=1 and x=2, i.e. near screen x=32.
+      // Scan a horizontal strip covering both chunks; every pixel must carry the
+      // tile colour (red) — a gap would appear as the black clear colour.
+      for (let x = 4; x <= 59; x++) {
+        const pixel = readPixel(backend, x, 8);
+
+        expect(pixel[0]).toBeGreaterThan(200); // red channel present → tile, not gap
+      }
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('pixelSnapMode is render-only: logical position is unchanged after render', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#00ff00');
+    const { map } = buildSeamMap(texture);
+    const node = new TileMapNode(map);
+
+    try {
+      node.setPosition(3.14, 7.77);
+      node.pixelSnapMode = 'geometry';
+
+      render(backend, node);
+
+      // Logical transform must not have been mutated by the render-only snap.
+      expect(node.x).toBe(3.14);
+      expect(node.y).toBe(7.77);
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('snapped tilemap rendering is deterministic across frames', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#0000ff');
+    const { map } = buildSeamMap(texture);
+    const node = new TileMapNode(map);
+
+    try {
+      node.setPosition(5.5, 2.3);
+      node.pixelSnapMode = 'geometry';
+
+      render(backend, node);
+
+      const buf1 = new Uint8Array(canvasSize * canvasSize * 4);
+
+      backend.context.readPixels(0, 0, canvasSize, canvasSize, backend.context.RGBA, backend.context.UNSIGNED_BYTE, buf1);
+
+      render(backend, node);
+
+      const buf2 = new Uint8Array(canvasSize * canvasSize * 4);
+
+      backend.context.readPixels(0, 0, canvasSize, canvasSize, backend.context.RGBA, backend.context.UNSIGNED_BYTE, buf2);
+
+      expect(Array.from(buf2)).toEqual(Array.from(buf1));
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('position mode also produces no seam gap across chunk boundary', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ff0000');
+    const { map } = buildSeamMap(texture);
+    const node = new TileMapNode(map);
+
+    try {
+      node.setPosition(0.7, 0.7);
+      node.pixelSnapMode = 'position';
+
+      render(backend, node);
+
+      // TileChunkNode chunk origins are integer multiples of tile pitch relative
+      // to the snapped layer origin, so both modes produce no seam.
+      for (let x = 4; x <= 59; x++) {
+        const pixel = readPixel(backend, x, 8);
+
+        expect(pixel[0]).toBeGreaterThan(200);
+      }
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('unsnapped tilemap at integer position renders without gaps', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ff0000');
+    const { map } = buildSeamMap(texture);
+    const node = new TileMapNode(map);
+
+    try {
+      // An integer position means no sub-pixel drift; no snapping needed.
+      node.setPosition(0, 0);
+      node.pixelSnapMode = 'none';
+
+      render(backend, node);
+
+      expectPixelNear(readPixel(backend, 8, 8), [255, 0, 0, 255]); // chunk 0
+      expectPixelNear(readPixel(backend, 32, 8), [255, 0, 0, 255]); // seam column
+      expectPixelNear(readPixel(backend, 40, 8), [255, 0, 0, 255]); // chunk 1
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgpu-pixel-snap.test.ts
+++ b/test/rendering/browser/webgpu-pixel-snap.test.ts
@@ -1,0 +1,364 @@
+/**
+ * WebGPU render-only pixel-snapping browser tests — opt-in, capability-aware.
+ *
+ * Mirrors `webgl2-pixel-snap.test.ts` case-for-case on the WebGPU backend.
+ * The exact snapping math is proven by `test/rendering/pixel-snap.test.ts`;
+ * these end-to-end tests verify that snapping flows through the real WebGPU
+ * pipeline without breaking rendering, keeps logical state untouched, produces
+ * seam-free geometry, stays deterministic, and downgrades gracefully under
+ * rotation.
+ *
+ * All WebGPU tests skip gracefully when WebGPU is unavailable (no adapter or
+ * software adapter lost mid-test). The double-skip contract ensures no false
+ * failures on headless CI or machines without --enable-unsafe-webgpu:
+ *  1. `setupBackend` skips when navigator.gpu / requestAdapter() is absent.
+ *  2. `renderScene` calls `getBackendDeviceOrSkip` (device-gone guard) and
+ *     catches DOMException device-loss mid-test.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import type { RenderNode } from '#rendering/RenderNode';
+import { NineSliceSprite } from '#rendering/sprite/NineSliceSprite';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: {
+      canvas: { width: canvasSize, height: canvasSize },
+      clearColor: Color.black,
+    },
+  }) as unknown as Application;
+
+const createSolidTexture = (color: string, width = 16, height = 16): Texture => {
+  const src = document.createElement('canvas');
+
+  src.width = width;
+  src.height = height;
+
+  const ctx = src.getContext('2d')!;
+
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, width, height);
+
+  return new Texture(src);
+};
+
+const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<WebGpuBackend | null> => {
+  if (!navigator.gpu) {
+    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
+
+    return null;
+  }
+
+  const adapter = await navigator.gpu.requestAdapter();
+
+  if (!adapter) {
+    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
+
+    return null;
+  }
+
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  await backend.initialize();
+  wireCoreRenderers(backend);
+
+  return backend;
+};
+
+// Read the presented WebGPU canvas back through a 2D canvas.
+const readCanvas = (backend: WebGpuBackend): ((x: number, y: number) => RgbaTuple) => {
+  const source = backend.context.canvas as HTMLCanvasElement;
+  const readback = document.createElement('canvas');
+
+  readback.width = canvasSize;
+  readback.height = canvasSize;
+
+  const ctx = readback.getContext('2d')!;
+
+  ctx.drawImage(source, 0, 0);
+
+  return (x: number, y: number): RgbaTuple => {
+    const { data } = ctx.getImageData(Math.floor(x), Math.floor(y), 1, 1);
+
+    return [data[0], data[1], data[2], data[3]];
+  };
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 12): void => {
+  for (let i = 0; i < 4; i++) {
+    expect(Math.abs(actual[i] - expected[i])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+// On the software (swiftshader) adapter the WebGPU device can be dropped
+// mid-test. Treat that as an unavailable-adapter skip rather than a failure.
+const isDeviceLoss = (error: unknown): boolean =>
+  error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+// Render a scene inside a validation error scope.
+// Returns false when the device dropped mid-test (caller should bail).
+const renderScene = async (
+  ctx: { skip: (reason: string) => void },
+  backend: WebGpuBackend,
+  root: RenderNode,
+): Promise<boolean> => {
+  const device = getBackendDeviceOrSkip(ctx, backend);
+
+  if (!device) {
+    return false;
+  }
+
+  device.pushErrorScope('validation');
+
+  let validationError: GPUError | null;
+
+  try {
+    backend.resetStats();
+    backend.clear(Color.black);
+    root.render(backend);
+    backend.flush();
+    validationError = await device.popErrorScope();
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+
+  expect(validationError).toBeNull();
+
+  return true;
+};
+
+// ---------------------------------------------------------------------------
+// Sprite — position snapping is render-only
+// ---------------------------------------------------------------------------
+
+describe('WebGPU pixel snapping — Sprite position mode', () => {
+  test('renders correctly at a fractional position and leaves logical state untouched', async ctx => {
+    const backend = await setupBackend(ctx);
+
+    if (!backend) {
+      return;
+    }
+
+    const texture = createSolidTexture('#ff0000', 16, 16);
+    const root = new Container();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.setPosition(12.37, 14.83);
+      sprite.pixelSnapMode = 'position';
+      root.addChild(sprite);
+
+      const worldBefore = sprite.getGlobalTransform().clone();
+
+      if (!(await renderScene(ctx, backend, root))) {
+        worldBefore.destroy();
+
+        return;
+      }
+
+      const readPixel = readCanvas(backend);
+
+      // Renders through the snap pipeline (interior covered, exterior clear).
+      expectPixelNear(readPixel(20, 22), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(2, 2), [0, 0, 0, 255]);
+
+      // Render-only: logical position and world transform are unchanged.
+      expect(sprite.x).toBe(12.37);
+      expect(sprite.y).toBe(14.83);
+      expect(sprite.getGlobalTransform().equals(worldBefore)).toBe(true);
+
+      worldBefore.destroy();
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('unsnapped baseline renders the same interior color', async ctx => {
+    const backend = await setupBackend(ctx);
+
+    if (!backend) {
+      return;
+    }
+
+    const texture = createSolidTexture('#ff0000', 16, 16);
+    const root = new Container();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.setPosition(12.37, 14.83);
+      sprite.pixelSnapMode = 'none';
+      root.addChild(sprite);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      const readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(20, 22), [255, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('snapped rendering is deterministic across frames', async ctx => {
+    const backend = await setupBackend(ctx);
+
+    if (!backend) {
+      return;
+    }
+
+    const texture = createSolidTexture('#00ff00', 16, 16);
+    const root = new Container();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.setPosition(9.6, 5.2);
+      sprite.pixelSnapMode = 'geometry';
+      root.addChild(sprite);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      const source = backend.context.canvas as HTMLCanvasElement;
+      const rb1 = document.createElement('canvas');
+
+      rb1.width = canvasSize;
+      rb1.height = canvasSize;
+      rb1.getContext('2d')!.drawImage(source, 0, 0);
+
+      const first = rb1.getContext('2d')!.getImageData(0, 0, canvasSize, canvasSize).data;
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      const rb2 = document.createElement('canvas');
+
+      rb2.width = canvasSize;
+      rb2.height = canvasSize;
+      rb2.getContext('2d')!.drawImage(source, 0, 0);
+
+      const second = rb2.getContext('2d')!.getImageData(0, 0, canvasSize, canvasSize).data;
+
+      expect(Array.from(second)).toEqual(Array.from(first));
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NineSlice — geometry snapping is seam-free and downgrades under rotation
+// ---------------------------------------------------------------------------
+
+describe('WebGPU pixel snapping — NineSlice geometry mode', () => {
+  test('produces no interior seams at a fractional placement', async ctx => {
+    const backend = await setupBackend(ctx);
+
+    if (!backend) {
+      return;
+    }
+
+    const texture = createSolidTexture('#ff0000', 32, 32);
+    const root = new Container();
+    const panel = new NineSliceSprite(texture, { slices: 8, width: 41, height: 41 });
+
+    try {
+      panel.setPosition(6.3, 6.3);
+      panel.pixelSnapMode = 'geometry';
+      root.addChild(panel);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      const readPixel = readCanvas(backend);
+
+      // Scan a horizontal line well inside the panel: every pixel must be the
+      // solid panel colour — a snapping-induced seam would show as black.
+      for (let x = 10; x <= 44; x++) {
+        const pixel = readPixel(x, 26);
+
+        expect(pixel[0]).toBeGreaterThan(200); // red present → no gap
+      }
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('geometry mode under rotation downgrades without error and keeps logical transform', async ctx => {
+    const backend = await setupBackend(ctx);
+
+    if (!backend) {
+      return;
+    }
+
+    const texture = createSolidTexture('#0000ff', 32, 32);
+    const root = new Container();
+    const panel = new NineSliceSprite(texture, { slices: 8, width: 30, height: 30 });
+
+    try {
+      panel.setPosition(32, 32);
+      panel.setRotation(25);
+      panel.pixelSnapMode = 'geometry';
+      root.addChild(panel);
+
+      const worldBefore = panel.getGlobalTransform().clone();
+
+      if (!(await renderScene(ctx, backend, root))) {
+        worldBefore.destroy();
+
+        return;
+      }
+
+      const readPixel = readCanvas(backend);
+
+      // Logical transform untouched by the (downgraded) snap.
+      expect(panel.getGlobalTransform().equals(worldBefore)).toBe(true);
+      // Still drew something blue near the centre.
+      expect(readPixel(32, 32)[2]).toBeGreaterThan(128);
+
+      worldBefore.destroy();
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgpu-tilemap-snap.test.ts
+++ b/test/rendering/browser/webgpu-tilemap-snap.test.ts
@@ -1,0 +1,349 @@
+/**
+ * WebGPU tilemap pixel-snapping browser tests — opt-in, capability-aware.
+ *
+ * Parity counterpart of `webgl2-tilemap-snap.test.ts` on the WebGPU backend.
+ * Verifies that `pixelSnapMode = 'geometry'` on a {@link TileMapNode} placed
+ * at a fractional world position produces no background/clear-colour gaps
+ * across a chunk boundary in the rendered output.
+ *
+ * All WebGPU tests skip gracefully when WebGPU is unavailable (no adapter or
+ * software adapter lost mid-test). The double-skip contract:
+ *  1. `setupBackend` skips when navigator.gpu / requestAdapter() is absent.
+ *  2. `renderScene` calls `getBackendDeviceOrSkip` (device-gone guard) and
+ *     catches DOMException device-loss mid-test.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import { TILE_TRANSFORM_IDENTITY, TileLayer, TileMap, TileMapNode } from '@codexo/exojs-tilemap';
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import type { RenderNode } from '#rendering/RenderNode';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { createSolidTexture, makeTileset, wireTilemapRenderers } from './_tilemapScene';
+import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: { canvas: { width: canvasSize, height: canvasSize }, clearColor: Color.black },
+  }) as unknown as Application;
+
+const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<WebGpuBackend | null> => {
+  if (!navigator.gpu) {
+    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
+
+    return null;
+  }
+
+  const adapter = await navigator.gpu.requestAdapter();
+
+  if (!adapter) {
+    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
+
+    return null;
+  }
+
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  await backend.initialize();
+  wireTilemapRenderers(backend);
+
+  return backend;
+};
+
+// Read the presented WebGPU canvas back through a 2D canvas.
+const readCanvas = (backend: WebGpuBackend): ((x: number, y: number) => RgbaTuple) => {
+  const source = backend.context.canvas as HTMLCanvasElement;
+  const readback = document.createElement('canvas');
+
+  readback.width = canvasSize;
+  readback.height = canvasSize;
+
+  const ctx = readback.getContext('2d')!;
+
+  ctx.drawImage(source, 0, 0);
+
+  return (x: number, y: number): RgbaTuple => {
+    const { data } = ctx.getImageData(Math.floor(x), Math.floor(y), 1, 1);
+
+    return [data[0], data[1], data[2], data[3]];
+  };
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 18): void => {
+  for (let i = 0; i < 4; i++) {
+    expect(Math.abs(actual[i] - expected[i])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+// On the software (swiftshader) adapter the WebGPU device can be dropped
+// mid-test. Treat that as an unavailable-adapter skip rather than a failure.
+const isDeviceLoss = (error: unknown): boolean =>
+  error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+// Render a scene inside a validation error scope.
+// Returns false when the device dropped mid-test (caller should bail).
+const renderScene = async (
+  ctx: { skip: (reason: string) => void },
+  backend: WebGpuBackend,
+  root: RenderNode,
+): Promise<boolean> => {
+  const device = getBackendDeviceOrSkip(ctx, backend);
+
+  if (!device) {
+    return false;
+  }
+
+  device.pushErrorScope('validation');
+
+  let validationError: GPUError | null;
+
+  try {
+    backend.resetStats();
+    backend.clear(Color.black);
+    root.render(backend);
+    backend.flush();
+    validationError = await device.popErrorScope();
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+
+  expect(validationError).toBeNull();
+
+  return true;
+};
+
+/**
+ * Build a 4×1 tile map with chunkWidth=2 so the chunk seam falls at tile x=2
+ * (screen x = node.x + 2*tileWidth). All tiles use a solid-colour tileset.
+ * Tile pitch is 16px; the canvas is 64px wide, leaving room for the seam at
+ * screen x≈32 when the node is near the origin.
+ */
+function buildSeamMap(texture: ReturnType<typeof createSolidTexture>): TileMap {
+  const tileset = makeTileset(texture);
+  const layer = new TileLayer({
+    id: 1,
+    name: 'ground',
+    width: 4,
+    height: 1,
+    tileWidth: 16,
+    tileHeight: 16,
+    chunkWidth: 2,
+    chunkHeight: 2,
+    tilesets: [tileset],
+  });
+
+  for (let tx = 0; tx < 4; tx++) {
+    layer.setTileAt(tx, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+  }
+
+  return new TileMap({
+    name: 'm',
+    width: 4,
+    height: 1,
+    tileWidth: 16,
+    tileHeight: 16,
+    tilesets: [tileset],
+    layers: [layer],
+  });
+}
+
+// ── pixel-snap seam tests ────────────────────────────────────────────────
+
+describe('WebGPU tilemap pixel snapping — chunk seam', () => {
+  test('geometry mode: no clear-colour gap across chunk boundary at fractional position', async ctx => {
+    const backend = await setupBackend(ctx);
+
+    if (!backend) {
+      return;
+    }
+
+    const texture = createSolidTexture('#ff0000');
+    const node = new TileMapNode(buildSeamMap(texture));
+
+    try {
+      // Fractional placement: without snapping, floating-point rounding can open
+      // a 1-pixel gap at the chunk seam. With 'geometry' mode each chunk's origin
+      // is snapped to the device-pixel grid, keeping all four tiles contiguous.
+      node.setPosition(0.7, 0.7);
+      node.pixelSnapMode = 'geometry';
+
+      if (!(await renderScene(ctx, backend, node))) {
+        return;
+      }
+
+      const readPixel = readCanvas(backend);
+
+      // The chunk seam is between tile x=1 and x=2, near screen x=32.
+      // Scan a horizontal strip covering both chunks; every pixel must carry the
+      // tile colour (red) — a gap would appear as the black clear colour.
+      for (let x = 4; x <= 59; x++) {
+        const pixel = readPixel(x, 8);
+
+        expect(pixel[0]).toBeGreaterThan(200); // red channel present → tile, not gap
+      }
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('pixelSnapMode is render-only: logical position is unchanged after render', async ctx => {
+    const backend = await setupBackend(ctx);
+
+    if (!backend) {
+      return;
+    }
+
+    const texture = createSolidTexture('#00ff00');
+    const node = new TileMapNode(buildSeamMap(texture));
+
+    try {
+      node.setPosition(3.14, 7.77);
+      node.pixelSnapMode = 'geometry';
+
+      if (!(await renderScene(ctx, backend, node))) {
+        return;
+      }
+
+      // Logical transform must not have been mutated by the render-only snap.
+      expect(node.x).toBe(3.14);
+      expect(node.y).toBe(7.77);
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('snapped tilemap rendering is deterministic across frames', async ctx => {
+    const backend = await setupBackend(ctx);
+
+    if (!backend) {
+      return;
+    }
+
+    const texture = createSolidTexture('#0000ff');
+    const node = new TileMapNode(buildSeamMap(texture));
+
+    try {
+      node.setPosition(5.5, 2.3);
+      node.pixelSnapMode = 'geometry';
+
+      if (!(await renderScene(ctx, backend, node))) {
+        return;
+      }
+
+      const source = backend.context.canvas as HTMLCanvasElement;
+      const rb1 = document.createElement('canvas');
+
+      rb1.width = canvasSize;
+      rb1.height = canvasSize;
+      rb1.getContext('2d')!.drawImage(source, 0, 0);
+
+      const first = rb1.getContext('2d')!.getImageData(0, 0, canvasSize, canvasSize).data;
+
+      if (!(await renderScene(ctx, backend, node))) {
+        return;
+      }
+
+      const rb2 = document.createElement('canvas');
+
+      rb2.width = canvasSize;
+      rb2.height = canvasSize;
+      rb2.getContext('2d')!.drawImage(source, 0, 0);
+
+      const second = rb2.getContext('2d')!.getImageData(0, 0, canvasSize, canvasSize).data;
+
+      expect(Array.from(second)).toEqual(Array.from(first));
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('position mode also produces no seam gap across chunk boundary', async ctx => {
+    const backend = await setupBackend(ctx);
+
+    if (!backend) {
+      return;
+    }
+
+    const texture = createSolidTexture('#ff0000');
+    const node = new TileMapNode(buildSeamMap(texture));
+
+    try {
+      node.setPosition(0.7, 0.7);
+      node.pixelSnapMode = 'position';
+
+      if (!(await renderScene(ctx, backend, node))) {
+        return;
+      }
+
+      const readPixel = readCanvas(backend);
+
+      // TileChunkNode chunk origins are integer multiples of tile pitch relative
+      // to the snapped layer origin, so both modes produce no seam.
+      for (let x = 4; x <= 59; x++) {
+        const pixel = readPixel(x, 8);
+
+        expect(pixel[0]).toBeGreaterThan(200);
+      }
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('unsnapped tilemap at integer position renders without gaps', async ctx => {
+    const backend = await setupBackend(ctx);
+
+    if (!backend) {
+      return;
+    }
+
+    const texture = createSolidTexture('#ff0000');
+    const node = new TileMapNode(buildSeamMap(texture));
+
+    try {
+      // An integer position means no sub-pixel drift; no snapping needed.
+      node.setPosition(0, 0);
+      node.pixelSnapMode = 'none';
+
+      if (!(await renderScene(ctx, backend, node))) {
+        return;
+      }
+
+      const readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(8, 8), [255, 0, 0, 255]); // chunk 0
+      expectPixelNear(readPixel(32, 8), [255, 0, 0, 255]); // seam column
+      expectPixelNear(readPixel(40, 8), [255, 0, 0, 255]); // chunk 1
+    } finally {
+      node.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/pixel-snap.test.ts
+++ b/test/rendering/pixel-snap.test.ts
@@ -1,0 +1,484 @@
+import { Matrix } from '#math/Matrix';
+import { Rectangle } from '#math/Rectangle';
+import { Container } from '#rendering/Container';
+import {
+  buildPixelSnapContext,
+  getPixelSnapDowngradeReason,
+  isPixelSnapMode,
+  type PixelSnapContext,
+  type PixelSnapMode,
+  type RenderQuad,
+  resolveEffectivePixelSnapMode,
+  snapBoundsInto,
+  snapLocalBoundary,
+  snapQuadsInto,
+  snapWorldTranslationInto,
+} from '#rendering/pixelSnap';
+import { NineSliceSprite } from '#rendering/sprite/NineSliceSprite';
+import { Sprite } from '#rendering/sprite/Sprite';
+import type { Texture } from '#rendering/texture/Texture';
+import { View } from '#rendering/View';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeTexture = (w = 64, h = 64): Texture =>
+  ({ width: w, height: h, flipY: false, updateSource: () => undefined }) as unknown as Texture;
+
+/** An axis-aligned, non-following view covering a `w × h` world region 1:1. */
+const makeView = (w = 100, h = 100): View => new View(w / 2, h / 2, w, h);
+
+const quad = (x0: number, y0: number, x1: number, y1: number): RenderQuad =>
+  ({ x0, y0, x1, y1, u0: 0, v0: 0, u1: 1, v1: 1 });
+
+/** A minimal axis-aligned context for the pure boundary-snapping helpers. */
+const ctxOf = (scaleX: number, scaleY: number): PixelSnapContext => ({
+  originX: 0,
+  originY: 0,
+  snappedOriginX: 0,
+  snappedOriginY: 0,
+  worldX: 0,
+  worldY: 0,
+  scaleX,
+  scaleY,
+  axisAligned: true,
+});
+
+// ---------------------------------------------------------------------------
+// Public API — Drawable.pixelSnapMode
+// ---------------------------------------------------------------------------
+
+describe('Drawable.pixelSnapMode — public API', () => {
+  test('defaults to none', () => {
+    expect(new Sprite(null).pixelSnapMode).toBe('none');
+  });
+
+  test('accepts every valid mode', () => {
+    const sprite = new Sprite(null);
+
+    for (const mode of ['position', 'geometry', 'none'] as const) {
+      sprite.pixelSnapMode = mode;
+      expect(sprite.pixelSnapMode).toBe(mode);
+    }
+  });
+
+  test('throws on an invalid value and leaves the prior mode unchanged', () => {
+    const sprite = new Sprite(null);
+
+    sprite.pixelSnapMode = 'geometry';
+
+    expect(() => {
+      sprite.pixelSnapMode = 'invalid' as PixelSnapMode;
+    }).toThrow();
+    expect(sprite.pixelSnapMode).toBe('geometry');
+  });
+
+  test('setting the same value is a no-op (does not invalidate the cache)', () => {
+    const sprite = new Sprite(null);
+
+    sprite.pixelSnapMode = 'position';
+    sprite.invalidateCache();
+    // Re-clear via a fresh read; then a same-value set must not re-dirty.
+    (sprite as unknown as { _cacheDirty: boolean })._cacheDirty = false;
+    sprite.pixelSnapMode = 'position';
+    expect((sprite as unknown as { _cacheDirty: boolean })._cacheDirty).toBe(false);
+  });
+});
+
+describe('isPixelSnapMode', () => {
+  test('accepts the three valid values', () => {
+    expect(isPixelSnapMode('none')).toBe(true);
+    expect(isPixelSnapMode('position')).toBe(true);
+    expect(isPixelSnapMode('geometry')).toBe(true);
+  });
+
+  test('rejects everything else', () => {
+    for (const value of ['', 'None', 'GEOMETRY', 0, null, undefined, {}]) {
+      expect(isPixelSnapMode(value)).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// snapLocalBoundary — the shared per-axis rounding primitive
+// ---------------------------------------------------------------------------
+
+describe('snapLocalBoundary', () => {
+  test('rounds to the nearest device pixel: round(L*scale)/scale', () => {
+    expect(snapLocalBoundary(10.3, 2)).toBeCloseTo(10.5, 10); // round(20.6)=21 → 10.5
+    expect(snapLocalBoundary(10, 1)).toBe(10);
+    expect(snapLocalBoundary(0, 4)).toBe(0);
+  });
+
+  test('the snapped value lands on a whole device pixel', () => {
+    for (const [l, s] of [[10.3, 2], [7.7, 3], [123.456, 1], [5.2, 0.5]] as const) {
+      expect(snapLocalBoundary(l, s) * s).toBeCloseTo(Math.round(l * s), 6);
+    }
+  });
+
+  test('ties round toward +infinity (Math.round)', () => {
+    expect(snapLocalBoundary(0.5, 1)).toBe(1);
+    expect(snapLocalBoundary(1.5, 1)).toBe(2);
+    expect(snapLocalBoundary(-0.5, 1)).toBeCloseTo(0, 10); // round(-0.5) → -0 (toward +∞, not -1)
+  });
+
+  test('is monotonic non-decreasing for positive scale', () => {
+    let prev = -Infinity;
+
+    for (let l = -5; l <= 5; l += 0.13) {
+      const snapped = snapLocalBoundary(l, 2);
+
+      expect(snapped).toBeGreaterThanOrEqual(prev);
+      prev = snapped;
+    }
+  });
+
+  test('preserves order under negative scale (flip) — no inverted spans', () => {
+    let prev = -Infinity;
+
+    for (let l = -5; l <= 5; l += 0.13) {
+      const snapped = snapLocalBoundary(l, -2);
+
+      expect(snapped).toBeGreaterThanOrEqual(prev);
+      prev = snapped;
+    }
+  });
+
+  test('returns the input unchanged for a degenerate (~0) scale', () => {
+    expect(snapLocalBoundary(3.7, 0)).toBe(3.7);
+    expect(snapLocalBoundary(3.7, 1e-9)).toBe(3.7);
+  });
+
+  test('returns non-finite input unchanged', () => {
+    expect(snapLocalBoundary(NaN, 2)).toBeNaN();
+    expect(snapLocalBoundary(Infinity, 2)).toBe(Infinity);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// snapQuadsInto — shared boundary plan (NineSlice / RepeatingSprite)
+// ---------------------------------------------------------------------------
+
+describe('snapQuadsInto — shared boundaries', () => {
+  const ctx = ctxOf(1.5, 1.5);
+
+  test('quads that share a boundary value snap to the SAME value (seam-free)', () => {
+    // Two adjacent quads: left [0,32], right [32,64]. The shared edge (32) must
+    // map to one value in both, or a gap/overlap opens.
+    const source = [quad(0, 0, 32.4, 16.4), quad(32.4, 0, 64.7, 16.4)];
+    const out: RenderQuad[] = [];
+
+    snapQuadsInto(source, ctx, out);
+
+    expect(out[0]!.x1).toBe(out[1]!.x0);
+  });
+
+  test('chunk-edge equality: a boundary shared across separate quad lists snaps identically', () => {
+    // Simulate two chunks: chunk A's right edge and chunk B's left edge are the
+    // same coordinate value but live in different snapQuadsInto calls.
+    const a: RenderQuad[] = [];
+    const b: RenderQuad[] = [];
+
+    snapQuadsInto([quad(0, 0, 96.3, 32)], ctx, a);
+    snapQuadsInto([quad(96.3, 0, 192.6, 32)], ctx, b);
+
+    expect(a[0]!.x1).toBe(b[0]!.x0);
+  });
+
+  test('preserves monotonic order (no negative spans) and UVs', () => {
+    const source = [quad(0, 0, 0.1, 0.1), quad(5.4, 7.2, 18.9, 20.1)];
+    const out: RenderQuad[] = [];
+
+    snapQuadsInto(source, ctx, out);
+
+    for (const q of out) {
+      expect(q.x1).toBeGreaterThanOrEqual(q.x0);
+      expect(q.y1).toBeGreaterThanOrEqual(q.y0);
+      expect(q.u0).toBe(0);
+      expect(q.v1).toBe(1);
+    }
+  });
+
+  test('reuses the output buffer across calls without reallocating object slots', () => {
+    const out: RenderQuad[] = [];
+
+    snapQuadsInto([quad(0, 0, 4, 4), quad(4, 0, 8, 4)], ctx, out);
+    const firstSlot = out[0];
+
+    expect(out.length).toBe(2);
+
+    snapQuadsInto([quad(0, 0, 4, 4)], ctx, out);
+    expect(out.length).toBe(1);
+    expect(out[0]).toBe(firstSlot); // same object instance reused
+  });
+});
+
+describe('snapBoundsInto', () => {
+  test('snaps all four edges and never produces a negative span', () => {
+    const ctx = ctxOf(1.3, 1.3);
+    const out = new Rectangle();
+
+    snapBoundsInto(new Rectangle(0.4, 0.6, 10.3, 12.7), ctx, out);
+
+    expect(out.width).toBeGreaterThanOrEqual(0);
+    expect(out.height).toBeGreaterThanOrEqual(0);
+    expect(out.left * ctx.scaleX).toBeCloseTo(Math.round(0.4 * ctx.scaleX), 6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildPixelSnapContext — device-pixel coordinate mapping
+// ---------------------------------------------------------------------------
+
+describe('buildPixelSnapContext — coordinate conversion', () => {
+  test('snapped origin is a whole device pixel and round-trips back to world', () => {
+    const view = makeView(100, 100);
+    const world = new Matrix().set(1, 0, 12.37, 0, 1, 7.91);
+    const ctx = buildPixelSnapContext(world, view, 100, 100);
+
+    expect(Number.isInteger(ctx.snappedOriginX)).toBe(true);
+    expect(Number.isInteger(ctx.snappedOriginY)).toBe(true);
+    expect(ctx.snappedOriginX).toBe(Math.round(ctx.originX));
+
+    const device = view.worldToScreen(ctx.worldX, ctx.worldY, 100, 100);
+
+    expect(device.x).toBeCloseTo(ctx.snappedOriginX, 3);
+    expect(device.y).toBeCloseTo(ctx.snappedOriginY, 3);
+  });
+
+  test('device-pixel ratio: doubling the target pixels doubles the device scale', () => {
+    const view = makeView(100, 100);
+    const world = new Matrix().set(1, 0, 0, 0, 1, 0);
+    const dpr1 = buildPixelSnapContext(world, view, 100, 100);
+    const dpr2 = buildPixelSnapContext(world, view, 200, 200);
+
+    expect(Math.abs(dpr1.scaleX)).toBeCloseTo(1, 3);
+    expect(Math.abs(dpr2.scaleX)).toBeCloseTo(2, 3);
+  });
+
+  test('snaps in DEVICE space (DPR-aware), not by blindly rounding CSS/world coords', () => {
+    const view = makeView(100, 100);
+    const world = new Matrix().set(1, 0, 10.5, 0, 1, 10.5);
+    const ctx = buildPixelSnapContext(world, view, 200, 200);
+
+    // Device scale is 2 at DPR 2 (200 device px over 100 world units).
+    expect(Math.abs(ctx.scaleX)).toBeCloseTo(2, 2);
+    // The snapped origin is an exact device pixel (round of the device-space origin).
+    expect(ctx.snappedOriginX).toBe(Math.round(ctx.originX));
+    // Snapping moves the origin by at most half a DEVICE pixel — never a full CSS px.
+    expect(Math.abs(ctx.worldX - 10.5) * Math.abs(ctx.scaleX)).toBeLessThanOrEqual(0.5 + 1e-6);
+  });
+
+  test('camera zoom scales the device mapping', () => {
+    const view = makeView(100, 100);
+    const world = new Matrix();
+
+    view.setZoom(2); // halves the visible area → doubles world→device scale
+    const ctx = buildPixelSnapContext(world, view, 100, 100);
+
+    expect(Math.abs(ctx.scaleX)).toBeCloseTo(2, 2);
+  });
+
+  test('camera offset shifts the origin but not the scale', () => {
+    const view = makeView(100, 100);
+    const world = new Matrix().set(1, 0, 30, 0, 1, 30);
+    const a = buildPixelSnapContext(world, view, 100, 100);
+
+    view.setCenter(40, 40);
+    const b = buildPixelSnapContext(world, view, 100, 100);
+
+    expect(Math.abs(a.scaleX)).toBeCloseTo(Math.abs(b.scaleX), 4);
+    expect(a.originX).not.toBeCloseTo(b.originX, 1);
+  });
+
+  test('negative world coordinates still snap to a whole device pixel', () => {
+    const view = makeView(100, 100);
+    const world = new Matrix().set(1, 0, -12.6, 0, 1, -3.2);
+    const ctx = buildPixelSnapContext(world, view, 100, 100);
+
+    expect(Number.isInteger(ctx.snappedOriginX)).toBe(true);
+    expect(Number.isInteger(ctx.snappedOriginY)).toBe(true);
+  });
+
+  test('degenerate target size yields a safe no-op context', () => {
+    const view = makeView(100, 100);
+    const world = new Matrix().set(1, 0, 5.4, 0, 1, 6.7);
+    const ctx = buildPixelSnapContext(world, view, 0, 0);
+
+    expect(ctx.axisAligned).toBe(false);
+    expect(ctx.worldX).toBe(5.4);
+    expect(ctx.worldY).toBe(6.7);
+  });
+
+  test('axis-aligned for pure / non-uniform / negative scale; not for rotation or skew', () => {
+    const view = makeView(100, 100);
+
+    const pure = new Matrix().set(2, 0, 10, 0, 2, 10);
+    const nonUniform = new Matrix().set(3, 0, 10, 0, 1, 10);
+    const flip = new Matrix().set(-2, 0, 10, 0, 2, 10);
+    const rotated = new Matrix().set(0.7071, 0.7071, 10, -0.7071, 0.7071, 10);
+    const skewed = new Matrix().set(1, 0.4, 10, 0, 1, 10);
+
+    expect(buildPixelSnapContext(pure, view, 100, 100).axisAligned).toBe(true);
+    expect(buildPixelSnapContext(nonUniform, view, 100, 100).axisAligned).toBe(true);
+    expect(buildPixelSnapContext(flip, view, 100, 100).axisAligned).toBe(true);
+    expect(buildPixelSnapContext(rotated, view, 100, 100).axisAligned).toBe(false);
+    expect(buildPixelSnapContext(skewed, view, 100, 100).axisAligned).toBe(false);
+  });
+
+  test('a rotated view downgrades axis alignment even for an axis-aligned node', () => {
+    const view = makeView(100, 100);
+
+    view.setRotation(30);
+    expect(buildPixelSnapContext(new Matrix(), view, 100, 100).axisAligned).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// snapWorldTranslationInto — position snapping is translation-only
+// ---------------------------------------------------------------------------
+
+describe('snapWorldTranslationInto', () => {
+  test('replaces only the translation, preserving the linear part, without mutating the source', () => {
+    const view = makeView(100, 100);
+    const world = new Matrix().set(2, 0.5, 12.4, -0.5, 2, 7.8);
+    const snapshot = world.clone();
+    const ctx = buildPixelSnapContext(world, view, 100, 100);
+    const out = new Matrix();
+
+    snapWorldTranslationInto(out, world, ctx);
+
+    // linear part copied verbatim
+    expect(out.a).toBe(world.a);
+    expect(out.b).toBe(world.b);
+    expect(out.c).toBe(world.c);
+    expect(out.d).toBe(world.d);
+    // translation replaced by the snapped world origin
+    expect(out.x).toBe(ctx.worldX);
+    expect(out.y).toBe(ctx.worldY);
+    // source untouched
+    expect(world.equals(snapshot)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveEffectivePixelSnapMode / downgrade
+// ---------------------------------------------------------------------------
+
+describe('resolveEffectivePixelSnapMode', () => {
+  test('passes none / position through regardless of alignment', () => {
+    for (const aligned of [true, false]) {
+      expect(resolveEffectivePixelSnapMode('none', aligned)).toBe('none');
+      expect(resolveEffectivePixelSnapMode('position', aligned)).toBe('position');
+    }
+  });
+
+  test('keeps geometry when axis-aligned, downgrades to position otherwise', () => {
+    expect(resolveEffectivePixelSnapMode('geometry', true)).toBe('geometry');
+    expect(resolveEffectivePixelSnapMode('geometry', false)).toBe('position');
+  });
+
+  test('is stateless — alignment restoring brings geometry back', () => {
+    expect(resolveEffectivePixelSnapMode('geometry', false)).toBe('position');
+    expect(resolveEffectivePixelSnapMode('geometry', true)).toBe('geometry');
+  });
+
+  test('downgrade reason is set only for a downgraded geometry request', () => {
+    expect(getPixelSnapDowngradeReason('geometry', false)).toBe('non-axis-aligned');
+    expect(getPixelSnapDowngradeReason('geometry', true)).toBeNull();
+    expect(getPixelSnapDowngradeReason('position', false)).toBeNull();
+    expect(getPixelSnapDowngradeReason('none', false)).toBeNull();
+  });
+});
+
+describe('effective alignment from a composed world transform', () => {
+  test('a rotated parent downgrades an otherwise axis-aligned child', () => {
+    const view = makeView(200, 200);
+    const parent = new Container();
+    const child = new Sprite(null);
+
+    parent.setRotation(20);
+    parent.addChild(child);
+
+    expect(buildPixelSnapContext(child.getGlobalTransform(), view, 200, 200).axisAligned).toBe(false);
+
+    parent.setRotation(0);
+    expect(buildPixelSnapContext(child.getGlobalTransform(), view, 200, 200).axisAligned).toBe(true);
+
+    parent.destroy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Logical / render separation — snapping never mutates logical state
+// ---------------------------------------------------------------------------
+
+describe('logical / render separation', () => {
+  test('Sprite: setting pixelSnapMode leaves logical transform, position and bounds untouched', () => {
+    const sprite = new Sprite(makeTexture(16, 16));
+
+    sprite.setPosition(10.37, 20.91);
+    const worldBefore = sprite.getGlobalTransform().clone();
+    const boundsBefore = sprite.getBounds().clone();
+    const verticesBefore = Float32Array.from(sprite.vertices);
+
+    sprite.pixelSnapMode = 'geometry';
+
+    expect(sprite.x).toBe(10.37);
+    expect(sprite.y).toBe(20.91);
+    expect(sprite.getGlobalTransform().equals(worldBefore)).toBe(true);
+    expect(sprite.getBounds().equals(boundsBefore)).toBe(true);
+    expect(Array.from(sprite.vertices)).toEqual(Array.from(verticesBefore));
+
+    worldBefore.destroy();
+    boundsBefore.destroy();
+    sprite.destroy();
+  });
+
+  test('NineSlice: render-time snapping does not rebuild or mutate the content quad cache', () => {
+    const sprite = new NineSliceSprite(makeTexture(48, 48), { slices: 8, width: 100, height: 100 });
+
+    sprite.setPosition(5.3, 9.7);
+    sprite.pixelSnapMode = 'geometry';
+
+    const contentQuads = sprite.quads; // builds + caches the content plan
+    const dirtyAfterBuild = (sprite as unknown as { _geometryDirty: boolean })._geometryDirty;
+
+    const view = makeView(200, 200);
+    const rendered = sprite.getRenderQuads(view, 200, 200);
+
+    // content cache reused (same reference), never re-dirtied by snapping
+    expect(sprite.quads).toBe(contentQuads);
+    expect((sprite as unknown as { _geometryDirty: boolean })._geometryDirty).toBe(dirtyAfterBuild);
+    // snapped quads are a separate buffer with the same count
+    expect(rendered).not.toBe(contentQuads);
+    expect(rendered.length).toBe(contentQuads.length);
+
+    sprite.destroy();
+  });
+
+  test('NineSlice: geometry snapping downgrades (returns the content plan) under rotation', () => {
+    const sprite = new NineSliceSprite(makeTexture(48, 48), { slices: 8, width: 100, height: 100 });
+
+    sprite.setRotation(15);
+    sprite.pixelSnapMode = 'geometry';
+
+    const view = makeView(200, 200);
+
+    expect(sprite.getRenderQuads(view, 200, 200)).toBe(sprite.quads);
+
+    sprite.destroy();
+  });
+
+  test('Sprite.getRenderBounds returns logical bounds for non-geometry modes', () => {
+    const sprite = new Sprite(makeTexture(16, 16));
+    const view = makeView(100, 100);
+    const out = new Rectangle();
+
+    sprite.pixelSnapMode = 'position';
+    expect(sprite.getRenderBounds(view, 100, 100, out)).toBe(sprite.getLocalBounds());
+
+    sprite.destroy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **render-only** `PixelSnapMode` to `Drawable` that aligns rendered output to the active render target's **device-pixel grid** without ever mutating logical position, transforms, collision, bounds, or tween/physics state. Implements Phase E2 of the v0.13 slice (Spec 06 authoritative).

## Public API

- `type PixelSnapMode = 'none' | 'position' | 'geometry'` — exported from `@codexo/exojs` and `@codexo/exojs/rendering`. `@stable`, default `'none'`.
- `drawable.pixelSnapMode` on every `Drawable` (Sprite, NineSliceSprite, RepeatingSprite, Mesh, Graphics, Text, Video, …).
- Tilemap passthrough: `TileMapView` / `TileMapNode` / `TileLayerNode` `.pixelSnapMode` (from `@codexo/exojs-tilemap`), cascading to the chunk drawables.
- Runtime validation: an invalid value throws atomically (prior mode preserved, no invalidation); setting the current value is a no-op.

## Coordinate-space model

`logical local → world (node matrix) → view/camera → device pixels (× view scale × pixel ratio)`. Snapping targets the **device pixels of the active render target** (root canvas = css × `pixelRatio`; `RenderTexture` = its own size), **not** integer world units. The world→device mapping is derived **forward-only** from `View.worldToScreen` plus a self-computed 2×2 Jacobian inverse.

> Implementation note: `View.screenToWorld` is *not* a clean inverse of `worldToScreen` for this use (the matrix inverse places the translation in different fields than `screenToWorld` reads) — a unit test caught this. The forward-only Jacobian approach is provably exact for affine views and sidesteps it entirely.

## position semantics

Snaps only the rendered **origin** (the world translation) at the shared transform-buffer write seam (`resolveUploadTransform`, called from both backends' `_resolveSnapTransform`). The linear part `(a, b, c, d)` is preserved, so `position` is safe under any transform. Logical `x`/`y` and cached matrices are untouched — a caller-owned scratch matrix is written to the GPU buffer.

## geometry semantics

`position` snap **plus** snapping a single **shared boundary plan**. Each unique boundary is snapped by the same pure function `snapLocalBoundary(L, scale) = round(L · scale) / scale`, so adjacent quads that share a boundary value snap to the **same** result — seams cannot open. The function is monotonic non-decreasing for any non-zero scale (incl. negative/flip), so spans never go negative. Rounding policy: **nearest device pixel** (`Math.round`, ties toward +∞), one policy everywhere (CPU debug, WebGL2, WGSL all agree).

## Downgrade rules

`geometry` is guaranteed only for **axis-aligned** transforms. Rotation or skew in the node, any ancestor, or the view cross-couples the device axes → `geometry` **auto-downgrades to `position`** for that frame (no throw, no logical change; dev-only one-time `warnOnce`). Axis-aligned **non-uniform** scale and **negative** scale (flip) remain geometry-compatible (per-axis device snapping). A pure `resolveEffectivePixelSnapMode` + `getPixelSnapDowngradeReason` make this testable.

## Logical / render separation

Snapping touches only the per-frame GPU data. `getGlobalTransform()`, `getBounds()`, `getLocalBounds()`, collision/query inputs, tween/physics state, NineSlice content-quad caches, and tilemap chunk revisions are all unchanged (asserted by unit + browser tests).

## Supported drawable types

| Type | position | geometry |
|---|---|---|
| Sprite | ✅ origin | ✅ quad edges |
| NineSliceSprite | ✅ origin | ✅ shared `x0..x3`/`y0..y3` (+ repeated-edge) boundaries, snapped once |
| RepeatingSprite | ✅ origin | ✅ destination quad (shader strategy) + repeat-segment quads (atlas strategy); repetition stays shader-based for bare textures |
| Tilemap (chunk nodes + view/node/layer passthrough) | ✅ chunk/layer origin | ✅ coherent chunk/layer origin snap; integer tile pitch keeps the grid exact, adjacent chunks gap-free |
| Mesh / Graphics / Text / Video / … | ✅ origin (universal seam) | no boundary provider → behaves as `position` |

## Camera / DPR / render-target handling

The snap context combines the node world matrix, the pass `View`, and the active target's device-pixel size, so it is correct under camera translation/zoom, viewport rectangles (split-screen), device pixel ratio (root canvas), and offscreen `RenderTexture`s. A degenerate target size yields a safe no-op context.

## Bounds / culling

Logical bounds remain logical. Culling stays on logical bounds — conservative, since snapping shifts rendered geometry by at most ~half a device pixel. No culling-bounds expansion was needed.

## Caching / invalidation

Setting `pixelSnapMode` invalidates the bitmap cache only — no geometry rebuild. Camera movement updates the snapped render transform/boundaries but never rebuilds content-keyed caches (NineSlice `_quads`, tilemap chunk pages) or bumps tile revisions; snapped quads use a reused per-drawable scratch buffer (no per-frame allocation once warm).

## WebGL2 / WebGPU parity

Both backends consume the same shared CPU helpers in `src/rendering/pixelSnap.ts` — identical rounding math, **no** GLSL/WGSL snapping. `WebGpuTransformStorage.writeCommand` / `push` gained a backward-compatible optional `transform` parameter (existing callers/tests unchanged).

## Tests

- **Unit** `test/rendering/pixel-snap.test.ts` (37): API default/valid/invalid/no-op; coordinate conversion (DPR1/2, camera offset, zoom, negatives, half-pixel ties, render target, degenerate); effective mode + downgrade (rotation/skew/parent/non-uniform/negative scale); shared boundaries (monotonic/collapse/no-negative/adjacent-equal/chunk-edge); logical/render separation.
- **Tilemap unit** `packages/exojs-tilemap/test/pixel-snap.test.ts` (20): default, cascade across all three node types, atomic invalid-value rejection (incl. empty layer), no-op, refresh/refreshLayers re-apply, render-only (stable `pages` ref, unchanged revisions/offsets/tile data).
- **Type** `packages/exojs-tilemap/test/pixel-snap-types.test.ts` (5): `PixelSnapMode` shape, property types on Drawable/Sprite/NineSlice + tilemap nodes, invalid-literal compile errors.
- **Browser** (Chromium WebGL2/WebGPU + Firefox WebGL2): sprite position render + logical-unchanged, determinism, NineSlice geometry seam-free at fractional placement, geometry downgrade under rotation, tilemap chunk-boundary no-gap.

> Note: a static solid-quad frame is already device-grid-quantised by the rasteriser (pixel-centre rule), so it cannot diff snapped vs unsnapped — the exact snapping math is proven by the unit tests; browser tests assert end-to-end correctness, the render-only contract, seam-freeness, and determinism.

## Browser results

- **Chromium WebGL2**: 126/126 ✅
- **Firefox WebGL2**: 126/126 ✅
- **Chromium WebGPU**: pixel-snap + tilemap-snap green ✅. One pre-existing flake — `webgpu-stencil-clip` hits swiftshader device-pool exhaustion when run after 14 other WebGPU files (`adapter.requestDevice()` throws in `_initialize`); it passes 17/17 in isolation and is unrelated to this change.

## Limitations / non-goals

`geometry` is guaranteed only for axis-aligned transforms (rotation/skew downgrade to `position`). Explicit non-goals (untouched): ScreenView / screen-space layout / UI toolkit, physics & collision-grid snapping, shader-based snapping, Y-sort, camera/render-target redesign, tilemap streaming, lighting, high-DPI asset policy. `UV snap` and `integer view scale` remain out of scope per Spec 06.

## Deviations from Spec 06

- Spec 06 lists non-uniform scale under "geometry disabled"; this PR **supports axis-aligned non-uniform scale** for geometry via independent per-axis device snapping (self-consistent, seam-free within a boundary plan) — a deliberate, documented refinement. Rotation/skew still downgrade.
- Snapping uses a forward-only world→device mapping (Jacobian) rather than the view inverse, because `View.screenToWorld` does not round-trip `worldToScreen` for this purpose.

Do not merge.
