### PR TITLE
fix(release): pack and publish exojs-tilemap in the coordinated release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ merged pull requests and commits since the previous tag (each with its commit /
 PR link); `pnpm release:notes` then renders that section into the published
 GitHub release with a `PREVIOUS_TAG...CURRENT_TAG` compare link.
 
-## [0.13.0] - Unreleased
+## [0.13.0] - 2026-06-13
 
 The scalable-sprites and tilemap release. `TextureRegion`, `NineSliceSprite`,
 and `RepeatingSprite` bring nine-slice and tiled-repeat rendering to both

--- a/scripts/release/external-consumers.ts
+++ b/scripts/release/external-consumers.ts
@@ -1,7 +1,7 @@
 /**
  * External consumer smoke for the coordinated release.
  *
- * Installs the three packed tarballs into a throwaway project OUTSIDE the
+ * Installs the four packed tarballs into a throwaway project OUTSIDE the
  * repository (so no workspace/source resolution can leak in) and proves they
  * work for the three audiences a published release must serve:
  *
@@ -11,8 +11,10 @@
  *     against the shipped `.d.ts`. Combined with `attw`'s `bundler 🟢` this is
  *     the Vite-consumer proof without needing Vite installed.
  *
- * Fully offline: the tarballs declare no runtime dependencies, so
- * `npm install --offline` of all three resolves with no registry access.
+ * Fully offline: the only runtime dependency in the set (@codexo/exojs-tiled →
+ * @codexo/exojs-tilemap) is satisfied by the tilemap tarball installed
+ * alongside, so `npm install --offline` of all four resolves with no registry
+ * access.
  */
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
@@ -47,15 +49,17 @@ const run = (command: string, args: string[], cwd: string): { code: number; outp
 
 const CONSUMER_TS = `import { Application, Scene } from '@codexo/exojs';
 import { ParticleSystem, particlesExtension } from '@codexo/exojs-particles';
+import { TileMap, tilemapExtension } from '@codexo/exojs-tilemap';
 import { TiledMap, tiledExtension } from '@codexo/exojs-tiled';
 
 export class DemoScene extends Scene {}
 
-export function bootstrap(): { app: Application; system: typeof ParticleSystem; map: typeof TiledMap } {
+export function bootstrap(): { app: Application; system: typeof ParticleSystem; tiles: typeof TileMap; map: typeof TiledMap } {
     const app = new Application();
     void particlesExtension;
+    void tilemapExtension;
     void tiledExtension;
-    return { app, system: ParticleSystem, map: TiledMap };
+    return { app, system: ParticleSystem, tiles: TileMap, map: TiledMap };
 }
 `;
 
@@ -79,6 +83,7 @@ const CONSUMER_TSCONFIG = JSON.stringify(
 
 const NODE_SMOKE = `import * as exo from '@codexo/exojs';
 import * as particles from '@codexo/exojs-particles';
+import * as tilemap from '@codexo/exojs-tilemap';
 import * as tiled from '@codexo/exojs-tiled';
 
 const checks = [
@@ -86,8 +91,11 @@ const checks = [
   ['@codexo/exojs Scene', typeof exo.Scene === 'function'],
   ['@codexo/exojs-particles ParticleSystem', typeof particles.ParticleSystem === 'function'],
   ['@codexo/exojs-particles particlesExtension', particles.particlesExtension != null],
+  ['@codexo/exojs-tilemap TileMap', typeof tilemap.TileMap === 'function'],
+  ['@codexo/exojs-tilemap tilemapExtension', tilemap.tilemapExtension != null],
   ['@codexo/exojs-tiled TiledMap', typeof tiled.TiledMap === 'function'],
   ['@codexo/exojs-tiled tiledExtension', tiled.tiledExtension != null],
+  ['facade TileMap identity (tiled === tilemap)', tiled.TileMap === tilemap.TileMap],
 ];
 const failed = checks.filter(([, ok]) => !ok).map(([name]) => name);
 if (failed.length > 0) {
@@ -98,7 +106,7 @@ console.log('NODE_OK ' + checks.length);
 `;
 
 /**
- * Runs the external-consumer checks against three tarball paths. Returns one
+ * Runs the external-consumer checks against four tarball paths. Returns one
  * {@link ConsumerCheck} per audience; `ok` overall is the conjunction.
  */
 export const verifyExternalConsumers = (tarballs: string[]): { ok: boolean; consumerDir: string; checks: ConsumerCheck[] } => {
@@ -111,12 +119,13 @@ export const verifyExternalConsumers = (tarballs: string[]): { ok: boolean; cons
       JSON.stringify({ name: 'exo-external-consumer', private: true, type: 'module', version: '1.0.0' }, null, 2),
     );
 
-    // 1. Install all three tarballs offline (no runtime deps → no registry).
+    // 1. Install all four tarballs offline (tiled's tilemap dep resolves
+    // against the tilemap tarball installed alongside → no registry).
     const install = run('npm', ['install', '--no-audit', '--no-fund', '--offline', '--no-save', ...tarballs], consumerDir);
     // `--no-save` keeps package.json clean; pass tarballs positionally.
     const installOk = install.code === 0 && existsSync(join(consumerDir, 'node_modules', '@codexo', 'exojs'));
     checks.push({
-      name: 'install (offline, 3 tarballs)',
+      name: 'install (offline, 4 tarballs)',
       ok: installOk,
       detail: installOk ? undefined : install.output.trim().split('\n').slice(-3).join(' '),
     });
@@ -149,10 +158,15 @@ export const verifyExternalConsumers = (tarballs: string[]): { ok: boolean; cons
   }
 };
 
-// CLI: pack the three official packages into a temp dir and run the checks.
+// CLI: pack the four official packages into a temp dir and run the checks.
 if (import.meta.url.startsWith('file:') && fileURLToPath(import.meta.url) === resolve(process.argv[1] ?? '')) {
   const staging = mkdtempSync(join(tmpdir(), 'exo-cons-pack-'));
-  const dirs = [repoRoot, resolve(repoRoot, 'packages/exojs-particles'), resolve(repoRoot, 'packages/exojs-tiled')];
+  const dirs = [
+    repoRoot,
+    resolve(repoRoot, 'packages/exojs-particles'),
+    resolve(repoRoot, 'packages/exojs-tilemap'),
+    resolve(repoRoot, 'packages/exojs-tiled'),
+  ];
   const version = (JSON.parse(readFileSync(resolve(repoRoot, 'package.json'), 'utf8')) as { version: string }).version;
 
   for (const dir of dirs) {
@@ -162,7 +176,7 @@ if (import.meta.url.startsWith('file:') && fileURLToPath(import.meta.url) === re
       process.exit(1);
     }
   }
-  const tarballs = ['codexo-exojs', 'codexo-exojs-particles', 'codexo-exojs-tiled'].map(n => join(staging, `${n}-${version}.tgz`));
+  const tarballs = ['codexo-exojs', 'codexo-exojs-particles', 'codexo-exojs-tilemap', 'codexo-exojs-tiled'].map(n => join(staging, `${n}-${version}.tgz`));
 
   process.stdout.write('\n=== verify:external-consumers ===\n');
   const result = verifyExternalConsumers(tarballs);

--- a/scripts/release/full-zip.ts
+++ b/scripts/release/full-zip.ts
@@ -3,8 +3,8 @@
  *
  * A self-contained, offline-servable snapshot of a coordinated release:
  *
- *   npm/      the three official tarballs (Core, Particles, Tiled)
- *   vendor/   each package's ESM tree (exojs, exojs-particles, exojs-tiled)
+ *   npm/      the four official tarballs (Core, Particles, Tilemap, Tiled)
+ *   vendor/   each package's ESM tree (exojs, exojs-particles, exojs-tilemap, exojs-tiled)
  *   examples/ src/** (TS), js/** (transpiled), assets/**, examples.json
  *   site/     the built static site (itself servable; references ./vendor + ./examples)
  *   README.md CHANGELOG.md LICENSE release-manifest.json checksums.sha256
@@ -33,6 +33,7 @@ export interface AssembleOptions {
 const VENDOR_PACKAGES = [
   { name: 'exojs', vendorDir: 'exojs' },
   { name: 'exojs-particles', vendorDir: 'exojs-particles' },
+  { name: 'exojs-tilemap', vendorDir: 'exojs-tilemap' },
   { name: 'exojs-tiled', vendorDir: 'exojs-tiled' },
 ] as const;
 
@@ -136,7 +137,7 @@ export const assembleFullReleaseTree = (options: AssembleOptions): AssembleResul
   rmSync(treeDir, { recursive: true, force: true });
   mkdirSync(treeDir, { recursive: true });
 
-  // npm/ — the three official tarballs.
+  // npm/ — the official tarballs (manifest-driven).
   const npmOut = join(treeDir, 'npm');
   for (const record of options.manifest.packages) {
     copyFile(resolve(options.stagingDir, record.file), npmOut);

--- a/scripts/release/prepare.ts
+++ b/scripts/release/prepare.ts
@@ -1,7 +1,7 @@
 /**
  * Prepare/verify stage of the coordinated release.
  *
- * Build-once contract: the caller builds the three official packages exactly
+ * Build-once contract: the caller builds the four official packages exactly
  * once; this stage packs them WITHOUT re-running their build (`--ignore-scripts`
  * skips `prepack`), hashes the resulting tarballs, and records the digests in a
  * `release-manifest.json` + `checksums.sha256`. The `publish` stage then
@@ -42,15 +42,16 @@ const readVersion = (packageJsonPath: string): { name: string; version: string }
   return { name: pkg.name, version: pkg.version };
 };
 
-/** Resolves the three official packages in canonical publish order. */
+/** Resolves the four official packages in canonical publish order (PUBLISH_ORDER). */
 export const officialPackages = (rootDir: string): OfficialPackage[] => [
   { name: '@codexo/exojs', dir: rootDir },
   { name: '@codexo/exojs-particles', dir: resolve(rootDir, 'packages/exojs-particles') },
+  { name: '@codexo/exojs-tilemap', dir: resolve(rootDir, 'packages/exojs-tilemap') },
   { name: '@codexo/exojs-tiled', dir: resolve(rootDir, 'packages/exojs-tiled') },
 ];
 
 /**
- * Asserts all three official packages share one lockstep version and returns it.
+ * Asserts all official packages share one lockstep version and returns it.
  * Throws otherwise — a coordinated release must be version-coherent.
  */
 export const assertLockstepVersion = (packages: OfficialPackage[]): string => {
@@ -63,7 +64,7 @@ export const assertLockstepVersion = (packages: OfficialPackage[]): string => {
 };
 
 /**
- * Packs the three official packages into `stagingDir` without rebuilding them
+ * Packs the official packages into `stagingDir` without rebuilding them
  * (`--ignore-scripts` so `prepack` does not fire). Returns the absolute tarball
  * path for each, in publish order. Throws if any pack fails or a tarball is
  * missing — a coordinated release cannot have a hole in the matrix.
@@ -124,7 +125,7 @@ export interface PrepareResult {
 }
 
 /**
- * End-to-end prepare: packs the three tarballs into a clean staging dir, hashes
+ * End-to-end prepare: packs the four tarballs into a clean staging dir, hashes
  * them, and writes `release-manifest.json` + `checksums.sha256`. The caller is
  * responsible for having built the packages first (build-once).
  *

--- a/scripts/release/run.ts
+++ b/scripts/release/run.ts
@@ -8,7 +8,7 @@
  *   tsx scripts/release/run.ts publish   [--execute] [--no-check-existing]
  *
  * `prepare` builds (optionally), freezes the exact source revision (failing on
- * a dirty tree or unknown revision), packs exactly three tarballs WITHOUT
+ * a dirty tree or unknown revision), packs exactly four tarballs WITHOUT
  * rebuilding them, hashes them into `release-manifest.json` + `checksums.sha256`,
  * runs attw and the external-consumer smoke against those exact tarballs, and
  * assembles the Full GitHub Release ZIP. `publish` consumes only the prepared
@@ -45,7 +45,12 @@ const die = (message: string): never => {
 };
 
 const ensureBuilt = (): void => {
-  const dists = [resolve(repoRoot, 'dist/esm'), resolve(repoRoot, 'packages/exojs-particles/dist/esm'), resolve(repoRoot, 'packages/exojs-tiled/dist/esm')];
+  const dists = [
+    resolve(repoRoot, 'dist/esm'),
+    resolve(repoRoot, 'packages/exojs-particles/dist/esm'),
+    resolve(repoRoot, 'packages/exojs-tilemap/dist/esm'),
+    resolve(repoRoot, 'packages/exojs-tiled/dist/esm'),
+  ];
   const missing = dists.filter(d => !existsSync(d));
   if (missing.length > 0) {
     die(`Not built — missing ${missing.join(', ')}. Run "pnpm build" + extension builds, or pass --build.`);
@@ -57,6 +62,7 @@ const build = (): void => {
   for (const [label, args, cwd] of [
     ['core', ['build'], repoRoot],
     ['particles', ['--filter', '@codexo/exojs-particles', 'build'], repoRoot],
+    ['tilemap', ['--filter', '@codexo/exojs-tilemap', 'build'], repoRoot],
     ['tiled', ['--filter', '@codexo/exojs-tiled', 'build'], repoRoot],
   ] as const) {
     const r = runner.run({ command: 'pnpm', args: [...args], cwd });
@@ -101,7 +107,7 @@ const doPrepare = (): void => {
 
   const revision = freezeRevision();
 
-  log('\n→ Packing three tarballs (no rebuild) + manifest + checksums…');
+  log('\n→ Packing four tarballs (no rebuild) + manifest + checksums…');
   const prepared = prepareRelease(runner, { rootDir: repoRoot, stagingDir, revision });
   let manifest = prepared.manifest;
   log(`  packed: ${manifest.packages.map(p => `${p.name}@${p.version} (${p.bytes}B)`).join(', ')}`);

--- a/scripts/verify-release-matrix.ts
+++ b/scripts/verify-release-matrix.ts
@@ -9,12 +9,13 @@
  *     lockstep version.
  *  2. Each extension's peerDependencies["@codexo/exojs"] is "<major>.<minor>.x".
  *  3. create-exo-app is versioned independently (a different version line).
- *  4. release.yml builds all three packages in the PREPARE stage.
- *  5. PREPARE runs `release:prepare` (packs three tarballs + Full ZIP) and
+ *  4. release.yml builds all four packages in the PREPARE stage.
+ *  5. PREPARE runs `release:prepare` (packs four tarballs + Full ZIP) and
  *     uploads the artifacts.
  *  6. PUBLISH consumes those artifacts (`download-artifact` + `release:publish`)
  *     and never rebuilds.
- *  7. The publish order Core → Particles → Tilemap → Tiled is the canonical PUBLISH_ORDER.
+ *  7. The publish order Core → Particles → Tilemap → Tiled is the canonical PUBLISH_ORDER,
+ *     and `officialPackages()` (what `release:prepare` actually packs) covers it exactly.
  *
  * Read-only: safe to run in dry-run/CI. Exits non-zero on any inconsistency.
  *
@@ -25,6 +26,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { PUBLISH_ORDER } from './release/manifest.ts';
+import { officialPackages } from './release/prepare.ts';
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -93,7 +95,7 @@ const requireInWorkflow = (needle: string, label: string): void => {
   }
 };
 
-// 4. PREPARE builds all three official packages exactly once (build-once).
+// 4. PREPARE builds all four official packages exactly once (build-once).
 requireInWorkflow('pnpm build', 'prepare builds core');
 requireInWorkflow('pnpm --filter @codexo/exojs-particles build', 'prepare builds particles');
 requireInWorkflow('pnpm --filter @codexo/exojs-tilemap build', 'prepare builds tilemap');
@@ -125,11 +127,33 @@ if (/run:\s*pnpm build\b/.test(publishSection)) {
   ok.push('publish job does not rebuild the runtime packages');
 }
 
-// 7. Canonical publish order Core → Particles → Tiled (enforced in code).
-if (PUBLISH_ORDER[0] === '@codexo/exojs' && PUBLISH_ORDER[1] === '@codexo/exojs-particles' && PUBLISH_ORDER[2] === '@codexo/exojs-tilemap' && PUBLISH_ORDER[3] === '@codexo/exojs-tiled') {
+// 7. Canonical publish order Core → Particles → Tilemap → Tiled (enforced in code).
+if (
+  PUBLISH_ORDER[0] === '@codexo/exojs' &&
+  PUBLISH_ORDER[1] === '@codexo/exojs-particles' &&
+  PUBLISH_ORDER[2] === '@codexo/exojs-tilemap' &&
+  PUBLISH_ORDER[3] === '@codexo/exojs-tiled'
+) {
   ok.push('PUBLISH_ORDER is Core → Particles → Tilemap → Tiled');
 } else {
   problems.push(`PUBLISH_ORDER must be Core → Particles → Tilemap → Tiled, got ${PUBLISH_ORDER.join(' → ')}`);
+}
+
+// 7b. What `release:prepare` actually packs (officialPackages) must cover the
+// canonical PUBLISH_ORDER exactly — a package missing here would silently never
+// be packed, and therefore never published.
+const packed = officialPackages(rootDir);
+const packedNames = packed.map(p => p.name);
+if (packedNames.length === PUBLISH_ORDER.length && packedNames.every((name, i) => name === PUBLISH_ORDER[i])) {
+  ok.push('officialPackages() packs exactly the PUBLISH_ORDER set, in order');
+} else {
+  problems.push(`officialPackages() must pack ${PUBLISH_ORDER.join(' → ')}, got ${packedNames.join(' → ')}`);
+}
+for (const pkg of packed) {
+  const manifestName = (JSON.parse(readFileSync(resolve(pkg.dir, 'package.json'), 'utf8')) as { name: string }).name;
+  if (manifestName !== pkg.name) {
+    problems.push(`officialPackages() maps ${pkg.name} to a directory whose package.json is "${manifestName}" (${pkg.dir}).`);
+  }
 }
 
 // --- Report ---

--- a/site/scripts/sync-exo-vendor.ts
+++ b/site/scripts/sync-exo-vendor.ts
@@ -340,7 +340,7 @@ const syncVendor = (): void => {
     console.log(`[vendor:sync] Copied ExoJS ESM runtime + declarations from ${sourceDistDir} -> ${flatTargetDir}`);
 
     // Sync extension packages (ESM trees only — no declaration patching needed).
-    const extensionPackages = ['exojs-particles', 'exojs-tiled'] as const;
+    const extensionPackages = ['exojs-particles', 'exojs-tilemap', 'exojs-tiled'] as const;
     for (const pkgName of extensionPackages) {
         let pkgRoot: string | null = null;
         try {

--- a/test/release/changelog-v0.13.test.ts
+++ b/test/release/changelog-v0.13.test.ts
@@ -29,6 +29,13 @@ const loadPackageJson = (name: string): Record<string, unknown> =>
 describe('v0.13 release text invariants', () => {
     const section = extractV013Section();
 
+    it('carries a concrete release date in the heading', () => {
+        // `release:notes` (publish job, AFTER npm publish) hard-fails on any
+        // heading that is not `## [0.13.0] - YYYY-MM-DD` — "Unreleased" would
+        // publish npm packages and then abort the GitHub release.
+        expect(readChangelog()).toMatch(/^## \[0\.13\.0\] - \d{4}-\d{2}-\d{2}$/m);
+    });
+
     it('contains no #this placeholder', () => {
         expect(section).not.toMatch(/#this/);
     });

--- a/test/release/prepare.test.ts
+++ b/test/release/prepare.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { PUBLISH_ORDER } from '../../scripts/release/manifest';
+import { assertLockstepVersion, officialPackages } from '../../scripts/release/prepare';
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+describe('officialPackages — the set release:prepare actually packs', () => {
+  it('covers the canonical PUBLISH_ORDER exactly, in order', () => {
+    // A package missing here is silently never packed — and therefore never
+    // published — while verify:lockstep and the publish unit tests still pass.
+    expect(officialPackages(rootDir).map(p => p.name)).toEqual([...PUBLISH_ORDER]);
+  });
+
+  it('maps every package name to the directory that declares it', () => {
+    for (const pkg of officialPackages(rootDir)) {
+      const manifest = JSON.parse(readFileSync(resolve(pkg.dir, 'package.json'), 'utf8')) as { name: string };
+      expect(manifest.name).toBe(pkg.name);
+    }
+  });
+});
+
+describe('assertLockstepVersion', () => {
+  it('returns the single shared version of the official packages', () => {
+    const version = assertLockstepVersion(officialPackages(rootDir));
+    const rootVersion = (JSON.parse(readFileSync(resolve(rootDir, 'package.json'), 'utf8')) as { version: string }).version;
+    expect(version).toBe(rootVersion);
+  });
+});


### PR DESCRIPTION
## Release blocker for v0.13.0

`officialPackages()` in `scripts/release/prepare.ts` was never updated when `@codexo/exojs-tilemap` joined `PUBLISH_ORDER` (ab06caeb): `release:prepare` packed only core/particles/tiled, so **tilemap would silently never be published**, while `@codexo/exojs-tiled@0.13.0` hard-depends on `@codexo/exojs-tilemap@0.13.0`. The offline external-consumer smoke would then deterministically fail the `prepare` stage of every v0.13.0 release run after tag push (tiled tarball install cannot resolve the tilemap dependency offline).

`verify:release-matrix`, `verify:lockstep` and the publish unit tests all pass with this gap because none of them inspect what `release:prepare` actually packs.

## Changes

- **scripts/release/prepare.ts** — add `@codexo/exojs-tilemap` to `officialPackages()` (publish-order slot 3)
- **scripts/release/run.ts** — `build()`/`ensureBuilt()` cover the tilemap dist
- **scripts/release/external-consumers.ts** — install all four tarballs (tiled→tilemap resolves offline against the tarball installed alongside), smoke tilemap exports, assert facade `TileMap` identity (`tiled.TileMap === tilemap.TileMap`)
- **scripts/release/full-zip.ts** — vendor `exojs-tilemap` ESM in the Full ZIP
- **site/scripts/sync-exo-vendor.ts** — sync the tilemap ESM vendor tree (gitignored output, additive)
- **scripts/verify-release-matrix.ts** — new gate 7b: `officialPackages()` must equal `PUBLISH_ORDER` exactly + each dir must declare the package it claims (closes the blind spot)
- **test/release/prepare.test.ts** — unit coverage for the same invariant

## Validation

- `pnpm typecheck` ✓
- `vitest run test/release/` — 47/47 ✓ (incl. new guard test)
- `pnpm verify:release-matrix` ✓ (new check: "officialPackages() packs exactly the PUBLISH_ORDER set, in order")
- prettier ✓; eslint on the new test file ✓ (`scripts/**` is outside the lint lanes, pre-existing)