### PR TITLE
chore(types): v0.15 — noUnusedLocals/Parameters + dead-code cleanup (ESLint follow-up B)

### DIFF
--- a/packages/exojs-config/typescript/base.json
+++ b/packages/exojs-config/typescript/base.json
@@ -16,6 +16,8 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "skipLibCheck": true
   }
 }

--- a/site/src/content/api/line.mdx
+++ b/site/src/content/api/line.mdx
@@ -40,7 +40,7 @@ within a configurable threshold (default `0.1`).
 - `getBounds(): Rectangle`
 - `getNormals(): Vector[]`
 - `intersectsWith(target: Collidable): boolean`
-- `project(axis: Vector, result: Interval): Interval`
+- `project(_axis: Vector, result: Interval): Interval`
 - `set(x1: number, y1: number, x2: number, y2: number): this`
 
 ## Properties

--- a/site/src/content/api/vector.mdx
+++ b/site/src/content/api/vector.mdx
@@ -52,7 +52,7 @@ always allocate a new `Vector`. Instance methods mutate in place and return
 - `multiply(x: number, y: number): this`
 - `normalize(): this`
 - `perp(): this`
-- `project(axis: Vector, interval: Interval): Interval`
+- `project(_axis: Vector, interval: Interval): Interval`
 - `rperp(): this`
 - `set(x: number, y: number): this`
 - `subtract(x: number, y: number): this`

--- a/site/src/content/api/web-gpu-shader-filter.mdx
+++ b/site/src/content/api/web-gpu-shader-filter.mdx
@@ -9,7 +9,7 @@ memberCount: 4
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/rendering/filters/WebGpuShaderFilter.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/filters/WebGpuShaderFilter.ts#L185"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/filters/WebGpuShaderFilter.ts#L156"
 ---
 ## Import
 
@@ -72,4 +72,4 @@ Texture/RenderTexture uniforms are bound as separate entries starting at
 
 ## Source
 
