### PR TITLE
v0.15 W7 — Physics step allocation: allocation-free contact graph + sorts (10a–10d)

### DIFF
--- a/packages/exojs-physics/src/ContactGraph.ts
+++ b/packages/exojs-physics/src/ContactGraph.ts
@@ -3,6 +3,7 @@ import type { Collider } from './Collider';
 import { Manifold } from './collision/Manifold';
 import { collide, testOverlap } from './collision/narrowphase';
 import type { CollisionEvent, ContactPoint, SensorEvent } from './events';
+import { sortInPlace } from './sort';
 import { shouldCollide } from './types';
 
 /**
@@ -66,9 +67,8 @@ export class ContactGraph {
     this.sensorExit.length = 0;
     this.solidContacts.length = 0;
 
-    for (const record of this._records.values()) {
-      record.seen = false;
-    }
+    // eslint-disable-next-line unicorn/no-array-for-each -- forEach is the allocation-free path; for…of over a Map allocates an iterator every step (W7 10a).
+    this._records.forEach(resetSeen);
 
     for (const pair of pairs) {
       const a = pair.a;
@@ -109,22 +109,18 @@ export class ContactGraph {
       }
     }
 
-    // Pairs that left the broad phase entirely while touching → fire end.
-    for (const [key, record] of this._records) {
-      if (!record.seen) {
-        if (record.touching) {
-          this._emitEnd(record);
-        }
+    // Pairs that left the broad phase entirely while touching → fire end. forEach
+    // + thisArg is the allocation-free iteration (for…of allocates an entry tuple
+    // per record each step); the thisArg binds `this`, so unbound-method is a
+    // false positive here (W7 10a).
+    // eslint-disable-next-line unicorn/no-array-for-each, @typescript-eslint/unbound-method
+    this._records.forEach(this._removeIfUnseen, this);
 
-        this._records.delete(key);
-      }
-    }
-
-    this.collisionStart.sort(byColliderPair);
-    this.collisionEnd.sort(byColliderPair);
-    this.sensorEnter.sort(bySensorPair);
-    this.sensorExit.sort(bySensorPair);
-    this.solidContacts.sort(byRecordPair);
+    sortInPlace(this.collisionStart, byColliderPair);
+    sortInPlace(this.collisionEnd, byColliderPair);
+    sortInPlace(this.sensorEnter, bySensorPair);
+    sortInPlace(this.sensorExit, bySensorPair);
+    sortInPlace(this.solidContacts, byRecordPair);
   }
 
   /** Remove every record referencing `collider` (called when a collider is destroyed). */
@@ -156,7 +152,29 @@ export class ContactGraph {
       this.collisionEnd.push(makeEndEvent(record.a, record.b));
     }
   }
+
+  /**
+   * `Map.forEach` callback (its `this` bound via the forEach thisArg) — drops a
+   * record the latest pass did not see, firing an end event if it was touching.
+   * A method reference + thisArg keeps the per-step iteration allocation-free,
+   * unlike `for (const [key, record] of map)` which allocates an entry tuple per
+   * record (~1000/step). Deleting the current entry during forEach is safe.
+   */
+  private _removeIfUnseen(record: ContactRecord, key: number): void {
+    if (!record.seen) {
+      if (record.touching) {
+        this._emitEnd(record);
+      }
+
+      this._records.delete(key);
+    }
+  }
 }
