### PR TITLE
docs(api): wire physics / aseprite / ldtk into the generated API docs (F2)

### DIFF
--- a/site/scripts/build-api.ts
+++ b/site/scripts/build-api.ts
@@ -10,11 +10,40 @@ const repoRoot = path.resolve(siteRoot, '..');
 const outputDir = path.resolve(siteRoot, 'src', 'content', 'api');
 const toPosix = (value: string): string => value.replaceAll('\\', '/');
 
-type Subsystem = 'animation' | 'audio' | 'core' | 'debug' | 'input' | 'math' | 'particles' | 'rendering' | 'resources' | 'tiled' | 'tilemap';
+type Subsystem =
+    | 'animation'
+    | 'aseprite'
+    | 'audio'
+    | 'core'
+    | 'debug'
+    | 'input'
+    | 'ldtk'
+    | 'math'
+    | 'particles'
+    | 'physics'
+    | 'rendering'
+    | 'resources'
+    | 'tiled'
+    | 'tilemap';
 type ApiKind = 'class' | 'enum';
 type ApiTier = 'stable' | 'advanced';
 
-const SUBSYSTEMS: ReadonlyArray<Subsystem> = ['animation', 'audio', 'core', 'debug', 'input', 'math', 'particles', 'rendering', 'resources', 'tiled', 'tilemap'];
+const SUBSYSTEMS: ReadonlyArray<Subsystem> = [
+    'animation',
+    'aseprite',
+    'audio',
+    'core',
+    'debug',
+    'input',
+    'ldtk',
+    'math',
+    'particles',
+    'physics',
+    'rendering',
+    'resources',
+    'tiled',
+    'tilemap',
+];
 
 /**
  * Official extension packages documented as their own API surfaces, alongside
@@ -59,6 +88,27 @@ const EXTENSION_PACKAGES: ReadonlyArray<ExtensionPackage> = [
         entryPoint: 'packages/exojs-tiled/src/index.ts',
         tsconfig: 'packages/exojs-tiled/tsconfig.json',
         sourceMarker: 'packages/exojs-tiled/src/',
+    },
+    {
+        importPath: '@codexo/exojs-physics',
+        subsystem: 'physics',
+        entryPoint: 'packages/exojs-physics/src/index.ts',
+        tsconfig: 'packages/exojs-physics/tsconfig.json',
+        sourceMarker: 'packages/exojs-physics/src/',
+    },
+    {
+        importPath: '@codexo/exojs-aseprite',
+        subsystem: 'aseprite',
+        entryPoint: 'packages/exojs-aseprite/src/index.ts',
+        tsconfig: 'packages/exojs-aseprite/tsconfig.json',
+        sourceMarker: 'packages/exojs-aseprite/src/',
+    },
+    {
+        importPath: '@codexo/exojs-ldtk',
+        subsystem: 'ldtk',
+        entryPoint: 'packages/exojs-ldtk/src/index.ts',
+        tsconfig: 'packages/exojs-ldtk/tsconfig.json',
+        sourceMarker: 'packages/exojs-ldtk/src/',
     },
 ];
 
@@ -328,6 +378,12 @@ const convertEntryPoints = async (entryPoints: ReadonlyArray<string>, tsconfig: 
     const app = await Application.bootstrapWithPlugins({
         entryPoints: entryPoints.map(entry => toPosix(path.resolve(repoRoot, entry))),
         tsconfig: toPosix(path.resolve(repoRoot, tsconfig)),
+        // Pin the source-path base to the repo root so every package reports
+        // repo-relative file names (packages/<pkg>/src/…). Without this TypeDoc
+        // infers a per-package base for packages that pull in no core *source*
+        // files (e.g. physics), yielding package-relative paths that miss the
+        // sourceMarker filter and break source links.
+        basePath: toPosix(repoRoot),
         excludeInternal: true,
         modifierTags: MODIFIER_TAGS,
     });

--- a/site/src/content/api/aseprite-format-error.mdx
+++ b/site/src/content/api/aseprite-format-error.mdx
@@ -1,0 +1,35 @@
+---
+title: "AsepriteFormatError"
+description: "Thrown when an Aseprite JSON document does not match the expected shape. `source` is the URL of the file being parsed."
+symbol: "AsepriteFormatError"
+kind: "class"
+subsystem: "aseprite"
+importPath: "@codexo/exojs-aseprite"
+memberCount: 6
+tier: "stable"
+sections: ["Import", "Constructors", "Properties", "Source"]
+sourcePath: "packages/exojs-aseprite/src/asepriteBinding.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-aseprite/src/asepriteBinding.ts#L52"
+---
+## Import
+
+`import { AsepriteFormatError } from '@codexo/exojs-aseprite'`
+
+Thrown when an Aseprite JSON document does not match the expected shape.
+`source` is the URL of the file being parsed.
+
+## Constructors
+
+- `new(source: string, message: string): AsepriteFormatError`
+
+## Properties
+
+- `cause: unknown`
+- `message: string`
+- `name: string`
+- `source: string`
+- `stack: string`
+
+## Source
+
+[packages/exojs-aseprite/src/asepriteBinding.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-aseprite/src/asepriteBinding.ts#L52)

--- a/site/src/content/api/aseprite-sheet.mdx
+++ b/site/src/content/api/aseprite-sheet.mdx
@@ -1,0 +1,42 @@
+---
+title: "AsepriteSheet"
+description: "Parsed representation of an Aseprite JSON sprite sheet export. `AsepriteSheet.parse(data, texture)` converts the raw JSON document into: - A Spritesheet whose frames correspond to the Aseprite frame array (keyed by zero-based index string: `\"0\"`, `\"1\"`, …). - A `clips` map of AnimatedSpriteClipDefinition entries built from `meta.frameTags`, one per named tag. Call createAnimatedSprite to obtain a ready-to-use AnimatedSprite with all clips pre-registered."
+symbol: "AsepriteSheet"
+kind: "class"
+subsystem: "aseprite"
+importPath: "@codexo/exojs-aseprite"
+memberCount: 5
+tier: "stable"
+sections: ["Import", "Methods", "Properties", "Source"]
+sourcePath: "packages/exojs-aseprite/src/AsepriteSheet.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-aseprite/src/AsepriteSheet.ts#L56"
+---
+## Import
+
+`import { AsepriteSheet } from '@codexo/exojs-aseprite'`
+
+Parsed representation of an Aseprite JSON sprite sheet export.
+
+`AsepriteSheet.parse(data, texture)` converts the raw JSON document into:
+- A Spritesheet whose frames correspond to the Aseprite frame array
+  (keyed by zero-based index string: `"0"`, `"1"`, …).
+- A `clips` map of AnimatedSpriteClipDefinition entries built from
+  `meta.frameTags`, one per named tag.
+
+Call createAnimatedSprite to obtain a ready-to-use
+AnimatedSprite with all clips pre-registered.
+
+## Methods
+
+- `createAnimatedSprite(): AnimatedSprite`
+- `destroy(): void`
+- `parse(data: AsepriteData, texture: Texture): AsepriteSheet`
+
+## Properties
+
+- `clips: ReadonlyMap<string, AnimatedSpriteClipDefinition>`
+- `spritesheet: Spritesheet`
+
+## Source
+
+[packages/exojs-aseprite/src/AsepriteSheet.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-aseprite/src/AsepriteSheet.ts#L56)

--- a/site/src/content/api/box-shape.mdx
+++ b/site/src/content/api/box-shape.mdx
@@ -1,0 +1,42 @@
+---
+title: "BoxShape"
+description: "Axis-aligned box of `width × height` centred on the collider's local origin — a convenience over PolygonShape. The result is a regular polygon, so it participates in the polygon narrow phase like any other convex shape."
+symbol: "BoxShape"
+kind: "class"
+subsystem: "physics"
+importPath: "@codexo/exojs-physics"
+memberCount: 12
+tier: "stable"
+sections: ["Import", "Constructors", "Properties", "Source"]
+sourcePath: "packages/exojs-physics/src/shapes/BoxShape.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/shapes/BoxShape.ts#L8"
+---
+## Import
+
+`import { BoxShape } from '@codexo/exojs-physics'`
+
+Axis-aligned box of `width × height` centred on the collider's local origin —
+a convenience over PolygonShape. The result is a regular polygon, so
+it participates in the polygon narrow phase like any other convex shape.
+
+## Constructors
+
+- `new(width: number, height: number): BoxShape`
+
+## Properties
+
+- `area: number`
+- `boundingRadius: number`
+- `centroidX: number`
+- `centroidY: number`
+- `count: number`
+- `height: number`
+- `normals: readonly number[]`
+- `type: "polygon"`
+- `unitInertia: number`
+- `vertices: readonly number[]`
+- `width: number`
+
+## Source
+
+[packages/exojs-physics/src/shapes/BoxShape.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/shapes/BoxShape.ts#L8)

--- a/site/src/content/api/circle-shape.mdx
+++ b/site/src/content/api/circle-shape.mdx
@@ -1,0 +1,37 @@
+---
+title: "CircleShape"
+description: "A circle of the given `radius` centred on the collider's local origin. The cheapest shape for both broad- and narrow-phase."
+symbol: "CircleShape"
+kind: "class"
+subsystem: "physics"
+importPath: "@codexo/exojs-physics"
+memberCount: 8
+tier: "stable"
+sections: ["Import", "Constructors", "Properties", "Source"]
+sourcePath: "packages/exojs-physics/src/shapes/CircleShape.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/shapes/CircleShape.ts#L7"
+---
+## Import
+
+`import { CircleShape } from '@codexo/exojs-physics'`
+
+A circle of the given `radius` centred on the collider's local origin.
+The cheapest shape for both broad- and narrow-phase.
+
+## Constructors
+
+- `new(radius: number): CircleShape`
+
+## Properties
+
+- `area: number`
+- `boundingRadius: number`
+- `centroidX: 0`
+- `centroidY: 0`
+- `radius: number`
+- `type: "circle"`
+- `unitInertia: number`
+
+## Source
+
+[packages/exojs-physics/src/shapes/CircleShape.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/shapes/CircleShape.ts#L7)

--- a/site/src/content/api/collider.mdx
+++ b/site/src/content/api/collider.mdx
@@ -1,0 +1,59 @@
+---
+title: "Collider"
+description: "Geometry attached to a PhysicsBody: a Shape plus a body-local offset/rotation, material (friction/restitution/density) and a collision filter. A body may own several colliders (compound). The collider also caches its world-space geometry — refreshed by synchronize — which the broad phase, narrow phase and queries read directly. Material fields and the filter are mutable; the shape and local placement are immutable (rebuild the collider to change geometry)."
+symbol: "Collider"
+kind: "class"
+subsystem: "physics"
+importPath: "@codexo/exojs-physics"
+memberCount: 21
+tier: "stable"
+sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
+sourcePath: "packages/exojs-physics/src/Collider.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/Collider.ts#L40"
+---
+## Import
+
+`import { Collider } from '@codexo/exojs-physics'`
+
+Geometry attached to a PhysicsBody: a Shape plus a body-local
+offset/rotation, material (friction/restitution/density) and a collision
+filter. A body may own several colliders (compound). The collider also caches
+its world-space geometry — refreshed by synchronize — which the broad
+phase, narrow phase and queries read directly.
+
+Material fields and the filter are mutable; the shape and local placement are
+immutable (rebuild the collider to change geometry).
+
+## Constructors
+
+- `new(options: ColliderOptions): Collider`
+
+## Methods
+
+- `_markDestroyed(): void`
+- `synchronize(bodyTransform: Transform): void`
+
+## Properties
+
+- `density: number`
+- `filter: CollisionFilter`
+- `friction: number`
+- `isSensor: boolean`
+- `localRotation: number`
+- `offsetX: number`
+- `offsetY: number`
+- `restitution: number`
+- `shape: AnyShape`
+- `aabb: Readonly<Aabb>`
+- `body: PhysicsBody`
+- `destroyed: boolean`
+- `id: number`
+- `localTransform: Readonly<Transform>`
+- `worldCenter: Readonly<Mutable2D>`
+- `worldNormals: readonly number[]`
+- `worldTransform: Readonly<Transform>`
+- `worldVertices: readonly number[]`
+
+## Source
+
+[packages/exojs-physics/src/Collider.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/Collider.ts#L40)

--- a/site/src/content/api/distance-joint.mdx
+++ b/site/src/content/api/distance-joint.mdx
@@ -1,0 +1,40 @@
+---
+title: "DistanceJoint"
+description: "Holds the anchor points on two bodies at a target length along their connecting axis. With `hertz === 0` it is rigid; with `hertz > 0` it behaves as a damped spring. Solved as a soft constraint in the sub-step loop, warm- started across frames."
+symbol: "DistanceJoint"
+kind: "class"
+subsystem: "physics"
+importPath: "@codexo/exojs-physics"
+memberCount: 9
+tier: "stable"
+sections: ["Import", "Constructors", "Properties", "Source"]
+sourcePath: "packages/exojs-physics/src/joints/DistanceJoint.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/joints/DistanceJoint.ts#L42"
+---
+## Import
+
+`import { DistanceJoint } from '@codexo/exojs-physics'`
+
+Holds the anchor points on two bodies at a target length along their
+connecting axis. With `hertz === 0` it is rigid; with `hertz > 0` it behaves
+as a damped spring. Solved as a soft constraint in the sub-step loop, warm-
+started across frames.
+
+## Constructors
+
+- `new(options: DistanceJointOptions): DistanceJoint`
+
+## Properties
+
+- `bodyA: PhysicsBody`
+- `bodyB: PhysicsBody`
+- `dampingRatio: number`
+- `enabled: boolean`
+- `hertz: number`
+- `length: number`
+- `maxLength: number`
+- `minLength: number`
+
+## Source
+
+[packages/exojs-physics/src/joints/DistanceJoint.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/joints/DistanceJoint.ts#L42)

--- a/site/src/content/api/joint.mdx
+++ b/site/src/content/api/joint.mdx
@@ -1,0 +1,36 @@
+---
+title: "Joint"
+description: "Base class for a two-body constraint solved alongside contacts in the sub-step loop. Concrete joints (distance, revolute, weld) implement the three solver hooks; the world owns the joint list and drives them, and joins the two bodies into one sleep island so a jointed pair sleeps and wakes together."
+symbol: "Joint"
+kind: "class"
+subsystem: "physics"
+importPath: "@codexo/exojs-physics"
+memberCount: 4
+tier: "stable"
+sections: ["Import", "Constructors", "Properties", "Source"]
+sourcePath: "packages/exojs-physics/src/joints/Joint.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/joints/Joint.ts#L10"
+---
+## Import
+
+`import { Joint } from '@codexo/exojs-physics'`
+
+Base class for a two-body constraint solved alongside contacts in the
+sub-step loop. Concrete joints (distance, revolute, weld) implement the
+three solver hooks; the world owns the joint list and drives them, and joins
+the two bodies into one sleep island so a jointed pair sleeps and wakes
+together.
+
+## Constructors
+
+- `new(bodyA: PhysicsBody, bodyB: PhysicsBody): Joint`
+
+## Properties
+
+- `bodyA: PhysicsBody`
+- `bodyB: PhysicsBody`
+- `enabled: boolean`
+
+## Source
+
+[packages/exojs-physics/src/joints/Joint.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/joints/Joint.ts#L10)

--- a/site/src/content/api/ldtk-map.mdx
+++ b/site/src/content/api/ldtk-map.mdx
@@ -1,0 +1,46 @@
+---
+title: "LdtkMap"
+description: "A parsed LDtk world document: holds the raw JSON data and the converted runtime TileMap for each level. `LdtkMap` is the parsed source model. Each LDtk level is independently convertible to a format-independent `TileMap`; access them via levels (by document order) or by name via getLevelByName. Construction is cheap — the runtime `TileMap[]` is supplied externally (built by import('./ldtkToTileMap').ldtkToTileMap). The map does **not** own tileset textures; those remain in the Loader cache."
+symbol: "LdtkMap"
+kind: "class"
+subsystem: "ldtk"
+importPath: "@codexo/exojs-ldtk"
+memberCount: 6
+tier: "stable"
+sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
+sourcePath: "packages/exojs-ldtk/src/LdtkMap.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-ldtk/src/LdtkMap.ts#L17"
+---
+## Import
+
+`import { LdtkMap } from '@codexo/exojs-ldtk'`
+
+A parsed LDtk world document: holds the raw JSON data and the converted
+runtime TileMap for each level.
+
+`LdtkMap` is the parsed source model. Each LDtk level is independently
+convertible to a format-independent `TileMap`; access them via
+levels (by document order) or by name via getLevelByName.
+
+Construction is cheap — the runtime `TileMap[]` is supplied externally
+(built by import('./ldtkToTileMap').ldtkToTileMap). The map does
+**not** own tileset textures; those remain in the Loader cache.
+
+## Constructors
+
+- `new(source: string, data: LdtkData, levels: readonly TileMap[]): LdtkMap`
+
+## Methods
+
+- `destroy(): void`
+- `getLevelByName(identifier: string): TileMap | undefined`
+
+## Properties
+
+- `data: LdtkData`
+- `levels: readonly TileMap[]`
+- `source: string`
+
+## Source
+
+[packages/exojs-ldtk/src/LdtkMap.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-ldtk/src/LdtkMap.ts#L17)

--- a/site/src/content/api/mouse-joint.mdx
+++ b/site/src/content/api/mouse-joint.mdx
@@ -1,0 +1,41 @@
+---
+title: "MouseJoint"
+description: "Softly pulls a single body's grab point toward a movable **target** point (typically the mouse cursor). The grab point is fixed on the body at creation; update target each frame to drag. A soft constraint bounded by maxForce — solved in the sub-step loop, warm-started. Internally the \"other\" body is a private static ground sentinel, so this is a single-body constraint that touches only the dragged body."
+symbol: "MouseJoint"
+kind: "class"
+subsystem: "physics"
+importPath: "@codexo/exojs-physics"
+memberCount: 8
+tier: "stable"
+sections: ["Import", "Constructors", "Properties", "Source"]
+sourcePath: "packages/exojs-physics/src/joints/MouseJoint.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/joints/MouseJoint.ts#L31"
+---
+## Import
+
+`import { MouseJoint } from '@codexo/exojs-physics'`
+
+Softly pulls a single body's grab point toward a movable **target** point
+(typically the mouse cursor). The grab point is fixed on the body at creation;
+update target each frame to drag. A soft constraint bounded by
+maxForce — solved in the sub-step loop, warm-started. Internally the
+"other" body is a private static ground sentinel, so this is a single-body
+constraint that touches only the dragged body.
+
+## Constructors
+
+- `new(options: MouseJointOptions): MouseJoint`
+
+## Properties
+
+- `bodyA: PhysicsBody`
+- `bodyB: PhysicsBody`
+- `dampingRatio: number`
+- `enabled: boolean`
+- `hertz: number`
+- `maxForce: number`
+- `target: VectorLike`
+
+## Source
+
+[packages/exojs-physics/src/joints/MouseJoint.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/joints/MouseJoint.ts#L31)

--- a/site/src/content/api/physics-binding.mdx
+++ b/site/src/content/api/physics-binding.mdx
@@ -1,0 +1,40 @@
+---
+title: "PhysicsBinding"
+description: "A link between a PhysicsBody and a SceneNode. After each PhysicsWorld.step, the body's world position **and rotation** are written onto the node (the body's angle is radians; the node's rotation is degrees). The node must be world-space-rooted; runtime scale is ignored and non-zero skew is rejected at bind time."
+symbol: "PhysicsBinding"
+kind: "class"
+subsystem: "physics"
+importPath: "@codexo/exojs-physics"
+memberCount: 5
+tier: "stable"
+sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
+sourcePath: "packages/exojs-physics/src/binding/PhysicsBinding.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/binding/PhysicsBinding.ts#L23"
+---
+## Import
+
+`import { PhysicsBinding } from '@codexo/exojs-physics'`
+
+A link between a PhysicsBody and a SceneNode. After each
+PhysicsWorld.step, the body's world position **and rotation** are
+written onto the node (the body's angle is radians; the node's rotation is
+degrees). The node must be world-space-rooted; runtime scale is ignored and
+non-zero skew is rejected at bind time.
+
+## Constructors
+
+- `new(body: PhysicsBody, node: SceneNode, drive: "body-to-node" | "node-to-body"): PhysicsBinding`
+
+## Methods
+
+- `sync(): void`
+
+## Properties
+
+- `body: PhysicsBody`
+- `drive: "body-to-node" | "node-to-body"`
+- `node: SceneNode`
+
+## Source
+
+[packages/exojs-physics/src/binding/PhysicsBinding.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/binding/PhysicsBinding.ts#L23)

--- a/site/src/content/api/physics-body.mdx
+++ b/site/src/content/api/physics-body.mdx
@@ -1,0 +1,76 @@
+---
+title: "PhysicsBody"
+description: "A rigid body: a world transform plus mass properties aggregated from its colliders. Dynamic bodies integrate under gravity, accumulated forces/torque and contact impulses each fixed sub-step; static bodies never move; kinematic bodies move by their velocity only and stay immovable under contacts. Drive a body with applyForce, applyTorque and applyImpulse, or set linearVelocityX/linearVelocityY/angularVelocity directly; reposition it (teleport, no velocity) with setTransform."
+symbol: "PhysicsBody"
+kind: "class"
+subsystem: "physics"
+importPath: "@codexo/exojs-physics"
+memberCount: 39
+tier: "stable"
+sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
+sourcePath: "packages/exojs-physics/src/PhysicsBody.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/PhysicsBody.ts#L48"
+---
+## Import
+
+`import { PhysicsBody } from '@codexo/exojs-physics'`
+
+A rigid body: a world transform plus mass properties aggregated from its
+colliders. Dynamic bodies integrate under gravity, accumulated forces/torque
+and contact impulses each fixed sub-step; static bodies never move; kinematic
+bodies move by their velocity only and stay immovable under contacts. Drive a
+body with applyForce, applyTorque and applyImpulse, or
+set linearVelocityX/linearVelocityY/angularVelocity
+directly; reposition it (teleport, no velocity) with setTransform.
+
+## Constructors
+
+- `new(options: BodyOptions): PhysicsBody`
+
+## Methods
+
+- `_markDestroyed(): void`
+- `_removeCollider(collider: Collider): void`
+- `addCollider(collider: Collider | ColliderOptions): Collider`
+- `applyForce(forceX: number, forceY: number): this`
+- `applyImpulse(impulseX: number, impulseY: number, pointX?: number, pointY?: number): this`
+- `applyTorque(torque: number): this`
+- `setTransform(position: VectorLike, angle: number): this`
+- `synchronizeColliders(): void`
+- `wake(): this`
+
+## Properties
+
+- `allowSleep: boolean`
+- `angularDamping: number`
+- `angularVelocity: number`
+- `fixedRotation: boolean`
+- `gravityScale: number`
+- `inertia: number`
+- `invInertia: number`
+- `invMass: number`
+- `isBullet: boolean`
+- `linearDamping: number`
+- `linearVelocityX: number`
+- `linearVelocityY: number`
+- `mass: number`
+- `type: BodyType`
+- `angle: number`
+- `attached: boolean`
+- `centerOfMassX: number`
+- `centerOfMassY: number`
+- `colliders: readonly Collider[]`
+- `destroyed: boolean`
+- `id: number`
+- `isMassReady: boolean`
+- `isSleeping: boolean`
+- `position: Vector`
+- `transform: Readonly<Transform>`
+- `worldCenterOfMassX: number`
+- `worldCenterOfMassY: number`
+- `x: number`
+- `y: number`
+
+## Source
+
+[packages/exojs-physics/src/PhysicsBody.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/PhysicsBody.ts#L48)

--- a/site/src/content/api/physics-world.mdx
+++ b/site/src/content/api/physics-world.mdx
@@ -1,0 +1,101 @@
+---
+title: "PhysicsWorld"
+description: "The collision/query world: owns bodies, colliders, the detection backend, bindings, the query engine and the fixed-step accumulator. Stepped by the caller (commonly from a `Scene.update`), each fixed sub-step it integrates body velocities, runs broad- and narrow-phase detection, solves contacts and integrates positions, then fires immutable contact/sensor events and writes bound node transforms. It holds **no module-level state**, so any number of worlds run in isolation (gate I-1). The dynamics are a native, warm-started **TGS-Soft** solver (Box2D-v3 \"soft step\"): each fixed step runs detection once, then several sub-steps, each integrating gravity over the sub-step and solving contacts with a soft position bias plus a bias-free relax pass; a 2-point block normal solve propagates stack loads, and restitution is a separate final pass. Decoupling stiffness from the iteration count keeps tall towers stable. The detection backend sits behind an internal seam, so the solver is swappable without touching this public surface. **Operating envelope.** The soft solver trades a little accuracy for robustness, so it has a few documented limits — each stays finite/stable and each is pinned by a gate in `dynamics.test.ts`: - **Mass ratio** — resting stacks are slop-accurate up to ~100:1. Beyond that the velocity-capped soft push-out (`maxBiasVelocity`) lets the lighter body settle progressively deeper (≈6px at 500:1, fully through a thin floor by ~5000:1) — always finite, never exploding (SG-MR3). - **No CCD** — detection runs once per fixed step with no swept test, so a body that travels farther than an obstacle's thickness in one step tunnels straight through it (it stays finite). Reliably stopping fast projectiles is a future bullet-mode feature (SG-X5). - **PhysicsWorldOptions.subStepCount** — the default `4` is load-bearing for tall-stack stability; lowering it below `2` visibly degrades stacking, so do not reduce it for performance."
+symbol: "PhysicsWorld"
+kind: "class"
+subsystem: "physics"
+importPath: "@codexo/exojs-physics"
+memberCount: 37
+tier: "stable"
+sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
+sourcePath: "packages/exojs-physics/src/PhysicsWorld.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/PhysicsWorld.ts#L124"
+---
+## Import
+
+`import { PhysicsWorld } from '@codexo/exojs-physics'`
+
+The collision/query world: owns bodies, colliders, the detection backend,
+bindings, the query engine and the fixed-step accumulator. Stepped by the
+caller (commonly from a `Scene.update`), each fixed sub-step it integrates
+body velocities, runs broad- and narrow-phase detection, solves contacts and
+integrates positions, then fires immutable contact/sensor events and writes
+bound node transforms. It holds **no module-level state**, so any number of
+worlds run in isolation (gate I-1).
+
+The dynamics are a native, warm-started **TGS-Soft** solver (Box2D-v3 "soft
+step"): each fixed step runs detection once, then several sub-steps, each
+integrating gravity over the sub-step and solving contacts with a soft
+position bias plus a bias-free relax pass; a 2-point block normal solve
+propagates stack loads, and restitution is a separate final pass. Decoupling
+stiffness from the iteration count keeps tall towers stable. The detection
+backend sits behind an internal seam, so the solver is swappable without
+touching this public surface.
+
+**Operating envelope.** The soft solver trades a little accuracy for
+robustness, so it has a few documented limits — each stays finite/stable and
+each is pinned by a gate in `dynamics.test.ts`:
+- **Mass ratio** — resting stacks are slop-accurate up to ~100:1. Beyond that
+  the velocity-capped soft push-out (`maxBiasVelocity`) lets the lighter body
+  settle progressively deeper (≈6px at 500:1, fully through a thin floor by
+  ~5000:1) — always finite, never exploding (SG-MR3).
+- **No CCD** — detection runs once per fixed step with no swept test, so a
+  body that travels farther than an obstacle's thickness in one step tunnels
+  straight through it (it stays finite). Reliably stopping fast projectiles is
+  a future bullet-mode feature (SG-X5).
+- **PhysicsWorldOptions.subStepCount** — the default `4` is
+  load-bearing for tall-stack stability; lowering it below `2` visibly
+  degrades stacking, so do not reduce it for performance.
+
+## Constructors
+
+- `new(options: PhysicsWorldOptions): PhysicsWorld`
+
+## Methods
+
+- `_allocateColliderId(): number`
+- `_registerCollider(collider: Collider): void`
+- `add(body: PhysicsBody): PhysicsBody`
+- `addJoint(joint: T): T`
+- `attach(node: SceneNode, options: AttachOptions): PhysicsBody`
+- `bind(body: PhysicsBody, node: SceneNode, options?: BindingOptions): PhysicsBinding`
+- `destroy(): void`
+- `destroyBody(body: PhysicsBody): void`
+- `destroyCollider(collider: Collider): void`
+- `forEachAabbHit(bounds: Aabb, filter: Partial<object> | undefined, callback: object): void`
+- `overlapShape(shape: AnyShape, position: VectorLike, filter?: Partial<object>, angle?: number): Collider[]`
+- `queryAabb(bounds: Aabb, filter?: Partial<object>, out?: Collider[]): Collider[]`
+- `queryPoint(point: VectorLike, filter?: Partial<object>): Collider[]`
+- `rayCast(origin: VectorLike, direction: VectorLike, filter?: Partial<object>, maxDistance?: number): RayHit | null`
+- `rayCastAll(origin: VectorLike, direction: VectorLike, filter?: Partial<object>, out?: RayHit[], maxDistance?: number): RayHit[]`
+- `removeJoint(joint: Joint): void`
+- `step(frameDeltaSeconds: number): void`
+- `unbind(body: PhysicsBody): void`
+
+## Properties
+
+- `contactHertz: number`
+- `dampingRatio: number`
+- `enableSleeping: boolean`
+- `gravity: Vector`
+- `interpolation: boolean`
+- `sleepAngularVelocity: number`
+- `sleepLinearVelocity: number`
+- `subStepCount: number`
+- `timeStepper: TimeStepper`
+- `timeToSleep: number`
+- `backend: PhysicsBackend`
+- `bodies: readonly PhysicsBody[]`
+- `colliders: readonly Collider[]`
+- `joints: readonly Joint[]`
+
+## Events
+
+- `onCollisionEnd: Signal<[CollisionEvent]>`
+- `onCollisionStart: Signal<[CollisionEvent]>`
+- `onSensorEnter: Signal<[SensorEvent]>`
+- `onSensorExit: Signal<[SensorEvent]>`
+
+## Source
+
+[packages/exojs-physics/src/PhysicsWorld.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/PhysicsWorld.ts#L124)

--- a/site/src/content/api/polygon-shape.mdx
+++ b/site/src/content/api/polygon-shape.mdx
@@ -1,0 +1,44 @@
+---
+title: "PolygonShape"
+description: "A convex polygon defined by ≥3 local-space vertices. Input vertices may be given in either winding; they are canonicalised to counter-clockwise and the outward edge normals are precomputed. Construction throws on any non-convex, degenerate, or under-specified input — there is no silent repair. Vertices and normals are exposed as flat `[x0, y0, x1, y1, …]` arrays to keep the narrow phase allocation-free; both are frozen."
+symbol: "PolygonShape"
+kind: "class"
+subsystem: "physics"
+importPath: "@codexo/exojs-physics"
+memberCount: 10
+tier: "stable"
+sections: ["Import", "Constructors", "Properties", "Source"]
+sourcePath: "packages/exojs-physics/src/shapes/PolygonShape.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/shapes/PolygonShape.ts#L16"
+---
+## Import
+
+`import { PolygonShape } from '@codexo/exojs-physics'`
+
+A convex polygon defined by ≥3 local-space vertices. Input vertices may be
+given in either winding; they are canonicalised to counter-clockwise and the
+outward edge normals are precomputed. Construction throws on any non-convex,
+degenerate, or under-specified input — there is no silent repair.
+
+Vertices and normals are exposed as flat `[x0, y0, x1, y1, …]` arrays to keep
+the narrow phase allocation-free; both are frozen.
+
+## Constructors
+
+- `new(vertices: readonly VectorLike[]): PolygonShape`
+
+## Properties
+
+- `area: number`
+- `boundingRadius: number`
+- `centroidX: number`
+- `centroidY: number`
+- `count: number`
+- `normals: readonly number[]`
+- `type: "polygon"`
+- `unitInertia: number`
+- `vertices: readonly number[]`
+
+## Source
+
+[packages/exojs-physics/src/shapes/PolygonShape.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/shapes/PolygonShape.ts#L16)

--- a/site/src/content/api/prismatic-joint.mdx
+++ b/site/src/content/api/prismatic-joint.mdx
@@ -1,0 +1,41 @@
+---
+title: "PrismaticJoint"
+description: "Constrains a body to **slide along a single axis** relative to another: the perpendicular translation and the relative rotation are locked (a 2×2 block); only translation along the axis is free, optionally driven by a motor and/or bounded by a translation limit. Solved in the sub-step loop, warm-started."
+symbol: "PrismaticJoint"
+kind: "class"
+subsystem: "physics"
+importPath: "@codexo/exojs-physics"
+memberCount: 10
+tier: "stable"
+sections: ["Import", "Constructors", "Properties", "Source"]
+sourcePath: "packages/exojs-physics/src/joints/PrismaticJoint.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/joints/PrismaticJoint.ts#L39"
+---
+## Import
+
+`import { PrismaticJoint } from '@codexo/exojs-physics'`
+
+Constrains a body to **slide along a single axis** relative to another: the
+perpendicular translation and the relative rotation are locked (a 2×2 block);
+only translation along the axis is free, optionally driven by a motor and/or
+bounded by a translation limit. Solved in the sub-step loop, warm-started.
+
+## Constructors
+
+- `new(options: PrismaticJointOptions): PrismaticJoint`
+
+## Properties
+
+- `bodyA: PhysicsBody`
+- `bodyB: PhysicsBody`
+- `enabled: boolean`
+- `enableLimit: boolean`
+- `enableMotor: boolean`
+- `lowerTranslation: number`
+- `maxMotorForce: number`
+- `motorSpeed: number`
+- `upperTranslation: number`
+
+## Source
+
+[packages/exojs-physics/src/joints/PrismaticJoint.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/joints/PrismaticJoint.ts#L39)

--- a/site/src/content/api/revolute-joint.mdx
+++ b/site/src/content/api/revolute-joint.mdx
@@ -1,0 +1,42 @@
+---
+title: "RevoluteJoint"
+description: "Pins a shared anchor point on two bodies (a hinge): the bodies may rotate freely about the pivot but the anchor points stay coincident. Solved as a 2-DOF point constraint (a 2×2 block) in the sub-step loop, warm-started."
+symbol: "RevoluteJoint"
+kind: "class"
+subsystem: "physics"
+importPath: "@codexo/exojs-physics"
+memberCount: 12
+tier: "stable"
+sections: ["Import", "Constructors", "Properties", "Source"]
+sourcePath: "packages/exojs-physics/src/joints/RevoluteJoint.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/joints/RevoluteJoint.ts#L40"
+---
+## Import
+
+`import { RevoluteJoint } from '@codexo/exojs-physics'`
+
+Pins a shared anchor point on two bodies (a hinge): the bodies may rotate
+freely about the pivot but the anchor points stay coincident. Solved as a
+2-DOF point constraint (a 2×2 block) in the sub-step loop, warm-started.
+
+## Constructors
+
+- `new(options: RevoluteJointOptions): RevoluteJoint`
+
+## Properties
+
+- `bodyA: PhysicsBody`
+- `bodyB: PhysicsBody`
+- `dampingRatio: number`
+- `enabled: boolean`
+- `enableLimit: boolean`
+- `enableMotor: boolean`
+- `hertz: number`
+- `lowerAngle: number`
+- `maxMotorTorque: number`
+- `motorSpeed: number`
+- `upperAngle: number`
+
+## Source
+
+[packages/exojs-physics/src/joints/RevoluteJoint.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/joints/RevoluteJoint.ts#L40)

--- a/site/src/content/api/shape.mdx
+++ b/site/src/content/api/shape.mdx
@@ -1,0 +1,43 @@
+---
+title: "Shape"
+description: "Immutable local-space collision geometry. A `Shape` carries no transform — a Collider positions it in a body. Shapes also expose the area-based mass properties (`area`, `centroid`, `unitInertia`) the body uses to derive mass and rotational inertia from a density; these are computed once at construction and frozen. `unitInertia` is the second moment of area about the shape's own centroid (∫ r² dA). Multiplying by density yields the rotational inertia contribution of the shape about its centroid."
+symbol: "Shape"
+kind: "class"
+subsystem: "physics"
+importPath: "@codexo/exojs-physics"
+memberCount: 7
+tier: "stable"
+sections: ["Import", "Constructors", "Properties", "Source"]
+sourcePath: "packages/exojs-physics/src/shapes/Shape.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/shapes/Shape.ts#L15"
+---
+## Import
+
+`import { Shape } from '@codexo/exojs-physics'`
+
+Immutable local-space collision geometry. A `Shape` carries no transform — a
+Collider positions it in a body. Shapes also expose the area-based
+mass properties (`area`, `centroid`, `unitInertia`) the body uses to derive
+mass and rotational inertia from a density; these are computed once at
+construction and frozen.
+
+`unitInertia` is the second moment of area about the shape's own centroid
+(∫ r² dA). Multiplying by density yields the rotational inertia contribution
+of the shape about its centroid.
+
+## Constructors
+
+- `new(): Shape`
+
+## Properties
+
+- `area: number`
+- `boundingRadius: number`
+- `centroidX: number`
+- `centroidY: number`
+- `type: ShapeType`
+- `unitInertia: number`
+
+## Source
+
+[packages/exojs-physics/src/shapes/Shape.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/shapes/Shape.ts#L15)

--- a/site/src/content/api/time-stepper.mdx
+++ b/site/src/content/api/time-stepper.mdx
@@ -1,0 +1,49 @@
+---
+title: "TimeStepper"
+description: "Fixed-timestep accumulator (package-owned; no engine clock dependency). Each frame, advance adds the variable frame delta to an internal accumulator and reports how many whole fixed sub-steps to run (`floor(accumulator / fixedDelta)`), clamped to maxSubSteps. When the clamp trips, the backlog beyond the clamp is discarded so a slow frame cannot cascade into an unbounded catch-up (the \"spiral of death\"). alpha is the leftover fraction of a step `[0, 1)`, for interpolating bound transforms between sub-steps. The stepper holds no mutable module-level state — two stepper instances are fully independent (world isolation, gate I-1)."
+symbol: "TimeStepper"
+kind: "class"
+subsystem: "physics"
+importPath: "@codexo/exojs-physics"
+memberCount: 7
+tier: "stable"
+sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
+sourcePath: "packages/exojs-physics/src/TimeStepper.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/TimeStepper.ts#L23"
+---
+## Import
+
+`import { TimeStepper } from '@codexo/exojs-physics'`
+
+Fixed-timestep accumulator (package-owned; no engine clock dependency). Each
+frame, advance adds the variable frame delta to an internal
+accumulator and reports how many whole fixed sub-steps to run
+(`floor(accumulator / fixedDelta)`), clamped to maxSubSteps. When the
+clamp trips, the backlog beyond the clamp is discarded so a slow frame cannot
+cascade into an unbounded catch-up (the "spiral of death").
+
+alpha is the leftover fraction of a step `[0, 1)`, for interpolating
+bound transforms between sub-steps.
+
+The stepper holds no mutable module-level state — two stepper instances are
+fully independent (world isolation, gate I-1).
+
+## Constructors
+
+- `new(options: TimeStepperOptions): TimeStepper`
+
+## Methods
+
+- `advance(frameDeltaSeconds: number): number`
+- `reset(): void`
+
+## Properties
+
+- `fixedDelta: number`
+- `maxSubSteps: number`
+- `accumulator: number`
+- `alpha: number`
+
+## Source
+
+[packages/exojs-physics/src/TimeStepper.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/TimeStepper.ts#L23)

--- a/site/src/content/api/weld-joint.mdx
+++ b/site/src/content/api/weld-joint.mdx
@@ -1,0 +1,39 @@
+---
+title: "WeldJoint"
+description: "Rigidly fixes the relative position and orientation of two bodies (they move as one rigid body). A 2-DOF point constraint (like RevoluteJoint) plus a 1-DOF angular constraint, solved in the sub-step loop. Both locks default to rigid; set `linearHertz`/`angularHertz` for a springy weld."
+symbol: "WeldJoint"
+kind: "class"
+subsystem: "physics"
+importPath: "@codexo/exojs-physics"
+memberCount: 8
+tier: "stable"
+sections: ["Import", "Constructors", "Properties", "Source"]
+sourcePath: "packages/exojs-physics/src/joints/WeldJoint.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/joints/WeldJoint.ts#L57"
+---
+## Import
+
+`import { WeldJoint } from '@codexo/exojs-physics'`
+
+Rigidly fixes the relative position and orientation of two bodies (they move
+as one rigid body). A 2-DOF point constraint (like RevoluteJoint) plus
+a 1-DOF angular constraint, solved in the sub-step loop. Both locks default to
+rigid; set `linearHertz`/`angularHertz` for a springy weld.
+
+## Constructors
+
+- `new(options: WeldJointOptions): WeldJoint`
+
+## Properties
+
+- `angularHertz: number`
+- `bodyA: PhysicsBody`
+- `bodyB: PhysicsBody`
+- `dampingRatio: number`
+- `enabled: boolean`
+- `linearHertz: number`
+- `referenceAngle: number`
+
+## Source
+
+[packages/exojs-physics/src/joints/WeldJoint.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/joints/WeldJoint.ts#L57)

--- a/site/src/content/api/wheel-joint.mdx
+++ b/site/src/content/api/wheel-joint.mdx
@@ -1,0 +1,40 @@
+---
+title: "WheelJoint"
+description: "A wheel attached to a chassis: free to **spin** (no rotation lock) and sprung along a **suspension axis** (a soft spring), but locked **laterally** (it cannot slide perpendicular to the axis). Optionally driven by a rotation motor. Used for vehicles. Solved in the sub-step loop, warm-started."
+symbol: "WheelJoint"
+kind: "class"
+subsystem: "physics"
+importPath: "@codexo/exojs-physics"
+memberCount: 9
+tier: "stable"
+sections: ["Import", "Constructors", "Properties", "Source"]
+sourcePath: "packages/exojs-physics/src/joints/WheelJoint.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/joints/WheelJoint.ts#L37"
+---
+## Import
+
+`import { WheelJoint } from '@codexo/exojs-physics'`
+
+A wheel attached to a chassis: free to **spin** (no rotation lock) and sprung
+along a **suspension axis** (a soft spring), but locked **laterally** (it
+cannot slide perpendicular to the axis). Optionally driven by a rotation
+motor. Used for vehicles. Solved in the sub-step loop, warm-started.
+
+## Constructors
+
+- `new(options: WheelJointOptions): WheelJoint`
+
+## Properties
+
+- `bodyA: PhysicsBody`
+- `bodyB: PhysicsBody`
+- `dampingRatio: number`
+- `enabled: boolean`
+- `enableMotor: boolean`
+- `hertz: number`
+- `maxMotorTorque: number`
+- `motorSpeed: number`
+
+## Source
+
+[packages/exojs-physics/src/joints/WheelJoint.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/joints/WheelJoint.ts#L37)

--- a/site/src/lib/api-reference.ts
+++ b/site/src/lib/api-reference.ts
@@ -2,7 +2,7 @@ import type { CollectionEntry } from 'astro:content';
 
 export type ApiEntry = CollectionEntry<'api'>;
 
-export const API_SUBSYSTEM_ORDER = ['core', 'rendering', 'input', 'audio', 'animation', 'resources', 'math', 'debug', 'particles', 'tilemap', 'tiled'] as const;
+export const API_SUBSYSTEM_ORDER = ['core', 'rendering', 'input', 'audio', 'animation', 'resources', 'math', 'debug', 'particles', 'tilemap', 'tiled', 'physics', 'aseprite', 'ldtk'] as const;
 
 export type ApiSubsystem = (typeof API_SUBSYSTEM_ORDER)[number];
 
@@ -50,6 +50,18 @@ export const API_SUBSYSTEM_META: Record<ApiSubsystem, { label: string; descripti
     tiled: {
         label: 'Tiled (official extension)',
         description: 'The @codexo/exojs-tiled package: load Tiled (.tmj) tilemaps through the loader.',
+    },
+    physics: {
+        label: 'Physics (official extension)',
+        description: 'The @codexo/exojs-physics package: rigid bodies, colliders, joints, sleeping, CCD, queries, and the TGS-Soft solver.',
+    },
+    aseprite: {
+        label: 'Aseprite (official extension)',
+        description: 'The @codexo/exojs-aseprite package: load Aseprite sprite sheets and their frame/tag animation data.',
+    },
+    ldtk: {
+        label: 'LDtk (official extension)',
+        description: 'The @codexo/exojs-ldtk package: load LDtk levels and layers through the loader.',
     },
 };
 


### PR DESCRIPTION
## F2 — Extension packages in the API docs

The separate extension packages were not in the API-doc generator. This adds **physics**, **aseprite** and **ldtk** to `build-api`'s `EXTENSION_PACKAGES` so their public classes/enums get MDX pages, plus the three new subsystems to the API navigation order + meta. **React stays hand-written** (hooks/JSX docs over generated API) — that lands with the guides (F3).

### Latent build-api bug fixed (surfaced by physics)
TypeDoc inferred a **per-package** source base for a package that pulls in no core *source* files (only type-only imports), so physics symbols reported package-relative file names (`shapes/BoxShape.ts`) that miss the `sourceMarker` filter **and** break source links — hence "no own symbols". Pinning `basePath` to the repo root makes every package report repo-relative paths (`packages/<pkg>/src/...`) consistently.

- Verified the fix is non-disruptive: **0** existing API pages changed (they were already repo-relative); only physics/aseprite/ldtk start generating.

### Generated
16 physics · 2 aseprite · 1 ldtk pages (269 total). Only **classes + enums** are paged (the generator's contract) — interfaces/types/functions aren't, so aseprite/ldtk are thin by design (their public surface is mostly data interfaces + a loader class).

### Verification (local, CI-parity)
- ✅ `verify:quick` (typecheck ×4 + lint:all + format:check + **docs:api:check**) — passed via pre-push; `docs:api:check` now gates these packages too.