### PR TITLE
feat(ui): serialize UI widgets + serialization guide (Phase 4C PR4)

### DIFF
--- a/site/src/content/api/button.mdx
+++ b/site/src/content/api/button.mdx
@@ -5,7 +5,7 @@ symbol: "Button"
 kind: "class"
 subsystem: "core"
 importPath: "@codexo/exojs"
-memberCount: 101
+memberCount: 105
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/ui/Button.ts"
@@ -89,9 +89,12 @@ Listen to Button.onClick for activation.
 - `bottom: number`
 - `cacheAsBitmap: boolean`
 - `children: RenderNode[]`
+- `colors: Readonly<Record<"normal" | "hover" | "pressed" | "disabled", Color>>`
+- `cornerRadius: number`
 - `cullable: boolean`
 - `enabled: boolean`
 - `filters: readonly Filter[]`
+- `fontSize: number`
 - `height: number`
 - `interactive: boolean`
 - `isAlignedBox: boolean`
@@ -106,6 +109,7 @@ Listen to Button.onClick for activation.
 - `scale: ObservableVector`
 - `skewX: number`
 - `skewY: number`
+- `textColor: Color`
 - `top: number`
 - `uiHeight: number`
 - `uiWidth: number`

--- a/site/src/content/api/panel.mdx
+++ b/site/src/content/api/panel.mdx
@@ -5,7 +5,7 @@ symbol: "Panel"
 kind: "class"
 subsystem: "core"
 importPath: "@codexo/exojs"
-memberCount: 100
+memberCount: 104
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/ui/Panel.ts"
@@ -87,9 +87,13 @@ The base building block for HUD boxes, dialogs, and menus — add content with
 - `tabIndex: number`
 - `anchor: ObservableVector`
 - `background: Graphics`
+- `borderColor: Color`
+- `borderWidth: number`
 - `bottom: number`
 - `cacheAsBitmap: boolean`
 - `children: RenderNode[]`
+- `color: Color`
+- `cornerRadius: number`
 - `cullable: boolean`
 - `enabled: boolean`
 - `filters: readonly Filter[]`

--- a/site/src/content/api/progress-bar.mdx
+++ b/site/src/content/api/progress-bar.mdx
@@ -5,7 +5,7 @@ symbol: "ProgressBar"
 kind: "class"
 subsystem: "core"
 importPath: "@codexo/exojs"
-memberCount: 100
+memberCount: 103
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/ui/ProgressBar.ts"
@@ -88,8 +88,10 @@ fraction in `[0, 1]`; setting it redraws only the fill.
 - `bottom: number`
 - `cacheAsBitmap: boolean`
 - `children: RenderNode[]`
+- `cornerRadius: number`
 - `cullable: boolean`
 - `enabled: boolean`
+- `fillColor: Color`
 - `filters: readonly Filter[]`
 - `height: number`
 - `interactive: boolean`
@@ -105,6 +107,7 @@ fraction in `[0, 1]`; setting it redraws only the fill.
 - `skewX: number`
 - `skewY: number`
 - `top: number`
+- `trackColor: Color`
 - `uiHeight: number`
 - `uiWidth: number`
 - `value: number`

--- a/site/src/content/api/stack.mdx
+++ b/site/src/content/api/stack.mdx
@@ -5,7 +5,7 @@ symbol: "Stack"
 kind: "class"
 subsystem: "core"
 importPath: "@codexo/exojs"
-memberCount: 101
+memberCount: 104
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/ui/Stack.ts"
@@ -93,6 +93,7 @@ Stack.addItem to add and re-flow in one step.
 - `cacheAsBitmap: boolean`
 - `children: RenderNode[]`
 - `cullable: boolean`
+- `direction: StackDirection`
 - `enabled: boolean`
 - `filters: readonly Filter[]`
 - `height: number`
@@ -101,6 +102,7 @@ Stack.addItem to add and re-flow in one step.
 - `left: number`
 - `mask: MaskSource`
 - `origin: ObservableVector`
+- `padding: number`
 - `parent: Container | null`
 - `position: ObservableVector`
 - `right: number`
@@ -108,6 +110,7 @@ Stack.addItem to add and re-flow in one step.
 - `scale: ObservableVector`
 - `skewX: number`
 - `skewY: number`
+- `spacing: number`
 - `top: number`
 - `uiHeight: number`
 - `uiWidth: number`

