### PR TITLE
fix(core): world-transform gating for AABB-vs-OBB collision (inherited rotation)

### DIFF
--- a/site/src/content/api/scene-node.mdx
+++ b/site/src/content/api/scene-node.mdx
@@ -1,6 +1,6 @@
 ---
 title: "SceneNode"
-description: "Transform-bearing leaf in the scene-graph hierarchy. Carries position, rotation, scale, skew, origin, and a 2-component Vector `anchor` used to derive `origin` from the local bounds. Implements Collidable so any node can participate directly in the SAT collision pipeline via its AABB or rotated/skewed quad. Transform state is dirty-flag-cached: position/rotation/scale/skew/origin mutations invalidate the local transform; either kind of mutation also invalidates the global transform (own + descendants) and the bounds rect for this node and every Container ancestor up the parent chain. The caches rebuild lazily on the next read. The fast-path `isAlignedBox` getter reports `true` when the rotation is a multiple of 90° and both skew components are zero; in that case the (cheaper) AABB-based collision test is used instead of the rotated/skewed quad SAT path. `_invalidate*` methods are exported as `public` for friend-class access from Container and InteractionManager; treat them as `@internal`. Subclasses: Container (carries children), RenderNode (carries draw payloads)."
+description: "Transform-bearing leaf in the scene-graph hierarchy. Carries position, rotation, scale, skew, origin, and a 2-component Vector `anchor` used to derive `origin` from the local bounds. Implements Collidable so any node can participate directly in the SAT collision pipeline via its AABB or rotated/skewed quad. Transform state is dirty-flag-cached: position/rotation/scale/skew/origin mutations invalidate the local transform; either kind of mutation also invalidates the global transform (own + descendants) and the bounds rect for this node and every Container ancestor up the parent chain. The caches rebuild lazily on the next read. Collision and hit-testing take the cheaper AABB path when the node's *world* box is axis-aligned (its own and any inherited rotation compose to a multiple of 90° with no skew) and the oriented-quad SAT path otherwise. The public `isAlignedBox` getter reports that predicate for this node's own rotation only. `_invalidate*` methods are exported as `public` for friend-class access from Container and InteractionManager; treat them as `@internal`. Subclasses: Container (carries children), RenderNode (carries draw payloads)."
 symbol: "SceneNode"
 kind: "class"
 subsystem: "core"
@@ -27,10 +27,10 @@ invalidates the global transform (own + descendants) and the bounds rect
 for this node and every Container ancestor up the parent chain.
 The caches rebuild lazily on the next read.
 
-The fast-path `isAlignedBox` getter reports `true` when the rotation is a
-multiple of 90° and both skew components are zero; in that case the
-(cheaper) AABB-based collision test is used instead of the rotated/skewed
-quad SAT path.
+Collision and hit-testing take the cheaper AABB path when the node's *world*
+box is axis-aligned (its own and any inherited rotation compose to a multiple
+of 90° with no skew) and the oriented-quad SAT path otherwise. The public
+`isAlignedBox` getter reports that predicate for this node's own rotation only.
 
 `_invalidate*` methods are exported as `public` for friend-class access
 from Container and InteractionManager; treat them as

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -73,10 +73,10 @@ const orientedCorners = [new Vector(), new Vector(), new Vector(), new Vector()]
  * for this node and every {@link Container} ancestor up the parent chain.
  * The caches rebuild lazily on the next read.
  *
- * The fast-path `isAlignedBox` getter reports `true` when the rotation is a
- * multiple of 90° and both skew components are zero; in that case the
- * (cheaper) AABB-based collision test is used instead of the rotated/skewed
- * quad SAT path.
+ * Collision and hit-testing take the cheaper AABB path when the node's *world*
+ * box is axis-aligned (its own and any inherited rotation compose to a multiple
+ * of 90° with no skew) and the oriented-quad SAT path otherwise. The public
+ * `isAlignedBox` getter reports that predicate for this node's own rotation only.
  *
  * `_invalidate*` methods are exported as `public` for friend-class access
  * from {@link Container} and {@link InteractionManager}; treat them as
