### PR TITLE
feat(physics): CCD bullet-vs-dynamic + normal reflection (P1)

### DIFF
--- a/packages/exojs-physics/src/PhysicsWorld.ts
+++ b/packages/exojs-physics/src/PhysicsWorld.ts
@@ -19,6 +19,8 @@ import type { BodyType, CollisionFilter, VectorLike } from './types';
 
 /** Gap left between a clamped bullet and the surface it hit (so it does not re-hit from inside). */
 const ccdSkin = 0.05;
+/** Impact speed (px/s) below which a bullet's CCD response does not bounce (mirrors the contact solver). */
+const ccdRestitutionThreshold = 1;
 
 /** Construction options for a {@link PhysicsWorld}. */
 export interface PhysicsWorldOptions {
@@ -682,11 +684,12 @@ export class PhysicsWorld implements BodyOwner {
   }
 
   /**
-   * Sweep each bullet's centre of mass along this fixed step's motion against the
-   * static colliders; if it would cross one, clamp the body just short of the
-   * surface and strip the into-surface velocity so it cannot tunnel. v1 sweeps
-   * the centre point (good for small/point-like projectiles) against static
-   * geometry only — a full swept-shape TOI and bullet-vs-dynamic are backlog.
+   * Sweep each bullet's centre of mass along this fixed step's motion against every
+   * other body's colliders; if it would cross one, clamp the body just short of the
+   * surface and resolve the impact about the surface normal (a slide for a non-bouncy
+   * body, an elastic reflection as restitution → 1) so it cannot tunnel. Sweeps the
+   * centre point — good for small/point-like projectiles; a full swept-shape TOI for
+   * large fast bodies is backlog (raise sub-steps or thicken geometry meanwhile).
    */
   private _advanceBullets(): void {
     for (const body of this._bodies) {
@@ -716,9 +719,9 @@ export class PhysicsWorld implements BodyOwner {
       let blocked: RayHit | null = null;
 
       for (const hit of hits) {
-        // Skip the bullet's own colliders; v1 sweeps against static geometry only.
-        // Hits are distance-sorted, so the first match is the nearest surface.
-        if (hit.body !== body && hit.body.type === 'static') {
+        // Sweep against every other body (static, kinematic, dynamic); sensors never
+        // block. Hits are distance-sorted, so the first match is the nearest surface.
+        if (hit.body !== body && !hit.collider.isSensor) {
           blocked = hit;
           break;
         }
@@ -729,7 +732,7 @@ export class PhysicsWorld implements BodyOwner {
       }
 
       // Clamp the CoM just short of the surface (a pure translation — the rotation
-      // is already applied), then strip the velocity heading into the surface.
+      // is already applied), then resolve the impact about the surface normal.
       const clampDistance = Math.max(0, blocked.distance - ccdSkin);
       const deltaX = body._ccdPrevX + dirX * clampDistance - newX;
       const deltaY = body._ccdPrevY + dirY * clampDistance - newY;
@@ -738,13 +741,34 @@ export class PhysicsWorld implements BodyOwner {
       this._ccdOrigin.y = body.y + deltaY;
       body.setTransform(this._ccdOrigin, body.angle);
 
-      const into = body.linearVelocityX * dirX + body.linearVelocityY * dirY;
+      // Reflect about the true surface normal: a slide for a non-bouncy body
+      // (restitution 0), an elastic bounce as restitution → 1. The body's own
+      // restitution combines (max) with the surface's, matching the contact solver.
+      const nx = blocked.normal.x;
+      const ny = blocked.normal.y;
+      const vn = body.linearVelocityX * nx + body.linearVelocityY * ny;
 
-      if (into > 0) {
-        body.linearVelocityX -= into * dirX;
-        body.linearVelocityY -= into * dirY;
+      if (vn < 0) {
+        const restitution = vn < -ccdRestitutionThreshold ? Math.max(this._bulletRestitution(body), blocked.collider.restitution) : 0;
+        const impulse = -(1 + restitution) * vn;
+
+        body.linearVelocityX += impulse * nx;
+        body.linearVelocityY += impulse * ny;
       }
     }
+  }
+
+  /** The highest restitution among a body's colliders (its CCD bounce factor). */
+  private _bulletRestitution(body: PhysicsBody): number {
+    let restitution = 0;
+
+    for (const collider of body.colliders) {
+      if (collider.restitution > restitution) {
+        restitution = collider.restitution;
+      }
+    }
+
+    return restitution;
   }
 
   /** Run `command` now, or queue it when inside an event dispatch (deferred to end of step). */

--- a/packages/exojs-physics/test/ccd.test.ts
+++ b/packages/exojs-physics/test/ccd.test.ts
@@ -85,4 +85,58 @@ describe('SG-C — continuous collision (bullet mode)', () => {
     expect(Math.abs(ball.x)).toBeLessThan(105);
     expect(Math.abs(ball.y)).toBeLessThan(105);
   });
+
+  it('SG-C4: a fast bullet does not tunnel through a thin *dynamic* body', () => {
+    // A thin dynamic target the bullet's per-step landings straddle without ever
+    // landing inside it, so discrete detection misses it — only a swept test catches it.
+    const make = (bullet: boolean): { world: PhysicsWorld; ball: PhysicsBody } => {
+      const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+      // Heavy thin dynamic target at x = 200 (barely shoved within the short run).
+      world.add(new PhysicsBody({ type: 'dynamic', position: { x: 200, y: 0 }, colliders: [{ shape: new BoxShape(8, 160), density: 50 }] }));
+
+      const ball = new PhysicsBody({ type: 'dynamic', position: { x: 55, y: 0 }, colliders: [{ shape: new CircleShape(6) }] });
+      ball.isBullet = bullet;
+      world.add(ball);
+      ball.linearVelocityX = 6000; // step landings 55 → 155 → 255 straddle the target without landing in it
+
+      return { world, ball };
+    };
+
+    // A non-bullet skips clean through the thin target (discrete detection misses it).
+    const plain = make(false);
+    for (let frame = 0; frame < 6; frame++) {
+      plain.world.step(FRAME);
+    }
+    expect(plain.ball.x).toBeGreaterThan(210); // tunnelled straight past the dynamic target
+
+    // The bullet is swept against the dynamic target too and stops just short of it.
+    const ccd = make(true);
+    for (let frame = 0; frame < 6; frame++) {
+      ccd.world.step(FRAME);
+    }
+    expect(ccd.ball.x).toBeLessThan(196); // clamped on the near side of the target's left face
+    expect(Number.isFinite(ccd.ball.x)).toBe(true);
+  });
+
+  it('SG-C5: a bullet hitting a wall obliquely deflects (keeps its tangential velocity)', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    world.add(new PhysicsBody({ type: 'static', position: { x: 200, y: 0 }, colliders: [{ shape: new BoxShape(4, 800) }] }));
+
+    // Fired right-and-down at a vertical wall: the wall normal is horizontal, so a
+    // correct impact resolves the x-component and leaves the y (tangential) intact.
+    const ball = new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [{ shape: new CircleShape(6) }] });
+    ball.isBullet = true;
+    world.add(ball);
+    ball.linearVelocityX = 6000;
+    ball.linearVelocityY = 2000;
+
+    for (let frame = 0; frame < 5; frame++) {
+      world.step(FRAME);
+    }
+
+    expect(ball.x).toBeLessThan(200); // stopped at the wall, did not tunnel
+    // It slides down the wall — a velocity-kill (stripping the whole travel vector)
+    // would have dead-stopped it at vy ≈ 0.
+    expect(ball.linearVelocityY).toBeGreaterThan(1000);
+  });
 });


### PR DESCRIPTION
## CCD P1 — close the sharp edges of `isBullet`

Rounds off bullet-mode CCD so the **already-shipped** `isBullet` flag behaves the way users expect, without taking on the full swept-shape-TOI machinery (deliberately deferred — see below).

### What changed
1. **Sweep vs every body, not just static** — the center-point sweep now blocks on static, kinematic *and* dynamic colliders (sensors never block). A fast bullet no longer tunnels through thin **moving** targets.
2. **Reflect about the true surface normal** instead of stripping the whole travel vector. Previously an oblique hit dead-stopped the bullet (it lost its tangential velocity too). Now:
   - restitution `0` → slides/deflects along the surface (tangential velocity preserved),
   - restitution → `1` → elastic bounce.
   - Restitution combines (`max`) with the surface, matching the discrete contact solver; below a 1 px/s impact threshold there is no bounce (mirrors the solver).

### Deliberately out of scope (deferred)
Full conservative-advancement **TOI** (GJK distance + TOI-islands) and **bullet-vs-bullet** for *large* fast bodies — the bug-prone, simulation-grade tier that Matter.js and Phaser Arcade ship without. The center-point sweep covers projectiles; for large fast bodies, raise sub-steps or thicken geometry. Tracked in the YAGNI list + `03-ccd.md`.

### Tests
- **SG-C4** — a fast bullet does not tunnel through a thin *dynamic* body (a non-bullet control does).
- **SG-C5** — an oblique hit deflects, keeping its tangential velocity (a velocity-kill left it at ~0).

### Verification (local, CI-parity)
- ✅ Full physics suite **118/118** (`--expose-gc`, dynamics + joints + sleeping + perf)
- ✅ `typecheck` (physics) · `eslint` clean · `prettier --check` clean

No API surface change — purely strengthens the existing `isBullet` behaviour.