### PR TITLE
feat(physics): joint infrastructure + DistanceJoint (A2.1)

### DIFF
--- a/packages/exojs-physics/src/PhysicsWorld.ts
+++ b/packages/exojs-physics/src/PhysicsWorld.ts
@@ -8,6 +8,7 @@ import { BindingRegistry } from './binding/BindingRegistry';
 import type { BindingOptions, PhysicsBinding } from './binding/PhysicsBinding';
 import { Collider } from './Collider';
 import type { CollisionEvent, SensorEvent } from './events';
+import type { Joint } from './joints/Joint';
 import type { BodyOwner } from './PhysicsBody';
 import { PhysicsBody } from './PhysicsBody';
 import type { QueryFilter, RayHit } from './query/QueryEngine';
@@ -149,6 +150,7 @@ export class PhysicsWorld implements BodyOwner {
   private readonly _backend: PhysicsBackend = new NativePhysicsBackend();
   private readonly _bodies: PhysicsBody[] = [];
   private readonly _colliders: Collider[] = [];
+  private readonly _joints: Joint[] = [];
   private readonly _bindings = new BindingRegistry();
   private readonly _query: QueryEngine;
   private readonly _commands: Array<() => void> = [];
@@ -270,6 +272,44 @@ export class PhysicsWorld implements BodyOwner {
     this._defer(() => this._removeCollider(collider));
   }
 
+  /** Live joints (read-only view). */
+  public get joints(): readonly Joint[] {
+    return this._joints;
+  }
+
+  /**
+   * Add a constraint joint. Construct it first (`new DistanceJoint({ … })`),
+   * then add it. Wakes both bodies; safe inside a callback (registration is
+   * deferred). Returns the joint.
+   */
+  public addJoint<T extends Joint>(joint: T): T {
+    this._assertAlive();
+    joint.bodyA.wake();
+    joint.bodyB.wake();
+
+    this._defer(() => {
+      if (!this._joints.includes(joint)) {
+        this._joints.push(joint);
+      }
+    });
+
+    return joint;
+  }
+
+  /** Remove a joint, waking both bodies so they respond to the lost constraint. Deferred when called inside a callback. */
+  public removeJoint(joint: Joint): void {
+    joint.bodyA.wake();
+    joint.bodyB.wake();
+
+    this._defer(() => {
+      const index = this._joints.indexOf(joint);
+
+      if (index !== -1) {
+        this._joints.splice(index, 1);
+      }
+    });
+  }
+
   // ── stepping ───────────────────────────────────────────────────────────
 
   /**
@@ -291,6 +331,7 @@ export class PhysicsWorld implements BodyOwner {
       const gravityY = this.gravity.y;
       const contactHertz = this.contactHertz;
       const dampingRatio = this.dampingRatio;
+      const hasJoints = this._joints.length > 0;
 
       for (let step = 0; step < steps; step++) {
         // Detection runs once per fixed step (collider geometry is already current
@@ -307,6 +348,10 @@ export class PhysicsWorld implements BodyOwner {
 
         this._backend.prepareSolve(h, contactHertz, dampingRatio);
 
+        if (hasJoints) {
+          this._prepareJoints(h);
+        }
+
         for (let subStep = 0; subStep < subStepCount; subStep++) {
           // Integrate gravity/forces over the sub-step (forces persist across
           // sub-steps; cleared once per frame by `_finalizePosition`).
@@ -321,15 +366,28 @@ export class PhysicsWorld implements BodyOwner {
           // load, which is what keeps tall stacks from pumping energy.
           this._backend.warmStart();
 
+          if (hasJoints) {
+            this._warmStartJoints();
+          }
+
           // Main soft-bias velocity solve, integrate positions (accumulating
-          // per-body delta), then the bias-free relax pass.
+          // per-body delta), then the bias-free relax pass. Joints solve right
+          // after the contacts in each pass (contacts are the stiffer constraint).
           this._backend.solveVelocities(true);
+
+          if (hasJoints) {
+            this._solveJoints(true);
+          }
 
           for (const body of this._bodies) {
             body._integratePosition(h);
           }
 
           this._backend.solveVelocities(false);
+
+          if (hasJoints) {
+            this._solveJoints(false);
+          }
         }
 
         // Separate restitution pass, then write the accumulated delta into each
@@ -406,6 +464,7 @@ export class PhysicsWorld implements BodyOwner {
 
     this._bodies.length = 0;
     this._colliders.length = 0;
+    this._joints.length = 0;
     this._commands.length = 0;
     this._bindings.clear();
     this._backend.destroy();
@@ -503,6 +562,16 @@ export class PhysicsWorld implements BodyOwner {
       }
     }
 
+    // Joints couple their two bodies into the same island (sleep/wake together).
+    for (const joint of this._joints) {
+      const bodyA = joint.bodyA;
+      const bodyB = joint.bodyB;
+
+      if (joint.enabled && bodyA.type === 'dynamic' && bodyB.type === 'dynamic') {
+        this._union(bodyA._islandIndex, bodyB._islandIndex);
+      }
+    }
+
     // Per-island minimum sleep time over its dynamic members.
     for (let i = 0; i < count; i++) {
       const body = bodies[i]!;
@@ -552,6 +621,27 @@ export class PhysicsWorld implements BodyOwner {
     }
 
     return index;
+  }
+
+  /** Build each joint's per-frame constraint data (once per fixed step). */
+  private _prepareJoints(h: number): void {
+    for (const joint of this._joints) {
+      joint._prepare(h);
+    }
+  }
+
+  /** Re-apply each joint's accumulated impulse (each sub-step). */
+  private _warmStartJoints(): void {
+    for (const joint of this._joints) {
+      joint._warmStart();
+    }
+  }
+
+  /** One joint velocity pass (each sub-step, after the contacts). */
+  private _solveJoints(useBias: boolean): void {
+    for (const joint of this._joints) {
+      joint._solve(useBias);
+    }
   }
 
   /** Run `command` now, or queue it when inside an event dispatch (deferred to end of step). */

--- a/packages/exojs-physics/src/debug/PhysicsDebugDraw.ts
+++ b/packages/exojs-physics/src/debug/PhysicsDebugDraw.ts
@@ -27,6 +27,8 @@ export interface PhysicsDebugDrawOptions {
   drawBroadphase?: boolean;
   /** Tint sleeping bodies distinctly (applies to the shape outline). Default `false`. */
   drawSleeping?: boolean;
+  /** Lines connecting the bodies of each joint. Default `false`. */
+  drawJoints?: boolean;
 }
 
 const segments = 24;
@@ -41,6 +43,7 @@ const colorNormal = new Color(1, 0.6, 0.1, 1);
 const colorCenter = new Color(1, 1, 1, 0.9);
 const colorBroadphase = new Color(0.2, 0.8, 0.8, 0.5);
 const colorSleeping = new Color(0.45, 0.45, 0.5, 0.7);
+const colorJoint = new Color(0.9, 0.5, 1, 0.8);
 
 /**
  * `DebugLayer` that visualises a {@link PhysicsWorld} — shapes, AABBs, contacts,
@@ -71,6 +74,7 @@ export class PhysicsDebugDraw extends DebugLayer {
       drawCenters: options.drawCenters ?? false,
       drawBroadphase: options.drawBroadphase ?? false,
       drawSleeping: options.drawSleeping ?? false,
+      drawJoints: options.drawJoints ?? false,
     };
   }
 
@@ -117,7 +121,20 @@ export class PhysicsDebugDraw extends DebugLayer {
       this._renderContacts(gfx);
     }
 
+    if (options.drawJoints) {
+      this._renderJoints(gfx);
+    }
+
     gfx.render(backend);
+  }
+
+  private _renderJoints(gfx: Graphics): void {
+    gfx.lineColor = colorJoint;
+
+    for (const joint of this._world.joints) {
+      gfx.moveTo(joint.bodyA.x, joint.bodyA.y);
+      gfx.lineTo(joint.bodyB.x, joint.bodyB.y);
+    }
   }
 
   public override destroy(): void {

--- a/packages/exojs-physics/src/joints/DistanceJoint.ts
+++ b/packages/exojs-physics/src/joints/DistanceJoint.ts
@@ -1,0 +1,181 @@
+import { applyInverseTransform, applyTransform, type Mutable2D } from '../math';
+import type { PhysicsBody } from '../PhysicsBody';
+import type { VectorLike } from '../types';
+import { Joint } from './Joint';
+
+/** Construction options for a {@link DistanceJoint}. */
+export interface DistanceJointOptions {
+  /** First body (often a static anchor). */
+  bodyA: PhysicsBody;
+  /** Second body. */
+  bodyB: PhysicsBody;
+  /** World-space anchor on body A at creation. Default: body A's position. */
+  anchorA?: VectorLike;
+  /** World-space anchor on body B at creation. Default: body B's position. */
+  anchorB?: VectorLike;
+  /** Target distance between the anchors. Default: their initial distance. */
+  length?: number;
+  /** Soft-spring frequency in Hz; `0` (default) makes it a rigid constraint. */
+  hertz?: number;
+  /** Soft-spring damping ratio (used when `hertz > 0`). Default `1`. */
+  dampingRatio?: number;
+}
+
+/** Reused output sink — physics steps single-threaded, so a shared scratch is safe. */
+const scratch: Mutable2D = { x: 0, y: 0 };
+
+/**
+ * Holds the anchor points on two bodies at a target {@link length} along their
+ * connecting axis. With `hertz === 0` it is rigid; with `hertz > 0` it behaves
+ * as a damped spring. Solved as a soft constraint in the sub-step loop, warm-
+ * started across frames.
+ */
+export class DistanceJoint extends Joint {
+  /** Target distance between the anchors. */
+  public length: number;
+  /** Soft-spring frequency in Hz (`0` = rigid). */
+  public hertz: number;
+  /** Soft-spring damping ratio. */
+  public dampingRatio: number;
+
+  private readonly _localAnchorAx: number;
+  private readonly _localAnchorAy: number;
+  private readonly _localAnchorBx: number;
+  private readonly _localAnchorBy: number;
+
+  private _rAx = 0;
+  private _rAy = 0;
+  private _rBx = 0;
+  private _rBy = 0;
+  private _nx = 0;
+  private _ny = 0;
+  private _separation = 0;
+  private _effMass = 0;
+  private _biasRate = 0;
+  private _massScale = 1;
+  private _impulseScale = 0;
+  private _impulse = 0;
+
+  public constructor(options: DistanceJointOptions) {
+    super(options.bodyA, options.bodyB);
+
+    const ax = options.anchorA?.x ?? options.bodyA.x;
+    const ay = options.anchorA?.y ?? options.bodyA.y;
+    const bx = options.anchorB?.x ?? options.bodyB.x;
+    const by = options.anchorB?.y ?? options.bodyB.y;
+
+    applyInverseTransform(options.bodyA.transform, ax, ay, scratch);
+    this._localAnchorAx = scratch.x;
+    this._localAnchorAy = scratch.y;
+    applyInverseTransform(options.bodyB.transform, bx, by, scratch);
+    this._localAnchorBx = scratch.x;
+    this._localAnchorBy = scratch.y;
+
+    this.length = options.length ?? Math.hypot(bx - ax, by - ay);
+    this.hertz = options.hertz ?? 0;
+    this.dampingRatio = options.dampingRatio ?? 1;
+  }
+
+  public override _prepare(h: number): void {
+    const bodyA = this.bodyA;
+    const bodyB = this.bodyB;
+
+    this._active = this.enabled && !bodyA.isSleeping && !bodyB.isSleeping && (bodyA.invMass > 0 || bodyB.invMass > 0);
+
+    if (!this._active) {
+      return;
+    }
+
+    applyTransform(bodyA.transform, this._localAnchorAx, this._localAnchorAy, scratch);
+    const pAx = scratch.x;
+    const pAy = scratch.y;
+    applyTransform(bodyB.transform, this._localAnchorBx, this._localAnchorBy, scratch);
+    const pBx = scratch.x;
+    const pBy = scratch.y;
+
+    this._rAx = pAx - bodyA.worldCenterOfMassX;
+    this._rAy = pAy - bodyA.worldCenterOfMassY;
+    this._rBx = pBx - bodyB.worldCenterOfMassX;
+    this._rBy = pBy - bodyB.worldCenterOfMassY;
+
+    let dx = pBx - pAx;
+    let dy = pBy - pAy;
+    const len = Math.hypot(dx, dy);
+
+    if (len > 1e-9) {
+      dx /= len;
+      dy /= len;
+    } else {
+      dx = 1;
+      dy = 0;
+    }
+
+    this._nx = dx;
+    this._ny = dy;
+    this._separation = len - this.length;
+
+    const crA = this._rAx * dy - this._rAy * dx;
+    const crB = this._rBx * dy - this._rBy * dx;
+    const k = bodyA.invMass + bodyB.invMass + bodyA.invInertia * crA * crA + bodyB.invInertia * crB * crB;
+    this._effMass = k > 0 ? 1 / k : 0;
+
+    if (this.hertz > 0) {
+      // Box2D-v3 soft factors from a damped spring at the sub-step `h`.
+      const omega = 2 * Math.PI * this.hertz;
+      const a1 = 2 * this.dampingRatio + h * omega;
+      const a2 = h * omega * a1;
+      const a3 = 1 / (1 + a2);
+
+      this._biasRate = omega / a1;
+      this._massScale = a2 * a3;
+      this._impulseScale = a3;
+    } else {
+      // Rigid: full mass, Baumgarte position bias, no impulse decay.
+      this._biasRate = 0.2 / h;
+      this._massScale = 1;
+      this._impulseScale = 0;
+    }
+  }
+
+  public override _warmStart(): void {
+    if (this._active) {
+      this._applyAxisImpulse(this._impulse);
+    }
+  }
+
+  public override _solve(useBias: boolean): void {
+    if (!this._active) {
+      return;
+    }
+
+    const bodyA = this.bodyA;
+    const bodyB = this.bodyB;
+
+    // Relative velocity of the anchors projected onto the axis.
+    const vax = bodyA.linearVelocityX - bodyA.angularVelocity * this._rAy;
+    const vay = bodyA.linearVelocityY + bodyA.angularVelocity * this._rAx;
+    const vbx = bodyB.linearVelocityX - bodyB.angularVelocity * this._rBy;
+    const vby = bodyB.linearVelocityY + bodyB.angularVelocity * this._rBx;
+    const cdot = (vbx - vax) * this._nx + (vby - vay) * this._ny;
+
+    const bias = useBias ? this._biasRate * this._separation : 0;
+    const impulse = -this._effMass * this._massScale * (cdot + bias) - this._impulseScale * this._impulse;
+
+    this._impulse += impulse;
+    this._applyAxisImpulse(impulse);
+  }
+
+  private _applyAxisImpulse(impulse: number): void {
+    const jx = impulse * this._nx;
+    const jy = impulse * this._ny;
+    const bodyA = this.bodyA;
+    const bodyB = this.bodyB;
+
+    bodyA.linearVelocityX -= bodyA.invMass * jx;
+    bodyA.linearVelocityY -= bodyA.invMass * jy;
+    bodyA.angularVelocity -= bodyA.invInertia * (this._rAx * jy - this._rAy * jx);
+    bodyB.linearVelocityX += bodyB.invMass * jx;
+    bodyB.linearVelocityY += bodyB.invMass * jy;
+    bodyB.angularVelocity += bodyB.invInertia * (this._rBx * jy - this._rBy * jx);
+  }
+}

--- a/packages/exojs-physics/src/joints/Joint.ts
+++ b/packages/exojs-physics/src/joints/Joint.ts
@@ -1,0 +1,32 @@
+import type { PhysicsBody } from '../PhysicsBody';
+
+/**
+ * Base class for a two-body constraint solved alongside contacts in the
+ * sub-step loop. Concrete joints (distance, revolute, weld) implement the
+ * three solver hooks; the world owns the joint list and drives them, and joins
+ * the two bodies into one sleep island so a jointed pair sleeps and wakes
+ * together.
+ */
+export abstract class Joint {
+  /** First constrained body. */
+  public readonly bodyA: PhysicsBody;
+  /** Second constrained body. */
+  public readonly bodyB: PhysicsBody;
+  /** When `false`, the joint is skipped by the solver (but still tracked by the world). */
+  public enabled = true;
+
+  /** Whether this joint solves this frame — set in {@link _prepare} (disabled, sleeping or two static bodies → `false`). */
+  protected _active = false;
+
+  protected constructor(bodyA: PhysicsBody, bodyB: PhysicsBody) {
+    this.bodyA = bodyA;
+    this.bodyB = bodyB;
+  }
+
+  /** @internal — build this frame's constraint data; called once per fixed step after detection. */
+  public abstract _prepare(h: number): void;
+  /** @internal — re-apply the accumulated impulse; called each sub-step (TGS-Soft warm-start). */
+  public abstract _warmStart(): void;
+  /** @internal — one velocity pass; `useBias` is the soft-bias pass, `false` the relax pass. */
+  public abstract _solve(useBias: boolean): void;
+}

--- a/packages/exojs-physics/src/public.ts
+++ b/packages/exojs-physics/src/public.ts
@@ -9,6 +9,8 @@ export { PhysicsBinding } from './binding/PhysicsBinding';
 export type { ColliderOptions } from './Collider';
 export { Collider } from './Collider';
 export type { CollisionEvent, ContactPoint, SensorEvent } from './events';
+export { DistanceJoint, type DistanceJointOptions } from './joints/DistanceJoint';
+export { Joint } from './joints/Joint';
 export type { BodyOptions } from './PhysicsBody';
 export { PhysicsBody } from './PhysicsBody';
 export { type PhysicsBuildInfo,physicsBuildInfo } from './physicsBuildInfo';

--- a/packages/exojs-physics/test/joints.test.ts
+++ b/packages/exojs-physics/test/joints.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import { BoxShape, DistanceJoint, PhysicsBody, PhysicsWorld } from '../src/index';
+
+/**
+ * Joints (spec `02-joints.md`). Soft constraints solved in the sub-step loop
+ * alongside contacts. SG-J prefix, default solver config, +Y down.
+ */
+
+const GRAVITY = 1000; // px/s²
+const FRAME = 1 / 60;
+
+const advance = (world: PhysicsWorld, seconds: number): void => {
+  const frames = Math.round(seconds / FRAME);
+
+  for (let frame = 0; frame < frames; frame++) {
+    world.step(FRAME);
+  }
+};
+
+describe('SG-J — joints', () => {
+  it('SG-J1: a distance joint holds a hanging body at the rest length', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    // Bob starts straight below the anchor, past the rest length: the joint pulls
+    // it up to 100 and holds it there against gravity.
+    const bob = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 150 }, colliders: [{ shape: new BoxShape(16, 16) }] }));
+
+    world.addJoint(new DistanceJoint({ bodyA: anchor, bodyB: bob, length: 100 }));
+
+    advance(world, 3);
+
+    // The bob hangs straight down at the rest length under gravity.
+    const distance = Math.hypot(bob.x - anchor.x, bob.y - anchor.y);
+    expect(distance).toBeCloseTo(100, 0); // within ~1px
+    expect(bob.x).toBeCloseTo(0, 0);
+    expect(bob.y).toBeGreaterThan(50); // below the anchor (+Y down)
+  });
+
+  it('SG-J2: a soft distance joint (hertz>0) settles bounded near the rest length', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    const bob = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 100 }, colliders: [{ shape: new BoxShape(16, 16) }] }));
+
+    world.addJoint(new DistanceJoint({ bodyA: anchor, bodyB: bob, length: 100, hertz: 2.5, dampingRatio: 1 }));
+
+    advance(world, 4);
+
+    // A damped spring sags under gravity but stays bounded near the rest length.
+    const distance = Math.hypot(bob.x - anchor.x, bob.y - anchor.y);
+    expect(distance).toBeGreaterThan(95);
+    expect(distance).toBeLessThan(160);
+    expect(bob.x).toBeCloseTo(0, 0);
+  });
+
+  it('SG-J3: waking one jointed body wakes the other (island edge)', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const a = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [{ shape: new BoxShape(16, 16) }] }));
+    const b = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 100, y: 0 }, colliders: [{ shape: new BoxShape(16, 16) }] }));
+
+    world.addJoint(new DistanceJoint({ bodyA: a, bodyB: b, length: 100 }));
+
+    advance(world, 2);
+    expect(a.isSleeping).toBe(true);
+    expect(b.isSleeping).toBe(true);
+
+    a.applyImpulse(2000, 0); // wake only a directly
+    world.step(1 / 60); // the island pass propagates the wake across the joint
+
+    expect(a.isSleeping).toBe(false);
+    expect(b.isSleeping).toBe(false);
+  });
+
+  it('SG-J4: joint simulation is deterministic across identical runs', () => {
+    const run = (): string => {
+      const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+      const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+      const bob = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 60, y: 120 }, colliders: [{ shape: new BoxShape(16, 16) }] }));
+
+      world.addJoint(new DistanceJoint({ bodyA: anchor, bodyB: bob, length: 100 }));
+
+      const trace: string[] = [];
+
+      for (let frame = 0; frame < 180; frame++) {
+        world.step(FRAME);
+        trace.push(`${bob.x.toFixed(4)},${bob.y.toFixed(4)}`);
+      }
+
+      return trace.join('|');
+    };
+
+    expect(run()).toBe(run());
+  });
+
+  it('SG-J5: removeJoint releases the body (it falls freely)', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    const bob = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 100 }, colliders: [{ shape: new BoxShape(16, 16) }] }));
+    const joint = world.addJoint(new DistanceJoint({ bodyA: anchor, bodyB: bob, length: 100 }));
+
+    advance(world, 1);
+    expect(Math.hypot(bob.x - anchor.x, bob.y - anchor.y)).toBeCloseTo(100, 0); // held
+
+    world.removeJoint(joint);
+    advance(world, 1);
+
+    expect(bob.y).toBeGreaterThan(250); // now falls freely under gravity
+  });
+});


