### PR TITLE
style: apply prettier to v0.13 source files

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -779,7 +779,13 @@ export default defineConfig([
 
   // Build-time constants intentionally follow ecosystem-style ALL_CAPS names.
   {
-    files: ['src/build-constants.d.ts', 'src/typings.d.ts', 'packages/exojs-particles/src/typings.d.ts', 'packages/exojs-tilemap/src/typings.d.ts', 'packages/exojs-tiled/src/typings.d.ts'],
+    files: [
+      'src/build-constants.d.ts',
+      'src/typings.d.ts',
+      'packages/exojs-particles/src/typings.d.ts',
+      'packages/exojs-tilemap/src/typings.d.ts',
+      'packages/exojs-tiled/src/typings.d.ts',
+    ],
     rules: {
       '@typescript-eslint/naming-convention': 'off',
     },
@@ -825,7 +831,14 @@ export default defineConfig([
 
   // Extension tilemap core — geometry and data-path relaxations.
   {
-    files: ['packages/exojs-tilemap/src/chunkGeometry.ts', 'packages/exojs-tilemap/src/TileChunk.ts', 'packages/exojs-tilemap/src/TileSet.ts', 'packages/exojs-tilemap/src/TileMapView.ts', 'packages/exojs-tilemap/src/TileLayer.ts', 'packages/exojs-tilemap/src/tilemapExtension.ts'],
+    files: [
+      'packages/exojs-tilemap/src/chunkGeometry.ts',
+      'packages/exojs-tilemap/src/TileChunk.ts',
+      'packages/exojs-tilemap/src/TileSet.ts',
+      'packages/exojs-tilemap/src/TileMapView.ts',
+      'packages/exojs-tilemap/src/TileLayer.ts',
+      'packages/exojs-tilemap/src/tilemapExtension.ts',
+    ],
     rules: {
       '@typescript-eslint/no-non-null-assertion': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'off',
@@ -846,7 +859,11 @@ export default defineConfig([
 
   // Extension particle modules with intentionally empty lifecycle stubs.
   {
-    files: ['packages/exojs-particles/src/modules/DeathModule.ts', 'packages/exojs-particles/src/modules/SpawnModule.ts', 'packages/exojs-particles/src/modules/UpdateModule.ts'],
+    files: [
+      'packages/exojs-particles/src/modules/DeathModule.ts',
+      'packages/exojs-particles/src/modules/SpawnModule.ts',
+      'packages/exojs-particles/src/modules/UpdateModule.ts',
+    ],
     rules: {
       '@typescript-eslint/no-empty-function': 'off',
     },

--- a/scripts/check-api-docs-sync.ts
+++ b/scripts/check-api-docs-sync.ts
@@ -13,116 +13,116 @@ const green = (s: string): string => `\x1b[32m${s}\x1b[0m`;
 const red = (s: string): string => `\x1b[31m${s}\x1b[0m`;
 
 function run(cmd: string, cwd: string): void {
-    execSync(cmd, { cwd, stdio: 'pipe' });
+  execSync(cmd, { cwd, stdio: 'pipe' });
 }
 
 function copyDirContents(src: string, dst: string): void {
-    fs.mkdirSync(dst, { recursive: true });
-    for (const entry of fs.readdirSync(src)) {
-        const srcPath = path.join(src, entry);
-        const dstPath = path.join(dst, entry);
-        if (fs.statSync(srcPath).isFile()) {
-            fs.copyFileSync(srcPath, dstPath);
-        }
+  fs.mkdirSync(dst, { recursive: true });
+  for (const entry of fs.readdirSync(src)) {
+    const srcPath = path.join(src, entry);
+    const dstPath = path.join(dst, entry);
+    if (fs.statSync(srcPath).isFile()) {
+      fs.copyFileSync(srcPath, dstPath);
     }
+  }
 }
 
 function collectFiles(dir: string): string[] {
-    const out: string[] = [];
-    if (!fs.existsSync(dir)) return out;
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-        if (entry.isFile() && entry.name.endsWith('.mdx')) {
-            out.push(entry.name);
-        }
+  const out: string[] = [];
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.endsWith('.mdx')) {
+      out.push(entry.name);
     }
-    return out.sort();
+  }
+  return out.sort();
 }
 
 function compareDirectories(currentDir: string, generatedDir: string): boolean {
-    const filesCurrent = collectFiles(currentDir);
-    const filesGenerated = collectFiles(generatedDir);
+  const filesCurrent = collectFiles(currentDir);
+  const filesGenerated = collectFiles(generatedDir);
 
-    const added = filesGenerated.filter(f => !filesCurrent.includes(f));
-    const removed = filesCurrent.filter(f => !filesGenerated.includes(f));
-    const common = filesCurrent.filter(f => filesGenerated.includes(f));
+  const added = filesGenerated.filter(f => !filesCurrent.includes(f));
+  const removed = filesCurrent.filter(f => !filesGenerated.includes(f));
+  const common = filesCurrent.filter(f => filesGenerated.includes(f));
 
-    let diffCount = 0;
-    const diffs: string[] = [];
+  let diffCount = 0;
+  const diffs: string[] = [];
 
-    for (const name of added) {
-        diffs.push(`  + ${name}`);
-        diffCount += 1;
+  for (const name of added) {
+    diffs.push(`  + ${name}`);
+    diffCount += 1;
+  }
+  for (const name of removed) {
+    diffs.push(`  - ${name}`);
+    diffCount += 1;
+  }
+
+  for (const name of common) {
+    const aContent = fs.readFileSync(path.join(currentDir, name), 'utf8');
+    const bContent = fs.readFileSync(path.join(generatedDir, name), 'utf8');
+    if (aContent !== bContent) {
+      diffs.push(`  ~ ${name}`);
+      diffCount += 1;
     }
-    for (const name of removed) {
-        diffs.push(`  - ${name}`);
-        diffCount += 1;
-    }
+  }
 
-    for (const name of common) {
-        const aContent = fs.readFileSync(path.join(currentDir, name), 'utf8');
-        const bContent = fs.readFileSync(path.join(generatedDir, name), 'utf8');
-        if (aContent !== bContent) {
-            diffs.push(`  ~ ${name}`);
-            diffCount += 1;
-        }
-    }
+  if (diffCount > 0) {
+    console.log(red(`API docs are out of sync — ${diffCount} file(s) differ:`));
+    for (const d of diffs) console.log(d);
+    console.log(red('\nRun `pnpm docs:api:generate` to regenerate.'));
+    return false;
+  }
 
-    if (diffCount > 0) {
-        console.log(red(`API docs are out of sync — ${diffCount} file(s) differ:`));
-        for (const d of diffs) console.log(d);
-        console.log(red('\nRun `pnpm docs:api:generate` to regenerate.'));
-        return false;
-    }
-
-    return true;
+  return true;
 }
 
 function main(): void {
-    console.log('Checking API doc synchronization...\n');
+  console.log('Checking API doc synchronization...\n');
 
-    // 1. Backup current API directory
-    const backupDir = path.resolve(tmpDir, 'backup');
+  // 1. Backup current API directory
+  const backupDir = path.resolve(tmpDir, 'backup');
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  if (fs.existsSync(apiDir)) {
+    copyDirContents(apiDir, backupDir);
+  }
+
+  // 2. Regenerate API docs (writes to the real apiDir)
+  console.log('Regenerating API docs...');
+  try {
+    run('pnpm --filter @codexo/exojs-examples build:api', repoRoot);
+  } catch {
+    console.log(red('API doc generation failed. Check TypeDoc errors above.'));
+    // Restore backup before exiting
+    if (fs.existsSync(backupDir)) {
+      fs.rmSync(apiDir, { recursive: true, force: true });
+      copyDirContents(backupDir, apiDir);
+    }
     fs.rmSync(tmpDir, { recursive: true, force: true });
-    if (fs.existsSync(apiDir)) {
-        copyDirContents(apiDir, backupDir);
-    }
+    process.exit(1);
+  }
 
-    // 2. Regenerate API docs (writes to the real apiDir)
-    console.log('Regenerating API docs...');
-    try {
-        run('pnpm --filter @codexo/exojs-examples build:api', repoRoot);
-    } catch {
-        console.log(red('API doc generation failed. Check TypeDoc errors above.'));
-        // Restore backup before exiting
-        if (fs.existsSync(backupDir)) {
-            fs.rmSync(apiDir, { recursive: true, force: true });
-            copyDirContents(backupDir, apiDir);
-        }
-        fs.rmSync(tmpDir, { recursive: true, force: true });
-        process.exit(1);
-    }
+  // 3. Copy generated output to a temp location for comparison, then restore backup
+  const generatedDir = path.resolve(tmpDir, 'generated');
+  copyDirContents(apiDir, generatedDir);
 
-    // 3. Copy generated output to a temp location for comparison, then restore backup
-    const generatedDir = path.resolve(tmpDir, 'generated');
-    copyDirContents(apiDir, generatedDir);
+  // Restore the original files from backup
+  fs.rmSync(apiDir, { recursive: true, force: true });
+  copyDirContents(backupDir, apiDir);
 
-    // Restore the original files from backup
-    fs.rmSync(apiDir, { recursive: true, force: true });
-    copyDirContents(backupDir, apiDir);
+  // 4. Compare
+  console.log('\nComparing regenerated output against committed content...');
+  const synced = compareDirectories(apiDir, generatedDir);
 
-    // 4. Compare
-    console.log('\nComparing regenerated output against committed content...');
-    const synced = compareDirectories(apiDir, generatedDir);
+  // 5. Clean up
+  fs.rmSync(tmpDir, { recursive: true, force: true });
 
-    // 5. Clean up
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-
-    if (synced) {
-        console.log(green('\nAPI docs are in sync with source.'));
-        process.exit(0);
-    } else {
-        process.exit(1);
-    }
+  if (synced) {
+    console.log(green('\nAPI docs are in sync with source.'));
+    process.exit(0);
+  } else {
+    process.exit(1);
+  }
 }
 
 void main();

--- a/scripts/ci/select-lanes.mjs
+++ b/scripts/ci/select-lanes.mjs
@@ -62,14 +62,14 @@ const RUNTIME_PACKAGES = ['exojs-config', 'exojs-particles', 'exojs-tilemap', 'e
  * the `site` area, because package READMEs feed the generated package API pages.
  * @param {string} file
  */
-const isPackageDocPath = (file) => /^packages\/[^/]+\/(README\.md|CHANGELOG\.md|LICENSE)$/.test(file);
+const isPackageDocPath = file => /^packages\/[^/]+\/(README\.md|CHANGELOG\.md|LICENSE)$/.test(file);
 
 /**
  * Engine area: core runtime code, shared root tooling, and runtime-package CODE.
  * Gates the unit/coverage, package-build-and-verify and browser lanes.
  * @param {string} file
  */
-const isEnginePath = (file) => {
+const isEnginePath = file => {
   // Core engine source, in-repo tests (incl. the browser/perf suites that import
   // package source through the vitest aliases), and repo automation scripts.
   if (file.startsWith('src/')) return true;
@@ -96,7 +96,7 @@ const isEnginePath = (file) => {
  * or example builds.
  * @param {string} file
  */
-const isSitePath = (file) => {
+const isSitePath = file => {
   if (file.startsWith('site/')) return true;
   if (file.startsWith('examples/')) return true;
   if (file.startsWith('packages/')) return true;
@@ -168,7 +168,10 @@ function parseChangedFiles(raw) {
       // Fall through to newline parsing below.
     }
   }
-  return text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  return text
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean);
 }
 
 /**
@@ -181,10 +184,7 @@ function parseChangedFiles(raw) {
  */
 function main() {
   const eventName = process.env['EVENT_NAME'] ?? '';
-  const areas =
-    eventName === 'pull_request'
-      ? selectAreas(parseChangedFiles(process.env['CHANGED_FILES']))
-      : { engine: true, site: true };
+  const areas = eventName === 'pull_request' ? selectAreas(parseChangedFiles(process.env['CHANGED_FILES'])) : { engine: true, site: true };
 
   // Human-readable trace to the job log (stderr keeps it out of $GITHUB_OUTPUT).
   process.stderr.write(`select-lanes: event=${eventName || 'unknown'} engine=${areas.engine} site=${areas.site}\n`);

--- a/src/rendering/sprite/NineSliceSprite.ts
+++ b/src/rendering/sprite/NineSliceSprite.ts
@@ -7,21 +7,11 @@ import { TextureRegion } from '#rendering/texture/TextureRegion';
 import type { View } from '#rendering/View';
 
 import type { NineSliceInsets, NineSliceModes, NineSliceOptions, NineSliceQuad } from './nineSlice';
-import {
-  buildNineSliceQuads,
-  equalInsets,
-  equalModes,
-  normalizeInsets,
-  normalizeModes,
-  validateBorder,
-  validateSlices,
-} from './nineSlice';
+import { buildNineSliceQuads, equalInsets, equalModes, normalizeInsets, normalizeModes, validateBorder, validateSlices } from './nineSlice';
 
 function validateSizeInput(width: number, height: number): void {
   if (!Number.isFinite(width) || !Number.isFinite(height)) {
-    throw new Error(
-      `NineSliceSprite: width and height must be finite numbers (got ${width}, ${height}).`,
-    );
+    throw new Error(`NineSliceSprite: width and height must be finite numbers (got ${width}, ${height}).`);
   }
   if (width < 0) {
     throw new Error(`NineSliceSprite: width must be non-negative (got ${width}).`);
@@ -51,14 +41,15 @@ export class NineSliceSprite extends Drawable {
   public constructor(texture: Texture | TextureRegion, options: NineSliceOptions) {
     super();
 
-    this._region = texture instanceof TextureRegion
-      ? texture
-      : new TextureRegion(texture, {
-          x: 0,
-          y: 0,
-          width: texture.width,
-          height: texture.height,
-        });
+    this._region =
+      texture instanceof TextureRegion
+        ? texture
+        : new TextureRegion(texture, {
+            x: 0,
+            y: 0,
+            width: texture.width,
+            height: texture.height,
+          });
 
     const region = this._region;
 
@@ -68,9 +59,7 @@ export class NineSliceSprite extends Drawable {
     this._slices = rawSlices;
 
     // Validate and own border
-    const rawBorder = options.border !== undefined
-      ? normalizeInsets(options.border)
-      : normalizeInsets(options.slices);
+    const rawBorder = options.border !== undefined ? normalizeInsets(options.border) : normalizeInsets(options.slices);
     validateBorder(rawBorder);
     this._border = rawBorder;
 
@@ -248,7 +237,10 @@ export class NineSliceSprite extends Drawable {
     const ctx = buildPixelSnapContext(this.getGlobalTransform(), view, targetPxWidth, targetPxHeight);
 
     if (!ctx.axisAligned) {
-      warnOnce('pixel-snap:geometry-downgrade', 'pixelSnapMode "geometry" downgraded to "position" for a rotated/skewed transform; rendered geometry is not boundary-snapped this frame.');
+      warnOnce(
+        'pixel-snap:geometry-downgrade',
+        'pixelSnapMode "geometry" downgraded to "position" for a rotated/skewed transform; rendered geometry is not boundary-snapped this frame.',
+      );
 
       return base;
     }
@@ -261,14 +253,7 @@ export class NineSliceSprite extends Drawable {
   // -----------------------------------------------------------------------
 
   private _rebuildGeometry(): void {
-    this._quads = buildNineSliceQuads(
-      this._region,
-      this._slices,
-      this._border,
-      this._width,
-      this._height,
-      this._modes,
-    );
+    this._quads = buildNineSliceQuads(this._region, this._slices, this._border, this._width, this._height, this._modes);
     this._geometryDirty = false;
   }
 }

--- a/src/rendering/sprite/RepeatingSprite.ts
+++ b/src/rendering/sprite/RepeatingSprite.ts
@@ -8,13 +8,7 @@ import { TextureRegion } from '#rendering/texture/TextureRegion';
 import type { View } from '#rendering/View';
 
 import type { RepeatingSpriteOptions, RepeatingSpriteQuad } from './repeatingSpritePlan';
-import {
-  buildRepeatingSpriteQuads,
-  validateFit,
-  validateMode,
-  validateOffset,
-  validateSizeInput,
-} from './repeatingSpritePlan';
+import { buildRepeatingSpriteQuads, validateFit, validateMode, validateOffset, validateSizeInput } from './repeatingSpritePlan';
 
 /**
  * A sprite that fills its destination by repeating, mirroring, or stretching
@@ -55,9 +49,7 @@ export class RepeatingSprite extends Drawable {
     super();
 
     this._source = source;
-    this._region = source instanceof TextureRegion
-      ? source
-      : new TextureRegion(source, { x: 0, y: 0, width: source.width, height: source.height });
+    this._region = source instanceof TextureRegion ? source : new TextureRegion(source, { x: 0, y: 0, width: source.width, height: source.height });
 
     const region = this._region;
     const opts = options ?? {};
@@ -303,7 +295,10 @@ export class RepeatingSprite extends Drawable {
     const ctx = buildPixelSnapContext(this.getGlobalTransform(), view, targetPxWidth, targetPxHeight);
 
     if (!ctx.axisAligned) {
-      warnOnce('pixel-snap:geometry-downgrade', 'pixelSnapMode "geometry" downgraded to "position" for a rotated/skewed transform; rendered geometry is not boundary-snapped this frame.');
+      warnOnce(
+        'pixel-snap:geometry-downgrade',
+        'pixelSnapMode "geometry" downgraded to "position" for a rotated/skewed transform; rendered geometry is not boundary-snapped this frame.',
+      );
 
       return base;
     }
@@ -328,7 +323,10 @@ export class RepeatingSprite extends Drawable {
     const ctx = buildPixelSnapContext(this.getGlobalTransform(), view, targetPxWidth, targetPxHeight);
 
     if (!ctx.axisAligned) {
-      warnOnce('pixel-snap:geometry-downgrade', 'pixelSnapMode "geometry" downgraded to "position" for a rotated/skewed transform; rendered geometry is not boundary-snapped this frame.');
+      warnOnce(
+        'pixel-snap:geometry-downgrade',
+        'pixelSnapMode "geometry" downgraded to "position" for a rotated/skewed transform; rendered geometry is not boundary-snapped this frame.',
+      );
 
       return base;
     }

--- a/src/rendering/sprite/Sprite.ts
+++ b/src/rendering/sprite/Sprite.ts
@@ -168,7 +168,10 @@ export class Sprite extends Drawable {
     const ctx = buildPixelSnapContext(this.getGlobalTransform(), view, targetPxWidth, targetPxHeight);
 
     if (!ctx.axisAligned) {
-      warnOnce('pixel-snap:geometry-downgrade', 'pixelSnapMode "geometry" downgraded to "position" for a rotated/skewed transform; rendered geometry is not boundary-snapped this frame.');
+      warnOnce(
+        'pixel-snap:geometry-downgrade',
+        'pixelSnapMode "geometry" downgraded to "position" for a rotated/skewed transform; rendered geometry is not boundary-snapped this frame.',
+      );
 
       return base;
     }

--- a/src/rendering/sprite/nineSlice.ts
+++ b/src/rendering/sprite/nineSlice.ts
@@ -54,53 +54,35 @@ function isFiniteNumber(value: number): boolean {
   return typeof value === 'number' && Number.isFinite(value);
 }
 
-export function validateSlices(
-  slices: NineSliceInsets,
-  regionWidth: number,
-  regionHeight: number,
-): void {
+export function validateSlices(slices: NineSliceInsets, regionWidth: number, regionHeight: number): void {
   const { left, top, right, bottom } = slices;
 
-  if (!isFiniteNumber(left) || !isFiniteNumber(top) ||
-      !isFiniteNumber(right) || !isFiniteNumber(bottom)) {
-    throw new Error(
-      `NineSliceSprite: slice values must be finite numbers (got left=${left}, top=${top}, right=${right}, bottom=${bottom}).`,
-    );
+  if (!isFiniteNumber(left) || !isFiniteNumber(top) || !isFiniteNumber(right) || !isFiniteNumber(bottom)) {
+    throw new Error(`NineSliceSprite: slice values must be finite numbers (got left=${left}, top=${top}, right=${right}, bottom=${bottom}).`);
   }
 
   if (left < 0 || top < 0 || right < 0 || bottom < 0) {
-    throw new Error(
-      `NineSliceSprite: slice values must be non-negative (got left=${left}, top=${top}, right=${right}, bottom=${bottom}).`,
-    );
+    throw new Error(`NineSliceSprite: slice values must be non-negative (got left=${left}, top=${top}, right=${right}, bottom=${bottom}).`);
   }
 
   if (left + right > regionWidth) {
-    throw new Error(
-      `NineSliceSprite: slices.left (${left}) + slices.right (${right}) exceeds region width (${regionWidth}).`,
-    );
+    throw new Error(`NineSliceSprite: slices.left (${left}) + slices.right (${right}) exceeds region width (${regionWidth}).`);
   }
 
   if (top + bottom > regionHeight) {
-    throw new Error(
-      `NineSliceSprite: slices.top (${top}) + slices.bottom (${bottom}) exceeds region height (${regionHeight}).`,
-    );
+    throw new Error(`NineSliceSprite: slices.top (${top}) + slices.bottom (${bottom}) exceeds region height (${regionHeight}).`);
   }
 }
 
 export function validateBorder(border: NineSliceInsets): void {
   const { left, top, right, bottom } = border;
 
-  if (!isFiniteNumber(left) || !isFiniteNumber(top) ||
-      !isFiniteNumber(right) || !isFiniteNumber(bottom)) {
-    throw new Error(
-      `NineSliceSprite: border values must be finite numbers (got left=${left}, top=${top}, right=${right}, bottom=${bottom}).`,
-    );
+  if (!isFiniteNumber(left) || !isFiniteNumber(top) || !isFiniteNumber(right) || !isFiniteNumber(bottom)) {
+    throw new Error(`NineSliceSprite: border values must be finite numbers (got left=${left}, top=${top}, right=${right}, bottom=${bottom}).`);
   }
 
   if (left < 0 || top < 0 || right < 0 || bottom < 0) {
-    throw new Error(
-      `NineSliceSprite: border values must be non-negative (got left=${left}, top=${top}, right=${right}, bottom=${bottom}).`,
-    );
+    throw new Error(`NineSliceSprite: border values must be non-negative (got left=${left}, top=${top}, right=${right}, bottom=${bottom}).`);
   }
 }
 
@@ -109,10 +91,7 @@ export function validateBorder(border: NineSliceInsets): void {
 // ---------------------------------------------------------------------------
 
 /** Normalise a uniform number or partial insets object into a full {@link NineSliceInsets}. */
-export function normalizeInsets(
-  value: number | Partial<NineSliceInsets>,
-  fallback?: NineSliceInsets,
-): NineSliceInsets {
+export function normalizeInsets(value: number | Partial<NineSliceInsets>, fallback?: NineSliceInsets): NineSliceInsets {
   if (typeof value === 'number') {
     return Object.freeze({ left: value, top: value, right: value, bottom: value });
   }
@@ -130,17 +109,13 @@ const validRepeatFits = new Set<string>(['clip', 'round']);
 
 function validateModeField(value: unknown, label: string): void {
   if (typeof value !== 'string' || !validRepeatModes.has(value)) {
-    throw new Error(
-      `NineSliceSprite: ${label} must be "stretch", "repeat", or "mirror-repeat".`,
-    );
+    throw new Error(`NineSliceSprite: ${label} must be "stretch", "repeat", or "mirror-repeat".`);
   }
 }
 
 function validateFitField(value: unknown, label: string): void {
   if (typeof value !== 'string' || !validRepeatFits.has(value)) {
-    throw new Error(
-      `NineSliceSprite: ${label} must be "clip" or "round".`,
-    );
+    throw new Error(`NineSliceSprite: ${label} must be "clip" or "round".`);
   }
 }
 
@@ -151,14 +126,38 @@ export function normalizeModes(modes: NineSliceModes | undefined): Readonly<Nine
 
   const normalized: Record<string, unknown> = {};
 
-  if (modes.edges !== undefined) { validateModeField(modes.edges, 'modes.edges'); normalized.edges = modes.edges; }
-  if (modes.center !== undefined) { validateModeField(modes.center, 'modes.center'); normalized.center = modes.center; }
-  if (modes.top !== undefined) { validateModeField(modes.top, 'modes.top'); normalized.top = modes.top; }
-  if (modes.right !== undefined) { validateModeField(modes.right, 'modes.right'); normalized.right = modes.right; }
-  if (modes.bottom !== undefined) { validateModeField(modes.bottom, 'modes.bottom'); normalized.bottom = modes.bottom; }
-  if (modes.left !== undefined) { validateModeField(modes.left, 'modes.left'); normalized.left = modes.left; }
-  if (modes.edgeFit !== undefined) { validateFitField(modes.edgeFit, 'modes.edgeFit'); normalized.edgeFit = modes.edgeFit; }
-  if (modes.centerFit !== undefined) { validateFitField(modes.centerFit, 'modes.centerFit'); normalized.centerFit = modes.centerFit; }
+  if (modes.edges !== undefined) {
+    validateModeField(modes.edges, 'modes.edges');
+    normalized.edges = modes.edges;
+  }
+  if (modes.center !== undefined) {
+    validateModeField(modes.center, 'modes.center');
+    normalized.center = modes.center;
+  }
+  if (modes.top !== undefined) {
+    validateModeField(modes.top, 'modes.top');
+    normalized.top = modes.top;
+  }
+  if (modes.right !== undefined) {
+    validateModeField(modes.right, 'modes.right');
+    normalized.right = modes.right;
+  }
+  if (modes.bottom !== undefined) {
+    validateModeField(modes.bottom, 'modes.bottom');
+    normalized.bottom = modes.bottom;
+  }
+  if (modes.left !== undefined) {
+    validateModeField(modes.left, 'modes.left');
+    normalized.left = modes.left;
+  }
+  if (modes.edgeFit !== undefined) {
+    validateFitField(modes.edgeFit, 'modes.edgeFit');
+    normalized.edgeFit = modes.edgeFit;
+  }
+  if (modes.centerFit !== undefined) {
+    validateFitField(modes.centerFit, 'modes.centerFit');
+    normalized.centerFit = modes.centerFit;
+  }
 
   return Object.freeze(normalized);
 }
@@ -170,14 +169,16 @@ export function equalInsets(a: Readonly<NineSliceInsets>, b: Readonly<NineSliceI
 }
 
 export function equalModes(a: Readonly<NineSliceModes>, b: Readonly<NineSliceModes>): boolean {
-  return a.edges === b.edges
-    && a.center === b.center
-    && a.top === b.top
-    && a.right === b.right
-    && a.bottom === b.bottom
-    && a.left === b.left
-    && a.edgeFit === b.edgeFit
-    && a.centerFit === b.centerFit;
+  return (
+    a.edges === b.edges &&
+    a.center === b.center &&
+    a.top === b.top &&
+    a.right === b.right &&
+    a.bottom === b.bottom &&
+    a.left === b.left &&
+    a.edgeFit === b.edgeFit &&
+    a.centerFit === b.centerFit
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -231,10 +232,7 @@ interface UvGrid {
  * filtering from sampling across slice seams. Outer boundaries use the full
  * region UV range when extrusion is present, or a half-texel inset otherwise.
  */
-function computeSliceUvGrid(
-  region: TextureRegion,
-  slices: NineSliceInsets,
-): UvGrid {
+function computeSliceUvGrid(region: TextureRegion, slices: NineSliceInsets): UvGrid {
   const tw = region.texture.width;
   const th = region.texture.height;
 
@@ -246,12 +244,8 @@ function computeSliceUvGrid(
   const ext = region.extrusion;
 
   // Outer boundary insets: use extrusion if available, otherwise half-texel.
-  const outerInsetU = ext.left > 0 || ext.right > 0
-    ? 0
-    : halfTexelInset / tw;
-  const outerInsetV = ext.top > 0 || ext.bottom > 0
-    ? 0
-    : halfTexelInset / th;
+  const outerInsetU = ext.left > 0 || ext.right > 0 ? 0 : halfTexelInset / tw;
+  const outerInsetV = ext.top > 0 || ext.bottom > 0 ? 0 : halfTexelInset / th;
 
   // Inner slice boundary insets: always apply half-texel to prevent
   // bilinear bleed across internal slice seams.
@@ -278,11 +272,11 @@ function computeSliceUvGrid(
 
   return {
     col0: { u0: uOuter0, u1 },
-    col1: { u0: u1,     u1: u2 },
-    col2: { u0: u2,     u1: uOuter1 },
+    col1: { u0: u1, u1: u2 },
+    col2: { u0: u2, u1: uOuter1 },
     row0: { u0: vOuter0, u1: v1 },
-    row1: { u0: v1,     u1: v2 },
-    row2: { u0: v2,     u1: vOuter1 },
+    row1: { u0: v1, u1: v2 },
+    row2: { u0: v2, u1: vOuter1 },
   };
 }
 
@@ -303,31 +297,21 @@ interface CompressedBorders {
   readonly bb: number;
 }
 
-function compressBorders(
-  border: NineSliceInsets,
-  width: number,
-  height: number,
-): CompressedBorders {
+function compressBorders(border: NineSliceInsets, width: number, height: number): CompressedBorders {
   let bl = border.left;
   let br = border.right;
   let bt = border.top;
   let bb = border.bottom;
 
   if (bl + br > width && bl + br > 0) {
-    warnOnce(
-      'nine-slice:h-compress',
-      'NineSliceSprite: horizontal borders exceed destination width; proportionally compressing.',
-    );
+    warnOnce('nine-slice:h-compress', 'NineSliceSprite: horizontal borders exceed destination width; proportionally compressing.');
     const k = width / (bl + br);
     bl *= k;
     br *= k;
   }
 
   if (bt + bb > height && bt + bb > 0) {
-    warnOnce(
-      'nine-slice:v-compress',
-      'NineSliceSprite: vertical borders exceed destination height; proportionally compressing.',
-    );
+    warnOnce('nine-slice:v-compress', 'NineSliceSprite: vertical borders exceed destination height; proportionally compressing.');
     const k = height / (bt + bb);
     bt *= k;
     bb *= k;

--- a/src/rendering/sprite/repeatingSpritePlan.ts
+++ b/src/rendering/sprite/repeatingSpritePlan.ts
@@ -43,9 +43,7 @@ const validRepeatFits = new Set<string>(['clip', 'round']);
 
 export function validateSizeInput(width: number, height: number): void {
   if (!Number.isFinite(width) || !Number.isFinite(height)) {
-    throw new Error(
-      `RepeatingSprite: width and height must be finite numbers (got ${width}, ${height}).`,
-    );
+    throw new Error(`RepeatingSprite: width and height must be finite numbers (got ${width}, ${height}).`);
   }
   if (width < 0) {
     throw new Error(`RepeatingSprite: width must be non-negative (got ${width}).`);
@@ -57,25 +55,19 @@ export function validateSizeInput(width: number, height: number): void {
 
 export function validateMode(mode: unknown, label: string): void {
   if (typeof mode !== 'string' || !validRepeatModes.has(mode)) {
-    throw new Error(
-      `RepeatingSprite: ${label} must be "stretch", "repeat", or "mirror-repeat" (got ${String(mode)}).`,
-    );
+    throw new Error(`RepeatingSprite: ${label} must be "stretch", "repeat", or "mirror-repeat" (got ${String(mode)}).`);
   }
 }
 
 export function validateFit(fit: unknown, label: string): void {
   if (typeof fit !== 'string' || !validRepeatFits.has(fit)) {
-    throw new Error(
-      `RepeatingSprite: ${label} must be "clip" or "round" (got ${String(fit)}).`,
-    );
+    throw new Error(`RepeatingSprite: ${label} must be "clip" or "round" (got ${String(fit)}).`);
   }
 }
 
 export function validateOffset(value: number, label: string): void {
   if (!Number.isFinite(value)) {
-    throw new Error(
-      `RepeatingSprite: ${label} must be a finite number (got ${value}).`,
-    );
+    throw new Error(`RepeatingSprite: ${label} must be a finite number (got ${value}).`);
   }
 }
 
@@ -92,12 +84,7 @@ export function validateOffset(value: number, label: string): void {
  * - `repeat`/`mirror-repeat` + `clip`: exact fraction `destLen / srcLen`
  * @internal
  */
-export function computeShaderTiling(
-  srcLen: number,
-  destLen: number,
-  mode: RepeatMode,
-  fit: RepeatFit,
-): number {
+export function computeShaderTiling(srcLen: number, destLen: number, mode: RepeatMode, fit: RepeatFit): number {
   if (mode === 'stretch' || srcLen <= 0 || destLen <= 0) {
     return 1;
   }
@@ -141,8 +128,8 @@ export function buildRepeatingSpriteQuads(
   const th = region.texture.height;
   const ext = region.extrusion;
 
-  const outerInsetU = (ext.left > 0 || ext.right > 0) ? 0 : halfTexelInset / tw;
-  const outerInsetV = (ext.top > 0 || ext.bottom > 0) ? 0 : halfTexelInset / th;
+  const outerInsetU = ext.left > 0 || ext.right > 0 ? 0 : halfTexelInset / tw;
+  const outerInsetV = ext.top > 0 || ext.bottom > 0 ? 0 : halfTexelInset / th;
 
   const uMin = region.u0 + outerInsetU;
   const uMax = region.u1 - outerInsetU;
@@ -191,13 +178,7 @@ export function buildRepeatingSpriteQuads(
  * discouraged by design.
  * @internal
  */
-function buildAxisSegmentsWithOffset(
-  srcLen: number,
-  destLen: number,
-  mode: RepeatMode,
-  fit: RepeatFit,
-  offset: number,
-): RepeatSegment[] {
+function buildAxisSegmentsWithOffset(srcLen: number, destLen: number, mode: RepeatMode, fit: RepeatFit, offset: number): RepeatSegment[] {
   if (destLen === 0 || srcLen <= 0) {
     return [];
   }

--- a/src/rendering/texture/TextureRegion.ts
+++ b/src/rendering/texture/TextureRegion.ts
@@ -78,7 +78,15 @@ function normalizeExtrusion(extrusion: number | TextureRegionInsets | undefined)
   });
 }
 
-function validateExtrusion(extrusion: TextureRegionInsets, x: number, y: number, width: number, height: number, textureWidth: number, textureHeight: number): void {
+function validateExtrusion(
+  extrusion: TextureRegionInsets,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  textureWidth: number,
+  textureHeight: number,
+): void {
   const { left, top, right, bottom } = extrusion;
 
   if (!isFinite(left) || !isFinite(top) || !isFinite(right) || !isFinite(bottom)) {
@@ -92,7 +100,7 @@ function validateExtrusion(extrusion: TextureRegionInsets, x: number, y: number,
   if (left > x || top > y || right > textureWidth - (x + width) || bottom > textureHeight - (y + height)) {
     throw new Error(
       `TextureRegion extrusion exceeds available source texture bounds: left=${left} (>${x}), top=${top} (>${y}), ` +
-      `right=${right} (>${textureWidth - (x + width)}), bottom=${bottom} (>${textureHeight - (y + height)}).`
+        `right=${right} (>${textureWidth - (x + width)}), bottom=${bottom} (>${textureHeight - (y + height)}).`,
     );
   }
 }
@@ -121,15 +129,11 @@ function validateOptions(options: TextureRegionOptions, textureWidth: number, te
   }
 
   if (x + width > textureWidth) {
-    throw new Error(
-      `TextureRegion right edge (${x + width}) exceeds texture width (${textureWidth}).`
-    );
+    throw new Error(`TextureRegion right edge (${x + width}) exceeds texture width (${textureWidth}).`);
   }
 
   if (y + height > textureHeight) {
-    throw new Error(
-      `TextureRegion bottom edge (${y + height}) exceeds texture height (${textureHeight}).`
-    );
+    throw new Error(`TextureRegion bottom edge (${y + height}) exceeds texture height (${textureHeight}).`);
   }
 }
 

--- a/src/rendering/texture/repeat.ts
+++ b/src/rendering/texture/repeat.ts
@@ -4,18 +4,13 @@
  * Shared by {@link NineSliceSprite} edges/center and {@link RepeatingSprite}.
  * @stable
  */
-export type RepeatMode =
-  | 'stretch'
-  | 'repeat'
-  | 'mirror-repeat';
+export type RepeatMode = 'stretch' | 'repeat' | 'mirror-repeat';
 
 /**
  * How a `'repeat'` or `'mirror-repeat'` run fits its destination span exactly.
  * @stable
  */
-export type RepeatFit =
-  | 'clip'
-  | 'round';
+export type RepeatFit = 'clip' | 'round';
 
 /**
  * A single placement segment produced by the repeat planner.
@@ -74,21 +69,15 @@ export interface RepeatPlan {
  */
 function validateInputs(sourceLength: number, destinationLength: number): void {
   if (!Number.isFinite(sourceLength) || !Number.isFinite(destinationLength)) {
-    throw new Error(
-      `RepeatPlanner: sourceLength and destinationLength must be finite numbers (got ${sourceLength}, ${destinationLength}).`,
-    );
+    throw new Error(`RepeatPlanner: sourceLength and destinationLength must be finite numbers (got ${sourceLength}, ${destinationLength}).`);
   }
 
   if (sourceLength <= 0) {
-    throw new Error(
-      `RepeatPlanner: sourceLength must be positive (got ${sourceLength}).`,
-    );
+    throw new Error(`RepeatPlanner: sourceLength must be positive (got ${sourceLength}).`);
   }
 
   if (destinationLength < 0) {
-    throw new Error(
-      `RepeatPlanner: destinationLength must be non-negative (got ${destinationLength}).`,
-    );
+    throw new Error(`RepeatPlanner: destinationLength must be non-negative (got ${destinationLength}).`);
   }
 }
 
@@ -134,7 +123,7 @@ function buildClipPlan(destinationLength: number, sourceLength: number, mirror: 
     const segLength = Math.min(sourceLength, remaining);
     const sourceFraction = segLength / sourceLength;
 
-    const mirrored = mirror && (index % 2 === 1);
+    const mirrored = mirror && index % 2 === 1;
 
     const segment: RepeatSegment = {
       destinationStart: cursor,
@@ -172,7 +161,7 @@ function buildRoundPlan(destinationLength: number, sourceLength: number, mirror:
   const segments: RepeatSegment[] = [];
 
   for (let i = 0; i < count; i++) {
-    const mirrored = mirror && (i % 2 === 1);
+    const mirrored = mirror && i % 2 === 1;
 
     const segment: RepeatSegment = {
       destinationStart: i * segLength,
@@ -228,12 +217,7 @@ function buildRoundPlan(destinationLength: number, sourceLength: number, mirror:
  * @throws When inputs are non-finite, negative, or zero-length source.
  * @advanced
  */
-export function planRepeat(
-  sourceLength: number,
-  destinationLength: number,
-  mode: RepeatMode,
-  fit: RepeatFit = 'round',
-): RepeatPlan {
+export function planRepeat(sourceLength: number, destinationLength: number, mode: RepeatMode, fit: RepeatFit = 'round'): RepeatPlan {
   validateInputs(sourceLength, destinationLength);
 
   switch (mode) {

--- a/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
@@ -207,20 +207,19 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
   }
 
   public render(sprite: RepeatingSprite): void {
-    const strategy  = sprite.resolvedStrategy;
-    const texture   = sprite.texture;
+    const strategy = sprite.resolvedStrategy;
+    const texture = sprite.texture;
     const blendMode = sprite.blendMode;
-    const modeX     = sprite.modeX;
-    const modeY     = sprite.modeY;
+    const modeX = sprite.modeX;
+    const modeY = sprite.modeY;
 
     const hasData = this._shaderQuadCount > 0 || this._geoQuadCount > 0;
 
     if (hasData) {
-      const pathChanged  = this._currentPath !== strategy;
-      const texChanged   = this._currentTexture !== texture;
+      const pathChanged = this._currentPath !== strategy;
+      const texChanged = this._currentTexture !== texture;
       const blendChanged = this._currentBlendMode !== blendMode;
-      const modeChanged  = strategy === 'shader'
-        && (this._currentModeX !== modeX || this._currentModeY !== modeY);
+      const modeChanged = strategy === 'shader' && (this._currentModeX !== modeX || this._currentModeY !== modeY);
 
       if (pathChanged || texChanged || blendChanged || modeChanged) {
         this.flush();
@@ -241,7 +240,7 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
 
     this._currentPath = strategy;
 
-    const command   = backend.activeDrawCommand;
+    const command = backend.activeDrawCommand;
     const nodeIndex = command !== null ? command.nodeIndex : backend._pushTransform(sprite);
 
     if (nodeIndex > this._maxNodeIndex) {
@@ -259,11 +258,11 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
 
   private _writeShaderInstance(sprite: RepeatingSprite, nodeIndex: number): void {
     const texture = sprite.texture;
-    const srcW    = sprite.region.width;
-    const srcH    = sprite.region.height;
-    let   destW   = sprite.width;
-    let   destH   = sprite.height;
-    const flipY   = texture instanceof Texture && texture.flipY;
+    const srcW = sprite.region.width;
+    const srcH = sprite.region.height;
+    let destW = sprite.width;
+    let destH = sprite.height;
+    const flipY = texture instanceof Texture && texture.flipY;
 
     // 'geometry' mode: snap the destination quad to the device grid. Repetition
     // stays shader-based; only the outer rectangle (and the tiling derived from
@@ -319,14 +318,14 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
       quads = sprite.getRenderQuads(backend.view, snap.width, snap.height);
     }
 
-    const flipY  = (sprite.texture instanceof Texture) && sprite.texture.flipY;
-    const tint   = sprite.tint.toRgba();
+    const flipY = sprite.texture instanceof Texture && sprite.texture.flipY;
+    const tint = sprite.tint.toRgba();
 
     let offset = 0;
 
     while (offset < quads.length) {
       const remaining = quads.length - offset;
-      const chunk     = Math.min(remaining, this._batchSize - this._geoQuadCount);
+      const chunk = Math.min(remaining, this._batchSize - this._geoQuadCount);
 
       if (chunk <= 0) {
         this.flush();
@@ -349,7 +348,7 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
       const u32 = this._geoU32;
 
       for (let i = 0; i < chunk; i++) {
-        const q   = quads[offset + i];
+        const q = quads[offset + i];
         const idx = (this._geoQuadCount + i) * geoWordsPerInstance;
 
         f32[idx + 0] = q.x0;
@@ -357,12 +356,12 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
         f32[idx + 2] = q.x1;
         f32[idx + 3] = q.y1;
 
-        const uMin  = (q.u0 * 0xffff) & 0xffff;
-        const uMax  = (q.u1 * 0xffff) & 0xffff;
+        const uMin = (q.u0 * 0xffff) & 0xffff;
+        const uMax = (q.u1 * 0xffff) & 0xffff;
         const v0Raw = (q.v0 * 0xffff) & 0xffff;
         const v1Raw = (q.v1 * 0xffff) & 0xffff;
-        const vMin  = flipY ? v1Raw : v0Raw;
-        const vMax  = flipY ? v0Raw : v1Raw;
+        const vMin = flipY ? v1Raw : v0Raw;
+        const vMax = flipY ? v0Raw : v1Raw;
 
         u32[idx + 4] = uMin | (vMin << 16);
         u32[idx + 5] = uMax | (vMax << 16);
@@ -386,7 +385,7 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
     const view = backend.view;
 
     if (this._currentView !== view || this._currentViewId !== (view as unknown as { updateId: number }).updateId) {
-      this._currentView   = view;
+      this._currentView = view;
       this._currentViewId = (view as unknown as { updateId: number }).updateId;
       const proj = view.getTransform().toArray(false);
       this._shaderPathShader.getUniform('u_projection').setValue(proj);
@@ -406,16 +405,16 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
 
   private _flushShaderBatch(backend: WebGl2Backend): void {
     const conn = this._connection;
-    const buf  = this._shaderBuf;
-    const vao  = this._shaderVao;
+    const buf = this._shaderBuf;
+    const vao = this._shaderVao;
 
     if (!conn || !buf || !vao || this._shaderQuadCount === 0) return;
 
-    const gl       = conn.gl;
-    const texture  = this._currentTexture;
-    const scaleMode = (texture instanceof Texture) ? texture.scaleMode : ScaleModes.Linear;
-    const wrapS    = repeatModeToWrap(this._currentModeX ?? 'repeat');
-    const wrapT    = repeatModeToWrap(this._currentModeY ?? 'repeat');
+    const gl = conn.gl;
+    const texture = this._currentTexture;
+    const scaleMode = texture instanceof Texture ? texture.scaleMode : ScaleModes.Linear;
+    const wrapS = repeatModeToWrap(this._currentModeX ?? 'repeat');
+    const wrapT = repeatModeToWrap(this._currentModeY ?? 'repeat');
 
     // Bind repeat sampler (overrides texture's own wrap params for this unit).
     const samplerHandle = this._getOrCreateSampler(gl, wrapS, wrapT, scaleMode);
@@ -441,8 +440,8 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
 
   private _flushGeoBatch(backend: WebGl2Backend): void {
     const conn = this._connection;
-    const buf  = this._geoBuf;
-    const vao  = this._geoVao;
+    const buf = this._geoBuf;
+    const vao = this._geoVao;
 
     if (!conn || !buf || !vao || this._geoQuadCount === 0) return;
 
@@ -463,21 +462,16 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
 
   private _resetBatchState(): void {
     this._shaderQuadCount = 0;
-    this._geoQuadCount    = 0;
-    this._maxNodeIndex    = 0;
-    this._currentTexture  = null;
+    this._geoQuadCount = 0;
+    this._maxNodeIndex = 0;
+    this._currentTexture = null;
     this._currentBlendMode = null;
-    this._currentModeX    = null;
-    this._currentModeY    = null;
-    this._currentPath     = null;
+    this._currentModeX = null;
+    this._currentModeY = null;
+    this._currentPath = null;
   }
 
-  private _getOrCreateSampler(
-    gl: WebGL2RenderingContext,
-    wrapS: WrapModes,
-    wrapT: WrapModes,
-    scaleMode: ScaleModes,
-  ): WebGLSampler {
+  private _getOrCreateSampler(gl: WebGL2RenderingContext, wrapS: WrapModes, wrapT: WrapModes, scaleMode: ScaleModes): WebGLSampler {
     const key = `${wrapS}:${wrapT}:${scaleMode}`;
     const existing = this._samplers.get(key);
     if (existing !== undefined) return existing;
@@ -509,8 +503,9 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
     this._connection = conn;
 
     // Shader-path VAO (uses float4 uvParams, not packed unorm16)
-    this._shaderBuf = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, this._shaderData, BufferUsage.DynamicDraw)
-      .connect(this._createBufRuntime(conn, 'shader'));
+    this._shaderBuf = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, this._shaderData, BufferUsage.DynamicDraw).connect(
+      this._createBufRuntime(conn, 'shader'),
+    );
 
     this._shaderVao = new WebGl2VertexArrayObject(RenderingPrimitives.TriangleStrip)
       .addAttribute(this._shaderBuf, this._shaderPathShader.getAttribute('a_quadBounds'), gl.FLOAT, false, shaderStrideBytes, 0, false, 1)
@@ -520,8 +515,7 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
       .connect(this._createVaoRuntime(conn, 'shader'));
 
     // Geometry-path VAO (packed unorm16 UVs, same layout as NineSlice)
-    this._geoBuf = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, this._geoData, BufferUsage.DynamicDraw)
-      .connect(this._createBufRuntime(conn, 'geo'));
+    this._geoBuf = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, this._geoData, BufferUsage.DynamicDraw).connect(this._createBufRuntime(conn, 'geo'));
 
     this._geoVao = new WebGl2VertexArrayObject(RenderingPrimitives.TriangleStrip)
       .addAttribute(this._geoBuf, this._geoPathShader.getAttribute('a_quadBounds'), gl.FLOAT, false, geoStrideBytes, 0, false, 1)
@@ -569,7 +563,7 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
 
   private _createConnection(gl: WebGL2RenderingContext): RendererConnection {
     const shaderVaoHandle = gl.createVertexArray();
-    const geoVaoHandle    = gl.createVertexArray();
+    const geoVaoHandle = gl.createVertexArray();
 
     if (shaderVaoHandle === null || geoVaoHandle === null) {
       throw new Error('WebGl2RepeatingSpriteRenderer: could not create vertex array object.');
@@ -583,9 +577,11 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
     if (handle === null) throw new Error('WebGl2RepeatingSpriteRenderer: could not create render buffer.');
 
     return {
-      bind: (buffer): void => { conn.gl.bindBuffer(buffer.type, handle); },
+      bind: (buffer): void => {
+        conn.gl.bindBuffer(buffer.type, handle);
+      },
       upload: (buffer, offset): void => {
-        const gl   = conn.gl;
+        const gl = conn.gl;
         const data = buffer.data;
         const state = conn.buffers.get(buffer);
 
@@ -634,8 +630,12 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
           appliedVersion = vao.version;
         }
       },
-      unbind: (): void => { conn.gl.bindVertexArray(null); },
-      draw: (_vao, size, start, type): void => { conn.gl.drawArrays(type, start, size); },
+      unbind: (): void => {
+        conn.gl.bindVertexArray(null);
+      },
+      draw: (_vao, size, start, type): void => {
+        conn.gl.drawArrays(type, start, size);
+      },
       drawInstanced: (_vao, count, start, instanceCount, type): void => {
         conn.gl.drawArraysInstanced(type, start, count, instanceCount);
       },

--- a/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
@@ -277,7 +277,14 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
 
     const pass = backend._passCoordinator.acquirePass().pass;
 
-    if (this._quadIndex > 0 && !maskClipsAll && this._instanceBuffer !== null && this._indexBuffer !== null && this._currentBlendMode !== null && this._currentTexture !== null) {
+    if (
+      this._quadIndex > 0 &&
+      !maskClipsAll &&
+      this._instanceBuffer !== null &&
+      this._indexBuffer !== null &&
+      this._currentBlendMode !== null &&
+      this._currentTexture !== null
+    ) {
       device.queue.writeBuffer(this._instanceBuffer, 0, this._instanceData, 0, this._quadIndex * instanceStrideBytes);
 
       const storage = backend.getTransformStorageBuffer(this._maxNodeIndex + 1);

--- a/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
@@ -123,12 +123,12 @@ fn geoFrag(input: VOut) -> @location(0) vec4<f32> {
 // Layout constants
 // ---------------------------------------------------------------------------
 
-const shaderStrideBytes      = 40;  // float32x4 bounds + float32x4 uvParams + unorm8x4 + uint32
-const geoStrideBytes         = 32;  // float32x4 bounds + unorm16x4 + unorm8x4 + uint32 (NineSlice layout)
-const projectionByteLength   = 64;
-const initialBatchCapacity   = 32;
-const indicesPerInstance   = 6;
-const quadIndices        = new Uint16Array([0, 1, 2, 0, 2, 3]);
+const shaderStrideBytes = 40; // float32x4 bounds + float32x4 uvParams + unorm8x4 + uint32
+const geoStrideBytes = 32; // float32x4 bounds + unorm16x4 + unorm8x4 + uint32 (NineSlice layout)
+const projectionByteLength = 64;
+const initialBatchCapacity = 32;
+const indicesPerInstance = 6;
+const quadIndices = new Uint16Array([0, 1, 2, 0, 2, 3]);
 
 // ---------------------------------------------------------------------------
 // Sampler address mode helper
@@ -224,70 +224,69 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     this._pipelines.clear();
     this._samplers.clear();
 
-    this._shaderInstBuf    = null;
-    this._geoInstBuf       = null;
-    this._indexBuffer      = null;
-    this._uniformBuffer    = null;
+    this._shaderInstBuf = null;
+    this._geoInstBuf = null;
+    this._indexBuffer = null;
+    this._uniformBuffer = null;
     this._transformBindGroup = null;
     this._transformStorageBuf = null;
-    this._textureBindGroupLayout       = null;
-    this._uniformBindGroupLayout       = null;
-    this._shaderModule     = null;
-    this._device           = null;
-    this._backend          = null;
+    this._textureBindGroupLayout = null;
+    this._uniformBindGroupLayout = null;
+    this._shaderModule = null;
+    this._device = null;
+    this._backend = null;
 
     this._shaderInstCapacity = 0;
-    this._shaderInstData     = new ArrayBuffer(0);
-    this._shaderInstF32      = new Float32Array(this._shaderInstData);
-    this._shaderInstU32      = new Uint32Array(this._shaderInstData);
-    this._geoInstCapacity    = 0;
-    this._geoInstData        = new ArrayBuffer(0);
-    this._geoInstF32         = new Float32Array(this._geoInstData);
-    this._geoInstU32         = new Uint32Array(this._geoInstData);
+    this._shaderInstData = new ArrayBuffer(0);
+    this._shaderInstF32 = new Float32Array(this._shaderInstData);
+    this._shaderInstU32 = new Uint32Array(this._shaderInstData);
+    this._geoInstCapacity = 0;
+    this._geoInstData = new ArrayBuffer(0);
+    this._geoInstF32 = new Float32Array(this._geoInstData);
+    this._geoInstU32 = new Uint32Array(this._geoInstData);
 
     this._shaderQuadCount = 0;
-    this._geoQuadCount    = 0;
-    this._maxNodeIndex    = 0;
-    this._currentTexture  = null;
+    this._geoQuadCount = 0;
+    this._maxNodeIndex = 0;
+    this._currentTexture = null;
     this._currentBlendMode = null;
-    this._currentModeX    = null;
-    this._currentModeY    = null;
-    this._currentPath     = null;
+    this._currentModeX = null;
+    this._currentModeY = null;
+    this._currentPath = null;
   }
 
   public render(sprite: RepeatingSprite): void {
     const backend = this._backend;
     if (!backend) return;
 
-    const texture  = sprite.texture;
+    const texture = sprite.texture;
     if (texture instanceof Texture && texture.source === null) return;
     if (texture.width === 0 || texture.height === 0) return;
 
-    const strategy  = sprite.resolvedStrategy;
+    const strategy = sprite.resolvedStrategy;
     const blendMode = sprite.blendMode;
-    const modeX     = sprite.modeX;
-    const modeY     = sprite.modeY;
+    const modeX = sprite.modeX;
+    const modeY = sprite.modeY;
 
     const hasData = this._shaderQuadCount > 0 || this._geoQuadCount > 0;
 
     if (hasData) {
-      const pathChanged  = this._currentPath !== strategy;
-      const texChanged   = this._currentTexture !== texture;
+      const pathChanged = this._currentPath !== strategy;
+      const texChanged = this._currentTexture !== texture;
       const blendChanged = this._currentBlendMode !== blendMode;
-      const modeChanged  = strategy === 'shader'
-        && (this._currentModeX !== modeX || this._currentModeY !== modeY);
+      const modeChanged = strategy === 'shader' && (this._currentModeX !== modeX || this._currentModeY !== modeY);
 
       if (pathChanged || texChanged || blendChanged || modeChanged) {
         this.flush();
       }
     }
 
-    this._currentTexture   = texture;
+    this._currentTexture = texture;
     this._currentBlendMode = blendMode;
-    this._currentPath      = strategy;
+    this._currentPath = strategy;
     backend.setBlendMode(blendMode);
 
-    const command   = backend.activeDrawCommand;
+    const command = backend.activeDrawCommand;
     const nodeIndex = command !== null ? command.nodeIndex : backend._pushTransform(sprite);
     if (nodeIndex > this._maxNodeIndex) this._maxNodeIndex = nodeIndex;
 
@@ -302,11 +301,11 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
 
   private _writeShaderInstance(sprite: RepeatingSprite, nodeIndex: number): void {
     const texture = sprite.texture;
-    const srcW    = sprite.region.width;
-    const srcH    = sprite.region.height;
-    let   destW   = sprite.width;
-    let   destH   = sprite.height;
-    const flipY   = texture instanceof Texture && texture.flipY;
+    const srcW = sprite.region.width;
+    const srcH = sprite.region.height;
+    let destW = sprite.width;
+    let destH = sprite.height;
+    const flipY = texture instanceof Texture && texture.flipY;
 
     // 'geometry' mode: snap the destination quad to the device grid. Repetition
     // stays shader-based; only the outer rectangle (and the tiling derived from
@@ -329,10 +328,10 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
 
     this._ensureShaderCapacity(this._shaderQuadCount + 1);
 
-    const words  = shaderStrideBytes / 4;
+    const words = shaderStrideBytes / 4;
     const offset = this._shaderQuadCount * words;
-    const f32    = this._shaderInstF32;
-    const u32    = this._shaderInstU32;
+    const f32 = this._shaderInstF32;
+    const u32 = this._shaderInstU32;
 
     f32[offset + 0] = 0;
     f32[offset + 1] = 0;
@@ -361,8 +360,8 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
 
     if (quads.length === 0) return;
 
-    const flipY = (sprite.texture instanceof Texture) && sprite.texture.flipY;
-    const tint  = sprite.tint.toRgba();
+    const flipY = sprite.texture instanceof Texture && sprite.texture.flipY;
+    const tint = sprite.tint.toRgba();
     const words = geoStrideBytes / 4;
 
     this._ensureGeoCapacity(this._geoQuadCount + quads.length);
@@ -371,7 +370,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     const u32 = this._geoInstU32;
 
     for (let i = 0; i < quads.length; i++) {
-      const q      = quads[i];
+      const q = quads[i];
       const offset = (this._geoQuadCount + i) * words;
 
       f32[offset + 0] = q.x0;
@@ -379,12 +378,12 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
       f32[offset + 2] = q.x1;
       f32[offset + 3] = q.y1;
 
-      const uMin  = (q.u0 * 0xffff) & 0xffff;
-      const uMax  = (q.u1 * 0xffff) & 0xffff;
+      const uMin = (q.u0 * 0xffff) & 0xffff;
+      const uMax = (q.u1 * 0xffff) & 0xffff;
       const v0Raw = (q.v0 * 0xffff) & 0xffff;
       const v1Raw = (q.v1 * 0xffff) & 0xffff;
-      const vMin  = flipY ? v1Raw : v0Raw;
-      const vMax  = flipY ? v0Raw : v1Raw;
+      const vMin = flipY ? v1Raw : v0Raw;
+      const vMax = flipY ? v0Raw : v1Raw;
 
       u32[offset + 4] = uMin | (vMin << 16);
       u32[offset + 5] = uMax | (vMax << 16);
@@ -397,7 +396,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
 
   public flush(): void {
     const backend = this._backend;
-    const device  = this._device;
+    const device = this._device;
     const uniform = this._uniformBuffer;
 
     if (!backend || !device || !uniform) return;
@@ -410,10 +409,10 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     this._projData.set([vm.a, vm.c, 0, 0, vm.b, vm.d, 0, 0, 0, 0, 1, 0, vm.x, vm.y, 0, vm.z]);
     device.queue.writeBuffer(uniform, 0, this._projData.buffer, this._projData.byteOffset, this._projData.byteLength);
 
-    const scissor     = backend.getScissorRect();
+    const scissor = backend.getScissorRect();
     const maskClipsAll = scissor !== null && (scissor.width <= 0 || scissor.height <= 0);
 
-    const pass    = backend._passCoordinator.acquirePass().pass;
+    const pass = backend._passCoordinator.acquirePass().pass;
     const stencil = backend._passCoordinator.stencilActive;
 
     if (this._shaderQuadCount > 0 && !maskClipsAll) {
@@ -426,22 +425,17 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
 
     backend._passCoordinator.endPass();
 
-    this._shaderQuadCount  = 0;
-    this._geoQuadCount     = 0;
-    this._maxNodeIndex     = 0;
-    this._currentTexture   = null;
+    this._shaderQuadCount = 0;
+    this._geoQuadCount = 0;
+    this._maxNodeIndex = 0;
+    this._currentTexture = null;
     this._currentBlendMode = null;
-    this._currentModeX     = null;
-    this._currentModeY     = null;
-    this._currentPath      = null;
+    this._currentModeX = null;
+    this._currentModeY = null;
+    this._currentPath = null;
   }
 
-  private _drawShaderBatch(
-    device: GPUDevice,
-    backend: WebGpuBackend,
-    pass: GPURenderPassEncoder,
-    stencil: boolean,
-  ): void {
+  private _drawShaderBatch(device: GPUDevice, backend: WebGpuBackend, pass: GPURenderPassEncoder, stencil: boolean): void {
     if (!this._shaderInstBuf || !this._indexBuffer || this._currentBlendMode === null || this._currentTexture === null) return;
 
     device.queue.writeBuffer(this._shaderInstBuf, 0, this._shaderInstData, 0, this._shaderQuadCount * shaderStrideBytes);
@@ -449,13 +443,16 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     const storage = backend.getTransformStorageBuffer(this._maxNodeIndex + 1);
     const uniformBindGroup = this._getOrCreateTransformBindGroup(device, this._uniformBuffer!, storage.buffer);
 
-    const modeX  = this._currentModeX ?? 'repeat';
-    const modeY  = this._currentModeY ?? 'repeat';
+    const modeX = this._currentModeX ?? 'repeat';
+    const modeY = this._currentModeY ?? 'repeat';
     const sampler = this._getOrCreateSampler(device, modeX, modeY);
     const texView = backend.getTextureBinding(this._currentTexture).view;
-    const textureBindGroup   = device.createBindGroup({
+    const textureBindGroup = device.createBindGroup({
       layout: this._textureBindGroupLayout!,
-      entries: [{ binding: 0, resource: texView }, { binding: 1, resource: sampler }],
+      entries: [
+        { binding: 0, resource: texView },
+        { binding: 1, resource: sampler },
+      ],
     });
 
     const pipeline = this._getPipeline('shader', this._currentBlendMode, backend.renderTargetFormat, stencil);
@@ -471,12 +468,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     backend.stats.drawCalls++;
   }
 
-  private _drawGeoBatch(
-    device: GPUDevice,
-    backend: WebGpuBackend,
-    pass: GPURenderPassEncoder,
-    stencil: boolean,
-  ): void {
+  private _drawGeoBatch(device: GPUDevice, backend: WebGpuBackend, pass: GPURenderPassEncoder, stencil: boolean): void {
     if (!this._geoInstBuf || !this._indexBuffer || this._currentBlendMode === null || this._currentTexture === null) return;
 
     device.queue.writeBuffer(this._geoInstBuf, 0, this._geoInstData, 0, this._geoQuadCount * geoStrideBytes);
@@ -486,9 +478,12 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
 
     // Geometry path: use backend's default (clamp) sampler.
     const binding = backend.getTextureBinding(this._currentTexture);
-    const textureBindGroup   = device.createBindGroup({
+    const textureBindGroup = device.createBindGroup({
       layout: this._textureBindGroupLayout!,
-      entries: [{ binding: 0, resource: binding.view }, { binding: 1, resource: binding.sampler }],
+      entries: [
+        { binding: 0, resource: binding.view },
+        { binding: 1, resource: binding.sampler },
+      ],
     });
 
     const pipeline = this._getPipeline('geo', this._currentBlendMode, backend.renderTargetFormat, stencil);
@@ -532,7 +527,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
       return this._transformBindGroup;
     }
     this._transformStorageBuf = storageBuf;
-    this._transformBindGroup  = device.createBindGroup({
+    this._transformBindGroup = device.createBindGroup({
       layout: this._uniformBindGroupLayout!,
       entries: [
         { binding: 0, resource: { buffer: uniformBuf } },
@@ -559,26 +554,30 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     const strideBytes = isShader ? shaderStrideBytes : geoStrideBytes;
 
     const buffers: GPUVertexBufferLayout[] = isShader
-      ? [{
-          arrayStride: strideBytes,
-          stepMode: 'instance',
-          attributes: [
-            { shaderLocation: 0, offset: 0,  format: 'float32x4' },
-            { shaderLocation: 1, offset: 16, format: 'float32x4' },
-            { shaderLocation: 2, offset: 32, format: 'unorm8x4' },
-            { shaderLocation: 3, offset: 36, format: 'uint32' },
-          ],
-        }]
-      : [{
-          arrayStride: strideBytes,
-          stepMode: 'instance',
-          attributes: [
-            { shaderLocation: 0, offset: 0,  format: 'float32x4' },
-            { shaderLocation: 1, offset: 16, format: 'unorm16x4' },
-            { shaderLocation: 2, offset: 24, format: 'unorm8x4' },
-            { shaderLocation: 3, offset: 28, format: 'uint32' },
-          ],
-        }];
+      ? [
+          {
+            arrayStride: strideBytes,
+            stepMode: 'instance',
+            attributes: [
+              { shaderLocation: 0, offset: 0, format: 'float32x4' },
+              { shaderLocation: 1, offset: 16, format: 'float32x4' },
+              { shaderLocation: 2, offset: 32, format: 'unorm8x4' },
+              { shaderLocation: 3, offset: 36, format: 'uint32' },
+            ],
+          },
+        ]
+      : [
+          {
+            arrayStride: strideBytes,
+            stepMode: 'instance',
+            attributes: [
+              { shaderLocation: 0, offset: 0, format: 'float32x4' },
+              { shaderLocation: 1, offset: 16, format: 'unorm16x4' },
+              { shaderLocation: 2, offset: 24, format: 'unorm8x4' },
+              { shaderLocation: 3, offset: 28, format: 'uint32' },
+            ],
+          },
+        ];
 
     const desc: GPURenderPipelineDescriptor = {
       layout,
@@ -607,8 +606,8 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
   private _ensureShaderCapacity(needed: number): void {
     if (!this._device || needed <= this._shaderInstCapacity) return;
     this._shaderInstCapacity = this._growCapacity(this._shaderInstCapacity, needed);
-    const oldData   = this._shaderInstData;
-    const carry     = this._shaderQuadCount * shaderStrideBytes;
+    const oldData = this._shaderInstData;
+    const carry = this._shaderQuadCount * shaderStrideBytes;
     this._shaderInstData = new ArrayBuffer(this._shaderInstCapacity * shaderStrideBytes);
     if (carry > 0) new Uint8Array(this._shaderInstData).set(new Uint8Array(oldData, 0, carry));
     this._shaderInstF32 = new Float32Array(this._shaderInstData);
@@ -624,7 +623,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     if (!this._device || needed <= this._geoInstCapacity) return;
     this._geoInstCapacity = this._growCapacity(this._geoInstCapacity, needed);
     const oldData = this._geoInstData;
-    const carry   = this._geoQuadCount * geoStrideBytes;
+    const carry = this._geoQuadCount * geoStrideBytes;
     this._geoInstData = new ArrayBuffer(this._geoInstCapacity * geoStrideBytes);
     if (carry > 0) new Uint8Array(this._geoInstData).set(new Uint8Array(oldData, 0, carry));
     this._geoInstF32 = new Float32Array(this._geoInstData);

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -1160,9 +1160,7 @@ export class Loader {
 
     this._handlerFunctions.set(keys.type, {
       load: (config, ctx) => handler.load(toRequest(config), ctx),
-      getIdentityKey: boundIdentityKey
-        ? (config) => boundIdentityKey(toRequest(config))
-        : undefined,
+      getIdentityKey: boundIdentityKey ? config => boundIdentityKey(toRequest(config)) : undefined,
     });
 
     for (const name of resolvedNames) {

--- a/test/extensions/dependency.test.ts
+++ b/test/extensions/dependency.test.ts
@@ -134,17 +134,13 @@ describe('Extension dependency graph', () => {
     it('direct same-ID/different-object roots', () => {
       const a1 = extension('A');
       const a2 = extension('A');
-      expect(() => buildSnapshot([a1, a2])).toThrow(
-        'Extension "A" was provided by multiple descriptor objects.',
-      );
+      expect(() => buildSnapshot([a1, a2])).toThrow('Extension "A" was provided by multiple descriptor objects.');
     });
 
     it('nested same-ID/different-object — rejected on entry', () => {
       const a2 = extension('A');
       const a1: Extension = { id: 'A', dependencies: [a2] };
-      expect(() => buildSnapshot([a1])).toThrow(
-        'Extension "A" was provided by multiple descriptor objects.',
-      );
+      expect(() => buildSnapshot([a1])).toThrow('Extension "A" was provided by multiple descriptor objects.');
     });
 
     it('nested same-ID/different-object caught before any binding materialisation', () => {
@@ -160,9 +156,7 @@ describe('Extension dependency graph', () => {
       const altShared = extension('shared');
       const A = extension('A', [shared]);
       const B = extension('B', [altShared]);
-      expect(() => buildSnapshot([A, B])).toThrow(
-        'Extension "shared" was provided by multiple descriptor objects.',
-      );
+      expect(() => buildSnapshot([A, B])).toThrow('Extension "shared" was provided by multiple descriptor objects.');
     });
 
     it('same-ID/same-object always deduped (roots)', () => {
@@ -185,9 +179,7 @@ describe('Extension dependency graph', () => {
     it('self-cycle', () => {
       const a: Extension = { id: 'A' };
       (a as { dependencies: Extension[] }).dependencies = [a];
-      expect(() => buildSnapshot([a])).toThrow(
-        'Extension dependency cycle detected: A → A',
-      );
+      expect(() => buildSnapshot([a])).toThrow('Extension dependency cycle detected: A → A');
     });
 
     it('two-node cycle', () => {
@@ -195,9 +187,7 @@ describe('Extension dependency graph', () => {
       const b: Extension = { id: 'B', dependencies: [] };
       (a as { dependencies: Extension[] }).dependencies = [b];
       (b as { dependencies: Extension[] }).dependencies = [a];
-      expect(() => buildSnapshot([a])).toThrow(
-        'Extension dependency cycle detected: A → B → A',
-      );
+      expect(() => buildSnapshot([a])).toThrow('Extension dependency cycle detected: A → B → A');
     });
 
     it('three-node cycle', () => {
@@ -207,9 +197,7 @@ describe('Extension dependency graph', () => {
       (a as { dependencies: Extension[] }).dependencies = [b];
       (b as { dependencies: Extension[] }).dependencies = [c];
       (c as { dependencies: Extension[] }).dependencies = [a];
-      expect(() => buildSnapshot([a])).toThrow(
-        'Extension dependency cycle detected: A → B → C → A',
-      );
+      expect(() => buildSnapshot([a])).toThrow('Extension dependency cycle detected: A → B → C → A');
     });
 
     it('cycle error includes complete path with repeated start at end', () => {
@@ -236,9 +224,7 @@ describe('Extension dependency graph', () => {
       const y: Extension = { id: 'Y', dependencies: [] };
       (y as { dependencies: Extension[] }).dependencies = [y]; // self-cycle
       const root = extension('root', [x, y]);
-      expect(() => buildSnapshot([root])).toThrow(
-        'Extension dependency cycle detected: Y → Y',
-      );
+      expect(() => buildSnapshot([root])).toThrow('Extension dependency cycle detected: Y → Y');
     });
 
     it('cycle detection prevents partial snapshot materialisation', () => {
@@ -315,9 +301,7 @@ describe('Extension dependency graph', () => {
       const snapshot = buildSnapshot([extA, extB]);
       const backend = createStubBackend();
 
-      expect(() => materializeRendererBindings(backend, [...snapshot.renderers])).toThrow(
-        'Two bindings target the same drawable type DrawableX',
-      );
+      expect(() => materializeRendererBindings(backend, [...snapshot.renderers])).toThrow('Two bindings target the same drawable type DrawableX');
     });
 
     it('dependency dedup happens before binding-conflict validation', () => {

--- a/test/release/changelog-v0.13.test.ts
+++ b/test/release/changelog-v0.13.test.ts
@@ -13,101 +13,101 @@ const readChangelog = (): string => readFileSync(changelogPath, 'utf8');
 
 /** Extract the 0.13.0 section text (from its heading to the next `## [` heading). */
 const extractV013Section = (): string => {
-    const content = readChangelog();
-    const startMarker = '## [0.13.0]';
-    const startIndex = content.indexOf(startMarker);
-    if (startIndex === -1) throw new Error('0.13.0 section not found in CHANGELOG.md');
-    const afterStart = content.indexOf('\n', startIndex);
-    const nextSection = content.indexOf('\n## [', afterStart + 1);
-    return content.slice(afterStart + 1, nextSection === -1 ? undefined : nextSection);
+  const content = readChangelog();
+  const startMarker = '## [0.13.0]';
+  const startIndex = content.indexOf(startMarker);
+  if (startIndex === -1) throw new Error('0.13.0 section not found in CHANGELOG.md');
+  const afterStart = content.indexOf('\n', startIndex);
+  const nextSection = content.indexOf('\n## [', afterStart + 1);
+  return content.slice(afterStart + 1, nextSection === -1 ? undefined : nextSection);
 };
 
 /** Load package.json manifests for the 4 lockstep packages. */
 const loadPackageJson = (name: string): Record<string, unknown> =>
-    JSON.parse(readFileSync(resolve(repoRoot, 'packages', name.replace('@codexo/', ''), 'package.json'), 'utf8'));
+  JSON.parse(readFileSync(resolve(repoRoot, 'packages', name.replace('@codexo/', ''), 'package.json'), 'utf8'));
 
 describe('v0.13 release text invariants', () => {
-    const section = extractV013Section();
+  const section = extractV013Section();
 
-    it('carries a concrete release date in the heading', () => {
-        // `release:notes` (publish job, AFTER npm publish) hard-fails on any
-        // heading that is not `## [0.13.0] - YYYY-MM-DD` — "Unreleased" would
-        // publish npm packages and then abort the GitHub release.
-        expect(readChangelog()).toMatch(/^## \[0\.13\.0\] - \d{4}-\d{2}-\d{2}$/m);
-    });
+  it('carries a concrete release date in the heading', () => {
+    // `release:notes` (publish job, AFTER npm publish) hard-fails on any
+    // heading that is not `## [0.13.0] - YYYY-MM-DD` — "Unreleased" would
+    // publish npm packages and then abort the GitHub release.
+    expect(readChangelog()).toMatch(/^## \[0\.13\.0\] - \d{4}-\d{2}-\d{2}$/m);
+  });
 
-    it('contains no #this placeholder', () => {
-        expect(section).not.toMatch(/#this/);
-    });
+  it('contains no #this placeholder', () => {
+    expect(section).not.toMatch(/#this/);
+  });
 
-    it('contains no stale Loader.loadEx reference', () => {
-        expect(section).not.toMatch(/\bloadEx\b/);
-    });
+  it('contains no stale Loader.loadEx reference', () => {
+    expect(section).not.toMatch(/\bloadEx\b/);
+  });
 
-    it('contains no stale Extension.descriptor reference', () => {
-        expect(section).not.toMatch(/Extension\.descriptor/);
-    });
+  it('contains no stale Extension.descriptor reference', () => {
+    expect(section).not.toMatch(/Extension\.descriptor/);
+  });
 
-    it('correctly documents TileLayer chunk default as 32', () => {
-        expect(section).toMatch(/32/);
-        expect(section).not.toMatch(/16×16/);
-    });
+  it('correctly documents TileLayer chunk default as 32', () => {
+    expect(section).toMatch(/32/);
+    expect(section).not.toMatch(/16×16/);
+  });
 
-    it('correctly names AssetHandler.getIdentityKey', () => {
-        expect(section).toMatch(/getIdentityKey/);
-    });
+  it('correctly names AssetHandler.getIdentityKey', () => {
+    expect(section).toMatch(/getIdentityKey/);
+  });
 
-    it('contains the published lockstep versions', () => {
-        expect(section).toMatch(/@codexo\/exojs\s+0\.13\.0/);
-        expect(section).toMatch(/@codexo\/exojs-particles\s+0\.13\.0/);
-        expect(section).toMatch(/@codexo\/exojs-tilemap\s+0\.13\.0/);
-        expect(section).toMatch(/@codexo\/exojs-tiled\s+0\.13\.0/);
-    });
+  it('contains the published lockstep versions', () => {
+    expect(section).toMatch(/@codexo\/exojs\s+0\.13\.0/);
+    expect(section).toMatch(/@codexo\/exojs-particles\s+0\.13\.0/);
+    expect(section).toMatch(/@codexo\/exojs-tilemap\s+0\.13\.0/);
+    expect(section).toMatch(/@codexo\/exojs-tiled\s+0\.13\.0/);
+  });
 
-    it('contains the correct peer dependency ranges', () => {
-        expect(section).toMatch(/0\.13\.x/);
-    });
+  it('contains the correct peer dependency ranges', () => {
+    expect(section).toMatch(/0\.13\.x/);
+  });
 
-    it('contains the Tiled → Tilemap dependency', () => {
-        expect(section).toMatch(/@codexo\/exojs-tilemap\s+0\.13\.0/);
-    });
+  it('contains the Tiled → Tilemap dependency', () => {
+    expect(section).toMatch(/@codexo\/exojs-tilemap\s+0\.13\.0/);
+  });
 
-    it('does not claim particles was newly extracted in v0.13', () => {
-        // The v0.12 section already documents this; the v0.13 section should not
-        // claim Core stopped shipping particles in this version.
-        expect(section).not.toMatch(/Core no longer ships the particles/);
-        expect(section).not.toMatch(/Core no longer includes any Tiled/);
-    });
+  it('does not claim particles was newly extracted in v0.13', () => {
+    // The v0.12 section already documents this; the v0.13 section should not
+    // claim Core stopped shipping particles in this version.
+    expect(section).not.toMatch(/Core no longer ships the particles/);
+    expect(section).not.toMatch(/Core no longer includes any Tiled/);
+  });
 
-    it('does not describe TiledMap as raw parsed source', () => {
-        expect(section).toMatch(/structured/);
-    });
+  it('does not describe TiledMap as raw parsed source', () => {
+    expect(section).toMatch(/structured/);
+  });
 });
 
 describe('package manifest / changelog version coherence', () => {
-    const packages = ['@codexo/exojs-particles', '@codexo/exojs-tilemap', '@codexo/exojs-tiled'];
+  const packages = ['@codexo/exojs-particles', '@codexo/exojs-tilemap', '@codexo/exojs-tiled'];
 
-    for (const pkg of packages) {
-        it(`${pkg} manifest version is 0.13.0`, () => {
-            const manifest = loadPackageJson(pkg);
-            expect(manifest.version).toBe('0.13.0');
-        });
-
-        it(`${pkg} peer dependency range is 0.13.x`, () => {
-            const manifest = loadPackageJson(pkg);
-            const peers = (manifest.peerDependencies ?? {}) as Record<string, string>;
-            expect(peers['@codexo/exojs']).toBe('0.13.x');
-        });
-    }
-
-    it('@codexo/exojs-tiled has @codexo/exojs-tilemap as a regular dependency', () => {
-        const manifest = loadPackageJson('@codexo/exojs-tiled');
-        const deps = (manifest.dependencies ?? {}) as Record<string, string>;
-        expect(deps['@codexo/exojs-tilemap']).toBeDefined();
+  for (const pkg of packages) {
+    it(`${pkg} manifest version is 0.13.0`, () => {
+      const manifest = loadPackageJson(pkg);
+      expect(manifest.version).toBe('0.13.0');
     });
 
-    it('root package version is 0.13.0', () => {
-        const root = JSON.parse(readFileSync(resolve(repoRoot, 'package.json'), 'utf8'));
-        expect(root.version).toBe('0.13.0');
+    it(`${pkg} peer dependency range is 0.13.x`, () => {
+      const manifest = loadPackageJson(pkg);
+      const peers = (manifest.peerDependencies ?? {}) as Record<string, string>;
+      expect(peers['@codexo/exojs']).toBe('0.13.x');
     });
+  }
+
+  it('@codexo/exojs-tiled has @codexo/exojs-tilemap as a regular dependency', () => {
+    const manifest = loadPackageJson('@codexo/exojs-tiled');
+    const deps = (manifest.dependencies ?? {}) as Record<string, string>;
+    expect(deps['@codexo/exojs-tilemap']).toBeDefined();
+  });
+
+  it('root package version is 0.13.0', () => {
+    const root = JSON.parse(readFileSync(resolve(repoRoot, 'package.json'), 'utf8'));
+    expect(root.version).toBe('0.13.0');
+  });
 });

--- a/test/release/publish.test.ts
+++ b/test/release/publish.test.ts
@@ -51,7 +51,7 @@ const publishedPackages = (invocations: CommandInvocation[]): string[] => publis
 const liveOptions = (): PublishOptions => ({ ...defaultPublishOptions('0.13.0'), dryRun: false, checkExisting: true });
 
 describe('publishRelease — dry-run', () => {
-    it('publishes all four to the temp dist-tag in Core→Particles→Tilemap→Tiled order, every call carries --dry-run', () => {
+  it('publishes all four to the temp dist-tag in Core→Particles→Tilemap→Tiled order, every call carries --dry-run', () => {
     const runner = createRecordingRunner(inv => (inv.args[0] === 'view' ? fail('E404') : ok()));
     const report = publishRelease(manifest, defaultPublishOptions('0.13.0'), runner, resolveArtifact);
 
@@ -78,7 +78,7 @@ describe('publishRelease — dry-run', () => {
 });
 
 describe('publishRelease — live happy path', () => {
-    it('publishes then promotes all four to latest', () => {
+  it('publishes then promotes all four to latest', () => {
     const runner = createRecordingRunner(inv => (inv.args[0] === 'view' ? fail('E404') : ok()));
     const report = publishRelease(manifest, liveOptions(), runner, resolveArtifact);
 

--- a/test/rendering/browser/_tilemapScene.ts
+++ b/test/rendering/browser/_tilemapScene.ts
@@ -1,6 +1,6 @@
 import { tiledExtension } from '@codexo/exojs-tiled';
 import type { TileTransform } from '@codexo/exojs-tilemap';
-import { TILE_TRANSFORM_IDENTITY, TileLayer, TileMap, tilemapExtension,TileSet } from '@codexo/exojs-tilemap';
+import { TILE_TRANSFORM_IDENTITY, TileLayer, TileMap, tilemapExtension, TileSet } from '@codexo/exojs-tilemap';
 
 import { materializeRendererBindings } from '#extensions/materialize';
 import { buildSnapshot } from '#extensions/snapshot';

--- a/test/rendering/browser/webgl2-renderer-perf.test.ts
+++ b/test/rendering/browser/webgl2-renderer-perf.test.ts
@@ -295,8 +295,24 @@ const makeSolidTexture = (color: string, size = 16): Texture => {
 
 /** Build N distinct solid-colour textures (colours cycle through a fixed palette). */
 const makeTextures = (count: number, size = 16): Texture[] => {
-  const colors = ['#ff0000', '#00ff00', '#0000ff', '#ffff00', '#ff00ff', '#00ffff', '#ffffff', '#888888',
-    '#ff8800', '#00ff88', '#8800ff', '#88ff00', '#ff0088', '#0088ff', '#884400', '#004488'];
+  const colors = [
+    '#ff0000',
+    '#00ff00',
+    '#0000ff',
+    '#ffff00',
+    '#ff00ff',
+    '#00ffff',
+    '#ffffff',
+    '#888888',
+    '#ff8800',
+    '#00ff88',
+    '#8800ff',
+    '#88ff00',
+    '#ff0088',
+    '#0088ff',
+    '#884400',
+    '#004488',
+  ];
 
   return Array.from({ length: count }, (_, i) => makeSolidTexture(colors[i % colors.length], size));
 };
@@ -327,17 +343,11 @@ interface SpritesScene {
  * `assign='cycle'`   — textures cycled round-robin across sprites.
  * `assign='distinct'` — sprite i gets texture i (count must equal textures.length).
  */
-const buildSprites = (
-  count: number,
-  textures: readonly Texture[],
-  assign: 'shared' | 'cycle' | 'distinct' = 'cycle',
-): SpritesScene => {
+const buildSprites = (count: number, textures: readonly Texture[], assign: 'shared' | 'cycle' | 'distinct' = 'cycle'): SpritesScene => {
   const root = new Container();
 
   for (let i = 0; i < count; i++) {
-    const tex = assign === 'shared'
-      ? textures[0]
-      : textures[i % textures.length];
+    const tex = assign === 'shared' ? textures[0] : textures[i % textures.length];
     const sprite = new Sprite(tex);
 
     scatterInView(sprite, i);
@@ -358,11 +368,7 @@ interface NineSliceScene {
  * 2 × sliceInset (2 × 16 = 32 < 64), so the 64px atlas satisfies validation.
  * Stretch mode produces 9 quads per sprite.
  */
-const buildNineSlices = (
-  count: number,
-  textures: readonly Texture[],
-  assign: 'shared' | 'cycle' = 'cycle',
-): NineSliceScene => {
+const buildNineSlices = (count: number, textures: readonly Texture[], assign: 'shared' | 'cycle' = 'cycle'): NineSliceScene => {
   const root = new Container();
   // NineSlice has no multi-texture merge — each texture switch flushes.
   // Pin document order so the optimizer can't coalesce same-texture sprites
@@ -394,11 +400,7 @@ interface RepeatingScene {
  * Build N shader-path repeating sprites (bare Texture — GPU sampler wrap, one
  * instance per sprite). `assign` is the same as for sprites.
  */
-const buildRepeatingShader = (
-  count: number,
-  textures: readonly Texture[],
-  assign: 'shared' | 'cycle' = 'cycle',
-): RepeatingScene => {
+const buildRepeatingShader = (count: number, textures: readonly Texture[], assign: 'shared' | 'cycle' = 'cycle'): RepeatingScene => {
   const root = new Container();
   // RepeatingSprite (shader path) has no multi-texture merge — each texture
   // switch flushes. Pin document order so the optimizer can't coalesce
@@ -645,9 +647,7 @@ describe('WebGL2 renderer perf — Tilemap', () => {
     backend.view.reset(pixelSize / 2, pixelSize / 2, pixelSize, pixelSize);
 
     const textures = makeTextures(4);
-    const tilesets = textures.map((t, i) =>
-      makeTileset(t, `ts${i}`, 1),
-    );
+    const tilesets = textures.map((t, i) => makeTileset(t, `ts${i}`, 1));
 
     // Assign tilesets in a (tx + ty) % 4 pattern so all four are interleaved.
     const node = buildDenseTilemapNode(32, 32, tilesets, (tx, ty) => (tx + ty) % 4);

--- a/test/rendering/browser/webgl2-repeating-sprite.test.ts
+++ b/test/rendering/browser/webgl2-repeating-sprite.test.ts
@@ -263,8 +263,10 @@ describe('WebGL2 RepeatingSprite — shader path', () => {
     const texture = createSolidTexture('#00ff00', 8, 8);
     const root = new Container();
     const sprite = new RepeatingSprite(texture, {
-      width: 48, height: 48,
-      modeX: 'stretch', modeY: 'stretch',
+      width: 48,
+      height: 48,
+      modeX: 'stretch',
+      modeY: 'stretch',
     });
 
     try {
@@ -287,8 +289,10 @@ describe('WebGL2 RepeatingSprite — shader path', () => {
     const texture = createSolidTexture('#0000ff', 16, 16);
     const root = new Container();
     const sprite = new RepeatingSprite(texture, {
-      width: 40, height: 40,
-      modeX: 'mirror-repeat', modeY: 'mirror-repeat',
+      width: 40,
+      height: 40,
+      modeX: 'mirror-repeat',
+      modeY: 'mirror-repeat',
     });
 
     try {
@@ -440,9 +444,12 @@ describe('WebGL2 RepeatingSprite — geometry path', () => {
     const region = new TextureRegion(texture, { x: 0, y: 0, width: 16, height: 16 });
     const root = new Container();
     const sprite = new RepeatingSprite(region, {
-      width: 40, height: 40,
-      modeX: 'repeat', modeY: 'repeat',
-      fitX: 'clip', fitY: 'clip',
+      width: 40,
+      height: 40,
+      modeX: 'repeat',
+      modeY: 'repeat',
+      fitX: 'clip',
+      fitY: 'clip',
     });
 
     try {
@@ -515,9 +522,12 @@ describe('WebGL2 RepeatingSprite — geometry path', () => {
     const region = new TextureRegion(texture, { x: 0, y: 0, width: 16, height: 16 });
     const root = new Container();
     const sprite = new RepeatingSprite(region, {
-      width: 48, height: 48,
-      modeX: 'mirror-repeat', modeY: 'mirror-repeat',
-      fitX: 'round', fitY: 'round',
+      width: 48,
+      height: 48,
+      modeX: 'mirror-repeat',
+      modeY: 'mirror-repeat',
+      fitX: 'round',
+      fitY: 'round',
     });
 
     try {

--- a/test/rendering/browser/webgl2-tilemap.test.ts
+++ b/test/rendering/browser/webgl2-tilemap.test.ts
@@ -12,7 +12,7 @@
  * Run via:  pnpm test:browser:webgl2
  */
 
-import { TILE_TRANSFORM_IDENTITY,TileLayer, TileMap, TileMapNode, TileSet } from '@codexo/exojs-tilemap';
+import { TILE_TRANSFORM_IDENTITY, TileLayer, TileMap, TileMapNode, TileSet } from '@codexo/exojs-tilemap';
 
 import type { Application } from '#core/Application';
 import { Color } from '#core/Color';
@@ -21,14 +21,7 @@ import type { Texture } from '#rendering/texture/Texture';
 import { TextureRegion } from '#rendering/texture/TextureRegion';
 import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
 
-import {
-  createQuadrantTexture,
-  createSolidTexture,
-  makeTileset,
-  singleTileMap,
-  wireTilemapRenderers,
-  wireViaTiledExtension,
-} from './_tilemapScene';
+import { createQuadrantTexture, createSolidTexture, makeTileset, singleTileMap, wireTilemapRenderers, wireViaTiledExtension } from './_tilemapScene';
 
 type RgbaTuple = readonly [number, number, number, number];
 
@@ -334,7 +327,17 @@ describe('WebGL2 tilemap — batch capacity overflow', () => {
     });
     // One 128×128 chunk → 16384 tiles in a single page, far beyond the 4096
     // instance batch → the renderer must flush in runs without overflowing.
-    const layer = new TileLayer({ id: 1, name: 'l', width: 128, height: 128, tileWidth: 1, tileHeight: 1, chunkWidth: 128, chunkHeight: 128, tilesets: [tileset] });
+    const layer = new TileLayer({
+      id: 1,
+      name: 'l',
+      width: 128,
+      height: 128,
+      tileWidth: 1,
+      tileHeight: 1,
+      chunkWidth: 128,
+      chunkHeight: 128,
+      tilesets: [tileset],
+    });
     layer.fillRect(0, 0, 128, 128, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
     const map = new TileMap({ name: 'm', width: 128, height: 128, tileWidth: 1, tileHeight: 1, tilesets: [tileset], layers: [layer] });
     const node = new TileMapNode(map);

--- a/test/rendering/browser/webgpu-pixel-snap.test.ts
+++ b/test/rendering/browser/webgpu-pixel-snap.test.ts
@@ -112,16 +112,11 @@ const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 12)
 
 // On the software (swiftshader) adapter the WebGPU device can be dropped
 // mid-test. Treat that as an unavailable-adapter skip rather than a failure.
-const isDeviceLoss = (error: unknown): boolean =>
-  error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
 
 // Render a scene inside a validation error scope.
 // Returns false when the device dropped mid-test (caller should bail).
-const renderScene = async (
-  ctx: { skip: (reason: string) => void },
-  backend: WebGpuBackend,
-  root: RenderNode,
-): Promise<boolean> => {
+const renderScene = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
   const device = getBackendDeviceOrSkip(ctx, backend);
 
   if (!device) {

--- a/test/rendering/browser/webgpu-repeating-sprite.test.ts
+++ b/test/rendering/browser/webgpu-repeating-sprite.test.ts
@@ -110,14 +110,9 @@ const createSolidTexture = (color: string, size = 16): Texture => {
   return new Texture(src);
 };
 
-const isDeviceLoss = (error: unknown): boolean =>
-  error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
 
-const renderScene = async (
-  ctx: { skip: (reason: string) => void },
-  backend: WebGpuBackend,
-  root: RenderNode,
-): Promise<boolean> => {
+const renderScene = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
   const device = getBackendDeviceOrSkip(ctx, backend);
 
   if (!device) {
@@ -194,8 +189,10 @@ describe('WebGPU RepeatingSprite — shader path', () => {
     const texture = createSolidTexture('#00ff00', 8);
     const root = new Container();
     const sprite = new RepeatingSprite(texture, {
-      width: 48, height: 48,
-      modeX: 'stretch', modeY: 'stretch',
+      width: 48,
+      height: 48,
+      modeX: 'stretch',
+      modeY: 'stretch',
     });
 
     try {
@@ -227,8 +224,10 @@ describe('WebGPU RepeatingSprite — shader path', () => {
     const texture = createSolidTexture('#0000ff', 16);
     const root = new Container();
     const sprite = new RepeatingSprite(texture, {
-      width: 40, height: 40,
-      modeX: 'mirror-repeat', modeY: 'mirror-repeat',
+      width: 40,
+      height: 40,
+      modeX: 'mirror-repeat',
+      modeY: 'mirror-repeat',
     });
 
     try {
@@ -454,9 +453,12 @@ describe('WebGPU RepeatingSprite — geometry path', () => {
     const region = new TextureRegion(texture, { x: 0, y: 0, width: 16, height: 16 });
     const root = new Container();
     const sprite = new RepeatingSprite(region, {
-      width: 48, height: 48,
-      modeX: 'mirror-repeat', modeY: 'mirror-repeat',
-      fitX: 'round', fitY: 'round',
+      width: 48,
+      height: 48,
+      modeX: 'mirror-repeat',
+      modeY: 'mirror-repeat',
+      fitX: 'round',
+      fitY: 'round',
     });
 
     try {

--- a/test/rendering/browser/webgpu-tilemap-interleave.test.ts
+++ b/test/rendering/browser/webgpu-tilemap-interleave.test.ts
@@ -83,8 +83,7 @@ const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 18)
   }
 };
 
-const isDeviceLoss = (error: unknown): boolean =>
-  error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
 
 const renderScene = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
   const device = getBackendDeviceOrSkip(ctx, backend);

--- a/test/rendering/browser/webgpu-tilemap-snap.test.ts
+++ b/test/rendering/browser/webgpu-tilemap-snap.test.ts
@@ -90,16 +90,11 @@ const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 18)
 
 // On the software (swiftshader) adapter the WebGPU device can be dropped
 // mid-test. Treat that as an unavailable-adapter skip rather than a failure.
-const isDeviceLoss = (error: unknown): boolean =>
-  error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
 
 // Render a scene inside a validation error scope.
 // Returns false when the device dropped mid-test (caller should bail).
-const renderScene = async (
-  ctx: { skip: (reason: string) => void },
-  backend: WebGpuBackend,
-  root: RenderNode,
-): Promise<boolean> => {
+const renderScene = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
   const device = getBackendDeviceOrSkip(ctx, backend);
 
   if (!device) {

--- a/test/rendering/browser/webgpu-tilemap.test.ts
+++ b/test/rendering/browser/webgpu-tilemap.test.ts
@@ -10,21 +10,14 @@
  * Run via:  pnpm test:browser:webgpu
  */
 
-import { TILE_TRANSFORM_IDENTITY,TileLayer, TileMap, TileMapNode } from '@codexo/exojs-tilemap';
+import { TILE_TRANSFORM_IDENTITY, TileLayer, TileMap, TileMapNode } from '@codexo/exojs-tilemap';
 
 import type { Application } from '#core/Application';
 import { Color } from '#core/Color';
 import type { RenderNode } from '#rendering/RenderNode';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
-import {
-  createQuadrantTexture,
-  createSolidTexture,
-  makeTileset,
-  singleTileMap,
-  wireTilemapRenderers,
-  wireViaTiledExtension,
-} from './_tilemapScene';
+import { createQuadrantTexture, createSolidTexture, makeTileset, singleTileMap, wireTilemapRenderers, wireViaTiledExtension } from './_tilemapScene';
 import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
 
 type RgbaTuple = readonly [number, number, number, number];
@@ -92,8 +85,7 @@ const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 18)
   }
 };
 
-const isDeviceLoss = (error: unknown): boolean =>
-  error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
 
 const renderScene = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
   const device = getBackendDeviceOrSkip(ctx, backend);

--- a/test/rendering/pixel-snap.test.ts
+++ b/test/rendering/pixel-snap.test.ts
@@ -23,14 +23,12 @@ import { View } from '#rendering/View';
 // Helpers
 // ---------------------------------------------------------------------------
 
-const makeTexture = (w = 64, h = 64): Texture =>
-  ({ width: w, height: h, flipY: false, updateSource: () => undefined }) as unknown as Texture;
+const makeTexture = (w = 64, h = 64): Texture => ({ width: w, height: h, flipY: false, updateSource: () => undefined }) as unknown as Texture;
 
 /** An axis-aligned, non-following view covering a `w × h` world region 1:1. */
 const makeView = (w = 100, h = 100): View => new View(w / 2, h / 2, w, h);
 
-const quad = (x0: number, y0: number, x1: number, y1: number): RenderQuad =>
-  ({ x0, y0, x1, y1, u0: 0, v0: 0, u1: 1, v1: 1 });
+const quad = (x0: number, y0: number, x1: number, y1: number): RenderQuad => ({ x0, y0, x1, y1, u0: 0, v0: 0, u1: 1, v1: 1 });
 
 /** A minimal axis-aligned context for the pure boundary-snapping helpers. */
 const ctxOf = (scaleX: number, scaleY: number): PixelSnapContext => ({
@@ -112,7 +110,12 @@ describe('snapLocalBoundary', () => {
   });
 
   test('the snapped value lands on a whole device pixel', () => {
-    for (const [l, s] of [[10.3, 2], [7.7, 3], [123.456, 1], [5.2, 0.5]] as const) {
+    for (const [l, s] of [
+      [10.3, 2],
+      [7.7, 3],
+      [123.456, 1],
+      [5.2, 0.5],
+    ] as const) {
       expect(snapLocalBoundary(l, s) * s).toBeCloseTo(Math.round(l * s), 6);
     }
   });

--- a/test/rendering/render-plan-player.test.ts
+++ b/test/rendering/render-plan-player.test.ts
@@ -171,18 +171,7 @@ describe('render plan player', () => {
 
     // Both groups have no nested sub-scopes between them: Phase 1 uploads both
     // before any draws, so uploads appear before begin events.
-    expect(spy.events).toEqual([
-      'upload:a:1:0:0:0',
-      'upload:b:1:1:1:1',
-      'begin:a',
-      'prepare:a',
-      'draw:a',
-      'end:a',
-      'begin:b',
-      'prepare:b',
-      'draw:b',
-      'end:b',
-    ]);
+    expect(spy.events).toEqual(['upload:a:1:0:0:0', 'upload:b:1:1:1:1', 'begin:a', 'prepare:a', 'draw:a', 'end:a', 'begin:b', 'prepare:b', 'draw:b', 'end:b']);
     expect(spy.slots).toEqual(['a:0:0', 'b:0:1']);
     expect(spy.uploads).toEqual(['a:1:0:0:0', 'b:1:1:1:1']);
   });

--- a/test/rendering/sprite/NineSliceSprite.test.ts
+++ b/test/rendering/sprite/NineSliceSprite.test.ts
@@ -6,14 +6,12 @@ import { TextureRegion } from '#rendering/texture/TextureRegion';
 // Helpers
 // ---------------------------------------------------------------------------
 
-const makeTexture = (w = 128, h = 64): Texture =>
-  ({ width: w, height: h, flipY: false, updateSource: () => undefined }) as unknown as Texture;
+const makeTexture = (w = 128, h = 64): Texture => ({ width: w, height: h, flipY: false, updateSource: () => undefined }) as unknown as Texture;
 
 const makeRegion = (texture: Texture, x = 0, y = 0, width?: number, height?: number): TextureRegion =>
   new TextureRegion(texture, { x, y, width: width ?? texture.width, height: height ?? texture.height });
 
-const getDirty = (sprite: NineSliceSprite): boolean =>
-  (sprite as unknown as Record<string, unknown>)['_geometryDirty'] as boolean;
+const getDirty = (sprite: NineSliceSprite): boolean => (sprite as unknown as Record<string, unknown>)['_geometryDirty'] as boolean;
 
 // ---------------------------------------------------------------------------
 // Constructor with Texture
@@ -184,26 +182,22 @@ describe('NineSliceSprite — no-op setters', () => {
 describe('NineSliceSprite — constructor validation', () => {
   test('throws when slices.left + slices.right exceeds region width', () => {
     const tex = makeTexture(64, 64);
-    expect(() => new NineSliceSprite(tex, { slices: { left: 40, top: 5, right: 30, bottom: 5 } }))
-      .toThrow(/exceeds region width/);
+    expect(() => new NineSliceSprite(tex, { slices: { left: 40, top: 5, right: 30, bottom: 5 } })).toThrow(/exceeds region width/);
   });
 
   test('throws when slices.top + slices.bottom exceeds region height', () => {
     const tex = makeTexture(64, 64);
-    expect(() => new NineSliceSprite(tex, { slices: { left: 5, top: 40, right: 5, bottom: 30 } }))
-      .toThrow(/exceeds region height/);
+    expect(() => new NineSliceSprite(tex, { slices: { left: 5, top: 40, right: 5, bottom: 30 } })).toThrow(/exceeds region height/);
   });
 
   test('throws on negative slice values', () => {
     const tex = makeTexture(64, 64);
-    expect(() => new NineSliceSprite(tex, { slices: { left: -1, top: 5, right: 5, bottom: 5 } }))
-      .toThrow(/non-negative/);
+    expect(() => new NineSliceSprite(tex, { slices: { left: -1, top: 5, right: 5, bottom: 5 } })).toThrow(/non-negative/);
   });
 
   test('does not throw when slices equal region dimensions (edge case)', () => {
     const tex = makeTexture(64, 64);
-    expect(() => new NineSliceSprite(tex, { slices: { left: 32, top: 32, right: 32, bottom: 32 } }))
-      .not.toThrow();
+    expect(() => new NineSliceSprite(tex, { slices: { left: 32, top: 32, right: 32, bottom: 32 } })).not.toThrow();
   });
 
   test('throws on negative width', () => {
@@ -250,14 +244,20 @@ describe('NineSliceSprite — setter validation (size)', () => {
   test('width setter throws on negative', () => {
     const tex = makeTexture(64, 64);
     const sprite = new NineSliceSprite(tex, { slices: 10 });
-    expect(() => { sprite.width = -1; }).toThrow(/non-negative/);
+    expect(() => {
+      sprite.width = -1;
+    }).toThrow(/non-negative/);
   });
 
   test('width setter preserves prior state on rejection', () => {
     const tex = makeTexture(64, 64);
     const sprite = new NineSliceSprite(tex, { slices: 10 });
     const prevWidth = sprite.width;
-    try { sprite.width = NaN; } catch { /* expected */ }
+    try {
+      sprite.width = NaN;
+    } catch {
+      /* expected */
+    }
     expect(sprite.width).toBe(prevWidth);
     expect(getDirty(sprite)).toBe(true); // initial state is dirty
   });
@@ -265,7 +265,9 @@ describe('NineSliceSprite — setter validation (size)', () => {
   test('height setter throws on NaN', () => {
     const tex = makeTexture(64, 64);
     const sprite = new NineSliceSprite(tex, { slices: 10 });
-    expect(() => { sprite.height = NaN; }).toThrow(/finite/);
+    expect(() => {
+      sprite.height = NaN;
+    }).toThrow(/finite/);
   });
 
   test('setSize throws on negative and preserves state', () => {
@@ -291,7 +293,11 @@ describe('NineSliceSprite — setter validation (size)', () => {
     const sprite = new NineSliceSprite(tex, { slices: 10 });
     void sprite.quads;
     const prevDirty = getDirty(sprite);
-    try { sprite.setSize(-1, 100); } catch { /* expected */ }
+    try {
+      sprite.setSize(-1, 100);
+    } catch {
+      /* expected */
+    }
     expect(getDirty(sprite)).toBe(prevDirty);
   });
 });
@@ -329,7 +335,11 @@ describe('NineSliceSprite — setter validation (slices)', () => {
     const tex = makeTexture(64, 64);
     const sprite = new NineSliceSprite(tex, { slices: 10 });
     const prevSlices = sprite.slices;
-    try { sprite.setSlices({ left: -1, top: 5, right: 5, bottom: 5 }); } catch { /* expected */ }
+    try {
+      sprite.setSlices({ left: -1, top: 5, right: 5, bottom: 5 });
+    } catch {
+      /* expected */
+    }
     expect(sprite.slices).toEqual(prevSlices);
   });
 
@@ -337,14 +347,22 @@ describe('NineSliceSprite — setter validation (slices)', () => {
     const tex = makeTexture(64, 64);
     const sprite = new NineSliceSprite(tex, { slices: 10 });
     void sprite.quads;
-    try { sprite.setSlices({ left: -1, top: 5, right: 5, bottom: 5 }); } catch { /* expected */ }
+    try {
+      sprite.setSlices({ left: -1, top: 5, right: 5, bottom: 5 });
+    } catch {
+      /* expected */
+    }
     expect(getDirty(sprite)).toBe(false);
   });
 
   test('valid constructor then invalid setSlices: prior slices preserved', () => {
     const tex = makeTexture(64, 64);
     const sprite = new NineSliceSprite(tex, { slices: { left: 8, top: 8, right: 8, bottom: 8 } });
-    try { sprite.setSlices({ left: 40, top: 40, right: 30, bottom: 30 }); } catch { /* expected */ }
+    try {
+      sprite.setSlices({ left: 40, top: 40, right: 30, bottom: 30 });
+    } catch {
+      /* expected */
+    }
     const slices = sprite.slices;
     expect(slices.left).toBe(8);
     expect(slices.top).toBe(8);
@@ -374,7 +392,11 @@ describe('NineSliceSprite — setter validation (border)', () => {
     const tex = makeTexture(64, 64);
     const sprite = new NineSliceSprite(tex, { slices: 10 });
     const prevBorder = sprite.border;
-    try { sprite.setBorder({ left: -1, top: 5, right: 5, bottom: 5 }); } catch { /* expected */ }
+    try {
+      sprite.setBorder({ left: -1, top: 5, right: 5, bottom: 5 });
+    } catch {
+      /* expected */
+    }
     expect(sprite.border).toEqual(prevBorder);
   });
 
@@ -611,7 +633,11 @@ describe('NineSliceSprite — geometry invalidation', () => {
     const tex = makeTexture(64, 64);
     const sprite = new NineSliceSprite(tex, { slices: 10 });
     void sprite.quads;
-    try { sprite.setSize(-1, 100); } catch { /* expected */ }
+    try {
+      sprite.setSize(-1, 100);
+    } catch {
+      /* expected */
+    }
     expect(getDirty(sprite)).toBe(false);
   });
 
@@ -633,71 +659,65 @@ describe('NineSliceSprite — geometry invalidation', () => {
 describe('NineSliceSprite — mode validation', () => {
   test('rejects invalid edges mode in constructor', () => {
     const tex = makeTexture(64, 64);
-    expect(() => new NineSliceSprite(tex, { slices: 10, modes: { edges: 'banana' as string } as NineSliceModes }))
-      .toThrow(/modes.edges must be/);
+    expect(() => new NineSliceSprite(tex, { slices: 10, modes: { edges: 'banana' as string } as NineSliceModes })).toThrow(/modes.edges must be/);
   });
 
   test('rejects invalid center mode in constructor', () => {
     const tex = makeTexture(64, 64);
-    expect(() => new NineSliceSprite(tex, { slices: 10, modes: { center: 'tile' as string } as NineSliceModes }))
-      .toThrow(/modes.center must be/);
+    expect(() => new NineSliceSprite(tex, { slices: 10, modes: { center: 'tile' as string } as NineSliceModes })).toThrow(/modes.center must be/);
   });
 
   test('rejects invalid top override in constructor', () => {
     const tex = makeTexture(64, 64);
-    expect(() => new NineSliceSprite(tex, { slices: 10, modes: { top: 'invalid' as string } as NineSliceModes }))
-      .toThrow(/modes.top must be/);
+    expect(() => new NineSliceSprite(tex, { slices: 10, modes: { top: 'invalid' as string } as NineSliceModes })).toThrow(/modes.top must be/);
   });
 
   test('rejects invalid right override in constructor', () => {
     const tex = makeTexture(64, 64);
-    expect(() => new NineSliceSprite(tex, { slices: 10, modes: { right: '' as string } as NineSliceModes }))
-      .toThrow(/modes.right must be/);
+    expect(() => new NineSliceSprite(tex, { slices: 10, modes: { right: '' as string } as NineSliceModes })).toThrow(/modes.right must be/);
   });
 
   test('rejects invalid bottom override in constructor', () => {
     const tex = makeTexture(64, 64);
-    expect(() => new NineSliceSprite(tex, { slices: 10, modes: { bottom: 42 as unknown as string } as NineSliceModes }))
-      .toThrow(/modes.bottom must be/);
+    expect(() => new NineSliceSprite(tex, { slices: 10, modes: { bottom: 42 as unknown as string } as NineSliceModes })).toThrow(/modes.bottom must be/);
   });
 
   test('rejects invalid left override in constructor', () => {
     const tex = makeTexture(64, 64);
-    expect(() => new NineSliceSprite(tex, { slices: 10, modes: { left: 'undefined' as string } as NineSliceModes }))
-      .toThrow(/modes.left must be/);
+    expect(() => new NineSliceSprite(tex, { slices: 10, modes: { left: 'undefined' as string } as NineSliceModes })).toThrow(/modes.left must be/);
   });
 
   test('rejects invalid edgeFit in constructor', () => {
     const tex = makeTexture(64, 64);
-    expect(() => new NineSliceSprite(tex, { slices: 10, modes: { edgeFit: 'stretch' as string } as NineSliceModes }))
-      .toThrow(/modes.edgeFit must be/);
+    expect(() => new NineSliceSprite(tex, { slices: 10, modes: { edgeFit: 'stretch' as string } as NineSliceModes })).toThrow(/modes.edgeFit must be/);
   });
 
   test('rejects invalid centerFit in constructor', () => {
     const tex = makeTexture(64, 64);
-    expect(() => new NineSliceSprite(tex, { slices: 10, modes: { centerFit: 'squeeze' as string } as NineSliceModes }))
-      .toThrow(/modes.centerFit must be/);
+    expect(() => new NineSliceSprite(tex, { slices: 10, modes: { centerFit: 'squeeze' as string } as NineSliceModes })).toThrow(/modes.centerFit must be/);
   });
 
   test('rejects invalid mode in setModes', () => {
     const tex = makeTexture(64, 64);
     const sprite = new NineSliceSprite(tex, { slices: 10 });
-    expect(() => sprite.setModes({ edges: 'garbage' as string } as NineSliceModes))
-      .toThrow(/modes.edges must be/);
+    expect(() => sprite.setModes({ edges: 'garbage' as string } as NineSliceModes)).toThrow(/modes.edges must be/);
   });
 
   test('rejects invalid fit in setModes', () => {
     const tex = makeTexture(64, 64);
     const sprite = new NineSliceSprite(tex, { slices: 10 });
-    expect(() => sprite.setModes({ edgeFit: 'trim' as string } as NineSliceModes))
-      .toThrow(/modes.edgeFit must be/);
+    expect(() => sprite.setModes({ edgeFit: 'trim' as string } as NineSliceModes)).toThrow(/modes.edgeFit must be/);
   });
 
   test('failed setModes is atomic — prior modes preserved', () => {
     const tex = makeTexture(64, 64);
     const sprite = new NineSliceSprite(tex, { slices: 10, modes: { edges: 'repeat' } });
     const prevModes = sprite.modes;
-    try { sprite.setModes({ edges: 'bad' as string } as NineSliceModes); } catch { /* expected */ }
+    try {
+      sprite.setModes({ edges: 'bad' as string } as NineSliceModes);
+    } catch {
+      /* expected */
+    }
     expect(sprite.modes).toBe(prevModes);
   });
 
@@ -705,7 +725,11 @@ describe('NineSliceSprite — mode validation', () => {
     const tex = makeTexture(64, 64);
     const sprite = new NineSliceSprite(tex, { slices: 10, modes: { edges: 'repeat' } });
     void sprite.quads;
-    try { sprite.setModes({ edges: 'bad' as string } as NineSliceModes); } catch { /* expected */ }
+    try {
+      sprite.setModes({ edges: 'bad' as string } as NineSliceModes);
+    } catch {
+      /* expected */
+    }
     expect(getDirty(sprite)).toBe(false);
   });
 

--- a/test/rendering/sprite/RepeatingSprite.test.ts
+++ b/test/rendering/sprite/RepeatingSprite.test.ts
@@ -6,14 +6,12 @@ import { TextureRegion } from '#rendering/texture/TextureRegion';
 // Helpers
 // ---------------------------------------------------------------------------
 
-const makeTex = (w = 128, h = 64): Texture =>
-  ({ width: w, height: h, flipY: false }) as unknown as Texture;
+const makeTex = (w = 128, h = 64): Texture => ({ width: w, height: h, flipY: false }) as unknown as Texture;
 
 const makeRegion = (tex: Texture, x = 0, y = 0, width?: number, height?: number): TextureRegion =>
   new TextureRegion(tex, { x, y, width: width ?? tex.width, height: height ?? tex.height });
 
-const getDirty = (sprite: RepeatingSprite): boolean =>
-  (sprite as unknown as Record<string, unknown>)['_geometryDirty'] as boolean;
+const getDirty = (sprite: RepeatingSprite): boolean => (sprite as unknown as Record<string, unknown>)['_geometryDirty'] as boolean;
 
 // ---------------------------------------------------------------------------
 // Strategy selection
@@ -97,10 +95,14 @@ describe('RepeatingSprite — constructor with Texture', () => {
   test('constructor options override all defaults', () => {
     const tex = makeTex(128, 64);
     const sprite = new RepeatingSprite(tex, {
-      width: 500, height: 250,
-      modeX: 'mirror-repeat', modeY: 'stretch',
-      fitX: 'clip', fitY: 'clip',
-      offsetX: 12, offsetY: -8,
+      width: 500,
+      height: 250,
+      modeX: 'mirror-repeat',
+      modeY: 'stretch',
+      fitX: 'clip',
+      fitY: 'clip',
+      offsetX: 12,
+      offsetY: -8,
     });
     expect(sprite.width).toBe(500);
     expect(sprite.height).toBe(250);
@@ -227,27 +229,37 @@ describe('RepeatingSprite — setter validation (size)', () => {
   test('width setter throws on negative', () => {
     const tex = makeTex();
     const sprite = new RepeatingSprite(tex);
-    expect(() => { sprite.width = -1; }).toThrow(/non-negative/);
+    expect(() => {
+      sprite.width = -1;
+    }).toThrow(/non-negative/);
   });
 
   test('width setter throws on NaN', () => {
     const tex = makeTex();
     const sprite = new RepeatingSprite(tex);
-    expect(() => { sprite.width = NaN; }).toThrow(/finite/);
+    expect(() => {
+      sprite.width = NaN;
+    }).toThrow(/finite/);
   });
 
   test('width setter preserves prior value on rejection', () => {
     const tex = makeTex(128, 64);
     const sprite = new RepeatingSprite(tex);
     const prev = sprite.width;
-    try { sprite.width = -5; } catch { /* expected */ }
+    try {
+      sprite.width = -5;
+    } catch {
+      /* expected */
+    }
     expect(sprite.width).toBe(prev);
   });
 
   test('height setter throws on Infinity', () => {
     const tex = makeTex();
     const sprite = new RepeatingSprite(tex);
-    expect(() => { sprite.height = Infinity; }).toThrow(/finite/);
+    expect(() => {
+      sprite.height = Infinity;
+    }).toThrow(/finite/);
   });
 
   test('setSize throws on negative', () => {
@@ -260,7 +272,11 @@ describe('RepeatingSprite — setter validation (size)', () => {
     const tex = makeTex();
     const sprite = new RepeatingSprite(tex, { width: 200, height: 100 });
     void sprite.quads;
-    try { sprite.setSize(Infinity, 50); } catch { /* expected */ }
+    try {
+      sprite.setSize(Infinity, 50);
+    } catch {
+      /* expected */
+    }
     expect(sprite.width).toBe(200);
     expect(sprite.height).toBe(100);
   });
@@ -270,7 +286,11 @@ describe('RepeatingSprite — setter validation (size)', () => {
     const region = makeRegion(tex);
     const sprite = new RepeatingSprite(region);
     void sprite.quads;
-    try { sprite.setSize(-10, 50); } catch { /* expected */ }
+    try {
+      sprite.setSize(-10, 50);
+    } catch {
+      /* expected */
+    }
     expect(getDirty(sprite)).toBe(false);
   });
 });
@@ -283,33 +303,45 @@ describe('RepeatingSprite — setter validation (modes/fits)', () => {
   test('modeX setter throws on invalid value', () => {
     const tex = makeTex();
     const sprite = new RepeatingSprite(tex);
-    expect(() => { sprite.modeX = 'tiling' as never; }).toThrow('modeX');
+    expect(() => {
+      sprite.modeX = 'tiling' as never;
+    }).toThrow('modeX');
   });
 
   test('modeX setter preserves prior value on rejection', () => {
     const tex = makeTex();
     const sprite = new RepeatingSprite(tex);
     const prev = sprite.modeX;
-    try { sprite.modeX = 'bad' as never; } catch { /* expected */ }
+    try {
+      sprite.modeX = 'bad' as never;
+    } catch {
+      /* expected */
+    }
     expect(sprite.modeX).toBe(prev);
   });
 
   test('modeY setter throws on invalid value', () => {
     const tex = makeTex();
     const sprite = new RepeatingSprite(tex);
-    expect(() => { sprite.modeY = null as never; }).toThrow('modeY');
+    expect(() => {
+      sprite.modeY = null as never;
+    }).toThrow('modeY');
   });
 
   test('fitX setter throws on invalid value', () => {
     const tex = makeTex();
     const sprite = new RepeatingSprite(tex);
-    expect(() => { sprite.fitX = 'repeat' as never; }).toThrow('fitX');
+    expect(() => {
+      sprite.fitX = 'repeat' as never;
+    }).toThrow('fitX');
   });
 
   test('fitY setter throws on invalid value', () => {
     const tex = makeTex();
     const sprite = new RepeatingSprite(tex);
-    expect(() => { sprite.fitY = 'tile' as never; }).toThrow('fitY');
+    expect(() => {
+      sprite.fitY = 'tile' as never;
+    }).toThrow('fitY');
   });
 });
 
@@ -321,19 +353,27 @@ describe('RepeatingSprite — setter validation (offset)', () => {
   test('offsetX setter throws on NaN', () => {
     const tex = makeTex();
     const sprite = new RepeatingSprite(tex);
-    expect(() => { sprite.offsetX = NaN; }).toThrow(/finite/);
+    expect(() => {
+      sprite.offsetX = NaN;
+    }).toThrow(/finite/);
   });
 
   test('offsetY setter throws on Infinity', () => {
     const tex = makeTex();
     const sprite = new RepeatingSprite(tex);
-    expect(() => { sprite.offsetY = Infinity; }).toThrow(/finite/);
+    expect(() => {
+      sprite.offsetY = Infinity;
+    }).toThrow(/finite/);
   });
 
   test('setOffset preserves both offsets on rejection', () => {
     const tex = makeTex();
     const sprite = new RepeatingSprite(tex, { offsetX: 5, offsetY: 10 });
-    try { sprite.setOffset(NaN, 20); } catch { /* expected */ }
+    try {
+      sprite.setOffset(NaN, 20);
+    } catch {
+      /* expected */
+    }
     expect(sprite.offsetX).toBe(5);
     expect(sprite.offsetY).toBe(10);
   });
@@ -343,7 +383,11 @@ describe('RepeatingSprite — setter validation (offset)', () => {
     const region = makeRegion(tex);
     const sprite = new RepeatingSprite(region);
     void sprite.quads;
-    try { sprite.setOffset(NaN, 0); } catch { /* expected */ }
+    try {
+      sprite.setOffset(NaN, 0);
+    } catch {
+      /* expected */
+    }
     expect(getDirty(sprite)).toBe(false);
   });
 });

--- a/test/rendering/sprite/nineSlice.test.ts
+++ b/test/rendering/sprite/nineSlice.test.ts
@@ -6,8 +6,7 @@ import { TextureRegion } from '#rendering/texture/TextureRegion';
 // Helpers
 // ---------------------------------------------------------------------------
 
-const makeTexture = (w = 128, h = 64): Texture =>
-  ({ width: w, height: h, flipY: false, updateSource: () => undefined }) as unknown as Texture;
+const makeTexture = (w = 128, h = 64): Texture => ({ width: w, height: h, flipY: false, updateSource: () => undefined }) as unknown as Texture;
 
 const makeRegion = (texture: Texture, x = 0, y = 0, width?: number, height?: number): TextureRegion =>
   new TextureRegion(texture, { x, y, width: width ?? texture.width, height: height ?? texture.height });
@@ -116,7 +115,9 @@ describe('normalizeInsets', () => {
 
   test('result is frozen', () => {
     const result = normalizeInsets({ left: 1, top: 2, right: 3, bottom: 4 });
-    expect(() => { (result as Record<string, number>).left = 99; }).toThrow();
+    expect(() => {
+      (result as Record<string, number>).left = 99;
+    }).toThrow();
   });
 });
 
@@ -484,17 +485,23 @@ describe('buildNineSliceQuads — per-edge mode overrides', () => {
     // Top should have exactly 1 quad (stretch), bottom should have multiple (repeat)
     // Top edge with 'stretch' override: should produce exactly 1 quad.
     // Edge is between dx1=10 and dx2=190. Corners are at x0=0,x1=10 (TL) and x0=190,x1=200 (TR).
-    const topQuads = quads.filter(q =>
-      q.y0 === 0 && Math.abs(q.y1 - 10) < 1e-6
-      && q.x0 > 0 && q.x1 < 200
-      && !(Math.abs(q.x0 - 0) < 1e-6 && Math.abs(q.x1 - 10) < 1e-6) // not TL
-      && !(Math.abs(q.x0 - 190) < 1e-6 && Math.abs(q.x1 - 200) < 1e-6) // not TR
+    const topQuads = quads.filter(
+      q =>
+        q.y0 === 0 &&
+        Math.abs(q.y1 - 10) < 1e-6 &&
+        q.x0 > 0 &&
+        q.x1 < 200 &&
+        !(Math.abs(q.x0 - 0) < 1e-6 && Math.abs(q.x1 - 10) < 1e-6) && // not TL
+        !(Math.abs(q.x0 - 190) < 1e-6 && Math.abs(q.x1 - 200) < 1e-6), // not TR
     );
-    const bottomQuads = quads.filter(q =>
-      Math.abs(q.y0 - 90) < 1e-6 && Math.abs(q.y1 - 100) < 1e-6
-      && q.x0 > 0 && q.x1 < 200
-      && !(Math.abs(q.x0 - 0) < 1e-6 && Math.abs(q.x1 - 10) < 1e-6) // not BL
-      && !(Math.abs(q.x0 - 190) < 1e-6 && Math.abs(q.x1 - 200) < 1e-6) // not BR
+    const bottomQuads = quads.filter(
+      q =>
+        Math.abs(q.y0 - 90) < 1e-6 &&
+        Math.abs(q.y1 - 100) < 1e-6 &&
+        q.x0 > 0 &&
+        q.x1 < 200 &&
+        !(Math.abs(q.x0 - 0) < 1e-6 && Math.abs(q.x1 - 10) < 1e-6) && // not BL
+        !(Math.abs(q.x0 - 190) < 1e-6 && Math.abs(q.x1 - 200) < 1e-6), // not BR
     );
     expect(topQuads.length).toBe(1);
     expect(bottomQuads.length).toBeGreaterThan(1);

--- a/test/rendering/sprite/repeatingSpritePlan.test.ts
+++ b/test/rendering/sprite/repeatingSpritePlan.test.ts
@@ -12,8 +12,7 @@ import { TextureRegion } from '#rendering/texture/TextureRegion';
 // Mock texture helper
 // ---------------------------------------------------------------------------
 
-const makeTex = (w = 128, h = 64) =>
-  ({ width: w, height: h, flipY: false }) as unknown as import('#rendering/texture/Texture').Texture;
+const makeTex = (w = 128, h = 64) => ({ width: w, height: h, flipY: false }) as unknown as import('#rendering/texture/Texture').Texture;
 
 const makeRegion = (w: number, h: number, x = 0, y = 0, tw?: number, th?: number) => {
   const tex = makeTex(tw ?? w + x + 4, th ?? h + y + 4);
@@ -111,9 +110,9 @@ describe('computeShaderTiling', () => {
   });
 
   test('repeat + round: nearest integer', () => {
-    expect(computeShaderTiling(64, 100, 'repeat', 'round')).toBe(2);  // round(100/64) = 2
-    expect(computeShaderTiling(64, 160, 'repeat', 'round')).toBe(3);  // round(160/64) = 3 (2.5 rounds up)
-    expect(computeShaderTiling(64, 130, 'repeat', 'round')).toBe(2);  // round(130/64) = 2
+    expect(computeShaderTiling(64, 100, 'repeat', 'round')).toBe(2); // round(100/64) = 2
+    expect(computeShaderTiling(64, 160, 'repeat', 'round')).toBe(3); // round(160/64) = 3 (2.5 rounds up)
+    expect(computeShaderTiling(64, 130, 'repeat', 'round')).toBe(2); // round(130/64) = 2
   });
 
   test('mirror-repeat + clip: exact ratio', () => {
@@ -256,9 +255,9 @@ describe('buildRepeatingSpriteQuads — atlas region UV', () => {
 
   test('extrusion shifts outer UV inward by zero', () => {
     const tex = makeTex(256, 256);
-    const regionNoExt  = new TextureRegion(tex, { x: 64, y: 64, width: 32, height: 32 });
+    const regionNoExt = new TextureRegion(tex, { x: 64, y: 64, width: 32, height: 32 });
     const regionWithExt = new TextureRegion(tex, { x: 64, y: 64, width: 32, height: 32, extrusion: 1 });
-    const quadsNo  = buildRepeatingSpriteQuads(regionNoExt,  32, 32, 'repeat', 'repeat', 'round', 'round', 0, 0);
+    const quadsNo = buildRepeatingSpriteQuads(regionNoExt, 32, 32, 'repeat', 'repeat', 'round', 'round', 0, 0);
     const quadsWith = buildRepeatingSpriteQuads(regionWithExt, 32, 32, 'repeat', 'repeat', 'round', 'round', 0, 0);
     // With extrusion, no half-texel inset on outer edges → UV touches region boundary
     // Without extrusion, half-texel inset shrinks the range slightly
@@ -282,7 +281,7 @@ describe('buildRepeatingSpriteQuads — offset', () => {
   test('positive offsetX shifts the pattern', () => {
     const r = makeRegion(64, 32);
     const withoutOffset = buildRepeatingSpriteQuads(r, 100, 32, 'repeat', 'stretch', 'clip', 'clip', 0, 0);
-    const withOffset    = buildRepeatingSpriteQuads(r, 100, 32, 'repeat', 'stretch', 'clip', 'clip', 10, 0);
+    const withOffset = buildRepeatingSpriteQuads(r, 100, 32, 'repeat', 'stretch', 'clip', 'clip', 10, 0);
     // The number of quads can change when offset splits a boundary
     expect(withOffset).not.toEqual(withoutOffset);
   });
@@ -299,7 +298,7 @@ describe('buildRepeatingSpriteQuads — offset', () => {
     const r = makeRegion(64, 32);
     // offset = -16 → phase = ((-16 % 64) + 64) % 64 = 48
     const negOffset = buildRepeatingSpriteQuads(r, 100, 32, 'repeat', 'stretch', 'clip', 'clip', -16, 0);
-    const posPhase  = buildRepeatingSpriteQuads(r, 100, 32, 'repeat', 'stretch', 'clip', 'clip', 48, 0);
+    const posPhase = buildRepeatingSpriteQuads(r, 100, 32, 'repeat', 'stretch', 'clip', 'clip', 48, 0);
     expect(negOffset).toEqual(posPhase);
   });
 

--- a/test/rendering/texture/TextureRegion.test.ts
+++ b/test/rendering/texture/TextureRegion.test.ts
@@ -5,17 +5,9 @@ import { TextureRegion, type TextureRegionInsets } from '#rendering/texture/Text
 // Helpers
 // ---------------------------------------------------------------------------
 
-const makeTexture = (w = 128, h = 64): Texture =>
-  ({ width: w, height: h, flipY: false, updateSource: () => undefined }) as unknown as Texture;
+const makeTexture = (w = 128, h = 64): Texture => ({ width: w, height: h, flipY: false, updateSource: () => undefined }) as unknown as Texture;
 
-const makeRegion = (
-  texture: Texture,
-  x = 0,
-  y = 0,
-  width?: number,
-  height?: number,
-  extrusion?: number | TextureRegionInsets,
-): TextureRegion =>
+const makeRegion = (texture: Texture, x = 0, y = 0, width?: number, height?: number, extrusion?: number | TextureRegionInsets): TextureRegion =>
   new TextureRegion(texture, {
     x,
     y,
@@ -72,10 +64,10 @@ describe('TextureRegion — UV coordinates', () => {
   test('sub-region UVs are normalised correctly', () => {
     const tex = makeTexture(256, 128);
     const region = makeRegion(tex, 32, 16, 64, 32);
-    expect(region.u0).toBe(32 / 256);   // 0.125
-    expect(region.v0).toBe(16 / 128);   // 0.125
-    expect(region.u1).toBe(96 / 256);   // 0.375
-    expect(region.v1).toBe(48 / 128);   // 0.375
+    expect(region.u0).toBe(32 / 256); // 0.125
+    expect(region.v0).toBe(16 / 128); // 0.125
+    expect(region.u1).toBe(96 / 256); // 0.375
+    expect(region.v1).toBe(48 / 128); // 0.375
   });
 
   test('sub-region UVs for non-square texture', () => {
@@ -90,10 +82,10 @@ describe('TextureRegion — UV coordinates', () => {
   test('UVs are derived from texture dimensions, not source dimensions', () => {
     const tex = makeTexture(512, 256);
     const region = makeRegion(tex, 64, 32, 128, 64);
-    expect(region.u0).toBe(64 / 512);   // 0.125
-    expect(region.v0).toBe(32 / 256);   // 0.125
-    expect(region.u1).toBe(192 / 512);  // 0.375
-    expect(region.v1).toBe(96 / 256);   // 0.375
+    expect(region.u0).toBe(64 / 512); // 0.125
+    expect(region.v0).toBe(32 / 256); // 0.125
+    expect(region.u1).toBe(192 / 512); // 0.375
+    expect(region.v1).toBe(96 / 256); // 0.375
   });
 
   test('U increases with x (left-to-right)', () => {
@@ -206,7 +198,10 @@ describe('TextureRegion — extrusion', () => {
   test('per-side extrusion via TextureRegionInsets', () => {
     const tex = makeTexture(256, 128);
     const region = new TextureRegion(tex, {
-      x: 16, y: 8, width: 64, height: 32,
+      x: 16,
+      y: 8,
+      width: 64,
+      height: 32,
       extrusion: { left: 1, top: 2, right: 3, bottom: 4 },
     });
     expect(region.extrusion).toEqual({ left: 1, top: 2, right: 3, bottom: 4 });
@@ -310,10 +305,16 @@ describe('TextureRegion — validation', () => {
 
   test('throws on per-side negative extrusion', () => {
     const tex = makeTexture(256, 128);
-    expect(() => new TextureRegion(tex, {
-      x: 10, y: 10, width: 64, height: 32,
-      extrusion: { left: 0, top: -1, right: 0, bottom: 0 },
-    })).toThrow();
+    expect(
+      () =>
+        new TextureRegion(tex, {
+          x: 10,
+          y: 10,
+          width: 64,
+          height: 32,
+          extrusion: { left: 0, top: -1, right: 0, bottom: 0 },
+        }),
+    ).toThrow();
   });
 
   test('throws when extrusion exceeds available source bounds', () => {

--- a/test/resources/asset-handler-options.test.ts
+++ b/test/resources/asset-handler-options.test.ts
@@ -220,9 +220,7 @@ describe('declarative bindAsset identity propagation', () => {
     loader = new Loader();
   });
 
-  function buildExampleBinding(
-    onLoad: (opts: ResolvedExampleOptions) => void,
-  ): AssetBinding<ExampleAsset, ExampleLoadOptions> {
+  function buildExampleBinding(onLoad: (opts: ResolvedExampleOptions) => void): AssetBinding<ExampleAsset, ExampleLoadOptions> {
     return {
       type: ExampleAsset,
       typeNames: ['example'],
@@ -413,9 +411,7 @@ describe('declarative bindAsset identity propagation', () => {
 
     materializeAssetBindings(loader, [capturingBinding]);
 
-    await expect(
-      loader.load(ExampleAsset, 'thing.dat', { format: 'alt', strict: false } as ExampleLoadOptions),
-    ).resolves.toBeInstanceOf(ExampleAsset);
+    await expect(loader.load(ExampleAsset, 'thing.dat', { format: 'alt', strict: false } as ExampleLoadOptions)).resolves.toBeInstanceOf(ExampleAsset);
 
     expect(seenRequest?.source).toBe('thing.dat');
     expect(seenRequest?.options).toEqual({ format: 'alt', strict: false });


### PR DESCRIPTION
Pure \prettier --write .\ over the 34 drifted files that blocked the v0.13.0 tag push via the pre-push \ormat:check\ gate. No code changes. Follow-up consideration: add \ormat:check\ to a CI lane so drift cannot accumulate again.