### PR TITLE
chore(lint): v0.15 — @vitest/eslint-plugin test-quality rules (ESLint follow-up C)

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,6 +1,7 @@
 import { coreInternalDirs, createImportBoundaries } from '@codexo/exojs-config/eslint';
 import eslintReact from '@eslint-react/eslint-plugin';
 import js from '@eslint/js';
+import vitest from '@vitest/eslint-plugin';
 import { defineConfig } from 'eslint/config';
 import prettier from 'eslint-config-prettier';
 import reactHooks from 'eslint-plugin-react-hooks';
@@ -1054,6 +1055,32 @@ export default defineConfig([
       // complex element types (unions, inline object literals). The base config
       // forces always-[] otherwise, which reads poorly for Array<{ ... }>.
       '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
+    },
+  },
+
+  // Vitest test-quality rules: the recommended set + `no-focused-tests` promoted
+  // to error so an accidentally committed `.only` fails CI. Layered on top of the
+  // structural test config above; covers both root and package test suites.
+  {
+    ...vitest.configs.recommended,
+    files: ['test/**/*.ts', 'packages/exojs-*/test/**/*.ts'],
+    rules: {
+      ...vitest.configs.recommended.rules,
+      // Primary value: block an accidentally committed `.only`.
+      'vitest/no-focused-tests': 'error',
+      // 27 deliberate device-conditional skips (WebGPU adapter / device-loss
+      // guards). Keep them visible but non-blocking rather than churn them.
+      'vitest/no-disabled-tests': 'warn',
+      // False positives in this suite, kept off:
+      //  - expect-expect: assertions run through shared helpers (mountControls,
+      //    renderText, …) the rule cannot see (148 hits).
+      //  - no-conditional-expect / no-standalone-expect: browser tests use
+      //    `if (!device) return` skip guards and assert via helpers.
+      //  - valid-title: parametrised `test(name, …)` over a case array.
+      'vitest/expect-expect': 'off',
+      'vitest/no-conditional-expect': 'off',
+      'vitest/no-standalone-expect': 'off',
+      'vitest/valid-title': 'off',
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "@vitest/browser": "^4.1.7",
     "@vitest/browser-playwright": "^4.1.7",
     "@vitest/coverage-istanbul": "^4.1.7",
+    "@vitest/eslint-plugin": "^1.6.20",
     "@webgpu/types": "^0.1.69",
     "eslint": "~10.4.1",
     "eslint-config-prettier": "^10.1.8",

--- a/packages/exojs-audio-fx/test/beat-detector.test.ts
+++ b/packages/exojs-audio-fx/test/beat-detector.test.ts
@@ -366,7 +366,7 @@ describe('BeatDetector', () => {
   // ---- Settling ----
 
   describe('settling period', () => {
-    it('default settling is 1500ms', () => {
+    it('default settling is 1500ms', async () => {
       const d = new BeatDetector();
       // Can't test worklet settling directly (no real audio), but we can
       // confirm the option is correctly passed to the worklet via processorOptions
@@ -378,10 +378,10 @@ describe('BeatDetector', () => {
       });
       d.destroy();
       const d2 = new BeatDetector({ settlingMs: 1500 });
-      // The promise resolves async; just check the object was constructed
-      d2.ready.then(() => {
-        expect(capturedProcessorOptions?.['settlingMs']).toBe(1500);
-      });
+      // The worklet (and thus the processorOptions capture) is created when
+      // `ready` resolves — await it so the assertion actually runs.
+      await d2.ready;
+      expect(capturedProcessorOptions?.['settlingMs']).toBe(1500);
       d2.destroy();
     });
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@vitest/coverage-istanbul':
         specifier: ^4.1.7
         version: 4.1.9(vitest@4.1.9)
+      '@vitest/eslint-plugin':
+        specifier: ^1.6.20
+        version: 1.6.20(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9)
       '@webgpu/types':
         specifier: ^0.1.69
         version: 0.1.70
@@ -1679,6 +1682,22 @@ packages:
     resolution: {integrity: sha512-4a7DsIwycTf4eYwEDtnMfMV8H80KSKH9PuMHhqL5SwPZzDyUKq2X/TPCVZ7NqIuSz7UbZckmEmkip6iZBI/gEA==}
     peerDependencies:
       vitest: 4.1.9
+
+  '@vitest/eslint-plugin@1.6.20':
+    resolution: {integrity: sha512-xRwWHFG0Utp6hXtbGiWk4VdKXCGdExD8kbWrrmFEiG5dk8anOJ+vbWbeOa8EbkocKQRTsx7JAWETccZiBgFp/Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': '*'
+      eslint: '>=8.57.0'
+      typescript: '>=5.0.0'
+      vitest: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+      typescript:
+        optional: true
+      vitest:
+        optional: true
 
   '@vitest/expect@4.1.9':
     resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
@@ -5697,6 +5716,18 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.3
       tinyrainbow: 3.1.0
+      vitest: 4.1.9(@types/node@25.9.3)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-istanbul@4.1.9)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/eslint-plugin@1.6.20(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.61.1
+      '@typescript-eslint/utils': 8.61.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.4.1(jiti@2.7.0)
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      typescript: 6.0.3
       vitest: 4.1.9(@types/node@25.9.3)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-istanbul@4.1.9)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## ESLint-Modernisierung — Folge-PR C (Spec 07 §7-C)

Adds `@vitest/eslint-plugin` (recommended) to the root + package test configs. `no-focused-tests` → **error** so a committed `.only` fails CI.

### Tuned to the real suite (measured)
- `no-disabled-tests`: **warn** — 27 deliberate device-conditional skips (WebGPU adapter / device-loss guards) stay visible without blocking.
- `expect-expect` / `no-conditional-expect` / `no-standalone-expect` / `valid-title`: **off** — false positives here (assertions via shared helpers `mountControls`/`renderText`; browser `if (!device) return` skip guards; parametrised `test(name, …)` titles).

### Found + fixed a real bug
`valid-expect-in-promise` (kept **error**) flagged a `BeatDetector` settling test that asserted inside a non-awaited `.ready.then(...)` → the assertion **never ran**. Fixed by awaiting `ready` (matches the ~15 sibling tests).

### Verifikation
`lint` 0 errors (36 no-disabled warnings, intended) · `lint:packages` 0 · `typecheck` ✓ · `format:check` ✓ · beat-detector suite 32 passed.