### PR TITLE
fix(v0.13): harden tilemap and scalable sprite integration

### DIFF
--- a/packages/exojs-tiled/README.md
+++ b/packages/exojs-tiled/README.md
@@ -103,15 +103,16 @@ The runtime binding additionally calls `TiledMap.toTileMap()` to produce the gen
 ### Load options
 
 ```ts
-await loader.load(TileMap, 'maps/world.tmj', { strict: true });
+// `.tmj`/`.tsj` are recognised by extension; a format hint is only needed for
+// Tiled data served from a generic `.json` path:
+await loader.load(TileMap, 'maps/world.json', { format: 'tiled' });
 ```
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `format` | `'tiled'` | — | Reserved discriminant; not currently used |
-| `strict` | `boolean` | `false` | Throw on unknown `.tmj`/`.tsj` fields |
+| `format` | `'tiled'` | `'tiled'` | Format hint for ambiguous `.json` paths. `.tmj`/`.tsj` are recognised by extension. `'tiled'` is the only accepted value (a foreign format is a compile error). Participates in the asset identity key. |
 
-Options are optional. Only result-changing values affect the Loader identity key.
+Options are optional. Parsing is always strict: `validateTiledMapData` throws a `TiledFormatError` on any malformed *known* field, and silently preserves *unknown* fields (so real-world Tiled files using features ExoJS does not model still load).
 
 ## Parsed API overview
 

