### PR TITLE
chore(release): data-drive lockstep package set; wire aseprite/ldtk/react

### DIFF
--- a/.github/workflows/_ci-checks.yml
+++ b/.github/workflows/_ci-checks.yml
@@ -108,7 +108,7 @@ jobs:
       # Root `pnpm typecheck` only covers src/**; the extension packages own a
       # separate tsconfig each, so typecheck them explicitly.
       - name: Typecheck extension packages
-        run: pnpm --filter "@codexo/exojs-particles" --filter "@codexo/exojs-tilemap" --filter "@codexo/exojs-tiled" --filter "@codexo/exojs-physics" --filter "@codexo/exojs-audio-fx" typecheck
+        run: pnpm --filter "@codexo/exojs-particles" --filter "@codexo/exojs-tilemap" --filter "@codexo/exojs-tiled" --filter "@codexo/exojs-physics" --filter "@codexo/exojs-audio-fx" --filter "@codexo/exojs-aseprite" --filter "@codexo/exojs-ldtk" --filter "@codexo/exojs-react" typecheck
 
   lint:
     name: Lint
@@ -375,7 +375,7 @@ jobs:
       # in workspace-dependency order (tilemap before tiled). A broken package
       # build is now caught here instead of only at release time.
       - name: Build extension packages
-        run: pnpm --filter "@codexo/exojs-particles" --filter "@codexo/exojs-tilemap" --filter "@codexo/exojs-tiled" --filter "@codexo/exojs-physics" --filter "@codexo/exojs-audio-fx" build
+        run: pnpm --filter "@codexo/exojs-particles" --filter "@codexo/exojs-tilemap" --filter "@codexo/exojs-tiled" --filter "@codexo/exojs-physics" --filter "@codexo/exojs-audio-fx" --filter "@codexo/exojs-aseprite" --filter "@codexo/exojs-ldtk" --filter "@codexo/exojs-react" build
 
       - name: Verify core package exports
         run: pnpm verify:exports
@@ -395,7 +395,7 @@ jobs:
       # Pack each extension package (dry run) so a broken `files`/`exports` set in
       # a package manifest is caught here, not at release time.
       - name: Extension package dry runs
-        run: pnpm --filter "@codexo/exojs-particles" --filter "@codexo/exojs-tilemap" --filter "@codexo/exojs-tiled" --filter "@codexo/exojs-physics" --filter "@codexo/exojs-audio-fx" pack --dry-run
+        run: pnpm --filter "@codexo/exojs-particles" --filter "@codexo/exojs-tilemap" --filter "@codexo/exojs-tiled" --filter "@codexo/exojs-physics" --filter "@codexo/exojs-audio-fx" --filter "@codexo/exojs-aseprite" --filter "@codexo/exojs-ldtk" --filter "@codexo/exojs-react" pack --dry-run
 
       # publint validates the published package.json itself (exports map, files,
       # types resolution, module/main coherence) — the layer attw does NOT cover

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,9 @@ jobs:
           pnpm --filter @codexo/exojs-tiled build
           pnpm --filter @codexo/exojs-physics build
           pnpm --filter @codexo/exojs-audio-fx build
+          pnpm --filter @codexo/exojs-aseprite build
+          pnpm --filter @codexo/exojs-ldtk build
+          pnpm --filter @codexo/exojs-react build
           pnpm site:build
 
       # The site build can regenerate tracked content with platform-dependent