@@ -419,11 +419,11 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
   }
 
   public getNormals(): Vector[] {
-    return this.isAlignedBox ? this.getBounds().getNormals() : this._orientedBoundsPolygon().getNormals();
+    return this._isWorldAligned() ? this.getBounds().getNormals() : this._orientedBoundsPolygon().getNormals();
   }
 
   public project(axis: Vector, result: Interval = new Interval()): Interval {
-    return this.isAlignedBox ? this.getBounds().project(axis, result) : this._orientedBoundsPolygon().project(axis, result);
+    return this._isWorldAligned() ? this.getBounds().project(axis, result) : this._orientedBoundsPolygon().project(axis, result);
   }
 
   /**
@@ -444,8 +444,23 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
     return (this._orientedBounds ??= new Polygon()).setPoints(orientedCorners);
   }
 
+  /**
+   * Whether the node's *world* box is axis-aligned — its own and every inherited
+   * rotation/skew compose to a transform that maps axes to axes (a multiple of
+   * 90°, no shear). When true the AABB equals the oriented box, so the cheaper
+   * AABB collision/hit-test path is exact; otherwise the oriented-quad SAT path
+   * is used. Unlike {@link isAlignedBox} (this node's own rotation only), this
+   * accounts for a rotated ancestor.
+   */
+  private _isWorldAligned(): boolean {
+    const matrix = this.getGlobalTransform();
+    const epsilon = 1e-9;
+
+    return (Math.abs(matrix.b) < epsilon && Math.abs(matrix.c) < epsilon) || (Math.abs(matrix.a) < epsilon && Math.abs(matrix.d) < epsilon);
+  }
+
   public intersectsWith(target: Collidable): boolean {
-    if (this.isAlignedBox) {
+    if (this._isWorldAligned()) {
       return this.getBounds().intersectsWith(target);
     }
 
@@ -470,7 +485,7 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
   }
 
   public collidesWith(target: Collidable): CollisionResponse | null {
-    if (this.isAlignedBox) {
+    if (this._isWorldAligned()) {
       return this.getBounds().collidesWith(target);
     }
 
@@ -491,7 +506,7 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
   /**
    * Hit-test the world-space point `(x, y)` against this node.
    *
-   * For axis-aligned nodes ({@link isAlignedBox} — rotation a multiple of 90°
+   * For world-axis-aligned nodes (own and inherited rotation a multiple of 90°
    * and no skew) the AABB equals the oriented box, so the cheap
    * {@link getBounds} test is exact. For rotated or skewed nodes the point is
    * mapped back into local space with the inverse of the global transform and
@@ -502,7 +517,7 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
    * empty AABB corners of a rotated node.
    */
   public contains(x: number, y: number): boolean {
-    if (this.isAlignedBox) {
+    if (this._isWorldAligned()) {
       return this.getBounds().contains(x, y);
     }
 

--- a/test/core/oriented-bounds.test.ts
+++ b/test/core/oriented-bounds.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import { SceneNode } from '#core/SceneNode';
 import { Rectangle } from '#math/Rectangle';
+import { Container } from '#rendering/Container';
+import { Drawable } from '#rendering/Drawable';
 
 /**
  * Oriented bounding-box (OBB) collision axes for rotated nodes. A rotated node's
@@ -39,5 +41,26 @@ describe('SceneNode oriented bounds (rotated SAT)', () => {
 
     expect(node.getBounds().intersectsWith(target)).toBe(true); // genuinely inside the loose AABB
     expect(node.intersectsWith(target)).toBe(false); // but the oriented box rejects it
+  });
+
+  it('uses oriented axes when the rotation is inherited from a rotated parent', () => {
+    // The child has no rotation of its own — its world box is rotated only because
+    // the parent is. isAlignedBox (a node-local check) is therefore true, yet the
+    // collision must still test the oriented world box.
+    const parent = new Container();
+    parent.setPosition(100, 100);
+    parent.setRotation(45);
+
+    const child = new Drawable();
+    child.getLocalBounds().set(-40, -40, 80, 80); // centred on the parent's pivot
+    parent.addChild(child);
+    child.updateParentTransform();
+
+    expect(child.isAlignedBox).toBe(true); // the child's own rotation is zero
+
+    const target = new Rectangle(148, 148, 6, 6); // in the world AABB corner, outside the diamond
+
+    expect(child.getBounds().intersectsWith(target)).toBe(true); // genuinely inside the loose world AABB
+    expect(child.intersectsWith(target)).toBe(false); // but the inherited-oriented box rejects it
   });
 });


### PR DESCRIPTION
## Inherited-rotation correctness for collision/hit-testing

Follow-up to #195. The OBB fix gated on `isAlignedBox`, which inspects only the node's **own** rotation. A node with no rotation of its own but a **rotated ancestor** has a rotated *world* box, yet `isAlignedBox` is `true` — so it took the AABB fast path and SAT silently tested the loose axis-aligned box.

This was **latent since the SAT routing was first added** (confirmed via git history: `isAlignedBox` has always been `rotation % 90 === 0`, node-local) and never surfaced because the only collision example (`rectangles-collision`) deliberately uses non-rotated axis-aligned rectangles.

### Fix
`getNormals()` / `project()` / `intersectsWith()` / `collidesWith()` / `contains()` now gate on the **global transform** mapping axes to axes — `(|b|<ε && |c|<ε) || (|a|<ε && |d|<ε)` — instead of the node-local `isAlignedBox`. The public `isAlignedBox` getter keeps its node-local meaning.

`contains()` (pointer hit-testing) is included because it had the identical latent bug; collision and picking are now consistently correct under arbitrary hierarchies.

The fast-vs-SAT choice only decides **which (both-correct) path runs**, so the epsilon is a performance heuristic, never a correctness risk (a misclassified node still gets a correct, if slightly slower, result).

### Test
A `Drawable` with no own rotation under a 45°-rotated `Container`: `isAlignedBox` is `true`, yet a target in the world-AABB corner (outside the inherited diamond) is correctly rejected — and the test asserts the AABB *does* intersect it, so it genuinely guards the inherited-OBB path.

### Verification (local, CI-parity)
- ✅ core suite **2498/2498** green (no interaction/collision regressions)
- ✅ `verify:quick` (typecheck ×4 + lint:all + format:check + docs:api:check) — passed via pre-push