### PR TITLE
feat(core)!: Phase-1 completion — app.systems registry + ObservableVector node-diet

### DIFF
--- a/site/src/content/api/application-status.mdx
+++ b/site/src/content/api/application-status.mdx
@@ -9,7 +9,7 @@ memberCount: 4
 tier: "stable"
 sections: ["Import", "Members", "Source"]
 sourcePath: "src/core/Application.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L34"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L35"
 ---
 ## Import
 
@@ -24,4 +24,4 @@ sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#
 
 ## Source
 
-[src/core/Application.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L34)
+[src/core/Application.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L35)

--- a/site/src/content/api/application.mdx
+++ b/site/src/content/api/application.mdx
@@ -1,23 +1,23 @@
 ---
 title: "Application"
-description: "Top-level engine instance. Owns the canvas, render backend, scene-stack controller, input + interaction managers, asset loader, tween manager, shared audio singleton, and the per-frame loop. Lifecycle: construct with options → `await app.start(scene)` → engine runs the request-animation-frame loop until `app.stop()` or `app.destroy()`. The render backend is chosen and initialized during `start()`; query Application.backend or Application.capabilities after start has resolved. The class exposes Signals for the major state-change points (Application.onResize, Application.onFrame, Application.onCanvasFocusChange, Application.onVisibilityChange, Application.onBackendLost, Application.onBackendRestored) so subscribers can react without subclassing. `pauseOnHidden = true` short-circuits the per-frame work while `document.hidden` is true (still consumes RAF callbacks but skips scene update + render). Useful for games; leave off for tools and background-active simulations."
+description: "Top-level engine instance. Owns the canvas, render backend, scene-stack controller, the app system registry (input, interaction, audio, tweens, rendering), asset loader, and the per-frame loop. Lifecycle: construct with options → `await app.start(scene)` → engine runs the request-animation-frame loop until `app.stop()` or `app.destroy()`. The render backend is chosen and initialized during `start()`; query Application.backend or Application.capabilities after start has resolved. The class exposes Signals for the major state-change points (Application.onResize, Application.onFrame, Application.onCanvasFocusChange, Application.onVisibilityChange, Application.onBackendLost, Application.onBackendRestored) so subscribers can react without subclassing. `pauseOnHidden = true` short-circuits the per-frame work while `document.hidden` is true (still consumes RAF callbacks but skips scene update + render). Useful for games; leave off for tools and background-active simulations."
 symbol: "Application"
 kind: "class"
 subsystem: "core"
 importPath: "@codexo/exojs"
-memberCount: 39
+memberCount: 40
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/core/Application.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L214"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L215"
 ---
 ## Import
 
 `import { Application } from '@codexo/exojs'`
 
 Top-level engine instance. Owns the canvas, render backend, scene-stack
-controller, input + interaction managers, asset loader, tween manager,
-shared audio singleton, and the per-frame loop.
+controller, the app system registry (input, interaction, audio, tweens,
+rendering), asset loader, and the per-frame loop.
 
 Lifecycle: construct with options → `await app.start(scene)` → engine
 runs the request-animation-frame loop until `app.stop()` or
@@ -62,6 +62,7 @@ background-active simulations.
 - `pauseOnHidden: boolean`
 - `random: Random`
 - `scene: SceneManager`
+- `systems: SystemRegistry`
 - `tweens: TweenManager`
 - `activeTime: Time`
 - `audio: AudioManager`
@@ -90,4 +91,4 @@ background-active simulations.
 
 ## Source
 
-[src/core/Application.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L214)
+[src/core/Application.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L215)

--- a/site/src/content/api/audio-manager.mdx
+++ b/site/src/content/api/audio-manager.mdx
@@ -9,7 +9,7 @@ memberCount: 18
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/audio/AudioManager.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/audio/AudioManager.ts#L23"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/audio/AudioManager.ts#L24"
 ---
 ## Import
 
@@ -58,4 +58,4 @@ AudioManager.muteOnHidden is enabled.
 
 ## Source
 
