### PR TITLE
refactor(rendering): v0.15 W2 1c — typed write channels (Mesh/Texture/Subtitle)

### DIFF
--- a/site/src/content/api/mesh.mdx
+++ b/site/src/content/api/mesh.mdx
@@ -90,28 +90,26 @@ after in-place mutation is the caller's responsibility (call
 - `clip: boolean`
 - `clipShape: Rectangle | Geometry | null`
 - `collisionType: CollisionType`
-- `colors: Uint32Array<ArrayBufferLike> | null`
 - `cursor: string | null`
 - `draggable: boolean`
 - `flags: Flags<SceneNodeTransformFlags>`
 - `focusable: boolean`
-- `geometry: Geometry | null`
-- `indices: Uint16Array<ArrayBufferLike> | null`
-- `material: MeshMaterial | null`
 - `name: string | null`
 - `preserveDrawOrder: boolean`
 - `tabIndex: number`
-- `uvs: Float32Array<ArrayBufferLike> | null`
-- `vertices: Float32Array`
 - `anchor: ObservableVector`
 - `blendMode: BlendModes`
 - `cacheAsBitmap: boolean`
+- `colors: Uint32Array<ArrayBufferLike> | null`
 - `cullable: boolean`
 - `filters: readonly Filter[]`
+- `geometry: Geometry | null`
 - `indexCount: number`
+- `indices: Uint16Array<ArrayBufferLike> | null`
 - `interactive: boolean`
 - `isAlignedBox: boolean`
 - `mask: MaskSource`
+- `material: MeshMaterial | null`
 - `origin: ObservableVector`
 - `parent: Container | null`
 - `pixelSnapMode: PixelSnapMode`
@@ -122,7 +120,9 @@ after in-place mutation is the caller's responsibility (call
 - `skewY: number`
 - `texture: Texture | RenderTexture | null`
 - `tint: Color`
+- `uvs: Float32Array<ArrayBufferLike> | null`
 - `vertexCount: number`
+- `vertices: Float32Array`
 - `visible: boolean`
 - `x: number`
 - `y: number`

--- a/site/src/content/api/subtitle-factory.mdx
+++ b/site/src/content/api/subtitle-factory.mdx
@@ -9,7 +9,7 @@ memberCount: 7
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/resources/factories/SubtitleFactory.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/resources/factories/SubtitleFactory.ts#L225"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/resources/factories/SubtitleFactory.ts#L236"
 ---
 ## Import
 
@@ -32,7 +32,7 @@ positional properties.
 - `create(source: SubtitleIntermediate): Promise<VTTCue[]>`
 - `createObjectUrl(blob: Blob): string`
 - `destroy(): void`
-- `process(response: Response): Promise<SubtitleIntermediate>`
+- `process(response: SubtitleSource): Promise<SubtitleIntermediate>`
 - `revokeObjectUrl(objectUrl: string): void`
 
 ## Properties
@@ -41,4 +41,4 @@ positional properties.
 
 ## Source
 