--- a/site/src/content/guide/runtime/serialization-and-prefabs.mdx
+++ b/site/src/content/guide/runtime/serialization-and-prefabs.mdx
@@ -1,0 +1,96 @@
+---
+title: 'Serialization & prefabs'
+description: 'Serialize scenes to JSON and back, capture reusable prefabs, persist save slots with SaveManager, and register serializers for your own node types.'
+---
+
+# Serialization & prefabs
+
+ExoJS can turn a scene-graph subtree into plain JSON and rebuild it later. The serializer captures **data and structure** — transforms, visuals, asset references, and the tree shape — **not behaviour**. Update logic, signal handlers, tweens, and systems live in your `Scene` / `System` code and are re-attached after a load. That boundary keeps the format small and matches the engine's code-first design.
+
+Use it for level/scene layouts, reusable prefabs, the structural half of save games, editor save/load, and snapshot tests.
+
+## Serializing a scene
+
+[`Scene.serialize()`](/ExoJS/en/api/scene/) returns a JSON-able descriptor; [`Scene.deserialize()`](/ExoJS/en/api/scene/) rebuilds the scene's `root` (and `ui` layer, if present) from one. Texture and other asset references resolve to their loader source keys, so the **referenced assets must be loaded into the application's loader before you deserialize**.
+
+```ts
+import { Scene } from '@codexo/exojs';
+
+declare const scene: Scene;
+
+// Capture the current layout as plain JSON.
+const data = scene.serialize();
+const json = JSON.stringify(data);
+
+// ...later, with the same assets pre-loaded, restore it.
+scene.deserialize(JSON.parse(json));
+```
+
+A freshly-constructed node serializes to just its `type` tag — only non-default fields are written, so the JSON stays compact.
+
+## Prefabs
+
+A [`Prefab`](/ExoJS/en/api/prefab/) captures a configured subtree once and stamps out independent copies — the data-driven counterpart to building objects in a code factory. There is no re-serialization per instance.
+
+```ts
+import { Prefab, type SceneNode } from '@codexo/exojs';
+
+declare const coin: SceneNode;
+
+const prefab = Prefab.from(coin);
+
+for (let i = 0; i < 10; i++) {
+  const instance = prefab.instantiate();
+  instance.setPosition(i * 32, 0);
+}
+```
+
+`prefab.toJSON()` and `Prefab.fromJSON(descriptor)` round-trip a prefab through disk or the network.
+
+## Persisting saves
+
+[`SaveManager`](/ExoJS/en/api/save-manager/) is a thin helper over `JsonStore` that saves and restores a scene's structural state by named slot. Pair it with your own game-state persistence (score, inventory, quest flags) for a complete save system — the serializer owns the *world layout*, your code owns the *gameplay variables*.
+
+```ts
+import { SaveManager, type Scene } from '@codexo/exojs';
+
+declare const scene: Scene;
+
+const saves = new SaveManager();
+
+void saves.save('slot-1', scene); // serialize + persist
+void saves.load('slot-1', scene); // fetch + deserialize (resolves false if empty)
+```
+
+## Custom node types
+
+Your own [`SceneNode`](/ExoJS/en/api/scene-node/) subclasses become serializable by registering a serializer with [`registerSerializer`](/ExoJS/en/api/serialization-registry/). The framework writes the common transform/visual fields and the type tag; your serializer only handles its own fields.
+
+```ts
+import { registerSerializer, SceneNode } from '@codexo/exojs';
+
+class Marker extends SceneNode {
+  public kind = 'spawn';
+}
+
+registerSerializer('Marker', Marker, {
+  write: node => ({ kind: node.kind }),
+  read: data => {
+    const marker = new Marker();
+    marker.kind = String(data.kind);
+    return marker;
+  },
+});
+```
+
+Extension packages register their own node types the same way through the `serializers` binding on their `Extension` descriptor.
+
+## What is not captured
+
+The format deliberately stops at structure:
+
+- **Behaviour** — update logic, signal handlers, tweens, input bindings, systems. Re-attach these in code after a load.
+- **Live/heavy references** — a node `mask` that points at another node, post-process `filters`, a `Geometry` clip shape, and custom materials are skipped (with a one-time warning). Transform, tint, blend mode, frame, and asset references all round-trip.
+- **Runtime-only assets** — a `RenderTexture` or other resource not loaded through the `Loader` has no source key, so the reference is omitted.
+
+Every value the serializer writes is JSON-serialisable; caches, matrices, and dirty flags never appear in the output.

