### PR TITLE
feat(physics): MouseJoint (soft drag-to-target constraint)

### DIFF
--- a/packages/exojs-physics/src/joints/MouseJoint.ts
+++ b/packages/exojs-physics/src/joints/MouseJoint.ts
@@ -1,0 +1,179 @@
+import { applyInverseTransform, applyTransform, type Mutable2D } from '../math';
+import { PhysicsBody } from '../PhysicsBody';
+import type { VectorLike } from '../types';
+import { Joint } from './Joint';
+
+/** Construction options for a {@link MouseJoint}. */
+export interface MouseJointOptions {
+  /** The body to drag. */
+  body: PhysicsBody;
+  /** World point to pull the body toward — also the grab point on the body at creation. */
+  target: VectorLike;
+  /** Soft-spring frequency in Hz (higher = snappier). Default `5`. */
+  hertz?: number;
+  /** Soft-spring damping ratio. Default `0.7`. */
+  dampingRatio?: number;
+  /** Maximum pulling force — clamps the per-step impulse so heavy bodies lag. Default `Infinity`. */
+  maxForce?: number;
+}
+
+/** Reused output sink — physics steps single-threaded, so a shared scratch is safe. */
+const scratch: Mutable2D = { x: 0, y: 0 };
+
+/**
+ * Softly pulls a single body's grab point toward a movable **target** point
+ * (typically the mouse cursor). The grab point is fixed on the body at creation;
+ * update {@link target} each frame to drag. A soft constraint bounded by
+ * {@link maxForce} — solved in the sub-step loop, warm-started. Internally the
+ * "other" body is a private static ground sentinel, so this is a single-body
+ * constraint that touches only the dragged body.
+ */
+export class MouseJoint extends Joint {
+  /** Soft-spring frequency in Hz. */
+  public hertz: number;
+  /** Soft-spring damping ratio. */
+  public dampingRatio: number;
+  /** Maximum pulling force. */
+  public maxForce: number;
+
+  private readonly _localAnchorX: number;
+  private readonly _localAnchorY: number;
+  private _targetX: number;
+  private _targetY: number;
+
+  private _rx = 0;
+  private _ry = 0;
+  private _cx = 0;
+  private _cy = 0;
+  private _invK11 = 0;
+  private _invK12 = 0;
+  private _invK22 = 0;
+  private _biasRate = 0;
+  private _massScale = 1;
+  private _impulseScale = 0;
+  private _impulseX = 0;
+  private _impulseY = 0;
+  private _maxImpulse = 0;
+
+  public constructor(options: MouseJointOptions) {
+    // Single-body constraint: a private static ground stands in for bodyA so the
+    // island/solver machinery (which assumes two bodies) sees a static anchor that
+    // it never integrates, unions or mutates.
+    super(new PhysicsBody({ type: 'static', position: options.target }), options.body);
+
+    applyInverseTransform(options.body.transform, options.target.x, options.target.y, scratch);
+    this._localAnchorX = scratch.x;
+    this._localAnchorY = scratch.y;
+    this._targetX = options.target.x;
+    this._targetY = options.target.y;
+
+    this.hertz = options.hertz ?? 5;
+    this.dampingRatio = options.dampingRatio ?? 0.7;
+    this.maxForce = options.maxForce ?? Infinity;
+  }
+
+  /** The world point the body is pulled toward. Reassigning wakes the body so a drag tracks live. */
+  public get target(): VectorLike {
+    return { x: this._targetX, y: this._targetY };
+  }
+
+  public set target(value: VectorLike) {
+    this._targetX = value.x;
+    this._targetY = value.y;
+    this.bodyB.wake();
+  }
+
+  public override _prepare(h: number): void {
+    const body = this.bodyB;
+
+    this._active = this.enabled && !body.isSleeping && body.invMass > 0;
+
+    if (!this._active) {
+      return;
+    }
+
+    applyTransform(body.transform, this._localAnchorX, this._localAnchorY, scratch);
+    this._rx = scratch.x - body.worldCenterOfMassX;
+    this._ry = scratch.y - body.worldCenterOfMassY;
+    this._cx = scratch.x - this._targetX;
+    this._cy = scratch.y - this._targetY;
+
+    const m = body.invMass;
+    const i = body.invInertia;
+
+    // 2×2 effective-mass matrix K (only the dragged body contributes) and its inverse.
+    const k11 = m + i * this._ry * this._ry;
+    const k12 = -i * this._rx * this._ry;
+    const k22 = m + i * this._rx * this._rx;
+    const det = k11 * k22 - k12 * k12;
+    const invDet = det !== 0 ? 1 / det : 0;
+
+    this._invK11 = invDet * k22;
+    this._invK12 = -invDet * k12;
+    this._invK22 = invDet * k11;
+    this._maxImpulse = this.maxForce * h;
+
+    const omega = 2 * Math.PI * this.hertz;
+    const a1 = 2 * this.dampingRatio + h * omega;
+    const a2 = h * omega * a1;
+    const a3 = 1 / (1 + a2);
+
+    this._biasRate = omega / a1;
+    this._massScale = a2 * a3;
+    this._impulseScale = a3;
+  }
+
+  public override _warmStart(): void {
+    if (!this._active) {
+      return;
+    }
+
+    this._applyImpulse(this._impulseX, this._impulseY);
+  }
+
+  public override _solve(useBias: boolean): void {
+    if (!this._active) {
+      return;
+    }
+
+    const body = this.bodyB;
+
+    // Velocity of the grab point.
+    const cdotX = body.linearVelocityX - body.angularVelocity * this._ry;
+    const cdotY = body.linearVelocityY + body.angularVelocity * this._rx;
+    const rhsX = cdotX + (useBias ? this._biasRate * this._cx : 0);
+    const rhsY = cdotY + (useBias ? this._biasRate * this._cy : 0);
+
+    const solvedX = this._invK11 * rhsX + this._invK12 * rhsY;
+    const solvedY = this._invK12 * rhsX + this._invK22 * rhsY;
+    let impulseX = -this._massScale * solvedX - this._impulseScale * this._impulseX;
+    let impulseY = -this._massScale * solvedY - this._impulseScale * this._impulseY;
+
+    // Clamp the accumulated impulse magnitude to maxForce·h (a heavy body lags).
+    const oldX = this._impulseX;
+    const oldY = this._impulseY;
+    this._impulseX += impulseX;
+    this._impulseY += impulseY;
+
+    const magnitude = Math.hypot(this._impulseX, this._impulseY);
+
+    if (magnitude > this._maxImpulse) {
+      const scale = this._maxImpulse / magnitude;
+
+      this._impulseX *= scale;
+      this._impulseY *= scale;
+    }
+
+    impulseX = this._impulseX - oldX;
+    impulseY = this._impulseY - oldY;
+    this._applyImpulse(impulseX, impulseY);
+  }
+
+  private _applyImpulse(jx: number, jy: number): void {
+    const body = this.bodyB;
+
+    body.linearVelocityX += body.invMass * jx;
+    body.linearVelocityY += body.invMass * jy;
+    body.angularVelocity += body.invInertia * (this._rx * jy - this._ry * jx);
+  }
+}

