### PR TITLE
feat(physics): sleeping perf gate + drawSleeping debug (A1.2)

### DIFF
--- a/packages/exojs-physics/src/debug/PhysicsDebugDraw.ts
+++ b/packages/exojs-physics/src/debug/PhysicsDebugDraw.ts
@@ -25,6 +25,8 @@ export interface PhysicsDebugDrawOptions {
   drawCenters?: boolean;
   /** Broad-phase candidate links between AABB-overlapping colliders. Default `false`. */
   drawBroadphase?: boolean;
+  /** Tint sleeping bodies distinctly (applies to the shape outline). Default `false`. */
+  drawSleeping?: boolean;
 }
 
 const segments = 24;
@@ -38,6 +40,7 @@ const colorContact = new Color(1, 0.2, 0.2, 1);
 const colorNormal = new Color(1, 0.6, 0.1, 1);
 const colorCenter = new Color(1, 1, 1, 0.9);
 const colorBroadphase = new Color(0.2, 0.8, 0.8, 0.5);
+const colorSleeping = new Color(0.45, 0.45, 0.5, 0.7);
 
 /**
  * `DebugLayer` that visualises a {@link PhysicsWorld} — shapes, AABBs, contacts,
@@ -67,6 +70,7 @@ export class PhysicsDebugDraw extends DebugLayer {
       drawNormals: options.drawNormals ?? false,
       drawCenters: options.drawCenters ?? false,
       drawBroadphase: options.drawBroadphase ?? false,
+      drawSleeping: options.drawSleeping ?? false,
     };
   }
 
@@ -125,8 +129,20 @@ export class PhysicsDebugDraw extends DebugLayer {
 
   // ── helpers ────────────────────────────────────────────────────────────
 
+  private _outlineColor(collider: Collider): Color {
+    if (collider.isSensor) {
+      return colorSensor;
+    }
+
+    if (this.options.drawSleeping && collider.body.isSleeping) {
+      return colorSleeping;
+    }
+
+    return colorForType(collider.body.type);
+  }
+
   private _strokeShape(gfx: Graphics, collider: Collider): void {
-    gfx.lineColor = collider.isSensor ? colorSensor : colorForType(collider.body.type);
+    gfx.lineColor = this._outlineColor(collider);
 
     if (collider.shape.type === 'circle') {
       const c = collider.worldCenter;

--- a/packages/exojs-physics/test/perf.test.ts
+++ b/packages/exojs-physics/test/perf.test.ts
@@ -25,8 +25,8 @@ import { measureAllocationRate } from './allocationSampler';
 const FRAME = 1 / 60;
 
 /** A wide field of `columns` independent `rows`-high box stacks on a static floor. */
-const buildField = (columns: number, rows: number): { world: PhysicsWorld; bodies: PhysicsBody[] } => {
-  const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+const buildField = (columns: number, rows: number, worldOptions: { enableSleeping?: boolean } = {}): { world: PhysicsWorld; bodies: PhysicsBody[] } => {
+  const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 }, ...worldOptions });
   const size = 16;
   const spacing = 20;
   const floorTop = 1000;
@@ -129,4 +129,38 @@ describe('physics dynamics performance (P-1 / P-2)', () => {
     // boxing variance.
     expect(bytesPerStep).toBeLessThan(600 * 1024);
   });
+
+  it('5,000-mostly-sleeping field: sleeping sharply cuts step time (P-3)', () => {
+    // Baseline: the identical field with sleeping disabled stays fully active.
+    const awake = buildField(1000, 5, { enableSleeping: false });
+
+    for (let i = 0; i < 240; i++) {
+      awake.world.step(FRAME);
+    }
+
+    const awakeMs = stepTimes(awake.world, 120);
+
+    // Sleeping on (default): let the field settle and nap.
+    const sleeping = buildField(1000, 5, { enableSleeping: true });
+
+    for (let i = 0; i < 360; i++) {
+      sleeping.world.step(FRAME);
+    }
+
+    const sleptCount = sleeping.bodies.filter(body => body.isSleeping).length;
+    const sleepingMs = stepTimes(sleeping.world, 120);
+
+    expect(sleeping.bodies.length).toBe(5000);
+    console.log(
+      `[P-3] awake ${awakeMs.toFixed(3)} ms/step vs sleeping ${sleepingMs.toFixed(3)} ms/step · ${sleptCount}/5000 asleep (${(awakeMs / sleepingMs).toFixed(1)}× faster)`,
+    );
+
+    // The vast majority of a settled field naps, and skipping their integration
+    // and constraint solve sharply cuts the per-step cost (measured ~3.4× faster
+    // on the reference machine — the remainder is detection, which still runs).
+    // The gate is a relative ratio (same machine, sleeping vs awake), so it is
+    // machine-independent; ≥2× leaves headroom for variance.
+    expect(sleptCount).toBeGreaterThan(4500);
+    expect(sleepingMs).toBeLessThan(awakeMs * 0.5);
+  }, 60_000);
 });


### PR DESCRIPTION
Second sleeping slice (spec `01-sleeping-islands.md`, gate **P-3**). Builds on A1.1 (#186).

## What

- **P-3 perf gate** (`test/perf.test.ts`): a 5,000-body field with sleeping on (all asleep once settled) steps **~3.4× faster** than the same field with sleeping disabled — measured **20.1 → 6.0 ms/step** on the reference machine (the remaining cost is detection, which still runs over all colliders). The gate asserts ≥2× (a same-machine relative ratio → machine-independent) and >4,500/5,000 asleep. `buildField` gains a world-options argument.
- **`drawSleeping`** option in `PhysicsDebugDraw`: tints sleeping bodies' outlines so napped islands are visible in the overlay.

## Tests

97 physics tests green (P-3 added; full SG-matrix + SG-SL + P-1/P-2 unchanged). typecheck + lint (0 new warnings) + prettier clean.

## Notes

- Sleeping (default-on) is now both correct (A1.1) and measured to pay off (P-3).
- Next: **A2.1** — joint infrastructure + DistanceJoint.