### PR TITLE
v0.15 W8 — TGS-Soft solver: 20-box stacking stability (11a–11d)

### DIFF
--- a/packages/exojs-physics/src/PhysicsBody.ts
+++ b/packages/exojs-physics/src/PhysicsBody.ts
@@ -71,19 +71,16 @@ export class PhysicsBody {
   /** Angular velocity in rad/s. */
   public angularVelocity = 0;
 
-  /** @internal — Transient position correction X accumulated by the NGS position solver and applied to the transform each sub-step. */
-  public _posCorrectionX = 0;
-  /** @internal — Transient position correction Y accumulated by the NGS position solver. */
-  public _posCorrectionY = 0;
-  /** @internal — Transient angle correction (radians) accumulated by the NGS position solver. */
-  public _angleCorrection = 0;
-
-  /** @internal — Velocity snapshot taken before this sub-step's gravity, so the restitution bias keys off the true impact speed (not the per-step gravity increment). */
-  public _prevVx = 0;
-  /** @internal — Velocity snapshot (Y) before this sub-step's gravity. */
-  public _prevVy = 0;
-  /** @internal — Angular-velocity snapshot before this sub-step's gravity. */
-  public _prevW = 0;
+  /** @internal — Delta position X accumulated across the frame's sub-steps by the TGS integrator; written into the transform once per frame by {@link _finalizePosition}. */
+  public _deltaPosX = 0;
+  /** @internal — Delta position Y accumulated across the frame's sub-steps by the TGS integrator. */
+  public _deltaPosY = 0;
+  /** @internal — Delta rotation (radians) accumulated across the frame's sub-steps by the TGS integrator. */
+  public _deltaAngle = 0;
+  /** @internal — `cos(_deltaAngle)`, cached so the solver can rotate the contact anchors by the live sub-step rotation without a per-contact trig call. */
+  public _deltaCos = 1;
+  /** @internal — `sin(_deltaAngle)`, cached alongside {@link _deltaCos}. */
+  public _deltaSin = 0;
 
   private _forceX = 0;
   private _forceY = 0;
@@ -292,65 +289,98 @@ export class PhysicsBody {
     return this;
   }
 
-  /** @internal — snapshot the current velocity (before this sub-step's gravity) for the restitution bias. */
-  public _snapshotVelocity(): void {
-    this._prevVx = this.linearVelocityX;
-    this._prevVy = this.linearVelocityY;
-    this._prevW = this.angularVelocity;
-  }
-
   /**
    * @internal — integrate velocity from gravity, accumulated forces/torque and
-   * damping over `dt`. No-op for static/kinematic (infinite mass keeps their
-   * velocity solver-driven only). Clears the force/torque accumulators.
+   * damping over the sub-step `h`. No-op for static/kinematic (infinite mass
+   * keeps their velocity solver-driven only). Called once per TGS sub-step, so
+   * gravity/forces are applied with `h` each sub-step (`N·h = dt`, same total
+   * impulse, but the small-step position error scales with `h²`). The
+   * force/torque accumulators are **not** cleared here — they are consumed by
+   * every sub-step and cleared once per frame by {@link _finalizePosition}.
    */
-  public _integrateVelocity(dt: number, gravityX: number, gravityY: number): void {
+  public _integrateVelocity(h: number, gravityX: number, gravityY: number): void {
     if (this.invMass === 0) {
       return;
     }
 
-    this.linearVelocityX += (gravityX * this.gravityScale + this._forceX * this.invMass) * dt;
-    this.linearVelocityY += (gravityY * this.gravityScale + this._forceY * this.invMass) * dt;
-    this.angularVelocity += this._torque * this.invInertia * dt;
+    this.linearVelocityX += (gravityX * this.gravityScale + this._forceX * this.invMass) * h;
+    this.linearVelocityY += (gravityY * this.gravityScale + this._forceY * this.invMass) * h;
+    this.angularVelocity += this._torque * this.invInertia * h;
 
     // Exponential damping (no-op when damping is 0).
-    this.linearVelocityX /= 1 + dt * this.linearDamping;
-    this.linearVelocityY /= 1 + dt * this.linearDamping;
-    this.angularVelocity /= 1 + dt * this.angularDamping;
-
-    this._forceX = 0;
-    this._forceY = 0;
-    this._torque = 0;
+    this.linearVelocityX /= 1 + h * this.linearDamping;
+    this.linearVelocityY /= 1 + h * this.linearDamping;
+    this.angularVelocity /= 1 + h * this.angularDamping;
   }
 
   /**
-   * @internal — integrate position from the current velocity over `dt` plus any
-   * accumulated NGS position correction, rotating about the centre of mass.
-   * Static bodies never move; dynamic + kinematic bodies advance by their
-   * velocity. The position correction is geometric (it never changes velocity)
-   * and is consumed here.
+   * @internal — accumulate this sub-step's velocity into the per-frame delta
+   * position/rotation (TGS sub-stepping). The transform itself is **not** moved
+   * here; {@link _finalizePosition} writes the accumulated delta once per frame.
+   * Tracking the delta (rather than moving the transform each sub-step) lets the
+   * solver recompute contact separation from it without re-running detection or
+   * re-syncing collider geometry per sub-step. Static bodies never move.
    */
-  public _integratePosition(dt: number): void {
+  public _integratePosition(h: number): void {
     if (this.type === 'static') {
-      this._posCorrectionX = 0;
-      this._posCorrectionY = 0;
-      this._angleCorrection = 0;
+      return;
+    }
+
+    this._deltaPosX += this.linearVelocityX * h;
+    this._deltaPosY += this.linearVelocityY * h;
+    this._deltaAngle += this.angularVelocity * h;
+
+    // Cache the rotation so the solver can rotate the contact anchors by the
+    // live sub-step rotation (TGS): without it the anchors stay frozen at frame
+    // start and a tilting tower's restoring torque is mis-computed, so the tilt
+    // grows instead of being corrected. Only non-zero rotation pays the trig.
+    if (this._deltaAngle !== 0) {
+      this._deltaCos = Math.cos(this._deltaAngle);
+      this._deltaSin = Math.sin(this._deltaAngle);
+    }
+  }
+
+  /**
+   * @internal — apply the frame's accumulated delta position/rotation to the
+   * transform (rotating about the centre of mass), re-sync collider geometry and
+   * clear the force/torque accumulators. Called once per frame after the
+   * sub-step loop. Static bodies never move; the force clear still runs (forces
+   * are a no-op on infinite mass but the accumulator is reset for consistency).
+   */
+  public _finalizePosition(): void {
+    this._forceX = 0;
+    this._forceY = 0;
+    this._torque = 0;
+
+    if (this.type === 'static' || (this._deltaPosX === 0 && this._deltaPosY === 0 && this._deltaAngle === 0)) {
+      this._resetDelta();
 
       return;
     }
 
-    const newComX = this.worldCenterOfMassX + this.linearVelocityX * dt + this._posCorrectionX;
-    const newComY = this.worldCenterOfMassY + this.linearVelocityY * dt + this._posCorrectionY;
-    const newAngle = this._transform.angle + this.angularVelocity * dt + this._angleCorrection;
+    const newComX = this.worldCenterOfMassX + this._deltaPosX;
+    const newComY = this.worldCenterOfMassY + this._deltaPosY;
+    const newAngle = this._transform.angle + this._deltaAngle;
     const cos = Math.cos(newAngle);
     const sin = Math.sin(newAngle);
 
     // origin = newCoM − R(newAngle)·comLocal (so rotation pivots about the CoM).
     setTransform(this._transform, newComX - (cos * this._comX - sin * this._comY), newComY - (sin * this._comX + cos * this._comY), newAngle);
 
-    this._posCorrectionX = 0;
-    this._posCorrectionY = 0;
-    this._angleCorrection = 0;
+    this._resetDelta();
+
+    for (const collider of this._colliders) {
+      collider.synchronize(this._transform);
+    }
+  }
+
+  /** Clear the per-frame TGS delta accumulators (position, rotation and its cached cos/sin). */
+  private _resetDelta(): void {
+    this._deltaPosX = 0;
+    this._deltaPosY = 0;
+    this._deltaAngle = 0;
+    this._deltaCos = 1;
+    this._deltaSin = 0;
   }
 
   /** Internal: detach a collider (called by the world during destruction). */

--- a/packages/exojs-physics/src/PhysicsWorld.ts
+++ b/packages/exojs-physics/src/PhysicsWorld.ts
@@ -22,13 +22,15 @@ export interface PhysicsWorldOptions {
   gravity?: VectorLike;
   /** Fixed timestep in seconds. Default `1 / 60`. */
   fixedDelta?: number;
-  /** Maximum sub-steps per `step` (spiral-of-death guard). Default `8`. */
+  /** Maximum fixed steps per `step` call (spiral-of-death guard). Default `8`. */
   maxSubSteps?: number;
-  /** Sequential-impulse velocity iterations per sub-step. Default `8`. */
-  velocityIterations?: number;
-  /** Split-impulse position-correction iterations per sub-step. Default `3`. */
-  positionIterations?: number;
-  /** Interpolate bound nodes between sub-steps (reserved; no effect yet). Default `true`. */
+  /** TGS-Soft sub-steps per fixed step (the solver's stiffness scales with this, not iteration count). Default `4`. Must be ≥ 1. */
+  subStepCount?: number;
+  /** Soft-contact stiffness in Hz (the contact behaves as a damped spring at this frequency). Default `30`. */
+  contactHertz?: number;
+  /** Soft-contact damping ratio (≥ 1 keeps contacts from oscillating). Default `10`. */
+  dampingRatio?: number;
+  /** Interpolate bound nodes between fixed steps (reserved; no effect yet). Default `true`. */
   interpolation?: boolean;
 }
 
@@ -76,12 +78,14 @@ export interface AttachOptions {
  * bound node transforms. It holds **no module-level state**, so any number of
  * worlds run in isolation (gate I-1).
  *
- * The dynamics are a native, warm-started **sequential-impulse** solver: a
- * 2-point block normal solve plus a non-linear Gauss-Seidel position-correction
- * pass. It integrates gravity/forces/impulses, resolves contacts and keeps
- * moderate stacks stable; very tall towers (beyond ~10 high) are a known limit
- * of the iteration budget. The detection backend sits behind an internal seam,
- * so the solver is swappable without touching this public surface.
+ * The dynamics are a native, warm-started **TGS-Soft** solver (Box2D-v3 "soft
+ * step"): each fixed step runs detection once, then several sub-steps, each
+ * integrating gravity over the sub-step and solving contacts with a soft
+ * position bias plus a bias-free relax pass; a 2-point block normal solve
+ * propagates stack loads, and restitution is a separate final pass. Decoupling
+ * stiffness from the iteration count keeps tall towers stable. The detection
+ * backend sits behind an internal seam, so the solver is swappable without
+ * touching this public surface.
  */
 export class PhysicsWorld implements BodyOwner {
   /** Fires when two solid colliders begin touching. Argument is an immutable snapshot. */
@@ -97,12 +101,14 @@ export class PhysicsWorld implements BodyOwner {
   public readonly gravity: Vector;
   /** The fixed-step accumulator. */
   public readonly timeStepper: TimeStepper;
-  /** Whether bound nodes interpolate between sub-steps (reserved; no effect yet). */
+  /** Whether bound nodes interpolate between fixed steps (reserved; no effect yet). */
   public readonly interpolation: boolean;
-  /** Sequential-impulse velocity iterations per sub-step. */
-  public readonly velocityIterations: number;
-  /** Split-impulse position-correction iterations per sub-step. */
-  public readonly positionIterations: number;
+  /** TGS-Soft sub-steps per fixed step. */
+  public readonly subStepCount: number;
+  /** Soft-contact stiffness in Hz. */
+  public readonly contactHertz: number;
+  /** Soft-contact damping ratio. */
+  public readonly dampingRatio: number;
 
   private readonly _backend: PhysicsBackend = new NativePhysicsBackend();
   private readonly _bodies: PhysicsBody[] = [];
@@ -123,8 +129,16 @@ export class PhysicsWorld implements BodyOwner {
       ...(options.maxSubSteps !== undefined && { maxSubSteps: options.maxSubSteps }),
     });
     this.interpolation = options.interpolation ?? true;
-    this.velocityIterations = options.velocityIterations ?? 8;
-    this.positionIterations = options.positionIterations ?? 3;
+
+    const subStepCount = options.subStepCount ?? 4;
+
+    if (!Number.isInteger(subStepCount) || subStepCount < 1) {
+      throw new RangeError(`PhysicsWorld: subStepCount must be an integer ≥ 1, received ${subStepCount}.`);
+    }
+
+    this.subStepCount = subStepCount;
+    this.contactHertz = options.contactHertz ?? 30;
+    this.dampingRatio = options.dampingRatio ?? 10;
     this._query = new QueryEngine(this._colliders);
   }
 
@@ -215,9 +229,11 @@ export class PhysicsWorld implements BodyOwner {
   // ── stepping ───────────────────────────────────────────────────────────
 
   /**
-   * Advance the world by `frameDeltaSeconds`. Accumulates into fixed sub-steps;
-   * each sub-step integrates velocities, runs detection, solves contacts and
-   * integrates positions. Then dispatches events and writes bound node transforms.
+   * Advance the world by `frameDeltaSeconds`. Accumulates into fixed steps; each
+   * fixed step runs detection once, then a TGS-Soft sub-step loop (integrate
+   * gravity, solve contacts with a soft bias, integrate positions, relax) and a
+   * restitution pass, then writes the accumulated motion into each body. Finally
+   * dispatches events and writes bound node transforms.
    */
   public step(frameDeltaSeconds: number): void {
     this._assertAlive();
@@ -225,24 +241,51 @@ export class PhysicsWorld implements BodyOwner {
     const steps = this.timeStepper.advance(frameDeltaSeconds);
 
     if (steps > 0) {
-      const dt = this.timeStepper.fixedDelta;
+      const subStepCount = this.subStepCount;
+      const h = this.timeStepper.fixedDelta / subStepCount;
       const gravityX = this.gravity.x;
       const gravityY = this.gravity.y;
+      const contactHertz = this.contactHertz;
+      const dampingRatio = this.dampingRatio;
 
       for (let step = 0; step < steps; step++) {
-        // Integrate velocities (gravity + forces), refresh geometry, then detect.
-        for (const body of this._bodies) {
-          body._snapshotVelocity();
-          body._integrateVelocity(dt, gravityX, gravityY);
-          body.synchronizeColliders();
+        // Detection runs once per fixed step (collider geometry is already current
+        // from the previous frame's finalize / attach / setTransform). TGS-Soft
+        // reuses the manifolds across the sub-steps below.
+        this._backend.detect(this._colliders);
+        this._backend.prepareSolve(h, contactHertz, dampingRatio);
+
+        for (let subStep = 0; subStep < subStepCount; subStep++) {
+          // Integrate gravity/forces over the sub-step (forces persist across
+          // sub-steps; cleared once per frame by `_finalizePosition`).
+          for (const body of this._bodies) {
+            body._integrateVelocity(h, gravityX, gravityY);
+          }
+
+          // Warm-start every sub-step (Box2D-v3 soft step): the relax pass leaves
+          // each contact's normal velocity at zero, so re-applying the
+          // accumulated impulse re-balances exactly this sub-step's gravity — the
+          // impulse converges to the per-sub-step load (m·h·g), not the per-frame
+          // load, which is what keeps tall stacks from pumping energy.
+          this._backend.warmStart();
+
+          // Main soft-bias velocity solve, integrate positions (accumulating
+          // per-body delta), then the bias-free relax pass.
+          this._backend.solveVelocities(true);
+
+          for (const body of this._bodies) {
+            body._integratePosition(h);
+          }
+
+          this._backend.solveVelocities(false);
         }
 
-        this._backend.detect(this._colliders);
-        this._backend.solve(this.velocityIterations, this.positionIterations);
+        // Separate restitution pass, then write the accumulated delta into each
+        // body's transform and re-sync collider geometry.
+        this._backend.applyRestitution();
 
-        // Integrate positions from the solved velocities.
         for (const body of this._bodies) {
-          body._integratePosition(dt);
+          body._finalizePosition();
         }
       }
 

--- a/packages/exojs-physics/src/backend/NativePhysicsBackend.ts
+++ b/packages/exojs-physics/src/backend/NativePhysicsBackend.ts
@@ -27,11 +27,20 @@ export class NativePhysicsBackend implements PhysicsBackend {
     this.contactGraph.update(this._pairs);
   }
 
-  public solve(velocityIterations: number, positionIterations: number): void {
-    this._solver.prepare(this.contactGraph.solidContacts);
+  public prepareSolve(h: number, contactHertz: number, dampingRatio: number): void {
+    this._solver.prepare(this.contactGraph.solidContacts, h, contactHertz, dampingRatio);
+  }
+
+  public warmStart(): void {
     this._solver.warmStart();
-    this._solver.solveVelocities(velocityIterations);
-    this._solver.solvePositions(positionIterations);
+  }
+
+  public solveVelocities(useBias: boolean): void {
+    this._solver.solveVelocities(useBias);
+  }
+
+  public applyRestitution(): void {
+    this._solver.applyRestitution();
   }
 
   public removeCollider(collider: Collider): void {

--- a/packages/exojs-physics/src/backend/PhysicsBackend.ts
+++ b/packages/exojs-physics/src/backend/PhysicsBackend.ts
@@ -15,10 +15,16 @@ export interface PhysicsBackend {
   readonly contactGraph: ContactGraph;
   /** The latest broad-phase candidate pairs (read-only; for debug draw). */
   readonly candidatePairs: readonly CandidatePair[];
-  /** Run one detection pass over `colliders`, refreshing the contact graph. */
+  /** Run one detection pass over `colliders`, refreshing the contact graph. Once per frame (TGS reuses the manifolds across sub-steps). */
   detect(colliders: readonly Collider[]): void;
-  /** Solve the contact-graph's solid contacts: warm-start + velocity iterations, then an NGS position pass. */
-  solve(velocityIterations: number, positionIterations: number): void;
+  /** Build the per-frame contact constraints from the solid contacts. `h` is the sub-step duration; the soft factors derive from it plus `contactHertz`/`dampingRatio`. Call once per frame after {@link detect}. */
+  prepareSolve(h: number, contactHertz: number, dampingRatio: number): void;
+  /** Re-apply the cached warm-start impulses to the contacting bodies (first sub-step only). */
+  warmStart(): void;
+  /** One velocity pass over the solid contacts. `useBias` selects the main soft-bias pass; `false` is the relax pass. */
+  solveVelocities(useBias: boolean): void;
+  /** Restitution pass, run once per frame after the sub-step loop. */
+  applyRestitution(): void;
   /** Forget any state referencing `collider` (called on destruction). */
   removeCollider(collider: Collider): void;
   /** Release all backend state. */

--- a/packages/exojs-physics/src/solver/ContactSolver.ts
+++ b/packages/exojs-physics/src/solver/ContactSolver.ts
@@ -1,21 +1,29 @@
 import type { ContactRecord } from '../ContactGraph';
 import type { PhysicsBody } from '../PhysicsBody';
 
-/** Position-correction factor (fraction of excess penetration removed per iteration by the NGS pass). */
-const baumgarte = 0.15;
-/** Penetration allowance (px) left uncorrected to avoid jitter. */
-const slop = 0.25;
 /** Relative normal speed (px/s) below which a contact is treated as resting (no restitution). */
 const restitutionThreshold = 1;
-/** Max position correction (px) per iteration, clamping the NGS pass against blow-up on deep penetration. */
-const maxCorrection = 4;
+/**
+ * Penetration allowance (px) the soft bias leaves uncorrected. The narrow phase
+ * only produces a manifold while the colliders overlap, so pushing penetration
+ * fully to zero lets a resting contact wink out for a frame (free-fall, then
+ * re-detect) — a periodic energy spike. Leaving a small slop keeps the contact
+ * persistently overlapping and the warm-start cache alive.
+ */
+const slop = 0.25;
+/**
+ * Cap on the soft-constraint push-out velocity (px/s). Bounds how fast the bias
+ * resolves deep penetration so a large overlap cannot fling bodies apart; the
+ * Box2D-v3 analogue is `contactSpeed = 3·lengthUnit`, retuned for ExoJS pixels.
+ */
+const maxBiasVelocity = 4;
 /** Reject the 2-point block solve when the contact matrix is worse-conditioned than this (fall back to sequential). */
 const maxConditionNumber = 1000;
 
 /**
- * Per-contact velocity/position constraint (1–2 points), computed once per
- * sub-step in {@link ContactSolver.prepare} and reused across iterations. Pooled
- * and reused across steps, so steady-state stepping allocates nothing.
+ * Per-contact velocity constraint (1–2 points), computed once per **frame** in
+ * {@link ContactSolver.prepare} and reused across all sub-steps and passes.
+ * Pooled and reused across frames, so steady-state stepping allocates nothing.
  */
 class ContactConstraint {
   public record!: ContactRecord;
@@ -26,17 +34,35 @@ class ContactConstraint {
   public tx = 0;
   public ty = 0;
   public friction = 0;
+  public restitution = 0;
   public pointCount = 0;
 
-  // Per-point contact arms (relative to each body's centre of mass).
+  // Soft-constraint factors (Box2D-v3 "soft step"), derived once per frame from
+  // contactHertz/dampingRatio and the sub-step `h`. Shared by both points.
+  public biasRate = 0;
+  public massScale = 1;
+  public impulseScale = 0;
+
+  // Per-point contact arms at frame start (relative to each body's centre of mass).
   public readonly rAx = [0, 0];
   public readonly rAy = [0, 0];
   public readonly rBx = [0, 0];
   public readonly rBy = [0, 0];
+  // Per-point arms rotated by the live sub-step rotation (refreshed each pass by
+  // {@link ContactSolver._updateArms}); the solve reads these so a rotating body's
+  // contact torque tracks its current orientation.
+  public readonly rotAx = [0, 0];
+  public readonly rotAy = [0, 0];
+  public readonly rotBx = [0, 0];
+  public readonly rotBy = [0, 0];
   public readonly normalMass = [0, 0];
   public readonly tangentMass = [0, 0];
+  /** Contact separation at frame start (= −penetration; negative when overlapping). */
+  public readonly baseSeparation = [0, 0];
+  /** Relative normal velocity at frame start (the impact speed the restitution pass keys off). */
+  public readonly relativeVelocity = [0, 0];
+  /** Push-out target normal velocity for the current pass (set per pass from the live separation). */
   public readonly velocityBias = [0, 0];
-  public readonly penetration = [0, 0];
 
   // 2-point block: the contact matrix `K` and its inverse (set only when the
   // manifold has two points and `K` is well-conditioned; else sequential).
@@ -50,17 +76,27 @@ class ContactConstraint {
 }
 
 /**
- * Native warm-started **sequential-impulse** contact solver. Each sub-step:
- * {@link prepare} builds per-contact constraints (effective masses, restitution
- * bias, and a 2×2 block matrix for two-point manifolds), {@link warmStart}
- * re-applies the cached impulses, then {@link solveVelocities} runs the velocity
- * iterations — friction via a Coulomb cone (per point), then the non-penetration
- * normal impulse. Two-point manifolds solve the normal impulses **as a 2×2 block
- * LCP** (Box2D-style), which converges far better for stacks than solving the
- * two points sequentially. {@link solvePositions} then removes penetration with a
- * non-linear Gauss-Seidel (NGS) geometric pass (no energy injected into
- * velocities). Accumulated impulses are written back to each {@link ContactRecord}
- * for warm-starting the next step.
+ * Native warm-started **TGS-Soft** contact solver (Box2D-v3 "soft step"). Driven
+ * by {@link PhysicsWorld} as a sub-stepping loop: detection runs once per frame,
+ * then {@link prepare} builds the per-contact constraints (effective masses,
+ * frame-start separation + impact velocity, soft factors, and a 2×2 block matrix
+ * for two-point manifolds) **once**, and each sub-step runs
+ * {@link warmStart} → {@link solveVelocities}(useBias=true) → integrate positions
+ * → {@link solveVelocities}(useBias=false) relax. A final {@link applyRestitution}
+ * pass adds bounce above the threshold.
+ *
+ * The position constraint is folded into the velocity solve as a **soft bias**
+ * (a damped-spring push-out whose stiffness is decoupled from the iteration
+ * count), recomputed each pass from the live per-body delta position/rotation —
+ * so there is no separate NGS geometric pass. The contact anchors are rotated by
+ * the live sub-step rotation each pass, so a tilting stack's restoring torque is
+ * computed against its current orientation (without this the tilt grows instead
+ * of being corrected). Two-point manifolds still solve the normal impulses **as a
+ * 2×2 block LCP** (Box2D-style), which propagates stack loads far better than
+ * solving the points sequentially; the block path carries the soft push-out as
+ * its velocity target (hard mass scale), while single-point contacts use the full
+ * soft mass/impulse scaling. Accumulated impulses are written back to each
+ * {@link ContactRecord} for warm-starting the next frame.
  *
  * Internal to {@link NativePhysicsBackend}; not part of the public surface.
  */
@@ -68,9 +104,24 @@ export class ContactSolver {
   private readonly _constraints: ContactConstraint[] = [];
   private _count = 0;
 
-  /** Build the per-contact constraints for this sub-step from the touching solid contacts. */
-  public prepare(contacts: readonly ContactRecord[]): void {
+  /**
+   * Build the per-contact constraints for this frame from the touching solid
+   * contacts. `h` is the sub-step duration (`fixedDelta / subStepCount`); the
+   * soft factors are derived from it together with `contactHertz`/`dampingRatio`.
+   * Runs once per frame (detection is not repeated per sub-step).
+   */
+  public prepare(contacts: readonly ContactRecord[], h: number, contactHertz: number, dampingRatio: number): void {
     this._count = 0;
+
+    // Box2D-v3 soft-constraint factors from a damped spring (hertz, zeta) at the
+    // sub-step `h`: omega = 2πf; a1 = 2ζ + hω; a2 = hω·a1; a3 = 1/(1+a2).
+    const omega = 2 * Math.PI * contactHertz;
+    const a1 = 2 * dampingRatio + h * omega;
+    const a2 = h * omega * a1;
+    const a3 = 1 / (1 + a2);
+    const biasRate = contactHertz > 0 ? omega / a1 : 0;
+    const massScale = contactHertz > 0 ? a2 * a3 : 1;
+    const impulseScale = contactHertz > 0 ? a3 : 0;
 
     for (const contact of contacts) {
       const manifold = contact.manifold;
@@ -96,10 +147,13 @@ export class ContactSolver {
       constraint.tx = tx;
       constraint.ty = ty;
       constraint.friction = Math.sqrt(contact.a.friction * contact.b.friction);
+      constraint.restitution = Math.max(contact.a.restitution, contact.b.restitution);
       constraint.pointCount = pointCount;
       constraint.block = false;
+      constraint.biasRate = biasRate;
+      constraint.massScale = massScale;
+      constraint.impulseScale = impulseScale;
 
-      const restitution = Math.max(contact.a.restitution, contact.b.restitution);
       const mA = bodyA.invMass;
       const mB = bodyB.invMass;
       const iA = bodyA.invInertia;
@@ -121,6 +175,11 @@ export class ContactSolver {
         constraint.rAy[i] = rAy;
         constraint.rBx[i] = rBx;
         constraint.rBy[i] = rBy;
+        // Frame start: no accumulated rotation yet, so the live arms equal the base arms.
+        constraint.rotAx[i] = rAx;
+        constraint.rotAy[i] = rAy;
+        constraint.rotBx[i] = rBx;
+        constraint.rotBy[i] = rBy;
 
         const rnA = rAx * ny - rAy * nx;
         const rnB = rBx * ny - rBy * nx;
@@ -131,16 +190,14 @@ export class ContactSolver {
 
         constraint.normalMass[i] = kn > 0 ? 1 / kn : 0;
         constraint.tangentMass[i] = kt > 0 ? 1 / kt : 0;
-        constraint.penetration[i] = point.penetration;
+        constraint.baseSeparation[i] = -point.penetration;
+        constraint.velocityBias[i] = 0;
 
-        // Restitution bias from the pre-gravity impact speed (above the threshold
-        // only) — using the post-gravity velocity would make a resting contact
-        // perpetually micro-bounce, since gravity·dt alone exceeds the threshold.
-        const relVx = bodyB._prevVx - bodyB._prevW * rBy - (bodyA._prevVx - bodyA._prevW * rAy);
-        const relVy = bodyB._prevVy + bodyB._prevW * rBx - (bodyA._prevVy + bodyA._prevW * rAx);
-        const vn = relVx * nx + relVy * ny;
-
-        constraint.velocityBias[i] = vn < -restitutionThreshold ? -restitution * vn : 0;
+        // Frame-start relative normal velocity (the true impact speed, captured
+        // before this frame's gravity since prepare runs ahead of the sub-step
+        // loop) — keys the restitution pass so a resting contact does not
+        // perpetually micro-bounce off the per-step gravity increment.
+        constraint.relativeVelocity[i] = normalVelocity(bodyA, bodyB, rAx, rAy, rBx, rBy, nx, ny);
       }
 
       if (pointCount === 2) {
@@ -170,12 +227,14 @@ export class ContactSolver {
     }
   }
 
-  /** Re-apply the cached impulses from the previous step (warm-starting). */
+  /** Re-apply the cached impulses from the previous frame (warm-starting); runs each sub-step. */
   public warmStart(): void {
     for (let ci = 0; ci < this._count; ci++) {
       const constraint = this._at(ci);
       const bodyA = constraint.bodyA;
       const bodyB = constraint.bodyB;
+
+      this._updateArms(constraint);
 
       for (let i = 0; i < constraint.pointCount; i++) {
         const normalImpulse = n(constraint.record.normalImpulse, i);
@@ -183,53 +242,76 @@ export class ContactSolver {
         const jx = normalImpulse * constraint.nx + tangentImpulse * constraint.tx;
         const jy = normalImpulse * constraint.ny + tangentImpulse * constraint.ty;
 
-        applyImpulse(bodyA, bodyB, n(constraint.rAx, i), n(constraint.rAy, i), n(constraint.rBx, i), n(constraint.rBy, i), jx, jy);
+        applyImpulse(bodyA, bodyB, n(constraint.rotAx, i), n(constraint.rotAy, i), n(constraint.rotBx, i), n(constraint.rotBy, i), jx, jy);
       }
-    }
-  }
-
-  /** Run the velocity iterations: friction (Coulomb cone) then the normal constraint (block when possible). */
-  public solveVelocities(iterations: number): void {
-    for (let iteration = 0; iteration < iterations; iteration++) {
-      for (let ci = 0; ci < this._count; ci++) {
-        this._solveVelocityContact(this._at(ci));
-      }
-    }
-  }
-
-  private _solveVelocityContact(constraint: ContactConstraint): void {
-    this._solveFriction(constraint);
-
-    if (constraint.block) {
-      this._solveNormalBlock(constraint);
-    } else {
-      this._solveNormalSequential(constraint);
     }
   }
 
   /**
-   * NGS (non-linear Gauss-Seidel) position correction: each iteration recomputes
-   * the current separation at every contact point from the corrections applied so
-   * far and pushes the bodies apart geometrically (capped per iteration at
-   * {@link maxCorrection}). Recomputing the separation makes the pass
-   * self-limiting — it stops at the slop and never over-corrects — so, unlike a
-   * fixed-bias split-impulse, it injects no energy even at low iteration counts.
-   * The corrections are applied to the transform by `_integratePosition`;
-   * velocities are untouched.
+   * One velocity pass over every contact: the normal constraint (block when
+   * possible) then friction (Coulomb cone). With `useBias` the normal solve
+   * carries the soft push-out bias (the main pass, recomputed from the live
+   * separation); without it the relax pass drives the normal velocity to zero so
+   * the bias velocity does not remain in the bodies as injected energy.
    */
-  public solvePositions(iterations: number): void {
-    for (let iteration = 0; iteration < iterations; iteration++) {
-      for (let ci = 0; ci < this._count; ci++) {
-        this._solvePositionContact(this._at(ci));
+  public solveVelocities(useBias: boolean): void {
+    for (let ci = 0; ci < this._count; ci++) {
+      this._solveVelocityContact(this._at(ci), useBias);
+    }
+  }
+
+  /**
+   * Restitution pass, run once after the sub-step loop. For each loaded point
+   * whose frame-start impact speed exceeded the threshold, add the impulse that
+   * brings the post-solve normal velocity to `−restitution·impactSpeed`. Kept
+   * separate from the main solve so resting contacts (impact below threshold) do
+   * not micro-bounce.
+   */
+  public applyRestitution(): void {
+    for (let ci = 0; ci < this._count; ci++) {
+      const constraint = this._at(ci);
+
+      if (constraint.restitution === 0) {
+        continue;
+      }
+
+      const bodyA = constraint.bodyA;
+      const bodyB = constraint.bodyB;
+      const nx = constraint.nx;
+      const ny = constraint.ny;
+
+      this._updateArms(constraint);
+
+      for (let i = 0; i < constraint.pointCount; i++) {
+        const relativeVelocity = n(constraint.relativeVelocity, i);
+
+        // Only points that carried load (normalImpulse > 0) and were struck
+        // above the resting threshold bounce.
+        if (relativeVelocity > -restitutionThreshold || n(constraint.record.normalImpulse, i) <= 0) {
+          continue;
+        }
+
+        const rAx = n(constraint.rotAx, i);
+        const rAy = n(constraint.rotAy, i);
+        const rBx = n(constraint.rotBx, i);
+        const rBy = n(constraint.rotBy, i);
+        const vn = normalVelocity(bodyA, bodyB, rAx, rAy, rBx, rBy, nx, ny);
+        const oldNormal = n(constraint.record.normalImpulse, i);
+        const newNormal = Math.max(0, oldNormal - n(constraint.normalMass, i) * (vn + constraint.restitution * relativeVelocity));
+        const deltaNormal = newNormal - oldNormal;
+
+        constraint.record.normalImpulse[i] = newNormal;
+        applyImpulse(bodyA, bodyB, rAx, rAy, rBx, rBy, deltaNormal * nx, deltaNormal * ny);
       }
     }
   }
 
-  private _solvePositionContact(constraint: ContactConstraint): void {
-    const bodyA = constraint.bodyA;
-    const bodyB = constraint.bodyB;
-    const nx = constraint.nx;
-    const ny = constraint.ny;
+  /** Refresh the live (rotated) contact arms from each body's accumulated sub-step rotation. */
+  private _updateArms(constraint: ContactConstraint): void {
+    const cosA = constraint.bodyA._deltaCos;
+    const sinA = constraint.bodyA._deltaSin;
+    const cosB = constraint.bodyB._deltaCos;
+    const sinB = constraint.bodyB._deltaSin;
 
     for (let i = 0; i < constraint.pointCount; i++) {
       const rAx = n(constraint.rAx, i);
@@ -237,26 +319,37 @@ export class ContactSolver {
       const rBx = n(constraint.rBx, i);
       const rBy = n(constraint.rBy, i);
 
-      // Displacement of the contact point on each body from corrections so far.
-      const dispAx = bodyA._posCorrectionX - bodyA._angleCorrection * rAy;
-      const dispAy = bodyA._posCorrectionY + bodyA._angleCorrection * rAx;
-      const dispBx = bodyB._posCorrectionX - bodyB._angleCorrection * rBy;
-      const dispBy = bodyB._posCorrectionY + bodyB._angleCorrection * rBx;
-
-      // Current separation (negative = penetrating), recomputed each iteration.
-      const separation = -n(constraint.penetration, i) + (dispBx - dispAx) * nx + (dispBy - dispAy) * ny;
-      const correction = clamp(baumgarte * (separation + slop), -maxCorrection, 0);
-      const impulse = -correction * n(constraint.normalMass, i);
-      const jx = impulse * nx;
-      const jy = impulse * ny;
-
-      bodyA._posCorrectionX -= jx * bodyA.invMass;
-      bodyA._posCorrectionY -= jy * bodyA.invMass;
-      bodyA._angleCorrection -= (rAx * jy - rAy * jx) * bodyA.invInertia;
-      bodyB._posCorrectionX += jx * bodyB.invMass;
-      bodyB._posCorrectionY += jy * bodyB.invMass;
-      bodyB._angleCorrection += (rBx * jy - rBy * jx) * bodyB.invInertia;
+      constraint.rotAx[i] = rAx * cosA - rAy * sinA;
+      constraint.rotAy[i] = rAx * sinA + rAy * cosA;
+      constraint.rotBx[i] = rBx * cosB - rBy * sinB;
+      constraint.rotBy[i] = rBx * sinB + rBy * cosB;
     }
+  }
+
+  private _solveVelocityContact(constraint: ContactConstraint, useBias: boolean): void {
+    this._updateArms(constraint);
+
+    // Recompute the per-point push-out target from the live separation (folds the
+    // position constraint into the velocity solve as a soft bias). With useBias
+    // off (relax pass) the target is zero — the plain hard normal solve.
+    for (let i = 0; i < constraint.pointCount; i++) {
+      // Push out only the penetration beyond the slop, capped — leaving the slop
+      // keeps the contact overlapping so the narrow phase does not drop it.
+      const excess = -currentSeparation(constraint, i) - slop;
+
+      constraint.velocityBias[i] = useBias && excess > 0 ? Math.min(constraint.biasRate * excess, maxBiasVelocity) : 0;
+    }
+
+    // Normal before friction (Box2D-v3 order): friction's Coulomb cone clamps to
+    // `μ·normalImpulse`, so it must see this pass's freshly-solved normal impulse —
+    // solving friction first uses last pass's cone and lets stacks creep laterally.
+    if (constraint.block) {
+      this._solveNormalBlock(constraint);
+    } else {
+      this._solveNormalSequential(constraint, useBias);
+    }
+
+    this._solveFriction(constraint);
   }
 
   /** Per-point friction: clamp the accumulated tangent impulse to the Coulomb cone `±μ·normalImpulse`. */
@@ -265,10 +358,10 @@ export class ContactSolver {
     const bodyB = constraint.bodyB;
 
     for (let i = 0; i < constraint.pointCount; i++) {
-      const rAx = n(constraint.rAx, i);
-      const rAy = n(constraint.rAy, i);
-      const rBx = n(constraint.rBx, i);
-      const rBy = n(constraint.rBy, i);
+      const rAx = n(constraint.rotAx, i);
+      const rAy = n(constraint.rotAy, i);
+      const rBx = n(constraint.rotBx, i);
+      const rBy = n(constraint.rotBy, i);
       const vtX = bodyB.linearVelocityX - bodyB.angularVelocity * rBy - (bodyA.linearVelocityX - bodyA.angularVelocity * rAy);
       const vtY = bodyB.linearVelocityY + bodyB.angularVelocity * rBx - (bodyA.linearVelocityY + bodyA.angularVelocity * rAx);
       const vt = vtX * constraint.tx + vtY * constraint.ty;
@@ -282,21 +375,31 @@ export class ContactSolver {
     }
   }
 
-  /** Single-point (or ill-conditioned) normal solve: accumulated, clamped ≥ 0. */
-  private _solveNormalSequential(constraint: ContactConstraint): void {
+  /**
+   * Single-point (or ill-conditioned) soft normal solve, accumulated and clamped
+   * ≥ 0. The Box2D-v3 incremental form: with the soft bias active the impulse is
+   * `−normalMass·massScale·(vn − bias) − impulseScale·accumulated`, which both
+   * pushes out the penetration and bleeds a little stored impulse (the damped
+   * spring). The relax pass passes `useBias=false`, collapsing it to the hard
+   * `−normalMass·vn` (no bias, full mass, no impulse decay).
+   */
+  private _solveNormalSequential(constraint: ContactConstraint, useBias: boolean): void {
     const bodyA = constraint.bodyA;
     const bodyB = constraint.bodyB;
     const nx = constraint.nx;
     const ny = constraint.ny;
+    const massScale = useBias ? constraint.massScale : 1;
+    const impulseScale = useBias ? constraint.impulseScale : 0;
 
     for (let i = 0; i < constraint.pointCount; i++) {
-      const rAx = n(constraint.rAx, i);
-      const rAy = n(constraint.rAy, i);
-      const rBx = n(constraint.rBx, i);
-      const rBy = n(constraint.rBy, i);
+      const rAx = n(constraint.rotAx, i);
+      const rAy = n(constraint.rotAy, i);
+      const rBx = n(constraint.rotBx, i);
+      const rBy = n(constraint.rotBy, i);
       const vn = normalVelocity(bodyA, bodyB, rAx, rAy, rBx, rBy, nx, ny);
       const oldNormal = n(constraint.record.normalImpulse, i);
-      const newNormal = Math.max(0, oldNormal - n(constraint.normalMass, i) * (vn - n(constraint.velocityBias, i)));
+      const impulse = -n(constraint.normalMass, i) * massScale * (vn - n(constraint.velocityBias, i)) - impulseScale * oldNormal;
+      const newNormal = Math.max(0, oldNormal + impulse);
       const deltaNormal = newNormal - oldNormal;
 
       constraint.record.normalImpulse[i] = newNormal;
@@ -306,8 +409,10 @@ export class ContactSolver {
 
   /**
    * Two-point block normal solve (Box2D LCP): find both new normal impulses
-   * `x ≥ 0` so the post-solve normal velocities are non-negative and
-   * complementary, trying the four corners (both active, one active, none).
+   * `x ≥ 0` so the post-solve normal velocities equal the push-out targets
+   * (`velocityBias`, zero in the relax pass) and are complementary, trying the
+   * four corners (both active, one active, none). The block path carries the
+   * soft push-out as its target but solves with a hard mass scale.
    */
   private _solveNormalBlock(constraint: ContactConstraint): void {
     const bodyA = constraint.bodyA;
@@ -316,10 +421,10 @@ export class ContactSolver {
     const ny = constraint.ny;
     const a1 = n(constraint.record.normalImpulse, 0);
     const a2 = n(constraint.record.normalImpulse, 1);
-    const vn1 = normalVelocity(bodyA, bodyB, n(constraint.rAx, 0), n(constraint.rAy, 0), n(constraint.rBx, 0), n(constraint.rBy, 0), nx, ny);
-    const vn2 = normalVelocity(bodyA, bodyB, n(constraint.rAx, 1), n(constraint.rAy, 1), n(constraint.rBx, 1), n(constraint.rBy, 1), nx, ny);
+    const vn1 = normalVelocity(bodyA, bodyB, n(constraint.rotAx, 0), n(constraint.rotAy, 0), n(constraint.rotBx, 0), n(constraint.rotBy, 0), nx, ny);
+    const vn2 = normalVelocity(bodyA, bodyB, n(constraint.rotAx, 1), n(constraint.rotAy, 1), n(constraint.rotBx, 1), n(constraint.rotBy, 1), nx, ny);
 
-    // Residual at zero impulse: b = (vn − bias) − K·a.
+    // Residual at the current impulse: b = (vn − bias) − K·a.
     const bx = vn1 - n(constraint.velocityBias, 0) - (constraint.k11 * a1 + constraint.k12 * a2);
     const by = vn2 - n(constraint.velocityBias, 1) - (constraint.k12 * a1 + constraint.k22 * a2);
 
@@ -374,8 +479,8 @@ export class ContactSolver {
     const nx = constraint.nx;
     const ny = constraint.ny;
 
-    applyImpulse(bodyA, bodyB, n(constraint.rAx, 0), n(constraint.rAy, 0), n(constraint.rBx, 0), n(constraint.rBy, 0), d1 * nx, d1 * ny);
-    applyImpulse(bodyA, bodyB, n(constraint.rAx, 1), n(constraint.rAy, 1), n(constraint.rBx, 1), n(constraint.rBy, 1), d2 * nx, d2 * ny);
+    applyImpulse(bodyA, bodyB, n(constraint.rotAx, 0), n(constraint.rotAy, 0), n(constraint.rotBx, 0), n(constraint.rotBy, 0), d1 * nx, d1 * ny);
+    applyImpulse(bodyA, bodyB, n(constraint.rotAx, 1), n(constraint.rotAy, 1), n(constraint.rotBx, 1), n(constraint.rotBy, 1), d2 * nx, d2 * ny);
   }
 
   private _acquire(): ContactConstraint {
@@ -402,6 +507,25 @@ export class ContactSolver {
     return constraint;
   }
 }
+
+/**
+ * Live contact separation at point `i`, recomputed from each body's accumulated
+ * delta position plus the rotation-induced shift of the (rotated) anchor since
+ * frame start, projected onto the normal. Negative when overlapping. This is what
+ * folds the position constraint into the velocity solve without a separate
+ * geometric pass or re-running detection per sub-step.
+ */
+const currentSeparation = (constraint: ContactConstraint, i: number): number => {
+  const bodyA = constraint.bodyA;
+  const bodyB = constraint.bodyB;
+  // Anchor displacement since frame start = linear delta + (rotated arm − base arm).
+  const dispAx = bodyA._deltaPosX + n(constraint.rotAx, i) - n(constraint.rAx, i);
+  const dispAy = bodyA._deltaPosY + n(constraint.rotAy, i) - n(constraint.rAy, i);
+  const dispBx = bodyB._deltaPosX + n(constraint.rotBx, i) - n(constraint.rBx, i);
+  const dispBy = bodyB._deltaPosY + n(constraint.rotBy, i) - n(constraint.rBy, i);
+
+  return n(constraint.baseSeparation, i) + (dispBx - dispAx) * constraint.nx + (dispBy - dispAy) * constraint.ny;
+};
 
 /** Relative normal velocity at a contact point: `dot(vB + ωB×rB − vA − ωA×rA, n)`. */
 const normalVelocity = (bodyA: PhysicsBody, bodyB: PhysicsBody, rAx: number, rAy: number, rBx: number, rBy: number, nx: number, ny: number): number => {

--- a/packages/exojs-physics/test/dynamics.test.ts
+++ b/packages/exojs-physics/test/dynamics.test.ts
@@ -5,16 +5,16 @@ import { PhysicsBody } from '../src/PhysicsBody';
 
 /**
  * The Solver Correctness & Stability matrix (spec `04` §2), exercised over the
- * Phase-2A/2B dynamics spike (warm-started sequential-impulse velocity solver
- * with a 2-point block normal solve + an NGS position-correction pass). All run
- * in the **standard solver config** (≤8 velocity iterations, ≤3 position
- * iterations, slop ≤ 0.5px, 1px/s restitution threshold) at the default
- * `fixedDelta = 1/60 s`. Coordinates are ExoJS pixels with +Y down, so gravity
- * is `(0, +g)` and "up" is decreasing y.
+ * native **TGS-Soft** solver (Box2D-v3 "soft step": sub-stepping + soft-constraint
+ * bias + relax pass + a 2-point block normal solve, with a separate restitution
+ * pass). All run in the **default solver config** (`subStepCount = 4`,
+ * `contactHertz = 30`, `dampingRatio = 10`, slop 0.25px, 1px/s restitution
+ * threshold) at the default `fixedDelta = 1/60 s`. Coordinates are ExoJS pixels
+ * with +Y down, so gravity is `(0, +g)` and "up" is decreasing y.
  *
- * Gates the native solver does **not** meet in the standard config (notably
- * SG-S2: a 20-box tower) are characterised in `dynamics-limits.test.ts` and fed
- * to the SGATE — they are not asserted at the spec target here.
+ * SG-S2 (a 20-box tower) — the gate the previous sequential-impulse + NGS solver
+ * could not meet (lateral tipping past ~10 boxes) — is now asserted here: TGS-Soft
+ * decouples stiffness from the iteration count and holds it stable.
  */
 
 const GRAVITY = 1000; // px/s²
@@ -349,18 +349,55 @@ describe('SG-S — stacking', () => {
 
     expect(Math.abs(boxes[9].x)).toBeLessThanOrEqual(1);
 
-    // Max penetration (floor contact + every adjacent pair). At the spec's 5s
-    // mark the tower is still gently compressing under its own weight: max
-    // penetration ~0.63px, converging to the 0.25px slop by ~15s (verified
-    // stable over 25s+). The 0.5px design target is approached but not met
-    // within 5s at the conservative correction gain — see the SGATE report.
+    // Max penetration (floor contact + every adjacent pair). TGS-Soft settles the
+    // tower to the 0.25px slop well within 5s (the soft bias pushes out the excess
+    // each sub-step), comfortably meeting the 0.5px design target the old NGS pass
+    // only approached.
     let maxPenetration = boxes[0].y + size / 2 - floorTop;
 
     for (let i = 0; i < boxes.length - 1; i++) {
       maxPenetration = Math.max(maxPenetration, size - (boxes[i].y - boxes[i + 1].y));
     }
 
-    expect(maxPenetration).toBeLessThanOrEqual(0.7);
+    expect(maxPenetration).toBeLessThanOrEqual(0.5);
+  });
+
+  it('SG-S2: a 20-box tower stays upright and settles (the old solver tipped past ~10)', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const size = 32;
+    const gap = 1;
+    const floorTop = 300;
+
+    addFloor(world, floorTop);
+
+    const boxes: PhysicsBody[] = [];
+
+    for (let i = 0; i < 20; i++) {
+      const bottomY = floorTop - gap * (i + 1) - i * size;
+
+      boxes.push(addBox(world, 0, bottomY - size / 2, size));
+    }
+
+    advance(world, 8);
+
+    expectAllFinite(world);
+
+    // Rest: every box slow, no lateral tip (the sequential-impulse + NGS solver
+    // grew an exponential lateral mode here), penetration bounded.
+    let maxDrift = 0;
+    let maxPenetration = boxes[0].y + size / 2 - floorTop;
+
+    for (let i = 0; i < boxes.length; i++) {
+      expect(speed(boxes[i])).toBeLessThanOrEqual(1);
+      maxDrift = Math.max(maxDrift, Math.abs(boxes[i].x));
+
+      if (i < boxes.length - 1) {
+        maxPenetration = Math.max(maxPenetration, size - (boxes[i].y - boxes[i + 1].y));
+      }
+    }
+
+    expect(maxDrift).toBeLessThanOrEqual(3);
+    expect(maxPenetration).toBeLessThanOrEqual(1);
   });
 
   it('SG-S5: a stack shoved horizontally leans but stays bounded (no explosion)', () => {


### PR DESCRIPTION
## v0.15 Welle 8 — TGS-Soft-Solver (Epic 11)

Replaces the native **sequential-impulse + NGS** solver with **TGS-Soft** (Box2D-v3 "soft step") behind the `NativePhysicsBackend` seam, bringing the **SG-S2 20-box tower** gate to pass. The old solver tipped past ~10 boxes (lateral mode); TGS-Soft decouples stiffness from the iteration count and holds it.

API-neutral except the solver-tuning knobs: `velocityIterations`/`positionIterations` (meaningless under TGS, used nowhere outside the package) → `subStepCount=4`, `contactHertz=30`, `dampingRatio=10`. The functional surface (add/attach/step/bind/query, body properties) is unchanged.

### Slices
- **11a** Sub-stepping — `PhysicsWorld.step`: detect + prepare once per fixed step, then N sub-steps of integrate → warm-start → solve(bias) → integrate position → relax. `PhysicsBody` accumulates per-frame delta pos/rot, written once in `_finalizePosition`. detect 1×/frame (manifold reuse; W7 keeps it allocation-free).
- **11b** Soft constraints — `biasRate`/`massScale`/`impulseScale` from `contactHertz`/`dampingRatio`/`h`; soft push-out bias folded into the velocity solve (no NGS pass). 2×2 block LCP kept (stack-load propagation), carrying the soft target.
- **11c** Relax + restitution — `useBias` flag (main pass biased, relax pass not); separate restitution pass keyed off frame-start impact speed.
- **11d** SG-matrix re-validation — SG-S2 added, SG-S1 penetration tightened 0.7→0.5px, all existing gates kept green (incl. **SG-D1 determinism**, SG-R restitution, SG-F friction).

### Key findings (measured)
- **Warm-start every sub-step**, not just the first — else the cached impulse carries the whole-frame load and over-pulses → tall stacks pump energy.
- **Keep a 0.25px slop** in the push-out — the narrow phase only emits a manifold while overlapping, so pushing to zero made resting contacts wink out for a frame (periodic energy spike).
- **Normal before friction** (fresh Coulomb cone); **rotate anchors** by the live sub-step rotation.

### Validation (full CI parity, local green)
- typecheck core + 5 packages + guides + examples · lint:all (0 err) · format:check · docs:api:check
- `pnpm test` — **3477 passed, 1 skipped**; physics **88 passed** incl. SG-S2
- Perf: **2.6 ms/step @1000 bodies** (6.4× headroom @60fps); **365 KB/step** allocation (< 600 KB W7 gate)
- Gestörte hohe Türme (init-rot) kippen *physikalisch* (Energie dissipiert, kein Pumping) — schlanke inverse Pendel; eine physikalische Grenze, kein Solver-Bug.