### PR TITLE
perf: v0.15 Welle 0 — Quick-Wins (Hot-Path-Allokationen + Typlöcher)

### DIFF
--- a/packages/exojs-particles/src/renderers/WebGpuParticleRenderer.ts
+++ b/packages/exojs-particles/src/renderers/WebGpuParticleRenderer.ts
@@ -393,55 +393,61 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
     const uvMaxX = (texCoords[2] & 0xffff) / 0xffff;
     const uvMaxY = ((texCoords[2] >>> 16) & 0xffff) / 0xffff;
 
-    this._uniformData.set([
-      projection[0],
-      projection[1],
-      0,
-      0,
-      projection[3],
-      projection[4],
-      0,
-      0,
-      0,
-      0,
-      1,
-      0,
-      projection[6],
-      projection[7],
-      0,
-      projection[8],
+    const u = this._uniformData;
 
-      transform[0],
-      transform[1],
-      0,
-      0,
-      transform[3],
-      transform[4],
-      0,
-      0,
-      0,
-      0,
-      1,
-      0,
-      transform[6],
-      transform[7],
-      0,
-      transform[8],
+    // projection mat4 (col-major, padded to 4×4)
+    u[0] = projection[0];
+    u[1] = projection[1];
+    u[2] = 0;
+    u[3] = 0;
+    u[4] = projection[3];
+    u[5] = projection[4];
+    u[6] = 0;
+    u[7] = 0;
+    u[8] = 0;
+    u[9] = 0;
+    u[10] = 1;
+    u[11] = 0;
+    u[12] = projection[6];
+    u[13] = projection[7];
+    u[14] = 0;
+    u[15] = projection[8];
 
-      shouldPremultiplySample ? 1 : 0,
-      0,
-      0,
-      0,
+    // transform mat4 (col-major, padded to 4×4)
+    u[16] = transform[0];
+    u[17] = transform[1];
+    u[18] = 0;
+    u[19] = 0;
+    u[20] = transform[3];
+    u[21] = transform[4];
+    u[22] = 0;
+    u[23] = 0;
+    u[24] = 0;
+    u[25] = 0;
+    u[26] = 1;
+    u[27] = 0;
+    u[28] = transform[6];
+    u[29] = transform[7];
+    u[30] = 0;
+    u[31] = transform[8];
 
-      quadMinX,
-      quadMinY,
-      quadSizeX,
-      quadSizeY,
-      uvMinX,
-      uvMinY,
-      uvMaxX,
-      uvMaxY,
-    ]);
+    // flags vec4
+    u[32] = shouldPremultiplySample ? 1 : 0;
+    u[33] = 0;
+    u[34] = 0;
+    u[35] = 0;
+
+    // localBounds vec4
+    u[36] = quadMinX;
+    u[37] = quadMinY;
+    u[38] = quadSizeX;
+    u[39] = quadSizeY;
+
+    // uvBounds vec4
+    u[40] = uvMinX;
+    u[41] = uvMinY;
+    u[42] = uvMaxX;
+    u[43] = uvMaxY;
   }
 
   private _writeInstanceData(system: ParticleSystem): number {

--- a/site/src/content/api/polygon.mdx
+++ b/site/src/content/api/polygon.mdx
@@ -5,7 +5,7 @@ symbol: "Polygon"
 kind: "class"
 subsystem: "math"
 importPath: "@codexo/exojs"
-memberCount: 21
+memberCount: 20
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/math/Polygon.ts"
@@ -52,7 +52,6 @@ cached lazily and invalidated on any positional or point mutation.
 - `position: Vector`
 - `x: number`
 - `y: number`
-- `temp: Polygon`
 
 ## Source
 

--- a/site/src/content/api/time.mdx
+++ b/site/src/content/api/time.mdx
@@ -5,7 +5,7 @@ symbol: "Time"
 kind: "class"
 subsystem: "core"
 importPath: "@codexo/exojs"
-memberCount: 35
+memberCount: 34
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/core/Time.ts"
@@ -68,7 +68,6 @@ reference across calls.
 - `milliseconds: number`
 - `minutes: number`
 - `seconds: number`
-- `temp: Time`
 
 ## Source
 

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -555,15 +555,21 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
 
   /** Mark own Bounds dirty AND propagate up to Container ancestors' Bounds. */
   public _invalidateBoundsCascade(): void {
+    // Mark own bounds + notify interaction for THIS node unconditionally —
+    // the manager filters to tracked interactive nodes so this call is O(1)
+    // for the common case (non-interactive node — fast Set.has miss).
     this.flags.push(SceneNodeTransformFlags.BoundsRect);
-
-    // Notify the InteractionManager so it can mark the quadtree entry stale.
-    // The manager filters to only tracked interactive nodes so this call is
-    // O(1) for the common case (non-interactive node — fast Set.has miss).
     this._stage?.interaction._notifyBoundsInvalidated(this as unknown as RenderNode);
 
-    if (this._parentNode) {
-      this._parentNode._invalidateBoundsCascade();
+    // Walk up, but stop at the first ancestor already flagged dirty: if a parent
+    // is already BoundsRect-dirty, its whole ancestor chain was already cascaded,
+    // so re-walking it is redundant work.
+    let ancestor = this._parentNode;
+
+    while (ancestor !== null && !ancestor.flags.has(SceneNodeTransformFlags.BoundsRect)) {
+      ancestor.flags.push(SceneNodeTransformFlags.BoundsRect);
+      ancestor._stage?.interaction._notifyBoundsInvalidated(ancestor);
+      ancestor = ancestor.parent;
     }
   }
 

--- a/src/core/Time.ts
+++ b/src/core/Time.ts
@@ -183,6 +183,11 @@ export class Time implements Cloneable {
   public static readonly oneMinute = new Time(1, Time.minutes);
   public static readonly oneHour = new Time(1, Time.hours);
 
+  /**
+   * Shared scratch {@link Time} instance for intermediate calculations. Never
+   * retain the reference across frames or async boundaries.
+   * @internal
+   */
   public static get temp(): Time {
     if (temp === null) {
       temp = new Time();

--- a/src/input/InputManager.ts
+++ b/src/input/InputManager.ts
@@ -63,7 +63,7 @@ export class InputManager implements System {
   private readonly _app: Application;
   private readonly canvas: HTMLCanvasElement;
   private readonly channels: Float32Array = new Float32Array(ChannelSize.Container);
-  private readonly pointers: Record<number, Pointer> = {};
+  private readonly pointers = new Map<number, Pointer>();
   private readonly _gamepads: readonly [Gamepad, Gamepad, Gamepad, Gamepad];
   private readonly gamepadsByBrowserIndex = new Map<number, Gamepad>();
   private readonly bindings: Set<InputBinding> = new Set<InputBinding>();
@@ -194,13 +194,13 @@ export class InputManager implements System {
    * no active pointer is present. Used by debug layers to show cursor info.
    */
   public getPrimaryPointerPosition(): { x: number; y: number } | null {
-    for (const pointer of Object.values(this.pointers)) {
+    for (const pointer of this.pointers.values()) {
       if (pointer.isPrimary && pointer.currentState !== PointerState.Cancelled) {
         return { x: pointer.x, y: pointer.y };
       }
     }
 
-    for (const pointer of Object.values(this.pointers)) {
+    for (const pointer of this.pointers.values()) {
       if (pointer.currentState !== PointerState.Cancelled) {
         return { x: pointer.x, y: pointer.y };
       }
@@ -210,7 +210,13 @@ export class InputManager implements System {
   }
 
   public get pointersInCanvas(): boolean {
-    return Object.values(this.pointers).some(pointer => pointer.currentState !== PointerState.OutsideCanvas && pointer.currentState !== PointerState.Cancelled);
+    for (const pointer of this.pointers.values()) {
+      if (pointer.currentState !== PointerState.OutsideCanvas && pointer.currentState !== PointerState.Cancelled) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   public get canvasFocused(): boolean {
@@ -345,9 +351,11 @@ export class InputManager implements System {
     this.removeEventListeners();
     this.gestureRecognizer.destroy();
 
-    for (const pointer of Object.values(this.pointers)) {
+    for (const pointer of this.pointers.values()) {
       pointer.destroy();
     }
+
+    this.pointers.clear();
 
     for (const pad of this._gamepads) {
       pad.destroy();
@@ -490,12 +498,12 @@ export class InputManager implements System {
       return;
     }
 
-    this.pointers[event.pointerId] = new Pointer(event, this._app, this.canvas, this.channels, slot);
+    this.pointers.set(event.pointerId, new Pointer(event, this._app, this.canvas, this.channels, slot));
     this.flags.push(InputManagerFlag.PointerUpdate);
   }
 
   private handlePointerLeave(event: PointerEvent): void {
-    const pointer = this.pointers[event.pointerId];
+    const pointer = this.pointers.get(event.pointerId);
 
     if (!pointer) {
       return;
@@ -511,7 +519,7 @@ export class InputManager implements System {
     this.canvas.focus();
     this.canvasFocusedValue = true;
 
-    const pointer = this.pointers[event.pointerId];
+    const pointer = this.pointers.get(event.pointerId);
 
     if (!pointer) {
       return;
@@ -525,7 +533,7 @@ export class InputManager implements System {
   }
 
   private handlePointerMove(event: PointerEvent): void {
-    const pointer = this.pointers[event.pointerId];
+    const pointer = this.pointers.get(event.pointerId);
 
     if (!pointer) {
       return;
@@ -537,7 +545,7 @@ export class InputManager implements System {
   }
 
   private handlePointerUp(event: PointerEvent): void {
-    const pointer = this.pointers[event.pointerId];
+    const pointer = this.pointers.get(event.pointerId);
 
     if (!pointer) {
       return;
@@ -551,7 +559,7 @@ export class InputManager implements System {
   }
 
   private handlePointerCancel(event: PointerEvent): void {
-    const pointer = this.pointers[event.pointerId];
+    const pointer = this.pointers.get(event.pointerId);
 
     if (!pointer) {
       return;
@@ -803,7 +811,7 @@ export class InputManager implements System {
   }
 
   private updatePointerEvents(): void {
-    for (const pointer of Object.values(this.pointers)) {
+    for (const pointer of this.pointers.values()) {
       const { stateFlags } = pointer;
 
       if (stateFlags.value === PointerStateFlag.None) {
@@ -844,7 +852,7 @@ export class InputManager implements System {
 
       if (stateFlags.pop(PointerStateFlag.Leave)) {
         this.onPointerLeave.dispatch(pointer);
-        delete this.pointers[pointer.id];
+        this.pointers.delete(pointer.id);
       }
     }
   }

--- a/src/math/Polygon.ts
+++ b/src/math/Polygon.ts
@@ -221,10 +221,24 @@ export class Polygon implements ShapeLike {
   }
 
   public project(axis: Vector, result: Interval = new Interval()): Interval {
-    const normal = axis.clone().normalize();
-    const projections = this._points.map(point => normal.dot(point.x, point.y));
+    // Normalize the axis into scalars (project() is public and may receive an
+    // unnormalized axis; SAT already passes unit normals, so this is a no-op there).
+    const length = Math.sqrt(axis.x * axis.x + axis.y * axis.y) || 1;
+    const nx = axis.x / length;
+    const ny = axis.y / length;
 
-    return result.set(Math.min(...projections), Math.max(...projections));
+    const points = this._points;
+    let min = Infinity;
+    let max = -Infinity;
+
+    for (let i = 0; i < points.length; i++) {
+      const projection = nx * points[i].x + ny * points[i].y;
+
+      if (projection < min) min = projection;
+      if (projection > max) max = projection;
+    }
+
+    return result.set(min, max);
   }
 
   public contains(x: number, y: number): boolean {
@@ -288,6 +302,11 @@ export class Polygon implements ShapeLike {
     this._edges.length = 0;
   }
 
+  /**
+   * Shared scratch `Polygon` instance for intermediate calculations. Never
+   * retain the reference across frames or async boundaries.
+   * @internal
+   */
   public static get temp(): Polygon {
     if (temp === null) {
       temp = new Polygon();

--- a/src/math/index.ts
+++ b/src/math/index.ts
@@ -1,5 +1,9 @@
 export * from './Circle';
 export * from './CircleLike';
+// `./Collision` provides the collision TYPES (CollisionType, Collidable,
+// CollisionResponse) — it does NOT export a `Collision` value despite the
+// filename. The `Collision` VALUE below is the query-namespace facade
+// (intersects.*/resolve.*) from `./collision-detection`. Keep these distinct.
 export * from './Collision';
 export { Collision } from './collision-detection';
 export * from './Ellipse';

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -238,7 +238,15 @@ export class Container extends RenderNode {
   }
 
   public override contains(x: number, y: number): boolean {
-    return this._children.some(child => child.contains(x, y));
+    const children = this._children;
+
+    for (let i = 0; i < children.length; i++) {
+      if (children[i].contains(x, y)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   protected override _invalidateChildrenTransform(): void {

--- a/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
@@ -384,9 +384,9 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
 
     const view = backend.view;
 
-    if (this._currentView !== view || this._currentViewId !== (view as unknown as { updateId: number }).updateId) {
+    if (this._currentView !== view || this._currentViewId !== view.updateId) {
       this._currentView = view;
-      this._currentViewId = (view as unknown as { updateId: number }).updateId;
+      this._currentViewId = view.updateId;
       const proj = view.getTransform().toArray(false);
       this._shaderPathShader.getUniform('u_projection').setValue(proj);
       this._geoPathShader.getUniform('u_projection').setValue(proj);

--- a/src/resources/AssetDefinitions.ts
+++ b/src/resources/AssetDefinitions.ts
@@ -48,8 +48,7 @@ export type AnyAssetConfig = {
   [K in keyof AssetDefinitions]: { type: K } & AssetDefinitions[K]['config'];
 }[keyof AssetDefinitions];
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AssetInput = AnyAssetConfig | Asset<any>;
+export type AssetInput = AnyAssetConfig | Asset<unknown>;
 
 export type InferAssetResource<I extends AssetInput> =
   I extends Asset<infer T> ? T : I extends { type: infer K extends keyof AssetDefinitions } ? AssetDefinitions[K]['resource'] : never;

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -36,7 +36,7 @@ import {
  * with {@link Loader.load} and related methods.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Loadable = abstract new (...args: any[]) => any;
+export type Loadable = abstract new (...args: any[]) => unknown;
 
 /** Maps each key of an `AssetInput` map to its resolved runtime resource type. */
 export type InferLoadedMap<M extends Record<string, AssetInput>> = {
@@ -694,7 +694,7 @@ export class Loader {
       const container = arg0 as Assets<Record<string, AssetInput>>;
       const items = Object.entries(container.entries).map(([alias, a]) => ({
         alias,
-        asset: a as Asset<unknown>,
+        asset: a,
       }));
 
       return this._createLoadingQueue(items, results => {
@@ -1004,7 +1004,7 @@ export class Loader {
       const container = arg0 as Assets<Record<string, AssetInput>>;
 
       for (const [alias, a] of Object.entries(container.entries)) {
-        const assetRef = a as Asset<unknown>;
+        const assetRef = a;
         const ctor = this._assetTypeMap.get(assetRef.type);
 
         if (!ctor) continue;

--- a/test/core/scene-node-cache.test.ts
+++ b/test/core/scene-node-cache.test.ts
@@ -229,4 +229,46 @@ describe('SceneNode.getBounds() — dirty-flag cache', () => {
 
     parent.destroy();
   });
+
+  test('cascade short-circuit skips no level: deep leaf move updates bounds at every ancestor', () => {
+    // A three-level chain whose extent is driven by the leaf, so a stale level
+    // would be observable as an un-grown getBounds() at that level. Containers
+    // sit at the origin; moving the leaf to a far corner must expand the union
+    // bounds (origin .. leaf) at every ancestor.
+    const grandparent = new Container();
+    const parent = new Container();
+    const leaf = new TestDrawable(10, 10);
+
+    grandparent.addChild(parent);
+    parent.addChild(leaf);
+    leaf.setPosition(0, 0);
+
+    // Warm every cache so each level holds a clean (non-dirty) bounds rect.
+    const grandparentW1 = grandparent.getBounds().width;
+    const parentW1 = parent.getBounds().width;
+    const leafW1 = leaf.getBounds().width;
+
+    expect(leafW1).toBeCloseTo(10);
+    expect(parentW1).toBeCloseTo(10);
+    expect(grandparentW1).toBeCloseTo(10);
+
+    // Move the deepest leaf once. The upward cascade must re-mark every
+    // ancestor; the short-circuit may only stop at an already-dirty one.
+    leaf.setPosition(300, 400);
+
+    // Each level must report the grown bounds — none may be skipped. The leaf
+    // itself merely translates (width unchanged), but every container's union
+    // with the far-moved leaf must now span out to the leaf.
+    expect(leaf.getBounds().x).toBeCloseTo(300);
+    expect(leaf.getBounds().y).toBeCloseTo(400);
+
+    expect(parent.getBounds().width).toBeCloseTo(310);
+    expect(parent.getBounds().height).toBeCloseTo(410);
+    expect(grandparent.getBounds().width).toBeCloseTo(310);
+    expect(grandparent.getBounds().height).toBeCloseTo(410);
+
+    leaf.destroy();
+    parent.destroy();
+    grandparent.destroy();
+  });
 });

--- a/test/input/pointer-channels.test.ts
+++ b/test/input/pointer-channels.test.ts
@@ -441,7 +441,7 @@ describe('Pointer coordinate mapping — scaled canvas', () => {
     return canvas;
   };
 
-  const getPointer = (im: InputManager, id: number): Pointer => (im as unknown as { pointers: Record<number, Pointer> }).pointers[id];
+  const getPointer = (im: InputManager, id: number): Pointer => (im as unknown as { pointers: Map<number, Pointer> }).pointers.get(id)!;
 
   test('constructor maps CSS-display coordinates to design pixels', () => {
     const canvas = createScaledCanvas();
@@ -508,7 +508,7 @@ describe('Pointer coordinate mapping — pixelRatio > 1', () => {
     return canvas;
   };
 
-  const getPointer = (im: InputManager, id: number): Pointer => (im as unknown as { pointers: Record<number, Pointer> }).pointers[id];
+  const getPointer = (im: InputManager, id: number): Pointer => (im as unknown as { pointers: Map<number, Pointer> }).pointers.get(id)!;
 
   test('pointer position is in design pixels regardless of pixelRatio', () => {
     const canvas = createDprCanvas();

--- a/test/math/polygon.test.ts
+++ b/test/math/polygon.test.ts
@@ -1,5 +1,52 @@
+import { Interval } from '#math/Interval';
 import { Polygon } from '#math/Polygon';
 import { Vector } from '#math/Vector';
+
+describe('Polygon.project()', () => {
+  // Unit square centred at origin with vertices at (0,0), (10,0), (10,10), (0,10).
+  const makeSquare = () => new Polygon([new Vector(0, 0), new Vector(10, 0), new Vector(10, 10), new Vector(0, 10)]);
+
+  test('(a) axis-aligned projection on (1,0) gives correct min/max', () => {
+    const polygon = makeSquare();
+    const result = polygon.project(new Vector(1, 0));
+
+    expect(result.min).toBe(0);
+    expect(result.max).toBe(10);
+
+    polygon.destroy();
+  });
+
+  test('(a) axis-aligned projection on (0,1) gives correct min/max', () => {
+    const polygon = makeSquare();
+    const result = polygon.project(new Vector(0, 1));
+
+    expect(result.min).toBe(0);
+    expect(result.max).toBe(10);
+
+    polygon.destroy();
+  });
+
+  test('(b) unnormalized axis (2,0) produces the same result as (1,0)', () => {
+    const polygon = makeSquare();
+    const normalized = polygon.project(new Vector(1, 0));
+    const unnormalized = polygon.project(new Vector(2, 0));
+
+    expect(unnormalized.min).toBeCloseTo(normalized.min);
+    expect(unnormalized.max).toBeCloseTo(normalized.max);
+
+    polygon.destroy();
+  });
+
+  test('(c) provided result interval is returned as the same reference', () => {
+    const polygon = makeSquare();
+    const result = new Interval();
+    const returned = polygon.project(new Vector(1, 0), result);
+
+    expect(returned).toBe(result);
+
+    polygon.destroy();
+  });
+});
 
 describe('Polygon', () => {
   test('setPoints handles shrinking point arrays safely', () => {


### PR DESCRIPTION
## v0.15 Welle 0 — Quick-Wins

Erster PR des v0.15-Härtungs-Release. Reiner Gewinn: Hot-Path-Mikro-Allokationen entfernt, Typlöcher geschlossen, Doku-Sichtbarkeit präzisiert. **Verhaltens-äquivalent** — keine öffentlichen Signaturen entfernt/umbenannt; public-API-snapshot-neutral.

Spec: `.workspace/specs/v0.15-hardening/01-quick-wins.md`

### Slices
1. **`Polygon.project()`** inline ohne `clone()`/`map`/Spread — allokationsfrei im SAT-Hot-Path (`getCollisionSat` ruft es 2·(nA+nB)× pro Paar). + Coverage-Test (Projektion, unnormalisierte Achse, `result`-Reuse).
2. **`Container.contains()`** `for`-Schleife statt `.some(closure)` — Hit-Test-Pfad.
3. **`_invalidateBoundsCascade`** bricht am ersten bereits `BoundsRect`-dirty Vorfahren ab. Invarianz verifiziert (3 Push-Stellen; Subtree markiert abwärts, Cascade aufwärts → disjunkt; einziger Override `Sprite` ist Blatt). + Korrektheitstest (kein übersprungenes Level).
4. **`InputManager.pointers`** `Record`→`Map` — kein `Object.values()`-Wegwerf-Array pro Frame in `updatePointerEvents`.
5. **WebGPU-Particle-Uniform** direkte Index-Writes statt 44-Element-Array-Literal pro Draw. Byte-identisch.
6. **Typlöcher:** `Loadable`/`AssetInput` `any`→`unknown`; gratuitösen `View.updateId`-Cast entfernt (+ dadurch redundante Folge-Casts in `Loader`/`SceneNode`).
7. **Doku:** `Collision`-Doppelbezeichner in `math/index` klargestellt; `Time.temp`/`Polygon.temp` `@internal`.

### Verifikation (lokale CI-Parität)
- typecheck (root + 5 Pakete + examples + guides) ✅
- lint:strict / lint / lint:packages ✅ · format:check ✅
- test: **3392 passed**, 1 skip, 0 fail ✅
- docs:api:check in-sync (`time.mdx`/`polygon.mdx` für `@internal` regeneriert) ✅

> WebGPU-Particle-**Browser**-Tests (headed) lokal nicht gelaufen; Slice 5 ist byte-identisch. CI fährt die WebGL2-Lane.
