### PR TITLE
feat(core): serialize rendering node types + interaction flags (Phase 4C PR2)

### DIFF
--- a/site/src/content/api/bitmap-text.mdx
+++ b/site/src/content/api/bitmap-text.mdx
@@ -5,7 +5,7 @@ symbol: "BitmapText"
 kind: "class"
 subsystem: "rendering"
 importPath: "@codexo/exojs"
-memberCount: 91
+memberCount: 92
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/rendering/text/BitmapText.ts"
@@ -97,6 +97,7 @@ label.style.align  = 'center';     // immediate rebuild
 - `cacheAsBitmap: boolean`
 - `cullable: boolean`
 - `filters: readonly Filter[]`
+- `font: BmFont`
 - `fontScale: number`
 - `interactive: boolean`
 - `isAlignedBox: boolean`

--- a/src/core/serialization/commonFields.ts
+++ b/src/core/serialization/commonFields.ts
@@ -1,7 +1,10 @@
 import { Color } from '#core/Color';
+import { warnOnce } from '#core/dev';
 import type { SceneNode } from '#core/SceneNode';
+import { Rectangle } from '#math/Rectangle';
 import { Drawable } from '#rendering/Drawable';
 import { isPixelSnapMode } from '#rendering/pixelSnap';
+import { RenderNode } from '#rendering/RenderNode';
 import { BlendModes } from '#rendering/types';
 
 import type { SerializedNode } from './types';