--- a/packages/exojs-aseprite/LICENSE
+++ b/packages/exojs-aseprite/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Codexo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/exojs-aseprite/README.md
+++ b/packages/exojs-aseprite/README.md
@@ -1,0 +1,83 @@
+# @codexo/exojs-aseprite
+
+Official ExoJS extension for loading [Aseprite](https://www.aseprite.org) JSON sprite-sheet
+exports into a ready-to-animate sprite, with one animation clip per Aseprite frame tag.
+
+## Installation
+
+```sh
+npm install @codexo/exojs @codexo/exojs-aseprite
+```
+
+`@codexo/exojs` is a peer dependency. This package has no other runtime dependencies.
+
+> Export your sprite sheet from Aseprite as a **JSON + PNG** pair (`File → Export Sprite Sheet`,
+> *Output → JSON Data*). Either array or hash frame mode works; frame tags become animation clips.
+
+## What this package provides
+
+- `AsepriteSheet` — parsed sprite sheet; the result of `loader.load(AsepriteSheet, url)`. Exposes
+  the underlying `spritesheet`, a `clips` map (one `AnimatedSpriteClipDefinition` per frame tag),
+  and `createAnimatedSprite()` for a ready-to-play `AnimatedSprite`
+- `asepriteExtension` — extension descriptor registering the Aseprite asset binding
+- `asepriteBinding` — the underlying `AssetBinding` (advanced/custom wiring)
+- `AsepriteFormatError` — typed error thrown on malformed Aseprite JSON
+- `AsepriteData` and related types (`AsepriteFrameData`, `AsepriteFrameTag`, `AsepriteMeta`,
+  `AsepriteSlice`, …) plus the `isAsepriteArrayData` guard
+
+## Usage
+
+Register the extension, load an Aseprite JSON export, and create an animated sprite. The extension
+fetches the JSON, resolves and loads the packed texture, and builds one clip per frame tag:
+
+```ts
+import { Application } from '@codexo/exojs';
+import { AsepriteSheet, asepriteExtension } from '@codexo/exojs-aseprite';
+
+const app = new Application({ extensions: [asepriteExtension] });
+
+const sheet = await app.loader.load(AsepriteSheet, 'sprites/hero.aseprite.json');
+
+const sprite = sheet.createAnimatedSprite();
+sprite.play('run'); // 'run' is an Aseprite frame-tag name
+app.scene.root.addChild(sprite);
+```
+
+Clip frame rate is derived from each frame's Aseprite `duration` (falling back to 12 fps). Frame
+indices in a tag are resolved against the ordered frame array; out-of-range indices are skipped.
+
+## `/register` convenience entry
+
+Importing `/register` registers `asepriteExtension` in the global `ExtensionRegistry`, so
+subsequently created Applications that use global defaults pick it up automatically:
+
+```ts
+// Side effect: registers asepriteExtension in the global ExtensionRegistry.
+import '@codexo/exojs-aseprite/register';
+
+// All named exports are also re-exported from /register:
+import { AsepriteSheet, asepriteExtension } from '@codexo/exojs-aseprite/register';
+```
+
+This is the only side-effectful entry — importing the package root (`@codexo/exojs-aseprite`) does
+**not** register anything.
+
+## Texture ownership
+
+The packed texture is loaded via the Loader and stays in the Loader cache. `AsepriteSheet.destroy()`
+releases the parsed sprite sheet; the Loader handles texture lifecycle and deduplication.
+
+## Core compatibility
+
+| `@codexo/exojs-aseprite` | `@codexo/exojs` |
+|---|---|
+| 0.14.x | 0.14.x |
+
+## Links
+
+- [API reference](https://exojs.dev/api/exojs-aseprite)
+- [Aseprite](https://www.aseprite.org)
+
+## License
+
+MIT © Codexo

--- a/packages/exojs-ldtk/LICENSE
+++ b/packages/exojs-ldtk/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Codexo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/exojs-ldtk/README.md
+++ b/packages/exojs-ldtk/README.md
@@ -1,0 +1,89 @@
+# @codexo/exojs-ldtk
+
+Official ExoJS extension for loading [LDtk](https://ldtk.io) level files (`.ldtk`) into runtime
+`TileMap`s — one per LDtk level — ready to render with the generic tilemap node.
+
+## Installation
+
+```sh
+npm install @codexo/exojs @codexo/exojs-ldtk
+```
+
+`@codexo/exojs` is a peer dependency. `@codexo/exojs-tilemap` is a regular dependency and is
+installed transitively — you do not need to install it manually.
+
+## What this package provides
+
+- `LdtkMap` — parsed LDtk world; the result of `loader.load(LdtkMap, url)`. Exposes the raw `data`,
+  the converted runtime `levels` (`readonly TileMap[]`, in document order), and
+  `getLevelByName(identifier)`
+- `ldtkToTileMap` — convert a single LDtk level to a `TileMap` (used internally; available for
+  custom pipelines), plus its `LdtkToTileMapOptions`
+- `ldtkExtension` — extension descriptor; depends on `tilemapExtension` automatically
+- `ldtkMapBinding` — the underlying `AssetBinding` (advanced/custom wiring)
+- The raw LDtk JSON types (`LdtkData`, `LdtkLevel`, `LdtkLayerInstance`, `LdtkEntityInstance`, …)
+  and the flip-bit constants (`ldtkFlipX`, `ldtkFlipY`, `ldtkFlipXy`, `ldtkFlipNone`)
+- `TileMap`, `TileMapNode`, `TileMapView`, `TileLayer`, `TileSet`, `ObjectLayer`, … re-exported
+  from `@codexo/exojs-tilemap` (same class identity — `instanceof TileMap` holds across both import
+  paths)
+
+## Usage
+
+Register the extension and load a `.ldtk` world. One extension enables **both** loading and
+rendering — `ldtkExtension` depends on `tilemapExtension`, so the tile chunk renderer bindings are
+materialised automatically:
+
+```ts
+import { Application } from '@codexo/exojs';
+import { LdtkMap, TileMapNode, ldtkExtension } from '@codexo/exojs-ldtk';
+
+const app = new Application({ extensions: [ldtkExtension] });
+
+const world = await app.loader.load(LdtkMap, 'levels/world.ldtk');
+
+// Render the first level (each LDtk level is its own TileMap):
+const level = world.getLevelByName('Level_0') ?? world.levels[0];
+app.scene.root.addChild(new TileMapNode(level));
+```
+
+`TileMapNode` is the same class exported by `@codexo/exojs-tilemap` (see its
+[README](https://www.npmjs.com/package/@codexo/exojs-tilemap) for the rendering/culling model and
+actor interleaving).
+
+## `/register` convenience entry
+
+Importing `/register` registers `ldtkExtension` (and its `tilemapExtension` dependency) in the
+global `ExtensionRegistry`, so subsequently created Applications that use global defaults pick them
+up automatically:
+
+```ts
+// Side effect: registers ldtkExtension in the global ExtensionRegistry.
+import '@codexo/exojs-ldtk/register';
+
+// All named exports are also re-exported from /register:
+import { LdtkMap, ldtkExtension } from '@codexo/exojs-ldtk/register';
+```
+
+This is the only side-effectful entry — importing the package root (`@codexo/exojs-ldtk`) does
+**not** register anything.
+
+## Texture ownership
+
+Tileset textures are loaded via the Loader and stay in the Loader cache. `LdtkMap.destroy()`
+destroys the owned runtime `TileMap`s but does **not** unload textures (Loader-owned) or remove any
+scene nodes — the application owns those.
+
+## Core compatibility
+
+| `@codexo/exojs-ldtk` | `@codexo/exojs` |
+|---|---|
+| 0.14.x | 0.14.x |
+
+## Links
+
+- [API reference](https://exojs.dev/api/exojs-ldtk)
+- [LDtk level editor](https://ldtk.io)
+
+## License
+
+MIT © Codexo

--- a/packages/exojs-react/package.json
+++ b/packages/exojs-react/package.json
@@ -8,6 +8,7 @@
     "directory": "packages/exojs-react"
   },
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/esm/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",

--- a/packages/exojs-tilemap/LICENSE
+++ b/packages/exojs-tilemap/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Codexo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/ci/select-lanes.mjs
+++ b/scripts/ci/select-lanes.mjs
@@ -52,9 +52,22 @@ import { pathToFileURL } from 'node:url';
  * NOT listed: `create-exo-app` (a standalone scaffolding CLI with no engine /
  * browser impact) and `site` (the examples app — covered by the `site` area).
  *
- * Adding a new runtime extension package == add its directory name here.
+ * Adding a new runtime extension package == add its directory name here. Keep in
+ * sync with `LOCKSTEP_PACKAGES` in scripts/release/lockstep-packages.ts (this
+ * file is dependency-free ESM and runs before any install, so it cannot import
+ * that TS module).
  */
-const RUNTIME_PACKAGES = ['exojs-config', 'exojs-particles', 'exojs-tilemap', 'exojs-tiled', 'exojs-physics', 'exojs-audio-fx'];
+const RUNTIME_PACKAGES = [
+  'exojs-config',
+  'exojs-particles',
+  'exojs-tilemap',
+  'exojs-tiled',
+  'exojs-physics',
+  'exojs-audio-fx',
+  'exojs-aseprite',
+  'exojs-ldtk',
+  'exojs-react',
+];
 
 /**
  * Documentation-only files inside a package. A change limited to these must NOT

--- a/scripts/release/RELEASING.md
+++ b/scripts/release/RELEASING.md
@@ -1,9 +1,12 @@
 # Releasing ExoJS
 
-The coordinated release publishes the six lockstep packages — `@codexo/exojs`,
+The coordinated release publishes the lockstep packages — `@codexo/exojs`,
 `@codexo/exojs-particles`, `@codexo/exojs-tilemap`, `@codexo/exojs-tiled`,
-`@codexo/exojs-physics`, `@codexo/exojs-audio-fx` — at one shared version via the
-two-stage, build-once pipeline (`scripts/release/`).
+`@codexo/exojs-physics`, `@codexo/exojs-audio-fx`, `@codexo/exojs-aseprite`,
+`@codexo/exojs-ldtk`, `@codexo/exojs-react` — at one shared version via the
+two-stage, build-once pipeline (`scripts/release/`). The package set is defined
+once in `scripts/release/lockstep-packages.ts` (the single source of truth every
+release script derives from).
 
 ## Normal release
 
@@ -18,8 +21,8 @@ pushed (leaving an untagged version in the tree indefinitely).
    `CHANGELOG.md` with the curated release notes. Merge this as a regular PR (or
    commit directly). The date must be concrete — `release:notes` rejects placeholders.
 
-3. **Run `release:cut` locally.** This bumps all six `package.json` files and peer
-   ranges, runs the lockstep and release-matrix gates, commits, and creates the
+3. **Run `release:cut` locally.** This bumps every lockstep `package.json` file and
+   peer ranges, runs the lockstep and release-matrix gates, commits, and creates the
    annotated tag — all in one step:
 
    ```bash
@@ -43,17 +46,20 @@ pushed (leaving an untagged version in the tree indefinitely).
    ```
 
 6. **Watch the CI.** The `Release` workflow checks out the **tag commit**, runs the
-   full CI gate, builds once, packs/hashes/attw/consumer-tests the six tarballs,
-   and publishes them directly to the `latest` dist-tag via OIDC (Core →
-   Particles → Tilemap → Tiled → Physics → Audio-FX). A GitHub release with
-   the Full ZIP is created automatically.
+   full CI gate, builds once, packs/hashes/attw/consumer-tests the tarballs, and
+   publishes them directly to the `latest` dist-tag via OIDC in lockstep order
+   (Core first, then the extensions). Every tarball is `attw`-checked; the offline
+   consumer smoke covers all packages **except `@codexo/exojs-react`** (its
+   `react`/`react-dom` peers are not resolvable in the offline throwaway project —
+   it is still bumped and published). A GitHub release with the Full ZIP is created
+   automatically.
 
 7. **Confirm the release.** After CI completes, verify:
 
    ```bash
    npm view @codexo/exojs version           # should show x.y.z
    npm view @codexo/exojs-physics version   # should show x.y.z
-   # repeat for all six packages
+   # repeat for every lockstep package
    ```
 
 The workflow checks out the **tag commit**, so fixes to release _scripts_ must be
@@ -78,8 +84,15 @@ first time it reaches that package. Bootstrap it ahead of time instead:
 3. Ensure its `package.json` has a `repository` field with the monorepo
    `directory` subpath — `npm publish --provenance` refuses to build the SLSA
    attestation without it. `verify:release-matrix` enforces this.
-4. Add the new package to `LOCKSTEP_DIRS` in `scripts/release/cut.ts` and the
-   relevant lists in `manifest.ts` / `prepare.ts`.
+4. Add the new package as a **single entry** in
+   `scripts/release/lockstep-packages.ts` — the source of truth that `cut.ts`,
+   `manifest.ts`, `prepare.ts`, `run.ts`, the `verify-*` gates and the
+   external-consumer smoke all derive from. Then mirror it in the two places that
+   cannot import that TS module: add its directory to `RUNTIME_PACKAGES` in
+   `scripts/ci/select-lanes.mjs`, and add its `--filter` to the build/typecheck/pack
+   steps in `.github/workflows/_ci-checks.yml` and the build step in `release.yml`
+   (`verify:release-matrix` enforces the `release.yml` build lines, so a forgotten
+   one fails CI rather than silently skipping the package).
 
 From then on every publish (including the new package's first real release) flows
 through OIDC with provenance, with no manual step during the release itself.

--- a/scripts/release/cut.ts
+++ b/scripts/release/cut.ts
@@ -29,18 +29,13 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { LOCKSTEP_PACKAGES } from './lockstep-packages.ts';
+
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
-const LOCKSTEP_DIRS: Array<{ name: string; dir: string }> = [
-  { name: '@codexo/exojs', dir: '.' },
-  { name: '@codexo/exojs-particles', dir: 'packages/exojs-particles' },
-  { name: '@codexo/exojs-tilemap', dir: 'packages/exojs-tilemap' },
-  { name: '@codexo/exojs-tiled', dir: 'packages/exojs-tiled' },
-  { name: '@codexo/exojs-physics', dir: 'packages/exojs-physics' },
-  { name: '@codexo/exojs-audio-fx', dir: 'packages/exojs-audio-fx' },
-];
+const LOCKSTEP_DIRS: Array<{ name: string; dir: string }> = LOCKSTEP_PACKAGES.map(p => ({ name: p.name, dir: p.dir }));
 
-const EXTENSION_NAMES = new Set(['@codexo/exojs-particles', '@codexo/exojs-tilemap', '@codexo/exojs-tiled', '@codexo/exojs-physics', '@codexo/exojs-audio-fx']);
+const EXTENSION_NAMES = new Set(LOCKSTEP_PACKAGES.filter(p => p.isExtension).map(p => p.name));
 
 const log = (msg: string): void => process.stdout.write(`${msg}\n`);
 const die = (msg: string): never => {

--- a/scripts/release/external-consumers.ts
+++ b/scripts/release/external-consumers.ts
@@ -22,6 +22,8 @@ import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { LOCKSTEP_PACKAGES } from './lockstep-packages.ts';
+
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const tscBin = resolve(repoRoot, 'node_modules', 'typescript', 'bin', 'tsc');
 
@@ -54,6 +56,8 @@ import { TiledMap, tiledExtension } from '@codexo/exojs-tiled';
 import { PhysicsWorld } from '@codexo/exojs-physics';
 import { PhysicsDebugDraw } from '@codexo/exojs-physics/debug';
 import { AudioAnalyser, BeatDetector, ReverbEffect } from '@codexo/exojs-audio-fx';
+import { AsepriteSheet, asepriteExtension } from '@codexo/exojs-aseprite';
+import { LdtkMap, ldtkExtension } from '@codexo/exojs-ldtk';
 
 export class DemoScene extends Scene {}
 
@@ -67,6 +71,10 @@ export function bootstrap(): { app: Application; system: typeof ParticleSystem; 
     void AudioAnalyser;
     void BeatDetector;
     void ReverbEffect;
+    void AsepriteSheet;
+    void asepriteExtension;
+    void LdtkMap;
+    void ldtkExtension;
     return { app, system: ParticleSystem, tiles: TileMap, map: TiledMap };
 }
 `;
@@ -96,6 +104,8 @@ import * as tiled from '@codexo/exojs-tiled';
 import * as physics from '@codexo/exojs-physics';
 import * as physicsDebug from '@codexo/exojs-physics/debug';
 import * as audioFx from '@codexo/exojs-audio-fx';
+import * as aseprite from '@codexo/exojs-aseprite';
+import * as ldtk from '@codexo/exojs-ldtk';
 
 const checks = [
   ['@codexo/exojs Application', typeof exo.Application === 'function'],
@@ -112,6 +122,11 @@ const checks = [
   ['@codexo/exojs-audio-fx AudioAnalyser', typeof audioFx.AudioAnalyser === 'function'],
   ['@codexo/exojs-audio-fx BeatDetector', typeof audioFx.BeatDetector === 'function'],
   ['@codexo/exojs-audio-fx ReverbEffect', typeof audioFx.ReverbEffect === 'function'],
+  ['@codexo/exojs-aseprite AsepriteSheet', typeof aseprite.AsepriteSheet === 'function'],
+  ['@codexo/exojs-aseprite asepriteExtension', aseprite.asepriteExtension != null],
+  ['@codexo/exojs-ldtk LdtkMap', typeof ldtk.LdtkMap === 'function'],
+  ['@codexo/exojs-ldtk ldtkExtension', ldtk.ldtkExtension != null],
+  ['facade ldtk TileMap identity (ldtk === tilemap)', ldtk.TileMap === tilemap.TileMap],
 ];
 const failed = checks.filter(([, ok]) => !ok).map(([name]) => name);
 if (failed.length > 0) {
@@ -177,14 +192,10 @@ export const verifyExternalConsumers = (tarballs: string[]): { ok: boolean; cons
 // CLI: pack the official packages into a temp dir and run the checks.
 if (import.meta.url.startsWith('file:') && fileURLToPath(import.meta.url) === resolve(process.argv[1] ?? '')) {
   const staging = mkdtempSync(join(tmpdir(), 'exo-cons-pack-'));
-  const dirs = [
-    repoRoot,
-    resolve(repoRoot, 'packages/exojs-particles'),
-    resolve(repoRoot, 'packages/exojs-tilemap'),
-    resolve(repoRoot, 'packages/exojs-tiled'),
-    resolve(repoRoot, 'packages/exojs-physics'),
-    resolve(repoRoot, 'packages/exojs-audio-fx'),
-  ];
+  // Offline-smoke subset (excludes @codexo/exojs-react — its react peers are not
+  // resolvable offline). Derived from the single source of truth.
+  const smokePackages = LOCKSTEP_PACKAGES.filter(p => p.inOfflineSmoke);
+  const dirs = smokePackages.map(p => (p.dir === '.' ? repoRoot : resolve(repoRoot, p.dir)));
   const version = (JSON.parse(readFileSync(resolve(repoRoot, 'package.json'), 'utf8')) as { version: string }).version;
 
   for (const dir of dirs) {
@@ -194,14 +205,7 @@ if (import.meta.url.startsWith('file:') && fileURLToPath(import.meta.url) === re
       process.exit(1);
     }
   }
-  const tarballs = [
-    'codexo-exojs',
-    'codexo-exojs-particles',
-    'codexo-exojs-tilemap',
-    'codexo-exojs-tiled',
-    'codexo-exojs-physics',
-    'codexo-exojs-audio-fx',
-  ].map(n => join(staging, `${n}-${version}.tgz`));
+  const tarballs = smokePackages.map(p => join(staging, `${p.name.replace('@', '').replace('/', '-')}-${version}.tgz`));
 
   process.stdout.write('\n=== verify:external-consumers ===\n');
   const result = verifyExternalConsumers(tarballs);

--- a/scripts/release/lockstep-packages.ts
+++ b/scripts/release/lockstep-packages.ts
@@ -1,0 +1,59 @@
+/**
+ * Single source of truth for the lockstep-released ExoJS packages.
+ *
+ * Every release script derives its package list from here — `manifest.ts`
+ * (PUBLISH_ORDER), `prepare.ts` (officialPackages), `cut.ts` (bump targets),
+ * `run.ts` (build set), `external-consumers.ts` (offline smoke set), and the
+ * `verify-*` gates. Adding the N-th package is a single entry in this array
+ * instead of a hand-edit across ~10 files.
+ *
+ * NOT derivable from here (different runtimes — kept in sync manually, guarded
+ * by `verify:release-matrix` where possible):
+ *   - `.github/workflows/release.yml` / `_ci-checks.yml` build/typecheck/pack
+ *     steps (YAML, enumerated `--filter`s; release.yml build lines are asserted
+ *     by `verify:release-matrix`).
+ *   - `scripts/ci/select-lanes.mjs` RUNTIME_PACKAGES (dependency-free ESM that
+ *     runs before any install, so it cannot import this TS module).
+ *   - `site/scripts/sync-exo-vendor.ts` / `full-zip.ts` vendor tree — a smaller,
+ *     site-owned set (the offline examples site only embeds packages it uses).
+ */
+
+/** Order is canonical PUBLISH_ORDER: Core first (peer of every extension), then extensions. */
+export interface LockstepPackage {
+  /** npm package name. */
+  readonly name: string;
+  /** Package directory relative to the repo root (`.` for Core). */
+  readonly dir: string;
+  /** Core is `false`; every opt-in package is an extension. */
+  readonly isExtension: boolean;
+  /**
+   * Package-policy shape: `true` ships a `/register` side-effect entry
+   * (`particles`/`tilemap`/`tiled`/`aseprite`/`ldtk`); `false` is a library that
+   * ships `sideEffects: false` (`physics`/`audio-fx`/`react`). Ignored for Core.
+   */
+  readonly hasRegister: boolean;
+  /**
+   * Whether the package participates in the offline external-consumer smoke
+   * (`npm install --offline` + Node/TS import in a throwaway project). `react`
+   * is excluded: its `react`/`react-dom` peers are not resolvable offline.
+   */
+  readonly inOfflineSmoke: boolean;
+}
+
+export const LOCKSTEP_PACKAGES = [
+  { name: '@codexo/exojs', dir: '.', isExtension: false, hasRegister: false, inOfflineSmoke: true },
+  { name: '@codexo/exojs-particles', dir: 'packages/exojs-particles', isExtension: true, hasRegister: true, inOfflineSmoke: true },
+  { name: '@codexo/exojs-tilemap', dir: 'packages/exojs-tilemap', isExtension: true, hasRegister: true, inOfflineSmoke: true },
+  { name: '@codexo/exojs-tiled', dir: 'packages/exojs-tiled', isExtension: true, hasRegister: true, inOfflineSmoke: true },
+  { name: '@codexo/exojs-physics', dir: 'packages/exojs-physics', isExtension: true, hasRegister: false, inOfflineSmoke: true },
+  { name: '@codexo/exojs-audio-fx', dir: 'packages/exojs-audio-fx', isExtension: true, hasRegister: false, inOfflineSmoke: true },
+  { name: '@codexo/exojs-aseprite', dir: 'packages/exojs-aseprite', isExtension: true, hasRegister: true, inOfflineSmoke: true },
+  { name: '@codexo/exojs-ldtk', dir: 'packages/exojs-ldtk', isExtension: true, hasRegister: true, inOfflineSmoke: true },
+  { name: '@codexo/exojs-react', dir: 'packages/exojs-react', isExtension: true, hasRegister: false, inOfflineSmoke: false },
+] as const satisfies readonly LockstepPackage[];
+
+/** Union of the official package names (literal type, preserved for `OfficialPackageName`). */
+export type OfficialPackageName = (typeof LOCKSTEP_PACKAGES)[number]['name'];
+
+/** The extension subset (everything except Core). */
+export const EXTENSION_PACKAGES = LOCKSTEP_PACKAGES.filter(p => p.isExtension);

--- a/scripts/release/manifest.ts
+++ b/scripts/release/manifest.ts
@@ -11,17 +11,12 @@
 import { createHash } from 'node:crypto';
 import { readFileSync, statSync } from 'node:fs';
 
-/** Lockstep publish order — Core first (peer of the extensions), then the extensions. */
-export const PUBLISH_ORDER = [
-  '@codexo/exojs',
-  '@codexo/exojs-particles',
-  '@codexo/exojs-tilemap',
-  '@codexo/exojs-tiled',
-  '@codexo/exojs-physics',
-  '@codexo/exojs-audio-fx',
-] as const;
+import { LOCKSTEP_PACKAGES, type OfficialPackageName } from './lockstep-packages.ts';
 
-export type OfficialPackageName = (typeof PUBLISH_ORDER)[number];
+/** Lockstep publish order — Core first (peer of the extensions), then the extensions. */
+export const PUBLISH_ORDER: readonly OfficialPackageName[] = LOCKSTEP_PACKAGES.map(p => p.name);
+
+export type { OfficialPackageName };
 
 export interface TarballRecord {
   name: OfficialPackageName;

--- a/scripts/release/prepare.ts
+++ b/scripts/release/prepare.ts
@@ -13,6 +13,7 @@ import { readFileSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { basename, resolve } from 'node:path';
 
 import type { CommandRunner } from './command-runner.ts';
+import { LOCKSTEP_PACKAGES } from './lockstep-packages.ts';
 import {
   PUBLISH_ORDER,
   type OfficialPackageName,
@@ -42,15 +43,9 @@ const readVersion = (packageJsonPath: string): { name: string; version: string }
   return { name: pkg.name, version: pkg.version };
 };
 
-/** Resolves the six official packages in canonical publish order (PUBLISH_ORDER). */
-export const officialPackages = (rootDir: string): OfficialPackage[] => [
-  { name: '@codexo/exojs', dir: rootDir },
-  { name: '@codexo/exojs-particles', dir: resolve(rootDir, 'packages/exojs-particles') },
-  { name: '@codexo/exojs-tilemap', dir: resolve(rootDir, 'packages/exojs-tilemap') },
-  { name: '@codexo/exojs-tiled', dir: resolve(rootDir, 'packages/exojs-tiled') },
-  { name: '@codexo/exojs-physics', dir: resolve(rootDir, 'packages/exojs-physics') },
-  { name: '@codexo/exojs-audio-fx', dir: resolve(rootDir, 'packages/exojs-audio-fx') },
-];
+/** Resolves the lockstep official packages in canonical publish order (PUBLISH_ORDER). */
+export const officialPackages = (rootDir: string): OfficialPackage[] =>
+  LOCKSTEP_PACKAGES.map(p => ({ name: p.name, dir: p.dir === '.' ? rootDir : resolve(rootDir, p.dir) }));
 
 /**
  * Asserts all official packages share one lockstep version and returns it.

--- a/scripts/release/run.ts
+++ b/scripts/release/run.ts
@@ -23,6 +23,7 @@ import { resolveRevision } from '../../packages/exojs-config/build-defines/index
 import { checkAllTarballTypes } from './attw.ts';
 import { createExecRunner } from './command-runner.ts';
 import { verifyExternalConsumers } from './external-consumers.ts';
+import { LOCKSTEP_PACKAGES } from './lockstep-packages.ts';
 import { assembleFullReleaseTree, compressTree, treeBytes } from './full-zip.ts';
 import { type ReleaseManifest, serializeManifest, renderChecksums } from './manifest.ts';
 import { prepareRelease } from './prepare.ts';
@@ -45,14 +46,7 @@ const die = (message: string): never => {
 };
 
 const ensureBuilt = (): void => {
-  const dists = [
-    resolve(repoRoot, 'dist/esm'),
-    resolve(repoRoot, 'packages/exojs-particles/dist/esm'),
-    resolve(repoRoot, 'packages/exojs-tilemap/dist/esm'),
-    resolve(repoRoot, 'packages/exojs-tiled/dist/esm'),
-    resolve(repoRoot, 'packages/exojs-physics/dist/esm'),
-    resolve(repoRoot, 'packages/exojs-audio-fx/dist/esm'),
-  ];
+  const dists = LOCKSTEP_PACKAGES.map(p => resolve(repoRoot, p.dir === '.' ? 'dist/esm' : `${p.dir}/dist/esm`));
   const missing = dists.filter(d => !existsSync(d));
   if (missing.length > 0) {
     die(`Not built — missing ${missing.join(', ')}. Run "pnpm build" + extension builds, or pass --build.`);
@@ -61,16 +55,12 @@ const ensureBuilt = (): void => {
 
 const build = (): void => {
   log('\n→ Building core + extensions (build-once)…');
-  for (const [label, args, cwd] of [
-    ['core', ['build'], repoRoot],
-    ['particles', ['--filter', '@codexo/exojs-particles', 'build'], repoRoot],
-    ['tilemap', ['--filter', '@codexo/exojs-tilemap', 'build'], repoRoot],
-    ['tiled', ['--filter', '@codexo/exojs-tiled', 'build'], repoRoot],
-    ['physics', ['--filter', '@codexo/exojs-physics', 'build'], repoRoot],
-    ['audio-fx', ['--filter', '@codexo/exojs-audio-fx', 'build'], repoRoot],
-  ] as const) {
-    const r = runner.run({ command: 'pnpm', args: [...args], cwd });
-    if (r.code !== 0) die(`build failed for ${label}:\n${r.stderr || r.stdout}`);
+  // Core is `pnpm build`; each extension is `pnpm --filter <name> build`. pnpm
+  // resolves workspace-dependency order itself (e.g. tilemap before tiled/ldtk).
+  for (const pkg of LOCKSTEP_PACKAGES) {
+    const args = pkg.isExtension ? ['--filter', pkg.name, 'build'] : ['build'];
+    const r = runner.run({ command: 'pnpm', args, cwd: repoRoot });
+    if (r.code !== 0) die(`build failed for ${pkg.name}:\n${r.stderr || r.stdout}`);
   }
 };
 
@@ -126,7 +116,12 @@ const doPrepare = (): void => {
 
   if (!has('--skip-consumers')) {
     log('\n→ External consumers (Node ESM + TypeScript bundler resolution, offline, outside repo)…');
-    const consumers = verifyExternalConsumers(prepared.tarballs);
+    // Offline-smoke subset only: `@codexo/exojs-react` is excluded because its
+    // `react`/`react-dom` peers cannot be resolved in an offline throwaway
+    // project. attw still type-checks every packed tarball (react included).
+    const smokeNames = new Set(LOCKSTEP_PACKAGES.filter(p => p.inOfflineSmoke).map(p => p.name));
+    const smokeTarballs = manifest.packages.filter(p => smokeNames.has(p.name)).map(p => resolve(stagingDir, p.file));
+    const consumers = verifyExternalConsumers(smokeTarballs);
     for (const c of consumers.checks) log(`  ${c.ok ? '✓' : '✗'} ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);
     if (!consumers.ok) die('external consumer smoke failed.');
   }

--- a/scripts/verify-lockstep-versions.ts
+++ b/scripts/verify-lockstep-versions.ts
@@ -1,13 +1,16 @@
 /**
- * Verifies that all six official ExoJS packages share the same version.
+ * Verifies that all official ExoJS lockstep packages share the same version.
  *
- * The lockstep version contract: @codexo/exojs, @codexo/exojs-particles,
- * @codexo/exojs-tilemap, @codexo/exojs-tiled, @codexo/exojs-physics, and
- * @codexo/exojs-audio-fx must all be on the same X.Y.Z version per release.
+ * The lockstep version contract: every package in `LOCKSTEP_PACKAGES`
+ * (`scripts/release/lockstep-packages.ts`) — Core plus each opt-in extension —
+ * must be on the same X.Y.Z version per release, and each extension's
+ * `peerDependencies["@codexo/exojs"]` must be `<major>.<minor>.x`.
  */
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import { EXTENSION_PACKAGES } from './release/lockstep-packages.ts';
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -27,13 +30,7 @@ function readPackage(relPath: string): PackageInfo {
 }
 
 const corePkg = readPackage('package.json');
-const extensionPkgs = [
-  readPackage('packages/exojs-particles/package.json'),
-  readPackage('packages/exojs-tilemap/package.json'),
-  readPackage('packages/exojs-tiled/package.json'),
-  readPackage('packages/exojs-physics/package.json'),
-  readPackage('packages/exojs-audio-fx/package.json'),
-];
+const extensionPkgs = EXTENSION_PACKAGES.map(p => readPackage(`${p.dir}/package.json`));
 const packages = [corePkg, ...extensionPkgs];
 
 const versions = [...new Set(packages.map(p => p.version))];
@@ -43,7 +40,9 @@ if (versions.length !== 1) {
   for (const p of packages) {
     process.stderr.write(`  ${p.name}: ${p.version}\n`);
   }
-  process.stderr.write('\nAll six packages must be on the same version before release.\n' + 'Update all six package.json files to the same version.\n');
+  process.stderr.write(
+    `\nAll ${packages.length} packages must be on the same version before release.\n` + 'Update every package.json file to the same version.\n',
+  );
   process.exit(1);
 }
 

--- a/scripts/verify-package-policy.ts
+++ b/scripts/verify-package-policy.ts
@@ -5,15 +5,16 @@ import { fileURLToPath } from 'node:url';
 
 import { verifyConfigPackage, verifyRuntimePackage } from '@codexo/exojs-config/package-policy';
 
+import { LOCKSTEP_PACKAGES } from './release/lockstep-packages.ts';
+
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
-const targets = [
-  { dir: root, name: '@codexo/exojs', isExtension: false },
-  { dir: resolve(root, 'packages/exojs-particles'), name: '@codexo/exojs-particles', isExtension: true },
-  { dir: resolve(root, 'packages/exojs-tiled'), name: '@codexo/exojs-tiled', isExtension: true },
-  { dir: resolve(root, 'packages/exojs-physics'), name: '@codexo/exojs-physics', isExtension: true, hasRegister: false },
-  { dir: resolve(root, 'packages/exojs-audio-fx'), name: '@codexo/exojs-audio-fx', isExtension: true, hasRegister: false },
-];
+const targets = LOCKSTEP_PACKAGES.map(p => ({
+  dir: p.dir === '.' ? root : resolve(root, p.dir),
+  name: p.name,
+  isExtension: p.isExtension,
+  hasRegister: p.hasRegister,
+}));
 
 let failed = 0;
 

--- a/scripts/verify-release-matrix.ts
+++ b/scripts/verify-release-matrix.ts
@@ -5,17 +5,17 @@
  * handles every official package, in the right order, with coherent versions,
  * via the two-stage build-once pipeline:
  *
- *  1. The five official packages (@codexo/exojs, -particles, -tilemap, -tiled, -physics)
- *     share one lockstep version.
+ *  1. Every lockstep package (`LOCKSTEP_PACKAGES`, Core + extensions) shares one
+ *     lockstep version.
  *  2. Each extension's peerDependencies["@codexo/exojs"] is "<major>.<minor>.x".
  *  3. create-exo-app is versioned independently (a different version line).
- *  4. release.yml builds all five packages in the PREPARE stage.
- *  5. PREPARE runs `release:prepare` (packs five tarballs + Full ZIP) and
+ *  4. release.yml builds every lockstep package in the PREPARE stage.
+ *  5. PREPARE runs `release:prepare` (packs the tarballs + Full ZIP) and
  *     uploads the artifacts.
  *  6. PUBLISH consumes those artifacts (`download-artifact` + `release:publish`)
  *     and never rebuilds.
- *  7. The publish order Core → Particles → Tilemap → Tiled → Physics is the canonical
- *     PUBLISH_ORDER, and `officialPackages()` (what `release:prepare` actually packs) covers it exactly.
+ *  7. PUBLISH_ORDER equals the canonical `LOCKSTEP_PACKAGES` order (Core first),
+ *     and `officialPackages()` (what `release:prepare` actually packs) covers it exactly.
  *
  * Read-only: safe to run in dry-run/CI. Exits non-zero on any inconsistency.
  *
@@ -25,6 +25,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { EXTENSION_PACKAGES, LOCKSTEP_PACKAGES } from './release/lockstep-packages.ts';
 import { PUBLISH_ORDER } from './release/manifest.ts';
 import { officialPackages } from './release/prepare.ts';
 
@@ -51,14 +52,12 @@ const problems: string[] = [];
 const ok: string[] = [];
 
 const core = readPkg('package.json');
-const particles = readPkg('packages/exojs-particles/package.json');
-const tilemap = readPkg('packages/exojs-tilemap/package.json');
-const tiled = readPkg('packages/exojs-tiled/package.json');
-const physics = readPkg('packages/exojs-physics/package.json');
-const audioFx = readPkg('packages/exojs-audio-fx/package.json');
 const createExoApp = readPkg('packages/create-exo-app/package.json');
 
-const official = [core, particles, tilemap, tiled, physics, audioFx];
+// Every lockstep package (Core first) + the extension subset, derived from the
+// single source of truth (scripts/release/lockstep-packages.ts).
+const official = LOCKSTEP_PACKAGES.map(p => readPkg(p.dir === '.' ? 'package.json' : `${p.dir}/package.json`));
+const extensions = EXTENSION_PACKAGES.map(p => readPkg(`${p.dir}/package.json`));
 
 // 1. Lockstep version.
 const versions = new Set(official.map(p => p.version));
@@ -73,7 +72,7 @@ const [major, minor] = version.split('.');
 const expectedPeer = `${major}.${minor}.x`;
 
 // 2. Extension peer ranges.
-for (const ext of [particles, tilemap, tiled, physics, audioFx]) {
+for (const ext of extensions) {
   if (ext.peer !== expectedPeer) {
     problems.push(`${ext.name}: peer "@codexo/exojs" is "${ext.peer ?? '(missing)'}", expected "${expectedPeer}"`);
   } else {
@@ -111,13 +110,14 @@ const requireInWorkflow = (needle: string, label: string): void => {
   }
 };
 
-// 4. PREPARE builds all four official packages exactly once (build-once).
-requireInWorkflow('pnpm build', 'prepare builds core');
-requireInWorkflow('pnpm --filter @codexo/exojs-particles build', 'prepare builds particles');
-requireInWorkflow('pnpm --filter @codexo/exojs-tilemap build', 'prepare builds tilemap');
-requireInWorkflow('pnpm --filter @codexo/exojs-tiled build', 'prepare builds tiled');
-requireInWorkflow('pnpm --filter @codexo/exojs-physics build', 'prepare builds physics');
-requireInWorkflow('pnpm --filter @codexo/exojs-audio-fx build', 'prepare builds audio-fx');
+// 4. PREPARE builds every lockstep package exactly once (build-once). Core is
+// `pnpm build`; each extension is `pnpm --filter <name> build`. Looping over the
+// SoT means a new package's build line is enforced in release.yml automatically.
+for (const pkg of LOCKSTEP_PACKAGES) {
+  const short = pkg.name.replace('@codexo/exojs-', '').replace('@codexo/exojs', 'core');
+  const needle = pkg.isExtension ? `pnpm --filter ${pkg.name} build` : 'pnpm build';
+  requireInWorkflow(needle, `prepare builds ${short}`);
+}
 
 // 5. PREPARE packs/hashes/zips and uploads the artifacts.
 requireInWorkflow('pnpm release:prepare', 'prepare packs tarballs + Full ZIP (release:prepare)');
@@ -145,17 +145,12 @@ if (/run:\s*pnpm build\b/.test(publishSection)) {
   ok.push('publish job does not rebuild the runtime packages');
 }
 
-// 7. Canonical publish order Core → Particles → Tilemap → Tiled (enforced in code).
-if (
-  PUBLISH_ORDER[0] === '@codexo/exojs' &&
-  PUBLISH_ORDER[1] === '@codexo/exojs-particles' &&
-  PUBLISH_ORDER[2] === '@codexo/exojs-tilemap' &&
-  PUBLISH_ORDER[3] === '@codexo/exojs-tiled' &&
-  PUBLISH_ORDER[4] === '@codexo/exojs-physics'
-) {
-  ok.push('PUBLISH_ORDER is Core → Particles → Tilemap → Tiled → Physics');
+// 7. Canonical publish order = the LOCKSTEP_PACKAGES order (Core first), enforced in code.
+const expectedOrder = LOCKSTEP_PACKAGES.map(p => p.name);
+if (PUBLISH_ORDER.length === expectedOrder.length && PUBLISH_ORDER.every((name, i) => name === expectedOrder[i])) {
+  ok.push(`PUBLISH_ORDER matches LOCKSTEP_PACKAGES order (${expectedOrder.join(' → ')})`);
 } else {
-  problems.push(`PUBLISH_ORDER must be Core → Particles → Tilemap → Tiled → Physics, got ${PUBLISH_ORDER.join(' → ')}`);
+  problems.push(`PUBLISH_ORDER must equal LOCKSTEP_PACKAGES order ${expectedOrder.join(' → ')}, got ${PUBLISH_ORDER.join(' → ')}`);
 }
 
 // 7b. What `release:prepare` actually packs (officialPackages) must cover the

--- a/test/release/manifest.test.ts
+++ b/test/release/manifest.test.ts
@@ -75,7 +75,7 @@ describe('renderChecksums', () => {
       fullZip: { file: 'exojs-v0.13.0-full.zip', sha256: 'zzz', bytes: 1 },
     });
     const lines = body.trimEnd().split('\n');
-    expect(lines).toHaveLength(6);
+    expect(lines).toHaveLength(PUBLISH_ORDER.length);
     expect(body).not.toContain('full.zip');
     for (const line of lines) expect(line).toMatch(/^[a-f0-9]{64} {2}codexo-/);
   });

--- a/test/release/publish.test.ts
+++ b/test/release/publish.test.ts
@@ -51,7 +51,7 @@ const publishedPackages = (invocations: CommandInvocation[]): string[] => publis
 const liveOptions = (): PublishOptions => ({ ...defaultPublishOptions('0.13.0'), dryRun: false, checkExisting: true });
 
 describe('publishRelease — dry-run', () => {
-  it('publishes all six to latest in Core→Particles→Tilemap→Tiled→Physics→AudioFx order, every call carries --dry-run', () => {
+  it('publishes every package to latest in PUBLISH_ORDER, every call carries --dry-run', () => {
     const runner = createRecordingRunner(inv => (inv.args[0] === 'view' ? fail('E404') : ok()));
     const report = publishRelease(manifest, defaultPublishOptions('0.13.0'), runner, resolveArtifact);
 
@@ -59,16 +59,9 @@ describe('publishRelease — dry-run', () => {
     expect(report.dryRun).toBe(true);
 
     const published = publishCalls(runner.invocations);
-    expect(published).toHaveLength(6);
-    // order by tarball file name reflects Core→Particles→Tilemap→Tiled→Physics→AudioFx
-    expect(published.map(i => i.args[1])).toEqual([
-      resolveArtifact(tarballName('@codexo/exojs')),
-      resolveArtifact(tarballName('@codexo/exojs-particles')),
-      resolveArtifact(tarballName('@codexo/exojs-tilemap')),
-      resolveArtifact(tarballName('@codexo/exojs-tiled')),
-      resolveArtifact(tarballName('@codexo/exojs-physics')),
-      resolveArtifact(tarballName('@codexo/exojs-audio-fx')),
-    ]);
+    expect(published).toHaveLength(PUBLISH_ORDER.length);
+    // Tarball order reflects the canonical PUBLISH_ORDER (Core first).
+    expect(published.map(i => i.args[1])).toEqual(PUBLISH_ORDER.map(name => resolveArtifact(tarballName(name))));
     for (const call of published) {
       expect(call.args).toContain('--dry-run');
       expect(call.args).toContain('--tag');
@@ -80,12 +73,12 @@ describe('publishRelease — dry-run', () => {
 });
 
 describe('publishRelease — live happy path', () => {
-  it('publishes all six directly to latest', () => {
+  it('publishes every package directly to latest', () => {
     const runner = createRecordingRunner(inv => (inv.args[0] === 'view' ? fail('E404') : ok()));
     const report = publishRelease(manifest, liveOptions(), runner, resolveArtifact);
 
     expect(report.ok).toBe(true);
-    expect(report.packages.map(p => p.publish)).toEqual(['published', 'published', 'published', 'published', 'published', 'published']);
+    expect(report.packages.map(p => p.publish)).toEqual(PUBLISH_ORDER.map(() => 'published'));
 
     // No dist-tag promotion step — direct publish replaces the former staging→promote flow.
     expect(distTagCalls(runner.invocations)).toHaveLength(0);
@@ -105,19 +98,9 @@ describe('publishRelease — idempotent resume', () => {
 
     expect(report.ok).toBe(true);
     expect(report.packages[0].publish).toBe('already-published');
-    expect(report.packages[1].publish).toBe('published');
-    expect(report.packages[2].publish).toBe('published');
-    expect(report.packages[3].publish).toBe('published');
-    expect(report.packages[4].publish).toBe('published');
-    expect(report.packages[5].publish).toBe('published');
-    // Core was NOT re-published.
-    expect(publishedPackages(runner.invocations)).toEqual([
-      resolveArtifact(tarballName('@codexo/exojs-particles')),
-      resolveArtifact(tarballName('@codexo/exojs-tilemap')),
-      resolveArtifact(tarballName('@codexo/exojs-tiled')),
-      resolveArtifact(tarballName('@codexo/exojs-physics')),
-      resolveArtifact(tarballName('@codexo/exojs-audio-fx')),
-    ]);
+    expect(report.packages.slice(1).every(p => p.publish === 'published')).toBe(true);
+    // Core was NOT re-published; every other package was, in order.
+    expect(publishedPackages(runner.invocations)).toEqual(PUBLISH_ORDER.slice(1).map(name => resolveArtifact(tarballName(name))));
   });
 
   it('a fully-published release re-run publishes nothing', () => {
@@ -171,7 +154,9 @@ describe('publishRelease — partial failure stops the chain', () => {
     const report = publishRelease(manifest, liveOptions(), runner, resolveArtifact);
 
     expect(report.ok).toBe(false);
-    expect(report.packages.map(p => p.publish)).toEqual(['published', 'published', 'published', 'failed', 'not-attempted', 'not-attempted']);
+    // Tiled is index 3 (Core, Particles, Tilemap published; Tiled fails; rest never attempted).
+    const expected = PUBLISH_ORDER.map((_, i) => (i < 3 ? 'published' : i === 3 ? 'failed' : 'not-attempted'));
+    expect(report.packages.map(p => p.publish)).toEqual(expected);
     expect(distTagCalls(runner.invocations)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## What

Refactors the release pipeline to derive the lockstep package set from a **single source of truth** (`scripts/release/lockstep-packages.ts`), and wires the three previously-unlisted packages — `@codexo/exojs-aseprite`, `-ldtk`, `-react` — into the coordinated release.

## Why

Adding a package used to mean hand-editing the same list across ~10 files (`cut`, `manifest` PUBLISH_ORDER, `prepare` officialPackages, `run`, `external-consumers`, the `verify-*` gates). Now it's **one SoT entry** (plus the two non-importable spots — `select-lanes.mjs` and the YAML `--filter` lists — which `verify:release-matrix` guards).

## Changes

- **SoT:** `scripts/release/lockstep-packages.ts` (9 packages, flags `isExtension`/`hasRegister`/`inOfflineSmoke`). `manifest`/`prepare`/`cut`/`run`/`external-consumers`/`verify-lockstep`/`verify-release-matrix`/`verify-package-policy` all derive from it.
- **Wired** aseprite/ldtk/react into bump, publish order, builds (`run.ts` + `release.yml`), CI typecheck/build/pack (`_ci-checks.yml`), `select-lanes` RUNTIME_PACKAGES, RELEASING.md.
- **react:** lockstep bump/publish/verify/CI, but **excluded from the offline consumer smoke** (its `react`/`react-dom` peers are not resolvable offline) and the vendor tree. React itself is never bundled (rollup `external` + peer). Added `sideEffects: false`.
- **README + LICENSE** for aseprite and ldtk.
- **Bug fix:** `tilemap`'s `files` listed `LICENSE` but the file was missing — its tarball shipped without a license. Added it.
- **Tests** made count-agnostic (`publish.test`/`manifest.test` derive from `PUBLISH_ORDER`).

## Verification (local CI parity)

- `verify:lockstep` (9@0.14.0) + `verify:release-matrix` ✓
- release/ci suites (publish/manifest/prepare/select-lanes/full-zip/attw/changelog) — 81 tests ✓
- offline external-consumer smoke — 8 tarballs (react excluded), aseprite/ldtk import + facade identity ✓
- `lint` (0 errors) + `prettier` + per-package typecheck (aseprite/ldtk/react) ✓
- `verify:package-policy`: tilemap/aseprite/react pass; tiled+ldtk show the known **non-gating** facade hint (`workspace:`/prod-dep — not a CI gate)

## Notes

- aseprite/ldtk/react are already on npm with OIDC configured, so no bootstrap step is needed.
- `verify:package-policy` is a script, not a CI gate; the tiled/ldtk facade hint is pre-existing for tiled and consistent for ldtk.