### PR TITLE
feat(physics): revolute + weld joints (A2.2 + A2.3)

### DIFF
--- a/packages/exojs-physics/src/joints/RevoluteJoint.ts
+++ b/packages/exojs-physics/src/joints/RevoluteJoint.ts
@@ -1,0 +1,169 @@
+import { applyInverseTransform, applyTransform, type Mutable2D } from '../math';
+import type { PhysicsBody } from '../PhysicsBody';
+import type { VectorLike } from '../types';
+import { Joint } from './Joint';
+
+/** Construction options for a {@link RevoluteJoint}. */
+export interface RevoluteJointOptions {
+  /** First body (often a static anchor). */
+  bodyA: PhysicsBody;
+  /** Second body. */
+  bodyB: PhysicsBody;
+  /** Shared world-space pivot point at creation. The two bodies are pinned here and may rotate freely about it. */
+  anchor: VectorLike;
+  /** Soft-spring frequency in Hz; `0` (default) makes it a rigid pin. */
+  hertz?: number;
+  /** Soft-spring damping ratio (used when `hertz > 0`). Default `1`. */
+  dampingRatio?: number;
+}
+
+/** Reused output sink — physics steps single-threaded, so a shared scratch is safe. */
+const scratch: Mutable2D = { x: 0, y: 0 };
+
+/**
+ * Pins a shared anchor point on two bodies (a hinge): the bodies may rotate
+ * freely about the pivot but the anchor points stay coincident. Solved as a
+ * 2-DOF point constraint (a 2×2 block) in the sub-step loop, warm-started.
+ */
+export class RevoluteJoint extends Joint {
+  /** Soft-spring frequency in Hz (`0` = rigid). */
+  public hertz: number;
+  /** Soft-spring damping ratio. */
+  public dampingRatio: number;
+
+  private readonly _localAnchorAx: number;
+  private readonly _localAnchorAy: number;
+  private readonly _localAnchorBx: number;
+  private readonly _localAnchorBy: number;
+
+  private _rAx = 0;
+  private _rAy = 0;
+  private _rBx = 0;
+  private _rBy = 0;
+  private _cx = 0;
+  private _cy = 0;
+  private _invK11 = 0;
+  private _invK12 = 0;
+  private _invK22 = 0;
+  private _biasRate = 0;
+  private _massScale = 1;
+  private _impulseScale = 0;
+  private _impulseX = 0;
+  private _impulseY = 0;
+
+  public constructor(options: RevoluteJointOptions) {
+    super(options.bodyA, options.bodyB);
+
+    applyInverseTransform(options.bodyA.transform, options.anchor.x, options.anchor.y, scratch);
+    this._localAnchorAx = scratch.x;
+    this._localAnchorAy = scratch.y;
+    applyInverseTransform(options.bodyB.transform, options.anchor.x, options.anchor.y, scratch);
+    this._localAnchorBx = scratch.x;
+    this._localAnchorBy = scratch.y;
+
+    this.hertz = options.hertz ?? 0;
+    this.dampingRatio = options.dampingRatio ?? 1;
+  }
+
+  public override _prepare(h: number): void {
+    const bodyA = this.bodyA;
+    const bodyB = this.bodyB;
+
+    this._active = this.enabled && !bodyA.isSleeping && !bodyB.isSleeping && (bodyA.invMass > 0 || bodyB.invMass > 0);
+
+    if (!this._active) {
+      return;
+    }
+
+    applyTransform(bodyA.transform, this._localAnchorAx, this._localAnchorAy, scratch);
+    const pAx = scratch.x;
+    const pAy = scratch.y;
+    applyTransform(bodyB.transform, this._localAnchorBx, this._localAnchorBy, scratch);
+    const pBx = scratch.x;
+    const pBy = scratch.y;
+
+    this._rAx = pAx - bodyA.worldCenterOfMassX;
+    this._rAy = pAy - bodyA.worldCenterOfMassY;
+    this._rBx = pBx - bodyB.worldCenterOfMassX;
+    this._rBy = pBy - bodyB.worldCenterOfMassY;
+
+    // Position error (the anchors should coincide).
+    this._cx = pBx - pAx;
+    this._cy = pBy - pAy;
+
+    const mA = bodyA.invMass;
+    const mB = bodyB.invMass;
+    const iA = bodyA.invInertia;
+    const iB = bodyB.invInertia;
+
+    // 2×2 effective-mass matrix K and its inverse.
+    const k11 = mA + mB + iA * this._rAy * this._rAy + iB * this._rBy * this._rBy;
+    const k12 = -iA * this._rAx * this._rAy - iB * this._rBx * this._rBy;
+    const k22 = mA + mB + iA * this._rAx * this._rAx + iB * this._rBx * this._rBx;
+    const det = k11 * k22 - k12 * k12;
+    const invDet = det !== 0 ? 1 / det : 0;
+
+    this._invK11 = invDet * k22;
+    this._invK12 = -invDet * k12;
+    this._invK22 = invDet * k11;
+
+    if (this.hertz > 0) {
+      const omega = 2 * Math.PI * this.hertz;
+      const a1 = 2 * this.dampingRatio + h * omega;
+      const a2 = h * omega * a1;
+      const a3 = 1 / (1 + a2);
+
+      this._biasRate = omega / a1;
+      this._massScale = a2 * a3;
+      this._impulseScale = a3;
+    } else {
+      this._biasRate = 0.2 / h;
+      this._massScale = 1;
+      this._impulseScale = 0;
+    }
+  }
+
+  public override _warmStart(): void {
+    if (this._active) {
+      this._applyImpulse(this._impulseX, this._impulseY);
+    }
+  }
+
+  public override _solve(useBias: boolean): void {
+    if (!this._active) {
+      return;
+    }
+
+    const bodyA = this.bodyA;
+    const bodyB = this.bodyB;
+
+    // Relative velocity of the anchors.
+    const cdotX = bodyB.linearVelocityX - bodyB.angularVelocity * this._rBy - (bodyA.linearVelocityX - bodyA.angularVelocity * this._rAy);
+    const cdotY = bodyB.linearVelocityY + bodyB.angularVelocity * this._rBx - (bodyA.linearVelocityY + bodyA.angularVelocity * this._rAx);
+
+    const rhsX = cdotX + (useBias ? this._biasRate * this._cx : 0);
+    const rhsY = cdotY + (useBias ? this._biasRate * this._cy : 0);
+
+    // Solve K·λ = −rhs, then apply the soft mass/impulse scaling.
+    const solvedX = this._invK11 * rhsX + this._invK12 * rhsY;
+    const solvedY = this._invK12 * rhsX + this._invK22 * rhsY;
+    const impulseX = -this._massScale * solvedX - this._impulseScale * this._impulseX;
+    const impulseY = -this._massScale * solvedY - this._impulseScale * this._impulseY;
+
+    this._impulseX += impulseX;
+    this._impulseY += impulseY;
+    this._applyImpulse(impulseX, impulseY);
+  }
+
+  private _applyImpulse(jx: number, jy: number): void {
+    const bodyA = this.bodyA;
+    const bodyB = this.bodyB;
+
+    bodyA.linearVelocityX -= bodyA.invMass * jx;
+    bodyA.linearVelocityY -= bodyA.invMass * jy;
+    bodyA.angularVelocity -= bodyA.invInertia * (this._rAx * jy - this._rAy * jx);
+    bodyB.linearVelocityX += bodyB.invMass * jx;
+    bodyB.linearVelocityY += bodyB.invMass * jy;
+    bodyB.angularVelocity += bodyB.invInertia * (this._rBx * jy - this._rBy * jx);
+  }
+}

