### PR TITLE
feat(core): app-scope the serializer registry (A2 multi-instance hardening)

### DIFF
--- a/site/src/content/api/application.mdx
+++ b/site/src/content/api/application.mdx
@@ -5,7 +5,7 @@ symbol: "Application"
 kind: "class"
 subsystem: "core"
 importPath: "@codexo/exojs"
-memberCount: 41
+memberCount: 42
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/core/Application.ts"
@@ -63,6 +63,7 @@ background-active simulations.
 - `pauseOnHidden: boolean`
 - `random: Random`
 - `scene: SceneManager`
+- `serializers: SerializationRegistry`
 - `systems: SystemRegistry`
 - `tweens: TweenManager`
 - `activeTime: Time`

--- a/site/src/content/api/serialization-registry.mdx
+++ b/site/src/content/api/serialization-registry.mdx
@@ -26,7 +26,7 @@ the Extension.serializers binding.
 
 ## Constructors
 
-- `new(): SerializationRegistry`
+- `new(_fallback: SerializationRegistry | null): SerializationRegistry`
 
 ## Methods
 

--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -28,7 +28,7 @@ import { Color } from './Color';
 import { computeLetterboxLayout } from './letterbox';
 import type { Scene } from './Scene';
 import { SceneManager } from './SceneManager';
-import { defaultSerializationRegistry } from './serialization/SerializationRegistry';
+import { defaultSerializationRegistry, SerializationRegistry } from './serialization/SerializationRegistry';
 import { Signal } from './Signal';
 import { SystemRegistry } from './SystemRegistry';
 import { Time } from './Time';
