### PR TITLE
feat(core): fixed-timestep loop (Scene.fixedUpdate / onFixedFrame / frameAlpha)

### DIFF
--- a/site/src/content/api/application-status.mdx
+++ b/site/src/content/api/application-status.mdx
@@ -9,7 +9,7 @@ memberCount: 4
 tier: "stable"
 sections: ["Import", "Members", "Source"]
 sourcePath: "src/core/Application.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L37"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L38"
 ---
 ## Import
 
@@ -24,4 +24,4 @@ sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#
 
 ## Source
 
-[src/core/Application.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L37)
+[src/core/Application.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L38)

--- a/site/src/content/api/application.mdx
+++ b/site/src/content/api/application.mdx
@@ -5,11 +5,11 @@ symbol: "Application"
 kind: "class"
 subsystem: "core"
 importPath: "@codexo/exojs"
-memberCount: 45
+memberCount: 48
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/core/Application.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L217"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L227"
 ---
 ## Import
 
@@ -74,6 +74,8 @@ background-active simulations.
 - `clearColor: Color`
 - `cursor: string`
 - `documentVisible: boolean`
+- `fixedTimeStep: number`
+- `frameAlpha: number`
 - `frameCount: number`
 - `frameTime: Time`
 - `height: number`
@@ -90,10 +92,11 @@ background-active simulations.
 - `onBackendRestored: Signal<[]>`
 - `onCanvasFocusChange: Signal<[focused]>`
 - `onError: Signal<[error]>`
+- `onFixedFrame: Signal<[Time]>`
 - `onFrame: Signal<[Time]>`
 - `onResize: Signal<[number, number, Application]>`
 - `onVisibilityChange: Signal<[visible]>`
 
 ## Source
 
-[src/core/Application.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L217)
+[src/core/Application.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L227)

--- a/site/src/content/api/scene-manager.mdx
+++ b/site/src/content/api/scene-manager.mdx
@@ -5,7 +5,7 @@ symbol: "SceneManager"
 kind: "class"
 subsystem: "core"
 importPath: "@codexo/exojs"
-memberCount: 9
+memberCount: 10
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/core/SceneManager.ts"
@@ -32,6 +32,7 @@ while it keeps rendering).
 ## Methods
 
 - `destroy(): void`
+- `fixedUpdate(delta: Time): this`
 - `setScene(scene: Scene | null, options: SetSceneOptions): Promise<SceneManager>`
 - `update(delta: Time): this`
 

--- a/site/src/content/api/scene.mdx
+++ b/site/src/content/api/scene.mdx
@@ -5,7 +5,7 @@ symbol: "Scene"
 kind: "class"
 subsystem: "core"
 importPath: "@codexo/exojs"
-memberCount: 21
+memberCount: 22
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/core/Scene.ts"
@@ -42,6 +42,7 @@ For one-off scenes, an anonymous subclass works just as well:
 - `deserialize(data: SerializedScene): this`
 - `destroy(): void`
 - `draw(_context: RenderingContext): void`
+- `fixedUpdate(_delta: Time): void`
 - `init(_loader: Loader): void | Promise<void>`
 - `load(_loader: Loader): void | Promise<void>`
 - `removeChild(child: RenderNode): this`

--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -25,6 +25,7 @@ import { Loader, type LoaderOptions } from '#resources/Loader';
 import { Capabilities } from './capabilities';
 import { Clock } from './Clock';
 import { Color } from './Color';
+import { FixedTimestep } from './FixedTimestep';
 import { computeLetterboxLayout } from './letterbox';
 import type { Scene } from './Scene';
 import { SceneManager } from './SceneManager';