--- a/packages/exojs-tiled/src/TiledMap.ts
+++ b/packages/exojs-tiled/src/TiledMap.ts
@@ -102,15 +102,35 @@ export class TiledMap {
    * Convert this parsed Tiled source model into a format-independent runtime
    * {@link TileMap} from `@codexo/exojs-tilemap`.
    *
-   * Only finite orthogonal maps with atlas tilesets are supported. Passing a
-   * map with collection-of-images tilesets throws {@link TiledFormatError}.
-   * Object, image, and group layers are not yet converted (Phase C2 scope:
-   * tile layers only; group layer children are flattened into the result).
+   * Only finite orthogonal maps with atlas tilesets are supported. A
+   * non-orthogonal or infinite map, or a collection-of-images tileset, throws
+   * {@link TiledFormatError} rather than silently producing wrong (misplaced)
+   * or empty geometry. Object, image, and group layers are not yet converted
+   * (Phase C2 scope: tile layers only; group layer children are flattened into
+   * the result).
    *
    * The returned `TileMap` does **not** own the tileset textures — they remain
    * in the Loader cache. Destroying the returned map does not unload textures.
    */
   public toTileMap(): TileMap {
+    // The runtime TileMap is finite + orthogonal in this release. Reject maps
+    // we cannot convert faithfully rather than silently producing misplaced
+    // (isometric/staggered/hexagonal) or empty (infinite/chunked) geometry.
+    if (this.orientation !== 'orthogonal') {
+      throw new TiledFormatError(
+        this.source,
+        'orientation',
+        `toTileMap() supports only orthogonal maps in this release, got "${this.orientation}"`,
+      );
+    }
+    if (this.infinite) {
+      throw new TiledFormatError(
+        this.source,
+        'infinite',
+        'toTileMap() supports only finite maps in this release; infinite (chunked) maps are not yet convertible',
+      );
+    }
+
     // Build runtime tilesets. Tilesets with a per-tile image collection are
     // not yet supported; collection-of-images tilesets throw TiledFormatError.
     // Tilesets with no image at all (no texture, no tileTextures) are silently

--- a/packages/exojs-tiled/src/public.ts
+++ b/packages/exojs-tiled/src/public.ts
@@ -104,11 +104,11 @@ declare module '@codexo/exojs' {
   interface AssetDefinitions {
     tileMap: {
       resource: TileMap;
-      config: { source: string; format?: 'tiled'; strict?: boolean };
+      config: { source: string; format?: 'tiled' };
     };
     tiledMap: {
       resource: TiledMap;
-      config: { source: string; format?: 'tiled'; strict?: boolean };
+      config: { source: string; format?: 'tiled' };
     };
   }
 }

--- a/packages/exojs-tiled/src/tiledMapBinding.ts
+++ b/packages/exojs-tiled/src/tiledMapBinding.ts
@@ -20,7 +20,7 @@ export const tiledMapBinding = {
     return {
       getIdentityKey(req) {
         const o = resolveTiledOptions(req.options);
-        return `${req.source}|${o.format}|${o.strict}`;
+        return `${req.source}|${o.format}`;
       },
       async load(req, ctx) {
         return loadTiledMap(req.source, ctx);

--- a/packages/exojs-tiled/src/tiledOptions.ts
+++ b/packages/exojs-tiled/src/tiledOptions.ts
@@ -6,24 +6,29 @@
 export interface TiledLoadOptions {
   /**
    * Explicit format hint for ambiguous file extensions.
-   * `.tmj` paths need no hint; required for `.json` paths that contain Tiled
-   * map data (`loader.load(TileMap, 'world.json', { format: 'tiled' })`).
-   * A mismatched hint (e.g. `format: 'ldtk'` for a `.tmj` file) is an error.
+   *
+   * `.tmj`/`.tsj` paths are recognised by extension and need no hint. Provide
+   * `format: 'tiled'` when loading Tiled map data from a generic `.json` path:
+   * `loader.load(TileMap, 'world.json', { format: 'tiled' })`. `'tiled'` is the
+   * only accepted value, so a foreign format (e.g. `'ldtk'`) is a compile error
+   * rather than a silent runtime fall-through.
+   *
+   * The hint participates in the asset identity key, so the same source loaded
+   * under different (future) formats resolves to distinct cache entries.
    */
   readonly format?: 'tiled';
-  /**
-   * When `true` (the default), validation errors in the Tiled map are fatal.
-   * Set to `false` to tolerate minor spec deviations at the cost of potentially
-   * incorrect map data; affects cache identity (a strict and a non-strict load
-   * of the same URL are treated as distinct assets).
-   */
-  readonly strict?: boolean;
 }
 
-/** Applies defaults and returns a normalized options object. */
-export function resolveTiledOptions(options: TiledLoadOptions | undefined): { format: 'tiled'; strict: boolean } {
+/**
+ * Applies defaults and returns a normalized options object.
+ *
+ * Tiled parsing is unconditionally strict: {@link validateTiledMapData} throws
+ * a `TiledFormatError` on any malformed *known* field and silently preserves
+ * unknown fields. There is intentionally no `strict` toggle — a permissive
+ * parse mode is a potential v0.14 follow-up, not part of v0.13.
+ */
+export function resolveTiledOptions(options: TiledLoadOptions | undefined): { format: 'tiled' } {
   return {
     format: options?.format ?? 'tiled',
-    strict: options?.strict ?? true,
   };
 }

--- a/packages/exojs-tiled/src/tiledRuntimeMapBinding.ts
+++ b/packages/exojs-tiled/src/tiledRuntimeMapBinding.ts
@@ -30,7 +30,7 @@ export const tiledRuntimeMapBinding = {
     return {
       getIdentityKey(req) {
         const o = resolveTiledOptions(req.options);
-        return `${req.source}|${o.format}|${o.strict}`;
+        return `${req.source}|${o.format}`;
       },
       async load(req, ctx) {
         const tiledMap = await ctx.loader.load(TiledMap, req.source, req.options);

--- a/packages/exojs-tiled/test/extension.test.ts
+++ b/packages/exojs-tiled/test/extension.test.ts
@@ -92,13 +92,8 @@ describe('@codexo/exojs-tiled asset handler — tiledMapBinding', () => {
 describe('tiledMapBinding.getIdentityKey', () => {
   const handler = tiledMapBinding.create();
 
-  it('includes source, format, and strict in the key', () => {
-    expect(handler.getIdentityKey!({ source: 'world.tmj' })).toBe('world.tmj|tiled|true');
-  });
-
-  it('strict:false produces a distinct key', () => {
-    const key = handler.getIdentityKey!({ source: 'world.tmj', options: { strict: false } });
-    expect(key).toBe('world.tmj|tiled|false');
+  it('includes source and format in the key', () => {
+    expect(handler.getIdentityKey!({ source: 'world.tmj' })).toBe('world.tmj|tiled');
   });
 });
 

--- a/packages/exojs-tiled/test/fixtures/orthogonal-rich.tmj
+++ b/packages/exojs-tiled/test/fixtures/orthogonal-rich.tmj
@@ -1,0 +1,126 @@
+{
+  "type": "map",
+  "version": "1.10",
+  "tiledversion": "1.10.2",
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "width": 4,
+  "height": 2,
+  "tilewidth": 16,
+  "tileheight": 16,
+  "infinite": false,
+  "backgroundcolor": "#223344",
+  "properties": [
+    { "name": "mood", "type": "string", "value": "calm" }
+  ],
+  "layers": [
+    {
+      "id": 1,
+      "name": "Ground",
+      "type": "tilelayer",
+      "visible": true,
+      "opacity": 0.5,
+      "x": 0,
+      "y": 0,
+      "offsetx": 8,
+      "offsety": -4,
+      "width": 4,
+      "height": 2,
+      "properties": [
+        { "name": "role", "type": "string", "value": "base" }
+      ],
+      "data": [
+        1, 2147483649, 1073741825, 3221225473,
+        536870913, 2684354561, 1610612737, 3758096385
+      ]
+    },
+    {
+      "id": 2,
+      "name": "Spawns",
+      "type": "objectgroup",
+      "visible": true,
+      "opacity": 1,
+      "x": 0,
+      "y": 0,
+      "draworder": "topdown",
+      "objects": [
+        {
+          "id": 1, "name": "hero", "type": "spawn",
+          "x": 16, "y": 16, "width": 0, "height": 0,
+          "rotation": 0, "visible": true, "point": true
+        },
+        {
+          "id": 2, "name": "chest", "type": "prop",
+          "x": 32, "y": 0, "width": 16, "height": 16,
+          "rotation": 0, "visible": true, "gid": 2
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "name": "Background",
+      "type": "imagelayer",
+      "visible": true,
+      "opacity": 1,
+      "x": 0,
+      "y": 0,
+      "image": "bg.png",
+      "repeatx": true,
+      "repeaty": false
+    },
+    {
+      "id": 4,
+      "name": "Decor",
+      "type": "group",
+      "visible": true,
+      "opacity": 1,
+      "x": 0,
+      "y": 0,
+      "layers": [
+        {
+          "id": 5,
+          "name": "DecorTiles",
+          "type": "tilelayer",
+          "visible": true,
+          "opacity": 1,
+          "x": 0,
+          "y": 0,
+          "width": 4,
+          "height": 2,
+          "data": [9, 0, 0, 0, 0, 0, 0, 0]
+        }
+      ]
+    }
+  ],
+  "tilesets": [
+    {
+      "firstgid": 1,
+      "name": "tiles-a",
+      "image": "tiles-a.png",
+      "imagewidth": 64,
+      "imageheight": 32,
+      "tilewidth": 16,
+      "tileheight": 16,
+      "columns": 4,
+      "tilecount": 8,
+      "spacing": 0,
+      "margin": 0,
+      "properties": [
+        { "name": "author", "type": "string", "value": "exo" }
+      ],
+      "tiles": [
+        {
+          "id": 0,
+          "type": "floor",
+          "properties": [
+            { "name": "solid", "type": "bool", "value": true }
+          ]
+        }
+      ]
+    },
+    {
+      "firstgid": 9,
+      "source": "tileset-b.tsj"
+    }
+  ]
+}

--- a/packages/exojs-tiled/test/fixtures/tileset-b.tsj
+++ b/packages/exojs-tiled/test/fixtures/tileset-b.tsj
@@ -1,0 +1,14 @@
+{
+  "name": "tiles-b",
+  "image": "tiles-b.png",
+  "imagewidth": 80,
+  "imageheight": 20,
+  "tilewidth": 16,
+  "tileheight": 16,
+  "columns": 4,
+  "tilecount": 4,
+  "spacing": 4,
+  "margin": 2,
+  "tiledversion": "1.10.2",
+  "version": "1.10"
+}

--- a/packages/exojs-tiled/test/tiledLoadOptions.test.ts
+++ b/packages/exojs-tiled/test/tiledLoadOptions.test.ts
@@ -1,0 +1,33 @@
+import { describe, expectTypeOf, it } from 'vitest';
+
+import type { TiledLoadOptions } from '../src/tiledOptions';
+
+// Type-level contract for the Tiled load options surface. These assertions are
+// verified by the package typecheck (the `@ts-expect-error` lines fail the build
+// if the rejected shapes ever start compiling again).
+
+describe('TiledLoadOptions typing', () => {
+  it('exposes only an optional `format` hint, fixed to "tiled"', () => {
+    expectTypeOf<TiledLoadOptions['format']>().toEqualTypeOf<'tiled' | undefined>();
+    // The whole options object is assignable from an empty object (all optional).
+    expectTypeOf<Record<string, never>>().toMatchTypeOf<TiledLoadOptions>();
+  });
+
+  it('compiles with no options, empty options, and the explicit format hint', () => {
+    const omitted: TiledLoadOptions | undefined = undefined;
+    const empty: TiledLoadOptions = {};
+    const hinted: TiledLoadOptions = { format: 'tiled' };
+    void omitted;
+    void empty;
+    void hinted;
+  });
+
+  it('rejects a foreign format and the removed `strict` option', () => {
+    // @ts-expect-error — only 'tiled' is an accepted format (no 'ldtk' fall-through)
+    const foreign: TiledLoadOptions = { format: 'ldtk' };
+    // @ts-expect-error — `strict` was removed; Tiled parsing is unconditionally strict
+    const strict: TiledLoadOptions = { strict: false };
+    void foreign;
+    void strict;
+  });
+});

--- a/packages/exojs-tiled/test/tiledRuntimeMapBinding.test.ts
+++ b/packages/exojs-tiled/test/tiledRuntimeMapBinding.test.ts
@@ -85,21 +85,14 @@ describe('tiledRuntimeMapBinding descriptor', () => {
 describe('tiledRuntimeMapBinding.getIdentityKey', () => {
   const handler = tiledRuntimeMapBinding.create();
 
-  it('includes source, format, and strict in the key', () => {
+  it('includes source and format in the key', () => {
     const key = handler.getIdentityKey!({ source: 'world.tmj' });
-    expect(key).toBe('world.tmj|tiled|true');
+    expect(key).toBe('world.tmj|tiled');
   });
 
   it('uses explicit format when provided', () => {
     const key = handler.getIdentityKey!({ source: 'world.tmj', options: { format: 'tiled' } });
-    expect(key).toBe('world.tmj|tiled|true');
-  });
-
-  it('strict:false produces a distinct key', () => {
-    const defaultKey = handler.getIdentityKey!({ source: 'world.tmj' });
-    const lenientKey = handler.getIdentityKey!({ source: 'world.tmj', options: { strict: false } });
-    expect(lenientKey).toBe('world.tmj|tiled|false');
-    expect(lenientKey).not.toBe(defaultKey);
+    expect(key).toBe('world.tmj|tiled');
   });
 
   it('different sources produce different keys', () => {
@@ -193,7 +186,7 @@ describe('tiledRuntimeMapBinding.load — options passthrough', () => {
 
   it('passes options to the TiledMap sub-load', async () => {
     const handler = tiledRuntimeMapBinding.create();
-    const opts = { format: 'tiled' as const, strict: false };
+    const opts = { format: 'tiled' as const };
     await handler.load({ source: 'world.tmj', options: opts }, context);
     expect(loaderLoad).toHaveBeenCalledWith(TiledMap, 'world.tmj', opts);
   });

--- a/packages/exojs-tiled/test/toTileMap.test.ts
+++ b/packages/exojs-tiled/test/toTileMap.test.ts
@@ -1,0 +1,303 @@
+import { readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import { Texture, type AssetLoaderContext } from '@codexo/exojs';
+import { TileLayer, TileMap, TileSet } from '@codexo/exojs-tilemap';
+
+import { loadTiledMap } from '../src/loadTiledMap';
+import { TiledMap } from '../src/TiledMap';
+import { TiledGroupLayer, TiledImageLayer, TiledObjectLayer, TiledTileLayer } from '../src/TiledLayer';
+import { tiledRuntimeMapBinding } from '../src/tiledRuntimeMapBinding';
+import { TiledFormatError } from '../src/validate';
+
+// ── Fixture loading ──────────────────────────────────────────────────────────
+
+const PKG_DIR = basename(process.cwd()) === 'exojs-tiled' ? process.cwd() : join(process.cwd(), 'packages', 'exojs-tiled');
+const FIXTURES_DIR = join(PKG_DIR, 'test', 'fixtures');
+
+function loadFixture(name: string): unknown {
+  return JSON.parse(readFileSync(join(FIXTURES_DIR, name), 'utf-8'));
+}
+
+// ── Mock context factory ─────────────────────────────────────────────────────
+//
+// loader.load resolves Texture sub-loads (sized to match each fixture atlas so
+// the runtime TileSet's atlas-dimension validation passes) and TiledMap
+// sub-loads (used by the runtime binding to share the Loader cache).
+
+const TEXTURE_SIZES: Record<string, { w: number; h: number }> = {
+  'tiles-a.png': { w: 64, h: 32 },
+  'tiles-b.png': { w: 80, h: 20 },
+};
+
+function makeContext(fixtures: Record<string, unknown>) {
+  const loaderLoad = vi.fn();
+
+  const context: AssetLoaderContext = {
+    loader: { load: loaderLoad } as unknown as AssetLoaderContext['loader'],
+    identityKey: 'test',
+    fetchText: vi.fn(),
+    fetchArrayBuffer: vi.fn(),
+    fetchJson: vi.fn(async (source: string): Promise<unknown> => {
+      if (Object.hasOwn(fixtures, source)) return fixtures[source];
+      throw new Error(`toTileMap.test: no fixture for "${source}"`);
+    }),
+  };
+
+  loaderLoad.mockImplementation(async (token: unknown, url: string): Promise<unknown> => {
+    if (token === Texture) {
+      const tex = new Texture();
+      const size = TEXTURE_SIZES[url] ?? { w: 256, h: 256 };
+      tex.width = size.w;
+      tex.height = size.h;
+      return tex;
+    }
+    if (token === TiledMap) {
+      return loadTiledMap(url, context);
+    }
+    throw new Error(`toTileMap.test: unexpected loader.load token: ${String(token)}`);
+  });
+
+  return { context, loaderLoad };
+}
+
+const richFixtures = {
+  'orthogonal-rich.tmj': loadFixture('orthogonal-rich.tmj'),
+  'tileset-b.tsj': loadFixture('tileset-b.tsj'),
+};
+
+// Expected flip transforms for the 8 Ground cells, in row-major order. The
+// fixture encodes all 8 (flipX, flipY, diagonal) combinations on base gid 1.
+const EXPECTED_FLIPS: ReadonlyArray<{ flipX: boolean; flipY: boolean; diagonal: boolean }> = [
+  { flipX: false, flipY: false, diagonal: false },
+  { flipX: true, flipY: false, diagonal: false },
+  { flipX: false, flipY: true, diagonal: false },
+  { flipX: true, flipY: true, diagonal: false },
+  { flipX: false, flipY: false, diagonal: true },
+  { flipX: true, flipY: false, diagonal: true },
+  { flipX: false, flipY: true, diagonal: true },
+  { flipX: true, flipY: true, diagonal: true },
+];
+
+// ── Source-model parsing breadth ─────────────────────────────────────────────
+
+describe('TiledMap source model — orthogonal-rich.tmj', () => {
+  const { context } = makeContext(richFixtures);
+
+  it('parses two tilesets sorted by firstGid (embedded + external)', async () => {
+    const map = await loadTiledMap('orthogonal-rich.tmj', context);
+    expect(map.tilesets).toHaveLength(2);
+    expect(map.tilesets[0].name).toBe('tiles-a');
+    expect(map.tilesets[0].firstGid).toBe(1);
+    expect(map.tilesets[1].name).toBe('tiles-b');
+    expect(map.tilesets[1].firstGid).toBe(9);
+    expect(map.tilesets[1].source).toBe('tileset-b.tsj');
+  });
+
+  it('preserves spacing and margin from the external .tsj', async () => {
+    const map = await loadTiledMap('orthogonal-rich.tmj', context);
+    expect(map.tilesets[1].spacing).toBe(4);
+    expect(map.tilesets[1].margin).toBe(2);
+  });
+
+  it('parses all four layer types (tile, object, image, group)', async () => {
+    const map = await loadTiledMap('orthogonal-rich.tmj', context);
+    expect(map.layers).toHaveLength(4);
+    expect(map.layers[0]).toBeInstanceOf(TiledTileLayer);
+    expect(map.layers[1]).toBeInstanceOf(TiledObjectLayer);
+    expect(map.layers[2]).toBeInstanceOf(TiledImageLayer);
+    expect(map.layers[3]).toBeInstanceOf(TiledGroupLayer);
+  });
+
+  it('preserves layer offsets, opacity, visibility, and properties', async () => {
+    const map = await loadTiledMap('orthogonal-rich.tmj', context);
+    const ground = map.layers[0] as TiledTileLayer;
+    expect(ground.offsetX).toBe(8);
+    expect(ground.offsetY).toBe(-4);
+    expect(ground.opacity).toBe(0.5);
+    expect(ground.visible).toBe(true);
+    expect(ground.getProperty('role')?.value).toBe('base');
+  });
+
+  it('preserves map properties and tile-level properties', async () => {
+    const map = await loadTiledMap('orthogonal-rich.tmj', context);
+    expect(map.getProperty('mood')?.value).toBe('calm');
+    const tileDef = map.tilesets[0].getTile(0);
+    expect(tileDef?.properties?.find(p => p.name === 'solid')?.value).toBe(true);
+  });
+
+  it('parses object-layer objects including a tile-object gid', async () => {
+    const map = await loadTiledMap('orthogonal-rich.tmj', context);
+    const objects = (map.layers[1] as TiledObjectLayer).objects;
+    expect(objects).toHaveLength(2);
+    expect(objects[0].name).toBe('hero');
+    expect(objects[0].point).toBe(true);
+    expect(objects[1].gid).toBe(2);
+  });
+
+  it('preserves a group layer with a nested tile layer', async () => {
+    const map = await loadTiledMap('orthogonal-rich.tmj', context);
+    const group = map.layers[3] as TiledGroupLayer;
+    expect(group.layers).toHaveLength(1);
+    expect(group.layers[0]).toBeInstanceOf(TiledTileLayer);
+    expect(group.layers[0].name).toBe('DecorTiles');
+  });
+});
+
+// ── toTileMap conversion ─────────────────────────────────────────────────────
+
+describe('TiledMap.toTileMap() — orthogonal-rich.tmj', () => {
+  const { context, loaderLoad } = makeContext(richFixtures);
+
+  it('is synchronous and performs no I/O', async () => {
+    const map = await loadTiledMap('orthogonal-rich.tmj', context);
+    loaderLoad.mockClear();
+    (context.fetchJson as ReturnType<typeof vi.fn>).mockClear();
+
+    const runtime = map.toTileMap();
+
+    expect(runtime).toBeInstanceOf(TileMap);
+    expect(runtime).not.toBeInstanceOf(Promise);
+    expect(loaderLoad).not.toHaveBeenCalled();
+    expect(context.fetchJson).not.toHaveBeenCalled();
+  });
+
+  it('converts only tile layers (object/image omitted, group flattened)', async () => {
+    const map = await loadTiledMap('orthogonal-rich.tmj', context);
+    const runtime = map.toTileMap();
+    // Ground + DecorTiles (flattened out of the group); Spawns/Background dropped.
+    expect(runtime.layers.map(l => l.name)).toEqual(['Ground', 'DecorTiles']);
+  });
+
+  it('converts both tilesets and transfers spacing/margin', async () => {
+    const map = await loadTiledMap('orthogonal-rich.tmj', context);
+    const runtime = map.toTileMap();
+    expect(runtime.tilesets).toHaveLength(2);
+    const tsB = runtime.getTileset('tiles-b');
+    expect(tsB).toBeInstanceOf(TileSet);
+    expect(tsB?.spacing).toBe(4);
+    expect(tsB?.margin).toBe(2);
+  });
+
+  it('decodes all 8 flip/transform combinations on the Ground layer', async () => {
+    const map = await loadTiledMap('orthogonal-rich.tmj', context);
+    const runtime = map.toTileMap();
+    const ground = runtime.getLayerByName('Ground')!;
+
+    for (let i = 0; i < EXPECTED_FLIPS.length; i++) {
+      const tile = ground.getTileAt(i % 4, Math.floor(i / 4));
+      expect(tile, `cell ${i}`).not.toBeNull();
+      expect(tile!.tileset.name).toBe('tiles-a');
+      expect(tile!.localTileId).toBe(0);
+      expect({ flipX: tile!.transform.flipX, flipY: tile!.transform.flipY, diagonal: tile!.transform.diagonal })
+        .toEqual(EXPECTED_FLIPS[i]);
+    }
+  });
+
+  it('resolves multi-tileset GIDs to the correct runtime tileset', async () => {
+    const map = await loadTiledMap('orthogonal-rich.tmj', context);
+    const runtime = map.toTileMap();
+    const decor = runtime.getLayerByName('DecorTiles')!;
+    const tile = decor.getTileAt(0, 0);
+    expect(tile).not.toBeNull();
+    expect(tile!.tileset.name).toBe('tiles-b');
+    expect(tile!.localTileId).toBe(0);
+  });
+
+  it('is deterministic across repeated calls and does not take texture ownership', async () => {
+    const map = await loadTiledMap('orthogonal-rich.tmj', context);
+    const first = map.toTileMap();
+    const second = map.toTileMap();
+
+    expect(first).not.toBe(second); // distinct instances
+    expect(first.layers.map(l => l.name)).toEqual(second.layers.map(l => l.name));
+
+    // Destroying one converted map must not affect the shared textures or a
+    // second conversion (textures are Loader-owned).
+    first.destroy();
+    const third = map.toTileMap();
+    expect(third.getLayerByName('Ground')!.getTileAt(0, 0)).not.toBeNull();
+  });
+});
+
+// ── Direct (runtime binding) vs source (.toTileMap) equivalence ───────────────
+
+describe('runtime binding vs source.toTileMap() equivalence', () => {
+  const { context } = makeContext(richFixtures);
+
+  function sampleLayers(map: TileMap): unknown {
+    return map.layers.map(layer => ({
+      name: layer.name,
+      width: layer.width,
+      height: layer.height,
+      tiles: sampleTiles(layer),
+    }));
+  }
+
+  function sampleTiles(layer: TileLayer): unknown[] {
+    const out: unknown[] = [];
+    for (let y = 0; y < layer.height; y++) {
+      for (let x = 0; x < layer.width; x++) {
+        const t = layer.getTileAt(x, y);
+        out.push(t === null ? null : { ts: t.tileset.name, id: t.localTileId, ...t.transform });
+      }
+    }
+    return out;
+  }
+
+  it('produces semantically equivalent runtime maps via both load paths', async () => {
+    const direct = await tiledRuntimeMapBinding.create().load({ source: 'orthogonal-rich.tmj' }, context);
+    const source = await loadTiledMap('orthogonal-rich.tmj', context);
+    const converted = source.toTileMap();
+
+    expect(direct).toBeInstanceOf(TileMap);
+    expect(sampleLayers(direct)).toEqual(sampleLayers(converted));
+    expect(direct.tilesets.map(t => t.name)).toEqual(converted.tilesets.map(t => t.name));
+    expect(direct.width).toBe(converted.width);
+    expect(direct.height).toBe(converted.height);
+  });
+});
+
+// ── Unsupported-map rejection (no silent corruption) ─────────────────────────
+
+describe('TiledMap.toTileMap() — rejects maps it cannot convert faithfully', () => {
+  const baseLayer = {
+    id: 1, name: 'Ground', type: 'tilelayer', visible: true, opacity: 1,
+    x: 0, y: 0, width: 2, height: 1, data: [1, 1],
+  };
+  const baseTileset = {
+    firstgid: 1, name: 'tiles', image: 'tiles-a.png', imagewidth: 64, imageheight: 32,
+    tilewidth: 16, tileheight: 16, columns: 4, tilecount: 8,
+  };
+
+  it('throws TiledFormatError for a non-orthogonal (isometric) map', async () => {
+    const { context } = makeContext({
+      'iso.tmj': {
+        type: 'map', version: '1.10', orientation: 'isometric', width: 2, height: 1,
+        tilewidth: 16, tileheight: 16, infinite: false,
+        layers: [baseLayer], tilesets: [baseTileset],
+      },
+    });
+    const map = await loadTiledMap('iso.tmj', context);
+    expect(() => map.toTileMap()).toThrow(TiledFormatError);
+    expect(() => map.toTileMap()).toThrow(/orthogonal/);
+  });
+
+  it('throws TiledFormatError for an infinite map', async () => {
+    const { context } = makeContext({
+      'inf.tmj': {
+        type: 'map', version: '1.10', orientation: 'orthogonal', width: 2, height: 1,
+        tilewidth: 16, tileheight: 16, infinite: true,
+        layers: [{
+          id: 1, name: 'Ground', type: 'tilelayer', visible: true, opacity: 1, x: 0, y: 0,
+          width: 2, height: 1,
+          chunks: [{ x: 0, y: 0, width: 2, height: 1, data: [1, 1] }],
+        }],
+        tilesets: [baseTileset],
+      },
+    });
+    const map = await loadTiledMap('inf.tmj', context);
+    expect(() => map.toTileMap()).toThrow(TiledFormatError);
+    expect(() => map.toTileMap()).toThrow(/infinite|finite/);
+  });
+});

--- a/packages/exojs-tilemap/README.md
+++ b/packages/exojs-tilemap/README.md
@@ -152,6 +152,11 @@ import '@codexo/exojs-tilemap/register';
   are bottom-left aligned (Tiled orthogonal convention).
 - **WebGL2 and WebGPU** share one CPU geometry builder and produce identical output (golden
   parity tested on both backends).
+- **Sampling.** Tile UVs are exact (no half-texel inset), which assumes **nearest** atlas
+  filtering — the typical pixel-art case. Under linear or mipmap filtering, author tilesets with
+  extruded tile margins to avoid neighbour bleed at tile edges (extrusion-aware tilemap UV
+  insetting is a planned follow-up; the `NineSlice` / `RepeatingSprite` geometry paths already
+  inset).
 
 ## Ownership & lifecycle
 

--- a/packages/exojs-tilemap/src/TileMapBand.ts
+++ b/packages/exojs-tilemap/src/TileMapBand.ts
@@ -37,6 +37,7 @@ import type { TileLayerNode } from './TileLayerNode';
 export class TileMapBand extends Container {
   private readonly _name: string;
   private readonly _layerNodes: TileLayerNode[];
+  private _destroyed = false;
 
   /**
    * @param name       The band name (unique within its owning view).
@@ -160,8 +161,16 @@ export class TileMapBand extends Container {
    * Destroy the band: detach it from its application parent, then destroy the
    * tile-layer nodes it owns (freeing their chunk geometry). Application actors,
    * sibling bands, the map, layers, and tileset textures are untouched.
+   *
+   * Idempotent: a second call (e.g. when {@link TileMapView.destroy} runs after
+   * the application already destroyed this band directly) is a safe no-op.
    */
   public override destroy(): void {
+    if (this._destroyed) {
+      return;
+    }
+    this._destroyed = true;
+
     this.parent?.removeChild(this);
 
     const owned = [...this._layerNodes];

--- a/packages/exojs-tilemap/src/chunkGeometry.ts
+++ b/packages/exojs-tilemap/src/chunkGeometry.ts
@@ -141,6 +141,12 @@ export function buildChunkPages(
       // Absolute source pixel rect = tileset-region offset + in-atlas tile rect.
       const sx = region.x + rect.x;
       const sy = region.y + rect.y;
+      // Exact tile UVs, no half-texel inset. This assumes NEAREST filtering on
+      // the tileset atlas (the typical pixel-art case). Under LINEAR/mipmap
+      // filtering an atlas WITHOUT extrusion padding can bleed neighbouring
+      // tiles at the edges; author tilesets with extruded margins for linear
+      // sampling. (Extrusion-aware tilemap UV insetting — already done on the
+      // NineSlice/RepeatingSprite geometry paths — is a v0.14 follow-up.)
       const u0 = sx / textureWidth;
       const v0 = sy / textureHeight;
       const u1 = (sx + rect.width) / textureWidth;

--- a/packages/exojs-tilemap/test/view.test.ts
+++ b/packages/exojs-tilemap/test/view.test.ts
@@ -411,6 +411,26 @@ describe('TileMapView ownership & destruction', () => {
     expect(view.destroyed).toBe(true);
   });
 
+  it('band.destroy() is idempotent and safe before a later view.destroy()', () => {
+    // Regression: TileMapBand had no destroyed guard, so a direct band.destroy()
+    // followed by view.destroy() (which re-invokes band.destroy()) re-ran
+    // Container.destroy() — itself not idempotent. The guard makes both safe.
+    const { view, worldRoot, actors, hero } = makeScene();
+    const groundBand = view.band('ground');
+
+    groundBand.destroy();
+    expect(groundBand.layerNodes).toHaveLength(0);
+    expect(() => groundBand.destroy()).not.toThrow();
+
+    // view.destroy() re-invokes band.destroy() on the already-destroyed band.
+    expect(() => view.destroy()).not.toThrow();
+    expect(view.destroyed).toBe(true);
+
+    // Application actors are untouched throughout.
+    expect(actors.parent).toBe(worldRoot);
+    expect(hero.parent).toBe(actors);
+  });
+
   it('destroying one band leaves the sibling band, actors, and map intact', () => {
     const { map, tileset, view, worldRoot, actors } = makeScene();
     const groundBand = view.band('ground');


### PR DESCRIPTION
## v0.13 — Phase F3: Integration Hardening, Gate Closure & Release-Scope Freeze

Final pre-release implementation/validation pass over the merged v0.13 feature set
(#107–#118). This is **not** a release: no version bump, tag, publish, or dist-tag change.

### ✅ Release-readiness verdict: **READY WITH DOCUMENTED NON-BLOCKING LIMITATIONS**

The v0.13 feature set is complete, coherent, externally consumable, documented, and safe to
freeze for a separate release-prep slice. No blocking defect remains. Browser golden lanes,
packed-consumer clean-room install, and the perf browser lane are validated by CI (they need
browser/WebGPU + clean-room npm environments not fully reproducible in the local hardening run)
and are flagged honestly below.

---

### 🐛 Blocking-class defects found & fixed (3)

1. **Misleading Tiled `strict` load option** — `loadTiledMap` never consumed options, so `strict`
   only fragmented the asset cache via `getIdentityKey` while having zero effect on parsing
   (`validate.ts` is unconditionally strict on known fields, tolerant of unknown ones). The README
   also claimed the wrong default (`false` vs. actual `true`) and a false behaviour ("throw on
   unknown fields"). **Decision:** *removed* `strict` from the public surface rather than
   implementing it — unknown-field rejection at default-true would break real Tiled files
   (`wangsets`, `transformations`, `grid`, …). Permissive parsing → v0.14. Identity key is now
   `${source}|${format}`.
2. **`toTileMap()` silent data corruption** — the documented "finite orthogonal only" contract was
   never enforced: isometric maps converted to misplaced orthogonal geometry; infinite maps to
   empty layers. Now throws `TiledFormatError`.
3. **`TileMapBand.destroy()` not idempotent** — `Container.destroy()` isn't idempotent, and the
   public `band.destroy()` is re-invoked by `view.destroy()`, double-running `super.destroy()`.
   Added a `_destroyed` guard matching `TileMap`/`TileLayer`/`TileMapView`.

### 🔎 Loader resolution matrix

| Call | Result | Status |
|---|---|---|
| `load('world.tmj')` | generic runtime `TileMap` | PASS |
| `load('config.json')` | generic JSON (Tiled never claims `.json`) | PASS |
| `load(TileMap, 'world.tmj')` | runtime `TileMap` (sub-loads `TiledMap`, shares cache) | PASS |
| `load(TiledMap, 'world.tmj')` | parsed source model | PASS |
| `load(TileMap, 'world.json', { format: 'tiled' })` | parses as Tiled | PASS |
| `load(TileMap, 'world.json')` *(no hint)* | parses as Tiled (`format` defaults `'tiled'`; **no** ambiguity throw) | PASS-WITH-LIMITATION (documented; supersedes spec) |
| `.tmj` + `format: 'ldtk'` | **compile error** (`format` type is `'tiled'`) | PASS |
| parser error | propagates; **no** fall-through to another parser | PASS |

### 🧩 Public API / naming

Naming grep is **clean** — no `TiledMapDocument`/`TiledMapAsset`/`TiledMapSource`/`RawTiledMap`/
`TiledMapView`/`defineAssetBinding`/`defineAssetHandler`/`createAssetBinding`. Terminology
(`TiledMapData` raw types / `TiledMap` source model / `TileMap` runtime) is consistent. The only
public-API change is the `strict` removal (justified above). The tiled facade re-exports only the
curated tilemap list; class identity holds across both import paths.

### 🧪 Tests & realistic fixtures

- **`toTileMap.test.ts`** + **`orthogonal-rich.tmj`** / **`tileset-b.tsj`** — multi-tileset
  (embedded + external `.tsj`, spacing/margin), **all 8 flip combinations**, object/image/group
  layer parsing, **source↔runtime equivalence**, `toTileMap()` sync + no-I/O + determinism + no
  texture ownership, and the new orientation/infinite rejection.
- **`tiledLoadOptions.test.ts`** — type contract (`format`-only; `strict` and foreign formats
  rejected via `@ts-expect-error`).
- **`view.test.ts`** — `TileMapBand` idempotence regression.

### 🖼️ Rendering / filtering limitations (documented, non-blocking)

- **Tilemap atlas under linear/mipmap filtering** — `chunkGeometry` uses exact tile UVs (no
  half-texel inset) → assumes **nearest** (typical pixel-art). Linear/mipmap on an unextruded atlas
  bleeds; documented in `chunkGeometry.ts` + tilemap README. Extrusion-aware tilemap UVs → v0.14.
  (`NineSlice`/`RepeatingSprite` geometry paths already inset — G-BLEED safe there.)
- **G-ATLAS-LIMITS** — `strategy:'shader'` over a sub-region is *impossible by construction*
  (`resolvedStrategy` derives from source type; no user strategy option) → no unsafe path.
- **G-MIRROR** — implemented via CPU segment-flip + GPU sampler `mirror-repeat` (the spec's
  triangle-wave shader formula was superseded by this implementation).

### 🧹 Ownership & lifecycle

No `destroy()` touches a Loader-owned texture (no double-free); actors survive view/band
destruction; no-op tile writes don't bump revisions; idempotent-destroy guards present on all
composition classes (after the band fix). Full audit: green.

### 📦 Package graph & consumers

`@codexo/exojs-tilemap` (peer → exojs) ← regular dep ← `@codexo/exojs-tiled` (peer → exojs).
`verify:lockstep` + `verify:release-matrix` pass (publish order Core → Particles → Tilemap →
Tiled). Packed tarballs inspected: tilemap ships all `dist/esm` + README + LICENSE; the tiled
tarball rewrites `workspace:*` → `@codexo/exojs-tilemap@0.12.0` (transitive install confirmed).
Class-identity (`instanceof` across both import paths) covered by `facade.test.ts`. Full clean-room
external-consumer install is a CI/release-prep lane.

### ⚡ Performance

TransformBuffer coalescing (#118) intact; revision-cached chunk geometry (camera pan = 0 rebuilds,
one tile edit = one chunk rebuild); `perf:renderers:quick` green. No new hot-path allocations.

### 🧊 Final v0.13 scope

- **MUST (shipped):** TextureRegion, NineSliceSprite, RepeatingSprite, PixelSnapMode; generic
  TileMap/TileLayer/TileSet runtime + multi-tileset + flip transforms + mutation; TileMapNode/
  TileLayerNode/TileMapView/TileMapBand; Tiled source model + `.tmj`/external-`.tsj` loading +
  `toTileMap`; extension dependency graph + typed declarative asset handlers + one-extension DX;
  coalesced TransformBuffer upload.
- **SHOULD (in, stable):** 3-mode render-only pixel snapping; layer bands/views; benchmark harness.
- **FOLLOW-UP (v0.14+):** tile animation; object/image/group **layer rendering**; infinite/
  procedural streaming; autotiling; tilemap extruded-atlas linear-filter hardening; multi-texture
  batching; persistent GPU arena; LDtk/RPG-Maker adapters; permissive Tiled parse mode; lighting;
  **focused examples** (NineSlice/Repeating/Tiled/multi-tileset/TileMapView/mutation/pixel-snap).
- **REMOVED/REJECTED:** `strict` Tiled option; shader-strategy-over-subregion (impossible by
  design); triangle-wave mirror shader.

### 🚫 Non-goals (honored)

No infinite/procedural streaming, autotiling, object/image/group **rendering**, tile animation,
lighting, physics, UI controls, ScreenView, multi-texture batching, persistent GPU buffers, shared
quad-renderer redesign — and **no** version bump/tag/publish/release.

### ✔️ Validation

`lint`, `typecheck`, `typecheck:guides`, `typecheck:examples`, `test` (**3012 pass / 1 skip**),
`verify:exports`, `verify:lockstep`, `verify:release-matrix`, `build`, `site:build`, both
extension-package `typecheck` + `build` — **all green**. Generated `site/**/api/*.mdx` were
reverted (regenerated by the docs build, not hand-committed). `.workspace/**` not committed.

### ⚠️ Deviation from prompt

**Examples (§25) were not added** in this slice. The examples subsystem (`examples:sync` codegen,
smoke tests, catalog, plus the known browser-harness extension-renderer wiring gap for tilemap)
carries verification risk that can't be cleanly closed here; examples are explicitly optional
(§33 "MAY") and non-blocking (§31). Listed as a concrete v0.14 follow-up above.

Internal audit reports + gate matrix + ZIP live under `.workspace/reports/v0.13-final-hardening/`
and `.workspace/output/v0.13-final-hardening.zip` (not committed).
