### PR TITLE
fix(release): parse attw --format json instead of scraping text

### DIFF
--- a/scripts/release/attw.ts
+++ b/scripts/release/attw.ts
@@ -5,12 +5,20 @@
  * for every entrypoint; the `node16`/`node10` resolutions surface a documented,
  * accepted limitation (extensionless relative barrel re-exports), so the three
  * rules that encode exactly those symptoms are ignored. We additionally assert
- * the positive `bundler: 🟢` signal so an ignored rule can never mask a genuine
+ * the positive bundler signal so an ignored rule can never mask a genuine
  * bundler regression.
  *
- * Invoked via `pnpm dlx` (no permanent dependency added).
+ * The check parses attw's machine-readable `--format json` output rather than
+ * scraping the human-rendered text: attw's text/table rendering is not stable
+ * across versions (a `@latest` bump changed the layout and silently broke the
+ * previous `bundler: 🟢` substring match — exit code 0, types fine, but the
+ * marker string no longer present), so the version is also pinned. Invoked via
+ * `pnpm dlx` (no permanent dependency added).
  */
 import type { CommandRunner } from './command-runner.ts';
+
+/** Pinned so the JSON shape and behaviour cannot drift mid-release. */
+const ATTW_VERSION = '0.18.3';
 
 const IGNORED_RULES = ['no-resolution', 'internal-resolution-error', 'cjs-resolves-to-esm'] as const;
 
@@ -20,21 +28,74 @@ export interface AttwResult {
   detail?: string;
 }
 
+interface AttwResolution {
+  resolution: { fileName: string } | null;
+}
+
+interface AttwEntrypoint {
+  resolutions?: Record<string, AttwResolution | undefined>;
+}
+
+interface AttwProblem {
+  kind?: string;
+  /** Set on resolution-scoped problems (e.g. `bundler`, `node16-cjs`). */
+  resolutionKind?: string;
+  /** Set on option-scoped problems (e.g. `InternalResolutionError` → `node16`). */
+  resolutionOption?: string;
+}
+
+interface AttwAnalysis {
+  entrypoints?: Record<string, AttwEntrypoint>;
+  problems?: AttwProblem[];
+}
+
+/**
+ * Pure interpreter of attw's `--format json` payload for one tarball. `ok` iff
+ * every entrypoint's `bundler` resolution resolved to a real file AND no
+ * reported problem is scoped to the `bundler` resolution — the latter catches a
+ * bundler defect that an `--ignore-rules` entry would otherwise hide from the
+ * exit code. The JSON `problems` array lists every problem regardless of
+ * `--ignore-rules` (that flag only affects the exit code), so the bundler scope
+ * is asserted explicitly here.
+ */
+export const interpretAttwJson = (stdout: string): { ok: boolean; detail?: string } => {
+  const start = stdout.indexOf('{');
+  if (start === -1) return { ok: false, detail: 'no attw json on stdout' };
+
+  let analysis: AttwAnalysis | undefined;
+  try {
+    analysis = (JSON.parse(stdout.slice(start)) as { analysis?: AttwAnalysis }).analysis;
+  } catch {
+    return { ok: false, detail: 'unparseable attw json' };
+  }
+
+  const entrypoints = analysis?.entrypoints ? Object.values(analysis.entrypoints) : [];
+  if (entrypoints.length === 0) return { ok: false, detail: 'no entrypoints analyzed' };
+
+  const unresolved = entrypoints.filter(e => e?.resolutions?.bundler?.resolution == null).length;
+  const problems = Array.isArray(analysis?.problems) ? analysis.problems : [];
+  const bundlerProblem = problems.find(p => p?.resolutionKind === 'bundler' || p?.resolutionOption === 'bundler');
+
+  if (unresolved === 0 && !bundlerProblem) return { ok: true };
+
+  const reasons = [
+    unresolved > 0 ? `${unresolved} entrypoint(s) with no bundler resolution` : '',
+    bundlerProblem ? `bundler problem: ${bundlerProblem.kind ?? 'unknown'}` : '',
+  ].filter(Boolean);
+  return { ok: false, detail: reasons.join('; ') };
+};
+
 export const checkTarballTypes = (runner: CommandRunner, tarball: string): AttwResult => {
   const result = runner.run({
     command: 'pnpm',
-    args: ['dlx', '@arethetypeswrong/cli@latest', tarball, '--ignore-rules', ...IGNORED_RULES],
+    args: ['dlx', `@arethetypeswrong/cli@${ATTW_VERSION}`, tarball, '--ignore-rules', ...IGNORED_RULES, '--format', 'json'],
   });
 
-  const output = `${result.stdout}\n${result.stderr}`;
-  const bundlerGreen = output.includes('bundler: 🟢');
-  const bundlerBroken = /bundler:\s*(💀|❌|🚫)/.test(output);
-
-  const ok = result.code === 0 && bundlerGreen && !bundlerBroken;
+  const interpreted = interpretAttwJson(result.stdout || result.stderr);
   return {
     tarball,
-    ok,
-    detail: ok ? undefined : `exit ${result.code}${bundlerGreen ? '' : ', no bundler:🟢'}${bundlerBroken ? ', bundler broken' : ''}`,
+    ok: interpreted.ok,
+    detail: interpreted.ok ? undefined : `${interpreted.detail} (exit ${result.code})`,
   };
 };
 

