### PR TITLE
perf(rendering): v0.15 W3 — render-plan allocation + GPU resource-accounting (2a·2b·2c·2e·2g)

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "perf:renderers": "tsx test/perf/rendering/run-sweep.ts full",
     "perf:renderers:quick": "tsx test/perf/rendering/run-sweep.ts quick",
     "perf:renderers:browser": "vitest run --project=browser-webgl-chromium webgl2-renderer-perf",
+    "perf:renderers:alloc": "node --import tsx/esm test/perf/rendering/run-allocation.ts",
     "perf:bench:rendering": "tsx test/perf/rendering-benchmark.ts",
     "perf:bench:audio": "tsx test/perf/audio-benchmark.ts",
     "perf:bench:collision": "tsx test/perf/collision-benchmark.ts",

--- a/site/src/content/api/drawable.mdx
+++ b/site/src/content/api/drawable.mdx
@@ -9,7 +9,7 @@ memberCount: 80
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/rendering/Drawable.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/Drawable.ts#L15"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/Drawable.ts#L17"
 ---
 ## Import
 
@@ -115,4 +115,4 @@ and are paired with a matching Renderer via RendererRegistry.
 
 ## Source
 
-[src/rendering/Drawable.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/Drawable.ts#L15)
+[src/rendering/Drawable.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/Drawable.ts#L17)

--- a/src/rendering/Drawable.ts
+++ b/src/rendering/Drawable.ts
@@ -1,5 +1,7 @@
 import { Color } from '#core/Color';
+import { drawableHasOwnMaterial, type MaterialKey, writeMaterialKeyInto } from '#rendering/plan/RenderCommand';
 import type { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
+import type { RenderBackend } from '#rendering/RenderBackend';
 
 import { isPixelSnapMode, type PixelSnapMode } from './pixelSnap';
 import { RenderNode } from './RenderNode';
@@ -16,6 +18,16 @@ export class Drawable extends RenderNode {
   private _tint: Color = Color.white.clone();
   private _blendMode: BlendModes = BlendModes.Normal;
   private _pixelSnapMode: PixelSnapMode = 'none';
+
+  /**
+   * Cached material key (Slice 2b). `null` until first computed or after
+   * {@link invalidateCache}. Bound to {@link _materialKeyBackend} so a backend
+   * switch (multi-app / multi-backend) recomputes rather than returning stale
+   * renderer ids. Drawables that carry their own {@link Material} bypass this
+   * cache entirely (the material can mutate its keys without notifying us).
+   */
+  private _materialKey: MaterialKey | null = null;
+  private _materialKeyBackend: RenderBackend | null = null;
 
   public get tint(): Color {
     return this._tint;
@@ -108,6 +120,64 @@ export class Drawable extends RenderNode {
   /** @internal */
   public override _renderPlanGetBlendMode(): BlendModes {
     return this._blendMode;
+  }
+
+  /**
+   * Resolve this drawable's {@link MaterialKey}, reusing a cached key when valid
+   * (Slice 2b). The cache busts on any tint/blend/texture/material/shader/
+   * pixel-snap mutation via {@link invalidateCache}, and on a backend switch.
+   *
+   * Drawables that own a {@link Material} are never cached — the material can
+   * change its `pipelineKey`/`bindKey` internally without notifying the node —
+   * so they recompute into the held key (still zero per-frame allocation).
+   *
+   * @internal
+   */
+  public _getOrComputeMaterialKey(backend: RenderBackend): MaterialKey {
+    const cached = this._materialKey;
+
+    if (cached !== null) {
+      if (drawableHasOwnMaterial(this)) {
+        // Own-material path: never trust the cache, but reuse the held object.
+        return writeMaterialKeyInto(cached, this, backend);
+      }
+
+      if (this._materialKeyBackend === backend) {
+        return cached;
+      }
+
+      // Backend switched: recompute into the held key, rebind to the backend.
+      this._materialKeyBackend = backend;
+
+      return writeMaterialKeyInto(cached, this, backend);
+    }
+
+    const key = writeMaterialKeyInto(
+      {
+        rendererId: 0,
+        blendMode: this._blendMode,
+        textureId: -1,
+        shaderId: -1,
+        pipelineKey: 0,
+        bindKey: 0,
+      },
+      this,
+      backend,
+    );
+
+    this._materialKey = key;
+    this._materialKeyBackend = backend;
+
+    return key;
+  }
+
+  public override invalidateCache(): this {
+    super.invalidateCache();
+    // Bust the cached material key; next emitDraw recomputes it. The held object
+    // is kept and rewritten in place on the next miss (no re-allocation).
+    this._materialKeyBackend = null;
+
+    return this;
   }
 
   public override destroy(): void {

--- a/src/rendering/GpuResourceAccountant.ts
+++ b/src/rendering/GpuResourceAccountant.ts
@@ -1,0 +1,150 @@
+import type { RenderStats } from './RenderStats';
+
+/**
+ * Per-backend GPU resource accountant (Slice 2g — Resource-Accounting).
+ *
+ * The GPU exposes no way to query VRAM usage (neither WebGL2 nor WebGPU report
+ * it — a deliberate security boundary), so the engine keeps its own running
+ * tally by booking every allocation (`+`) and every free (`−`) at the points
+ * where the backend creates or destroys a GPU texture / buffer. The same
+ * bookkeeping runs against the Node fake-context, so it is fully deterministic
+ * and CI-testable.
+ *
+ * The accountant owns the authoritative running total ({@link liveBytes}) and
+ * mirrors it into {@link RenderStats.gpuMemoryBytes}. Unlike the per-frame
+ * counters, that total is **not** zeroed by {@link resetRenderStats} — live
+ * resources outlive frames. The per-frame upload / download accumulators are
+ * written straight into the stats object and reset each tick.
+ *
+ * One accountant per backend instance (never module-global) so that multiple
+ * concurrent {@link Application}s keep independent tallies.
+ *
+ * @internal
+ */
+export class GpuResourceAccountant {
+  private readonly _stats: RenderStats;
+  private _liveBytes = 0;
+
+  public constructor(stats: RenderStats) {
+    this._stats = stats;
+    this._stats.gpuMemoryBytes = 0;
+  }
+
+  /** Current running total of live GPU resource bytes (textures + buffers). */
+  public get liveBytes(): number {
+    return this._liveBytes;
+  }
+
+  /**
+   * Record an allocation of `bytes` GPU memory (texture storage or buffer).
+   * Pass a non-negative value; the running total and the mirrored
+   * `stats.gpuMemoryBytes` both increase.
+   */
+  public allocate(bytes: number): void {
+    if (bytes <= 0) {
+      return;
+    }
+
+    this._liveBytes += bytes;
+    this._stats.gpuMemoryBytes = this._liveBytes;
+  }
+
+  /**
+   * Record a free of `bytes` GPU memory. Clamped at zero so a double-free or a
+   * missed allocation can never drive the tally negative. To avoid transient
+   * spikes on resize, book the free **before** the matching re-allocation.
+   */
+  public free(bytes: number): void {
+    if (bytes <= 0) {
+      return;
+    }
+
+    this._liveBytes = Math.max(0, this._liveBytes - bytes);
+    this._stats.gpuMemoryBytes = this._liveBytes;
+  }
+
+  /**
+   * Re-book a resource whose byte size changed in place (e.g. a texture resize):
+   * frees the previous size and allocates the next, never dipping below zero.
+   * Returns the new size so callers can stash it for the next free.
+   */
+  public reallocate(previousBytes: number, nextBytes: number): number {
+    this.free(previousBytes);
+    this.allocate(nextBytes);
+
+    return nextBytes;
+  }
+
+  /** Record `bytes` of content-texture pixel data uploaded this frame (CPU → GPU). */
+  public recordTextureUpload(bytes: number): void {
+    if (bytes <= 0) {
+      return;
+    }
+
+    this._stats.textureUploadBytes += bytes;
+  }
+
+  /** Record `bytes` of buffer data uploaded this frame (CPU → GPU). */
+  public recordBufferUpload(bytes: number): void {
+    if (bytes <= 0) {
+      return;
+    }
+
+    this._stats.bufferUploadBytes += bytes;
+  }
+
+  /** Record a GPU → CPU readback of `bytes` this frame (e.g. `mapAsync`, `readPixels`). */
+  public recordDownload(bytes: number): void {
+    if (bytes <= 0) {
+      return;
+    }
+
+    this._stats.downloadBytes += bytes;
+    this._stats.downloadCount++;
+  }
+}
+
+/**
+ * Estimated bytes for a 2D texture of `width × height` at `bytesPerPixel`,
+ * including the mip chain when `mipLevelCount > 1`. A full mip chain adds
+ * roughly ¹⁄₃ over the base level; this sums the exact per-level footprint
+ * (each level a quarter of the previous, floored at 1×1).
+ *
+ * @internal
+ */
+export const estimateTextureBytes = (width: number, height: number, bytesPerPixel: number, mipLevelCount = 1): number => {
+  const baseWidth = Math.max(1, Math.floor(width));
+  const baseHeight = Math.max(1, Math.floor(height));
+  const levels = Math.max(1, Math.floor(mipLevelCount));
+
+  let total = 0;
+  let levelWidth = baseWidth;
+  let levelHeight = baseHeight;
+
+  for (let level = 0; level < levels; level++) {
+    total += levelWidth * levelHeight * bytesPerPixel;
+
+    if (levelWidth === 1 && levelHeight === 1) {
+      break;
+    }
+
+    levelWidth = Math.max(1, levelWidth >> 1);
+    levelHeight = Math.max(1, levelHeight >> 1);
+  }
+
+  return total;
+};
+
+/** Bytes per pixel for the {@link DataTexture} formats (shared by both backends). @internal */
+export const dataTextureBytesPerPixel = (format: 'r8' | 'r32f' | 'rgba8' | 'rgba32f'): number => {
+  switch (format) {
+    case 'r8':
+      return 1;
+    case 'r32f':
+      return 4;
+    case 'rgba8':
+      return 4;
+    case 'rgba32f':
+      return 16;
+  }
+};

--- a/src/rendering/RenderStats.ts
+++ b/src/rendering/RenderStats.ts
@@ -28,6 +28,40 @@ export interface RenderStats {
    * time from the clamped simulation delta passed to update recipients.
    */
   rawFrameDeltaMs: number;
+  /**
+   * Estimated bytes of live GPU memory: the sum over all resident textures
+   * (`width · height · bytesPerPixel`, including mip chains) plus all resident
+   * GPU buffers (`byteLength`). The GPU exposes no VRAM query, so the engine
+   * books every allocation and free itself; this is an upper-bound estimate of
+   * the engine-owned footprint, not a driver figure.
+   *
+   * Unlike the other counters this is a **running total**, not a per-frame
+   * accumulator: it is **not** zeroed by {@link resetRenderStats} — live
+   * resources outlive frames. It rises when textures/buffers are created and
+   * falls when they are destroyed.
+   */
+  gpuMemoryBytes: number;
+  /**
+   * Bytes of content-texture pixel data uploaded CPU → GPU this frame
+   * (`texSubImage2D` / `texImage2D` pixel uploads on WebGL2; `writeTexture` on
+   * WebGPU). Per-frame accumulator; a static frame that re-uploads nothing
+   * reports 0.
+   */
+  textureUploadBytes: number;
+  /**
+   * Bytes of buffer data uploaded CPU → GPU this frame (vertex / index /
+   * transform-storage writes). Per-frame accumulator.
+   */
+  bufferUploadBytes: number;
+  /**
+   * Bytes read back GPU → CPU this frame (e.g. `mapAsync` of a storage buffer,
+   * render-texture readback). Practically 0 in the 2D render path today; the
+   * counter exists so readback paths (screenshots, GPU picking, particle
+   * compute) are accounted for when present. Per-frame accumulator.
+   */
+  downloadBytes: number;
+  /** Number of GPU → CPU readback operations issued this frame. Per-frame accumulator. */
+  downloadCount: number;
 }
 
 /**
@@ -43,11 +77,21 @@ export const createRenderStats = (): RenderStats => ({
   renderTargetChanges: 0,
   frameTimeMs: 0,
   rawFrameDeltaMs: 0,
+  gpuMemoryBytes: 0,
+  textureUploadBytes: 0,
+  bufferUploadBytes: 0,
+  downloadBytes: 0,
+  downloadCount: 0,
 });
 
 /**
  * Advance the frame counter and zero all per-frame accumulators in place.
  * Call once at the start of each render tick before recording new data.
+ *
+ * Note: {@link RenderStats.gpuMemoryBytes} is intentionally **not** reset here.
+ * It is a running total of live GPU resources owned by the backend's resource
+ * accountant, which persists across frames; zeroing it each tick would make it
+ * read 0 after the first frame.
  */
 export const resetRenderStats = (stats: RenderStats): RenderStats => {
   stats.frame++;
@@ -59,6 +103,10 @@ export const resetRenderStats = (stats: RenderStats): RenderStats => {
   stats.renderTargetChanges = 0;
   stats.frameTimeMs = 0;
   stats.rawFrameDeltaMs = 0;
+  stats.textureUploadBytes = 0;
+  stats.bufferUploadBytes = 0;
+  stats.downloadBytes = 0;
+  stats.downloadCount = 0;
 
   return stats;
 };

--- a/src/rendering/plan/RenderCommand.ts
+++ b/src/rendering/plan/RenderCommand.ts
@@ -33,25 +33,28 @@ export const enum RenderEntryKind {
  * incompatible state.
  */
 export interface MaterialKey {
-  readonly rendererId: number;
-  readonly blendMode: BlendModes;
-  readonly textureId: number;
-  readonly shaderId: number;
-  readonly pipelineKey: number;
-  readonly bindKey: number;
+  rendererId: number;
+  blendMode: BlendModes;
+  textureId: number;
+  shaderId: number;
+  pipelineKey: number;
+  bindKey: number;
 }
 
 /** @internal */
 export interface DrawCommand {
   readonly kind: RenderEntryKind.Draw;
-  readonly drawable: Drawable;
+  /** Mutable so the builder can recycle a pooled command across frames. */
+  drawable: Drawable;
   nodeIndex: number;
   seq: number;
   zIndex: number;
   material: MaterialKey;
   /** Assigned by the optimizer; consecutive draws with the same groupIndex
-   *  form a batch-safe unit.  Undefined before optimisation. */
-  groupIndex?: number;
+   *  form a batch-safe unit.  `undefined` before optimisation (and reset to
+   *  `undefined` when a pooled command is recycled). Required-but-nullable so the
+   *  builder can explicitly clear it under `exactOptionalPropertyTypes`. */
+  groupIndex: number | undefined;
   minX: number;
   minY: number;
   maxX: number;
@@ -166,25 +169,55 @@ const getMaterial = (drawable: Drawable): Material | null => {
  *
  * @internal
  */
-export const makeMaterialKey = (drawable: Drawable, backend: RenderBackend | null): MaterialKey => {
+export const makeMaterialKey = (drawable: Drawable, backend: RenderBackend | null): MaterialKey =>
+  writeMaterialKeyInto(
+    {
+      rendererId: 0,
+      blendMode: drawable.blendMode,
+      textureId: -1,
+      shaderId: -1,
+      pipelineKey: 0,
+      bindKey: 0,
+    },
+    drawable,
+    backend,
+  );
+
+/**
+ * In-place variant of {@link makeMaterialKey}: derives the same material key but
+ * writes it into `target` instead of allocating a fresh object. Used by the
+ * per-drawable material-key cache (Slice 2b) so a cache miss reuses the held key
+ * rather than producing per-frame garbage. Returns `target` for chaining.
+ *
+ * @internal
+ */
+export const writeMaterialKeyInto = (target: MaterialKey, drawable: Drawable, backend: RenderBackend | null): MaterialKey => {
   const rendererId = getRendererId(drawable, backend);
   const blendMode = drawable.blendMode;
   const textureId = getTextureId(drawable);
   const shaderId = getShaderId(drawable);
   const material = getMaterial(drawable);
 
-  const pipelineKey = material !== null ? material.pipelineKey : rendererId * 31 + blendMode;
-  const bindKey = material !== null ? material.bindKey : rendererId * 31 + (textureId > 0 ? textureId : 0);
+  target.rendererId = rendererId;
+  target.blendMode = blendMode;
+  target.textureId = textureId;
+  target.shaderId = shaderId;
+  target.pipelineKey = material !== null ? material.pipelineKey : rendererId * 31 + blendMode;
+  target.bindKey = material !== null ? material.bindKey : rendererId * 31 + (textureId > 0 ? textureId : 0);
 
-  return {
-    rendererId,
-    blendMode,
-    textureId,
-    shaderId,
-    pipelineKey,
-    bindKey,
-  };
+  return target;
 };
+
+/**
+ * Whether `drawable` carries its own {@link Material}. Such a drawable can mutate
+ * its material's `pipelineKey`/`bindKey` internally without notifying the node,
+ * so its material key must not be cached — it is recomputed every frame. The
+ * default (material-less) path is safe to cache and invalidate via the existing
+ * `invalidateCache` setters.
+ *
+ * @internal
+ */
+export const drawableHasOwnMaterial = (drawable: Drawable): boolean => getMaterial(drawable) !== null;
 
 /**
  * Whether a draw command's renderer reads the shared {@link TransformBuffer} /

--- a/src/rendering/plan/RenderInstruction.ts
+++ b/src/rendering/plan/RenderInstruction.ts
@@ -1,4 +1,4 @@
-import { type DrawCommand, type MaterialKey, RenderEntryKind } from './RenderCommand';
+import type { DrawCommand } from './RenderCommand';
 import type { GroupScope } from './RenderScope';
 
 /**
@@ -12,83 +12,12 @@ import type { GroupScope } from './RenderScope';
  * stable {@link DrawCommand.nodeIndex} (within the `[0, plan.nodeCount)`
  * slot space).
  *
+ * Batch units (maximal runs of consecutive instructions in a {@link GroupScope}
+ * sharing GPU pipeline/bind state) are not materialized: the plan player walks
+ * each instruction's {@link DrawCommand.groupIndex} adjacency directly over
+ * `scope.entries` (Slice 2c), and the upload-boundary hooks receive an entries
+ * range rather than a collected group array — keeping playback allocation-free.
+ *
  * @internal
  */
 export type RenderInstruction = DrawCommand;
-
-/**
- * A materialized batch unit: a maximal run of consecutive
- * {@link RenderInstruction}s within a single {@link GroupScope} that share a
- * GPU pipeline/bind state and may therefore be submitted together.
- *
- * The optimizer ({@link RenderPlanOptimizer}) already stamps this grouping
- * implicitly onto each {@link DrawCommand.groupIndex}; a `RenderGroup` makes
- * that batch unit explicit as a value without altering playback. The mesh
- * renderers continue to detect batches by comparing adjacent `groupIndex`es,
- * so this representation is purely additive.
- *
- * @internal
- */
-export interface RenderGroup {
-  /** Optimizer-assigned batch identity shared by every instruction in the run. */
-  readonly groupIndex: number;
-  /** Pipeline/bind state shared by the run; taken from its first instruction. */
-  readonly material: MaterialKey;
-  /** Draw instructions in submit order. */
-  readonly instructions: readonly RenderInstruction[];
-}
-
-interface MutableRenderGroup {
-  groupIndex: number;
-  material: MaterialKey;
-  instructions: RenderInstruction[];
-}
-
-/**
- * Materialize the {@link RenderGroup} batch units contained directly in
- * `scope`. Consecutive draw instructions that share a defined `groupIndex`
- * coalesce into one group; any non-draw entry (a nested group or barrier)
- * breaks the run, and a draw whose `groupIndex` is still `undefined` (i.e.
- * the plan has not been optimized) forms its own singleton group — mirroring
- * the adjacency semantics the mesh renderers already rely on.
- *
- * This is a read-only view over an (optimized) scope; it does not mutate the
- * plan or affect playback order.
- *
- * @internal
- */
-export function collectRenderGroups(scope: GroupScope): RenderGroup[] {
-  const groups: RenderGroup[] = [];
-  let current: MutableRenderGroup | null = null;
-
-  for (const entry of scope.entries) {
-    if (entry.kind !== RenderEntryKind.Draw) {
-      current = null;
-
-      continue;
-    }
-
-    const command = entry.command;
-    const groupIndex = command.groupIndex;
-
-    if (current !== null && groupIndex !== undefined && groupIndex === current.groupIndex) {
-      current.instructions.push(command);
-
-      continue;
-    }
-
-    current = {
-      groupIndex: groupIndex ?? 0,
-      material: command.material,
-      instructions: [command],
-    };
-    groups.push(current);
-
-    if (groupIndex === undefined) {
-      // Unoptimized / non-batchable draw: never coalesce with the next one.
-      current = null;
-    }
-  }
-
-  return groups;
-}

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -5,14 +5,17 @@ import type { RenderBackend } from '#rendering/RenderBackend';
 import type { RenderNode } from '#rendering/RenderNode';
 import type { View } from '#rendering/View';
 
-import { type DrawCommand, makeMaterialKey, RenderEntryKind } from './RenderCommand';
+import { type DrawCommand, RenderEntryKind } from './RenderCommand';
 import { MutableRenderPlan, type RenderPlan } from './RenderPlan';
-import { type BarrierScope, ClipKind, type EffectDescriptor, type GroupScope, type ScopeEntry } from './RenderScope';
-
-interface PendingEntryPlacement {
-  seq: number;
-  zIndex: number;
-}
+import {
+  type BarrierScope,
+  type BarrierScopeEntry,
+  ClipKind,
+  type DrawScopeEntry,
+  type EffectDescriptor,
+  type GroupScope,
+  type GroupScopeEntry,
+} from './RenderScope';
 
 interface MutableGroupScope extends GroupScope {
   _nextSeq: number;
@@ -51,7 +54,31 @@ export class RenderPlanBuilder {
   private readonly _groupPool: MutableGroupScope[] = [];
   private readonly _scopeStack: MutableGroupScope[] = [];
   private _groupPoolCursor = 0;
-  private _pendingEntryPlacement: PendingEntryPlacement | null = null;
+
+  // Frame-persistent free-lists (Slice 2b). Each lives on the builder INSTANCE
+  // (never module-global) to keep the multi-instance invariant: a second app /
+  // backend uses its own builder and its own pools. Cursors reset every frame in
+  // build() + _resetRuntimeState(); the backing objects survive and are mutated
+  // in place, so a steady-state static scene allocates zero plan objects.
+  private readonly _commandPool: DrawCommand[] = [];
+  private _commandPoolCursor = 0;
+  private readonly _drawEntryPool: DrawScopeEntry[] = [];
+  private _drawEntryPoolCursor = 0;
+  private readonly _groupEntryPool: GroupScopeEntry[] = [];
+  private _groupEntryPoolCursor = 0;
+  private readonly _barrierEntryPool: BarrierScopeEntry[] = [];
+  private _barrierEntryPoolCursor = 0;
+
+  // Reserved placement (replaces the per-call `{ seq, zIndex }` literal).
+  private _reservedSeq = 0;
+  private _reservedZ = 0;
+
+  // Placement inherited by emitDraw from a drawable emitNode (replaces the
+  // `_pendingEntryPlacement` object); `_hasPending` distinguishes "no pending".
+  private _hasPending = false;
+  private _pendingSeq = 0;
+  private _pendingZ = 0;
+
   private _nodeIndex = 0;
 
   public build(root: RenderNode, backend: RenderBackend): RenderPlan {
@@ -59,8 +86,12 @@ export class RenderPlanBuilder {
     this._view = null;
     this._plan.reset();
     this._groupPoolCursor = 0;
+    this._commandPoolCursor = 0;
+    this._drawEntryPoolCursor = 0;
+    this._groupEntryPoolCursor = 0;
+    this._barrierEntryPoolCursor = 0;
     this._scopeStack.length = 0;
-    this._pendingEntryPlacement = null;
+    this._hasPending = false;
     this._nodeIndex = 0;
 
     const rootScope = this._acquireGroupScope(false);
@@ -92,7 +123,9 @@ export class RenderPlanBuilder {
   }
 
   public emitNode(node: RenderNode, seq?: number): void {
-    const placement = this._reserveEntryPlacement(seq, node.zIndex);
+    this._reserveEntryPlacement(seq, node.zIndex);
+    const reservedSeq = this._reservedSeq;
+    const reservedZ = this._reservedZ;
 
     if (node._renderPlanHasBarrierEffects()) {
       const effect = this._createEffectDescriptor(node);
@@ -131,12 +164,7 @@ export class RenderPlanBuilder {
         height,
       };
 
-      this._pushEntry({
-        kind: RenderEntryKind.Barrier,
-        seq: placement.seq,
-        zIndex: placement.zIndex,
-        scope: barrierScope,
-      });
+      this._pushBarrierEntry(reservedSeq, reservedZ, barrierScope);
 
       if (childPlan !== null) {
         this._scopeStack.push(childPlan);
@@ -152,12 +180,14 @@ export class RenderPlanBuilder {
     }
 
     if (node._isDrawableForRenderPlan()) {
-      this._pendingEntryPlacement = placement;
+      this._hasPending = true;
+      this._pendingSeq = reservedSeq;
+      this._pendingZ = reservedZ;
 
       try {
         node._collectForRenderPlan(this);
       } finally {
-        this._pendingEntryPlacement = null;
+        this._hasPending = false;
       }
 
       return;
@@ -165,12 +195,7 @@ export class RenderPlanBuilder {
 
     const groupScope = this._acquireGroupScope(this._resolvePreserveDrawOrder(node));
 
-    this._pushEntry({
-      kind: RenderEntryKind.Group,
-      seq: placement.seq,
-      zIndex: placement.zIndex,
-      scope: groupScope,
-    });
+    this._pushGroupEntry(reservedSeq, reservedZ, groupScope);
 
     this._scopeStack.push(groupScope);
 
@@ -182,40 +207,48 @@ export class RenderPlanBuilder {
   }
 
   public emitDraw(drawable: Drawable, seq?: number): void {
-    const pendingPlacement = this._pendingEntryPlacement;
+    const hasPending = this._hasPending;
+    const pendingSeq = this._pendingSeq;
+    const pendingZ = this._pendingZ;
 
-    if (pendingPlacement !== null) {
-      this._pendingEntryPlacement = null;
+    if (hasPending) {
+      this._hasPending = false;
     }
 
-    const zIndex = pendingPlacement?.zIndex ?? drawable.zIndex;
-    const placement = this._reserveEntryPlacement(seq ?? pendingPlacement?.seq, zIndex);
-    const bounds = drawable.getBounds();
-    const command: DrawCommand = {
-      kind: RenderEntryKind.Draw,
-      drawable,
-      nodeIndex: this._nodeIndex++,
-      seq: placement.seq,
-      zIndex: placement.zIndex,
-      material: makeMaterialKey(drawable, this.backend),
-      minX: bounds.left,
-      minY: bounds.top,
-      maxX: bounds.right,
-      maxY: bounds.bottom,
-    };
+    const zIndex = hasPending ? pendingZ : drawable.zIndex;
 
-    this._pushEntry({
-      kind: RenderEntryKind.Draw,
-      seq: placement.seq,
-      zIndex: placement.zIndex,
-      command,
-    });
+    this._reserveEntryPlacement(seq ?? (hasPending ? pendingSeq : undefined), zIndex);
+
+    const placementSeq = this._reservedSeq;
+    const placementZ = this._reservedZ;
+    const bounds = drawable.getBounds();
+    const command = this._acquireDrawCommand();
+
+    command.drawable = drawable;
+    command.nodeIndex = this._nodeIndex++;
+    command.seq = placementSeq;
+    command.zIndex = placementZ;
+    // Reset the optimizer's batch index: a recycled command must not carry a
+    // stale groupIndex from a previous frame (collectRenderGroups would coalesce
+    // on it before optimize() runs).
+    command.groupIndex = undefined;
+    command.material = drawable._getOrComputeMaterialKey(this.backend);
+    command.minX = bounds.left;
+    command.minY = bounds.top;
+    command.maxX = bounds.right;
+    command.maxY = bounds.bottom;
+
+    this._pushDrawEntry(placementSeq, placementZ, command);
   }
 
   private _resetRuntimeState(): void {
     this._scopeStack.length = 0;
-    this._pendingEntryPlacement = null;
+    this._hasPending = false;
     this._groupPoolCursor = 0;
+    this._commandPoolCursor = 0;
+    this._drawEntryPoolCursor = 0;
+    this._groupEntryPoolCursor = 0;
+    this._barrierEntryPoolCursor = 0;
     this._view = null;
     this._nodeIndex = 0;
   }
@@ -242,7 +275,84 @@ export class RenderPlanBuilder {
     return scope;
   }
 
-  private _reserveEntryPlacement(seq: number | undefined, zIndex: number): PendingEntryPlacement {
+  private _acquireDrawCommand(): DrawCommand {
+    const pooled = this._commandPool[this._commandPoolCursor];
+
+    if (pooled !== undefined) {
+      this._commandPoolCursor++;
+
+      return pooled;
+    }
+
+    const command: DrawCommand = {
+      kind: RenderEntryKind.Draw,
+      drawable: undefined as unknown as Drawable,
+      nodeIndex: 0,
+      seq: 0,
+      zIndex: 0,
+      material: undefined as unknown as DrawCommand['material'],
+      groupIndex: undefined,
+      minX: 0,
+      minY: 0,
+      maxX: 0,
+      maxY: 0,
+    };
+
+    this._commandPool[this._commandPoolCursor] = command;
+    this._commandPoolCursor++;
+
+    return command;
+  }
+
+  private _pushDrawEntry(seq: number, zIndex: number, command: DrawCommand): void {
+    let entry = this._drawEntryPool[this._drawEntryPoolCursor];
+
+    if (entry === undefined) {
+      entry = { kind: RenderEntryKind.Draw, seq, zIndex, command };
+      this._drawEntryPool[this._drawEntryPoolCursor] = entry;
+    } else {
+      entry.seq = seq;
+      entry.zIndex = zIndex;
+      entry.command = command;
+    }
+
+    this._drawEntryPoolCursor++;
+    this._currentScope().entries.push(entry);
+  }
+
+  private _pushGroupEntry(seq: number, zIndex: number, scope: GroupScope): void {
+    let entry = this._groupEntryPool[this._groupEntryPoolCursor];
+
+    if (entry === undefined) {
+      entry = { kind: RenderEntryKind.Group, seq, zIndex, scope };
+      this._groupEntryPool[this._groupEntryPoolCursor] = entry;
+    } else {
+      entry.seq = seq;
+      entry.zIndex = zIndex;
+      entry.scope = scope;
+    }
+
+    this._groupEntryPoolCursor++;
+    this._currentScope().entries.push(entry);
+  }
+
+  private _pushBarrierEntry(seq: number, zIndex: number, scope: BarrierScope): void {
+    let entry = this._barrierEntryPool[this._barrierEntryPoolCursor];
+
+    if (entry === undefined) {
+      entry = { kind: RenderEntryKind.Barrier, seq, zIndex, scope };
+      this._barrierEntryPool[this._barrierEntryPoolCursor] = entry;
+    } else {
+      entry.seq = seq;
+      entry.zIndex = zIndex;
+      entry.scope = scope;
+    }
+
+    this._barrierEntryPoolCursor++;
+    this._currentScope().entries.push(entry);
+  }
+
+  private _reserveEntryPlacement(seq: number | undefined, zIndex: number): void {
     const scope = this._currentScope();
     const nextSeq = seq ?? scope._nextSeq;
 
@@ -256,11 +366,8 @@ export class RenderPlanBuilder {
       scope.hasMixedZ = true;
     }
 
-    return { seq: nextSeq, zIndex };
-  }
-
-  private _pushEntry(entry: ScopeEntry): void {
-    this._currentScope().entries.push(entry);
+    this._reservedSeq = nextSeq;
+    this._reservedZ = zIndex;
   }
 
   private _currentScope(): MutableGroupScope {

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -229,8 +229,8 @@ export class RenderPlanBuilder {
     command.seq = placementSeq;
     command.zIndex = placementZ;
     // Reset the optimizer's batch index: a recycled command must not carry a
-    // stale groupIndex from a previous frame (collectRenderGroups would coalesce
-    // on it before optimize() runs).
+    // stale groupIndex from a previous frame (the plan player's group-adjacency
+    // walk would coalesce on it before optimize() runs).
     command.groupIndex = undefined;
     command.material = drawable._getOrComputeMaterialKey(this.backend);
     command.minX = bounds.left;

--- a/src/rendering/plan/RenderPlanPlayer.ts
+++ b/src/rendering/plan/RenderPlanPlayer.ts
@@ -2,9 +2,9 @@ import type { RenderBackend } from '#rendering/RenderBackend';
 
 import { RenderEntryKind } from './RenderCommand';
 import { RenderEffectExecutor } from './RenderEffectExecutor';
-import { collectRenderGroups, type RenderGroup, type RenderInstruction } from './RenderInstruction';
+import type { RenderInstruction } from './RenderInstruction';
 import type { RenderPlan } from './RenderPlan';
-import type { GroupScope, RenderScope } from './RenderScope';
+import type { GroupScope, RenderScope, ScopeEntry } from './RenderScope';
 
 interface RenderInstructionSlot {
   readonly groupInstructionIndex: number;
@@ -23,15 +23,55 @@ interface RenderPlanPlaybackContext {
   passGroupIndex: number;
 }
 
+/**
+ * Playback hooks the backend may implement. The render-group hooks describe a
+ * batch unit as the entries range `entries[startIndex, startIndex + count)` —
+ * every entry in that range is a {@link RenderEntryKind.Draw}, so the backend
+ * reads each command via `entries[i].command`. The plan player no longer
+ * materializes a `RenderGroup[]` per scope (Slice 2c); the range carries the
+ * same information allocation-free.
+ */
 interface RenderPlanPlaybackHooks {
   _beginDrawPlan?(nodeCount: number): void;
-  _beginRenderGroup?(group: RenderGroup): void;
-  _prepareRenderGroupUpload?(group: RenderGroup, context: RenderGroupPlaybackContext): void;
+  _beginRenderGroup?(entries: readonly ScopeEntry[], startIndex: number, count: number): void;
+  _prepareRenderGroupUpload?(entries: readonly ScopeEntry[], startIndex: number, count: number, context: RenderGroupPlaybackContext): void;
   _prepareRenderInstructionSlot?(instruction: RenderInstruction, slot: RenderInstructionSlot): void;
   _prepareDrawCommand?(instruction: RenderInstruction): void;
-  _endRenderGroup?(group: RenderGroup): void;
+  _endRenderGroup?(entries: readonly ScopeEntry[], startIndex: number, count: number): void;
   _endDrawPlan?(): void;
 }
+
+/**
+ * Length of the batch run starting at `entries[startIndex]` (which must be a
+ * draw): the maximal span of consecutive draw entries sharing the same defined
+ * `groupIndex`. A draw with `groupIndex === undefined` is its own singleton run
+ * (it never coalesces), and any non-draw entry ends the run. This is exactly the
+ * adjacency the (deleted) `collectRenderGroups` materialized, walked in place.
+ */
+const groupRunLength = (entries: readonly ScopeEntry[], startIndex: number): number => {
+  const first = entries[startIndex];
+
+  // Callers only enter with a draw at `startIndex`.
+  const groupIndex = (first as Extract<ScopeEntry, { kind: RenderEntryKind.Draw }>).command.groupIndex;
+
+  if (groupIndex === undefined) {
+    return 1;
+  }
+
+  let count = 1;
+
+  for (let i = startIndex + 1; i < entries.length; i++) {
+    const entry = entries[i]!;
+
+    if (entry.kind !== RenderEntryKind.Draw || entry.command.groupIndex !== groupIndex) {
+      break;
+    }
+
+    count++;
+  }
+
+  return count;
+};
 
 /** @internal */
 export class RenderPlanPlayer {
@@ -80,10 +120,7 @@ export class RenderPlanPlayer {
   }
 
   private static _playGroup(scope: GroupScope, backend: RenderBackend, hooks: RenderPlanPlaybackHooks, context: RenderPlanPlaybackContext): void {
-    const groups = collectRenderGroups(scope);
-    let groupCursor = 0;
-    let currentGroup: RenderGroup | null = null;
-    let currentInstructionIndex = 0;
+    const entries = scope.entries;
 
     // Phase 1 — populate the CPU transform buffer for all groups in this scope
     // before any renderer draws execute. Without this separation, each
@@ -96,33 +133,47 @@ export class RenderPlanPlayer {
     // calls bindTransformBufferTexture/getTransformStorageBuffer, so all
     // subsequent flushes within the same scope find an unchanged hash and skip
     // the upload entirely.
+    //
+    // The pre-pass walks `groupIndex` adjacency directly over `entries` — the
+    // same runs the (deleted) `collectRenderGroups` produced, in the same order
+    // — so no `RenderGroup[]`/`instructions[]` is materialized per scope/frame.
     if (hooks._prepareRenderGroupUpload !== undefined) {
       let preInstructionIndex = context.passInstructionIndex;
+      let groupOrdinal = 0;
 
-      for (let gi = 0; gi < groups.length; gi++) {
-        // In-bounds: gi < groups.length.
-        const group = groups[gi]!;
+      for (let i = 0; i < entries.length; ) {
+        if (entries[i]!.kind !== RenderEntryKind.Draw) {
+          i++;
 
-        hooks._prepareRenderGroupUpload(
-          group,
-          this._createRenderGroupPlaybackContext(group.instructions.length, preInstructionIndex, context.passGroupIndex + gi),
-        );
-        preInstructionIndex += group.instructions.length;
+          continue;
+        }
+
+        const count = groupRunLength(entries, i);
+
+        hooks._prepareRenderGroupUpload(entries, i, count, this._createRenderGroupPlaybackContext(count, preInstructionIndex, context.passGroupIndex + groupOrdinal));
+        preInstructionIndex += count;
+        groupOrdinal++;
+        i += count;
       }
     }
 
     // Phase 2 — execute draws in document order. Transform writes are already
     // done; _prepareRenderGroupUpload is intentionally not called a second time.
-    for (const entry of scope.entries) {
+    // Group boundaries are the same `groupIndex` adjacency Phase 1 walked.
+    let groupStart = -1;
+    let groupCount = 0;
+    let currentInstructionIndex = 0;
+
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i]!;
+
       if (entry.kind === RenderEntryKind.Draw) {
-        if (currentGroup === null) {
-          // Invariant: collectRenderGroups yields groups whose total instruction
-          // count equals the draw-entry count, and groupCursor only advances when
-          // a group is fully consumed, so a group exists for every draw entry.
-          currentGroup = groups[groupCursor]!;
+        if (groupStart === -1) {
+          groupStart = i;
+          groupCount = groupRunLength(entries, i);
           currentInstructionIndex = 0;
 
-          hooks._beginRenderGroup?.(currentGroup);
+          hooks._beginRenderGroup?.(entries, groupStart, groupCount);
           context.passGroupIndex++;
         }
 
@@ -142,11 +193,11 @@ export class RenderPlanPlayer {
         currentInstructionIndex++;
         context.passInstructionIndex++;
 
-        if (currentGroup !== null && currentInstructionIndex === currentGroup.instructions.length) {
-          hooks._endRenderGroup?.(currentGroup);
-          currentGroup = null;
+        if (currentInstructionIndex === groupCount) {
+          hooks._endRenderGroup?.(entries, groupStart, groupCount);
+          groupStart = -1;
+          groupCount = 0;
           currentInstructionIndex = 0;
-          groupCursor++;
         }
       } else if (entry.kind === RenderEntryKind.Group) {
         this._playGroup(entry.scope, backend, hooks, context);
@@ -165,11 +216,7 @@ export class RenderPlanPlayer {
     };
   }
 
-  private static _createRenderGroupPlaybackContext(
-    groupInstructionCount: number,
-    firstPassInstructionIndex: number,
-    passGroupIndex: number,
-  ): RenderGroupPlaybackContext {
+  private static _createRenderGroupPlaybackContext(groupInstructionCount: number, firstPassInstructionIndex: number, passGroupIndex: number): RenderGroupPlaybackContext {
     return Object.freeze({
       groupInstructionCount,
       firstPassInstructionIndex,

--- a/src/rendering/plan/RenderPlanPlayer.ts
+++ b/src/rendering/plan/RenderPlanPlayer.ts
@@ -150,7 +150,12 @@ export class RenderPlanPlayer {
 
         const count = groupRunLength(entries, i);
 
-        hooks._prepareRenderGroupUpload(entries, i, count, this._createRenderGroupPlaybackContext(count, preInstructionIndex, context.passGroupIndex + groupOrdinal));
+        hooks._prepareRenderGroupUpload(
+          entries,
+          i,
+          count,
+          this._createRenderGroupPlaybackContext(count, preInstructionIndex, context.passGroupIndex + groupOrdinal),
+        );
         preInstructionIndex += count;
         groupOrdinal++;
         i += count;
@@ -216,7 +221,11 @@ export class RenderPlanPlayer {
     };
   }
 
-  private static _createRenderGroupPlaybackContext(groupInstructionCount: number, firstPassInstructionIndex: number, passGroupIndex: number): RenderGroupPlaybackContext {
+  private static _createRenderGroupPlaybackContext(
+    groupInstructionCount: number,
+    firstPassInstructionIndex: number,
+    passGroupIndex: number,
+  ): RenderGroupPlaybackContext {
     return Object.freeze({
       groupInstructionCount,
       firstPassInstructionIndex,

--- a/src/rendering/plan/RenderScope.ts
+++ b/src/rendering/plan/RenderScope.ts
@@ -29,28 +29,34 @@ export interface EffectDescriptor {
   readonly blendMode: BlendModes;
 }
 
-/** @internal */
+/**
+ * @internal
+ *
+ * `seq`/`zIndex`/`command` are mutable so the {@link RenderPlanBuilder} can
+ * recycle a pooled entry across frames (Slice 2b). `kind` stays `readonly` —
+ * a pooled entry never changes its discriminant.
+ */
 export interface DrawScopeEntry {
   readonly kind: RenderEntryKind.Draw;
-  readonly seq: number;
-  readonly zIndex: number;
-  readonly command: DrawCommand;
+  seq: number;
+  zIndex: number;
+  command: DrawCommand;
 }
 
 /** @internal */
 export interface GroupScopeEntry {
   readonly kind: RenderEntryKind.Group;
-  readonly seq: number;
-  readonly zIndex: number;
-  readonly scope: GroupScope;
+  seq: number;
+  zIndex: number;
+  scope: GroupScope;
 }
 
 /** @internal */
 export interface BarrierScopeEntry {
   readonly kind: RenderEntryKind.Barrier;
-  readonly seq: number;
-  readonly zIndex: number;
-  readonly scope: BarrierScope;
+  seq: number;
+  zIndex: number;
+  scope: BarrierScope;
 }
 
 /** @internal */

--- a/src/rendering/webgl2/AbstractWebGl2BatchedRenderer.ts
+++ b/src/rendering/webgl2/AbstractWebGl2BatchedRenderer.ts
@@ -111,9 +111,11 @@ export abstract class AbstractWebGl2BatchedRenderer extends AbstractWebGl2Render
     this.connection = this.createConnection(gl);
     this.indexBuffer = new WebGl2RenderBuffer(BufferTypes.ElementArrayBuffer, this.indexData, BufferUsage.StaticDraw).connect(
       this.createBufferRuntime(this.connection),
+      backend.accountant,
     );
     this.vertexBuffer = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, this.vertexData, BufferUsage.DynamicDraw).connect(
       this.createBufferRuntime(this.connection),
+      backend.accountant,
     );
     this.shader.sync();
     this.vao = this.createVao(gl, this.indexBuffer, this.vertexBuffer).connect(this.createVaoRuntime(this.connection));

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -9,8 +9,8 @@ import type { Drawable } from '#rendering/Drawable';
 import type { Geometry } from '#rendering/geometry/Geometry';
 import type { Mesh } from '#rendering/mesh/Mesh';
 import { resolveUploadTransform } from '#rendering/pixelSnap';
-import { type DrawCommand, drawCommandUsesSharedTransform } from '#rendering/plan/RenderCommand';
-import type { RenderGroup } from '#rendering/plan/RenderInstruction';
+import { type DrawCommand, drawCommandUsesSharedTransform, RenderEntryKind } from '#rendering/plan/RenderCommand';
+import type { ScopeEntry } from '#rendering/plan/RenderScope';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import { RenderBackendType } from '#rendering/RenderBackendType';
 import type { Renderer } from '#rendering/Renderer';
@@ -274,7 +274,7 @@ export class WebGl2Backend implements RenderBackend {
   }
 
   /** @internal */
-  public _prepareRenderGroupUpload(group: RenderGroup): void {
+  public _prepareRenderGroupUpload(entries: readonly ScopeEntry[], startIndex: number, count: number): void {
     // Pack the whole render group's world transforms (+ tint) into the shared
     // transform buffer at the group's upload boundary, keyed by each draw
     // command's stable nodeIndex. Every draw the player will submit for this
@@ -282,14 +282,23 @@ export class WebGl2Backend implements RenderBackend {
     // write previously done in `_prepareDrawCommand` is no longer needed and
     // the buffer is filled one contiguous group slice at a time.
     //
+    // The group is the entries range `[startIndex, startIndex + count)`; every
+    // entry in it is a draw, so the player no longer materializes a group array.
+    //
     // Renderers that pack their own per-node data (Text, Particle) never read
     // the shared buffer, so their commands are skipped — no consuming draw ever
     // references their slots (nodeIndex is unique per command).
-    const instructions = group.instructions;
+    const end = startIndex + count;
 
-    for (let i = 0; i < instructions.length; i++) {
-      // In-bounds: `i` ranges over `0..instructions.length-1`.
-      const command = instructions[i]!;
+    for (let i = startIndex; i < end; i++) {
+      const entry = entries[i]!;
+
+      // Every entry in a group run is a draw; narrow to read its command.
+      if (entry.kind !== RenderEntryKind.Draw) {
+        continue;
+      }
+
+      const command = entry.command;
 
       if (drawCommandUsesSharedTransform(command, this)) {
         this._writeTransformCommand(command);

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -7,6 +7,7 @@ import { Vector } from '#math/Vector';
 import type { BackendRenderPass } from '#rendering/BackendRenderPass';
 import type { Drawable } from '#rendering/Drawable';
 import type { Geometry } from '#rendering/geometry/Geometry';
+import { dataTextureBytesPerPixel, estimateTextureBytes, GpuResourceAccountant } from '#rendering/GpuResourceAccountant';
 import type { Mesh } from '#rendering/mesh/Mesh';
 import { resolveUploadTransform } from '#rendering/pixelSnap';
 import { type DrawCommand, drawCommandUsesSharedTransform, RenderEntryKind } from '#rendering/plan/RenderCommand';
@@ -77,6 +78,8 @@ interface ManagedTextureState {
   version: number;
   width: number;
   height: number;
+  /** GPU bytes currently booked for this texture's storage (0 until first upload). */
+  accountedBytes: number;
 }
 
 interface ManagedRenderTargetState {
@@ -168,6 +171,7 @@ export class WebGl2Backend implements RenderBackend {
   private _clearColor: Color = new Color();
   private _boundFramebuffer: WebGLFramebuffer | null = null;
   private readonly _stats: RenderStats = createRenderStats();
+  private readonly _accountant: GpuResourceAccountant = new GpuResourceAccountant(this._stats);
   private readonly _transformBuffer = new TransformBuffer();
   private _transformTexture: DataTexture<'rgba32f'> | null = null;
   private _transformTextureHash = 0;
@@ -239,6 +243,16 @@ export class WebGl2Backend implements RenderBackend {
 
   public get stats(): RenderStats {
     return this._stats;
+  }
+
+  /**
+   * Per-backend GPU resource accountant (VRAM / upload / download bookkeeping).
+   * Used by this backend's renderers (e.g. batched vertex/index buffers) to
+   * book their own allocations and uploads. Not part of any public surface.
+   * @internal
+   */
+  public get accountant(): GpuResourceAccountant {
+    return this._accountant;
   }
 
   /** @internal */
@@ -976,6 +990,32 @@ export class WebGl2Backend implements RenderBackend {
     return texture;
   }
 
+  /**
+   * Re-book a managed texture's GPU storage with the resource accountant after a
+   * full `texImage2D` (re)allocation: frees the previously booked size (if any —
+   * e.g. on resize) and allocates the new `width · height · bytesPerPixel`
+   * footprint, including the mip chain when the texture generates mips.
+   */
+  private _bookTextureStorage(state: ManagedTextureState, texture: Texture | RenderTexture, bytesPerPixel: number): void {
+    const nextBytes = estimateTextureBytes(texture.width, texture.height, bytesPerPixel, this._textureMipLevelCount(texture));
+
+    state.accountedBytes = this._accountant.reallocate(state.accountedBytes, nextBytes);
+  }
+
+  private _textureMipLevelCount(texture: Texture | RenderTexture): number {
+    if (!texture.generateMipMap) {
+      return 1;
+    }
+
+    const maxSize = Math.max(texture.width, texture.height);
+
+    if (maxSize <= 1) {
+      return 1;
+    }
+
+    return Math.floor(Math.log2(maxSize)) + 1;
+  }
+
   private _destroyManagedResources(): void {
     for (const renderTarget of [...this._renderTargetStates.keys()]) {
       this._evictRenderTarget(renderTarget, false);
@@ -1030,6 +1070,7 @@ export class WebGl2Backend implements RenderBackend {
         version: -1,
         width: 0,
         height: 0,
+        accountedBytes: 0,
       };
 
       this._textureStates.set(texture, state);
@@ -1104,6 +1145,8 @@ export class WebGl2Backend implements RenderBackend {
       }
 
       this._context.deleteTexture(state.handle);
+      this._accountant.free(state.accountedBytes);
+      state.accountedBytes = 0;
       this._textureStates.delete(texture);
     }
 
@@ -1301,8 +1344,12 @@ export class WebGl2Backend implements RenderBackend {
         // packing for the upload, then restore the GL default.
         gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1);
 
+        const bytesPerPixel = dataTextureBytesPerPixel(format);
+
         if (needsAlloc || region === null || region.full) {
           gl.texImage2D(gl.TEXTURE_2D, 0, formatInfo.internalFormat, texture.width, texture.height, 0, formatInfo.format, formatInfo.type, texture.buffer);
+          this._bookTextureStorage(state, texture, bytesPerPixel);
+          this._accountant.recordTextureUpload(texture.width * texture.height * bytesPerPixel);
         } else {
           // Partial upload: pack a contiguous sub-region from the row-major
           // buffer into a temporary view that gl.texSubImage2D can read.
@@ -1321,21 +1368,28 @@ export class WebGl2Backend implements RenderBackend {
           }
 
           gl.texSubImage2D(gl.TEXTURE_2D, 0, region.x, region.y, region.width, region.height, formatInfo.format, formatInfo.type, subView);
+          this._accountant.recordTextureUpload(region.width * region.height * bytesPerPixel);
         }
 
         gl.pixelStorei(gl.UNPACK_ALIGNMENT, 4);
       } else if (texture instanceof RenderTexture) {
         if (state.version === -1 || state.width !== texture.width || state.height !== texture.height || texture.source === null) {
           gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, texture.width, texture.height, 0, gl.RGBA, gl.UNSIGNED_BYTE, texture.source);
+          this._bookTextureStorage(state, texture, RGBA8_BYTES_PER_PIXEL);
+          this._accountant.recordTextureUpload(texture.width * texture.height * RGBA8_BYTES_PER_PIXEL);
         } else {
           gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, texture.width, texture.height, gl.RGBA, gl.UNSIGNED_BYTE, texture.source);
+          this._accountant.recordTextureUpload(texture.width * texture.height * RGBA8_BYTES_PER_PIXEL);
         }
       } else if (texture.source) {
         if (state.version === -1 || state.width !== texture.width || state.height !== texture.height) {
           gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, texture.source);
+          this._bookTextureStorage(state, texture, RGBA8_BYTES_PER_PIXEL);
         } else {
           gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, texture.source);
         }
+
+        this._accountant.recordTextureUpload(texture.width * texture.height * RGBA8_BYTES_PER_PIXEL);
       }
 
       if (texture.generateMipMap && (texture instanceof RenderTexture || texture.source !== null)) {
@@ -1411,6 +1465,9 @@ export class WebGl2Backend implements RenderBackend {
     gl.scissor(x, y, width, height);
   }
 }
+
+// Content + render textures upload as gl.RGBA / gl.UNSIGNED_BYTE = 4 bytes/px.
+const RGBA8_BYTES_PER_PIXEL = 4;
 
 interface WebGl2DataTextureFormatInfo {
   readonly internalFormat: number; // gl.R8 / gl.R32F / gl.RGBA8 / gl.RGBA32F

--- a/src/rendering/webgl2/WebGl2MaskCompositor.ts
+++ b/src/rendering/webgl2/WebGl2MaskCompositor.ts
@@ -62,9 +62,11 @@ export class WebGl2MaskCompositor {
     const bufferHandles = new Map<WebGl2RenderBuffer, WebGLBuffer>();
     const indexBuffer = new WebGl2RenderBuffer(BufferTypes.ElementArrayBuffer, quadIndices, BufferUsage.StaticDraw).connect(
       this._createBufferRuntime(gl, bufferHandles),
+      backend.accountant,
     );
     const vertexBuffer = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, this._vertexData, BufferUsage.DynamicDraw).connect(
       this._createBufferRuntime(gl, bufferHandles),
+      backend.accountant,
     );
 
     // Force shader finalize so getAttribute() below sees a populated

--- a/src/rendering/webgl2/WebGl2MeshRenderer.ts
+++ b/src/rendering/webgl2/WebGl2MeshRenderer.ts
@@ -37,14 +37,19 @@ interface MeshRendererConnection {
   readonly dynamicNodeIndexBuffer: WebGl2RenderBuffer;
 }
 
+// Mutable so the per-frame pool (`_pendingDraws` + `_pendingCount` cursor) can
+// reuse slots: `render()` overwrites every field of a reclaimed slot instead of
+// allocating a fresh literal. EVERY field must be rewritten per reuse (a stale
+// `command`/`material`/`texture`/`supportsInstancing` from the previous frame
+// would render a ghost mesh).
 interface PendingMeshDraw {
-  readonly mesh: Mesh;
-  readonly command: DrawCommand | null;
-  readonly material: Material | null;
-  readonly shader: Shader;
-  readonly blendMode: BlendModes;
-  readonly texture: Texture | RenderTexture;
-  readonly supportsInstancing: boolean;
+  mesh: Mesh;
+  command: DrawCommand | null;
+  material: Material | null;
+  shader: Shader;
+  blendMode: BlendModes;
+  texture: Texture | RenderTexture;
+  supportsInstancing: boolean;
 }
 
 interface StaticGeometryCacheEntry {
@@ -78,7 +83,12 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> {
   private _indexData: Uint16Array = new Uint16Array(initialIndexCapacity);
   private _nodeIndexData: Uint32Array = new Uint32Array(initialNodeIndexCapacity);
 
+  // Frame-persistent pool of pending-draw slots. `render()` fills slots front to
+  // back up to `_pendingCount`; `flush()` consumes `[0, _pendingCount)` and then
+  // only resets the cursor (the slot objects survive for the next frame, so no
+  // PendingMeshDraw literal is allocated per mesh per frame).
   private readonly _pendingDraws: PendingMeshDraw[] = [];
+  private _pendingCount = 0;
   private readonly _staticGeometryCache = new Map<Geometry, StaticGeometryCacheEntry>();
   private _connection: MeshRendererConnection | null = null;
   private _currentBlendMode: BlendModes | null = null;
@@ -105,15 +115,25 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> {
     const command = backend.activeDrawCommand;
     const supportsInstancing = material === null ? true : this._isInstancingCompatible(shader);
 
-    this._pendingDraws.push({
-      mesh,
-      command,
-      material,
-      shader,
-      blendMode,
-      texture,
-      supportsInstancing,
-    });
+    // Reuse a pooled slot if one exists at the cursor, otherwise grow the pool.
+    // Overwrite every field (see PendingMeshDraw): a forgotten field leaks the
+    // previous frame's mesh into this slot.
+    let slot = this._pendingDraws[this._pendingCount];
+
+    if (slot === undefined) {
+      slot = { mesh, command, material, shader, blendMode, texture, supportsInstancing };
+      this._pendingDraws.push(slot);
+    } else {
+      slot.mesh = mesh;
+      slot.command = command;
+      slot.material = material;
+      slot.shader = shader;
+      slot.blendMode = blendMode;
+      slot.texture = texture;
+      slot.supportsInstancing = supportsInstancing;
+    }
+
+    this._pendingCount++;
   }
 
   /**
@@ -173,35 +193,37 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> {
   public flush(): void {
     const backend = this.getBackendOrNull();
     const connection = this._connection;
+    const count = this._pendingCount;
 
-    if (backend === null || connection === null || this._pendingDraws.length === 0) {
-      this._pendingDraws.length = 0;
+    if (backend === null || connection === null || count === 0) {
+      this._pendingCount = 0;
       return;
     }
 
-    for (let i = 0; i < this._pendingDraws.length; i++) {
-      // In-bounds: `i` ranges over `0..length-1`.
+    for (let i = 0; i < count; i++) {
+      // In-bounds: `i` ranges over `0..count-1` (pool slots filled by render()).
       const draw = this._pendingDraws[i]!;
 
       if (this._canBatchStatic(draw)) {
         let end = i + 1;
 
-        // In-bounds: `end` and `end - 1` stay within `0..length-1` per the loop guard.
-        while (end < this._pendingDraws.length && this._isSameBatch(this._pendingDraws[end - 1]!, this._pendingDraws[end]!)) {
+        // In-bounds: `end` and `end - 1` stay within `0..count-1` per the loop guard.
+        while (end < count && this._isSameBatch(this._pendingDraws[end - 1]!, this._pendingDraws[end]!)) {
           end++;
         }
 
         if (end - i >= 2) {
-          this._drawStaticBatch(this._pendingDraws.slice(i, end), backend, connection);
+          this._drawStaticBatch(i, end, backend, connection);
           i = end - 1;
           continue;
         }
       }
 
-      this._drawSingle(draw, backend, connection);
+      this._drawSingle(i, backend, connection);
     }
 
-    this._pendingDraws.length = 0;
+    // Reset only the cursor; pooled slots stay allocated for the next frame.
+    this._pendingCount = 0;
   }
 
   public destroy(): void {
@@ -292,11 +314,15 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> {
     this._connection = null;
     this._currentBlendMode = null;
     this._pendingDraws.length = 0;
+    this._pendingCount = 0;
   }
 
-  private _drawSingle(draw: PendingMeshDraw, backend: WebGl2Backend, connection: MeshRendererConnection): void {
+  private _drawSingle(index: number, backend: WebGl2Backend, connection: MeshRendererConnection): void {
+    // In-bounds: callers pass an index in `0..count-1`.
+    const draw = this._pendingDraws[index]!;
+
     if (this._canBatchStatic(draw)) {
-      this._drawStaticBatch([draw], backend, connection);
+      this._drawStaticBatch(index, index + 1, backend, connection);
       return;
     }
 
@@ -343,10 +369,18 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> {
     backend.stats.drawCalls++;
   }
 
-  private _drawStaticBatch(batch: PendingMeshDraw[], backend: WebGl2Backend, connection: MeshRendererConnection): void {
-    // Callers only invoke this with a non-empty batch (slice of >= 1 or [draw]).
-    const first = batch[0]!;
+  /**
+   * Draw the pooled pending-draws in the half-open range `[start, end)` as one
+   * instanced batch. Callers (flush single-draw and run-batching) guarantee
+   * `end > start` and that every slot in the range shares geometry/shader/
+   * material/blend/texture (see {@link _isSameBatch}). Iterating the range
+   * in place avoids the per-batch array copy a `slice()` would allocate.
+   */
+  private _drawStaticBatch(start: number, end: number, backend: WebGl2Backend, connection: MeshRendererConnection): void {
+    // In-bounds: `start < end <= _pendingCount`, so `start` is a filled slot.
+    const first = this._pendingDraws[start]!;
     const geometry = first.mesh.geometry!;
+    const count = end - start;
     const cacheEntry = this._getOrCreateStaticGeometryEntry(geometry, first.mesh, connection);
     const vao = this._getOrCreateStaticGeometryVao(cacheEntry, first.shader, connection.gl, connection.dynamicNodeIndexBuffer);
 
@@ -354,11 +388,11 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> {
 
     let maxNodeIndex = 0;
 
-    this._ensureNodeIndexCapacity(batch.length);
+    this._ensureNodeIndexCapacity(count);
 
-    for (let i = 0; i < batch.length; i++) {
-      // In-bounds: `i` ranges over `0..batch.length-1`.
-      const command = batch[i]!.command!;
+    for (let i = 0; i < count; i++) {
+      // In-bounds: `start + i` ranges over `[start, end)`, all filled slots.
+      const command = this._pendingDraws[start + i]!.command!;
       const nodeIndex = command.nodeIndex >>> 0;
 
       this._nodeIndexData[i] = nodeIndex;
@@ -370,8 +404,8 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> {
 
     this._bindInstancedShaderState(first.shader, first.texture, first.material, backend, maxNodeIndex);
     backend.bindVertexArrayObject(vao);
-    connection.dynamicNodeIndexBuffer.upload(this._nodeIndexData.subarray(0, batch.length));
-    vao.drawInstanced(cacheEntry.indexCount, 0, batch.length, RenderingPrimitives.Triangles);
+    connection.dynamicNodeIndexBuffer.upload(this._nodeIndexData.subarray(0, count));
+    vao.drawInstanced(cacheEntry.indexCount, 0, count, RenderingPrimitives.Triangles);
 
     backend.stats.batches++;
     backend.stats.drawCalls++;

--- a/src/rendering/webgl2/WebGl2MeshRenderer.ts
+++ b/src/rendering/webgl2/WebGl2MeshRenderer.ts
@@ -251,12 +251,15 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> {
     const buffers = new Map<WebGl2RenderBuffer, { handle: WebGLBuffer; dataByteLength: number }>();
     const dynamicIndexBuffer = new WebGl2RenderBuffer(BufferTypes.ElementArrayBuffer, this._indexData, BufferUsage.DynamicDraw).connect(
       this._createBufferRuntime(gl, buffers),
+      backend.accountant,
     );
     const dynamicVertexBuffer = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, this._vertexData, BufferUsage.DynamicDraw).connect(
       this._createBufferRuntime(gl, buffers),
+      backend.accountant,
     );
     const dynamicNodeIndexBuffer = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, this._nodeIndexData, BufferUsage.DynamicDraw).connect(
       this._createBufferRuntime(gl, buffers),
+      backend.accountant,
     );
 
     const dynamicVaoHandle = gl.createVertexArray();
@@ -550,11 +553,14 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> {
 
     this._packIndices(mesh, 0, indexData);
 
+    const accountant = this.getBackend().accountant;
     const vertexBuffer = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, floatView, BufferUsage.StaticDraw).connect(
       this._createBufferRuntime(connection.gl, connection.buffers),
+      accountant,
     );
     const indexBuffer = new WebGl2RenderBuffer(BufferTypes.ElementArrayBuffer, indexData, BufferUsage.StaticDraw).connect(
       this._createBufferRuntime(connection.gl, connection.buffers),
+      accountant,
     );
 
     vertexBuffer.upload(floatView);

--- a/src/rendering/webgl2/WebGl2NineSliceSpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2NineSliceSpriteRenderer.ts
@@ -261,6 +261,7 @@ export class WebGl2NineSliceSpriteRenderer extends AbstractWebGl2Renderer<NineSl
     this._connection = this._createConnection(gl);
     this._instanceBuffer = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, this._instanceData, BufferUsage.DynamicDraw).connect(
       this._createBufferRuntime(this._connection),
+      backend.accountant,
     );
     this._shader.sync();
 

--- a/src/rendering/webgl2/WebGl2RenderBuffer.ts
+++ b/src/rendering/webgl2/WebGl2RenderBuffer.ts
@@ -1,5 +1,6 @@
 import type { TypedArray } from '#core/types';
 import { emptyArrayBuffer } from '#core/utils';
+import type { GpuResourceAccountant } from '#rendering/GpuResourceAccountant';
 import type { BufferTypes, BufferUsage } from '#rendering/types';
 
 type DataContainer = ArrayBuffer | SharedArrayBuffer | ArrayBufferView | TypedArray;
@@ -24,6 +25,14 @@ export class WebGl2RenderBuffer {
   private _runtime: WebGl2RenderBufferRuntime | null = null;
   private _data: DataContainer = emptyArrayBuffer;
   private _version = 0;
+  private _accountant: GpuResourceAccountant | null = null;
+  /**
+   * High-water mark of GPU storage booked with the accountant. The runtime only
+   * issues a fresh `bufferData` (storage reallocation) when the upload exceeds
+   * the previously sized buffer, so storage tracks the largest byte length ever
+   * uploaded; per-upload byte traffic is booked separately each call.
+   */
+  private _accountedBytes = 0;
 
   public constructor(type: BufferTypes, data: DataContainer, usage: BufferUsage) {
     this._type = type;
@@ -50,11 +59,13 @@ export class WebGl2RenderBuffer {
     return this._version;
   }
 
-  public connect(runtime: WebGl2RenderBufferRuntime): this {
+  public connect(runtime: WebGl2RenderBufferRuntime, accountant?: GpuResourceAccountant): this {
     this._runtime = runtime;
+    this._accountant = accountant ?? null;
 
     if (this._data.byteLength > 0) {
       runtime.upload(this, 0);
+      this._bookUpload();
     }
 
     return this;
@@ -71,6 +82,7 @@ export class WebGl2RenderBuffer {
     this._version++;
 
     this._runtime?.upload(this, offset);
+    this._bookUpload();
   }
 
   public bind(): void {
@@ -80,5 +92,31 @@ export class WebGl2RenderBuffer {
   public destroy(): void {
     this._runtime?.destroy(this);
     this._runtime = null;
+
+    if (this._accountedBytes > 0) {
+      this._accountant?.free(this._accountedBytes);
+      this._accountedBytes = 0;
+    }
+  }
+
+  /**
+   * Book the just-issued GPU upload with the resource accountant: the full
+   * uploaded byte count as per-frame upload traffic, plus any growth of the
+   * resident storage high-water mark as a (re)allocation.
+   */
+  private _bookUpload(): void {
+    const accountant = this._accountant;
+
+    if (accountant === null || this._runtime === null) {
+      return;
+    }
+
+    const byteLength = this._data.byteLength;
+
+    accountant.recordBufferUpload(byteLength);
+
+    if (byteLength > this._accountedBytes) {
+      this._accountedBytes = accountant.reallocate(this._accountedBytes, byteLength);
+    }
   }
 }

--- a/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
@@ -517,7 +517,10 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
       .connect(this._createVaoRuntime(conn, 'shader'));
 
     // Geometry-path VAO (packed unorm16 UVs, same layout as NineSlice)
-    this._geoBuf = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, this._geoData, BufferUsage.DynamicDraw).connect(this._createBufRuntime(conn, 'geo'), backend.accountant);
+    this._geoBuf = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, this._geoData, BufferUsage.DynamicDraw).connect(
+      this._createBufRuntime(conn, 'geo'),
+      backend.accountant,
+    );
 
     this._geoVao = new WebGl2VertexArrayObject(RenderingPrimitives.TriangleStrip)
       .addAttribute(this._geoBuf, this._geoPathShader.getAttribute('a_quadBounds'), gl.FLOAT, false, geoStrideBytes, 0, false, 1)

--- a/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
@@ -506,6 +506,7 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
     // Shader-path VAO (uses float4 uvParams, not packed unorm16)
     this._shaderBuf = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, this._shaderData, BufferUsage.DynamicDraw).connect(
       this._createBufRuntime(conn, 'shader'),
+      backend.accountant,
     );
 
     this._shaderVao = new WebGl2VertexArrayObject(RenderingPrimitives.TriangleStrip)
@@ -516,7 +517,7 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
       .connect(this._createVaoRuntime(conn, 'shader'));
 
     // Geometry-path VAO (packed unorm16 UVs, same layout as NineSlice)
-    this._geoBuf = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, this._geoData, BufferUsage.DynamicDraw).connect(this._createBufRuntime(conn, 'geo'));
+    this._geoBuf = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, this._geoData, BufferUsage.DynamicDraw).connect(this._createBufRuntime(conn, 'geo'), backend.accountant);
 
     this._geoVao = new WebGl2VertexArrayObject(RenderingPrimitives.TriangleStrip)
       .addAttribute(this._geoBuf, this._geoPathShader.getAttribute('a_quadBounds'), gl.FLOAT, false, geoStrideBytes, 0, false, 1)

--- a/src/rendering/webgl2/WebGl2SpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2SpriteRenderer.ts
@@ -231,6 +231,7 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> {
     this._connection = this._createConnection(gl);
     this._instanceBuffer = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, this._instanceData, BufferUsage.DynamicDraw).connect(
       this._createBufferRuntime(this._connection),
+      backend.accountant,
     );
     this._shader.sync();
 

--- a/src/rendering/webgl2/WebGl2StencilClipper.ts
+++ b/src/rendering/webgl2/WebGl2StencilClipper.ts
@@ -56,7 +56,10 @@ export class WebGl2StencilClipper {
     this._shader.connect(createWebGl2ShaderProgram(gl));
     this._shader.sync();
 
-    const vertexBuffer = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, this._positions, BufferUsage.DynamicDraw).connect(this._createBufferRuntime(gl));
+    const vertexBuffer = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, this._positions, BufferUsage.DynamicDraw).connect(
+      this._createBufferRuntime(gl),
+      backend.accountant,
+    );
     const vao = new WebGl2VertexArrayObject(RenderingPrimitives.Triangles)
       .addAttribute(vertexBuffer, this._shader.getAttribute('a_position'), gl.FLOAT, false, positionStrideBytes, 0)
       .connect(this._createVaoRuntime(gl, vaoHandle));

--- a/src/rendering/webgl2/WebGl2TextRenderer.ts
+++ b/src/rendering/webgl2/WebGl2TextRenderer.ts
@@ -160,9 +160,11 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
 
     const indexBuffer = new WebGl2RenderBuffer(BufferTypes.ElementArrayBuffer, this._indexData, BufferUsage.DynamicDraw).connect(
       this._createBufferRuntime(gl, buffers),
+      backend.accountant,
     );
     const vertexBuffer = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, this._vertexData, BufferUsage.DynamicDraw).connect(
       this._createBufferRuntime(gl, buffers),
+      backend.accountant,
     );
 
     const vaoHandle = gl.createVertexArray();

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -10,6 +10,7 @@ import { Vector } from '#math/Vector';
 import type { BackendRenderPass } from '#rendering/BackendRenderPass';
 import type { Drawable } from '#rendering/Drawable';
 import type { Geometry } from '#rendering/geometry/Geometry';
+import { dataTextureBytesPerPixel, estimateTextureBytes, GpuResourceAccountant } from '#rendering/GpuResourceAccountant';
 import type { Mesh } from '#rendering/mesh/Mesh';
 import { resolveUploadTransform } from '#rendering/pixelSnap';
 import { type DrawCommand, drawCommandUsesSharedTransform, RenderEntryKind } from '#rendering/plan/RenderCommand';
@@ -42,6 +43,8 @@ interface ManagedWebGpuTextureState {
   height: number;
   mipLevelCount: number;
   hasContent: boolean;
+  /** GPU bytes currently booked for this texture's storage with the resource accountant. */
+  accountedBytes: number;
 }
 
 interface PixelClipBoundsState {
@@ -52,6 +55,8 @@ interface PixelClipBoundsState {
 }
 
 const managedTextureFormat: GPUTextureFormat = 'rgba8unorm';
+// Managed content + render textures use rgba8unorm = 4 bytes/px.
+const MANAGED_TEXTURE_BYTES_PER_PIXEL = 4;
 
 /**
  * WebGPU implementation of {@link RenderBackend}. Manages the GPU device,
@@ -114,6 +119,7 @@ export class WebGpuBackend implements RenderBackend {
   private _clearRequested = false;
   private _hasPresentedFrame = false;
   private readonly _stats: RenderStats = createRenderStats();
+  private readonly _accountant: GpuResourceAccountant = new GpuResourceAccountant(this._stats);
   private _transformStorage: WebGpuTransformStorage | null = new WebGpuTransformStorage();
   private _activeDrawCommand: DrawCommand | null = null;
   private _passCoordinatorInstance: WebGpuPassCoordinator | null = null;
@@ -181,6 +187,17 @@ export class WebGpuBackend implements RenderBackend {
     return this._stats;
   }
 
+  /**
+   * Per-backend GPU resource accountant (VRAM / upload / download bookkeeping).
+   * Shared with this backend's transform storage and compute readback paths so
+   * they can book their own allocations and uploads. Not part of any public
+   * surface.
+   * @internal
+   */
+  public get accountant(): GpuResourceAccountant {
+    return this._accountant;
+  }
+
   /** @internal */
   public get activeDrawCommand(): DrawCommand | null {
     return this._activeDrawCommand;
@@ -238,7 +255,7 @@ export class WebGpuBackend implements RenderBackend {
     // destroy and replace the buffer mid-frame while earlier command buffers
     // may still reference the old allocation.
     if (nodeCount > 0 && this._device !== null && !this._deviceLost) {
-      storage.reserve(this._device, nodeCount);
+      storage.reserve(this._device, nodeCount, this._accountant);
     }
 
     this._activeDrawCommand = null;
@@ -722,7 +739,7 @@ export class WebGpuBackend implements RenderBackend {
 
   /** @internal */
   public getTransformStorageBuffer(minCount: number): { readonly buffer: GPUBuffer; readonly count: number } {
-    return this._getTransformStorage().getBuffer(this.device, minCount);
+    return this._getTransformStorage().getBuffer(this.device, minCount, this._accountant);
   }
 
   /**
@@ -1060,6 +1077,8 @@ export class WebGpuBackend implements RenderBackend {
         usage: this._getTextureUsage(texture),
       });
 
+      const mipLevelCount = this._getMipLevelCount(texture);
+
       state = {
         texture: gpuTexture,
         view: gpuTexture.createView(),
@@ -1067,9 +1086,12 @@ export class WebGpuBackend implements RenderBackend {
         version: -1,
         width: texture.width,
         height: texture.height,
-        mipLevelCount: this._getMipLevelCount(texture),
+        mipLevelCount,
         hasContent: false,
+        accountedBytes: 0,
       };
+
+      state.accountedBytes = this._accountant.reallocate(0, this._estimateTextureBytes(texture, mipLevelCount));
 
       const destroyHandler = (): void => {
         this._evictTexture(texture);
@@ -1112,6 +1134,8 @@ export class WebGpuBackend implements RenderBackend {
         state.height = texture.height;
         state.mipLevelCount = mipLevelCount;
         state.hasContent = false;
+        // Free the previous storage before booking the new size (no transient spike).
+        state.accountedBytes = this._accountant.reallocate(state.accountedBytes, this._estimateTextureBytes(texture, mipLevelCount));
       }
 
       state.sampler = this._createSampler(texture);
@@ -1135,6 +1159,7 @@ export class WebGpuBackend implements RenderBackend {
             },
             { width: texture.width, height: texture.height },
           );
+          this._accountant.recordTextureUpload(texture.width * texture.height * formatInfo.bytesPerPixel);
         } else {
           // Partial upload: pack the dirty region into a contiguous buffer.
           const channels = formatInfo.channels;
@@ -1156,6 +1181,7 @@ export class WebGpuBackend implements RenderBackend {
             { bytesPerRow: region.width * bytesPerPixel, rowsPerImage: region.height },
             { width: region.width, height: region.height },
           );
+          this._accountant.recordTextureUpload(region.width * region.height * bytesPerPixel);
         }
 
         state.hasContent = true;
@@ -1175,6 +1201,7 @@ export class WebGpuBackend implements RenderBackend {
             height: texture.height,
           },
         );
+        this._accountant.recordTextureUpload(texture.width * texture.height * MANAGED_TEXTURE_BYTES_PER_PIXEL);
 
         if (state.mipLevelCount > 1) {
           this._generateMipmaps(state.texture, state.mipLevelCount);
@@ -1198,6 +1225,8 @@ export class WebGpuBackend implements RenderBackend {
 
     if (state) {
       state.texture.destroy();
+      this._accountant.free(state.accountedBytes);
+      state.accountedBytes = 0;
       this._textureStates.delete(texture);
     }
 
@@ -1332,6 +1361,23 @@ export class WebGpuBackend implements RenderBackend {
       default:
         return 'nearest';
     }
+  }
+
+  /** Bytes per pixel for a texture's GPU format (DataTexture formats, else managed `rgba8unorm`). */
+  private _textureBytesPerPixel(texture: Texture | RenderTexture): number {
+    if (texture instanceof DataTexture) {
+      // `instanceof DataTexture` erases the generic, widening `format` to `any`;
+      // the class invariant guarantees it is a `DataTextureFormat`.
+      const format: DataTextureFormat = texture.format;
+      return dataTextureBytesPerPixel(format);
+    }
+
+    return MANAGED_TEXTURE_BYTES_PER_PIXEL;
+  }
+
+  /** Estimated VRAM bytes for a texture's storage (base level + mip chain). */
+  private _estimateTextureBytes(texture: Texture | RenderTexture, mipLevelCount: number): number {
+    return estimateTextureBytes(texture.width, texture.height, this._textureBytesPerPixel(texture), mipLevelCount);
   }
 
   private _getMipLevelCount(texture: Texture | RenderTexture): number {

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -12,8 +12,8 @@ import type { Drawable } from '#rendering/Drawable';
 import type { Geometry } from '#rendering/geometry/Geometry';
 import type { Mesh } from '#rendering/mesh/Mesh';
 import { resolveUploadTransform } from '#rendering/pixelSnap';
-import { type DrawCommand, drawCommandUsesSharedTransform } from '#rendering/plan/RenderCommand';
-import type { RenderGroup } from '#rendering/plan/RenderInstruction';
+import { type DrawCommand, drawCommandUsesSharedTransform, RenderEntryKind } from '#rendering/plan/RenderCommand';
+import type { ScopeEntry } from '#rendering/plan/RenderScope';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import { RenderBackendType } from '#rendering/RenderBackendType';
 import type { Renderer } from '#rendering/Renderer';
@@ -246,21 +246,30 @@ export class WebGpuBackend implements RenderBackend {
   }
 
   /** @internal */
-  public _prepareRenderGroupUpload(group: RenderGroup): void {
+  public _prepareRenderGroupUpload(entries: readonly ScopeEntry[], startIndex: number, count: number): void {
     // Pack the whole render group's world transforms (+ tint) into the shared
     // transform storage at the group's upload boundary, keyed by each draw
     // command's stable nodeIndex. Every draw the player will submit for this
     // group is covered here, before the group's first draw.
     //
+    // The group is the entries range `[startIndex, startIndex + count)`; every
+    // entry in it is a draw, so the player no longer materializes a group array.
+    //
     // Renderers that pack their own per-node data (Text, Particle) never read
     // the shared storage, so their commands are skipped — no consuming draw
     // ever references their slots (nodeIndex is unique per command).
     const storage = this._getTransformStorage();
-    const instructions = group.instructions;
+    const end = startIndex + count;
 
-    for (let i = 0; i < instructions.length; i++) {
-      // i is bounded by instructions.length via the for-loop guard.
-      const command = instructions[i]!;
+    for (let i = startIndex; i < end; i++) {
+      const entry = entries[i]!;
+
+      // Every entry in a group run is a draw; narrow to read its command.
+      if (entry.kind !== RenderEntryKind.Draw) {
+        continue;
+      }
+
+      const command = entry.command;
 
       if (drawCommandUsesSharedTransform(command, this)) {
         storage.writeCommand(command, this._resolveSnapTransform(command.drawable));

--- a/src/rendering/webgpu/WebGpuTransformStorage.ts
+++ b/src/rendering/webgpu/WebGpuTransformStorage.ts
@@ -1,6 +1,7 @@
 import type { Color } from '#core/Color';
 import type { Matrix } from '#math/Matrix';
 import type { Drawable } from '#rendering/Drawable';
+import type { GpuResourceAccountant } from '#rendering/GpuResourceAccountant';
 import type { DrawCommand } from '#rendering/plan/RenderCommand';
 import { TransformBuffer } from '#rendering/TransformBuffer';
 
@@ -13,6 +14,9 @@ export class WebGpuTransformStorage {
   private _storageCapacity = 0;
   private _storageHash = 0;
   private _storageCount = -1;
+  private _accountant: GpuResourceAccountant | null = null;
+  /** GPU bytes currently booked for the storage buffer with the resource accountant. */
+  private _accountedBytes = 0;
 
   /**
    * Underlying shared transform buffer. Exposed for internal stats / tests
@@ -70,7 +74,9 @@ export class WebGpuTransformStorage {
    * objects are destroyed or re-created. Capacity only grows, never shrinks.
    * @internal
    */
-  public reserve(device: GPUDevice, recordCount: number): void {
+  public reserve(device: GPUDevice, recordCount: number, accountant?: GpuResourceAccountant): void {
+    this._accountant = accountant ?? this._accountant;
+
     const minCount = Math.max(1, recordCount);
     const requiredBytes = minCount * slotFloatCount * Float32Array.BYTES_PER_ELEMENT;
 
@@ -81,7 +87,9 @@ export class WebGpuTransformStorage {
     this._growBuffer(device, requiredBytes);
   }
 
-  public getBuffer(device: GPUDevice, minCount: number): { readonly buffer: GPUBuffer; readonly count: number } {
+  public getBuffer(device: GPUDevice, minCount: number, accountant?: GpuResourceAccountant): { readonly buffer: GPUBuffer; readonly count: number } {
+    this._accountant = accountant ?? this._accountant;
+
     const requiredCount = Math.max(1, minCount);
     const requiredBytes = requiredCount * slotFloatCount * Float32Array.BYTES_PER_ELEMENT;
     const snapshot = this._buffer.commitSnapshot(requiredCount);
@@ -95,6 +103,7 @@ export class WebGpuTransformStorage {
 
       device.queue.writeBuffer(this._storageBuffer!, 0, this._buffer.data.buffer, this._buffer.data.byteOffset, bytes);
       this._buffer.recordUpload(snapshot.count);
+      this._accountant?.recordBufferUpload(bytes);
       this._storageHash = snapshot.hash;
       this._storageCount = snapshot.count;
     }
@@ -111,6 +120,11 @@ export class WebGpuTransformStorage {
     this._storageCapacity = 0;
     this._storageHash = 0;
     this._storageCount = -1;
+
+    if (this._accountedBytes > 0) {
+      this._accountant?.free(this._accountedBytes);
+      this._accountedBytes = 0;
+    }
   }
 
   private _growBuffer(device: GPUDevice, requiredBytes: number): void {
@@ -128,5 +142,7 @@ export class WebGpuTransformStorage {
     this._storageCapacity = nextCapacity;
     this._storageHash = 0;
     this._storageCount = -1;
+    // Re-book the storage footprint (free the prior buffer's bytes, allocate the new).
+    this._accountedBytes = this._accountant?.reallocate(this._accountedBytes, nextCapacity) ?? this._accountedBytes;
   }
 }

--- a/src/rendering/webgpu/compute/WebGpuStorageBuffer.ts
+++ b/src/rendering/webgpu/compute/WebGpuStorageBuffer.ts
@@ -34,6 +34,14 @@ export class WebGpuStorageBuffer {
   }
 
   /**
+   * Optional sink invoked after each {@link read} with the number of bytes read
+   * back GPU → CPU. Lets a consumer route readback traffic into a backend's
+   * resource accountant (`RenderStats.downloadBytes` / `downloadCount`) without
+   * coupling this primitive to the backend. Defaults to a no-op.
+   */
+  public onReadback: ((bytes: number) => void) | null = null;
+
+  /**
    * Copy this buffer's contents into a CPU-mappable readback buffer and
    * await the result. Allocates the readback buffer lazily on first call;
    * subsequent calls re-use it.
@@ -66,6 +74,8 @@ export class WebGpuStorageBuffer {
     bytes.set(mapped.subarray(0, target.byteLength));
 
     this._readbackBuffer.unmap();
+
+    this.onReadback?.(target.byteLength);
   }
 
   public destroy(): void {

--- a/test/perf/rendering/allocation.test.ts
+++ b/test/perf/rendering/allocation.test.ts
@@ -16,15 +16,24 @@ import { buildScenarioCatalog } from './scenarios';
  * live at stop, discarding the immediately-dead plan garbage (a ~500× undercount).
  * The `sampler counts dead garbage` test below guards that invariant.
  *
- * Budgets are the measured status quo (`pnpm perf:renderers:alloc`) plus headroom;
- * they tighten as 2b–2f drive the static scene toward ~0 plan garbage/frame.
+ * Budgets are the measured status quo plus headroom; they tighten as 2b–2f drive
+ * the static scene toward ~0 plan garbage/frame.
+ *
+ * NOTE: the source-accurate numbers come from THIS test (the vitest `rendering-perf`
+ * project resolves `#*` imports to `src` and wires GLSL). The standalone
+ * `pnpm perf:renderers:alloc` launcher resolves `#*` to the built `dist/esm` (its
+ * `default` import condition) and so reports the LAST BUILD, not the working tree —
+ * use it only as a rough cross-check, not as the before/after gate.
  */
 
-// Status-quo budgets (bytes/frame), measured: empty ≈ 3 KB (harness/recorder
-// floor), static ≈ 645 KB, moving ≈ 1020 KB. ~1.5× headroom; tighten per slice.
+// Budgets (bytes/frame), measured against src. empty ≈ 2.6 KB (harness/recorder
+// floor). After Slice 2b (DrawCommand/ScopeEntry pooled, MaterialKey cached):
+// static ≈ 317 KB (was ≈ 644), moving ≈ 580 KB (was ≈ 916). The remainder is the
+// RenderPlanOptimizer (→ 2f) + per-scope collectRenderGroups (→ 2c). ~1.3× headroom
+// for the statistical sampler; tighten again per following slice.
 const EMPTY_BUDGET = 16 * 1024;
-const STATIC_BUDGET = 1024 * 1024;
-const MOVING_BUDGET = 1536 * 1024;
+const STATIC_BUDGET = 420 * 1024;
+const MOVING_BUDGET = 768 * 1024;
 
 const findScenario = (id: string): ReturnType<typeof buildScenarioCatalog>[number] => {
   const scenario = buildScenarioCatalog('full').find(s => s.id === id);

--- a/test/perf/rendering/allocation.test.ts
+++ b/test/perf/rendering/allocation.test.ts
@@ -1,4 +1,3 @@
- 
 import { describe, expect, it } from 'vitest';
 
 import { measureFrameAllocation } from './allocation';
@@ -11,23 +10,21 @@ import { buildScenarioCatalog } from './scenarios';
  * RATE (throwaway garbage, not retained heap) on an empty, a static, and a moving
  * reference scene via the V8 allocation sampling profiler (see `allocation.ts`).
  *
- * Unlike the physics perf gate — which diffs `heapUsed` and therefore needs
- * `--expose-gc` to force a clean number — the sampling profiler records at
- * allocation time and counts immediately-dead objects too. It needs no flag, so
- * the budget is always enforced (no `forceGc`-conditional contract here).
+ * The sampler needs no `--expose-gc` and the budget is always enforced — but it
+ * is only correct because `allocation.ts` passes `includeObjectsCollectedBy*GC`
+ * to `startSampling`. Without those flags the profiler reports ONLY objects still
+ * live at stop, discarding the immediately-dead plan garbage (a ~500× undercount).
+ * The `sampler counts dead garbage` test below guards that invariant.
  *
- * Budgets are the measured status quo plus headroom; they tighten as 2b–2f land.
- * The static scene's eventual target is ~0 plan garbage/frame (pooling/caching);
- * the empty scene proves the harness/sampler itself adds no per-frame garbage.
+ * Budgets are the measured status quo (`pnpm perf:renderers:alloc`) plus headroom;
+ * they tighten as 2b–2f drive the static scene toward ~0 plan garbage/frame.
  */
 
-// Budgets (bytes/frame), calibrated against the measured status quo via
-// `pnpm perf:renderers:alloc`: empty ≈ 0.08 KB, static/moving 1000-sprite ≈ 2 KB
-// (10000-sprite ≈ 15 KB confirms the sampler scales with load). ~4× headroom for
-// CI/sampler noise; tighten as 2b–2f drive the static scene toward ~0.
-const EMPTY_BUDGET = 4 * 1024;
-const STATIC_BUDGET = 8 * 1024;
-const MOVING_BUDGET = 8 * 1024;
+// Status-quo budgets (bytes/frame), measured: empty ≈ 3 KB (harness/recorder
+// floor), static ≈ 645 KB, moving ≈ 1020 KB. ~1.5× headroom; tighten per slice.
+const EMPTY_BUDGET = 16 * 1024;
+const STATIC_BUDGET = 1024 * 1024;
+const MOVING_BUDGET = 1536 * 1024;
 
 const findScenario = (id: string): ReturnType<typeof buildScenarioCatalog>[number] => {
   const scenario = buildScenarioCatalog('full').find(s => s.id === id);
@@ -44,6 +41,33 @@ const log = (label: string, bytesPerFrame: number): void => {
 };
 
 describe('render-plan allocation gate', () => {
+  it('sampler counts dead garbage (guards the GC-inclusion flags)', async () => {
+    const harness = createWebGl2Harness();
+    const { root } = buildSpriteScene({ count: 0, textures: makeTextures(1) });
+
+    // JSON.parse is opaque to V8's optimizer — it cannot scalar-replace or
+    // dead-code the resulting 1000-object array, so the allocation is real and
+    // immediately dead (the sink is overwritten each frame).
+    const junkJson = `[${'{"a":1,"b":2},'.repeat(999)}{"a":1,"b":2}]`;
+    let sink: unknown = null;
+
+    const base = await measureFrameAllocation(harness, root);
+    const withJunk = await measureFrameAllocation(harness, root, {
+      beforeFrame: (): void => {
+        sink = JSON.parse(junkJson) as unknown;
+      },
+    });
+
+    void sink;
+    root.destroy();
+    harness.destroy();
+
+    // 1000 small objects ≈ 32–56 B each. If the sampler discarded GC'd garbage
+    // this delta would collapse toward 0 (measured ~0.1 B/obj without the flags).
+    const bytesPerObject = (withJunk.bytesPerFrame - base.bytesPerFrame) / 1000;
+    expect(bytesPerObject).toBeGreaterThan(20);
+  });
+
   it('empty scene allocates near-nothing (harness/sampler sanity)', async () => {
     const harness = createWebGl2Harness();
     const { root } = buildSpriteScene({ count: 0, textures: makeTextures(1) });

--- a/test/perf/rendering/allocation.test.ts
+++ b/test/perf/rendering/allocation.test.ts
@@ -1,0 +1,85 @@
+ 
+import { describe, expect, it } from 'vitest';
+
+import { measureFrameAllocation } from './allocation';
+import { buildSpriteScene, makeTextures } from './fixtures';
+import { createWebGl2Harness } from './harness';
+import { buildScenarioCatalog } from './scenarios';
+
+/**
+ * Render-plan allocation gate (spec 04 §2a). Samples the per-frame allocation
+ * RATE (throwaway garbage, not retained heap) on an empty, a static, and a moving
+ * reference scene via the V8 allocation sampling profiler (see `allocation.ts`).
+ *
+ * Unlike the physics perf gate — which diffs `heapUsed` and therefore needs
+ * `--expose-gc` to force a clean number — the sampling profiler records at
+ * allocation time and counts immediately-dead objects too. It needs no flag, so
+ * the budget is always enforced (no `forceGc`-conditional contract here).
+ *
+ * Budgets are the measured status quo plus headroom; they tighten as 2b–2f land.
+ * The static scene's eventual target is ~0 plan garbage/frame (pooling/caching);
+ * the empty scene proves the harness/sampler itself adds no per-frame garbage.
+ */
+
+// Budgets (bytes/frame), calibrated against the measured status quo via
+// `pnpm perf:renderers:alloc`: empty ≈ 0.08 KB, static/moving 1000-sprite ≈ 2 KB
+// (10000-sprite ≈ 15 KB confirms the sampler scales with load). ~4× headroom for
+// CI/sampler noise; tighten as 2b–2f drive the static scene toward ~0.
+const EMPTY_BUDGET = 4 * 1024;
+const STATIC_BUDGET = 8 * 1024;
+const MOVING_BUDGET = 8 * 1024;
+
+const findScenario = (id: string): ReturnType<typeof buildScenarioCatalog>[number] => {
+  const scenario = buildScenarioCatalog('full').find(s => s.id === id);
+
+  if (scenario === undefined) {
+    throw new Error(`scenario not found: ${id}`);
+  }
+
+  return scenario;
+};
+
+const log = (label: string, bytesPerFrame: number): void => {
+  console.log(`[alloc] ${label.padEnd(20)} ${(bytesPerFrame / 1024).toFixed(2).padStart(9)} KB/frame`);
+};
+
+describe('render-plan allocation gate', () => {
+  it('empty scene allocates near-nothing (harness/sampler sanity)', async () => {
+    const harness = createWebGl2Harness();
+    const { root } = buildSpriteScene({ count: 0, textures: makeTextures(1) });
+
+    const alloc = await measureFrameAllocation(harness, root);
+    log('empty', alloc.bytesPerFrame);
+
+    root.destroy();
+    harness.destroy();
+
+    expect(alloc.bytesPerFrame).toBeLessThan(EMPTY_BUDGET);
+  });
+
+  it('static sprite scene stays within the plan-allocation budget', async () => {
+    const harness = createWebGl2Harness();
+    const scene = findScenario('sprite/1000/1tex/static').build(harness);
+
+    const alloc = await measureFrameAllocation(harness, scene.root, { beforeFrame: scene.beforeFrame });
+    log('sprite/1000 static', alloc.bytesPerFrame);
+
+    scene.teardown?.();
+    harness.destroy();
+
+    expect(alloc.bytesPerFrame).toBeLessThan(STATIC_BUDGET);
+  });
+
+  it('moving sprite scene stays within the (looser) moving budget', async () => {
+    const harness = createWebGl2Harness();
+    const scene = findScenario('sprite/1000/1tex/moving').build(harness);
+
+    const alloc = await measureFrameAllocation(harness, scene.root, { beforeFrame: scene.beforeFrame });
+    log('sprite/1000 moving', alloc.bytesPerFrame);
+
+    scene.teardown?.();
+    harness.destroy();
+
+    expect(alloc.bytesPerFrame).toBeLessThan(MOVING_BUDGET);
+  });
+});

--- a/test/perf/rendering/allocation.test.ts
+++ b/test/perf/rendering/allocation.test.ts
@@ -25,21 +25,24 @@ import { buildScenarioCatalog } from './scenarios';
  * Budgets ratchet down per slice; run with `--disableConsoleIntercept` to see them.
  */
 
-// Sprite reference budgets (bytes/frame), measured against src. empty ≈ 2.6 KB
-// (harness/recorder floor). After Slice 2b (DrawCommand/ScopeEntry pooled,
-// MaterialKey cached): static ≈ 317 KB (was ≈ 644), moving ≈ 580 KB (was ≈ 916).
+// Sprite reference budgets (bytes/frame), measured against src. empty ≈ 2.2 KB
+// (harness/recorder floor). After Slice 2c (collectRenderGroups eliminated — the
+// plan player walks groupIndex adjacency over scope.entries inline, so no
+// per-scope RenderGroup[]/instructions[] is materialized each frame): static
+// ≈ 288 KB (was ≈ 318 post-2b), moving ≈ 550 KB (was ≈ 578).
 const EMPTY_BUDGET = 16 * 1024;
-const STATIC_BUDGET = 420 * 1024;
-const MOVING_BUDGET = 768 * 1024;
+const STATIC_BUDGET = 384 * 1024;
+const MOVING_BUDGET = 736 * 1024;
 
 // Complex-scene budgets — these exercise the paths flat sprites hide: many Group
-// scopes (deep nesting → per-scope collectRenderGroups, 2c), per-drawable Mesh
-// draws (2e), and per-effect Barrier scopes + child plans (2c). Source-accurate
-// post-2b status quo (nested ≈ 430, mesh ≈ 779, filtered ≈ 1425 KB) + ~1.3×
-// headroom; tighten as 2c (nested/filtered) and 2e (mesh) land.
-const NESTED_BUDGET = 576 * 1024;
+// scopes (deep nesting → per-scope plan work, 2c) and per-effect Barrier scopes
+// + child plans (2c). 2c eliminated the per-scope group materialization, so the
+// scope-heavy scenes dropped the most: nested 431→363, filtered 1425→1310 KB.
+// Source-accurate post-2c status quo + ~1.3× headroom; mesh stays its post-2b
+// budget (per-drawable Mesh draws are 2e's target — tighten when 2e lands).
+const NESTED_BUDGET = 480 * 1024;
 const MESH_BUDGET = 1024 * 1024;
-const FILTERED_BUDGET = 1856 * 1024;
+const FILTERED_BUDGET = 1728 * 1024;
 
 const findScenario = (id: string): ReturnType<typeof buildScenarioCatalog>[number] => {
   const scenario = buildScenarioCatalog('full').find(s => s.id === id);

--- a/test/perf/rendering/allocation.test.ts
+++ b/test/perf/rendering/allocation.test.ts
@@ -38,10 +38,12 @@ const MOVING_BUDGET = 736 * 1024;
 // scopes (deep nesting → per-scope plan work, 2c) and per-effect Barrier scopes
 // + child plans (2c). 2c eliminated the per-scope group materialization, so the
 // scope-heavy scenes dropped the most: nested 431→363, filtered 1425→1310 KB.
-// Source-accurate post-2c status quo + ~1.3× headroom; mesh stays its post-2b
-// budget (per-drawable Mesh draws are 2e's target — tighten when 2e lands).
+// 2e eliminated the WebGl2 mesh renderer's per-batch `slice()` copy and the
+// per-mesh `PendingMeshDraw` literal (the queue now pools its slots and
+// `_drawStaticBatch` walks an index range), dropping mesh 753→644 KB.
+// Source-accurate post-2e status quo + ~1.3× headroom.
 const NESTED_BUDGET = 480 * 1024;
-const MESH_BUDGET = 1024 * 1024;
+const MESH_BUDGET = 832 * 1024;
 const FILTERED_BUDGET = 1728 * 1024;
 
 const findScenario = (id: string): ReturnType<typeof buildScenarioCatalog>[number] => {

--- a/test/perf/rendering/allocation.test.ts
+++ b/test/perf/rendering/allocation.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
+import type { RenderNode } from '#rendering/RenderNode';
+
 import { measureFrameAllocation } from './allocation';
-import { buildSpriteScene, makeTextures } from './fixtures';
+import { buildFilteredScene, buildMeshScene, buildNestedScene, buildSpriteScene, makeTextures } from './fixtures';
 import { createWebGl2Harness } from './harness';
 import { buildScenarioCatalog } from './scenarios';
 
 /**
  * Render-plan allocation gate (spec 04 §2a). Samples the per-frame allocation
- * RATE (throwaway garbage, not retained heap) on an empty, a static, and a moving
- * reference scene via the V8 allocation sampling profiler (see `allocation.ts`).
+ * RATE (throwaway garbage, not retained heap) on reference scenes via the V8
+ * allocation sampling profiler (see `allocation.ts`).
  *
  * The sampler needs no `--expose-gc` and the budget is always enforced — but it
  * is only correct because `allocation.ts` passes `includeObjectsCollectedBy*GC`
@@ -16,24 +18,28 @@ import { buildScenarioCatalog } from './scenarios';
  * live at stop, discarding the immediately-dead plan garbage (a ~500× undercount).
  * The `sampler counts dead garbage` test below guards that invariant.
  *
- * Budgets are the measured status quo plus headroom; they tighten as 2b–2f drive
- * the static scene toward ~0 plan garbage/frame.
- *
  * NOTE: the source-accurate numbers come from THIS test (the vitest `rendering-perf`
  * project resolves `#*` imports to `src` and wires GLSL). The standalone
- * `pnpm perf:renderers:alloc` launcher resolves `#*` to the built `dist/esm` (its
- * `default` import condition) and so reports the LAST BUILD, not the working tree —
- * use it only as a rough cross-check, not as the before/after gate.
+ * `pnpm perf:renderers:alloc` launcher resolves `#*` to the built `dist/esm` and so
+ * reports the LAST BUILD, not the working tree — use it only as a rough cross-check.
+ * Budgets ratchet down per slice; run with `--disableConsoleIntercept` to see them.
  */
 
-// Budgets (bytes/frame), measured against src. empty ≈ 2.6 KB (harness/recorder
-// floor). After Slice 2b (DrawCommand/ScopeEntry pooled, MaterialKey cached):
-// static ≈ 317 KB (was ≈ 644), moving ≈ 580 KB (was ≈ 916). The remainder is the
-// RenderPlanOptimizer (→ 2f) + per-scope collectRenderGroups (→ 2c). ~1.3× headroom
-// for the statistical sampler; tighten again per following slice.
+// Sprite reference budgets (bytes/frame), measured against src. empty ≈ 2.6 KB
+// (harness/recorder floor). After Slice 2b (DrawCommand/ScopeEntry pooled,
+// MaterialKey cached): static ≈ 317 KB (was ≈ 644), moving ≈ 580 KB (was ≈ 916).
 const EMPTY_BUDGET = 16 * 1024;
 const STATIC_BUDGET = 420 * 1024;
 const MOVING_BUDGET = 768 * 1024;
+
+// Complex-scene budgets — these exercise the paths flat sprites hide: many Group
+// scopes (deep nesting → per-scope collectRenderGroups, 2c), per-drawable Mesh
+// draws (2e), and per-effect Barrier scopes + child plans (2c). Source-accurate
+// post-2b status quo (nested ≈ 430, mesh ≈ 779, filtered ≈ 1425 KB) + ~1.3×
+// headroom; tighten as 2c (nested/filtered) and 2e (mesh) land.
+const NESTED_BUDGET = 576 * 1024;
+const MESH_BUDGET = 1024 * 1024;
+const FILTERED_BUDGET = 1856 * 1024;
 
 const findScenario = (id: string): ReturnType<typeof buildScenarioCatalog>[number] => {
   const scenario = buildScenarioCatalog('full').find(s => s.id === id);
@@ -47,6 +53,19 @@ const findScenario = (id: string): ReturnType<typeof buildScenarioCatalog>[numbe
 
 const log = (label: string, bytesPerFrame: number): void => {
   console.log(`[alloc] ${label.padEnd(20)} ${(bytesPerFrame / 1024).toFixed(2).padStart(9)} KB/frame`);
+};
+
+/** Build-and-measure a scene whose root is supplied directly (no scenario catalog). */
+const measureScene = async (label: string, root: RenderNode, budget: number): Promise<void> => {
+  const harness = createWebGl2Harness();
+
+  const alloc = await measureFrameAllocation(harness, root);
+  log(label, alloc.bytesPerFrame);
+
+  root.destroy();
+  harness.destroy();
+
+  expect(alloc.bytesPerFrame).toBeLessThan(budget);
 };
 
 describe('render-plan allocation gate', () => {
@@ -115,4 +134,11 @@ describe('render-plan allocation gate', () => {
 
     expect(alloc.bytesPerFrame).toBeLessThan(MOVING_BUDGET);
   });
+
+  it('nested hierarchy (deep group scopes) stays within budget', () =>
+    measureScene('nested/1000 d4', buildNestedScene({ count: 1000, perContainer: 8, depth: 4, textures: makeTextures(1) }).root, NESTED_BUDGET));
+
+  it('mesh drawables stay within budget', () => measureScene('mesh/1000', buildMeshScene({ count: 1000, textures: makeTextures(1) }).root, MESH_BUDGET));
+
+  it('effect-barrier scene stays within budget', () => measureScene('filtered/100', buildFilteredScene({ count: 100, textures: makeTextures(1) }).root, FILTERED_BUDGET));
 });

--- a/test/perf/rendering/allocation.test.ts
+++ b/test/perf/rendering/allocation.test.ts
@@ -145,5 +145,6 @@ describe('render-plan allocation gate', () => {
 
   it('mesh drawables stay within budget', () => measureScene('mesh/1000', buildMeshScene({ count: 1000, textures: makeTextures(1) }).root, MESH_BUDGET));
 
-  it('effect-barrier scene stays within budget', () => measureScene('filtered/100', buildFilteredScene({ count: 100, textures: makeTextures(1) }).root, FILTERED_BUDGET));
+  it('effect-barrier scene stays within budget', () =>
+    measureScene('filtered/100', buildFilteredScene({ count: 100, textures: makeTextures(1) }).root, FILTERED_BUDGET));
 });

--- a/test/perf/rendering/allocation.ts
+++ b/test/perf/rendering/allocation.ts
@@ -1,0 +1,115 @@
+/**
+ * Allocation sampler for the render-perf harness.
+ *
+ * Measures the render plan's per-frame **allocation rate** — every byte a frame
+ * allocates, including the immediately-dead throwaway objects (`DrawCommand`,
+ * `MaterialKey`, `ScopeEntry`, the per-scope `RenderGroup[]` …).
+ *
+ * ── Why not a `heapUsed` delta ──────────────────────────────────────────────
+ * The obvious approach — GC to a floor, render N frames, diff `heapUsed` — does
+ * NOT work here. The plan's per-frame objects die the instant the frame ends, and
+ * V8 reclaims them *concurrently* (minor mark-compact / scavenge) during the
+ * sampling window, so they never show up in a heap-size delta. (Measured: a 1000-
+ * sprite static frame allocates ~4000 objects yet a `heapUsed` delta reports only
+ * ~6 KB/frame — it sees retained growth, not the throwaway rate.) Bumping the
+ * young generation does not help; the concurrent collector still runs.
+ *
+ * Instead this uses V8's **allocation sampling profiler** via `node:inspector`
+ * (`HeapProfiler.startSampling`), which records at allocation time and therefore
+ * counts dead-on-arrival objects too. It is statistical (one sample per
+ * `samplingInterval` bytes) but accurate over a window of many frames, and needs
+ * no `--expose-gc`.
+ *
+ * @internal Test/perf-only.
+ */
+import { Session } from 'node:inspector';
+
+import type { RenderNode } from '#rendering/RenderNode';
+
+import type { WebGl2Harness } from './harness';
+
+export interface FrameAllocationOptions {
+  /** Frames sampled for the rate (default 200). More frames → less statistical noise. */
+  readonly frames?: number;
+  /** Warm-up frames before sampling, so one-time cache/buffer/pool growth is excluded (default 30). */
+  readonly warmup?: number;
+  /** Sampling interval in bytes (default 64 — one sample per ~64 B allocated). */
+  readonly samplingInterval?: number;
+  /** Per-frame mutation (move sprites, pan camera) — runs inside the sampled loop. */
+  readonly beforeFrame?: () => void;
+}
+
+export interface FrameAllocation {
+  /** Mean bytes allocated per frame (throwaway rate, includes immediately-dead objects). */
+  readonly bytesPerFrame: number;
+  /** Total bytes allocated across the sampled window. */
+  readonly totalBytes: number;
+  /** Frames sampled. */
+  readonly frames: number;
+}
+
+/** Render one frame leanly — no `FrameMetrics` object, just the plan build + flush. */
+const renderOnce = (harness: WebGl2Harness, root: RenderNode, beforeFrame?: () => void): void => {
+  harness.backend.resetStats();
+  harness.recorder.reset();
+  beforeFrame?.();
+  harness.backend.clear();
+  root.render(harness.backend);
+  harness.backend.flush();
+};
+
+/** Recursively sum `selfSize` across the sampling-profile tree = total sampled bytes. */
+const sumSelfSize = (node: import('node:inspector').HeapProfiler.SamplingHeapProfileNode): number =>
+  node.selfSize + node.children.reduce((total, child) => total + sumSelfSize(child), 0);
+
+/**
+ * Sample the per-frame allocation rate of rendering `root` against `harness`.
+ * See the module comment for why this uses the allocation sampling profiler
+ * rather than a `heapUsed` delta.
+ */
+export const measureFrameAllocation = async (harness: WebGl2Harness, root: RenderNode, options: FrameAllocationOptions = {}): Promise<FrameAllocation> => {
+  const frames = options.frames ?? 200;
+  const warmup = options.warmup ?? 30;
+  const samplingInterval = options.samplingInterval ?? 64;
+  const { beforeFrame } = options;
+
+  // Warm-up: let caches/buffers/pools reach steady size so their one-time growth
+  // is not counted (it happens before sampling starts).
+  for (let i = 0; i < warmup; i++) {
+    renderOnce(harness, root, beforeFrame);
+  }
+
+  const session = new Session();
+  session.connect();
+
+  const post = <T>(method: string, params?: Record<string, unknown>): Promise<T> =>
+    new Promise((resolve, reject) => {
+      session.post(method, params, (error: Error | null, result?: unknown) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve(result as T);
+      });
+    });
+
+  await post('HeapProfiler.enable');
+  await post('HeapProfiler.startSampling', { samplingInterval });
+
+  for (let i = 0; i < frames; i++) {
+    renderOnce(harness, root, beforeFrame);
+  }
+
+  const { profile } = await post<{ profile: import('node:inspector').HeapProfiler.SamplingHeapProfile }>('HeapProfiler.stopSampling');
+  await post('HeapProfiler.disable');
+  session.disconnect();
+
+  const totalBytes = sumSelfSize(profile.head);
+
+  return {
+    bytesPerFrame: totalBytes / frames,
+    totalBytes,
+    frames,
+  };
+};

--- a/test/perf/rendering/allocation.ts
+++ b/test/perf/rendering/allocation.ts
@@ -15,10 +15,11 @@
  * young generation does not help; the concurrent collector still runs.
  *
  * Instead this uses V8's **allocation sampling profiler** via `node:inspector`
- * (`HeapProfiler.startSampling`), which records at allocation time and therefore
- * counts dead-on-arrival objects too. It is statistical (one sample per
- * `samplingInterval` bytes) but accurate over a window of many frames, and needs
- * no `--expose-gc`.
+ * (`HeapProfiler.startSampling` *with* the `includeObjectsCollectedBy*GC` flags —
+ * without them it reports only objects still live at stop and misses the dead-on-
+ * arrival plan garbage entirely, a ~500× undercount). It records at allocation
+ * time, is statistical (one sample per `samplingInterval` bytes) but accurate over
+ * a window of many frames, and needs no `--expose-gc`.
  *
  * @internal Test/perf-only.
  */
@@ -33,7 +34,12 @@ export interface FrameAllocationOptions {
   readonly frames?: number;
   /** Warm-up frames before sampling, so one-time cache/buffer/pool growth is excluded (default 30). */
   readonly warmup?: number;
-  /** Sampling interval in bytes (default 64 — one sample per ~64 B allocated). */
+  /**
+   * Sampling interval in bytes (default 512). Finer (smaller) intervals count
+   * small allocations more precisely but bloat the inspector profile — at 64 a
+   * multi-MB/frame scene over 200 frames overflows V8's 512 MB string cap on the
+   * profile transfer. 512 stays accurate over the window while keeping it small.
+   */
   readonly samplingInterval?: number;
   /** Per-frame mutation (move sprites, pan camera) — runs inside the sampled loop. */
   readonly beforeFrame?: () => void;
@@ -70,7 +76,7 @@ const sumSelfSize = (node: import('node:inspector').HeapProfiler.SamplingHeapPro
 export const measureFrameAllocation = async (harness: WebGl2Harness, root: RenderNode, options: FrameAllocationOptions = {}): Promise<FrameAllocation> => {
   const frames = options.frames ?? 200;
   const warmup = options.warmup ?? 30;
-  const samplingInterval = options.samplingInterval ?? 64;
+  const samplingInterval = options.samplingInterval ?? 512;
   const { beforeFrame } = options;
 
   // Warm-up: let caches/buffers/pools reach steady size so their one-time growth
@@ -95,7 +101,16 @@ export const measureFrameAllocation = async (harness: WebGl2Harness, root: Rende
     });
 
   await post('HeapProfiler.enable');
-  await post('HeapProfiler.startSampling', { samplingInterval });
+  // CRITICAL: without these two flags the sampling profiler reports only objects
+  // still LIVE at stopSampling — it discards everything the GC reclaimed during
+  // the window, i.e. exactly the immediately-dead plan garbage we want to count.
+  // (Measured: omitting them undercounts a known 1000-object/frame allocation by
+  // ~500×.) Requires Node ≥ 20; older runtimes ignore the extra keys.
+  await post('HeapProfiler.startSampling', {
+    samplingInterval,
+    includeObjectsCollectedByMajorGC: true,
+    includeObjectsCollectedByMinorGC: true,
+  });
 
   for (let i = 0; i < frames; i++) {
     renderOnce(harness, root, beforeFrame);

--- a/test/perf/rendering/allocation.ts
+++ b/test/perf/rendering/allocation.ts
@@ -2,8 +2,10 @@
  * Allocation sampler for the render-perf harness.
  *
  * Measures the render plan's per-frame **allocation rate** — every byte a frame
- * allocates, including the immediately-dead throwaway objects (`DrawCommand`,
- * `MaterialKey`, `ScopeEntry`, the per-scope `RenderGroup[]` …).
+ * allocates, including the immediately-dead throwaway objects the plan still
+ * produces (per-frame closures, mesh batch records, filter scratch …). The big
+ * historical sources — `DrawCommand`/`ScopeEntry`/`MaterialKey` (pooled in 2b)
+ * and the per-scope `RenderGroup[]` (eliminated in 2c) — no longer allocate.
  *
  * ── Why not a `heapUsed` delta ──────────────────────────────────────────────
  * The obvious approach — GC to a floor, render N frames, diff `heapUsed` — does

--- a/test/perf/rendering/fixtures.ts
+++ b/test/perf/rendering/fixtures.ts
@@ -9,6 +9,8 @@
  */
 import { Container } from '#rendering/Container';
 import type { Drawable } from '#rendering/Drawable';
+import { ColorFilter } from '#rendering/filters/ColorFilter';
+import { Mesh } from '#rendering/mesh/Mesh';
 import { NineSliceSprite } from '#rendering/sprite/NineSliceSprite';
 import { RepeatingSprite } from '#rendering/sprite/RepeatingSprite';
 import { Sprite } from '#rendering/sprite/Sprite';
@@ -186,6 +188,129 @@ export const buildRepeatingScene = (config: RepeatingSceneConfig): RepeatingScen
     const sprite = new RepeatingSprite(source, { width, height, modeX, modeY });
 
     scatterInView(sprite, i, viewW, viewH, Math.max(width, height));
+    root.addChild(sprite);
+    sprites.push(sprite);
+  }
+
+  return { root, sprites };
+};
+
+// ── Complex scenes (high plan-allocation) ──────────────────────────────────
+// A flat sprite list collapses to ~1 scope and batches into ~1 draw, so it
+// allocates almost nothing per frame. These exercise the paths the cheap path
+// hides: many Group scopes (deep nesting → per-scope collectRenderGroups, 2c),
+// per-drawable Mesh draws (2e), and per-effect Barrier scopes + child plans (2c).
+
+/** Local-space unit quad (x,y pairs) sized `size`, for a textured {@link Mesh}. */
+const quadVertices = (size: number): Float32Array => new Float32Array([0, 0, size, 0, size, size, 0, size]);
+const QUAD_INDICES = new Uint16Array([0, 1, 2, 0, 2, 3]);
+const QUAD_UVS = new Float32Array([0, 0, 1, 0, 1, 1, 0, 1]);
+
+export interface NestedSceneConfig {
+  readonly count: number;
+  /** Sprites per leaf container (default 8). */
+  readonly perContainer?: number;
+  /** Container chain depth per group (default 2). */
+  readonly depth?: number;
+  readonly textures: readonly Texture[];
+  readonly assign?: TextureAssign;
+  readonly viewW?: number;
+  readonly viewH?: number;
+}
+
+/**
+ * `count` sprites packed into a balanced container hierarchy: groups of
+ * `perContainer` sprites, each group a chain of `depth` nested containers under
+ * the root. A flat list is ~1 scope; this is ~`count / perContainer × depth`
+ * Group scopes, so it exercises the per-scope `collectRenderGroups` allocation.
+ */
+export const buildNestedScene = (config: NestedSceneConfig): SpriteScene => {
+  const { count, perContainer = 8, depth = 2, textures, assign = 'cycle', viewW = 1280, viewH = 720 } = config;
+  const root = new Container();
+  const sprites: Sprite[] = [];
+  let group: Container = root;
+
+  for (let i = 0; i < count; i++) {
+    if (i % perContainer === 0) {
+      let leaf = new Container();
+      root.addChild(leaf);
+
+      for (let d = 1; d < depth; d++) {
+        const next = new Container();
+        leaf.addChild(next);
+        leaf = next;
+      }
+
+      group = leaf;
+    }
+
+    const texture = textures[assignIndex(assign, i, count, textures.length)];
+    const sprite = new Sprite(texture);
+
+    scatterInView(sprite, i, viewW, viewH);
+    group.addChild(sprite);
+    sprites.push(sprite);
+  }
+
+  return { root, sprites };
+};
+
+export interface MeshSceneConfig {
+  readonly count: number;
+  readonly textures: readonly Texture[];
+  readonly assign?: TextureAssign;
+  readonly size?: number;
+  readonly viewW?: number;
+  readonly viewH?: number;
+}
+
+export interface MeshScene {
+  readonly root: Container;
+  readonly meshes: readonly Mesh[];
+}
+
+/** `count` textured-quad {@link Mesh} drawables — exercises the mesh-renderer draw path (2e). */
+export const buildMeshScene = (config: MeshSceneConfig): MeshScene => {
+  const { count, textures, assign = 'cycle', size = 64, viewW = 1280, viewH = 720 } = config;
+  const root = new Container();
+  const meshes: Mesh[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const texture = textures[assignIndex(assign, i, count, textures.length)];
+    const mesh = new Mesh({ vertices: quadVertices(size), indices: QUAD_INDICES, uvs: QUAD_UVS, texture });
+
+    scatterInView(mesh, i, viewW, viewH, size);
+    root.addChild(mesh);
+    meshes.push(mesh);
+  }
+
+  return { root, meshes };
+};
+
+export interface FilteredSceneConfig {
+  readonly count: number;
+  readonly textures: readonly Texture[];
+  readonly assign?: TextureAssign;
+  readonly viewW?: number;
+  readonly viewH?: number;
+}
+
+/**
+ * `count` sprites each carrying a {@link ColorFilter}, so the plan emits a
+ * Barrier scope + child plan per sprite (the effect-node path through
+ * `collectRenderGroups` / `RenderEffectExecutor`, 2c).
+ */
+export const buildFilteredScene = (config: FilteredSceneConfig): SpriteScene => {
+  const { count, textures, assign = 'cycle', viewW = 1280, viewH = 720 } = config;
+  const root = new Container();
+  const sprites: Sprite[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const texture = textures[assignIndex(assign, i, count, textures.length)];
+    const sprite = new Sprite(texture);
+
+    sprite.addFilter(new ColorFilter());
+    scatterInView(sprite, i, viewW, viewH);
     root.addChild(sprite);
     sprites.push(sprite);
   }

--- a/test/perf/rendering/fixtures.ts
+++ b/test/perf/rendering/fixtures.ts
@@ -198,8 +198,9 @@ export const buildRepeatingScene = (config: RepeatingSceneConfig): RepeatingScen
 // ── Complex scenes (high plan-allocation) ──────────────────────────────────
 // A flat sprite list collapses to ~1 scope and batches into ~1 draw, so it
 // allocates almost nothing per frame. These exercise the paths the cheap path
-// hides: many Group scopes (deep nesting → per-scope collectRenderGroups, 2c),
-// per-drawable Mesh draws (2e), and per-effect Barrier scopes + child plans (2c).
+// hides: many Group scopes (deep nesting → per-scope plan work the inline group
+// walk of 2c made allocation-free), per-drawable Mesh draws (2e), and per-effect
+// Barrier scopes + child plans (2c).
 
 /** Local-space unit quad (x,y pairs) sized `size`, for a textured {@link Mesh}. */
 const quadVertices = (size: number): Float32Array => new Float32Array([0, 0, size, 0, size, size, 0, size]);
@@ -222,7 +223,8 @@ export interface NestedSceneConfig {
  * `count` sprites packed into a balanced container hierarchy: groups of
  * `perContainer` sprites, each group a chain of `depth` nested containers under
  * the root. A flat list is ~1 scope; this is ~`count / perContainer × depth`
- * Group scopes, so it exercises the per-scope `collectRenderGroups` allocation.
+ * Group scopes, so it stresses the per-scope plan playback that 2c made
+ * allocation-free (it formerly materialized a `RenderGroup[]` per scope).
  */
 export const buildNestedScene = (config: NestedSceneConfig): SpriteScene => {
   const { count, perContainer = 8, depth = 2, textures, assign = 'cycle', viewW = 1280, viewH = 720 } = config;
@@ -298,7 +300,7 @@ export interface FilteredSceneConfig {
 /**
  * `count` sprites each carrying a {@link ColorFilter}, so the plan emits a
  * Barrier scope + child plan per sprite (the effect-node path through
- * `collectRenderGroups` / `RenderEffectExecutor`, 2c).
+ * `RenderEffectExecutor` and the per-scope plan playback 2c made allocation-free).
  */
 export const buildFilteredScene = (config: FilteredSceneConfig): SpriteScene => {
   const { count, textures, assign = 'cycle', viewW = 1280, viewH = 720 } = config;

--- a/test/perf/rendering/resource-accounting.test.ts
+++ b/test/perf/rendering/resource-accounting.test.ts
@@ -1,0 +1,390 @@
+// ---------------------------------------------------------------------------
+// Slice 2g — GPU resource accounting (VRAM / upload / download).
+//
+// Drives the real WebGl2Backend against the Node fake-context recording harness
+// and asserts the new RenderStats fields:
+//   - gpuMemoryBytes    : running Σ of live texture/buffer bytes (NOT per-frame reset)
+//   - textureUploadBytes : per-frame content-texture pixel bytes uploaded
+//   - bufferUploadBytes  : per-frame buffer bytes uploaded
+//   - downloadBytes / downloadCount: per-frame GPU→CPU readback (0 in render path)
+//
+// Determinism: DataTextures have an exact, known footprint (no source decode,
+// no mips by default), and the booking runs identically against the fake
+// context — no GPU, no flake.
+//
+// The backend's renderers allocate their own GPU buffers (instance/index/etc.)
+// at connect time, so a freshly wired backend already reports a non-zero
+// `gpuMemoryBytes` baseline. All VRAM assertions therefore measure the *delta*
+// produced by adding or freeing a texture of known size, which is exact.
+// ---------------------------------------------------------------------------
+import { Sprite } from '#rendering/sprite/Sprite';
+import { DataTexture } from '#rendering/texture/DataTexture';
+
+import { buildSpriteScene, makeTexture } from './fixtures';
+import { createWebGl2Harness, measureFrame, measureSteadyFrame, type WebGl2Harness } from './harness';
+
+/** rgba8 DataTexture footprint = width·height·4, no mips. */
+const rgba8Bytes = (size: number): number => size * size * 4;
+
+/** Warm a single-sprite scene to steady state and return its VRAM total. */
+const warmAndReadVram = (harness: WebGl2Harness, texture: DataTexture): number => {
+  measureSteadyFrame(harness, buildSpriteScene({ count: 1, textures: [texture] }).root);
+
+  return harness.backend.stats.gpuMemoryBytes;
+};
+
+describe('GPU resource accounting (RenderStats)', () => {
+  describe('new fields exist with the right reset semantics', () => {
+    test('the new accounting fields are present and numeric on a fresh backend', () => {
+      const harness = createWebGl2Harness();
+
+      try {
+        const stats = harness.backend.stats;
+
+        // All five fields exist and are finite numbers. The per-frame upload
+        // fields may already be non-zero because the core renderers allocate +
+        // upload their GPU buffers at connect time (before the first frame);
+        // resetStats() then zeroes them (asserted in the reset-policy test).
+        for (const value of [stats.gpuMemoryBytes, stats.textureUploadBytes, stats.bufferUploadBytes, stats.downloadBytes, stats.downloadCount]) {
+          expect(typeof value).toBe('number');
+          expect(Number.isFinite(value)).toBe(true);
+          expect(value).toBeGreaterThanOrEqual(0);
+        }
+
+        // No GPU→CPU readback happens at wire-up.
+        expect(stats.downloadBytes).toBe(0);
+        expect(stats.downloadCount).toBe(0);
+
+        // The first resetStats() clears the per-frame accumulators…
+        harness.backend.resetStats();
+        expect(harness.backend.stats.textureUploadBytes).toBe(0);
+        expect(harness.backend.stats.bufferUploadBytes).toBe(0);
+        // …but preserves the running VRAM total booked at connect.
+        expect(harness.backend.stats.gpuMemoryBytes).toBeGreaterThanOrEqual(0);
+      } finally {
+        harness.destroy();
+      }
+    });
+  });
+
+  describe('gpuMemoryBytes — texture VRAM (measured as deltas)', () => {
+    test('adding N distinct content textures raises VRAM by exactly their summed footprint', () => {
+      const harness = createWebGl2Harness();
+
+      try {
+        const size = 64;
+
+        // Warm with a tiny placeholder texture so the renderer buffers + the
+        // shared transform texture are already allocated and out of the delta.
+        const baselineTex = new DataTexture({ width: 8, height: 8, format: 'rgba8' });
+        const baseline = warmAndReadVram(harness, baselineTex);
+
+        const textureCount = 4;
+        const textures = Array.from({ length: textureCount }, () => new DataTexture({ width: size, height: size, format: 'rgba8' }));
+
+        measureSteadyFrame(harness, buildSpriteScene({ count: textureCount, textures, assign: 'distinct' }).root);
+
+        const delta = harness.backend.stats.gpuMemoryBytes - baseline;
+
+        // The four new content textures are the only new GPU storage of a known
+        // size; the transform texture for a 4-row buffer adds at most a few
+        // hundred bytes, so the delta is the content sum plus that tiny term.
+        expect(delta).toBeGreaterThanOrEqual(textureCount * rgba8Bytes(size));
+        // …and the content textures clearly dominate (delta is not e.g. 2× the sum).
+        expect(delta).toBeLessThan(textureCount * rgba8Bytes(size) + rgba8Bytes(size));
+      } finally {
+        harness.destroy();
+      }
+    });
+
+    test('one freshly uploaded content texture contributes exactly its footprint', () => {
+      const harness = createWebGl2Harness();
+
+      try {
+        const size = 128;
+
+        // Warm with the eventual texture's slot already holding a small texture,
+        // then swap in the full-size one and measure the resize delta exactly.
+        const baselineTex = new DataTexture({ width: 8, height: 8, format: 'rgba8' });
+        const baseline = warmAndReadVram(harness, baselineTex);
+
+        const texture = new DataTexture({ width: size, height: size, format: 'rgba8' });
+
+        measureSteadyFrame(harness, buildSpriteScene({ count: 1, textures: [texture] }).root);
+
+        const delta = harness.backend.stats.gpuMemoryBytes - baseline;
+
+        // Adding one 128² rgba8 texture (the baseline 8² texture is now unused
+        // but still resident, so it does not subtract). Delta ≥ the new content.
+        expect(delta).toBeGreaterThanOrEqual(rgba8Bytes(size));
+        expect(delta).toBeLessThan(rgba8Bytes(size) + rgba8Bytes(64));
+      } finally {
+        harness.destroy();
+      }
+    });
+
+    test('freeing a texture lowers gpuMemoryBytes by exactly that texture footprint', () => {
+      const harness = createWebGl2Harness();
+
+      try {
+        const size = 256;
+        const keep = new DataTexture({ width: size, height: size, format: 'rgba8' });
+        const drop = new DataTexture({ width: size, height: size, format: 'rgba8' });
+
+        measureSteadyFrame(harness, buildSpriteScene({ count: 2, textures: [keep, drop], assign: 'distinct' }).root);
+
+        const before = harness.backend.stats.gpuMemoryBytes;
+
+        // Destroying the texture fires its destroy listener → backend evicts it
+        // and decrements the accountant by exactly the booked size.
+        drop.destroy();
+
+        expect(before - harness.backend.stats.gpuMemoryBytes).toBe(rgba8Bytes(size));
+      } finally {
+        harness.destroy();
+      }
+    });
+
+    test('larger textures book proportionally more VRAM', () => {
+      const small = createWebGl2Harness();
+      const large = createWebGl2Harness();
+
+      try {
+        const baseS = warmAndReadVram(small, new DataTexture({ width: 8, height: 8, format: 'rgba8' }));
+        const baseL = warmAndReadVram(large, new DataTexture({ width: 8, height: 8, format: 'rgba8' }));
+
+        const deltaSmall = warmAndReadVram(small, new DataTexture({ width: 64, height: 64, format: 'rgba8' })) - baseS;
+        const deltaLarge = warmAndReadVram(large, new DataTexture({ width: 128, height: 128, format: 'rgba8' })) - baseL;
+
+        // 128² is 4× the pixels of 64²; the content deltas reflect that exactly.
+        expect(deltaLarge - deltaSmall).toBe(rgba8Bytes(128) - rgba8Bytes(64));
+      } finally {
+        small.destroy();
+        large.destroy();
+      }
+    });
+
+    test('rgba32f costs 4× an rgba8 texture of the same dimensions', () => {
+      const harness8 = createWebGl2Harness();
+      const harness32 = createWebGl2Harness();
+
+      try {
+        const size = 64;
+
+        const base8 = warmAndReadVram(harness8, new DataTexture({ width: 8, height: 8, format: 'rgba8' }));
+        const base32 = warmAndReadVram(harness32, new DataTexture({ width: 8, height: 8, format: 'rgba8' }));
+
+        const delta8 = warmAndReadVram(harness8, new DataTexture({ width: size, height: size, format: 'rgba8' })) - base8;
+        const delta32 = warmAndReadVram(harness32, new DataTexture({ width: size, height: size, format: 'rgba32f' })) - base32;
+
+        // Same dimensions; the content delta is (16 − 4) bytes/px × size².
+        expect(delta32 - delta8).toBe(size * size * (16 - 4));
+      } finally {
+        harness8.destroy();
+        harness32.destroy();
+      }
+    });
+  });
+
+  describe('gpuMemoryBytes — multi-instance isolation', () => {
+    test('two backends keep independent VRAM tallies', () => {
+      const a = createWebGl2Harness();
+      const b = createWebGl2Harness();
+
+      try {
+        const baseA = warmAndReadVram(a, new DataTexture({ width: 8, height: 8, format: 'rgba8' }));
+        const baseB = warmAndReadVram(b, new DataTexture({ width: 8, height: 8, format: 'rgba8' }));
+
+        const deltaA = warmAndReadVram(a, new DataTexture({ width: 64, height: 64, format: 'rgba8' })) - baseA;
+        const deltaB = warmAndReadVram(b, new DataTexture({ width: 256, height: 256, format: 'rgba8' })) - baseB;
+
+        // Each backend booked only its own texture; the deltas differ by the
+        // exact content-size difference and do not bleed across instances.
+        expect(deltaB - deltaA).toBe(rgba8Bytes(256) - rgba8Bytes(64));
+      } finally {
+        a.destroy();
+        b.destroy();
+      }
+    });
+  });
+
+  describe('textureUploadBytes — per-frame content uploads', () => {
+    test('a first frame uploads at least the content-texture pixel bytes', () => {
+      const harness = createWebGl2Harness();
+
+      try {
+        const size = 128;
+        const texture = new DataTexture({ width: size, height: size, format: 'rgba8' });
+
+        measureFrame(harness, buildSpriteScene({ count: 1, textures: [texture] }).root);
+
+        // The frame uploads the content texture (full texImage2D) plus the
+        // transform texture; content bytes must be included in the total.
+        expect(harness.backend.stats.textureUploadBytes).toBeGreaterThanOrEqual(rgba8Bytes(size));
+      } finally {
+        harness.destroy();
+      }
+    });
+
+    test('a subsequent static frame uploads zero texture bytes', () => {
+      const harness = createWebGl2Harness();
+
+      try {
+        const size = 128;
+        const texture = new DataTexture({ width: size, height: size, format: 'rgba8' });
+        const { root } = buildSpriteScene({ count: 1, textures: [texture] });
+
+        // Warm: content + transform uploaded; transforms unchanged thereafter.
+        measureSteadyFrame(harness, root, 3);
+
+        // A further render with nothing mutated re-uploads nothing.
+        measureFrame(harness, root);
+
+        expect(harness.backend.stats.textureUploadBytes).toBe(0);
+      } finally {
+        harness.destroy();
+      }
+    });
+
+    test('uploading a content texture adds exactly its byte count to textureUploadBytes', () => {
+      const harness = createWebGl2Harness();
+
+      try {
+        const size = 64;
+        const a = new DataTexture({ width: size, height: size, format: 'rgba8' });
+        const b = new DataTexture({ width: size, height: size, format: 'rgba8' });
+
+        // Warm steady with texture `a` only — transforms quiescent.
+        const sceneA = buildSpriteScene({ count: 1, textures: [a] });
+
+        measureSteadyFrame(harness, sceneA.root, 3);
+
+        // Add a second, never-before-seen texture `b` in a fresh scene. The only
+        // new texture upload this frame is `b`'s full upload; transforms for two
+        // sprites also change, but those are buffer (not texture) uploads.
+        const sceneB = buildSpriteScene({ count: 2, textures: [a, b], assign: 'distinct' });
+
+        measureFrame(harness, sceneB.root);
+
+        // textureUploadBytes for this frame = b's content upload (a is unchanged)
+        // + the transform-texture re-upload (width 3 × rows × 16 B). Assert the
+        // content portion is present and the transform remainder is tiny.
+        const uploaded = harness.backend.stats.textureUploadBytes;
+
+        expect(uploaded).toBeGreaterThanOrEqual(rgba8Bytes(size));
+        expect(uploaded - rgba8Bytes(size)).toBeLessThan(rgba8Bytes(size));
+      } finally {
+        harness.destroy();
+      }
+    });
+
+    test('textureUploadBytes is per-frame (reset each tick) while gpuMemoryBytes persists', () => {
+      const harness = createWebGl2Harness();
+
+      try {
+        const texture = new DataTexture({ width: 64, height: 64, format: 'rgba8' });
+        const { root } = buildSpriteScene({ count: 1, textures: [texture] });
+
+        measureFrame(harness, root);
+        const uploadedFirst = harness.backend.stats.textureUploadBytes;
+        const vramAfterFirst = harness.backend.stats.gpuMemoryBytes;
+
+        // Drive a couple more idempotent frames to reach a quiescent state.
+        measureFrame(harness, root);
+        measureFrame(harness, root);
+
+        // VRAM (a running total) is unchanged across idempotent frames…
+        expect(harness.backend.stats.gpuMemoryBytes).toBe(vramAfterFirst);
+        // …the first frame uploaded the content texture…
+        expect(uploadedFirst).toBeGreaterThan(0);
+        // …and the per-frame upload accumulator has dropped back to zero.
+        expect(harness.backend.stats.textureUploadBytes).toBe(0);
+      } finally {
+        harness.destroy();
+      }
+    });
+  });
+
+  describe('bufferUploadBytes — per-frame buffer uploads', () => {
+    test('a frame that draws sprites uploads instance/index buffer bytes', () => {
+      const harness = createWebGl2Harness();
+
+      try {
+        const { root } = buildSpriteScene({ count: 16, textures: [makeTexture(64)] });
+
+        const metrics = measureFrame(harness, root);
+
+        expect(harness.backend.stats.bufferUploadBytes).toBeGreaterThan(0);
+        // Cross-check against the recorder's independent buffer-byte tally.
+        expect(harness.backend.stats.bufferUploadBytes).toBe(metrics.uploadedBufferBytes);
+      } finally {
+        harness.destroy();
+      }
+    });
+  });
+
+  describe('downloadBytes — readback', () => {
+    test('the render path performs no GPU→CPU readback', () => {
+      const harness = createWebGl2Harness();
+
+      try {
+        const { root } = buildSpriteScene({ count: 8, textures: [makeTexture(64)] });
+
+        measureSteadyFrame(harness, root);
+
+        expect(harness.backend.stats.downloadBytes).toBe(0);
+        expect(harness.backend.stats.downloadCount).toBe(0);
+      } finally {
+        harness.destroy();
+      }
+    });
+  });
+
+  describe('reset policy', () => {
+    test('resetStats zeroes per-frame fields but preserves gpuMemoryBytes', () => {
+      const harness = createWebGl2Harness();
+
+      try {
+        const texture = new DataTexture({ width: 64, height: 64, format: 'rgba8' });
+        const { root } = buildSpriteScene({ count: 1, textures: [texture] });
+
+        measureSteadyFrame(harness, root);
+
+        const vram = harness.backend.stats.gpuMemoryBytes;
+
+        expect(vram).toBeGreaterThan(0);
+
+        harness.backend.resetStats();
+
+        expect(harness.backend.stats.gpuMemoryBytes).toBe(vram);
+        expect(harness.backend.stats.textureUploadBytes).toBe(0);
+        expect(harness.backend.stats.bufferUploadBytes).toBe(0);
+        expect(harness.backend.stats.downloadBytes).toBe(0);
+        expect(harness.backend.stats.downloadCount).toBe(0);
+      } finally {
+        harness.destroy();
+      }
+    });
+  });
+
+  describe('Sprite content-texture sanity', () => {
+    test('a Sprite over a DataTexture books its texture VRAM after one render', () => {
+      const harness = createWebGl2Harness();
+
+      try {
+        const size = 64;
+        const baseline = warmAndReadVram(harness, new DataTexture({ width: 8, height: 8, format: 'rgba8' }));
+
+        const texture = new DataTexture({ width: size, height: size, format: 'rgba8' });
+        const sprite = new Sprite(texture);
+
+        sprite.setPosition(10, 10);
+        measureSteadyFrame(harness, sprite);
+
+        expect(harness.backend.stats.gpuMemoryBytes - baseline).toBeGreaterThanOrEqual(rgba8Bytes(size));
+      } finally {
+        harness.destroy();
+      }
+    });
+  });
+});

--- a/test/perf/rendering/run-allocation.ts
+++ b/test/perf/rendering/run-allocation.ts
@@ -5,12 +5,22 @@
  *   node --import tsx/esm test/perf/rendering/run-allocation.ts
  *   (or: pnpm perf:renderers:alloc)
  *
+ * ⚠️ RESOLVES TO `dist`, NOT THE WORKING TREE. This launcher runs under plain
+ * `node --import tsx/esm`, so the package's `#*` subpath imports resolve via their
+ * `default` condition to `./dist/esm/*.js` — i.e. the LAST BUILD, not your edited
+ * `src`. (The `@codexo/source` condition would point at `src`, but then tsx chokes
+ * on the raw `.frag`/`.vert` GLSL imports, which only the vitest projects wire up.)
+ * For a source-accurate before/after gate use the allocation TEST instead
+ * (`vitest --project=rendering-perf test/perf/rendering/allocation.test.ts`,
+ * add `--disableConsoleIntercept` to see the per-scene numbers); that project
+ * resolves `#*` → `src` and handles GLSL. Treat this script's numbers as a coarse
+ * post-build cross-check only.
+ *
  * Scenes are built directly via the `fixtures` builders rather than through
  * {@link buildScenarioCatalog}: the catalog pulls in the tilemap fixtures, whose
  * `@codexo/*` package imports resolve to `src` (no built dist) and then hit raw
- * `.frag` GLSL imports that node/tsx cannot load — only the vitest projects wire
- * the GLSL handling. So the tilemap family is profiled by the allocation TEST
- * (run under vitest), not here.
+ * `.frag` GLSL imports that node/tsx cannot load. So the tilemap family is profiled
+ * by the allocation TEST (run under vitest), not here.
  *
  * Spec 04 "Harte Regel": no perf PR merges without a before/after number on the
  * scenes it targets. STILL UNCOVERED here and needing dedicated fixtures before

--- a/test/perf/rendering/run-allocation.ts
+++ b/test/perf/rendering/run-allocation.ts
@@ -27,7 +27,7 @@ import { resolve } from 'node:path';
 
 import type { FrameAllocation } from './allocation';
 import { measureFrameAllocation } from './allocation';
-import { buildNineSliceScene, buildRepeatingScene, buildSpriteScene, makeTextures } from './fixtures';
+import { buildFilteredScene, buildMeshScene, buildNestedScene, buildNineSliceScene, buildRepeatingScene, buildSpriteScene, makeTextures } from './fixtures';
 import type { WebGl2Harness } from './harness';
 import { createWebGl2Harness } from './harness';
 
@@ -62,6 +62,11 @@ const SAMPLES: readonly Sample[] = [
   { id: 'nine-slice/100/8tex/stretch', build: () => ({ root: buildNineSliceScene({ count: 100, textures: makeTextures(8), assign: 'cycle', slice: 16, width: 96, height: 96, fill: 'stretch', viewW: VIEW.w, viewH: VIEW.h }).root }) },
   { id: 'repeating/geometry/100/1tex', build: () => ({ root: buildRepeatingScene({ count: 100, textures: makeTextures(1), path: 'geometry', width: 128, height: 128, modeX: 'repeat', modeY: 'repeat', viewW: VIEW.w, viewH: VIEW.h }).root }) },
   { id: 'repeating/shader/100/1tex', build: () => ({ root: buildRepeatingScene({ count: 100, textures: makeTextures(1), path: 'shader', width: 128, height: 128, modeX: 'repeat', modeY: 'repeat', viewW: VIEW.w, viewH: VIEW.h }).root }) },
+  // Complex scenes — the ones that decide 2b-2f ROI (flat sprite lists barely allocate).
+  { id: 'nested/1000/8per/d2', build: () => ({ root: buildNestedScene({ count: 1000, perContainer: 8, depth: 2, textures: makeTextures(1), viewW: VIEW.w, viewH: VIEW.h }).root }) },
+  { id: 'nested/1000/8per/d4', build: () => ({ root: buildNestedScene({ count: 1000, perContainer: 8, depth: 4, textures: makeTextures(1), viewW: VIEW.w, viewH: VIEW.h }).root }) },
+  { id: 'mesh/1000/1tex', build: () => ({ root: buildMeshScene({ count: 1000, textures: makeTextures(1), viewW: VIEW.w, viewH: VIEW.h }).root }) },
+  { id: 'filtered/100/1tex', build: () => ({ root: buildFilteredScene({ count: 100, textures: makeTextures(1), viewW: VIEW.w, viewH: VIEW.h }).root }) },
 ];
 
 const results: Array<FrameAllocation & { id: string }> = [];

--- a/test/perf/rendering/run-allocation.ts
+++ b/test/perf/rendering/run-allocation.ts
@@ -23,11 +23,11 @@
  * by the allocation TEST (run under vitest), not here.
  *
  * Spec 04 "Harte Regel": no perf PR merges without a before/after number on the
- * scenes it targets. STILL UNCOVERED here and needing dedicated fixtures before
- * slices 2c/2e/2f can be judged: deep container nesting + effect/barrier nodes
- * (→ 2c collectRenderGroups), mixed-zIndex/material optimizer load (→ 2b/2f), and
- * mesh/graphics scenes (→ 2e). 2d (TransformBuffer hash) is CPU time, not
- * allocation — it needs a wall-clock profile, not this sampler.
+ * scenes it targets. The allocation TEST now covers deep container nesting +
+ * effect/barrier nodes (the per-scope plan-playback path 2c addressed) and
+ * mesh/graphics scenes (→ 2e); this standalone launcher stays GLSL-free and so
+ * still cannot profile the tilemap family. 2d (TransformBuffer hash) is CPU
+ * time, not allocation — it needs a wall-clock profile, not this sampler.
  *
  * @internal Test/perf-only.
  */

--- a/test/perf/rendering/run-allocation.ts
+++ b/test/perf/rendering/run-allocation.ts
@@ -31,7 +31,7 @@
  *
  * @internal Test/perf-only.
  */
- 
+
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
@@ -48,33 +48,95 @@ interface Sample {
   build(harness: WebGl2Harness): { root: import('#rendering/RenderNode').RenderNode; beforeFrame?: () => void };
 }
 
-const movingSprites = (count: number) => (harness: WebGl2Harness): { root: import('#rendering/RenderNode').RenderNode; beforeFrame?: () => void } => {
-  const { root, sprites } = buildSpriteScene({ count, textures: makeTextures(1), viewW: VIEW.w, viewH: VIEW.h });
-  let frame = 0;
-  const beforeFrame = (): void => {
-    frame++;
-    const dx = frame % 2 === 0 ? 1 : -1;
-    for (const sprite of sprites) {
-      sprite.setPosition(sprite.position.x + dx, sprite.position.y);
-    }
-  };
+const movingSprites =
+  (count: number) =>
+  (harness: WebGl2Harness): { root: import('#rendering/RenderNode').RenderNode; beforeFrame?: () => void } => {
+    const { root, sprites } = buildSpriteScene({ count, textures: makeTextures(1), viewW: VIEW.w, viewH: VIEW.h });
+    let frame = 0;
+    const beforeFrame = (): void => {
+      frame++;
+      const dx = frame % 2 === 0 ? 1 : -1;
+      for (const sprite of sprites) {
+        sprite.setPosition(sprite.position.x + dx, sprite.position.y);
+      }
+    };
 
-  return { root, beforeFrame };
-};
+    return { root, beforeFrame };
+  };
 
 const SAMPLES: readonly Sample[] = [
   { id: 'sprite/1000/1tex/static', build: () => ({ root: buildSpriteScene({ count: 1000, textures: makeTextures(1), viewW: VIEW.w, viewH: VIEW.h }).root }) },
   { id: 'sprite/1000/1tex/moving', build: movingSprites(1000) },
-  { id: 'sprite/1000/8tex/static', build: () => ({ root: buildSpriteScene({ count: 1000, textures: makeTextures(8), assign: 'cycle', viewW: VIEW.w, viewH: VIEW.h }).root }) },
+  {
+    id: 'sprite/1000/8tex/static',
+    build: () => ({ root: buildSpriteScene({ count: 1000, textures: makeTextures(8), assign: 'cycle', viewW: VIEW.w, viewH: VIEW.h }).root }),
+  },
   { id: 'sprite/10000/1tex/static', build: () => ({ root: buildSpriteScene({ count: 10000, textures: makeTextures(1), viewW: VIEW.w, viewH: VIEW.h }).root }) },
   { id: 'sprite/10000/1tex/moving', build: movingSprites(10000) },
-  { id: 'nine-slice/100/1tex/stretch', build: () => ({ root: buildNineSliceScene({ count: 100, textures: makeTextures(1), slice: 16, width: 96, height: 96, fill: 'stretch', viewW: VIEW.w, viewH: VIEW.h }).root }) },
-  { id: 'nine-slice/100/8tex/stretch', build: () => ({ root: buildNineSliceScene({ count: 100, textures: makeTextures(8), assign: 'cycle', slice: 16, width: 96, height: 96, fill: 'stretch', viewW: VIEW.w, viewH: VIEW.h }).root }) },
-  { id: 'repeating/geometry/100/1tex', build: () => ({ root: buildRepeatingScene({ count: 100, textures: makeTextures(1), path: 'geometry', width: 128, height: 128, modeX: 'repeat', modeY: 'repeat', viewW: VIEW.w, viewH: VIEW.h }).root }) },
-  { id: 'repeating/shader/100/1tex', build: () => ({ root: buildRepeatingScene({ count: 100, textures: makeTextures(1), path: 'shader', width: 128, height: 128, modeX: 'repeat', modeY: 'repeat', viewW: VIEW.w, viewH: VIEW.h }).root }) },
+  {
+    id: 'nine-slice/100/1tex/stretch',
+    build: () => ({
+      root: buildNineSliceScene({ count: 100, textures: makeTextures(1), slice: 16, width: 96, height: 96, fill: 'stretch', viewW: VIEW.w, viewH: VIEW.h })
+        .root,
+    }),
+  },
+  {
+    id: 'nine-slice/100/8tex/stretch',
+    build: () => ({
+      root: buildNineSliceScene({
+        count: 100,
+        textures: makeTextures(8),
+        assign: 'cycle',
+        slice: 16,
+        width: 96,
+        height: 96,
+        fill: 'stretch',
+        viewW: VIEW.w,
+        viewH: VIEW.h,
+      }).root,
+    }),
+  },
+  {
+    id: 'repeating/geometry/100/1tex',
+    build: () => ({
+      root: buildRepeatingScene({
+        count: 100,
+        textures: makeTextures(1),
+        path: 'geometry',
+        width: 128,
+        height: 128,
+        modeX: 'repeat',
+        modeY: 'repeat',
+        viewW: VIEW.w,
+        viewH: VIEW.h,
+      }).root,
+    }),
+  },
+  {
+    id: 'repeating/shader/100/1tex',
+    build: () => ({
+      root: buildRepeatingScene({
+        count: 100,
+        textures: makeTextures(1),
+        path: 'shader',
+        width: 128,
+        height: 128,
+        modeX: 'repeat',
+        modeY: 'repeat',
+        viewW: VIEW.w,
+        viewH: VIEW.h,
+      }).root,
+    }),
+  },
   // Complex scenes — the ones that decide 2b-2f ROI (flat sprite lists barely allocate).
-  { id: 'nested/1000/8per/d2', build: () => ({ root: buildNestedScene({ count: 1000, perContainer: 8, depth: 2, textures: makeTextures(1), viewW: VIEW.w, viewH: VIEW.h }).root }) },
-  { id: 'nested/1000/8per/d4', build: () => ({ root: buildNestedScene({ count: 1000, perContainer: 8, depth: 4, textures: makeTextures(1), viewW: VIEW.w, viewH: VIEW.h }).root }) },
+  {
+    id: 'nested/1000/8per/d2',
+    build: () => ({ root: buildNestedScene({ count: 1000, perContainer: 8, depth: 2, textures: makeTextures(1), viewW: VIEW.w, viewH: VIEW.h }).root }),
+  },
+  {
+    id: 'nested/1000/8per/d4',
+    build: () => ({ root: buildNestedScene({ count: 1000, perContainer: 8, depth: 4, textures: makeTextures(1), viewW: VIEW.w, viewH: VIEW.h }).root }),
+  },
   { id: 'mesh/1000/1tex', build: () => ({ root: buildMeshScene({ count: 1000, textures: makeTextures(1), viewW: VIEW.w, viewH: VIEW.h }).root }) },
   { id: 'filtered/100/1tex', build: () => ({ root: buildFilteredScene({ count: 100, textures: makeTextures(1), viewW: VIEW.w, viewH: VIEW.h }).root }) },
 ];

--- a/test/perf/rendering/run-allocation.ts
+++ b/test/perf/rendering/run-allocation.ts
@@ -1,0 +1,87 @@
+/**
+ * Allocation bench launcher — runs the sampler across the sprite, nine-slice and
+ * repeating families and writes the numbers to `.workspace/output/render-perf/`.
+ *
+ *   node --import tsx/esm test/perf/rendering/run-allocation.ts
+ *   (or: pnpm perf:renderers:alloc)
+ *
+ * Scenes are built directly via the `fixtures` builders rather than through
+ * {@link buildScenarioCatalog}: the catalog pulls in the tilemap fixtures, whose
+ * `@codexo/*` package imports resolve to `src` (no built dist) and then hit raw
+ * `.frag` GLSL imports that node/tsx cannot load — only the vitest projects wire
+ * the GLSL handling. So the tilemap family is profiled by the allocation TEST
+ * (run under vitest), not here.
+ *
+ * Spec 04 "Harte Regel": no perf PR merges without a before/after number on the
+ * scenes it targets. STILL UNCOVERED here and needing dedicated fixtures before
+ * slices 2c/2e/2f can be judged: deep container nesting + effect/barrier nodes
+ * (→ 2c collectRenderGroups), mixed-zIndex/material optimizer load (→ 2b/2f), and
+ * mesh/graphics scenes (→ 2e). 2d (TransformBuffer hash) is CPU time, not
+ * allocation — it needs a wall-clock profile, not this sampler.
+ *
+ * @internal Test/perf-only.
+ */
+ 
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import type { FrameAllocation } from './allocation';
+import { measureFrameAllocation } from './allocation';
+import { buildNineSliceScene, buildRepeatingScene, buildSpriteScene, makeTextures } from './fixtures';
+import type { WebGl2Harness } from './harness';
+import { createWebGl2Harness } from './harness';
+
+const VIEW = { w: 1280, h: 720 };
+
+interface Sample {
+  readonly id: string;
+  build(harness: WebGl2Harness): { root: import('#rendering/RenderNode').RenderNode; beforeFrame?: () => void };
+}
+
+const movingSprites = (count: number) => (harness: WebGl2Harness): { root: import('#rendering/RenderNode').RenderNode; beforeFrame?: () => void } => {
+  const { root, sprites } = buildSpriteScene({ count, textures: makeTextures(1), viewW: VIEW.w, viewH: VIEW.h });
+  let frame = 0;
+  const beforeFrame = (): void => {
+    frame++;
+    const dx = frame % 2 === 0 ? 1 : -1;
+    for (const sprite of sprites) {
+      sprite.setPosition(sprite.position.x + dx, sprite.position.y);
+    }
+  };
+
+  return { root, beforeFrame };
+};
+
+const SAMPLES: readonly Sample[] = [
+  { id: 'sprite/1000/1tex/static', build: () => ({ root: buildSpriteScene({ count: 1000, textures: makeTextures(1), viewW: VIEW.w, viewH: VIEW.h }).root }) },
+  { id: 'sprite/1000/1tex/moving', build: movingSprites(1000) },
+  { id: 'sprite/1000/8tex/static', build: () => ({ root: buildSpriteScene({ count: 1000, textures: makeTextures(8), assign: 'cycle', viewW: VIEW.w, viewH: VIEW.h }).root }) },
+  { id: 'sprite/10000/1tex/static', build: () => ({ root: buildSpriteScene({ count: 10000, textures: makeTextures(1), viewW: VIEW.w, viewH: VIEW.h }).root }) },
+  { id: 'sprite/10000/1tex/moving', build: movingSprites(10000) },
+  { id: 'nine-slice/100/1tex/stretch', build: () => ({ root: buildNineSliceScene({ count: 100, textures: makeTextures(1), slice: 16, width: 96, height: 96, fill: 'stretch', viewW: VIEW.w, viewH: VIEW.h }).root }) },
+  { id: 'nine-slice/100/8tex/stretch', build: () => ({ root: buildNineSliceScene({ count: 100, textures: makeTextures(8), assign: 'cycle', slice: 16, width: 96, height: 96, fill: 'stretch', viewW: VIEW.w, viewH: VIEW.h }).root }) },
+  { id: 'repeating/geometry/100/1tex', build: () => ({ root: buildRepeatingScene({ count: 100, textures: makeTextures(1), path: 'geometry', width: 128, height: 128, modeX: 'repeat', modeY: 'repeat', viewW: VIEW.w, viewH: VIEW.h }).root }) },
+  { id: 'repeating/shader/100/1tex', build: () => ({ root: buildRepeatingScene({ count: 100, textures: makeTextures(1), path: 'shader', width: 128, height: 128, modeX: 'repeat', modeY: 'repeat', viewW: VIEW.w, viewH: VIEW.h }).root }) },
+];
+
+const results: Array<FrameAllocation & { id: string }> = [];
+
+for (const sample of SAMPLES) {
+  const harness = createWebGl2Harness();
+  const scene = sample.build(harness);
+  const alloc = await measureFrameAllocation(harness, scene.root, { beforeFrame: scene.beforeFrame });
+
+  results.push({ id: sample.id, ...alloc });
+  console.log(`${sample.id.padEnd(34)} ${(alloc.bytesPerFrame / 1024).toFixed(2).padStart(9)} KB/frame`);
+
+  scene.root.destroy();
+  harness.destroy();
+}
+
+const outDir = resolve(process.cwd(), '.workspace/output/render-perf');
+mkdirSync(outDir, { recursive: true });
+
+const outPath = resolve(outDir, 'allocation.json');
+writeFileSync(outPath, `${JSON.stringify({ results }, null, 2)}\n`);
+
+console.log(`\nWrote ${outPath}`);

--- a/test/rendering/helpers/collectRenderGroups.ts
+++ b/test/rendering/helpers/collectRenderGroups.ts
@@ -1,0 +1,125 @@
+import { type DrawCommand, type MaterialKey, RenderEntryKind } from '#rendering/plan/RenderCommand';
+import type { GroupScope, ScopeEntry } from '#rendering/plan/RenderScope';
+
+/**
+ * A materialized batch unit: a maximal run of consecutive draw commands within a
+ * single {@link GroupScope} that share a GPU pipeline/bind state and may
+ * therefore be submitted together.
+ *
+ * The optimizer ({@link RenderPlanOptimizer}) stamps this grouping implicitly
+ * onto each {@link DrawCommand.groupIndex}; a `RenderGroup` makes that batch unit
+ * explicit as a value. The plan player no longer materializes these per frame —
+ * it walks `groupIndex` adjacency over `scope.entries` inline (Slice 2c). This
+ * collector survives only as a **test helper**: render-plan tests assert grouping
+ * structure against it without re-deriving the adjacency rule, and the upload-
+ * boundary mocks reconstruct the group's commands from the entries range.
+ *
+ * @internal Test-only.
+ */
+export interface RenderGroup {
+  /** Optimizer-assigned batch identity shared by every command in the run. */
+  readonly groupIndex: number;
+  /** Pipeline/bind state shared by the run; taken from its first command. */
+  readonly material: MaterialKey;
+  /** Draw commands in submit order. */
+  readonly instructions: readonly DrawCommand[];
+}
+
+interface MutableRenderGroup {
+  groupIndex: number;
+  material: MaterialKey;
+  instructions: DrawCommand[];
+}
+
+/**
+ * Materialize the {@link RenderGroup} batch units contained directly in `scope`.
+ * Consecutive draw commands that share a defined `groupIndex` coalesce into one
+ * group; any non-draw entry (a nested group or barrier) breaks the run, and a
+ * draw whose `groupIndex` is still `undefined` (i.e. the plan has not been
+ * optimized) forms its own singleton group — mirroring the adjacency semantics
+ * the plan player walks inline and the mesh renderers rely on.
+ *
+ * @internal Test-only.
+ */
+export const collectRenderGroups = (scope: GroupScope): RenderGroup[] => {
+  const groups: RenderGroup[] = [];
+  let current: MutableRenderGroup | null = null;
+
+  for (const entry of scope.entries) {
+    if (entry.kind !== RenderEntryKind.Draw) {
+      current = null;
+
+      continue;
+    }
+
+    const command = entry.command;
+    const groupIndex = command.groupIndex;
+
+    if (current !== null && groupIndex !== undefined && groupIndex === current.groupIndex) {
+      current.instructions.push(command);
+
+      continue;
+    }
+
+    current = {
+      groupIndex: groupIndex ?? 0,
+      material: command.material,
+      instructions: [command],
+    };
+    groups.push(current);
+
+    if (groupIndex === undefined) {
+      // Unoptimized / non-batchable draw: never coalesce with the next one.
+      current = null;
+    }
+  }
+
+  return groups;
+};
+
+/**
+ * Iterate the draw commands of the group range `[startIndex, startIndex + count)`
+ * the refactored plan-player hooks pass. Every entry in a group range is a draw,
+ * so this is the read-only equivalent of looping a materialized group's
+ * `instructions` — letting the upload-boundary mocks pack exactly the same
+ * commands while the production player passes only an entries range.
+ *
+ * @internal Test-only.
+ */
+export const forEachGroupCommand = (entries: readonly ScopeEntry[], startIndex: number, count: number, visit: (command: DrawCommand) => void): void => {
+  for (let i = startIndex; i < startIndex + count; i++) {
+    const entry = entries[i];
+
+    if (entry?.kind !== RenderEntryKind.Draw) {
+      throw new Error(`forEachGroupCommand: entry ${i} in [${startIndex}, ${startIndex + count}) is not a draw`);
+    }
+
+    visit(entry.command);
+  }
+};
+
+/**
+ * Reconstruct the {@link RenderGroup} a plan-player upload boundary describes
+ * from the `(entries, startIndex, count)` range the refactored hooks pass. Lets
+ * the begin/end/upload mocks keep asserting against a `RenderGroup` (e.g. its
+ * `instructions`' drawable ids) while the production player passes only a range.
+ *
+ * @internal Test-only.
+ */
+export const renderGroupFromRange = (entries: readonly ScopeEntry[], startIndex: number, count: number): RenderGroup => {
+  const instructions: DrawCommand[] = [];
+
+  forEachGroupCommand(entries, startIndex, count, command => instructions.push(command));
+
+  const first = instructions[0];
+
+  if (first === undefined) {
+    throw new Error('renderGroupFromRange: empty group range');
+  }
+
+  return {
+    groupIndex: first.groupIndex ?? 0,
+    material: first.material,
+    instructions,
+  };
+};

--- a/test/rendering/render-instructions.test.ts
+++ b/test/rendering/render-instructions.test.ts
@@ -1,13 +1,15 @@
 import { Container } from '#rendering/Container';
 import { Drawable } from '#rendering/Drawable';
 import { type DrawCommand, RenderEntryKind } from '#rendering/plan/RenderCommand';
-import { collectRenderGroups, type RenderInstruction } from '#rendering/plan/RenderInstruction';
+import type { RenderInstruction } from '#rendering/plan/RenderInstruction';
 import { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
 import { RenderPlanOptimizer } from '#rendering/plan/RenderPlanOptimizer';
 import type { GroupScope } from '#rendering/plan/RenderScope';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import { createRenderStats } from '#rendering/RenderStats';
 import { RenderTarget } from '#rendering/RenderTarget';
+
+import { collectRenderGroups } from './helpers/collectRenderGroups';
 
 class BoxDrawable extends Drawable {
   public constructor() {

--- a/test/rendering/render-plan-player.test.ts
+++ b/test/rendering/render-plan-player.test.ts
@@ -1,9 +1,10 @@
 import { Drawable } from '#rendering/Drawable';
 import { type DrawCommand, type MaterialKey, RenderEntryKind } from '#rendering/plan/RenderCommand';
-import type { RenderGroup } from '#rendering/plan/RenderInstruction';
 import { RenderPlanPlayer } from '#rendering/plan/RenderPlanPlayer';
-import type { DrawScopeEntry, GroupScope, GroupScopeEntry } from '#rendering/plan/RenderScope';
+import type { DrawScopeEntry, GroupScope, GroupScopeEntry, ScopeEntry } from '#rendering/plan/RenderScope';
 import type { RenderBackend } from '#rendering/RenderBackend';
+
+import { renderGroupFromRange } from './helpers/collectRenderGroups';
 
 class BoxDrawable extends Drawable {
   public constructor(public readonly id: string) {
@@ -70,15 +71,24 @@ const createPlaybackSpy = (): PlaybackSpy => {
   const slots: string[] = [];
   const uploads: string[] = [];
 
+  // Reconstruct each group's drawable ids from the `(entries, startIndex, count)`
+  // range the refactored hooks pass — the player no longer materializes a group.
+  const groupIds = (entries: readonly ScopeEntry[], startIndex: number, count: number): string =>
+    renderGroupFromRange(entries, startIndex, count)
+      .instructions.map(command => (command.drawable as BoxDrawable).id)
+      .join(',');
+
   const backend = {
-    _beginRenderGroup(group: RenderGroup) {
-      events.push(`begin:${group.instructions.map(command => (command.drawable as BoxDrawable).id).join(',')}`);
+    _beginRenderGroup(entries: readonly ScopeEntry[], startIndex: number, count: number) {
+      events.push(`begin:${groupIds(entries, startIndex, count)}`);
     },
     _prepareRenderGroupUpload(
-      group: RenderGroup,
+      entries: readonly ScopeEntry[],
+      startIndex: number,
+      count: number,
       context: { groupInstructionCount: number; firstPassInstructionIndex: number; lastPassInstructionIndex: number; passGroupIndex: number },
     ) {
-      const ids = group.instructions.map(command => (command.drawable as BoxDrawable).id).join(',');
+      const ids = groupIds(entries, startIndex, count);
       const upload = `${ids}:${context.groupInstructionCount}:${context.firstPassInstructionIndex}:${context.lastPassInstructionIndex}:${context.passGroupIndex}`;
 
       uploads.push(upload);
@@ -98,8 +108,8 @@ const createPlaybackSpy = (): PlaybackSpy => {
 
       return this;
     },
-    _endRenderGroup(group: RenderGroup) {
-      events.push(`end:${group.instructions.map(command => (command.drawable as BoxDrawable).id).join(',')}`);
+    _endRenderGroup(entries: readonly ScopeEntry[], startIndex: number, count: number) {
+      events.push(`end:${groupIds(entries, startIndex, count)}`);
     },
   } as unknown as RenderBackend;
 

--- a/test/rendering/transform-buffer-group-upload.test.ts
+++ b/test/rendering/transform-buffer-group-upload.test.ts
@@ -1,11 +1,12 @@
 import { Color } from '#core/Color';
 import { Drawable } from '#rendering/Drawable';
 import { type DrawCommand, type MaterialKey, RenderEntryKind } from '#rendering/plan/RenderCommand';
-import type { RenderGroup } from '#rendering/plan/RenderInstruction';
 import { RenderPlanPlayer } from '#rendering/plan/RenderPlanPlayer';
-import type { DrawScopeEntry, GroupScope, GroupScopeEntry } from '#rendering/plan/RenderScope';
+import type { DrawScopeEntry, GroupScope, GroupScopeEntry, ScopeEntry } from '#rendering/plan/RenderScope';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import { TransformBuffer } from '#rendering/TransformBuffer';
+
+import { forEachGroupCommand } from './helpers/collectRenderGroups';
 
 const floatsPerSlot = 12;
 
@@ -95,10 +96,10 @@ const packPerGroupUpload = (scope: GroupScope): TransformBuffer => {
   buffer.begin();
 
   const backend = {
-    _prepareRenderGroupUpload(group: RenderGroup) {
-      for (const command of group.instructions) {
+    _prepareRenderGroupUpload(entries: readonly ScopeEntry[], startIndex: number, count: number) {
+      forEachGroupCommand(entries, startIndex, count, command => {
         buffer.write(command.nodeIndex, command.drawable.getGlobalTransform(), command.drawable.tint);
-      }
+      });
     },
     _prepareDrawCommand() {
       // Mirrors the refactored backend contract: no transform write here.

--- a/test/rendering/transform-buffer-upload-count.test.ts
+++ b/test/rendering/transform-buffer-upload-count.test.ts
@@ -1,12 +1,13 @@
 import { Color } from '#core/Color';
 import { Drawable } from '#rendering/Drawable';
 import { type DrawCommand, drawCommandUsesSharedTransform, type MaterialKey, RenderEntryKind } from '#rendering/plan/RenderCommand';
-import type { RenderGroup } from '#rendering/plan/RenderInstruction';
 import { RenderPlanPlayer } from '#rendering/plan/RenderPlanPlayer';
-import type { DrawScopeEntry, GroupScope } from '#rendering/plan/RenderScope';
+import type { DrawScopeEntry, GroupScope, ScopeEntry } from '#rendering/plan/RenderScope';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import { TransformBuffer } from '#rendering/TransformBuffer';
 import { WebGpuTransformStorage } from '#rendering/webgpu/WebGpuTransformStorage';
+
+import { forEachGroupCommand } from './helpers/collectRenderGroups';
 
 // Sprite/Mesh-like: renderer reads the shared transform storage.
 class ConsumingDrawable extends Drawable {
@@ -47,8 +48,8 @@ const material = (key: number): MaterialKey => ({
 });
 
 // One coalescing group: every command shares the same groupIndex/material key,
-// so `collectRenderGroups` packs them into a single RenderGroup → a single
-// upload boundary fires for the whole run.
+// so the plan player walks them as a single group run → a single upload
+// boundary fires for the whole run.
 const createDrawCommand = (drawable: Drawable, nodeIndex: number): DrawCommand => ({
   kind: RenderEntryKind.Draw,
   drawable,
@@ -101,14 +102,14 @@ class Webgl2UploadModel {
     const buffer = this.buffer;
     const backend = {
       rendererRegistry: makeRegistry(),
-      _prepareRenderGroupUpload(group: RenderGroup) {
-        for (const command of group.instructions) {
+      _prepareRenderGroupUpload(entries: readonly ScopeEntry[], startIndex: number, count: number) {
+        forEachGroupCommand(entries, startIndex, count, command => {
           if (drawCommandUsesSharedTransform(command, this as unknown as RenderBackend)) {
             buffer.write(command.nodeIndex, command.drawable.getGlobalTransform(), command.drawable.tint);
           } else {
             buffer.recordSkippedWrite();
           }
-        }
+        });
       },
       _prepareDrawCommand() {
         // Refactored backend contract: no transform write in this hook.
@@ -180,14 +181,14 @@ const withGpuBufferUsage = (run: () => void): void => {
 const playWebgpu = (storage: WebGpuTransformStorage, scope: GroupScope): void => {
   const backend = {
     rendererRegistry: makeRegistry(),
-    _prepareRenderGroupUpload(group: RenderGroup) {
-      for (const command of group.instructions) {
+    _prepareRenderGroupUpload(entries: readonly ScopeEntry[], startIndex: number, count: number) {
+      forEachGroupCommand(entries, startIndex, count, command => {
         if (drawCommandUsesSharedTransform(command, this as unknown as RenderBackend)) {
           storage.writeCommand(command);
         } else {
           storage.recordSkippedWrite();
         }
-      }
+      });
     },
     _prepareDrawCommand() {},
     draw() {

--- a/test/rendering/transform-storage-filter.test.ts
+++ b/test/rendering/transform-storage-filter.test.ts
@@ -1,11 +1,12 @@
 import { Color } from '#core/Color';
 import { Drawable } from '#rendering/Drawable';
 import { type DrawCommand, drawCommandUsesSharedTransform, type MaterialKey, RenderEntryKind } from '#rendering/plan/RenderCommand';
-import type { RenderGroup } from '#rendering/plan/RenderInstruction';
 import { RenderPlanPlayer } from '#rendering/plan/RenderPlanPlayer';
-import type { DrawScopeEntry, GroupScope } from '#rendering/plan/RenderScope';
+import type { DrawScopeEntry, GroupScope, ScopeEntry } from '#rendering/plan/RenderScope';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import { TransformBuffer } from '#rendering/TransformBuffer';
+
+import { forEachGroupCommand } from './helpers/collectRenderGroups';
 
 const floatsPerSlot = 12;
 
@@ -101,15 +102,15 @@ const playFiltered = (scope: GroupScope): FilteredPlayback => {
 
   const backend = {
     rendererRegistry: makeRegistry(),
-    _prepareRenderGroupUpload(group: RenderGroup) {
-      for (const command of group.instructions) {
+    _prepareRenderGroupUpload(entries: readonly ScopeEntry[], startIndex: number, count: number) {
+      forEachGroupCommand(entries, startIndex, count, command => {
         if (drawCommandUsesSharedTransform(command, this as unknown as RenderBackend)) {
           buffer.write(command.nodeIndex, command.drawable.getGlobalTransform(), command.drawable.tint);
           writtenNodeIndices.push(command.nodeIndex);
         } else {
           buffer.recordSkippedWrite();
         }
-      }
+      });
     },
     _prepareDrawCommand() {
       // Mirrors the refactored backend contract: no transform write here.

--- a/test/rendering/webgpu-transform-group-upload.test.ts
+++ b/test/rendering/webgpu-transform-group-upload.test.ts
@@ -1,11 +1,12 @@
 import { Color } from '#core/Color';
 import { Drawable } from '#rendering/Drawable';
 import { type DrawCommand, drawCommandUsesSharedTransform, type MaterialKey, RenderEntryKind } from '#rendering/plan/RenderCommand';
-import type { RenderGroup } from '#rendering/plan/RenderInstruction';
 import { RenderPlanPlayer } from '#rendering/plan/RenderPlanPlayer';
-import type { DrawScopeEntry, GroupScope } from '#rendering/plan/RenderScope';
+import type { DrawScopeEntry, GroupScope, ScopeEntry } from '#rendering/plan/RenderScope';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import { WebGpuTransformStorage } from '#rendering/webgpu/WebGpuTransformStorage';
+
+import { forEachGroupCommand } from './helpers/collectRenderGroups';
 
 // Sprite/Mesh-like: renderer reads shared transform storage.
 class ConsumingDrawable extends Drawable {
@@ -95,14 +96,14 @@ const playGroupUpload = (scope: GroupScope): GroupUploadPlayback => {
 
   const backend = {
     rendererRegistry: makeRegistry(),
-    _prepareRenderGroupUpload(group: RenderGroup) {
-      for (const command of group.instructions) {
+    _prepareRenderGroupUpload(entries: readonly ScopeEntry[], startIndex: number, count: number) {
+      forEachGroupCommand(entries, startIndex, count, command => {
         if (drawCommandUsesSharedTransform(command, this as unknown as RenderBackend)) {
           storage.writeCommand(command);
         } else {
           storage.recordSkippedWrite();
         }
-      }
+      });
     },
     _prepareDrawCommand(command: DrawCommand) {
       prepareDrawCommandCalls.push(command);
@@ -262,14 +263,14 @@ describe('WebGPU group-upload: nodeIndex slot contract', () => {
 
     const backend = {
       rendererRegistry: makeRegistry(),
-      _prepareRenderGroupUpload(group: RenderGroup) {
-        for (const cmd of group.instructions) {
+      _prepareRenderGroupUpload(entries: readonly ScopeEntry[], startIndex: number, count: number) {
+        forEachGroupCommand(entries, startIndex, count, cmd => {
           if (drawCommandUsesSharedTransform(cmd, this as unknown as RenderBackend)) {
             storage2.writeCommand(cmd);
           } else {
             storage2.recordSkippedWrite();
           }
-        }
+        });
       },
       _prepareDrawCommand() {},
       draw(drawable: Drawable) {


### PR DESCRIPTION
v0.15 Welle 3 (Epic 2 — Render-Plan-Performance). Eliminiert die Pro-Frame-Allokation des Render-Plans durch Pooling/Caching und fügt engine-internes GPU-Resource-Accounting hinzu. **Keine strukturelle Render-Änderung** — drawCalls/batches/Gruppierung/Phase-1-Upload-Reihenfolge unverändert; `test/rendering` 1035/1035 grün.

## Allocation-Bilanz (source-genau, KB/frame)

| Szene | Start (2a) | Final | Δ |
|---|---:|---:|---:|
| sprite/1000 static | 644 | **287** | −55% |
| sprite/1000 moving | 916 | **550** | −40% |
| nested/d4 (500 scopes) | ~892 | **362** | −59% |
| mesh/1000 | ~1225 | **644** | −47% |
| filtered/100 (barriers) | ~1498 | **1310** | −13% |

## Slices

- **2a — Allocation-Gate:** V8-HeapProfiler-Sampling (`node:inspector`) der Pro-Frame-Allocation-Rate als source-genauer vitest-Gate. **Kritischer Fix: der Sampler unterzählte ~500×** (fehlende `includeObjectsCollectedBy*GC`-Flags → der GC-eingesammelte Wegwerf-Müll, den 2a misst, wurde verworfen); ein Sanity-Test schützt die Flags jetzt. Komplexe Fixtures (nested/mesh/filtered).
- **2b — Pooling + MaterialKey-Cache:** frame-persistente Free-Lists für `DrawCommand`/`ScopeEntry`, `PendingEntryPlacement` eliminiert, `MaterialKey` am Drawable gecacht (backend-gebunden, über die bestehenden `invalidateCache`-Setter).
- **2c — `collectRenderGroups` eliminiert:** der Plan-Player läuft die `groupIndex`-Adjazenz inline über `scope.entries` in beiden Phasen, statt pro Scope ein `RenderGroup[]`/`instructions[]` zu materialisieren. Upload-Reihenfolge + Kontext-Tupel identisch (Wächter `transform-buffer-upload-count` grün).
- **2e — `slice()`→Index-Range + `PendingMeshDraw`-Pool:** `WebGl2MeshRenderer`, WebGl2-only.
- **2g — GPU-Resource-Accounting:** net-new `RenderStats`-Felder (`gpuMemoryBytes` VRAM-Schätzung als laufende Summe, `textureUploadBytes`/`bufferUploadBytes`/`downloadBytes`/`downloadCount` pro Frame) über einen per-Backend `GpuResourceAccountant`. Die GPU exponiert keinen VRAM-Query — engine-internes Booking ist der einzige Weg.

**2d (TransformBuffer-Hash) gemessen → gestrichen:** 0.9% des Frame-Budgets selbst bei 10000 bewegten Drawables, im Rauschen (Spec-Vorgabe: streichen statt spekulativ einbauen).

**2f (Plan-Cache für statische Frames) folgt als separater PR** — die invasivste Änderung der Welle (eigenes Plan-Invalidierungs-Signal, das Transform/Tint ausschließt).

## CI-Parität (lokal grün)
typecheck (core + 5 Pakete + guides + examples) · lint:all · format:check · docs:api:check · test (exojs 2403, rendering-perf 45+15). WebGl2-Real-GPU-Batch-Tests grün.