--- a/packages/exojs-physics/src/joints/WeldJoint.ts
+++ b/packages/exojs-physics/src/joints/WeldJoint.ts
@@ -1,0 +1,211 @@
+import { applyInverseTransform, applyTransform, type Mutable2D } from '../math';
+import type { PhysicsBody } from '../PhysicsBody';
+import type { VectorLike } from '../types';
+import { Joint } from './Joint';
+
+/** Construction options for a {@link WeldJoint}. */
+export interface WeldJointOptions {
+  /** First body. */
+  bodyA: PhysicsBody;
+  /** Second body. */
+  bodyB: PhysicsBody;
+  /** World-space anchor the linear constraint acts at. Default: the midpoint of the two bodies. */
+  anchor?: VectorLike;
+  /** Locked relative angle `angleB − angleA`. Default: the current relative angle at creation. */
+  referenceAngle?: number;
+  /** Soft frequency (Hz) for the position lock; `0` (default) is rigid. */
+  linearHertz?: number;
+  /** Soft frequency (Hz) for the angle lock; `0` (default) is rigid. */
+  angularHertz?: number;
+  /** Soft damping ratio (used when a hertz is `> 0`). Default `1`. */
+  dampingRatio?: number;
+}
+
+/** Reused output sink — physics steps single-threaded, so a shared scratch is safe. */
+const scratch: Mutable2D = { x: 0, y: 0 };
+
+interface SoftFactors {
+  biasRate: number;
+  massScale: number;
+  impulseScale: number;
+}
+
+/** Box2D-v3 soft-constraint factors at sub-step `h`, or rigid Baumgarte when `hertz === 0`. */
+const computeSoftFactors = (hertz: number, dampingRatio: number, h: number, out: SoftFactors): void => {
+  if (hertz > 0) {
+    const omega = 2 * Math.PI * hertz;
+    const a1 = 2 * dampingRatio + h * omega;
+    const a2 = h * omega * a1;
+    const a3 = 1 / (1 + a2);
+
+    out.biasRate = omega / a1;
+    out.massScale = a2 * a3;
+    out.impulseScale = a3;
+  } else {
+    out.biasRate = 0.2 / h;
+    out.massScale = 1;
+    out.impulseScale = 0;
+  }
+};
+
+/**
+ * Rigidly fixes the relative position and orientation of two bodies (they move
+ * as one rigid body). A 2-DOF point constraint (like {@link RevoluteJoint}) plus
+ * a 1-DOF angular constraint, solved in the sub-step loop. Both locks default to
+ * rigid; set `linearHertz`/`angularHertz` for a springy weld.
+ */
+export class WeldJoint extends Joint {
+  /** Locked relative angle `angleB − angleA`. */
+  public referenceAngle: number;
+  /** Soft frequency for the position lock (`0` = rigid). */
+  public linearHertz: number;
+  /** Soft frequency for the angle lock (`0` = rigid). */
+  public angularHertz: number;
+  /** Soft damping ratio. */
+  public dampingRatio: number;
+
+  private readonly _localAnchorAx: number;
+  private readonly _localAnchorAy: number;
+  private readonly _localAnchorBx: number;
+  private readonly _localAnchorBy: number;
+
+  private _rAx = 0;
+  private _rAy = 0;
+  private _rBx = 0;
+  private _rBy = 0;
+  private _cx = 0;
+  private _cy = 0;
+  private _invK11 = 0;
+  private _invK12 = 0;
+  private _invK22 = 0;
+  private _angleError = 0;
+  private _effMassAngle = 0;
+  private readonly _linear: SoftFactors = { biasRate: 0, massScale: 1, impulseScale: 0 };
+  private readonly _angular: SoftFactors = { biasRate: 0, massScale: 1, impulseScale: 0 };
+  private _impulseX = 0;
+  private _impulseY = 0;
+  private _impulseAngle = 0;
+
+  public constructor(options: WeldJointOptions) {
+    super(options.bodyA, options.bodyB);
+
+    const ax = options.anchor?.x ?? (options.bodyA.x + options.bodyB.x) / 2;
+    const ay = options.anchor?.y ?? (options.bodyA.y + options.bodyB.y) / 2;
+
+    applyInverseTransform(options.bodyA.transform, ax, ay, scratch);
+    this._localAnchorAx = scratch.x;
+    this._localAnchorAy = scratch.y;
+    applyInverseTransform(options.bodyB.transform, ax, ay, scratch);
+    this._localAnchorBx = scratch.x;
+    this._localAnchorBy = scratch.y;
+
+    this.referenceAngle = options.referenceAngle ?? options.bodyB.angle - options.bodyA.angle;
+    this.linearHertz = options.linearHertz ?? 0;
+    this.angularHertz = options.angularHertz ?? 0;
+    this.dampingRatio = options.dampingRatio ?? 1;
+  }
+
+  public override _prepare(h: number): void {
+    const bodyA = this.bodyA;
+    const bodyB = this.bodyB;
+
+    this._active = this.enabled && !bodyA.isSleeping && !bodyB.isSleeping && (bodyA.invMass > 0 || bodyB.invMass > 0);
+
+    if (!this._active) {
+      return;
+    }
+
+    applyTransform(bodyA.transform, this._localAnchorAx, this._localAnchorAy, scratch);
+    const pAx = scratch.x;
+    const pAy = scratch.y;
+    applyTransform(bodyB.transform, this._localAnchorBx, this._localAnchorBy, scratch);
+    const pBx = scratch.x;
+    const pBy = scratch.y;
+
+    this._rAx = pAx - bodyA.worldCenterOfMassX;
+    this._rAy = pAy - bodyA.worldCenterOfMassY;
+    this._rBx = pBx - bodyB.worldCenterOfMassX;
+    this._rBy = pBy - bodyB.worldCenterOfMassY;
+    this._cx = pBx - pAx;
+    this._cy = pBy - pAy;
+
+    const mA = bodyA.invMass;
+    const mB = bodyB.invMass;
+    const iA = bodyA.invInertia;
+    const iB = bodyB.invInertia;
+
+    const k11 = mA + mB + iA * this._rAy * this._rAy + iB * this._rBy * this._rBy;
+    const k12 = -iA * this._rAx * this._rAy - iB * this._rBx * this._rBy;
+    const k22 = mA + mB + iA * this._rAx * this._rAx + iB * this._rBx * this._rBx;
+    const det = k11 * k22 - k12 * k12;
+    const invDet = det !== 0 ? 1 / det : 0;
+
+    this._invK11 = invDet * k22;
+    this._invK12 = -invDet * k12;
+    this._invK22 = invDet * k11;
+
+    this._angleError = bodyB.angle - bodyA.angle - this.referenceAngle;
+    const kAngle = iA + iB;
+    this._effMassAngle = kAngle > 0 ? 1 / kAngle : 0;
+
+    computeSoftFactors(this.linearHertz, this.dampingRatio, h, this._linear);
+    computeSoftFactors(this.angularHertz, this.dampingRatio, h, this._angular);
+  }
+
+  public override _warmStart(): void {
+    if (!this._active) {
+      return;
+    }
+
+    const bodyA = this.bodyA;
+    const bodyB = this.bodyB;
+
+    bodyA.angularVelocity -= bodyA.invInertia * this._impulseAngle;
+    bodyB.angularVelocity += bodyB.invInertia * this._impulseAngle;
+    this._applyLinearImpulse(this._impulseX, this._impulseY);
+  }
+
+  public override _solve(useBias: boolean): void {
+    if (!this._active) {
+      return;
+    }
+
+    const bodyA = this.bodyA;
+    const bodyB = this.bodyB;
+
+    // Angular lock first.
+    const cdotAngle = bodyB.angularVelocity - bodyA.angularVelocity;
+    const biasAngle = useBias ? this._angular.biasRate * this._angleError : 0;
+    const impulseAngle = -this._effMassAngle * this._angular.massScale * (cdotAngle + biasAngle) - this._angular.impulseScale * this._impulseAngle;
+
+    this._impulseAngle += impulseAngle;
+    bodyA.angularVelocity -= bodyA.invInertia * impulseAngle;
+    bodyB.angularVelocity += bodyB.invInertia * impulseAngle;
+
+    // Linear (point) lock.
+    const cdotX = bodyB.linearVelocityX - bodyB.angularVelocity * this._rBy - (bodyA.linearVelocityX - bodyA.angularVelocity * this._rAy);
+    const cdotY = bodyB.linearVelocityY + bodyB.angularVelocity * this._rBx - (bodyA.linearVelocityY + bodyA.angularVelocity * this._rAx);
+    const rhsX = cdotX + (useBias ? this._linear.biasRate * this._cx : 0);
+    const rhsY = cdotY + (useBias ? this._linear.biasRate * this._cy : 0);
+    const solvedX = this._invK11 * rhsX + this._invK12 * rhsY;
+    const solvedY = this._invK12 * rhsX + this._invK22 * rhsY;
+    const impulseX = -this._linear.massScale * solvedX - this._linear.impulseScale * this._impulseX;
+    const impulseY = -this._linear.massScale * solvedY - this._linear.impulseScale * this._impulseY;
+
+    this._impulseX += impulseX;
+    this._impulseY += impulseY;
+    this._applyLinearImpulse(impulseX, impulseY);
+  }
+
+  private _applyLinearImpulse(jx: number, jy: number): void {
+    const bodyA = this.bodyA;
+    const bodyB = this.bodyB;
+
+    bodyA.linearVelocityX -= bodyA.invMass * jx;
+    bodyA.linearVelocityY -= bodyA.invMass * jy;
+    bodyA.angularVelocity -= bodyA.invInertia * (this._rAx * jy - this._rAy * jx);
+    bodyB.linearVelocityX += bodyB.invMass * jx;
+    bodyB.linearVelocityY += bodyB.invMass * jy;
+    bodyB.angularVelocity += bodyB.invInertia * (this._rBx * jy - this._rBy * jx);
+  }
+}