--- a/packages/exojs-physics/src/public.ts
+++ b/packages/exojs-physics/src/public.ts
@@ -11,6 +11,7 @@ export { Collider } from './Collider';
 export type { CollisionEvent, ContactPoint, SensorEvent } from './events';
 export { DistanceJoint, type DistanceJointOptions } from './joints/DistanceJoint';
 export { Joint } from './joints/Joint';
+export { MouseJoint, type MouseJointOptions } from './joints/MouseJoint';
 export { PrismaticJoint, type PrismaticJointOptions } from './joints/PrismaticJoint';
 export { RevoluteJoint, type RevoluteJointOptions } from './joints/RevoluteJoint';
 export { WeldJoint, type WeldJointOptions } from './joints/WeldJoint';

--- a/packages/exojs-physics/test/joints.test.ts
+++ b/packages/exojs-physics/test/joints.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { BoxShape, CircleShape, DistanceJoint, PhysicsBody, PhysicsWorld, PrismaticJoint, RevoluteJoint, WeldJoint, WheelJoint } from '../src/index';
+import { BoxShape, CircleShape, DistanceJoint, MouseJoint, PhysicsBody, PhysicsWorld, PrismaticJoint, RevoluteJoint, WeldJoint, WheelJoint } from '../src/index';
 
 /**
  * Joints (spec `02-joints.md`). Soft constraints solved in the sub-step loop
@@ -289,5 +289,36 @@ describe('SG-J — joints', () => {
 
     expect(Math.abs(wheel.x)).toBeLessThan(2); // lateral locked — did not slide sideways
     expect(Math.abs(wheel.angularVelocity)).toBeGreaterThan(5); // rotation is free — still spinning
+  });
+
+  it('SG-J17: a mouse joint drags a body to its target and tracks it when moved', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const body = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [{ shape: new BoxShape(20, 20) }] }));
+
+    // Grab the body at its centre and pull it toward (50, 0).
+    const joint = world.addJoint(new MouseJoint({ body, target: { x: 0, y: 0 }, hertz: 5, dampingRatio: 1 }));
+    joint.target = { x: 50, y: 0 };
+
+    advance(world, 1);
+    expect(body.x).toBeGreaterThan(40); // converged near the target
+
+    // Move the target — the body follows.
+    joint.target = { x: 50, y: 60 };
+    advance(world, 1);
+    expect(body.y).toBeGreaterThan(45);
+  });
+
+  it('SG-J18: maxForce caps how hard a mouse joint can pull', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const heavy = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [{ shape: new BoxShape(20, 20), density: 100 }] }));
+
+    // A tiny force against a far target: it creeps but cannot snap across.
+    const joint = world.addJoint(new MouseJoint({ body: heavy, target: { x: 0, y: 0 }, hertz: 5, dampingRatio: 1, maxForce: 50 }));
+    joint.target = { x: 1000, y: 0 };
+
+    advance(world, 1);
+
+    expect(heavy.x).toBeGreaterThan(0); // it did move toward the target
+    expect(heavy.x).toBeLessThan(200); // but maxForce kept it from reaching the far target
   });
 });


### PR DESCRIPTION
## MouseJoint — the mouse-drag primitive

Softly pulls a single body's **grab point** toward a movable **target** point — the standard primitive for dragging bodies with the cursor (physics sandboxes, puzzle/grab mechanics). It's the one genuinely "rounds-the-package" joint that was hiding in the spring/pulley/gear backlog; pulley/gear stay deferred (niche), and a dedicated spring is unnecessary (`DistanceJoint`'s `hertz` already springs).

### Behaviour
- Grab point is fixed on the body at creation (the initial `target` maps to a body-local anchor).
- Reassign `joint.target = {x, y}` each frame to drag; the setter **wakes the body** so the drag tracks live.
- Soft constraint (`hertz` / `dampingRatio`), bounded by `maxForce` so heavy bodies lag instead of snapping.

### Implementation
Reuses the existing soft-constraint joint infrastructure (Box2D-v3 soft factors, sub-step solve, warm-start). Being **single-body**, it stands a private static *ground sentinel* in for `bodyA` so the island/solver machinery — which assumes two bodies — sees a static anchor it never integrates, unions or mutates (verified: dynamic-only island unions, `wake()` harmless on static, static `bodyA` is already an exercised hinge case). Only the dragged body is touched. No base-class refactor.

### Tests
- **SG-J17** — drags a body to its target and tracks a moved target.
- **SG-J18** — `maxForce` caps the pull (a heavy body creeps, can't snap across).

### Verification (local, CI-parity)
- ✅ Full physics suite **120/120** (`--expose-gc`)
- ✅ `typecheck` · `eslint` clean · `prettier --check` clean

### Public API
`MouseJoint` / `MouseJointOptions`