--- a/site/src/lib/guide-structure.ts
+++ b/site/src/lib/guide-structure.ts
@@ -217,6 +217,17 @@ const RAW_PARTS: ReadonlyArray<RawPart> = [
                 examples: ['ui/hud-and-widgets', 'application-scenes/hud-overlay-scene'],
                 apiLinks: ['uiroot', 'widget', 'button', 'panel', 'label', 'progress-bar', 'focus-manager'],
             },
+            {
+                slug: 'serialization-and-prefabs',
+                level: 'advanced',
+                learningGoals: [
+                    'serialize a scene to JSON and restore it',
+                    'capture reusable prefabs and instantiate many independent copies',
+                    'persist save slots with SaveManager and register serializers for custom node types',
+                ],
+                prerequisites: ['runtime/scene-graph'],
+                apiLinks: ['scene', 'prefab', 'save-manager', 'serialization-registry', 'scene-node'],
+            },
         ],
     },
     {

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -269,7 +269,15 @@ export class Scene {
    * after {@link Scene.deserialize}.
    */
   public serialize(): SerializedScene {
-    return { version: SERIALIZATION_VERSION, root: serializeTree(this._root, this._app?.loader ?? null) };
+    const loader = this._app?.loader ?? null;
+    const data: SerializedScene = { version: SERIALIZATION_VERSION, root: serializeTree(this._root, loader) };
+    const ui = this._peekUI();
+
+    if (ui !== null) {
+      data.ui = serializeTree(ui, loader);
+    }
+
+    return data;
   }
 
   /**
@@ -283,7 +291,14 @@ export class Scene {
    * throw. Returns `this`.
    */
   public deserialize(data: SerializedScene): this {
-    deserializeInto(this._root, migrate(data).root, this._app?.loader ?? null);
+    const migrated = migrate(data);
+    const loader = this._app?.loader ?? null;
+
+    deserializeInto(this._root, migrated.root, loader);
+
+    if (migrated.ui !== undefined) {
+      deserializeInto(this.ui, migrated.ui, loader);
+    }
 
     return this;
   }

--- a/src/core/serialization/coreSerializers.ts
+++ b/src/core/serialization/coreSerializers.ts
@@ -12,6 +12,7 @@ import { registerRenderingSerializers } from './renderingSerializers';
 import type { SerializationRegistry } from './SerializationRegistry';
 import { deserializeStyleOptions, serializeStyle } from './serializerHelpers';
 import type { SerializedNode } from './types';
+import { registerUiSerializers } from './uiSerializers';
 
 // ── Container ────────────────────────────────────────────────────────────────
 
@@ -104,10 +105,9 @@ const textSerializer: NodeSerializer<Text> = {
 };
 
 /**
- * Register all built-in node serializers (core leaf types + rendering package)
- * on `registry`. Called once, lazily, from the serialization framework. UI
- * widgets are not yet covered (they need read-accessors for their authored
- * options) — see the Phase 4C follow-up.
+ * Register all built-in node serializers (core leaf types + rendering package +
+ * UI widgets) on `registry`. Called once, lazily, from the serialization
+ * framework.
  * @internal
  */
 export function registerCoreSerializers(registry: SerializationRegistry): void {
@@ -116,4 +116,5 @@ export function registerCoreSerializers(registry: SerializationRegistry): void {
   registry.register('Text', Text, textSerializer);
 
   registerRenderingSerializers(registry);
+  registerUiSerializers(registry);
 }

--- a/src/core/serialization/types.ts
+++ b/src/core/serialization/types.ts
@@ -34,6 +34,8 @@ export interface SerializedScene {
   version: number;
   /** The scene's structural root container subtree. */
   root: SerializedNode;
+  /** The scene's screen-fixed UI layer ({@link Scene.ui}), if it was materialized. */
+  ui?: SerializedNode;
 }
 
 /**

--- a/src/core/serialization/uiSerializers.ts
+++ b/src/core/serialization/uiSerializers.ts
@@ -1,0 +1,228 @@
+import type { RenderNode } from '#rendering/RenderNode';
+import { Button } from '#ui/Button';
+import { Label } from '#ui/Label';
+import { Panel } from '#ui/Panel';
+import { ProgressBar } from '#ui/ProgressBar';
+import { Stack } from '#ui/Stack';
+import { UIRoot } from '#ui/UIRoot';
+
+import type { NodeSerializer } from './NodeSerializer';
+import type { SerializationRegistry } from './SerializationRegistry';
+import { arrayToColor, colorToArray, deserializeStyleOptions, serializeStyle } from './serializerHelpers';
+import type { SerializedNode } from './types';
+
+const num = (value: unknown): number | undefined => (typeof value === 'number' ? value : undefined);
+
+// Widget composition note: widgets own internal children (a Label's Text, a
+// Panel's background Graphics, etc.) that their constructors rebuild — those are
+// never serialized. Only user-added children of the container widgets (Panel,
+// Stack, UIRoot) round-trip. Anchoring (anchorIn) references a UIRoot and is not
+// serialized; the resolved position still round-trips via the common fields.
+
+// ── Label ────────────────────────────────────────────────────────────────────
+
+const labelSerializer: NodeSerializer<Label> = {
+  write(node) {
+    const out: Record<string, unknown> = { text: node.text };
+    const style = serializeStyle(node.textNode.style);
+
+    if (style !== undefined) out.style = style;
+    if (!node.enabled) out.enabled = false;
+
+    return out;
+  },
+  read(data) {
+    const label = new Label(typeof data.text === 'string' ? data.text : '', deserializeStyleOptions(data.style));
+
+    if (data.enabled === false) label.enabled = false;
+
+    return label;
+  },
+};
+
+// ── Panel ────────────────────────────────────────────────────────────────────
+
+const panelSerializer: NodeSerializer<Panel> = {
+  write(node, ctx) {
+    const out: Record<string, unknown> = {
+      width: node.uiWidth,
+      height: node.uiHeight,
+      color: colorToArray(node.color),
+      borderColor: colorToArray(node.borderColor),
+      borderWidth: node.borderWidth,
+      cornerRadius: node.cornerRadius,
+    };
+
+    if (!node.enabled) out.enabled = false;
+
+    const userChildren = node.children.filter(child => child !== node.background);
+    if (userChildren.length > 0) out.children = userChildren.map(child => ctx.writeNode(child));
+
+    return out;
+  },
+  read(data, ctx) {
+    const panel = new Panel({
+      width: num(data.width),
+      height: num(data.height),
+      color: arrayToColor(data.color),
+      borderColor: arrayToColor(data.borderColor),
+      borderWidth: num(data.borderWidth),
+      cornerRadius: num(data.cornerRadius),
+    });
+
+    if (data.enabled === false) panel.enabled = false;
+
+    const children = data.children;
+    if (Array.isArray(children)) {
+      for (const child of children) {
+        panel.addChild(ctx.readNode(child as SerializedNode) as RenderNode);
+      }
+    }
+
+    return panel;
+  },
+};
+
+// ── Button ───────────────────────────────────────────────────────────────────
+
+const buttonSerializer: NodeSerializer<Button> = {
+  write(node) {
+    const out: Record<string, unknown> = {
+      width: node.uiWidth,
+      height: node.uiHeight,
+      label: node.label,
+      cornerRadius: node.cornerRadius,
+      color: colorToArray(node.colors.normal),
+      hoverColor: colorToArray(node.colors.hover),
+      pressedColor: colorToArray(node.colors.pressed),
+      disabledColor: colorToArray(node.colors.disabled),
+      textColor: colorToArray(node.textColor),
+      fontSize: node.fontSize,
+    };
+
+    if (!node.enabled) out.enabled = false;
+
+    return out;
+  },
+  read(data) {
+    const button = new Button({
+      width: num(data.width),
+      height: num(data.height),
+      label: typeof data.label === 'string' ? data.label : undefined,
+      cornerRadius: num(data.cornerRadius),
+      color: arrayToColor(data.color),
+      hoverColor: arrayToColor(data.hoverColor),
+      pressedColor: arrayToColor(data.pressedColor),
+      disabledColor: arrayToColor(data.disabledColor),
+      textColor: arrayToColor(data.textColor),
+      fontSize: num(data.fontSize),
+    });
+
+    if (data.enabled === false) button.enabled = false;
+
+    return button;
+  },
+};
+
+// ── ProgressBar ──────────────────────────────────────────────────────────────
+
+const progressBarSerializer: NodeSerializer<ProgressBar> = {
+  write(node) {
+    const out: Record<string, unknown> = {
+      width: node.uiWidth,
+      height: node.uiHeight,
+      value: node.value,
+      trackColor: colorToArray(node.trackColor),
+      fillColor: colorToArray(node.fillColor),
+      cornerRadius: node.cornerRadius,
+    };
+
+    if (!node.enabled) out.enabled = false;
+
+    return out;
+  },
+  read(data) {
+    const bar = new ProgressBar({
+      width: num(data.width),
+      height: num(data.height),
+      value: num(data.value),
+      trackColor: arrayToColor(data.trackColor),
+      fillColor: arrayToColor(data.fillColor),
+      cornerRadius: num(data.cornerRadius),
+    });
+
+    if (data.enabled === false) bar.enabled = false;
+
+    return bar;
+  },
+};
+
+// ── Stack ────────────────────────────────────────────────────────────────────
+
+const stackSerializer: NodeSerializer<Stack> = {
+  write(node, ctx) {
+    const out: Record<string, unknown> = {
+      direction: node.direction,
+      spacing: node.spacing,
+      padding: node.padding,
+    };
+
+    if (!node.enabled) out.enabled = false;
+    if (node.children.length > 0) out.children = node.children.map(child => ctx.writeNode(child));
+
+    return out;
+  },
+  read(data, ctx) {
+    const stack = new Stack({
+      direction: data.direction === 'row' || data.direction === 'column' ? data.direction : undefined,
+      spacing: num(data.spacing),
+      padding: num(data.padding),
+    });
+
+    if (data.enabled === false) stack.enabled = false;
+
+    const children = data.children;
+    if (Array.isArray(children)) {
+      for (const child of children) {
+        stack.addChild(ctx.readNode(child as SerializedNode) as RenderNode);
+      }
+
+      stack.layout();
+    }
+
+    return stack;
+  },
+};
+
+// ── UIRoot ───────────────────────────────────────────────────────────────────
+
+const uiRootSerializer: NodeSerializer<UIRoot> = {
+  write(node, ctx) {
+    return node.children.length > 0 ? { children: node.children.map(child => ctx.writeNode(child)) } : {};
+  },
+  read(data, ctx) {
+    const root = new UIRoot();
+    const children = data.children;
+
+    if (Array.isArray(children)) {
+      for (const child of children) {
+        root.addChild(ctx.readNode(child as SerializedNode) as RenderNode);
+      }
+    }
+
+    return root;
+  },
+};
+
+/**
+ * Register the UI widget node serializers on `registry`.
+ * @internal
+ */
+export function registerUiSerializers(registry: SerializationRegistry): void {
+  registry.register('Label', Label, labelSerializer);
+  registry.register('Panel', Panel, panelSerializer);
+  registry.register('Button', Button, buttonSerializer);
+  registry.register('ProgressBar', ProgressBar, progressBarSerializer);
+  registry.register('Stack', Stack, stackSerializer);
+  registry.register('UIRoot', UIRoot, uiRootSerializer);
+}

--- a/src/ui/Button.ts
+++ b/src/ui/Button.ts
@@ -81,6 +81,26 @@ export class Button extends Widget {
     this._positionLabel();
   }
 
+  /** The per-state fill colours (`normal` / `hover` / `pressed` / `disabled`). */
+  public get colors(): Readonly<Record<'normal' | 'hover' | 'pressed' | 'disabled', Color>> {
+    return this._colors;
+  }
+
+  /** Corner radius in pixels. */
+  public get cornerRadius(): number {
+    return this._cornerRadius;
+  }
+
+  /** Label fill colour. */
+  public get textColor(): Color {
+    return this._label.style.fillColor;
+  }
+
+  /** Label font size in pixels. */
+  public get fontSize(): number {
+    return this._label.style.fontSize;
+  }
+
   private readonly _onPointerOver = (): void => {
     this._pointerInside = true;
     this._refreshState();

--- a/src/ui/Panel.ts
+++ b/src/ui/Panel.ts
@@ -43,6 +43,26 @@ export class Panel extends Widget {
     return this._background;
   }
 
+  /** Fill colour. */
+  public get color(): Color {
+    return this._color;
+  }
+
+  /** Border colour (drawn only when {@link borderWidth} is greater than 0). */
+  public get borderColor(): Color {
+    return this._borderColor;
+  }
+
+  /** Border thickness in pixels. */
+  public get borderWidth(): number {
+    return this._borderWidth;
+  }
+
+  /** Corner radius in pixels. */
+  public get cornerRadius(): number {
+    return this._cornerRadius;
+  }
+
   protected override _relayout(): void {
     const g = this._background;
 

--- a/src/ui/ProgressBar.ts
+++ b/src/ui/ProgressBar.ts
@@ -53,6 +53,21 @@ export class ProgressBar extends Widget {
     }
   }
 
+  /** Track (background) colour. */
+  public get trackColor(): Color {
+    return this._trackColor;
+  }
+
+  /** Fill (foreground) colour. */
+  public get fillColor(): Color {
+    return this._fillColor;
+  }
+
+  /** Corner radius in pixels. */
+  public get cornerRadius(): number {
+    return this._cornerRadius;
+  }
+
   protected override _relayout(): void {
     this._drawTrack();
     this._drawFill();

--- a/src/ui/Stack.ts
+++ b/src/ui/Stack.ts
@@ -32,6 +32,21 @@ export class Stack extends Widget {
     this._padding = options.padding ?? 0;
   }
 
+  /** Flow direction (`'row'` or `'column'`). */
+  public get direction(): StackDirection {
+    return this._direction;
+  }
+
+  /** Gap between items in pixels. */
+  public get spacing(): number {
+    return this._spacing;
+  }
+
+  /** Inner padding around all items in pixels. */
+  public get padding(): number {
+    return this._padding;
+  }
+
   /** Add a child and re-flow the stack. */
   public addItem(child: RenderNode): this {
     this.addChild(child);

--- a/test/core/serialization.test.ts
+++ b/test/core/serialization.test.ts
@@ -28,6 +28,11 @@ import { BlendModes } from '#rendering/types';
 import { Video } from '#rendering/video/Video';
 import type { JsonStore } from '#resources/JsonStore';
 import type { Loadable, Loader } from '#resources/Loader';
+import { Button } from '#ui/Button';
+import { Label } from '#ui/Label';
+import { Panel } from '#ui/Panel';
+import { ProgressBar } from '#ui/ProgressBar';
+import { Stack } from '#ui/Stack';
 
 /** Build a canvas-backed texture with known dimensions (matches the unit-test convention). */
 function createTexture(width: number, height: number): Texture {
@@ -616,6 +621,118 @@ describe('serialization — SaveManager', () => {
     const scene = new Scene();
 
     expect(await saves.load('nope', scene)).toBe(false);
+    scene.destroy();
+  });
+});
+
+describe('serialization — UI widgets', () => {
+  it('round-trips a Label (text + style)', () => {
+    const label = new Label('Score', { fontSize: 18, fillColor: new Color(10, 20, 30, 1) });
+
+    const data = serializeTree(label);
+    expect(data.type).toBe('Label');
+    expect(data.text).toBe('Score');
+
+    const restored = deserializeTree(data) as Label;
+    expect(restored.text).toBe('Score');
+    expect(restored.textNode.style.fontSize).toBe(18);
+    expect(restored.textNode.style.fillColor.r).toBe(10);
+  });
+
+  it('round-trips a Panel (options + user children, excluding the internal background)', () => {
+    const panel = new Panel({ width: 120, height: 90, borderWidth: 2, cornerRadius: 12 });
+    const content = new Container();
+    content.name = 'content';
+    panel.addChild(content);
+
+    const data = serializeTree(panel);
+    expect(data.type).toBe('Panel');
+    expect(data.width).toBe(120);
+    expect(data.cornerRadius).toBe(12);
+    // Only the user child is serialized, not the background Graphics.
+    expect(data.children).toHaveLength(1);
+
+    const restored = deserializeTree(data) as Panel;
+    expect(restored.uiWidth).toBe(120);
+    expect(restored.borderWidth).toBe(2);
+    const userChildren = restored.children.filter(child => child !== restored.background);
+    expect(userChildren).toHaveLength(1);
+    expect(userChildren[0].name).toBe('content');
+  });
+
+  it('round-trips a Button (label, colours, size, enabled)', () => {
+    const button = new Button({ label: 'Play', width: 100, height: 36, color: new Color(10, 20, 30, 1) });
+    button.enabled = false;
+
+    const data = serializeTree(button);
+    expect(data.type).toBe('Button');
+    expect(data.label).toBe('Play');
+    expect(data.color).toEqual([10, 20, 30, 1]);
+    expect(data.enabled).toBe(false);
+
+    const restored = deserializeTree(data) as Button;
+    expect(restored.label).toBe('Play');
+    expect(restored.uiWidth).toBe(100);
+    expect(restored.colors.normal.r).toBe(10);
+    expect(restored.enabled).toBe(false);
+  });
+
+  it('round-trips a ProgressBar (value + colours)', () => {
+    const bar = new ProgressBar({ width: 200, height: 16, value: 0.42, fillColor: new Color(1, 2, 3, 1) });
+
+    const data = serializeTree(bar);
+    expect(data.type).toBe('ProgressBar');
+    expect(data.value).toBeCloseTo(0.42);
+
+    const restored = deserializeTree(data) as ProgressBar;
+    expect(restored.value).toBeCloseTo(0.42);
+    expect(restored.fillColor.g).toBe(2);
+  });
+
+  it('round-trips a Stack (options + items)', () => {
+    const stack = new Stack({ direction: 'row', spacing: 12, padding: 4 });
+    stack.addItem(new Label('A'));
+    stack.addItem(new Label('B'));
+
+    const data = serializeTree(stack);
+    expect(data.type).toBe('Stack');
+    expect(data.direction).toBe('row');
+    expect(data.spacing).toBe(12);
+    expect(data.children).toHaveLength(2);
+
+    const restored = deserializeTree(data) as Stack;
+    expect(restored.direction).toBe('row');
+    expect(restored.padding).toBe(4);
+    expect(restored.children).toHaveLength(2);
+  });
+});
+
+describe('serialization — Scene UI layer', () => {
+  it('round-trips scene.ui widgets through serialize/deserialize', () => {
+    const scene = new Scene();
+    const button = new Button({ label: 'Start', width: 100, height: 30 });
+    scene.ui.addChild(button);
+
+    const data = scene.serialize();
+    expect(data.ui).toBeDefined();
+    expect(data.ui?.children).toHaveLength(1);
+
+    const target = new Scene();
+    target.deserialize(data);
+
+    expect(target.ui.children).toHaveLength(1);
+    expect(target.ui.children[0]).toBeInstanceOf(Button);
+    expect((target.ui.children[0] as Button).label).toBe('Start');
+
+    scene.destroy();
+    target.destroy();
+  });
+
+  it('omits ui when the scene has no UI layer', () => {
+    const scene = new Scene();
+    scene.addChild(new Container());
+
+    expect(scene.serialize().ui).toBeUndefined();
     scene.destroy();
   });
 });


### PR DESCRIPTION
**v0.14 Phase 4 — Feature-Build C (Serialisierung/Prefabs), PR4 (Follow-up).** Schließt die letzte Lücke nach PR1 (#144) / PR2 (#145) / PR3 (#146): die UI-Widget-Ebene + Docs.

### UI-Widget-Serializer (`uiSerializers.ts`)
Label · Panel · Button · ProgressBar · Stack · UIRoot round-trippen jetzt. **Interne Kinder** (Label-Text, Panel-Background, …) werden vom Widget-Konstruktor neu gebaut und NICHT serialisiert; nur **User-Kinder** der Container-Widgets (Panel/Stack/UIRoot) werden erfasst. Anchoring wird nicht serialisiert (die aufgelöste Position round-trippt via Common-Felder). `Scene.serialize/deserialize` nimmt jetzt die `scene.ui`-Ebene mit (`SerializedScene.ui`).

### Widget-Read-Accessoren (additive Public-API — nötig, um authored Optionen zu lesen)
Panel `color`/`borderColor`/`borderWidth`/`cornerRadius` · Button `colors`/`cornerRadius`/`textColor`/`fontSize` · ProgressBar `trackColor`/`fillColor`/`cornerRadius` · Stack `direction`/`spacing`/`padding`.

### Docs
Neues Guide-Kapitel **„Serialization & prefabs"** (Runtime-Teil): Scene serialize/deserialize, Prefabs, SaveManager, Custom-Serializer, Daten-nicht-Verhalten-Grenze.

### Gates (lokal grün)
typecheck · **typecheck:guides** · **guide-structure 19/19** · lint:all (0 errors) · format:check · **3318 unit tests** · docs:api:check in sync.

Damit ist **Feature-Build C vollständig** (PR1→PR4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)