### PR TITLE
v0.15 W6 — Asset-Container: binary archive format + single-request loading (9a/9b)

### DIFF
--- a/scripts/build-container.ts
+++ b/scripts/build-container.ts
@@ -1,0 +1,79 @@
+/**
+ * Build an ExoJS asset container (`.exoa`) from a JSON manifest.
+ *
+ * Usage:  tsx scripts/build-container.ts <manifest.json>
+ *
+ * Manifest shape (paths resolved relative to the manifest's own directory):
+ *
+ *   {
+ *     "output": "dist/level1.exoa",
+ *     "assets": [
+ *       { "alias": "hero",  "type": "texture", "file": "hero.png", "mime": "image/png" },
+ *       { "alias": "jump",  "type": "sound",   "file": "jump.wav" },
+ *       { "alias": "level", "type": "json",    "file": "level1.json" }
+ *     ]
+ *   }
+ *
+ * `type` is the loader type name (lowercase, e.g. `texture`/`sound`/`json`), the
+ * same tag used by the config-map load path — not the constructor name. The
+ * container is unpacked at runtime via `loader.loadContainer(url)`.
+ *
+ * Shares the format with the runtime reader through `encodeContainer`
+ * (src/resources/AssetContainer.ts), so builder and reader never drift.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import process from 'node:process';
+
+import { type ContainerInput, encodeContainer } from '../src/resources/AssetContainer';
+
+interface ManifestAsset {
+  alias: string;
+  type: string;
+  file: string;
+  mime?: string;
+  options?: unknown;
+}
+
+interface ContainerManifest {
+  output: string;
+  assets: ManifestAsset[];
+}
+
+function main(): void {
+  const manifestPath = process.argv[2];
+
+  if (!manifestPath) {
+    console.error('Usage: tsx scripts/build-container.ts <manifest.json>');
+    process.exit(1);
+  }
+
+  const manifestDir = dirname(resolve(manifestPath));
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as ContainerManifest;
+
+  if (!Array.isArray(manifest.assets) || typeof manifest.output !== 'string') {
+    console.error('Manifest must have a string "output" and an "assets" array.');
+    process.exit(1);
+  }
+
+  const inputs: ContainerInput[] = manifest.assets.map(asset => {
+    const fileBytes = readFileSync(resolve(manifestDir, asset.file));
+
+    return {
+      alias: asset.alias,
+      type: asset.type,
+      bytes: new Uint8Array(fileBytes.buffer, fileBytes.byteOffset, fileBytes.byteLength),
+      ...(asset.mime !== undefined && { mime: asset.mime }),
+      ...(asset.options !== undefined && { options: asset.options }),
+    };
+  });
+
+  const container = encodeContainer(inputs);
+  const outputPath = resolve(manifestDir, manifest.output);
+
+  writeFileSync(outputPath, new Uint8Array(container));
+
+  console.log(`Wrote ${inputs.length} asset(s) → ${outputPath} (${container.byteLength} bytes)`);
+}
+
+main();

--- a/site/src/content/api/loader.mdx
+++ b/site/src/content/api/loader.mdx
@@ -5,11 +5,11 @@ symbol: "Loader"
 kind: "class"
 subsystem: "resources"
 importPath: "@codexo/exojs"
-memberCount: 28
+memberCount: 29
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/resources/Loader.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/resources/Loader.ts#L267"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/resources/Loader.ts#L270"
 ---
 ## Import
 
@@ -66,6 +66,7 @@ subsequent `load` or get calls without re-fetching.
 - `load(type: T, items: Readonly<Record<K, BatchValue>>, options?: unknown): LoadingQueue<Record<K, LoadReturn<T>>>`
 - `loadAll(): Promise<void>`
 - `loadBundle(name: string, options: LoadBundleOptions): Promise<void>`
+- `loadContainer(url: string): Promise<void>`
 - `peek(type: typeof Json, alias: string): T | null`
 - `peek(type: T, alias: string): LoadReturn<T> | null`
 - `register(type: AssetConstructor<T>, factory: AssetFactory<T>): this`
@@ -93,4 +94,4 @@ subsequent `load` or get calls without re-fetching.
 
 ## Source
 
-[src/resources/Loader.ts](https://github.com/Exoridus/ExoJS/blob/main/src/resources/Loader.ts#L267)
+[src/resources/Loader.ts](https://github.com/Exoridus/ExoJS/blob/main/src/resources/Loader.ts#L270)

--- a/src/extensions/Extension.ts
+++ b/src/extensions/Extension.ts
@@ -48,6 +48,19 @@ export interface AssetHandler<Result = unknown, Options = undefined> {
    */
   getIdentityKey?(request: AssetLoadRequest<Options>): string;
   load(request: AssetLoadRequest<Options>, context: AssetLoaderContext): Promise<Result>;
