### PR TITLE
refactor(physics): v0.15 W2 1d — Shape discriminated union (remove 12 casts)

### DIFF
--- a/packages/exojs-physics/src/Collider.ts
+++ b/packages/exojs-physics/src/Collider.ts
@@ -3,16 +3,14 @@ import { createAabb } from './Aabb';
 import type { Mutable2D, Transform } from './math';
 import { applyRotation, applyTransform, composeTransforms, createTransform } from './math';
 import type { PhysicsBody } from './PhysicsBody';
-import type { CircleShape } from './shapes/CircleShape';
-import type { PolygonShape } from './shapes/PolygonShape';
-import type { Shape } from './shapes/Shape';
+import type { AnyShape } from './shapes/AnyShape';
 import type { CollisionFilter, VectorLike } from './types';
 import { resolveFilter } from './types';
 
 /** Construction options for a collider. */
 export interface ColliderOptions {
   /** The collision geometry. */
-  shape: Shape;
+  shape: AnyShape;
   /** Density (mass per px²) for the owning body's mass; ignored for static/kinematic. Default `1`. */
   density?: number;
   /** Coulomb friction coefficient (used by the solver once dynamics ship). Default `0.2`. */
@@ -41,7 +39,7 @@ export interface ColliderOptions {
  */
 export class Collider {
   /** Stable id, assigned when the owning body joins a world (`-1` until then). */
-  public readonly shape: Shape;
+  public readonly shape: AnyShape;
   public readonly offsetX: number;
   public readonly offsetY: number;
   public readonly localRotation: number;
@@ -82,7 +80,7 @@ export class Collider {
     this._localTransform = createTransform(this.offsetX, this.offsetY, this.localRotation);
 
     if (this.shape.type === 'polygon') {
-      const polygon = this.shape as PolygonShape;
+      const polygon = this.shape;
       this._worldVertices = new Array<number>(polygon.count * 2).fill(0);
       this._worldNormals = new Array<number>(polygon.count * 2).fill(0);
     } else {
@@ -152,7 +150,7 @@ export class Collider {
     const world = composeTransforms(bodyTransform, this._localTransform, this._worldTransform);
 
     if (this.shape.type === 'circle') {
-      const radius = (this.shape as CircleShape).radius;
+      const radius = this.shape.radius;
 
       this._worldCenter.x = world.x;
       this._worldCenter.y = world.y;
@@ -164,7 +162,7 @@ export class Collider {
       return;
     }
 
-    const polygon = this.shape as PolygonShape;
+    const polygon = this.shape;
     const local = polygon.vertices;
     const normals = polygon.normals;
     const out: Mutable2D = { x: 0, y: 0 };

--- a/packages/exojs-physics/src/PhysicsWorld.ts
+++ b/packages/exojs-physics/src/PhysicsWorld.ts
@@ -12,7 +12,7 @@ import type { BodyOwner } from './PhysicsBody';
 import { PhysicsBody } from './PhysicsBody';
 import type { QueryFilter, RayHit } from './query/QueryEngine';
 import { QueryEngine } from './query/QueryEngine';
-import type { Shape } from './shapes/Shape';
+import type { AnyShape } from './shapes/AnyShape';
 import { TimeStepper } from './TimeStepper';
 import type { BodyType, CollisionFilter, VectorLike } from './types';
 
@@ -48,7 +48,7 @@ export interface AttachOptions {
   /** When `true`, the body never rotates under contacts. Default `false`. */
   fixedRotation?: boolean;
   /** The collider geometry. */
-  shape: Shape;
+  shape: AnyShape;
   /** Body-local offset of the collider. Default `(0, 0)`. */
   offset?: VectorLike;
   /** Body-local rotation of the collider (radians). Default `0`. */
@@ -290,7 +290,7 @@ export class PhysicsWorld implements BodyOwner {
   }
 
   /** Colliders overlapping `shape` placed at `position`/`angle`. Fresh array. */
-  public overlapShape(shape: Shape, position: VectorLike, filter?: QueryFilter, angle?: number): Collider[] {
+  public overlapShape(shape: AnyShape, position: VectorLike, filter?: QueryFilter, angle?: number): Collider[] {
     return this._query.overlapShape(shape, position, filter, angle);
   }
 

--- a/packages/exojs-physics/src/collision/CollisionProxy.ts
+++ b/packages/exojs-physics/src/collision/CollisionProxy.ts
@@ -1,5 +1,5 @@
 import type { Mutable2D } from '../math';
-import type { Shape } from '../shapes/Shape';
+import type { AnyShape } from '../shapes/AnyShape';
 
 /**
  * The geometric surface the narrow phase needs: a shape plus its cached world
@@ -8,7 +8,7 @@ import type { Shape } from '../shapes/Shape';
  * allocating a body/collider.
  */
 export interface CollisionProxy {
-  readonly shape: Shape;
+  readonly shape: AnyShape;
   readonly worldCenter: Readonly<Mutable2D>;
   readonly worldVertices: readonly number[];
   readonly worldNormals: readonly number[];

--- a/packages/exojs-physics/src/collision/narrowphase.ts
+++ b/packages/exojs-physics/src/collision/narrowphase.ts
@@ -1,5 +1,3 @@
-import type { CircleShape } from '../shapes/CircleShape';
-import type { PolygonShape } from '../shapes/PolygonShape';
 import type { CollisionProxy } from './CollisionProxy';
 import type { Manifold } from './Manifold';
 
@@ -24,8 +22,11 @@ export const collide = (a: CollisionProxy, b: CollisionProxy, manifold: Manifold
   return tb === 'circle' ? collideCirclePolygon(b, a, manifold, true) : collidePolygons(a, b, manifold);
 };
 
-const radiusOf = (collider: CollisionProxy): number => (collider.shape as CircleShape).radius;
-const countOf = (collider: CollisionProxy): number => (collider.shape as PolygonShape).count;
+// radiusOf/countOf are only ever called after the `collide` dispatch has matched
+// the shape kind, so the discriminant always holds; the fallback is unreachable
+// but keeps these allocation-free helpers cast-free and type-safe.
+const radiusOf = (collider: CollisionProxy): number => (collider.shape.type === 'circle' ? collider.shape.radius : 0);
+const countOf = (collider: CollisionProxy): number => (collider.shape.type === 'polygon' ? collider.shape.count : 0);
 
 const collideCircles = (a: CollisionProxy, b: CollisionProxy, manifold: Manifold): boolean => {
   const ca = a.worldCenter;

--- a/packages/exojs-physics/src/debug/PhysicsDebugDraw.ts
+++ b/packages/exojs-physics/src/debug/PhysicsDebugDraw.ts
@@ -10,8 +10,6 @@ import type { Collider } from '../Collider';
 import { Manifold } from '../collision/Manifold';
 import { collide } from '../collision/narrowphase';
 import type { PhysicsWorld } from '../PhysicsWorld';
-import type { CircleShape } from '../shapes/CircleShape';
-import type { PolygonShape } from '../shapes/PolygonShape';
 
 /** Toggles for the physics debug overlay. */
 export interface PhysicsDebugDrawOptions {
@@ -132,7 +130,7 @@ export class PhysicsDebugDraw extends DebugLayer {
 
     if (collider.shape.type === 'circle') {
       const c = collider.worldCenter;
-      const r = (collider.shape as CircleShape).radius;
+      const r = collider.shape.radius;
 
       this._strokeCircle(gfx, c.x, c.y, r);
       // A spoke to the surface conveys orientation once bodies rotate.
@@ -143,7 +141,7 @@ export class PhysicsDebugDraw extends DebugLayer {
     }
 
     const verts = collider.worldVertices;
-    const count = (collider.shape as PolygonShape).count;
+    const count = collider.shape.count;
 
     gfx.moveTo(verts[0], verts[1]);
 

--- a/packages/exojs-physics/src/query/QueryEngine.ts
+++ b/packages/exojs-physics/src/query/QueryEngine.ts
@@ -6,9 +6,7 @@ import { testOverlap } from '../collision/narrowphase';
 import type { Mutable2D } from '../math';
 import { applyRotation, applyTransform, createTransform } from '../math';
 import type { PhysicsBody } from '../PhysicsBody';
-import type { CircleShape } from '../shapes/CircleShape';
-import type { PolygonShape } from '../shapes/PolygonShape';
-import type { Shape } from '../shapes/Shape';
+import type { AnyShape } from '../shapes/AnyShape';
 import type { VectorLike } from '../types';
 import { resolveFilter, shouldCollide } from '../types';
 
@@ -154,7 +152,7 @@ export class QueryEngine {
   }
 
   /** Colliders overlapping `shape` placed at `position`/`angle`. Allocates a fresh array. */
-  public overlapShape(shape: Shape, position: VectorLike, filter?: QueryFilter, angle = 0): Collider[] {
+  public overlapShape(shape: AnyShape, position: VectorLike, filter?: QueryFilter, angle = 0): Collider[] {
     const proxy = makeProxy(shape, position.x, position.y, angle);
     const out: Collider[] = [];
     const resolved = filter ? resolveFilter(filter) : null;
@@ -181,7 +179,7 @@ const pointInCollider = (collider: Collider, px: number, py: number): boolean =>
 
   if (collider.shape.type === 'circle') {
     const c = collider.worldCenter;
-    const r = (collider.shape as CircleShape).radius;
+    const r = collider.shape.radius;
     const dx = px - c.x;
     const dy = py - c.y;
 
@@ -190,7 +188,7 @@ const pointInCollider = (collider: Collider, px: number, py: number): boolean =>
 
   const verts = collider.worldVertices;
   const normals = collider.worldNormals;
-  const count = (collider.shape as PolygonShape).count;
+  const count = collider.shape.count;
 
   for (let i = 0; i < count; i++) {
     if (normals[i * 2] * (px - verts[i * 2]) + normals[i * 2 + 1] * (py - verts[i * 2 + 1]) > 0) {
@@ -212,7 +210,8 @@ const rayCastCollider = (collider: Collider, ox: number, oy: number, dx: number,
 
 const rayCastCircle = (collider: Collider, ox: number, oy: number, dx: number, dy: number, maxDistance: number): RayHit | null => {
   const c = collider.worldCenter;
-  const r = (collider.shape as CircleShape).radius;
+  // Dispatched only for circle colliders; the fallback is unreachable.
+  const r = collider.shape.type === 'circle' ? collider.shape.radius : 0;
   const mx = ox - c.x;
   const my = oy - c.y;
   const b = mx * dx + my * dy;
@@ -250,7 +249,8 @@ const rayCastCircle = (collider: Collider, ox: number, oy: number, dx: number, d
 const rayCastPolygon = (collider: Collider, ox: number, oy: number, dx: number, dy: number, maxDistance: number): RayHit | null => {
   const verts = collider.worldVertices;
   const normals = collider.worldNormals;
-  const count = (collider.shape as PolygonShape).count;
+  // Dispatched only for polygon colliders; the fallback is unreachable.
+  const count = collider.shape.type === 'polygon' ? collider.shape.count : 0;
 
   let tmin = 0;
   let tmax = maxDistance;
@@ -307,12 +307,12 @@ const rayCastPolygon = (collider: Collider, ox: number, oy: number, dx: number, 
 };
 
 /** Build a throwaway collision proxy for a shape placed at `(x, y)` with `angle`. */
-const makeProxy = (shape: Shape, x: number, y: number, angle: number): CollisionProxy => {
+const makeProxy = (shape: AnyShape, x: number, y: number, angle: number): CollisionProxy => {
   if (shape.type === 'circle') {
     return { shape, worldCenter: { x, y }, worldVertices: [], worldNormals: [] };
   }
 
-  const polygon = shape as PolygonShape;
+  const polygon = shape;
   const transform = createTransform(x, y, angle);
   const worldVertices: number[] = [];
   const worldNormals: number[] = [];

--- a/packages/exojs-physics/src/shapes/AnyShape.ts
+++ b/packages/exojs-physics/src/shapes/AnyShape.ts
@@ -1,0 +1,10 @@
+import type { CircleShape } from './CircleShape';
+import type { PolygonShape } from './PolygonShape';
+
+/**
+ * Discriminated union of the concrete shape kinds. Narrow via the literal
+ * `shape.type` discriminant (`'circle'` → {@link CircleShape}, `'polygon'` →
+ * {@link PolygonShape}) — no `as` casts needed. {@link BoxShape} is a
+ * {@link PolygonShape} subclass and carries `type: 'polygon'`.
+ */
+export type AnyShape = CircleShape | PolygonShape;

--- a/packages/exojs-physics/src/shapes/CircleShape.ts
+++ b/packages/exojs-physics/src/shapes/CircleShape.ts
@@ -1,4 +1,3 @@
-import type { ShapeType } from './Shape';
 import { Shape } from './Shape';
 
 /**
@@ -6,7 +5,7 @@ import { Shape } from './Shape';
  * The cheapest shape for both broad- and narrow-phase.
  */
 export class CircleShape extends Shape {
-  public readonly type: ShapeType = 'circle';
+  public readonly type = 'circle' as const;
   public readonly radius: number;
   public readonly boundingRadius: number;
   public readonly area: number;

--- a/packages/exojs-physics/src/shapes/PolygonShape.ts
+++ b/packages/exojs-physics/src/shapes/PolygonShape.ts
@@ -1,5 +1,4 @@
 import type { VectorLike } from '../types';
-import type { ShapeType } from './Shape';
 import { Shape } from './Shape';
 
 /** Vertices closer than this (px) are treated as coincident → degenerate. */
@@ -15,7 +14,7 @@ const weldEpsilon = 1e-4;
  * the narrow phase allocation-free; both are frozen.
  */
 export class PolygonShape extends Shape {
-  public readonly type: ShapeType = 'polygon';
+  public readonly type = 'polygon' as const;
 
   /** Local-space vertices, CCW, flattened. */
   public readonly vertices: readonly number[];

--- a/packages/exojs-physics/src/shapes/index.ts
+++ b/packages/exojs-physics/src/shapes/index.ts
@@ -1,3 +1,4 @@
+export type { AnyShape } from './AnyShape';
 export { BoxShape } from './BoxShape';
 export { CircleShape } from './CircleShape';
 export { PolygonShape } from './PolygonShape';


### PR DESCRIPTION
## Welle 2 — Slice 1d (Physics-Shape als echte Discriminated Union)

Each shape subclass carries a **literal** `type` (`'circle' as const` / `'polygon' as const`) instead of the widened `ShapeType`. A new `AnyShape = CircleShape | PolygonShape` union types the `shape` field on `CollisionProxy`, `Collider`/`ColliderOptions`, `PhysicsBodyOptions`, `overlapShape` (world + query) and `makeProxy` — **the actual lever**: with `shape` a union, `shape.type === '…'` narrows to the concrete class.

Removes all **12** `as CircleShape`/`as PolygonShape` casts (Collider ×3, narrowphase ×2, QueryEngine ×5, PhysicsDebugDraw ×2). The four dispatch helpers without an inline guard (radiusOf/countOf/rayCastCircle/rayCastPolygon) use a `type === '…' ? … : 0` expression whose fallback is unreachable per the dispatch contract.

`BoxShape` (PolygonShape subclass) keeps `type: 'polygon'`. `overlapShape`'s signature gets stricter (AnyShape, not abstract Shape) — every concrete shape satisfies it, no real call site breaks.

### Verifikation
physics typecheck 0 · lint:packages 0 · **87 physics tests green** (SG matrix / manifold / queries unchanged) · docs:api in sync · format green.