+
+/** `Map.forEach` callback — clears the per-pass `seen` flag (no iterator allocation). */
+const resetSeen = (record: ContactRecord): void => {
+  record.seen = false;
+};
 
 /**
  * Stride for packing two collider ids into one pair key. Multiplying by this

--- a/packages/exojs-physics/src/broadphase/SweepAndPrune.ts
+++ b/packages/exojs-physics/src/broadphase/SweepAndPrune.ts
@@ -1,4 +1,5 @@
 import type { Collider } from '../Collider';
+import { sortInPlace } from '../sort';
 import type { BroadPhase, CandidatePair } from './BroadPhase';
 
 /**
@@ -29,7 +30,7 @@ export class SweepAndPrune implements BroadPhase {
       sorted.push(collider);
     }
 
-    sorted.sort(byMinX);
+    sortInPlace(sorted, byMinX);
 
     const count = sorted.length;
 
@@ -83,7 +84,7 @@ export class SweepAndPrune implements BroadPhase {
       }
     }
 
-    out.sort(byPairId);
+    sortInPlace(out, byPairId);
 
     return out;
   }

--- a/packages/exojs-physics/src/collision/narrowphase.ts
+++ b/packages/exojs-physics/src/collision/narrowphase.ts
@@ -404,7 +404,10 @@ const collidePolygons = (a: CollisionProxy, b: CollisionProxy, manifold: Manifol
   // Reference-face tangent (the side-plane direction).
   let tx = v2x - v1x;
   let ty = v2y - v1y;
-  const tl = Math.hypot(tx, ty);
+  // sqrt(x²+y²) over Math.hypot — avoids hypot's variadic/internal-allocation
+  // path on the narrow-phase hot path; the operands are bounded edge lengths,
+  // so the overflow protection hypot adds is not needed here.
+  const tl = Math.sqrt(tx * tx + ty * ty);
   tx /= tl;
   ty /= tl;
 

--- a/packages/exojs-physics/src/sort.ts
+++ b/packages/exojs-physics/src/sort.ts
@@ -1,0 +1,59 @@
+/**
+ * In-place heap sort — deterministic, O(n log n) regardless of input order, and
+ * allocation-free. `Array.prototype.sort` allocates an internal temp buffer in
+ * V8's TimSort for arrays larger than ~10 elements; the broad-phase and contact
+ * sorts run over ~1,000 elements every step, so that temp buffer is per-step
+ * garbage. Heap sort sorts in place with only a constant number of locals.
+ *
+ * Heap sort is not stable, but every physics comparator (`byMinX`, `byPairId`,
+ * `byRecordPair`, `byColliderPair`, `bySensorPair`) breaks ties on collider id,
+ * so no two elements ever compare equal — the ordering is total and therefore
+ * bit-identical to the `Array.prototype.sort` it replaces (gate SG-D1, replay
+ * determinism). Do not use this with a comparator that can return 0 for distinct
+ * elements; the result order would then differ from a stable sort.
+ *
+ * @internal
+ */
+export function sortInPlace<T>(array: T[], compare: (a: T, b: T) => number): void {
+  const n = array.length;
+
+  // Heapify: turn the array into a max-heap bottom-up.
+  for (let i = (n >> 1) - 1; i >= 0; i--) {
+    siftDown(array, i, n, compare);
+  }
+
+  // Repeatedly move the max (root) to the sorted tail, then restore the heap.
+  for (let end = n - 1; end > 0; end--) {
+    const root = array[0]!;
+    array[0] = array[end]!;
+    array[end] = root;
+    siftDown(array, 0, end, compare);
+  }
+}
+
+function siftDown<T>(array: T[], start: number, end: number, compare: (a: T, b: T) => number): void {
+  let parent = start;
+
+  for (;;) {
+    let child = parent * 2 + 1;
+
+    if (child >= end) {
+      break;
+    }
+
+    // Pick the larger of the two children.
+    if (child + 1 < end && compare(array[child]!, array[child + 1]!) < 0) {
+      child++;
+    }
+
+    // Parent already dominates the larger child — heap property restored.
+    if (compare(array[parent]!, array[child]!) >= 0) {
+      break;
+    }
+
+    const tmp = array[parent]!;
+    array[parent] = array[child]!;
+    array[child] = tmp;
+    parent = child;
+  }
+}

--- a/packages/exojs-physics/test/perf.test.ts
+++ b/packages/exojs-physics/test/perf.test.ts
@@ -15,11 +15,11 @@ import { measureAllocationRate } from './allocationSampler';
  * regression guard is asserted. P-1 (allocation) is measured with V8's
  * allocation sampling profiler (see allocationSampler.ts — a heapUsed delta
  * cannot see the short-lived per-step garbage; it previously read ~0 and made
- * the engine look allocation-free when it was not). The narrow/broad-phase
- * scratch reuse roughly halves per-step allocation (~1560 → ~810 KB/step); the
- * remainder is dominated by the contact solver and ContactGraph and is tracked
- * as a follow-up (W4 spec backlog). The gate is a regression guard for the
- * reuse win, not a zero-allocation assertion.
+ * the engine look allocation-free when it was not). Scratch reuse (W4) plus the
+ * W7 allocation-free ContactGraph iterators and in-place sorts bring the steady-
+ * state rate ~1560 → ~810 → ~484 KB/step. The remainder is V8 double-boxing in
+ * the scalar float hot loops (solver block LCP, narrow-phase clip — both verified
+ * allocation-free), removable only by an invasive typed-array rewrite (post-1.0).
  */
 
 const FRAME = 1 / 60;
