### PR TITLE
perf(math)!: modernize Random PRNG (MT19937 -> xoshiro128**)

### DIFF
--- a/site/src/content/api/random.mdx
+++ b/site/src/content/api/random.mdx
@@ -1,23 +1,27 @@
 ---
 title: "Random"
-description: "Seedable pseudo-random number generator based on the Mersenne Twister (MT19937) algorithm. Produces 32-bit unsigned integers with period 2^19937−1, normalised to the `[min, max)` range requested by each next call. The generator is deterministic: calling `setSeed(s)` followed by the same sequence of `next()` calls always produces the same output. Use `reset()` to replay from the current seed without changing it."
+description: "Seedable pseudo-random number generator using the xoshiro128** algorithm. xoshiro128** (Blackman & Vigna, 2018) keeps a compact 128-bit state — four 32-bit words — and produces high-quality 32-bit outputs that clear the full BigCrush / PractRand test batteries. It replaces the previous Mersenne Twister: ~16 bytes of state instead of ~2.5 KB, faster, and entirely 32-bit (no 64-bit arithmetic), which suits JavaScript well. The generator is deterministic: calling `setSeed(s)` followed by the same sequence of `next()` calls always produces the same output. Use `reset()` to replay from the current seed without changing it."
 symbol: "Random"
 kind: "class"
 subsystem: "math"
 importPath: "@codexo/exojs"
-memberCount: 8
+memberCount: 7
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/math/Random.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/math/Random.ts#L12"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/math/Random.ts#L20"
 ---
 ## Import
 
 `import { Random } from '@codexo/exojs'`
 
-Seedable pseudo-random number generator based on the Mersenne Twister
-(MT19937) algorithm. Produces 32-bit unsigned integers with period 2^19937−1,
-normalised to the `[min, max)` range requested by each next call.
+Seedable pseudo-random number generator using the xoshiro128** algorithm.
+
+xoshiro128** (Blackman & Vigna, 2018) keeps a compact 128-bit state — four
+32-bit words — and produces high-quality 32-bit outputs that clear the full
+BigCrush / PractRand test batteries. It replaces the previous Mersenne
+Twister: ~16 bytes of state instead of ~2.5 KB, faster, and entirely 32-bit
+(no 64-bit arithmetic), which suits JavaScript well.
 
 The generator is deterministic: calling `setSeed(s)` followed by the same
 sequence of `next()` calls always produces the same output. Use `reset()`
@@ -36,10 +40,9 @@ to replay from the current seed without changing it.
 
 ## Properties
 
-- `iteration: number`
 - `seed: number`
 - `value: number`
 
 ## Source
 