+  /**
+   * Optionally produce the asset directly from in-memory bytes, bypassing the
+   * network and cache. This is what lets the type be packed into an asset
+   * container ({@link Loader.loadContainer} — one fetch yields N assets): the
+   * loader hands the handler the asset's slice instead of a URL.
+   *
+   * Implement it when the asset can be built from its raw bytes alone (the
+   * factory-backed core handlers do). Omit it when loading needs a URL fetch,
+   * sub-asset resolution, or anything bytes alone cannot supply — such types
+   * cannot be embedded in a container and raise a clear error if attempted.
+   * @advanced
+   */
+  createFromBytes?(bytes: ArrayBuffer, options?: Options): Promise<Result>;
   destroy?(): void;
 }
 

--- a/src/resources/AssetContainer.ts
+++ b/src/resources/AssetContainer.ts
@@ -1,0 +1,197 @@
+/**
+ * Binary asset container (`.exoa`) — format constants, reader, and writer.
+ *
+ * A container packs N assets into one file so a single HTTP request yields all
+ * of them (the FFX VBF / Unreal `.pak` model). Layout:
+ *
+ * ```
+ * magic "EXOA" (4B) │ version u32 LE │ indexLength u32 LE │ index (JSON, UTF-8)
+ * data: concatenated asset bytes [slice0][slice1]…[sliceN]
+ * ```
+ *
+ * The index is a small JSON table of contents read once — zero-copy matters only
+ * for the asset *data*, not the TOC, so JSON keeps it trivial to build, parse,
+ * and extend. `offset`/`length` are relative to the start of the data section.
+ *
+ * `encodeContainer` (writer) and `parseContainer` (reader) share these constants
+ * so the build tooling and the runtime never drift. The writer is exported for
+ * the `scripts/build-container` tool and tests; it is tree-shaken out of the
+ * runtime bundle, which only pulls in the reader via `Loader.loadContainer`.
+ *
+ * @internal
+ */
+
+/** Magic bytes at the start of every container: ASCII `"EXOA"`. */
+export const CONTAINER_MAGIC = 'EXOA';
+
+/** Current container format version written by {@link encodeContainer}. */
+export const CONTAINER_VERSION = 1;
+
+/** Fixed header size: magic (4) + version (4) + indexLength (4). */
+export const CONTAINER_HEADER_SIZE = 12;
+
+/**
+ * One entry in a container's index. `offset`/`length` address the asset's bytes
+ * within the data section (after the header + index). `type` is the asset type
+ * name resolved against the loader's type map; `options` are forwarded to the
+ * handler's `createFromBytes`.
+ */
+export interface ContainerEntry {
+  /** Loader alias the unpacked resource is stored under. */
+  readonly alias: string;
+  /** Asset type name (resolved to a constructor via the loader's type map). */
+  readonly type: string;
+  /** Byte offset of this asset within the data section. */
+  readonly offset: number;
+  /** Byte length of this asset's slice. */
+  readonly length: number;
+  /** Optional MIME hint (informational; the factory determines type from bytes). */
+  readonly mime?: string;
+  /** Optional per-asset options forwarded to the handler. */
+  readonly options?: unknown;
+}
+
+/** Result of {@link parseContainer}: the validated index plus where data begins. */
+export interface ParsedContainer {
+  readonly version: number;
+  readonly entries: readonly ContainerEntry[];
+  /** Byte offset where the data section starts (header size + index length). */
+  readonly dataStart: number;
+}
+
+/** Input for {@link encodeContainer}: an asset's bytes plus its index metadata. */
+export interface ContainerInput {
+  readonly alias: string;
+  readonly type: string;
+  readonly bytes: ArrayBuffer | Uint8Array;
+  readonly mime?: string;
+  readonly options?: unknown;
+}
+
+function toUint8(bytes: ArrayBuffer | Uint8Array): Uint8Array {
+  return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+}
+
+/**
+ * Pack assets into a container `ArrayBuffer`. The inverse of
+ * {@link parseContainer}; used by the build tooling and the roundtrip test.
+ */
+export function encodeContainer(inputs: readonly ContainerInput[]): ArrayBuffer {
+  const slices: Uint8Array[] = [];
+  const index: ContainerEntry[] = [];
+  let offset = 0;
+
+  for (const input of inputs) {
+    const slice = toUint8(input.bytes);
+    index.push({
+      alias: input.alias,
+      type: input.type,
+      offset,
+      length: slice.byteLength,
+      ...(input.mime !== undefined && { mime: input.mime }),
+      ...(input.options !== undefined && { options: input.options }),
+    });
+    slices.push(slice);
+    offset += slice.byteLength;
+  }
+
+  const indexBytes = new TextEncoder().encode(JSON.stringify(index));
+  const dataLength = offset;
+  const total = CONTAINER_HEADER_SIZE + indexBytes.byteLength + dataLength;
+  const buffer = new ArrayBuffer(total);
+  const bytes = new Uint8Array(buffer);
+  const view = new DataView(buffer);
+
+  // Header.
+  for (let i = 0; i < CONTAINER_MAGIC.length; i++) {
+    bytes[i] = CONTAINER_MAGIC.charCodeAt(i);
+  }
+  view.setUint32(4, CONTAINER_VERSION, true);
+  view.setUint32(8, indexBytes.byteLength, true);
+
+  // Index, then concatenated data slices.
+  bytes.set(indexBytes, CONTAINER_HEADER_SIZE);
+  let cursor = CONTAINER_HEADER_SIZE + indexBytes.byteLength;
+  for (const slice of slices) {
+    bytes.set(slice, cursor);
+    cursor += slice.byteLength;
+  }
+
+  return buffer;
+}
+
+function fail(detail: string): never {
+  throw new Error(`Invalid asset container: ${detail}.`);
+}
+
+function readEntry(value: unknown, i: number, dataLength: number): ContainerEntry {
+  if (typeof value !== 'object' || value === null) {
+    fail(`index entry ${i} is not an object`);
+  }
+
+  const record = value as Record<string, unknown>;
+  const { alias, type, offset, length, mime } = record;
+
+  if (typeof alias !== 'string') fail(`index entry ${i} has a non-string "alias"`);
+  if (typeof type !== 'string') fail(`index entry ${i} ("${alias}") has a non-string "type"`);
+  if (typeof offset !== 'number' || !Number.isFinite(offset) || offset < 0) fail(`index entry "${alias}" has an invalid "offset"`);
+  if (typeof length !== 'number' || !Number.isFinite(length) || length < 0) fail(`index entry "${alias}" has an invalid "length"`);
+  if (offset + length > dataLength) fail(`index entry "${alias}" runs past the data section (offset ${offset} + length ${length} > ${dataLength})`);
+  if (mime !== undefined && typeof mime !== 'string') fail(`index entry "${alias}" has a non-string "mime"`);
+
+  return {
+    alias,
+    type,
+    offset,
+    length,
+    ...(typeof mime === 'string' && { mime }),
+    ...(record.options !== undefined && { options: record.options }),
+  };
+}
+
+/**
+ * Parse and validate a container's header and index. Throws (never returns
+ * partial/garbage data) on a bad magic, unsupported version, truncated buffer,
+ * malformed index, or an entry whose slice runs past the data section.
+ */
+export function parseContainer(buffer: ArrayBuffer): ParsedContainer {
+  if (buffer.byteLength < CONTAINER_HEADER_SIZE) {
+    fail(`buffer too small for a ${CONTAINER_HEADER_SIZE}-byte header (got ${buffer.byteLength})`);
+  }
+
+  const bytes = new Uint8Array(buffer);
+  const view = new DataView(buffer);
+
+  for (let i = 0; i < CONTAINER_MAGIC.length; i++) {
+    if (bytes[i] !== CONTAINER_MAGIC.charCodeAt(i)) {
+      fail(`bad magic (expected "${CONTAINER_MAGIC}")`);
+    }
+  }
+
+  const version = view.getUint32(4, true);
+  if (version > CONTAINER_VERSION) {
+    fail(`unsupported version ${version} (this build reads up to ${CONTAINER_VERSION})`);
+  }
+
+  const indexLength = view.getUint32(8, true);
+  const dataStart = CONTAINER_HEADER_SIZE + indexLength;
+  if (dataStart > buffer.byteLength) {
+    fail(`index length ${indexLength} runs past the buffer (size ${buffer.byteLength})`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(bytes.subarray(CONTAINER_HEADER_SIZE, dataStart)));
+  } catch {
+    fail('index is not valid JSON');
+  }
+
+  if (!Array.isArray(parsed)) {
+    fail('index is not an array');
+  }
+
+  const dataLength = buffer.byteLength - dataStart;
+  const entries = parsed.map((entry, i) => readEntry(entry, i, dataLength));
+
+  return { version, entries, dataStart };
+}

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -3,6 +3,7 @@ import type { AssetHandler, AssetLoadRequest } from '#extensions/Extension';
 import { type BmFont } from '#rendering/text/BmFont';
 
 import { Asset, AssetImpl } from './Asset';
