### PR TITLE
feat(physics): rope limits + revolute motor/limits (mechanism pack M1)

### DIFF
--- a/packages/exojs-physics/src/joints/DistanceJoint.ts
+++ b/packages/exojs-physics/src/joints/DistanceJoint.ts
@@ -19,6 +19,15 @@ export interface DistanceJointOptions {
   hertz?: number;
   /** Soft-spring damping ratio (used when `hertz > 0`). Default `1`. */
   dampingRatio?: number;
+  /**
+   * Minimum allowed distance. Specifying `minLength` and/or `maxLength` turns the
+   * joint into a **rope/limit** (distance kept within `[minLength, maxLength]`,
+   * slack between, rigid limits). Otherwise the joint is a rigid/soft **equality**
+   * at `length`. Defaults to `0` in limit mode.
+   */
+  minLength?: number;
+  /** Maximum allowed distance (the rope length). See {@link minLength}. Defaults to `Infinity` in limit mode. */
+  maxLength?: number;
 }
 
 /** Reused output sink — physics steps single-threaded, so a shared scratch is safe. */
@@ -37,7 +46,14 @@ export class DistanceJoint extends Joint {
   public hertz: number;
   /** Soft-spring damping ratio. */
   public dampingRatio: number;
+  /** Minimum allowed distance (rope/limit mode). */
+  public minLength: number;
+  /** Maximum allowed distance (rope/limit mode). */
+  public maxLength: number;
 
+  private readonly _limited: boolean;
+  private _minImpulse = -Infinity;
+  private _maxImpulse = Infinity;
   private readonly _localAnchorAx: number;
   private readonly _localAnchorAy: number;
   private readonly _localAnchorBx: number;
@@ -74,6 +90,9 @@ export class DistanceJoint extends Joint {
     this.length = options.length ?? Math.hypot(bx - ax, by - ay);
     this.hertz = options.hertz ?? 0;
     this.dampingRatio = options.dampingRatio ?? 1;
+    this._limited = options.minLength !== undefined || options.maxLength !== undefined;
+    this.minLength = options.minLength ?? (this._limited ? 0 : this.length);
+    this.maxLength = options.maxLength ?? (this._limited ? Infinity : this.length);
   }
 
   public override _prepare(h: number): void {
@@ -112,14 +131,36 @@ export class DistanceJoint extends Joint {
 
     this._nx = dx;
     this._ny = dy;
-    this._separation = len - this.length;
 
     const crA = this._rAx * dy - this._rAy * dx;
     const crB = this._rBx * dy - this._rBy * dx;
     const k = bodyA.invMass + bodyB.invMass + bodyA.invInertia * crA * crA + bodyB.invInertia * crB * crB;
     this._effMass = k > 0 ? 1 / k : 0;
 
-    if (this.hertz > 0) {
+    if (this._limited) {
+      // Rope/limit: solve only the violated bound; slack between min and max.
+      if (len > this.maxLength) {
+        this._separation = len - this.maxLength;
+        this._minImpulse = -Infinity; // pull together only (tension)
+        this._maxImpulse = 0;
+      } else if (len < this.minLength) {
+        this._separation = len - this.minLength;
+        this._minImpulse = 0; // push apart only (compression)
+        this._maxImpulse = Infinity;
+      } else {
+        this._active = false; // slack — nothing to solve this frame
+        this._impulse = 0;
+
+        return;
+      }
+    } else {
+      this._separation = len - this.length;
+      this._minImpulse = -Infinity;
+      this._maxImpulse = Infinity;
+    }
+
+    // Soft spring only for the equality joint; rope limits are rigid.
+    if (this.hertz > 0 && !this._limited) {
       // Box2D-v3 soft factors from a damped spring at the sub-step `h`.
       const omega = 2 * Math.PI * this.hertz;
       const a1 = 2 * this.dampingRatio + h * omega;
@@ -159,10 +200,13 @@ export class DistanceJoint extends Joint {
     const cdot = (vbx - vax) * this._nx + (vby - vay) * this._ny;
 
     const bias = useBias ? this._biasRate * this._separation : 0;
-    const impulse = -this._effMass * this._massScale * (cdot + bias) - this._impulseScale * this._impulse;
+    const raw = -this._effMass * this._massScale * (cdot + bias) - this._impulseScale * this._impulse;
+    // Clamp the accumulated impulse to the limit's sign range (±Infinity = equality, no clamp).
+    const clamped = Math.min(this._maxImpulse, Math.max(this._minImpulse, this._impulse + raw));
+    const applied = clamped - this._impulse;
 
-    this._impulse += impulse;
-    this._applyAxisImpulse(impulse);
+    this._impulse = clamped;
+    this._applyAxisImpulse(applied);
   }
 
   private _applyAxisImpulse(impulse: number): void {

--- a/packages/exojs-physics/src/joints/RevoluteJoint.ts
+++ b/packages/exojs-physics/src/joints/RevoluteJoint.ts
@@ -15,6 +15,18 @@ export interface RevoluteJointOptions {
   hertz?: number;
   /** Soft-spring damping ratio (used when `hertz > 0`). Default `1`. */
   dampingRatio?: number;
+  /** Enable the angular motor (drives `ωB − ωA` toward {@link motorSpeed}). Default `false`. */
+  enableMotor?: boolean;
+  /** Target relative angular velocity in rad/s when the motor is enabled. Default `0`. */
+  motorSpeed?: number;
+  /** Maximum motor torque — clamps the per-step motor impulse. Default `0`. */
+  maxMotorTorque?: number;
+  /** Enable the angle limit (keeps the relative angle in `[lowerAngle, upperAngle]`). Default `false`. */
+  enableLimit?: boolean;
+  /** Lower relative-angle limit in radians (relative to the angle at creation). Default `0`. */
+  lowerAngle?: number;
+  /** Upper relative-angle limit in radians. Default `0`. */
+  upperAngle?: number;
 }
 
 /** Reused output sink — physics steps single-threaded, so a shared scratch is safe. */
@@ -30,6 +42,18 @@ export class RevoluteJoint extends Joint {
   public hertz: number;
   /** Soft-spring damping ratio. */
   public dampingRatio: number;
+  /** When `true`, the motor drives `ωB − ωA` toward {@link motorSpeed}. */
+  public enableMotor: boolean;
+  /** Target relative angular velocity (rad/s) for the motor. */
+  public motorSpeed: number;
+  /** Maximum motor torque. */
+  public maxMotorTorque: number;
+  /** When `true`, the relative angle is constrained to `[lowerAngle, upperAngle]`. */
+  public enableLimit: boolean;
+  /** Lower relative-angle limit (radians, relative to the creation angle). */
+  public lowerAngle: number;
+  /** Upper relative-angle limit (radians). */
+  public upperAngle: number;
 
   private readonly _localAnchorAx: number;
   private readonly _localAnchorAy: number;
@@ -50,6 +74,13 @@ export class RevoluteJoint extends Joint {
   private _impulseScale = 0;
   private _impulseX = 0;
   private _impulseY = 0;
+  private readonly _referenceAngle: number;
+  private _axialMass = 0;
+  private _h = 0;
+  private _invH = 0;
+  private _motorImpulse = 0;
+  private _lowerImpulse = 0;
+  private _upperImpulse = 0;
 
   public constructor(options: RevoluteJointOptions) {
     super(options.bodyA, options.bodyB);
@@ -63,6 +94,13 @@ export class RevoluteJoint extends Joint {
 
     this.hertz = options.hertz ?? 0;
     this.dampingRatio = options.dampingRatio ?? 1;
+    this.enableMotor = options.enableMotor ?? false;
+    this.motorSpeed = options.motorSpeed ?? 0;
+    this.maxMotorTorque = options.maxMotorTorque ?? 0;
+    this.enableLimit = options.enableLimit ?? false;
+    this.lowerAngle = options.lowerAngle ?? 0;
+    this.upperAngle = options.upperAngle ?? 0;
+    this._referenceAngle = options.bodyB.angle - options.bodyA.angle;
   }
 
   public override _prepare(h: number): void {
@@ -107,6 +145,20 @@ export class RevoluteJoint extends Joint {
     this._invK12 = -invDet * k12;
     this._invK22 = invDet * k11;
 
+    // Angular (motor/limit) effective mass + sub-step rate.
+    this._axialMass = iA + iB > 0 ? 1 / (iA + iB) : 0;
+    this._h = h;
+    this._invH = 1 / h;
+
+    if (!this.enableMotor) {
+      this._motorImpulse = 0;
+    }
+
+    if (!this.enableLimit) {
+      this._lowerImpulse = 0;
+      this._upperImpulse = 0;
+    }
+
     if (this.hertz > 0) {
       const omega = 2 * Math.PI * this.hertz;
       const a1 = 2 * this.dampingRatio + h * omega;
@@ -124,9 +176,16 @@ export class RevoluteJoint extends Joint {
   }
 
   public override _warmStart(): void {
-    if (this._active) {
-      this._applyImpulse(this._impulseX, this._impulseY);
+    if (!this._active) {
+      return;
     }
+
+    // Angular warm-start: motor + limits (lower pushes +, upper pushes −).
+    const axial = this._motorImpulse + this._lowerImpulse - this._upperImpulse;
+    this.bodyA.angularVelocity -= this.bodyA.invInertia * axial;
+    this.bodyB.angularVelocity += this.bodyB.invInertia * axial;
+
+    this._applyImpulse(this._impulseX, this._impulseY);
   }
 
   public override _solve(useBias: boolean): void {
@@ -136,6 +195,60 @@ export class RevoluteJoint extends Joint {
 
     const bodyA = this.bodyA;
     const bodyB = this.bodyB;
+    const iA = bodyA.invInertia;
+    const iB = bodyB.invInertia;
+
+    // Angular motor: drive ωB − ωA toward motorSpeed, clamped to ±maxMotorTorque·h.
+    if (this.enableMotor) {
+      const cdot = bodyB.angularVelocity - bodyA.angularVelocity - this.motorSpeed;
+      const max = this.maxMotorTorque * this._h;
+      const old = this._motorImpulse;
+
+      this._motorImpulse = Math.min(max, Math.max(-max, old - this._axialMass * cdot));
+
+      const applied = this._motorImpulse - old;
+      bodyA.angularVelocity -= iA * applied;
+      bodyB.angularVelocity += iB * applied;
+    }
+
+    // Angle limits: one-sided constraints keeping the relative angle in [lower, upper].
+    if (this.enableLimit) {
+      const angle = bodyB.angle + bodyB._deltaAngle - (bodyA.angle + bodyA._deltaAngle) - this._referenceAngle;
+
+      // Lower limit (angle ≥ lowerAngle): a positive impulse increases the angle.
+      const cLower = angle - this.lowerAngle;
+      let biasLower = 0;
+
+      if (cLower > 0) {
+        biasLower = cLower * this._invH; // speculative: allow approach, engage at the surface
+      } else if (useBias) {
+        biasLower = 0.2 * this._invH * cLower; // Baumgarte push-back when violated
+      }
+
+      const oldLower = this._lowerImpulse;
+      this._lowerImpulse = Math.max(0, oldLower - this._axialMass * (bodyB.angularVelocity - bodyA.angularVelocity + biasLower));
+
+      const appliedLower = this._lowerImpulse - oldLower;
+      bodyA.angularVelocity -= iA * appliedLower;
+      bodyB.angularVelocity += iB * appliedLower;
+
+      // Upper limit (angle ≤ upperAngle): a positive impulse decreases the angle.
+      const cUpper = this.upperAngle - angle;
+      let biasUpper = 0;
+
+      if (cUpper > 0) {
+        biasUpper = cUpper * this._invH;
+      } else if (useBias) {
+        biasUpper = 0.2 * this._invH * cUpper;
+      }
+
+      const oldUpper = this._upperImpulse;
+      this._upperImpulse = Math.max(0, oldUpper - this._axialMass * (bodyA.angularVelocity - bodyB.angularVelocity + biasUpper));
+
+      const appliedUpper = this._upperImpulse - oldUpper;
+      bodyA.angularVelocity += iA * appliedUpper;
+      bodyB.angularVelocity -= iB * appliedUpper;
+    }
 
     // Relative velocity of the anchors.
     const cdotX = bodyB.linearVelocityX - bodyB.angularVelocity * this._rBy - (bodyA.linearVelocityX - bodyA.angularVelocity * this._rAy);

--- a/packages/exojs-physics/test/joints.test.ts
+++ b/packages/exojs-physics/test/joints.test.ts
@@ -182,4 +182,49 @@ describe('SG-J — joints', () => {
     expect(Math.abs(Math.hypot(b.x - a.x, b.y - a.y) - distance0)).toBeLessThan(2);
     expect(Math.abs(b.angle - a.angle - relativeAngle0)).toBeLessThan(0.05);
   });
+
+  it('SG-J10: a distance joint with maxLength acts as a rope — slack allowed, clamped at max', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    // Bob starts above the rope's full length → slack → falls freely until taut.
+    const bob = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 50 }, colliders: [{ shape: new BoxShape(16, 16) }] }));
+
+    world.addJoint(new DistanceJoint({ bodyA: anchor, bodyB: bob, maxLength: 100 }));
+
+    // While within maxLength the rope is slack → the bob falls freely (not held at 50).
+    advance(world, 0.05);
+    expect(Math.hypot(bob.x, bob.y)).toBeGreaterThan(50);
+
+    advance(world, 2);
+    const distance = Math.hypot(bob.x, bob.y);
+    expect(distance).toBeLessThan(101); // never stretches past the rope length
+    expect(distance).toBeGreaterThan(95); // hangs taut at ~max
+  });
+
+  it('SG-J11: a motorized revolute joint reaches and holds its target speed', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    const wheel = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [{ shape: new BoxShape(40, 40) }] }));
+
+    world.addJoint(new RevoluteJoint({ bodyA: anchor, bodyB: wheel, anchor: { x: 0, y: 0 }, enableMotor: true, motorSpeed: 5, maxMotorTorque: 1e8 }));
+
+    advance(world, 1);
+
+    expect(wheel.angularVelocity).toBeCloseTo(5, 0); // driven to the target rad/s and held
+  });
+
+  it('SG-J12: a revolute joint angle limit caps the swing', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    // A bar pinned at its left end; gravity swings it until the limit blocks it.
+    const bar = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 50, y: 0 }, colliders: [{ shape: new BoxShape(100, 10) }] }));
+    const limit = Math.PI / 4;
+
+    world.addJoint(new RevoluteJoint({ bodyA: anchor, bodyB: bar, anchor: { x: 0, y: 0 }, enableLimit: true, lowerAngle: -limit, upperAngle: limit }));
+
+    advance(world, 3);
+
+    expect(Math.abs(bar.angle)).toBeLessThan(limit + 0.05); // never past the limit
+    expect(Math.abs(bar.angle)).toBeGreaterThan(limit - 0.15); // swung to and rests at the limit
+  });
 });