-[src/math/Random.ts](https://github.com/Exoridus/ExoJS/blob/main/src/math/Random.ts#L12)
+[src/math/Random.ts](https://github.com/Exoridus/ExoJS/blob/main/src/math/Random.ts#L20)

--- a/src/math/Random.ts
+++ b/src/math/Random.ts
@@ -1,23 +1,29 @@
-const limit = 2 ** 32 - 1;
+/** 32-bit left rotation. */
+const rotl = (value: number, shift: number): number => ((value << shift) | (value >>> (32 - shift))) >>> 0;
+
+/** Reciprocal of 2^32, mapping a 32-bit unsigned integer to the half-open `[0, 1)` interval. */
+const normalize = 1 / 2 ** 32;
 
 /**
- * Seedable pseudo-random number generator based on the Mersenne Twister
- * (MT19937) algorithm. Produces 32-bit unsigned integers with period 2^19937−1,
- * normalised to the `[min, max)` range requested by each {@link next} call.
+ * Seedable pseudo-random number generator using the xoshiro128** algorithm.
+ *
+ * xoshiro128** (Blackman & Vigna, 2018) keeps a compact 128-bit state — four
+ * 32-bit words — and produces high-quality 32-bit outputs that clear the full
+ * BigCrush / PractRand test batteries. It replaces the previous Mersenne
+ * Twister: ~16 bytes of state instead of ~2.5 KB, faster, and entirely 32-bit
+ * (no 64-bit arithmetic), which suits JavaScript well.
  *
  * The generator is deterministic: calling `setSeed(s)` followed by the same
  * sequence of `next()` calls always produces the same output. Use `reset()`
  * to replay from the current seed without changing it.
  */
 export class Random {
-  private _state: Uint32Array = new Uint32Array(624);
-  private _iteration = 0;
+  private readonly _state = new Uint32Array(4);
   private _seed = 0;
   private _value = 0;
 
   public constructor(seed: number = Date.now()) {
     this.setSeed(seed);
-    this._twist();
   }
 
   /** The seed value currently in use. */
@@ -25,14 +31,9 @@ export class Random {
     return this._seed;
   }
 
-  /** The last raw random value produced by {@link next}, normalised to the requested range. */
+  /** The last value produced by {@link next}, normalised to its requested range. */
   public get value(): number {
     return this._value;
-  }
-
-  /** How many values have been drawn from the current state array before the next twist. */
-  public get iteration(): number {
-    return this._iteration;
   }
 
   /**
@@ -52,16 +53,23 @@ export class Random {
    * Returns `this` for chaining.
    */
   public reset(): this {
-    this._state[0] = this._seed;
+    // Expand the 32-bit seed into the 128-bit state with SplitMix32 so even
+    // low-entropy seeds (e.g. 0 or 1) yield a well-distributed initial state.
+    let z = this._seed | 0;
 
-    for (let i = 1; i < 624; i++) {
-      const s = this._state[i - 1] ^ (this._state[i - 1] >>> 30);
+    for (let i = 0; i < 4; i++) {
+      z = (z + 0x9e3779b9) | 0;
 
-      this._state[i] = ((((s & 0xffff0000) >>> 16) * 1812433253) << 16) + (s & 0x0000ffff) * 1812433253 + i;
-      this._state[i] |= 0;
+      let t = z ^ (z >>> 16);
+      t = Math.imul(t, 0x21f0aaad);
+      t ^= t >>> 15;
+      t = Math.imul(t, 0x735a2d97);
+      t ^= t >>> 15;
+
+      this._state[i] = t >>> 0;
     }
 
-    this._iteration = 0;
+    this._value = 0;
 
     return this;
   }
@@ -71,48 +79,23 @@ export class Random {
    * half-open interval `[min, max)`. Defaults to `[0, 1)`.
    */
   public next(min = 0, max = 1): number {
-    if (this._iteration >= 624) {
-      this._twist();
-    }
+    const state = this._state;
+    const result = Math.imul(rotl(Math.imul(state[1], 5), 7), 9) >>> 0;
+    const t = state[1] << 9;
 
-    this._value = this._state[this._iteration++];
-    this._value ^= this._value >>> 11;
-    this._value ^= (this._value << 7) & 0x9d2c5680;
-    this._value ^= (this._value << 15) & 0xefc60000;
-    this._value ^= this._value >>> 18;
-    this._value = ((this._value >>> 0) / limit) * (max - min) + min;
+    state[2] ^= state[0];
+    state[3] ^= state[1];
+    state[1] ^= state[2];
+    state[0] ^= state[3];
+    state[2] ^= t;
+    state[3] = rotl(state[3], 11);
+
+    this._value = result * normalize * (max - min) + min;
 
     return this._value;
   }
 
   public destroy(): void {
     // no-op — pure value class, kept for Destroyable interface conformance
-  }
-
-  private _twist(): void {
-    const state = this._state;
-
-    // first 624-397=227 words
-    for (let i = 0; i < 227; i++) {
-      const bits = (state[i] & 0x80000000) | (state[i + 1] & 0x7fffffff);
-
-      state[i] = state[i + 397] ^ (bits >>> 1) ^ ((bits & 1) * 0x9908b0df);
-    }
-
-    // remaining words (except the very last one)
-    for (let i = 227; i < 623; i++) {
-      const bits = (state[i] & 0x80000000) | (state[i + 1] & 0x7fffffff);
-
-      state[i] = state[i - 227] ^ (bits >>> 1) ^ ((bits & 1) * 0x9908b0df);
-    }
-
-    // last word is computed pretty much the same way, but i + 1 must wrap around to 0
-    const bits = (state[623] & 0x80000000) | (state[0] & 0x7fffffff);
-
-    state[623] = state[396] ^ (bits >>> 1) ^ ((bits & 1) * 0x9908b0df);
-
-    // word used for next random number
-    this._iteration = 0;
-    this._value = 0;
   }
 }

--- a/test/math/random.test.ts
+++ b/test/math/random.test.ts
@@ -1,0 +1,105 @@
+import { Random } from '#math/Random';
+
+describe('Random (xoshiro128**)', () => {
+  test('is deterministic: equal seeds produce identical sequences', () => {
+    const a = new Random(123456);
+    const b = new Random(123456);
+
+    for (let i = 0; i < 256; i++) {
+      expect(a.next()).toBe(b.next());
+    }
+  });
+
+  test('different seeds produce different sequences', () => {
+    const a = new Random(1);
+    const b = new Random(2);
+
+    const sameCount = Array.from({ length: 64 }, () => a.next() === b.next()).filter(Boolean).length;
+
+    expect(sameCount).toBeLessThan(64);
+  });
+
+  test('next() defaults to the half-open interval [0, 1)', () => {
+    const random = new Random(42);
+
+    for (let i = 0; i < 5000; i++) {
+      const value = random.next();
+
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThan(1);
+    }
+  });
+
+  test('next(min, max) stays within the half-open interval [min, max)', () => {
+    const random = new Random(7);
+
+    for (let i = 0; i < 5000; i++) {
+      const value = random.next(10, 20);
+
+      expect(value).toBeGreaterThanOrEqual(10);
+      expect(value).toBeLessThan(20);
+    }
+  });
+
+  test('reset() replays the sequence from the current seed', () => {
+    const random = new Random(99);
+    const first = [random.next(), random.next(), random.next(), random.next()];
+
+    random.reset();
+    const second = [random.next(), random.next(), random.next(), random.next()];
+
+    expect(second).toEqual(first);
+  });
+
+  test('setSeed() updates the seed getter and rewinds the sequence', () => {
+    const random = new Random(1);
+
+    expect(random.seed).toBe(1);
+
+    const original = random.next();
+
+    random.setSeed(500);
+    expect(random.seed).toBe(500);
+
+    random.setSeed(1);
+    expect(random.next()).toBe(original);
+  });
+
+  test('value getter reflects the last drawn value', () => {
+    const random = new Random(3);
+    const drawn = random.next(5, 6);
+
+    expect(random.value).toBe(drawn);
+  });
+
+  test('setSeed() and reset() return this for chaining', () => {
+    const random = new Random(1);
+
+    expect(random.setSeed(5)).toBe(random);
+    expect(random.reset()).toBe(random);
+  });
+
+  test('a zero seed does not collapse into a constant stream', () => {
+    const random = new Random(0);
+    const values = new Set([random.next(), random.next(), random.next(), random.next()]);
+
+    expect(values.size).toBeGreaterThan(1);
+  });
+
+  test('draws are roughly uniform over [0, 1)', () => {
+    const random = new Random(20260620);
+    const samples = 100000;
+    let sum = 0;
+
+    for (let i = 0; i < samples; i++) {
+      sum += random.next();
+    }
+
+    expect(sum / samples).toBeGreaterThan(0.48);
+    expect(sum / samples).toBeLessThan(0.52);
+  });
+
+  test('destroy() is a safe no-op', () => {
+    expect(() => new Random(1).destroy()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Random-Modernisierung (Folge-PR zu Phase 3)

Wie am Phase-3-Checkpoint vereinbart: **REPLACE der `Random`-Implementierung** (kein Provider). Random war **MT19937** (kein RC4), mit ~2.5 KB State pro Instanz.

### Änderung
- **MT19937 → xoshiro128\*\*** (Blackman & Vigna 2018), geseedet via **SplitMix32**.
  - Kompakter **128-bit State (~16 B)** statt ~2.5 KB `Uint32Array(624)`, schneller, **rein 32-bit** (kein BigInt/64-bit-Mul wie PCG es in JS bräuchte), BigCrush/PractRand-sauber.
  - Weiterhin **deterministisch + seedbar**.
- **Public API bewahrt:** `constructor(seed)`, `seed`/`value`-Getter, `next(min, max)`, `setSeed`, `reset`, `destroy`.
- **Entfernt:** der MT-spezifische `iteration`-Getter (grep-verifiziert ungenutzt; pre-1.0 clean break). `memberCount` 8→7.
- **Bugfix nebenbei:** `next()` nutzt jetzt echte half-open `[min, max)`-Normalisierung (÷2^32 statt ÷(2^32−1), was `max` zurückgeben konnte).

### Tests
- **Neu: `test/math/random.test.ts`** (11 Tests: Determinismus, Range, reset-Replay, Seed-Getter, Gleichverteilung, Zero-Seed-Guard) — zuvor gab es **keinen** Random-Unit-Test.

### Gates (alle lokal grün)
- `typecheck` · volle Suite **3223 passed, 1 skipped** · `format:check` · `lint:all` (0 errors) · `typecheck:examples` · `typecheck:guides` · `docs:api:check` (regeneriert, in sync)