-[src/audio/AudioManager.ts](https://github.com/Exoridus/ExoJS/blob/main/src/audio/AudioManager.ts#L23)
+[src/audio/AudioManager.ts](https://github.com/Exoridus/ExoJS/blob/main/src/audio/AudioManager.ts#L24)

--- a/site/src/content/api/input-manager.mdx
+++ b/site/src/content/api/input-manager.mdx
@@ -9,7 +9,7 @@ memberCount: 38
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/input/InputManager.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/input/InputManager.ts#L59"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/input/InputManager.ts#L60"
 ---
 ## Import
 
@@ -83,4 +83,4 @@ automatically — you do not instantiate this class yourself.
 
 ## Source
 
-[src/input/InputManager.ts](https://github.com/Exoridus/ExoJS/blob/main/src/input/InputManager.ts#L59)
+[src/input/InputManager.ts](https://github.com/Exoridus/ExoJS/blob/main/src/input/InputManager.ts#L60)

--- a/site/src/content/api/interaction-manager.mdx
+++ b/site/src/content/api/interaction-manager.mdx
@@ -9,7 +9,7 @@ memberCount: 5
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Source"]
 sourcePath: "src/input/InteractionManager.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/input/InteractionManager.ts#L68"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/input/InteractionManager.ts#L69"
 ---
 ## Import
 
@@ -44,4 +44,4 @@ this class yourself.
 
 ## Source
 
-[src/input/InteractionManager.ts](https://github.com/Exoridus/ExoJS/blob/main/src/input/InteractionManager.ts#L68)
+[src/input/InteractionManager.ts](https://github.com/Exoridus/ExoJS/blob/main/src/input/InteractionManager.ts#L69)

--- a/site/src/content/api/observable-vector.mdx
+++ b/site/src/content/api/observable-vector.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ObservableVector"
-description: "A AbstractVector subclass that fires a callback whenever its components change. Used internally by Rectangle and other types to invalidate cached state (e.g. normals) on position mutations. Setting individual components (`x`, `y`) fires the callback only when the value actually changes. Batch mutations via `set()` fire at most one callback per call."
+description: "An AbstractVector subclass that notifies an owner whenever its components change. Used internally by Rectangle, `SceneNode`, View and other types to invalidate cached state (normals, transforms) on mutation. Instead of a per-instance callback closure, the vector holds a reference to its `owner` plus a numeric `channel` and calls `owner._onObservableChange(channel)` on change. This keeps hot per-node vectors closure-free — a `SceneNode` carries four of these, so dropping the bound closures saves four allocations per node. Pass `owner = null` for a plain, non-reactive vector. Setting individual components (`x`, `y`) notifies only when the value actually changes. Batch mutations via `set()` notify at most once per call."
 symbol: "ObservableVector"
 kind: "class"
 subsystem: "math"
@@ -9,23 +9,29 @@ memberCount: 27
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/math/ObservableVector.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/math/ObservableVector.ts#L12"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/math/ObservableVector.ts#L30"
 ---
 ## Import
 
 `import { ObservableVector } from '@codexo/exojs'`
 
-A AbstractVector subclass that fires a callback whenever its
-components change. Used internally by Rectangle and other types to
-invalidate cached state (e.g. normals) on position mutations.
+An AbstractVector subclass that notifies an owner whenever its
+components change. Used internally by Rectangle, `SceneNode`,
+View and other types to invalidate cached state (normals, transforms)
+on mutation.
 
-Setting individual components (`x`, `y`) fires the callback only when the
-value actually changes. Batch mutations via `set()` fire at most one
-callback per call.
+Instead of a per-instance callback closure, the vector holds a reference to
+its `owner` plus a numeric `channel` and calls `owner._onObservableChange(channel)`
+on change. This keeps hot per-node vectors closure-free — a `SceneNode`
+carries four of these, so dropping the bound closures saves four allocations
+per node. Pass `owner = null` for a plain, non-reactive vector.
+
+Setting individual components (`x`, `y`) notifies only when the value
+actually changes. Batch mutations via `set()` notify at most once per call.
 
 ## Constructors
 
-- `new(callback: object | null, x: number, y: number): ObservableVector`
+- `new(owner: ObservableVectorOwner | null, channel: number, x: number, y: number): ObservableVector`
 
 ## Methods
 
@@ -61,4 +67,4 @@ callback per call.
 
 ## Source
 
-[src/math/ObservableVector.ts](https://github.com/Exoridus/ExoJS/blob/main/src/math/ObservableVector.ts#L12)
+[src/math/ObservableVector.ts](https://github.com/Exoridus/ExoJS/blob/main/src/math/ObservableVector.ts#L30)

--- a/site/src/content/api/rectangle.mdx
+++ b/site/src/content/api/rectangle.mdx
@@ -9,7 +9,7 @@ memberCount: 28
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/math/Rectangle.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/math/Rectangle.ts#L40"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/math/Rectangle.ts#L39"
 ---
 ## Import
 
@@ -62,4 +62,4 @@ computed and cached; they are invalidated when position or size mutates.
 
 ## Source
 
-[src/math/Rectangle.ts](https://github.com/Exoridus/ExoJS/blob/main/src/math/Rectangle.ts#L40)
+[src/math/Rectangle.ts](https://github.com/Exoridus/ExoJS/blob/main/src/math/Rectangle.ts#L39)

--- a/site/src/content/api/rendering-context.mdx
+++ b/site/src/content/api/rendering-context.mdx
@@ -9,7 +9,7 @@ memberCount: 10
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/rendering/RenderingContext.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/RenderingContext.ts#L35"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/RenderingContext.ts#L37"
 ---
 ## Import
 
@@ -33,7 +33,7 @@ The conceptual model is "the context renders the node":
 - `render(node: RenderNode, options: RenderOptions): void`
 - `renderTo(node: RenderNode, options: RenderToOptions): RenderTexture`
 - `resize(width: number, height: number): void`
-- `update(deltaMs: number): void`
+- `update(delta: Time): void`
 
 ## Properties
 
@@ -45,4 +45,4 @@ The conceptual model is "the context renders the node":
 
 ## Source
 
-[src/rendering/RenderingContext.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/RenderingContext.ts#L35)
+[src/rendering/RenderingContext.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/RenderingContext.ts#L37)

--- a/site/src/content/api/scene-node.mdx
+++ b/site/src/content/api/scene-node.mdx
@@ -9,7 +9,7 @@ memberCount: 42
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/core/SceneNode.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/SceneNode.ts#L74"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/SceneNode.ts#L84"
 ---
 ## Import
 
@@ -92,4 +92,4 @@ Subclasses: Container (carries children), RenderNode
 
 ## Source
 
-[src/core/SceneNode.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/SceneNode.ts#L74)
+[src/core/SceneNode.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/SceneNode.ts#L84)

--- a/site/src/content/api/scene.mdx
+++ b/site/src/content/api/scene.mdx
@@ -9,7 +9,7 @@ memberCount: 17
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/core/Scene.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Scene.ts#L239"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Scene.ts#L118"
 ---
 ## Import
 
@@ -55,9 +55,9 @@ For one-off scenes, an anonymous subclass works just as well:
 - `inputs: SceneInputs`
 - `root: Container`
 - `stackMode: SceneStackMode`
-- `systems: SceneSystems`
+- `systems: SystemRegistry`
 - `tweens: SceneTweens`
 
 ## Source
 
-[src/core/Scene.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Scene.ts#L239)
+[src/core/Scene.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Scene.ts#L118)

--- a/site/src/content/api/system-registry.mdx
+++ b/site/src/content/api/system-registry.mdx
@@ -1,0 +1,44 @@
+---
+title: "SystemRegistry"
+description: "Ordered registry of per-frame Systems, shared by Scene (as `scene.systems`) and `Application` (as `app.systems`). Systems tick once per frame in ascending `order` (ties keep insertion order) and are destroyed in reverse registration order when the registry is destroyed. Structural mutations made from inside a system's `update()` (a system adding or removing another, or itself) are deferred until the tick completes, so the iteration is never invalidated mid-frame."
+symbol: "SystemRegistry"
+kind: "class"
+subsystem: "core"
+importPath: "@codexo/exojs"
+memberCount: 6
+tier: "stable"
+sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
+sourcePath: "src/core/SystemRegistry.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/SystemRegistry.ts#L15"
+---
+## Import
+
+`import { SystemRegistry } from '@codexo/exojs'`
+
+Ordered registry of per-frame Systems, shared by Scene (as
+`scene.systems`) and `Application` (as `app.systems`). Systems tick once per
+frame in ascending `order` (ties keep insertion order) and are destroyed in
+reverse registration order when the registry is destroyed.
+
+Structural mutations made from inside a system's `update()` (a system adding
+or removing another, or itself) are deferred until the tick completes, so the
+iteration is never invalidated mid-frame.
+
+## Constructors
+
+- `new(): SystemRegistry`
+
+## Methods
+
+- `add(system: T): T`
+- `destroy(): void`
+- `has(system: System): boolean`
+- `remove(system: System): boolean`
+
+## Properties
+
+- `size: number`
+
+## Source
+
+[src/core/SystemRegistry.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/SystemRegistry.ts#L15)

--- a/site/src/content/api/tween-manager.mdx
+++ b/site/src/content/api/tween-manager.mdx
@@ -9,7 +9,7 @@ memberCount: 8
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Source"]
 sourcePath: "src/animation/TweenManager.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/animation/TweenManager.ts#L14"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/animation/TweenManager.ts#L17"
 ---
 ## Import
 
@@ -36,8 +36,8 @@ stopped tweens are evicted automatically.
 - `destroy(): void`
 - `remove(tween: Tween): this`
 - `sequence(tweens: readonly Tween<object>[]): Tween`
-- `update(deltaSeconds: number): void`
+- `update(delta: Time): void`
 
 ## Source
 
-[src/animation/TweenManager.ts](https://github.com/Exoridus/ExoJS/blob/main/src/animation/TweenManager.ts#L14)
+[src/animation/TweenManager.ts](https://github.com/Exoridus/ExoJS/blob/main/src/animation/TweenManager.ts#L17)

--- a/src/animation/TweenManager.ts
+++ b/src/animation/TweenManager.ts
@@ -1,3 +1,6 @@
+import type { System } from '#core/System';
+import type { Time } from '#core/Time';
+
 import { Tween } from './Tween';
 
 /**
@@ -11,7 +14,9 @@ import { Tween } from './Tween';
  * stopped tweens are evicted automatically.
  * @stable
  */
-export class TweenManager {
+export class TweenManager implements System {
+  /** App-systems tick band — tweens after audio. @internal */
+  public readonly order = 400;
   private _tweens: Tween[] = [];
   private _destroyed = false;
 
@@ -82,17 +87,17 @@ export class TweenManager {
   }
 
   /**
-   * Advance all active tweens by deltaSeconds. Called once per frame by
-   * Application.update(). Uses a snapshot of the list so that callbacks that
-   * add or remove tweens do not corrupt mid-iteration.
+   * Advance all active tweens by the frame `delta` (read as seconds). Ticked
+   * once per frame via {@link Application.systems}. Uses a snapshot of the list
+   * so that callbacks that add or remove tweens do not corrupt mid-iteration.
    */
-  public update(deltaSeconds: number): void {
+  public update(delta: Time): void {
     if (this._destroyed) return;
 
     const snapshot = [...this._tweens];
 
     for (const tween of snapshot) {
-      tween.update(deltaSeconds);
+      tween.update(delta.seconds);
     }
   }
 

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -1,4 +1,5 @@
 import { Signal } from '#core/Signal';
+import type { System } from '#core/System';
 
 import { getAudioContext, isAudioContextReady, onAudioContextReady } from './audio-context';
 import { AudioBus } from './AudioBus';
@@ -20,7 +21,9 @@ import type { Playable, PlayOptions, Voice } from './Playable';
  * voice, and propagates visibility-driven mute when
  * {@link AudioManager.muteOnHidden} is enabled.
  */
-export class AudioManager {
+export class AudioManager implements System {
+  /** App-systems tick band — audio after interaction. @internal */
+  public readonly order = 300;
   public readonly master: AudioBus;
   public readonly music: AudioBus;
   public readonly sound: AudioBus;

--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -28,6 +28,7 @@ import { computeLetterboxLayout } from './letterbox';
 import type { Scene } from './Scene';
 import { SceneManager } from './SceneManager';
 import { Signal } from './Signal';
+import { SystemRegistry } from './SystemRegistry';
 import { Time } from './Time';
 import { canvasSourceToDataUrl } from './utils';
 
@@ -190,8 +191,8 @@ const defaultInputSettings: Required<InputApplicationOptions> = {
 
 /**
  * Top-level engine instance. Owns the canvas, render backend, scene-stack
- * controller, input + interaction managers, asset loader, tween manager,
- * shared audio singleton, and the per-frame loop.
+ * controller, the app system registry (input, interaction, audio, tweens,
+ * rendering), asset loader, and the per-frame loop.
  *
  * Lifecycle: construct with options → `await app.start(scene)` → engine
  * runs the request-animation-frame loop until `app.stop()` or
@@ -221,6 +222,13 @@ export class Application {
   /** Per-Application seedable RNG. Isolated from other Applications and from the global `rand()`. */
   public readonly random: Random;
   public readonly tweens: TweenManager = new TweenManager();
+  /**
+   * App-level system registry, ticked once per frame in ascending `order`. The
+   * core managers occupy reserved bands (input 100, interaction 200, audio 300,
+   * tweens 400, rendering 500); register your own app-wide systems at order
+   * 600+ via `app.systems.add(...)`. Scene-scoped systems live on `scene.systems`.
+   */
+  public readonly systems = new SystemRegistry();
   public readonly onResize = new Signal<[number, number, Application]>();
   public readonly onFrame = new Signal<[Time]>();
   public readonly onCanvasFocusChange = new Signal<[focused: boolean]>();
@@ -333,6 +341,14 @@ export class Application {
     this.scene = new SceneManager(this);
     this.random = new Random(this.options.seed);
     this._updateHandler = this.update.bind(this);
+
+    // Register the core managers as ordered app systems (reserved order bands);
+    // they tick from one loop, ahead of any user systems (order 600+).
+    this.systems.add(this.input);
+    this.systems.add(this.interaction);
+    this.systems.add(this._audio);
+    this.systems.add(this.tweens);
+    this.systems.add(this._rendering);
 
     this._startupClock.start();
 
@@ -519,9 +535,9 @@ export class Application {
    *
    * Each normal frame runs two distinct phases:
    *
-   * **Update phase** — input and interaction flush, audio update, tween
-   * advancement, optional view runtime update, then `scene.update(delta)` for
-   * each participating scene in stack order.
+   * **Update phase** — the app systems tick in ascending `order` (input,
+   * interaction, audio, tweens, rendering, plus any user systems at 600+), then
+   * `scene.update(delta)` for each participating scene in stack order.
    *
    * **Render phase** — `scene.draw(context)` for each participating scene in
    * stack order, followed by the transition overlay when active.
@@ -552,12 +568,7 @@ export class Application {
       this.backend.resetStats();
       this.backend.stats.rawFrameDeltaMs = rawDeltaMs;
 
-      this.input.update();
-      this.interaction.update();
-      this._audio.update();
-      this.tweens.update(frameDelta.seconds);
-
-      this._rendering.update(frameDelta.milliseconds);
+      this.systems._tick(frameDelta);
 
       this.scene.update(frameDelta);
       this.onFrame.dispatch(frameDelta);
@@ -747,9 +758,10 @@ export class Application {
   }
 
   /**
-   * Tear down every owned subsystem (loader, interaction, input, tweens,
-   * backend, scene manager, all clocks, all signals) and release event
-   * listeners. The application instance is unusable after this call.
+   * Tear down every owned subsystem (loader, the app systems — input,
+   * interaction, audio, tweens, rendering — backend, scene manager, all clocks,
+   * all signals) and release event listeners. The application instance is
+   * unusable after this call.
    */
   public destroy(): void {
     if (typeof document !== 'undefined') {
@@ -761,10 +773,7 @@ export class Application {
 
     this.stop();
     this.loader.destroy();
-    this.interaction.destroy();
-    this.input.destroy();
-    this.tweens.destroy();
-    this._audio.destroy();
+    this.systems.destroy();
     this._backend.destroy();
     this.scene.destroy();
     this._startupClock.destroy();
@@ -864,7 +873,15 @@ export class Application {
       this._backend.destroy();
       this._backendType = 'webgl2';
       this._backend = this.createBackend(this._backendType, this._snapshot);
+
+      // Swap the rendering system for one bound to the rebuilt backend so
+      // app.systems keeps ticking the live RenderingContext.
+      const previousRendering = this._rendering;
+      this.systems.remove(previousRendering);
+      previousRendering.destroy();
       this._rendering = new RenderingContext(this._backend);
+      this.systems.add(this._rendering);
+
       await this._backend.initialize();
     }
   }

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -7,7 +7,7 @@ import type { Loader } from '#resources/Loader';
 
 import type { Application } from './Application';
 import { DisposalScope } from './DisposalScope';
-import type { System } from './System';
+import { SystemRegistry } from './SystemRegistry';
 import type { Time } from './Time';
 import type { Destroyable } from './types';
 
@@ -84,127 +84,6 @@ class SceneTweens implements Destroyable {
 }
 
 /**
- * Scene-bound system registry. Systems added via {@link Scene.systems} are
- * ticked once per frame after {@link Scene.update} (ascending `order`) and
- * destroyed with the scene. See {@link System}.
- *
- * Structural mutations made from inside a system's `update()` (a system adding
- * or removing another, or itself) are deferred until the tick completes.
- */
-class SceneSystems implements Destroyable {
-  private readonly _systems: System[] = [];
-  private readonly _set = new Set<System>();
-  private readonly _pending: Array<{ add: boolean; system: System }> = [];
-  private _ticking = false;
-  private _sorted = true;
-
-  /** Add `system`; returns it for fluent capture. Ticks from the next frame. */
-  public add<T extends System>(system: T): T {
-    if (this._ticking) {
-      this._pending.push({ add: true, system });
-    } else {
-      this._insert(system);
-    }
-
-    return system;
-  }
-
-  /** Remove `system` without destroying it. Returns `true` if it was registered. */
-  public remove(system: System): boolean {
-    if (this._ticking) {
-      if (!this._set.has(system)) {
-        return false;
-      }
-
-      this._pending.push({ add: false, system });
-
-      return true;
-    }
-
-    return this._delete(system);
-  }
-
-  /** Whether `system` is registered. */
-  public has(system: System): boolean {
-    return this._set.has(system);
-  }
-
-  /** Number of registered systems. */
-  public get size(): number {
-    return this._set.size;
-  }
-
-  /** @internal — ticked by {@link SceneManager} after `Scene.update`. */
-  public _tick(delta: Time): void {
-    if (this._systems.length === 0) {
-      return;
-    }
-
-    if (!this._sorted) {
-      this._systems.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
-      this._sorted = true;
-    }
-
-    this._ticking = true;
-
-    for (let index = 0; index < this._systems.length; index++) {
-      this._systems[index].update(delta);
-    }
-
-    this._ticking = false;
-    this._drainPending();
-  }
-
-  public destroy(): void {
-    for (let index = this._systems.length - 1; index >= 0; index--) {
-      this._systems[index].destroy();
-    }
-
-    this._systems.length = 0;
-    this._set.clear();
-    this._pending.length = 0;
-  }
-
-  private _insert(system: System): void {
-    if (!this._set.has(system)) {
-      this._set.add(system);
-      this._systems.push(system);
-      this._sorted = false;
-    }
-  }
-
-  private _delete(system: System): boolean {
-    if (!this._set.delete(system)) {
-      return false;
-    }
-
-    const index = this._systems.indexOf(system);
-
-    if (index !== -1) {
-      this._systems.splice(index, 1);
-    }
-
-    return true;
-  }
-
-  private _drainPending(): void {
-    if (this._pending.length === 0) {
-      return;
-    }
-
-    for (const { add, system } of this._pending) {
-      if (add) {
-        this._insert(system);
-      } else {
-        this._delete(system);
-      }
-    }
-
-    this._pending.length = 0;
-  }
-}
-
-/**
  * How a {@link Scene} composes with scenes already on the stack.
  * - `'overlay'`: render on top, scenes below also render and update.
  * - `'modal'`: render on top, scenes below render but do not update.
@@ -242,7 +121,7 @@ export class Scene {
   protected _stackMode: SceneStackMode = 'overlay';
   private _inputs: SceneInputs | null = null;
   private _tweens: SceneTweens | null = null;
-  private _systems: SceneSystems | null = null;
+  private _systems: SystemRegistry | null = null;
   private readonly _disposal = new DisposalScope();
 
   public get app(): Application | null {
@@ -325,9 +204,9 @@ export class Scene {
    * manual `step()` / `destroy()` wiring. Available before the scene is
    * attached to an Application (systems tick only while the scene is active).
    */
-  public get systems(): SceneSystems {
+  public get systems(): SystemRegistry {
     if (this._systems === null) {
-      this._systems = this._disposal.track(new SceneSystems());
+      this._systems = this._disposal.track(new SystemRegistry());
     }
 
     return this._systems;

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -14,7 +14,7 @@ import { Flags } from '#math/Flags';
 import { Interval } from '#math/Interval';
 import type { Line } from '#math/Line';
 import { Matrix } from '#math/Matrix';
-import { ObservableVector } from '#math/ObservableVector';
+import { ObservableVector, type ObservableVectorOwner } from '#math/ObservableVector';
 import { Rectangle } from '#math/Rectangle';
 import { degreesToRadians, trimRotation } from '#math/utils';
 import type { Vector } from '#math/Vector';
@@ -46,6 +46,16 @@ enum SceneNodeTransformFlags {
   BoundsRect = 1 << 9, // own _bounds is stale
 }
 
+// Internal: which reactive vector fired a change, so the single
+// `_onObservableChange` handler can route to the right dirty path without each
+// vector carrying a bound closure (4 fewer allocations per node).
+enum SceneNodeVectorChannel {
+  Position,
+  Scale,
+  Origin,
+  Anchor,
+}
+
 /**
  * Transform-bearing leaf in the scene-graph hierarchy. Carries position,
  * rotation, scale, skew, origin, and a 2-component {@link Vector} `anchor`
@@ -71,7 +81,7 @@ enum SceneNodeTransformFlags {
  * Subclasses: {@link Container} (carries children), {@link RenderNode}
  * (carries draw payloads).
  */
-export class SceneNode implements Collidable {
+export class SceneNode implements Collidable, ObservableVectorOwner {
   public readonly collisionType: CollisionType = CollisionType.SceneNode;
 
   public readonly flags: Flags<SceneNodeTransformFlags> = new Flags<SceneNodeTransformFlags>(
@@ -80,9 +90,9 @@ export class SceneNode implements Collidable {
 
   protected _bounds = new Bounds();
   protected _transform: Matrix = new Matrix();
-  protected _position: ObservableVector = new ObservableVector(this._setPositionDirty.bind(this), 0, 0);
-  protected _scale: ObservableVector = new ObservableVector(this._setScalingDirty.bind(this), 1, 1);
-  protected _origin: ObservableVector = new ObservableVector(this._setOriginDirty.bind(this), 0, 0);
+  protected _position: ObservableVector = new ObservableVector(this, SceneNodeVectorChannel.Position, 0, 0);
+  protected _scale: ObservableVector = new ObservableVector(this, SceneNodeVectorChannel.Scale, 1, 1);
+  protected _origin: ObservableVector = new ObservableVector(this, SceneNodeVectorChannel.Origin, 0, 0);
   protected _rotation = 0;
   protected _skewX = 0;
   protected _skewY = 0;
@@ -95,7 +105,7 @@ export class SceneNode implements Collidable {
   private _visible = true;
   private _globalTransform = new Matrix();
   private _localBounds = new Rectangle();
-  private _anchor = new ObservableVector(this._updateOrigin.bind(this), 0, 0);
+  private _anchor = new ObservableVector(this, SceneNodeVectorChannel.Anchor, 0, 0);
   private _parentNode: Container | null = null;
   private _zIndex = 0;
   private _cullable = true;
@@ -492,6 +502,30 @@ export class SceneNode implements Collidable {
    */
   public _setStage(stage: Stage | null): void {
     this._stage = stage;
+  }
+
+  /**
+   * Routes a change from one of this node's reactive {@link ObservableVector}
+   * components (position/scale/origin/anchor) to the matching dirty path. The
+   * vectors carry only a numeric channel, so this single handler replaces the
+   * four bound closures they used to allocate per node.
+   * @internal
+   */
+  public _onObservableChange(channel: number): void {
+    switch (channel) {
+      case SceneNodeVectorChannel.Position:
+        this._setPositionDirty();
+        break;
+      case SceneNodeVectorChannel.Scale:
+        this._setScalingDirty();
+        break;
+      case SceneNodeVectorChannel.Origin:
+        this._setOriginDirty();
+        break;
+      case SceneNodeVectorChannel.Anchor:
+        this._updateOrigin();
+        break;
+    }
   }
 
   /** Mark own + all descendants' GlobalTransform + Bounds dirty. */

--- a/src/core/SystemRegistry.ts
+++ b/src/core/SystemRegistry.ts
@@ -1,0 +1,126 @@
+import type { System } from './System';
+import type { Time } from './Time';
+import type { Destroyable } from './types';
+
+/**
+ * Ordered registry of per-frame {@link System}s, shared by {@link Scene} (as
+ * `scene.systems`) and `Application` (as `app.systems`). Systems tick once per
+ * frame in ascending `order` (ties keep insertion order) and are destroyed in
+ * reverse registration order when the registry is destroyed.
+ *
+ * Structural mutations made from inside a system's `update()` (a system adding
+ * or removing another, or itself) are deferred until the tick completes, so the
+ * iteration is never invalidated mid-frame.
+ */
+export class SystemRegistry implements Destroyable {
+  private readonly _systems: System[] = [];
+  private readonly _set = new Set<System>();
+  private readonly _pending: Array<{ add: boolean; system: System }> = [];
+  private _ticking = false;
+  private _sorted = true;
+
+  /** Add `system`; returns it for fluent capture. Ticks from the next frame. */
+  public add<T extends System>(system: T): T {
+    if (this._ticking) {
+      this._pending.push({ add: true, system });
+    } else {
+      this._insert(system);
+    }
+
+    return system;
+  }
+
+  /** Remove `system` without destroying it. Returns `true` if it was registered. */
+  public remove(system: System): boolean {
+    if (this._ticking) {
+      if (!this._set.has(system)) {
+        return false;
+      }
+
+      this._pending.push({ add: false, system });
+
+      return true;
+    }
+
+    return this._delete(system);
+  }
+
+  /** Whether `system` is registered. */
+  public has(system: System): boolean {
+    return this._set.has(system);
+  }
+
+  /** Number of registered systems. */
+  public get size(): number {
+    return this._set.size;
+  }
+
+  /** @internal — ticked by the owner (SceneManager / Application) each frame. */
+  public _tick(delta: Time): void {
+    if (this._systems.length === 0) {
+      return;
+    }
+
+    if (!this._sorted) {
+      this._systems.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+      this._sorted = true;
+    }
+
+    this._ticking = true;
+
+    for (let index = 0; index < this._systems.length; index++) {
+      this._systems[index].update(delta);
+    }
+
+    this._ticking = false;
+    this._drainPending();
+  }
+
+  public destroy(): void {
+    for (let index = this._systems.length - 1; index >= 0; index--) {
+      this._systems[index].destroy();
+    }
+
+    this._systems.length = 0;
+    this._set.clear();
+    this._pending.length = 0;
+  }
+
+  private _insert(system: System): void {
+    if (!this._set.has(system)) {
+      this._set.add(system);
+      this._systems.push(system);
+      this._sorted = false;
+    }
+  }
+
+  private _delete(system: System): boolean {
+    if (!this._set.delete(system)) {
+      return false;
+    }
+
+    const index = this._systems.indexOf(system);
+
+    if (index !== -1) {
+      this._systems.splice(index, 1);
+    }
+
+    return true;
+  }
+
+  private _drainPending(): void {
+    if (this._pending.length === 0) {
+      return;
+    }
+
+    for (const { add, system } of this._pending) {
+      if (add) {
+        this._insert(system);
+      } else {
+        this._delete(system);
+      }
+    }
+
+    this._pending.length = 0;
+  }
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -12,6 +12,7 @@ export * from './SceneNode';
 export * from './Signal';
 export * from './Stage';
 export * from './System';
+export * from './SystemRegistry';
 export * from './Time';
 export * from './Timer';
 export * from './types';

--- a/src/input/InputManager.ts
+++ b/src/input/InputManager.ts
@@ -1,5 +1,6 @@
 import type { Application } from '#core/Application';
 import { Signal } from '#core/Signal';
+import type { System } from '#core/System';
 import { stopEvent } from '#core/utils';
 import { Flags } from '#math/Flags';
 import { getDistance } from '#math/utils';
@@ -56,7 +57,9 @@ enum InputManagerFlag {
  * Driven each frame by {@link Application.update}; constructed
  * automatically — you do not instantiate this class yourself.
  */
-export class InputManager {
+export class InputManager implements System {
+  /** App-systems tick band — input flushes first; see Application.systems. @internal */
+  public readonly order = 100;
   private readonly _app: Application;
   private readonly canvas: HTMLCanvasElement;
   private readonly channels: Float32Array = new Float32Array(ChannelSize.Container);

--- a/src/input/InteractionManager.ts
+++ b/src/input/InteractionManager.ts
@@ -1,6 +1,7 @@
 import type { Application } from '#core/Application';
 import type { Signal } from '#core/Signal';
 import type { InteractionHooks, Stage } from '#core/Stage';
+import type { System } from '#core/System';
 import type { QuadtreeItem } from '#math/Quadtree';
 import { Quadtree } from '#math/Quadtree';
 import { Rectangle } from '#math/Rectangle';
@@ -65,7 +66,9 @@ interface IndexedNode {
  * Constructed automatically by {@link Application}; you do not instantiate
  * this class yourself.
  */
-export class InteractionManager implements InteractionHooks {
+export class InteractionManager implements InteractionHooks, System {
+  /** App-systems tick band — interaction after input. @internal */
+  public readonly order = 200;
   private readonly _app: Application;
 
   // Persistent quadtree — null when no interactive nodes are present.

--- a/src/math/ObservableVector.ts
+++ b/src/math/ObservableVector.ts
@@ -1,25 +1,45 @@
 import { AbstractVector } from './AbstractVector';
 
 /**
- * A {@link AbstractVector} subclass that fires a callback whenever its
- * components change. Used internally by {@link Rectangle} and other types to
- * invalidate cached state (e.g. normals) on position mutations.
+ * Receiver of {@link ObservableVector} change notifications. The vector calls
+ * `_onObservableChange(channel)` whenever a component actually changes, passing
+ * the numeric `channel` it was constructed with so a single owner can tell
+ * several vectors apart (e.g. a node's position vs. scale vs. origin) without
+ * allocating a bound closure per vector.
+ * @internal
+ */
+export interface ObservableVectorOwner {
+  _onObservableChange(channel: number): void;
+}
+
+/**
+ * An {@link AbstractVector} subclass that notifies an owner whenever its
+ * components change. Used internally by {@link Rectangle}, `SceneNode`,
+ * {@link View} and other types to invalidate cached state (normals, transforms)
+ * on mutation.
  *
- * Setting individual components (`x`, `y`) fires the callback only when the
- * value actually changes. Batch mutations via `set()` fire at most one
- * callback per call.
+ * Instead of a per-instance callback closure, the vector holds a reference to
+ * its `owner` plus a numeric `channel` and calls `owner._onObservableChange(channel)`
+ * on change. This keeps hot per-node vectors closure-free — a `SceneNode`
+ * carries four of these, so dropping the bound closures saves four allocations
+ * per node. Pass `owner = null` for a plain, non-reactive vector.
+ *
+ * Setting individual components (`x`, `y`) notifies only when the value
+ * actually changes. Batch mutations via `set()` notify at most once per call.
  */
 export class ObservableVector extends AbstractVector {
   private _x: number;
   private _y: number;
-  private _callback: (() => void) | null;
+  private _owner: ObservableVectorOwner | null;
+  private readonly _channel: number;
 
-  public constructor(callback: (() => void) | null, x = 0, y = 0) {
+  public constructor(owner: ObservableVectorOwner | null, channel = 0, x = 0, y = 0) {
     super();
 
     this._x = x;
     this._y = y;
-    this._callback = callback;
+    this._owner = owner;
+    this._channel = channel;
   }
 
   public get x(): number {
@@ -29,7 +49,7 @@ export class ObservableVector extends AbstractVector {
   public set x(x: number) {
     if (this._x !== x) {
       this._x = x;
-      this._callback?.();
+      this._owner?._onObservableChange(this._channel);
     }
   }
 
@@ -40,7 +60,7 @@ export class ObservableVector extends AbstractVector {
   public set y(y: number) {
     if (this._y !== y) {
       this._y = y;
-      this._callback?.();
+      this._owner?._onObservableChange(this._channel);
     }
   }
 
@@ -60,7 +80,7 @@ export class ObservableVector extends AbstractVector {
     if (this._x !== x || this._y !== y) {
       this._x = x;
       this._y = y;
-      this._callback?.();
+      this._owner?._onObservableChange(this._channel);
     }
 
     return this;
@@ -87,7 +107,7 @@ export class ObservableVector extends AbstractVector {
   }
 
   public clone(): this {
-    return new ObservableVector(this._callback ?? ((): void => {}), this._x, this._y) as this;
+    return new ObservableVector(this._owner, this._channel, this._x, this._y) as this;
   }
 
   public copy(vector: AbstractVector): this {
@@ -95,8 +115,8 @@ export class ObservableVector extends AbstractVector {
   }
 
   public destroy(): void {
-    // Clear the callback to prevent leaks if this vector is retained by an
-    // external scope after the owning object is destroyed.
-    this._callback = null;
+    // Drop the owner reference to prevent leaks if this vector is retained by
+    // an external scope after the owning object is destroyed.
+    this._owner = null;
   }
 }

--- a/src/math/Rectangle.ts
+++ b/src/math/Rectangle.ts
@@ -17,7 +17,7 @@ import type { Ellipse } from './Ellipse';
 import { Interval } from './Interval';
 import type { Line } from './Line';
 import type { Matrix } from './Matrix';
-import { ObservableVector } from './ObservableVector';
+import { ObservableVector, type ObservableVectorOwner } from './ObservableVector';
 import type { Polygon } from './Polygon';
 import type { ShapeLike } from './ShapeLike';
 import { Size } from './Size';
@@ -25,8 +25,7 @@ import { inRange } from './utils';
 import type { Vector } from './Vector';
 
 let temp: Rectangle | null = null;
-const noop = (): void => {};
-const tempPoint = new ObservableVector(noop);
+const tempPoint = new ObservableVector(null);
 
 /**
  * Mutable axis-aligned rectangle defined by a top-left origin `(x, y)` and
@@ -37,7 +36,7 @@ const tempPoint = new ObservableVector(noop);
  * `Rectangle.temp` is a shared scratch instance. Edge normals are lazily
  * computed and cached; they are invalidated when position or size mutates.
  */
-export class Rectangle implements ShapeLike {
+export class Rectangle implements ShapeLike, ObservableVectorOwner {
   public readonly collisionType: CollisionType = CollisionType.Rectangle;
 
   private readonly _position: ObservableVector;
@@ -46,14 +45,16 @@ export class Rectangle implements ShapeLike {
   private _normalsDirty = false;
 
   public constructor(x = 0, y = x, width = 0, height = width) {
-    this._position = new ObservableVector(
-      () => {
-        this._normalsDirty = true;
-      },
-      x,
-      y,
-    );
+    this._position = new ObservableVector(this, 0, x, y);
     this._size = new Size(width, height);
+  }
+
+  /**
+   * Receives change notifications from `_position`; marks the cached edge
+   * normals stale so the next {@link getNormals} recomputes them. @internal
+   */
+  public _onObservableChange(): void {
+    this._normalsDirty = true;
   }
 
   public get position(): Vector {
@@ -173,7 +174,7 @@ export class Rectangle implements ShapeLike {
   public getNormals(): Vector[] {
     if (this._normalsDirty || this._normals === null) {
       this._updateNormals(
-        this._normals || (this._normals = [new ObservableVector(noop), new ObservableVector(noop), new ObservableVector(noop), new ObservableVector(noop)]),
+        this._normals || (this._normals = [new ObservableVector(null), new ObservableVector(null), new ObservableVector(null), new ObservableVector(null)]),
       );
 
       this._normalsDirty = false;

--- a/src/rendering/RenderingContext.ts
+++ b/src/rendering/RenderingContext.ts
@@ -1,4 +1,6 @@
 import type { Color } from '#core/Color';
+import type { System } from '#core/System';
+import type { Time } from '#core/Time';
 import type { RenderPassCoordinatorHost } from '#rendering/pass/RenderPassCoordinator';
 import { StencilAttachmentMode } from '#rendering/pass/RenderPassDescriptor';
 import { playRenderTree } from '#rendering/plan/playRenderTree';
@@ -32,7 +34,9 @@ export interface RenderOptions {
  *   context.renderTo(node, opts)    // into an off-screen RenderTexture
  * @stable
  */
-export class RenderingContext {
+export class RenderingContext implements System {
+  /** App-systems tick band — rendering last (camera + render-plan prep). @internal */
+  public readonly order = 500;
   private readonly _backend: RenderBackend;
   private _camera: Camera;
   private readonly _screenView: View;
@@ -89,11 +93,22 @@ export class RenderingContext {
   }
 
   /**
-   * Advance follow, shake, and bounds-constraint animations on the
-   * active camera. Call once per frame before rendering.
+   * Advance follow, shake, and bounds-constraint animations on the active
+   * camera. Ticked once per frame via {@link Application.systems}.
    */
-  public update(deltaMs: number): void {
-    this._camera.update(deltaMs);
+  public update(delta: Time): void {
+    this._camera.update(delta.milliseconds);
+  }
+
+  /**
+   * Destroy the resources this context owns — the active {@link Camera} and the
+   * screen-space {@link View}. The {@link RenderBackend} is owned by the
+   * Application and destroyed separately.
+   * @internal — invoked via Application.systems on teardown.
+   */
+  public destroy(): void {
+    this._camera.destroy();
+    this._screenView.destroy();
   }
 
   /**

--- a/src/rendering/View.ts
+++ b/src/rendering/View.ts
@@ -3,7 +3,7 @@ import { SceneNode } from '#core/SceneNode';
 import { Flags } from '#math/Flags';
 import { Matrix } from '#math/Matrix';
 import { ObservableSize } from '#math/ObservableSize';
-import { ObservableVector } from '#math/ObservableVector';
+import { ObservableVector, type ObservableVectorOwner } from '#math/ObservableVector';
 import type { PointLike } from '#math/PointLike';
 import { Rectangle } from '#math/Rectangle';
 import { clamp, degreesToRadians, trimRotation } from '#math/utils';
@@ -56,7 +56,7 @@ export interface ViewShakeOptions {
  * shake animations.
  * @stable
  */
-export class View {
+export class View implements ObservableVectorOwner {
   private readonly _center: ObservableVector;
   private readonly _size: ObservableSize;
   private readonly _viewport: Rectangle = new Rectangle(0, 0, 1, 1);
@@ -86,11 +86,21 @@ export class View {
   private _updateId = 0;
 
   public constructor(centerX: number, centerY: number, width: number, height: number) {
-    this._center = new ObservableVector(this._setPositionDirty.bind(this), centerX, centerY);
+    this._center = new ObservableVector(this, 0, centerX, centerY);
     this._size = new ObservableSize(this._setScalingDirty.bind(this), width, height);
     this._zoomBaseWidth = width;
     this._zoomBaseHeight = height;
     this._flags.push(ViewFlags.Transform, ViewFlags.TransformInverse, ViewFlags.BoundingBox);
+  }
+
+  /**
+   * Receives change notifications from the reactive `_center` vector and marks
+   * the view transform stale. (`_size` is an {@link ObservableSize}, which still
+   * carries its own callback.)
+   * @internal
+   */
+  public _onObservableChange(): void {
+    this._setPositionDirty();
   }
 
   public get center(): ObservableVector {

--- a/test/animation/tween-manager.test.ts
+++ b/test/animation/tween-manager.test.ts
@@ -1,7 +1,10 @@
 ﻿import { Tween } from '#animation/Tween';
 import { TweenManager } from '#animation/TweenManager';
 import { TweenState } from '#animation/types';
+import { Time } from '#core/Time';
 
+/** TweenManager.update() takes a Time; tests express their deltas in seconds. */
+const sec = (seconds: number): Time => new Time(seconds, Time.seconds);
 const makeTarget = () => ({ x: 0, y: 0 });
 
 describe('TweenManager', () => {
@@ -22,7 +25,7 @@ describe('TweenManager', () => {
     manager.create(a).to({ x: 100 }, 1.0).start();
     manager.create(b).to({ x: 200 }, 1.0).start();
 
-    manager.update(0.5);
+    manager.update(sec(0.5));
     expect(a.x).toBeCloseTo(50, 5);
     expect(b.x).toBeCloseTo(100, 5);
   });
@@ -32,11 +35,11 @@ describe('TweenManager', () => {
     const target = makeTarget();
     const tween = manager.create(target).to({ x: 100 }, 1.0).start();
 
-    manager.update(1.0); // completes
+    manager.update(sec(1.0)); // completes
     expect(tween.state).toBe(TweenState.Complete);
 
     // Further updates should not error and target should stay at 100
-    manager.update(1.0);
+    manager.update(sec(1.0));
     expect(target.x).toBe(100);
   });
 
@@ -46,7 +49,7 @@ describe('TweenManager', () => {
     const tween = new Tween(target).to({ x: 100 }, 1.0).start();
 
     manager.add(tween);
-    manager.update(0.5);
+    manager.update(sec(0.5));
     expect(target.x).toBeCloseTo(50, 5);
   });
 
@@ -56,7 +59,7 @@ describe('TweenManager', () => {
     const tween = manager.create(target).to({ x: 100 }, 1.0).start();
 
     manager.add(tween); // add again
-    manager.update(1.0); // should complete once, not advance twice
+    manager.update(sec(1.0)); // should complete once, not advance twice
     expect(target.x).toBe(100);
     expect(tween.state).toBe(TweenState.Complete);
   });
@@ -66,9 +69,9 @@ describe('TweenManager', () => {
     const target = makeTarget();
     const tween = manager.create(target).to({ x: 100 }, 1.0).start();
 
-    manager.update(0.3);
+    manager.update(sec(0.3));
     manager.remove(tween);
-    manager.update(0.7);
+    manager.update(sec(0.7));
     expect(target.x).toBeCloseTo(30, 5); // frozen at 0.3s
   });
 
@@ -80,7 +83,7 @@ describe('TweenManager', () => {
     manager.create(makeTarget()).to({ x: 200 }, 1.0).onComplete(onComplete).start();
 
     manager.clear();
-    manager.update(1.0); // no tweens remain — nothing should fire
+    manager.update(sec(1.0)); // no tweens remain — nothing should fire
     expect(onComplete).not.toHaveBeenCalled();
   });
 
@@ -90,7 +93,7 @@ describe('TweenManager', () => {
 
     manager.create(target).to({ x: 100 }, 1.0).start();
     manager.destroy();
-    manager.update(1.0);
+    manager.update(sec(1.0));
     expect(target.x).toBe(0); // never advanced
   });
 
@@ -105,7 +108,7 @@ describe('TweenManager', () => {
       manager.create(b).to({ x: 200 }, 1.0).start();
     });
 
-    expect(() => manager.update(1.0)).not.toThrow();
+    expect(() => manager.update(sec(1.0))).not.toThrow();
     expect(tweenA.state).toBe(TweenState.Complete);
   });
 });

--- a/test/animation/tween.test.ts
+++ b/test/animation/tween.test.ts
@@ -2,6 +2,10 @@
 import { Tween } from '#animation/Tween';
 import { TweenManager } from '#animation/TweenManager';
 import { TweenState } from '#animation/types';
+import { Time } from '#core/Time';
+
+/** TweenManager.update() takes a Time; tests express their deltas in seconds. */
+const sec = (seconds: number): Time => new Time(seconds, Time.seconds);
 
 // Minimal sprite-like target.
 const makeSprite = (x = 0, y = 0, alpha = 1) => ({ x, y, alpha });
@@ -231,7 +235,7 @@ describe('Tween', () => {
       tween.stop();
       // After stop, updating manager should not move sprite.
       const xAtStop = sprite.x;
-      manager.update(1.0);
+      manager.update(sec(1.0));
       expect(sprite.x).toBe(xAtStop);
     });
   });
@@ -334,14 +338,14 @@ describe('Tween', () => {
       const target = makeSprite();
       const tween = manager.create(target).to({ x: 100 }, 1.0).start();
 
-      manager.update(1.0); // complete — tween removed from manager
+      manager.update(sec(1.0)); // complete — tween removed from manager
       expect(tween.state).toBe(TweenState.Complete);
 
       const secondComplete = vi.fn();
       tween.onComplete(secondComplete).start();
       expect(tween.state).toBe(TweenState.Active);
 
-      manager.update(1.0); // manager must drive it — second completion fires
+      manager.update(sec(1.0)); // manager must drive it — second completion fires
       expect(secondComplete).toHaveBeenCalledTimes(1);
       expect(tween.state).toBe(TweenState.Complete);
     });
@@ -351,7 +355,7 @@ describe('Tween', () => {
       const target = makeSprite();
       const tween = manager.create(target).to({ x: 100 }, 1.0).start();
 
-      manager.update(0.3);
+      manager.update(sec(0.3));
       tween.stop();
       expect(tween.state).toBe(TweenState.Stopped);
 
@@ -359,7 +363,7 @@ describe('Tween', () => {
       tween.onComplete(onComplete).start();
       expect(tween.state).toBe(TweenState.Active);
 
-      manager.update(1.0); // manager drives the restarted tween
+      manager.update(sec(1.0)); // manager drives the restarted tween
       expect(onComplete).toHaveBeenCalledTimes(1);
       expect(tween.state).toBe(TweenState.Complete);
     });
@@ -372,7 +376,7 @@ describe('Tween', () => {
       const tween = manager.create(target).to({ x: 100 }, 1.0).start();
 
       tween.start(); // re-call while active — resets elapsed, no double-registration
-      manager.update(0.5);
+      manager.update(sec(0.5));
       expect(target.x).toBeCloseTo(50, 5); // exactly one advancement
     });
 
@@ -402,7 +406,7 @@ describe('Tween', () => {
       forward.start();
 
       // 50 × 0.1s = 5 seconds; enough for ≥2 complete cycles of each tween
-      for (let i = 0; i < 50; i++) manager.update(0.1);
+      for (let i = 0; i < 50; i++) manager.update(sec(0.1));
 
       expect(forwardCompleteCount).toBeGreaterThanOrEqual(2);
       expect(backwardCompleteCount).toBeGreaterThanOrEqual(2);

--- a/test/audio/audio-manager-update.test.ts
+++ b/test/audio/audio-manager-update.test.ts
@@ -87,86 +87,39 @@ describe('AudioManager.update()', () => {
     sound.destroy();
   });
 
-  // 4. Application.update() invokes mixer.update() between interaction and tweens
-  test('Application.update() calls audio.update() between interaction.update() and tweens.update()', async () => {
+  // 4. Application.update() ticks the app systems in ascending order. The core
+  // managers register on app.systems with reserved bands, so the loop runs
+  // interaction (200) → audio (300) → tweens (400). Stand in with ordered probes.
+  test('Application.update() ticks app systems in ascending order', async () => {
     vi.resetModules();
 
     const callOrder: string[] = [];
 
-    const mixerMock = {
-      update: vi.fn(() => {
-        callOrder.push('mixer');
-      }),
-      _applyVisibility: vi.fn(),
-      destroy: vi.fn(),
-    };
-    vi.doMock('#rendering/webgl2/WebGl2Backend', () => ({
-      WebGl2Backend: vi.fn(function () {
-        return {
-          initialize: vi.fn(),
-          flush: vi.fn(),
-          resize: vi.fn(),
-          destroy: vi.fn(),
-          resetStats: vi.fn().mockReturnThis(),
-          stats: { frameTimeMs: 0 },
-        };
-      }),
-    }));
-    vi.doMock('#rendering/webgpu/WebGpuBackend', () => ({
-      WebGpuBackend: vi.fn(),
-    }));
+    vi.doMock('#rendering/webgl2/WebGl2Backend', () => ({ WebGl2Backend: vi.fn() }));
+    vi.doMock('#rendering/webgpu/WebGpuBackend', () => ({ WebGpuBackend: vi.fn() }));
     vi.doMock('#resources/Loader', () => ({
       Loader: vi.fn(function () {
         return { destroy: vi.fn() };
       }),
     }));
-    vi.doMock('#input/InputManager', () => ({
-      InputManager: vi.fn(function () {
-        return {
-          update: vi.fn(),
-          destroy: vi.fn(),
-          onCanvasFocusChange: { add: vi.fn() },
-        };
-      }),
-    }));
-    vi.doMock('#input/InteractionManager', () => ({
-      InteractionManager: vi.fn(function () {
-        return {
-          update: vi.fn(() => {
-            callOrder.push('interaction');
-          }),
-          destroy: vi.fn(),
-        };
-      }),
-    }));
-    vi.doMock('#core/SceneManager', () => ({
-      SceneManager: vi.fn(function () {
-        return { update: vi.fn(), setScene: vi.fn(), destroy: vi.fn() };
-      }),
-    }));
 
     const { Application, ApplicationStatus } = await import('#core/Application');
+    const { SystemRegistry } = await import('#core/SystemRegistry');
 
     const app = Object.create(Application.prototype) as import('#core/Application').Application;
     const rawApp = app as unknown as Record<string, unknown>;
 
-    const tweens = {
-      update: vi.fn(() => {
-        callOrder.push('tweens');
-      }),
-    };
+    // Register out of order to prove the registry sorts by `order`, not insertion.
+    const systems = new SystemRegistry();
+    systems.add({ order: 400, update: () => callOrder.push('tweens'), destroy: vi.fn() });
+    systems.add({ order: 200, update: () => callOrder.push('interaction'), destroy: vi.fn() });
+    systems.add({ order: 300, update: () => callOrder.push('audio'), destroy: vi.fn() });
 
     rawApp['_status'] = ApplicationStatus.Running;
-    rawApp['_audio'] = mixerMock;
-    rawApp['input'] = { update: vi.fn() };
-    rawApp['interaction'] = {
-      update: () => {
-        callOrder.push('interaction');
-      },
-    };
-    rawApp['tweens'] = tweens;
+    rawApp['pauseOnHidden'] = false;
+    rawApp['_documentVisible'] = true;
+    rawApp['systems'] = systems;
     rawApp['scene'] = { update: vi.fn() };
-    rawApp['_rendering'] = { update: vi.fn() };
     rawApp['_backend'] = {
       flush: vi.fn(),
       resetStats: vi.fn().mockReturnThis(),
@@ -184,13 +137,7 @@ describe('AudioManager.update()', () => {
 
     app.update();
 
-    const mixerIdx = callOrder.indexOf('mixer');
-    const interactionIdx = callOrder.indexOf('interaction');
-    const tweensIdx = callOrder.indexOf('tweens');
-
-    expect(mixerMock.update).toHaveBeenCalledTimes(1);
-    expect(mixerIdx).toBeGreaterThan(interactionIdx);
-    expect(tweensIdx).toBeGreaterThan(mixerIdx);
+    expect(callOrder).toEqual(['interaction', 'audio', 'tweens']);
 
     vi.resetModules();
   });

--- a/test/core/__snapshots__/root-index-snapshot.test.ts.snap
+++ b/test/core/__snapshots__/root-index-snapshot.test.ts.snap
@@ -155,6 +155,7 @@ exports[`root index export surface snapshot > sorted runtime export names match 
   "SvgAsset",
   "SvgFactory",
   "SwitchProGamepadMapping",
+  "SystemRegistry",
   "Text",
   "TextAsset",
   "TextFactory",

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -326,6 +326,7 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "SweptHit: interface",
   "SwitchProGamepadMapping: class",
   "System: interface",
+  "SystemRegistry: class",
   "Text: class",
   "TextAlignment: type alias",
   "TextAsset: class",

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -227,6 +227,7 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "NineSliceSprite: class",
   "ObservableSize: class",
   "ObservableVector: class",
+  "ObservableVectorOwner: interface",
   "OscillatorType: type alias",
   "Pausable: interface",
   "PixelSnapMode: type alias",

--- a/test/core/application-loop.test.ts
+++ b/test/core/application-loop.test.ts
@@ -215,7 +215,8 @@ describe('Application.update() — loop timing (F1 + F2)', () => {
       app.update();
 
       // Should receive 16ms (≈0.016s), not a huge accumulated spike
-      expect(tweensUpdateSpy).toHaveBeenCalledWith(expect.closeTo(0.016, 4));
+      const receivedDelta = tweensUpdateSpy.mock.calls[0][0] as Time;
+      expect(receivedDelta.seconds).toBeCloseTo(0.016, 4);
     });
   });
 
@@ -232,10 +233,10 @@ describe('Application.update() — loop timing (F1 + F2)', () => {
       app.update();
 
       expect(tweensUpdateSpy).toHaveBeenCalledTimes(1);
-      const receivedSeconds = tweensUpdateSpy.mock.calls[0][0] as number;
+      const receivedDelta = tweensUpdateSpy.mock.calls[0][0] as Time;
 
       // MAX_DELTA_MS = 100 → 0.1 seconds
-      expect(receivedSeconds).toBeLessThanOrEqual(0.1);
+      expect(receivedDelta.seconds).toBeLessThanOrEqual(0.1);
     });
 
     test('a very large raw delta is clamped before sceneManager.update receives it', () => {
@@ -259,9 +260,9 @@ describe('Application.update() — loop timing (F1 + F2)', () => {
       app.update();
 
       expect(tweensUpdateSpy).toHaveBeenCalledTimes(1);
-      const receivedSeconds = tweensUpdateSpy.mock.calls[0][0] as number;
+      const receivedDelta = tweensUpdateSpy.mock.calls[0][0] as Time;
 
-      expect(receivedSeconds).toBeCloseTo(0.016, 4);
+      expect(receivedDelta.seconds).toBeCloseTo(0.016, 4);
     });
 
     test('a delta exactly at the cap boundary (100ms) passes through unchanged', () => {
@@ -271,9 +272,9 @@ describe('Application.update() — loop timing (F1 + F2)', () => {
 
       app.update();
 
-      const receivedSeconds = tweensUpdateSpy.mock.calls[0][0] as number;
+      const receivedDelta = tweensUpdateSpy.mock.calls[0][0] as Time;
 
-      expect(receivedSeconds).toBeCloseTo(0.1, 4);
+      expect(receivedDelta.seconds).toBeCloseTo(0.1, 4);
     });
 
     test('a delta one millisecond above the cap is clamped to exactly the cap', () => {
@@ -283,10 +284,10 @@ describe('Application.update() — loop timing (F1 + F2)', () => {
 
       app.update();
 
-      const receivedSeconds = tweensUpdateSpy.mock.calls[0][0] as number;
+      const receivedDelta = tweensUpdateSpy.mock.calls[0][0] as Time;
 
       // Must be <= 0.1, not 0.101
-      expect(receivedSeconds).toBeLessThanOrEqual(0.1);
+      expect(receivedDelta.seconds).toBeLessThanOrEqual(0.1);
     });
 
     test('raw delta beyond cap is still recorded in backend.stats.rawFrameDeltaMs', () => {
@@ -304,10 +305,10 @@ describe('Application.update() — loop timing (F1 + F2)', () => {
 
       app.update();
 
-      const receivedSeconds = tweensUpdateSpy.mock.calls[0][0] as number;
+      const receivedDelta = tweensUpdateSpy.mock.calls[0][0] as Time;
 
       // Simulation delta is clamped to 100ms = 0.1s
-      expect(receivedSeconds).toBeLessThanOrEqual(0.1);
+      expect(receivedDelta.seconds).toBeLessThanOrEqual(0.1);
       // Raw stat records the actual 200ms
       expect(app.backend.stats.rawFrameDeltaMs).toBe(200);
     });

--- a/test/core/application-on-frame.test.ts
+++ b/test/core/application-on-frame.test.ts
@@ -154,12 +154,10 @@ describe('Application.onFrame', () => {
     };
 
     rawApp['_status'] = ApplicationStatus.Running;
-    rawApp['_audio'] = { update: vi.fn(), destroy: vi.fn() };
-    rawApp['input'] = { update: vi.fn() };
-    rawApp['interaction'] = { update: vi.fn() };
-    rawApp['tweens'] = { update: vi.fn() };
+    rawApp['pauseOnHidden'] = false;
+    rawApp['_documentVisible'] = true;
+    rawApp['systems'] = { _tick: vi.fn() };
     rawApp['scene'] = sceneManager;
-    rawApp['_rendering'] = { update: vi.fn() };
     rawApp['_backend'] = backend;
     rawApp['_frameClock'] = { elapsedTime: { milliseconds: 16, seconds: 0.016 }, restart: vi.fn() };
     rawApp['_updateHandler'] = vi.fn();

--- a/test/core/application.test.ts
+++ b/test/core/application.test.ts
@@ -179,10 +179,8 @@ describe('Application', () => {
     const { Application, ApplicationStatus } = await loadApplicationHarness();
     const app = Object.create(Application.prototype) as import('#core/Application').Application;
     const rawApp = app as unknown as Record<string, unknown>;
-    const inputManager = { update: vi.fn() };
-    const tweens = { update: vi.fn() };
+    const systemsTick = vi.fn();
     const sceneManager = { update: vi.fn() };
-    const renderingUpdate = vi.fn();
     const backend = {
       flush: vi.fn(),
       resetStats: vi.fn().mockReturnThis(),
@@ -193,15 +191,11 @@ describe('Application', () => {
       restart: vi.fn(),
     };
 
-    const interaction = { update: vi.fn() };
-
     rawApp['_status'] = ApplicationStatus.Running;
-    rawApp['_audio'] = { update: vi.fn(), destroy: vi.fn() };
-    rawApp['input'] = inputManager;
-    rawApp['interaction'] = interaction;
-    rawApp['tweens'] = tweens;
+    rawApp['pauseOnHidden'] = false;
+    rawApp['_documentVisible'] = true;
+    rawApp['systems'] = { _tick: systemsTick };
     rawApp['scene'] = sceneManager;
-    rawApp['_rendering'] = { update: renderingUpdate };
     rawApp['_backend'] = backend;
     rawApp['_frameClock'] = frameClock;
     rawApp['_updateHandler'] = vi.fn();
@@ -212,9 +206,8 @@ describe('Application', () => {
 
     app.update();
 
-    expect(inputManager.update).toHaveBeenCalledTimes(1);
+    expect(systemsTick).toHaveBeenCalledTimes(1);
     expect(sceneManager.update).toHaveBeenCalledTimes(1);
-    expect(renderingUpdate).toHaveBeenCalledWith(16);
     expect(backend.resetStats).toHaveBeenCalledTimes(1);
     expect(backend.flush).toHaveBeenCalledTimes(1);
     expect(backend.stats.frameTimeMs).toBeGreaterThanOrEqual(0);

--- a/test/math/observable-vector.test.ts
+++ b/test/math/observable-vector.test.ts
@@ -1,16 +1,16 @@
-﻿import { ObservableVector } from '#math/ObservableVector';
+import { ObservableVector } from '#math/ObservableVector';
 
 describe('ObservableVector.destroy()', () => {
   // destroy() should not throw
   test('destroy() does not throw', () => {
-    const v = new ObservableVector(() => {}, 1, 2);
+    const v = new ObservableVector(null, 0, 1, 2);
 
     expect(() => v.destroy()).not.toThrow();
   });
 
   // Calling destroy() twice is safe
   test('destroy() is safe to call twice', () => {
-    const v = new ObservableVector(() => {}, 1, 2);
+    const v = new ObservableVector(null, 0, 1, 2);
 
     expect(() => {
       v.destroy();
@@ -18,29 +18,29 @@ describe('ObservableVector.destroy()', () => {
     }).not.toThrow();
   });
 
-  // Callback is no longer invoked after destroy()
-  test('callback is no longer invoked after destroy()', () => {
-    const spy = vi.fn();
-    const v = new ObservableVector(spy, 0, 0);
+  // Owner is no longer notified after destroy()
+  test('owner is no longer notified after destroy()', () => {
+    const onChange = vi.fn();
+    const v = new ObservableVector({ _onObservableChange: onChange }, 0, 0, 0);
 
-    // Confirm callback fires before destroy
+    // Confirm the owner is notified before destroy
     v.x = 10;
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledTimes(1);
 
     v.destroy();
-    spy.mockClear();
+    onChange.mockClear();
 
-    // Now mutations should NOT invoke the callback
+    // Now mutations should NOT notify the owner
     v.x = 20;
     v.y = 30;
     v.set(40, 50);
 
-    expect(spy).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   // Setting x/y after destroy() still mutates the values (no error)
   test('setting values after destroy() still works without throwing', () => {
-    const v = new ObservableVector(() => {}, 0, 0);
+    const v = new ObservableVector(null, 0, 0, 0);
 
     v.destroy();
 
@@ -51,5 +51,48 @@ describe('ObservableVector.destroy()', () => {
 
     expect(v.x).toBe(5);
     expect(v.y).toBe(10);
+  });
+});
+
+describe('ObservableVector owner notification', () => {
+  // The owner is notified with the channel the vector was constructed with, so
+  // one owner can disambiguate several vectors without a per-vector closure.
+  test('notifies the owner with its channel on change', () => {
+    const onChange = vi.fn();
+    const v = new ObservableVector({ _onObservableChange: onChange }, 7, 0, 0);
+
+    v.x = 1;
+    expect(onChange).toHaveBeenLastCalledWith(7);
+
+    v.y = 2;
+    expect(onChange).toHaveBeenLastCalledWith(7);
+
+    v.set(3, 4);
+    expect(onChange).toHaveBeenCalledTimes(3);
+  });
+
+  // No notification fires when a component is set to its current value.
+  test('does not notify when the value is unchanged', () => {
+    const onChange = vi.fn();
+    const v = new ObservableVector({ _onObservableChange: onChange }, 0, 5, 6);
+
+    v.x = 5;
+    v.y = 6;
+    v.set(5, 6);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  // A null owner is a plain, non-reactive vector (no callbacks, no throw).
+  test('a null owner mutates silently', () => {
+    const v = new ObservableVector(null, 0, 0, 0);
+
+    expect(() => {
+      v.x = 1;
+      v.set(2, 3);
+    }).not.toThrow();
+
+    expect(v.x).toBe(2);
+    expect(v.y).toBe(3);
   });
 });


### PR DESCRIPTION
Completes the two remaining Phase-1 posts from spec `05` (the foundation main wave + audio re-architecture landed in #133). Both were already fully spec'd; no new design needed.

## 4b — ObservableVector closure elimination (§4b)
`ObservableVector` held a bound callback closure, so every `SceneNode` allocated four (position/scale/origin/anchor) — 40k closures at 10k nodes. It now holds an `owner` + numeric `channel` and calls `owner._onObservableChange(channel)` on change → four fewer allocations per node, identical behaviour. `SceneNode`/`Rectangle`/`View` migrate; Rectangle's scratch point + lazy normals use a `null` owner.

## 2B — Application.systems manager migration (§2)
The five hardcoded manager calls in the frame loop become ordered `System`s ticked from one registry. `SystemRegistry` (generalized from Scene's internal `SceneSystems`) now backs **both** `scene.systems` and the new **`app.systems`**. Core managers sit on reserved order bands (input 100, interaction 200, audio 300, tweens 400, rendering 500); user app-systems slot in at 600+. **DE-F2:** manager `update` signatures converge on `(delta: Time)` (tweens was seconds, rendering was ms). `RenderingContext` gains a `destroy()` (camera + screenView; backend stays Application-owned).

## Verification
- 3204 tests green across all projects
- typecheck (src + examples + guides), `lint:all`, `format:check`, `docs:api:check` all green locally

## Breaking
- `new ObservableVector(owner, channel, x, y)` (was `(callback, x, y)`)
- `TweenManager.update` / `RenderingContext.update` now take `Time`

Scene-stack simplification (§5) stays deferred to Phase 4 (UI bundle). Per the JIT spec strategy (`04`-§6), phases 2/3/4 get full specs when they begin.