@@ -116,11 +116,17 @@ describe('physics dynamics performance (P-1 / P-2)', () => {
 
     console.log(`[P-1] ${(bytesPerStep / 1024).toFixed(2)} KB/step allocation (sampling profiler)`);
 
-    // Regression guard for the scratch-reuse win: ~810 KB/step after reuse vs
-    // ~1560 KB/step before (narrow/broad-phase pooling roughly halves it). The
-    // remaining ~810 KB is dominated by the contact solver (_solveNormalBlock) +
-    // ContactGraph.update — outside this slice's scope (W4 spec backlog). The
-    // threshold sits between the two rates, so losing the reuse trips the gate.
-    expect(bytesPerStep).toBeLessThan(1_100 * 1024);
+    // Sharp gate (W7): the ContactGraph iterators + broad-phase/contact sorts are
+    // now allocation-free (forEach with a bound method instead of entry-tuple
+    // destructuring; an in-place heap sort instead of Array.prototype.sort's temp
+    // buffer), dropping the steady-state rate ~810 → ~484 KB/step. The remainder
+    // is not poolable garbage: it is V8 double-boxing + sampler misattribution in
+    // the scalar float hot loops (the solver block LCP and narrow-phase clip are
+    // verified allocation-free — see _solveNormalBlock/collide), removable only by
+    // an invasive typed-array solver rewrite (post-1.0 follow-up). Measured ~484
+    // KB/step (±1, very stable); the gate sits at 600 KB — tight enough that
+    // reverting the W7 reuse (≈810) trips it, with headroom for cross-machine V8
+    // boxing variance.
+    expect(bytesPerStep).toBeLessThan(600 * 1024);
   });
 });


### PR DESCRIPTION
**Welle 7 — Physics-Step-Allokation** (Epic 10, Spec `11`). Macht den eingeschwungenen Physics-Step dort allokationsfrei, wo es billig geht: **~810 → ~484 KB/step** (Sampling-Profiler, 1000-Body-Feld). Rein intern — kein Public-API, kein Verhaltensbruch (volle SG-Matrix + **SG-D1 Determinismus bit-identisch**, 87 Tests grün). Muss **vor W8** liegen (TGS-Sub-Stepping läuft `detect`/`ContactGraph.update` N×/Frame).

## Slices
- **10a ContactGraph-Iteratoren:** der `seen`-Reset + das End-Event-Cleanup liefen die Record-Map mit `for…of` / `[key, record]`-Destructuring → Iterator + ~1000 Tupel/Step. Ersetzt durch `Map.forEach` (Modul-Funktion für den Reset, gebundene Methode + thisArg fürs Cleanup) → allokationsfrei.
- **10b In-Place-Sorts:** `Array.prototype.sort` allokiert einen TimSort-Temp-Puffer für die ~1000-Element-Arrays. Neuer **`sortInPlace`** (Heapsort, `src/sort.ts`, `@internal`). **Deterministisch:** jeder Comparator bricht Ties auf Collider-id → keine gleichen Elemente → Ordnung bit-identisch zum ersetzten Sort (SG-D1). Auf ContactGraphs 5 Event/Contact-Sorts + SweepAndPrunes 2 angewandt.
- **10c Narrow-Phase:** `Math.hypot(tx,ty)` → `Math.sqrt(tx*tx + ty*ty)` im Clip-Hot-Path (begrenzte Kantenlängen, kein Overflow-Risiko; innerhalb der SG-Toleranzen).
- **10d Gate scharf:** perf.test-Allokations-Guard 1.100 → **600 KB/step**.

## Befund (korrigiert die Spec-Annahme)
Die verbleibenden ~484 KB sind **kein poolbarer Müll**: `_solveNormalBlock` + der Narrow-Phase-Clip sind als skalar/allokationsfrei verifiziert. Es ist **V8-Double-Boxing in den Float-Hot-Loops + Sampler-Misattribution** an die heißeste Funktion — nur durch einen invasiven typed-array-Solver-Umbau entfernbar (post-1.0). Das **bestätigt** die Spec-Notiz, dass die Solver-„Allokation" Misattribution war: das Beheben der echten ContactGraph/SAP-Quellen ließ die `_solveNormalBlock`-Zahl unverändert. Messung sehr stabil (483.4/483.8/483.9 KB über 3 Läufe).

## CI-Parität (lokal grün)
typecheck (core + 5 Pakete) · lint:all (0 errors, 0 warnings) · format:check · docs:api:check · `pnpm test` **3476 passed** (physics 87 inkl. scharfem Gate). Keine Public-Symbole (`sortInPlace` ist `@internal`) → kein root-index/docs-Delta.