### PR TITLE
feat(core): immediate-mode drawGeometry (Phase 4D PR1)

### DIFF
--- a/site/src/content/api/rendering-context.mdx
+++ b/site/src/content/api/rendering-context.mdx
@@ -5,11 +5,11 @@ symbol: "RenderingContext"
 kind: "class"
 subsystem: "rendering"
 importPath: "@codexo/exojs"
-memberCount: 10
+memberCount: 11
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/rendering/RenderingContext.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/RenderingContext.ts#L37"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/RenderingContext.ts#L57"
 ---
 ## Import
 
@@ -30,6 +30,7 @@ The conceptual model is "the context renders the node":
 
 ## Methods
 
+- `drawGeometry(geometry: Geometry, transform: Matrix, options: DrawGeometryOptions): void`
 - `render(node: RenderNode, options: RenderOptions): void`
 - `renderTo(node: RenderNode, options: RenderToOptions): RenderTexture`
 - `resize(width: number, height: number): void`
@@ -45,4 +46,4 @@ The conceptual model is "the context renders the node":
 
 ## Source
 
-[src/rendering/RenderingContext.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/RenderingContext.ts#L37)
+[src/rendering/RenderingContext.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/RenderingContext.ts#L57)

--- a/src/rendering/RenderingContext.ts
+++ b/src/rendering/RenderingContext.ts
@@ -1,6 +1,10 @@
 import type { Color } from '#core/Color';
 import type { System } from '#core/System';
 import type { Time } from '#core/Time';
+import type { Matrix } from '#math/Matrix';
+import type { Geometry } from '#rendering/geometry/Geometry';
+import type { MeshMaterial } from '#rendering/material/MeshMaterial';
+import { ImmediateMesh } from '#rendering/mesh/ImmediateMesh';
 import type { RenderPassCoordinatorHost } from '#rendering/pass/RenderPassCoordinator';
 import { StencilAttachmentMode } from '#rendering/pass/RenderPassDescriptor';
 import { playRenderTree } from '#rendering/plan/playRenderTree';
@@ -23,6 +27,22 @@ export interface RenderOptions {
   view?: View;
 }
 
+/** Options for {@link RenderingContext.drawGeometry}. */
+export interface DrawGeometryOptions {
+  /**
+   * Custom look (shader / uniforms / textures / blend mode) for this draw. Must
+   * target `'mesh'`. Defaults to the standard mesh material (vertex colors,
+   * optional texture), so an untextured colored geometry needs no material.
+   */
+  material?: MeshMaterial;
+
+  /** Tint multiplied into the geometry's vertex colors. Defaults to white (no tint). */
+  tint?: Color;
+
+  /** Override the view used for this draw. Defaults to the context's active camera. */
+  view?: View;
+}
+
 /**
  * Owns rendering orchestration: builds, optimizes and plays the internal
  * RenderPlan for a RenderNode subtree, manages render-target/view state for
@@ -40,6 +60,8 @@ export class RenderingContext implements System {
   private readonly _backend: RenderBackend;
   private _camera: Camera;
   private readonly _screenView: View;
+  /** Lazily-created pooled drawable reused by every {@link drawGeometry} call. */
+  private _immediateMesh: ImmediateMesh | null = null;
 
   public constructor(backend: RenderBackend) {
     this._backend = backend;
@@ -109,6 +131,8 @@ export class RenderingContext implements System {
   public destroy(): void {
     this._camera.destroy();
     this._screenView.destroy();
+    this._immediateMesh?.destroy();
+    this._immediateMesh = null;
   }
 
   /**
@@ -185,6 +209,56 @@ export class RenderingContext implements System {
     }
 
     return target;
+  }
+
+  /**
+   * Immediately draw a single {@link Geometry} with `transform` as its world
+   * matrix — no retained {@link RenderNode} required. Useful for procedural or
+   * data-driven shapes that would be wasteful to wrap in a node.
+   *
+   * The draw is submitted through the mesh renderer and flushed at once, so it
+   * lands in call order relative to the surrounding {@link render} calls: a
+   * `drawGeometry` issued after a layer's `render` draws on top of it. All
+   * output is presented at the frame-end backend flush, as usual.
+   *
+   * `transform` is taken as the raw world matrix (`a, b, c, d, tx, ty`),
+   * bypassing the position / rotation / scale / origin composition a node would
+   * apply — build it with {@link Matrix} directly. The geometry must use the
+   * `triangle-list` topology and the standard mesh attribute layout (position,
+   * optional texcoord and color); custom per-vertex attributes are dropped.
+   *
+   * This is the single-draw convenience of the immediate API: each call is its
+   * own flush and draw call, and the geometry is repacked every call, so it is
+   * best for a handful of draws. An instanced batch path for drawing many like
+   * items as one upload + one draw follows in a later release.
+   *
+   * @param geometry  Source geometry (interleaved vertex data + layout).
+   * @param transform World matrix applied to the geometry's local vertices.
+   * @param options   Optional {@link DrawGeometryOptions.material material},
+   *                  {@link DrawGeometryOptions.tint tint}, and
+   *                  {@link DrawGeometryOptions.view view}.
+   */
+  public drawGeometry(geometry: Geometry, transform: Matrix, options: DrawGeometryOptions = {}): void {
+    const material = options.material ?? null;
+
+    // Defensive guard for JS callers; the MeshMaterial type already enforces
+    // this for TypeScript callers (its `target` is the literal 'mesh').
+    if (material !== null && (material.target as string) !== 'mesh') {
+      throw new Error(`drawGeometry material must target 'mesh' (got '${String(material.target)}').`);
+    }
+
+    const view = options.view ?? this._camera;
+    const mesh = (this._immediateMesh ??= new ImmediateMesh());
+
+    // Set the view first: this flushes whatever renderer a prior render() /
+    // drawGeometry left pending, so the shared transform buffer is free for this
+    // draw's synthetic slot and the pooled mesh is safe to reconfigure. The
+    // immediate flush below then keeps a later drawGeometry from observing this
+    // pooled mesh through a still-deferred draw.
+    this._backend.setView(view);
+    mesh.configure(geometry, transform, material, options.tint ?? null);
+    this._backend.draw(mesh);
+    this._backend.flush();
   }
 
   /** Per-frame render counters. Convenience over backend.stats. */

--- a/src/rendering/index.ts
+++ b/src/rendering/index.ts
@@ -12,7 +12,7 @@ export type { RenderBackend } from './RenderBackend';
 export { RenderBackendType } from './RenderBackendType';
 export type { DrawableConstructor, Renderer } from './Renderer';
 export { RendererRegistry } from './RendererRegistry';
-export type { RenderOptions, RenderToOptions } from './RenderingContext';
+export type { DrawGeometryOptions, RenderOptions, RenderToOptions } from './RenderingContext';
 export { RenderingContext } from './RenderingContext';
 export type { MaskSource } from './RenderNode';
 export { RenderNode } from './RenderNode';

--- a/src/rendering/mesh/ImmediateMesh.ts
+++ b/src/rendering/mesh/ImmediateMesh.ts
@@ -1,0 +1,82 @@
+import { Color } from '#core/Color';
+import type { Matrix } from '#math/Matrix';
+import type { Geometry } from '#rendering/geometry/Geometry';
+import type { MeshMaterial } from '#rendering/material/MeshMaterial';
+
+import { Mesh, readGeometry } from './Mesh';
+
+// A degenerate triangle that satisfies the Mesh constructor's validation; it is
+// overwritten on the first configure() before the mesh is ever drawn.
+const placeholderVertices = (): Float32Array => new Float32Array([0, 0, 1, 0, 0, 1]);
+
+/**
+ * Writable view over the (publicly `readonly`) {@link Mesh} data fields. The
+ * pooled immediate mesh reconfigures these in place between draws; the readonly
+ * cast mirrors the pattern the WebGPU mesh renderer uses for its draw-call slots.
+ */
+interface MutableMeshFields {
+  vertices: Float32Array;
+  indices: Uint16Array | null;
+  uvs: Float32Array | null;
+  colors: Uint32Array | null;
+  material: MeshMaterial | null;
+}
+
+/**
+ * Pooled, reconfigurable mesh backing the immediate {@link RenderingContext.drawGeometry}
+ * path. It never enters the scene graph: it is reconfigured per call, submitted
+ * via `backend.draw`, and flushed immediately, so a single instance is reused
+ * across every immediate draw without per-call allocation.
+ *
+ * Unlike a regular {@link Mesh}, its world matrix is the raw {@link Matrix}
+ * handed to `drawGeometry` — there is no parent, origin, position, rotation, or
+ * scale to compose. {@link getGlobalTransform} therefore returns that matrix
+ * verbatim, a lossless 1:1 mapping onto the renderer's `a, b, c, d, tx, ty`
+ * transform slot, which both backends read at their transform-write seam.
+ *
+ * @internal
+ */
+export class ImmediateMesh extends Mesh {
+  private _rawTransform: Matrix | null = null;
+  private _sourceGeometry: Geometry | null = null;
+  private _sourceVersion = -1;
+
+  public constructor() {
+    super({ vertices: placeholderVertices() });
+  }
+
+  public override getGlobalTransform(): Matrix {
+    return this._rawTransform ?? super.getGlobalTransform();
+  }
+
+  /**
+   * Reconfigure this pooled mesh for one immediate draw.
+   *
+   * The geometry is re-flattened only when its identity or data {@link Geometry.version}
+   * changed — the steady-state case (same procedural geometry, fresh transform each
+   * frame) reuses the previously flattened arrays and allocates nothing. The raw
+   * transform reference is held directly (not copied): `drawGeometry` flushes the
+   * draw synchronously, so the caller cannot mutate it before it is consumed.
+   * @internal
+   */
+  public configure(geometry: Geometry, transform: Matrix, material: MeshMaterial | null, tint: Color | null): void {
+    const fields = this as unknown as MutableMeshFields;
+
+    if (geometry !== this._sourceGeometry || geometry.version !== this._sourceVersion) {
+      const data = readGeometry(geometry);
+
+      fields.vertices = data.vertices;
+      fields.uvs = data.uvs;
+      fields.colors = data.colors;
+      fields.indices = data.indices;
+      this._sourceGeometry = geometry;
+      this._sourceVersion = geometry.version;
+    }
+
+    fields.material = material;
+    this._rawTransform = transform;
+    // setTint ignores a falsy argument, so a missing tint must reset to white
+    // rather than retain the previous draw's tint through the pool.
+    this.setTint(tint ?? Color.white);
+  }
+}

--- a/src/rendering/mesh/Mesh.ts
+++ b/src/rendering/mesh/Mesh.ts
@@ -220,8 +220,12 @@ const findAttribute = (attributes: readonly GeometryAttribute[], names: Set<stri
  * `triangle-list` topology and the canonical attribute layout (`f32` position
  * and texcoord, `u8`/`u32`/`f32` color) are supported — this is the immediate
  * (non-batched) bridge; shared GPU buffers and instancing arrive later.
+ *
+ * Exported (not barrelled) so the pooled immediate-draw mesh can reuse the exact
+ * same flattening the `Mesh` constructor applies.
+ * @internal
  */
-function readGeometry(geometry: Geometry): {
+export function readGeometry(geometry: Geometry): {
   vertices: Float32Array;
   uvs: Float32Array | null;
   colors: Uint32Array | null;

--- a/src/rendering/webgl2/WebGl2MeshRenderer.ts
+++ b/src/rendering/webgl2/WebGl2MeshRenderer.ts
@@ -253,8 +253,20 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> {
   }
 
   private _drawDynamicInstancedSingle(draw: PendingMeshDraw, backend: WebGl2Backend, connection: MeshRendererConnection): void {
+    const nodeIndex = draw.command?.nodeIndex ?? 0;
+
+    if (draw.command === null) {
+      // The synthetic, non-plan path does not arrive through a render-group
+      // upload boundary, so write its transform into the shared buffer directly.
+      // This must run BEFORE _bindInstancedShaderState, whose
+      // bindTransformBufferTexture uploads the buffer: a write afterwards would
+      // miss this frame's upload, leaving the slot stale (zeroed on the first
+      // frame) so the draw collapses to the origin.
+      backend._writeTransformCommand(this._createSyntheticCommand(draw.mesh, nodeIndex));
+    }
+
     this._setBlendMode(draw.blendMode, backend);
-    this._bindInstancedShaderState(draw.shader, draw.texture, draw.material, backend, draw.command?.nodeIndex ?? 0);
+    this._bindInstancedShaderState(draw.shader, draw.texture, draw.material, backend, nodeIndex);
 
     this._ensureVertexCapacity(draw.mesh.vertexCount);
     this._ensureIndexCapacity(draw.mesh.indexCount);
@@ -262,14 +274,6 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> {
 
     this._packVertices(draw.mesh, 0);
     this._packIndices(draw.mesh, 0);
-
-    const nodeIndex = draw.command?.nodeIndex ?? 0;
-
-    if (draw.command === null) {
-      // The synthetic, non-plan path does not arrive through a render-group
-      // upload boundary, so write its transform into the shared buffer directly.
-      backend._writeTransformCommand(this._createSyntheticCommand(draw.mesh, nodeIndex));
-    }
 
     this._nodeIndexData[0] = nodeIndex >>> 0;
 

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -108,6 +108,7 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "Destroyable: interface",
   "DisposalScope: class",
   "DistanceModel: type alias",
+  "DrawGeometryOptions: interface",
   "Drawable: class",
   "DrawableConstructor: type alias",
   "Ease: class",

--- a/test/rendering/browser/webgl2-draw-geometry.test.ts
+++ b/test/rendering/browser/webgl2-draw-geometry.test.ts
@@ -1,0 +1,390 @@
+/**
+ * WebGL2 immediate-draw browser tests — opt-in, capability-aware.
+ *
+ * Exercises {@link RenderingContext.drawGeometry}: a node-free immediate draw of
+ * a {@link Geometry} through the pooled mesh path and the synthetic (non-plan)
+ * instanced transform seam (`_drawDynamicInstancedSingle` with a null command →
+ * `_writeTransformCommand`). Confirms the geometry renders at its world
+ * position, the raw transform is applied verbatim, and a tint modulates color.
+ *
+ * Run via:  pnpm test:browser:webgl
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Matrix } from '#math/Matrix';
+import { Geometry } from '#rendering/geometry/Geometry';
+import { RenderingContext } from '#rendering/RenderingContext';
+import { View } from '#rendering/View';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+
+// The browser project rewrites `.vert`/`.frag` imports to empty strings, so the
+// default engine shaders the renderers compile on connect must be mocked with
+// valid sources. The mesh sources keep the REAL pinned attribute locations
+// (0/1/2/6) and the shared TransformBuffer fetch so the synthetic transform path
+// renders correctly.
+const shaderSources = vi.hoisted(() => ({
+  spriteVertexSource: `#version 300 es
+precision mediump float;
+in vec4 a_localBounds;
+in vec4 a_uvBounds;
+in vec4 a_color;
+in uint a_textureSlot;
+in uint a_nodeIndex;
+uniform mat3 u_projection;
+uniform sampler2D u_transforms;
+out vec2 v_uv;
+out vec4 v_color;
+flat out uint v_textureSlot;
+void main() {
+  vec2 local;
+  if (gl_VertexID == 0) local = vec2(a_localBounds.x, a_localBounds.y);
+  else if (gl_VertexID == 1) local = vec2(a_localBounds.z, a_localBounds.y);
+  else if (gl_VertexID == 2) local = vec2(a_localBounds.x, a_localBounds.w);
+  else local = vec2(a_localBounds.z, a_localBounds.w);
+
+  vec2 uv;
+  if (gl_VertexID == 0) uv = vec2(a_uvBounds.x, a_uvBounds.y);
+  else if (gl_VertexID == 1) uv = vec2(a_uvBounds.z, a_uvBounds.y);
+  else if (gl_VertexID == 2) uv = vec2(a_uvBounds.x, a_uvBounds.w);
+  else uv = vec2(a_uvBounds.z, a_uvBounds.w);
+
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
+  vec3 clip = u_projection * vec3(world, 1.0);
+
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = uv;
+  v_color = a_color;
+  v_textureSlot = a_textureSlot;
+}`,
+
+  spriteFragmentSource: `#version 300 es
+precision mediump float;
+in vec2 v_uv;
+in vec4 v_color;
+flat in uint v_textureSlot;
+uniform sampler2D u_texture0;
+uniform sampler2D u_texture1;
+uniform sampler2D u_texture2;
+uniform sampler2D u_texture3;
+uniform sampler2D u_texture4;
+uniform sampler2D u_texture5;
+uniform sampler2D u_texture6;
+uniform sampler2D u_texture7;
+out vec4 outColor;
+vec4 sampleTexture(uint slot, vec2 uv) {
+  if (slot == uint(0)) return texture(u_texture0, uv);
+  if (slot == uint(1)) return texture(u_texture1, uv);
+  if (slot == uint(2)) return texture(u_texture2, uv);
+  if (slot == uint(3)) return texture(u_texture3, uv);
+  if (slot == uint(4)) return texture(u_texture4, uv);
+  if (slot == uint(5)) return texture(u_texture5, uv);
+  if (slot == uint(6)) return texture(u_texture6, uv);
+  return texture(u_texture7, uv);
+}
+void main() {
+  outColor = sampleTexture(v_textureSlot, v_uv) * v_color;
+}`,
+
+  meshVertexSource: `#version 300 es
+precision lowp float;
+layout(location = 0) in vec2 a_position;
+layout(location = 1) in vec2 a_texcoord;
+layout(location = 2) in vec4 a_color;
+layout(location = 6) in uint a_nodeIndex;
+uniform mat3 u_projection;
+uniform sampler2D u_transforms;
+out vec2 v_texcoord;
+out vec4 v_color;
+out vec4 v_tint;
+void main(void) {
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  mat3 transform = mat3(
+    m0.x, m0.z, 0.0,
+    m0.y, m0.w, 0.0,
+    m1.x, m1.y, 1.0
+  );
+  gl_Position = vec4((u_projection * transform * vec3(a_position, 1.0)).xy, 0.0, 1.0);
+  v_texcoord = a_texcoord;
+  v_color = a_color;
+  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+}`,
+
+  meshFragmentSource: `#version 300 es
+precision lowp float;
+uniform sampler2D u_texture;
+in vec2 v_texcoord;
+in vec4 v_color;
+in vec4 v_tint;
+layout(location = 0) out vec4 fragColor;
+void main(void) {
+  vec4 base = texture(u_texture, v_texcoord) * v_color * v_tint;
+  fragColor = vec4(base.rgb * base.a, base.a);
+}`,
+
+  particleVertexSource: `#version 300 es
+precision mediump float;
+in vec2 a_translation;
+in vec2 a_scale;
+in float a_rotation;
+in vec4 a_color;
+in vec2 a_uvMin;
+in vec2 a_uvMax;
+uniform mat3 u_projection;
+uniform mat3 u_systemTransform;
+uniform vec4 u_localBounds;
+out vec2 v_uv;
+out vec4 v_color;
+void main() {
+  vec2 corner;
+  if (gl_VertexID == 0) corner = vec2(0.0, 0.0);
+  else if (gl_VertexID == 1) corner = vec2(1.0, 0.0);
+  else if (gl_VertexID == 2) corner = vec2(1.0, 1.0);
+  else corner = vec2(0.0, 1.0);
+
+  vec2 local = mix(u_localBounds.xy, u_localBounds.zw, corner);
+  local *= a_scale;
+  float angle = radians(a_rotation);
+  mat2 rotationMatrix = mat2(cos(angle), -sin(angle), sin(angle), cos(angle));
+  vec2 worldPos = (u_systemTransform * vec3(rotationMatrix * local + a_translation, 1.0)).xy;
+  vec3 clip = u_projection * vec3(worldPos, 1.0);
+
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = mix(a_uvMin, a_uvMax, corner);
+  v_color = a_color;
+}`,
+
+  particleFragmentSource: `#version 300 es
+precision mediump float;
+in vec2 v_uv;
+in vec4 v_color;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() {
+  outColor = texture(u_texture, v_uv) * v_color;
+}`,
+
+  textVertexSource: `#version 300 es
+precision mediump float;
+in vec2 a_position;
+in vec2 a_texcoord;
+in float a_nodeIndex;
+uniform mat3 u_projection;
+out vec2 v_uv;
+void main() {
+  float nodeIndex = a_nodeIndex;
+  vec3 clip = u_projection * vec3(a_position + vec2(nodeIndex * 0.0), 1.0);
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = a_texcoord;
+}`,
+
+  textFragmentSource: `#version 300 es
+precision mediump float;
+in vec2 v_uv;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() {
+  outColor = texture(u_texture, v_uv);
+}`,
+}));
+
+vi.mock('#rendering/webgl2/glsl/sprite.vert', () => ({ default: shaderSources.spriteVertexSource }));
+vi.mock('#rendering/webgl2/glsl/sprite.frag', () => ({ default: shaderSources.spriteFragmentSource }));
+vi.mock('#rendering/webgl2/glsl/mesh.vert', () => ({ default: shaderSources.meshVertexSource }));
+vi.mock('#rendering/webgl2/glsl/mesh.frag', () => ({ default: shaderSources.meshFragmentSource }));
+vi.mock('#rendering/webgl2/glsl/particle.vert', () => ({ default: shaderSources.particleVertexSource }));
+vi.mock('#rendering/webgl2/glsl/particle.frag', () => ({ default: shaderSources.particleFragmentSource }));
+vi.mock('#rendering/webgl2/glsl/text.vert', () => ({ default: shaderSources.textVertexSource }));
+vi.mock('#rendering/webgl2/glsl/text-color.frag', () => ({ default: shaderSources.textFragmentSource }));
+vi.mock('#rendering/webgl2/glsl/text-msdf.frag', () => ({ default: shaderSources.textFragmentSource }));
+vi.mock('#rendering/webgl2/glsl/text-sdf.frag', () => ({ default: shaderSources.textFragmentSource }));
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+const defaultWebGlAttributes: WebGLContextAttributes = {
+  alpha: false,
+  antialias: false,
+  premultipliedAlpha: false,
+  preserveDrawingBuffer: true,
+  stencil: false,
+  depth: false,
+};
+
+const createBackend = async (): Promise<WebGl2Backend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const app = {
+    canvas,
+    options: {
+      clearColor: Color.black,
+      canvas: { width: canvasSize, height: canvasSize },
+      rendering: {
+        debug: false,
+        webglAttributes: defaultWebGlAttributes,
+        spriteRendererBatchSize: 1024,
+        particleRendererBatchSize: 1024,
+      },
+    },
+  } as unknown as Application;
+
+  const backend = new WebGl2Backend(app);
+
+  await backend.initialize();
+  wireCoreRenderers(backend, app.options.rendering);
+
+  return backend;
+};
+
+// A solid-color quad (two triangles) in world space. Layout: position f32x2 @0,
+// color u8x4-norm @8, stride 12. No texcoord — the default mesh path samples the
+// 1×1 white texture, so the output is the vertex color × tint.
+const coloredQuad = (x0: number, y0: number, x1: number, y1: number, rgba: RgbaTuple): Geometry => {
+  const stride = 12;
+  const corners: ReadonlyArray<readonly [number, number]> = [
+    [x0, y0],
+    [x1, y0],
+    [x1, y1],
+    [x0, y0],
+    [x1, y1],
+    [x0, y1],
+  ];
+  const buffer = new ArrayBuffer(corners.length * stride);
+  const view = new DataView(buffer);
+
+  corners.forEach(([x, y], index) => {
+    const base = index * stride;
+
+    view.setFloat32(base + 0, x, true);
+    view.setFloat32(base + 4, y, true);
+    view.setUint8(base + 8, rgba[0]);
+    view.setUint8(base + 9, rgba[1]);
+    view.setUint8(base + 10, rgba[2]);
+    view.setUint8(base + 11, rgba[3]);
+  });
+
+  return new Geometry({
+    attributes: [
+      { name: 'a_position', size: 2, type: 'f32', normalized: false, offset: 0 },
+      { name: 'a_color', size: 4, type: 'u8', normalized: true, offset: 8 },
+    ],
+    vertexData: buffer,
+    stride,
+  });
+};
+
+// A screen-space view matching the canvas: world (0,0)..(64,64) maps to the
+// whole surface, top-left origin.
+const screenView = (): View => new View(canvasSize / 2, canvasSize / 2, canvasSize, canvasSize);
+
+const readPixel = (backend: WebGl2Backend, x: number, y: number): RgbaTuple => {
+  const pixel = new Uint8Array(4);
+  const gl = backend.context;
+
+  gl.readPixels(Math.floor(x), backend.renderTarget.height - Math.floor(y) - 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixel);
+
+  return [pixel[0], pixel[1], pixel[2], pixel[3]];
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 5): void => {
+  for (let index = 0; index < 4; index++) {
+    expect(Math.abs(actual[index] - expected[index]), `channel ${index}: got [${actual.join(', ')}] expected [${expected.join(', ')}]`).toBeLessThanOrEqual(
+      tolerance,
+    );
+  }
+};
+
+describe('WebGL2 RenderingContext.drawGeometry', () => {
+  test('renders a colored geometry quad at its world position', async () => {
+    const backend = await createBackend();
+    const context = new RenderingContext(backend);
+    const geometry = coloredQuad(16, 16, 48, 48, [255, 0, 0, 255]);
+
+    try {
+      backend.resetStats();
+      backend.clear(Color.black);
+      context.drawGeometry(geometry, new Matrix(), { view: screenView() });
+
+      expect(backend.stats.drawCalls).toBeGreaterThan(0);
+      expectPixelNear(readPixel(backend, 32, 32), [255, 0, 0, 255]); // inside the quad
+      expectPixelNear(readPixel(backend, 4, 4), [0, 0, 0, 255]); // outside → cleared black
+    } finally {
+      geometry.destroy();
+      context.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('applies the raw transform verbatim (translation)', async () => {
+    const backend = await createBackend();
+    const context = new RenderingContext(backend);
+    const geometry = coloredQuad(0, 0, 32, 32, [0, 255, 0, 255]);
+
+    try {
+      backend.resetStats();
+      backend.clear(Color.black);
+      // Translate the quad from (0,0)-(32,32) to (32,32)-(64,64).
+      context.drawGeometry(geometry, new Matrix(1, 0, 32, 0, 1, 32), { view: screenView() });
+
+      expectPixelNear(readPixel(backend, 48, 48), [0, 255, 0, 255]); // inside the moved quad
+      expectPixelNear(readPixel(backend, 12, 12), [0, 0, 0, 255]); // original location now empty
+    } finally {
+      geometry.destroy();
+      context.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('modulates the geometry color by the tint', async () => {
+    const backend = await createBackend();
+    const context = new RenderingContext(backend);
+    // White geometry × a fractional tint resolves to the tint color.
+    const geometry = coloredQuad(16, 16, 48, 48, [255, 255, 255, 255]);
+
+    try {
+      backend.resetStats();
+      backend.clear(Color.black);
+      context.drawGeometry(geometry, new Matrix(), { tint: new Color(96, 160, 224), view: screenView() });
+
+      expectPixelNear(readPixel(backend, 32, 32), [96, 160, 224, 255]);
+    } finally {
+      geometry.destroy();
+      context.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('draws multiple immediate geometries in call order', async () => {
+    const backend = await createBackend();
+    const context = new RenderingContext(backend);
+    const red = coloredQuad(8, 8, 32, 32, [255, 0, 0, 255]);
+    const blue = coloredQuad(24, 24, 56, 56, [0, 0, 255, 255]);
+
+    try {
+      backend.resetStats();
+      backend.clear(Color.black);
+      // Blue is drawn after red, so it layers on top in the overlap region.
+      context.drawGeometry(red, new Matrix(), { view: screenView() });
+      context.drawGeometry(blue, new Matrix(), { view: screenView() });
+
+      expectPixelNear(readPixel(backend, 12, 12), [255, 0, 0, 255]); // red-only region
+      expectPixelNear(readPixel(backend, 50, 50), [0, 0, 255, 255]); // blue-only region
+      expectPixelNear(readPixel(backend, 28, 28), [0, 0, 255, 255]); // overlap → blue on top
+    } finally {
+      red.destroy();
+      blue.destroy();
+      context.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgpu-draw-geometry.test.ts
+++ b/test/rendering/browser/webgpu-draw-geometry.test.ts
@@ -1,0 +1,246 @@
+/**
+ * WebGPU immediate-draw browser tests — opt-in, capability-aware.
+ *
+ * Exercises {@link RenderingContext.drawGeometry}: a node-free immediate draw of
+ * a {@link Geometry} through the pooled mesh path and the synthetic (non-plan)
+ * transform seam. Confirms the geometry renders at its world position, that the
+ * raw transform is applied verbatim, and that a tint modulates the vertex color.
+ *
+ * All tests skip gracefully when WebGPU is unavailable.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Matrix } from '#math/Matrix';
+import { Geometry } from '#rendering/geometry/Geometry';
+import { RenderingContext } from '#rendering/RenderingContext';
+import { View } from '#rendering/View';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: {
+      canvas: { width: canvasSize, height: canvasSize },
+      clearColor: Color.black,
+    },
+  }) as unknown as Application;
+
+const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<WebGpuBackend> => {
+  if (!navigator.gpu) {
+    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
+  }
+
+  const adapter = await navigator.gpu.requestAdapter();
+
+  if (!adapter) {
+    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
+  }
+
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  await backend.initialize();
+  wireCoreRenderers(backend);
+
+  return backend;
+};
+
+// A solid-color quad (two triangles) in world space. Layout: position f32x2 @0,
+// color u8x4-norm @8, stride 12. No texcoord — the default mesh path samples the
+// 1×1 white texture, so the output is the vertex color × tint.
+const coloredQuad = (x0: number, y0: number, x1: number, y1: number, rgba: RgbaTuple): Geometry => {
+  const stride = 12;
+  const corners: ReadonlyArray<readonly [number, number]> = [
+    [x0, y0],
+    [x1, y0],
+    [x1, y1],
+    [x0, y0],
+    [x1, y1],
+    [x0, y1],
+  ];
+  const buffer = new ArrayBuffer(corners.length * stride);
+  const view = new DataView(buffer);
+
+  corners.forEach(([x, y], index) => {
+    const base = index * stride;
+
+    view.setFloat32(base + 0, x, true);
+    view.setFloat32(base + 4, y, true);
+    view.setUint8(base + 8, rgba[0]);
+    view.setUint8(base + 9, rgba[1]);
+    view.setUint8(base + 10, rgba[2]);
+    view.setUint8(base + 11, rgba[3]);
+  });
+
+  return new Geometry({
+    attributes: [
+      { name: 'a_position', size: 2, type: 'f32', normalized: false, offset: 0 },
+      { name: 'a_color', size: 4, type: 'u8', normalized: true, offset: 8 },
+    ],
+    vertexData: buffer,
+    stride,
+  });
+};
+
+// A screen-space view matching the canvas: world (0,0)..(64,64) maps to the
+// whole surface, top-left origin.
+const screenView = (): View => new View(canvasSize / 2, canvasSize / 2, canvasSize, canvasSize);
+
+const readCanvas = (backend: WebGpuBackend): ((x: number, y: number) => RgbaTuple) => {
+  const source = backend.context.canvas as HTMLCanvasElement;
+  const readback = document.createElement('canvas');
+
+  readback.width = canvasSize;
+  readback.height = canvasSize;
+
+  const ctx = readback.getContext('2d');
+
+  if (!ctx) {
+    throw new Error('2D context is required for canvas readback.');
+  }
+
+  ctx.drawImage(source, 0, 0);
+
+  return (x: number, y: number): RgbaTuple => {
+    const { data } = ctx.getImageData(Math.floor(x), Math.floor(y), 1, 1);
+
+    return [data[0], data[1], data[2], data[3]];
+  };
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 6): void => {
+  for (let index = 0; index < 4; index++) {
+    expect(Math.abs(actual[index] - expected[index]), `channel ${index}: got [${actual.join(', ')}] expected [${expected.join(', ')}]`).toBeLessThanOrEqual(
+      tolerance,
+    );
+  }
+};
+
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+interface DrawCall {
+  readonly geometry: Geometry;
+  readonly transform: Matrix;
+  readonly tint?: Color;
+}
+
+// Run one or more drawGeometry calls through the real flush path inside a
+// validation error scope. Returns false when the device dropped mid-test.
+const drawGeometries = async (
+  ctx: { skip: (reason: string) => void },
+  backend: WebGpuBackend,
+  context: RenderingContext,
+  calls: readonly DrawCall[],
+): Promise<boolean> => {
+  const device = getBackendDeviceOrSkip(ctx, backend);
+
+  if (!device) {
+    return false;
+  }
+
+  device.pushErrorScope('validation');
+
+  let validationError: GPUError | null;
+
+  try {
+    backend.resetStats();
+    backend.clear(Color.black);
+
+    for (const call of calls) {
+      context.drawGeometry(call.geometry, call.transform, { tint: call.tint, view: screenView() });
+    }
+
+    validationError = await device.popErrorScope();
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+
+  expect(validationError).toBeNull();
+  expect(backend.stats.drawCalls).toBeGreaterThan(0);
+
+  return true;
+};
+
+describe('WebGPU RenderingContext.drawGeometry', () => {
+  test('renders a colored geometry quad at its world position', async ctx => {
+    const backend = await setupBackend(ctx);
+    const context = new RenderingContext(backend);
+    const geometry = coloredQuad(16, 16, 48, 48, [255, 0, 0, 255]);
+
+    try {
+      if (!(await drawGeometries(ctx, backend, context, [{ geometry, transform: new Matrix() }]))) {
+        return;
+      }
+
+      const readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(32, 32), [255, 0, 0, 255]); // inside the quad
+      expectPixelNear(readPixel(4, 4), [0, 0, 0, 255]); // outside → cleared black
+    } finally {
+      geometry.destroy();
+      context.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('applies the raw transform verbatim (translation)', async ctx => {
+    const backend = await setupBackend(ctx);
+    const context = new RenderingContext(backend);
+    const geometry = coloredQuad(0, 0, 32, 32, [0, 255, 0, 255]);
+
+    try {
+      // Translate the quad from (0,0)-(32,32) to (32,32)-(64,64).
+      if (!(await drawGeometries(ctx, backend, context, [{ geometry, transform: new Matrix(1, 0, 32, 0, 1, 32) }]))) {
+        return;
+      }
+
+      const readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(48, 48), [0, 255, 0, 255]); // inside the moved quad
+      expectPixelNear(readPixel(12, 12), [0, 0, 0, 255]); // original location now empty
+    } finally {
+      geometry.destroy();
+      context.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('modulates the geometry color by the tint', async ctx => {
+    const backend = await setupBackend(ctx);
+    const context = new RenderingContext(backend);
+    // White geometry × a fractional tint resolves to the tint color.
+    const geometry = coloredQuad(16, 16, 48, 48, [255, 255, 255, 255]);
+
+    try {
+      if (!(await drawGeometries(ctx, backend, context, [{ geometry, transform: new Matrix(), tint: new Color(96, 160, 224) }]))) {
+        return;
+      }
+
+      expectPixelNear(readCanvas(backend)(32, 32), [96, 160, 224, 255]);
+    } finally {
+      geometry.destroy();
+      context.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/rendering-context.test.ts
+++ b/test/rendering/rendering-context.test.ts
@@ -1,7 +1,12 @@
 import { Color } from '#core/Color';
+import { Matrix } from '#math/Matrix';
 import { Rectangle } from '#math/Rectangle';
 import { Camera } from '#rendering/Camera';
 import { Container } from '#rendering/Container';
+import { Geometry } from '#rendering/geometry/Geometry';
+import { MeshMaterial } from '#rendering/material/MeshMaterial';
+import { ShaderSource } from '#rendering/material/ShaderSource';
+import { Mesh } from '#rendering/mesh/Mesh';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import { RenderBackendType } from '#rendering/RenderBackendType';
 import { RenderingContext } from '#rendering/RenderingContext';
@@ -343,5 +348,229 @@ describe('RenderingContext', () => {
     expect(setViewSpy).toHaveBeenCalledTimes(2);
     expect(setViewSpy.mock.calls[0][0]).toBe(leftCam);
     expect(setViewSpy.mock.calls[1][0]).toBe(rightCam);
+  });
+});
+
+// Standard interleaved mesh layout: position f32x2 @0, texcoord f32x2 @8,
+// color u8x4 @16, stride 20 — three vertices (red, green, blue).
+const createStandardGeometry = (): Geometry => {
+  const stride = 20;
+  const vertices = [
+    { x: 0, y: 0, u: 0, v: 0, rgba: [255, 0, 0, 255] },
+    { x: 10, y: 0, u: 1, v: 0, rgba: [0, 255, 0, 255] },
+    { x: 5, y: 10, u: 0.5, v: 1, rgba: [0, 0, 255, 255] },
+  ];
+  const buffer = new ArrayBuffer(vertices.length * stride);
+  const view = new DataView(buffer);
+
+  vertices.forEach((vertex, index) => {
+    const base = index * stride;
+    view.setFloat32(base + 0, vertex.x, true);
+    view.setFloat32(base + 4, vertex.y, true);
+    view.setFloat32(base + 8, vertex.u, true);
+    view.setFloat32(base + 12, vertex.v, true);
+    view.setUint8(base + 16, vertex.rgba[0]);
+    view.setUint8(base + 17, vertex.rgba[1]);
+    view.setUint8(base + 18, vertex.rgba[2]);
+    view.setUint8(base + 19, vertex.rgba[3]);
+  });
+
+  return new Geometry({
+    attributes: [
+      { name: 'a_position', size: 2, type: 'f32', normalized: false, offset: 0 },
+      { name: 'a_texcoord', size: 2, type: 'f32', normalized: false, offset: 8 },
+      { name: 'a_color', size: 4, type: 'u8', normalized: true, offset: 16 },
+    ],
+    vertexData: buffer,
+    stride,
+  });
+};
+
+const minimalMeshMaterial = (): MeshMaterial =>
+  new MeshMaterial({
+    shader: new ShaderSource({
+      glsl: {
+        vertex: '#version 300 es\nvoid main(){gl_Position=vec4(0.0);}',
+        fragment: '#version 300 es\nprecision lowp float;out vec4 c;void main(){c=vec4(1.0);}',
+      },
+    }),
+  });
+
+describe('RenderingContext.drawGeometry', () => {
+  test('submits a pooled mesh through the backend and flushes immediately', () => {
+    const { backend, drawEvents, getFlushCallCount } = createMockBackend();
+    const context = new RenderingContext(backend);
+    const geometry = createStandardGeometry();
+
+    context.drawGeometry(geometry, new Matrix());
+
+    expect(drawEvents).toHaveLength(1);
+    expect(drawEvents[0]).toBeInstanceOf(Mesh);
+    expect(getFlushCallCount()).toBe(1);
+
+    geometry.destroy();
+  });
+
+  test('uses the raw transform verbatim as the mesh world matrix', () => {
+    const { backend, drawEvents } = createMockBackend();
+    const context = new RenderingContext(backend);
+    const geometry = createStandardGeometry();
+    const transform = new Matrix(2, 0, 10, 0, 3, 20);
+
+    context.drawGeometry(geometry, transform);
+
+    const world = drawEvents[0].getGlobalTransform();
+
+    expect(world.a).toBe(2);
+    expect(world.d).toBe(3);
+    expect(world.x).toBe(10);
+    expect(world.y).toBe(20);
+    // No origin/position composition is applied — it is the matrix as given.
+    expect(world.a).toBe(transform.a);
+    expect(world.x).toBe(transform.x);
+
+    geometry.destroy();
+  });
+
+  test('flattens the geometry onto the pooled mesh', () => {
+    const { backend, drawEvents } = createMockBackend();
+    const context = new RenderingContext(backend);
+    const geometry = createStandardGeometry();
+
+    context.drawGeometry(geometry, new Matrix());
+
+    const mesh = drawEvents[0] as Mesh;
+
+    expect(mesh.vertexCount).toBe(3);
+    expect(Array.from(mesh.vertices)).toEqual([0, 0, 10, 0, 5, 10]);
+    expect(mesh.uvs?.[4]).toBeCloseTo(0.5);
+    // RGBA8 packed little-endian: R | G<<8 | B<<16 | A<<24.
+    expect(mesh.colors?.[0]).toBe(0xff0000ff);
+    expect(mesh.colors?.[2]).toBe(0xffff0000);
+
+    geometry.destroy();
+  });
+
+  test('applies the tint and defaults to white', () => {
+    const { backend, drawEvents } = createMockBackend();
+    const context = new RenderingContext(backend);
+    const geometry = createStandardGeometry();
+
+    context.drawGeometry(geometry, new Matrix());
+    expect(drawEvents[0].tint.equals(Color.white)).toBe(true);
+
+    context.drawGeometry(geometry, new Matrix(), { tint: new Color(255, 0, 0) });
+    expect(drawEvents[1].tint.equals(new Color(255, 0, 0))).toBe(true);
+
+    geometry.destroy();
+  });
+
+  test('resets the tint to white when a later call omits it (pooled reuse)', () => {
+    const { backend, drawEvents } = createMockBackend();
+    const context = new RenderingContext(backend);
+    const geometry = createStandardGeometry();
+
+    context.drawGeometry(geometry, new Matrix(), { tint: new Color(0, 128, 255) });
+    expect(drawEvents[0].tint.equals(new Color(0, 128, 255))).toBe(true);
+
+    context.drawGeometry(geometry, new Matrix());
+    expect(drawEvents[1].tint.equals(Color.white)).toBe(true);
+
+    geometry.destroy();
+  });
+
+  test('reuses a single pooled mesh instance across calls', () => {
+    const { backend, drawEvents } = createMockBackend();
+    const context = new RenderingContext(backend);
+    const geometry = createStandardGeometry();
+
+    context.drawGeometry(geometry, new Matrix());
+    context.drawGeometry(geometry, new Matrix());
+
+    expect(drawEvents).toHaveLength(2);
+    expect(drawEvents[0]).toBe(drawEvents[1]);
+
+    geometry.destroy();
+  });
+
+  test('re-flattens only when the geometry identity or version changes', () => {
+    const { backend, drawEvents } = createMockBackend();
+    const context = new RenderingContext(backend);
+    const geometry = createStandardGeometry();
+
+    context.drawGeometry(geometry, new Matrix());
+    const firstVertices = (drawEvents[0] as Mesh).vertices;
+
+    // Same geometry, unchanged version → flattened arrays are reused as-is.
+    context.drawGeometry(geometry, new Matrix(2, 0, 0, 0, 2, 0));
+    expect((drawEvents[1] as Mesh).vertices).toBe(firstVertices);
+
+    // Bumping the version forces a re-flatten into fresh arrays.
+    geometry.invalidate();
+    context.drawGeometry(geometry, new Matrix());
+    expect((drawEvents[2] as Mesh).vertices).not.toBe(firstVertices);
+
+    geometry.destroy();
+  });
+
+  test('draws after a render() in call order (immediate draws layer on top)', () => {
+    const { backend, drawEvents } = createMockBackend();
+    const context = new RenderingContext(backend);
+    const sprite = new Sprite(createTexture());
+    const geometry = createStandardGeometry();
+
+    context.render(sprite);
+    context.drawGeometry(geometry, new Matrix());
+
+    expect(drawEvents).toHaveLength(2);
+    expect(drawEvents[0]).toBe(sprite);
+    expect(drawEvents[1]).toBeInstanceOf(Mesh);
+    expect(drawEvents[1]).not.toBe(sprite);
+
+    geometry.destroy();
+  });
+
+  test('defaults to the active camera and honors a custom view', () => {
+    const { backend, setViewSpy } = createMockBackend();
+    const context = new RenderingContext(backend);
+    const geometry = createStandardGeometry();
+    const customView = new View(100, 100, 200, 200);
+
+    context.drawGeometry(geometry, new Matrix());
+    expect(setViewSpy).toHaveBeenLastCalledWith(context.camera);
+
+    context.drawGeometry(geometry, new Matrix(), { view: customView });
+    expect(setViewSpy).toHaveBeenLastCalledWith(customView);
+
+    geometry.destroy();
+  });
+
+  test('attaches a mesh material to the pooled mesh', () => {
+    const { backend, drawEvents } = createMockBackend();
+    const context = new RenderingContext(backend);
+    const geometry = createStandardGeometry();
+    const material = minimalMeshMaterial();
+
+    context.drawGeometry(geometry, new Matrix(), { material });
+    expect((drawEvents[0] as Mesh).material).toBe(material);
+
+    // A later call without a material clears it through the pool.
+    context.drawGeometry(geometry, new Matrix());
+    expect((drawEvents[1] as Mesh).material).toBeNull();
+
+    material.destroy();
+    geometry.destroy();
+  });
+
+  test('rejects a material that does not target mesh', () => {
+    const { backend, drawEvents } = createMockBackend();
+    const context = new RenderingContext(backend);
+    const geometry = createStandardGeometry();
+    const spriteMaterial = { target: 'sprite' } as unknown as MeshMaterial;
+
+    expect(() => context.drawGeometry(geometry, new Matrix(), { material: spriteMaterial })).toThrow(/must target 'mesh'/);
+    expect(drawEvents).toHaveLength(0);
+
+    geometry.destroy();
   });
 });


### PR DESCRIPTION
## Phase 4 — Feature-Build D (Immediate-Render), PR-1

First slice of the additive immediate-render API: a **node-free single draw** of a `Geometry`, so procedural / data-driven shapes (tiles, bullets, procedural meshes) can be drawn without a retained `RenderNode`.

### API (new, public)
```ts
context.drawGeometry(geometry: Geometry, transform: Matrix, options?: {
  material?: MeshMaterial;  // default mesh material
  tint?: Color;
  view?: View;              // default: active camera
}): void;
```
- `DrawGeometryOptions` exported via the rendering barrel (auto root-exported).

### How it works
- Reuses the **existing mesh-renderer path** — no third renderer, no new public `Drawable`. Internally a pooled, reconfigurable `ImmediateMesh` (`@internal`) is driven through the **synthetic (non-plan) transform seam** that already backs the fade `TransitionOverlay`.
- `ImmediateMesh.getGlobalTransform()` returns the passed matrix **verbatim** — a lossless 1:1 mapping onto the `a,b,c,d,tx,ty` transform slot, bypassing node position/rotation/scale/origin composition. Both backends read `getGlobalTransform()` at their transform-write seam (WebGl2 `_writeTransformCommand`, WebGPU CPU-bake + custom-uniform), so no backend renderer abstraction was needed.
- **Ordering/flush contract:** each call sets the view (flushing any pending renderer), reconfigures the pooled mesh, draws, and flushes immediately — so immediate draws land in call order relative to `render()` and layer on top. Geometry is flattened once per identity/`version` and reused across frames.

### Drive-by fix
`WebGl2MeshRenderer._drawDynamicInstancedSingle` wrote the synthetic transform **after** `bindTransformBufferTexture` uploaded the buffer, so a fresh single synthetic draw uploaded a stale (zeroed) slot and collapsed to the origin. The write now precedes the bind. This also removes the 1-frame transform lag the fade overlay had on this path.

### Scope
In: D1(c) single `drawGeometry`, D2 existing Geometry + optional MeshMaterial + Matrix + Color tint, D4 node-free, D5 core. Out (later PRs / post-1.0): `RenderBatch`/`drawBatch` instancing (PR-2), per-instance attributes, WebGPU core-instancing, ParticleSystem rückport.

### Tests / gates
- **Stub-backend:** call/order/pooling/tint-reset/material-guard/raw-transform/geometry-flatten-cache contract.
- **Browser WebGl2 + WebGPU:** pixel checks (world position, raw transform translation, tint modulation, call-order layering).
- Green locally: `typecheck`, `lint:all`, `format:check`, `test` (3323 passed), `docs:api:check`; root-index snapshot + `rendering-context.mdx` regenerated.

Part of v0.14 Phase 4D. Next: PR-2 `RenderBatch` (instanced).