### PR DESCRIPTION
First joints slice (spec `02-joints.md`). Builds on the sleeping islands (A1).

## What

Two-body constraints solved as **soft constraints in the sub-step loop alongside contacts** (warm-started). `DistanceJoint` holds two anchors at a target length — rigid by default, a damped spring when `hertz > 0`.

- **`Joint` base + `DistanceJoint`** (`src/joints/`); **`world.addJoint` / `removeJoint`** (deferred, wake both bodies); `prepare`/`warmStart`/`solve` interleaved with the contact solve each sub-step — guarded by `hasJoints`, so a joint-free world pays nothing.
- **Sleep-island edges**: a jointed dynamic pair sleeps and wakes as one (reuses A1's union-find).
- **`drawJoints`** debug option.
- Public exports: `Joint`, `DistanceJoint`, `DistanceJointOptions`.

## Tests

`test/joints.test.ts` — SG-J1 distance held under gravity, SG-J2 soft spring settles bounded, SG-J3 waking one jointed body wakes the other (via the island edge), SG-J4 determinism, SG-J5 `removeJoint` releases the body. Full SG-matrix + SG-SL + perf unchanged (**102 physics tests**). typecheck + lint (0 new warnings) + prettier clean.

## Notes

- Deferred to a follow-up: `minLength`/`maxLength` rope limits — the equality + spring joint is the foundation; limits are purely additive.
- Next: **A2.2** RevoluteJoint, then **A2.3** WeldJoint.