### PR TITLE
fix(ci): validate extension package changes

### DIFF
--- a/.github/workflows/_ci-checks.yml
+++ b/.github/workflows/_ci-checks.yml
@@ -43,57 +43,34 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
 
-      # Path filtering only narrows pull-request runs. Pushes to main, tag
-      # releases (via release.yml), and manual dispatches skip this step and
-      # fall through to the "run everything" branch below, so a release is
-      # never partially checked.
-      - name: Filter changed paths
-        id: filter
+      # On pull requests, list every changed file (dorny/paths-filter resolves
+      # the base / merge-base robustly) and hand the list to
+      # scripts/ci/select-lanes.mjs, which decides the effective lanes. Pushes to
+      # main, tag releases (via release.yml) and manual dispatches skip this step;
+      # select-lanes then runs every lane, so a release is never partially
+      # checked.
+      #
+      # The path-to-lane mapping lives in scripts/ci/select-lanes.mjs — NOT in
+      # this YAML — so it is a single source of truth that
+      # test/ci/select-lanes.test.ts can assert deterministically.
+      - name: List changed files
+        id: changed
         if: ${{ github.event_name == 'pull_request' }}
         uses: dorny/paths-filter@v3
         with:
+          list-files: json
           filters: |
-            engine:
-              - 'src/**'
-              - 'test/**'
-              - 'scripts/**'
-              - 'rollup.config.ts'
-              - 'vitest.config.ts'
-              - 'tsconfig.json'
-              - 'tsconfig.test.json'
-              - 'tsconfig.eslint.json'
-              - 'package.json'
-              - 'pnpm-lock.yaml'
-              - '.github/workflows/**'
-            site:
-              - 'site/**'
-              - 'examples/**'
-              - 'packages/**'
-              - 'tsconfig.guides.json'
-              - 'tsconfig.examples.json'
-              - 'tsconfig.eslint.json'
-              - 'package.json'
-              - 'pnpm-lock.yaml'
-              - '.github/workflows/**'
+            all:
+              - '**'
 
       - name: Decide effective lanes
         id: decide
         env:
-          FILTER_OUTCOME: ${{ steps.filter.outcome }}
-          FILTER_ENGINE: ${{ steps.filter.outputs.engine }}
-          FILTER_SITE: ${{ steps.filter.outputs.site }}
-        run: |
-          if [ "$FILTER_OUTCOME" = "success" ]; then
-            engine="$FILTER_ENGINE"
-            site="$FILTER_SITE"
-          else
-            # Not a pull request (push to main, tag release, dispatch): run all lanes.
-            engine=true
-            site=true
-          fi
-          echo "engine=$engine" >> "$GITHUB_OUTPUT"
-          echo "site=$site" >> "$GITHUB_OUTPUT"
-          echo "Effective lanes — engine=$engine site=$site"
+          EVENT_NAME: ${{ github.event_name }}
+          CHANGED_FILES: ${{ steps.changed.outputs.all_files }}
+        # Dependency-free ESM, run with the runner's ambient node — deliberately
+        # no pnpm install in this always-on detector job.
+        run: node scripts/ci/select-lanes.mjs >> "$GITHUB_OUTPUT"
 
   typecheck:
     name: Typecheck
@@ -127,6 +104,14 @@ jobs:
 
       - name: Typecheck guides
         run: pnpm typecheck:guides
+
+      # Root `pnpm typecheck` only covers src/**; the extension packages own a
+      # separate tsconfig each, so typecheck them explicitly. (Package lint is
+      # intentionally NOT run here — the packages' eslint typed-linting config is
+      # not wired up yet and crashes; tracked separately, out of scope for the
+      # path-coverage fix.)
+      - name: Typecheck extension packages
+        run: pnpm --filter "@codexo/exojs-particles" --filter "@codexo/exojs-tilemap" --filter "@codexo/exojs-tiled" typecheck
 
   lint:
     name: Lint
@@ -375,14 +360,35 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Build
+      # Core build first (verify:exports inspects the core dist tree).
+      - name: Build core
         run: pnpm build
 
-      - name: Verify package exports
+      # The extension packages each have their own rollup build; pnpm runs them
+      # in workspace-dependency order (tilemap before tiled). A broken package
+      # build is now caught here instead of only at release time.
+      - name: Build extension packages
+        run: pnpm --filter "@codexo/exojs-particles" --filter "@codexo/exojs-tilemap" --filter "@codexo/exojs-tiled" build
+
+      - name: Verify core package exports
         run: pnpm verify:exports
 
-      - name: Package dry run
+      # Lockstep versions + peer-range coherence + deterministic publish-order
+      # matrix across all four published packages (the same gates release.yml
+      # runs before a publish).
+      - name: Verify lockstep versions and peer ranges
+        run: pnpm verify:lockstep
+
+      - name: Verify release publish matrix
+        run: pnpm verify:release-matrix
+
+      - name: Core package dry run
         run: pnpm pack --dry-run
+
+      # Pack each extension package (dry run) so a broken `files`/`exports` set in
+      # a package manifest is caught here, not at release time.
+      - name: Extension package dry runs
+        run: pnpm --filter "@codexo/exojs-particles" --filter "@codexo/exojs-tilemap" --filter "@codexo/exojs-tiled" pack --dry-run
 
   site-build:
     name: Site build