@@ -112,6 +113,11 @@ export interface ApplicationOptions {
   /** Seed for the per-Application {@link Application.random} RNG. Omit for a non-deterministic seed. */
   seed?: number;
   /**
+   * Fixed-timestep size in **seconds** for {@link Scene.fixedUpdate} / {@link Application.onFixedFrame}.
+   * Default `1 / 60`. Must be positive.
+   */
+  fixedTimeStep?: number;
+  /**
    * Extension selection.
    * `undefined` → Core + globally registered extensions.
    * `[]`         → Core only.
@@ -137,6 +143,10 @@ export interface AutoBackendConfig {
 export type BackendConfig = AutoBackendConfig | WebGl2BackendConfig | WebGpuBackendConfig;
 
 const maxDeltaMs = 100;
+/** Default fixed-timestep size in milliseconds (60 Hz). */
+const defaultFixedStepMs = 1000 / 60;
+/** Max fixed steps run in one frame — the spiral-of-death guard. */
+const maxFixedSteps = 5;
 
 const createDefaultCanvas = (): HTMLCanvasElement => document.createElement('canvas');
 
@@ -242,6 +252,8 @@ export class Application {
   public readonly serializers = new SerializationRegistry(defaultSerializationRegistry);
   public readonly onResize = new Signal<[number, number, Application]>();
   public readonly onFrame = new Signal<[Time]>();
+  /** Dispatched once per fixed-timestep step (zero or more times per frame), ahead of {@link onFrame}. */
+  public readonly onFixedFrame = new Signal<[Time]>();
   public readonly onCanvasFocusChange = new Signal<[focused: boolean]>();
   public readonly onVisibilityChange = new Signal<[visible: boolean]>();
   public readonly onBackendLost = new Signal();
@@ -254,6 +266,9 @@ export class Application {
   private readonly _startupClock: Clock = new Clock();
   private readonly _activeClock: Clock = new Clock();
   private readonly _frameClock: Clock = new Clock();
+  private readonly _fixed: FixedTimestep;
+  private readonly _fixedTime: Time;
+  private _frameAlpha = 0;
 
   private _status: ApplicationStatus = ApplicationStatus.Stopped;
   private _pixelRatio: number = defaultCanvasSettings.pixelRatio;
@@ -359,6 +374,11 @@ export class Application {
     this.random = new Random(this.options.seed);
     this._updateHandler = this.update.bind(this);
 
+    const fixedStepMs = this.options.fixedTimeStep !== undefined ? this.options.fixedTimeStep * 1000 : defaultFixedStepMs;
+
+    this._fixed = new FixedTimestep(fixedStepMs, maxFixedSteps);
+    this._fixedTime = new Time(fixedStepMs);
+
     // Register the core managers as ordered app systems (reserved order bands);
     // they tick from one loop, ahead of any user systems (order 600+).
     this.systems.add(this.input);
@@ -401,6 +421,21 @@ export class Application {
 
   public get frameCount(): number {
     return this._frameCount;
+  }
+
+  /**
+   * Interpolation factor `[0, 1)` — the leftover sub-step fraction after this
+   * frame's fixed steps. Lerp rendered state between its previous and current
+   * fixed-step values by this to smooth motion when the fixed rate is below the
+   * frame rate.
+   */
+  public get frameAlpha(): number {
+    return this._frameAlpha;
+  }
+
+  /** Fixed-timestep size in seconds (see {@link ApplicationOptions.fixedTimeStep}). */
+  public get fixedTimeStep(): number {
+    return this._fixed.stepMs / 1000;
   }
 
   /**
@@ -566,6 +601,7 @@ export class Application {
         await this.scene.setScene(scene);
         this._frameRequest = requestAnimationFrame(this._updateHandler);
         this._frameClock.restart();
+        this._fixed.reset();
         this._activeClock.start();
         this._status = ApplicationStatus.Running;
       } catch (error) {
@@ -605,6 +641,7 @@ export class Application {
     if (this._status === ApplicationStatus.Running) {
       if (this.pauseOnHidden && !this._documentVisible) {
         this._frameClock.restart();
+        this._fixed.reset();
         this._frameRequest = requestAnimationFrame(this._updateHandler);
 
         return this;
@@ -619,6 +656,17 @@ export class Application {
       this.backend.stats.rawFrameDeltaMs = rawDeltaMs;
 
       this.systems._tick(frameDelta);
+
+      // Fixed-timestep steps (0..N) for deterministic logic/physics, after input
+      // so they see this frame's input and before the variable update/draw.
+      const fixedSteps = this._fixed.advance(clampedDeltaMs);
+
+      for (let step = 0; step < fixedSteps; step++) {
+        this.scene.fixedUpdate(this._fixedTime);
+        this.onFixedFrame.dispatch(this._fixedTime);
+      }
+
+      this._frameAlpha = this._fixed.alpha;
 
       this.scene.update(frameDelta);
       this.onFrame.dispatch(frameDelta);
@@ -833,6 +881,7 @@ export class Application {
     this._frameClock.destroy();
     this.onResize.destroy();
     this.onFrame.destroy();
+    this.onFixedFrame.destroy();
     this.onCanvasFocusChange.destroy();
     this.onVisibilityChange.destroy();
     this.onBackendLost.destroy();

--- a/src/core/FixedTimestep.ts
+++ b/src/core/FixedTimestep.ts
@@ -1,0 +1,68 @@
+/**
+ * Fixed-timestep accumulator (Gaffer's "Fix Your Timestep"). Converts the
+ * variable per-frame delta into a whole number of fixed-size steps, carrying the
+ * sub-step remainder across frames as an interpolation {@link FixedTimestep.alpha}.
+ *
+ * Pure timing logic — no scene or signal coupling — so the loop can drive it and
+ * tests can exercise the step/alpha maths directly. The {@link maxSteps} cap is
+ * the spiral-of-death guard: when a frame is so long it would need more than
+ * `maxSteps` catch-up steps, the surplus whole-step backlog is dropped rather
+ * than accumulated (which would make the next frame even longer).
+ *
+ * @internal
+ */
+export class FixedTimestep {
+  private _accumulatorMs = 0;
+
+  public constructor(
+    private readonly _stepMs: number,
+    private readonly _maxSteps: number,
+  ) {
+    if (!(_stepMs > 0) || !Number.isFinite(_stepMs)) {
+      throw new RangeError(`FixedTimestep: step must be a positive finite number of ms, received ${_stepMs}.`);
+    }
+  }
+
+  /** The fixed step size in milliseconds. */
+  public get stepMs(): number {
+    return this._stepMs;
+  }
+
+  /** Leftover fraction `[0, 1)` of a step — the render interpolation factor. */
+  public get alpha(): number {
+    return this._accumulatorMs / this._stepMs;
+  }
+
+  /** Add a frame's elapsed time and return how many fixed steps to run now (capped at `maxSteps`). */
+  public advance(frameDeltaMs: number): number {
+    this._accumulatorMs += frameDeltaMs;
+
+    // Tolerance so an accumulator that lands a rounding-error below a whole
+    // multiple of the step (e.g. 3×step) still yields that many steps.
+    const epsilon = this._stepMs * 1e-9;
+    let steps = 0;
+
+    while (this._accumulatorMs >= this._stepMs - epsilon && steps < this._maxSteps) {
+      this._accumulatorMs -= this._stepMs;
+      steps++;
+    }
+
+    // Capped: drop the whole-step backlog, keep only the sub-step remainder so
+    // alpha stays in [0, 1) and the next frame does not replay the lost time.
+    if (this._accumulatorMs > this._stepMs) {
+      this._accumulatorMs %= this._stepMs;
+    }
+
+    // Clamp the tiny negative the epsilon subtraction can leave.
+    if (this._accumulatorMs < 0) {
+      this._accumulatorMs = 0;
+    }
+
+    return steps;
+  }
+
+  /** Clear the accumulator (e.g. on start/resume so a paused gap is not caught up). */
+  public reset(): void {
+    this._accumulatorMs = 0;
+  }
+}

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -340,6 +340,18 @@ export class Scene {
   }
 
   /**
+   * Fixed-timestep logic hook. Called zero or more times per frame with a
+   * constant `delta` ({@link Application.fixedTimeStep}) before {@link Scene.update},
+   * so physics and deterministic gameplay advance at a frame-rate-independent
+   * rate. Put `physicsWorld.step(delta)` and movement here; leave camera, UI and
+   * purely visual work in {@link Scene.update}. Default is a no-op. Override in
+   * subclass.
+   */
+  public fixedUpdate(_delta: Time): void {
+    // override in subclass
+  }
+
+  /**
    * Explicit per-frame rendering entry point. Override to choose
    * what gets rendered.
    *

--- a/src/core/SceneManager.ts
+++ b/src/core/SceneManager.ts
@@ -186,6 +186,22 @@ export class SceneManager {
     return this;
   }
 
+  /**
+   * Drive one fixed-timestep step on the active scene (unless paused). Called
+   * zero or more times per frame by the {@link Application} loop, ahead of
+   * {@link SceneManager.update}. No drawing or transition advance happens here —
+   * those are per-frame, not per fixed step.
+   */
+  public fixedUpdate(delta: Time): this {
+    const scene = this._activeScene;
+
+    if (scene !== null && !scene.paused) {
+      scene.fixedUpdate(delta);
+    }
+
+    return this;
+  }
+
   public destroy(): void {
     if (this._transition) {
       const transition = this._transition;

--- a/test/audio/audio-manager-update.test.ts
+++ b/test/audio/audio-manager-update.test.ts
@@ -129,6 +129,7 @@ describe('AudioManager.update()', () => {
       elapsedTime: { milliseconds: 16, seconds: 0.016 },
       restart: vi.fn(),
     };
+    rawApp['_fixed'] = { advance: () => 0, alpha: 0 };
     rawApp['_updateHandler'] = vi.fn();
     rawApp['_frameCount'] = 0;
     rawApp['onFrame'] = { dispatch: vi.fn() };

--- a/test/core/application-loop.test.ts
+++ b/test/core/application-loop.test.ts
@@ -364,4 +364,59 @@ describe('Application.update() — loop timing (F1 + F2)', () => {
       expect(app.backend.resetStats).not.toHaveBeenCalled();
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Fixed timestep — accumulator-driven fixedUpdate / onFixedFrame / frameAlpha
+  // -------------------------------------------------------------------------
+
+  describe('Fixed timestep', () => {
+    const STEP_MS = 1000 / 60;
+
+    test('runs one fixed step per single-step frame', () => {
+      const fixedSpy = vi.spyOn(app.scene, 'fixedUpdate');
+
+      mockFrameElapsed(app, STEP_MS);
+      app.update();
+
+      expect(fixedSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('runs multiple fixed steps for a multi-step frame', () => {
+      const fixedSpy = vi.spyOn(app.scene, 'fixedUpdate');
+
+      mockFrameElapsed(app, STEP_MS * 3);
+      app.update();
+
+      expect(fixedSpy).toHaveBeenCalledTimes(3);
+    });
+
+    test('dispatches onFixedFrame once per fixed step', () => {
+      let count = 0;
+      app.onFixedFrame.add(() => {
+        count++;
+      });
+
+      mockFrameElapsed(app, STEP_MS * 2);
+      app.update();
+
+      expect(count).toBe(2);
+    });
+
+    test('frameAlpha reports the leftover sub-step fraction', () => {
+      mockFrameElapsed(app, STEP_MS * 1.5);
+      app.update();
+
+      expect(app.frameAlpha).toBeCloseTo(0.5, 4);
+    });
+
+    test('caps fixed steps per frame (spiral-of-death guard)', () => {
+      const fixedSpy = vi.spyOn(app.scene, 'fixedUpdate');
+
+      // The frame delta is clamped to 100 ms first → 6 steps wanted, capped at 5.
+      mockFrameElapsed(app, 1000);
+      app.update();
+
+      expect(fixedSpy).toHaveBeenCalledTimes(5);
+    });
+  });
 });

--- a/test/core/application-on-frame.test.ts
+++ b/test/core/application-on-frame.test.ts
@@ -176,6 +176,7 @@ describe('Application.onFrame', () => {
     rawApp['scene'] = sceneManager;
     rawApp['_backend'] = backend;
     rawApp['_frameClock'] = { elapsedTime: { milliseconds: 16, seconds: 0.016 }, restart: vi.fn() };
+    rawApp['_fixed'] = { advance: () => 0, alpha: 0 };
     rawApp['_updateHandler'] = vi.fn();
     rawApp['_frameCount'] = 0;
     rawApp['onFrame'] = onFrame;

--- a/test/core/application.test.ts
+++ b/test/core/application.test.ts
@@ -214,6 +214,7 @@ describe('Application', () => {
     rawApp['scene'] = sceneManager;
     rawApp['_backend'] = backend;
     rawApp['_frameClock'] = frameClock;
+    rawApp['_fixed'] = { advance: () => 0, alpha: 0 };
     rawApp['_updateHandler'] = vi.fn();
     rawApp['_frameCount'] = 0;
     rawApp['onFrame'] = { dispatch: vi.fn() };
@@ -507,6 +508,7 @@ describe('Application', () => {
     rawApp['scene'] = sceneManager;
     rawApp['_activeClock'] = activeClock;
     rawApp['_frameClock'] = frameClock;
+    rawApp['_fixed'] = { advance: () => 0, alpha: 0 };
 
     app.stop();
     await Promise.resolve();

--- a/test/core/fixed-timestep.test.ts
+++ b/test/core/fixed-timestep.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { FixedTimestep } from '#core/FixedTimestep';
+
+/**
+ * The fixed-timestep accumulator that converts variable frame deltas into a
+ * whole number of fixed-size steps plus a leftover interpolation alpha.
+ */
+describe('FixedTimestep', () => {
+  const STEP = 1000 / 60; // ms
+
+  it('runs one step when exactly one step of time elapses', () => {
+    const fixed = new FixedTimestep(STEP, 5);
+
+    expect(fixed.advance(STEP)).toBe(1);
+    expect(fixed.alpha).toBeCloseTo(0, 5);
+  });
+
+  it('runs no step and reports a fractional alpha for a partial step', () => {
+    const fixed = new FixedTimestep(STEP, 5);
+
+    expect(fixed.advance(STEP * 0.5)).toBe(0);
+    expect(fixed.alpha).toBeCloseTo(0.5, 5);
+  });
+
+  it('accumulates leftover time across frames', () => {
+    const fixed = new FixedTimestep(STEP, 5);
+
+    expect(fixed.advance(STEP * 0.7)).toBe(0);
+    expect(fixed.alpha).toBeCloseTo(0.7, 5);
+    expect(fixed.advance(STEP * 0.7)).toBe(1); // 1.4 steps accumulated → 1 step, 0.4 left
+    expect(fixed.alpha).toBeCloseTo(0.4, 5);
+  });
+
+  it('runs multiple steps for a multi-step delta', () => {
+    const fixed = new FixedTimestep(STEP, 5);
+
+    expect(fixed.advance(STEP * 3)).toBe(3);
+    expect(fixed.alpha).toBeCloseTo(0, 5);
+  });
+
+  it('caps steps at maxSteps and drops the backlog (spiral-of-death guard)', () => {
+    const fixed = new FixedTimestep(STEP, 5);
+
+    expect(fixed.advance(STEP * 100)).toBe(5); // capped
+    expect(fixed.alpha).toBeGreaterThanOrEqual(0);
+    expect(fixed.alpha).toBeLessThan(1); // backlog dropped, not carried into the next frame
+
+    expect(fixed.advance(STEP * 0.1)).toBeLessThanOrEqual(1); // no replay of the dropped backlog
+  });
+
+  it('reset() clears the accumulator', () => {
+    const fixed = new FixedTimestep(STEP, 5);
+
+    fixed.advance(STEP * 0.8);
+    fixed.reset();
+
+    expect(fixed.alpha).toBe(0);
+  });
+});

--- a/test/core/scene-manager.test.ts
+++ b/test/core/scene-manager.test.ts
@@ -92,7 +92,7 @@ const tick = (manager: SceneManager, milliseconds = 16): void => {
   manager.update(new Time(milliseconds));
 };
 
-type SceneHooks = Partial<Pick<Scene, 'load' | 'init' | 'update' | 'draw' | 'unload'>>;
+type SceneHooks = Partial<Pick<Scene, 'load' | 'init' | 'update' | 'fixedUpdate' | 'draw' | 'unload'>>;
 
 const makeScene = (hooks: SceneHooks = {}): Scene => Object.assign(new Scene(), hooks);
 
@@ -202,6 +202,21 @@ describe('SceneManager', () => {
     expect(manager.currentScene).toBe(second);
     expect(firstUnload).toHaveBeenCalledTimes(1);
     expect(secondInit).toHaveBeenCalledTimes(1);
+  });
+
+  test('fixedUpdate dispatches to the active scene unless it is paused', async () => {
+    const manager = new SceneManager(createApplicationStub());
+    const fixedUpdate = vi.fn();
+    const scene = makeScene({ fixedUpdate });
+
+    await manager.setScene(scene);
+
+    manager.fixedUpdate(new Time(16));
+    expect(fixedUpdate).toHaveBeenCalledTimes(1);
+
+    scene.paused = true;
+    manager.fixedUpdate(new Time(16));
+    expect(fixedUpdate).toHaveBeenCalledTimes(1); // paused → skipped
   });
 
   test('setScene to the already-active scene is a no-op', async () => {


### PR DESCRIPTION
## Fixed timestep (Gaffer's "Fix Your Timestep")

Decouples deterministic logic/physics from the variable render rate — the Unity `Update` / `FixedUpdate` split.

Each frame, after input, the loop runs **0..N fixed steps** (`scene.fixedUpdate(fixedDelta)` + `onFixedFrame`), then the variable `scene.update` / draw exactly as before. Put `physicsWorld.step(delta)` and movement in `fixedUpdate`; leave camera/UI/visual work in `update`.

**Always on, default `1/60`s, configurable** via `new Application({ fixedTimeStep })`. `fixedUpdate` is a no-op by default → existing games are behaviour-identical and the empty accumulator loop is free. (Discussed opt-in vs always-on: always-on wins — no behaviour change, negligible cost, and it makes the correct deterministic pattern discoverable.)

### What's added
- **`FixedTimestep`** (`@internal`): a pure accumulator → step count + interpolation `alpha`. An epsilon keeps exact multiples (e.g. 3×step) from losing a step to float error; a `maxSteps` spiral-of-death guard drops whole-step backlog instead of carrying it; `reset()` on start/resume so a paused gap is not caught up.
- **`Scene.fixedUpdate(delta)`** (no-op default) + **`SceneManager.fixedUpdate`** (skips a paused scene).
- **`Application.onFixedFrame`**, **`Application.frameAlpha`** (the leftover sub-step fraction for render interpolation — the scene graph is **not** auto-interpolated; alpha is exposed, lerp is opt-in), **`ApplicationOptions.fixedTimeStep`**.

### Tests
- `FixedTimestep` maths: steps per delta, accumulation, multi-step, spiral cap, reset (6).
- Loop: runs the right number of fixed steps, `onFixedFrame` per step, `frameAlpha` leftover, spiral cap at 5 (5).
- `SceneManager.fixedUpdate` skips a paused scene (1).

### Note
Three `Object.create(Application.prototype)` loop tests hand-build the app and stub the fields `update()` touches; they gained a `_fixed` no-op stub alongside `_frameClock`. API docs regenerated for the new members.

### Verification (local, CI-parity)
- ✅ core suite **2510/2510** green
- ✅ `verify:quick` (typecheck ×4 + lint:all + format:check + docs:api:check) — passed via pre-push