### PR TITLE
test(perf): source-accurate allocation bench via node GLSL loader (incl. tilemap)

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "perf:renderers": "tsx test/perf/rendering/run-sweep.ts full",
     "perf:renderers:quick": "tsx test/perf/rendering/run-sweep.ts quick",
     "perf:renderers:browser": "vitest run --project=browser-webgl-chromium webgl2-renderer-perf",
-    "perf:renderers:alloc": "node --import tsx/esm test/perf/rendering/run-allocation.ts",
+    "perf:renderers:alloc": "node --conditions=@codexo/source --import ./scripts/glsl-register.mjs --import tsx/esm test/perf/rendering/run-allocation.ts",
     "perf:bench:rendering": "tsx test/perf/rendering-benchmark.ts",
     "perf:bench:audio": "tsx test/perf/audio-benchmark.ts",
     "perf:bench:collision": "tsx test/perf/collision-benchmark.ts",

--- a/scripts/glsl-loader.mjs
+++ b/scripts/glsl-loader.mjs
@@ -1,0 +1,71 @@
+/**
+ * Node ESM loader hook making a plain `node --import tsx/esm` run source-accurate
+ * for the in-repo perf benches — the node/tsx counterpart of the vitest config's
+ * `realShaderPlugin` + `aliasConfig`. Two jobs:
+ *
+ *  1. **GLSL imports.** Engine modules import shaders as
+ *     `import src from '#rendering/.../x.frag'`, which `package.json#imports` maps
+ *     to `./src/.../x.frag`. Node resolves the path but has no loader for the
+ *     extension, so this hook loads the file as its source text exported as
+ *     `default` (exactly like the vitest/rollup transforms).
+ *
+ *  2. **Workspace package specifiers.** `@codexo/exojs` and the extension packages
+ *     (`@codexo/exojs-tilemap` etc.) do NOT expose a `@codexo/source` export
+ *     condition, so `--conditions=@codexo/source` cannot redirect them to `src`;
+ *     the vitest config aliases them explicitly, and so do we. Their package-
+ *     internal `#*` imports still resolve to `src` via the `@codexo/source`
+ *     condition (passed on the node command line).
+ *
+ * Pair with `--conditions=@codexo/source`. Entrypoint: `scripts/glsl-register.mjs`.
+ */
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+// Mirror of vitest.config.ts `aliasConfig` — public cross-package specifiers → source.
+// Longest-first so subpaths (`@codexo/exojs/debug`) match before the bare root.
+const packageAliases = new Map([
+  ['@codexo/exojs/extensions', 'src/extensions/index.ts'],
+  ['@codexo/exojs/renderer-sdk', 'src/renderer-sdk.ts'],
+  ['@codexo/exojs/debug', 'src/debug/index.ts'],
+  ['@codexo/exojs', 'src/index.ts'],
+  ['@codexo/exojs-tilemap', 'packages/exojs-tilemap/src/index.ts'],
+  ['@codexo/exojs-tiled', 'packages/exojs-tiled/src/index.ts'],
+  ['@codexo/exojs-physics', 'packages/exojs-physics/src/index.ts'],
+  ['@codexo/exojs-particles', 'packages/exojs-particles/src/index.ts'],
+  ['@codexo/exojs-audio-fx', 'packages/exojs-audio-fx/src/index.ts'],
+]);
+
+const isGlsl = specifier => specifier.endsWith('.vert') || specifier.endsWith('.frag');
+
+export async function resolve(specifier, context, nextResolve) {
+  const alias = packageAliases.get(specifier);
+
+  if (alias !== undefined) {
+    return { url: pathToFileURL(join(repoRoot, alias)).href, format: 'module', shortCircuit: true };
+  }
+
+  const result = await nextResolve(specifier, context);
+
+  if (isGlsl(result.url)) {
+    return { ...result, format: 'glsl-source', shortCircuit: true };
+  }
+
+  return result;
+}
+
+export async function load(url, context, nextLoad) {
+  if (context.format === 'glsl-source' || isGlsl(url)) {
+    const source = await readFile(fileURLToPath(url), 'utf8');
+
+    return {
+      format: 'module',
+      source: `export default ${JSON.stringify(source)};`,
+      shortCircuit: true,
+    };
+  }
+
+  return nextLoad(url, context);
+}

