### PR TITLE
feat(tilemap): typed ObjectLayer schema — ObjectKind + generic accessors (B2, D3)

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -796,6 +796,18 @@ export default defineConfig([
     },
   },
 
+  // ObjectLayer exposes `ObjectKind`, a PascalCase `as const` enum-like value
+  // object whose members (Rectangle, Polygon, …) are PascalCase by convention
+  // and whose string values are the Tiled wire format. This matches how the
+  // core engine declares enum-like constants; the package naming policy is
+  // relaxed here just for this file.
+  {
+    files: ['packages/exojs-tilemap/src/ObjectLayer.ts'],
+    rules: {
+      '@typescript-eslint/naming-convention': 'off',
+    },
+  },
+
   // Extension bitmask / validation constants follow ALL_CAPS convention.
   {
     files: [

--- a/packages/exojs-tilemap/src/ObjectLayer.ts
+++ b/packages/exojs-tilemap/src/ObjectLayer.ts
@@ -1,7 +1,33 @@
 import type { ResolvedTile, TileProperties, TilePropertyValue } from './types';
 
+/**
+ * Geometry kinds for a {@link TileMapObject}, as an `as const` value object.
+ *
+ * Modelled as a frozen string map (not a TS `enum`) so the values stay
+ * wire-compatible with the Tiled string serialisation, survive
+ * `verbatimModuleSyntax` (no emitted runtime helper), and follow the package
+ * convention for enum-like constants. Use the members for ergonomic, typo-safe
+ * call sites: `layer.byKind(ObjectKind.Polygon)`.
+ * @stable
+ */
+export const ObjectKind = {
+  Rectangle: 'rectangle',
+  Ellipse: 'ellipse',
+  Polygon: 'polygon',
+  Polyline: 'polyline',
+  Point: 'point',
+  Tile: 'tile',
+} as const;
+
 /** Geometry discriminant for a {@link TileMapObject}. */
-export type TileMapObjectKind = 'rectangle' | 'ellipse' | 'polygon' | 'polyline' | 'point' | 'tile';
+export type ObjectKind = (typeof ObjectKind)[keyof typeof ObjectKind];
+
+/**
+ * Geometry discriminant for a {@link TileMapObject}.
+ * Structural alias of {@link ObjectKind}; retained so existing code keeps
+ * compiling. New code may prefer {@link ObjectKind}.
+ */
+export type TileMapObjectKind = ObjectKind;
 
 /** A point in object-layer space (pixels, relative to the object). */
 export interface ObjectPoint {
@@ -10,7 +36,7 @@ export interface ObjectPoint {
 }
 
 /** Fields shared by every {@link TileMapObject} kind. */
-interface TileMapObjectBase {
+interface TileMapObjectBase<P extends TileProperties = TileProperties> {
   /** Source-unique object id. */
   readonly id: number;
   /** Object name (may be empty; not unique). */
@@ -30,39 +56,39 @@ interface TileMapObjectBase {
   /** Whether the object is marked visible. */
   readonly visible: boolean;
   /** Immutable custom properties. */
-  readonly properties: TileProperties;
+  readonly properties: P;
 }
 
 /** An axis-aligned rectangle object spanning `[x, y, width, height]`. */
-export interface RectangleObject extends TileMapObjectBase {
-  readonly kind: 'rectangle';
+export interface RectangleObject<P extends TileProperties = TileProperties> extends TileMapObjectBase<P> {
+  readonly kind: typeof ObjectKind.Rectangle;
 }
 
 /** An ellipse inscribed in `[x, y, width, height]`. */
-export interface EllipseObject extends TileMapObjectBase {
-  readonly kind: 'ellipse';
+export interface EllipseObject<P extends TileProperties = TileProperties> extends TileMapObjectBase<P> {
+  readonly kind: typeof ObjectKind.Ellipse;
 }
 
 /** A single point at `(x, y)`. */
-export interface PointObject extends TileMapObjectBase {
-  readonly kind: 'point';
+export interface PointObject<P extends TileProperties = TileProperties> extends TileMapObjectBase<P> {
+  readonly kind: typeof ObjectKind.Point;
 }
 
 /** A closed polygon; `points` are relative to the object origin. */
-export interface PolygonObject extends TileMapObjectBase {
-  readonly kind: 'polygon';
+export interface PolygonObject<P extends TileProperties = TileProperties> extends TileMapObjectBase<P> {
+  readonly kind: typeof ObjectKind.Polygon;
   readonly points: readonly ObjectPoint[];
 }
 
 /** An open polyline; `points` are relative to the object origin. */
-export interface PolylineObject extends TileMapObjectBase {
-  readonly kind: 'polyline';
+export interface PolylineObject<P extends TileProperties = TileProperties> extends TileMapObjectBase<P> {
+  readonly kind: typeof ObjectKind.Polyline;
   readonly points: readonly ObjectPoint[];
 }
 
 /** A tile (GID) object carrying a resolved tile reference. */
-export interface TileObject extends TileMapObjectBase {
-  readonly kind: 'tile';
+export interface TileObject<P extends TileProperties = TileProperties> extends TileMapObjectBase<P> {
+  readonly kind: typeof ObjectKind.Tile;
   readonly tile: ResolvedTile;
 }
 
@@ -70,9 +96,55 @@ export interface TileObject extends TileMapObjectBase {
  * A format-independent map object. The geometry kind is the discriminant;
  * narrow on `kind` to read shape-specific fields. Text objects and templates
  * are intentionally not represented (data-only release).
+ *
+ * The optional property-shape parameter `P` lets typed accessors
+ * (see {@link ObjectLayer.byType}) narrow `properties` to a developer-declared
+ * schema. It defaults to the generic {@link TileProperties} bag, so the plain
+ * `TileMapObject` form is unchanged.
  * @advanced
  */
-export type TileMapObject = RectangleObject | EllipseObject | PointObject | PolygonObject | PolylineObject | TileObject;
+export type TileMapObject<P extends TileProperties = TileProperties> =
+  | RectangleObject<P>
+  | EllipseObject<P>
+  | PointObject<P>
+  | PolygonObject<P>
+  | PolylineObject<P>
+  | TileObject<P>;
+
+/**
+ * A developer-declared mapping from object `type`/class strings to the property
+ * shape an object of that type is expected to carry. Supplied as the type
+ * parameter to {@link ObjectLayer} to unlock the typed accessors
+ * ({@link ObjectLayer.byType}, {@link ObjectLayer.where}).
+ *
+ * @remarks
+ * A schema is a **developer promise, not a runtime guarantee.** Tiled data is
+ * untyped at runtime and ExoJS performs no validation against the schema —
+ * the property objects are returned exactly as parsed. The schema only refines
+ * the static type of `properties` for ergonomic, typo-safe field access. If the
+ * source data does not match the declared shape, reads still succeed but the
+ * static type is a fiction. Validate at the boundary if you need certainty.
+ *
+ * @example
+ * ```ts
+ * const EntityType = { Spawn: 'spawn', Pickup: 'pickup' } as const;
+ * interface LevelObjects {
+ *   [EntityType.Spawn]:  { team: 'red' | 'blue' };
+ *   [EntityType.Pickup]: { item: 'coin' | 'gem'; amount: number };
+ * }
+ * const entities = map.getObjectLayer<LevelObjects>('Entities');
+ * entities.byType(EntityType.Spawn)[0].properties.team; // 'red' | 'blue'
+ * ```
+ * @stable
+ */
+export type ObjectSchema = Record<string, TileProperties>;
+
+/**
+ * A {@link TileMapObject} whose `properties` are narrowed to the schema shape
+ * declared for the object `type` `T` in schema `S`.
+ * @advanced
+ */
+export type TypedObject<S extends ObjectSchema, T extends keyof S & string> = TileMapObject<S[T]>;
 
 /** Filter for {@link ObjectLayer.query}. Unspecified fields match everything. */
 export interface ObjectQuery {
@@ -114,11 +186,26 @@ export interface ObjectLayerOptions {
  * A data-only layer of {@link TileMapObject}s — spawn points, trigger zones,
  * collision regions, markers. Object layers are not rendered by the tile
  * renderer; they are parsed and exposed for gameplay use (e.g. building physics
- * colliders, placing entities). Query with {@link query}.
+ * colliders, placing entities).
+ *
+ * Query with {@link query} (untyped, fully back-compatible) or, when an
+ * {@link ObjectSchema} type argument `S` is supplied, with the typed accessors
+ * {@link byType}, {@link byKind}, and {@link where} — these narrow `properties`
+ * to the developer-declared shape. The schema is **opt-in**: the default type
+ * parameter reproduces the original untyped behaviour, so
+ * `new ObjectLayer(options)` and `map.getObjectLayer('x')` are unchanged.
+ *
+ * @remarks
+ * A schema is a developer promise, not a runtime guarantee — Tiled data is
+ * untyped at runtime and ExoJS performs no validation. See {@link ObjectSchema}.
+ *
+ * @typeParam S - Optional {@link ObjectSchema} mapping object `type` strings to
+ * their property shapes. Defaults to a generic schema (every type maps to the
+ * loose {@link TileProperties} bag).
  *
  * @advanced
  */
-export class ObjectLayer {
+export class ObjectLayer<S extends ObjectSchema = ObjectSchema> {
   /** Layer-kind discriminant (distinguishes object layers from tile layers). */
   public readonly kind = 'object' as const;
 
@@ -180,6 +267,40 @@ export class ObjectLayer {
 
       return true;
     });
+  }
+
+  /**
+   * Objects whose `type` equals `type`, with `properties` narrowed to the
+   * schema shape `S[T]`. Returns a fresh array (insertion order).
+   *
+   * The narrowing is a static convenience only — no runtime validation is
+   * performed (see {@link ObjectSchema}). On an unschematised layer this
+   * behaves like `query({ type })` with `TileProperties` properties.
+   */
+  public byType<T extends keyof S & string>(type: T): Array<TypedObject<S, T>> {
+    return this.objects.filter(object => object.type === type) as unknown as Array<TypedObject<S, T>>;
+  }
+
+  /**
+   * Objects of the given geometry {@link ObjectKind}, narrowed to that
+   * geometry's member type (e.g. `byKind(ObjectKind.Polygon)` yields
+   * {@link PolygonObject}s with their `points`). Returns a fresh array.
+   */
+  public byKind<K extends ObjectKind>(kind: K): Array<Extract<TileMapObject, { kind: K }>> {
+    return this.objects.filter(object => object.kind === kind) as Array<Extract<TileMapObject, { kind: K }>>;
+  }
+
+  /**
+   * Objects of `type` (typed as in {@link byType}) that also satisfy
+   * `predicate`. A convenience combination of {@link byType} and `Array.filter`
+   * that keeps the narrowed `properties` type inside the predicate. Returns a
+   * fresh array.
+   */
+  public where<T extends keyof S & string>(
+    type: T,
+    predicate: (object: TypedObject<S, T>) => boolean,
+  ): Array<TypedObject<S, T>> {
+    return this.byType(type).filter(object => predicate(object));
   }
 
   /** First object with the given id, or undefined. */

--- a/packages/exojs-tilemap/src/TileMap.ts
+++ b/packages/exojs-tilemap/src/TileMap.ts
@@ -1,4 +1,4 @@
-import type { ObjectLayer } from './ObjectLayer';
+import type { ObjectLayer, ObjectSchema } from './ObjectLayer';
 import { type TileLayer } from './TileLayer';
 import type { TileMapViewOptions } from './TileMapView';
 import { TileMapView } from './TileMapView';
@@ -231,9 +231,16 @@ export class TileMap {
 
   /**
    * Get an object layer by name (first match in insertion order), or undefined.
+   *
+   * Supply an {@link ObjectSchema} type argument `S` to obtain a typed view of
+   * the layer — `getObjectLayer<LevelObjects>('Entities')` returns an
+   * `ObjectLayer<LevelObjects>` whose {@link ObjectLayer.byType} / {@link
+   * ObjectLayer.where} accessors narrow `properties`. The schema is a static
+   * developer promise only; no runtime validation is performed and the call
+   * remains fully back-compatible when omitted.
    */
-  public getObjectLayer(name: string): ObjectLayer | undefined {
-    return this._objectLayers.find(layer => layer.name === name);
+  public getObjectLayer<S extends ObjectSchema = ObjectSchema>(name: string): ObjectLayer<S> | undefined {
+    return this._objectLayers.find(layer => layer.name === name) as ObjectLayer<S> | undefined;
   }
 
   // ── Scene composition ─────────────────────────────────────────────────

--- a/packages/exojs-tilemap/src/public.ts
+++ b/packages/exojs-tilemap/src/public.ts
@@ -9,6 +9,7 @@ export type {
   ObjectLayerOptions,
   ObjectPoint,
   ObjectQuery,
+  ObjectSchema,
   PointObject,
   PolygonObject,
   PolylineObject,
@@ -16,8 +17,9 @@ export type {
   TileMapObject,
   TileMapObjectKind,
   TileObject,
+  TypedObject,
 } from './ObjectLayer';
-export { ObjectLayer } from './ObjectLayer';
+export { ObjectKind, ObjectLayer } from './ObjectLayer';
 // The mutable TileChunk implementation is package-internal —
 // only the ReadonlyTileChunk interface is exported publicly.
 export type { ReadonlyTileChunk } from './TileChunk';

--- a/packages/exojs-tilemap/test/object-layer.test.ts
+++ b/packages/exojs-tilemap/test/object-layer.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { TileMapObject } from '../src/index';
-import { ObjectLayer, TileMap } from '../src/index';
+import { ObjectKind, ObjectLayer, TileMap } from '../src/index';
 
 const rectangle = (id: number, name: string, type: string, properties: Record<string, string> = {}): TileMapObject => ({
   kind: 'rectangle',
@@ -15,6 +15,20 @@ const rectangle = (id: number, name: string, type: string, properties: Record<st
   rotation: 0,
   visible: true,
   properties,
+});
+
+const point = (id: number, name: string, type: string): TileMapObject => ({
+  kind: 'point',
+  id,
+  name,
+  type,
+  x: id,
+  y: id,
+  width: 0,
+  height: 0,
+  rotation: 0,
+  visible: true,
+  properties: {},
 });
 
 describe('ObjectLayer', () => {
@@ -69,6 +83,81 @@ describe('ObjectLayer', () => {
     expect(layer.getObjectByName('hero')?.id).toBe(7);
     expect(layer.getObjectById(99)).toBeUndefined();
     expect(layer.getObjectByName('missing')).toBeUndefined();
+  });
+});
+
+interface LevelObjects {
+  spawn: { team: 'red' | 'blue' };
+  trigger: { event: string; once?: boolean };
+  pickup: { item: 'coin' | 'gem'; amount: number };
+}
+
+describe('ObjectLayer typed accessors (byType / byKind / where)', () => {
+  const layer = new ObjectLayer<LevelObjects>({
+    id: 1,
+    objects: [
+      rectangle(1, 'spawn-a', 'spawn', { team: 'red' }),
+      rectangle(2, 'spawn-b', 'spawn', { team: 'blue' }),
+      rectangle(3, 'gate', 'trigger', { event: 'open' }),
+      rectangle(4, 'coin', 'pickup', { item: 'coin', amount: '3' }),
+      rectangle(5, 'gem', 'pickup', { item: 'gem', amount: '10' }),
+      point(6, 'marker', 'waypoint'),
+    ],
+  });
+
+  it('byType returns only objects of the given type, with their properties', () => {
+    const spawns = layer.byType('spawn');
+    expect(spawns.map(o => o.id)).toEqual([1, 2]);
+    expect(spawns.map(o => o.properties.team)).toEqual(['red', 'blue']);
+
+    expect(layer.byType('pickup')).toHaveLength(2);
+    // A type with no matches yields an empty array.
+    expect(layer.byType('trigger')).toHaveLength(1);
+  });
+
+  it('byType returns a fresh array each call', () => {
+    expect(layer.byType('spawn')).not.toBe(layer.byType('spawn'));
+  });
+
+  it('byKind narrows by geometry discriminant', () => {
+    const rects = layer.byKind(ObjectKind.Rectangle);
+    expect(rects).toHaveLength(5);
+    expect(rects.every(o => o.kind === 'rectangle')).toBe(true);
+
+    const points = layer.byKind(ObjectKind.Point);
+    expect(points.map(o => o.id)).toEqual([6]);
+
+    // A kind that no object uses yields an empty array.
+    expect(layer.byKind(ObjectKind.Tile)).toHaveLength(0);
+  });
+
+  it('byKind accepts the raw wire string as well as the ObjectKind member', () => {
+    expect(layer.byKind('point')).toHaveLength(1);
+    expect(layer.byKind(ObjectKind.Point)).toHaveLength(1);
+  });
+
+  it('where combines byType with a predicate over the narrowed properties', () => {
+    const gems = layer.where('pickup', o => o.properties.item === 'gem');
+    expect(gems.map(o => o.id)).toEqual([5]);
+
+    const reds = layer.where('spawn', o => o.properties.team === 'red');
+    expect(reds.map(o => o.id)).toEqual([1]);
+
+    const none = layer.where('pickup', () => false);
+    expect(none).toHaveLength(0);
+  });
+
+  it('untyped layers still expose byType/byKind/where with loose properties', () => {
+    const untyped = new ObjectLayer({
+      id: 2,
+      objects: [rectangle(1, 'a', 'spawn', { team: 'red' }), point(2, 'b', 'marker')],
+    });
+
+    expect(untyped.byType('spawn')).toHaveLength(1);
+    expect(untyped.byKind(ObjectKind.Point)).toHaveLength(1);
+    expect(untyped.where('spawn', o => o.properties.team === 'red')).toHaveLength(1);
+    // query() is unchanged.
+    expect(untyped.query({ type: 'spawn' })).toHaveLength(1);
   });
 });
 

--- a/packages/exojs-tilemap/test/object-schema-types.test.ts
+++ b/packages/exojs-tilemap/test/object-schema-types.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Compile-time type contracts for the opt-in ObjectLayer schema (D3).
+ *
+ * Uses Vitest's built-in `expectTypeOf` (the same convention as
+ * pixel-snap-types.test.ts and test/core/type-assertions.test.ts): the
+ * assertions are validated by the TypeScript compiler, not at runtime. Imports
+ * go through the PUBLIC package specifier so the contracts cover exactly what
+ * consumers see.
+ *
+ * The schema is a developer promise — there is no runtime validation — so these
+ * tests assert only the *static* narrowing of `properties` for byType / where
+ * and the geometry discriminant narrowing for byKind, plus that the default
+ * (un-schematised) form preserves the original untyped behaviour.
+ */
+
+import type { PolygonObject, TileMapObject, TileProperties } from '@codexo/exojs-tilemap';
+import { ObjectKind, ObjectLayer, TileMap } from '@codexo/exojs-tilemap';
+import { describe, expectTypeOf, it } from 'vitest';
+
+const EntityType = { Spawn: 'spawn', Trigger: 'trigger', Pickup: 'pickup' } as const;
+
+interface LevelObjects {
+  [EntityType.Spawn]: { team: 'red' | 'blue' };
+  [EntityType.Trigger]: { event: string; once?: boolean };
+  [EntityType.Pickup]: { item: 'coin' | 'gem'; amount: number };
+}
+
+describe('ObjectKind value object', () => {
+  it('is a frozen string map whose members are the wire-format literals', () => {
+    expectTypeOf(ObjectKind.Rectangle).toEqualTypeOf<'rectangle'>();
+    expectTypeOf(ObjectKind.Polygon).toEqualTypeOf<'polygon'>();
+    expectTypeOf(ObjectKind.Tile).toEqualTypeOf<'tile'>();
+  });
+
+  it('ObjectKind type is the union of the six geometry literals', () => {
+    expectTypeOf<ObjectKind>().toEqualTypeOf<
+      'rectangle' | 'ellipse' | 'polygon' | 'polyline' | 'point' | 'tile'
+    >();
+  });
+
+  it('TileMapObjectKind remains a structural alias of ObjectKind', () => {
+    expectTypeOf<import('@codexo/exojs-tilemap').TileMapObjectKind>().toEqualTypeOf<ObjectKind>();
+  });
+});
+
+describe('ObjectLayer typed accessors (schema is opt-in)', () => {
+  // `expectTypeOf` evaluates its argument at runtime, so these contracts
+  // operate on element *types* (never index into the empty arrays returned by
+  // calls on an empty layer). The assertions are checked by `tsc`.
+  it('byType narrows properties to the declared schema shape', () => {
+    const layer = new ObjectLayer<LevelObjects>({ id: 1 });
+
+    type Spawn = ReturnType<typeof layer.byType<typeof EntityType.Spawn>>[number];
+    type Pickup = ReturnType<typeof layer.byType<typeof EntityType.Pickup>>[number];
+    type Trigger = ReturnType<typeof layer.byType<typeof EntityType.Trigger>>[number];
+
+    expectTypeOf<Spawn['properties']['team']>().toEqualTypeOf<'red' | 'blue'>();
+    expectTypeOf<Pickup['properties']['amount']>().toEqualTypeOf<number>();
+    expectTypeOf<Pickup['properties']['item']>().toEqualTypeOf<'coin' | 'gem'>();
+    expectTypeOf<Trigger['properties']['once']>().toEqualTypeOf<boolean | undefined>();
+  });
+
+  it('byType rejects a type key absent from the schema', () => {
+    const layer = new ObjectLayer<LevelObjects>({ id: 1 });
+    // @ts-expect-error — 'enemy' is not a key of LevelObjects
+    layer.byType('enemy');
+  });
+
+  it('where keeps the narrowed properties type inside the predicate', () => {
+    const layer = new ObjectLayer<LevelObjects>({ id: 1 });
+
+    type Big = ReturnType<typeof layer.where<typeof EntityType.Pickup>>[number];
+    expectTypeOf<Big['properties']['item']>().toEqualTypeOf<'coin' | 'gem'>();
+    expectTypeOf<Parameters<Parameters<typeof layer.where<'pickup'>>[1]>[0]['properties']['amount']>().toEqualTypeOf<number>();
+  });
+
+  it('byKind narrows to the matching geometry member type', () => {
+    const layer = new ObjectLayer<LevelObjects>({ id: 1 });
+
+    type Polys = ReturnType<typeof layer.byKind<typeof ObjectKind.Polygon>>;
+    expectTypeOf<Polys>().toEqualTypeOf<PolygonObject[]>();
+    // PolygonObject carries `points`; the narrowing exposes it.
+    expectTypeOf<Polys[number]['points']>().toEqualTypeOf<readonly { readonly x: number; readonly y: number }[]>();
+  });
+});
+
+describe('default (un-schematised) ObjectLayer preserves untyped behaviour', () => {
+  it('byType yields loose TileProperties when no schema is supplied', () => {
+    const layer = new ObjectLayer({ id: 1 });
+    // Any string is an acceptable type key on the default schema …
+    type AnyObj = ReturnType<typeof layer.byType<'whatever'>>[number];
+    expectTypeOf<AnyObj['properties']>().toEqualTypeOf<TileProperties>();
+  });
+
+  it('query still returns the generic TileMapObject[] union', () => {
+    const layer = new ObjectLayer({ id: 1 });
+    expectTypeOf(layer.query()).toEqualTypeOf<TileMapObject[]>();
+    expectTypeOf(layer.objects).toEqualTypeOf<readonly TileMapObject[]>();
+  });
+
+  it('TileMap.getObjectLayer threads the schema parameter through', () => {
+    const map = new TileMap({ width: 2, height: 2, tileWidth: 16, tileHeight: 16 });
+
+    expectTypeOf(map.getObjectLayer('x')).toEqualTypeOf<ObjectLayer<Record<string, TileProperties>> | undefined>();
+    expectTypeOf(map.getObjectLayer<LevelObjects>('Entities')).toEqualTypeOf<ObjectLayer<LevelObjects> | undefined>();
+  });
+});

--- a/site/src/content/api/object-layer.mdx
+++ b/site/src/content/api/object-layer.mdx
@@ -1,15 +1,15 @@
 ---
 title: "ObjectLayer"
-description: "A data-only layer of TileMapObjects — spawn points, trigger zones, collision regions, markers. Object layers are not rendered by the tile renderer; they are parsed and exposed for gameplay use (e.g. building physics colliders, placing entities). Query with query."
+description: "A data-only layer of TileMapObjects — spawn points, trigger zones, collision regions, markers. Object layers are not rendered by the tile renderer; they are parsed and exposed for gameplay use (e.g. building physics colliders, placing entities). Query with query (untyped, fully back-compatible) or, when an ObjectSchema type argument `S` is supplied, with the typed accessors byType, byKind, and where — these narrow `properties` to the developer-declared shape. The schema is **opt-in**: the default type parameter reproduces the original untyped behaviour, so `new ObjectLayer(options)` and `map.getObjectLayer('x')` are unchanged."
 symbol: "ObjectLayer"
 kind: "class"
 subsystem: "tilemap"
 importPath: "@codexo/exojs-tilemap"
-memberCount: 14
+memberCount: 17
 tier: "advanced"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "packages/exojs-tilemap/src/ObjectLayer.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/ObjectLayer.ts#L121"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/ObjectLayer.ts#L208"
 ---
 ## Import
 
@@ -18,17 +18,27 @@ sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/s
 A data-only layer of TileMapObjects — spawn points, trigger zones,
 collision regions, markers. Object layers are not rendered by the tile
 renderer; they are parsed and exposed for gameplay use (e.g. building physics
-colliders, placing entities). Query with query.
+colliders, placing entities).
+
+Query with query (untyped, fully back-compatible) or, when an
+ObjectSchema type argument `S` is supplied, with the typed accessors
+byType, byKind, and where — these narrow `properties`
+to the developer-declared shape. The schema is **opt-in**: the default type
+parameter reproduces the original untyped behaviour, so
+`new ObjectLayer(options)` and `map.getObjectLayer('x')` are unchanged.
 
 ## Constructors
 
-- `new(options: ObjectLayerOptions): ObjectLayer`
+- `new(options: ObjectLayerOptions): ObjectLayer<S>`
 
 ## Methods
 
-- `getObjectById(id: number): TileMapObject | undefined`
-- `getObjectByName(name: string): TileMapObject | undefined`
-- `query(filter: ObjectQuery): TileMapObject[]`
+- `byKind(kind: K): Extract<RectangleObject<Readonly<Record<string, TilePropertyValue>>>, object> | Extract<EllipseObject<Readonly<Record<string, TilePropertyValue>>>, object> | Extract<PointObject<Readonly<Record<string, TilePropertyValue>>>, object> | Extract<PolygonObject<Readonly<Record<string, TilePropertyValue>>>, object> | Extract<PolylineObject<Readonly<Record<string, TilePropertyValue>>>, object> | Extract<TileObject<Readonly<Record<string, TilePropertyValue>>>, object>[]`
+- `byType(type: T): TypedObject<S, T>[]`
+- `getObjectById(id: number): TileMapObject<Readonly<Record<string, TilePropertyValue>>> | undefined`
+- `getObjectByName(name: string): TileMapObject<Readonly<Record<string, TilePropertyValue>>> | undefined`
+- `query(filter: ObjectQuery): TileMapObject<Readonly<Record<string, TilePropertyValue>>>[]`
+- `where(type: T, predicate: object): TypedObject<S, T>[]`
 
 ## Properties
 
@@ -36,7 +46,7 @@ colliders, placing entities). Query with query.
 - `id: number`
 - `kind: "object"`
 - `name: string`
-- `objects: readonly TileMapObject[]`
+- `objects: readonly TileMapObject<Readonly<Record<string, TilePropertyValue>>>[]`
 - `offsetX: number`
 - `offsetY: number`
 - `opacity: number`
@@ -45,4 +55,4 @@ colliders, placing entities). Query with query.
 
 ## Source
 
-[packages/exojs-tilemap/src/ObjectLayer.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/ObjectLayer.ts#L121)
+[packages/exojs-tilemap/src/ObjectLayer.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/ObjectLayer.ts#L208)

--- a/site/src/content/api/tile-map.mdx
+++ b/site/src/content/api/tile-map.mdx
@@ -40,7 +40,7 @@ and local tile ID, so different tilesets may have different tile dimensions.
 - `destroy(): void`
 - `getLayerById(id: number): TileLayer | undefined`
 - `getLayerByName(name: string): TileLayer | undefined`
-- `getObjectLayer(name: string): ObjectLayer | undefined`
+- `getObjectLayer(name: string): ObjectLayer<S> | undefined`
 - `getTileAt(layerId: number, tx: number, ty: number): ResolvedTile | null`
 - `getTileLayer(name: string): TileLayer | undefined`
 - `getTileset(name: string): TileSet | undefined`
@@ -61,7 +61,7 @@ and local tile ID, so different tilesets may have different tile dimensions.
 - `width: number`
 - `destroyed: boolean`
 - `layers: readonly TileLayer[]`
-- `objectLayers: readonly ObjectLayer[]`
+- `objectLayers: readonly ObjectLayer<ObjectSchema>[]`
 - `pixelHeight: number`
 - `pixelWidth: number`
 - `revision: number`


### PR DESCRIPTION
## B2 — typed ObjectLayer schema (v0.14 wave 1, D3)

Opt-in, type-safe object-layer API. **Fully additive** — untyped usage and `query()` are unchanged.

- `ObjectKind` is now an `as const` object (enum-style DX, wire-compatible with Tiled strings, no TS enum); `TileMapObjectKind` kept as a structural alias.
- `ObjectLayer<S extends ObjectSchema = ObjectSchema>` with typed accessors: `byType(type)` (`properties` typed as `S[type]`), `byKind(kind)` (narrowed by the geometry discriminant), `where(type, predicate)`. Default type param reproduces the old untyped behaviour, so `getObjectLayer('x')` keeps working.
- `getObjectLayer<S>(name)` threads the schema type param through.

```ts
interface LevelObjects { spawn: { team: 'red' | 'blue' }; pickup: { item: 'coin'; amount: number } }
const e = map.getObjectLayer<LevelObjects>('Entities');
e.byType('spawn')[0].properties.team;        // 'red' | 'blue'
e.byKind(ObjectKind.Polygon);
e.where('pickup', o => o.properties.amount > 5);
```

Schema is a developer promise (Tiled data is untyped at runtime, no runtime validation — documented). Runtime + `expectTypeOf` compile-time tests added.

### Verification (local, all green)
tilemap+tiled typecheck · test suite (3370 passed) · lint:packages · format:check · docs:api:check (in sync)