--- a/packages/exojs-physics/src/public.ts
+++ b/packages/exojs-physics/src/public.ts
@@ -11,6 +11,8 @@ export { Collider } from './Collider';
 export type { CollisionEvent, ContactPoint, SensorEvent } from './events';
 export { DistanceJoint, type DistanceJointOptions } from './joints/DistanceJoint';
 export { Joint } from './joints/Joint';
+export { RevoluteJoint, type RevoluteJointOptions } from './joints/RevoluteJoint';
+export { WeldJoint, type WeldJointOptions } from './joints/WeldJoint';
 export type { BodyOptions } from './PhysicsBody';
 export { PhysicsBody } from './PhysicsBody';
 export { type PhysicsBuildInfo,physicsBuildInfo } from './physicsBuildInfo';

--- a/packages/exojs-physics/test/joints.test.ts
+++ b/packages/exojs-physics/test/joints.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { BoxShape, DistanceJoint, PhysicsBody, PhysicsWorld } from '../src/index';
+import { BoxShape, DistanceJoint, PhysicsBody, PhysicsWorld, RevoluteJoint, WeldJoint } from '../src/index';
 
 /**
  * Joints (spec `02-joints.md`). Soft constraints solved in the sub-step loop
@@ -105,5 +105,81 @@ describe('SG-J — joints', () => {
     advance(world, 1);
 
     expect(bob.y).toBeGreaterThan(250); // now falls freely under gravity
+  });
+
+  it('SG-J6: a revolute joint pins the bob to the pivot as it swings', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    // Bob hangs down-right of the pivot at the world origin; it swings under gravity.
+    const bob = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 70, y: 70 }, colliders: [{ shape: new BoxShape(16, 16) }] }));
+
+    world.addJoint(new RevoluteJoint({ bodyA: anchor, bodyB: bob, anchor: { x: 0, y: 0 } }));
+
+    const radius = Math.hypot(70, 70);
+    let minX = bob.x;
+
+    for (let frame = 0; frame < 240; frame++) {
+      world.step(FRAME);
+      // The pinned point holds: the bob's centre stays at a fixed radius from the pivot.
+      expect(Math.abs(Math.hypot(bob.x, bob.y) - radius)).toBeLessThan(1.5);
+      minX = Math.min(minX, bob.x);
+    }
+
+    expect(minX).toBeLessThan(-30); // it swung through the bottom to the far side
+  });
+
+  it('SG-J7: a two-link revolute chain keeps its shared hinge coincident', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    const link1 = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 50, y: 0 }, colliders: [{ shape: new BoxShape(100, 8) }] }));
+    const link2 = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 150, y: 0 }, colliders: [{ shape: new BoxShape(100, 8) }] }));
+
+    world.addJoint(new RevoluteJoint({ bodyA: anchor, bodyB: link1, anchor: { x: 0, y: 0 } })); // link1 left ↔ origin
+    world.addJoint(new RevoluteJoint({ bodyA: link1, bodyB: link2, anchor: { x: 100, y: 0 } })); // link2 left ↔ link1 right
+
+    advance(world, 4);
+
+    // link1's right end and link2's left end (the shared hinge) stay coincident.
+    const r1x = link1.x + Math.cos(link1.angle) * 50;
+    const r1y = link1.y + Math.sin(link1.angle) * 50;
+    const l2x = link2.x - Math.cos(link2.angle) * 50;
+    const l2y = link2.y - Math.sin(link2.angle) * 50;
+
+    expect(Math.hypot(r1x - l2x, r1y - l2y)).toBeLessThan(2);
+    expect(Number.isFinite(link2.y)).toBe(true);
+  });
+
+  it('SG-J8: a weld joint holds a body rigidly to a static anchor (position + angle)', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    const box = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 50, y: 30 }, colliders: [{ shape: new BoxShape(20, 20) }] }));
+
+    world.addJoint(new WeldJoint({ bodyA: anchor, bodyB: box }));
+
+    advance(world, 3);
+
+    // Welded to an immovable anchor → it holds both position and angle against gravity.
+    expect(box.x).toBeCloseTo(50, 0);
+    expect(box.y).toBeCloseTo(30, 0);
+    expect(Math.abs(box.angle)).toBeLessThan(0.02);
+  });
+
+  it('SG-J9: two welded dynamic bodies keep their relative pose while swinging', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    const a = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 60, y: 0 }, colliders: [{ shape: new BoxShape(20, 20) }] }));
+    const b = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 100, y: 0 }, colliders: [{ shape: new BoxShape(20, 20) }] }));
+
+    world.addJoint(new RevoluteJoint({ bodyA: anchor, bodyB: a, anchor: { x: 0, y: 0 } })); // a swings about the origin
+    world.addJoint(new WeldJoint({ bodyA: a, bodyB: b })); // b welded rigidly to a
+
+    const distance0 = Math.hypot(b.x - a.x, b.y - a.y);
+    const relativeAngle0 = b.angle - a.angle;
+
+    advance(world, 3);
+
+    // The weld keeps b rigid to a: same separation and same relative orientation.
+    expect(Math.abs(Math.hypot(b.x - a.x, b.y - a.y) - distance0)).toBeLessThan(2);
+    expect(Math.abs(b.angle - a.angle - relativeAngle0)).toBeLessThan(0.05);
   });
 });


### PR DESCRIPTION
Two more joint types on the A2.1 infrastructure — combined into one slice since they share all the joint machinery.

## What

- **`RevoluteJoint`** — a hinge pinning a shared anchor point (2-DOF point constraint solved as a 2×2 block); the bodies rotate freely about the pivot.
- **`WeldJoint`** — rigidly fixes relative position **and** orientation (the revolute point constraint plus a 1-DOF angle lock). Both locks rigid by default, springy via `linearHertz` / `angularHertz`.

Both are warm-started, solved in the sub-step loop after the contacts, and act as sleep-island edges (a jointed pair sleeps/wakes together).

## Tests

`test/joints.test.ts` — SG-J6 revolute pendulum holds the pivot distance through the swing, SG-J7 two-link chain keeps its shared hinge coincident, SG-J8 weld holds a body rigid to a static anchor (position + angle), SG-J9 two welded bodies keep their relative pose while swinging. **106 physics tests** green. typecheck + lint (0 new warnings) + prettier clean.

## Notes

- Combined A2.2 + A2.3 into one PR (cohesive — both are new joint types on the same infrastructure).
- Next + final physics slice: **A3.1** CCD / bullet-mode.