### PR TITLE
feat(physics): body sleeping with islands (A1.1)

### DIFF
--- a/packages/exojs-physics/src/PhysicsBody.ts
+++ b/packages/exojs-physics/src/PhysicsBody.ts
@@ -71,6 +71,9 @@ export class PhysicsBody {
   /** Angular velocity in rad/s. */
   public angularVelocity = 0;
 
+  /** When `false`, this body is never put to sleep. Default `true`. */
+  public allowSleep = true;
+
   /** @internal — Delta position X accumulated across the frame's sub-steps by the TGS integrator; written into the transform once per frame by {@link _finalizePosition}. */
   public _deltaPosX = 0;
   /** @internal — Delta position Y accumulated across the frame's sub-steps by the TGS integrator. */
@@ -85,6 +88,13 @@ export class PhysicsBody {
   private _forceX = 0;
   private _forceY = 0;
   private _torque = 0;
+
+  /** @internal — seconds the body has stayed below the sleep thresholds (frozen while asleep). Read by the world's island pass. */
+  public _sleepTime = 0;
+  /** @internal — dense union-find index assigned by the world's island pass each step. */
+  public _islandIndex = 0;
+
+  private _sleeping = false;
 
   private _id = -1;
   private _owner: BodyOwner | null = null;
@@ -178,6 +188,11 @@ export class PhysicsBody {
     return this._destroyed;
   }
 
+  /** `true` when the body is asleep — skipped by the integrator and solver until woken. */
+  public get isSleeping(): boolean {
+    return this._sleeping;
+  }
+
   /**
    * Attach a collider to this body. Accepts a {@link Collider} instance or its
    * {@link ColliderOptions} (a convenience that constructs the collider for you).
@@ -219,6 +234,8 @@ export class PhysicsBody {
       throw new Error('PhysicsBody: cannot move a destroyed body.');
     }
 
+    this.wake();
+
     setTransform(this._transform, position.x, position.y, angle);
 
     for (const collider of this._colliders) {
@@ -250,6 +267,7 @@ export class PhysicsBody {
    * sub-step and then cleared. No-op on static/kinematic bodies. Returns `this`.
    */
   public applyForce(forceX: number, forceY: number): this {
+    this.wake();
     this._forceX += forceX;
     this._forceY += forceY;
 
@@ -261,6 +279,7 @@ export class PhysicsBody {
    * on static/kinematic bodies (and fixed-rotation bodies). Returns `this`.
    */
   public applyTorque(torque: number): this {
+    this.wake();
     this._torque += torque;
 
     return this;
@@ -276,6 +295,7 @@ export class PhysicsBody {
       return this;
     }
 
+    this.wake();
     this.linearVelocityX += impulseX * this.invMass;
     this.linearVelocityY += impulseY * this.invMass;
 
@@ -299,7 +319,7 @@ export class PhysicsBody {
    * every sub-step and cleared once per frame by {@link _finalizePosition}.
    */
   public _integrateVelocity(h: number, gravityX: number, gravityY: number): void {
-    if (this.invMass === 0) {
+    if (this.invMass === 0 || this._sleeping) {
       return;
     }
 
@@ -322,7 +342,7 @@ export class PhysicsBody {
    * re-syncing collider geometry per sub-step. Static bodies never move.
    */
   public _integratePosition(h: number): void {
-    if (this.type === 'static') {
+    if (this.type === 'static' || this._sleeping) {
       return;
     }
 
@@ -338,6 +358,49 @@ export class PhysicsBody {
       this._deltaCos = Math.cos(this._deltaAngle);
       this._deltaSin = Math.sin(this._deltaAngle);
     }
+  }
+
+  /**
+   * @internal — advance the sleep timer over one fixed step `dt`. A body below
+   * both velocity thresholds accumulates time; a too-fast body, or one that opts
+   * out via {@link allowSleep}, resets it. The sleep/wake decision is made per
+   * island by the world (so a stack sleeps as a unit) from {@link _sleepTime}.
+   */
+  public _accumulateSleepTime(dt: number, linearThreshold: number, angularThreshold: number): void {
+    const tooFast =
+      this.linearVelocityX * this.linearVelocityX + this.linearVelocityY * this.linearVelocityY > linearThreshold * linearThreshold ||
+      Math.abs(this.angularVelocity) > angularThreshold;
+
+    this._sleepTime = !this.allowSleep || tooFast ? 0 : this._sleepTime + dt;
+  }
+
+  /** @internal — set the sleep state. Sleeping zeroes the velocity; waking resets the sleep timer. */
+  public _setSleeping(sleeping: boolean): void {
+    if (this._sleeping === sleeping) {
+      return;
+    }
+
+    this._sleeping = sleeping;
+
+    if (sleeping) {
+      this.linearVelocityX = 0;
+      this.linearVelocityY = 0;
+      this.angularVelocity = 0;
+    } else {
+      this._sleepTime = 0;
+    }
+  }
+
+  /**
+   * Wake the body if it is asleep, resetting its sleep timer. The rest of its
+   * island wakes with it on the next step (a contact to an awake body keeps the
+   * whole island awake). Returns `this`.
+   */
+  public wake(): this {
+    this._setSleeping(false);
+    this._sleepTime = 0;
+
+    return this;
   }
 
   /**

--- a/packages/exojs-physics/src/PhysicsWorld.ts
+++ b/packages/exojs-physics/src/PhysicsWorld.ts
@@ -37,6 +37,14 @@ export interface PhysicsWorldOptions {
   dampingRatio?: number;
   /** Interpolate bound nodes between fixed steps (reserved; no effect yet). Default `true`. */
   interpolation?: boolean;
+  /** Put resting bodies to sleep so they skip integration and solving. Default `true`. */
+  enableSleeping?: boolean;
+  /** Linear speed at or below which a body is a sleep candidate, px/s. Default `5`. */
+  sleepLinearVelocity?: number;
+  /** Angular speed at or below which a body is a sleep candidate, rad/s. Default `0.06`. */
+  sleepAngularVelocity?: number;
+  /** Seconds a body must stay below the sleep thresholds before it sleeps. Default `0.5`. */
+  timeToSleep?: number;
 }
 
 /**
@@ -129,6 +137,14 @@ export class PhysicsWorld implements BodyOwner {
   public readonly contactHertz: number;
   /** Soft-contact damping ratio. */
   public readonly dampingRatio: number;
+  /** Whether resting bodies are put to sleep. */
+  public readonly enableSleeping: boolean;
+  /** Linear sleep threshold (px/s). */
+  public readonly sleepLinearVelocity: number;
+  /** Angular sleep threshold (rad/s). */
+  public readonly sleepAngularVelocity: number;
+  /** Seconds below the thresholds before a body sleeps. */
+  public readonly timeToSleep: number;
 
   private readonly _backend: PhysicsBackend = new NativePhysicsBackend();
   private readonly _bodies: PhysicsBody[] = [];
@@ -136,6 +152,10 @@ export class PhysicsWorld implements BodyOwner {
   private readonly _bindings = new BindingRegistry();
   private readonly _query: QueryEngine;
   private readonly _commands: Array<() => void> = [];
+  /** Pooled union-find parent array for the per-step island pass (reused; sized to the body count). */
+  private readonly _islandParent: number[] = [];
+  /** Pooled per-island minimum sleep time, indexed by union-find root. */
+  private readonly _islandMinSleep: number[] = [];
 
   private _nextBodyId = 1;
   private _nextColliderId = 1;
@@ -159,6 +179,10 @@ export class PhysicsWorld implements BodyOwner {
     this.subStepCount = subStepCount;
     this.contactHertz = options.contactHertz ?? 30;
     this.dampingRatio = options.dampingRatio ?? 10;
+    this.enableSleeping = options.enableSleeping ?? true;
+    this.sleepLinearVelocity = options.sleepLinearVelocity ?? 5;
+    this.sleepAngularVelocity = options.sleepAngularVelocity ?? 0.06;
+    this.timeToSleep = options.timeToSleep ?? 0.5;
     this._query = new QueryEngine(this._colliders);
   }
 
@@ -273,6 +297,14 @@ export class PhysicsWorld implements BodyOwner {
         // from the previous frame's finalize / attach / setTransform). TGS-Soft
         // reuses the manifolds across the sub-steps below.
         this._backend.detect(this._colliders);
+
+        // Sleep decision runs after detection (islands need the current contact
+        // set) and before the solver (so sleeping contacts are skipped, and a
+        // sleeping island touched by an awake body is woken first).
+        if (this.enableSleeping) {
+          this._updateSleeping(this.timeStepper.fixedDelta);
+        }
+
         this._backend.prepareSolve(h, contactHertz, dampingRatio);
 
         for (let subStep = 0; subStep < subStepCount; subStep++) {
@@ -426,6 +458,100 @@ export class PhysicsWorld implements BodyOwner {
     }
 
     this._dispatching = false;
+  }
+
+  /**
+   * Accumulate per-body sleep timers and put/keep islands of resting bodies
+   * asleep so a stack sleeps and wakes as one unit. An island is a connected
+   * component of dynamic bodies joined by touching solid contacts (static and
+   * kinematic bodies are boundaries, not nodes); it sleeps once every member has
+   * stayed below the sleep thresholds for `timeToSleep`, and wakes the instant
+   * any member does (e.g. an awake body merges into it via a new contact).
+   * Deterministic: union-find roots break ties by lower index and the contact
+   * set is id-sorted.
+   */
+  private _updateSleeping(dt: number): void {
+    const bodies = this._bodies;
+    const count = bodies.length;
+    const parent = this._islandParent;
+    const minSleep = this._islandMinSleep;
+
+    // Assign dense indices, reset the union-find, and accumulate sleep timers for
+    // awake dynamic bodies (a sleeping body's timer stays frozen ≥ timeToSleep).
+    for (let i = 0; i < count; i++) {
+      const body = bodies[i]!;
+
+      body._islandIndex = i;
+      parent[i] = i;
+      minSleep[i] = Infinity;
+
+      if (body.type === 'dynamic' && !body.isSleeping) {
+        body._accumulateSleepTime(dt, this.sleepLinearVelocity, this.sleepAngularVelocity);
+      }
+    }
+
+    parent.length = count;
+    minSleep.length = count;
+
+    // Union dynamic↔dynamic solid contacts into islands.
+    for (const contact of this._backend.contactGraph.solidContacts) {
+      const bodyA = contact.a.body;
+      const bodyB = contact.b.body;
+
+      if (bodyA.type === 'dynamic' && bodyB.type === 'dynamic') {
+        this._union(bodyA._islandIndex, bodyB._islandIndex);
+      }
+    }
+
+    // Per-island minimum sleep time over its dynamic members.
+    for (let i = 0; i < count; i++) {
+      const body = bodies[i]!;
+
+      if (body.type === 'dynamic') {
+        const root = this._find(i);
+
+        if (body._sleepTime < minSleep[root]!) {
+          minSleep[root] = body._sleepTime;
+        }
+      }
+    }
+
+    // Sleep an island iff every member has rested for `timeToSleep`; otherwise
+    // wake it (which also wakes any member dragged awake by a fresh contact).
+    const timeToSleep = this.timeToSleep;
+
+    for (let i = 0; i < count; i++) {
+      const body = bodies[i]!;
+
+      if (body.type === 'dynamic') {
+        body._setSleeping(minSleep[this._find(i)]! >= timeToSleep);
+      }
+    }
+  }
+
+  /** Union-find union by lower index (deterministic roots). */
+  private _union(a: number, b: number): void {
+    const rootA = this._find(a);
+    const rootB = this._find(b);
+
+    if (rootA < rootB) {
+      this._islandParent[rootB] = rootA;
+    } else if (rootB < rootA) {
+      this._islandParent[rootA] = rootB;
+    }
+  }
+
+  /** Union-find find with path halving. */
+  private _find(index: number): number {
+    const parent = this._islandParent;
+
+    while (parent[index]! !== index) {
+      const grandparent = parent[parent[index]!]!;
+      parent[index] = grandparent;
+      index = grandparent;
+    }
+
+    return index;
   }
 
   /** Run `command` now, or queue it when inside an event dispatch (deferred to end of step). */

--- a/packages/exojs-physics/src/solver/ContactSolver.ts
+++ b/packages/exojs-physics/src/solver/ContactSolver.ts
@@ -133,6 +133,15 @@ export class ContactSolver {
 
       const bodyA = contact.a.body;
       const bodyB = contact.b.body;
+
+      // Skip contacts where either body is asleep: a sleeping island's solid
+      // contacts are all sleeping↔sleeping or sleeping↔static (both at rest), so
+      // there is nothing to solve. A sleeping body touched by an awake one is
+      // woken (island merge) before this runs, so it is never skipped wrongly.
+      if (bodyA.isSleeping || bodyB.isSleeping) {
+        continue;
+      }
+
       const constraint = this._acquire();
       const nx = manifold.normalX;
       const ny = manifold.normalY;

--- a/packages/exojs-physics/test/sleeping.test.ts
+++ b/packages/exojs-physics/test/sleeping.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+
+import { BoxShape, PhysicsWorld } from '../src/index';
+import { PhysicsBody } from '../src/PhysicsBody';
+
+/**
+ * Sleeping & islands (spec `01-sleeping-islands.md`, gate P-3). Bodies that come
+ * to rest stop integrating/solving; connected bodies sleep and wake as a unit
+ * via an island graph. SG-SL prefix, default solver config, +Y down.
+ */
+
+const GRAVITY = 1000; // px/s²
+const FRAME = 1 / 60;
+
+const advance = (world: PhysicsWorld, seconds: number): void => {
+  const frames = Math.round(seconds / FRAME);
+
+  for (let frame = 0; frame < frames; frame++) {
+    world.step(FRAME);
+  }
+};
+
+/** A wide static floor whose top surface sits at `topY`. */
+const addFloor = (world: PhysicsWorld, topY: number): PhysicsBody =>
+  world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: topY + 20 }, colliders: [{ shape: new BoxShape(1200, 40) }] }));
+
+/** A 32×32 dynamic box centred at `(x, y)`. */
+const addBox = (world: PhysicsWorld, x: number, y: number): PhysicsBody =>
+  world.add(new PhysicsBody({ type: 'dynamic', position: { x, y }, colliders: [{ shape: new BoxShape(32, 32), friction: 0.5 }] }));
+
+/** A vertical stack of `count` boxes resting bottom-up from `floorTopY`. */
+const addStack = (world: PhysicsWorld, count: number, floorTopY: number): PhysicsBody[] => {
+  const boxes: PhysicsBody[] = [];
+
+  for (let i = 0; i < count; i++) {
+    boxes.push(addBox(world, 0, floorTopY - 16 - i * 32));
+  }
+
+  return boxes;
+};
+
+describe('SG-SL — sleeping', () => {
+  it('SG-SL1: a box that comes to rest falls asleep after timeToSleep', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    addFloor(world, 300);
+    const box = addBox(world, 0, 300 - 16 - 2); // 2px above its resting height
+
+    // Still settling within the first 0.1s → must be awake.
+    advance(world, 0.1);
+    expect(box.isSleeping).toBe(false);
+
+    // After resting longer than the default timeToSleep (0.5s) → asleep.
+    advance(world, 2);
+    expect(box.isSleeping).toBe(true);
+    expect(box.linearVelocityX).toBe(0); // sleeping zeroes velocity
+    expect(box.linearVelocityY).toBe(0);
+    expect(box.angularVelocity).toBe(0);
+  });
+
+  it('SG-SL2: a body dropped onto a sleeping body wakes it and is supported (no tunnelling)', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    addFloor(world, 300);
+    const bottom = addBox(world, 0, 300 - 16 - 2);
+
+    advance(world, 2);
+    expect(bottom.isSleeping).toBe(true);
+
+    // Drop a second box from above onto the sleeping one.
+    const top = addBox(world, 0, 300 - 16 - 64);
+    advance(world, 2);
+
+    // The top box rests ON the bottom box — if wake-on-contact failed, the
+    // solver would skip the contact and the top box would tunnel through.
+    expect(top.y).toBeLessThan(bottom.y - 24); // a box-height above
+    expect(bottom.y).toBeGreaterThan(300 - 16 - 5); // bottom still on the floor
+    expect(bottom.y).toBeLessThan(300 - 16 + 5);
+  });
+
+  it('SG-SL3: an impulse wakes a sleeping body immediately', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    addFloor(world, 300);
+    const box = addBox(world, 0, 300 - 16 - 2);
+
+    advance(world, 2);
+    expect(box.isSleeping).toBe(true);
+
+    box.applyImpulse(30000, 0); // horizontal kick
+    expect(box.isSleeping).toBe(false); // woken on the spot
+    expect(box.linearVelocityX).toBeGreaterThan(0);
+  });
+
+  it('SG-SL4: a settling stack falls asleep', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    addFloor(world, 300);
+    const boxes = addStack(world, 4, 300);
+
+    advance(world, 3);
+
+    for (const box of boxes) {
+      expect(box.isSleeping).toBe(true);
+    }
+  });
+
+  it('SG-SL5: allowSleep=false on one stack member keeps the whole island awake', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    addFloor(world, 300);
+    const boxes = addStack(world, 3, 300);
+    boxes[1]!.allowSleep = false; // the middle box never sleeps
+
+    advance(world, 3);
+
+    // The island sleeps as a unit, so one non-sleeping member keeps all awake.
+    for (const box of boxes) {
+      expect(box.isSleeping).toBe(false);
+    }
+  });
+
+  it('SG-SL6: sleep transitions are deterministic across identical runs', () => {
+    const run = (): string => {
+      const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+      addFloor(world, 300);
+      const boxes = addStack(world, 4, 300);
+      const trace: string[] = [];
+
+      for (let frame = 0; frame < 240; frame++) {
+        world.step(FRAME);
+        trace.push(boxes.map(box => (box.isSleeping ? '1' : '0')).join(''));
+      }
+
+      return trace.join('|');
+    };
+
+    expect(run()).toBe(run());
+  });
+});


### PR DESCRIPTION
First slice of the physics feature matrix (spec `01-sleeping-islands.md`, gate P-3 follows in A1.2).

## What

Resting bodies stop integrating and solving — large mostly-static scenes get much cheaper. Connected dynamic bodies sleep and wake as **one island** (union-find over the contact graph), so a stack never half-sleeps.

- **`PhysicsBody`**: `isSleeping` / `allowSleep` / `wake()`; sleep timer; integration skipped while asleep; `applyForce` / `applyTorque` / `applyImpulse` / `setTransform` wake the body.
- **`PhysicsWorld`**: `enableSleeping` (default `true`) + `sleepLinearVelocity` / `sleepAngularVelocity` / `timeToSleep` options. A per-step island pass (after detect, before solve) sleeps an island once every member has rested for `timeToSleep`, and wakes it the instant an awake body merges in via a new contact.
- **`ContactSolver`**: skips contacts where either body is asleep.

## Why islands (not per-body)

A naive per-body sleep left a sleeping body in a half-state — integration skipped but the solver still wrote velocity into it — which corrupted coupled stacks (3 SG-S stacking tests failed). The island design (sleep/wake as a unit + solver-skip) is the minimal *correct* increment. Island merge also gives wake-on-contact for free.

## Tests

`test/sleeping.test.ts` — SG-SL1 sleep after `timeToSleep`; SG-SL2 wake-on-contact **with support (no tunnelling)**; SG-SL3 wake-on-impulse; SG-SL4 stack sleeps; SG-SL5 `allowSleep=false` keeps the whole island awake; SG-SL6 determinism. Full SG-matrix + perf unchanged (91 physics tests green).

## Notes

- Default-on. Existing behaviour is unchanged until a body is truly at rest for `timeToSleep`.
- Known limit: direct velocity-field writes (`body.linearVelocityX = …`) do not wake (they are public fields, not setters) — use `applyImpulse` / `wake()`.
- `@codexo/exojs-physics` is not in `build-api` EXTENSION_PACKAGES, so no `docs:api` impact.
- Next: **A1.2** — perf gate P-3 (5000-mostly-sleeping bench) + `drawSleeping` debug.