### PR TITLE
feat(physics): CCD / bullet-mode (A3.1)

### DIFF
--- a/packages/exojs-physics/src/PhysicsBody.ts
+++ b/packages/exojs-physics/src/PhysicsBody.ts
@@ -21,6 +21,8 @@ export interface BodyOptions {
   gravityScale?: number;
   /** When `true`, the body never rotates under contacts (infinite rotational inertia). Default `false`. */
   fixedRotation?: boolean;
+  /** When `true`, the body is swept against static geometry each step (CCD) so it cannot tunnel through thin walls. Default `false`. */
+  isBullet?: boolean;
   /** Colliders to attach up-front. Each may be a {@link Collider} instance or its {@link ColliderOptions}. */
   colliders?: Array<Collider | ColliderOptions>;
 }
@@ -54,6 +56,8 @@ export class PhysicsBody {
   public gravityScale: number;
   /** When `true`, rotational inertia is treated as infinite. */
   public fixedRotation: boolean;
+  /** When `true`, the body is swept against static geometry each step (CCD) so it cannot tunnel through thin walls. */
+  public isBullet: boolean;
 
   /** Total mass (0 for static/kinematic). */
   public mass = 0;
@@ -93,6 +97,10 @@ export class PhysicsBody {
   public _sleepTime = 0;
   /** @internal — dense union-find index assigned by the world's island pass each step. */
   public _islandIndex = 0;
+  /** @internal — world-space centre of mass at the start of the current fixed step (CCD swept-test origin). */
+  public _ccdPrevX = 0;
+  /** @internal — see {@link _ccdPrevX}. */
+  public _ccdPrevY = 0;
 
   private _sleeping = false;
 
@@ -113,6 +121,7 @@ export class PhysicsBody {
     this.angularDamping = options.angularDamping ?? 0;
     this.gravityScale = options.gravityScale ?? 1;
     this.fixedRotation = options.fixedRotation ?? false;
+    this.isBullet = options.isBullet ?? false;
 
     // Build up-front colliders now (no id/world registration until the body
     // joins a world via `world.add()`). They sit in `_colliders` unsynchronised;

--- a/packages/exojs-physics/src/PhysicsWorld.ts
+++ b/packages/exojs-physics/src/PhysicsWorld.ts
@@ -17,6 +17,9 @@ import type { AnyShape } from './shapes/AnyShape';
 import { TimeStepper } from './TimeStepper';
 import type { BodyType, CollisionFilter, VectorLike } from './types';
 
+/** Gap left between a clamped bullet and the surface it hit (so it does not re-hit from inside). */
+const ccdSkin = 0.05;
+
 /** Construction options for a {@link PhysicsWorld}. */
 export interface PhysicsWorldOptions {
   /** Gravity in px/s² (+Y down). Integrated each sub-step. Default `(0, 0)`. */
@@ -158,6 +161,10 @@ export class PhysicsWorld implements BodyOwner {
   private readonly _islandParent: number[] = [];
   /** Pooled per-island minimum sleep time, indexed by union-find root. */
   private readonly _islandMinSleep: number[] = [];
+  /** Pooled ray-hit buffer + origin/direction for the CCD swept test. */
+  private readonly _ccdHits: RayHit[] = [];
+  private readonly _ccdOrigin = { x: 0, y: 0 };
+  private readonly _ccdDir = { x: 0, y: 0 };
 
   private _nextBodyId = 1;
   private _nextColliderId = 1;
@@ -332,6 +339,7 @@ export class PhysicsWorld implements BodyOwner {
       const contactHertz = this.contactHertz;
       const dampingRatio = this.dampingRatio;
       const hasJoints = this._joints.length > 0;
+      const hasBullets = this._hasBullets();
 
       for (let step = 0; step < steps; step++) {
         // Detection runs once per fixed step (collider geometry is already current
@@ -350,6 +358,10 @@ export class PhysicsWorld implements BodyOwner {
 
         if (hasJoints) {
           this._prepareJoints(h);
+        }
+
+        if (hasBullets) {
+          this._recordBulletPositions();
         }
 
         for (let subStep = 0; subStep < subStepCount; subStep++) {
@@ -396,6 +408,10 @@ export class PhysicsWorld implements BodyOwner {
 
         for (const body of this._bodies) {
           body._finalizePosition();
+        }
+
+        if (hasBullets) {
+          this._advanceBullets();
         }
       }
 
@@ -641,6 +657,93 @@ export class PhysicsWorld implements BodyOwner {
   private _solveJoints(useBias: boolean): void {
     for (const joint of this._joints) {
       joint._solve(useBias);
+    }
+  }
+
+  /** Whether any dynamic body is flagged for continuous collision (bullet mode). */
+  private _hasBullets(): boolean {
+    for (const body of this._bodies) {
+      if (body.isBullet && body.type === 'dynamic') {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /** Snapshot each bullet's centre of mass at the start of the fixed step (the swept-test origin). */
+  private _recordBulletPositions(): void {
+    for (const body of this._bodies) {
+      if (body.isBullet && body.type === 'dynamic') {
+        body._ccdPrevX = body.worldCenterOfMassX;
+        body._ccdPrevY = body.worldCenterOfMassY;
+      }
+    }
+  }
+
+  /**
+   * Sweep each bullet's centre of mass along this fixed step's motion against the
+   * static colliders; if it would cross one, clamp the body just short of the
+   * surface and strip the into-surface velocity so it cannot tunnel. v1 sweeps
+   * the centre point (good for small/point-like projectiles) against static
+   * geometry only — a full swept-shape TOI and bullet-vs-dynamic are backlog.
+   */
+  private _advanceBullets(): void {
+    for (const body of this._bodies) {
+      if (!body.isBullet || body.type !== 'dynamic' || body.isSleeping) {
+        continue;
+      }
+
+      const newX = body.worldCenterOfMassX;
+      const newY = body.worldCenterOfMassY;
+      let dirX = newX - body._ccdPrevX;
+      let dirY = newY - body._ccdPrevY;
+      const distance = Math.hypot(dirX, dirY);
+
+      if (distance < 1e-6) {
+        continue;
+      }
+
+      dirX /= distance;
+      dirY /= distance;
+
+      this._ccdOrigin.x = body._ccdPrevX;
+      this._ccdOrigin.y = body._ccdPrevY;
+      this._ccdDir.x = dirX;
+      this._ccdDir.y = dirY;
+
+      const hits = this._query.rayCastAll(this._ccdOrigin, this._ccdDir, undefined, this._ccdHits, distance);
+      let blocked: RayHit | null = null;
+
+      for (const hit of hits) {
+        // Skip the bullet's own colliders; v1 sweeps against static geometry only.
+        // Hits are distance-sorted, so the first match is the nearest surface.
+        if (hit.body !== body && hit.body.type === 'static') {
+          blocked = hit;
+          break;
+        }
+      }
+
+      if (blocked === null) {
+        continue;
+      }
+
+      // Clamp the CoM just short of the surface (a pure translation — the rotation
+      // is already applied), then strip the velocity heading into the surface.
+      const clampDistance = Math.max(0, blocked.distance - ccdSkin);
+      const deltaX = body._ccdPrevX + dirX * clampDistance - newX;
+      const deltaY = body._ccdPrevY + dirY * clampDistance - newY;
+
+      this._ccdOrigin.x = body.x + deltaX;
+      this._ccdOrigin.y = body.y + deltaY;
+      body.setTransform(this._ccdOrigin, body.angle);
+
+      const into = body.linearVelocityX * dirX + body.linearVelocityY * dirY;
+
+      if (into > 0) {
+        body.linearVelocityX -= into * dirX;
+        body.linearVelocityY -= into * dirY;
+      }
     }
   }
 

--- a/packages/exojs-physics/test/ccd.test.ts
+++ b/packages/exojs-physics/test/ccd.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { BoxShape, CircleShape, PhysicsBody, PhysicsWorld } from '../src/index';
+
+/**
+ * Continuous collision detection / bullet-mode (spec `03-ccd.md`, gate C-1).
+ * A body flagged `isBullet` is swept against static geometry each step so it
+ * cannot tunnel through thin walls. SG-C prefix, +Y down.
+ */
+
+const FRAME = 1 / 60;
+
+/** A world with a thin static wall at `x = 200` and a small ball fired at it from the left. */
+const fireAtWall = (bullet: boolean): { world: PhysicsWorld; ball: PhysicsBody } => {
+  const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+
+  world.add(new PhysicsBody({ type: 'static', position: { x: 200, y: 0 }, colliders: [{ shape: new BoxShape(4, 400) }] }));
+
+  const ball = new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [{ shape: new CircleShape(6) }] });
+  ball.isBullet = bullet;
+  world.add(ball);
+  ball.linearVelocityX = 6000; // ~100 px per fixed step — far more than the 4px wall thickness
+
+  return { world, ball };
+};
+
+describe('SG-C — continuous collision (bullet mode)', () => {
+  it('SG-C1: a fast bullet does not tunnel through a thin static wall', () => {
+    // Without CCD the body tunnels straight through (the documented limit).
+    const plain = fireAtWall(false);
+    for (let frame = 0; frame < 30; frame++) {
+      plain.world.step(FRAME);
+    }
+    expect(plain.ball.x).toBeGreaterThan(220); // passed clean through the wall
+
+    // With isBullet the swept test stops it at the wall.
+    const ccd = fireAtWall(true);
+    for (let frame = 0; frame < 30; frame++) {
+      ccd.world.step(FRAME);
+    }
+    expect(ccd.ball.x).toBeLessThan(200); // never crossed the wall plane at x = 200
+    expect(Number.isFinite(ccd.ball.x)).toBe(true);
+  });
+
+  it('SG-C2: a bullet that does not cross a wall is not falsely stopped', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    // The wall spans y ∈ [−200, 200]; the bullet flies past well above it.
+    world.add(new PhysicsBody({ type: 'static', position: { x: 200, y: 0 }, colliders: [{ shape: new BoxShape(4, 400) }] }));
+
+    const ball = new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 300 }, colliders: [{ shape: new CircleShape(6) }] });
+    ball.isBullet = true;
+    world.add(ball);
+    ball.linearVelocityX = 6000;
+
+    for (let frame = 0; frame < 10; frame++) {
+      world.step(FRAME);
+    }
+
+    expect(ball.x).toBeGreaterThan(400); // flew freely past the wall's x without being clamped
+  });
+
+  it('SG-C3: a fast bullet stays finite and contained in a closed static box', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const wall = (x: number, y: number, w: number, h: number): void => {
+      world.add(new PhysicsBody({ type: 'static', position: { x, y }, colliders: [{ shape: new BoxShape(w, h) }] }));
+    };
+    wall(0, -110, 240, 20);
+    wall(0, 110, 240, 20);
+    wall(-110, 0, 20, 240);
+    wall(110, 0, 20, 240);
+
+    const ball = new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [{ shape: new CircleShape(6), restitution: 0.5 }] });
+    ball.isBullet = true;
+    world.add(ball);
+    ball.linearVelocityX = 5000;
+    ball.linearVelocityY = 3000;
+
+    for (let frame = 0; frame < 120; frame++) {
+      world.step(FRAME);
+    }
+
+    // CCD keeps it inside the thin-walled box — never escaping, never NaN.
+    expect(Number.isFinite(ball.x)).toBe(true);
+    expect(Number.isFinite(ball.y)).toBe(true);
+    expect(Math.abs(ball.x)).toBeLessThan(105);
+    expect(Math.abs(ball.y)).toBeLessThan(105);
+  });
+});


### PR DESCRIPTION
Final slice of the physics feature matrix (spec `03-ccd.md`, gate C-1).

## What

Bodies flagged `isBullet` are **swept against static geometry each fixed step** so they cannot tunnel through thin walls. v1 sweeps the **centre of mass** (good for small/point-like projectiles) via the hardened `rayCastAll`: if the motion would cross a static collider, the body is clamped just short of the surface and the into-surface velocity is stripped; the discrete solver then resolves the resting contact.

- `PhysicsBody`: `isBullet` field + `BodyOptions.isBullet`.
- `PhysicsWorld`: per-fixed-step swept clamp, guarded by `hasBullets` so a bullet-free world pays nothing (allocation-free — pooled ray-hit buffer + origin/direction).

## Tests

`test/ccd.test.ts` — SG-C1 a fast bullet does not tunnel a thin wall (a plain body does, asserted as the contrast), SG-C2 a bullet that misses the wall is not falsely stopped, SG-C3 a fast bullet stays finite and contained in a closed box. **109 physics tests** green. typecheck + lint (0 new warnings) + prettier clean.

## Notes / backlog

- v1 stops bullets at the surface (velocity-kill, no bounce) — ideal for projectiles/arrows; fast bouncing balls are better served by the discrete solver.
- Backlog: full swept-shape TOI (the centre-point sweep approximates for small bullets) and bullet-vs-dynamic.

**Completes the physics feature matrix (A): sleeping → joints → CCD.**