### PR TITLE
feat(physics)!: free body construction + world.add/attach (B1, D1+D2)

### DIFF
--- a/packages/exojs-physics/README.md
+++ b/packages/exojs-physics/README.md
@@ -23,23 +23,29 @@ npm install @codexo/exojs @codexo/exojs-physics
 
 ```ts
 import { Scene, Sprite, Vector, type Time } from '@codexo/exojs';
-import { BoxShape, CircleShape, PhysicsWorld } from '@codexo/exojs-physics';
+import { BoxShape, CircleShape, Collider, PhysicsBody, PhysicsWorld } from '@codexo/exojs-physics';
 
 class GameScene extends Scene {
   private readonly world = new PhysicsWorld({ gravity: new Vector(0, 980) });
 
   public override onStart(): void {
+    // Construct bodies/colliders freely, then hand them to the world: `add`
+    // assigns ids, registers the colliders and aggregates the mass model.
     // Static ground (an explicit static body + box collider).
-    this.world.createStaticCollider({ shape: new BoxShape(800, 32), position: new Vector(400, 600), friction: 0.9 });
+    this.world.add(
+      new PhysicsBody({ type: 'static', position: new Vector(400, 600), colliders: [new Collider({ shape: new BoxShape(800, 32), friction: 0.9 })] }),
+    );
 
-    // A kinematic platform you move yourself.
-    const platform = this.world.createBody({ type: 'kinematic', position: new Vector(200, 400) });
-    platform.createCollider({ shape: new BoxShape(120, 16) });
+    // A kinematic platform you move yourself. Attach more colliders any time.
+    const platform = new PhysicsBody({ type: 'kinematic', position: new Vector(200, 400) });
+    platform.addCollider(new Collider({ shape: new BoxShape(120, 16) }));
+    this.world.add(platform);
 
     // A sensor trigger.
-    const trigger = this.world.createStaticCollider({ shape: new CircleShape(40), position: new Vector(600, 500), isSensor: true });
-    this.world.onSensorEnter.add(({ sensor, other }) => {
-      if (sensor === trigger) console.log('entered the trigger');
+    const triggerCollider = new Collider({ shape: new CircleShape(40), isSensor: true });
+    this.world.add(new PhysicsBody({ type: 'static', position: new Vector(600, 500), colliders: [triggerCollider] }));
+    this.world.onSensorEnter.add(({ sensor }) => {
+      if (sensor === triggerCollider) console.log('entered the trigger');
     });
   }
 
@@ -54,8 +60,9 @@ class GameScene extends Scene {
 | Area | API |
 |---|---|
 | World | `PhysicsWorld`, `step`, `gravity`, `timeStepper`, `destroy` |
-| Bodies | `createBody` (`dynamic`/`static`/`kinematic`), `setTransform`, mass/inertia from colliders |
-| Colliders | `createCollider`, `createStaticCollider`, density/friction/restitution, `isSensor`, filter, offset |
+| Bodies | `new PhysicsBody` + `world.add` (`dynamic`/`static`/`kinematic`), `setTransform`, mass/inertia from colliders |
+| Colliders | `new Collider` + `body.addCollider` / `colliders: [...]`, density/friction/restitution, `isSensor`, filter, offset |
+| Attach | `world.attach(node, def)` — body + collider + `bind` in one call |
 | Shapes | `CircleShape`, `PolygonShape` (convex-validated), `BoxShape` |
 | Filtering | `CollisionFilter` (category/mask/group), `shouldCollide` |
 | Events | `onCollisionStart` / `onCollisionEnd` / `onSensorEnter` / `onSensorExit` — immutable snapshots |

--- a/packages/exojs-physics/src/Collider.ts
+++ b/packages/exojs-physics/src/Collider.ts
@@ -40,8 +40,7 @@ export interface ColliderOptions {
  * immutable (rebuild the collider to change geometry).
  */
 export class Collider {
-  public readonly id: number;
-  public readonly body: PhysicsBody;
+  /** Stable id, assigned when the owning body joins a world (`-1` until then). */
   public readonly shape: Shape;
   public readonly offsetX: number;
   public readonly offsetY: number;
@@ -53,6 +52,8 @@ export class Collider {
   public isSensor: boolean;
   public readonly filter: CollisionFilter;
 
+  private _id = -1;
+  private _body: PhysicsBody | null = null;
   private readonly _localTransform: Transform;
   private readonly _worldTransform: Transform = createTransform();
   private readonly _aabb: Aabb = createAabb();
@@ -62,15 +63,13 @@ export class Collider {
 
   private _destroyed = false;
 
-  public constructor(id: number, body: PhysicsBody, options: ColliderOptions) {
+  public constructor(options: ColliderOptions) {
     const density = options.density ?? 1;
 
     if (!Number.isFinite(density) || density < 0) {
       throw new RangeError(`Collider: density must be a non-negative finite number, received ${density}.`);
     }
 
-    this.id = id;
-    this.body = body;
     this.shape = options.shape;
     this.offsetX = options.offset?.x ?? 0;
     this.offsetY = options.offset?.y ?? 0;
@@ -90,6 +89,23 @@ export class Collider {
       this._worldVertices = [];
       this._worldNormals = [];
     }
+  }
+
+  /** Stable id, assigned when the owning body joins a world via `world.add()`; `-1` until then. */
+  public get id(): number {
+    return this._id;
+  }
+
+  /**
+   * The body this collider belongs to. `null` until the collider has been added
+   * to a body that has joined a world (free-standing colliders have no body yet).
+   */
+  public get body(): PhysicsBody {
+    if (this._body === null) {
+      throw new Error('Collider: this collider has not been attached to a body in a world yet.');
+    }
+
+    return this._body;
   }
 
   /** The collider's world AABB (valid after the latest {@link synchronize}). */
@@ -175,6 +191,12 @@ export class Collider {
     this._aabb.minY = minY;
     this._aabb.maxX = maxX;
     this._aabb.maxY = maxY;
+  }
+
+  /** @internal — bind this collider to its body and id (called when the body joins a world). */
+  public _attach(body: PhysicsBody, id: number): void {
+    this._body = body;
+    this._id = id;
   }
 
   /** Internal: mark destroyed (called by the world). */

--- a/packages/exojs-physics/src/PhysicsBody.ts
+++ b/packages/exojs-physics/src/PhysicsBody.ts
@@ -21,6 +21,8 @@ export interface BodyOptions {
   gravityScale?: number;
   /** When `true`, the body never rotates under contacts (infinite rotational inertia). Default `false`. */
   fixedRotation?: boolean;
+  /** Colliders to attach up-front. Each may be a {@link Collider} instance or its {@link ColliderOptions}. */
+  colliders?: Array<Collider | ColliderOptions>;
 }
 
 /**
@@ -42,7 +44,6 @@ export interface BodyOwner {
  * directly; reposition it (teleport, no velocity) with {@link setTransform}.
  */
 export class PhysicsBody {
-  public readonly id: number;
   public readonly type: BodyType;
 
   /** Linear damping applied to the velocity each sub-step. */
@@ -88,7 +89,9 @@ export class PhysicsBody {
   private _forceY = 0;
   private _torque = 0;
 
-  private readonly _owner: BodyOwner;
+  private _id = -1;
+  private _owner: BodyOwner | null = null;
+  private _attached = false;
   private readonly _transform: Transform;
   private readonly _colliders: Collider[] = [];
   private _comX = 0;
@@ -96,15 +99,32 @@ export class PhysicsBody {
   private _massReady = false;
   private _destroyed = false;
 
-  public constructor(owner: BodyOwner, id: number, options: BodyOptions = {}) {
-    this.id = id;
+  public constructor(options: BodyOptions = {}) {
     this.type = options.type ?? 'dynamic';
-    this._owner = owner;
     this._transform = createTransform(options.position?.x ?? 0, options.position?.y ?? 0, options.angle ?? 0);
     this.linearDamping = options.linearDamping ?? 0;
     this.angularDamping = options.angularDamping ?? 0;
     this.gravityScale = options.gravityScale ?? 1;
     this.fixedRotation = options.fixedRotation ?? false;
+
+    // Build up-front colliders now (no id/world registration until the body
+    // joins a world via `world.add()`). They sit in `_colliders` unsynchronised;
+    // `_attachToWorld` assigns ids, registers them and computes the mass model.
+    if (options.colliders) {
+      for (const entry of options.colliders) {
+        this._colliders.push(entry instanceof Collider ? entry : new Collider(entry));
+      }
+    }
+  }
+
+  /** Stable id, assigned when the body joins a world via `world.add()`; `-1` until then. */
+  public get id(): number {
+    return this._id;
+  }
+
+  /** `true` once the body has been added to a world (guards against double-add). */
+  public get attached(): boolean {
+    return this._attached;
   }
 
   /** World X. */
@@ -161,22 +181,36 @@ export class PhysicsBody {
     return this._destroyed;
   }
 
-  /** Attach a new collider, recomputing mass and synchronising world geometry. */
-  public createCollider(options: ColliderOptions): Collider {
+  /**
+   * Attach a collider to this body. Accepts a {@link Collider} instance or its
+   * {@link ColliderOptions} (a convenience that constructs the collider for you).
+   * When the body is already in a world, the collider is id-allocated, registered,
+   * the mass model is recomputed and the world geometry synchronised immediately;
+   * on a free-standing body the collider is simply held until `world.add()`.
+   * Returns the collider.
+   */
+  public addCollider(collider: Collider | ColliderOptions): Collider {
     if (this._destroyed) {
-      throw new Error('PhysicsBody: cannot create a collider on a destroyed body.');
+      throw new Error('PhysicsBody: cannot add a collider to a destroyed body.');
     }
 
     // Collider imports PhysicsBody type-only (erased), so this value import is
     // one-directional — no runtime cycle.
-    const collider = new Collider(this._owner._allocateColliderId(), this, options);
+    const instance = collider instanceof Collider ? collider : new Collider(collider);
 
-    this._colliders.push(collider);
-    this._recomputeMass();
-    collider.synchronize(this._transform);
-    this._owner._registerCollider(collider);
+    this._colliders.push(instance);
 
-    return collider;
+    // Before the body joins a world there is no owner to allocate ids / register
+    // with; `_attachToWorld` does that (and the mass/sync pass) for every held
+    // collider. Once attached, mirror the world's create order exactly.
+    if (this._attached && this._owner) {
+      instance._attach(this, this._owner._allocateColliderId());
+      this._recomputeMass();
+      instance.synchronize(this._transform);
+      this._owner._registerCollider(instance);
+    }
+
+    return instance;
   }
 
   /**
@@ -326,6 +360,43 @@ export class PhysicsBody {
     if (index !== -1) {
       this._colliders.splice(index, 1);
       this._recomputeMass();
+    }
+  }
+
+  /**
+   * @internal — join `owner`'s world with the allocated `id`. Allocates ids for
+   * and registers every held collider, then aggregates the mass model and
+   * synchronises world geometry. Called once by {@link PhysicsWorld.add}.
+   *
+   * Ordering matters and mirrors the per-collider create path exactly: ids and
+   * the body link go on first, then a single mass recompute over the full
+   * collider set (so the centre of mass / inertia aggregate is correct), then
+   * `synchronize` over every collider (the cached world geometry the broad/narrow
+   * phase reads), then world registration last. Recomputing mass before all
+   * colliders are linked, or syncing before the mass model exists, would feed the
+   * solver a stale CoM and produce subtle integration bugs.
+   */
+  public _attachToWorld(owner: BodyOwner, id: number): void {
+    if (this._destroyed) {
+      throw new Error('PhysicsBody: cannot add a destroyed body to a world.');
+    }
+
+    this._owner = owner;
+    this._id = id;
+    this._attached = true;
+
+    for (const collider of this._colliders) {
+      collider._attach(this, owner._allocateColliderId());
+    }
+
+    this._recomputeMass();
+
+    for (const collider of this._colliders) {
+      collider.synchronize(this._transform);
+    }
+
+    for (const collider of this._colliders) {
+      owner._registerCollider(collider);
     }
   }
 

--- a/packages/exojs-physics/src/PhysicsWorld.ts
+++ b/packages/exojs-physics/src/PhysicsWorld.ts
@@ -6,15 +6,15 @@ import { NativePhysicsBackend } from './backend/NativePhysicsBackend';
 import type { PhysicsBackend } from './backend/PhysicsBackend';
 import { BindingRegistry } from './binding/BindingRegistry';
 import type { BindingOptions, PhysicsBinding } from './binding/PhysicsBinding';
-import type { Collider, ColliderOptions } from './Collider';
+import { Collider } from './Collider';
 import type { CollisionEvent, SensorEvent } from './events';
-import type { BodyOptions, BodyOwner } from './PhysicsBody';
+import type { BodyOwner } from './PhysicsBody';
 import { PhysicsBody } from './PhysicsBody';
 import type { QueryFilter, RayHit } from './query/QueryEngine';
 import { QueryEngine } from './query/QueryEngine';
 import type { Shape } from './shapes/Shape';
 import { TimeStepper } from './TimeStepper';
-import type { VectorLike } from './types';
+import type { BodyType, CollisionFilter, VectorLike } from './types';
 
 /** Construction options for a {@link PhysicsWorld}. */
 export interface PhysicsWorldOptions {
@@ -32,12 +32,39 @@ export interface PhysicsWorldOptions {
   interpolation?: boolean;
 }
 
-/** {@link PhysicsWorld.createStaticCollider} options: a collider plus its static body placement. */
-export interface StaticColliderOptions extends ColliderOptions {
-  /** World position of the implicit static body. Default `(0, 0)`. */
+/**
+ * {@link PhysicsWorld.attach} convenience options: a body type plus a single
+ * collider, attached to a scene node in one call.
+ */
+export interface AttachOptions {
+  /** Simulation role of the created body. Default `'dynamic'`. */
+  type?: BodyType;
+  /** Initial world position of the body. Default the node's position is left untouched and `(0, 0)` is used. */
   position?: VectorLike;
-  /** Rotation (radians) of the implicit static body. Default `0`. */
+  /** Initial rotation (radians) of the body. Default `0`. */
   angle?: number;
+  /** Per-body multiplier on world gravity. Default `1`. */
+  gravityScale?: number;
+  /** When `true`, the body never rotates under contacts. Default `false`. */
+  fixedRotation?: boolean;
+  /** The collider geometry. */
+  shape: Shape;
+  /** Body-local offset of the collider. Default `(0, 0)`. */
+  offset?: VectorLike;
+  /** Body-local rotation of the collider (radians). Default `0`. */
+  rotation?: number;
+  /** Collider density (mass per px²). Default `1`. */
+  density?: number;
+  /** Coulomb friction coefficient. Default `0.2`. */
+  friction?: number;
+  /** Restitution / bounciness in `[0, 1]`. Default `0`. */
+  restitution?: number;
+  /** When `true`, the collider generates overlap events but no contact response. Default `false`. */
+  isSensor?: boolean;
+  /** Category/mask/group collision filter; partials merge over the defaults. */
+  filter?: Partial<CollisionFilter>;
+  /** Binding options forwarded to {@link PhysicsWorld.bind}. */
+  binding?: BindingOptions;
 }
 
 /**
@@ -110,11 +137,26 @@ export class PhysicsWorld implements BodyOwner {
 
   // ── lifecycle ──────────────────────────────────────────────────────────
 
-  /** Create a body. Safe to call inside an event callback (deferred to end of step). */
-  public createBody(options?: BodyOptions): PhysicsBody {
+  /**
+   * Add a body to the world: allocates the body and its collider ids, registers
+   * the colliders, computes the mass model and tracks the body for stepping.
+   * Construct the body freely first (`new PhysicsBody({ … })`), then add it.
+   * Safe to call inside an event callback — the body push is deferred to the end
+   * of the step, exactly like collider registration. Returns the body.
+   *
+   * @throws if the body has already been added to a world.
+   */
+  public add(body: PhysicsBody): PhysicsBody {
     this._assertAlive();
 
-    const body = new PhysicsBody(this, this._nextBodyId++, options);
+    if (body.attached) {
+      throw new Error('PhysicsWorld.add: this body has already been added to a world.');
+    }
+
+    // Allocate the id + link/register colliders + aggregate mass now (matches the
+    // old createBody, which allocated the id synchronously); only the body-list
+    // push is deferred so it is safe inside an event dispatch.
+    body._attachToWorld(this, this._nextBodyId++);
 
     this._defer(() => {
       if (!body.destroyed) {
@@ -125,11 +167,36 @@ export class PhysicsWorld implements BodyOwner {
     return body;
   }
 
-  /** Sugar: an explicit static body carrying a single collider. The body is addressable via `collider.body`. */
-  public createStaticCollider(options: StaticColliderOptions): Collider {
-    const body = this.createBody({ type: 'static', position: options.position, angle: options.angle });
+  /**
+   * Convenience: create a body carrying a single collider, add it to the world
+   * and bind it to `node` in one call. The node tracks `body.position` after each
+   * step. Returns the body. Equivalent to `new PhysicsBody(...)` + `add` + `bind`.
+   */
+  public attach(node: SceneNode, options: AttachOptions): PhysicsBody {
+    const body = new PhysicsBody({
+      type: options.type,
+      position: options.position,
+      angle: options.angle,
+      gravityScale: options.gravityScale,
+      fixedRotation: options.fixedRotation,
+      colliders: [
+        new Collider({
+          shape: options.shape,
+          offset: options.offset,
+          rotation: options.rotation,
+          density: options.density,
+          friction: options.friction,
+          restitution: options.restitution,
+          isSensor: options.isSensor,
+          filter: options.filter,
+        }),
+      ],
+    });
 
-    return body.createCollider(options);
+    this.add(body);
+    this.bind(body, node, options.binding);
+
+    return body;
   }
 
   /** Destroy a body and its colliders. Deferred when called inside a callback. */

--- a/packages/exojs-physics/src/public.ts
+++ b/packages/exojs-physics/src/public.ts
@@ -12,7 +12,7 @@ export type { CollisionEvent, ContactPoint, SensorEvent } from './events';
 export type { BodyOptions } from './PhysicsBody';
 export { PhysicsBody } from './PhysicsBody';
 export { type PhysicsBuildInfo,physicsBuildInfo } from './physicsBuildInfo';
-export type { PhysicsWorldOptions, StaticColliderOptions } from './PhysicsWorld';
+export type { AttachOptions, PhysicsWorldOptions } from './PhysicsWorld';
 export { PhysicsWorld } from './PhysicsWorld';
 export type { QueryFilter, RayHit } from './query/QueryEngine';
 export { BoxShape } from './shapes/BoxShape';

--- a/packages/exojs-physics/test/binding.test.ts
+++ b/packages/exojs-physics/test/binding.test.ts
@@ -1,7 +1,7 @@
 import type { SceneNode } from '@codexo/exojs';
 import { describe, expect, it } from 'vitest';
 
-import { BoxShape, PhysicsWorld } from '../src/index';
+import { BoxShape, PhysicsBody, PhysicsWorld } from '../src/index';
 
 interface FakeNode {
   skewX: number;
@@ -35,8 +35,7 @@ const fakeNode = (skewX = 0, skewY = 0): FakeNode => ({
 describe('SceneNode binding (gate B-1)', () => {
   it('writes the body position onto the node on bind and after each step', () => {
     const world = new PhysicsWorld();
-    const body = world.createBody({ type: 'kinematic', position: { x: 10, y: 20 } });
-    body.createCollider({ shape: new BoxShape(10, 10) });
+    const body = world.add(new PhysicsBody({ type: 'kinematic', position: { x: 10, y: 20 }, colliders: [{ shape: new BoxShape(10, 10) }] }));
     const node = fakeNode();
 
     world.bind(body, node as unknown as SceneNode);
@@ -51,8 +50,9 @@ describe('SceneNode binding (gate B-1)', () => {
 
   it('writes the body rotation onto the node (radians → degrees)', () => {
     const world = new PhysicsWorld();
-    const body = world.createBody({ type: 'kinematic', position: { x: 0, y: 0 }, angle: Math.PI / 2 });
-    body.createCollider({ shape: new BoxShape(10, 10) });
+    const body = world.add(
+      new PhysicsBody({ type: 'kinematic', position: { x: 0, y: 0 }, angle: Math.PI / 2, colliders: [{ shape: new BoxShape(10, 10) }] }),
+    );
     const node = fakeNode();
 
     world.bind(body, node as unknown as SceneNode);
@@ -67,16 +67,14 @@ describe('SceneNode binding (gate B-1)', () => {
 
   it('rejects binding a node with non-zero skew', () => {
     const world = new PhysicsWorld();
-    const body = world.createBody({ type: 'kinematic', position: { x: 0, y: 0 } });
-    body.createCollider({ shape: new BoxShape(10, 10) });
+    const body = world.add(new PhysicsBody({ type: 'kinematic', position: { x: 0, y: 0 }, colliders: [{ shape: new BoxShape(10, 10) }] }));
 
     expect(() => world.bind(body, fakeNode(15, 0) as unknown as SceneNode)).toThrow();
   });
 
   it('stops tracking after unbind', () => {
     const world = new PhysicsWorld();
-    const body = world.createBody({ type: 'kinematic', position: { x: 0, y: 0 } });
-    body.createCollider({ shape: new BoxShape(10, 10) });
+    const body = world.add(new PhysicsBody({ type: 'kinematic', position: { x: 0, y: 0 }, colliders: [{ shape: new BoxShape(10, 10) }] }));
     const node = fakeNode();
 
     world.bind(body, node as unknown as SceneNode);

--- a/packages/exojs-physics/test/dynamics.test.ts
+++ b/packages/exojs-physics/test/dynamics.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { BoxShape, CircleShape, PhysicsWorld } from '../src/index';
-import type { PhysicsBody } from '../src/PhysicsBody';
+import { PhysicsBody } from '../src/PhysicsBody';
 
 /**
  * The Solver Correctness & Stability matrix (spec `04` §2), exercised over the
@@ -31,7 +31,7 @@ const advance = (world: PhysicsWorld, seconds: number): void => {
 
 /** A wide static floor whose top surface sits at `topY`. */
 const addFloor = (world: PhysicsWorld, topY: number, friction = 0.5, halfWidth = 600): void => {
-  world.createStaticCollider({ shape: new BoxShape(halfWidth * 2, 40), position: { x: 0, y: topY + 20 }, friction });
+  world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: topY + 20 }, colliders: [{ shape: new BoxShape(halfWidth * 2, 40), friction }] }));
 };
 
 /** A dynamic box of `width`×`height` centred at `(x, y)`. */
@@ -43,11 +43,14 @@ const addBox = (
   height = width,
   options: { friction?: number; restitution?: number; density?: number; fixedRotation?: boolean } = {},
 ): PhysicsBody => {
-  const body = world.createBody({ type: 'dynamic', position: { x, y }, fixedRotation: options.fixedRotation });
-
-  body.createCollider({ shape: new BoxShape(width, height), density: options.density ?? 1, friction: options.friction ?? 0.5, restitution: options.restitution ?? 0 });
-
-  return body;
+  return world.add(
+    new PhysicsBody({
+      type: 'dynamic',
+      position: { x, y },
+      fixedRotation: options.fixedRotation,
+      colliders: [{ shape: new BoxShape(width, height), density: options.density ?? 1, friction: options.friction ?? 0.5, restitution: options.restitution ?? 0 }],
+    }),
+  );
 };
 
 const speed = (body: PhysicsBody): number => Math.hypot(body.linearVelocityX, body.linearVelocityY);
@@ -102,8 +105,8 @@ describe('SG-A — angular response', () => {
     const supportY = 300;
 
     // Two static pillars symmetric about x = 0.
-    world.createStaticCollider({ shape: new BoxShape(20, 40), position: { x: -40, y: supportY + 20 } });
-    world.createStaticCollider({ shape: new BoxShape(20, 40), position: { x: 40, y: supportY + 20 } });
+    world.add(new PhysicsBody({ type: 'static', position: { x: -40, y: supportY + 20 }, colliders: [{ shape: new BoxShape(20, 40) }] }));
+    world.add(new PhysicsBody({ type: 'static', position: { x: 40, y: supportY + 20 }, colliders: [{ shape: new BoxShape(20, 40) }] }));
 
     const beam = addBox(world, 0, supportY - 16 - 0.5, 120, 32);
 
@@ -126,8 +129,13 @@ describe('SG-R — restitution', () => {
 
     addFloor(world, floorTop);
 
-    const ball = world.createBody({ type: 'dynamic', position: { x: 0, y: contactCenterY - dropHeight } });
-    ball.createCollider({ shape: new CircleShape(radius), density: 1, friction: 0, restitution: 0.8 });
+    const ball = world.add(
+      new PhysicsBody({
+        type: 'dynamic',
+        position: { x: 0, y: contactCenterY - dropHeight },
+        colliders: [{ shape: new CircleShape(radius), density: 1, friction: 0, restitution: 0.8 }],
+      }),
+    );
 
     let contacted = false;
     let peakY = Infinity;
@@ -197,8 +205,13 @@ describe('SG-R — restitution', () => {
 
     addFloor(world, floorTop);
 
-    const ball = world.createBody({ type: 'dynamic', position: { x: 0, y: contactCenterY - 200 } });
-    ball.createCollider({ shape: new CircleShape(radius), density: 1, friction: 0, restitution: 0.6 });
+    const ball = world.add(
+      new PhysicsBody({
+        type: 'dynamic',
+        position: { x: 0, y: contactCenterY - 200 },
+        colliders: [{ shape: new CircleShape(radius), density: 1, friction: 0, restitution: 0.6 }],
+      }),
+    );
 
     const peaks: number[] = [];
     let prevVy = 0;
@@ -410,8 +423,9 @@ describe('SG-K — kinematic interaction', () => {
     const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
     const platformTop = 300;
 
-    const platform = world.createBody({ type: 'kinematic', position: { x: 0, y: platformTop + 20 } });
-    platform.createCollider({ shape: new BoxShape(200, 40), friction: 0.9 });
+    const platform = world.add(
+      new PhysicsBody({ type: 'kinematic', position: { x: 0, y: platformTop + 20 }, colliders: [{ shape: new BoxShape(200, 40), friction: 0.9 }] }),
+    );
     platform.linearVelocityX = 100;
 
     const rider = addBox(world, 0, platformTop - 16 - 0.5, 32, 32, { friction: 0.9 });
@@ -431,8 +445,9 @@ describe('SG-K — kinematic interaction', () => {
     const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
     const platformTop = 300;
 
-    const platform = world.createBody({ type: 'kinematic', position: { x: 0, y: platformTop + 20 } });
-    platform.createCollider({ shape: new BoxShape(200, 40), friction: 0.5 });
+    const platform = world.add(
+      new PhysicsBody({ type: 'kinematic', position: { x: 0, y: platformTop + 20 }, colliders: [{ shape: new BoxShape(200, 40), friction: 0.5 }] }),
+    );
 
     for (let i = 0; i < 4; i++) {
       addBox(world, 0, platformTop - 16 - 1 - i * 33, 32);
@@ -540,8 +555,13 @@ describe('SG-D — deterministic replay', () => {
       bodies.push(addBox(world, -20, floorTop - 16 - 1, 32));
       bodies.push(addBox(world, 18, floorTop - 48 - 1, 28));
 
-      const ball = world.createBody({ type: 'dynamic', position: { x: 0, y: floorTop - 120 } });
-      ball.createCollider({ shape: new CircleShape(12), density: 1.5, friction: 0.4, restitution: 0.4 });
+      const ball = world.add(
+        new PhysicsBody({
+          type: 'dynamic',
+          position: { x: 0, y: floorTop - 120 },
+          colliders: [{ shape: new CircleShape(12), density: 1.5, friction: 0.4, restitution: 0.4 }],
+        }),
+      );
       bodies.push(ball);
 
       for (let frame = 0; frame < 240; frame++) {

--- a/packages/exojs-physics/test/events.test.ts
+++ b/packages/exojs-physics/test/events.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { CollisionEvent, SensorEvent } from '../src/index';
-import { BoxShape, PhysicsWorld } from '../src/index';
+import { BoxShape, PhysicsBody, PhysicsWorld } from '../src/index';
 import { colliderAt } from './support';
 
 const DT = 1 / 60;
@@ -10,8 +10,7 @@ describe('contact events', () => {
   it('fires collisionStart once on overlap and collisionEnd on separation', () => {
     const world = new PhysicsWorld();
     colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
-    const movingBody = world.createBody({ type: 'kinematic', position: { x: 8, y: 0 } });
-    movingBody.createCollider({ shape: new BoxShape(10, 10) });
+    const movingBody = world.add(new PhysicsBody({ type: 'kinematic', position: { x: 8, y: 0 }, colliders: [{ shape: new BoxShape(10, 10) }] }));
 
     const starts: CollisionEvent[] = [];
     const ends: CollisionEvent[] = [];
@@ -35,8 +34,7 @@ describe('contact events', () => {
   it('produces frozen, immutable event snapshots with an A→B normal', () => {
     const world = new PhysicsWorld();
     colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
-    const body = world.createBody({ type: 'kinematic', position: { x: 8, y: 0 } });
-    body.createCollider({ shape: new BoxShape(10, 10) });
+    const body = world.add(new PhysicsBody({ type: 'kinematic', position: { x: 8, y: 0 }, colliders: [{ shape: new BoxShape(10, 10) }] }));
 
     let event: CollisionEvent | null = null;
     world.onCollisionStart.add(e => {
@@ -56,8 +54,7 @@ describe('contact events', () => {
   it('fires sensorEnter / sensorExit without a collision event', () => {
     const world = new PhysicsWorld();
     const sensor = colliderAt(world, new BoxShape(20, 20), { x: 0, y: 0 }, 0, 'static', { isSensor: true });
-    const body = world.createBody({ type: 'kinematic', position: { x: 5, y: 0 } });
-    body.createCollider({ shape: new BoxShape(10, 10) });
+    const body = world.add(new PhysicsBody({ type: 'kinematic', position: { x: 5, y: 0 }, colliders: [{ shape: new BoxShape(10, 10) }] }));
 
     const enters: SensorEvent[] = [];
     const exits: SensorEvent[] = [];
@@ -79,8 +76,7 @@ describe('contact events', () => {
   it('defers body destruction requested inside a callback', () => {
     const world = new PhysicsWorld();
     colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
-    const projectile = world.createBody({ type: 'kinematic', position: { x: 8, y: 0 } });
-    projectile.createCollider({ shape: new BoxShape(10, 10) });
+    const projectile = world.add(new PhysicsBody({ type: 'kinematic', position: { x: 8, y: 0 }, colliders: [{ shape: new BoxShape(10, 10) }] }));
 
     world.onCollisionStart.add(() => {
       // Deferred: must not throw or corrupt the live arrays mid-dispatch.
@@ -95,8 +91,9 @@ describe('contact events', () => {
   it('does not fire events for filtered-out pairs', () => {
     const world = new PhysicsWorld();
     colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 }, 0, 'static', { filter: { category: 0x0001, mask: 0x0001 } });
-    const other = world.createBody({ type: 'kinematic', position: { x: 5, y: 0 } });
-    other.createCollider({ shape: new BoxShape(10, 10), filter: { category: 0x0002, mask: 0x0002 } });
+    const other = world.add(
+      new PhysicsBody({ type: 'kinematic', position: { x: 5, y: 0 }, colliders: [{ shape: new BoxShape(10, 10), filter: { category: 0x0002, mask: 0x0002 } }] }),
+    );
 
     const start = vi.fn();
     world.onCollisionStart.add(start);

--- a/packages/exojs-physics/test/manifold.test.ts
+++ b/packages/exojs-physics/test/manifold.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { Manifold } from '../src/collision/Manifold';
 import { collide } from '../src/collision/narrowphase';
-import { BoxShape, CircleShape, PhysicsWorld } from '../src/index';
+import { BoxShape, CircleShape, PhysicsBody, PhysicsWorld } from '../src/index';
 import { colliderAt } from './support';
 
 const manifold = new Manifold();
@@ -79,8 +79,8 @@ describe('narrow phase — manifold generation (gate B-2)', () => {
   it('feature ids stay stable across a slow horizontal approach (SG-M1)', () => {
     const world = new PhysicsWorld();
     const a = colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
-    const movingBody = world.createBody({ type: 'static', position: { x: 20, y: 0 } });
-    const b = movingBody.createCollider({ shape: new BoxShape(10, 10) });
+    const movingBody = world.add(new PhysicsBody({ type: 'static', position: { x: 20, y: 0 } }));
+    const b = movingBody.addCollider({ shape: new BoxShape(10, 10) });
 
     let previousIds: number[] | null = null;
 

--- a/packages/exojs-physics/test/perf.test.ts
+++ b/packages/exojs-physics/test/perf.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { BoxShape, PhysicsWorld } from '../src/index';
-import type { PhysicsBody } from '../src/PhysicsBody';
+import { PhysicsBody } from '../src/PhysicsBody';
 
 /**
  * Phase-2B performance gates (spec `04` §3): P-1 steady-state allocation and P-2
@@ -27,7 +27,9 @@ const buildField = (columns: number, rows: number): { world: PhysicsWorld; bodie
   const floorTop = 1000;
   const width = columns * spacing + 200;
 
-  world.createStaticCollider({ shape: new BoxShape(width, 40), position: { x: width / 2, y: floorTop + 20 }, friction: 0.5 });
+  world.add(
+    new PhysicsBody({ type: 'static', position: { x: width / 2, y: floorTop + 20 }, colliders: [{ shape: new BoxShape(width, 40), friction: 0.5 }] }),
+  );
 
   const bodies: PhysicsBody[] = [];
 
@@ -35,9 +37,14 @@ const buildField = (columns: number, rows: number): { world: PhysicsWorld; bodie
     const x = 100 + c * spacing;
 
     for (let r = 0; r < rows; r++) {
-      const body = world.createBody({ type: 'dynamic', position: { x, y: floorTop - size / 2 - 1 - r * size } });
+      const body = world.add(
+        new PhysicsBody({
+          type: 'dynamic',
+          position: { x, y: floorTop - size / 2 - 1 - r * size },
+          colliders: [{ shape: new BoxShape(size, size), density: 1, friction: 0.5 }],
+        }),
+      );
 
-      body.createCollider({ shape: new BoxShape(size, size), density: 1, friction: 0.5 });
       bodies.push(body);
     }
   }

--- a/packages/exojs-physics/test/support.ts
+++ b/packages/exojs-physics/test/support.ts
@@ -1,5 +1,6 @@
 // Shared test helpers (not a *.test.ts file, so it is not collected as a suite).
-import type { Collider, ColliderOptions } from '../src/Collider';
+import { Collider, type ColliderOptions } from '../src/Collider';
+import { PhysicsBody } from '../src/PhysicsBody';
 import { type PhysicsWorld } from '../src/PhysicsWorld';
 import type { Shape } from '../src/shapes/Shape';
 import type { BodyType, VectorLike } from '../src/types';
@@ -13,7 +14,9 @@ export const colliderAt = (
   type: BodyType = 'static',
   options: Partial<ColliderOptions> = {},
 ): Collider => {
-  const body = world.createBody({ type, position, angle });
+  const collider = new Collider({ shape, ...options });
 
-  return body.createCollider({ shape, ...options });
+  world.add(new PhysicsBody({ type, position, angle, colliders: [collider] }));
+
+  return collider;
 };

--- a/packages/exojs-physics/test/world-isolation.test.ts
+++ b/packages/exojs-physics/test/world-isolation.test.ts
@@ -1,15 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
 import type { CollisionEvent } from '../src/index';
-import { BoxShape, physicsBuildInfo,PhysicsWorld } from '../src/index';
+import { BoxShape, PhysicsBody, physicsBuildInfo,PhysicsWorld } from '../src/index';
 import { colliderAt } from './support';
 
 const DT = 1 / 60;
 
 const overlappingPair = (world: PhysicsWorld): CollisionEvent[] => {
   colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
-  const body = world.createBody({ type: 'kinematic', position: { x: 8, y: 0 } });
-  body.createCollider({ shape: new BoxShape(10, 10) });
+  world.add(new PhysicsBody({ type: 'kinematic', position: { x: 8, y: 0 }, colliders: [{ shape: new BoxShape(10, 10) }] }));
 
   const events: CollisionEvent[] = [];
   world.onCollisionStart.add(e => events.push(e));

--- a/packages/exojs-physics/test/world.test.ts
+++ b/packages/exojs-physics/test/world.test.ts
@@ -1,25 +1,87 @@
+import type { SceneNode } from '@codexo/exojs';
 import { describe, expect, it } from 'vitest';
 
-import { BoxShape, PhysicsWorld } from '../src/index';
+import { BoxShape, CircleShape, Collider, PhysicsBody, PhysicsWorld } from '../src/index';
+
+interface FakeNode {
+  skewX: number;
+  skewY: number;
+  x: number;
+  y: number;
+  rotation: number;
+  setPosition(x: number, y: number): FakeNode;
+  setRotation(degrees: number): FakeNode;
+}
+
+const fakeNode = (): FakeNode => ({
+  skewX: 0,
+  skewY: 0,
+  x: 0,
+  y: 0,
+  rotation: 0,
+  setPosition(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+
+    return this;
+  },
+  setRotation(degrees: number) {
+    this.rotation = degrees;
+
+    return this;
+  },
+});
 
 describe('PhysicsWorld lifecycle and mass model', () => {
-  it('createStaticCollider yields an addressable static body', () => {
+  it('adds a freely-constructed static body carrying a collider', () => {
     const world = new PhysicsWorld();
-    const ground = world.createStaticCollider({ shape: new BoxShape(800, 32), position: { x: 0, y: 600 } });
+    const collider = new Collider({ shape: new BoxShape(800, 32) });
+    const ground = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 600 }, colliders: [collider] }));
 
-    expect(ground.body.type).toBe('static');
-    expect(ground.body.x).toBe(0);
-    expect(ground.body.y).toBe(600);
-    expect(world.colliders).toContain(ground);
+    expect(ground.attached).toBe(true);
+    expect(ground.type).toBe('static');
+    expect(ground.x).toBe(0);
+    expect(ground.y).toBe(600);
+    expect(collider.body).toBe(ground);
+    expect(collider.id).toBeGreaterThan(0);
+    expect(world.bodies).toContain(ground);
+    expect(world.colliders).toContain(collider);
+  });
+
+  it('constructs a body and colliders before the world assigns ids', () => {
+    const collider = new Collider({ shape: new BoxShape(10, 10) });
+    const body = new PhysicsBody({ type: 'dynamic', colliders: [collider] });
+
+    // Unattached: no id, no body link, no mass model yet.
+    expect(body.id).toBe(-1);
+    expect(body.attached).toBe(false);
+    expect(collider.id).toBe(-1);
+    expect(body.isMassReady).toBe(false);
+
+    const world = new PhysicsWorld();
+    world.add(body);
+
+    expect(body.id).toBeGreaterThan(0);
+    expect(collider.id).toBeGreaterThan(0);
+    expect(collider.body).toBe(body);
+    expect(body.isMassReady).toBe(true);
+    expect(body.mass).toBeCloseTo(100, 6);
+  });
+
+  it('rejects adding the same body twice', () => {
+    const world = new PhysicsWorld();
+    const body = world.add(new PhysicsBody({ type: 'dynamic', colliders: [{ shape: new BoxShape(10, 10) }] }));
+
+    expect(() => world.add(body)).toThrow();
   });
 
   it('derives mass and inertia for a dynamic body from collider density', () => {
     const world = new PhysicsWorld();
-    const body = world.createBody({ type: 'dynamic', position: { x: 0, y: 0 } });
+    const body = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 } }));
 
     expect(body.isMassReady).toBe(false); // no collider yet
 
-    body.createCollider({ shape: new BoxShape(10, 10), density: 2 });
+    body.addCollider({ shape: new BoxShape(10, 10), density: 2 });
 
     expect(body.isMassReady).toBe(true);
     expect(body.mass).toBeCloseTo(200, 6); // density 2 × area 100
@@ -29,10 +91,10 @@ describe('PhysicsWorld lifecycle and mass model', () => {
 
   it('treats static and kinematic bodies as infinite mass', () => {
     const world = new PhysicsWorld();
-    const staticBody = world.createBody({ type: 'static', position: { x: 0, y: 0 } });
-    const kinematicBody = world.createBody({ type: 'kinematic', position: { x: 0, y: 0 } });
-    staticBody.createCollider({ shape: new BoxShape(10, 10), density: 5 });
-    kinematicBody.createCollider({ shape: new BoxShape(10, 10), density: 5 });
+    const staticBody = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 }, colliders: [{ shape: new BoxShape(10, 10), density: 5 }] }));
+    const kinematicBody = world.add(
+      new PhysicsBody({ type: 'kinematic', position: { x: 0, y: 0 }, colliders: [{ shape: new BoxShape(10, 10), density: 5 }] }),
+    );
 
     expect(staticBody.invMass).toBe(0);
     expect(staticBody.invInertia).toBe(0);
@@ -42,8 +104,7 @@ describe('PhysicsWorld lifecycle and mass model', () => {
 
   it('fixedRotation removes angular response', () => {
     const world = new PhysicsWorld();
-    const body = world.createBody({ type: 'dynamic', fixedRotation: true });
-    body.createCollider({ shape: new BoxShape(10, 10), density: 1 });
+    const body = world.add(new PhysicsBody({ type: 'dynamic', fixedRotation: true, colliders: [{ shape: new BoxShape(10, 10), density: 1 }] }));
 
     expect(body.invMass).toBeGreaterThan(0);
     expect(body.invInertia).toBe(0);
@@ -51,8 +112,8 @@ describe('PhysicsWorld lifecycle and mass model', () => {
 
   it('destroyCollider detaches and recomputes mass', () => {
     const world = new PhysicsWorld();
-    const body = world.createBody({ type: 'dynamic' });
-    const collider = body.createCollider({ shape: new BoxShape(10, 10), density: 1 });
+    const body = world.add(new PhysicsBody({ type: 'dynamic' }));
+    const collider = body.addCollider({ shape: new BoxShape(10, 10), density: 1 });
 
     expect(body.mass).toBeCloseTo(100, 6);
 
@@ -67,7 +128,30 @@ describe('PhysicsWorld lifecycle and mass model', () => {
     const world = new PhysicsWorld();
     world.destroy();
 
-    expect(() => world.createBody()).toThrow();
+    expect(() => world.add(new PhysicsBody())).toThrow();
     expect(() => world.step(1 / 60)).toThrow();
+  });
+});
+
+describe('PhysicsWorld.attach convenience', () => {
+  it('creates a body + collider and binds the node so it follows the body', () => {
+    const world = new PhysicsWorld();
+    const node = fakeNode();
+    const body = world.attach(node as unknown as SceneNode, { type: 'kinematic', position: { x: 10, y: 20 }, shape: new CircleShape(16) });
+
+    expect(body.attached).toBe(true);
+    expect(body.type).toBe('kinematic');
+    expect(body.colliders).toHaveLength(1);
+    expect(body.colliders[0].shape).toBeInstanceOf(CircleShape);
+
+    // Bound immediately on attach.
+    expect(node.x).toBe(10);
+    expect(node.y).toBe(20);
+
+    // Node tracks the body after a step.
+    body.setTransform({ x: 55, y: 77 });
+    world.step(1 / 60);
+    expect(node.x).toBe(55);
+    expect(node.y).toBe(77);
   });
 });


### PR DESCRIPTION
## B1 — Physics construction idiom (v0.14 wave 1, D1+D2)

Bodies/colliders are now constructed freely and joined to the world, matching the engine's `new Sprite()` + `addChild()` idiom — the original v0.14 trigger (D1/D2 from `00-refactor-spec`).

```ts
const body = new PhysicsBody({ type: 'kinematic', position: new Vector(200, 400),
  colliders: [new Collider({ shape: new BoxShape(120, 16) })] });
world.add(body);
body.addCollider(new Collider({ shape: new CircleShape(8), offset: new Vector(60, 0) }));

const b2 = world.attach(sprite, { type: 'dynamic', shape: new CircleShape(16) });
```

- `world.add(body)` assigns ids + registers colliders + aggregates mass; `id` is `-1`/unattached until then; double-add throws. **Solver-critical ordering** (link → single mass recompute over the full set → synchronise → register) preserved exactly from the old per-collider path. Id allocation stays synchronous; only the body-list push is deferred (event-callback-safe, as before).
- `world.attach(node, def)` convenience: body + collider + bind in one call.
- `PhysicsBody.createCollider` -> `addCollider(Collider | ColliderOptions)`.
- Removed `createBody`/`createStaticCollider`/`StaticColliderOptions`.

8 test files migrated; new tests cover free construction, double-add throw, attach moving a node.

### BREAKING
`new PhysicsBody(options)` + `world.add(body)`; `createBody`/`createStaticCollider`/`StaticColliderOptions`/`createCollider` removed.

### Verification (local, all green)
physics typecheck · full test suite (3354 passed, incl. full solver/dynamics matrix) · lint:packages · format:check