### PR TITLE
fix(release): add repository field to extension package manifests

### DIFF
--- a/packages/exojs-particles/package.json
+++ b/packages/exojs-particles/package.json
@@ -2,6 +2,11 @@
   "name": "@codexo/exojs-particles",
   "version": "0.13.0",
   "description": "Particle system extension for ExoJS.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Exoridus/ExoJS.git",
+    "directory": "packages/exojs-particles"
+  },
   "type": "module",
   "sideEffects": [
     "./dist/esm/register.js"

--- a/packages/exojs-tiled/package.json
+++ b/packages/exojs-tiled/package.json
@@ -2,6 +2,11 @@
   "name": "@codexo/exojs-tiled",
   "version": "0.13.0",
   "description": "Tiled map format asset extension for ExoJS.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Exoridus/ExoJS.git",
+    "directory": "packages/exojs-tiled"
+  },
   "type": "module",
   "sideEffects": [
     "./dist/esm/register.js"

--- a/packages/exojs-tilemap/package.json
+++ b/packages/exojs-tilemap/package.json
@@ -2,6 +2,11 @@
   "name": "@codexo/exojs-tilemap",
   "version": "0.13.0",
   "description": "Generic, format-independent tilemap runtime for ExoJS.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Exoridus/ExoJS.git",
+    "directory": "packages/exojs-tilemap"
+  },
   "type": "module",
   "sideEffects": [
     "./dist/esm/register.js"


### PR DESCRIPTION
## Partial-publish root cause (v0.13.0 publish job)

The coordinated publish got past prepare (all earlier fixes worked) and **Core published with SLSA provenance via OIDC** — proving Trusted Publishing works. But the very next package, @codexo/exojs-particles, failed: \
pm publish --provenance\ **requires a \epository\ field** to build the provenance statement, and all three extension manifests lacked one. The chain stopped, leaving Core published and particles/tiled not.

## Fix
Add \epository\ (with the monorepo \directory\ subpath) to particles, tilemap, tiled. The idempotent publish re-run then skips already-published Core + tilemap and publishes particles + tiled **with provenance**, then promotes all four to latest.

Validated: JSON parse, prettier, \erify:release-matrix\ all green.