@@ -437,6 +443,8 @@ jobs:
     steps:
       - name: Evaluate required job results
         env:
+          ENGINE: ${{ needs.changes.outputs.engine }}
+          SITE: ${{ needs.changes.outputs.site }}
           CHANGES_RESULT: ${{ needs.changes.result }}
           TYPECHECK_RESULT: ${{ needs.typecheck.result }}
           LINT_RESULT: ${{ needs.lint.result }}
@@ -445,6 +453,7 @@ jobs:
           PACKAGE_VERIFY_RESULT: ${{ needs['package-verify'].result }}
           SITE_BUILD_RESULT: ${{ needs['site-build'].result }}
         run: |
+          echo "areas: engine=$ENGINE site=$SITE"
           echo "changes: $CHANGES_RESULT"
           echo "typecheck: $TYPECHECK_RESULT"
           echo "lint: $LINT_RESULT"
@@ -453,28 +462,66 @@ jobs:
           echo "package-verify: $PACKAGE_VERIFY_RESULT"
           echo "site-build: $SITE_BUILD_RESULT"
 
-          # Path filtering can legitimately skip whole lanes (e.g. a docs-only
-          # PR skips the engine lanes; an engine-only PR skips the site build),
-          # so "skipped" is an acceptable result. Only a real "failure" or
-          # "cancelled" fails the gate. The changes job must not be skipped — a
-          # skipped detector would silently skip everything and false-green.
           failed=0
+
+          # The change detector must run — a skipped detector would silently
+          # false-green every downstream lane.
           if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "::error::Detect changes did not succeed (result: $CHANGES_RESULT)."
             failed=1
           fi
-          for result in \
-            "$TYPECHECK_RESULT" \
-            "$LINT_RESULT" \
-            "$UNIT_TESTS_RESULT" \
-            "$BROWSER_TESTS_RESULT" \
-            "$PACKAGE_VERIFY_RESULT" \
-            "$SITE_BUILD_RESULT"; do
+
+          # A real "failure" or "cancelled" in any required lane fails the gate.
+          # "skipped" is tolerated HERE because path filtering can legitimately
+          # skip a whole area (a docs-only PR skips the engine lanes; an
+          # engine-only PR skips the site build). Wrongly-skipped IMPACTED lanes
+          # are caught by the contract checks below.
+          for entry in \
+            "typecheck=$TYPECHECK_RESULT" \
+            "lint=$LINT_RESULT" \
+            "unit-tests=$UNIT_TESTS_RESULT" \
+            "browser-tests=$BROWSER_TESTS_RESULT" \
+            "package-verify=$PACKAGE_VERIFY_RESULT" \
+            "site-build=$SITE_BUILD_RESULT"; do
+            name="${entry%%=*}"
+            result="${entry#*=}"
             if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+              echo "::error::Required job '$name' $result."
               failed=1
             fi
           done
 
+          # Contract enforcement (the core of this fix): when the detector
+          # classifies a change as engine-impacting, the engine lanes MUST have
+          # run. A "skipped" here means the path filter wrongly excluded an
+          # impacted change — exactly the defect that let package-only PRs go
+          # green while their unit / package / browser lanes were skipped.
+          if [ "$ENGINE" = "true" ]; then
+            for entry in \
+              "unit-tests=$UNIT_TESTS_RESULT" \
+              "browser-tests=$BROWSER_TESTS_RESULT" \
+              "package-verify=$PACKAGE_VERIFY_RESULT"; do
+              name="${entry%%=*}"
+              result="${entry#*=}"
+              if [ "$result" = "skipped" ]; then
+                echo "::error::Engine change detected but required lane '$name' was skipped (path-filter regression)."
+                failed=1
+              fi
+            done
+          fi
+
+          # Likewise a site-impacting change must build the site — unless the
+          # package build failed first, in which case site-build is intentionally
+          # skipped and the package-verify failure is already counted above.
+          if [ "$SITE" = "true" ] && [ "$PACKAGE_VERIFY_RESULT" != "failure" ]; then
+            if [ "$SITE_BUILD_RESULT" = "skipped" ]; then
+              echo "::error::Site change detected but 'site-build' was skipped (path-filter regression)."
+              failed=1
+            fi
+          fi
+
           if [ "$failed" -ne 0 ]; then
-            echo "::error::At least one required CI job failed or was cancelled."
+            echo "::error::At least one required CI check failed, was cancelled, or was wrongly skipped."
             exit 1
           fi
+          echo "All required CI checks satisfied."

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "format:check": "prettier --check .",
     "test": "vitest run --project=exojs --project=exojs-particles --project=exojs-tilemap --project=exojs-tiled --project=rendering-perf",
     "test:core": "vitest run --project=exojs",
-    "test:coverage": "vitest run --coverage --project=exojs",
+    "test:coverage": "vitest run --coverage --project=exojs --project=exojs-particles --project=exojs-tilemap --project=exojs-tiled --project=rendering-perf",
     "test:watch": "vitest --project=exojs",
     "test:browser": "pnpm run test:browser:webgl && pnpm run test:browser:webgpu && pnpm run test:browser:webgl:firefox && pnpm run test:browser:webgpu:firefox",
     "test:browser:webgl": "vitest run --project=browser-webgl-chromium",

