### PR TITLE
docs(site): v0.15 site/docs sync — Text API, storage, SceneManager

### DIFF
--- a/site/src/content/guide/debugging/debugging-and-inspection.mdx
+++ b/site/src/content/guide/debugging/debugging-and-inspection.mdx
@@ -95,7 +95,7 @@ The panel does not show drawables with zero filters — they are invisible to th
 
 ### Enabling the layer
 
-`RenderPassInspectorLayer` extends `DebugLayer` and is designed to be driven via `app.onFrame` — the same pattern used by `DebugOverlay` for the other debug layers. It is not pushed onto the scene stack. The inspector walks `scene.currentScene?.root` each frame, so it sees whichever scene is currently active.
+`RenderPassInspectorLayer` extends `DebugLayer` and is designed to be driven via `app.onFrame` — the same pattern used by `DebugOverlay` for the other debug layers. It is not added to the scene graph. The inspector walks `scene.currentScene?.root` each frame, so it sees whichever scene is currently active.
 
 Import from the debug entrypoint, construct against the application, subscribe to `app.onFrame`, and toggle visibility:
 

--- a/site/src/content/guide/recipes/camera-follow-and-parallax.mdx
+++ b/site/src/content/guide/recipes/camera-follow-and-parallax.mdx
@@ -132,4 +132,4 @@ Three layers of colored circles with pointer-driven parallax offsets, demonstrat
 
 ## Where to go next
 
-The next recipe, [Pause menu](/ExoJS/en/guide/recipes/pause-menu/), covers how to freeze gameplay and overlay a menu using the scene stack.
+The next recipe, [Pause menu](/ExoJS/en/guide/recipes/pause-menu/), covers how to freeze gameplay and overlay a menu using `scene.paused` and the `scene.ui` layer.

