### PR TITLE
feat(tilemap): serialize TileMapNode via Extension.serializers binding

### DIFF
--- a/packages/exojs-tilemap/src/tilemapExtension.ts
+++ b/packages/exojs-tilemap/src/tilemapExtension.ts
@@ -3,6 +3,8 @@ import type { RenderBackend } from '@codexo/exojs/rendering';
 import { RenderBackendType } from '@codexo/exojs/rendering';
 
 import { TileChunkNode } from './TileChunkNode';
+import { TileMapNode } from './TileMapNode';
+import { tileMapNodeSerializer } from './tilemapSerializers';
 import { WebGl2TileChunkRenderer } from './webgl2/WebGl2TileChunkRenderer';
 import { WebGpuTileChunkRenderer } from './webgpu/WebGpuTileChunkRenderer';
 
@@ -37,9 +39,10 @@ function buildTileChunkRendererBinding(batchSize: number): RendererBinding {
 /**
  * Default immutable tilemap extension descriptor.
  *
- * Registers the WebGL2/WebGPU tile chunk renderers (`renderers`); it carries no
- * asset bindings — there is no generic on-disk tilemap format in this slice, so
- * format adapters (e.g. `@codexo/exojs-tiled`) own loading and depend on this
+ * Registers the WebGL2/WebGPU tile chunk renderers (`renderers`) and the
+ * {@link TileMapNode} scene serializer (`serializers`); it carries no asset
+ * bindings — there is no generic on-disk tilemap format in this slice, so format
+ * adapters (e.g. `@codexo/exojs-tiled`) own loading and depend on this
  * descriptor to pull in rendering.
  *
  * Install + register directly for procedural / hand-built maps
@@ -53,4 +56,5 @@ function buildTileChunkRendererBinding(batchSize: number): RendererBinding {
 export const tilemapExtension: Extension = Object.freeze({
   id: '@codexo/exojs-tilemap',
   renderers: [buildTileChunkRendererBinding(tileRendererBatchSize)],
+  serializers: [{ typeName: 'TileMapNode', target: TileMapNode, serializer: tileMapNodeSerializer }],
 });

--- a/packages/exojs-tilemap/src/tilemapSerializers.ts
+++ b/packages/exojs-tilemap/src/tilemapSerializers.ts
@@ -1,0 +1,54 @@
+import type { NodeSerializer } from '@codexo/exojs';
+import type { PixelSnapMode } from '@codexo/exojs/rendering';
+
+import { TileMap } from './TileMap';
+import { TileMapNode } from './TileMapNode';
+
+/**
+ * Scene serializer for {@link TileMapNode} — the convenience node that renders a
+ * whole {@link TileMap}.
+ *
+ * Captures the **map reference** (its Loader source key) plus the render-only
+ * `pixelSnapMode`; the per-layer / per-chunk nodes are derived from the map and
+ * rebuilt on construction, so they are never written. The referenced `TileMap`
+ * must be pre-loaded into the target Loader (e.g. `loader.load(TileMap, 'world.tmj')`)
+ * before deserialize — procedurally-built maps have no source key and cannot be
+ * referenced.
+ *
+ * Standalone `TileLayerNode` / `TileMapBand` placement (the actor-interleaving
+ * cases) is not yet covered.
+ *
+ * @internal — registered via {@link tilemapExtension}'s `serializers` binding.
+ */
+export const tileMapNodeSerializer: NodeSerializer<TileMapNode> = {
+  write(node, ctx) {
+    const out: Record<string, unknown> = {};
+    const source = ctx.keyFor(node.map);
+
+    if (source !== null) {
+      out.map = source;
+    }
+
+    if (node.pixelSnapMode !== 'none') {
+      out.pixelSnapMode = node.pixelSnapMode;
+    }
+
+    return out;
+  },
+  read(data, ctx) {
+    const map = ctx.resolveAsset(typeof data.map === 'string' ? data.map : null, TileMap);
+
+    if (map === null) {
+      throw new Error('TileMapNode deserialize requires its TileMap to be pre-loaded into the Loader (procedural maps have no source key).');
+    }
+
+    const node = new TileMapNode(map);
+
+    // The TileMapNode setter validates the value (throws on an invalid mode).
+    if (typeof data.pixelSnapMode === 'string') {
+      node.pixelSnapMode = data.pixelSnapMode as PixelSnapMode;
+    }
+
+    return node;
+  },
+};

--- a/packages/exojs-tilemap/test/serialization.test.ts
+++ b/packages/exojs-tilemap/test/serialization.test.ts
@@ -1,0 +1,57 @@
+import type { Loadable, Loader } from '@codexo/exojs';
+import { Prefab, registerSerializer } from '@codexo/exojs';
+import { describe, expect, it } from 'vitest';
+
+import { TileMap } from '../src/TileMap';
+import { tilemapExtension } from '../src/tilemapExtension';
+import { TileMapNode } from '../src/TileMapNode';
+import { tileMapNodeSerializer } from '../src/tilemapSerializers';
+
+/** Minimal Loader stand-in implementing the two methods the serialization context uses. */
+function fakeLoader(map: TileMap, source: string): Loader {
+  return {
+    keyFor: (resource: object) => (resource === map ? { type: TileMap, source } : null),
+    peek: (type: Loadable, alias: string) => (type === TileMap && alias === source ? map : null),
+  } as unknown as Loader;
+}
+
+// Register the serializer into the default registry, exactly as the extension's
+// `serializers` binding does at Application construction.
+registerSerializer('TileMapNode', TileMapNode, tileMapNodeSerializer);
+
+describe('tilemap serialization', () => {
+  it('carries the TileMapNode serializer on the extension descriptor', () => {
+    const typeNames = (tilemapExtension.serializers ?? []).map(binding => binding.typeName);
+
+    expect(typeNames).toContain('TileMapNode');
+  });
+
+  it('round-trips a TileMapNode (map reference + pixelSnapMode) via Prefab', () => {
+    const map = new TileMap({ name: 'world', width: 4, height: 4, tileWidth: 32, tileHeight: 32 });
+    const loader = fakeLoader(map, 'world.tmj');
+    const node = new TileMapNode(map);
+    node.pixelSnapMode = 'position';
+
+    const data = Prefab.from(node, loader).toJSON();
+
+    expect(data.type).toBe('TileMapNode');
+    expect(data.map).toBe('world.tmj');
+    expect(data.pixelSnapMode).toBe('position');
+
+    const restored = Prefab.fromJSON(data).instantiate(loader) as TileMapNode;
+
+    expect(restored).toBeInstanceOf(TileMapNode);
+    expect(restored.map).toBe(map);
+    expect(restored.pixelSnapMode).toBe('position');
+
+    node.destroy();
+    restored.destroy();
+    map.destroy();
+  });
+
+  it('throws when the referenced map is not pre-loaded', () => {
+    const emptyLoader = { keyFor: () => null, peek: () => null } as unknown as Loader;
+
+    expect(() => Prefab.fromJSON({ type: 'TileMapNode', map: 'missing.tmj' }).instantiate(emptyLoader)).toThrow(/pre-loaded/);
+  });
+});


### PR DESCRIPTION
**Tilemap-Serialisierung — Zwischenschritt nach Feature-Build C (#144–#147).** Schließt die Serialisierungs-Lücke für Tilemaps und ist der **erste echte End-to-End-Konsument** des `Extension.serializers?`-Bindings.

### Inhalt
- **TileMapNode-Serializer** (`src/tilemapSerializers.ts`): serialisiert den **TileMap-Source-Key** (via `Loader.keyFor`-Reverse-Lookup) + render-only `pixelSnapMode`. Die Layer-/Chunk-Nodes sind aus der Map abgeleitet und werden beim Konstruieren neu gebaut → nicht serialisiert. Referenzierte Maps müssen vorgeladen sein (`loader.load(TileMap, 'world.tmj')`); prozedurale Maps haben keinen Source-Key.
- Registriert über das `tilemapExtension`-`serializers`-Binding → materialisiert bei App-Konstruktion in die Serialisierungs-Registry (neben den Renderer-Bindings).

### Nicht abgedeckt (JIT)
Standalone `TileLayerNode` / `TileMapBand`-Platzierung (Actor-Interleaving).

### Gates (lokal grün)
tilemap typecheck · lint · **249 Paket-Tests** · lint:all · **3321 unit tests** · docs:api in sync (Serializer ist @internal → keine neue API-Seite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)