--- a/scripts/ci/select-lanes.mjs
+++ b/scripts/ci/select-lanes.mjs
@@ -1,0 +1,199 @@
+// @ts-check
+import { pathToFileURL } from 'node:url';
+
+/**
+ * CI lane selection — the single source of truth for which validation lanes a
+ * set of changed files must trigger.
+ *
+ * Consumed by:
+ *   - the "Detect changes" job in .github/workflows/_ci-checks.yml (run with the
+ *     runner's ambient `node`, no `pnpm install`); and
+ *   - test/ci/select-lanes.test.ts, which asserts representative changed-file
+ *     sets against `selectAreas` / `effectiveLanes`.
+ *
+ * Written as dependency-free ESM (`.mjs`) on purpose: the detector job runs this
+ * with the runner's ambient `node` BEFORE any dependency install, so it must not
+ * import anything outside `node:` built-ins. Keep it that way — adding a runtime
+ * import here would force a `pnpm install` into the always-on detector job.
+ *
+ * Background / the defect this prevents:
+ * a PR touching only `packages/exojs-tilemap/**` or `packages/exojs-tiled/**`
+ * used to leave `engine` false, so the unit, package-verify and browser lanes
+ * were skipped while Required CI still went green. The extension packages are
+ * runtime engine code (their source is imported by the in-repo unit AND browser
+ * tests via the vitest aliases), so a change to them must run the full engine
+ * validation set — not just the docs/site lane.
+ */
+
+/**
+ * @typedef {{ engine: boolean, site: boolean }} LaneAreas
+ * @typedef {{
+ *   typecheck: boolean,
+ *   lint: boolean,
+ *   unit: boolean,
+ *   coverage: boolean,
+ *   browserWebgl2: boolean,
+ *   browserWebgpu: boolean,
+ *   browserFirefox: boolean,
+ *   packageVerify: boolean,
+ *   siteBuild: boolean,
+ * }} EffectiveLanes
+ */
+
+/**
+ * Runtime workspace packages whose CODE participates in the engine validation
+ * lanes (unit tests, package build/verify, browser rendering tests).
+ *
+ *   - exojs-config    shared vitest/eslint/tsconfig/rollup presets — a change
+ *                     here can alter how every package builds, types and tests.
+ *   - exojs-particles / exojs-tilemap / exojs-tiled  runtime extension packages
+ *                     whose source the in-repo unit and browser tests import.
+ *
+ * NOT listed: `create-exo-app` (a standalone scaffolding CLI with no engine /
+ * browser impact) and `site` (the examples app — covered by the `site` area).
+ *
+ * Adding a new runtime extension package == add its directory name here.
+ */
+const RUNTIME_PACKAGES = ['exojs-config', 'exojs-particles', 'exojs-tilemap', 'exojs-tiled'];
+
+/**
+ * Documentation-only files inside a package. A change limited to these must NOT
+ * drag in the expensive engine lanes — it still triggers the docs/site lane via
+ * the `site` area, because package READMEs feed the generated package API pages.
+ * @param {string} file
+ */
+const isPackageDocPath = (file) => /^packages\/[^/]+\/(README\.md|CHANGELOG\.md|LICENSE)$/.test(file);
+
+/**
+ * Engine area: core runtime code, shared root tooling, and runtime-package CODE.
+ * Gates the unit/coverage, package-build-and-verify and browser lanes.
+ * @param {string} file
+ */
+const isEnginePath = (file) => {
+  // Core engine source, in-repo tests (incl. the browser/perf suites that import
+  // package source through the vitest aliases), and repo automation scripts.
+  if (file.startsWith('src/')) return true;
+  if (file.startsWith('test/')) return true;
+  if (file.startsWith('scripts/')) return true;
+  // A workflow change can alter any lane, so revalidate everything.
+  if (file.startsWith('.github/workflows/')) return true;
+  // Shared root build / test / type configuration.
+  if (file === 'rollup.config.ts' || file === 'vitest.config.ts') return true;
+  if (file === 'tsconfig.json' || file === 'tsconfig.test.json' || file === 'tsconfig.eslint.json') return true;
+  // Root manifest + lockfile + workspace topology all affect the whole build.
+  if (file === 'package.json' || file === 'pnpm-lock.yaml' || file === 'pnpm-workspace.yaml') return true;
+  // Runtime-package CODE (source, tests, build config, manifest) — but not docs.
+  for (const pkg of RUNTIME_PACKAGES) {
+    if (file.startsWith(`packages/${pkg}/`) && !isPackageDocPath(file)) return true;
+  }
+  return false;
+};
+
+/**
+ * Site area: anything that can change the generated examples site / API docs.
+ * Gates the site-build lane. Mirrors (and intentionally keeps) the prior `site`
+ * filter: every `packages/**` change — docs included — can affect generated docs
+ * or example builds.
+ * @param {string} file
+ */
+const isSitePath = (file) => {
+  if (file.startsWith('site/')) return true;
+  if (file.startsWith('examples/')) return true;
+  if (file.startsWith('packages/')) return true;
+  if (file.startsWith('.github/workflows/')) return true;
+  if (file === 'tsconfig.guides.json' || file === 'tsconfig.examples.json' || file === 'tsconfig.eslint.json') return true;
+  if (file === 'package.json' || file === 'pnpm-lock.yaml' || file === 'pnpm-workspace.yaml') return true;
+  return false;
+};
+
+/**
+ * Classify a list of changed files into the effective validation areas.
+ * @param {readonly string[]} changedFiles
+ * @returns {LaneAreas}
+ */
+export function selectAreas(changedFiles) {
+  let engine = false;
+  let site = false;
+  for (const raw of changedFiles) {
+    // Normalise Windows separators and trim stray whitespace/blank entries.
+    const file = String(raw).replace(/\\/g, '/').trim();
+    if (file === '') continue;
+    if (!engine && isEnginePath(file)) engine = true;
+    if (!site && isSitePath(file)) site = true;
+    if (engine && site) break;
+  }
+  return { engine, site };
+}
+
+/**
+ * Map effective areas to the concrete CI lanes. This MIRRORS the job `if:` gates
+ * in _ci-checks.yml — keep the two in sync:
+ *   - typecheck + lint are ungated (always run, on every PR);
+ *   - unit/coverage, package-verify and all three browser lanes gate on `engine`
+ *     (the WebGPU + Firefox browser lanes still run when engine is true; they are
+ *     merely `continue-on-error`, i.e. non-blocking, in the workflow);
+ *   - site-build gates on `site`.
+ * @param {LaneAreas} areas
+ * @returns {EffectiveLanes}
+ */
+export function effectiveLanes(areas) {
+  const { engine, site } = areas;
+  return {
+    typecheck: true,
+    lint: true,
+    unit: engine,
+    coverage: engine,
+    browserWebgl2: engine,
+    browserWebgpu: engine,
+    browserFirefox: engine,
+    packageVerify: engine,
+    siteBuild: site,
+  };
+}
+
+/**
+ * Parse the changed-file list emitted by dorny/paths-filter (`list-files: json`)
+ * — tolerant of an empty value or a newline-delimited list.
+ * @param {string | undefined} raw
+ * @returns {string[]}
+ */
+function parseChangedFiles(raw) {
+  const text = (raw ?? '').trim();
+  if (text === '') return [];
+  if (text.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(text);
+      if (Array.isArray(parsed)) return parsed.map(String);
+    } catch {
+      // Fall through to newline parsing below.
+    }
+  }
+  return text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+}
+
+/**
+ * CLI entry: read the event name + changed-file list from the environment and
+ * print `engine=<bool>` / `site=<bool>` lines for `$GITHUB_OUTPUT`.
+ *
+ * On any non-`pull_request` event the changed-file list is irrelevant and every
+ * area runs: a push to main, a tag release (via release.yml) or a manual
+ * dispatch is always validated in full, never partially.
+ */
+function main() {
+  const eventName = process.env['EVENT_NAME'] ?? '';
+  const areas =
+    eventName === 'pull_request'
+      ? selectAreas(parseChangedFiles(process.env['CHANGED_FILES']))
+      : { engine: true, site: true };
+
+  // Human-readable trace to the job log (stderr keeps it out of $GITHUB_OUTPUT).
+  process.stderr.write(`select-lanes: event=${eventName || 'unknown'} engine=${areas.engine} site=${areas.site}\n`);
+  process.stdout.write(`engine=${areas.engine}\nsite=${areas.site}\n`);
+}
+
+// Only run the CLI when executed directly (`node scripts/ci/select-lanes.mjs`),
+// never when imported by the test suite.
+const invokedPath = process.argv[1];
+if (invokedPath && import.meta.url === pathToFileURL(invokedPath).href) {
+  main();
+}

