### PR TITLE
v0.15 W4 — Robustheit: deser validation (4a) + physics scratch-reuse & honest alloc gate (5a)

### DIFF
--- a/packages/exojs-physics/src/Collider.ts
+++ b/packages/exojs-physics/src/Collider.ts
@@ -56,6 +56,10 @@ export class Collider {
   private readonly _worldTransform: Transform = createTransform();
   private readonly _aabb: Aabb = createAabb();
   private readonly _worldCenter: Mutable2D = { x: 0, y: 0 };
+  // Reused per-vertex scratch for synchronize()'s polygon transform loop so a
+  // collider sync allocates nothing. Instance-private: never held across the
+  // call, never aliased between colliders.
+  private readonly _syncScratch: Mutable2D = { x: 0, y: 0 };
   private readonly _worldVertices: number[];
   private readonly _worldNormals: number[];
 
@@ -165,7 +169,7 @@ export class Collider {
     const polygon = this.shape;
     const local = polygon.vertices;
     const normals = polygon.normals;
-    const out: Mutable2D = { x: 0, y: 0 };
+    const out = this._syncScratch;
     let minX = Infinity;
     let minY = Infinity;
     let maxX = -Infinity;

--- a/packages/exojs-physics/src/broadphase/SweepAndPrune.ts
+++ b/packages/exojs-physics/src/broadphase/SweepAndPrune.ts
@@ -11,12 +11,19 @@ import type { BroadPhase, CandidatePair } from './BroadPhase';
  */
 export class SweepAndPrune implements BroadPhase {
   private readonly _sorted: Collider[] = [];
+  // Pooled CandidatePair objects, reused across steps instead of allocating one
+  // per overlapping pair. `out` holds references into the pool and is consumed
+  // within the same step (ContactGraph reads pair.a/pair.b before the next
+  // computePairs overwrites the pool), so the reuse is safe.
+  private readonly _pairPool: CandidatePair[] = [];
 
   public computePairs(colliders: readonly Collider[], out: CandidatePair[]): CandidatePair[] {
     out.length = 0;
 
     const sorted = this._sorted;
     sorted.length = 0;
+    const pool = this._pairPool;
+    let poolCount = 0;
 
     for (const collider of colliders) {
       sorted.push(collider);
@@ -59,7 +66,20 @@ export class SweepAndPrune implements BroadPhase {
           continue;
         }
 
-        out.push(a.id < b.id ? { a, b } : { a: b, b: a });
+        const lo = a.id < b.id ? a : b;
+        const hi = a.id < b.id ? b : a;
+        let pair = pool[poolCount];
+
+        if (pair === undefined) {
+          pair = { a: lo, b: hi };
+          pool.push(pair);
+        } else {
+          pair.a = lo;
+          pair.b = hi;
+        }
+
+        poolCount++;
+        out.push(pair);
       }
     }
 

--- a/packages/exojs-physics/src/collision/narrowphase.ts
+++ b/packages/exojs-physics/src/collision/narrowphase.ts
@@ -203,8 +203,28 @@ const newClipPair = (): [ClipVertex, ClipVertex] => [
   { x: 0, y: 0, id: 0 },
 ];
 
-/** Max separation of `b` from any face of `a`, with the supporting face index. */
-const findMaxSeparation = (a: CollisionProxy, b: CollisionProxy): { separation: number; edge: number } => {
+// Module-local clip scratch reused across collidePolygons calls instead of
+// allocating a fresh pair per contact. The narrow phase is single-threaded and
+// non-reentrant — a world step calls `collide` strictly sequentially per pair,
+// with no nested self-call or async — so module-global scratch is safe and may
+// be shared across worlds (world-isolation.test.ts guards the multi-world
+// invariant). The three pairs MUST stay separate: incident → clipped1 →
+// clipped2 are simultaneously live (each clip reads the previous clip's output).
+const _incidentScratch = newClipPair();
+const _clipped1Scratch = newClipPair();
+const _clipped2Scratch = newClipPair();
+
+interface Separation {
+  separation: number;
+  edge: number;
+}
+
+// Two separate scratches: collidePolygons holds sepA and sepB at the same time.
+const _sepA: Separation = { separation: 0, edge: 0 };
+const _sepB: Separation = { separation: 0, edge: 0 };
+
+/** Max separation of `b` from any face of `a`, with the supporting face index. Writes into and returns `out` (allocation-free). */
+const findMaxSeparation = (a: CollisionProxy, b: CollisionProxy, out: Separation): Separation => {
   const av = a.worldVertices;
   const an = a.worldNormals;
   const ac = countOf(a);
@@ -246,7 +266,10 @@ const findMaxSeparation = (a: CollisionProxy, b: CollisionProxy): { separation: 
     }
   }
 
-  return { separation: best, edge: bestEdge };
+  out.separation = best;
+  out.edge = bestEdge;
+
+  return out;
 };
 
 /** Incident face of `inc` = the face most anti-parallel to the reference normal. */
@@ -332,13 +355,13 @@ const encodeId = (flip: boolean, refEdge: number, incidentId: number): number =>
 
 /** Convex polygon vs convex polygon: SAT reference face + Sutherland-Hodgman clip. */
 const collidePolygons = (a: CollisionProxy, b: CollisionProxy, manifold: Manifold): boolean => {
-  const sepA = findMaxSeparation(a, b);
+  const sepA = findMaxSeparation(a, b, _sepA);
 
   if (sepA.separation >= 0) {
     return false;
   }
 
-  const sepB = findMaxSeparation(b, a);
+  const sepB = findMaxSeparation(b, a, _sepB);
 
   if (sepB.separation >= 0) {
     return false;
@@ -375,7 +398,7 @@ const collidePolygons = (a: CollisionProxy, b: CollisionProxy, manifold: Manifol
   const refNx = rn[refEdge * 2]!;
   const refNy = rn[refEdge * 2 + 1]!;
 
-  const incident = newClipPair();
+  const incident = _incidentScratch;
   findIncidentFace(refNx, refNy, inc, incident);
 
   // Reference-face tangent (the side-plane direction).
@@ -388,13 +411,13 @@ const collidePolygons = (a: CollisionProxy, b: CollisionProxy, manifold: Manifol
   const negSide = -(tx * v1x + ty * v1y);
   const posSide = tx * v2x + ty * v2y;
 
-  const clipped1 = newClipPair();
+  const clipped1 = _clipped1Scratch;
 
   if (clipSegment(-tx, -ty, negSide, incident, clipped1, encodeId(flip, refEdge, 0xffe)) < 2) {
     return false;
   }
 
-  const clipped2 = newClipPair();
+  const clipped2 = _clipped2Scratch;
 
   if (clipSegment(tx, ty, posSide, clipped1, clipped2, encodeId(flip, refEdge, 0xfff)) < 2) {
     return false;
@@ -454,7 +477,7 @@ export const testOverlap = (a: CollisionProxy, b: CollisionProxy): boolean => {
     return circlePolygonOverlap(b, a);
   }
 
-  return findMaxSeparation(a, b).separation < 0 && findMaxSeparation(b, a).separation < 0;
+  return findMaxSeparation(a, b, _sepA).separation < 0 && findMaxSeparation(b, a, _sepB).separation < 0;
 };
 
 const circlePolygonOverlap = (circle: CollisionProxy, polygon: CollisionProxy): boolean => {

--- a/packages/exojs-physics/test/allocationSampler.ts
+++ b/packages/exojs-physics/test/allocationSampler.ts
@@ -1,0 +1,95 @@
+/**
+ * Allocation-rate sampler for the physics perf gate.
+ *
+ * Mirrors the render-perf harness's method (root `test/perf/rendering/
+ * allocation.ts`): a `heapUsed` delta does NOT measure short-lived per-step
+ * garbage — V8 reclaims it concurrently during the window, so it never shows up
+ * in a heap-size diff (a `heapUsed` delta reports retained growth plus noise,
+ * not the throwaway rate). Instead this uses V8's allocation **sampling
+ * profiler** via `node:inspector`, started with the `includeObjectsCollectedBy*
+ * GC` flags — without them the profile reports only objects still live at stop
+ * and misses the dead-on-arrival garbage entirely (a ~500× undercount). It
+ * records at allocation time, is statistical (one sample per `samplingInterval`
+ * bytes) but accurate over a window of many iterations, and needs no
+ * `--expose-gc`.
+ *
+ * Kept as a small package-local copy (rather than importing the root render
+ * helper) so the physics package test suite stays self-contained.
+ *
+ * @internal Test/perf-only.
+ */
+import { Session } from 'node:inspector';
+
+export interface AllocationRate {
+  /** Mean bytes allocated per iteration (includes immediately-dead garbage). */
+  readonly bytesPerIteration: number;
+  /** Total bytes sampled across the window. */
+  readonly totalBytes: number;
+  /** Iterations sampled. */
+  readonly iterations: number;
+}
+
+/** Recursively sum `selfSize` across the sampling-profile tree = total sampled bytes. */
+const sumSelfSize = (node: import('node:inspector').HeapProfiler.SamplingHeapProfileNode): number =>
+  node.selfSize + node.children.reduce((total, child) => total + sumSelfSize(child), 0);
+
+export interface AllocationSampleOptions {
+  /** Iterations sampled for the rate (default 200). More → less statistical noise. */
+  readonly iterations?: number;
+  /** Warm-up iterations before sampling, excluding one-time growth (default 0; callers usually pre-settle). */
+  readonly warmup?: number;
+  /** Sampling interval in bytes (default 256). Smaller = finer but larger profiles. */
+  readonly samplingInterval?: number;
+}
+
+/**
+ * Sample the per-iteration allocation rate of `run` (e.g. one `world.step`).
+ * See the module comment for why this uses the sampling profiler rather than a
+ * `heapUsed` delta.
+ */
+export const measureAllocationRate = async (run: () => void, options: AllocationSampleOptions = {}): Promise<AllocationRate> => {
+  const iterations = options.iterations ?? 200;
+  const warmup = options.warmup ?? 0;
+  const samplingInterval = options.samplingInterval ?? 256;
+
+  for (let i = 0; i < warmup; i++) {
+    run();
+  }
+
+  const session = new Session();
+  session.connect();
+
+  const post = <T>(method: string, params?: Record<string, unknown>): Promise<T> =>
+    new Promise((resolve, reject) => {
+      session.post(method, params, (error: Error | null, result?: unknown) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve(result as T);
+      });
+    });
+
+  await post('HeapProfiler.enable');
+  // CRITICAL: without these flags the profiler reports only objects still LIVE
+  // at stopSampling and discards the throwaway per-step garbage this gate exists
+  // to catch (a ~500× undercount). Node ≥ 20; older runtimes ignore the keys.
+  await post('HeapProfiler.startSampling', {
+    samplingInterval,
+    includeObjectsCollectedByMajorGC: true,
+    includeObjectsCollectedByMinorGC: true,
+  });
+
+  for (let i = 0; i < iterations; i++) {
+    run();
+  }
+
+  const { profile } = await post<{ profile: import('node:inspector').HeapProfiler.SamplingHeapProfile }>('HeapProfiler.stopSampling');
+  await post('HeapProfiler.disable');
+  session.disconnect();
+
+  const totalBytes = sumSelfSize(profile.head);
+
+  return { bytesPerIteration: totalBytes / iterations, totalBytes, iterations };
+};

--- a/packages/exojs-physics/test/perf.test.ts
+++ b/packages/exojs-physics/test/perf.test.ts
@@ -81,15 +81,7 @@ describe('physics dynamics performance (P-1 / P-2)', () => {
     // P-2 — steady-state step time.
     const msPerStep = stepTimes(world, 180);
 
-    // P-1 — steady-state allocation rate via the sampling profiler. The scene is
-    // already settled (every contact persistent, no begin/end events allocate in
-    // the window), so the sampler measures only the per-step narrow/broad-phase
-    // and solver work.
-    const alloc = await measureAllocationRate(() => world.step(FRAME), { iterations: 200 });
-    const bytesPerStep = alloc.bytesPerIteration;
-
     console.log(`[P-2] ${msPerStep.toFixed(3)} ms/step · 1,000 bodies (${(1000 / msPerStep).toFixed(0)} body-steps/ms · ${(16.67 / msPerStep).toFixed(0)}× headroom at 60fps)`);
-    console.log(`[P-1] ${(bytesPerStep / 1024).toFixed(2)} KB/step allocation (sampling profiler)`);
 
     // Sanity: nothing exploded.
     for (const body of bodies) {
@@ -100,12 +92,35 @@ describe('physics dynamics performance (P-1 / P-2)', () => {
     // Catastrophic-regression guard only (P-2 is recorded, not tightly enforced).
     expect(msPerStep).toBeLessThan(100);
 
-    // Regression guard for the scratch-reuse win: the sampling profiler measures
-    // ~810 KB/step after reuse vs ~1560 KB/step before (narrow/broad-phase
-    // pooling roughly halves per-step allocation). The remaining ~810 KB is
-    // dominated by the contact solver (_solveNormalBlock) and ContactGraph.update
-    // — outside this slice's scope (see the W4 spec backlog). The threshold sits
-    // between the two rates, so losing the reuse trips the gate.
+    // P-1 — steady-state allocation rate via the sampling profiler. The scene is
+    // already settled (every contact persistent, no begin/end events allocate in
+    // the window), so the sampler measures only the per-step narrow/broad-phase
+    // and solver work.
+    //
+    // Skipped entirely under istanbul coverage: it instruments the physics package
+    // source, which both inflates the per-step allocation ~7× (measured ~5.8 MB vs
+    // ~0.8 MB — the absolute byte gate is meaningless) and slows the 200-iteration
+    // sampling run past the test timeout. The sharp gate runs in the normal
+    // `pnpm test` run + `verify:ci`. (Detection: istanbul prefixes every function
+    // with a `cov_…()` prologue; globalThis.__coverage__ is not yet populated at
+    // test time. The render-perf gate needs no guard — its src resolves via
+    // #*-subpath imports istanbul leaves alone.)
+    if (world.step.toString().includes('cov_')) {
+      console.log('[P-1] allocation gate skipped under coverage (instrumentation inflates + slows the measurement)');
+
+      return;
+    }
+
+    const alloc = await measureAllocationRate(() => world.step(FRAME), { iterations: 200 });
+    const bytesPerStep = alloc.bytesPerIteration;
+
+    console.log(`[P-1] ${(bytesPerStep / 1024).toFixed(2)} KB/step allocation (sampling profiler)`);
+
+    // Regression guard for the scratch-reuse win: ~810 KB/step after reuse vs
+    // ~1560 KB/step before (narrow/broad-phase pooling roughly halves it). The
+    // remaining ~810 KB is dominated by the contact solver (_solveNormalBlock) +
+    // ContactGraph.update — outside this slice's scope (W4 spec backlog). The
+    // threshold sits between the two rates, so losing the reuse trips the gate.
     expect(bytesPerStep).toBeLessThan(1_100 * 1024);
   });
 });

--- a/packages/exojs-physics/test/perf.test.ts
+++ b/packages/exojs-physics/test/perf.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { BoxShape, PhysicsWorld } from '../src/index';
 import { PhysicsBody } from '../src/PhysicsBody';
+import { measureAllocationRate } from './allocationSampler';
 
 /**
  * Phase-2B performance gates (spec `04` §3): P-1 steady-state allocation and P-2
@@ -11,13 +12,17 @@ import { PhysicsBody } from '../src/PhysicsBody';
  *
  * P-2 (step time) is **recorded** on the reference machine, not enforced as a
  * tight CI threshold (machine-dependent) — only a generous catastrophic-
- * regression guard is asserted. P-1 (allocation) is measured as the retained
- * heap delta across steps; with `--expose-gc` it is forced-collected for a clean
- * number, otherwise it is an upper bound. Numbers are printed for the record.
+ * regression guard is asserted. P-1 (allocation) is measured with V8's
+ * allocation sampling profiler (see allocationSampler.ts — a heapUsed delta
+ * cannot see the short-lived per-step garbage; it previously read ~0 and made
+ * the engine look allocation-free when it was not). The narrow/broad-phase
+ * scratch reuse roughly halves per-step allocation (~1560 → ~810 KB/step); the
+ * remainder is dominated by the contact solver and ContactGraph and is tracked
+ * as a follow-up (W4 spec backlog). The gate is a regression guard for the
+ * reuse win, not a zero-allocation assertion.
  */
 
 const FRAME = 1 / 60;
-const forceGc = (globalThis as { gc?: () => void }).gc;
 
 /** A wide field of `columns` independent `rows`-high box stacks on a static floor. */
 const buildField = (columns: number, rows: number): { world: PhysicsWorld; bodies: PhysicsBody[] } => {
@@ -63,7 +68,7 @@ const stepTimes = (world: PhysicsWorld, steps: number): number => {
 };
 
 describe('physics dynamics performance (P-1 / P-2)', () => {
-  it('1,000-body settled field: step time + steady-state allocation', () => {
+  it('1,000-body settled field: step time + steady-state allocation', async () => {
     const { world, bodies } = buildField(200, 5);
 
     expect(bodies.length).toBe(1000);
@@ -76,20 +81,15 @@ describe('physics dynamics performance (P-1 / P-2)', () => {
     // P-2 — steady-state step time.
     const msPerStep = stepTimes(world, 180);
 
-    // P-1 — retained heap delta across steady-state steps.
-    forceGc?.();
-    const heapBefore = process.memoryUsage().heapUsed;
-
-    for (let i = 0; i < 300; i++) {
-      world.step(FRAME);
-    }
-
-    forceGc?.();
-    const heapAfter = process.memoryUsage().heapUsed;
-    const bytesPerStep = (heapAfter - heapBefore) / 300;
+    // P-1 — steady-state allocation rate via the sampling profiler. The scene is
+    // already settled (every contact persistent, no begin/end events allocate in
+    // the window), so the sampler measures only the per-step narrow/broad-phase
+    // and solver work.
+    const alloc = await measureAllocationRate(() => world.step(FRAME), { iterations: 200 });
+    const bytesPerStep = alloc.bytesPerIteration;
 
     console.log(`[P-2] ${msPerStep.toFixed(3)} ms/step · 1,000 bodies (${(1000 / msPerStep).toFixed(0)} body-steps/ms · ${(16.67 / msPerStep).toFixed(0)}× headroom at 60fps)`);
-    console.log(`[P-1] ${(bytesPerStep / 1024).toFixed(2)} KB/step retained heap${forceGc ? ' (forced GC)' : ' (upper bound, no --expose-gc)'}`);
+    console.log(`[P-1] ${(bytesPerStep / 1024).toFixed(2)} KB/step allocation (sampling profiler)`);
 
     // Sanity: nothing exploded.
     for (const body of bodies) {
@@ -100,9 +100,12 @@ describe('physics dynamics performance (P-1 / P-2)', () => {
     // Catastrophic-regression guard only (P-2 is recorded, not tightly enforced).
     expect(msPerStep).toBeLessThan(100);
 
-    // With forced GC the steady-state allocation should be near zero (pooling).
-    if (forceGc) {
-      expect(bytesPerStep).toBeLessThan(8 * 1024);
-    }
+    // Regression guard for the scratch-reuse win: the sampling profiler measures
+    // ~810 KB/step after reuse vs ~1560 KB/step before (narrow/broad-phase
+    // pooling roughly halves per-step allocation). The remaining ~810 KB is
+    // dominated by the contact solver (_solveNormalBlock) and ContactGraph.update
+    // — outside this slice's scope (see the W4 spec backlog). The threshold sits
+    // between the two rates, so losing the reuse trips the gate.
+    expect(bytesPerStep).toBeLessThan(1_100 * 1024);
   });
 });

--- a/src/core/serialization/SerializationRegistry.ts
+++ b/src/core/serialization/SerializationRegistry.ts
@@ -127,7 +127,7 @@ export const defaultSerializationRegistry = new SerializationRegistry();
  * ```ts
  * registerSerializer('PowerUp', PowerUp, {
  *   write: (node) => ({ kind: node.kind }),
- *   read: (data) => new PowerUp(data.kind as string),
+ *   read: (data) => new PowerUp(typeof data.kind === 'string' ? data.kind : ''),
  * });
  * ```
  */

--- a/src/core/serialization/coreSerializers.ts
+++ b/src/core/serialization/coreSerializers.ts
@@ -3,15 +3,14 @@ import { Rectangle } from '#math/Rectangle';
 import { Container } from '#rendering/Container';
 import type { RenderNode } from '#rendering/RenderNode';
 import { Sprite } from '#rendering/sprite/Sprite';
-import type { LayoutOptions } from '#rendering/text/LayoutOptions';
 import { SDF_RADIUS, Text } from '#rendering/text/Text';
 import { Texture } from '#rendering/texture/Texture';
 
 import type { NodeSerializer } from './NodeSerializer';
+import { asSerializedNode } from './read';
 import { registerRenderingSerializers } from './renderingSerializers';
 import type { SerializationRegistry } from './SerializationRegistry';
-import { compact, deserializeStyleOptions, serializeStyle } from './serializerHelpers';
-import type { SerializedNode } from './types';
+import { compact, deserializeStyleOptions, readLayoutOptions, serializeStyle } from './serializerHelpers';
 import { registerUiSerializers } from './uiSerializers';
 
 // ── Container ────────────────────────────────────────────────────────────────
@@ -30,7 +29,8 @@ const containerSerializer: NodeSerializer<Container> = {
 
     if (Array.isArray(children)) {
       for (const child of children) {
-        node.addChild(ctx.readNode(child as SerializedNode) as RenderNode);
+        const childNode = asSerializedNode(child);
+        if (childNode !== null) node.addChild(ctx.readNode(childNode) as RenderNode);
       }
     }
 
@@ -95,7 +95,7 @@ const textSerializer: NodeSerializer<Text> = {
     return out;
   },
   read(data) {
-    const layout = typeof data.layout === 'object' && data.layout !== null ? (data.layout as LayoutOptions) : undefined;
+    const layout = readLayoutOptions(data.layout);
 
     return new Text(
       typeof data.text === 'string' ? data.text : '',

--- a/src/core/serialization/read.ts
+++ b/src/core/serialization/read.ts
@@ -1,0 +1,115 @@
+import type { FontWeight } from '#rendering/text/TextStyle';
+import type { TextAlignment } from '#rendering/text/types';
+import type { RepeatFit, RepeatMode } from '#rendering/texture/repeat';
+
+import type { SerializedNode } from './types';
+
+/**
+ * Validating read helpers for deserialization — **check instead of cast**.
+ *
+ * Deserialized JSON is treated as untrusted input (it may come from a save
+ * file, cloud sync, shared prefab, or user-generated content). Every field
+ * access goes through one of these helpers so a manipulated or corrupt document
+ * can only ever cause a field to be *ignored* (falling back to the constructor
+ * default) — never to inject an unchecked value of the wrong type/domain into
+ * the engine. Structural top-level errors are rejected at the boundary
+ * (`migrate` / `Scene.deserialize`); per-field garbage degrades to defaults.
+ *
+ * The `read*` helpers take `(data, key)` for field access; the `as*` helpers
+ * narrow an already-extracted value (used for nested elements).
+ *
+ * @internal
+ */
+
+type Data = Record<string, unknown>;
+
+/** Read a string field; `fallback` (or `undefined`) when absent or not a string. */
+export function readString(data: Data, key: string): string | undefined;
+export function readString(data: Data, key: string, fallback: string): string;
+export function readString(data: Data, key: string, fallback?: string): string | undefined {
+  const value = data[key];
+
+  return typeof value === 'string' ? value : fallback;
+}
+
+/**
+ * Read a finite-number field; `fallback` (or `undefined`) when absent, not a
+ * number, or non-finite. The finite check rejects `NaN`/`Infinity` smuggled in
+ * through a hand-edited document.
+ */
+export function readNumber(data: Data, key: string): number | undefined;
+export function readNumber(data: Data, key: string, fallback: number): number;
+export function readNumber(data: Data, key: string, fallback?: number): number | undefined {
+  const value = data[key];
+
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+/** Read a boolean field; `fallback` (or `undefined`) when absent or not a boolean. */
+export function readBoolean(data: Data, key: string): boolean | undefined;
+export function readBoolean(data: Data, key: string, fallback: boolean): boolean;
+export function readBoolean(data: Data, key: string, fallback?: boolean): boolean | undefined {
+  const value = data[key];
+
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+/**
+ * Read a string field constrained to `allowed`; `fallback` (or `undefined`)
+ * when absent or not a member. The cast is performed **after** the runtime
+ * membership check, so it is sound — this is the helper that replaces the bare
+ * `data.x as SomeEnum` casts.
+ */
+export function readEnum<T extends string>(data: Data, key: string, allowed: readonly T[]): T | undefined;
+export function readEnum<T extends string>(data: Data, key: string, allowed: readonly T[], fallback: T): T;
+export function readEnum<T extends string>(data: Data, key: string, allowed: readonly T[], fallback?: T): T | undefined {
+  const value = data[key];
+
+  return typeof value === 'string' && (allowed as readonly string[]).includes(value) ? (value as T) : fallback;
+}
+
+/** Read an object-valued (non-array) field as a record, or `undefined`. */
+export function readObject(data: Data, key: string): Data | undefined {
+  return asObject(data[key]) ?? undefined;
+}
+
+/** Narrow an already-extracted value to a plain object record, or `null`. */
+export function asObject(value: unknown): Data | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) ? (value as Data) : null;
+}
+
+/**
+ * Narrow an already-extracted value to a {@link SerializedNode} (an object
+ * carrying a string `type` tag), or `null`. Guards the recursive child descent
+ * so a `children` array containing non-objects is skipped rather than crashing
+ * with `Cannot read 'type' of …`.
+ */
+export function asSerializedNode(value: unknown): SerializedNode | null {
+  return typeof value === 'object' && value !== null && typeof (value as Data).type === 'string' ? (value as SerializedNode) : null;
+}
+
+/**
+ * Narrow an already-extracted value to an array of finite numbers (non-numeric
+ * or non-finite entries collapse to `0`), or `null` when not an array.
+ */
+export function asNumberArray(value: unknown): number[] | null {
+  return Array.isArray(value) ? value.map(entry => (typeof entry === 'number' && Number.isFinite(entry) ? entry : 0)) : null;
+}
+
+// ── Serialized-enum value lists ──────────────────────────────────────────────
+// `satisfies readonly T[]` makes a typo here a compile error (a listed value
+// that is not a union member fails to type-check). If a new union member is
+// added upstream, an omission here only makes an otherwise-valid value fall
+// back to its default — never unsafe — so keep these in sync deliberately.
+
+/** Allowed {@link FontWeight} values for {@link readEnum}. */
+export const FONT_WEIGHTS = ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900'] as const satisfies readonly FontWeight[];
+
+/** Allowed {@link TextAlignment} values for {@link readEnum}. */
+export const TEXT_ALIGNMENTS = ['left', 'center', 'right', 'justify'] as const satisfies readonly TextAlignment[];
+
+/** Allowed {@link RepeatMode} values for {@link readEnum}. */
+export const REPEAT_MODES = ['stretch', 'repeat', 'mirror-repeat'] as const satisfies readonly RepeatMode[];
+
+/** Allowed {@link RepeatFit} values for {@link readEnum}. */
+export const REPEAT_FITS = ['clip', 'round'] as const satisfies readonly RepeatFit[];

--- a/src/core/serialization/renderingSerializers.ts
+++ b/src/core/serialization/renderingSerializers.ts
@@ -9,22 +9,62 @@ import { NineSliceSprite } from '#rendering/sprite/NineSliceSprite';
 import { RepeatingSprite } from '#rendering/sprite/RepeatingSprite';
 import { BitmapText } from '#rendering/text/BitmapText';
 import { BmFont } from '#rendering/text/BmFont';
-import type { LayoutOptions } from '#rendering/text/LayoutOptions';
-import type { RepeatFit, RepeatMode } from '#rendering/texture/repeat';
 import { Texture } from '#rendering/texture/Texture';
 import { Video } from '#rendering/video/Video';
 
 import type { NodeSerializer } from './NodeSerializer';
+import { asNumberArray, asObject, asSerializedNode, readBoolean, readEnum, REPEAT_FITS, REPEAT_MODES } from './read';
 import type { SerializationRegistry } from './SerializationRegistry';
-import { compact, deserializeStyleOptions, serializeStyle } from './serializerHelpers';
-import type { SerializedNode } from './types';
+import { compact, deserializeStyleOptions, readLayoutOptions, serializeStyle } from './serializerHelpers';
 
 // ── Small helpers ────────────────────────────────────────────────────────────
 
 const toF32 = (value: unknown): Float32Array => (Array.isArray(value) ? new Float32Array(value.map(Number)) : new Float32Array());
 const toU16 = (value: unknown): Uint16Array => (Array.isArray(value) ? new Uint16Array(value.map(Number)) : new Uint16Array());
 const toU32 = (value: unknown): Uint32Array => (Array.isArray(value) ? new Uint32Array(value.map(Number)) : new Uint32Array());
-const num = (value: unknown): number | undefined => (typeof value === 'number' ? value : undefined);
+const num = (value: unknown): number | undefined => (typeof value === 'number' && Number.isFinite(value) ? value : undefined);
+
+/** Read a {@link NineSliceInsets} from JSON, defaulting any missing/invalid edge to 0 (never `undefined` — `slices` is required and `undefined` would crash `normalizeInsets`). */
+const readInsets = (value: unknown): NineSliceInsets => {
+  const source = asObject(value);
+
+  return {
+    left: num(source?.left) ?? 0,
+    top: num(source?.top) ?? 0,
+    right: num(source?.right) ?? 0,
+    bottom: num(source?.bottom) ?? 0,
+  };
+};
+
+/** Read {@link NineSliceModes} from JSON, keeping only valid enum fields (invalid ones fall back to the renderer's defaults). */
+const readModes = (value: unknown): NineSliceModes | undefined => {
+  const source = asObject(value);
+
+  if (source === null) {
+    return undefined;
+  }
+
+  const out: { -readonly [K in keyof NineSliceModes]: NineSliceModes[K] } = {};
+
+  const edges = readEnum(source, 'edges', REPEAT_MODES);
+  if (edges !== undefined) out.edges = edges;
+  const center = readEnum(source, 'center', REPEAT_MODES);
+  if (center !== undefined) out.center = center;
+  const top = readEnum(source, 'top', REPEAT_MODES);
+  if (top !== undefined) out.top = top;
+  const right = readEnum(source, 'right', REPEAT_MODES);
+  if (right !== undefined) out.right = right;
+  const bottom = readEnum(source, 'bottom', REPEAT_MODES);
+  if (bottom !== undefined) out.bottom = bottom;
+  const left = readEnum(source, 'left', REPEAT_MODES);
+  if (left !== undefined) out.left = left;
+  const edgeFit = readEnum(source, 'edgeFit', REPEAT_FITS);
+  if (edgeFit !== undefined) out.edgeFit = edgeFit;
+  const centerFit = readEnum(source, 'centerFit', REPEAT_FITS);
+  if (centerFit !== undefined) out.centerFit = centerFit;
+
+  return out;
+};
 
 // ── Mesh ─────────────────────────────────────────────────────────────────────
 
@@ -78,7 +118,8 @@ const graphicsSerializer: NodeSerializer<Graphics> = {
 
     if (Array.isArray(children)) {
       for (const child of children) {
-        node.addChild(ctx.readNode(child as SerializedNode) as RenderNode);
+        const childNode = asSerializedNode(child);
+        if (childNode !== null) node.addChild(ctx.readNode(childNode) as RenderNode);
       }
     }
 
@@ -113,9 +154,9 @@ const nineSliceSerializer: NodeSerializer<NineSliceSprite> = {
     return new NineSliceSprite(
       texture,
       compact({
-        slices: data.slices as NineSliceInsets,
-        border: data.border as NineSliceInsets,
-        modes: data.modes as NineSliceModes,
+        slices: readInsets(data.slices),
+        border: asObject(data.border) !== null ? readInsets(data.border) : undefined,
+        modes: readModes(data.modes),
         width: num(data.width),
         height: num(data.height),
       }),
@@ -155,10 +196,10 @@ const repeatingSerializer: NodeSerializer<RepeatingSprite> = {
       compact({
         width: num(data.width),
         height: num(data.height),
-        modeX: data.modeX as RepeatMode,
-        modeY: data.modeY as RepeatMode,
-        fitX: data.fitX as RepeatFit,
-        fitY: data.fitY as RepeatFit,
+        modeX: readEnum(data, 'modeX', REPEAT_MODES),
+        modeY: readEnum(data, 'modeY', REPEAT_MODES),
+        fitX: readEnum(data, 'fitX', REPEAT_FITS),
+        fitY: readEnum(data, 'fitY', REPEAT_FITS),
         offsetX: num(data.offsetX),
         offsetY: num(data.offsetY),
       }),
@@ -199,18 +240,25 @@ const animatedSpriteSerializer: NodeSerializer<AnimatedSprite> = {
     const clips: Record<string, AnimatedSpriteClipDefinition> = {};
     const clipsData = data.clips;
 
-    if (typeof clipsData === 'object' && clipsData !== null) {
-      for (const [name, raw] of Object.entries(clipsData as Record<string, unknown>)) {
-        const clip = raw as { frames?: unknown; fps?: unknown; loop?: unknown };
+    const clipsObject = asObject(clipsData);
+
+    if (clipsObject !== null) {
+      for (const [name, raw] of Object.entries(clipsObject)) {
+        const clip = asObject(raw);
+
+        if (clip === null) {
+          continue;
+        }
+
         const frames = Array.isArray(clip.frames)
           ? clip.frames.map(frame => {
-              const values = frame as number[];
+              const values = asNumberArray(frame) ?? [];
 
-              return new Rectangle(Number(values[0]), Number(values[1]), Number(values[2]), Number(values[3]));
+              return new Rectangle(values[0] ?? 0, values[1] ?? 0, values[2] ?? 0, values[3] ?? 0);
             })
           : [];
 
-        clips[name] = compact({ frames, fps: num(clip.fps), loop: typeof clip.loop === 'boolean' ? clip.loop : undefined });
+        clips[name] = compact({ frames, fps: num(clip.fps), loop: readBoolean(clip, 'loop') });
       }
     }
 
@@ -253,7 +301,7 @@ const bitmapTextSerializer: NodeSerializer<BitmapText> = {
       throw new Error('BitmapText deserialize requires its BmFont to be pre-loaded into the Loader.');
     }
 
-    const layout = typeof data.layout === 'object' && data.layout !== null ? (data.layout as LayoutOptions) : undefined;
+    const layout = readLayoutOptions(data.layout);
 
     return new BitmapText(
       typeof data.text === 'string' ? data.text : '',

--- a/src/core/serialization/serialize.ts
+++ b/src/core/serialization/serialize.ts
@@ -8,6 +8,7 @@ import type { Loadable, Loader } from '#resources/Loader';
 import { applyCommonFields, writeCommonFields } from './commonFields';
 import { registerCoreSerializers } from './coreSerializers';
 import type { DeserializeContext, SerializeContext } from './NodeSerializer';
+import { asObject, asSerializedNode } from './read';
 import { defaultSerializationRegistry, type SerializationRegistry } from './SerializationRegistry';
 import { SERIALIZATION_VERSION, type SerializedNode, type SerializedScene } from './types';
 
@@ -172,24 +173,48 @@ export function deserializeInto(
 
   if (Array.isArray(children)) {
     for (const child of children) {
-      container.addChild(ctx.readNode(child as SerializedNode) as RenderNode);
+      const childNode = asSerializedNode(child);
+      if (childNode !== null) container.addChild(ctx.readNode(childNode) as RenderNode);
     }
   }
 }
 
 /**
- * Validate and migrate a {@link SerializedScene} to the current
- * {@link SERIALIZATION_VERSION}. Throws if the data is newer than supported.
+ * Validate and migrate a serialized scene document to the current
+ * {@link SERIALIZATION_VERSION}, returning a structurally-sound
+ * {@link SerializedScene}.
+ *
+ * This is the **untrusted top-level boundary**: the parameter is `unknown`
+ * because a save file / cloud document is not guaranteed to match the type. The
+ * frame (`version`/`root`/`ui`) is validated here so downstream `deserialize*`
+ * paths can rely on `root` being a real node. Throws on a non-object document,
+ * a version newer than supported, or a missing/invalid root; an invalid `ui` is
+ * dropped (it is optional) rather than thrown.
+ *
  * The migration chain is empty at v1; future version bumps register
  * version→version+1 transforms here.
  * @internal
  */
-export function migrate(data: SerializedScene): SerializedScene {
-  const version = typeof data.version === 'number' ? data.version : 0;
+export function migrate(data: unknown): SerializedScene {
+  const scene = asObject(data);
+
+  if (scene === null) {
+    throw new Error('Cannot deserialize scene: the document is not an object.');
+  }
+
+  const version = typeof scene.version === 'number' ? scene.version : 0;
 
   if (version > SERIALIZATION_VERSION) {
     throw new Error(`Cannot deserialize scene: data version ${version} is newer than the supported version ${SERIALIZATION_VERSION}.`);
   }
 
-  return data;
+  const root = asSerializedNode(scene.root);
+
+  if (root === null) {
+    throw new Error('Cannot deserialize scene: the document has no valid root node.');
+  }
+
+  const ui = asSerializedNode(scene.ui);
+
+  return ui !== null ? { version, root, ui } : { version, root };
 }

--- a/src/core/serialization/serializerHelpers.ts
+++ b/src/core/serialization/serializerHelpers.ts
@@ -1,6 +1,8 @@
 import { Color } from '#core/Color';
-import type { FontWeight, TextStyleOptions } from '#rendering/text/TextStyle';
-import type { TextAlignment } from '#rendering/text/types';
+import type { LayoutOptions } from '#rendering/text/LayoutOptions';
+import type { TextStyleOptions } from '#rendering/text/TextStyle';
+
+import { FONT_WEIGHTS, readBoolean, readEnum, readNumber, TEXT_ALIGNMENTS } from './read';
 
 // ── Options bags ───────────────────────────────────────────────────────────────
 
@@ -91,7 +93,10 @@ export function deserializeStyleOptions(data: unknown): TextStyleOptions | undef
   const options: TextStyleOptions = {};
 
   if (typeof source.fontFamily === 'string') options.fontFamily = source.fontFamily;
-  if (typeof source.fontWeight === 'string') options.fontWeight = source.fontWeight as FontWeight;
+
+  const fontWeight = readEnum(source, 'fontWeight', FONT_WEIGHTS);
+  if (fontWeight !== undefined) options.fontWeight = fontWeight;
+
   if (source.fontStyle === 'italic' || source.fontStyle === 'normal') options.fontStyle = source.fontStyle;
   if (typeof source.fontSize === 'number') options.fontSize = source.fontSize;
 
@@ -102,7 +107,10 @@ export function deserializeStyleOptions(data: unknown): TextStyleOptions | undef
   if (outlineColor !== undefined) options.outlineColor = outlineColor;
 
   if (typeof source.outlineWidth === 'number') options.outlineWidth = source.outlineWidth;
-  if (typeof source.align === 'string') options.align = source.align as TextAlignment;
+
+  const align = readEnum(source, 'align', TEXT_ALIGNMENTS);
+  if (align !== undefined) options.align = align;
+
   if (typeof source.lineHeight === 'number') options.lineHeight = source.lineHeight;
   if (typeof source.leading === 'number') options.leading = source.leading;
 
@@ -128,4 +136,47 @@ export function deserializeStyleOptions(data: unknown): TextStyleOptions | undef
   }
 
   return options;
+}
+
+// ── LayoutOptions ─────────────────────────────────────────────────────────────
+
+const OVERFLOWS = ['visible', 'clip', 'ellipsis'] as const satisfies ReadonlyArray<NonNullable<LayoutOptions['overflow']>>;
+const DIRECTIONS = ['ltr', 'rtl'] as const satisfies ReadonlyArray<NonNullable<LayoutOptions['direction']>>;
+const WHITE_SPACES = ['normal', 'pre', 'pre-line'] as const satisfies ReadonlyArray<NonNullable<LayoutOptions['whiteSpace']>>;
+
+/**
+ * Rebuild {@link LayoutOptions} from a serialized layout object, dropping
+ * unknown or mistyped fields. Returns `undefined` when nothing valid remains,
+ * so a corrupt `layout` value degrades to the node's constructor defaults.
+ */
+export function readLayoutOptions(value: unknown): LayoutOptions | undefined {
+  if (typeof value !== 'object' || value === null) {
+    return undefined;
+  }
+
+  const source = value as Record<string, unknown>;
+  const out: LayoutOptions = {};
+
+  const maxWidth = readNumber(source, 'maxWidth');
+  if (maxWidth !== undefined) out.maxWidth = maxWidth;
+
+  const maxHeight = readNumber(source, 'maxHeight');
+  if (maxHeight !== undefined) out.maxHeight = maxHeight;
+
+  const overflow = readEnum(source, 'overflow', OVERFLOWS);
+  if (overflow !== undefined) out.overflow = overflow;
+
+  const letterSpacing = readNumber(source, 'letterSpacing');
+  if (letterSpacing !== undefined) out.letterSpacing = letterSpacing;
+
+  const direction = readEnum(source, 'direction', DIRECTIONS);
+  if (direction !== undefined) out.direction = direction;
+
+  const breakWords = readBoolean(source, 'breakWords');
+  if (breakWords !== undefined) out.breakWords = breakWords;
+
+  const whiteSpace = readEnum(source, 'whiteSpace', WHITE_SPACES);
+  if (whiteSpace !== undefined) out.whiteSpace = whiteSpace;
+
+  return Object.keys(out).length > 0 ? out : undefined;
 }

--- a/src/core/serialization/uiSerializers.ts
+++ b/src/core/serialization/uiSerializers.ts
@@ -7,11 +7,11 @@ import { Stack } from '#ui/Stack';
 import { UIRoot } from '#ui/UIRoot';
 
 import type { NodeSerializer } from './NodeSerializer';
+import { asSerializedNode } from './read';
 import type { SerializationRegistry } from './SerializationRegistry';
 import { arrayToColor, colorToArray, compact, deserializeStyleOptions, serializeStyle } from './serializerHelpers';
-import type { SerializedNode } from './types';
 
-const num = (value: unknown): number | undefined => (typeof value === 'number' ? value : undefined);
+const num = (value: unknown): number | undefined => (typeof value === 'number' && Number.isFinite(value) ? value : undefined);
 
 // Widget composition note: widgets own internal children (a Label's Text, a
 // Panel's background Graphics, etc.) that their constructors rebuild — those are
@@ -77,7 +77,8 @@ const panelSerializer: NodeSerializer<Panel> = {
     const children = data.children;
     if (Array.isArray(children)) {
       for (const child of children) {
-        panel.addChild(ctx.readNode(child as SerializedNode) as RenderNode);
+        const childNode = asSerializedNode(child);
+        if (childNode !== null) panel.addChild(ctx.readNode(childNode) as RenderNode);
       }
     }
 
@@ -192,7 +193,8 @@ const stackSerializer: NodeSerializer<Stack> = {
     const children = data.children;
     if (Array.isArray(children)) {
       for (const child of children) {
-        stack.addChild(ctx.readNode(child as SerializedNode) as RenderNode);
+        const childNode = asSerializedNode(child);
+        if (childNode !== null) stack.addChild(ctx.readNode(childNode) as RenderNode);
       }
 
       stack.layout();
@@ -214,7 +216,8 @@ const uiRootSerializer: NodeSerializer<UIRoot> = {
 
     if (Array.isArray(children)) {
       for (const child of children) {
-        root.addChild(ctx.readNode(child as SerializedNode) as RenderNode);
+        const childNode = asSerializedNode(child);
+        if (childNode !== null) root.addChild(ctx.readNode(childNode) as RenderNode);
       }
     }
 

--- a/test/core/serialization-validation.test.ts
+++ b/test/core/serialization-validation.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  asNumberArray,
+  asObject,
+  asSerializedNode,
+  FONT_WEIGHTS,
+  readBoolean,
+  readEnum,
+  readNumber,
+  readObject,
+  readString,
+  REPEAT_MODES,
+} from '#core/serialization/read';
+import { _resetDefaultSerializers, deserializeTree, migrate } from '#core/serialization/serialize';
+import { SERIALIZATION_VERSION, type SerializedNode } from '#core/serialization/types';
+import { Container } from '#rendering/Container';
+import { RepeatingSprite } from '#rendering/sprite/RepeatingSprite';
+import { Sprite } from '#rendering/sprite/Sprite';
+import type { GlyphAtlas } from '#rendering/text/GlyphAtlas';
+import type { GlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
+import { resetDefaultGlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
+import { Text } from '#rendering/text/Text';
+import type { GlyphInfo } from '#rendering/text/types';
+import { Texture } from '#rendering/texture/Texture';
+import type { Loadable, Loader } from '#resources/Loader';
+
+// Text construction needs a GlyphAtlasPool; inject a mock so the Text-based
+// cases run without a real canvas 2D context (mirrors serialization.test.ts).
+const fixedGlyphInfo: GlyphInfo = { x: 0, y: 0, width: 8, height: 16, advance: 10, ascent: 13, page: 0, uvLeft: 0, uvTop: 0, uvRight: 0.01, uvBottom: 0.02 };
+const mockAtlas: Partial<GlyphAtlas> = { getGlyph: vi.fn(() => fixedGlyphInfo), pages: [] as unknown as GlyphAtlas['pages'], mode: 'sdf', clear: vi.fn() };
+const mockPool = { getAtlas: vi.fn(() => mockAtlas) };
+
+beforeEach(() => resetDefaultGlyphAtlasPool(mockPool as unknown as GlyphAtlasPool));
+afterEach(() => resetDefaultGlyphAtlasPool());
+afterEach(_resetDefaultSerializers);
+
+/** Minimal Loader stand-in exposing only `peek`/`keyFor` for asset resolution. */
+function fakeLoader(entries: ReadonlyArray<{ type: Loadable; source: string; resource: object }>): Loader {
+  return {
+    peek: (type: Loadable, source: string) => entries.find(e => e.type === type && e.source === source)?.resource ?? null,
+    keyFor: (resource: object) => {
+      const entry = entries.find(e => e.resource === resource);
+
+      return entry ? { type: entry.type, source: entry.source } : null;
+    },
+  } as unknown as Loader;
+}
+
+// A SerializedNode is an open bag; the helpers must tolerate arbitrary garbage
+// in any field. Cast through `unknown` so the tests can feed wrong-typed values.
+const node = (data: Record<string, unknown>): SerializedNode => data as SerializedNode;
+
+describe('serialization validation — read helpers', () => {
+  it('readString returns the value or the fallback', () => {
+    expect(readString({ a: 'x' }, 'a', 'fb')).toBe('x');
+    expect(readString({ a: 42 }, 'a', 'fb')).toBe('fb');
+    expect(readString({}, 'a')).toBeUndefined();
+  });
+
+  it('readNumber rejects non-numbers, NaN and Infinity', () => {
+    expect(readNumber({ a: 5 }, 'a', 0)).toBe(5);
+    expect(readNumber({ a: '5' }, 'a', 0)).toBe(0);
+    expect(readNumber({ a: NaN }, 'a', 0)).toBe(0);
+    expect(readNumber({ a: Infinity }, 'a', 0)).toBe(0);
+    expect(readNumber({ a: -Infinity }, 'a', 0)).toBe(0);
+    expect(readNumber({}, 'a')).toBeUndefined();
+  });
+
+  it('readBoolean only accepts real booleans', () => {
+    expect(readBoolean({ a: true }, 'a', false)).toBe(true);
+    expect(readBoolean({ a: 'true' }, 'a', false)).toBe(false);
+    expect(readBoolean({ a: 1 }, 'a', false)).toBe(false);
+  });
+
+  it('readEnum accepts only listed members', () => {
+    expect(readEnum({ a: 'bold' }, 'a', FONT_WEIGHTS, 'normal')).toBe('bold');
+    expect(readEnum({ a: 'ultraheavy' }, 'a', FONT_WEIGHTS, 'normal')).toBe('normal');
+    expect(readEnum({ a: 42 }, 'a', FONT_WEIGHTS, 'normal')).toBe('normal');
+    expect(readEnum({ a: 'repeat' }, 'a', REPEAT_MODES)).toBe('repeat');
+    expect(readEnum({ a: 'bogus' }, 'a', REPEAT_MODES)).toBeUndefined();
+  });
+
+  it('readObject / asObject narrow only plain objects', () => {
+    expect(readObject({ a: { k: 1 } }, 'a')).toEqual({ k: 1 });
+    expect(readObject({ a: [1, 2] }, 'a')).toBeUndefined();
+    expect(readObject({ a: 'x' }, 'a')).toBeUndefined();
+    expect(asObject(null)).toBeNull();
+    expect(asObject([1])).toBeNull();
+    expect(asObject({ k: 1 })).toEqual({ k: 1 });
+  });
+
+  it('asSerializedNode requires an object with a string type tag', () => {
+    expect(asSerializedNode({ type: 'Sprite' })).toEqual({ type: 'Sprite' });
+    expect(asSerializedNode({ notType: 'Sprite' })).toBeNull();
+    expect(asSerializedNode({ type: 42 })).toBeNull();
+    expect(asSerializedNode(null)).toBeNull();
+    expect(asSerializedNode('Sprite')).toBeNull();
+    expect(asSerializedNode(42)).toBeNull();
+  });
+
+  it('asNumberArray coerces non-finite entries to 0 and rejects non-arrays', () => {
+    expect(asNumberArray([1, 2, 3])).toEqual([1, 2, 3]);
+    expect(asNumberArray([1, NaN, '3', Infinity])).toEqual([1, 0, 0, 0]);
+    expect(asNumberArray('123')).toBeNull();
+    expect(asNumberArray(null)).toBeNull();
+  });
+});
+
+describe('serialization validation — node deserialization (untrusted input)', () => {
+  it('does not throw when fields hold the wrong type', () => {
+    expect(() => deserializeTree(node({ type: 'Sprite', x: 'foo', rotation: {}, visible: 'yes' }))).not.toThrow();
+    expect(deserializeTree(node({ type: 'Sprite', x: 'foo' }))).toBeInstanceOf(Sprite);
+  });
+
+  it('keeps constructor defaults for mistyped common fields', () => {
+    const result = deserializeTree(node({ type: 'Container', x: 'foo', y: null, rotation: [] }));
+
+    expect(result.x).toBe(0);
+    expect(result.y).toBe(0);
+    expect(result.rotation).toBe(0);
+  });
+
+  it('falls back to defaults for unknown enum values (fontWeight / align)', () => {
+    const text = deserializeTree(node({ type: 'Text', text: 'hi', style: { fontWeight: 'ultraheavy', align: 'sideways' } })) as Text;
+
+    expect(text.style.fontWeight).toBe('normal');
+    expect(text.style.align).toBe('left');
+  });
+
+  it('drops invalid enum values on a RepeatingSprite, using the renderer defaults', () => {
+    const texture = new Texture(Object.assign(document.createElement('canvas'), { width: 16, height: 16 }));
+    const loader = fakeLoader([{ type: Texture as unknown as Loadable, source: 'tex', resource: texture }]);
+    const sprite = deserializeTree(node({ type: 'RepeatingSprite', texture: 'tex', modeX: 'bogus', offsetX: NaN, width: 64 }), loader) as RepeatingSprite;
+
+    expect(sprite.modeX).not.toBe('bogus'); // the bogus value was rejected
+    expect(REPEAT_MODES).toContain(sprite.modeX); // …and replaced by a valid renderer default
+    expect(Number.isFinite(sprite.offsetX)).toBe(true); // NaN rejected → default
+    expect(sprite.width).toBe(64); // valid value preserved
+  });
+
+  it('skips non-object children instead of crashing', () => {
+    const result = deserializeTree(node({ type: 'Container', children: [null, 'x', 42, [], { type: 'Sprite' }, { notType: true }] })) as Container;
+
+    expect(result.children.length).toBe(1); // only the one valid child node survives
+    expect(result.children[0]).toBeInstanceOf(Sprite);
+  });
+
+  it('round-trips valid data unchanged (no regression for trusted input)', () => {
+    const result = deserializeTree(node({ type: 'Container', x: 10, y: -5, rotation: 1.5, children: [{ type: 'Sprite' }] })) as Container;
+
+    expect(result.x).toBe(10);
+    expect(result.y).toBe(-5);
+    expect(result.rotation).toBe(1.5);
+    expect(result.children.length).toBe(1);
+  });
+});
+
+describe('serialization validation — top-level frame (migrate)', () => {
+  it('throws on a non-object document', () => {
+    expect(() => migrate(null)).toThrow();
+    expect(() => migrate('garbage')).toThrow();
+    expect(() => migrate(42)).toThrow();
+  });
+
+  it('throws on a missing or invalid root', () => {
+    expect(() => migrate({ version: SERIALIZATION_VERSION })).toThrow();
+    expect(() => migrate({ version: SERIALIZATION_VERSION, root: 'garbage' })).toThrow();
+    expect(() => migrate({ version: SERIALIZATION_VERSION, root: { noType: true } })).toThrow();
+  });
+
+  it('throws when the document version is newer than supported', () => {
+    expect(() => migrate({ version: SERIALIZATION_VERSION + 1, root: { type: 'Container' } })).toThrow();
+  });
+
+  it('accepts a well-formed document and drops an invalid ui layer', () => {
+    const ok = migrate({ version: SERIALIZATION_VERSION, root: { type: 'Container' } });
+    expect(ok.root.type).toBe('Container');
+    expect(ok.ui).toBeUndefined();
+
+    const droppedUi = migrate({ version: SERIALIZATION_VERSION, root: { type: 'Container' }, ui: 'garbage' });
+    expect(droppedUi.ui).toBeUndefined(); // invalid ui dropped, not thrown
+
+    const withUi = migrate({ version: SERIALIZATION_VERSION, root: { type: 'Container' }, ui: { type: 'UIRoot' } });
+    expect(withUi.ui?.type).toBe('UIRoot');
+  });
+});

--- a/test/core/serialization-validation.test.ts
+++ b/test/core/serialization-validation.test.ts
@@ -14,13 +14,13 @@ import {
 } from '#core/serialization/read';
 import { _resetDefaultSerializers, deserializeTree, migrate } from '#core/serialization/serialize';
 import { SERIALIZATION_VERSION, type SerializedNode } from '#core/serialization/types';
-import { Container } from '#rendering/Container';
-import { RepeatingSprite } from '#rendering/sprite/RepeatingSprite';
+import { type Container } from '#rendering/Container';
+import { type RepeatingSprite } from '#rendering/sprite/RepeatingSprite';
 import { Sprite } from '#rendering/sprite/Sprite';
 import type { GlyphAtlas } from '#rendering/text/GlyphAtlas';
 import type { GlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
 import { resetDefaultGlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
-import { Text } from '#rendering/text/Text';
+import { type Text } from '#rendering/text/Text';
 import type { GlyphInfo } from '#rendering/text/types';
 import { Texture } from '#rendering/texture/Texture';
 import type { Loadable, Loader } from '#resources/Loader';


### PR DESCRIPTION
## Welle 4 — Robustheit

Two independent, low-risk slices.

### 4a — Deserialization validation boundary (core, `5bbaca7d`)
Treat deserialized documents as untrusted input (strict / Fall A). New
`read.ts` with validating helpers (check instead of cast); 14 value casts + 6
recursion casts replaced; `migrate(data: unknown)` is now the real top-level
boundary (throws on non-object/missing root, drops an invalid ui). Fixes two
real crashes on hostile input: missing nine-slice `slices`
(`normalizeInsets(undefined)` threw) and non-object `children` (`Cannot read
'type' of …`). Adversarial test suite (17 cases); valid saves round-trip
identically (55 serialization tests green). Internal-only — no public API change.

### 5a — Physics scratch-reuse + honest allocation gate (exojs-physics, `a89bc87f`)
Scratch-reuse of the four confirmed per-step sources (3 separate clip pairs,
`findMaxSeparation` out-param, `Collider._syncScratch`, pooled `CandidatePair`),
allocation-free in steady state without aliasing (full SG matrix +
world-isolation green, 87 tests).

**Finding:** the previous "~0 KB/step, allocation-free" gate measured retained
heap (forced GC *before* the read) — an artifact; the step was never
allocation-free. Replaced with V8's allocation sampling profiler (shared
`allocationSampler.ts`, mirroring render-2a; no `--expose-gc` needed). Measured
**~1560 → ~810 KB/step** — the reuse roughly halves per-step allocation. The
remaining ~810 KB is dominated by the contact solver (`_solveNormalBlock`) and
`ContactGraph.update`, outside this slice's scope → backlog. The gate is now a
regression guard (< 1100 KB/step), not a false ~0.

## Verification
`verify:quick` green (typecheck core+guides+examples+packages, lint:all,
format:check, docs:api:check). Full physics suite (87) + serialization suites
(55) green locally. No new public symbols; root-index snapshots + docs:api
unchanged.