### PR TITLE
feat(examples): Tiled+physics examples + ObjectLayer→collider bridge (B3)

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1047,7 +1047,13 @@ export default defineConfig([
       unicorn,
     },
     rules: {
-      'simple-import-sort/imports': 'error',
+      // Example sources are authored in TypeScript and transpiled to the linted
+      // `.js` by `examples:sync`; that transpile strips the blank lines between
+      // import groups, so a single sorted group (no group separators) is the only
+      // shape an example `.js` can hold. Collapse all imports into one group so
+      // examples that mix a package import with a relative one (e.g. a shared
+      // recipe) still lint clean.
+      'simple-import-sort/imports': ['error', { groups: [['^\\u0000', '^node:', '^@?\\w', '^', '^\\.']] }],
       'simple-import-sort/exports': 'error',
       'unused-imports/no-unused-imports': 'error',
       '@typescript-eslint/no-empty-function': 'warn',

--- a/examples/examples.json
+++ b/examples/examples.json
@@ -405,8 +405,7 @@
                 "debug"
             ],
             "capabilities": [
-                "pointer",
-                "audio"
+                "pointer"
             ]
         },
         {
@@ -1008,6 +1007,33 @@
             ]
         }
     ],
+    "physics": [
+        {
+            "slug": "sprite-follows-body",
+            "path": "physics/sprite-follows-body.js",
+            "language": "typescript",
+            "title": "Sprite Follows Body",
+            "description": "The minimal physics binding: world.attach builds a body + collider and binds it to a sprite, which then tracks the body each step as it falls onto a static floor.",
+            "backend": "core",
+            "tags": [
+                "physics",
+                "binding"
+            ]
+        },
+        {
+            "slug": "tiled-map-physics-actor",
+            "path": "physics/tiled-map-physics-actor.js",
+            "language": "typescript",
+            "title": "Tiled Map + Physics Actor",
+            "description": "Build static colliders from a tilemap object layer with the ObjectLayer-to-collider bridge, then drop a dynamic actor that falls and bounces across the rendered level.",
+            "backend": "core",
+            "tags": [
+                "physics",
+                "tilemap",
+                "collision"
+            ]
+        }
+    ],
     "render-targets": [
         {
             "slug": "bloom-lite",
@@ -1311,8 +1337,7 @@
                 "scene"
             ],
             "capabilities": [
-                "gamepad",
-                "audio"
+                "gamepad"
             ]
         },
         {

--- a/examples/physics/sprite-follows-body.js
+++ b/examples/physics/sprite-follows-body.js
@@ -1,0 +1,103 @@
+// Auto-generated from sprite-follows-body.ts — edit the .ts source, not this file.
+import { Application, Color, Json, Scene, Sprite, Spritesheet, Texture, Vector } from '@codexo/exojs';
+import { BoxShape, PhysicsWorld } from '@codexo/exojs-physics';
+import { mountControls } from '@examples/runtime';
+// The minimal physics binding: `world.attach(node, { ... })` builds a body +
+// collider and binds it to the node in one call. After every `world.step(...)`
+// the body's position and rotation are written onto the bound sprite, so the
+// sprite simply "follows the body". A static floor stops the falling actor.
+const app = new Application({
+    canvas: {
+        width: 1280,
+        height: 720,
+        mount: document.body,
+        sizingMode: 'fit',
+    },
+    clearColor: new Color(18, 22, 33),
+});
+class SpriteFollowsBodyScene extends Scene {
+    world;
+    actor;
+    actorBody;
+    floor;
+    floorY = 0;
+    settled = 0;
+    hud;
+    async load(loader) {
+        await loader.load(Texture, {
+            characters: assets.demo.spritesheets.platformerCharacters.image,
+            pixel: assets.demo.textures.pixelWhite,
+        });
+        await loader.load(Json, { characters: assets.demo.spritesheets.platformerCharacters.data });
+    }
+    init(loader) {
+        const { width, height } = this.app.canvas;
+        // Gravity in px/s², +Y down — matches the engine's screen space.
+        this.world = new PhysicsWorld({ gravity: { x: 0, y: 1400 } });
+        const characters = new Spritesheet(loader.get(Texture, 'characters'), loader.get(Json, 'characters'));
+        this.floorY = height - 80;
+        // ── Static floor ──────────────────────────────────────────────────
+        // A wide static body. `world.attach` binds it to the floor sprite, so
+        // the sprite is positioned from the body (no manual placement needed).
+        const floorWidth = width - 120;
+        const floorHeight = 48;
+        this.floor = new Sprite(loader.get(Texture, 'pixel')).setAnchor(0.5);
+        this.floor.width = floorWidth;
+        this.floor.height = floorHeight;
+        this.floor.tint = new Color(70, 92, 120);
+        this.world.attach(this.floor, {
+            type: 'static',
+            position: { x: width / 2, y: this.floorY },
+            shape: new BoxShape(floorWidth, floorHeight),
+        });
+        // ── Dynamic actor ─────────────────────────────────────────────────
+        // A dynamic body dropped from above. Its collider is a box sized to the
+        // character art; `world.attach` binds the sprite, so it falls, lands and
+        // tracks the body (position + rotation) every step.
+        this.actor = characters.getFrameSprite('character_beige_front').setAnchor(0.5).setScale(1.1);
+        this.actorBody = this.world.attach(this.actor, {
+            type: 'dynamic',
+            position: { x: width / 2, y: 140 },
+            shape: new BoxShape(70, 90),
+            friction: 0.4,
+            restitution: 0.15,
+        });
+        // A small sideways nudge so the landing is visibly dynamic.
+        this.actorBody.applyImpulse(900, 0);
+        this.hud = mountControls({
+            title: 'Sprite Follows Body',
+            controls: [{ keys: 'Auto', action: 'actor falls and lands on the floor' }],
+            status: 'Dropping…',
+            hint: 'world.attach(sprite, { … }) creates a body + collider and binds it; world.step writes the body transform onto the sprite each frame.',
+        });
+    }
+    update(delta) {
+        // Advance the simulation; bound sprites are synced inside step().
+        this.world.step(delta.seconds);
+        const { width, height } = this.app.canvas;
+        const body = this.actorBody;
+        const restingSpeed = Math.hypot(body.linearVelocityX, body.linearVelocityY);
+        if (body.y > this.floorY - 60 && restingSpeed < 6) {
+            this.settled += delta.seconds;
+        }
+        else {
+            this.settled = 0;
+        }
+        this.hud.setStatus(this.settled > 0 ? `Resting on the floor (${restingSpeed.toFixed(0)} px/s)` : `Falling… y=${body.y.toFixed(0)} px`);
+        // Loop: after a short rest (or if it tumbles off-screen) drop it again.
+        if (this.settled > 1.2 || body.y > height + 200 || Math.abs(body.x - width / 2) > width) {
+            this.settled = 0;
+            body.setTransform(new Vector(width / 2, 140), (Math.random() - 0.5) * 0.6);
+            body.linearVelocityX = 0;
+            body.linearVelocityY = 0;
+            body.angularVelocity = 0;
+            body.applyImpulse((Math.random() - 0.5) * 1800, 0);
+        }
+    }
+    draw(context) {
+        context.backend.clear();
+        context.render(this.floor);
+        context.render(this.actor);
+    }
+}
+app.start(new SpriteFollowsBodyScene());

--- a/examples/physics/sprite-follows-body.ts
+++ b/examples/physics/sprite-follows-body.ts
@@ -1,0 +1,122 @@
+import { Application, Color, Json, Scene, Sprite, Spritesheet, type SpritesheetData, Texture, Vector } from '@codexo/exojs';
+import { BoxShape, type PhysicsBody, PhysicsWorld } from '@codexo/exojs-physics';
+import { mountControls } from '@examples/runtime';
+
+// The minimal physics binding: `world.attach(node, { ... })` builds a body +
+// collider and binds it to the node in one call. After every `world.step(...)`
+// the body's position and rotation are written onto the bound sprite, so the
+// sprite simply "follows the body". A static floor stops the falling actor.
+
+const app = new Application({
+    canvas: {
+        width: 1280,
+        height: 720,
+        mount: document.body,
+        sizingMode: 'fit',
+    },
+    clearColor: new Color(18, 22, 33),
+});
+
+class SpriteFollowsBodyScene extends Scene {
+    private world!: PhysicsWorld;
+    private actor!: Sprite;
+    private actorBody!: PhysicsBody;
+    private floor!: Sprite;
+    private floorY = 0;
+    private settled = 0;
+    private hud!: ReturnType<typeof mountControls>;
+
+    override async load(loader): Promise<void> {
+        await loader.load(Texture, {
+            characters: assets.demo.spritesheets.platformerCharacters.image,
+            pixel: assets.demo.textures.pixelWhite,
+        });
+        await loader.load(Json, { characters: assets.demo.spritesheets.platformerCharacters.data });
+    }
+
+    override init(loader): void {
+        const { width, height } = this.app.canvas;
+
+        // Gravity in px/s², +Y down — matches the engine's screen space.
+        this.world = new PhysicsWorld({ gravity: { x: 0, y: 1400 } });
+
+        const characters = new Spritesheet(loader.get(Texture, 'characters'), loader.get(Json, 'characters') as SpritesheetData);
+
+        this.floorY = height - 80;
+
+        // ── Static floor ──────────────────────────────────────────────────
+        // A wide static body. `world.attach` binds it to the floor sprite, so
+        // the sprite is positioned from the body (no manual placement needed).
+        const floorWidth = width - 120;
+        const floorHeight = 48;
+
+        this.floor = new Sprite(loader.get(Texture, 'pixel')).setAnchor(0.5);
+        this.floor.width = floorWidth;
+        this.floor.height = floorHeight;
+        this.floor.tint = new Color(70, 92, 120);
+
+        this.world.attach(this.floor, {
+            type: 'static',
+            position: { x: width / 2, y: this.floorY },
+            shape: new BoxShape(floorWidth, floorHeight),
+        });
+
+        // ── Dynamic actor ─────────────────────────────────────────────────
+        // A dynamic body dropped from above. Its collider is a box sized to the
+        // character art; `world.attach` binds the sprite, so it falls, lands and
+        // tracks the body (position + rotation) every step.
+        this.actor = characters.getFrameSprite('character_beige_front').setAnchor(0.5).setScale(1.1);
+        this.actorBody = this.world.attach(this.actor, {
+            type: 'dynamic',
+            position: { x: width / 2, y: 140 },
+            shape: new BoxShape(70, 90),
+            friction: 0.4,
+            restitution: 0.15,
+        });
+
+        // A small sideways nudge so the landing is visibly dynamic.
+        this.actorBody.applyImpulse(900, 0);
+
+        this.hud = mountControls({
+            title: 'Sprite Follows Body',
+            controls: [{ keys: 'Auto', action: 'actor falls and lands on the floor' }],
+            status: 'Dropping…',
+            hint: 'world.attach(sprite, { … }) creates a body + collider and binds it; world.step writes the body transform onto the sprite each frame.',
+        });
+    }
+
+    override update(delta): void {
+        // Advance the simulation; bound sprites are synced inside step().
+        this.world.step(delta.seconds);
+
+        const { width, height } = this.app.canvas;
+        const body = this.actorBody;
+        const restingSpeed = Math.hypot(body.linearVelocityX, body.linearVelocityY);
+
+        if (body.y > this.floorY - 60 && restingSpeed < 6) {
+            this.settled += delta.seconds;
+        } else {
+            this.settled = 0;
+        }
+
+        this.hud.setStatus(this.settled > 0 ? `Resting on the floor (${restingSpeed.toFixed(0)} px/s)` : `Falling… y=${body.y.toFixed(0)} px`);
+
+        // Loop: after a short rest (or if it tumbles off-screen) drop it again.
+        if (this.settled > 1.2 || body.y > height + 200 || Math.abs(body.x - width / 2) > width) {
+            this.settled = 0;
+            body.setTransform(new Vector(width / 2, 140), (Math.random() - 0.5) * 0.6);
+            body.linearVelocityX = 0;
+            body.linearVelocityY = 0;
+            body.angularVelocity = 0;
+            body.applyImpulse((Math.random() - 0.5) * 1800, 0);
+        }
+    }
+
+    override draw(context): void {
+        context.backend.clear();
+        context.render(this.floor);
+        context.render(this.actor);
+    }
+}
+
+app.start(new SpriteFollowsBodyScene());

--- a/examples/physics/tiled-map-physics-actor.js
+++ b/examples/physics/tiled-map-physics-actor.js
@@ -1,0 +1,170 @@
+// Auto-generated from tiled-map-physics-actor.ts — edit the .ts source, not this file.
+import { Application, Color, Json, Scene, Spritesheet, Texture, TextureRegion, Vector } from '@codexo/exojs';
+import { BoxShape, PhysicsWorld } from '@codexo/exojs-physics';
+import { PhysicsDebugDraw } from '@codexo/exojs-physics/debug';
+import { ObjectKind, ObjectLayer, TILE_TRANSFORM_IDENTITY, TileLayer, TileMap, tilemapExtension, TileMapNode, TileSet } from '@codexo/exojs-tilemap';
+import { mountControls } from '@examples/runtime';
+import { buildCollidersFromObjectLayer } from '../shared/physics-tilemap.js';
+// Combined Tiled + physics demo.
+//
+//   1. A hand-built `TileMap` is rendered with a `TileMapNode` (tilemap
+//      extension installed below).
+//   2. An `ObjectLayer` carries the level's solid regions — exactly the data a
+//      Tiled "collision" object layer would hold.
+//   3. `buildCollidersFromObjectLayer` (the shared bridge recipe) walks that
+//      layer and adds one static `PhysicsBody` per region to the world.
+//   4. A dynamic actor is dropped in with `world.attach` and falls onto the
+//      generated colliders, bouncing between the walls.
+//
+// The green outlines are the physics debug overlay — every outline was built
+// from an object-layer rectangle by the bridge, so they line up with the tiles.
+const TILE = 64;
+const COLUMNS = 20;
+const ROWS = 11;
+const app = new Application({
+    canvas: {
+        width: COLUMNS * TILE,
+        height: ROWS * TILE,
+        mount: document.body,
+        sizingMode: 'fit',
+    },
+    clearColor: new Color(38, 46, 66),
+    // The tilemap extension wires the per-backend tile chunk renderers so
+    // TileMapNode can draw. Physics is a plain library — no extension needed.
+    extensions: [tilemapExtension],
+});
+class TiledMapPhysicsActorScene extends Scene {
+    world;
+    mapNode;
+    actor;
+    actorBody;
+    debug;
+    hud;
+    async load(loader) {
+        await loader.load(Texture, {
+            tiles: assets.demo.tilesets.map.image,
+            characters: assets.demo.spritesheets.platformerCharacters.image,
+        });
+        await loader.load(Json, { characters: assets.demo.spritesheets.platformerCharacters.data });
+    }
+    init(loader) {
+        this.world = new PhysicsWorld({ gravity: { x: 0, y: 1500 } });
+        // ── Tileset + a single ground tile layer ──────────────────────────
+        // The map-pack tilesheet is a uniform 64×64 grid (17 columns), so it
+        // works as a classic grid tileset. We only need one solid-looking tile.
+        const tilesTexture = loader.get(Texture, 'tiles');
+        const tileset = new TileSet({
+            name: 'map',
+            texture: new TextureRegion(tilesTexture, { x: 0, y: 0, width: tilesTexture.width, height: tilesTexture.height }),
+            tileWidth: TILE,
+            tileHeight: TILE,
+            tileCount: 204,
+            columns: 17,
+        });
+        const groundTile = 0; // top-left grid tile — a solid block.
+        const layer = new TileLayer({ id: 1, name: 'ground', width: COLUMNS, height: ROWS, tileWidth: TILE, tileHeight: TILE, tilesets: [tileset] });
+        // Paint a floor row + two side walls + two floating platforms.
+        for (let tx = 0; tx < COLUMNS; tx++) {
+            layer.setTileAt(tx, ROWS - 1, { tileset, localTileId: groundTile, transform: TILE_TRANSFORM_IDENTITY });
+        }
+        for (let ty = 0; ty < ROWS; ty++) {
+            layer.setTileAt(0, ty, { tileset, localTileId: groundTile, transform: TILE_TRANSFORM_IDENTITY });
+            layer.setTileAt(COLUMNS - 1, ty, { tileset, localTileId: groundTile, transform: TILE_TRANSFORM_IDENTITY });
+        }
+        for (let tx = 4; tx <= 7; tx++) {
+            layer.setTileAt(tx, 6, { tileset, localTileId: groundTile, transform: TILE_TRANSFORM_IDENTITY });
+        }
+        for (let tx = 12; tx <= 15; tx++) {
+            layer.setTileAt(tx, 4, { tileset, localTileId: groundTile, transform: TILE_TRANSFORM_IDENTITY });
+        }
+        // ── Object layer: the solid regions, exactly mirroring the tiles ──
+        // In a Tiled project these rectangles would be drawn in a "collision"
+        // object layer; here we author them by hand to match the painted tiles.
+        const map = new TileMap({
+            name: 'level',
+            width: COLUMNS,
+            height: ROWS,
+            tileWidth: TILE,
+            tileHeight: TILE,
+            tilesets: [tileset],
+            layers: [layer],
+            objectLayers: [
+                new ObjectLayer({
+                    id: 10,
+                    name: 'collision',
+                    objects: [
+                        rect(1, 0, (ROWS - 1) * TILE, COLUMNS * TILE, TILE, 'floor'),
+                        rect(2, 0, 0, TILE, ROWS * TILE, 'wall-left'),
+                        rect(3, (COLUMNS - 1) * TILE, 0, TILE, ROWS * TILE, 'wall-right'),
+                        rect(4, 4 * TILE, 6 * TILE, 4 * TILE, TILE, 'platform-a'),
+                        rect(5, 12 * TILE, 4 * TILE, 4 * TILE, TILE, 'platform-b'),
+                    ],
+                }),
+            ],
+        });
+        this.mapNode = new TileMapNode(map);
+        // ── The bridge: ObjectLayer → static physics colliders ────────────
+        const collision = map.getObjectLayer('collision');
+        if (collision) {
+            const built = buildCollidersFromObjectLayer(this.world, collision, { friction: 0.7, restitution: 0.05 });
+            this.hud = mountControls({
+                title: 'Tiled Map + Physics Actor',
+                controls: [{ keys: 'Auto', action: 'actor falls and bounces across the level' }],
+                status: `${built.length} static colliders built from the object layer`,
+                hint: 'buildCollidersFromObjectLayer() turns a Tiled object layer into static bodies; the actor falls onto them via world.attach.',
+            });
+        }
+        // ── Dynamic actor ─────────────────────────────────────────────────
+        const characters = new Spritesheet(loader.get(Texture, 'characters'), loader.get(Json, 'characters'));
+        this.actor = characters.getFrameSprite('character_green_front').setAnchor(0.5);
+        this.actorBody = this.world.attach(this.actor, {
+            type: 'dynamic',
+            position: { x: 5 * TILE, y: 2 * TILE },
+            shape: new BoxShape(48, 64),
+            friction: 0.3,
+            restitution: 0.25,
+        });
+        this.actorBody.applyImpulse(2600, 0);
+        // Physics debug overlay: outlines every collider so the bridge output
+        // is visible on top of the rendered tiles.
+        this.debug = new PhysicsDebugDraw(this.app, this.world, { drawShapes: true, drawCenters: true });
+    }
+    update(delta) {
+        this.world.step(delta.seconds);
+        const { width, height } = this.app.canvas;
+        const body = this.actorBody;
+        // Loop the demo: nudge the actor again once it settles, and rescue it if
+        // it ever escapes the bounds.
+        const speed = Math.hypot(body.linearVelocityX, body.linearVelocityY);
+        if ((speed < 8 && body.y > height - 3 * TILE) || body.x < 0 || body.x > width || body.y > height + 200) {
+            body.setTransform(new Vector(5 * TILE, 2 * TILE), 0);
+            body.linearVelocityX = 0;
+            body.linearVelocityY = 0;
+            body.angularVelocity = 0;
+            body.applyImpulse((Math.random() * 2 + 1) * 1400 * (Math.random() < 0.5 ? -1 : 1), -600);
+        }
+    }
+    draw(context) {
+        context.backend.clear();
+        context.render(this.mapNode);
+        context.render(this.actor);
+        this.debug.render(context.backend);
+    }
+}
+/** Author a rectangle collision object (top-left origin, like Tiled). */
+function rect(id, x, y, width, height, name) {
+    return {
+        kind: ObjectKind.Rectangle,
+        id,
+        name,
+        type: 'solid',
+        x,
+        y,
+        width,
+        height,
+        rotation: 0,
+        visible: true,
+        properties: {},
+    };
+}
+app.start(new TiledMapPhysicsActorScene());

--- a/examples/physics/tiled-map-physics-actor.ts
+++ b/examples/physics/tiled-map-physics-actor.ts
@@ -1,0 +1,194 @@
+import { Application, Color, Json, Scene, Sprite, Spritesheet, type SpritesheetData, Texture, TextureRegion, Vector } from '@codexo/exojs';
+import { BoxShape, type PhysicsBody, PhysicsWorld } from '@codexo/exojs-physics';
+import { PhysicsDebugDraw } from '@codexo/exojs-physics/debug';
+import { ObjectKind, ObjectLayer, type RectangleObject, TILE_TRANSFORM_IDENTITY, TileLayer, TileMap, tilemapExtension, TileMapNode, TileSet } from '@codexo/exojs-tilemap';
+import { mountControls } from '@examples/runtime';
+
+import { buildCollidersFromObjectLayer } from '../shared/physics-tilemap.js';
+
+// Combined Tiled + physics demo.
+//
+//   1. A hand-built `TileMap` is rendered with a `TileMapNode` (tilemap
+//      extension installed below).
+//   2. An `ObjectLayer` carries the level's solid regions — exactly the data a
+//      Tiled "collision" object layer would hold.
+//   3. `buildCollidersFromObjectLayer` (the shared bridge recipe) walks that
+//      layer and adds one static `PhysicsBody` per region to the world.
+//   4. A dynamic actor is dropped in with `world.attach` and falls onto the
+//      generated colliders, bouncing between the walls.
+//
+// The green outlines are the physics debug overlay — every outline was built
+// from an object-layer rectangle by the bridge, so they line up with the tiles.
+
+const TILE = 64;
+const COLUMNS = 20;
+const ROWS = 11;
+
+const app = new Application({
+    canvas: {
+        width: COLUMNS * TILE,
+        height: ROWS * TILE,
+        mount: document.body,
+        sizingMode: 'fit',
+    },
+    clearColor: new Color(38, 46, 66),
+    // The tilemap extension wires the per-backend tile chunk renderers so
+    // TileMapNode can draw. Physics is a plain library — no extension needed.
+    extensions: [tilemapExtension],
+});
+
+class TiledMapPhysicsActorScene extends Scene {
+    private world!: PhysicsWorld;
+    private mapNode!: TileMapNode;
+    private actor!: Sprite;
+    private actorBody!: PhysicsBody;
+    private debug!: PhysicsDebugDraw;
+    private hud!: ReturnType<typeof mountControls>;
+
+    override async load(loader): Promise<void> {
+        await loader.load(Texture, {
+            tiles: assets.demo.tilesets.map.image,
+            characters: assets.demo.spritesheets.platformerCharacters.image,
+        });
+        await loader.load(Json, { characters: assets.demo.spritesheets.platformerCharacters.data });
+    }
+
+    override init(loader): void {
+        this.world = new PhysicsWorld({ gravity: { x: 0, y: 1500 } });
+
+        // ── Tileset + a single ground tile layer ──────────────────────────
+        // The map-pack tilesheet is a uniform 64×64 grid (17 columns), so it
+        // works as a classic grid tileset. We only need one solid-looking tile.
+        const tilesTexture = loader.get(Texture, 'tiles');
+        const tileset = new TileSet({
+            name: 'map',
+            texture: new TextureRegion(tilesTexture, { x: 0, y: 0, width: tilesTexture.width, height: tilesTexture.height }),
+            tileWidth: TILE,
+            tileHeight: TILE,
+            tileCount: 204,
+            columns: 17,
+        });
+
+        const groundTile = 0; // top-left grid tile — a solid block.
+        const layer = new TileLayer({ id: 1, name: 'ground', width: COLUMNS, height: ROWS, tileWidth: TILE, tileHeight: TILE, tilesets: [tileset] });
+
+        // Paint a floor row + two side walls + two floating platforms.
+        for (let tx = 0; tx < COLUMNS; tx++) {
+            layer.setTileAt(tx, ROWS - 1, { tileset, localTileId: groundTile, transform: TILE_TRANSFORM_IDENTITY });
+        }
+        for (let ty = 0; ty < ROWS; ty++) {
+            layer.setTileAt(0, ty, { tileset, localTileId: groundTile, transform: TILE_TRANSFORM_IDENTITY });
+            layer.setTileAt(COLUMNS - 1, ty, { tileset, localTileId: groundTile, transform: TILE_TRANSFORM_IDENTITY });
+        }
+        for (let tx = 4; tx <= 7; tx++) {
+            layer.setTileAt(tx, 6, { tileset, localTileId: groundTile, transform: TILE_TRANSFORM_IDENTITY });
+        }
+        for (let tx = 12; tx <= 15; tx++) {
+            layer.setTileAt(tx, 4, { tileset, localTileId: groundTile, transform: TILE_TRANSFORM_IDENTITY });
+        }
+
+        // ── Object layer: the solid regions, exactly mirroring the tiles ──
+        // In a Tiled project these rectangles would be drawn in a "collision"
+        // object layer; here we author them by hand to match the painted tiles.
+        const map = new TileMap({
+            name: 'level',
+            width: COLUMNS,
+            height: ROWS,
+            tileWidth: TILE,
+            tileHeight: TILE,
+            tilesets: [tileset],
+            layers: [layer],
+            objectLayers: [
+                new ObjectLayer({
+                    id: 10,
+                    name: 'collision',
+                    objects: [
+                        rect(1, 0, (ROWS - 1) * TILE, COLUMNS * TILE, TILE, 'floor'),
+                        rect(2, 0, 0, TILE, ROWS * TILE, 'wall-left'),
+                        rect(3, (COLUMNS - 1) * TILE, 0, TILE, ROWS * TILE, 'wall-right'),
+                        rect(4, 4 * TILE, 6 * TILE, 4 * TILE, TILE, 'platform-a'),
+                        rect(5, 12 * TILE, 4 * TILE, 4 * TILE, TILE, 'platform-b'),
+                    ],
+                }),
+            ],
+        });
+
+        this.mapNode = new TileMapNode(map);
+
+        // ── The bridge: ObjectLayer → static physics colliders ────────────
+        const collision = map.getObjectLayer('collision');
+
+        if (collision) {
+            const built = buildCollidersFromObjectLayer(this.world, collision, { friction: 0.7, restitution: 0.05 });
+
+            this.hud = mountControls({
+                title: 'Tiled Map + Physics Actor',
+                controls: [{ keys: 'Auto', action: 'actor falls and bounces across the level' }],
+                status: `${built.length} static colliders built from the object layer`,
+                hint: 'buildCollidersFromObjectLayer() turns a Tiled object layer into static bodies; the actor falls onto them via world.attach.',
+            });
+        }
+
+        // ── Dynamic actor ─────────────────────────────────────────────────
+        const characters = new Spritesheet(loader.get(Texture, 'characters'), loader.get(Json, 'characters') as SpritesheetData);
+
+        this.actor = characters.getFrameSprite('character_green_front').setAnchor(0.5);
+        this.actorBody = this.world.attach(this.actor, {
+            type: 'dynamic',
+            position: { x: 5 * TILE, y: 2 * TILE },
+            shape: new BoxShape(48, 64),
+            friction: 0.3,
+            restitution: 0.25,
+        });
+        this.actorBody.applyImpulse(2600, 0);
+
+        // Physics debug overlay: outlines every collider so the bridge output
+        // is visible on top of the rendered tiles.
+        this.debug = new PhysicsDebugDraw(this.app, this.world, { drawShapes: true, drawCenters: true });
+    }
+
+    override update(delta): void {
+        this.world.step(delta.seconds);
+
+        const { width, height } = this.app.canvas;
+        const body = this.actorBody;
+
+        // Loop the demo: nudge the actor again once it settles, and rescue it if
+        // it ever escapes the bounds.
+        const speed = Math.hypot(body.linearVelocityX, body.linearVelocityY);
+
+        if ((speed < 8 && body.y > height - 3 * TILE) || body.x < 0 || body.x > width || body.y > height + 200) {
+            body.setTransform(new Vector(5 * TILE, 2 * TILE), 0);
+            body.linearVelocityX = 0;
+            body.linearVelocityY = 0;
+            body.angularVelocity = 0;
+            body.applyImpulse((Math.random() * 2 + 1) * 1400 * (Math.random() < 0.5 ? -1 : 1), -600);
+        }
+    }
+
+    override draw(context): void {
+        context.backend.clear();
+        context.render(this.mapNode);
+        context.render(this.actor);
+        this.debug.render(context.backend);
+    }
+}
+
+/** Author a rectangle collision object (top-left origin, like Tiled). */
+function rect(id: number, x: number, y: number, width: number, height: number, name: string): RectangleObject {
+    return {
+        kind: ObjectKind.Rectangle,
+        id,
+        name,
+        type: 'solid',
+        x,
+        y,
+        width,
+        height,
+        rotation: 0,
+        visible: true,
+        properties: {},
+    };
+}
+
+app.start(new TiledMapPhysicsActorScene());

--- a/examples/shared/physics-tilemap.js
+++ b/examples/shared/physics-tilemap.js
@@ -1,0 +1,141 @@
+// Auto-generated from physics-tilemap.ts — edit the .ts source, not this file.
+// Shared example recipe: build static physics colliders from a Tiled object
+// layer.
+//
+// This module is the integration seam between two intentionally decoupled
+// packages: `@codexo/exojs-tilemap` (data-only object layers) and
+// `@codexo/exojs-physics` (the simulation world). Neither package depends on
+// the other — tilemap never imports physics, physics never imports tilemap
+// (see the B4/D4 ADR on shared geometry vs. separate collision detection). The
+// glue therefore lives here, in example/app land, where depending on both is
+// legitimate. Copy it into your own project and adapt as needed; it is a
+// recipe, not engine API.
+//
+// It walks an `ObjectLayer`, maps each geometry kind to the closest convex
+// physics shape, and adds one static `PhysicsBody` per object to the world:
+//
+//   - Rectangle → `BoxShape`            (centred on the object's centre)
+//   - Polygon   → `PolygonShape`        (convex; concave inputs are skipped)
+//   - Ellipse   → `CircleShape`         (radius = the larger semi-axis)
+//   - Point / Polyline / Tile           (no closed area → skipped)
+//
+// Object coordinates are in object-layer pixel space with +Y down, matching the
+// engine's screen space, so positions map straight through. Rotation (Tiled
+// degrees, clockwise) is converted to radians on the body.
+import { BoxShape, CircleShape, PhysicsBody, PolygonShape, } from '@codexo/exojs-physics';
+import { ObjectKind } from '@codexo/exojs-tilemap';
+const DEGREES_TO_RADIANS = Math.PI / 180;
+/**
+ * Build a static {@link PhysicsBody} (one box / polygon / circle collider) for
+ * every closed-area object in `layer`, add them to `world`, and return the
+ * `{ object, body }` pairs. Point, polyline and tile objects carry no closed
+ * area and are skipped; non-convex polygons are skipped (the polygon shape
+ * rejects them) with a console warning.
+ *
+ * The bodies are `static`, so they never move and form the level's solid world.
+ */
+export function buildCollidersFromObjectLayer(world, layer, options = {}) {
+    const accept = options.accept ?? (() => true);
+    const built = [];
+    for (const object of layer.objects) {
+        if (!accept(object)) {
+            continue;
+        }
+        const placement = shapeForObject(object);
+        if (placement === null) {
+            continue;
+        }
+        const body = new PhysicsBody({
+            type: 'static',
+            position: { x: placement.x, y: placement.y },
+            angle: object.rotation * DEGREES_TO_RADIANS,
+            colliders: [
+                {
+                    shape: placement.shape,
+                    friction: options.friction ?? 0.6,
+                    restitution: options.restitution ?? 0,
+                    filter: options.filter,
+                },
+            ],
+        });
+        world.add(body);
+        built.push({ object, body });
+    }
+    return built;
+}
+/**
+ * Map one object to a convex shape + body position, or `null` when the object
+ * has no closed area (point / polyline / tile) or is a degenerate / non-convex
+ * polygon. The body is positioned at the object's geometric centre so the
+ * shape, which is centred on the collider origin, lines up with the object.
+ */
+function shapeForObject(object) {
+    switch (object.kind) {
+        case ObjectKind.Rectangle: {
+            if (object.width <= 0 || object.height <= 0) {
+                return null;
+            }
+            // The body sits at the rectangle's centre; the box is centred on it.
+            // Rotation pivots about the object origin in Tiled, so rotate the
+            // centre offset (w/2, h/2) by the object's angle around that origin.
+            const angle = object.rotation * DEGREES_TO_RADIANS;
+            const cos = Math.cos(angle);
+            const sin = Math.sin(angle);
+            const halfWidth = object.width / 2;
+            const halfHeight = object.height / 2;
+            return {
+                shape: new BoxShape(object.width, object.height),
+                x: object.x + (cos * halfWidth - sin * halfHeight),
+                y: object.y + (sin * halfWidth + cos * halfHeight),
+            };
+        }
+        case ObjectKind.Ellipse: {
+            // No native ellipse collider — approximate with a circle whose radius
+            // is the larger semi-axis (a conservative, fully-covering bound).
+            const radius = Math.max(object.width, object.height) / 2;
+            if (radius <= 0) {
+                return null;
+            }
+            const angle = object.rotation * DEGREES_TO_RADIANS;
+            const cos = Math.cos(angle);
+            const sin = Math.sin(angle);
+            const halfWidth = object.width / 2;
+            const halfHeight = object.height / 2;
+            return {
+                shape: new CircleShape(radius),
+                x: object.x + (cos * halfWidth - sin * halfHeight),
+                y: object.y + (sin * halfWidth + cos * halfHeight),
+            };
+        }
+        case ObjectKind.Polygon: {
+            if (object.points.length < 3) {
+                return null;
+            }
+            try {
+                // Polygon points are relative to the object origin; the body
+                // carries the world origin + rotation, so the shape keeps the
+                // local points and we place the body at the object origin.
+                const shape = new PolygonShape(object.points.map(point => ({ x: point.x, y: point.y })));
+                return { shape, x: object.x, y: object.y };
+            }
+            catch (error) {
+                // PolygonShape throws on non-convex / degenerate input — there is
+                // no automatic convex decomposition. Skip and let the author know.
+                warn(`physics-tilemap: skipped non-convex/degenerate polygon "${object.name || object.id}": ${describeError(error)}`);
+                return null;
+            }
+        }
+        default:
+            // Point, polyline and tile objects have no closed collision area.
+            return null;
+    }
+}
+function describeError(error) {
+    return error instanceof Error ? error.message : String(error);
+}
+// Indirect through globalThis so the example lint rule (`no-console`) and the
+// recipe stay clean while still surfacing authoring mistakes in the console.
+function warn(message) {
+    const logger = globalThis.console;
+    logger?.warn?.(message);
+}

--- a/examples/shared/physics-tilemap.ts
+++ b/examples/shared/physics-tilemap.ts
@@ -1,0 +1,206 @@
+// Shared example recipe: build static physics colliders from a Tiled object
+// layer.
+//
+// This module is the integration seam between two intentionally decoupled
+// packages: `@codexo/exojs-tilemap` (data-only object layers) and
+// `@codexo/exojs-physics` (the simulation world). Neither package depends on
+// the other — tilemap never imports physics, physics never imports tilemap
+// (see the B4/D4 ADR on shared geometry vs. separate collision detection). The
+// glue therefore lives here, in example/app land, where depending on both is
+// legitimate. Copy it into your own project and adapt as needed; it is a
+// recipe, not engine API.
+//
+// It walks an `ObjectLayer`, maps each geometry kind to the closest convex
+// physics shape, and adds one static `PhysicsBody` per object to the world:
+//
+//   - Rectangle → `BoxShape`            (centred on the object's centre)
+//   - Polygon   → `PolygonShape`        (convex; concave inputs are skipped)
+//   - Ellipse   → `CircleShape`         (radius = the larger semi-axis)
+//   - Point / Polyline / Tile           (no closed area → skipped)
+//
+// Object coordinates are in object-layer pixel space with +Y down, matching the
+// engine's screen space, so positions map straight through. Rotation (Tiled
+// degrees, clockwise) is converted to radians on the body.
+
+import {
+    BoxShape,
+    CircleShape,
+    type CollisionFilter,
+    PhysicsBody,
+    type PhysicsWorld,
+    PolygonShape,
+    type Shape,
+} from '@codexo/exojs-physics';
+import { ObjectKind, type ObjectLayer, type TileMapObject } from '@codexo/exojs-tilemap';
+
+const DEGREES_TO_RADIANS = Math.PI / 180;
+
+/** Options for {@link buildCollidersFromObjectLayer}. */
+export interface ObjectLayerColliderOptions {
+    /** Coulomb friction for every generated collider. Default `0.6`. */
+    friction?: number;
+    /** Restitution / bounciness in `[0, 1]` for every generated collider. Default `0`. */
+    restitution?: number;
+    /** Category/mask/group collision filter shared by every generated collider. */
+    filter?: Partial<CollisionFilter>;
+    /**
+     * Skip an object (e.g. by a custom property) before a body is built for it.
+     * Return `true` to keep the object, `false` to drop it. Default keeps all
+     * closed-area objects.
+     */
+    accept?: (object: TileMapObject) => boolean;
+}
+
+/** A single static body produced from one object, paired with its source object. */
+export interface ObjectLayerCollider {
+    /** The source object the body was built from. */
+    readonly object: TileMapObject;
+    /** The static body added to the world. */
+    readonly body: PhysicsBody;
+}
+
+/**
+ * Build a static {@link PhysicsBody} (one box / polygon / circle collider) for
+ * every closed-area object in `layer`, add them to `world`, and return the
+ * `{ object, body }` pairs. Point, polyline and tile objects carry no closed
+ * area and are skipped; non-convex polygons are skipped (the polygon shape
+ * rejects them) with a console warning.
+ *
+ * The bodies are `static`, so they never move and form the level's solid world.
+ */
+export function buildCollidersFromObjectLayer(
+    world: PhysicsWorld,
+    layer: ObjectLayer,
+    options: ObjectLayerColliderOptions = {},
+): Array<ObjectLayerCollider> {
+    const accept = options.accept ?? (() => true);
+    const built: Array<ObjectLayerCollider> = [];
+
+    for (const object of layer.objects) {
+        if (!accept(object)) {
+            continue;
+        }
+
+        const placement = shapeForObject(object);
+
+        if (placement === null) {
+            continue;
+        }
+
+        const body = new PhysicsBody({
+            type: 'static',
+            position: { x: placement.x, y: placement.y },
+            angle: object.rotation * DEGREES_TO_RADIANS,
+            colliders: [
+                {
+                    shape: placement.shape,
+                    friction: options.friction ?? 0.6,
+                    restitution: options.restitution ?? 0,
+                    filter: options.filter,
+                },
+            ],
+        });
+
+        world.add(body);
+        built.push({ object, body });
+    }
+
+    return built;
+}
+
+/** A shape plus the world position its origin should be placed at. */
+interface ShapePlacement {
+    readonly shape: Shape;
+    readonly x: number;
+    readonly y: number;
+}
+
+/**
+ * Map one object to a convex shape + body position, or `null` when the object
+ * has no closed area (point / polyline / tile) or is a degenerate / non-convex
+ * polygon. The body is positioned at the object's geometric centre so the
+ * shape, which is centred on the collider origin, lines up with the object.
+ */
+function shapeForObject(object: TileMapObject): ShapePlacement | null {
+    switch (object.kind) {
+        case ObjectKind.Rectangle: {
+            if (object.width <= 0 || object.height <= 0) {
+                return null;
+            }
+
+            // The body sits at the rectangle's centre; the box is centred on it.
+            // Rotation pivots about the object origin in Tiled, so rotate the
+            // centre offset (w/2, h/2) by the object's angle around that origin.
+            const angle = object.rotation * DEGREES_TO_RADIANS;
+            const cos = Math.cos(angle);
+            const sin = Math.sin(angle);
+            const halfWidth = object.width / 2;
+            const halfHeight = object.height / 2;
+
+            return {
+                shape: new BoxShape(object.width, object.height),
+                x: object.x + (cos * halfWidth - sin * halfHeight),
+                y: object.y + (sin * halfWidth + cos * halfHeight),
+            };
+        }
+
+        case ObjectKind.Ellipse: {
+            // No native ellipse collider — approximate with a circle whose radius
+            // is the larger semi-axis (a conservative, fully-covering bound).
+            const radius = Math.max(object.width, object.height) / 2;
+
+            if (radius <= 0) {
+                return null;
+            }
+
+            const angle = object.rotation * DEGREES_TO_RADIANS;
+            const cos = Math.cos(angle);
+            const sin = Math.sin(angle);
+            const halfWidth = object.width / 2;
+            const halfHeight = object.height / 2;
+
+            return {
+                shape: new CircleShape(radius),
+                x: object.x + (cos * halfWidth - sin * halfHeight),
+                y: object.y + (sin * halfWidth + cos * halfHeight),
+            };
+        }
+
+        case ObjectKind.Polygon: {
+            if (object.points.length < 3) {
+                return null;
+            }
+
+            try {
+                // Polygon points are relative to the object origin; the body
+                // carries the world origin + rotation, so the shape keeps the
+                // local points and we place the body at the object origin.
+                const shape = new PolygonShape(object.points.map(point => ({ x: point.x, y: point.y })));
+
+                return { shape, x: object.x, y: object.y };
+            } catch (error) {
+                // PolygonShape throws on non-convex / degenerate input — there is
+                // no automatic convex decomposition. Skip and let the author know.
+                warn(`physics-tilemap: skipped non-convex/degenerate polygon "${object.name || object.id}": ${describeError(error)}`);
+
+                return null;
+            }
+        }
+
+        default:
+            // Point, polyline and tile objects have no closed collision area.
+            return null;
+    }
+}
+
+function describeError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+// Indirect through globalThis so the example lint rule (`no-console`) and the
+// recipe stay clean while still surfacing authoring mistakes in the console.
+function warn(message: string): void {
+    const logger = (globalThis as { console?: { warn?: (message: string) => void } }).console;
+
+    logger?.warn?.(message);
+}

--- a/site/public/preview.html
+++ b/site/public/preview.html
@@ -69,6 +69,10 @@
                 var audioFxEntry;
                 var tiledEntry;
                 var tiledRegisterEntry;
+                var tilemapEntry;
+                var tilemapRegisterEntry;
+                var physicsEntry;
+                var physicsDebugEntry;
                 if (!safeVersion || safeVersion === 'current') {
                     exoEntry = './vendor/exojs/esm/index.js?no-cache=' + noCache;
                     exoDebugEntry = './vendor/exojs/esm/debug/index.js?no-cache=' + noCache;
@@ -79,6 +83,10 @@
                     audioFxEntry = './vendor/exojs-audio-fx/esm/index.js?no-cache=' + noCache;
                     tiledEntry = './vendor/exojs-tiled/esm/index.js?no-cache=' + noCache;
                     tiledRegisterEntry = './vendor/exojs-tiled/esm/register.js?no-cache=' + noCache;
+                    tilemapEntry = './vendor/exojs-tilemap/esm/index.js?no-cache=' + noCache;
+                    tilemapRegisterEntry = './vendor/exojs-tilemap/esm/register.js?no-cache=' + noCache;
+                    physicsEntry = './vendor/exojs-physics/esm/index.js?no-cache=' + noCache;
+                    physicsDebugEntry = './vendor/exojs-physics/esm/debug/index.js?no-cache=' + noCache;
                 } else {
                     // jsDelivr serves immutable npm tarballs — the version pin
                     // alone is enough, no cache-buster needed.
@@ -92,6 +100,10 @@
                     audioFxEntry = cdnBase + 'exojs-audio-fx@' + safeVersion + '/dist/esm/index.js';
                     tiledEntry = cdnBase + 'exojs-tiled@' + safeVersion + '/dist/esm/index.js';
                     tiledRegisterEntry = cdnBase + 'exojs-tiled@' + safeVersion + '/dist/esm/register.js';
+                    tilemapEntry = cdnBase + 'exojs-tilemap@' + safeVersion + '/dist/esm/index.js';
+                    tilemapRegisterEntry = cdnBase + 'exojs-tilemap@' + safeVersion + '/dist/esm/register.js';
+                    physicsEntry = cdnBase + 'exojs-physics@' + safeVersion + '/dist/esm/index.js';
+                    physicsDebugEntry = cdnBase + 'exojs-physics@' + safeVersion + '/dist/esm/debug/index.js';
                 }
 
                 var importMap = {
@@ -105,6 +117,10 @@
                         '@codexo/exojs-audio-fx': audioFxEntry,
                         '@codexo/exojs-tiled': tiledEntry,
                         '@codexo/exojs-tiled/register': tiledRegisterEntry,
+                        '@codexo/exojs-tilemap': tilemapEntry,
+                        '@codexo/exojs-tilemap/register': tilemapRegisterEntry,
+                        '@codexo/exojs-physics': physicsEntry,
+                        '@codexo/exojs-physics/debug': physicsDebugEntry,
                         '@examples/runtime': './examples/shared/runtime.js?no-cache=' + noCache,
                     },
                 };

