### PR TITLE
perf(rendering): O(n^2)->O(n) RenderPlanOptimizer overlap grouping (W3)

### DIFF
--- a/src/rendering/plan/RenderPlanOptimizer.ts
+++ b/src/rendering/plan/RenderPlanOptimizer.ts
@@ -154,6 +154,20 @@ export class RenderPlanOptimizer {
       return;
     }
 
+    // O(1) position lookup. Each `entries.indexOf(entry, segStart)` below was an
+    // O(n) scan; with many same-z draws (e.g. cycled textures over a flat list)
+    // that made this method O(n^2). A scope's entries are distinct objects, so a
+    // single Map over `entries[segStart..segEnd)` yields the same first-match
+    // index `indexOf` returned — and the only reorder this method performs is the
+    // last thing it does before `break`, so no lookup ever runs against stale
+    // positions (the map stays valid for the whole scan).
+    const positionIndex = new Map<ScopeEntry, number>();
+
+    for (let i = segStart; i < segEnd; i++) {
+      // In-bounds: i in [segStart, segEnd).
+      positionIndex.set(entries[i]!, i);
+    }
+
     for (const group of keyGroups.values()) {
       if (group.length <= 1) {
         continue;
@@ -162,9 +176,10 @@ export class RenderPlanOptimizer {
       const positions: number[] = [];
 
       for (const g of group) {
-        const pos = entries.indexOf(g.entry, segStart);
+        const pos = positionIndex.get(g.entry);
 
-        if (pos >= segStart && pos < segEnd) {
+        // The map holds only entries in [segStart, segEnd); a hit is in range.
+        if (pos !== undefined) {
           positions.push(pos);
         }
       }


### PR DESCRIPTION
Macht den `RenderPlanOptimizer` bei multi-material Szenen drastisch schneller — der letzte v0.15-Render-Perf-Slice. **Nicht** der ursprünglich geplante Plan-Cache (2f), sondern ein Algorithmus-Fix (warum: unten).

## Befund (gemessen)
`RenderPlanOptimizer.optimize` kostete bei **10000 Sprites / 8 cycled Texturen 14 ms/Frame (71% der Plan-CPU)** — fast das ganze 60fps-Budget. Bei 1 Textur harmlos (1.3 ms). Ursache: `_overlapAwareGroup` machte ein O(n) `entries.indexOf` pro Gruppen-Eintrag → O(n²) bei vielen gleichfarbigen, überlappenden Draws.

## Fix
Ein einmaliger `Map<entry, position>`-Index über das Segment ersetzt die `indexOf`-Suchen (O(1) Lookup). +17/-2 Zeilen.

## Ergebnis (optimize CPU, ms/frame)
| Szene | vorher | nachher |
|---|---:|---:|
| 10000 / 8tex | 14.1 | **2.3** (~6x) |
| 1000 / 8tex | 0.33 | 0.21 |
| 1 Textur | unverändert | unverändert |

## Korrektheit
**Bit-identische Gruppierung** — jeder `command.groupIndex` + die Entry-Reihenfolge über 8 Szenen gehasht und identisch; `test/rendering` 1035/1035 inkl. der Wächter `render-instructions` + `transform-buffer-upload-count`.

## Warum statt 2f (Plan-Cache)
Das per-Call-Site-Profil zeigte: die Reststatik war zu 89% der Optimizer, und der Hauptschmerz war **CPU-Zeit, nicht Allocation**. Ein Plan-Cache würde die Cull-Menge einfrieren — Korrektheits-Risiko, wenn ein Objekt ins Frustum eintritt (pixi v8 trennt darum Culling vom Instruction-Cache). Den Algorithmus zu fixen ist sicher, hat keinen Cull-Trade-off und hilft auch bewegten Szenen.

Volle CI-Parität lokal grün (test 3423, lint:all, format, docs:api, typecheck core+5 Pakete).