@@ -28,6 +31,25 @@ export function writeCommonFields(node: SceneNode, out: SerializedNode): void {
   if (node.zIndex !== 0) out.zIndex = node.zIndex;
   if (!node.cullable) out.cullable = false;
   if (node.name !== null) out.name = node.name;
+
+  if (node instanceof RenderNode) {
+    if (node.interactive) out.interactive = true;
+    if (node.draggable) out.draggable = true;
+    if (node.focusable) out.focusable = true;
+    if (node.tabIndex !== 0) out.tabIndex = node.tabIndex;
+    if (node.cursor !== null) out.cursor = node.cursor;
+    if (node.clip) out.clip = true;
+    if (node.preserveDrawOrder) out.preserveDrawOrder = true;
+    if (node.cacheAsBitmap) out.cacheAsBitmap = true;
+
+    const clipShape = node.clipShape;
+
+    if (clipShape instanceof Rectangle) {
+      out.clipShape = [clipShape.x, clipShape.y, clipShape.width, clipShape.height];
+    } else if (clipShape !== null) {
+      warnOnce('serialize:geometry-clipshape', 'A Geometry clipShape is not serialized (deferred); the deserialized node clips to its bounds instead.');
+    }
+  }
 
   if (node instanceof Drawable) {
     const tint = node.tint;
@@ -67,6 +89,23 @@ export function applyCommonFields(node: SceneNode, data: SerializedNode): void {
   if (typeof data.zIndex === 'number') node.zIndex = data.zIndex;
   if (data.cullable === false) node.cullable = false;
   if (typeof data.name === 'string') node.name = data.name;
+
+  if (node instanceof RenderNode) {
+    if (data.interactive === true) node.interactive = true;
+    if (data.draggable === true) node.draggable = true;
+    if (data.focusable === true) node.focusable = true;
+    if (typeof data.tabIndex === 'number') node.tabIndex = data.tabIndex;
+    if (typeof data.cursor === 'string') node.cursor = data.cursor;
+    if (data.clip === true) node.clip = true;
+    if (data.preserveDrawOrder === true) node.preserveDrawOrder = true;
+    if (data.cacheAsBitmap === true) node.cacheAsBitmap = true;
+
+    const clipShape = data.clipShape;
+
+    if (Array.isArray(clipShape) && clipShape.length === 4) {
+      node.clipShape = new Rectangle(Number(clipShape[0]), Number(clipShape[1]), Number(clipShape[2]), Number(clipShape[3]));
+    }
+  }
 
   if (node instanceof Drawable) {
     const tint = data.tint;

--- a/src/core/serialization/coreSerializers.ts
+++ b/src/core/serialization/coreSerializers.ts
@@ -1,4 +1,3 @@
-import { Color } from '#core/Color';
 import { warnOnce } from '#core/dev';
 import { Rectangle } from '#math/Rectangle';
 import { Container } from '#rendering/Container';
@@ -6,25 +5,13 @@ import type { RenderNode } from '#rendering/RenderNode';
 import { Sprite } from '#rendering/sprite/Sprite';
 import type { LayoutOptions } from '#rendering/text/LayoutOptions';
 import { SDF_RADIUS, Text } from '#rendering/text/Text';
-import type { FontWeight, TextStyleOptions } from '#rendering/text/TextStyle';
-import { TextStyle } from '#rendering/text/TextStyle';
-import type { TextAlignment } from '#rendering/text/types';
 import { Texture } from '#rendering/texture/Texture';
 
 import type { NodeSerializer } from './NodeSerializer';
+import { registerRenderingSerializers } from './renderingSerializers';
 import type { SerializationRegistry } from './SerializationRegistry';
+import { deserializeStyleOptions, serializeStyle } from './serializerHelpers';
 import type { SerializedNode } from './types';
-
-// ── Color helpers ──────────────────────────────────────────────────────────
-
-/** Serialize a colour to `[r, g, b, a]` (r/g/b 0..255, a 0..1). */
-const colorToArray = (color: Color): [number, number, number, number] => [color.r, color.g, color.b, color.a];
-
-/** Deserialize a `[r, g, b, a]` tuple back to a {@link Color}, or `undefined`. */
-const arrayToColor = (value: unknown): Color | undefined =>
-  Array.isArray(value) && value.length === 4 ? new Color(Number(value[0]), Number(value[1]), Number(value[2]), Number(value[3])) : undefined;
-
-const colorEquals = (color: Color, r: number, g: number, b: number, a: number): boolean => color.r === r && color.g === g && color.b === b && color.a === a;
 
 // ── Container ────────────────────────────────────────────────────────────────
 
@@ -94,84 +81,6 @@ const spriteSerializer: NodeSerializer<Sprite> = {
 
 // ── Text ─────────────────────────────────────────────────────────────────────
 
-/** Serialize the plain-data fields of a {@link TextStyle}, omitting defaults. */
-function serializeStyle(style: TextStyle): Record<string, unknown> | undefined {
-  const out: Record<string, unknown> = {};
-
-  if (style.fontFamily !== 'Arial') out.fontFamily = style.fontFamily;
-  if (style.fontWeight !== 'normal') out.fontWeight = style.fontWeight;
-  if (style.fontStyle !== 'normal') out.fontStyle = style.fontStyle;
-  if (style.fontSize !== 20) out.fontSize = style.fontSize;
-  if (!colorEquals(style.fillColor, 255, 255, 255, 1)) out.fillColor = colorToArray(style.fillColor);
-  if (!colorEquals(style.outlineColor, 0, 0, 0, 1)) out.outlineColor = colorToArray(style.outlineColor);
-  if (style.outlineWidth !== 0) out.outlineWidth = style.outlineWidth;
-  if (style.align !== 'left') out.align = style.align;
-  if (style.lineHeight !== 1.2) out.lineHeight = style.lineHeight;
-  if (style.leading !== 0) out.leading = style.leading;
-  if (!colorEquals(style.shadowColor, 0, 0, 0, 1)) out.shadowColor = colorToArray(style.shadowColor);
-  if (style.shadowOffsetX !== 0) out.shadowOffsetX = style.shadowOffsetX;
-  if (style.shadowOffsetY !== 0) out.shadowOffsetY = style.shadowOffsetY;
-  if (style.shadowAlpha !== 0) out.shadowAlpha = style.shadowAlpha;
-  if (style.shadowBlur !== 0) out.shadowBlur = style.shadowBlur;
-
-  if (style.gradientColors !== null) {
-    out.gradientColors = [colorToArray(style.gradientColors[0]), colorToArray(style.gradientColors[1])];
-  }
-
-  if (style.gradientAxis !== 'vertical') out.gradientAxis = style.gradientAxis;
-
-  return Object.keys(out).length > 0 ? out : undefined;
-}
-
-/** Rebuild a {@link TextStyle} from serialized style data, or `undefined`. */
-function deserializeStyle(data: unknown): TextStyle | undefined {
-  if (typeof data !== 'object' || data === null) {
-    return undefined;
-  }
-
-  const source = data as Record<string, unknown>;
-  const options: TextStyleOptions = {};
-
-  if (typeof source.fontFamily === 'string') options.fontFamily = source.fontFamily;
-  if (typeof source.fontWeight === 'string') options.fontWeight = source.fontWeight as FontWeight;
-  if (source.fontStyle === 'italic' || source.fontStyle === 'normal') options.fontStyle = source.fontStyle;
-  if (typeof source.fontSize === 'number') options.fontSize = source.fontSize;
-
-  const fillColor = arrayToColor(source.fillColor);
-  if (fillColor !== undefined) options.fillColor = fillColor;
-
-  const outlineColor = arrayToColor(source.outlineColor);
-  if (outlineColor !== undefined) options.outlineColor = outlineColor;
-
-  if (typeof source.outlineWidth === 'number') options.outlineWidth = source.outlineWidth;
-  if (typeof source.align === 'string') options.align = source.align as TextAlignment;
-  if (typeof source.lineHeight === 'number') options.lineHeight = source.lineHeight;
-  if (typeof source.leading === 'number') options.leading = source.leading;
-
-  const shadowColor = arrayToColor(source.shadowColor);
-  if (shadowColor !== undefined) options.shadowColor = shadowColor;
-
-  if (typeof source.shadowOffsetX === 'number') options.shadowOffsetX = source.shadowOffsetX;
-  if (typeof source.shadowOffsetY === 'number') options.shadowOffsetY = source.shadowOffsetY;
-  if (typeof source.shadowAlpha === 'number') options.shadowAlpha = source.shadowAlpha;
-  if (typeof source.shadowBlur === 'number') options.shadowBlur = source.shadowBlur;
-
-  if (Array.isArray(source.gradientColors) && source.gradientColors.length === 2) {
-    const top = arrayToColor(source.gradientColors[0]);
-    const bottom = arrayToColor(source.gradientColors[1]);
-
-    if (top !== undefined && bottom !== undefined) {
-      options.gradientColors = [top, bottom];
-    }
-  }
-
-  if (source.gradientAxis === 'horizontal' || source.gradientAxis === 'vertical') {
-    options.gradientAxis = source.gradientAxis;
-  }
-
-  return new TextStyle(options);
-}
-
 const textSerializer: NodeSerializer<Text> = {
   write(node) {
     const out: Record<string, unknown> = { text: node.text };
@@ -185,10 +94,9 @@ const textSerializer: NodeSerializer<Text> = {
     return out;
   },
   read(data) {
-    const style = deserializeStyle(data.style);
     const layout = typeof data.layout === 'object' && data.layout !== null ? (data.layout as LayoutOptions) : undefined;
 
-    return new Text(typeof data.text === 'string' ? data.text : '', style, layout, {
+    return new Text(typeof data.text === 'string' ? data.text : '', deserializeStyleOptions(data.style), layout, {
       colorGlyphs: data.colorGlyphs === true,
       sdfRadius: typeof data.sdfRadius === 'number' ? data.sdfRadius : undefined,
     });
@@ -196,12 +104,16 @@ const textSerializer: NodeSerializer<Text> = {
 };
 
 /**
- * Register the built-in core node serializers (`Container`, `Sprite`, `Text`)
- * on `registry`. Called once, lazily, from the serialization framework.
+ * Register all built-in node serializers (core leaf types + rendering package)
+ * on `registry`. Called once, lazily, from the serialization framework. UI
+ * widgets are not yet covered (they need read-accessors for their authored
+ * options) — see the Phase 4C follow-up.
  * @internal
  */
 export function registerCoreSerializers(registry: SerializationRegistry): void {
   registry.register('Container', Container, containerSerializer);
   registry.register('Sprite', Sprite, spriteSerializer);
   registry.register('Text', Text, textSerializer);
+
+  registerRenderingSerializers(registry);
 }

--- a/src/core/serialization/renderingSerializers.ts
+++ b/src/core/serialization/renderingSerializers.ts
@@ -1,0 +1,305 @@
+import { warnOnce } from '#core/dev';
+import { Rectangle } from '#math/Rectangle';
+import { Mesh } from '#rendering/mesh/Mesh';
+import { Graphics } from '#rendering/primitives/Graphics';
+import type { RenderNode } from '#rendering/RenderNode';
+import { AnimatedSprite, type AnimatedSpriteClipDefinition } from '#rendering/sprite/AnimatedSprite';
+import type { NineSliceInsets, NineSliceModes } from '#rendering/sprite/nineSlice';
+import { NineSliceSprite } from '#rendering/sprite/NineSliceSprite';
+import { RepeatingSprite } from '#rendering/sprite/RepeatingSprite';
+import { BitmapText } from '#rendering/text/BitmapText';
+import { BmFont } from '#rendering/text/BmFont';
+import type { LayoutOptions } from '#rendering/text/LayoutOptions';
+import type { RepeatFit, RepeatMode } from '#rendering/texture/repeat';
+import { Texture } from '#rendering/texture/Texture';
+import { Video } from '#rendering/video/Video';
+
+import type { NodeSerializer } from './NodeSerializer';
+import type { SerializationRegistry } from './SerializationRegistry';
+import { deserializeStyleOptions, serializeStyle } from './serializerHelpers';
+import type { SerializedNode } from './types';
+
+// ── Small helpers ────────────────────────────────────────────────────────────
+
+const toF32 = (value: unknown): Float32Array => (Array.isArray(value) ? new Float32Array(value.map(Number)) : new Float32Array());
+const toU16 = (value: unknown): Uint16Array => (Array.isArray(value) ? new Uint16Array(value.map(Number)) : new Uint16Array());
+const toU32 = (value: unknown): Uint32Array => (Array.isArray(value) ? new Uint32Array(value.map(Number)) : new Uint32Array());
+const num = (value: unknown): number | undefined => (typeof value === 'number' ? value : undefined);
+
+// ── Mesh ─────────────────────────────────────────────────────────────────────
+
+const meshSerializer: NodeSerializer<Mesh> = {
+  write(node, ctx) {
+    const out: Record<string, unknown> = { vertices: [...node.vertices] };
+
+    if (node.indices !== null) out.indices = [...node.indices];
+    if (node.uvs !== null) out.uvs = [...node.uvs];
+    if (node.colors !== null) out.colors = [...node.colors];
+
+    const source = ctx.keyFor(node.texture);
+    if (source !== null) out.texture = source;
+
+    if (node.material !== null) {
+      warnOnce('serialize:mesh-material', 'Mesh.material is not serialized (custom materials are deferred); the deserialized mesh uses the default material.');
+    }
+
+    return out;
+  },
+  read(data, ctx) {
+    return new Mesh({
+      vertices: toF32(data.vertices),
+      indices: data.indices !== undefined ? toU16(data.indices) : undefined,
+      uvs: data.uvs !== undefined ? toF32(data.uvs) : undefined,
+      colors: data.colors !== undefined ? toU32(data.colors) : undefined,
+      texture: ctx.resolveAsset(typeof data.texture === 'string' ? data.texture : null, Texture),
+    });
+  },
+};
+
+// ── Graphics ───────────────────────────────────────────────────────────────
+// Graphics is immediate-mode: its authored result is the baked Mesh children it
+// accumulates. Round-trips the rendered geometry (gradient fills, drawn via
+// runtime DataTextures, degrade to their vertex colours — texture refs are
+// unkeyed and dropped). The pen state is transient and not serialized.
+
+const graphicsSerializer: NodeSerializer<Graphics> = {
+  write(node, ctx) {
+    if (node.children.length === 0) {
+      return {};
+    }
+
+    return { children: node.children.map(child => ctx.writeNode(child)) };
+  },
+  read(data, ctx) {
+    const node = new Graphics();
+    const children = data.children;
+
+    if (Array.isArray(children)) {
+      for (const child of children) {
+        node.addChild(ctx.readNode(child as SerializedNode) as RenderNode);
+      }
+    }
+
+    return node;
+  },
+};
+
+// ── NineSliceSprite ──────────────────────────────────────────────────────────
+
+const nineSliceSerializer: NodeSerializer<NineSliceSprite> = {
+  write(node, ctx) {
+    const out: Record<string, unknown> = {
+      slices: { ...node.slices },
+      border: { ...node.border },
+      modes: { ...node.modes },
+      width: node.width,
+      height: node.height,
+    };
+
+    const source = ctx.keyFor(node.texture);
+    if (source !== null) out.texture = source;
+
+    return out;
+  },
+  read(data, ctx) {
+    const texture = ctx.resolveAsset(typeof data.texture === 'string' ? data.texture : null, Texture);
+
+    if (texture === null) {
+      throw new Error('NineSliceSprite deserialize requires its texture to be pre-loaded into the Loader.');
+    }
+
+    return new NineSliceSprite(texture, {
+      slices: data.slices as NineSliceInsets,
+      border: data.border as NineSliceInsets,
+      modes: data.modes as NineSliceModes,
+      width: num(data.width),
+      height: num(data.height),
+    });
+  },
+};
+
+// ── RepeatingSprite ──────────────────────────────────────────────────────────
+
+const repeatingSerializer: NodeSerializer<RepeatingSprite> = {
+  write(node, ctx) {
+    const out: Record<string, unknown> = {
+      width: node.width,
+      height: node.height,
+      modeX: node.modeX,
+      modeY: node.modeY,
+      fitX: node.fitX,
+      fitY: node.fitY,
+      offsetX: node.offsetX,
+      offsetY: node.offsetY,
+    };
+
+    const source = ctx.keyFor(node.texture);
+    if (source !== null) out.texture = source;
+
+    return out;
+  },
+  read(data, ctx) {
+    const texture = ctx.resolveAsset(typeof data.texture === 'string' ? data.texture : null, Texture);
+
+    if (texture === null) {
+      throw new Error('RepeatingSprite deserialize requires its texture to be pre-loaded into the Loader.');
+    }
+
+    return new RepeatingSprite(texture, {
+      width: num(data.width),
+      height: num(data.height),
+      modeX: data.modeX as RepeatMode,
+      modeY: data.modeY as RepeatMode,
+      fitX: data.fitX as RepeatFit,
+      fitY: data.fitY as RepeatFit,
+      offsetX: num(data.offsetX),
+      offsetY: num(data.offsetY),
+    });
+  },
+};
+
+// ── AnimatedSprite ───────────────────────────────────────────────────────────
+// Clips round-trip fully; playback resumes at the active clip's first frame
+// (the exact current frame / elapsed time is runtime state and not restored).
+
+const animatedSpriteSerializer: NodeSerializer<AnimatedSprite> = {
+  write(node, ctx) {
+    const out: Record<string, unknown> = {};
+
+    const source = ctx.keyFor(node.texture);
+    if (source !== null) out.texture = source;
+
+    const clips: Record<string, unknown> = {};
+
+    for (const [name, clip] of Object.entries(node._getClipDefinitions())) {
+      clips[name] = {
+        frames: clip.frames.map(frame => [frame.x, frame.y, frame.width, frame.height]),
+        fps: clip.fps,
+        loop: clip.loop,
+      };
+    }
+
+    out.clips = clips;
+
+    if (node.currentClip !== null) out.currentClip = node.currentClip;
+    if (node.playing) out.playing = true;
+
+    return out;
+  },
+  read(data, ctx) {
+    const texture = ctx.resolveAsset(typeof data.texture === 'string' ? data.texture : null, Texture);
+    const clips: Record<string, AnimatedSpriteClipDefinition> = {};
+    const clipsData = data.clips;
+
+    if (typeof clipsData === 'object' && clipsData !== null) {
+      for (const [name, raw] of Object.entries(clipsData as Record<string, unknown>)) {
+        const clip = raw as { frames?: unknown; fps?: unknown; loop?: unknown };
+        const frames = Array.isArray(clip.frames)
+          ? clip.frames.map(frame => {
+              const values = frame as number[];
+
+              return new Rectangle(Number(values[0]), Number(values[1]), Number(values[2]), Number(values[3]));
+            })
+          : [];
+
+        clips[name] = { frames, fps: num(clip.fps), loop: typeof clip.loop === 'boolean' ? clip.loop : undefined };
+      }
+    }
+
+    const sprite = new AnimatedSprite(texture, clips);
+
+    if (typeof data.currentClip === 'string' && data.currentClip in clips) {
+      sprite.play(data.currentClip);
+
+      if (data.playing !== true) {
+        sprite.pause();
+      }
+    }
+
+    return sprite;
+  },
+};
+
+// ── BitmapText ─────────────────────────────────────────────────────────────
+
+const bitmapTextSerializer: NodeSerializer<BitmapText> = {
+  write(node, ctx) {
+    const out: Record<string, unknown> = { text: node.text };
+
+    const source = ctx.keyFor(node.font);
+    if (source !== null) out.font = source;
+
+    if (node.msdf) out.msdf = true;
+    if (node.fontScale !== 1) out.scale = node.fontScale;
+
+    const style = serializeStyle(node.style);
+    if (style !== undefined) out.style = style;
+    if (Object.keys(node.layout).length > 0) out.layout = { ...node.layout };
+
+    return out;
+  },
+  read(data, ctx) {
+    const font = ctx.resolveAsset(typeof data.font === 'string' ? data.font : null, BmFont);
+
+    if (font === null) {
+      throw new Error('BitmapText deserialize requires its BmFont to be pre-loaded into the Loader.');
+    }
+
+    const layout = typeof data.layout === 'object' && data.layout !== null ? (data.layout as LayoutOptions) : undefined;
+
+    return new BitmapText(typeof data.text === 'string' ? data.text : '', font, {
+      ...deserializeStyleOptions(data.style),
+      msdf: data.msdf === true,
+      scale: num(data.scale),
+      layout,
+    });
+  },
+};
+
+// ── Video ────────────────────────────────────────────────────────────────────
+// Captures the source URL + playback options. Deserialize creates a fresh
+// `<video>` element (requires a DOM); the live decode/audio graph is rebuilt by
+// the Video constructor.
+
+const videoSerializer: NodeSerializer<Video> = {
+  write(node) {
+    const out: Record<string, unknown> = { src: node.videoElement.src };
+
+    if (node.volume !== 1) out.volume = node.volume;
+    if (node.loop) out.loop = true;
+    if (node.playbackRate !== 1) out.playbackRate = node.playbackRate;
+    if (node.muted) out.muted = true;
+    if (node.currentTime > 0) out.time = node.currentTime;
+
+    return out;
+  },
+  read(data) {
+    const element = document.createElement('video');
+
+    if (typeof data.src === 'string') {
+      element.src = data.src;
+    }
+
+    return new Video(element, {
+      volume: num(data.volume),
+      loop: data.loop === true ? true : undefined,
+      playbackRate: num(data.playbackRate),
+      muted: data.muted === true ? true : undefined,
+      time: num(data.time),
+    });
+  },
+};
+
+/**
+ * Register the rendering-package node serializers on `registry`.
+ * @internal
+ */
+export function registerRenderingSerializers(registry: SerializationRegistry): void {
+  registry.register('Mesh', Mesh, meshSerializer);
+  registry.register('Graphics', Graphics, graphicsSerializer);
+  registry.register('NineSliceSprite', NineSliceSprite, nineSliceSerializer);
+  registry.register('RepeatingSprite', RepeatingSprite, repeatingSerializer);
+  registry.register('AnimatedSprite', AnimatedSprite, animatedSpriteSerializer);
+  registry.register('BitmapText', BitmapText, bitmapTextSerializer);
+  registry.register('Video', Video, videoSerializer);
+}

--- a/src/core/serialization/serializerHelpers.ts
+++ b/src/core/serialization/serializerHelpers.ts
@@ -1,0 +1,112 @@
+import { Color } from '#core/Color';
+import type { FontWeight, TextStyleOptions } from '#rendering/text/TextStyle';
+import type { TextAlignment } from '#rendering/text/types';
+
+// ── Colour ───────────────────────────────────────────────────────────────────
+
+/** Serialize a colour to `[r, g, b, a]` (r/g/b 0..255, a 0..1). */
+export const colorToArray = (color: Color): [number, number, number, number] => [color.r, color.g, color.b, color.a];
+
+/** Deserialize a `[r, g, b, a]` tuple back to a {@link Color}, or `undefined`. */
+export const arrayToColor = (value: unknown): Color | undefined =>
+  Array.isArray(value) && value.length === 4 ? new Color(Number(value[0]), Number(value[1]), Number(value[2]), Number(value[3])) : undefined;
+
+const colorEquals = (color: Color, r: number, g: number, b: number, a: number): boolean => color.r === r && color.g === g && color.b === b && color.a === a;
+
+// ── TextStyle ────────────────────────────────────────────────────────────────
+
+/** Serialize the plain-data fields of a {@link TextStyle}, omitting defaults. */
+export function serializeStyle(style: {
+  fontFamily: string;
+  fontWeight: string;
+  fontStyle: string;
+  fontSize: number;
+  fillColor: Color;
+  outlineColor: Color;
+  outlineWidth: number;
+  align: string;
+  lineHeight: number;
+  leading: number;
+  shadowColor: Color;
+  shadowOffsetX: number;
+  shadowOffsetY: number;
+  shadowAlpha: number;
+  shadowBlur: number;
+  gradientColors: [Color, Color] | null;
+  gradientAxis: string;
+}): Record<string, unknown> | undefined {
+  const out: Record<string, unknown> = {};
+
+  if (style.fontFamily !== 'Arial') out.fontFamily = style.fontFamily;
+  if (style.fontWeight !== 'normal') out.fontWeight = style.fontWeight;
+  if (style.fontStyle !== 'normal') out.fontStyle = style.fontStyle;
+  if (style.fontSize !== 20) out.fontSize = style.fontSize;
+  if (!colorEquals(style.fillColor, 255, 255, 255, 1)) out.fillColor = colorToArray(style.fillColor);
+  if (!colorEquals(style.outlineColor, 0, 0, 0, 1)) out.outlineColor = colorToArray(style.outlineColor);
+  if (style.outlineWidth !== 0) out.outlineWidth = style.outlineWidth;
+  if (style.align !== 'left') out.align = style.align;
+  if (style.lineHeight !== 1.2) out.lineHeight = style.lineHeight;
+  if (style.leading !== 0) out.leading = style.leading;
+  if (!colorEquals(style.shadowColor, 0, 0, 0, 1)) out.shadowColor = colorToArray(style.shadowColor);
+  if (style.shadowOffsetX !== 0) out.shadowOffsetX = style.shadowOffsetX;
+  if (style.shadowOffsetY !== 0) out.shadowOffsetY = style.shadowOffsetY;
+  if (style.shadowAlpha !== 0) out.shadowAlpha = style.shadowAlpha;
+  if (style.shadowBlur !== 0) out.shadowBlur = style.shadowBlur;
+
+  if (style.gradientColors !== null) {
+    out.gradientColors = [colorToArray(style.gradientColors[0]), colorToArray(style.gradientColors[1])];
+  }
+
+  if (style.gradientAxis !== 'vertical') out.gradientAxis = style.gradientAxis;
+
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/** Rebuild {@link TextStyleOptions} from serialized style data, or `undefined`. */
+export function deserializeStyleOptions(data: unknown): TextStyleOptions | undefined {
+  if (typeof data !== 'object' || data === null) {
+    return undefined;
+  }
+
+  const source = data as Record<string, unknown>;
+  const options: TextStyleOptions = {};
+
+  if (typeof source.fontFamily === 'string') options.fontFamily = source.fontFamily;
+  if (typeof source.fontWeight === 'string') options.fontWeight = source.fontWeight as FontWeight;
+  if (source.fontStyle === 'italic' || source.fontStyle === 'normal') options.fontStyle = source.fontStyle;
+  if (typeof source.fontSize === 'number') options.fontSize = source.fontSize;
+
+  const fillColor = arrayToColor(source.fillColor);
+  if (fillColor !== undefined) options.fillColor = fillColor;
+
+  const outlineColor = arrayToColor(source.outlineColor);
+  if (outlineColor !== undefined) options.outlineColor = outlineColor;
+
+  if (typeof source.outlineWidth === 'number') options.outlineWidth = source.outlineWidth;
+  if (typeof source.align === 'string') options.align = source.align as TextAlignment;
+  if (typeof source.lineHeight === 'number') options.lineHeight = source.lineHeight;
+  if (typeof source.leading === 'number') options.leading = source.leading;
+
+  const shadowColor = arrayToColor(source.shadowColor);
+  if (shadowColor !== undefined) options.shadowColor = shadowColor;
+
+  if (typeof source.shadowOffsetX === 'number') options.shadowOffsetX = source.shadowOffsetX;
+  if (typeof source.shadowOffsetY === 'number') options.shadowOffsetY = source.shadowOffsetY;
+  if (typeof source.shadowAlpha === 'number') options.shadowAlpha = source.shadowAlpha;
+  if (typeof source.shadowBlur === 'number') options.shadowBlur = source.shadowBlur;
+
+  if (Array.isArray(source.gradientColors) && source.gradientColors.length === 2) {
+    const top = arrayToColor(source.gradientColors[0]);
+    const bottom = arrayToColor(source.gradientColors[1]);
+
+    if (top !== undefined && bottom !== undefined) {
+      options.gradientColors = [top, bottom];
+    }
+  }
+
+  if (source.gradientAxis === 'horizontal' || source.gradientAxis === 'vertical') {
+    options.gradientAxis = source.gradientAxis;
+  }
+
+  return options;
+}

--- a/src/rendering/sprite/AnimatedSprite.ts
+++ b/src/rendering/sprite/AnimatedSprite.ts
@@ -128,6 +128,22 @@ export class AnimatedSprite extends Sprite {
     return this;
   }
 
+  /**
+   * Returns the registered clips as serializable definitions (frames as
+   * {@link Rectangle}s, `fps`, `loop`). Used by scene serialization to read
+   * back clip state the normalized internal store no longer exposes directly.
+   * @internal
+   */
+  public _getClipDefinitions(): Record<string, { frames: Rectangle[]; fps: number; loop: boolean }> {
+    const out: Record<string, { frames: Rectangle[]; fps: number; loop: boolean }> = {};
+
+    for (const [name, clip] of this._clips) {
+      out[name] = { frames: clip.frames.map(frame => frame.clone()), fps: 1000 / clip.frameDurationMs, loop: clip.loop };
+    }
+
+    return out;
+  }
+
   /** Remove a registered clip by name. Stops playback first if the clip is currently active. */
   public removeClip(name: string): this {
     if (this._currentClipName === name) {

--- a/src/rendering/text/BitmapText.ts
+++ b/src/rendering/text/BitmapText.ts
@@ -224,6 +224,11 @@ export class BitmapText extends AbstractText {
     return this._msdf;
   }
 
+  /** The {@link BmFont} this text renders from. Replace via {@link setFont}. */
+  public get font(): BmFont {
+    return this._font;
+  }
+
   /** Per-page quad data consumed by the text renderer. */
   public get pageQuads(): readonly TextPageQuads[] {
     return this._pageQuads;

--- a/test/core/serialization.test.ts
+++ b/test/core/serialization.test.ts
@@ -8,7 +8,14 @@ import { deserializeTree, serializeTree } from '#core/serialization/serialize';
 import { SERIALIZATION_VERSION, type SerializedNode } from '#core/serialization/types';
 import { Rectangle } from '#math/Rectangle';
 import { Container } from '#rendering/Container';
+import { Mesh } from '#rendering/mesh/Mesh';
+import { Graphics } from '#rendering/primitives/Graphics';
+import { AnimatedSprite } from '#rendering/sprite/AnimatedSprite';
+import { NineSliceSprite } from '#rendering/sprite/NineSliceSprite';
+import { RepeatingSprite } from '#rendering/sprite/RepeatingSprite';
 import { Sprite } from '#rendering/sprite/Sprite';
+import { BitmapText, type BmFontData } from '#rendering/text/BitmapText';
+import { BmFont } from '#rendering/text/BmFont';
 import type { GlyphAtlas } from '#rendering/text/GlyphAtlas';
 import type { GlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
 import { resetDefaultGlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
@@ -16,6 +23,7 @@ import { Text } from '#rendering/text/Text';
 import type { GlyphInfo } from '#rendering/text/types';
 import { Texture } from '#rendering/texture/Texture';
 import { BlendModes } from '#rendering/types';
+import { Video } from '#rendering/video/Video';
 import type { Loadable, Loader } from '#resources/Loader';
 
 /** Build a canvas-backed texture with known dimensions (matches the unit-test convention). */
@@ -328,5 +336,203 @@ describe('serialization — Scene entry point', () => {
 
     expect(() => scene.deserialize({ version: 999, root: { type: 'Container' } })).toThrow(/newer than/);
     scene.destroy();
+  });
+});
+
+describe('serialization — RenderNode interaction flags', () => {
+  it('round-trips interaction flags and a Rectangle clipShape', () => {
+    const node = new Container();
+
+    node.interactive = true;
+    node.draggable = true;
+    node.focusable = true;
+    node.tabIndex = 3;
+    node.cursor = 'pointer';
+    node.clip = true;
+    node.clipShape = new Rectangle(0, 0, 50, 40);
+    node.preserveDrawOrder = true;
+    node.cacheAsBitmap = true;
+
+    const data = serializeTree(node);
+
+    expect(data).toMatchObject({
+      interactive: true,
+      draggable: true,
+      focusable: true,
+      tabIndex: 3,
+      cursor: 'pointer',
+      clip: true,
+      preserveDrawOrder: true,
+      cacheAsBitmap: true,
+      clipShape: [0, 0, 50, 40],
+    });
+
+    const restored = deserializeTree(data) as Container;
+
+    expect(restored.interactive).toBe(true);
+    expect(restored.draggable).toBe(true);
+    expect(restored.focusable).toBe(true);
+    expect(restored.tabIndex).toBe(3);
+    expect(restored.cursor).toBe('pointer');
+    expect(restored.clip).toBe(true);
+    expect(restored.preserveDrawOrder).toBe(true);
+    expect(restored.cacheAsBitmap).toBe(true);
+    expect(restored.clipShape).toBeInstanceOf(Rectangle);
+    expect((restored.clipShape as Rectangle).width).toBe(50);
+  });
+});
+
+describe('serialization — Mesh', () => {
+  it('round-trips vertex/index/uv/colour arrays', () => {
+    const mesh = new Mesh({
+      vertices: new Float32Array([0, 0, 10, 0, 10, 10]),
+      indices: new Uint16Array([0, 1, 2]),
+      uvs: new Float32Array([0, 0, 1, 0, 1, 1]),
+      colors: new Uint32Array([0xffffffff, 0xff00ff00, 0xffff0000]),
+    });
+
+    const data = serializeTree(mesh);
+
+    expect(data.type).toBe('Mesh');
+    expect(data.vertices).toEqual([0, 0, 10, 0, 10, 10]);
+    expect(data.indices).toEqual([0, 1, 2]);
+
+    const restored = deserializeTree(data) as Mesh;
+
+    expect(Array.from(restored.vertices)).toEqual([0, 0, 10, 0, 10, 10]);
+    expect(Array.from(restored.indices ?? [])).toEqual([0, 1, 2]);
+    expect(Array.from(restored.colors ?? [])).toEqual([0xffffffff, 0xff00ff00, 0xffff0000]);
+  });
+});
+
+describe('serialization — Graphics', () => {
+  it('round-trips as a Graphics with its baked mesh children', () => {
+    const graphics = new Graphics();
+
+    graphics.fillColor = new Color(255, 0, 0, 1);
+    graphics.drawRoundedRectangle(0, 0, 40, 20, 4);
+
+    const data = serializeTree(graphics);
+
+    expect(data.type).toBe('Graphics');
+
+    const restored = deserializeTree(data) as Graphics;
+
+    expect(restored).toBeInstanceOf(Graphics);
+    expect(restored.children.length).toBe(graphics.children.length);
+  });
+});
+
+describe('serialization — NineSliceSprite', () => {
+  it('round-trips slices/border/modes/size + texture ref', () => {
+    const texture = createTexture(48, 48);
+    const loader = fakeLoader([{ type: Texture, source: 'panel.png', resource: texture }]);
+    const ns = new NineSliceSprite(texture, { slices: { top: 16, bottom: 16, left: 16, right: 16 }, width: 100, height: 80 });
+
+    const data = serializeTree(ns, loader);
+
+    expect(data.type).toBe('NineSliceSprite');
+    expect(data.texture).toBe('panel.png');
+    expect(data.slices).toEqual({ top: 16, bottom: 16, left: 16, right: 16 });
+    expect(data.width).toBe(100);
+
+    const restored = deserializeTree(data, loader) as NineSliceSprite;
+
+    expect(restored.width).toBe(100);
+    expect(restored.height).toBe(80);
+    expect(restored.slices.top).toBe(16);
+  });
+});
+
+describe('serialization — RepeatingSprite', () => {
+  it('round-trips modes/fits/offsets/size + texture ref', () => {
+    const texture = createTexture(32, 32);
+    const loader = fakeLoader([{ type: Texture, source: 'tile.png', resource: texture }]);
+    const rs = new RepeatingSprite(texture, { width: 128, height: 64, offsetX: 8, modeX: 'mirror-repeat' });
+
+    const data = serializeTree(rs, loader);
+
+    expect(data.type).toBe('RepeatingSprite');
+    expect(data.modeX).toBe('mirror-repeat');
+    expect(data.offsetX).toBe(8);
+
+    const restored = deserializeTree(data, loader) as RepeatingSprite;
+
+    expect(restored.modeX).toBe('mirror-repeat');
+    expect(restored.width).toBe(128);
+    expect(restored.offsetX).toBe(8);
+  });
+});
+
+describe('serialization — AnimatedSprite', () => {
+  it('round-trips clips + active clip + playing state', () => {
+    const texture = createTexture(64, 16);
+    const loader = fakeLoader([{ type: Texture, source: 'hero.png', resource: texture }]);
+    const sprite = new AnimatedSprite(texture, {
+      run: { frames: [new Rectangle(0, 0, 16, 16), new Rectangle(16, 0, 16, 16)], fps: 10, loop: true },
+    });
+
+    sprite.play('run');
+
+    const data = serializeTree(sprite, loader);
+
+    expect(data.type).toBe('AnimatedSprite');
+    expect(data.currentClip).toBe('run');
+    expect(data.playing).toBe(true);
+
+    const restored = deserializeTree(data, loader) as AnimatedSprite;
+
+    expect(restored.currentClip).toBe('run');
+    expect(restored.playing).toBe(true);
+    expect(() => restored.play('run')).not.toThrow();
+  });
+});
+
+describe('serialization — BitmapText', () => {
+  it('round-trips text, font ref, msdf and scale', () => {
+    const fontData: BmFontData = {
+      pages: ['font_0.png'],
+      chars: new Map([[65, { x: 0, y: 0, width: 8, height: 12, xOffset: 0, yOffset: 2, xAdvance: 10, page: 0 }]]),
+      kernings: new Map(),
+      lineHeight: 16,
+      base: 12,
+    };
+    const font = new BmFont(fontData, [{ width: 64, height: 64 } as unknown as Texture]);
+    const loader = fakeLoader([{ type: BmFont, source: 'ui.fnt', resource: font }]);
+    const bitmapText = new BitmapText('A', font, { msdf: true, scale: 2 });
+
+    const data = serializeTree(bitmapText, loader);
+
+    expect(data.type).toBe('BitmapText');
+    expect(data.font).toBe('ui.fnt');
+    expect(data.msdf).toBe(true);
+    expect(data.scale).toBe(2);
+
+    const restored = deserializeTree(data, loader) as BitmapText;
+
+    expect(restored.text).toBe('A');
+    expect(restored.msdf).toBe(true);
+    expect(restored.fontScale).toBe(2);
+    expect(restored.font).toBe(font);
+  });
+});
+
+describe('serialization — Video', () => {
+  it('round-trips src and playback options', () => {
+    const element = document.createElement('video');
+
+    element.src = 'clip.mp4';
+
+    const video = new Video(element, { loop: true });
+    const data = serializeTree(video);
+
+    expect(data.type).toBe('Video');
+    expect(typeof data.src).toBe('string');
+    expect(data.loop).toBe(true);
+
+    const restored = deserializeTree(data) as Video;
+
+    expect(restored).toBeInstanceOf(Video);
+    expect(restored.loop).toBe(true);
   });
 });


### PR DESCRIPTION
**v0.14 Phase 4 — Feature-Build C (Serialisierung/Prefabs), PR2 von 3.** Baut auf PR1 (#144) auf. Spec `12`.

### Common-Feld-Framework
RenderNode-Interaktions-Flags round-trippen jetzt: `interactive`, `draggable`, `focusable`, `tabIndex`, `cursor`, `clip`, `preserveDrawOrder`, `cacheAsBitmap` + **Rectangle-`clipShape`**. Geometry-`clipShape` bleibt deferred (Warn), wie mask/filters/material (D7).

### Neue Node-Serializer (`renderingSerializers.ts`)
- **Mesh** — vertex/index/uv/colour-Arrays + Textur-Ref (material deferred).
- **Graphics** — round-trippt seine gebackenen Mesh-Kinder + Typ; Gradient-Fills degradieren zu Vertex-Farben (ihre Runtime-DataTextures sind unkeyed).
- **NineSliceSprite** — slices/border/modes/size + Textur-Ref.
- **RepeatingSprite** — modes/fits/offsets/size + Textur-Ref.
- **AnimatedSprite** — clips + aktiver Clip + playing (Frame/elapsed reset beim Laden).
- **BitmapText** — text + BmFont-Ref + msdf + scale + style + layout.
- **Video** — Quell-URL + Playback-Optionen (baut ein `<video>`-Element neu).

Geteilte Style/Color-Helfer nach `serializerHelpers.ts` extrahiert (Text + BitmapText). Zwei Read-Accessoren für die Serialisierung: `AnimatedSprite._getClipDefinitions()` (@internal) + `BitmapText.font`-Getter.

### Deferred → PR3-Follow-up
**UI-Widgets** (Label/Panel/Button/ProgressBar/Stack/UIRoot): brauchen Public-Read-Accessoren für ihre authored Optionen (aktuell private) + interne-vs-User-Kinder-Handling + Anchor/UIRoot-Kopplung. Bewusst auf PR3 verschoben (gleiche Defer-Begründung wie D7).

### Gates (lokal grün)
typecheck · lint:all (0 errors) · format:check · **3307 unit tests** · docs:api:check in sync · root-index unverändert (keine neuen Barrel-Symbole).

🤖 Generated with [Claude Code](https://claude.com/claude-code)