### PR TITLE
refactor(core): shared Registry<K,V> primitive (Phase 3 — Provider consolidation)

### DIFF
--- a/site/src/content/api/renderer-registry.mdx
+++ b/site/src/content/api/renderer-registry.mdx
@@ -9,7 +9,7 @@ memberCount: 7
 tier: "advanced"
 sections: ["Import", "Constructors", "Methods", "Source"]
 sourcePath: "src/rendering/RendererRegistry.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/RendererRegistry.ts#L19"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/RendererRegistry.ts#L28"
 ---
 ## Import
 
@@ -42,4 +42,4 @@ custom renderer registration.
 
 ## Source
 
-[src/rendering/RendererRegistry.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/RendererRegistry.ts#L19)
+[src/rendering/RendererRegistry.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/RendererRegistry.ts#L28)

--- a/src/core/Registry.ts
+++ b/src/core/Registry.ts
@@ -1,0 +1,112 @@
+/**
+ * Options for a {@link Registry}.
+ *
+ * @typeParam Key - lookup key, typically a constructor token.
+ * @typeParam Value - stored value.
+ * @internal
+ */
+export interface RegistryOptions<Key, Value> {
+  /**
+   * Resolution walker. Given a key with no direct entry, returns the next key
+   * to try (e.g. the prototype-chain parent), or `null` to stop. Omit for
+   * exact-match-only lookup.
+   */
+  walk?: (key: Key) => Key | null;
+
+  /**
+   * Per-value disposer, invoked once per **unique** value during
+   * {@link Registry.destroy}. Values shared across several keys (e.g. one
+   * renderer bound to multiple drawable types) are disposed exactly once.
+   */
+  dispose?: (value: Value) => void;
+}
+
+/**
+ * Generic key→value store with inheritance-aware resolution.
+ *
+ * Backs the engine's constructor-keyed dispatch registries
+ * ({@link FactoryRegistry}, {@link RendererRegistry}). Both previously
+ * duplicated the same prototype-chain walk and destroy-time de-duplication;
+ * this primitive owns that shared mechanism.
+ *
+ * Conflict policy and error messaging stay with the caller: {@link Registry.set}
+ * always overwrites and {@link Registry.resolve} returns `undefined` on a miss,
+ * so each owner enforces its own throw/overwrite behaviour with a
+ * domain-specific message.
+ *
+ * @typeParam Key - lookup key, typically a constructor token.
+ * @typeParam Value - stored value; must never be `undefined`.
+ * @internal
+ */
+export class Registry<Key, Value> {
+  private readonly _entries = new Map<Key, Value>();
+  private readonly _walk: ((key: Key) => Key | null) | null;
+  private readonly _dispose: ((value: Value) => void) | null;
+
+  public constructor(options: RegistryOptions<Key, Value> = {}) {
+    this._walk = options.walk ?? null;
+    this._dispose = options.dispose ?? null;
+  }
+
+  /** Stores `value` under `key`, overwriting any existing entry. */
+  public set(key: Key, value: Value): void {
+    this._entries.set(key, value);
+  }
+
+  /** Returns `true` if `key` has a direct entry (no walk). */
+  public hasOwn(key: Key): boolean {
+    return this._entries.has(key);
+  }
+
+  /** Returns `true` if `key` or any of its walk-ancestors has an entry. */
+  public has(key: Key): boolean {
+    return this._find(key) !== undefined;
+  }
+
+  /**
+   * Returns the value for `key`, walking the key hierarchy on a direct miss.
+   * Returns `undefined` if neither `key` nor any ancestor matches.
+   */
+  public resolve(key: Key): Value | undefined {
+    return this._find(key);
+  }
+
+  /** Iterates every stored value (including duplicates from shared entries). */
+  public values(): IterableIterator<Value> {
+    return this._entries.values();
+  }
+
+  /**
+   * Disposes every unique value (if a disposer was configured) and clears the
+   * store.
+   */
+  public destroy(): void {
+    if (this._dispose !== null) {
+      const seen = new Set<Value>();
+
+      for (const value of this._entries.values()) {
+        if (!seen.has(value)) {
+          seen.add(value);
+          this._dispose(value);
+        }
+      }
+    }
+
+    this._entries.clear();
+  }
+
+  private _find(key: Key): Value | undefined {
+    let current: Key | null = key;
+    let value: Value | undefined;
+
+    while (current !== null && value === undefined) {
+      value = this._entries.get(current);
+
+      if (value === undefined) {
+        current = this._walk !== null ? this._walk(current) : null;
+      }
+    }
+
+    return value;
+  }
+}

--- a/src/rendering/RendererRegistry.ts
+++ b/src/rendering/RendererRegistry.ts
@@ -1,6 +1,15 @@
+import { Registry } from '#core/Registry';
+
 import type { Drawable } from './Drawable';
 import type { RenderBackend } from './RenderBackend';
 import type { DrawableConstructor, Renderer } from './Renderer';
+
+/** Climbs one step up the prototype chain, returning the parent constructor. */
+const parentConstructor = (type: DrawableConstructor): DrawableConstructor | null => {
+  const prototype = Object.getPrototypeOf(type.prototype) as { constructor?: DrawableConstructor } | null;
+
+  return prototype?.constructor ?? null;
+};
 
 /**
  * Instance-based renderer registry.
@@ -17,7 +26,16 @@ import type { DrawableConstructor, Renderer } from './Renderer';
  * @advanced
  */
 export class RendererRegistry<Runtime extends RenderBackend> {
-  private readonly _renderers = new Map<DrawableConstructor, Renderer<Runtime>>();
+  private readonly _renderers = new Registry<DrawableConstructor, Renderer<Runtime>>({
+    walk: parentConstructor,
+    dispose: renderer => {
+      renderer.disconnect();
+
+      if ('destroy' in renderer && typeof renderer.destroy === 'function') {
+        (renderer as Renderer<Runtime> & { destroy(): void }).destroy();
+      }
+    },
+  });
   private readonly _resolved = new Map<DrawableConstructor, Renderer<Runtime>>();
   private _backend: Runtime | null = null;
 
@@ -31,7 +49,7 @@ export class RendererRegistry<Runtime extends RenderBackend> {
    * @throws Error if a renderer is already registered for this drawable type.
    */
   public registerRenderer<Target extends Drawable>(drawableType: DrawableConstructor<Target>, renderer: Renderer<Runtime, Target>): void {
-    if (this._renderers.has(drawableType)) {
+    if (this._renderers.hasOwn(drawableType)) {
       throw new Error(`A renderer is already registered for ${drawableType.name}.`);
     }
 
@@ -69,7 +87,7 @@ export class RendererRegistry<Runtime extends RenderBackend> {
 
     // Validate: no target already registered — throw before any mutation
     for (const target of targets) {
-      if (this._renderers.has(target)) {
+      if (this._renderers.hasOwn(target)) {
         throw new Error(`A renderer is already registered for ${target.name}.`);
       }
     }
@@ -112,18 +130,7 @@ export class RendererRegistry<Runtime extends RenderBackend> {
       return cached;
     }
 
-    let constructor: DrawableConstructor | null = ctor;
-    let renderer: Renderer<Runtime> | undefined;
-
-    while (constructor !== null && !renderer) {
-      renderer = this._renderers.get(constructor);
-
-      if (!renderer) {
-        const prototype = Object.getPrototypeOf(constructor.prototype) as { constructor?: DrawableConstructor } | null;
-
-        constructor = prototype?.constructor ?? null;
-      }
-    }
+    const renderer = this._renderers.resolve(ctor);
 
     if (!renderer) {
       throw new Error(
@@ -166,20 +173,7 @@ export class RendererRegistry<Runtime extends RenderBackend> {
    * instance is disconnected and destroyed exactly once.
    */
   public destroy(): void {
-    const seen = new Set<Renderer<Runtime>>();
-
-    for (const renderer of this._renderers.values()) {
-      if (!seen.has(renderer)) {
-        seen.add(renderer);
-        renderer.disconnect();
-
-        if ('destroy' in renderer && typeof renderer.destroy === 'function') {
-          (renderer as Renderer<Runtime> & { destroy(): void }).destroy();
-        }
-      }
-    }
-
-    this._renderers.clear();
+    this._renderers.destroy();
     this._resolved.clear();
     this._backend = null;
   }

--- a/src/resources/FactoryRegistry.ts
+++ b/src/resources/FactoryRegistry.ts
@@ -1,3 +1,5 @@
+import { Registry } from '#core/Registry';
+
 import type { AssetFactory } from './AssetFactory';
 
 /**
@@ -6,6 +8,13 @@ import type { AssetFactory } from './AssetFactory';
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AssetConstructor<T = unknown> = abstract new (...args: any[]) => T;
+
+/** Climbs one step up the prototype chain, returning the parent constructor. */
+const parentConstructor = (type: AssetConstructor): AssetConstructor | null => {
+  const prototype = Object.getPrototypeOf(type.prototype) as { constructor?: AssetConstructor } | null;
+
+  return prototype?.constructor ?? null;
+};
 
 /**
  * Maps {@link AssetConstructor} tokens to their corresponding
@@ -19,7 +28,10 @@ export type AssetConstructor<T = unknown> = abstract new (...args: any[]) => T;
  * @internal Used by {@link Loader}; consumers interact through `loader.register()`.
  */
 export class FactoryRegistry {
-  private readonly _factories = new Map<AssetConstructor, AssetFactory>();
+  private readonly _factories = new Registry<AssetConstructor, AssetFactory>({
+    walk: parentConstructor,
+    dispose: factory => factory.destroy(),
+  });
 
   /** Registers `factory` as the handler for `type` and its subclasses. */
   public register<T>(type: AssetConstructor<T>, factory: AssetFactory<T>): void {
@@ -31,18 +43,7 @@ export class FactoryRegistry {
    * chain if necessary. Throws if no matching factory is found.
    */
   public resolve<T>(type: AssetConstructor<T>): AssetFactory<T> {
-    let constructor: AssetConstructor | null = type;
-    let factory: AssetFactory | undefined;
-
-    while (constructor !== null && !factory) {
-      factory = this._factories.get(constructor);
-
-      if (!factory) {
-        const prototype = Object.getPrototypeOf(constructor.prototype) as { constructor?: AssetConstructor } | null;
-
-        constructor = prototype?.constructor ?? null;
-      }
-    }
+    const factory = this._factories.resolve(type);
 
     if (!factory) {
       throw new Error(`No factory registered for ${type.name}. ` + 'Register one with loader.register() before loading.');
@@ -56,19 +57,7 @@ export class FactoryRegistry {
    * prototype-chain ancestors.
    */
   public has(type: AssetConstructor): boolean {
-    let constructor: AssetConstructor | null = type;
-
-    while (constructor !== null) {
-      if (this._factories.has(constructor)) {
-        return true;
-      }
-
-      const prototype = Object.getPrototypeOf(constructor.prototype) as { constructor?: AssetConstructor } | null;
-
-      constructor = prototype?.constructor ?? null;
-    }
-
-    return false;
+    return this._factories.has(type);
   }
 
   /**
@@ -76,10 +65,6 @@ export class FactoryRegistry {
    * clears the registry.
    */
   public destroy(): void {
-    for (const factory of this._factories.values()) {
-      factory.destroy();
-    }
-
-    this._factories.clear();
+    this._factories.destroy();
   }
 }


### PR DESCRIPTION
## Phase 3 — Provider-Konsolidierung (Option A)

Spec-Checkpoint ergab: Phase 3 ist großteils „schon fertig oder YAGNI". Der **einzige belegte Code-Gewinn** ist die De-Duplizierung der beiden bestehenden Registries — genau das macht dieser PR. Kein spekulativer Provider-Bau.

### Änderung
- **Neu: `src/core/Registry.ts`** — dünnes, `@internal` `Registry<Key, Value>`-Primitiv: kapselt den konstruktor-keyed **Prototype-Walk** + die **Destroy-Dedup** (pro unique value), die `FactoryRegistry` (`:37-45`) und `RendererRegistry` (`:118-126`) zuvor dupliziert hatten.
- **`FactoryRegistry` + `RendererRegistry`** delegieren jetzt Storage + walk-aware Resolution an das Primitiv.
  - Konflikt-Policy + Fehlermeldungen bleiben **beim Caller** (Factory überschreibt still; Renderer wirft `"A renderer is already registered for X."`).
  - `RendererRegistry` legt seinen Resolution-Cache + Backend-`connect`/`disconnect` **darüber**.
- **Keine public API-Änderung.** `Registry` ist `@internal` (nicht im `core`-Barrel → kein root-index/snapshot-churn). Nur der `renderer-registry.mdx` Source-Anker verschiebt sich (`#L19`→`#L28`).

### Bewusst NICHT in diesem PR (ADRs, dokumentiert)
- **PhysicsBackend** bleibt `@internal` — externer-Adapter-Plan ist „perspektivisch, nicht jetzt"; als künftiger Provider-Punkt markiert.
- **SpatialIndex** → Phase 4 (interne Physics-Perf, kein Swap-Provider).
- **Random/CollisionBackend** → YAGNI als Swap-Provider. (Random-Modernisierung MT19937→PCG/xoshiro folgt als **separater** Replace-PR.)

### Gates (alle lokal grün)
- `typecheck` (src) · volle Suite **3212 passed, 1 skipped** · `format:check` · `lint:all` (0 errors) · `typecheck:examples` · `typecheck:guides` · `docs:api:check` (regeneriert)