--- a/scripts/glsl-register.mjs
+++ b/scripts/glsl-register.mjs
@@ -1,0 +1,22 @@
+/**
+ * Source-accurate node/tsx entrypoint for the perf-bench scripts.
+ *
+ * Use via `node --conditions=@codexo/source --import ./scripts/glsl-register.mjs
+ * --import tsx/esm <script>`. It does the two things a plain node/tsx run lacks
+ * to evaluate the engine source (rather than the last `dist` build):
+ *
+ *  1. Registers the GLSL loader hook (`glsl-loader.mjs`) so `.vert`/`.frag`
+ *     imports resolve to their source text.
+ *  2. Installs the build-time constants (`__DEV__`/`__VERSION__`/`__REVISION__`)
+ *     as real globals. The engine references the bare `__DEV__` (e.g. `src/core/
+ *     dev.ts`); rollup replaces it at build time and vitest's `define` + the
+ *     `_setup-dev-global` setup file inject it for tests — under plain node it is
+ *     undefined and any guarded code path throws `__DEV__ is not defined`.
+ */
+import { register } from 'node:module';
+
+globalThis.__DEV__ = true;
+globalThis.__VERSION__ = '0.0.0';
+globalThis.__REVISION__ = 'source';
+
+register('./glsl-loader.mjs', import.meta.url);

--- a/test/perf/rendering/run-allocation.ts
+++ b/test/perf/rendering/run-allocation.ts
@@ -1,33 +1,22 @@
 /**
- * Allocation bench launcher — runs the sampler across the sprite, nine-slice and
- * repeating families and writes the numbers to `.workspace/output/render-perf/`.
+ * Allocation bench launcher — samples per-frame plan allocation across the
+ * sprite, nine-slice, repeating, nested, mesh, effect-barrier AND tilemap
+ * families, and writes the numbers to `.workspace/output/render-perf/`.
  *
- *   node --import tsx/esm test/perf/rendering/run-allocation.ts
- *   (or: pnpm perf:renderers:alloc)
+ *   pnpm perf:renderers:alloc
  *
- * ⚠️ RESOLVES TO `dist`, NOT THE WORKING TREE. This launcher runs under plain
- * `node --import tsx/esm`, so the package's `#*` subpath imports resolve via their
- * `default` condition to `./dist/esm/*.js` — i.e. the LAST BUILD, not your edited
- * `src`. (The `@codexo/source` condition would point at `src`, but then tsx chokes
- * on the raw `.frag`/`.vert` GLSL imports, which only the vitest projects wire up.)
- * For a source-accurate before/after gate use the allocation TEST instead
- * (`vitest --project=rendering-perf test/perf/rendering/allocation.test.ts`,
- * add `--disableConsoleIntercept` to see the per-scene numbers); that project
- * resolves `#*` → `src` and handles GLSL. Treat this script's numbers as a coarse
- * post-build cross-check only.
+ * SOURCE-ACCURATE. The `perf:renderers:alloc` script passes
+ * `--conditions=@codexo/source` (so the `#*` imports resolve to `src`, not the
+ * last `dist` build) and `--import ./scripts/glsl-register.mjs` — a node ESM
+ * loader hook that loads `.vert`/`.frag` as source text (the node/tsx counterpart
+ * of the vitest `realShaderPlugin`) and installs the `__DEV__`/`__VERSION__`/
+ * `__REVISION__` build-constant globals. Those three pieces are what a plain
+ * `node --import tsx/esm` run lacks: it would resolve to `dist`, choke on the raw
+ * GLSL imports, and throw `__DEV__ is not defined`. Always run via the script.
  *
- * Scenes are built directly via the `fixtures` builders rather than through
- * {@link buildScenarioCatalog}: the catalog pulls in the tilemap fixtures, whose
- * `@codexo/*` package imports resolve to `src` (no built dist) and then hit raw
- * `.frag` GLSL imports that node/tsx cannot load. So the tilemap family is profiled
- * by the allocation TEST (run under vitest), not here.
- *
- * Spec 04 "Harte Regel": no perf PR merges without a before/after number on the
- * scenes it targets. The allocation TEST now covers deep container nesting +
- * effect/barrier nodes (the per-scope plan-playback path 2c addressed) and
- * mesh/graphics scenes (→ 2e); this standalone launcher stays GLSL-free and so
- * still cannot profile the tilemap family. 2d (TransformBuffer hash) is CPU
- * time, not allocation — it needs a wall-clock profile, not this sampler.
+ * The vitest `rendering-perf` allocation TEST measures the same way and is the CI
+ * gate; this launcher is the all-scenes sweep (incl. tilemap, which needs the
+ * extension's chunk shaders — hence the GLSL loader).
  *
  * @internal Test/perf-only.
  */