@@ -232,6 +232,14 @@ export class Application {
    * 600+ via `app.systems.add(...)`. Scene-scoped systems live on `scene.systems`.
    */
   public readonly systems = new SystemRegistry();
+  /**
+   * App-scoped serializer registry, chained to the global
+   * {@link defaultSerializationRegistry}. Extension serializers materialise here
+   * rather than globally, so two {@link Application} instances in one process
+   * keep their extension serializers isolated; core and globally-registered
+   * (via `registerSerializer`) serializers remain shared through the fallback.
+   */
+  public readonly serializers = new SerializationRegistry(defaultSerializationRegistry);
   public readonly onResize = new Signal<[number, number, Application]>();
   public readonly onFrame = new Signal<[Time]>();
   public readonly onCanvasFocusChange = new Signal<[focused: boolean]>();
@@ -327,7 +335,7 @@ export class Application {
 
     try {
       materializeAssetBindings(this.loader, [...coreAssetBindings, ...this._snapshot.assets]);
-      materializeSerializerBindings(defaultSerializationRegistry, this._snapshot.serializers);
+      materializeSerializerBindings(this.serializers, this._snapshot.serializers);
     } catch (error) {
       try {
         this.loader.destroy();

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -270,11 +270,12 @@ export class Scene {
    */
   public serialize(): SerializedScene {
     const loader = this._app?.loader ?? null;
-    const data: SerializedScene = { version: SERIALIZATION_VERSION, root: serializeTree(this._root, loader) };
+    const registry = this._app?.serializers;
+    const data: SerializedScene = { version: SERIALIZATION_VERSION, root: serializeTree(this._root, loader, registry) };
     const ui = this._peekUI();
 
     if (ui !== null) {
-      data.ui = serializeTree(ui, loader);
+      data.ui = serializeTree(ui, loader, registry);
     }
 
     return data;
@@ -293,11 +294,12 @@ export class Scene {
   public deserialize(data: SerializedScene): this {
     const migrated = migrate(data);
     const loader = this._app?.loader ?? null;
+    const registry = this._app?.serializers;
 
-    deserializeInto(this._root, migrated.root, loader);
+    deserializeInto(this._root, migrated.root, loader, registry);
 
     if (migrated.ui !== undefined) {
-      deserializeInto(this.ui, migrated.ui, loader);
+      deserializeInto(this.ui, migrated.ui, loader, registry);
     }
 
     return this;

--- a/src/core/serialization/SerializationRegistry.ts
+++ b/src/core/serialization/SerializationRegistry.ts
@@ -46,6 +46,15 @@ export class SerializationRegistry {
   private readonly _byName = new Map<string, SerializerEntry>();
 
   /**
+   * @param _fallback Optional parent registry consulted when this registry has
+   *   no own entry for a lookup. An {@link Application} owns its own registry
+   *   chained to the {@link defaultSerializationRegistry}, so app-scoped
+   *   extension serializers stay isolated per Application while core and
+   *   globally-registered serializers remain shared.
+   */
+  public constructor(private readonly _fallback: SerializationRegistry | null = null) {}
+
+  /**
    * Register `serializer` for `ctor` under `typeName`. Re-registering the same
    * `(typeName, ctor)` pair overwrites silently; registering an existing
    * `typeName` against a **different** constructor throws.
@@ -69,7 +78,7 @@ export class SerializationRegistry {
    * @internal
    */
   public resolveByNode(node: SceneNode): SerializerEntry | undefined {
-    return this._byCtor.resolve(node.constructor as SceneNodeConstructor);
+    return this._byCtor.resolve(node.constructor as SceneNodeConstructor) ?? this._fallback?.resolveByNode(node);
   }
 
   /**
@@ -77,12 +86,12 @@ export class SerializationRegistry {
    * @internal
    */
   public resolveByName(typeName: string): SerializerEntry | undefined {
-    return this._byName.get(typeName);
+    return this._byName.get(typeName) ?? this._fallback?.resolveByName(typeName);
   }
 
   /** Returns `true` if a serializer is registered under `typeName`. */
   public hasType(typeName: string): boolean {
-    return this._byName.has(typeName);
+    return this._byName.has(typeName) || (this._fallback?.hasType(typeName) ?? false);
   }
 }
 

--- a/src/core/serialization/serialize.ts
+++ b/src/core/serialization/serialize.ts
@@ -8,7 +8,7 @@ import type { Loadable, Loader } from '#resources/Loader';
 import { applyCommonFields, writeCommonFields } from './commonFields';
 import { registerCoreSerializers } from './coreSerializers';
 import type { DeserializeContext, SerializeContext } from './NodeSerializer';
-import { defaultSerializationRegistry } from './SerializationRegistry';
+import { defaultSerializationRegistry, type SerializationRegistry } from './SerializationRegistry';
 import { SERIALIZATION_VERSION, type SerializedNode, type SerializedScene } from './types';
 
 // Core serializers register lazily (not as an import side effect) so they
@@ -26,11 +26,11 @@ function ensureCoreSerializers(): void {
   registerCoreSerializers(defaultSerializationRegistry);
 }
 
-function createSerializeContext(loader: Loader | null): SerializeContext {
+function createSerializeContext(loader: Loader | null, registry: SerializationRegistry): SerializeContext {
   const ctx: SerializeContext = {
     version: SERIALIZATION_VERSION,
     loader,
-    writeNode: node => writeNodeWith(node, ctx),
+    writeNode: node => writeNodeWith(node, ctx, registry),
     keyFor: resource => {
       if (resource === null || resource === undefined || typeof resource !== 'object' || loader === null) {
         return null;
@@ -54,11 +54,11 @@ function createSerializeContext(loader: Loader | null): SerializeContext {
   return ctx;
 }
 
-function createDeserializeContext(loader: Loader | null, version: number): DeserializeContext {
+function createDeserializeContext(loader: Loader | null, version: number, registry: SerializationRegistry): DeserializeContext {
   const ctx: DeserializeContext = {
     version,
     loader,
-    readNode: data => readNodeWith(data, ctx),
+    readNode: data => readNodeWith(data, ctx, registry),
     resolveAsset: <T>(source: string | null | undefined, type: AssetConstructor<T>): T | null => {
       if (source === null || source === undefined || loader === null) {
         return null;
@@ -80,8 +80,8 @@ function createDeserializeContext(loader: Loader | null, version: number): Deser
   return ctx;
 }
 
-function writeNodeWith(node: SceneNode, ctx: SerializeContext): SerializedNode {
-  const entry = defaultSerializationRegistry.resolveByNode(node);
+function writeNodeWith(node: SceneNode, ctx: SerializeContext, registry: SerializationRegistry): SerializedNode {
+  const entry = registry.resolveByNode(node);
 
   if (entry === undefined) {
     throw new Error(`No serializer registered for node type "${node.constructor.name}". Register one via registerSerializer().`);
@@ -95,8 +95,8 @@ function writeNodeWith(node: SceneNode, ctx: SerializeContext): SerializedNode {
   return out;
 }
 
-function readNodeWith(data: SerializedNode, ctx: DeserializeContext): SceneNode {
-  const entry = defaultSerializationRegistry.resolveByName(data.type);
+function readNodeWith(data: SerializedNode, ctx: DeserializeContext, registry: SerializationRegistry): SceneNode {
+  const entry = registry.resolveByName(data.type);
 
   if (entry === undefined) {
     throw new Error(`No serializer registered for type "${data.type}". Register one via registerSerializer().`);
@@ -114,10 +114,10 @@ function readNodeWith(data: SerializedNode, ctx: DeserializeContext): SceneNode 
  * {@link Loader} so texture/asset references resolve to their source keys.
  * @internal
  */
-export function serializeTree(node: SceneNode, loader: Loader | null = null): SerializedNode {
+export function serializeTree(node: SceneNode, loader: Loader | null = null, registry: SerializationRegistry = defaultSerializationRegistry): SerializedNode {
   ensureCoreSerializers();
 
-  return writeNodeWith(node, createSerializeContext(loader));
+  return writeNodeWith(node, createSerializeContext(loader, registry), registry);
 }
 
 /**
@@ -125,10 +125,10 @@ export function serializeTree(node: SceneNode, loader: Loader | null = null): Se
  * must be pre-loaded into `loader`.
  * @internal
  */
-export function deserializeTree(data: SerializedNode, loader: Loader | null = null): SceneNode {
+export function deserializeTree(data: SerializedNode, loader: Loader | null = null, registry: SerializationRegistry = defaultSerializationRegistry): SceneNode {
   ensureCoreSerializers();
 
-  return readNodeWith(data, createDeserializeContext(loader, SERIALIZATION_VERSION));
+  return readNodeWith(data, createDeserializeContext(loader, SERIALIZATION_VERSION, registry), registry);
 }
 
 /**
@@ -138,10 +138,15 @@ export function deserializeTree(data: SerializedNode, loader: Loader | null = nu
  * eagerly-created scene root.
  * @internal
  */
-export function deserializeInto(container: Container, data: SerializedNode, loader: Loader | null = null): void {
+export function deserializeInto(
+  container: Container,
+  data: SerializedNode,
+  loader: Loader | null = null,
+  registry: SerializationRegistry = defaultSerializationRegistry,
+): void {
   ensureCoreSerializers();
 
-  const ctx = createDeserializeContext(loader, SERIALIZATION_VERSION);
+  const ctx = createDeserializeContext(loader, SERIALIZATION_VERSION, registry);
 
   container.removeChildren();
   applyCommonFields(container, data);

--- a/src/rendering/text/GlyphAtlasPool.ts
+++ b/src/rendering/text/GlyphAtlasPool.ts
@@ -9,7 +9,14 @@ import { type AtlasMode, GlyphAtlas, SDF_RADIUS } from './GlyphAtlas';
  * requests them.
  *
  * Use {@link getDefaultGlyphAtlasPool} to obtain the shared process-wide
- * instance. Tests can mock that function to inject a fake pool.
+ * instance; tests reset it via {@link resetDefaultGlyphAtlasPool} for isolation.
+ *
+ * Process-wide is intentional: an atlas is a content cache keyed by font variant
+ * + mode, so sharing it across {@link Application} instances on the same backend
+ * is correct and memory-efficient (identical glyphs rasterize once). Strict
+ * per-backend isolation for mixed-backend multi-app setups is a deferred
+ * enhancement — it would require routing the pool through the render context,
+ * which text layout reaches before a node is attached to a scene.
  * @advanced
  */
 export class GlyphAtlasPool {

--- a/test/core/serialization-registry-fallback.test.ts
+++ b/test/core/serialization-registry-fallback.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import type { NodeSerializer } from '#core/serialization/NodeSerializer';
+import { SerializationRegistry } from '#core/serialization/SerializationRegistry';
+import { Container } from '#rendering/Container';
+
+// Concrete SceneNode subclasses used purely as registry keys.
+class GlobalNode extends Container {}
+class AppNode extends Container {}
+
+const stub = <T extends Container>(): NodeSerializer<T> => ({
+  write: () => ({}),
+  read: () => new Container() as unknown as T,
+});
+
+/**
+ * A2: Application owns its own serializer registry chained to the global
+ * `defaultSerializationRegistry`. Extension serializers materialise on the
+ * app-scoped registry, so two Applications in one process stay isolated while
+ * core/global registrations remain shared through the fallback.
+ */
+describe('SerializationRegistry fallback chain (app-scoped serializers)', () => {
+  it('inherits fallback entries while keeping its own entries isolated from the parent', () => {
+    const global = new SerializationRegistry();
+    global.register('GlobalNode', GlobalNode, stub<GlobalNode>());
+
+    const app = new SerializationRegistry(global);
+    app.register('AppNode', AppNode, stub<AppNode>());
+
+    // The app registry resolves both its own and the inherited global serializer.
+    expect(app.resolveByName('AppNode')?.typeName).toBe('AppNode');
+    expect(app.resolveByName('GlobalNode')?.typeName).toBe('GlobalNode');
+    expect(app.resolveByNode(new AppNode())?.typeName).toBe('AppNode');
+    expect(app.resolveByNode(new GlobalNode())?.typeName).toBe('GlobalNode');
+    expect(app.hasType('AppNode')).toBe(true);
+    expect(app.hasType('GlobalNode')).toBe(true);
+
+    // The global registry must NOT see the app-scoped serializer.
+    expect(global.resolveByName('AppNode')).toBeUndefined();
+    expect(global.resolveByNode(new AppNode())).toBeUndefined();
+    expect(global.hasType('AppNode')).toBe(false);
+  });
+
+  it('isolates two app registries that share one global fallback', () => {
+    const global = new SerializationRegistry();
+    const appA = new SerializationRegistry(global);
+    const appB = new SerializationRegistry(global);
+
+    appA.register('AppNode', AppNode, stub<AppNode>());
+
+    expect(appA.hasType('AppNode')).toBe(true);
+    expect(appB.hasType('AppNode')).toBe(false);
+  });
+});


### PR DESCRIPTION
## A2 — multi-instance hardening (v0.14 wave 1)

`Application` now owns a `SerializationRegistry` chained to the global `defaultSerializationRegistry` via a new optional fallback. Extension serializers materialise on the **app-scoped** registry instead of globally, so two `Application` instances in one process keep their extension serializers isolated; core + globally-registered serializers stay shared through the fallback.

- `serializeTree`/`deserializeTree`/`deserializeInto` take an optional `registry` (default: global); `Scene.serialize/deserialize` thread `app.serializers` through.
- New fallback-chain unit test (`test/core/serialization-registry-fallback.test.ts`).
- Remaining process-wide singletons documented as **intentional**: `GlyphAtlasPool` (per-font-variant glyph cache — correct to share per backend; strict per-backend isolation deferred) and `ExtensionRegistry` (global descriptors by design).

### Scope notes (A2/A3/A6 group)
- **A3** (`System.update(delta)`): deliberately not changed — `update()` omitting the unused `delta` is idiomatic TS for `System` implementers; an unused `_delta` param would be noise. Documented as a non-fix.
- **A6** (`worldCoM`): code already uses `worldCenterOfMassX/Y` consistently; only spec/memory naming is aligned (no code change).

### New public API (additive)
`Application.serializers`; `SerializationRegistry` optional fallback constructor arg.

### Verification (local, all green)
typecheck · typecheck:guides · lint:strict · lint:packages · extension package typechecks · format:check · full test suite · docs:api:generate