-[src/rendering/filters/WebGpuShaderFilter.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/filters/WebGpuShaderFilter.ts#L185)
+[src/rendering/filters/WebGpuShaderFilter.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/filters/WebGpuShaderFilter.ts#L156)

--- a/src/input/GestureRecognizer.ts
+++ b/src/input/GestureRecognizer.ts
@@ -32,8 +32,6 @@ export class GestureRecognizer {
   public readonly onRotate: Signal<[angleDelta: number, center: Vector]>;
   public readonly onLongPress: Signal<[pointer: Pointer]>;
 
-  private readonly distanceThreshold: number;
-
   // Active touch pointers (only touch type; index in order of arrival).
   private readonly touchPointers = new Map<number, Pointer>();
 
@@ -48,12 +46,11 @@ export class GestureRecognizer {
   private readonly centerVec = new Vector();
 
   public constructor(
-    distanceThreshold: number,
+    _distanceThreshold: number,
     onPinch: Signal<[scale: number, center: Vector]>,
     onRotate: Signal<[angleDelta: number, center: Vector]>,
     onLongPress: Signal<[pointer: Pointer]>,
   ) {
-    this.distanceThreshold = distanceThreshold;
     this.onPinch = onPinch;
     this.onRotate = onRotate;
     this.onLongPress = onLongPress;

--- a/src/math/Line.ts
+++ b/src/math/Line.ts
@@ -120,7 +120,7 @@ export class Line implements ShapeLike {
     return [];
   }
 
-  public project(axis: Vector, result: Interval = new Interval()): Interval {
+  public project(_axis: Vector, result: Interval = new Interval()): Interval {
     return result;
   }
 

--- a/src/math/Vector.ts
+++ b/src/math/Vector.ts
@@ -93,7 +93,7 @@ export class Vector extends AbstractVector implements ShapeLike {
     return [this.clone().rperp().normalize()];
   }
 
-  public project(axis: Vector, interval: Interval = new Interval()): Interval {
+  public project(_axis: Vector, interval: Interval = new Interval()): Interval {
     return interval;
   }
 

--- a/src/math/triangulate.ts
+++ b/src/math/triangulate.ts
@@ -174,7 +174,7 @@ function pointInTriangle(px: number, py: number, ax: number, ay: number, bx: num
  * Returns true if vertex v is an ear: the triangle (previousVertexIndex, v, nextVertexIndex) contains
  * no other polygon vertex strictly inside it.
  */
-function isEar(vertices: ArrayLike<number>, prev: Uint32Array, next: Uint32Array, previousVertexIndex: number, v: number, nextVertexIndex: number): boolean {
+function isEar(vertices: ArrayLike<number>, _prev: Uint32Array, next: Uint32Array, previousVertexIndex: number, v: number, nextVertexIndex: number): boolean {
   const ax = vertices[previousVertexIndex * 2];
   const ay = vertices[previousVertexIndex * 2 + 1];
   const bx = vertices[v * 2];

--- a/src/rendering/filters/WebGpuShaderFilter.ts
+++ b/src/rendering/filters/WebGpuShaderFilter.ts
@@ -84,35 +84,6 @@ const vertexStrideBytes = 16;
 /** Resolution uniform buffer size: vec2<f32> = 8 bytes, padded to 16 */
 const resolutionBufferBytes = 16;
 
-/**
- * Number of scalar floats written for a given uniform value type (used for
- * computing slot alignment in the user uniform buffer).
- */
-function uniformSlotFloats(value: ShaderFilterUniformValue): number {
-  if (
-    value instanceof Texture ||
-    (value instanceof Object && 'width' in value && 'height' in value && !(value instanceof Float32Array) && !(value instanceof Int32Array))
-  ) {
-    // Texture / RenderTexture — not placed in the uniform buffer
-    return 0;
-  }
-
-  if (typeof value === 'number') {
-    return 1;
-  }
-
-  if (value instanceof Float32Array) {
-    return value.length;
-  }
-
-  if (value instanceof Int32Array) {
-    return value.length;
-  }
-
-  // Readonly tuple
-  return (value as readonly number[]).length;
-}
-
 /** Returns true when the value is a texture (goes into a bind group, not a UBO). */
 function isTextureValue(value: ShaderFilterUniformValue): value is Texture | RenderTexture {
   return (
@@ -292,7 +263,7 @@ export class WebGpuShaderFilter extends Filter {
   // Private helpers
   // ---------------------------------------------------------------------------
 
-  private _ensureConnected(backend: WebGpuBackend, output: RenderTexture): void {
+  private _ensureConnected(backend: WebGpuBackend, _output: RenderTexture): void {
     if (this._connection !== null) {
       return;
     }

--- a/src/rendering/text/Text.ts
+++ b/src/rendering/text/Text.ts
@@ -69,9 +69,6 @@ export class Text extends AbstractText {
   private _destroyed = false;
   private _faceLoadVersion = 0;
 
-  /** Resolves when an in-flight FontFace load finishes. Null when no face load is pending. */
-  private _faceLoadPromise: Promise<void> | null = null;
-
   /** Per-page quad geometry built by `_rebuild()`. */
   private _pageQuads: TextPageQuads[] = [];
   private _textBounds: TextSize = { width: 0, height: 0 };
@@ -84,7 +81,7 @@ export class Text extends AbstractText {
     this._sdfRadius = options.sdfRadius ?? SDF_RADIUS;
 
     const face = this._extractFace(options);
-    if (face !== null) this._faceLoadPromise = this._loadFace(face);
+    if (face !== null) void this._loadFace(face);
 
     this._rebuild('font');
   }
@@ -97,7 +94,7 @@ export class Text extends AbstractText {
     this._style = v instanceof TextStyle ? v : new TextStyle(v);
     if (!(v instanceof TextStyle)) {
       const face = this._extractFace(v);
-      if (face !== null) this._faceLoadPromise = this._loadFace(face);
+      if (face !== null) void this._loadFace(face);
     }
     this._rebuild('font');
   }
@@ -171,7 +168,6 @@ export class Text extends AbstractText {
   public override destroy(): void {
     this._destroyed = true;
     this._faceLoadVersion++;
-    this._faceLoadPromise = null;
     this._pageQuads = [];
     this._atlas = null;
     super.destroy();

--- a/src/rendering/webgl2/WebGl2SpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2SpriteRenderer.ts
@@ -570,7 +570,7 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> {
       unbind: (): void => {
         connection.gl.bindVertexArray(null);
       },
-      draw: (vao, size, start, type): void => {
+      draw: (_vao, size, start, type): void => {
         connection.gl.drawArrays(type, start, size);
       },
       drawInstanced: (_vao, count, start, instanceCount, type): void => {

--- a/src/rendering/webgl2/WebGl2StencilClipper.ts
+++ b/src/rendering/webgl2/WebGl2StencilClipper.ts
@@ -209,7 +209,7 @@ export class WebGl2StencilClipper {
       unbind: (): void => {
         gl.bindVertexArray(null);
       },
-      draw: (vao: WebGl2VertexArrayObject, size: number, start: number, type: number): void => {
+      draw: (_vao: WebGl2VertexArrayObject, size: number, start: number, type: number): void => {
         gl.drawArrays(type, start, size);
       },
       destroy: (vao: WebGl2VertexArrayObject): void => {

--- a/src/resources/Asset.ts
+++ b/src/resources/Asset.ts
@@ -5,8 +5,7 @@ import type { AnyAssetConfig, AssetDefinitions } from './AssetDefinitions';
 // ---------------------------------------------------------------------------
 
 /** @internal */
-// eslint-disable-next-line unused-imports/no-unused-vars
-export class AssetImpl<Phantom> {
+export class AssetImpl {
   /** @internal */
   public readonly _config: AnyAssetConfig;
 

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -822,7 +822,7 @@ export class Loader {
     const configMap = arg0 as Record<string, AssetInput>;
     const items = Object.entries(configMap).map(([alias, value]) => ({
       alias,
-      asset: (value instanceof AssetImpl ? value : new (Asset as new (c: AssetInput) => Asset<unknown>)(value)) as Asset<unknown>,
+      asset: value instanceof AssetImpl ? value : new (Asset as new (c: AssetInput) => Asset<unknown>)(value),
     }));
 
     return this._createLoadingQueue(items, results => {

--- a/src/resources/utils.ts
+++ b/src/resources/utils.ts
@@ -114,7 +114,7 @@ const matchesWebmVideo = (arrayBuffer: ArrayBuffer): boolean => {
   const header = new Uint8Array(arrayBuffer);
   const matching = [0x1a, 0x45, 0xdf, 0xa3].every((byte, i) => byte === header[i]);
   const sliced = header.subarray(4, 4 + 4096);
-  const index = sliced.findIndex((el, i, arr) => arr[i] === 0x42 && arr[i + 1] === 0x82);
+  const index = sliced.findIndex((_el, i, arr) => arr[i] === 0x42 && arr[i + 1] === 0x82);
 
   if (!matching || index === -1) {
     return false;


### PR DESCRIPTION
## ESLint-Modernisierung — Folge-PR B (Spec 07 §7-B)

Enables `noUnusedLocals` + `noUnusedParameters` in the shared `base.json` (inherited by root + all 5 packages). Cleared the **11** dead declarations the flags surfaced (measured — exactly the spec's list, Text.ts now at :73 post-3c).

### Removed (genuinely dead)
- `WebGpuShaderFilter.uniformSlotFloats` — orphaned function, no callers.
- `Text._faceLoadPromise` — written, never read; the side effect is `_loadFace(face)`, now `void`-invoked.
- `GestureRecognizer.distanceThreshold` field.
- `AssetImpl<Phantom>` unused type param (+ its eslint-disable); the real phantom marker is `Asset<T>._resource`.

### `_`-prefixed (intentional conformance params)
Line/Vector `project(axis)` stubs, triangulate `prev`, `_ensureConnected(output)`, `draw(vao)` callbacks (×2), `findIndex(el)`.

### Drive-by
Dropping `AssetImpl`'s generic made the outer `as Asset<unknown>` cast in `Loader.ts` redundant (`no-unnecessary-type-assertion`) — removed. Verified the warning is caused by this change (absent on main).

### Verifikation
typecheck (root + examples + guides + 5 packages) **0** · lint:strict + format:check green · **2403** core tests green.