--- a/test/release/attw.test.ts
+++ b/test/release/attw.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { interpretAttwJson } from '../../scripts/release/attw';
+
+/** Minimal attw `--format json` payload: one entrypoint, configurable problems. */
+const payload = (opts: { bundlerResolved?: boolean; problems?: Array<{ kind: string; resolutionKind?: string; resolutionOption?: string }> }): string =>
+  JSON.stringify({
+    analysis: {
+      packageName: '@codexo/exojs-tilemap',
+      entrypoints: {
+        '.': {
+          resolutions: {
+            bundler: { resolution: opts.bundlerResolved === false ? null : { fileName: '/dist/esm/index.d.ts' } },
+            node10: { resolution: { fileName: '/dist/esm/index.d.ts' } },
+          },
+        },
+      },
+      problems: opts.problems ?? [],
+    },
+  });
+
+describe('interpretAttwJson', () => {
+  it('passes when bundler resolves and only ignored (non-bundler) problems exist', () => {
+    // Exactly the real v0.13 shape: node10/node16 problems, bundler clean.
+    const stdout = payload({
+      problems: [
+        { kind: 'CJSResolvesToESM', resolutionKind: 'node16-cjs' },
+        { kind: 'InternalResolutionError', resolutionOption: 'node16' },
+        { kind: 'NoResolution', resolutionKind: 'node10' },
+      ],
+    });
+    expect(interpretAttwJson(stdout)).toEqual({ ok: true });
+  });
+
+  it('passes with no problems at all', () => {
+    expect(interpretAttwJson(payload({})).ok).toBe(true);
+  });
+
+  it('fails when a problem is scoped to the bundler resolution (even if it would be an ignored rule)', () => {
+    const result = interpretAttwJson(payload({ problems: [{ kind: 'NoResolution', resolutionKind: 'bundler' }] }));
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain('bundler problem');
+  });
+
+  it('fails when a bundler problem is reported via resolutionOption', () => {
+    expect(interpretAttwJson(payload({ problems: [{ kind: 'InternalResolutionError', resolutionOption: 'bundler' }] })).ok).toBe(false);
+  });
+
+  it('fails when an entrypoint has no bundler resolution', () => {
+    const result = interpretAttwJson(payload({ bundlerResolved: false }));
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain('no bundler resolution');
+  });
+
+  it('fails on non-JSON output (the human/table rendering that broke the old parser)', () => {
+    expect(interpretAttwJson('No problems found 🌟\nbundler: 🟢').ok).toBe(false);
+  });
+
+  it('tolerates a leading banner before the JSON object', () => {
+    expect(interpretAttwJson(`some banner line\n${payload({})}`).ok).toBe(true);
+  });
+
+  it('fails when no entrypoints were analyzed', () => {
+    expect(interpretAttwJson(JSON.stringify({ analysis: { entrypoints: {} } })).ok).toBe(false);
+  });
+});

--- a/test/release/attw.test.ts
+++ b/test/release/attw.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { interpretAttwJson } from '../../scripts/release/attw';
 
 /** Minimal attw `--format json` payload: one entrypoint, configurable problems. */
-const payload = (opts: { bundlerResolved?: boolean; problems?: Array<{ kind: string; resolutionKind?: string; resolutionOption?: string }> }): string =>
+const payload = (opts: { bundlerResolved?: boolean; problems?: { kind: string; resolutionKind?: string; resolutionOption?: string }[] }): string =>
   JSON.stringify({
     analysis: {
       packageName: '@codexo/exojs-tilemap',


### PR DESCRIPTION
## Third v0.13.0 release-run blocker (prepare stage)

After the dirty-tree fix (#124), the prepare stage got past `freezeRevision` and failed in the attw step: every tarball reported `exit 0, no bundler:🟢`. attw **exited 0** (types are fine) — the gate broke purely because `@arethetypeswrong/cli@latest` (now 0.18.3) changed its human-rendered layout, so the `output.includes("bundler: 🟢")` substring no longer matched. Locally the cached attw still produced the old layout, which is why `release:prepare` passed on my machine but not in CI.

## Fix

- Pin `@arethetypeswrong/cli@0.18.3` (no more `@latest` format drift mid-release).
- Parse the machine-readable `--format json` payload instead of scraping text:
  - every entrypoint's `bundler` resolution must resolve to a real file, AND
  - no reported problem may be scoped to the `bundler` resolution.
- The JSON `problems` array lists **all** problems regardless of `--ignore-rules` (that flag only changes the exit code), so a bundler defect hidden behind an ignored rule still fails the gate — preserving the exact guarantee the old positive `bundler: 🟢` marker gave.
- Pure `interpretAttwJson` extracted and unit-tested (8 cases incl. the real v0.13 node10/node16-ignored-but-bundler-clean shape, bundler-broken via both `resolutionKind` and `resolutionOption`, and the text-format that broke the old parser).

## Validation

- `pnpm typecheck` ✓
- `vitest run test/release/attw.test.ts` — 8/8 ✓
- `pnpm release:prepare` locally: attw ✓ all four tarballs, external consumers ✓ (only the Full-ZIP step needs a prior `site:build`, which CI runs).

scripts-only + test; no packaged source changes, so release artifacts stay content-identical to the audited candidates.