### PR TITLE
docs(config): correct stale base.json strict-flags comment

### DIFF
--- a/packages/exojs-config/typescript/base.json
+++ b/packages/exojs-config/typescript/base.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "_comment": "Shared baseline compiler options for every ExoJS package. Package-local configs add rootDir/outDir/include/exclude, customConditions (package-specific source condition), and any package-specific lib/types/paths. Stricter options (noUncheckedIndexedAccess, exactOptionalPropertyTypes, module:Preserve, skipLibCheck:false) are intentionally NOT enabled here — the tree does not yet satisfy them; migrate intentionally.",
+  "_comment": "Shared baseline compiler options for every ExoJS package. Package-local configs add rootDir/outDir/include/exclude, customConditions (package-specific source condition), and any package-specific lib/types/paths. Strict type-safety flags including noUncheckedIndexedAccess and exactOptionalPropertyTypes are enabled below (turned on in v0.15 once the whole tree satisfied them). The remaining stricter options (module:Preserve, skipLibCheck:false) are intentionally NOT enabled yet.",
   "compilerOptions": {
     "target": "es2022",
     "module": "esnext",


### PR DESCRIPTION
Follow-up aus dem v0.15 max-effort-Review (`.workspace/reports/v0.15-review/`).

Der `_comment` in `packages/exojs-config/typescript/base.json` behauptete, `noUncheckedIndexedAccess` und `exactOptionalPropertyTypes` seien absichtlich NICHT aktiviert — beide sind aber seit v0.15 W2 (#171) an (Z. 21–22). Der stale Kommentar hätte Contributors verleiten können, Fehler zu unterdrücken statt zu fixen.

Korrigiert auf die Realität; `module:Preserve` und `skipLibCheck:false` bleiben bewusst aus. Reiner Kommentar, kein Verhaltensänderung.