+import { parseContainer } from './AssetContainer';
 import type { AssetDefinitions, AssetInput, InferAssetResource } from './AssetDefinitions';
 import type { AssetFactory } from './AssetFactory';
 import type { AssetManifest, LoadBundleOptions } from './AssetManifest';
@@ -232,6 +233,8 @@ interface HandlerEntry {
   load: (config: unknown, ctx: AssetLoaderContext) => Promise<unknown>;
   /** Optional discriminator for in-flight identity keying; overrides source-only default. */
   getIdentityKey?: (config: unknown) => string;
+  /** Optional byte-source constructor used by container loading (bypasses fetch). */
+  createFromBytes?: (bytes: ArrayBuffer, options?: unknown) => Promise<unknown>;
 }
 
 // ---------------------------------------------------------------------------
@@ -594,6 +597,46 @@ export class Loader {
     if (failures.length > 0) {
       throw new BundleLoadError(name, failures);
     }
+  }
+
+  /**
+   * Load every asset packed into a binary container (`.exoa`) in a **single
+   * request**. Unlike {@link loadBundle} (one fetch per entry), a container is
+   * one file with an embedded index: its bytes are fetched once (and cached
+   * cross-session like any asset), then each slice is unpacked through its
+   * type's handler and stored under the entry's alias — retrievable with
+   * {@link get} exactly as if it had been loaded individually.
+   *
+   * Each entry's asset type must support byte-source construction
+   * ({@link AssetHandler.createFromBytes}); the factory-backed core types
+   * (textures, audio, JSON, text, binary, …) do. Throws on a malformed
+   * container, an unknown type, or a type that cannot be built from bytes.
+   *
+   * @param url Path to the container file, resolved against the loader base path.
+   */
+  public async loadContainer(url: string): Promise<void> {
+    const buffer = await this._contextFetch<ArrayBuffer>(url, '__ctx_binary', response => response.arrayBuffer());
+    const { entries, dataStart } = parseContainer(buffer);
+
+    // Resolve every type up front so an unknown type fails before any asset is stored.
+    const resolved = entries.map(entry => {
+      const type = this._assetTypeMap.get(entry.type);
+
+      if (!type) {
+        throw new Error(`Container "${url}" references unknown asset type "${entry.type}".`);
+      }
+
+      return { entry, type };
+    });
+
+    await Promise.all(
+      resolved.map(({ entry, type }) => {
+        const start = dataStart + entry.offset;
+        const slice = buffer.slice(start, start + entry.length);
+
+        return this._injectSource(type, entry.alias, slice, entry.options);
+      }),
+    );
   }
 
   /**
@@ -1186,10 +1229,12 @@ export class Loader {
     };
 
     const boundIdentityKey = handler.getIdentityKey?.bind(handler);
+    const boundCreateFromBytes = handler.createFromBytes?.bind(handler);
 
     this._handlerFunctions.set(keys.type, {
       load: (config, ctx) => handler.load(toRequest(config), ctx),
       ...(boundIdentityKey && { getIdentityKey: (config: unknown) => boundIdentityKey(toRequest(config)) }),
+      ...(boundCreateFromBytes && { createFromBytes: (bytes: ArrayBuffer, options?: unknown) => boundCreateFromBytes(bytes, options as Options) }),
     });
 
     for (const name of resolvedNames) {
@@ -1544,6 +1589,27 @@ export class Loader {
       { storageName, key: source, url, requestOptions: this._fetchOptions, factory, options: undefined },
       this._stores,
     ) as Promise<T>;
+  }
+
+  /**
+   * Construct an asset from in-memory `bytes` (no fetch) and store it under
+   * `alias`. Uses the type's {@link AssetHandler.createFromBytes} when present,
+   * otherwise a `register()`-style factory; throws if neither can build from
+   * bytes. The backing path for {@link loadContainer}.
+   */
+  private async _injectSource(type: AssetConstructor, alias: string, bytes: ArrayBuffer, options?: unknown): Promise<void> {
+    const handlerEntry = this._handlerFunctions.get(type);
+    let resource: unknown;
+
+    if (handlerEntry?.createFromBytes) {
+      resource = await handlerEntry.createFromBytes(bytes, options);
+    } else if (this._registry.has(type)) {
+      resource = await this._registry.resolve(type).create(bytes, options);
+    } else {
+      throw new Error(`Asset type "${type.name}" cannot be built from container bytes (no createFromBytes handler).`);
+    }
+
+    this._storeResource(type, alias, resource);
   }
 
   private async _fetch(type: AssetConstructor, alias: string, path: string, options?: unknown): Promise<unknown> {

--- a/src/resources/coreAssetBindings.ts
+++ b/src/resources/coreAssetBindings.ts
@@ -37,6 +37,9 @@ function binaryFactoryHandler<T>(
         const raw = await context.fetchArrayBuffer(source);
         return factory.create(raw, options);
       },
+      createFromBytes(bytes: ArrayBuffer, options?: unknown): Promise<T> {
+        return factory.create(bytes, options);
+      },
       destroy() {
         factory.destroy();
       },
@@ -52,6 +55,9 @@ function textFactoryHandler<T>(makeFactory: () => { create(raw: string, options?
       async load({ source, options }: AssetLoadRequest, context: AssetLoaderContext): Promise<T> {
         const raw = await context.fetchText(source);
         return factory.create(raw, options);
+      },
+      createFromBytes(bytes: ArrayBuffer, options?: unknown): Promise<T> {
+        return factory.create(new TextDecoder().decode(bytes), options);
       },
       destroy() {
         factory.destroy();
@@ -116,11 +122,17 @@ const jsonBinding = binding(Json as unknown as AssetConstructor, { typeNames: ['
   async load({ source }: AssetLoadRequest, context: AssetLoaderContext): Promise<unknown> {
     return context.fetchJson(source);
   },
+  createFromBytes(bytes: ArrayBuffer): Promise<unknown> {
+    return Promise.resolve(JSON.parse(new TextDecoder().decode(bytes)));
+  },
 }));
 
 const textBinding = binding(TextAsset as unknown as AssetConstructor, { typeNames: ['text'] }, () => ({
   async load({ source }: AssetLoadRequest, context: AssetLoaderContext): Promise<string> {
     return context.fetchText(source);
+  },
+  createFromBytes(bytes: ArrayBuffer): Promise<string> {
+    return Promise.resolve(new TextDecoder().decode(bytes));
   },
 }));
 

--- a/test/resources/asset-container.test.ts
+++ b/test/resources/asset-container.test.ts
@@ -1,0 +1,157 @@
+import { materializeAssetBindings } from '#extensions/materialize';
+import { CONTAINER_HEADER_SIZE, CONTAINER_MAGIC, type ContainerInput, encodeContainer, parseContainer } from '#resources/AssetContainer';
+import { coreAssetBindings } from '#resources/coreAssetBindings';
+import { Loader } from '#resources/Loader';
+import { BinaryAsset, Json, TextAsset } from '#resources/tokens';
+
+const utf8 = (text: string): Uint8Array => new TextEncoder().encode(text);
+
+function createCoreLoader(): Loader {
+  const loader = new Loader({ basePath: '/' });
+  materializeAssetBindings(loader, coreAssetBindings);
+
+  return loader;
+}
+
+/** A fetch stub whose single `arrayBuffer()` body is `container`. */
+function mockContainerFetch(container: ArrayBuffer): ReturnType<typeof vi.fn> {
+  const spy = vi.fn(async (): Promise<Response> => ({ ok: true, status: 200, statusText: 'OK', arrayBuffer: async () => container }) as unknown as Response);
+  global.fetch = spy;
+
+  return spy;
+}
+
+describe('asset container format', () => {
+  test('encode → parse round-trips the index and data offsets', () => {
+    const inputs: ContainerInput[] = [
+      { alias: 'level', type: 'json', bytes: utf8('{"score":1}'), mime: 'application/json' },
+      { alias: 'note', type: 'text', bytes: utf8('hello') },
+    ];
+
+    const { version, entries, dataStart } = parseContainer(encodeContainer(inputs));
+
+    expect(version).toBe(1);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({ alias: 'level', type: 'json', offset: 0, length: 11, mime: 'application/json' });
+    expect(entries[1]).toMatchObject({ alias: 'note', type: 'text', offset: 11, length: 5 });
+
+    const buffer = encodeContainer(inputs);
+    const second = entries[1]!;
+    const slice = buffer.slice(dataStart + second.offset, dataStart + second.offset + second.length);
+
+    expect(new TextDecoder().decode(slice)).toBe('hello');
+  });
+
+  test('preserves arbitrary binary bytes (no JSON coercion of data)', () => {
+    const raw = new Uint8Array([0, 255, 1, 254, 128]);
+    const { entries, dataStart } = parseContainer(encodeContainer([{ alias: 'b', type: 'binary', bytes: raw }]));
+    const buffer = encodeContainer([{ alias: 'b', type: 'binary', bytes: raw }]);
+    const first = entries[0]!;
+
+    expect(new Uint8Array(buffer.slice(dataStart + first.offset, dataStart + first.offset + first.length))).toEqual(raw);
+  });
+
+  test('an empty container round-trips', () => {
+    expect(parseContainer(encodeContainer([])).entries).toHaveLength(0);
+  });
+
+  test('rejects a buffer smaller than the header', () => {
+    expect(() => parseContainer(new ArrayBuffer(4))).toThrow(/too small/);
+  });
+
+  test('rejects bad magic', () => {
+    const buffer = encodeContainer([{ alias: 'a', type: 'text', bytes: utf8('x') }]);
+    new Uint8Array(buffer)[0] = 'Z'.charCodeAt(0);
+
+    expect(() => parseContainer(buffer)).toThrow(/bad magic/);
+  });
+
+  test('rejects an unsupported (future) version', () => {
+    const buffer = encodeContainer([]);
+    new DataView(buffer).setUint32(4, 999, true);
+
+    expect(() => parseContainer(buffer)).toThrow(/unsupported version/);
+  });
+
+  test('rejects an index length that runs past the buffer', () => {
+    const buffer = encodeContainer([{ alias: 'a', type: 'text', bytes: utf8('x') }]);
+    new DataView(buffer).setUint32(8, 0xffff, true);
+
+    expect(() => parseContainer(buffer)).toThrow(/runs past the buffer/);
+  });
+
+  test('rejects an entry whose slice runs past the data section', () => {
+    const indexBytes = utf8(JSON.stringify([{ alias: 'a', type: 'text', offset: 0, length: 999 }]));
+    const buffer = new ArrayBuffer(CONTAINER_HEADER_SIZE + indexBytes.byteLength + 2);
+    const bytes = new Uint8Array(buffer);
+    const view = new DataView(buffer);
+
+    for (let i = 0; i < CONTAINER_MAGIC.length; i++) {
+      bytes[i] = CONTAINER_MAGIC.charCodeAt(i);
+    }
+    view.setUint32(4, 1, true);
+    view.setUint32(8, indexBytes.byteLength, true);
+    bytes.set(indexBytes, CONTAINER_HEADER_SIZE);
+
+    expect(() => parseContainer(buffer)).toThrow(/runs past the data section/);
+  });
+
+  test('rejects a non-array index', () => {
+    const indexBytes = utf8(JSON.stringify({ not: 'an array' }));
+    const buffer = new ArrayBuffer(CONTAINER_HEADER_SIZE + indexBytes.byteLength);
+    const bytes = new Uint8Array(buffer);
+    const view = new DataView(buffer);
+
+    for (let i = 0; i < CONTAINER_MAGIC.length; i++) {
+      bytes[i] = CONTAINER_MAGIC.charCodeAt(i);
+    }
+    view.setUint32(4, 1, true);
+    view.setUint32(8, indexBytes.byteLength, true);
+    bytes.set(indexBytes, CONTAINER_HEADER_SIZE);
+
+    expect(() => parseContainer(buffer)).toThrow(/index is not an array/);
+  });
+});
+
+describe('Loader.loadContainer', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('loads N assets from one container in a single request', async () => {
+    const container = encodeContainer([
+      { alias: 'level', type: 'json', bytes: utf8('{"score":42}') },
+      { alias: 'readme', type: 'text', bytes: utf8('hello world') },
+      { alias: 'blob', type: 'binary', bytes: new Uint8Array([1, 2, 3, 4]) },
+    ]);
+    const fetchSpy = mockContainerFetch(container);
+
+    const loader = createCoreLoader();
+    await loader.loadContainer('assets/pack.exoa');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(loader.get(Json, 'level')).toEqual({ score: 42 });
+    expect(loader.get(TextAsset, 'readme')).toBe('hello world');
+    expect(new Uint8Array(loader.get(BinaryAsset, 'blob') as ArrayBuffer)).toEqual(new Uint8Array([1, 2, 3, 4]));
+  });
+
+  test('throws on an unknown asset type and stores nothing', async () => {
+    const container = encodeContainer([{ alias: 'x', type: 'nonsense', bytes: utf8('x') }]);
+    mockContainerFetch(container);
+
+    const loader = createCoreLoader();
+
+    await expect(loader.loadContainer('x.exoa')).rejects.toThrow(/unknown asset type "nonsense"/);
+  });
+
+  test('throws on a malformed container', async () => {
+    mockContainerFetch(new ArrayBuffer(4));
+
+    const loader = createCoreLoader();
+
+    await expect(loader.loadContainer('bad.exoa')).rejects.toThrow(/Invalid asset container/);
+  });
+});


### PR DESCRIPTION
**Welle 6 — Asset-Container Stufe 1 (Archiv)** (Epic 9, Spec `10`). Ein binäres Container-Format (`.exoa`) liefert **N Assets aus EINEM HTTP-Request** — die natürliche Evolution von `AssetManifest`-Bundles, die heute pro Eintrag einen Fetch machen (`loadBundle`, N Fetches).

## 9a — Format + Reader + `loadContainer` + Source-Injection (`3cfd8659`)
- **Format** (`AssetContainer.ts`, `@internal`): magic `"EXOA"` + version + u32 indexLength + JSON-Index `[{alias,type,offset,length,mime?,options?}]` + konkatenierte Byte-Slices. `parseContainer` härtet jedes Feld (falsches Magic, zukünftige Version, abgeschnittener Buffer, Slice out-of-bounds, Nicht-Array-Index → wirft, nie Garbage). `encodeContainer` (Writer) ist mit Builder + Test geteilt (kein Drift) und tree-shaked aus dem Runtime-Bundle.
- **Source-Injection** (der eine nicht-additive Teil): Core-Typen laufen über die **Handler-Bahn** (nicht die FactoryRegistry, die für sie leer ist), daher bekommt der `AssetHandler`-Vertrag ein optionales **`createFromBytes(bytes, options)`** — die factory-gestützten binary/text/json-Handler bauen direkt aus einem Slice, ohne Fetch. `Loader.loadContainer(url)` holt den Container **einmal** (via `_contextFetch`-Pass-through, IDB-cachebar), parst den Index, und `_injectSource` entpackt jeden Slice über `createFromBytes` + `_storeResource` — abrufbar mit `loader.get` wie einzeln geladen. Subtitle/bmFont (process-/sub-asset-gebunden) lassen `createFromBytes` weg und werfen klar, wenn eingebettet.

## 9b — Builder + Tests (`814f0803`)
- `scripts/build-container.ts`: packt eine `.exoa` aus einem JSON-Manifest (alias/type/file), nutzt `encodeContainer` (geteiltes Format). Real verifiziert (Manifest → Container, Magic, Bytelänge).
- `asset-container.test.ts` (12 Tests): Format-Roundtrip + Härtung + `loadContainer` end-to-end (3 Assets aus einem Container, **fetch genau 1×**, `loader.get` liefert jedes; unbekannter Typ + kaputter Container werfen).

## Offene Entscheidungen (Spec §) — autonom mit Spec-Defaults entschieden
1. **Eager** (nicht Lazy) — `loadContainer` entpackt sofort alle N. ✓
2. **Embedded-only** (nicht Hybrid). ✓
3. **Source-Injection: Handler-Vertrag erweitern** (`createFromBytes`, optional/additiv) — nicht die Loader-interne Factory-Doppelhaltung. ✓
4. **`.exoa` / Magic `"EXOA"`** (früh festgenagelt). ✓
5. **`loadContainer` public, Reader-Internals `@internal`** (kein root-index-Delta, nur `loader.mdx`). ✓

**8c** (aus W5, MemoryStore als L0-Source-Cache) bleibt **Backlog** (optional, Loader-`CacheStrategy`-berührend). **Stufe 2 (FlatBuffers)** = Backlog (Spec §, post-1.0).

## CI-Parität (lokal grün)
typecheck (core + guides + examples + 5 Pakete) · lint:all (0 errors) · format:check · docs:api:check (loader.mdx sync) · `pnpm test` **3476 passed**. Kein Public-API-Bruch (createFromBytes optional → keine Extension bricht).