### PR TITLE
fix(release): reset tracked build side-effects before release:prepare

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
           pnpm verify:release-matrix
 
       # Build core + extensions exactly once. `release:prepare --build` invokes
-      # `pnpm build` + the three extension builds, then packs WITHOUT rebuilding.
+      # `pnpm build` + the four extension builds, then packs WITHOUT rebuilding.
       - name: Build site (vendored ESM for the Full ZIP)
         env:
           EXOJS_PACKAGE_PATH: ..
@@ -101,6 +101,17 @@ jobs:
           pnpm --filter @codexo/exojs-tilemap build
           pnpm --filter @codexo/exojs-tiled build
           pnpm site:build
+
+      # The site build can regenerate tracked content with platform-dependent
+      # output (this killed the v0.12.0 and first v0.13.0 release runs with
+      # "Working tree is dirty" in freezeRevision). The tag is the source of
+      # truth and everything packed comes from untracked dist/ output, so log
+      # the drift for diagnosis and reset tracked files to the tag state.
+      - name: Reset tracked build side-effects (keep tag tree pristine)
+        run: |
+          echo "Tracked drift after builds (empty = clean):"
+          git status --porcelain
+          git checkout -- .
 
       # Build-once prepare: pack 4 tarballs (no rebuild) -> hash -> manifest +
       # checksums -> attw (bundler) -> external consumers -> Full GitHub ZIP.


### PR DESCRIPTION
The prepare job dies in freezeRevision (''Working tree is dirty'') because the site build regenerates tracked content with platform-dependent output on Linux runners — same root failure as the v0.12.0 release run and today's first v0.13.0 run (27452834618). The tag is the source of truth and everything packed comes from untracked dist/, so this logs the drift (diagnosis) and resets tracked files before release:prepare. Workflow-level fix on purpose: a dispatch-from-main rerun picks up the workflow from main while still building the immutable v0.13.0 tag checkout.