### PR DESCRIPTION
First half of the **mechanism pack** (spec `05-mechanism-pack.md`) — on the existing joint infrastructure, no solver-core changes.

## What

- **DistanceJoint `minLength`/`maxLength`** → a **rope/limit** joint: distance kept within `[min, max]`, **slack** between, rigid limits (impulse-sign clamp). The default (no min/max) **equality** joint is byte-for-byte unchanged (±∞ bounds).
- **RevoluteJoint motor + limits:**
  - `enableMotor` / `motorSpeed` / `maxMotorTorque` — drives `ωB − ωA` toward `motorSpeed`, impulse clamped to `±maxMotorTorque·h`.
  - `enableLimit` / `lowerAngle` / `upperAngle` — keeps the relative angle in range via one-sided constraints with a speculative + Baumgarte bias.
  - Both warm-started, solved before the point constraint; the 2×2 point block is unchanged.

## Unlocks
Slack ropes/chains + grappling, driven wheels (arcade), motorized/limited hinges, ragdoll joint ranges.

## Tests
`test/joints.test.ts` — SG-J10 rope slack + clamp at `maxLength`; SG-J11 motor reaches and holds the target speed; SG-J12 angle limit caps the swing. **112 physics tests** green. typecheck + lint (0 new warnings) + prettier clean.

## Notes
- Additive only (new option fields on existing joints; no new exported classes → no `docs:api` impact).
- **M2** (PrismaticJoint + WheelJoint) is the follow-up — sliders/pistons/elevators + car suspension.