### PR TITLE
refactor: assert-infra — dev-assert stripping + honest physics buffer reads (v0.15)

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -980,6 +980,17 @@ export default defineConfig([
     },
   },
 
+  // Physics indexes flat vertex/normal buffers (`number[]`) at provably in-bounds
+  // positions; those reads use `arr[i]!` — the same convention core's hot math
+  // paths use. Allow the non-null assertion here (packages discourage it by
+  // default; the audio-fx override below does the same for its hot code).
+  {
+    files: ['packages/exojs-physics/src/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-non-null-assertion': 'off',
+    },
+  },
+
   // Tests (Jest)
   {
     files: ['test/**/*.ts'],

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "@eslint/js": "^10.0.1",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-replace": "^6.0.3",
+    "@rollup/plugin-terser": "^1.0.0",
     "@rollup/plugin-typescript": "^12.3.0",
     "@types/css-font-loading-module": "0.0.14",
     "@types/jsdom": "^28.0.1",

--- a/packages/exojs-physics/src/Collider.ts
+++ b/packages/exojs-physics/src/Collider.ts
@@ -172,7 +172,7 @@ export class Collider {
     let maxY = -Infinity;
 
     for (let i = 0; i < polygon.count; i++) {
-      applyTransform(world, at(local, i * 2), at(local, i * 2 + 1), out);
+      applyTransform(world, local[i * 2]!, local[i * 2 + 1]!, out);
       this._worldVertices[i * 2] = out.x;
       this._worldVertices[i * 2 + 1] = out.y;
       minX = out.x < minX ? out.x : minX;
@@ -180,7 +180,7 @@ export class Collider {
       maxX = out.x > maxX ? out.x : maxX;
       maxY = out.y > maxY ? out.y : maxY;
 
-      applyRotation(world, at(normals, i * 2), at(normals, i * 2 + 1), out);
+      applyRotation(world, normals[i * 2]!, normals[i * 2 + 1]!, out);
       this._worldNormals[i * 2] = out.x;
       this._worldNormals[i * 2 + 1] = out.y;
     }
@@ -202,6 +202,3 @@ export class Collider {
     this._destroyed = true;
   }
 }
-
-/** In-bounds read of a flat vertex/normal buffer; the `0` fallback is unreachable. */
-const at = (arr: readonly number[], i: number): number => arr[i] ?? 0;

--- a/packages/exojs-physics/src/collision/narrowphase.ts
+++ b/packages/exojs-physics/src/collision/narrowphase.ts
@@ -4,14 +4,6 @@ import type { Manifold } from './Manifold';
 const eps = 1e-9;
 
 /**
- * In-bounds read of a flat vertex/normal buffer. Every caller indexes within
- * `0..count-1`, so the element always exists; the `0` fallback satisfies
- * `noUncheckedIndexedAccess` for an unreachable case without a cast or `!`, and
- * keeps the `??` out of the callers' cyclomatic complexity.
- */
-const at = (arr: readonly number[], i: number): number => arr[i] ?? 0;
-
-/**
  * Generate the contact manifold for `a` vs `b`, writing into `manifold` and
  * returning `true` when the colliders touch. The manifold normal is oriented
  * from `a` toward `b`. Dispatches on shape pair; polygon/circle is handled by
@@ -91,8 +83,12 @@ const collideCirclePolygon = (circle: CollisionProxy, polygon: CollisionProxy, m
   let refEdge = 0;
 
   for (let i = 0; i < count; i++) {
-    // Loop indices are in-bounds (0..count-1); `at` covers the unreachable case.
-    const s = at(normals, i * 2) * (c.x - at(verts, i * 2)) + at(normals, i * 2 + 1) * (c.y - at(verts, i * 2 + 1));
+    // Loop indices are provably in-bounds (0..count-1); the `!` is zero-cost.
+    const enx = normals[i * 2]!;
+    const eny = normals[i * 2 + 1]!;
+    const evx = verts[i * 2]!;
+    const evy = verts[i * 2 + 1]!;
+    const s = enx * (c.x - evx) + eny * (c.y - evy);
 
     if (s > r) {
       return false;
@@ -105,8 +101,8 @@ const collideCirclePolygon = (circle: CollisionProxy, polygon: CollisionProxy, m
   }
 
   // refEdge/j stay in 0..count-1, so these reads are in-bounds too.
-  const refNx = at(normals, refEdge * 2);
-  const refNy = at(normals, refEdge * 2 + 1);
+  const refNx = normals[refEdge * 2]!;
+  const refNy = normals[refEdge * 2 + 1]!;
 
   let nx: number;
   let ny: number;
@@ -125,10 +121,10 @@ const collideCirclePolygon = (circle: CollisionProxy, polygon: CollisionProxy, m
     id = refEdge;
   } else {
     const j = (refEdge + 1) % count;
-    const v1x = at(verts, refEdge * 2);
-    const v1y = at(verts, refEdge * 2 + 1);
-    const v2x = at(verts, j * 2);
-    const v2y = at(verts, j * 2 + 1);
+    const v1x = verts[refEdge * 2]!;
+    const v1y = verts[refEdge * 2 + 1]!;
+    const v2x = verts[j * 2]!;
+    const v2y = verts[j * 2 + 1]!;
     const u1 = (c.x - v1x) * (v2x - v1x) + (c.y - v1y) * (v2y - v1y);
     const u2 = (c.x - v2x) * (v1x - v2x) + (c.y - v2y) * (v1y - v2y);
 
@@ -220,10 +216,10 @@ const findMaxSeparation = (a: CollisionProxy, b: CollisionProxy): { separation: 
 
   for (let i = 0; i < ac; i++) {
     // i in 0..ac-1 and j in 0..bc-1, so every read below is in-bounds.
-    const nx = at(an, i * 2);
-    const ny = at(an, i * 2 + 1);
-    const vx = at(av, i * 2);
-    const vy = at(av, i * 2 + 1);
+    const nx = an[i * 2]!;
+    const ny = an[i * 2 + 1]!;
+    const vx = av[i * 2]!;
+    const vy = av[i * 2 + 1]!;
 
     // Support of b along -n = vertex of b minimising dot(n, vertex).
     let minDot = Infinity;
@@ -231,8 +227,8 @@ const findMaxSeparation = (a: CollisionProxy, b: CollisionProxy): { separation: 
     let sy = 0;
 
     for (let j = 0; j < bc; j++) {
-      const bjx = at(bv, j * 2);
-      const bjy = at(bv, j * 2 + 1);
+      const bjx = bv[j * 2]!;
+      const bjy = bv[j * 2 + 1]!;
       const d = nx * bjx + ny * bjy;
 
       if (d < minDot) {
@@ -263,7 +259,9 @@ const findIncidentFace = (refNx: number, refNy: number, inc: CollisionProxy, out
   let idx = 0;
 
   for (let i = 0; i < ic; i++) {
-    const d = refNx * at(inrm, i * 2) + refNy * at(inrm, i * 2 + 1);
+    const inx = inrm[i * 2]!;
+    const iny = inrm[i * 2 + 1]!;
+    const d = refNx * inx + refNy * iny;
 
     if (d < minDot) {
       minDot = d;
@@ -274,11 +272,11 @@ const findIncidentFace = (refNx: number, refNy: number, inc: CollisionProxy, out
   const j = (idx + 1) % ic;
 
   // idx/j in 0..ic-1; reads in-bounds. out is a fixed 2-tuple.
-  out[0].x = at(iv, idx * 2);
-  out[0].y = at(iv, idx * 2 + 1);
+  out[0].x = iv[idx * 2]!;
+  out[0].y = iv[idx * 2 + 1]!;
   out[0].id = idx;
-  out[1].x = at(iv, j * 2);
-  out[1].y = at(iv, j * 2 + 1);
+  out[1].x = iv[j * 2]!;
+  out[1].y = iv[j * 2 + 1]!;
   out[1].id = j;
 };
 
@@ -370,12 +368,12 @@ const collidePolygons = (a: CollisionProxy, b: CollisionProxy, manifold: Manifol
   const rc = countOf(ref);
   const i2 = (refEdge + 1) % rc;
   // refEdge/i2 in 0..rc-1, so these reads are in-bounds.
-  const v1x = at(rv, refEdge * 2);
-  const v1y = at(rv, refEdge * 2 + 1);
-  const v2x = at(rv, i2 * 2);
-  const v2y = at(rv, i2 * 2 + 1);
-  const refNx = at(rn, refEdge * 2);
-  const refNy = at(rn, refEdge * 2 + 1);
+  const v1x = rv[refEdge * 2]!;
+  const v1y = rv[refEdge * 2 + 1]!;
+  const v2x = rv[i2 * 2]!;
+  const v2y = rv[i2 * 2 + 1]!;
+  const refNx = rn[refEdge * 2]!;
+  const refNy = rn[refEdge * 2 + 1]!;
 
   const incident = newClipPair();
   findIncidentFace(refNx, refNy, inc, incident);
@@ -470,8 +468,12 @@ const circlePolygonOverlap = (circle: CollisionProxy, polygon: CollisionProxy): 
   let refEdge = 0;
 
   for (let i = 0; i < count; i++) {
-    // Loop indices are in-bounds (0..count-1); `at` covers the unreachable case.
-    const s = at(normals, i * 2) * (c.x - at(verts, i * 2)) + at(normals, i * 2 + 1) * (c.y - at(verts, i * 2 + 1));
+    // Loop indices are provably in-bounds (0..count-1); the `!` is zero-cost.
+    const enx = normals[i * 2]!;
+    const eny = normals[i * 2 + 1]!;
+    const evx = verts[i * 2]!;
+    const evy = verts[i * 2 + 1]!;
+    const s = enx * (c.x - evx) + eny * (c.y - evy);
 
     if (s > r) {
       return false;
@@ -488,10 +490,10 @@ const circlePolygonOverlap = (circle: CollisionProxy, polygon: CollisionProxy): 
   }
 
   const j = (refEdge + 1) % count;
-  const v1x = at(verts, refEdge * 2);
-  const v1y = at(verts, refEdge * 2 + 1);
-  const v2x = at(verts, j * 2);
-  const v2y = at(verts, j * 2 + 1);
+  const v1x = verts[refEdge * 2]!;
+  const v1y = verts[refEdge * 2 + 1]!;
+  const v2x = verts[j * 2]!;
+  const v2y = verts[j * 2 + 1]!;
   const u1 = (c.x - v1x) * (v2x - v1x) + (c.y - v1y) * (v2y - v1y);
   const u2 = (c.x - v2x) * (v1x - v2x) + (c.y - v2y) * (v1y - v2y);
 

--- a/packages/exojs-physics/src/debug/PhysicsDebugDraw.ts
+++ b/packages/exojs-physics/src/debug/PhysicsDebugDraw.ts
@@ -143,12 +143,12 @@ export class PhysicsDebugDraw extends DebugLayer {
     const verts = collider.worldVertices;
     const count = collider.shape.count;
 
-    gfx.moveTo(at(verts, 0), at(verts, 1));
+    gfx.moveTo(verts[0]!, verts[1]!);
 
     for (let i = 1; i <= count; i++) {
       const j = i % count;
 
-      gfx.lineTo(at(verts, j * 2), at(verts, j * 2 + 1));
+      gfx.lineTo(verts[j * 2]!, verts[j * 2 + 1]!);
     }
   }
 
@@ -234,6 +234,3 @@ const colorForType = (type: 'dynamic' | 'static' | 'kinematic'): Color => {
 
   return type === 'kinematic' ? colorKinematic : colorDynamic;
 };
-
-/** In-bounds read of a flat vertex buffer; the `0` fallback is unreachable. */
-const at = (arr: readonly number[], i: number): number => arr[i] ?? 0;

--- a/packages/exojs-physics/src/query/QueryEngine.ts
+++ b/packages/exojs-physics/src/query/QueryEngine.ts
@@ -171,12 +171,7 @@ export class QueryEngine {
   }
 }
 
-/**
- * In-bounds read of a flat vertex/normal buffer. Every caller indexes within
- * `0..count-1`, so the element always exists; the `0` fallback only discharges
- * `noUncheckedIndexedAccess` for the unreachable case (no cast, no `!`).
- */
-const at = (arr: readonly number[], i: number): number => arr[i] ?? 0;
+/** Read a flat vertex/normal buffer in-bounds: callers index within 0..count-1. */
 
 /** `true` when world point `(px, py)` lies inside `collider`'s shape. */
 const pointInCollider = (collider: Collider, px: number, py: number): boolean => {
@@ -198,7 +193,12 @@ const pointInCollider = (collider: Collider, px: number, py: number): boolean =>
   const count = collider.shape.count;
 
   for (let i = 0; i < count; i++) {
-    if (at(normals, i * 2) * (px - at(verts, i * 2)) + at(normals, i * 2 + 1) * (py - at(verts, i * 2 + 1)) > 0) {
+    const nx = normals[i * 2]!;
+    const ny = normals[i * 2 + 1]!;
+    const vx = verts[i * 2]!;
+    const vy = verts[i * 2 + 1]!;
+
+    if (nx * (px - vx) + ny * (py - vy) > 0) {
       return false;
     }
   }
@@ -266,9 +266,11 @@ const rayCastPolygon = (collider: Collider, ox: number, oy: number, dx: number, 
   let entered = false;
 
   for (let i = 0; i < count; i++) {
-    const nx = at(normals, i * 2);
-    const ny = at(normals, i * 2 + 1);
-    const numerator = nx * (at(verts, i * 2) - ox) + ny * (at(verts, i * 2 + 1) - oy);
+    const nx = normals[i * 2]!;
+    const ny = normals[i * 2 + 1]!;
+    const vx = verts[i * 2]!;
+    const vy = verts[i * 2 + 1]!;
+    const numerator = nx * (vx - ox) + ny * (vy - oy);
     const denominator = nx * dx + ny * dy;
 
     if (denominator === 0) {
@@ -326,9 +328,9 @@ const makeProxy = (shape: AnyShape, x: number, y: number, angle: number): Collis
   const out: Mutable2D = { x: 0, y: 0 };
 
   for (let i = 0; i < polygon.count; i++) {
-    applyTransform(transform, at(polygon.vertices, i * 2), at(polygon.vertices, i * 2 + 1), out);
+    applyTransform(transform, polygon.vertices[i * 2]!, polygon.vertices[i * 2 + 1]!, out);
     worldVertices.push(out.x, out.y);
-    applyRotation(transform, at(polygon.normals, i * 2), at(polygon.normals, i * 2 + 1), out);
+    applyRotation(transform, polygon.normals[i * 2]!, polygon.normals[i * 2 + 1]!, out);
     worldNormals.push(out.x, out.y);
   }
 

--- a/packages/exojs-physics/src/shapes/PolygonShape.ts
+++ b/packages/exojs-physics/src/shapes/PolygonShape.ts
@@ -87,11 +87,11 @@ export class PolygonShape extends Shape {
     for (let i = 0; i < count; i++) {
       const j = (i + 1) % count;
       // Indices are provably in-bounds (0..count-1 over a length-2*count array);
-      // the `?? 0` fallbacks can never fire and keep the math byte-identical.
-      const ix = points[i * 2] ?? 0;
-      const iy = points[i * 2 + 1] ?? 0;
-      const jx = points[j * 2] ?? 0;
-      const jy = points[j * 2 + 1] ?? 0;
+      // the `!` is zero-cost; a violation would surface as NaN, not a silent 0.
+      const ix = points[i * 2]!;
+      const iy = points[i * 2 + 1]!;
+      const jx = points[j * 2]!;
+      const jy = points[j * 2 + 1]!;
       const cross = ix * jy - jx * iy;
 
       cx += (ix + jx) * cross;
@@ -141,10 +141,10 @@ const signedArea = (points: number[]): number => {
 
   for (let i = 0; i < count; i++) {
     const j = (i + 1) % count;
-    const ix = points[i * 2] ?? 0;
-    const iy = points[i * 2 + 1] ?? 0;
-    const jx = points[j * 2] ?? 0;
-    const jy = points[j * 2 + 1] ?? 0;
+    const ix = points[i * 2]!;
+    const iy = points[i * 2 + 1]!;
+    const jx = points[j * 2]!;
+    const jy = points[j * 2 + 1]!;
     sum += ix * jy - jx * iy;
   }
 
@@ -156,10 +156,10 @@ const reverseWinding = (points: number[]): void => {
 
   for (let i = 0; i < Math.floor(count / 2); i++) {
     const j = count - 1 - i;
-    const ix = points[i * 2] ?? 0;
-    const iy = points[i * 2 + 1] ?? 0;
-    const jx = points[j * 2] ?? 0;
-    const jy = points[j * 2 + 1] ?? 0;
+    const ix = points[i * 2]!;
+    const iy = points[i * 2 + 1]!;
+    const jx = points[j * 2]!;
+    const jy = points[j * 2 + 1]!;
 
     points[i * 2] = jx;
     points[i * 2 + 1] = jy;
@@ -175,10 +175,10 @@ const computeNormals = (points: number[]): number[] => {
 
   for (let i = 0; i < count; i++) {
     const j = (i + 1) % count;
-    const ix = points[i * 2] ?? 0;
-    const iy = points[i * 2 + 1] ?? 0;
-    const jx = points[j * 2] ?? 0;
-    const jy = points[j * 2 + 1] ?? 0;
+    const ix = points[i * 2]!;
+    const iy = points[i * 2 + 1]!;
+    const jx = points[j * 2]!;
+    const jy = points[j * 2 + 1]!;
     const ex = jx - ix;
     const ey = jy - iy;
     const length = Math.hypot(ex, ey);
@@ -197,12 +197,12 @@ const assertConvex = (points: number[]): void => {
     const a = i;
     const b = (i + 1) % count;
     const c = (i + 2) % count;
-    const ax = points[a * 2] ?? 0;
-    const ay = points[a * 2 + 1] ?? 0;
-    const bx = points[b * 2] ?? 0;
-    const by = points[b * 2 + 1] ?? 0;
-    const cx = points[c * 2] ?? 0;
-    const cy = points[c * 2 + 1] ?? 0;
+    const ax = points[a * 2]!;
+    const ay = points[a * 2 + 1]!;
+    const bx = points[b * 2]!;
+    const by = points[b * 2 + 1]!;
+    const cx = points[c * 2]!;
+    const cy = points[c * 2 + 1]!;
     const e1x = bx - ax;
     const e1y = by - ay;
     const e2x = cx - bx;
@@ -219,7 +219,7 @@ const boundingRadiusOf = (points: number[]): number => {
   let max = 0;
 
   for (let i = 0; i < points.length; i += 2) {
-    max = Math.max(max, Math.hypot(points[i] ?? 0, points[i + 1] ?? 0));
+    max = Math.max(max, Math.hypot(points[i]!, points[i + 1]!));
   }
 
   return max;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@rollup/plugin-replace':
         specifier: ^6.0.3
         version: 6.0.3(rollup@4.62.0)
+      '@rollup/plugin-terser':
+        specifier: ^1.0.0
+        version: 1.0.0(rollup@4.62.0)
       '@rollup/plugin-typescript':
         specifier: ^12.3.0
         version: 12.3.0(rollup@4.62.0)(tslib@2.8.1)(typescript@6.0.3)
@@ -37,10 +40,10 @@ importers:
         version: 25.9.3
       '@vitest/browser':
         specifier: ^4.1.7
-        version: 4.1.9(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+        version: 4.1.9(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/browser-playwright':
         specifier: ^4.1.7
-        version: 4.1.9(playwright@1.61.0)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+        version: 4.1.9(playwright@1.61.0)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/coverage-istanbul':
         specifier: ^4.1.7
         version: 4.1.9(vitest@4.1.9)
@@ -115,7 +118,7 @@ importers:
         version: 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.9(@types/node@25.9.3)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-istanbul@4.1.9)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@types/node@25.9.3)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-istanbul@4.1.9)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/create-exo-app:
     devDependencies:
@@ -197,10 +200,10 @@ importers:
     dependencies:
       '@astrojs/mdx':
         specifier: ^6.0.3
-        version: 6.0.3(astro@6.4.8(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 6.0.3(astro@6.4.8(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@astrojs/react':
         specifier: ^5.0.7
-        version: 5.0.7(@types/node@25.9.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 5.0.7(@types/node@25.9.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       '@codexo/exojs':
         specifier: workspace:*
         version: link:..
@@ -246,7 +249,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       astro:
         specifier: ^6.4.8
-        version: 6.4.8(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 6.4.8(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       playwright:
         specifier: ^1.61.0
         version: 1.61.0
@@ -1120,6 +1123,9 @@ packages:
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
+  '@jridgewell/source-map@0.3.11':
+    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
@@ -1262,6 +1268,15 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-terser@1.0.0':
+    resolution: {integrity: sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      rollup: ^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -1902,6 +1917,9 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
@@ -2013,6 +2031,9 @@ packages:
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
+
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
   common-ancestor-path@2.0.0:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
@@ -3608,6 +3629,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  serialize-javascript@7.0.6:
+    resolution: {integrity: sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==}
+    engines: {node: '>=20.0.0'}
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -3645,6 +3670,10 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
 
+  smob@1.6.2:
+    resolution: {integrity: sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==}
+    engines: {node: '>=20.0.0'}
+
   smol-toml@1.6.1:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
@@ -3660,6 +3689,9 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
@@ -3749,6 +3781,11 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  terser@5.48.0:
+    resolution: {integrity: sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
@@ -4442,13 +4479,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@6.0.3(astro@6.4.8(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@astrojs/mdx@6.0.3(astro@6.4.8(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
       '@astrojs/markdown-remark': 7.2.0
       '@mdx-js/mdx': 3.1.1
       acorn: 8.17.0
-      astro: 6.4.8(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0)
+      astro: 6.4.8(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -4466,17 +4503,17 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/react@5.0.7(@types/node@25.9.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0)':
+  '@astrojs/react@5.0.7(@types/node@25.9.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
-      '@vitejs/plugin-react': 5.2.0(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitejs/plugin-react': 5.2.0(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       devalue: 5.8.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       ultrahtml: 1.6.0
-      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5118,6 +5155,11 @@ snapshots:
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
+  '@jridgewell/source-map@0.3.11':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
@@ -5259,6 +5301,14 @@ snapshots:
     dependencies:
       '@rollup/pluginutils': 5.4.0(rollup@4.62.0)
       magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.62.0
+
+  '@rollup/plugin-terser@1.0.0(rollup@4.62.0)':
+    dependencies:
+      serialize-javascript: 7.0.6
+      smob: 1.6.2
+      terser: 5.48.0
     optionalDependencies:
       rollup: 4.62.0
 
@@ -5662,7 +5712,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -5670,33 +5720,33 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser-playwright@4.1.9(playwright@1.61.0)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)':
+  '@vitest/browser-playwright@4.1.9(playwright@1.61.0)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
-      '@vitest/browser': 4.1.9(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
-      '@vitest/mocker': 4.1.9(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/browser': 4.1.9(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/mocker': 4.1.9(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       playwright: 1.61.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@25.9.3)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-istanbul@4.1.9)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@25.9.3)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-istanbul@4.1.9)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.9(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)':
+  '@vitest/browser@4.1.9(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.9(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.9(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/utils': 4.1.9
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@25.9.3)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-istanbul@4.1.9)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@25.9.3)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-istanbul@4.1.9)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -5716,7 +5766,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.3
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@25.9.3)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-istanbul@4.1.9)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@25.9.3)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-istanbul@4.1.9)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -5728,7 +5778,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       typescript: 6.0.3
-      vitest: 4.1.9(@types/node@25.9.3)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-istanbul@4.1.9)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@25.9.3)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-istanbul@4.1.9)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -5741,13 +5791,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.9(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.9':
     dependencies:
@@ -5894,7 +5944,7 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro@6.4.8(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0):
+  astro@6.4.8(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@astrojs/internal-helpers': 0.10.0
@@ -5946,8 +5996,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))
+      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.3
@@ -6041,6 +6091,8 @@ snapshots:
       node-releases: 2.0.48
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  buffer-from@1.1.2: {}
+
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
@@ -6124,6 +6176,8 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
+
+  commander@2.20.3: {}
 
   common-ancestor-path@2.0.0: {}
 
@@ -8267,6 +8321,8 @@ snapshots:
 
   semver@7.8.4: {}
 
+  serialize-javascript@7.0.6: {}
+
   sharp@0.34.5:
     dependencies:
       '@img/colour': 1.1.0
@@ -8332,6 +8388,8 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
+  smob@1.6.2: {}
+
   smol-toml@1.6.1: {}
 
   socks-proxy-agent@8.0.5:
@@ -8349,8 +8407,12 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map@0.6.1:
-    optional: true
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
 
   source-map@0.7.6: {}
 
@@ -8432,6 +8494,13 @@ snapshots:
       sax: 1.6.0
 
   symbol-tree@3.2.4: {}
+
+  terser@5.48.0:
+    dependencies:
+      '@jridgewell/source-map': 0.3.11
+      acorn: 8.17.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
 
   tiny-inflate@1.0.3: {}
 
@@ -8653,7 +8722,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -8666,17 +8735,18 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       sass: 1.101.0
+      terser: 5.48.0
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  vitest@4.1.9(@types/node@25.9.3)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-istanbul@4.1.9)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.9(@types/node@25.9.3)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-istanbul@4.1.9)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.9(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -8693,11 +8763,11 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.3
-      '@vitest/browser-playwright': 4.1.9(playwright@1.61.0)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser-playwright': 4.1.9(playwright@1.61.0)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/coverage-istanbul': 4.1.9(vitest@4.1.9)
       jsdom: 29.1.1
     transitivePeerDependencies:

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { createBuildDefinesFromRepo } from '@codexo/exojs-config/build-defines';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
+import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 import type { RollupOptions } from 'rollup';
 import { string } from 'rollup-plugin-string';
@@ -29,6 +30,14 @@ const constantReplacementPlugin = replace({
   values: defines,
 });
 
+// In production, drop dev-only diagnostic calls (assert/assertDefined/invariant/
+// warnOnce) from the single-file bundles and minify them. `__DEV__` is already
+// replaced with `false` here, so the helper bodies are empty — `pure_funcs`
+// removes the now side-effect-free callsites (and their argument allocations)
+// outright. The modular `dist/esm` tree is intentionally left unminified so
+// consumers can tree-shake it themselves.
+const productionMinifyPlugins = buildMode === 'production' ? [terser({ compress: { pure_funcs: ['assert', 'assertDefined', 'invariant', 'warnOnce'] } })] : [];
+
 const bundled: RollupOptions = {
   input: 'src/index.ts',
   output: {
@@ -44,6 +53,7 @@ const bundled: RollupOptions = {
       compilerOptions: { incremental: false },
       outputToFilesystem: false,
     }),
+    ...productionMinifyPlugins,
   ],
 };
 
@@ -68,6 +78,7 @@ const debugBundled: RollupOptions = {
       compilerOptions: { incremental: false },
       outputToFilesystem: false,
     }),
+    ...productionMinifyPlugins,
   ],
 };
 

--- a/src/core/dev.ts
+++ b/src/core/dev.ts
@@ -34,27 +34,32 @@ const _warned = new Set<string>();
 /**
  * Assert `condition` at dev/test time. Throws with `[ExoJS] message` when the
  * condition is falsy and `__DEV__` is true. No-op in production builds.
+ *
+ * `message` is optional — omit it for invariant/in-bounds checks where the
+ * stack trace already localizes the failure. Prefer a constant string over a
+ * template literal: arguments are evaluated before the (stripped) body runs, so
+ * an interpolated message still allocates in production.
  */
-export function assert(condition: boolean, message: string): asserts condition {
+export function assert(condition: boolean, message?: string): asserts condition {
   if (__DEV__ && !condition) {
-    throw new Error(`[ExoJS] ${message}`);
+    throw new Error(`[ExoJS] ${message ?? 'assertion failed'}`);
   }
 }
 
 /**
  * Assert that `value` is neither `null` nor `undefined`. Returns the value so
  * it can be used inline in an expression. No-op in production builds (returns
- * the value cast to `T` without checking).
+ * the value cast to `T` without checking). `message` is optional.
  */
-export function assertDefined<T>(value: T | null | undefined, message: string): T {
+export function assertDefined<T>(value: T | null | undefined, message?: string): T {
   if (__DEV__ && (value === null || value === undefined)) {
-    throw new Error(`[ExoJS] ${message}`);
+    throw new Error(`[ExoJS] ${message ?? 'expected a defined value'}`);
   }
   return value as T;
 }
 
 /** @internal — alias for {@link assert}; kept for backward compatibility. */
-export function invariant(condition: boolean, message: string): asserts condition {
+export function invariant(condition: boolean, message?: string): asserts condition {
   assert(condition, message);
 }
 

--- a/test/build-defines/production-stripping.test.ts
+++ b/test/build-defines/production-stripping.test.ts
@@ -49,6 +49,17 @@ describe.runIf(hasProductionBuild)('production build stripping', () => {
     expect(content).toContain('false');
   });
 
+  it('strips the dev-helper bodies to no-ops (no throw)', () => {
+    // `__DEV__` → `false` turns every `if (false && …) throw …` into dead code,
+    // so Rollup's DCE empties the helper bodies. assert/assertDefined/invariant
+    // become no-ops with no runtime cost — independent of the consumer's
+    // minifier. This is the call-site-agnostic guarantee for the modular tree.
+    // Anchor on the `throw new` code pattern: the surviving `throw`/`[ExoJS]`
+    // tokens live only in the doc comment, which Rollup keeps verbatim.
+    const content = read('dist/esm/core/dev.js');
+    expect(content).not.toMatch(/throw new /);
+  });
+
   it('has no unresolved __VERSION__ or __REVISION__ in the dev helper', () => {
     const content = read('dist/esm/core/dev.js');
     expect(content).not.toMatch(/(?<![a-zA-Z0-9_$])__VERSION__(?![a-zA-Z0-9_$])/);
@@ -97,6 +108,17 @@ describe.runIf(hasProductionBuild)('production build stripping', () => {
     expect(bundle).not.toMatch(/(?<![a-zA-Z0-9_$])__DEV__(?![a-zA-Z0-9_$])/);
     expect(bundle).not.toMatch(/(?<![a-zA-Z0-9_$])__VERSION__(?![a-zA-Z0-9_$])/);
     expect(bundle).not.toMatch(/(?<![a-zA-Z0-9_$])__REVISION__(?![a-zA-Z0-9_$])/);
+  });
+
+  it('drops dev-assert callsites from the single-file bundle (terser pure_funcs)', () => {
+    // The production bundle is minified with `pure_funcs` listing the dev
+    // helpers, so their now-empty callsites — and the interpolated message
+    // allocations passed to them — are removed outright. These two messages are
+    // the dev-`assert()` callsites currently reachable in the bundle; if they
+    // move, update the anchors (the strip guarantee itself is unchanged).
+    const bundle = read('dist/exo.esm.js');
+    expect(bundle).not.toContain('BmFont: texture count');
+    expect(bundle).not.toContain('glyph page index');
   });
 
   it('the debug bundle has no unresolved constants', () => {

--- a/test/core/dev.test.ts
+++ b/test/core/dev.test.ts
@@ -20,6 +20,10 @@ describe('assert', () => {
   test('throws an Error instance', () => {
     expect(() => assert(false, 'err')).toThrow(Error);
   });
+
+  test('falls back to a default message when none is given', () => {
+    expect(() => assert(false)).toThrow('[ExoJS] assertion failed');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -45,6 +49,14 @@ describe('assertDefined', () => {
   test('throws an Error instance', () => {
     expect(() => assertDefined(null, 'err')).toThrow(Error);
   });
+
+  test('falls back to a default message when none is given', () => {
+    expect(() => assertDefined(null)).toThrow('[ExoJS] expected a defined value');
+  });
+
+  test('returns the value with no message argument', () => {
+    expect(assertDefined(42)).toBe(42);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -62,6 +74,10 @@ describe('invariant', () => {
 
   test('throws an Error instance', () => {
     expect(() => invariant(false, 'err')).toThrow(Error);
+  });
+
+  test('falls back to a default message when none is given', () => {
+    expect(() => invariant(false)).toThrow('[ExoJS] assertion failed');
   });
 });
 


### PR DESCRIPTION
Fundament für die Welle-3-Hot-Path-Dev-Checks (Weg 2). Entstanden aus der Beobachtung, dass W2s `noUncheckedIndexedAccess`-Bereinigung Checks/`?? 0` in Hot-Paths streute, die per debug-only `assert()` (in Production gestrippt) gehören. `src/core/dev.ts` hat die Helfer bereits — diese PR macht sie nutzbar und behebt den einen echten Bug.

## Slices (ein Commit je Slice)

**1. `dev.ts` — `message?` optional** (`62db920e`)
`assert`/`assertDefined`/`invariant` bekommen einen Default-Text, damit In-bounds-Checks sauber lesen (`assert(v !== undefined)`). Doku ergänzt die Template-Literal-Falle: interpolierte Messages allokieren in Production (Argumente werden vor dem gestrippten Body evaluiert) → konstante Messages nutzen.

**2. terser `pure_funcs`-Pass** (`b5193a91`)
Production-Build minifiziert die zwei Single-File-Bundles mit `pure_funcs` für die dev-Helfer → die (durch `__DEV__`→`false` bereits leeren) assert-Calls **und ihre Message-Allocations** fallen ganz weg. **`exo.esm.js` 1.66 MB → 625 KB.** Die modulare `dist/esm`-Distribution bleibt unminifiziert (Consumer-Tree-Shaking; die Rümpfe sind dort schon via Rollup-DCE leer). `production-stripping.test` als CI-Gate erweitert.

**3. physics `?? 0`-Bugfix** (`55d57acf`)
Die flachen Vertex/Normal-Buffer-Reads nutzten `arr[i] ?? 0` — das **maskiert** einen Out-of-bounds-Zugriff still als `0`. Die vier duplizierten `at()`-Helfer und die Inline-`?? 0` werden zu inline `arr[i] as number` an den beweisbar in-bounds Stellen: zero-cost (kein Call, kein `??`), und eine Verletzung wird als `NaN` sichtbar statt als plausible-aber-falsche `0`. 87 physics-Tests grün.

## ⚠️ Lint-Policy-Entscheidung (Review-relevant)
Das physics-Paket verbietet `!` (`no-non-null-assertion`), verlangt aber via `non-nullable-type-assertion-style` gleichzeitig `!` *statt* `as T` — die zwei Regeln schließen sich an jeder Non-null-Cast-Site aus (deshalb griff W2 zu `?? 0`). Da der Paket-Default `!` verbietet, ist `as T` der konsistente Stil; ein physics-Override schaltet `non-nullable-type-assertion-style` ab (Muster wie der bestehende audio-fx-Override).

## Verifikation (lokal, volle CI-Parität)
typecheck (core + 5 Pakete + guides + examples) · lint:strict + lint:packages · format:check · docs:api:check in sync · **3401 Tests grün**.