--- a/test/ci/select-lanes.test.ts
+++ b/test/ci/select-lanes.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+
+import { effectiveLanes, selectAreas } from '../../scripts/ci/select-lanes.mjs';
+
+// Deterministic coverage for the CI path-to-lane policy. The logic under test is
+// scripts/ci/select-lanes.mjs — the SAME module the "Detect changes" job in
+// .github/workflows/_ci-checks.yml runs — so these assertions exercise the real
+// lane-selection decision, not a copy of it.
+
+/** Areas + concrete lanes for a set of changed files. */
+const decide = (...files: readonly string[]) => {
+  const areas = selectAreas(files);
+  return { areas, lanes: effectiveLanes(areas) };
+};
+
+describe('CI lane selection — engine/site areas', () => {
+  it('tilemap SOURCE change runs every engine lane (unit, coverage, package-verify, all browsers) and site', () => {
+    const { areas, lanes } = decide('packages/exojs-tilemap/src/TileMap.ts');
+    expect(areas).toEqual({ engine: true, site: true });
+    expect(lanes.unit).toBe(true);
+    expect(lanes.coverage).toBe(true);
+    expect(lanes.packageVerify).toBe(true);
+    expect(lanes.browserWebgl2).toBe(true);
+    expect(lanes.browserWebgpu).toBe(true);
+    expect(lanes.browserFirefox).toBe(true);
+    expect(lanes.typecheck).toBe(true);
+    expect(lanes.lint).toBe(true);
+    expect(lanes.siteBuild).toBe(true);
+  });
+
+  it('tilemap TEST-only change still runs unit + engine lanes', () => {
+    const { areas, lanes } = decide('packages/exojs-tilemap/test/view.test.ts');
+    expect(areas.engine).toBe(true);
+    expect(lanes.unit).toBe(true);
+    expect(lanes.coverage).toBe(true);
+    expect(lanes.packageVerify).toBe(true);
+    expect(lanes.browserWebgl2).toBe(true);
+  });
+
+  it('tiled SOURCE change runs engine + package validation + browser lanes', () => {
+    const { areas, lanes } = decide('packages/exojs-tiled/src/TiledMap.ts');
+    expect(areas).toEqual({ engine: true, site: true });
+    expect(lanes.unit).toBe(true);
+    expect(lanes.packageVerify).toBe(true);
+    expect(lanes.browserWebgl2).toBe(true);
+    expect(lanes.browserWebgpu).toBe(true);
+    expect(lanes.browserFirefox).toBe(true);
+  });
+
+  it('tiled FIXTURE change runs unit + package validation', () => {
+    const { areas, lanes } = decide('packages/exojs-tiled/test/fixtures/orthogonal-rich.tmj');
+    expect(areas.engine).toBe(true);
+    expect(lanes.unit).toBe(true);
+    expect(lanes.packageVerify).toBe(true);
+  });
+
+  it('package README-only change is docs/site, NOT engine (no unit/coverage/package-verify/browser)', () => {
+    const { areas, lanes } = decide('packages/exojs-tilemap/README.md');
+    expect(areas).toEqual({ engine: false, site: true });
+    expect(lanes.unit).toBe(false);
+    expect(lanes.coverage).toBe(false);
+    expect(lanes.packageVerify).toBe(false);
+    expect(lanes.browserWebgl2).toBe(false);
+    expect(lanes.browserWebgpu).toBe(false);
+    expect(lanes.browserFirefox).toBe(false);
+    expect(lanes.siteBuild).toBe(true);
+    // typecheck + lint are ungated, so they still run on every PR.
+    expect(lanes.typecheck).toBe(true);
+    expect(lanes.lint).toBe(true);
+  });
+
+  it('package LICENSE / CHANGELOG changes are docs/site, NOT engine', () => {
+    expect(selectAreas(['packages/exojs-tiled/LICENSE'])).toEqual({ engine: false, site: true });
+    expect(selectAreas(['packages/exojs-particles/CHANGELOG.md'])).toEqual({ engine: false, site: true });
+  });
+
+  it('core engine SOURCE change keeps existing behavior (engine lanes, no site)', () => {
+    const { areas, lanes } = decide('src/rendering/Drawable.ts');
+    expect(areas).toEqual({ engine: true, site: false });
+    expect(lanes.unit).toBe(true);
+    expect(lanes.browserWebgl2).toBe(true);
+    expect(lanes.packageVerify).toBe(true);
+    expect(lanes.siteBuild).toBe(false);
+  });
+
+  it('site-only change runs site build but NOT engine/browser/package lanes', () => {
+    const { areas, lanes } = decide('site/src/pages/index.astro');
+    expect(areas).toEqual({ engine: false, site: true });
+    expect(lanes.unit).toBe(false);
+    expect(lanes.browserWebgl2).toBe(false);
+    expect(lanes.browserWebgpu).toBe(false);
+    expect(lanes.packageVerify).toBe(false);
+    expect(lanes.siteBuild).toBe(true);
+  });
+
+  it('workflow change triggers broad validation (engine + site)', () => {
+    expect(selectAreas(['.github/workflows/ci.yml'])).toEqual({ engine: true, site: true });
+    expect(selectAreas(['.github/workflows/_ci-checks.yml'])).toEqual({ engine: true, site: true });
+  });
+
+  it('lockfile / workspace-topology change triggers broad validation (engine + site)', () => {
+    const lock = decide('pnpm-lock.yaml');
+    expect(lock.areas).toEqual({ engine: true, site: true });
+    expect(lock.lanes.unit).toBe(true);
+    expect(lock.lanes.packageVerify).toBe(true);
+    expect(lock.lanes.siteBuild).toBe(true);
+    expect(selectAreas(['pnpm-workspace.yaml'])).toEqual({ engine: true, site: true });
+  });
+
+  it('shared exojs-config package source change triggers engine lanes (affects every build/test)', () => {
+    const { areas } = decide('packages/exojs-config/vitest/index.ts');
+    expect(areas.engine).toBe(true);
+  });
+
+  it('create-exo-app change does NOT trigger engine lanes (no engine/browser impact)', () => {
+    const { areas, lanes } = decide('packages/create-exo-app/src/index.ts');
+    expect(areas.engine).toBe(false);
+    expect(lanes.unit).toBe(false);
+    expect(lanes.browserWebgpu).toBe(false);
+    expect(lanes.packageVerify).toBe(false);
+    // It still counts as a packages/** change for the docs/site lane.
+    expect(areas.site).toBe(true);
+  });
+
+  it('directional dependency (tilemap → tiled) needs no per-package routing: the unit lane runs ALL projects', () => {
+    // A tilemap-only change validates the dependent tiled package transitively
+    // because the unit lane runs every jsdom project, and triggers the browser
+    // lanes (the root tilemap browser tests import both package sources).
+    const { lanes } = decide('packages/exojs-tilemap/src/TileMapView.ts');
+    expect(lanes.unit).toBe(true);
+    expect(lanes.browserWebgl2).toBe(true);
+    expect(lanes.packageVerify).toBe(true);
+  });
+
+  it('negative: a root docs-only change selects no engine and no site lanes', () => {
+    const { areas, lanes } = decide('README.md');
+    expect(areas).toEqual({ engine: false, site: false });
+    expect(lanes.unit).toBe(false);
+    expect(lanes.browserWebgpu).toBe(false);
+    expect(lanes.packageVerify).toBe(false);
+    expect(lanes.siteBuild).toBe(false);
+    // Only the ungated lanes remain.
+    expect(lanes.typecheck).toBe(true);
+    expect(lanes.lint).toBe(true);
+  });
+
+  it('handles Windows backslash separators and blank/whitespace entries', () => {
+    expect(selectAreas(['packages\\exojs-tilemap\\src\\TileMap.ts', '', '   '])).toEqual({ engine: true, site: true });
+  });
+});
+
+describe('CI lane selection — PR #119 regression', () => {
+  // The exact shape of PR #119 (the merged v0.13 hardening): only files under
+  // the two extension packages. Before this fix `engine` stayed false, so the
+  // unit, package-verify and all three browser lanes were SKIPPED while Required
+  // CI still went green. This locks in the corrected behavior.
+  const PR_119_FILES = [
+    'packages/exojs-tiled/README.md',
+    'packages/exojs-tiled/src/TiledMap.ts',
+    'packages/exojs-tiled/src/public.ts',
+    'packages/exojs-tiled/src/tiledMapBinding.ts',
+    'packages/exojs-tiled/src/tiledOptions.ts',
+    'packages/exojs-tiled/src/tiledRuntimeMapBinding.ts',
+    'packages/exojs-tiled/test/extension.test.ts',
+    'packages/exojs-tiled/test/fixtures/orthogonal-rich.tmj',
+    'packages/exojs-tiled/test/fixtures/tileset-b.tsj',
+    'packages/exojs-tiled/test/tiledLoadOptions.test.ts',
+    'packages/exojs-tiled/test/tiledRuntimeMapBinding.test.ts',
+    'packages/exojs-tiled/test/toTileMap.test.ts',
+    'packages/exojs-tilemap/README.md',
+    'packages/exojs-tilemap/src/TileMapBand.ts',
+    'packages/exojs-tilemap/src/chunkGeometry.ts',
+    'packages/exojs-tilemap/test/view.test.ts',
+  ];
+
+  it('selects every lane that PR #119 wrongly skipped', () => {
+    const { areas, lanes } = decide(...PR_119_FILES);
+    expect(areas).toEqual({ engine: true, site: true });
+    // Previously skipped — must now run:
+    expect(lanes.unit).toBe(true);
+    expect(lanes.coverage).toBe(true);
+    expect(lanes.packageVerify).toBe(true);
+    expect(lanes.browserWebgl2).toBe(true);
+    expect(lanes.browserWebgpu).toBe(true);
+    expect(lanes.browserFirefox).toBe(true);
+    // Always ran, still run:
+    expect(lanes.typecheck).toBe(true);
+    expect(lanes.lint).toBe(true);
+    expect(lanes.siteBuild).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Changes to the extension packages — **`@codexo/exojs-tilemap`** and **`@codexo/exojs-tiled`** — could merge with a green **Required CI** while the lanes that actually validate them never ran. This PR makes every change path trigger (and actually execute) the lanes that validate its real impact, and hardens Required CI so an incorrectly-skipped impacted lane can no longer hide behind a green aggregate.

This is a **CI-correctness change only** — no product features, no public-API changes, no version bumps, no release changes.

## The defect

The reusable workflow `_ci-checks.yml` classified each PR into two areas, `engine` and `site`, with `dorny/paths-filter`. The gated lanes (`unit-tests`, `package-verify`, all three `browser-tests`) keyed off **`engine`**.

`packages/**` was listed only in the **`site`** filter group — **never in `engine`**. So a PR touching only `packages/exojs-tilemap/**` / `packages/exojs-tiled/**` left `engine=false`, every engine lane was **skipped**, and Required CI treated "skipped" as acceptable → **green**.

Worse, three further gaps meant that even *triggering* those lanes would not have validated the packages:

| Gap | Detail |
| --- | --- |
| Unit lane command | `test:coverage` ran `vitest --coverage --project=exojs` — **core only**; the `exojs-tilemap` / `exojs-tiled` / `exojs-particles` vitest projects never ran in CI. |
| Package-verify command | The lane built **core only** (`pnpm build`) and never built/packed the extension packages, nor ran `verify:lockstep` / `verify:release-matrix`. |
| Typecheck command | Root `pnpm typecheck` (`tsc`, `src/**` only) never typechecked package source. |

### Evidence from PR #119 (the merged v0.13 hardening, `a541a90d`)

PR #119 changed **only** files under `packages/exojs-tiled/**` and `packages/exojs-tilemap/**`. The jobs that actually ran were:

```
Detect changes · Typecheck · Lint · Site build · Required CI
```

These were **skipped** while Required CI still went green:

```
Unit Tests (Coverage)
Package Build + Verify
Browser Tests
Browser Tests (Firefox, experimental)
Browser Tests (Chromium WebGPU, experimental)
```

The two extension packages are runtime engine code: their source is imported by the in-repo unit tests **and** by the root WebGL2/WebGPU browser tests (`test/rendering/browser/_tilemapScene.ts` imports `@codexo/exojs-tiled`; the `webgl2-tilemap*` / `webgpu-tilemap*` suites import `@codexo/exojs-tilemap`). A change to them must run the full engine validation set, not just the docs/site lane.

## Final path-filter model

The path→lane decision moved out of inline YAML globs into a **single, dependency-free source of truth**: `scripts/ci/select-lanes.mjs`, exporting `selectAreas(files)` → `{ engine, site }` and `effectiveLanes(areas)`.

- The **Detect changes** job lists every changed file (`dorny/paths-filter` with `list-files: json` and a catch-all `**`) and runs `node scripts/ci/select-lanes.mjs` to emit `engine` / `site`. It runs with the runner's **ambient node, no `pnpm install`**, so the always-on detector job stays fast.
- The **same module** is asserted by `test/ci/select-lanes.test.ts`, so the policy is verified deterministically — not by reading YAML.

`engine` now includes runtime-package **code** (`packages/exojs-config|exojs-particles|exojs-tilemap|exojs-tiled/**`, excluding `README`/`CHANGELOG`/`LICENSE`) plus `pnpm-workspace.yaml`. Package **docs** stay docs-only (site lane). `create-exo-app` (standalone scaffolding CLI) stays out of `engine`.

### Path-to-lane policy

| Change path | typecheck | lint | unit/cov | WebGL2 | WebGPU | Firefox | pkg build+verify | site |
| --- | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
| `src/**`, `test/**`, `scripts/**` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — |
| `packages/exojs-{config,particles,tilemap,tiled}/**` *(code)* | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| `packages/*/README·CHANGELOG·LICENSE` | ✓* | ✓* | — | — | — | — | — | ✓ |
| `packages/create-exo-app/**` | ✓* | ✓* | — | — | — | — | — | ✓ |
| `site/**`, `examples/**` | ✓* | ✓* | — | — | — | — | — | ✓ |
| `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| `tsconfig.json·test·eslint`, `vitest.config.ts`, `rollup.config.ts` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | (eslint→site too) |
| `.github/workflows/**` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |

`✓*` = typecheck/lint are **ungated** (run on every PR). WebGPU + Firefox browser lanes **run** when `engine` is true but remain `continue-on-error` (non-blocking) — unchanged policy.

## Lane command coverage (so a triggered lane actually validates the package)

- **Unit / Coverage** — `test:coverage` now runs all five jsdom projects (`exojs`, `exojs-particles`, `exojs-tilemap`, `exojs-tiled`, `rendering-perf`) with coverage. Package tests now execute in CI.
- **Package Build + Verify** — now builds core **and** all three extension packages, runs `verify:exports` + `verify:lockstep` + `verify:release-matrix`, and dry-run-packs core + the three extension packages.
- **Typecheck** — adds an explicit `typecheck` of the three extension packages (each owns a tsconfig).

## Required CI

Required CI now consumes the `engine` / `site` outputs and **enforces the contract**: a real `failure`/`cancelled` still fails the gate, and — additionally — when `engine` is classified true, `unit-tests` / `browser-tests` / `package-verify` **must not be `skipped`**; when `site` is true (and the package build did not fail), `site-build` must not be `skipped`. A path-filter regression that wrongly excludes an impacted lane now fails Required CI instead of false-greening.

## tilemap / tiled impact

- **tilemap change →** tilemap+tiled unit tests, package build/verify, Chromium WebGL2 + WebGPU + Firefox WebGL2 browser tests, typecheck, lint, site.
- **tiled change →** the same set. tiled depends on tilemap; no per-package routing is needed because the unit lane runs **all** jsdom projects and the browser lane runs **all** rendering tests, so a change to either validates the dependent transitively. A tilemap change reaches tiled (downstream); a tiled change does not need to re-imply tilemap, but conservatively still runs the full set.

## Before / after — a package-only PR (the PR #119 shape)

| Lane | Before | After |
| --- | --- | --- |
| Detect changes | ran | ran |
| Typecheck | ran (core only) | ran (core **+ packages**) |
| Lint | ran (core only) | ran (core only — package lint deferred, see non-goals) |
| Unit Tests (Coverage) | **skipped** | **runs** (+ package projects) |
| Package Build + Verify | **skipped** | **runs** (+ package builds/packs, lockstep, release-matrix) |
| Browser Tests (Chromium WebGL2) | **skipped** | **runs** |
| Browser Tests (Chromium WebGPU, exp) | **skipped** | **runs** (non-blocking) |
| Browser Tests (Firefox, exp) | **skipped** | **runs** (non-blocking) |
| Site build | ran | ran |
| Required CI | green — **hid the skips** | green only if impacted lanes actually ran |

## Regression tests

`test/ci/select-lanes.test.ts` (16 cases) asserts the real `select-lanes.mjs` policy, including: tilemap/tiled source, tilemap test-only, tiled fixture, package README/LICENSE/CHANGELOG (docs-only → NOT engine), core source (unchanged), site-only, workflow, lockfile/workspace, `exojs-config`, `create-exo-app` (NOT engine), Windows backslash paths, negative root-docs, and the **exact PR #119 changed-file set** locking in the lanes it previously skipped.

## CI-cost trade-off — **balanced, correctness-biased**

- Package **source/test** PR: gains the unit, package-verify and browser lanes it always needed (these are required to validate the change).
- Package **README/LICENSE/CHANGELOG** PR: stays docs-only — site build + the ungated typecheck/lint, **no** browser/unit/package-verify. A spelling fix does not spin up WebGPU.
- Fixture-only PR: unit + package validation (the fixtures are test inputs), no browser added beyond engine policy.
- Always-on detector job stays install-free.

## Non-goals (explicitly out of scope)

No product features · no public-API changes · no version bumps · no publish/release changes · no Dependabot/auto-merge/branch-protection changes · no new third-party actions · no unrelated test-semantics changes · no unrelated flaky-browser fixes. **Package eslint lint is intentionally NOT added to CI**: the packages' eslint typed-linting config is not wired up and currently exits 2 (`@typescript-eslint` rules require type information that the package lint invocation does not provide) — a pre-existing, unrelated tooling gap left for a separate change.

## Local validation

All commands green except a single Windows-only GPU environment flake (non-blocking, unrelated to this change):

| Command | Result |
| --- | --- |
| `pnpm lint` | ✓ |
| `pnpm typecheck` | ✓ |
| `pnpm typecheck:guides` | ✓ |
| `pnpm typecheck:examples` | ✓ |
| `pnpm test` | ✓ 3028 passed / 1 skipped (198 files) |
| `pnpm verify:exports` | ✓ (10 entry targets) |
| `pnpm verify:lockstep` | ✓ |
| `pnpm verify:release-matrix` | ✓ (16 checks) |
| `pnpm build` | ✓ |
| `pnpm site:build` | ✓ (602 pages) |
| `pnpm test:coverage` | ✓ runs all 5 jsdom projects + coverage (3028 tests; statements 70.3%) |
| tilemap typecheck / test / build | ✓ (240 package tests) |
| tiled typecheck / test / build | ✓ (267 package tests) |
| 3× package typecheck / build / `pack --dry-run` | ✓ (3 tarballs described) |
| `pnpm test:browser:webgl` (Chromium WebGL2) | ✓ (136 tests) |
| `pnpm test:browser:webgl:firefox` (Firefox WebGL2) | ✓ (136 tests) |
| `pnpm test:browser:webgpu` (Chromium WebGPU) | 76/77 — one Windows D3D12 `E_OUTOFMEMORY` device-loss flake in `webgpu-stencil-clip` (env, not a regression; the WebGPU lane is `continue-on-error` on CI) |

Local browser runs are Windows/SwiftShader — the authoritative browser validation is this PR's Linux CI run.

## Actual jobs triggered by this PR

This PR touches `.github/workflows/**` + `scripts/**` + `test/**` + `package.json`, so it classifies as `engine=true, site=true` and exercises the **full** corrected gate end-to-end (including the new package-build/pack steps, the package vitest projects in the unit lane, package typecheck, and the contract-checking Required CI).

Live run `27365800718` — **all 10 jobs green**:

| Job | Result |
| --- | --- |
| Detect changes | ✓ (`select-lanes.mjs` ran with ambient node, no install → `engine=true, site=true`) |
| Typecheck | ✓ (incl. the new extension-package typecheck) |
| Lint | ✓ |
| **Unit Tests (Coverage)** | ✓ (now runs the `exojs-tilemap` / `-tiled` / `-particles` vitest projects) |
| **Package Build + Verify** | ✓ (now builds + dry-run-packs the 3 extension packages, runs `verify:lockstep` + `verify:release-matrix`) |
| **Browser Tests** (Chromium WebGL2) | ✓ |
| **Browser Tests (Chromium WebGPU, experimental)** | ✓ |
| **Browser Tests (Firefox, experimental)** | ✓ |
| Site build | ✓ |
| Required CI | ✓ |

The five lanes PR #119 skipped — **Unit Tests, Package Build + Verify, Browser Tests, Browser Tests (Firefox), Browser Tests (Chromium WebGPU)** — now run and pass.

> Note: this PR also changes `.github/workflows/**`, which already flipped `engine` before the fix, so the live run cannot *isolate* the package-only → `engine` behavior. That is proven deterministically by `test/ci/select-lanes.test.ts` (which asserts the exact PR #119 changed-file set). The live run proves the corrected lanes and their new commands execute and pass on real CI.