@@ -40,6 +29,7 @@ import { measureFrameAllocation } from './allocation';
 import { buildFilteredScene, buildMeshScene, buildNestedScene, buildNineSliceScene, buildRepeatingScene, buildSpriteScene, makeTextures } from './fixtures';
 import type { WebGl2Harness } from './harness';
 import { createWebGl2Harness } from './harness';
+import { buildTilemapScene, makeTilesets, wireTilemapRenderers } from './tilemapFixtures';
 
 const VIEW = { w: 1280, h: 720 };
 
@@ -139,6 +129,34 @@ const SAMPLES: readonly Sample[] = [
   },
   { id: 'mesh/1000/1tex', build: () => ({ root: buildMeshScene({ count: 1000, textures: makeTextures(1), viewW: VIEW.w, viewH: VIEW.h }).root }) },
   { id: 'filtered/100/1tex', build: () => ({ root: buildFilteredScene({ count: 100, textures: makeTextures(1), viewW: VIEW.w, viewH: VIEW.h }).root }) },
+  // Tilemap — measurable source-accurate now that the GLSL loader handles the
+  // chunk shaders (this family used to be excluded). static = chunk geometry
+  // fully cached; pan = camera moves but geometry is reused (revision unchanged).
+  {
+    id: 'tilemap/80x64/static',
+    build: harness => {
+      wireTilemapRenderers(harness.backend);
+      const scene = buildTilemapScene({ widthTiles: 80, heightTiles: 64, chunkSize: 32, tilesets: makeTilesets(1) });
+      harness.view.reset(scene.pixelWidth / 2, scene.pixelHeight / 2, scene.pixelWidth, scene.pixelHeight);
+
+      return { root: scene.node };
+    },
+  },
+  {
+    id: 'tilemap/80x64/pan',
+    build: harness => {
+      wireTilemapRenderers(harness.backend);
+      const scene = buildTilemapScene({ widthTiles: 80, heightTiles: 64, chunkSize: 32, tilesets: makeTilesets(1) });
+      harness.view.reset(scene.pixelWidth / 2, scene.pixelHeight / 2, scene.pixelWidth, scene.pixelHeight);
+      let frame = 0;
+      const beforeFrame = (): void => {
+        frame++;
+        harness.view.setCenter(scene.pixelWidth / 2 + (frame % 8) * 16, scene.pixelHeight / 2);
+      };
+
+      return { root: scene.node, beforeFrame };
+    },
+  },
 ];
 
 const results: Array<FrameAllocation & { id: string }> = [];


### PR DESCRIPTION
Macht den standalone Allocation-Bench (`pnpm perf:renderers:alloc`) source-genau. Er lief bisher unter plain node/tsx und maß damit den letzten `dist`-Build (nicht den working tree), konnte keine echten `.vert`/`.frag`-Shader laden und schloss die ganze Tilemap-Familie aus.

## Was fehlte (drei Teile)
1. **GLSL-Loading:** node/tsx hat keinen Loader für `.vert`/`.frag` (nur rollup + vitest wiren das).
2. **source-Condition:** ohne `--conditions=@codexo/source` resolven die `#*`-Imports zu `dist`.
3. **Build-Konstanten:** `__DEV__`/`__VERSION__`/`__REVISION__` werden von rollup/vitest injiziert, fehlen unter plain node → `__DEV__ is not defined`.

## Lösung
- `scripts/glsl-loader.mjs` — node-ESM-Loader-Hook: lädt `.vert`/`.frag` als Source-Text (das node/tsx-Pendant des vitest `realShaderPlugin`) **und** aliast die `@codexo/exojs*`-Workspace-Pakete auf `src` (Spiegel der vitest `aliasConfig` — die Extension-Pakete exportieren keine `@codexo/source`-Condition).
- `scripts/glsl-register.mjs` — registriert den Hook + setzt die Build-Konstanten-Globals.
- `run-allocation.ts` — + Tilemap static/pan-Szenarien; `package.json` ruft mit `--conditions=@codexo/source` + Loader.

## Tilemap-Caching belegt (die ursprüngliche Frage)
| Szene | KB/frame |
|---|---|
| tilemap/80x64 static | 7.7 |
| tilemap/80x64 pan | 6.2 |

5120 Tiles → ~7 KB/Frame, pan ≈ static (0 Chunk-Geometry-Rebuilds) — ~200× weniger als dieselben Tiles als Einzel-Sprites. Bestätigt das revisions-basierte Chunk-Caching.

Berührt keinen src-/Test-Code; `pnpm test` unverändert. typecheck/lint/format grün.