--- a/site/src/content/guide/recipes/cinematics.mdx
+++ b/site/src/content/guide/recipes/cinematics.mdx
@@ -54,7 +54,7 @@ class CinematicScene extends Scene {
 
         // Title reveal — 1 second, starts after 1.6s delay
         this.titleState = { count: 0 };
-        this.titleText = new Text('', { fill: 'white', fontSize: 56 });
+        this.titleText = new Text('', { fillColor: Color.white, fontSize: 56 });
         this.titleText.setPosition(150, 120);
 
         this.app.tweens.create(this.titleState)

--- a/site/src/content/guide/recipes/ui-patterns.mdx
+++ b/site/src/content/guide/recipes/ui-patterns.mdx
@@ -24,9 +24,9 @@ init(loader) {
         .setAnchor(0.5).setScale(1.7).setPosition(170, 420);
 
     this.box = new Text('', {
-        fill: 'white', fontSize: 30,
-        wordWrap: true, wordWrapWidth: 600,
-        lineHeight: 40,
+        fillColor: Color.white, fontSize: 30,
+        maxWidth: 600,
+        lineHeight: 1.4,
     });
     this.box.setPosition(270, 360);
 
@@ -78,7 +78,7 @@ this.app.input.onPointerTap.add(() => {
 });
 ```
 
-The pattern is self-contained: the scene owns the dialog state, `update` drives the reveal, input handles progression. No modal state manager, no scene-stack push — just a flag and a counter.
+The pattern is self-contained: the scene owns the dialog state, `update` drives the reveal, input handles progression. No modal state manager, no extra scenes — just a flag and a counter.
 
 ## Tween-driven progress indicator
 
@@ -87,7 +87,7 @@ A radial progress ring using a custom shader filter and a tween. The shader draw
 ```js
 init(loader) {
     this.progress = { v: 0 };
-    this.label = new Text('0%', { fill: 'white', fontSize: 42 });
+    this.label = new Text('0%', { fillColor: Color.white, fontSize: 42 });
     this.label.setPosition(360, 410);
 
     this.ring = new Sprite(loader.get(Texture, 'uv')).setScale(2.2);

--- a/site/src/content/guide/rendering/text.mdx
+++ b/site/src/content/guide/rendering/text.mdx
@@ -21,14 +21,13 @@ const label = new Text('Hello', {
 });
 ```
 
-The second argument is a `TextStyleOptions` object — all properties are optional, all have defaults. The `TextStyle` is stored as `text.style`. Assign a new style to rebuild the mesh; mutating style fields alone does not rebuild:
+The second argument is a `TextOptions` object — a flat merge of [`TextStyleOptions`](/ExoJS/en/api/text-style/) (visual appearance) and `LayoutOptions` (flow and overflow). All properties are optional and have defaults. The live `TextStyle` is stored as `text.style`; mutating its fields is cheap and is applied automatically before the next render pass — no manual rebuild call is needed:
 
 ```js
-import { Color, TextStyle } from '@codexo/exojs';
+import { Color } from '@codexo/exojs';
 
-label.style.fontSize = 32;
-label.style.fillColor = Color.tomato;
-label.style = label.style; // apply style changes and rebuild
+label.style.fontSize = 32;            // rebuilds the glyph mesh on the next draw
+label.style.fillColor = Color.tomato; // updates only the mesh tint — no atlas work
 ```
 
 ## Font loading
@@ -46,7 +45,7 @@ init(loader) {
     this.title = new Text('Custom Font', {
         fontFamily: 'MyFont',
         fontSize: 48,
-        fill: 'white',
+        fillColor: Color.white,
     });
 }
 ```
@@ -55,51 +54,67 @@ The `FontFace` asset is registered with the document's `document.fonts` set. Onc
 
 ## Style properties
 
-`TextStyle` exposes these configurable properties:
+The visual appearance comes from [`TextStyleOptions`](/ExoJS/en/api/text-style/). All properties are optional:
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `fontFamily` | `string` | `'Arial'` | CSS font family name |
-| `fontSize` | `number` | `20` | Font size in pixels |
-| `fontWeight` | `string` | `'bold'` | CSS font weight |
+| `fontWeight` | `FontWeight` | `'normal'` | CSS font weight (`'normal'`, `'bold'`, or `'100'`–`'900'`) |
 | `fontStyle` | `'normal' \| 'italic'` | `'normal'` | Font style |
-| `fill` | `string \| CanvasGradient \| CanvasPattern` | `'black'` | Stored style property (not currently applied by the renderer) |
-| `fillColor` | `Color` | `Color.white` | Tint used when building the text mesh |
-| `stroke` | `string \| CanvasGradient \| CanvasPattern` | `'black'` | Stored style property (not currently applied by the renderer) |
-| `strokeThickness` | `number` | `1` | Stored style property (not currently applied by the renderer) |
-| `align` | `'left' \| 'center' \| 'right'` | `'left'` | Text alignment |
-| `lineHeight` | `number` | `1.2` | Multiplier on `fontSize` for vertical spacing |
-| `wordWrap` | `boolean` | `false` | Style flag (currently not applied by the layout engine) |
-| `wordWrapWidth` | `number` | `100` | Style width hint (currently not applied by the layout engine) |
-| `baseline` | `CanvasTextBaseline` | `'alphabetic'` | Stored style property (not currently applied by the renderer) |
-| `lineJoin` | `CanvasLineJoin` | `'miter'` | Stored style property (not currently applied by the renderer) |
-| `miterLimit` | `number` | `10` | Stored style property (not currently applied by the renderer) |
-| `padding` | `number` | `0` | Stored style property (not currently applied by the renderer) |
+| `fontSize` | `number` | `20` | Font size in pixels |
+| `fillColor` | `Color` | `Color.white` | Glyph fill colour |
+| `outlineColor` | `Color` | `Color.black` | SDF outline colour |
+| `outlineWidth` | `number` | `0` | Outline width in SDF units (`0`–`0.5`); `0` disables the outline |
+| `align` | `'left' \| 'center' \| 'right'` | `'left'` | Horizontal alignment |
+| `lineHeight` | `number` | `1.2` | Line-height multiplier on `fontSize` |
+| `leading` | `number` | `0` | Extra pixel gap between lines |
+| `shadowColor` | `Color` | `Color.black` | Drop-shadow colour |
+| `shadowOffsetX` | `number` | `0` | Horizontal shadow offset in pixels |
+| `shadowOffsetY` | `number` | `0` | Vertical shadow offset in pixels |
+| `shadowAlpha` | `number` | `0` | Shadow opacity (`0`–`1`); `0` disables the shadow |
+| `shadowBlur` | `number` | `0` | Shadow blur softness (`0`–`1`) |
+| `gradientColors` | `[Color, Color] \| null` | `null` | Two-stop fill gradient `[top, bottom]`; overrides `fillColor` |
+| `gradientAxis` | `'vertical' \| 'horizontal'` | `'vertical'` | Gradient orientation |
 
-Current renderer path applies `fontFamily`, `fontSize`, `fontWeight`, `fontStyle`, `align`, `lineHeight`, and `fillColor`. Other `TextStyle` fields are currently stored but not applied.
+Text flow and overflow come from `LayoutOptions`, merged into the same options object:
 
-Glyphs are rasterized in white, and the mesh tint is initialized from `fillColor` when the mesh is rebuilt.
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `maxWidth` | `number` | — | Word-wrap boundary in pixels; longer lines break at word boundaries |
+| `maxHeight` | `number` | — | Clip boundary in pixels |
+| `overflow` | `'visible' \| 'clip' \| 'ellipsis'` | `'visible'` | Behaviour when text exceeds `maxHeight` |
+| `letterSpacing` | `number` | `0` | Extra pixel gap between glyphs |
+| `breakWords` | `boolean` | `false` | Break words wider than `maxWidth` at character boundaries |
+| `whiteSpace` | `'normal' \| 'pre' \| 'pre-line'` | `'pre-line'` | Whitespace handling |
+
+Glyphs are rasterized into the shared SDF atlas; the mesh tint is initialized from `fillColor` when the mesh is built.
 
 ## Multiline text and wrap settings
 
 Multiline text works by embedding `\n` characters in the string:
 
 ```js
+import { Color, Text } from '@codexo/exojs';
+
 const dialog = new Text('Line one\nLine two\nLine three', {
-    fill: 'white',
+    fillColor: Color.white,
     fontSize: 18,
     lineHeight: 1.5,
 });
 ```
 
-`wordWrap` and `wordWrapWidth` are available on `TextStyle`, but the current text layout only applies explicit line breaks (`\n`) and alignment:
+To wrap long runs automatically, set `maxWidth` (in pixels) — lines that exceed it break at word boundaries. Add `breakWords: true` to also split individual words that are wider than `maxWidth`:
 
 ```js
+import { Color, Text } from '@codexo/exojs';
+
+const longString = 'A long run of text that wraps automatically once it exceeds the layout width.';
+
 const wrapped = new Text(longString, {
-    fill: 'white',
+    fillColor: Color.white,
     fontSize: 16,
-    wordWrap: true,
-    wordWrapWidth: 400,
+    maxWidth: 400,
+    breakWords: true,
 });
 ```
 
@@ -108,12 +123,14 @@ const wrapped = new Text(longString, {
 The `align` property controls horizontal positioning relative to the `Text` node's local origin:
 
 ```js
+import { Color, Text } from '@codexo/exojs';
+
 const centered = new Text('Centered Title', {
     align: 'center',
-    fill: 'white',
+    fillColor: Color.white,
     fontSize: 32,
 });
-centered.setPosition(canvasWidth / 2, 20);
+centered.setPosition(400, 20);
 ```
 
 A center-aligned text node at `(400, 20)` centers its glyphs horizontally around `x=400` in local space.
@@ -124,16 +141,15 @@ A center-aligned text node at `(400, 20)` centers its glyphs horizontally around
 
 ```js
 this.ui = new Container();
-this.scoreLabel = new Text('Score: 0', { fill: 'white', fontSize: 24 });
+this.scoreLabel = new Text('Score: 0', { fillColor: Color.white, fontSize: 24 });
 this.scoreLabel.setPosition(10, 10);
 this.ui.addChild(this.scoreLabel);
 this.addChild(this.ui);
 ```
 
-The text node's internal mesh is a `Container` child. Assigning to `text.text` destroys the previous mesh and builds a new one. This means:
-- Changing text every frame is fine — the old mesh is discarded and a fresh one is built.
-- Mutating `style` fields alone does not rebuild the mesh.
-- To apply style changes, assign `text.style = ...` so the mesh is rebuilt.
+The text node's internal mesh is a `Container` child. Assigning to `text.text` rebuilds the glyph mesh. This means:
+- Changing text every frame is fine — the mesh is rebuilt on demand, at most once per frame.
+- Mutating `style` fields (e.g. `text.style.fillColor = ...`) is also picked up automatically before the next draw — no manual rebuild needed.
 
 ## Text constraints
 

--- a/site/src/content/guide/runtime/application.mdx
+++ b/site/src/content/guide/runtime/application.mdx
@@ -130,7 +130,9 @@ Once an application exists, its subsystems are accessible as properties:
 - `app.canvas` — the render target.
 - `app.loader` — the [`Loader`](/ExoJS/en/api/loader/) used by every scene to register and resolve assets.
 - `app.input` — the `InputManager` for keyboard, pointer, and gamepad routing.
-- `app.scene` — the scene stack controller (push/pop/replace).
+- `app.scene` — the [`SceneManager`](/ExoJS/en/api/scene-manager/) that holds the single active scene; switch scenes via `setScene` (with optional fade).
+- `app.audio` — the [`AudioManager`](/ExoJS/en/api/audio-manager/) for playback, busses, and the spatial listener.
+- `app.systems` — the [`SystemRegistry`](/ExoJS/en/api/system-registry/) for app-scoped `System` instances.
 - `app.tweens` — the global `TweenManager`.
 
 Most code reaches these through the active scene (`this.app.input`, `this.app.tweens`) rather than holding a top-level reference, but both work.

--- a/site/src/content/guide/shipping/troubleshooting.mdx
+++ b/site/src/content/guide/shipping/troubleshooting.mdx
@@ -127,8 +127,7 @@ The fix: start audio in response to a click, tap, or keypress:
 
 ```js no-check
 button.addEventListener('click', () => {
-    app.audio.resume(); // or play your first sound here
-    mySound.play();
+    mySound.play(); // the engine resumes the AudioContext on the first user gesture
 });
 ```
 


### PR DESCRIPTION
## Was

Bringt Site/Guides/ApiDoc/Playground auf den echten **v0.15-API-Stand** (Voraussetzung für die spätere Release-Welle W10 — **kein** Versions-Bump/Tag/Publish hier).

## Befund (Audit: 5 parallele Agenten über alle Guides/Recipes/API-Seiten/Examples)

Der eigentliche Drift war kleiner als erwartet — `src/`, Examples und die generierten API-Seiten waren bereits v0.15-korrekt (W5/W6 hatten sie mitgezogen). Übrig blieben **7 mdx-Dateien**, primär Text-API + ein paar veraltete Prosa-Konzepte.

### Fixes
- **`rendering/text.mdx`** (Hauptbrocken): `fill`→`fillColor`, `wordWrap`/`wordWrapWidth`→`maxWidth`/`breakWords`; Property-Tabelle komplett neu auf die echten `TextStyleOptions` + `LayoutOptions` (9 nicht-existente PixiJS-Erbe-Keys raus: `fill`/`stroke`/`strokeThickness`/`wordWrap`/`wordWrapWidth`/`baseline`/`lineJoin`/`miterLimit`/`padding`); Auto-Rebuild-Prosa korrigiert (Style-Mutationen wirken automatisch vor dem nächsten Draw — kein `style = style`-Trick mehr); Imports in die Demo-Blöcke, damit sie jetzt von `typecheck:guides` (excess-property-Gate) erfasst werden.
- **`recipes/cinematics.mdx`, `recipes/ui-patterns.mdx`**: `fill`→`fillColor`, `wordWrap`→`maxWidth`.
- **`runtime/application.mdx`**: `app.scene` ist der `SceneManager` (kein push/pop-Stack mehr); `app.audio` + `app.systems` dokumentiert.
- **`shipping/troubleshooting.mdx`**: nicht-existentes `app.audio.resume()` entfernt — die Engine resumed den AudioContext automatisch beim ersten User-Gesture.
- **Veraltete „scene stack"-Verweise** (Stack in v0.14 entfernt) in `camera-follow-and-parallax`, `debugging-and-inspection`, `ui-patterns`.

### Warum rutschte das durch?
Die `fill`-Blöcke waren Methodenfragmente/import-los → `typecheck:guides` überspringt sie (nur import-haltige Blöcke werden extrahiert). Beim Fix wurden die standalone-fähigen Blöcke mit Imports versehen, sodass die Drift künftig gefangen wird.

## Build-Artefakte (nicht committet, gitignored)
`pnpm build` + `pnpm vendor:sync:exo` ausgeführt → `dist/` + `site/public/vendor/exojs/` (inkl. `esm-typings.json`, `monaco-registry.json`) neu gebaut; der Playground exponiert jetzt die v0.15-`KeyValueStore`-Backends (`MemoryStore`/`WebStorageStore`/`IndexedDbKeyValueStore`) statt des entfernten `SaveManager`/`JsonStore`. Beide Verzeichnisse sind gitignored Deploy-Artefakte.

## Gates (lokal grün)
`typecheck:guides` · `docs:api:generate` (kein Diff) · `docs:api:check` · `format:check` · `site:build` (610 Seiten).