--- a/site/scripts/sync-exo-vendor.ts
+++ b/site/scripts/sync-exo-vendor.ts
@@ -340,7 +340,7 @@ const syncVendor = (): void => {
     console.log(`[vendor:sync] Copied ExoJS ESM runtime + declarations from ${sourceDistDir} -> ${flatTargetDir}`);
 
     // Sync extension packages (ESM trees only — no declaration patching needed).
-    const extensionPackages = ['exojs-particles', 'exojs-audio-fx', 'exojs-tilemap', 'exojs-tiled'] as const;
+    const extensionPackages = ['exojs-particles', 'exojs-audio-fx', 'exojs-tilemap', 'exojs-tiled', 'exojs-physics'] as const;
     for (const pkgName of extensionPackages) {
         let pkgRoot: string | null = null;
         try {

--- a/site/src/lib/chapters.ts
+++ b/site/src/lib/chapters.ts
@@ -20,12 +20,13 @@ export const CHAPTERS: ReadonlyArray<ChapterMeta> = [
     { order: 12, slug: 'geometry-graphics', title: 'Geometry & Graphics', complexity: 'High' },
     { order: 13, slug: 'render-targets', title: 'Render Targets', complexity: 'High' },
     { order: 14, slug: 'performance', title: 'Performance', complexity: 'Medium' },
-    { order: 15, slug: 'audio-fx', title: 'Audio FX', complexity: 'Medium' },
-    { order: 16, slug: 'beat-detection', title: 'Beat Detection', complexity: 'High' },
-    { order: 17, slug: 'debug-layer', title: 'Debug Layer', complexity: 'Low' },
-    { order: 18, slug: 'custom-renderers', title: 'Custom Renderers', complexity: 'Very high' },
-    { order: 19, slug: 'showcase', title: 'Showcase', complexity: 'Mixed' },
-    { order: 20, slug: 'ui', title: 'UI', complexity: 'Medium' },
+    { order: 15, slug: 'physics', title: 'Physics', complexity: 'Medium' },
+    { order: 17, slug: 'audio-fx', title: 'Audio FX', complexity: 'Medium' },
+    { order: 18, slug: 'beat-detection', title: 'Beat Detection', complexity: 'High' },
+    { order: 19, slug: 'debug-layer', title: 'Debug Layer', complexity: 'Low' },
+    { order: 20, slug: 'custom-renderers', title: 'Custom Renderers', complexity: 'Very high' },
+    { order: 21, slug: 'showcase', title: 'Showcase', complexity: 'Mixed' },
+    { order: 22, slug: 'ui', title: 'UI', complexity: 'Medium' },
 ];
 
 export const CHAPTER_BY_SLUG = new Map(CHAPTERS.map(chapter => [chapter.slug, chapter]));

--- a/test/site/physics-tilemap-bridge.test.ts
+++ b/test/site/physics-tilemap-bridge.test.ts
@@ -1,0 +1,191 @@
+import { BoxShape, CircleShape, PhysicsBody, PhysicsWorld, PolygonShape } from '@codexo/exojs-physics';
+import { ObjectKind, ObjectLayer, type TileMapObject } from '@codexo/exojs-tilemap';
+import { describe, expect, it, vi } from 'vitest';
+
+import { buildCollidersFromObjectLayer } from '../../examples/shared/physics-tilemap';
+
+// The example physics↔tilemap bridge recipe (examples/shared/physics-tilemap.ts)
+// is the only place that depends on BOTH @codexo/exojs-tilemap and
+// @codexo/exojs-physics; neither package depends on the other, so the glue lives
+// in example/app land. These tests exercise the recipe end-to-end against the
+// real (aliased-to-source) packages.
+
+const base = {
+  name: '',
+  type: 'solid',
+  rotation: 0,
+  visible: true,
+  properties: {},
+} as const;
+
+const rectangle = (id: number, x: number, y: number, width: number, height: number, extra: Partial<TileMapObject> = {}): TileMapObject => ({
+  ...base,
+  kind: ObjectKind.Rectangle,
+  id,
+  x,
+  y,
+  width,
+  height,
+  ...extra,
+});
+
+const layerWith = (objects: TileMapObject[]): ObjectLayer => new ObjectLayer({ id: 1, name: 'collision', objects });
+
+describe('buildCollidersFromObjectLayer', () => {
+  it('builds one static body + collider per rectangle, centred on the object', () => {
+    const world = new PhysicsWorld();
+    const layer = layerWith([rectangle(1, 100, 200, 64, 32)]);
+
+    const built = buildCollidersFromObjectLayer(world, layer);
+
+    expect(built).toHaveLength(1);
+
+    const { body } = built[0];
+
+    expect(body.type).toBe('static');
+    expect(body.colliders).toHaveLength(1);
+    expect(body.colliders[0].shape).toBeInstanceOf(BoxShape);
+    // Body sits at the rectangle centre (top-left origin + half extents).
+    expect(body.x).toBeCloseTo(132);
+    expect(body.y).toBeCloseTo(216);
+    // The body joined the world (id allocated, registered after the step defer).
+    expect(world.bodies).toContain(body);
+  });
+
+  it('maps an ellipse to a circle whose radius is the larger semi-axis', () => {
+    const world = new PhysicsWorld();
+    const layer = layerWith([rectangle(1, 0, 0, 80, 40, { kind: ObjectKind.Ellipse })]);
+
+    const [{ body }] = buildCollidersFromObjectLayer(world, layer);
+    const shape = body.colliders[0].shape;
+
+    expect(shape).toBeInstanceOf(CircleShape);
+    expect((shape as CircleShape).radius).toBeCloseTo(40);
+  });
+
+  it('maps a convex polygon to a PolygonShape, placed at the object origin', () => {
+    const world = new PhysicsWorld();
+    const polygon: TileMapObject = {
+      ...base,
+      kind: ObjectKind.Polygon,
+      id: 1,
+      x: 50,
+      y: 60,
+      width: 0,
+      height: 0,
+      points: [
+        { x: 0, y: 0 },
+        { x: 64, y: 0 },
+        { x: 32, y: 48 },
+      ],
+    };
+
+    const [{ body }] = buildCollidersFromObjectLayer(world, layerWith([polygon]));
+
+    expect(body.colliders[0].shape).toBeInstanceOf(PolygonShape);
+    expect(body.x).toBeCloseTo(50);
+    expect(body.y).toBeCloseTo(60);
+  });
+
+  it('skips point, polyline and tile objects (no closed area)', () => {
+    const world = new PhysicsWorld();
+    const objects: TileMapObject[] = [
+      { ...base, kind: ObjectKind.Point, id: 1, x: 10, y: 10, width: 0, height: 0 },
+      {
+        ...base,
+        kind: ObjectKind.Polyline,
+        id: 2,
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        points: [
+          { x: 0, y: 0 },
+          { x: 10, y: 0 },
+        ],
+      },
+    ];
+
+    const built = buildCollidersFromObjectLayer(world, layerWith(objects));
+
+    expect(built).toHaveLength(0);
+    expect(world.colliders).toHaveLength(0);
+  });
+
+  it('skips and warns on a non-convex polygon (no automatic decomposition)', () => {
+    const world = new PhysicsWorld();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // An arrow/dart shape — concave, so PolygonShape rejects it.
+    const concave: TileMapObject = {
+      ...base,
+      kind: ObjectKind.Polygon,
+      id: 1,
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      points: [
+        { x: 0, y: 0 },
+        { x: 40, y: 20 },
+        { x: 0, y: 40 },
+        { x: 10, y: 20 },
+      ],
+    };
+
+    const built = buildCollidersFromObjectLayer(world, layerWith([concave]));
+
+    expect(built).toHaveLength(0);
+    expect(warn).toHaveBeenCalledOnce();
+
+    warn.mockRestore();
+  });
+
+  it('forwards friction, restitution and filter onto every generated collider', () => {
+    const world = new PhysicsWorld();
+    const layer = layerWith([rectangle(1, 0, 0, 32, 32), rectangle(2, 64, 0, 32, 32)]);
+
+    const built = buildCollidersFromObjectLayer(world, layer, { friction: 0.9, restitution: 0.3, filter: { category: 0b10 } });
+
+    expect(built).toHaveLength(2);
+
+    for (const { body } of built) {
+      expect(body.colliders[0].friction).toBeCloseTo(0.9);
+      expect(body.colliders[0].restitution).toBeCloseTo(0.3);
+      expect(body.colliders[0].filter.category).toBe(0b10);
+    }
+  });
+
+  it('honours a custom accept predicate', () => {
+    const world = new PhysicsWorld();
+    const layer = layerWith([rectangle(1, 0, 0, 32, 32, { type: 'solid' }), rectangle(2, 64, 0, 32, 32, { type: 'decoration' })]);
+
+    const built = buildCollidersFromObjectLayer(world, layer, { accept: object => object.type === 'solid' });
+
+    expect(built).toHaveLength(1);
+    expect(built[0].object.id).toBe(1);
+  });
+
+  it('produces a solid floor a dynamic body lands on (integration)', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+    // A wide floor (top at y = 400, 40px tall → centre at y = 420).
+    buildCollidersFromObjectLayer(world, layerWith([rectangle(1, 0, 400, 800, 40)]), { friction: 0.6 });
+
+    // A dynamic 40px box dropped from above must come to rest on the floor.
+    const box = world.add(
+      new PhysicsBody({
+        type: 'dynamic',
+        position: { x: 400, y: 200 },
+        colliders: [{ shape: new BoxShape(40, 40), density: 1 }],
+      }),
+    );
+
+    for (let frame = 0; frame < 180; frame++) {
+      world.step(1 / 60);
+    }
+
+    // The box bottom should rest on the floor top (y ≈ 400): centre ≈ 380.
+    expect(box.y).toBeGreaterThan(360);
+    expect(box.y).toBeLessThan(400);
+    expect(Math.hypot(box.linearVelocityX, box.linearVelocityY)).toBeLessThan(5);
+  });
+});

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -55,6 +55,8 @@
       "@codexo/exojs-tiled/register": ["./packages/exojs-tiled/src/register.ts"],
       "@codexo/exojs-tilemap": ["./packages/exojs-tilemap/src/index.ts"],
       "@codexo/exojs-tilemap/register": ["./packages/exojs-tilemap/src/register.ts"],
+      "@codexo/exojs-physics": ["./packages/exojs-physics/src/index.ts"],
+      "@codexo/exojs-physics/debug": ["./packages/exojs-physics/src/debug/index.ts"],
       "@codexo/exojs-audio-fx": ["./packages/exojs-audio-fx/src/index.ts"],
       "@examples/runtime": ["./examples/shared/runtime.d.ts"]
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,8 +17,11 @@ const aliasConfig = [
   { find: '@codexo/exojs', replacement: fileURLToPath(new URL('./src/index.ts', import.meta.url)) },
   // @codexo/exojs-tiled depends on @codexo/exojs-tilemap; neither package
   // exports a `@codexo/source` condition, so alias to source for in-repo tests.
+  // @codexo/exojs-physics is aliased too so the example physics↔tilemap bridge
+  // recipe (examples/shared/physics-tilemap.ts) can be unit-tested in-repo.
   { find: '@codexo/exojs-tilemap', replacement: fileURLToPath(new URL('./packages/exojs-tilemap/src/index.ts', import.meta.url)) },
   { find: '@codexo/exojs-tiled', replacement: fileURLToPath(new URL('./packages/exojs-tiled/src/index.ts', import.meta.url)) },
+  { find: '@codexo/exojs-physics', replacement: fileURLToPath(new URL('./packages/exojs-physics/src/index.ts', import.meta.url)) },
 ] as const;
 
 // Shared resolution/plugin wiring for the repository-local browser projects.


### PR DESCRIPTION
## What

Adds the v0.14 Phase 4 **B3** deliverable: two runnable combined Tiled + physics examples plus a reusable **ObjectLayer → collider bridge** recipe, exercising the freshly-merged B1 (free body construction + `world.add`/`world.attach`, #156) and B2 (typed `ObjectLayer` schema, #157) APIs.

### New examples (`examples/physics/`)
- **`sprite-follows-body`** — the minimal binding: `world.attach(sprite, { … })` builds a body + collider and binds it; the sprite tracks the body each `world.step`, falling onto a static floor (Kenney platformer character).
- **`tiled-map-physics-actor`** — a hand-built `TileMap` rendered via `TileMapNode` (tilemap extension), an `ObjectLayer` of solid regions, the bridge turning that layer into static `PhysicsBody`s, and a dynamic actor that falls/bounces. The physics `/debug` overlay outlines every generated collider.

### The bridge — `examples/shared/physics-tilemap.ts`
`buildCollidersFromObjectLayer(world, layer, options)` walks an `ObjectLayer` and adds one static body per closed-area object: Rectangle→`BoxShape`, Polygon→`PolygonShape` (convex; concave skipped with a warning), Ellipse→`CircleShape` (larger semi-axis). Point/polyline/tile are skipped. Forwards friction/restitution/filter and supports a custom `accept` predicate.

**Placement rationale:** the bridge lives in **example/app land**, not in either package. `@codexo/exojs-tilemap` must never depend on `@codexo/exojs-physics` and vice-versa (the B4/D4 ADR, #158, keeps geometry shared but collision detection separate). The recipe is the only place that legitimately depends on *both*, so app-land is the correct, coupling-free home — and it stays a copy-paste recipe rather than engine API.

### Tests
`test/site/physics-tilemap-bridge.test.ts` (8 cases) drives the recipe end-to-end against the real (aliased-to-source) packages: rectangle/ellipse/polygon mapping + centring, skip rules, non-convex warn-and-skip, option forwarding, the `accept` predicate, and an integration test where a dynamic box comes to rest on a bridge-built floor.

### Wiring
- `tsconfig.examples.json`: `@codexo/exojs-physics` + `/debug` path mappings.
- `vitest.config.ts`: `@codexo/exojs-physics` source alias (so the bridge test resolves).
- `eslint.config.ts`: example `.js` import-sort collapsed to a single group — the `examples:sync` transpile strips blank lines between import groups, so an example mixing a package import with a relative recipe import could otherwise never lint clean.
- `examples/examples.json` + `site/src/lib/chapters.ts`: new **Physics** category (catalog↔chapters parity is asserted in `examples-catalog.test.ts`).
- `site/public/preview.html` + `site/scripts/sync-exo-vendor.ts`: physics (+ `/debug`) and tilemap (+ `/register`) added to the playground import map and vendor sync so the examples actually run in the playground.

## Verification (all green locally; CI builds no dist)
- `pnpm typecheck:examples` ✓
- `pnpm lint` (examples) + `pnpm lint:packages` ✓
- `pnpm format:check` ✓
- `pnpm --filter @codexo/exojs-examples examples:sync` (generated `.js` + catalog committed) ✓
- Bridge test ✓; full `exojs` project (2377) + `exojs-physics`/`exojs-tilemap` (352) ✓

Not merged.