### PR TITLE
feat(physics)!: promote dynamics API to public (Phase 2B)

### DIFF
--- a/packages/exojs-physics/src/PhysicsBody.ts
+++ b/packages/exojs-physics/src/PhysicsBody.ts
@@ -13,11 +13,11 @@ export interface BodyOptions {
   position?: VectorLike;
   /** Initial rotation in radians. Default `0`. */
   angle?: number;
-  /** Linear damping applied by the dynamics spike each sub-step. Default `0`. */
+  /** Linear damping applied to the velocity each sub-step. Default `0`. */
   linearDamping?: number;
-  /** Angular damping applied by the dynamics spike each sub-step. Default `0`. */
+  /** Angular damping applied to the angular velocity each sub-step. Default `0`. */
   angularDamping?: number;
-  /** Per-body multiplier on world gravity, applied by the dynamics spike each sub-step. Default `1`. */
+  /** Per-body multiplier on world gravity (e.g. `0` to ignore gravity). Default `1`. */
   gravityScale?: number;
   /** When `true`, the body never rotates under contacts (infinite rotational inertia). Default `false`. */
   fixedRotation?: boolean;
@@ -34,21 +34,22 @@ export interface BodyOwner {
 
 /**
  * A rigid body: a world transform plus mass properties aggregated from its
- * colliders. A **provisional** dynamics spike (Phase 2A) now integrates dynamic
- * bodies under gravity, accumulated forces/torque and contact impulses; static
- * bodies stay fixed and kinematic bodies move by their velocity only. The
- * velocity/force surface is `@internal` until the solver clears the SGATE and is
- * promoted to stable public API in Phase 2B.
+ * colliders. Dynamic bodies integrate under gravity, accumulated forces/torque
+ * and contact impulses each fixed sub-step; static bodies never move; kinematic
+ * bodies move by their velocity only and stay immovable under contacts. Drive a
+ * body with {@link applyForce}, {@link applyTorque} and {@link applyImpulse}, or
+ * set {@link linearVelocityX}/{@link linearVelocityY}/{@link angularVelocity}
+ * directly; reposition it (teleport, no velocity) with {@link setTransform}.
  */
 export class PhysicsBody {
   public readonly id: number;
   public readonly type: BodyType;
 
-  /** Linear damping applied each sub-step by the dynamics spike. */
+  /** Linear damping applied to the velocity each sub-step. */
   public linearDamping: number;
-  /** Angular damping applied each sub-step by the dynamics spike. */
+  /** Angular damping applied to the angular velocity each sub-step. */
   public angularDamping: number;
-  /** Per-body multiplier on world gravity, applied each sub-step by the dynamics spike. */
+  /** Per-body multiplier on world gravity (e.g. `0` to ignore gravity). */
   public gravityScale: number;
   /** When `true`, rotational inertia is treated as infinite. */
   public fixedRotation: boolean;
@@ -62,11 +63,11 @@ export class PhysicsBody {
   /** Inverse rotational inertia (`0` = no angular response). */
   public invInertia = 0;
 
-  /** @internal — Linear velocity X in px/s. Provisional spike surface; promoted to stable public API at Phase 2B (post-SGATE). */
+  /** Linear velocity X in px/s. */
   public linearVelocityX = 0;
-  /** @internal — Linear velocity Y in px/s. Provisional spike surface; promoted to stable public API at Phase 2B (post-SGATE). */
+  /** Linear velocity Y in px/s. */
   public linearVelocityY = 0;
-  /** @internal — Angular velocity in rad/s. Provisional spike surface; promoted to stable public API at Phase 2B (post-SGATE). */
+  /** Angular velocity in rad/s. */
   public angularVelocity = 0;
 
   /** @internal — Transient position correction X accumulated by the NGS position solver and applied to the transform each sub-step. */
@@ -203,17 +204,20 @@ export class PhysicsBody {
     }
   }
 
-  /** @internal — World-space centre of mass X (body origin + rotated local CoM). Provisional spike surface; promoted at Phase 2B. */
+  /** World-space centre of mass X (body origin + rotated local centre of mass). */
   public get worldCenterOfMassX(): number {
     return this._transform.x + this._transform.cos * this._comX - this._transform.sin * this._comY;
   }
 
-  /** @internal — World-space centre of mass Y. Provisional spike surface; promoted at Phase 2B. */
+  /** World-space centre of mass Y. */
   public get worldCenterOfMassY(): number {
     return this._transform.y + this._transform.sin * this._comX + this._transform.cos * this._comY;
   }
 
-  /** @internal — Accumulate a world-space force at the centre of mass (applied on the next sub-step). Provisional spike surface; promoted at Phase 2B. Returns `this`. */
+  /**
+   * Accumulate a world-space force at the centre of mass; integrated on the next
+   * sub-step and then cleared. No-op on static/kinematic bodies. Returns `this`.
+   */
   public applyForce(forceX: number, forceY: number): this {
     this._forceX += forceX;
     this._forceY += forceY;
@@ -221,7 +225,10 @@ export class PhysicsBody {
     return this;
   }
 
-  /** @internal — Accumulate a torque (applied on the next sub-step). Provisional spike surface; promoted at Phase 2B. Returns `this`. */
+  /**
+   * Accumulate a torque; integrated on the next sub-step and then cleared. No-op
+   * on static/kinematic bodies (and fixed-rotation bodies). Returns `this`.
+   */
   public applyTorque(torque: number): this {
     this._torque += torque;
 
@@ -232,8 +239,6 @@ export class PhysicsBody {
    * Apply an instantaneous world-space impulse at `(pointX, pointY)` (world space;
    * defaults to the centre of mass), changing velocity immediately. No-op on
    * static/kinematic bodies (infinite mass). Returns `this`.
-   *
-   * @internal — Provisional spike surface; promoted to stable public API at Phase 2B (post-SGATE).
    */
   public applyImpulse(impulseX: number, impulseY: number, pointX?: number, pointY?: number): this {
     if (this.invMass === 0) {

--- a/packages/exojs-physics/src/PhysicsWorld.ts
+++ b/packages/exojs-physics/src/PhysicsWorld.ts
@@ -18,7 +18,7 @@ import type { VectorLike } from './types';
 
 /** Construction options for a {@link PhysicsWorld}. */
 export interface PhysicsWorldOptions {
-  /** Gravity in px/s² (+Y down). Integrated each sub-step by the dynamics spike. Default `(0, 0)`. */
+  /** Gravity in px/s² (+Y down). Integrated each sub-step. Default `(0, 0)`. */
   gravity?: VectorLike;
   /** Fixed timestep in seconds. Default `1 / 60`. */
   fixedDelta?: number;
@@ -49,11 +49,12 @@ export interface StaticColliderOptions extends ColliderOptions {
  * bound node transforms. It holds **no module-level state**, so any number of
  * worlds run in isolation (gate I-1).
  *
- * The dynamics are a **provisional spike** (Phase 2A/2B): a warm-started
- * sequential-impulse velocity solver plus a split-impulse position-correction
- * pass — it integrates gravity/forces/impulses, resolves contacts and keeps
- * stacks stable. The dynamics API stays `@internal` until the solver clears the
- * SGATE, after which it is promoted to the stable public surface.
+ * The dynamics are a native, warm-started **sequential-impulse** solver: a
+ * 2-point block normal solve plus a non-linear Gauss-Seidel position-correction
+ * pass. It integrates gravity/forces/impulses, resolves contacts and keeps
+ * moderate stacks stable; very tall towers (beyond ~10 high) are a known limit
+ * of the iteration budget. The detection backend sits behind an internal seam,
+ * so the solver is swappable without touching this public surface.
  */
 export class PhysicsWorld implements BodyOwner {
   /** Fires when two solid colliders begin touching. Argument is an immutable snapshot. */
@@ -65,7 +66,7 @@ export class PhysicsWorld implements BodyOwner {
   /** Fires when a collider leaves a sensor. */
   public readonly onSensorExit = new Signal<[SensorEvent]>();
 
-  /** World gravity (px/s², +Y down). Integrated each sub-step by the dynamics spike. */
+  /** World gravity (px/s², +Y down). Integrated each sub-step. */
   public readonly gravity: Vector;
   /** The fixed-step accumulator. */
   public readonly timeStepper: TimeStepper;


### PR DESCRIPTION
## Was

Der SGATE hat **continue native** gewählt — also ist die Dynamics-Oberfläche kein provisorischer Spike mehr. Diese PR promotet sie von `@internal` zur **stabilen Public-API** und entfernt die „spike"-Sprache aus den Docs. **JSDoc-only, kein Verhaltens-Change.**

## Public ab jetzt

| Member | |
|---|---|
| `PhysicsBody.linearVelocityX` / `linearVelocityY` / `angularVelocity` | Velocity-State (les-/setzbar) |
| `applyForce(fx, fy)` · `applyTorque(t)` | über den nächsten Sub-Step integriert |
| `applyImpulse(ix, iy, px?, py?)` | sofortige Velocity-Änderung, optional am Punkt |
| `worldCenterOfMassX` / `worldCenterOfMassY` | Welt-Schwerpunkt (read) |

Solver-interne Scratch-Felder (`_posCorrection*`, `_prev*`, die `_integrate*`/`_snapshot*`-Hooks) behalten `_`-Präfix + `@internal`.

## Breaking

`BREAKING CHANGE`: Die Velocity/Force-Member von `PhysicsBody` sind jetzt Public-API (waren `@internal`). Pre-1.0, keine Shims.

## Gates (lokal grün)

`typecheck` · `lint:packages` · `format:check` · 80 Physics-Tests. Branch sauber auf main rebased (nach Perf-PR #142).

---

Damit ist **Phase 2B abgeschlossen**: Perf-Gates (P-1 ≈0 Alloc, P-2 ~2.3ms/1000 Bodies, #142) + Public-Dynamics-API. Nächste Physics-Schritte (JIT, später): Phase 3 (Examples/Guides/Site-API), Phase 4 (Sleeping/CCD/Joints).