-[src/resources/factories/SubtitleFactory.ts](https://github.com/Exoridus/ExoJS/blob/main/src/resources/factories/SubtitleFactory.ts#L225)
+[src/resources/factories/SubtitleFactory.ts](https://github.com/Exoridus/ExoJS/blob/main/src/resources/factories/SubtitleFactory.ts#L236)

--- a/src/rendering/mesh/ImmediateMesh.ts
+++ b/src/rendering/mesh/ImmediateMesh.ts
@@ -10,20 +10,6 @@ import { Mesh, readGeometry } from './Mesh';
 const placeholderVertices = (): Float32Array => new Float32Array([0, 0, 1, 0, 0, 1]);
 
 /**
- * Writable view over the (publicly `readonly`) {@link Mesh} data fields. The
- * pooled immediate mesh reconfigures these in place between draws; the readonly
- * cast mirrors the pattern the WebGPU mesh renderer uses for its draw-call slots.
- */
-interface MutableMeshFields {
-  vertices: Float32Array;
-  indices: Uint16Array | null;
-  uvs: Float32Array | null;
-  colors: Uint32Array | null;
-  material: MeshMaterial | null;
-  geometry: Geometry | null;
-}
-
-/**
  * Pooled, reconfigurable mesh backing the immediate {@link RenderingContext.drawGeometry}
  * path. It never enters the scene graph: it is reconfigured per call, submitted
  * via `backend.draw`, and flushed immediately, so a single instance is reused
@@ -61,14 +47,12 @@ export class ImmediateMesh extends Mesh {
    * @internal
    */
   public configure(geometry: Geometry, transform: Matrix, material: MeshMaterial | null, tint: Color | null): void {
-    const fields = this as unknown as MutableMeshFields;
-
     this._flattenGeometry(geometry);
     // Single immediate draws go through the dynamic (non-static-cached) path, so
     // the geometry reference is left off the mesh — only the flattened arrays are
     // consumed. (The batch source path sets it for the shared GPU buffer cache.)
-    fields.geometry = null;
-    fields.material = material;
+    this._geometry = null;
+    this._material = material;
     this._rawTransform = transform;
     // setTint ignores a falsy argument, so a missing tint must reset to white
     // rather than retain the previous draw's tint through the pool.
@@ -84,11 +68,9 @@ export class ImmediateMesh extends Mesh {
    * @internal
    */
   public configureBatchSource(geometry: Geometry, material: MeshMaterial | null): void {
-    const fields = this as unknown as MutableMeshFields;
-
     this._flattenGeometry(geometry);
-    fields.geometry = geometry;
-    fields.material = material;
+    this._geometry = geometry;
+    this._material = material;
     this._rawTransform = null;
     this.setTint(Color.white);
   }
@@ -100,13 +82,12 @@ export class ImmediateMesh extends Mesh {
       return;
     }
 
-    const fields = this as unknown as MutableMeshFields;
     const data = readGeometry(geometry);
 
-    fields.vertices = data.vertices;
-    fields.uvs = data.uvs;
-    fields.colors = data.colors;
-    fields.indices = data.indices;
+    this._vertices = data.vertices;
+    this._uvs = data.uvs;
+    this._colors = data.colors;
+    this._indices = data.indices;
     this._sourceGeometry = geometry;
     this._sourceVersion = geometry.version;
   }

--- a/src/rendering/mesh/Mesh.ts
+++ b/src/rendering/mesh/Mesh.ts
@@ -71,16 +71,41 @@ export interface MeshOptions {
  * `recomputeLocalBounds()`).
  */
 export class Mesh extends Drawable {
-  public readonly vertices: Float32Array;
-  public readonly indices: Uint16Array | null;
-  public readonly uvs: Float32Array | null;
-  public readonly colors: Uint32Array | null;
+  // Backing fields are `protected` so the pooled `ImmediateMesh` subclass can
+  // reconfigure them in place; the public getters keep the data read-only for
+  // every external consumer (the v1 immutable-after-construction contract).
+  protected _vertices: Float32Array;
+  protected _indices: Uint16Array | null;
+  protected _uvs: Float32Array | null;
+  protected _colors: Uint32Array | null;
+  protected _material: MeshMaterial | null;
+  protected _geometry: Geometry | null;
+
+  public get vertices(): Float32Array {
+    return this._vertices;
+  }
+
+  public get indices(): Uint16Array | null {
+    return this._indices;
+  }
+
+  public get uvs(): Float32Array | null {
+    return this._uvs;
+  }
+
+  public get colors(): Uint32Array | null {
+    return this._colors;
+  }
 
   /** Custom material attached to this mesh, or `null` for the default mesh path. */
-  public readonly material: MeshMaterial | null;
+  public get material(): MeshMaterial | null {
+    return this._material;
+  }
 
   /** Source geometry when constructed from the geometry form, otherwise `null`. */
-  public readonly geometry: Geometry | null;
+  public get geometry(): Geometry | null {
+    return this._geometry;
+  }
 
   private _texture: Texture | RenderTexture | null;
 
@@ -150,12 +175,12 @@ export class Mesh extends Drawable {
       throw new Error(`Non-indexed Mesh requires a vertex count that is a multiple of 3 (got ${vertexCount}).`);
     }
 
-    this.vertices = vertices;
-    this.indices = indices;
-    this.uvs = uvs;
-    this.colors = colors;
-    this.material = material;
-    this.geometry = geometry;
+    this._vertices = vertices;
+    this._indices = indices;
+    this._uvs = uvs;
+    this._colors = colors;
+    this._material = material;
+    this._geometry = geometry;
     this._texture = texture;
 
     this.recomputeLocalBounds();

--- a/src/rendering/texture/DataTexture.ts
+++ b/src/rendering/texture/DataTexture.ts
@@ -189,7 +189,7 @@ export class DataTexture<F extends DataTextureFormat = DataTextureFormat> extend
     this._dirty = { full: true, x: 0, y: 0, width: this.width, height: this.height };
     this.setSize(this.width, this.height);
     // setSize is a no-op when dimensions don't change; force version bump for sync detection.
-    (this as unknown as { _version: number })._version++;
+    this._bumpVersion();
 
     return this;
   }
@@ -227,7 +227,7 @@ export class DataTexture<F extends DataTextureFormat = DataTextureFormat> extend
       this._dirty = { full: false, x: minX, y: minY, width: maxX - minX, height: maxY - minY };
     }
 
-    (this as unknown as { _version: number })._version++;
+    this._bumpVersion();
 
     return this;
   }

--- a/src/rendering/texture/Texture.ts
+++ b/src/rendering/texture/Texture.ts
@@ -167,6 +167,15 @@ export class Texture {
   }
 
   /**
+   * Increment the version counter so backends re-upload on the next frame.
+   * @internal — for subclasses (e.g. {@link DataTexture}) that mutate texture
+   * data through paths the base setters don't cover.
+   */
+  protected _bumpVersion(): void {
+    this._version++;
+  }
+
+  /**
    * Register a callback to be invoked just before this texture is destroyed.
    * Useful for backends to release their GPU-side texture objects.
    */

--- a/src/resources/coreAssetBindings.ts
+++ b/src/resources/coreAssetBindings.ts
@@ -137,8 +137,7 @@ const subtitleBinding = binding(SubtitleAsset as unknown as AssetConstructor, { 
       const text = await context.fetchText(source);
       const url = source.split('?')[0].toLowerCase();
       const fmt = url.endsWith('.srt') ? 'srt' : 'vtt';
-      const fakeResponse = { text: () => Promise.resolve(text), url: source } as unknown as Response;
-      const intermediate = await factory.process(fakeResponse);
+      const intermediate = await factory.process({ text: () => Promise.resolve(text), url: source });
       return factory.create({ ...intermediate, fmt });
     },
     destroy() {

--- a/src/resources/factories/SubtitleFactory.ts
+++ b/src/resources/factories/SubtitleFactory.ts
@@ -11,6 +11,17 @@ interface SubtitleIntermediate {
   text: string;
 }
 
+/**
+ * The narrow slice of `Response` that {@link SubtitleFactory.process} actually
+ * reads. A real `Response` satisfies it structurally, so the network/cache
+ * strategies still pass their fetched response unchanged — but an in-memory
+ * `{ text, url }` source (see `coreAssetBindings`) also fits without a cast.
+ */
+interface SubtitleSource {
+  text(): Promise<string>;
+  url: string;
+}
+
 // ---------------------------------------------------------------------------
 // VTT helpers
 // ---------------------------------------------------------------------------
@@ -229,7 +240,7 @@ export class SubtitleFactory extends AbstractAssetFactory<VTTCue[]> {
    * Reads the response body as UTF-8 text and records the subtitle format
    * derived from the response URL's file extension.
    */
-  public async process(response: Response): Promise<SubtitleIntermediate> {
+  public async process(response: SubtitleSource): Promise<SubtitleIntermediate> {
     const text = await response.text();
     const url = response.url.split('?')[0].toLowerCase();
     const fmt: SubtitleFormat = url.endsWith('.srt') ? 'srt' : 'vtt';


### PR DESCRIPTION
## Welle 2 — Slice 1c (Typsystem: konkrete Typlöcher schließen)

Eliminates the five `as unknown as` inheritance-bypass casts + one fake-`Response` cast (Spec 03 §1c).

- **Mesh data fields** (vertices/indices/uvs/colors/material/geometry): `public readonly` → `protected` backing + public getters. External read API unchanged (v1 immutable-after-construction contract). The pooled `ImmediateMesh` subclass now sets `this._*` directly instead of casting `this as unknown as MutableMeshFields` (×3).
- **`Texture._version`** stays private behind a new `@internal protected _bumpVersion()`; `DataTexture.commit`/`commitRect` call it instead of `(this as unknown as { _version })._version++` (×2).
- **`SubtitleFactory.process`** takes a narrow `SubtitleSource` ({ text(); url }) instead of full `Response` (method param bivariance — a real `Response` still satisfies it, so the network/cache strategies are unchanged). coreAssetBindings' in-memory `{ text, url }` now type-checks without a cast.

### Verifikation
typecheck 0 · lint:strict + format green · root-index snapshots unchanged · 219 mesh/texture/resource tests green. `mesh.mdx` + `subtitle-factory.mdx` regenerated.