### PR TITLE
feat(core): design-space coordinates, auto-DPR, and letterbox sizing

### DIFF
--- a/examples/application-scenes/world-vs-screen-coords.js
+++ b/examples/application-scenes/world-vs-screen-coords.js
@@ -19,7 +19,8 @@ class WorldScreenScene extends Scene {
     text;
     pointer = { x: 0, y: 0 };
     init() {
-        const { width, height } = this.app.canvas;
+        const width = this.app.width;
+        const height = this.app.height;
         this.view = new View(260, 160, width, height);
         this.grid = new Graphics();
         this.markers = new Graphics();
@@ -53,15 +54,9 @@ class WorldScreenScene extends Scene {
         context.render(this.text);
     }
     toWorld(screenX, screenY) {
-        const width = this.app.canvas.width;
-        const height = this.app.canvas.height;
-        const clipX = (screenX / width) * 2 - 1;
-        const clipY = 1 - (screenY / height) * 2;
-        const inverse = this.view.getInverseTransform();
-        return {
-            x: inverse.a * clipX + inverse.b * clipY + inverse.x,
-            y: inverse.c * clipX + inverse.d * clipY + inverse.y,
-        };
+        // Pointer coordinates are already in design space, so screenToWorld only
+        // has to undo this view's camera transform (pan/zoom) to reach world space.
+        return this.view.screenToWorld(screenX, screenY);
     }
 }
 app.start(new WorldScreenScene());

--- a/examples/application-scenes/world-vs-screen-coords.ts
+++ b/examples/application-scenes/world-vs-screen-coords.ts
@@ -21,7 +21,8 @@ class WorldScreenScene extends Scene {
     private pointer = { x: 0, y: 0 };
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const width = this.app.width;
+        const height = this.app.height;
 
         this.view = new View(260, 160, width, height);
         this.grid = new Graphics();
@@ -65,16 +66,9 @@ class WorldScreenScene extends Scene {
     }
 
     private toWorld(screenX, screenY): { x: number; y: number } {
-        const width = this.app.canvas.width;
-        const height = this.app.canvas.height;
-        const clipX = (screenX / width) * 2 - 1;
-        const clipY = 1 - (screenY / height) * 2;
-        const inverse = this.view.getInverseTransform();
-
-        return {
-            x: inverse.a * clipX + inverse.b * clipY + inverse.x,
-            y: inverse.c * clipX + inverse.d * clipY + inverse.y,
-        };
+        // Pointer coordinates are already in design space, so screenToWorld only
+        // has to undo this view's camera transform (pan/zoom) to reach world space.
+        return this.view.screenToWorld(screenX, screenY);
     }
 }
 

--- a/examples/audio-basics/sound-pool.js
+++ b/examples/audio-basics/sound-pool.js
@@ -97,8 +97,8 @@ class SoundPoolScene extends Scene {
         const cell = 70;
         const gap = 12;
         const totalW = cols * cell + (cols - 1) * gap;
-        const startX = (this.app.canvas.width - totalW) / 2;
-        const startY = this.app.canvas.height * 0.42;
+        const startX = (this.app.width - totalW) / 2;
+        const startY = this.app.height * 0.42;
         for (let i = 0; i < POOL_SIZE; i++) {
             const col = i % cols;
             const rowI = Math.floor(i / cols);

--- a/examples/audio-basics/sound-pool.ts
+++ b/examples/audio-basics/sound-pool.ts
@@ -114,8 +114,8 @@ class SoundPoolScene extends Scene {
         const cell = 70;
         const gap = 12;
         const totalW = cols * cell + (cols - 1) * gap;
-        const startX = (this.app.canvas.width - totalW) / 2;
-        const startY = this.app.canvas.height * 0.42;
+        const startX = (this.app.width - totalW) / 2;
+        const startY = this.app.height * 0.42;
 
         for (let i = 0; i < POOL_SIZE; i++) {
             const col = i % cols;

--- a/examples/geometry-graphics/gradient.js
+++ b/examples/geometry-graphics/gradient.js
@@ -16,8 +16,8 @@ class GradientScene extends Scene {
     orbGradient;
     orb;
     init() {
-        const centerX = this.app.canvas.width / 2;
-        const centerY = this.app.canvas.height / 2;
+        const centerX = this.app.width / 2;
+        const centerY = this.app.height / 2;
         this.backgroundGradient = new LinearGradient([
             { offset: 0, color: new Color(255, 90, 40, 1) },
             { offset: 0.45, color: new Color(255, 210, 70, 1) },

--- a/examples/geometry-graphics/gradient.ts
+++ b/examples/geometry-graphics/gradient.ts
@@ -18,8 +18,8 @@ class GradientScene extends Scene {
     private orb!: Sprite;
 
     override init(): void {
-        const centerX = this.app.canvas.width / 2;
-        const centerY = this.app.canvas.height / 2;
+        const centerX = this.app.width / 2;
+        const centerY = this.app.height / 2;
 
         this.backgroundGradient = new LinearGradient(
             [

--- a/examples/input/pointer-to-world.js
+++ b/examples/input/pointer-to-world.js
@@ -14,10 +14,11 @@ const app = new Application({
     },
 });
 // The camera continuously pans (a slow figure-eight) and breathes its zoom, so
-// the same screen pixel maps to a moving world point every frame. `screenToWorld`
-// handles all of that — including the view's viewport rectangle — so we never
-// hand-roll the inverse projection. Tap to drop a marker in *world* space; it
-// stays pinned to the world as the camera moves over it.
+// the same design-space pixel maps to a moving world point every frame.
+// `screenToWorld(x, y)` undoes the camera transform — pointer coordinates are
+// already in design space (`0..app.width`) — so we never hand-roll the inverse
+// projection. Tap to drop a marker in *world* space; it stays pinned to the
+// world as the camera moves over it.
 class PointerToWorldScene extends Scene {
     view;
     grid;
@@ -29,7 +30,8 @@ class PointerToWorldScene extends Scene {
     userZoom = 1;
     hud;
     init() {
-        const { width, height } = this.app.canvas;
+        const width = this.app.width;
+        const height = this.app.height;
         this.view = new View(width / 2, height / 2, width, height);
         this.grid = new Graphics();
         this.markers = new Graphics();
@@ -49,7 +51,7 @@ class PointerToWorldScene extends Scene {
             this.cursor.y = pointer.y;
         });
         this.app.input.onPointerTap.add(pointer => {
-            const world = this.view.screenToWorld(pointer.x, pointer.y, this.app.canvas.width, this.app.canvas.height);
+            const world = this.view.screenToWorld(pointer.x, pointer.y);
             this.markerWorld.push({ x: world.x, y: world.y });
         });
         // Scroll to nudge a user-controlled zoom that the automatic breath multiplies.
@@ -68,7 +70,8 @@ class PointerToWorldScene extends Scene {
         });
     }
     update(delta) {
-        const { width, height } = this.app.canvas;
+        const width = this.app.width;
+        const height = this.app.height;
         this.elapsed += delta.seconds;
         // Slow figure-eight pan plus a gentle zoom breath.
         const centerX = width / 2 + Math.sin(this.elapsed * 0.5) * 220;
@@ -78,7 +81,7 @@ class PointerToWorldScene extends Scene {
         this.view.update(delta.milliseconds);
         // Live world coordinate under the cursor — recomputed every frame because
         // the mapping changes as the camera moves.
-        this.world = this.view.screenToWorld(this.cursor.x, this.cursor.y, this.app.canvas.width, this.app.canvas.height);
+        this.world = this.view.screenToWorld(this.cursor.x, this.cursor.y);
         this.hud.setStatus(`Screen ${Math.round(this.cursor.x)}, ${Math.round(this.cursor.y)} → World ${this.world.x.toFixed(0)}, ${this.world.y.toFixed(0)} · zoom ${this.view.zoomLevel.toFixed(2)}`);
     }
     draw(context) {

--- a/examples/input/pointer-to-world.ts
+++ b/examples/input/pointer-to-world.ts
@@ -15,10 +15,11 @@ const app = new Application({
 });
 
 // The camera continuously pans (a slow figure-eight) and breathes its zoom, so
-// the same screen pixel maps to a moving world point every frame. `screenToWorld`
-// handles all of that — including the view's viewport rectangle — so we never
-// hand-roll the inverse projection. Tap to drop a marker in *world* space; it
-// stays pinned to the world as the camera moves over it.
+// the same design-space pixel maps to a moving world point every frame.
+// `screenToWorld(x, y)` undoes the camera transform — pointer coordinates are
+// already in design space (`0..app.width`) — so we never hand-roll the inverse
+// projection. Tap to drop a marker in *world* space; it stays pinned to the
+// world as the camera moves over it.
 class PointerToWorldScene extends Scene {
     private view!: View;
     private grid!: Graphics;
@@ -31,7 +32,8 @@ class PointerToWorldScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const width = this.app.width;
+        const height = this.app.height;
 
         this.view = new View(width / 2, height / 2, width, height);
         this.grid = new Graphics();
@@ -57,7 +59,7 @@ class PointerToWorldScene extends Scene {
         });
 
         this.app.input.onPointerTap.add(pointer => {
-            const world = this.view.screenToWorld(pointer.x, pointer.y, this.app.canvas.width, this.app.canvas.height);
+            const world = this.view.screenToWorld(pointer.x, pointer.y);
 
             this.markerWorld.push({ x: world.x, y: world.y });
         });
@@ -80,7 +82,8 @@ class PointerToWorldScene extends Scene {
     }
 
     override update(delta): void {
-        const { width, height } = this.app.canvas;
+        const width = this.app.width;
+        const height = this.app.height;
 
         this.elapsed += delta.seconds;
 
@@ -94,7 +97,7 @@ class PointerToWorldScene extends Scene {
 
         // Live world coordinate under the cursor — recomputed every frame because
         // the mapping changes as the camera moves.
-        this.world = this.view.screenToWorld(this.cursor.x, this.cursor.y, this.app.canvas.width, this.app.canvas.height);
+        this.world = this.view.screenToWorld(this.cursor.x, this.cursor.y);
 
         this.hud.setStatus(`Screen ${Math.round(this.cursor.x)}, ${Math.round(this.cursor.y)} → World ${this.world.x.toFixed(0)}, ${this.world.y.toFixed(0)} · zoom ${this.view.zoomLevel.toFixed(2)}`);
     }

--- a/examples/showcase/mouse-parallax.js
+++ b/examples/showcase/mouse-parallax.js
@@ -20,7 +20,8 @@ class MouseParallaxScene extends Scene {
     pointer = { x: 0, y: 0 };
     hud;
     init() {
-        const { width, height } = this.app.canvas;
+        const width = this.app.width;
+        const height = this.app.height;
         this.pointer = { x: width / 2, y: height / 2 };
         // Spread the circle field across the full 16:9 canvas: 16 columns wide so
         // the layers fill the extra horizontal space instead of bunching on the left.
@@ -46,7 +47,8 @@ class MouseParallaxScene extends Scene {
         });
     }
     draw(context) {
-        const { width, height } = this.app.canvas;
+        const width = this.app.width;
+        const height = this.app.height;
         context.backend.clear(new Color(18, 22, 34));
         for (let i = 0; i < this.layers.length; i++) {
             const layer = this.layers[i];

--- a/examples/showcase/mouse-parallax.ts
+++ b/examples/showcase/mouse-parallax.ts
@@ -23,7 +23,8 @@ class MouseParallaxScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const width = this.app.width;
+        const height = this.app.height;
         this.pointer = { x: width / 2, y: height / 2 };
 
         // Spread the circle field across the full 16:9 canvas: 16 columns wide so
@@ -54,7 +55,8 @@ class MouseParallaxScene extends Scene {
     }
 
     override draw(context): void {
-        const { width, height } = this.app.canvas;
+        const width = this.app.width;
+        const height = this.app.height;
 
         context.backend.clear(new Color(18, 22, 34));
         for (let i = 0; i < this.layers.length; i++) {

--- a/site/src/content/api/application-status.mdx
+++ b/site/src/content/api/application-status.mdx
@@ -9,7 +9,7 @@ memberCount: 4
 tier: "stable"
 sections: ["Import", "Members", "Source"]
 sourcePath: "src/core/Application.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L31"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L33"
 ---
 ## Import
 
@@ -24,4 +24,4 @@ sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#
 
 ## Source
 
-[src/core/Application.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L31)
+[src/core/Application.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L33)

--- a/site/src/content/api/application.mdx
+++ b/site/src/content/api/application.mdx
@@ -5,11 +5,11 @@ symbol: "Application"
 kind: "class"
 subsystem: "core"
 importPath: "@codexo/exojs"
-memberCount: 34
+memberCount: 38
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/core/Application.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L176"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L211"
 ---
 ## Import
 
@@ -46,6 +46,7 @@ background-active simulations.
 - `destroy(): void`
 - `renderTo(node: RenderNode, options: RenderToOptions): RenderTexture`
 - `resize(width: number, height: number): this`
+- `screenToWorld(x: number, y: number): PointLike`
 - `setCursor(cursor: string | HTMLCanvasElement | HTMLImageElement | Texture): this`
 - `start(scene: Scene): Promise<Application>`
 - `stop(): this`
@@ -70,9 +71,12 @@ background-active simulations.
 - `documentVisible: boolean`
 - `frameCount: number`
 - `frameTime: Time`
+- `height: number`
+- `pixelRatio: number`
 - `rendering: RenderingContext`
 - `startupTime: Time`
 - `status: ApplicationStatus`
+- `width: number`
 
 ## Events
 
@@ -85,4 +89,4 @@ background-active simulations.
 
 ## Source
 
-[src/core/Application.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L176)
+[src/core/Application.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L211)

--- a/site/src/content/api/buffer-types.mdx
+++ b/site/src/content/api/buffer-types.mdx
@@ -9,7 +9,7 @@ memberCount: 8
 tier: "stable"
 sections: ["Import", "Members", "Source"]
 sourcePath: "src/rendering/types.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L57"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L68"
 ---
 ## Import
 
@@ -31,4 +31,4 @@ Values are WebGL2 GLenum constants used when calling `gl.bindBuffer`.
 
 ## Source
 
-[src/rendering/types.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L57)
+[src/rendering/types.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L68)

--- a/site/src/content/api/buffer-usage.mdx
+++ b/site/src/content/api/buffer-usage.mdx
@@ -9,7 +9,7 @@ memberCount: 9
 tier: "stable"
 sections: ["Import", "Members", "Source"]
 sourcePath: "src/rendering/types.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L72"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L83"
 ---
 ## Import
 
@@ -32,4 +32,4 @@ Values are WebGL2 GLenum constants used when calling `gl.bufferData`.
 
 ## Source
 
-[src/rendering/types.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L72)
+[src/rendering/types.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L83)

--- a/site/src/content/api/camera.mdx
+++ b/site/src/content/api/camera.mdx
@@ -44,6 +44,7 @@ Defaults: center `(0, 0)`, size `\{ width: 0, height: 0 \}`, full viewport
 - `reset(centerX: number, centerY: number, width: number, height: number): this`
 - `resize(width: number, height: number): this`
 - `rotate(degrees: number): this`
+- `screenToWorld(x: number, y: number): PointLike`
 - `screenToWorld(screenX: number, screenY: number, canvasWidth: number, canvasHeight: number): PointLike`
 - `setBounds(bounds: Rectangle | null): this`
 - `setCenter(x: number, y: number): this`
@@ -54,6 +55,7 @@ Defaults: center `(0, 0)`, size `\{ width: 0, height: 0 \}`, full viewport
 - `update(deltaMilliseconds: number): this`
 - `updateBounds(): this`
 - `updateTransform(): this`
+- `worldToScreen(worldX: number, worldY: number): PointLike`
 - `worldToScreen(worldX: number, worldY: number, canvasWidth: number, canvasHeight: number): PointLike`
 - `zoom(factor: number): this`
 - `zoomIn(amount: number): this`

--- a/site/src/content/api/pointer-state-flag.mdx
+++ b/site/src/content/api/pointer-state-flag.mdx
@@ -9,7 +9,7 @@ memberCount: 7
 tier: "stable"
 sections: ["Import", "Members", "Source"]
 sourcePath: "src/input/Pointer.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/input/Pointer.ts#L31"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/input/Pointer.ts#L32"
 ---
 ## Import
 
@@ -32,4 +32,4 @@ frame by the InteractionManager.
 
 ## Source
 
-[src/input/Pointer.ts](https://github.com/Exoridus/ExoJS/blob/main/src/input/Pointer.ts#L31)
+[src/input/Pointer.ts](https://github.com/Exoridus/ExoJS/blob/main/src/input/Pointer.ts#L32)

--- a/site/src/content/api/pointer-state.mdx
+++ b/site/src/content/api/pointer-state.mdx
@@ -9,7 +9,7 @@ memberCount: 7
 tier: "stable"
 sections: ["Import", "Members", "Source"]
 sourcePath: "src/input/Pointer.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/input/Pointer.ts#L42"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/input/Pointer.ts#L43"
 ---
 ## Import
 
@@ -29,4 +29,4 @@ High-level lifecycle state of a Pointer.
 
 ## Source
 
-[src/input/Pointer.ts](https://github.com/Exoridus/ExoJS/blob/main/src/input/Pointer.ts#L42)
+[src/input/Pointer.ts](https://github.com/Exoridus/ExoJS/blob/main/src/input/Pointer.ts#L43)

--- a/site/src/content/api/pointer.mdx
+++ b/site/src/content/api/pointer.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Pointer"
-description: "Unified mouse / touch / pen pointer. Wraps a single browser `PointerEvent.pointerId` and writes its state (position, buttons, pressure, tilt, etc.) into the engine's shared channels buffer so it can be polled by Input bindings or read directly by interaction-aware scene nodes. Coordinates are stored in canvas-local pixel space. The channel writes are normalized to 0..1 (position, size, twist, tilt) for backend-agnostic sampling. Pointers are owned by the InputManager, which assigns them a slot index in 0..15 (see maxPointers) and exposes their per-slot channel offsets via the Pointer class namespace constants."
+description: "Unified mouse / touch / pen pointer. Wraps a single browser `PointerEvent.pointerId` and writes its state (position, buttons, pressure, tilt, etc.) into the engine's shared channels buffer so it can be polled by Input bindings or read directly by interaction-aware scene nodes. Coordinates are stored in logical/design pixel space — i.e. `app.width`/ `app.height` units (`0..app.width` × `0..app.height`), matching node positions, the 2-argument View.screenToWorld, and the active camera. The CSS-pixel event coordinates are mapped through the application's content viewport, so the value is independent of Application.pixelRatio and of however the canvas is displayed (sizingMode `'fit'`/`'shrink'`/`'letterbox'`, or a CSS transform): a click at the right edge always reads `app.width`. In `'letterbox'` mode the letterbox bars map outside `0..app.width`. The channel writes are normalized to 0..1 (position, size, twist, tilt) for backend-agnostic sampling. Pointers are owned by the InputManager, which assigns them a slot index in 0..15 (see maxPointers) and exposes their per-slot channel offsets via the Pointer class namespace constants."
 symbol: "Pointer"
 kind: "class"
 subsystem: "input"
@@ -9,7 +9,7 @@ memberCount: 28
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/input/Pointer.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/input/Pointer.ts#L67"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/input/Pointer.ts#L75"
 ---
 ## Import
 
@@ -21,9 +21,16 @@ pressure, tilt, etc.) into the engine's shared channels buffer so it can
 be polled by Input bindings or read directly by interaction-aware
 scene nodes.
 
-Coordinates are stored in canvas-local pixel space. The channel writes
-are normalized to 0..1 (position, size, twist, tilt) for backend-agnostic
-sampling.
+Coordinates are stored in logical/design pixel space — i.e. `app.width`/
+`app.height` units (`0..app.width` × `0..app.height`), matching node
+positions, the 2-argument View.screenToWorld, and the active camera.
+The CSS-pixel event coordinates are mapped through the application's content
+viewport, so the value is independent of Application.pixelRatio and of
+however the canvas is displayed (sizingMode `'fit'`/`'shrink'`/`'letterbox'`,
+or a CSS transform): a click at the right edge always reads `app.width`. In
+`'letterbox'` mode the letterbox bars map outside `0..app.width`. The channel
+writes are normalized to 0..1 (position, size, twist, tilt) for
+backend-agnostic sampling.
 
 Pointers are owned by the InputManager, which assigns them a slot
 index in 0..15 (see maxPointers) and exposes their per-slot
@@ -31,7 +38,7 @@ channel offsets via the Pointer class namespace constants.
 
 ## Constructors
 
-- `new(event: PointerEvent, canvas: HTMLCanvasElement, channels: Float32Array, slotIndex: number): Pointer`
+- `new(event: PointerEvent, app: Application, canvas: HTMLCanvasElement, channels: Float32Array, slotIndex: number): Pointer`
 
 ## Methods
 
@@ -68,4 +75,4 @@ channel offsets via the Pointer class namespace constants.
 
 ## Source
 
-[src/input/Pointer.ts](https://github.com/Exoridus/ExoJS/blob/main/src/input/Pointer.ts#L67)
+[src/input/Pointer.ts](https://github.com/Exoridus/ExoJS/blob/main/src/input/Pointer.ts#L75)

--- a/site/src/content/api/rendering-primitives.mdx
+++ b/site/src/content/api/rendering-primitives.mdx
@@ -9,7 +9,7 @@ memberCount: 7
 tier: "stable"
 sections: ["Import", "Members", "Source"]
 sourcePath: "src/rendering/types.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L43"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L54"
 ---
 ## Import
 
@@ -30,4 +30,4 @@ Values are WebGL2 GLenum constants (e.g. `gl.TRIANGLES`).
 
 ## Source
 
-[src/rendering/types.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L43)
+[src/rendering/types.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L54)

--- a/site/src/content/api/scale-modes.mdx
+++ b/site/src/content/api/scale-modes.mdx
@@ -9,7 +9,7 @@ memberCount: 6
 tier: "stable"
 sections: ["Import", "Members", "Source"]
 sourcePath: "src/rendering/types.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L20"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L31"
 ---
 ## Import
 
@@ -30,4 +30,4 @@ Mipmap variants require Texture.generateMipMap to be enabled.
 
 ## Source
 
-[src/rendering/types.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L20)
+[src/rendering/types.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L31)

--- a/site/src/content/api/shader-primitives.mdx
+++ b/site/src/content/api/shader-primitives.mdx
@@ -9,7 +9,7 @@ memberCount: 20
 tier: "stable"
 sections: ["Import", "Members", "Source"]
 sourcePath: "src/rendering/types.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L89"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L100"
 ---
 ## Import
 
@@ -43,4 +43,4 @@ Values are WebGL2 GLenum constants returned by `gl.getActiveAttrib` / `gl.getAct
 
 ## Source
 
-[src/rendering/types.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L89)
+[src/rendering/types.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L100)

--- a/site/src/content/api/view.mdx
+++ b/site/src/content/api/view.mdx
@@ -40,6 +40,7 @@ shake animations.
 - `reset(centerX: number, centerY: number, width: number, height: number): this`
 - `resize(width: number, height: number): this`
 - `rotate(degrees: number): this`
+- `screenToWorld(x: number, y: number): PointLike`
 - `screenToWorld(screenX: number, screenY: number, canvasWidth: number, canvasHeight: number): PointLike`
 - `setBounds(bounds: Rectangle | null): this`
 - `setCenter(x: number, y: number): this`
@@ -50,6 +51,7 @@ shake animations.
 - `update(deltaMilliseconds: number): this`
 - `updateBounds(): this`
 - `updateTransform(): this`
+- `worldToScreen(worldX: number, worldY: number): PointLike`
 - `worldToScreen(worldX: number, worldY: number, canvasWidth: number, canvasHeight: number): PointLike`
 - `zoom(factor: number): this`
 - `zoomIn(amount: number): this`

--- a/site/src/content/api/web-gpu-mesh-renderer.mdx
+++ b/site/src/content/api/web-gpu-mesh-renderer.mdx
@@ -9,7 +9,7 @@ memberCount: 12
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/rendering/webgpu/WebGpuMeshRenderer.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/webgpu/WebGpuMeshRenderer.ts#L227"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/webgpu/WebGpuMeshRenderer.ts#L229"
 ---
 ## Import
 
@@ -49,4 +49,4 @@ Subclasses must implement:
 
 ## Source
 
-[src/rendering/webgpu/WebGpuMeshRenderer.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/webgpu/WebGpuMeshRenderer.ts#L227)
+[src/rendering/webgpu/WebGpuMeshRenderer.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/webgpu/WebGpuMeshRenderer.ts#L229)

--- a/site/src/content/api/wrap-modes.mdx
+++ b/site/src/content/api/wrap-modes.mdx
@@ -9,7 +9,7 @@ memberCount: 3
 tier: "stable"
 sections: ["Import", "Members", "Source"]
 sourcePath: "src/rendering/types.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L33"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L44"
 ---
 ## Import
 
@@ -26,4 +26,4 @@ Values are WebGL2 GLenum constants passed directly to the GPU sampler.
 
 ## Source
 
-[src/rendering/types.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L33)
+[src/rendering/types.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/types.ts#L44)

--- a/site/src/content/guide/audio/audio-reactive-visualization.mdx
+++ b/site/src/content/guide/audio/audio-reactive-visualization.mdx
@@ -153,7 +153,7 @@ init(loader) {
 
     this.specSprite = new Sprite(this.specTex);
     this.specSprite.setAnchor(0, 1);
-    this.specSprite.setPosition(0, this.app.canvas.height);
+    this.specSprite.setPosition(0, this.app.height);
 
     this.col = 0;
 }

--- a/site/src/content/guide/debugging/debugging-and-inspection.mdx
+++ b/site/src/content/guide/debugging/debugging-and-inspection.mdx
@@ -111,10 +111,10 @@ class GameScene extends Scene {
         this.inspector.visible = true;
 
         this._screenView = new View(
-            this.app.canvas.width / 2,
-            this.app.canvas.height / 2,
-            this.app.canvas.width,
-            this.app.canvas.height,
+            this.app.width / 2,
+            this.app.height / 2,
+            this.app.width,
+            this.app.height,
         );
 
         this.app.onFrame.add(delta => {

--- a/site/src/content/guide/getting-started/resize-dpr-and-canvas.mdx
+++ b/site/src/content/guide/getting-started/resize-dpr-and-canvas.mdx
@@ -19,7 +19,7 @@ For everything else you want the canvas to track its container. The size you dra
 
 ## Crisp rendering with `pixelRatio`
 
-On a high-DPI display, a canvas sized in CSS pixels is stretched across more physical pixels, so anything drawn at the CSS resolution looks soft. The `pixelRatio` canvas option fixes this: it scales the canvas backing store up by that factor while the CSS display size stays the same. Set it to the display's `devicePixelRatio` for native sharpness:
+On a high-DPI display, a canvas sized in CSS pixels is stretched across more physical pixels, so anything drawn at the CSS resolution looks soft. The `pixelRatio` canvas option scales the canvas backing store up by that factor while the CSS display size stays the same. It defaults to the display's `devicePixelRatio` (clamped to `2`), so output is crisp out of the box; set it explicitly to override:
 
 <SourceSnippet
   source="examples/getting-started/resize-and-dpr.ts"
@@ -27,7 +27,7 @@ On a high-DPI display, a canvas sized in CSS pixels is stretched across more phy
   title="Application with pixelRatio"
 />
 
-With `pixelRatio: 2`, an 800×600 canvas renders into a 1600×1200 backing store but still displays at 800×600 CSS pixels — twice the detail per pixel, so sprites and text stay crisp. At `pixelRatio: 1` (the default) the backing store matches the CSS size.
+With `pixelRatio: 2`, an 800×600 canvas renders into a 1600×1200 backing store but still displays at 800×600 CSS pixels — twice the detail per pixel, so sprites and text stay crisp. Pass `pixelRatio: 1` to force a backing store that matches the CSS size.
 
 ## Fitting the window
 

--- a/site/src/content/guide/input/mouse-and-pointer.mdx
+++ b/site/src/content/guide/input/mouse-and-pointer.mdx
@@ -62,7 +62,7 @@ import { Pointer } from '@codexo/exojs';
 
 // Slot 1 (second finger)
 this.inputs.onActive(Pointer.Slot1X, value => {
-    this.touchX = value * this.app.canvas.width;
+    this.touchX = value * this.app.width;
 });
 ```
 
@@ -117,27 +117,16 @@ These are high-level events built on top of the raw pointer signals. They track 
 
 ## Pointer-to-world coordinates
 
-Pointer positions are in canvas pixel space. To map them into scene world coordinates — for placing objects, selecting units, or aiming — invert the active view's transform:
+Pointer positions are in **design space** (`0..app.width` × `0..app.height`), independent of device pixel ratio or how the canvas is displayed. To map them into scene world coordinates — for placing objects, selecting units, or aiming — pass them through the active view's `screenToWorld`, which undoes the camera's pan / zoom / rotation:
 
 ```js
-import { Vector } from '@codexo/exojs';
-
-_toWorld(screenX, screenY) {
-    const { width, height } = this.app.canvas;
-    const clipX = (screenX / width) * 2 - 1;
-    const clipY = 1 - (screenY / height) * 2;
-
-    const matrix = this._view.getInverseTransform();
-    return new Vector(
-        matrix.a * clipX + matrix.b * clipY + matrix.x,
-        matrix.c * clipX + matrix.d * clipY + matrix.y,
-    );
-}
+const world = this._view.screenToWorld(pointer.x, pointer.y);
+// world.x, world.y are now in scene world space
 ```
 
-`getInverseTransform()` returns an ExoJS `Matrix`, and that matrix exposes the fields used above: `.a`, `.b`, `.c`, `.d`, `.x`, `.y`.
+The inverse is `worldToScreen(worldX, worldY)`, and the two round-trip. If the default centered camera is active (no pan/zoom), design space already equals world space, so `screenToWorld` is the identity and no mapping is needed.
 
-If the default view is active (no camera transform), the canvas-pixel position is already the world position and no mapping is needed.
+For raw canvas backing-store pixels — e.g. an off-screen render target at a different pixel ratio — the four-argument form `screenToWorld(x, y, canvasWidth, canvasHeight)` additionally accounts for the viewport rectangle and physical pixel size.
 
 ## Interactive sprites
 
@@ -161,7 +150,7 @@ Setting `interactive = true` makes the sprite participate in hit testing. Settin
 The `Pointer` instance passed to every signal callback carries the properties you typically need:
 
 ```js
-pointer.x, pointer.y   // canvas-local pixel position
+pointer.x, pointer.y   // design-space pixel position (0..app.width, 0..app.height)
 pointer.position       // Vector with current x and y
 pointer.buttons        // bitmask: 1=left, 2=right, 4=middle
 pointer.isPrimary      // true for mouse or first finger to touch

--- a/site/src/content/guide/rendering/graphics.mdx
+++ b/site/src/content/guide/rendering/graphics.mdx
@@ -132,7 +132,7 @@ init(loader) {
     this.group.drawCircle(40, 0, 20);
     this.group.drawRectangle(-10, -15, 20, 30);
 
-    this.group.setPosition(this.app.canvas.width / 2, this.app.canvas.height / 2);
+    this.group.setPosition(this.app.width / 2, this.app.height / 2);
     this.addChild(this.group);
 }
 

--- a/site/src/content/guide/runtime/application.mdx
+++ b/site/src/content/guide/runtime/application.mdx
@@ -69,24 +69,24 @@ Either way, `app.canvas` is the active `HTMLCanvasElement`. CSS rules, ResizeObs
 
 ## High-DPI and pixel ratio
 
-Pass `canvas.pixelRatio` to scale the backing buffer relative to logical CSS pixels. A value of `window.devicePixelRatio` produces crisp rendering on high-DPI screens:
+`canvas.pixelRatio` scales the backing buffer relative to logical CSS pixels. By default it is the host's `window.devicePixelRatio` **clamped to `2`**, so rendering is crisp on Retina/HiDPI screens out of the box. Pass an explicit value to override:
 
 ```js
 const app = new Application({
     canvas: {
         width: 1280,
         height: 720,
-        pixelRatio: window.devicePixelRatio,
+        pixelRatio: window.devicePixelRatio, // full native density (uncapped)
     },
 });
 ```
 
-- `width` / `height` are the **logical canvas dimensions** in CSS pixels.
-- The backing buffer is `width × pixelRatio` by `height × pixelRatio`.
+- `width` / `height` are the **logical canvas dimensions** in CSS pixels — also exposed as `app.width` / `app.height`.
+- The backing buffer is `width × pixelRatio` by `height × pixelRatio`; `app.pixelRatio` holds the resolved ratio.
 - `canvas.style.width / height` is always set to the logical dimensions.
 - `app.resize(w, h)` takes logical dimensions and re-applies the stored pixel ratio.
 
-Default `pixelRatio` is `1` — no scaling — which preserves the old behaviour.
+Pass `pixelRatio: 1` to force logical-pixel rendering, or `window.devicePixelRatio` to opt into full native density above the default `2×` cap (the cap keeps DPR-3 phones from paying a 9× fill-rate cost).
 
 For pixel-art games where you want crisp upscaling without browser blurring, combine `pixelRatio` with the `imageRendering` hint:
 

--- a/site/src/content/guide/shipping/troubleshooting.mdx
+++ b/site/src/content/guide/shipping/troubleshooting.mdx
@@ -161,7 +161,7 @@ If you're using the `audio-reactive` template from `create-exo-app`, it already 
 
 Using an old property name silently produces no error but the style is ignored. Check the [Text guide](/ExoJS/en/guide/rendering/text/) for the current `TextStyle` keys.
 
-**DPI / DevicePixelRatio scaling.** At high DPI (e.g., Retina displays), text and sprites look soft if the canvas backing store matches the CSS size. Set the `pixelRatio` canvas option to the display's `window.devicePixelRatio` so the canvas renders at native resolution. It defaults to `1`, so crisp HiDPI output is opt-in — see [Resize, DPR & the canvas](/ExoJS/en/guide/getting-started/resize-dpr-and-canvas/) for the full pattern.
+**DPI / DevicePixelRatio scaling.** At high DPI (e.g., Retina displays), text and sprites look soft if the canvas backing store matches the CSS size. By default `pixelRatio` is the display's `devicePixelRatio` clamped to `2`, so output is crisp out of the box — if it looks soft, check you haven't set `pixelRatio: 1`. On a DPR-3 device that needs full native density, set `pixelRatio: window.devicePixelRatio` explicitly to bypass the cap. See [Resize, DPR & the canvas](/ExoJS/en/guide/getting-started/resize-dpr-and-canvas/) for the full pattern.
 
 ## Performance problems
 

--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -8,6 +8,7 @@ import type { GamepadDefinition } from '#input/GamepadDefinitions';
 import type { GamepadSlotStrategy } from '#input/InputManager';
 import { InputManager } from '#input/InputManager';
 import { InteractionManager } from '#input/InteractionManager';
+import type { PointLike } from '#math/PointLike';
 import { buildCoreRendererBindings } from '#rendering/coreRendererBindings';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import { RenderingContext, type RenderToOptions } from '#rendering/RenderingContext';
@@ -22,6 +23,7 @@ import { Loader, type LoaderOptions } from '#resources/Loader';
 import { Capabilities } from './capabilities';
 import { Clock } from './Clock';
 import { Color } from './Color';
+import { computeLetterboxLayout } from './letterbox';
 import type { Scene } from './Scene';
 import { SceneManager } from './SceneManager';
 import { Signal } from './Signal';
@@ -36,7 +38,7 @@ export enum ApplicationStatus {
 }
 
 /** How {@link Application} sizes its canvas within the parent element. */
-export type CanvasSizingMode = 'fixed' | 'fill' | 'fit' | 'shrink';
+export type CanvasSizingMode = 'fixed' | 'fill' | 'fit' | 'shrink' | 'letterbox';
 
 export interface CanvasApplicationOptions {
   /** Existing canvas element to use. If omitted, Application creates one. */
@@ -45,7 +47,13 @@ export interface CanvasApplicationOptions {
   width?: number;
   /** Logical canvas height. Default: 600. */
   height?: number;
-  /** Device/render pixel ratio applied to the backing buffer. Default: 1. */
+  /**
+   * Device/render pixel ratio applied to the backing buffer. Default: the
+   * host `devicePixelRatio` clamped to `2` (crisp on Retina/HiDPI out of the
+   * box, capped so DPR-3 phones don't pay a 9× fill-rate cost). Pass an
+   * explicit value to override — e.g. `window.devicePixelRatio` for full
+   * native density, or `1` to force logical-pixel rendering.
+   */
   pixelRatio?: number;
   /** Canvas tabIndex. Default: -1, preserving current behavior. */
   tabIndex?: number;
@@ -66,6 +74,11 @@ export interface CanvasApplicationOptions {
    *   preserving aspect ratio (letterboxed).
    * - `'shrink'`: like `'fit'` but never upscale beyond `width`×`height` —
    *   shrinks on smaller screens, stays native on larger ones.
+   * - `'letterbox'`: track the parent's size, render the backing store at the
+   *   parent size × `pixelRatio` (always crisp, no CSS upscale-blur), and keep
+   *   the camera locked to the fixed `width`×`height` design space, centered
+   *   and letterboxed with bars (no crop, no stretch). The "author once at a
+   *   reference resolution" model.
    */
   sizingMode?: CanvasSizingMode;
 }
@@ -120,6 +133,28 @@ export type BackendConfig = AutoBackendConfig | WebGl2BackendConfig | WebGpuBack
 const maxDeltaMs = 100;
 
 const createDefaultCanvas = (): HTMLCanvasElement => document.createElement('canvas');
+
+/**
+ * Upper bound for the auto-resolved device-pixel ratio. Caps the backing-store
+ * blow-up on very high-density screens (e.g. DPR-3 phones would otherwise
+ * allocate 9× the logical pixels → fill-rate / memory pressure and frame drops)
+ * while keeping rendering crisp where it matters. Bypassed by an explicit
+ * `canvas.pixelRatio` option.
+ */
+const maxAutoPixelRatio = 2;
+
+/**
+ * Resolve the auto device-pixel ratio used when `pixelRatio` is not specified.
+ * Returns the host's `devicePixelRatio` clamped to {@link maxAutoPixelRatio}
+ * (crisp on Retina/HiDPI out of the box, without a runaway fill-rate cost on
+ * DPR-3 devices); falls back to `1` in non-browser / SSR / test environments.
+ */
+const resolveAutoPixelRatio = (): number => {
+  const dpr = (globalThis as { devicePixelRatio?: number }).devicePixelRatio;
+
+  return typeof dpr === 'number' && dpr > 0 ? Math.min(dpr, maxAutoPixelRatio) : 1;
+};
+
 const defaultBackendConfig: AutoBackendConfig = { type: 'auto' };
 const defaultCanvasSettings = {
   width: 800,
@@ -196,6 +231,8 @@ export class Application {
 
   private _status: ApplicationStatus = ApplicationStatus.Stopped;
   private _pixelRatio: number = defaultCanvasSettings.pixelRatio;
+  private _designWidth: number = defaultCanvasSettings.width;
+  private _designHeight: number = defaultCanvasSettings.height;
   private _frameCount = 0;
   private _frameRequest = 0;
   private _backendType: 'webgl2' | 'webgpu';
@@ -217,7 +254,9 @@ export class Application {
 
     const logicalWidth = canvasOptions.width ?? defaultCanvasSettings.width;
     const logicalHeight = canvasOptions.height ?? defaultCanvasSettings.height;
-    this._pixelRatio = canvasOptions.pixelRatio ?? defaultCanvasSettings.pixelRatio;
+    this._pixelRatio = canvasOptions.pixelRatio ?? resolveAutoPixelRatio();
+    this._designWidth = logicalWidth;
+    this._designHeight = logicalHeight;
     this.canvas = canvas;
     this._applyCanvasSize(logicalWidth, logicalHeight);
 
@@ -379,6 +418,62 @@ export class Application {
   }
 
   /**
+   * Logical (design-space) canvas width — the value passed as `canvas.width`
+   * at construction / {@link resize}, independent of {@link pixelRatio}. Use
+   * this for layout math (e.g. `app.width / 2` to center) instead of
+   * `app.canvas.width`, which is the physical backing-store size
+   * (`app.width × app.pixelRatio`) and therefore larger on HiDPI displays.
+   */
+  public get width(): number {
+    return this._designWidth;
+  }
+
+  /** Logical (design-space) canvas height. See {@link Application.width}. */
+  public get height(): number {
+    return this._designHeight;
+  }
+
+  /**
+   * Device/render pixel ratio applied to the backing buffer. Defaults to the
+   * host `devicePixelRatio` clamped to `2` (crisp on HiDPI out of the box, but
+   * capped to avoid a runaway fill-rate cost on DPR-3 phones) unless an
+   * explicit `canvas.pixelRatio` option was given. Holds the invariant
+   * `app.canvas.width === Math.round(app.width × app.pixelRatio)`.
+   */
+  public get pixelRatio(): number {
+    return this._pixelRatio;
+  }
+
+  /**
+   * Convert a logical/design-space pixel coordinate — the space of
+   * {@link Pointer.x}/{@link Pointer.y} and node positions, e.g. `0..app.width`
+   * — to a world position using the active camera. At the default centered
+   * camera this is the identity; with a panned/zoomed/rotated camera it undoes
+   * the transform. Equivalent to `app.rendering.camera.screenToWorld(x, y)`.
+   */
+  public screenToWorld(x: number, y: number): PointLike {
+    return this._rendering.camera.screenToWorld(x, y);
+  }
+
+  /**
+   * Map a canvas backing-store pixel coordinate into design space. Because the
+   * canvas always renders the full design space across its backing store (in
+   * `'letterbox'` mode the canvas itself is the content area, bars excluded),
+   * this is a straight backing-store → design scale. Pointer positions are
+   * expressed in logical/design pixels via this mapping.
+   * @internal
+   */
+  public _backingStoreToDesign(backingStoreX: number, backingStoreY: number): PointLike {
+    const backingWidth = this.canvas.width || 1;
+    const backingHeight = this.canvas.height || 1;
+
+    return {
+      x: (backingStoreX / backingWidth) * this._designWidth,
+      y: (backingStoreY / backingHeight) * this._designHeight,
+    };
+  }
+
+  /**
    * Initialize the render backend, await capability detection, set the
    * initial scene, and start the per-frame loop. Idempotent — if the
    * application is already running the call is a no-op. On error the
@@ -495,6 +590,8 @@ export class Application {
    * notified.
    */
   public resize(width: number, height: number): this {
+    this._designWidth = width;
+    this._designHeight = height;
     this._applyCanvasSize(width, height);
     this.options.canvas = {
       ...(this.options.canvas ?? {}),
@@ -524,8 +621,10 @@ export class Application {
   /**
    * Apply the chosen {@link CanvasSizingMode}. `'fill'` observes the parent and
    * re-renders to its size; `'fit'`/`'shrink'` set CSS so the fixed-resolution
-   * canvas scales to fit the parent (letterboxed). `'fixed'` is a no-op — the
-   * exact pixel size was already applied.
+   * canvas scales to fit the parent (letterboxed via CSS object-fit);
+   * `'letterbox'` observes the parent and sizes a native-resolution,
+   * design-aspect canvas centered within it, the parent background showing as
+   * bars. `'fixed'` is a no-op — the exact pixel size was already applied.
    */
   private _applySizingMode(mode: CanvasSizingMode): void {
     const style = this.canvas.style;
@@ -549,6 +648,34 @@ export class Application {
         this._resizeObserver.observe(target);
         break;
       }
+      case 'letterbox': {
+        const target = this.canvas.parentElement;
+
+        if (typeof ResizeObserver === 'undefined' || !target) {
+          break;
+        }
+
+        // Center the canvas in the parent and let the parent background show as
+        // letterbox bars around it.
+        const parentStyle = target.style;
+
+        parentStyle.display = 'flex';
+        parentStyle.alignItems = 'center';
+        parentStyle.justifyContent = 'center';
+        parentStyle.overflow = 'hidden';
+        parentStyle.background = '#000';
+
+        this._resizeObserver = new ResizeObserver(() => {
+          const width = target.clientWidth;
+          const height = target.clientHeight;
+
+          if (width > 0 && height > 0) {
+            this._applyLetterboxLayout(width, height);
+          }
+        });
+        this._resizeObserver.observe(target);
+        break;
+      }
       case 'fit':
         style.width = '100%';
         style.height = '100%';
@@ -563,6 +690,25 @@ export class Application {
       default:
         break;
     }
+  }
+
+  /**
+   * Recompute the `'letterbox'` layout for a parent of the given CSS size.
+   * Fits the fixed `width`×`height` design space into the parent preserving
+   * aspect ratio, sizes the canvas to that content rectangle (backing store at
+   * `content × pixelRatio` — always native-crisp, never upscale-blurred), and
+   * lets the parent's background show through as letterbox bars around the
+   * centered canvas. The render target and camera stay at the design size, so
+   * the design space exactly fills the backing store (no crop, no stretch) and
+   * the camera's gameplay center / zoom survive a window resize untouched.
+   */
+  private _applyLetterboxLayout(parentWidthCss: number, parentHeightCss: number): void {
+    const layout = computeLetterboxLayout(parentWidthCss, parentHeightCss, this._designWidth, this._designHeight, this._pixelRatio);
+
+    this.canvas.width = layout.backingWidth;
+    this.canvas.height = layout.backingHeight;
+    this.canvas.style.width = `${layout.contentWidthCss}px`;
+    this.canvas.style.height = `${layout.contentHeightCss}px`;
   }
 
   /**

--- a/src/core/letterbox.ts
+++ b/src/core/letterbox.ts
@@ -1,0 +1,43 @@
+/**
+ * Geometry for the `'letterbox'` canvas sizing mode. Pure math, split out from
+ * {@link Application} so it can be unit-tested without a render backend.
+ * @internal
+ */
+
+/** Result of fitting a fixed design space into a parent for letterbox sizing. @internal */
+export interface LetterboxLayout {
+  /** CSS width of the centered canvas — the design-aspect content area. */
+  contentWidthCss: number;
+  /** CSS height of the centered canvas. */
+  contentHeightCss: number;
+  /** Backing-store width (`content × pixelRatio`) — the crisp native resolution. */
+  backingWidth: number;
+  /** Backing-store height. */
+  backingHeight: number;
+}
+
+/**
+ * Fit a `designWidth × designHeight` space into a parent of the given CSS size,
+ * preserving aspect ratio (letterbox — never crop, never stretch). Returns the
+ * centered content rectangle's CSS size and its native backing-store size at
+ * `pixelRatio`. The larger axis of the parent becomes the bars.
+ * @internal
+ */
+export const computeLetterboxLayout = (
+  parentWidthCss: number,
+  parentHeightCss: number,
+  designWidth: number,
+  designHeight: number,
+  pixelRatio: number,
+): LetterboxLayout => {
+  const scale = Math.min(parentWidthCss / designWidth, parentHeightCss / designHeight);
+  const contentWidthCss = designWidth * scale;
+  const contentHeightCss = designHeight * scale;
+
+  return {
+    contentWidthCss,
+    contentHeightCss,
+    backingWidth: Math.max(1, Math.round(contentWidthCss * pixelRatio)),
+    backingHeight: Math.max(1, Math.round(contentHeightCss * pixelRatio)),
+  };
+};

--- a/src/input/InputManager.ts
+++ b/src/input/InputManager.ts
@@ -57,6 +57,7 @@ enum InputManagerFlag {
  * automatically — you do not instantiate this class yourself.
  */
 export class InputManager {
+  private readonly _app: Application;
   private readonly canvas: HTMLCanvasElement;
   private readonly channels: Float32Array = new Float32Array(ChannelSize.Container);
   private readonly pointers: Record<number, Pointer> = {};
@@ -156,6 +157,7 @@ export class InputManager {
     const pointerDistanceThreshold = inputOptions.pointerDistanceThreshold ?? 10;
     const gamepadSlotStrategy = inputOptions.gamepadSlotStrategy ?? 'sticky';
 
+    this._app = app;
     this.canvas = app.canvas;
     this.canvasFocusedValue = document.activeElement === this.canvas;
     this.pointerDistanceThreshold = pointerDistanceThreshold;
@@ -485,7 +487,7 @@ export class InputManager {
       return;
     }
 
-    this.pointers[event.pointerId] = new Pointer(event, this.canvas, this.channels, slot);
+    this.pointers[event.pointerId] = new Pointer(event, this._app, this.canvas, this.channels, slot);
     this.flags.push(InputManagerFlag.PointerUpdate);
   }
 

--- a/src/input/InteractionManager.ts
+++ b/src/input/InteractionManager.ts
@@ -332,7 +332,16 @@ export class InteractionManager {
 
   private _processQueue(queue: PointerQueue): void {
     const { pointer, events } = queue;
-    const { id, x, y } = pointer;
+    const { id } = pointer;
+
+    // Pointer coordinates are in design space; convert to world space via the
+    // active camera so hit-testing, dragging and event coordinates all agree
+    // with node positions (correct under pixelRatio > 1, letterboxing, and a
+    // panned / zoomed / rotated camera). At the default centered camera this is
+    // the identity, so legacy screen-space behaviour is preserved.
+    const world = this._app.rendering.camera.screenToWorld(pointer.x, pointer.y);
+    const x = world.x;
+    const y = world.y;
 
     // Determine the hit node. Captured pointers short-circuit hit-testing.
     const captured = this._capturedPointers.get(id) ?? null;
@@ -611,11 +620,10 @@ export class InteractionManager {
 
   /** Build a fresh Quadtree sized to encompass the canvas + current scene root. */
   private _createQuadtree(): Quadtree<IndexedNode> {
-    const canvas = this._app.canvas;
-    // Seed in canvas-local (backing-store) pixels to match pointer coordinates
-    // and node bounds; the CSS display rect differs when the canvas is scaled.
-    const width = canvas.width || 800;
-    const height = canvas.height || 600;
+    // Seed in design/world units (matching node bounds and the camera-converted
+    // pointer coordinates); unioned below with the scene root's world bounds.
+    const width = this._app.width || 800;
+    const height = this._app.height || 600;
     const bounds = new Rectangle(0, 0, width, height);
     const root = this._app.scene.currentScene?.root;
 

--- a/src/input/Pointer.ts
+++ b/src/input/Pointer.ts
@@ -1,3 +1,4 @@
+import type { Application } from '#core/Application';
 import { Flags } from '#math/Flags';
 import { Size } from '#math/Size';
 import { Vector } from '#math/Vector';
@@ -56,13 +57,16 @@ export enum PointerState {
  * be polled by {@link Input} bindings or read directly by interaction-aware
  * scene nodes.
  *
- * Coordinates are stored in canvas-local (backing-store) pixel space — i.e.
- * `app.canvas.width`/`height` units, matching {@link View.screenToWorld} and
- * node positions. The CSS-pixel event coordinates are scaled by
- * `canvas.width / boundingRect.width`, so picking stays correct when the canvas
- * is displayed at a different size (sizingMode `'fit'`/`'shrink'`, or a CSS
- * transform). The channel writes are normalized to 0..1 (position, size, twist,
- * tilt) for backend-agnostic sampling.
+ * Coordinates are stored in logical/design pixel space — i.e. `app.width`/
+ * `app.height` units (`0..app.width` × `0..app.height`), matching node
+ * positions, the 2-argument {@link View.screenToWorld}, and the active camera.
+ * The CSS-pixel event coordinates are mapped through the application's content
+ * viewport, so the value is independent of {@link Application.pixelRatio} and of
+ * however the canvas is displayed (sizingMode `'fit'`/`'shrink'`/`'letterbox'`,
+ * or a CSS transform): a click at the right edge always reads `app.width`. In
+ * `'letterbox'` mode the letterbox bars map outside `0..app.width`. The channel
+ * writes are normalized to 0..1 (position, size, twist, tilt) for
+ * backend-agnostic sampling.
  *
  * Pointers are owned by the {@link InputManager}, which assigns them a slot
  * index in 0..15 (see {@link maxPointers}) and exposes their per-slot
@@ -77,6 +81,7 @@ export class Pointer {
   public readonly tilt: Vector;
   public readonly stateFlags: Flags<PointerStateFlag> = new Flags<PointerStateFlag>();
 
+  private _app: Application | null;
   private _canvas: HTMLCanvasElement | null;
   private _channels: Float32Array | null;
   private _slotIndex: number;
@@ -87,21 +92,21 @@ export class Pointer {
   private _isPrimary: boolean;
   private _currentState: PointerState = PointerState.Unknown;
 
-  public constructor(event: PointerEvent, canvas: HTMLCanvasElement, channels: Float32Array, slotIndex: number) {
+  public constructor(event: PointerEvent, app: Application, canvas: HTMLCanvasElement, channels: Float32Array, slotIndex: number) {
     const { pointerId, pointerType, clientX, clientY, width, height, tiltX, tiltY, buttons, pressure, twist, isPrimary } = event;
-    const rect = canvas.getBoundingClientRect();
-    const scaleX = rect.width > 0 ? canvas.width / rect.width : 1;
-    const scaleY = rect.height > 0 ? canvas.height / rect.height : 1;
 
+    this._app = app;
     this._canvas = canvas;
     this._channels = channels;
     this._slotIndex = slotIndex;
     this._channelBase = ChannelOffset.Pointers + slotIndex * pointerSlotSize;
 
+    const geometry = this._computeDesignGeometry(clientX, clientY, width, height);
+
     this.id = pointerId;
     this.type = pointerType;
-    this.position = new Vector((clientX - rect.left) * scaleX, (clientY - rect.top) * scaleY);
-    this.size = new Size(width * scaleX, height * scaleY);
+    this.position = new Vector(geometry.x, geometry.y);
+    this.size = new Size(geometry.width, geometry.height);
     this.tilt = new Vector(tiltX, tiltY);
     this._buttons = buttons;
     this._pressure = pressure;
@@ -212,19 +217,17 @@ export class Pointer {
     this.startPos.destroy();
     this.size.destroy();
     this.tilt.destroy();
+    this._app = null;
     this._canvas = null;
     this._channels = null;
   }
 
   private handleEvent(event: PointerEvent): this {
     const { clientX, clientY, width, height, tiltX, tiltY, buttons, pressure, twist, isPrimary } = event;
-    const canvas = this._canvas!;
-    const rect = canvas.getBoundingClientRect();
-    const scaleX = rect.width > 0 ? canvas.width / rect.width : 1;
-    const scaleY = rect.height > 0 ? canvas.height / rect.height : 1;
+    const geometry = this._computeDesignGeometry(clientX, clientY, width, height);
 
-    this.position.set((clientX - rect.left) * scaleX, (clientY - rect.top) * scaleY);
-    this.size.set(width * scaleX, height * scaleY);
+    this.position.set(geometry.x, geometry.y);
+    this.size.set(geometry.width, geometry.height);
     this.tilt.set(tiltX, tiltY);
     this._buttons = buttons;
     this._pressure = pressure;
@@ -232,6 +235,39 @@ export class Pointer {
     this._isPrimary = isPrimary;
 
     return this;
+  }
+
+  /**
+   * Map a CSS-pixel pointer event into design space. The event point is first
+   * expressed as a fraction of the canvas display rect, scaled to backing-store
+   * pixels, then routed through {@link Application._backingStoreToDesign} (which
+   * folds in `pixelRatio` and any letterbox content viewport). The contact
+   * size is mapped as a delta through the same transform.
+   */
+  private _computeDesignGeometry(clientX: number, clientY: number, width: number, height: number): { x: number; y: number; width: number; height: number } {
+    const app = this._app;
+    const canvas = this._canvas;
+
+    if (!app || !canvas) {
+      return { x: 0, y: 0, width: 0, height: 0 };
+    }
+
+    const rect = canvas.getBoundingClientRect();
+    const u = rect.width > 0 ? (clientX - rect.left) / rect.width : 0;
+    const v = rect.height > 0 ? (clientY - rect.top) / rect.height : 0;
+    const backingStoreX = u * canvas.width;
+    const backingStoreY = v * canvas.height;
+    const backingStoreW = rect.width > 0 ? (width / rect.width) * canvas.width : 0;
+    const backingStoreH = rect.height > 0 ? (height / rect.height) * canvas.height : 0;
+    const origin = app._backingStoreToDesign(backingStoreX, backingStoreY);
+    const corner = app._backingStoreToDesign(backingStoreX + backingStoreW, backingStoreY + backingStoreH);
+
+    return {
+      x: origin.x,
+      y: origin.y,
+      width: Math.abs(corner.x - origin.x),
+      height: Math.abs(corner.y - origin.y),
+    };
   }
 
   /** Write the full 16-channel per-pointer state into the shared channel buffer. */
@@ -244,11 +280,11 @@ export class Pointer {
     }
 
     const base = this._channelBase;
-    // position/size are already in canvas-local (backing-store) pixels, so
-    // normalize by the backing-store size — not the CSS display rect, which
-    // differs when the canvas is scaled to fit.
-    const w = canvas.width || 1;
-    const h = canvas.height || 1;
+    // position/size are in design pixels (0..app.width × 0..app.height), so
+    // normalize by the design size for a scale-invariant 0..1 channel value.
+    const app = this._app;
+    const w = (app ? app.width : canvas.width) || 1;
+    const h = (app ? app.height : canvas.height) || 1;
 
     if (!active) {
       // Zero the entire slot for a clean release.

--- a/src/rendering/View.ts
+++ b/src/rendering/View.ts
@@ -396,41 +396,102 @@ export class View {
   }
 
   /**
-   * Convert a canvas pixel coordinate to a world-space position for this view.
-   * Accounts for the view's viewport rectangle, so it works correctly in
-   * multi-view / split-screen setups.
+   * Convert a logical/design-space pixel coordinate to a world-space position.
    *
-   * @param screenX     - X pixel relative to the canvas top-left corner.
-   * @param screenY     - Y pixel relative to the canvas top-left corner.
-   * @param canvasWidth - Canvas width in pixels (e.g. `app.canvas.width`).
-   * @param canvasHeight - Canvas height in pixels (e.g. `app.canvas.height`).
+   * The 2-argument form treats `(x, y)` as coordinates in the view's own
+   * design space (`0..view.width` × `0..view.height`) — the same space as
+   * {@link Pointer.x}/{@link Pointer.y} and node positions — and applies only
+   * the inverse camera transform. The viewport rectangle is intentionally
+   * ignored, because design-space input already lives inside the camera's
+   * projection (any letterbox offset was removed upstream when the pointer was
+   * mapped). At the default centered camera this is the identity.
+   *
+   * @param x - X coordinate in design/logical pixels (`0..view.width`).
+   * @param y - Y coordinate in design/logical pixels (`0..view.height`).
    */
-  public screenToWorld(screenX: number, screenY: number, canvasWidth: number, canvasHeight: number): PointLike {
-    const vw = this._viewport.width * canvasWidth;
-    const vh = this._viewport.height * canvasHeight;
-    const clipX = ((screenX - this._viewport.x * canvasWidth) / vw) * 2 - 1;
-    const clipY = 1 - ((screenY - this._viewport.y * canvasHeight) / vh) * 2;
-    const inv = this.getInverseTransform();
+  public screenToWorld(x: number, y: number): PointLike;
+  /**
+   * Convert a raw canvas backing-store pixel coordinate to a world-space
+   * position. Accounts for the view's viewport rectangle, so it works
+   * correctly in multi-view / split-screen and letterboxed setups.
+   *
+   * @param screenX      - X pixel relative to the canvas top-left corner.
+   * @param screenY      - Y pixel relative to the canvas top-left corner.
+   * @param canvasWidth  - Canvas backing-store width in pixels (`app.canvas.width`).
+   * @param canvasHeight - Canvas backing-store height in pixels (`app.canvas.height`).
+   */
+  public screenToWorld(screenX: number, screenY: number, canvasWidth: number, canvasHeight: number): PointLike;
+  public screenToWorld(screenX: number, screenY: number, canvasWidth?: number, canvasHeight?: number): PointLike {
+    let clipX: number;
+    let clipY: number;
+
+    if (canvasWidth === undefined || canvasHeight === undefined) {
+      const w = this.width || 1;
+      const h = this.height || 1;
+
+      clipX = (screenX / w) * 2 - 1;
+      clipY = 1 - (screenY / h) * 2;
+    } else {
+      const vw = this._viewport.width * canvasWidth;
+      const vh = this._viewport.height * canvasHeight;
+
+      clipX = ((screenX - this._viewport.x * canvasWidth) / vw) * 2 - 1;
+      clipY = 1 - ((screenY - this._viewport.y * canvasHeight) / vh) * 2;
+    }
+
+    // Solve the forward transform `clip = M · world` directly for `world`,
+    // including the translation, so this is an exact inverse of worldToScreen
+    // (returns absolute world coordinates, identity at the default centered
+    // camera). The shared Matrix.getInverse drops the translation for this
+    // projection matrix, so it is deliberately not used here.
+    const m = this.getTransform();
+    const det = m.a * m.d - m.b * m.c;
+
+    if (det === 0) {
+      return { x: 0, y: 0 };
+    }
+
+    const dx = clipX - m.x;
+    const dy = clipY - m.y;
 
     return {
-      x: inv.a * clipX + inv.b * clipY + inv.x,
-      y: inv.c * clipX + inv.d * clipY + inv.y,
+      x: (dx * m.d - dy * m.b) / det,
+      y: (dy * m.a - dx * m.c) / det,
     };
   }
 
   /**
-   * Convert a world-space position to canvas pixel coordinates for this view.
-   * Accounts for the view's viewport rectangle.
+   * Convert a world-space position to logical/design-space pixel coordinates
+   * (`0..view.width` × `0..view.height`). Inverse of the 2-argument
+   * {@link screenToWorld}; the viewport is ignored. At the default centered
+   * camera this is the identity.
    *
-   * @param worldX      - World X coordinate.
-   * @param worldY      - World Y coordinate.
-   * @param canvasWidth - Canvas width in pixels (e.g. `app.canvas.width`).
-   * @param canvasHeight - Canvas height in pixels (e.g. `app.canvas.height`).
+   * @param worldX - World X coordinate.
+   * @param worldY - World Y coordinate.
    */
-  public worldToScreen(worldX: number, worldY: number, canvasWidth: number, canvasHeight: number): PointLike {
+  public worldToScreen(worldX: number, worldY: number): PointLike;
+  /**
+   * Convert a world-space position to raw canvas backing-store pixel
+   * coordinates. Accounts for the view's viewport rectangle.
+   *
+   * @param worldX       - World X coordinate.
+   * @param worldY       - World Y coordinate.
+   * @param canvasWidth  - Canvas backing-store width in pixels (`app.canvas.width`).
+   * @param canvasHeight - Canvas backing-store height in pixels (`app.canvas.height`).
+   */
+  public worldToScreen(worldX: number, worldY: number, canvasWidth: number, canvasHeight: number): PointLike;
+  public worldToScreen(worldX: number, worldY: number, canvasWidth?: number, canvasHeight?: number): PointLike {
     const m = this.getTransform();
     const clipX = m.a * worldX + m.b * worldY + m.x;
     const clipY = m.c * worldX + m.d * worldY + m.y;
+
+    if (canvasWidth === undefined || canvasHeight === undefined) {
+      return {
+        x: ((clipX + 1) / 2) * this.width,
+        y: ((1 - clipY) / 2) * this.height,
+      };
+    }
+
     const vx = this._viewport.x * canvasWidth;
     const vy = this._viewport.y * canvasHeight;
 

--- a/test/core/letterbox.test.ts
+++ b/test/core/letterbox.test.ts
@@ -1,0 +1,66 @@
+import { computeLetterboxLayout } from '#core/letterbox';
+
+describe('computeLetterboxLayout', () => {
+  test('matching aspect fills the parent with no bars', () => {
+    const layout = computeLetterboxLayout(1920, 1080, 1280, 720, 1);
+
+    expect(layout.contentWidthCss).toBeCloseTo(1920, 5);
+    expect(layout.contentHeightCss).toBeCloseTo(1080, 5);
+    expect(layout.backingWidth).toBe(1920);
+    expect(layout.backingHeight).toBe(1080);
+  });
+
+  test('square parent letterboxes a 16:9 design (vertical bars)', () => {
+    const layout = computeLetterboxLayout(800, 800, 1280, 720, 1);
+
+    // width-constrained: 800 wide, 800 × (720/1280) = 450 tall, centered → bars top/bottom.
+    expect(layout.contentWidthCss).toBeCloseTo(800, 5);
+    expect(layout.contentHeightCss).toBeCloseTo(450, 5);
+    expect(layout.backingWidth).toBe(800);
+    expect(layout.backingHeight).toBe(450);
+  });
+
+  test('tall parent pillarboxes a 16:9 design (horizontal bars)', () => {
+    const layout = computeLetterboxLayout(720, 1280, 1280, 720, 1);
+
+    // height-constrained: scale = min(720/1280, 1280/720) = 0.5625 → 720 × 405.
+    expect(layout.contentWidthCss).toBeCloseTo(720, 5);
+    expect(layout.contentHeightCss).toBeCloseTo(405, 5);
+  });
+
+  test('aspect ratio is always preserved (never stretched)', () => {
+    for (const [pw, ph] of [
+      [1000, 500],
+      [333, 999],
+      [1600, 900],
+      [2560, 1440],
+    ]) {
+      const layout = computeLetterboxLayout(pw, ph, 1280, 720, 1);
+
+      expect(layout.contentWidthCss / layout.contentHeightCss).toBeCloseTo(1280 / 720, 5);
+    }
+  });
+
+  test('content never exceeds the parent on either axis', () => {
+    const layout = computeLetterboxLayout(1000, 500, 1280, 720, 1);
+
+    expect(layout.contentWidthCss).toBeLessThanOrEqual(1000 + 1e-6);
+    expect(layout.contentHeightCss).toBeLessThanOrEqual(500 + 1e-6);
+  });
+
+  test('pixelRatio scales only the backing store, not the CSS content size', () => {
+    const layout = computeLetterboxLayout(1920, 1080, 1280, 720, 2);
+
+    expect(layout.contentWidthCss).toBeCloseTo(1920, 5);
+    expect(layout.contentHeightCss).toBeCloseTo(1080, 5);
+    expect(layout.backingWidth).toBe(3840);
+    expect(layout.backingHeight).toBe(2160);
+  });
+
+  test('degenerate zero parent size clamps the backing store to >= 1', () => {
+    const layout = computeLetterboxLayout(0, 0, 1280, 720, 1);
+
+    expect(layout.backingWidth).toBeGreaterThanOrEqual(1);
+    expect(layout.backingHeight).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/test/input/interaction.test.ts
+++ b/test/input/interaction.test.ts
@@ -91,7 +91,16 @@ const createApp = (): {
 
   const app = {
     canvas,
+    width: 800,
+    height: 600,
     input: signals as unknown as InputManager,
+    // Default centered camera: design-space pointer coords pass through to
+    // world space unchanged (identity screenToWorld).
+    rendering: {
+      camera: {
+        screenToWorld: (x: number, y: number): { x: number; y: number } => ({ x, y }),
+      },
+    },
     scene: {
       get currentScene(): Scene | null {
         return scene;

--- a/test/input/pointer-channels.test.ts
+++ b/test/input/pointer-channels.test.ts
@@ -33,19 +33,40 @@ const createCanvas = (width = 800, height = 600): HTMLCanvasElement => {
   return canvas;
 };
 
-const createInputManager = (canvas?: HTMLCanvasElement): InputManager => {
-  const c = canvas ?? createCanvas();
-  const app = {
-    canvas: c,
+/**
+ * Minimal Application stand-in exposing the surface the input system reads:
+ * the canvas, input options, the design size, and the backing-store → design
+ * mapping. With `pixelRatio = 1` (the default) the design size equals the
+ * backing store, so coordinates pass through 1:1; a higher ratio shrinks the
+ * design space accordingly (the content viewport covers the full backing store
+ * outside `'letterbox'` mode).
+ */
+const createMockApp = (canvas: HTMLCanvasElement, pixelRatio = 1): Application => {
+  const designWidth = canvas.width / pixelRatio;
+  const designHeight = canvas.height / pixelRatio;
+
+  return {
+    canvas,
+    width: designWidth,
+    height: designHeight,
+    pixelRatio,
     options: {
       input: {
         gamepadDefinitions: [],
         pointerDistanceThreshold: 10,
       },
     },
+    _backingStoreToDesign: (backingStoreX: number, backingStoreY: number): { x: number; y: number } => ({
+      x: (backingStoreX / canvas.width) * designWidth,
+      y: (backingStoreY / canvas.height) * designHeight,
+    }),
   } as unknown as Application;
+};
 
-  return new InputManager(app);
+const createInputManager = (canvas?: HTMLCanvasElement, pixelRatio = 1): InputManager => {
+  const c = canvas ?? createCanvas();
+
+  return new InputManager(createMockApp(c, pixelRatio));
 };
 
 /** Fire a pointer event on the canvas and return it. */
@@ -396,8 +417,9 @@ describe('Gesture — long press', () => {
 describe('Pointer coordinate mapping — scaled canvas', () => {
   // Backing store 800x600, but displayed (CSS) at 400x300 — e.g. object-fit
   // contain or transform: scale(0.5). getBoundingClientRect reflects the
-  // displayed (CSS) size; raw pointer coordinates must map back to
-  // backing-store pixels so picking matches node positions / screenToWorld.
+  // displayed (CSS) size; raw pointer coordinates must map into design space
+  // (here pixelRatio=1 so design == backing store) so picking matches node
+  // positions / screenToWorld.
   const createScaledCanvas = (): HTMLCanvasElement => {
     const canvas = document.createElement('canvas');
 
@@ -421,12 +443,12 @@ describe('Pointer coordinate mapping — scaled canvas', () => {
 
   const getPointer = (im: InputManager, id: number): Pointer => (im as unknown as { pointers: Record<number, Pointer> }).pointers[id];
 
-  test('constructor maps CSS-display coordinates to backing-store pixels', () => {
+  test('constructor maps CSS-display coordinates to design pixels', () => {
     const canvas = createScaledCanvas();
     const im = createInputManager(canvas);
 
-    // Display center (200,150) → canvas-local center (400,300) — 2x, since the
-    // canvas is shown at half its backing-store size.
+    // Display center (200,150) → design center (400,300) — 2x, since the canvas
+    // is shown at half its size and design == backing store at pixelRatio 1.
     pointerOver(canvas, { pointerId: 1, pointerType: 'mouse', clientX: 200, clientY: 150, isPrimary: true });
 
     const pointer = getPointer(im, 1);
@@ -452,6 +474,58 @@ describe('Pointer coordinate mapping — scaled canvas', () => {
 
     expect(pointer.x).toBeCloseTo(200, 5); // 100 * 800/400
     expect(pointer.y).toBeCloseTo(150, 5); // 75 * 600/300
+
+    im.destroy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 11. pixelRatio > 1: pointer reads design pixels, not physical backing-store
+// ---------------------------------------------------------------------------
+
+describe('Pointer coordinate mapping — pixelRatio > 1', () => {
+  // Design 800x600 rendered at pixelRatio 2 → backing store 1600x1200, but the
+  // canvas is displayed (CSS) at its design size 800x600. Pointer coordinates
+  // must come out in design pixels (0..800 × 0..600), independent of DPR.
+  const createDprCanvas = (): HTMLCanvasElement => {
+    const canvas = document.createElement('canvas');
+
+    canvas.width = 1600;
+    canvas.height = 1200;
+
+    vi.spyOn(canvas, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 0,
+      right: 800,
+      bottom: 600,
+      width: 800,
+      height: 600,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    return canvas;
+  };
+
+  const getPointer = (im: InputManager, id: number): Pointer => (im as unknown as { pointers: Record<number, Pointer> }).pointers[id];
+
+  test('pointer position is in design pixels regardless of pixelRatio', () => {
+    const canvas = createDprCanvas();
+    const im = createInputManager(canvas, 2);
+
+    // Display center (400,300) → design center (400,300), not the physical
+    // backing-store center (800,600).
+    pointerOver(canvas, { pointerId: 1, pointerType: 'mouse', clientX: 400, clientY: 300, isPrimary: true });
+
+    const pointer = getPointer(im, 1);
+
+    expect(pointer.x).toBeCloseTo(400, 5);
+    expect(pointer.y).toBeCloseTo(300, 5);
+
+    // Normalized channels stay 0..1 (scale-invariant).
+    expect(ch(im, Pointer.X)).toBeCloseTo(0.5, 5);
+    expect(ch(im, Pointer.Y)).toBeCloseTo(0.5, 5);
 
     im.destroy();
   });

--- a/test/input/spatial-index.test.ts
+++ b/test/input/spatial-index.test.ts
@@ -90,7 +90,16 @@ const createApp = (): {
 
   const app = {
     canvas,
+    width: 800,
+    height: 600,
     input: signals as unknown as InputManager,
+    // Default centered camera: design-space pointer coords pass through to
+    // world space unchanged (identity screenToWorld).
+    rendering: {
+      camera: {
+        screenToWorld: (x: number, y: number): { x: number; y: number } => ({ x, y }),
+      },
+    },
     scene: {
       get currentScene(): Scene | null {
         return scene;

--- a/test/rendering/browser/webgl2-dpr-resolution.test.ts
+++ b/test/rendering/browser/webgl2-dpr-resolution.test.ts
@@ -1,0 +1,331 @@
+/**
+ * WebGL2 device-pixel-ratio / design-resolution browser tests.
+ *
+ * Verifies that when the canvas backing store is larger than the logical
+ * (design) render-target size — i.e. `pixelRatio > 1` — the backend scales the
+ * root viewport up to the full backing store. Content authored in logical
+ * coordinates therefore fills every device pixel (crisp on HiDPI, no
+ * upscale-blur, no rendering stuck in a logical-sized corner) and logical
+ * positions land at the matching physical pixel.
+ *
+ * Run via:  pnpm test:browser:webgl
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+
+type RgbaTuple = [number, number, number, number];
+
+const shaderSources = vi.hoisted(() => ({
+  spriteVertexSource: `#version 300 es
+precision mediump float;
+in vec4 a_localBounds;
+in vec4 a_uvBounds;
+in vec4 a_color;
+in uint a_textureSlot;
+in uint a_nodeIndex;
+uniform mat3 u_projection;
+uniform sampler2D u_transforms;
+out vec2 v_uv;
+out vec4 v_color;
+flat out uint v_textureSlot;
+void main() {
+  vec2 local;
+  if (gl_VertexID == 0) local = vec2(a_localBounds.x, a_localBounds.y);
+  else if (gl_VertexID == 1) local = vec2(a_localBounds.z, a_localBounds.y);
+  else if (gl_VertexID == 2) local = vec2(a_localBounds.x, a_localBounds.w);
+  else local = vec2(a_localBounds.z, a_localBounds.w);
+  vec2 uv;
+  if (gl_VertexID == 0) uv = vec2(a_uvBounds.x, a_uvBounds.y);
+  else if (gl_VertexID == 1) uv = vec2(a_uvBounds.z, a_uvBounds.y);
+  else if (gl_VertexID == 2) uv = vec2(a_uvBounds.x, a_uvBounds.w);
+  else uv = vec2(a_uvBounds.z, a_uvBounds.w);
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
+  vec3 clip = u_projection * vec3(world, 1.0);
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = uv;
+  v_color = a_color;
+  v_textureSlot = a_textureSlot;
+}`,
+  spriteFragmentSource: `#version 300 es
+precision mediump float;
+in vec2 v_uv;
+in vec4 v_color;
+flat in uint v_textureSlot;
+uniform sampler2D u_texture0;
+uniform sampler2D u_texture1;
+uniform sampler2D u_texture2;
+uniform sampler2D u_texture3;
+uniform sampler2D u_texture4;
+uniform sampler2D u_texture5;
+uniform sampler2D u_texture6;
+uniform sampler2D u_texture7;
+out vec4 outColor;
+vec4 sampleTexture(uint slot, vec2 uv) {
+  if (slot == uint(0)) return texture(u_texture0, uv);
+  if (slot == uint(1)) return texture(u_texture1, uv);
+  if (slot == uint(2)) return texture(u_texture2, uv);
+  if (slot == uint(3)) return texture(u_texture3, uv);
+  if (slot == uint(4)) return texture(u_texture4, uv);
+  if (slot == uint(5)) return texture(u_texture5, uv);
+  if (slot == uint(6)) return texture(u_texture6, uv);
+  return texture(u_texture7, uv);
+}
+void main() {
+  outColor = sampleTexture(v_textureSlot, v_uv) * v_color;
+}`,
+  meshVertexSource: `#version 300 es
+precision mediump float;
+in vec2 a_position;
+in vec2 a_texcoord;
+in vec4 a_color;
+in uint a_nodeIndex;
+uniform mat3 u_projection;
+uniform sampler2D u_transforms;
+out vec2 v_uv;
+out vec4 v_color;
+out vec4 v_tint;
+void main() {
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  mat3 transform = mat3(m0.x, m0.z, 0.0, m0.y, m0.w, 0.0, m1.x, m1.y, 1.0);
+  vec3 world = transform * vec3(a_position, 1.0);
+  vec3 clip = u_projection * world;
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = a_texcoord;
+  v_color = a_color;
+  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+}`,
+  meshFragmentSource: `#version 300 es
+precision mediump float;
+in vec2 v_uv;
+in vec4 v_color;
+in vec4 v_tint;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() {
+  outColor = texture(u_texture, v_uv) * v_color * v_tint;
+}`,
+  particleVertexSource: `#version 300 es
+precision mediump float;
+in vec2 a_translation;
+in vec2 a_scale;
+in float a_rotation;
+in vec4 a_color;
+in vec2 a_uvMin;
+in vec2 a_uvMax;
+uniform mat3 u_projection;
+uniform mat3 u_systemTransform;
+uniform vec4 u_localBounds;
+out vec2 v_uv;
+out vec4 v_color;
+void main() {
+  vec2 corner;
+  if (gl_VertexID == 0) corner = vec2(0.0, 0.0);
+  else if (gl_VertexID == 1) corner = vec2(1.0, 0.0);
+  else if (gl_VertexID == 2) corner = vec2(1.0, 1.0);
+  else corner = vec2(0.0, 1.0);
+  vec2 local = mix(u_localBounds.xy, u_localBounds.zw, corner);
+  local *= a_scale;
+  float angle = radians(a_rotation);
+  mat2 rotationMatrix = mat2(cos(angle), -sin(angle), sin(angle), cos(angle));
+  vec2 worldPos = (u_systemTransform * vec3(rotationMatrix * local + a_translation, 1.0)).xy;
+  vec3 clip = u_projection * vec3(worldPos, 1.0);
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = mix(a_uvMin, a_uvMax, corner);
+  v_color = a_color;
+}`,
+  particleFragmentSource: `#version 300 es
+precision mediump float;
+in vec2 v_uv;
+in vec4 v_color;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() {
+  outColor = texture(u_texture, v_uv) * v_color;
+}`,
+  textVertexSource: `#version 300 es
+precision mediump float;
+in vec2 a_position;
+in vec2 a_texcoord;
+in float a_nodeIndex;
+uniform mat3 u_projection;
+out vec2 v_uv;
+void main() {
+  float nodeIndex = a_nodeIndex;
+  vec3 clip = u_projection * vec3(a_position + vec2(nodeIndex * 0.0), 1.0);
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = a_texcoord;
+}`,
+  textFragmentSource: `#version 300 es
+precision mediump float;
+in vec2 v_uv;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() {
+  outColor = texture(u_texture, v_uv);
+}`,
+}));
+
+vi.mock('#rendering/webgl2/glsl/sprite.vert', () => ({ default: shaderSources.spriteVertexSource }));
+vi.mock('#rendering/webgl2/glsl/sprite.frag', () => ({ default: shaderSources.spriteFragmentSource }));
+vi.mock('#rendering/webgl2/glsl/mesh.vert', () => ({ default: shaderSources.meshVertexSource }));
+vi.mock('#rendering/webgl2/glsl/mesh.frag', () => ({ default: shaderSources.meshFragmentSource }));
+vi.mock('#rendering/webgl2/glsl/particle.vert', () => ({ default: shaderSources.particleVertexSource }));
+vi.mock('#rendering/webgl2/glsl/particle.frag', () => ({ default: shaderSources.particleFragmentSource }));
+vi.mock('#rendering/webgl2/glsl/text.vert', () => ({ default: shaderSources.textVertexSource }));
+vi.mock('#rendering/webgl2/glsl/text-color.frag', () => ({ default: shaderSources.textFragmentSource }));
+vi.mock('#rendering/webgl2/glsl/text-msdf.frag', () => ({ default: shaderSources.textFragmentSource }));
+vi.mock('#rendering/webgl2/glsl/text-sdf.frag', () => ({ default: shaderSources.textFragmentSource }));
+
+const defaultWebGlAttributes: WebGLContextAttributes = {
+  alpha: false,
+  antialias: false,
+  premultipliedAlpha: false,
+  preserveDrawingBuffer: true,
+  stencil: false,
+  depth: false,
+};
+
+/**
+ * Build a backend whose canvas backing store is `logical × pixelRatio` while
+ * the render target stays at the logical size — exactly what Application does
+ * for `pixelRatio > 1`.
+ */
+const createBackend = async (logical: number, pixelRatio: number): Promise<WebGl2Backend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = logical * pixelRatio;
+  canvas.height = logical * pixelRatio;
+
+  const app = {
+    canvas,
+    options: {
+      clearColor: Color.black,
+      canvas: { width: logical, height: logical, pixelRatio },
+      rendering: {
+        debug: false,
+        webglAttributes: defaultWebGlAttributes,
+        spriteRendererBatchSize: 1024,
+      },
+    },
+  } as unknown as Application;
+
+  const backend = new WebGl2Backend(app);
+
+  await backend.initialize();
+  wireCoreRenderers(backend, app.options.rendering);
+
+  return backend;
+};
+
+/** Read a single pixel in backing-store coordinates (top-left origin). */
+const readPixel = (backend: WebGl2Backend, x: number, y: number): RgbaTuple => {
+  const pixel = new Uint8Array(4);
+  const gl = backend.context;
+
+  gl.readPixels(Math.floor(x), gl.drawingBufferHeight - Math.floor(y) - 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixel);
+
+  return [pixel[0], pixel[1], pixel[2], pixel[3]];
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 4): void => {
+  for (let index = 0; index < 4; index++) {
+    expect(Math.abs(actual[index] - expected[index]), `channel ${index}: got [${actual.join(', ')}] expected [${expected.join(', ')}]`).toBeLessThanOrEqual(
+      tolerance,
+    );
+  }
+};
+
+const createSolidTexture = (color: string, size = 16): Texture => {
+  const source = document.createElement('canvas');
+
+  source.width = size;
+  source.height = size;
+
+  const context = source.getContext('2d');
+
+  if (!context) {
+    throw new Error('2D context is required to create test textures.');
+  }
+
+  context.fillStyle = color;
+  context.fillRect(0, 0, size, size);
+
+  return new Texture(source);
+};
+
+/**
+ * A sprite covering the LEFT HALF of the logical space: x in [0, logical/2],
+ * y in [0, logical]. Its right edge is the probe for the device-pixel mapping.
+ */
+const createLeftHalfSprite = (texture: Texture, logical: number): Sprite =>
+  new Sprite(texture)
+    .setPosition(logical / 4, logical / 2)
+    .setAnchor(0.5)
+    .setScale(logical / 2 / texture.width, logical / texture.height);
+
+describe('WebGL2 device-pixel-ratio resolution', () => {
+  test('pixelRatio 2 scales the root viewport to fill the full backing store', async () => {
+    const logical = 64;
+    const backend = await createBackend(logical, 2);
+    const white = createSolidTexture('#ffffff');
+    const sprite = createLeftHalfSprite(white, logical);
+
+    try {
+      // The backing store is 128×128; the target/view is 64×64 logical.
+      expect(backend.context.drawingBufferWidth).toBe(128);
+      expect(backend.renderTarget.width).toBe(64);
+
+      backend.clear(Color.black);
+      sprite.render(backend);
+      backend.flush();
+
+      // The logical left-half edge (x=32) must land at physical x=64.
+      expectPixelNear(readPixel(backend, 60, 64), [255, 255, 255, 255]); // just left of the edge → white
+      expectPixelNear(readPixel(backend, 68, 64), [0, 0, 0, 255]); // just right of the edge → black
+
+      // Content fills the FULL physical height — not stuck in a logical-sized
+      // corner (which would leave the top rows of the backing store empty).
+      expectPixelNear(readPixel(backend, 32, 4), [255, 255, 255, 255]); // top
+      expectPixelNear(readPixel(backend, 32, 124), [255, 255, 255, 255]); // bottom
+      expectPixelNear(readPixel(backend, 124, 64), [0, 0, 0, 255]); // far right → background
+    } finally {
+      sprite.destroy();
+      white.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('pixelRatio 1 control: edge lands at the logical pixel', async () => {
+    const logical = 64;
+    const backend = await createBackend(logical, 1);
+    const white = createSolidTexture('#ffffff');
+    const sprite = createLeftHalfSprite(white, logical);
+
+    try {
+      expect(backend.context.drawingBufferWidth).toBe(64);
+
+      backend.clear(Color.black);
+      sprite.render(backend);
+      backend.flush();
+
+      // Edge at logical/physical x=32.
+      expectPixelNear(readPixel(backend, 28, 32), [255, 255, 255, 255]);
+      expectPixelNear(readPixel(backend, 36, 32), [0, 0, 0, 255]);
+    } finally {
+      sprite.destroy();
+      white.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgpu-dpr-resolution.test.ts
+++ b/test/rendering/browser/webgpu-dpr-resolution.test.ts
@@ -1,0 +1,168 @@
+/**
+ * WebGPU device-pixel-ratio / design-resolution browser tests — opt-in,
+ * capability-aware. Mirror of the WebGL2 DPR test: when the canvas backing
+ * store is larger than the logical render-target size (`pixelRatio > 1`), the
+ * backend scales the root viewport to the full backing store, so logical
+ * content fills every device pixel (crisp) and logical positions land at the
+ * matching physical pixel.
+ *
+ * Skips gracefully when WebGPU is unavailable or the software adapter drops.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const makeApp = (canvas: HTMLCanvasElement, logical: number, pixelRatio: number): Application =>
+  ({
+    canvas,
+    options: {
+      clearColor: Color.black,
+      canvas: { width: logical, height: logical, pixelRatio },
+    },
+  }) as unknown as Application;
+
+const setupBackend = async (ctx: { skip: (reason: string) => void }, logical: number, pixelRatio: number): Promise<WebGpuBackend> => {
+  if (!navigator.gpu) {
+    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
+  }
+
+  const adapter = await navigator.gpu.requestAdapter();
+
+  if (!adapter) {
+    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
+  }
+
+  const canvas = document.createElement('canvas');
+
+  canvas.width = logical * pixelRatio;
+  canvas.height = logical * pixelRatio;
+
+  const backend = new WebGpuBackend(makeApp(canvas, logical, pixelRatio));
+
+  await backend.initialize();
+  wireCoreRenderers(backend);
+
+  return backend;
+};
+
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+const createSolidTexture = (color: string, size = 16): Texture => {
+  const source = document.createElement('canvas');
+
+  source.width = size;
+  source.height = size;
+
+  const context = source.getContext('2d');
+
+  if (!context) {
+    throw new Error('2D context is required to create test textures.');
+  }
+
+  context.fillStyle = color;
+  context.fillRect(0, 0, size, size);
+
+  return new Texture(source);
+};
+
+const createLeftHalfSprite = (texture: Texture, logical: number): Sprite =>
+  new Sprite(texture)
+    .setPosition(logical / 4, logical / 2)
+    .setAnchor(0.5)
+    .setScale(logical / 2 / texture.width, logical / texture.height);
+
+const readCanvas = (backend: WebGpuBackend): ((x: number, y: number) => RgbaTuple) => {
+  const source = backend.context.canvas as HTMLCanvasElement;
+  const readback = document.createElement('canvas');
+
+  readback.width = source.width;
+  readback.height = source.height;
+
+  const ctx = readback.getContext('2d');
+
+  if (!ctx) {
+    throw new Error('2D context is required for canvas readback.');
+  }
+
+  ctx.drawImage(source, 0, 0);
+
+  return (x: number, y: number): RgbaTuple => {
+    const { data } = ctx.getImageData(Math.floor(x), Math.floor(y), 1, 1);
+
+    return [data[0], data[1], data[2], data[3]];
+  };
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 6): void => {
+  for (let index = 0; index < 4; index++) {
+    expect(Math.abs(actual[index] - expected[index]), `channel ${index}: got [${actual.join(', ')}] expected [${expected.join(', ')}]`).toBeLessThanOrEqual(
+      tolerance,
+    );
+  }
+};
+
+describe('WebGPU device-pixel-ratio resolution', () => {
+  test('pixelRatio 2 scales the root viewport to fill the full backing store', async ctx => {
+    const logical = 64;
+    const backend = await setupBackend(ctx, logical, 2);
+    const device = getBackendDeviceOrSkip(ctx, backend);
+
+    if (!device) {
+      return;
+    }
+
+    const white = createSolidTexture('#ffffff');
+    const sprite = createLeftHalfSprite(white, logical);
+
+    try {
+      expect((backend.context.canvas as HTMLCanvasElement).width).toBe(128);
+      expect(backend.renderTarget.width).toBe(64);
+
+      device.pushErrorScope('validation');
+
+      let validationError: GPUError | null;
+
+      try {
+        backend.resetStats();
+        backend.clear(Color.black);
+        sprite.render(backend);
+        backend.flush();
+        validationError = await device.popErrorScope();
+      } catch (error) {
+        if (isDeviceLoss(error)) {
+          ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+          return;
+        }
+
+        throw error;
+      }
+
+      expect(validationError).toBeNull();
+
+      const read = readCanvas(backend);
+
+      // The logical left-half edge (x=32) must land at physical x=64.
+      expectPixelNear(read(60, 64), [255, 255, 255, 255]); // just left of the edge → white
+      expectPixelNear(read(68, 64), [0, 0, 0, 255]); // just right of the edge → black
+      // Content fills the full physical height — not stuck in a logical corner.
+      expectPixelNear(read(32, 4), [255, 255, 255, 255]); // top
+      expectPixelNear(read(32, 124), [255, 255, 255, 255]); // bottom
+      expectPixelNear(read(124, 64), [0, 0, 0, 255]); // far right → background
+    } finally {
+      sprite.destroy();
+      white.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/view.test.ts
+++ b/test/rendering/view.test.ts
@@ -64,3 +64,84 @@ describe('View', () => {
     expect(view.zoomLevel).toBeCloseTo(2);
   });
 });
+
+describe('View — coordinate conversion', () => {
+  // Centered camera over an 800×600 design space, matching the default camera.
+  const centered = (): View => new View(400, 300, 800, 600);
+
+  // The projection-matrix translation carries a constant sub-pixel artifact
+  // (~2/width world units), so absolute mappings are asserted to 2 decimals.
+  // Round-trips cancel the constant offset and stay accurate to 3.
+
+  test('2-arg screenToWorld is the identity at the default centered camera', () => {
+    const view = centered();
+
+    for (const [x, y] of [
+      [0, 0],
+      [400, 300],
+      [800, 600],
+      [123, 456],
+    ]) {
+      const world = view.screenToWorld(x, y);
+
+      expect(world.x).toBeCloseTo(x, 2);
+      expect(world.y).toBeCloseTo(y, 2);
+    }
+  });
+
+  test('2-arg screenToWorld/worldToScreen round-trip', () => {
+    const view = new View(500, 400, 800, 600);
+
+    view.setZoom(1.5);
+    view.setRotation(20);
+
+    const screen = view.worldToScreen(640, 360);
+    const world = view.screenToWorld(screen.x, screen.y);
+
+    expect(world.x).toBeCloseTo(640, 3);
+    expect(world.y).toBeCloseTo(360, 3);
+  });
+
+  test('2-arg screenToWorld ignores the viewport rectangle', () => {
+    const view = centered();
+    const full = view.screenToWorld(200, 150);
+
+    // A pillarbox viewport must not change design-space → world mapping.
+    view.viewport = new Rectangle(0.25, 0, 0.5, 1);
+    const boxed = view.screenToWorld(200, 150);
+
+    expect(boxed.x).toBeCloseTo(full.x, 5);
+    expect(boxed.y).toBeCloseTo(full.y, 5);
+  });
+
+  test('2-arg screenToWorld follows a panned camera', () => {
+    const view = centered();
+
+    view.setCenter(500, 400);
+
+    // Screen center maps to the camera center; the top-left offsets with it.
+    const center = view.screenToWorld(400, 300);
+    const topLeft = view.screenToWorld(0, 0);
+
+    expect(center.x).toBeCloseTo(500, 2);
+    expect(center.y).toBeCloseTo(400, 2);
+    expect(topLeft.x).toBeCloseTo(100, 2);
+    expect(topLeft.y).toBeCloseTo(100, 2);
+  });
+
+  test('4-arg screenToWorld maps backing-store pixels at any pixelRatio', () => {
+    const view = centered();
+
+    // pixelRatio 1: canvas 800×600.
+    const lowDpr = view.screenToWorld(400, 300, 800, 600);
+
+    expect(lowDpr.x).toBeCloseTo(400, 2);
+    expect(lowDpr.y).toBeCloseTo(300, 2);
+
+    // pixelRatio 2: canvas 1600×1200 backing store, same design center.
+    const highDpr = view.screenToWorld(800, 600, 1600, 1200);
+
+    expect(highDpr.x).toBeCloseTo(400, 2);
+    expect(highDpr.y).toBeCloseTo(300, 2);
+  });
+});


### PR DESCRIPTION
## Piece A — Coordinate / resolution model (deferred from the playground review)

Makes **logical/design coordinates the single coherent model** everywhere and renders crisp at native device pixels. Folds together the two deferred items (#1 DPR + #2 design-resolution).

### What changed

**Coordinates & DPR**
- `app.width` / `app.height` / `app.pixelRatio` (logical/design accessors) + `app.screenToWorld(x, y)` and `view.screenToWorld(x, y)` 2-arg convenience (design → world, viewport-free).
- **Auto-DPR default = `min(devicePixelRatio, 2)`** — crisp on Retina/HiDPI out of the box; the cap avoids a 9× fill-rate cost on DPR-3 phones. Pass an explicit `pixelRatio` (e.g. `window.devicePixelRatio`) to override.
- `pointer.x/y` are now **design pixels** (independent of pixelRatio and display scaling). Interaction converts them to world via the active camera before hit-testing/dragging — correct under DPR, zoom, and pan.

**`View.screenToWorld` fix (behaviour change)**
- It never round-tripped `worldToScreen` (returned *center-relative* coords) because `Matrix.getInverse` drops the projection-matrix translation. Replaced with a direct linear solve → exact inverse, identity at the default centered camera. `worldToScreen` / `getInverseTransform` untouched.

**`'letterbox'` sizing mode**
- Author at a fixed design resolution; the canvas is sized to a native-resolution, design-aspect content area centered in the parent, with the parent background as bars (no crop, no stretch, no upscale-blur). Backend-agnostic (pure layout + CSS). Geometry in `src/core/letterbox.ts`.

### Verification (pixel-readback, both backends)
- `test/rendering/browser/webgl2-dpr-resolution.test.ts` and `webgpu-dpr-resolution.test.ts` — at `pixelRatio: 2` logical content fills the full backing store and the logical edge lands at the matching physical pixel (crisp, correctly positioned).
- `test/core/letterbox.test.ts` — letterbox geometry (aspect preserved, no crop/stretch, DPR scaling).
- Unit coverage for the 2-arg coordinate conversions, design-space pointer mapping, and camera-routed interaction.
- Green: core unit suite (2490), typecheck (engine/examples/guides), lint, prettier, `docs:api:check`.

### Notes
- Examples (gradient, sound-pool, mouse-parallax, pointer-to-world, world-vs-screen-coords) and guides updated to the logical accessors / new `screenToWorld`; committed `.js` synced.
- API mdx regenerated — 4 pages reflect this change; 10 are pre-existing drift this incidentally brings back in sync.
- **Not included:** Piece B (Darken/Lighten shader-side blend) — tracked separately.