### PR TITLE
test(aseprite, ldtk): meaningful characterization suites (F1)

### DIFF
--- a/packages/exojs-aseprite/test/aseprite-binding.test.ts
+++ b/packages/exojs-aseprite/test/aseprite-binding.test.ts
@@ -1,0 +1,166 @@
+import { readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+
+import { type AssetLoaderContext, Texture } from '@codexo/exojs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { asepriteBinding,AsepriteFormatError } from '../src/asepriteBinding';
+import { AsepriteSheet } from '../src/AsepriteSheet';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const PKG_DIR = basename(process.cwd()) === 'exojs-aseprite' ? process.cwd() : join(process.cwd(), 'packages', 'exojs-aseprite');
+const FIXTURES_DIR = join(PKG_DIR, 'test', 'fixtures');
+
+function loadFixture(name: string): unknown {
+  return JSON.parse(readFileSync(join(FIXTURES_DIR, name), 'utf-8'));
+}
+
+// ── Context factory ────────────────────────────────────────────────────────────
+
+function makeContext(fixtures: Record<string, unknown>) {
+  const loaderLoad = vi.fn();
+
+  const context: AssetLoaderContext = {
+    loader: { load: loaderLoad } as unknown as AssetLoaderContext['loader'],
+    identityKey: 'test',
+    fetchText: vi.fn(),
+    fetchArrayBuffer: vi.fn(),
+    fetchJson: vi.fn(async (source: string): Promise<unknown> => {
+      if (Object.hasOwn(fixtures, source)) return fixtures[source];
+      throw new Error(`aseprite-binding.test: no fixture for "${source}"`);
+    }),
+  };
+
+  loaderLoad.mockImplementation(async (token: unknown): Promise<unknown> => {
+    if (token === Texture) {
+      const tex = new Texture();
+      tex.width = 48;
+      tex.height = 16;
+      return tex;
+    }
+    throw new Error(`aseprite-binding.test: unexpected loader.load token: ${String(token)}`);
+  });
+
+  return { context, loaderLoad };
+}
+
+// ── Descriptor ───────────────────────────────────────────────────────────────
+
+describe('asepriteBinding descriptor', () => {
+  it('targets the AsepriteSheet constructor', () => {
+    expect(asepriteBinding.type).toBe(AsepriteSheet);
+  });
+
+  it('declares typeNames ["asepriteSheet"]', () => {
+    expect(asepriteBinding.typeNames).toEqual(['asepriteSheet']);
+  });
+
+  it('does NOT claim file extensions (token-only binding)', () => {
+    expect((asepriteBinding as { extensions?: unknown }).extensions).toBeUndefined();
+  });
+
+  it('create() returns a handler with a load function', () => {
+    expect(typeof asepriteBinding.create().load).toBe('function');
+  });
+
+  it('create() handler has no custom getIdentityKey (default source identity)', () => {
+    expect(asepriteBinding.create().getIdentityKey).toBeUndefined();
+  });
+});
+
+// ── load() — happy path ─────────────────────────────────────────────────────────
+
+describe('asepriteBinding.load — array fixture', () => {
+  const fixtures = { 'sprites/hero.json': loadFixture('hero.array.json') };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a fully-parsed AsepriteSheet', async () => {
+    const { context } = makeContext(fixtures);
+    const handler = asepriteBinding.create();
+    const sheet = await handler.load({ source: 'sprites/hero.json' }, context);
+    expect(sheet).toBeInstanceOf(AsepriteSheet);
+    expect(sheet.spritesheet.frames.size).toBe(3);
+    expect(sheet.clips.size).toBe(2);
+  });
+
+  it('resolves the packed image URL relative to the JSON source and sub-loads it as a Texture', async () => {
+    const { context, loaderLoad } = makeContext(fixtures);
+    const handler = asepriteBinding.create();
+    await handler.load({ source: 'sprites/hero.json' }, context);
+    expect(loaderLoad).toHaveBeenCalledWith(Texture, 'sprites/hero.png');
+  });
+
+  it('passes absolute image references through unchanged', async () => {
+    const doc = loadFixture('hero.array.json') as { meta: { image: string } };
+    doc.meta.image = 'https://cdn.example.com/hero.png';
+    const { context, loaderLoad } = makeContext({ 'sprites/hero.json': doc });
+    const handler = asepriteBinding.create();
+    await handler.load({ source: 'sprites/hero.json' }, context);
+    expect(loaderLoad).toHaveBeenCalledWith(Texture, 'https://cdn.example.com/hero.png');
+  });
+
+  it('loads the hash-form fixture identically', async () => {
+    const { context } = makeContext({ 'sprites/hero.json': loadFixture('hero.hash.json') });
+    const handler = asepriteBinding.create();
+    const sheet = await handler.load({ source: 'sprites/hero.json' }, context);
+    expect(sheet.spritesheet.frames.size).toBe(3);
+  });
+});
+
+// ── load() — validation / AsepriteFormatError ───────────────────────────────────
+
+describe('asepriteBinding.load — AsepriteFormatError on malformed input', () => {
+  async function loadRaw(raw: unknown): Promise<AsepriteSheet> {
+    const { context } = makeContext({ 'doc.json': raw });
+    return asepriteBinding.create().load({ source: 'doc.json' }, context);
+  }
+
+  it('rejects a non-object root', async () => {
+    await expect(loadRaw(null)).rejects.toThrow(/root must be an object/);
+    await expect(loadRaw(42)).rejects.toThrow(AsepriteFormatError);
+  });
+
+  it('rejects a document missing "frames"', async () => {
+    await expect(loadRaw({ meta: { image: 'x.png' } })).rejects.toThrow(/missing required field "frames"/);
+  });
+
+  it('rejects a document missing "meta"', async () => {
+    await expect(loadRaw({ frames: [] })).rejects.toThrow(/missing required field "meta"/);
+  });
+
+  it('rejects a document whose "meta" is not an object', async () => {
+    await expect(loadRaw({ frames: [], meta: null })).rejects.toThrow(/missing required field "meta"/);
+  });
+
+  it('rejects an empty or missing "meta.image"', async () => {
+    await expect(loadRaw({ frames: [], meta: { image: '' } })).rejects.toThrow(/"meta.image" must be a non-empty string/);
+    await expect(loadRaw({ frames: [], meta: {} })).rejects.toThrow(/"meta.image" must be a non-empty string/);
+  });
+
+  it('rejects "frames" that is neither an array nor an object', async () => {
+    await expect(loadRaw({ frames: 5, meta: { image: 'x.png' } })).rejects.toThrow(/"frames" must be an array or an object/);
+  });
+
+  it('attaches the source URL and typed name to the thrown error', async () => {
+    let caught: unknown;
+    try {
+      await loadRaw(null);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(AsepriteFormatError);
+    expect((caught as AsepriteFormatError).name).toBe('AsepriteFormatError');
+    expect((caught as AsepriteFormatError).source).toBe('doc.json');
+    expect((caught as Error).message).toContain('[AsepriteFormatError] doc.json:');
+  });
+
+  it('does not attempt to load a texture when validation fails', async () => {
+    const { context, loaderLoad } = makeContext({ 'doc.json': { frames: 5, meta: { image: 'x.png' } } });
+    await expect(asepriteBinding.create().load({ source: 'doc.json' }, context)).rejects.toThrow(AsepriteFormatError);
+    expect(loaderLoad).not.toHaveBeenCalled();
+  });
+});

--- a/packages/exojs-aseprite/test/aseprite-extension.test.ts
+++ b/packages/exojs-aseprite/test/aseprite-extension.test.ts
@@ -1,0 +1,85 @@
+import { ExtensionRegistry } from '@codexo/exojs/extensions';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { buildSnapshot } from '../../../src/extensions/snapshot';
+import { resetExtensionRegistryForTesting } from '../../../src/extensions/testing';
+import { asepriteBinding } from '../src/asepriteBinding';
+import { asepriteExtension } from '../src/asepriteExtension';
+
+// ── Descriptor ───────────────────────────────────────────────────────────────
+
+describe('asepriteExtension descriptor', () => {
+  it('has the package id', () => {
+    expect(asepriteExtension.id).toBe('@codexo/exojs-aseprite');
+  });
+
+  it('is a frozen, immutable descriptor', () => {
+    expect(Object.isFrozen(asepriteExtension)).toBe(true);
+  });
+
+  it('registers exactly one asset binding (the aseprite binding)', () => {
+    expect(asepriteExtension.assets).toHaveLength(1);
+    expect(asepriteExtension.assets![0]).toBe(asepriteBinding);
+  });
+
+  it('declares no dependencies, renderers, or serializers', () => {
+    expect(asepriteExtension.dependencies).toBeUndefined();
+    expect(asepriteExtension.renderers).toBeUndefined();
+    expect(asepriteExtension.serializers).toBeUndefined();
+  });
+});
+
+// ── buildSnapshot materialization ──────────────────────────────────────────────
+
+describe('buildSnapshot([asepriteExtension])', () => {
+  it('materializes a single extension with the aseprite binding', () => {
+    const snapshot = buildSnapshot([asepriteExtension]);
+    expect(snapshot.extensions.map(e => e.id)).toEqual(['@codexo/exojs-aseprite']);
+    expect(snapshot.assets).toHaveLength(1);
+    expect(snapshot.assets).toContain(asepriteBinding);
+  });
+
+  it('contributes no renderers or serializers', () => {
+    const snapshot = buildSnapshot([asepriteExtension]);
+    expect(snapshot.renderers).toHaveLength(0);
+    expect(snapshot.serializers).toHaveLength(0);
+  });
+});
+
+// ── Side-effect contract: root entry vs /register ───────────────────────────────
+
+describe('@codexo/exojs-aseprite root entry (side-effect-free)', () => {
+  beforeEach(() => {
+    resetExtensionRegistryForTesting();
+  });
+
+  it('root import does NOT register asepriteExtension in the ExtensionRegistry', async () => {
+    await import('../src/index');
+    expect(ExtensionRegistry.has('@codexo/exojs-aseprite')).toBe(false);
+  });
+});
+
+describe('@codexo/exojs-aseprite/register entry', () => {
+  beforeEach(() => {
+    resetExtensionRegistryForTesting();
+  });
+
+  it('registers asepriteExtension on import', async () => {
+    await import('../src/register');
+    expect(ExtensionRegistry.has('@codexo/exojs-aseprite')).toBe(true);
+  });
+});
+
+describe('export parity', () => {
+  it('root and register expose the same named exports', async () => {
+    const root = await import('../src/index');
+    const register = await import('../src/register');
+    const rootKeys = Object.keys(root)
+      .filter(k => k !== 'default')
+      .sort();
+    const registerKeys = Object.keys(register)
+      .filter(k => k !== 'default')
+      .sort();
+    expect(rootKeys).toEqual(registerKeys);
+  });
+});

--- a/packages/exojs-aseprite/test/aseprite-sheet.test.ts
+++ b/packages/exojs-aseprite/test/aseprite-sheet.test.ts
@@ -1,0 +1,280 @@
+import { readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+
+import { AnimatedSprite, Spritesheet, Texture } from '@codexo/exojs';
+import { describe, expect, it } from 'vitest';
+
+import type { AsepriteData } from '../src/AsepriteData';
+import { isAsepriteArrayData } from '../src/AsepriteData';
+import { AsepriteSheet } from '../src/AsepriteSheet';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const PKG_DIR = basename(process.cwd()) === 'exojs-aseprite' ? process.cwd() : join(process.cwd(), 'packages', 'exojs-aseprite');
+const FIXTURES_DIR = join(PKG_DIR, 'test', 'fixtures');
+
+function loadFixture(name: string): AsepriteData {
+  return JSON.parse(readFileSync(join(FIXTURES_DIR, name), 'utf-8')) as AsepriteData;
+}
+
+const arrayData = loadFixture('hero.array.json');
+const hashData = loadFixture('hero.hash.json');
+
+function newTexture(): Texture {
+  const tex = new Texture();
+  tex.width = 48;
+  tex.height = 16;
+
+  return tex;
+}
+
+// ── isAsepriteArrayData ────────────────────────────────────────────────────────
+
+describe('isAsepriteArrayData', () => {
+  it('returns true for the array-frames form', () => {
+    expect(isAsepriteArrayData(arrayData)).toBe(true);
+  });
+
+  it('returns false for the hash-frames form', () => {
+    expect(isAsepriteArrayData(hashData)).toBe(false);
+  });
+});
+
+// ── AsepriteSheet.parse — array form ───────────────────────────────────────────
+
+describe('AsepriteSheet.parse — array form', () => {
+  it('returns an AsepriteSheet instance', () => {
+    const sheet = AsepriteSheet.parse(arrayData, newTexture());
+    expect(sheet).toBeInstanceOf(AsepriteSheet);
+  });
+
+  it('builds a Spritesheet with one frame per Aseprite frame', () => {
+    const sheet = AsepriteSheet.parse(arrayData, newTexture());
+    expect(sheet.spritesheet).toBeInstanceOf(Spritesheet);
+    expect(sheet.spritesheet.frames.size).toBe(3);
+  });
+
+  it('keys spritesheet frames by zero-based index string', () => {
+    const sheet = AsepriteSheet.parse(arrayData, newTexture());
+    expect(sheet.spritesheet.frames.has('0')).toBe(true);
+    expect(sheet.spritesheet.frames.has('1')).toBe(true);
+    expect(sheet.spritesheet.frames.has('2')).toBe(true);
+  });
+
+  it('maps each frame rectangle to the Aseprite frame pixel region', () => {
+    const sheet = AsepriteSheet.parse(arrayData, newTexture());
+    const frame2 = sheet.spritesheet.getFrame('2');
+    expect(frame2.x).toBe(32);
+    expect(frame2.y).toBe(0);
+    expect(frame2.width).toBe(16);
+    expect(frame2.height).toBe(16);
+  });
+
+  it('forwards the supplied texture onto the Spritesheet', () => {
+    const texture = newTexture();
+    const sheet = AsepriteSheet.parse(arrayData, texture);
+    expect(sheet.spritesheet.texture).toBe(texture);
+  });
+});
+
+// ── AsepriteSheet.parse — clips from frameTags ─────────────────────────────────
+
+describe('AsepriteSheet.parse — clips from frameTags', () => {
+  it('creates one clip per frame tag', () => {
+    const sheet = AsepriteSheet.parse(arrayData, newTexture());
+    expect(sheet.clips.size).toBe(2);
+    expect(sheet.clips.has('walk')).toBe(true);
+    expect(sheet.clips.has('bounce')).toBe(true);
+  });
+
+  it('resolves a clip to one rectangle per inclusive frame in the [from,to] range', () => {
+    const sheet = AsepriteSheet.parse(arrayData, newTexture());
+    // walk: from 0 to 1 inclusive -> 2 frames.
+    expect(sheet.clips.get('walk')!.frames).toHaveLength(2);
+  });
+
+  it('clip frames are live references into the spritesheet frames', () => {
+    const sheet = AsepriteSheet.parse(arrayData, newTexture());
+    expect(sheet.clips.get('walk')!.frames[0]).toBe(sheet.spritesheet.getFrame('0'));
+    expect(sheet.clips.get('walk')!.frames[1]).toBe(sheet.spritesheet.getFrame('1'));
+  });
+
+  it('marks every clip as looping regardless of direction', () => {
+    const sheet = AsepriteSheet.parse(arrayData, newTexture());
+    expect(sheet.clips.get('walk')!.loop).toBe(true);
+    expect(sheet.clips.get('bounce')!.loop).toBe(true);
+  });
+
+  it('does NOT expand a pingpong tag into a reversed segment (plays only from->to)', () => {
+    const sheet = AsepriteSheet.parse(arrayData, newTexture());
+    // bounce: from 1 to 2 pingpong -> 2 frames (1, 2), not 3 (1, 2, 1).
+    expect(sheet.clips.get('bounce')!.frames).toHaveLength(2);
+  });
+
+  it('derives clip fps from the average frame duration (100ms -> 10fps)', () => {
+    const sheet = AsepriteSheet.parse(arrayData, newTexture());
+    expect(sheet.clips.get('walk')!.fps).toBe(10);
+  });
+});
+
+// ── AsepriteSheet.parse — fps averaging and fallbacks ──────────────────────────
+
+describe('AsepriteSheet.parse — fps derivation', () => {
+  function makeData(durations: number[], tag: { from: number; to: number }): AsepriteData {
+    return {
+      frames: durations.map((duration, i) => ({
+        duration,
+        frame: { x: i * 16, y: 0, w: 16, h: 16 },
+        rotated: false,
+        trimmed: false,
+        sourceSize: { w: 16, h: 16 },
+        spriteSourceSize: { x: 0, y: 0, w: 16, h: 16 },
+      })),
+      meta: {
+        app: 'aseprite',
+        version: '1.3',
+        image: 'x.png',
+        format: 'RGBA8888',
+        size: { w: 48, h: 16 },
+        scale: '1',
+        frameTags: [{ name: 'clip', from: tag.from, to: tag.to, direction: 'forward' }],
+      },
+    };
+  }
+
+  it('averages mixed durations across the range (100/200/300 -> 200ms -> 5fps)', () => {
+    const sheet = AsepriteSheet.parse(makeData([100, 200, 300], { from: 0, to: 2 }), newTexture());
+    expect(sheet.clips.get('clip')!.fps).toBe(5);
+  });
+
+  it('falls back to 12fps when all frame durations are zero', () => {
+    const sheet = AsepriteSheet.parse(makeData([0, 0, 0], { from: 0, to: 2 }), newTexture());
+    expect(sheet.clips.get('clip')!.fps).toBe(12);
+  });
+});
+
+// ── AsepriteSheet.parse — frame-index edge cases ───────────────────────────────
+
+describe('AsepriteSheet.parse — frame-index handling in tags', () => {
+  function makeData(tag: { from: number; to: number }): AsepriteData {
+    return {
+      frames: [0, 1, 2].map(i => ({
+        duration: 100,
+        frame: { x: i * 16, y: 0, w: 16, h: 16 },
+        rotated: false,
+        trimmed: false,
+        sourceSize: { w: 16, h: 16 },
+        spriteSourceSize: { x: 0, y: 0, w: 16, h: 16 },
+      })),
+      meta: {
+        app: 'aseprite',
+        version: '1.3',
+        image: 'x.png',
+        format: 'RGBA8888',
+        size: { w: 48, h: 16 },
+        scale: '1',
+        frameTags: [{ name: 'clip', from: tag.from, to: tag.to, direction: 'forward' }],
+      },
+    };
+  }
+
+  it('silently skips out-of-range frame indices in a tag', () => {
+    // from 1 to 10 against 3 frames -> only indices 1 and 2 resolve.
+    const sheet = AsepriteSheet.parse(makeData({ from: 1, to: 10 }), newTexture());
+    expect(sheet.clips.get('clip')!.frames).toHaveLength(2);
+  });
+
+  it('omits a clip whose entire range is out of bounds (zero resolved frames)', () => {
+    const sheet = AsepriteSheet.parse(makeData({ from: 5, to: 9 }), newTexture());
+    expect(sheet.clips.has('clip')).toBe(false);
+  });
+});
+
+// ── AsepriteSheet.parse — missing frameTags ────────────────────────────────────
+
+describe('AsepriteSheet.parse — no frame tags', () => {
+  it('produces an empty clips map when meta.frameTags is absent', () => {
+    const data: AsepriteData = {
+      frames: [
+        {
+          duration: 100,
+          frame: { x: 0, y: 0, w: 16, h: 16 },
+          rotated: false,
+          trimmed: false,
+          sourceSize: { w: 16, h: 16 },
+          spriteSourceSize: { x: 0, y: 0, w: 16, h: 16 },
+        },
+      ],
+      meta: {
+        app: 'aseprite',
+        version: '1.3',
+        image: 'x.png',
+        format: 'RGBA8888',
+        size: { w: 16, h: 16 },
+        scale: '1',
+      },
+    };
+    const sheet = AsepriteSheet.parse(data, newTexture());
+    expect(sheet.clips.size).toBe(0);
+  });
+});
+
+// ── AsepriteSheet.parse — hash form ────────────────────────────────────────────
+
+describe('AsepriteSheet.parse — hash form', () => {
+  it('produces the same frame count and index-string keys as the array form', () => {
+    const sheet = AsepriteSheet.parse(hashData, newTexture());
+    expect(sheet.spritesheet.frames.size).toBe(3);
+    // Frames are re-keyed by ordinal index, NOT by the hash filename keys.
+    expect(sheet.spritesheet.frames.has('0')).toBe(true);
+    expect(sheet.spritesheet.frames.has('hero 0.aseprite')).toBe(false);
+  });
+
+  it('preserves frame order from object insertion order', () => {
+    const sheet = AsepriteSheet.parse(hashData, newTexture());
+    expect(sheet.spritesheet.getFrame('1').x).toBe(16);
+  });
+
+  it('builds the same clips as the array form', () => {
+    const sheet = AsepriteSheet.parse(hashData, newTexture());
+    expect([...sheet.clips.keys()].sort()).toEqual(['bounce', 'walk']);
+  });
+});
+
+// ── createAnimatedSprite ───────────────────────────────────────────────────────
+
+describe('AsepriteSheet.createAnimatedSprite', () => {
+  it('returns an AnimatedSprite with every tag pre-defined as a playable clip', () => {
+    const sheet = AsepriteSheet.parse(arrayData, newTexture());
+    const sprite = sheet.createAnimatedSprite();
+    expect(sprite).toBeInstanceOf(AnimatedSprite);
+    expect(() => sprite.play('walk')).not.toThrow();
+    expect(() => sprite.play('bounce')).not.toThrow();
+  });
+
+  it('play() activates the named clip and adopts its looping flag', () => {
+    const sheet = AsepriteSheet.parse(arrayData, newTexture());
+    const sprite = sheet.createAnimatedSprite();
+    sprite.play('walk');
+    expect(sprite.currentClip).toBe('walk');
+    expect(sprite.playing).toBe(true);
+    expect(sprite.loop).toBe(true);
+  });
+
+  it('throws when playing a clip that has no matching tag', () => {
+    const sheet = AsepriteSheet.parse(arrayData, newTexture());
+    const sprite = sheet.createAnimatedSprite();
+    expect(() => sprite.play('missing')).toThrow(/clip "missing" is not defined/);
+  });
+});
+
+// ── destroy ────────────────────────────────────────────────────────────────────
+
+describe('AsepriteSheet.destroy', () => {
+  it('clears the underlying spritesheet frames', () => {
+    const sheet = AsepriteSheet.parse(arrayData, newTexture());
+    expect(sheet.spritesheet.frames.size).toBe(3);
+    sheet.destroy();
+    expect(sheet.spritesheet.frames.size).toBe(0);
+  });
+});

--- a/packages/exojs-aseprite/test/fixtures/hero.array.json
+++ b/packages/exojs-aseprite/test/fixtures/hero.array.json
@@ -1,0 +1,50 @@
+{
+  "frames": [
+    {
+      "filename": "hero 0.aseprite",
+      "frame": { "x": 0, "y": 0, "w": 16, "h": 16 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 16, "h": 16 },
+      "sourceSize": { "w": 16, "h": 16 },
+      "duration": 100
+    },
+    {
+      "filename": "hero 1.aseprite",
+      "frame": { "x": 16, "y": 0, "w": 16, "h": 16 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 16, "h": 16 },
+      "sourceSize": { "w": 16, "h": 16 },
+      "duration": 100
+    },
+    {
+      "filename": "hero 2.aseprite",
+      "frame": { "x": 32, "y": 0, "w": 16, "h": 16 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 16, "h": 16 },
+      "sourceSize": { "w": 16, "h": 16 },
+      "duration": 100
+    }
+  ],
+  "meta": {
+    "app": "https://www.aseprite.org/",
+    "version": "1.3.7",
+    "image": "hero.png",
+    "format": "RGBA8888",
+    "size": { "w": 48, "h": 16 },
+    "scale": "1",
+    "frameTags": [
+      { "name": "walk", "from": 0, "to": 1, "direction": "forward" },
+      { "name": "bounce", "from": 1, "to": 2, "direction": "pingpong" }
+    ],
+    "slices": [
+      {
+        "name": "hitbox",
+        "color": "#0000ffff",
+        "keys": [{ "frame": 0, "bounds": { "x": 2, "y": 2, "w": 12, "h": 12 } }]
+      }
+    ]
+  }
+}

--- a/packages/exojs-aseprite/test/fixtures/hero.hash.json
+++ b/packages/exojs-aseprite/test/fixtures/hero.hash.json
@@ -1,0 +1,47 @@
+{
+  "frames": {
+    "hero 0.aseprite": {
+      "frame": { "x": 0, "y": 0, "w": 16, "h": 16 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 16, "h": 16 },
+      "sourceSize": { "w": 16, "h": 16 },
+      "duration": 100
+    },
+    "hero 1.aseprite": {
+      "frame": { "x": 16, "y": 0, "w": 16, "h": 16 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 16, "h": 16 },
+      "sourceSize": { "w": 16, "h": 16 },
+      "duration": 100
+    },
+    "hero 2.aseprite": {
+      "frame": { "x": 32, "y": 0, "w": 16, "h": 16 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 16, "h": 16 },
+      "sourceSize": { "w": 16, "h": 16 },
+      "duration": 100
+    }
+  },
+  "meta": {
+    "app": "https://www.aseprite.org/",
+    "version": "1.3.7",
+    "image": "hero.png",
+    "format": "RGBA8888",
+    "size": { "w": 48, "h": 16 },
+    "scale": "1",
+    "frameTags": [
+      { "name": "walk", "from": 0, "to": 1, "direction": "forward" },
+      { "name": "bounce", "from": 1, "to": 2, "direction": "pingpong" }
+    ],
+    "slices": [
+      {
+        "name": "hitbox",
+        "color": "#0000ffff",
+        "keys": [{ "frame": 0, "bounds": { "x": 2, "y": 2, "w": 12, "h": 12 } }]
+      }
+    ]
+  }
+}

--- a/packages/exojs-ldtk/test/fixtures/world.ldtk
+++ b/packages/exojs-ldtk/test/fixtures/world.ldtk
@@ -1,0 +1,75 @@
+{
+  "jsonVersion": "1.5.3",
+  "defaultGridSize": 16,
+  "defs": {
+    "tilesets": [
+      {
+        "uid": 1,
+        "identifier": "Atlas",
+        "relPath": "tiles.png",
+        "tileGridSize": 16,
+        "pxWid": 64,
+        "pxHei": 64,
+        "spacing": 0,
+        "padding": 0
+      }
+    ],
+    "layers": [
+      { "uid": 101, "identifier": "Tiles", "type": "Tiles", "gridSize": 16, "tilesetDefUid": 1 },
+      { "uid": 102, "identifier": "Entities", "type": "Entities", "gridSize": 16 }
+    ]
+  },
+  "levels": [
+    {
+      "identifier": "Level_0",
+      "uid": 1,
+      "iid": "aaaaaaaa-0000-0000-0000-000000000001",
+      "worldX": 0,
+      "worldY": 0,
+      "pxWid": 64,
+      "pxHei": 64,
+      "layerInstances": [
+        {
+          "__identifier": "Tiles",
+          "__type": "Tiles",
+          "__cWid": 4,
+          "__cHei": 4,
+          "__gridSize": 16,
+          "layerDefUid": 101,
+          "levelId": 1,
+          "visible": true,
+          "iid": "bbbbbbbb-0000-0000-0000-000000000001",
+          "__tilesetDefUid": 1,
+          "gridTiles": [
+            { "px": [0, 0], "src": [0, 0], "f": 0, "t": 0 },
+            { "px": [16, 0], "src": [16, 0], "f": 1, "t": 1 }
+          ],
+          "autoLayerTiles": []
+        },
+        {
+          "__identifier": "Entities",
+          "__type": "Entities",
+          "__cWid": 4,
+          "__cHei": 4,
+          "__gridSize": 16,
+          "layerDefUid": 102,
+          "levelId": 1,
+          "visible": true,
+          "iid": "bbbbbbbb-0000-0000-0000-000000000002",
+          "entityInstances": [
+            {
+              "__identifier": "Player",
+              "__type": "Player",
+              "px": [8, 8],
+              "width": 16,
+              "height": 16,
+              "fieldInstances": [],
+              "iid": "cccccccc-0000-0000-0000-000000000001",
+              "defUid": 200
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/exojs-ldtk/test/ldtk-conversion.test.ts
+++ b/packages/exojs-ldtk/test/ldtk-conversion.test.ts
@@ -1,0 +1,764 @@
+import { type Texture, TextureRegion } from '@codexo/exojs';
+import { TileSet } from '@codexo/exojs-tilemap';
+import { describe, expect, it } from 'vitest';
+
+import type {
+  LdtkData,
+  LdtkEntityInstance,
+  LdtkLayerInstance,
+  LdtkLevel,
+} from '../src/LdtkData';
+import { ldtkFlipNone, ldtkFlipX, ldtkFlipXy, ldtkFlipY } from '../src/LdtkData';
+import { ldtkToTileMap } from '../src/ldtkToTileMap';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function fakeTexture(): Texture {
+  return {
+    width: 512,
+    height: 512,
+    uid: 0,
+    label: 'test',
+    destroy: () => {},
+    destroyed: false,
+  } as unknown as Texture;
+}
+
+function makeTileset(name = 'Atlas', tileCount = 4): TileSet {
+  return new TileSet({
+    name,
+    texture: new TextureRegion(fakeTexture(), { x: 0, y: 0, width: 512, height: 512 }),
+    tileWidth: 16,
+    tileHeight: 16,
+    tileCount,
+  });
+}
+
+/** Build a single-level document containing exactly one layer instance. */
+function docWithLayer(layer: LdtkLayerInstance, level: Partial<LdtkLevel> = {}): LdtkData {
+  return {
+    jsonVersion: '1.5.3',
+    defaultGridSize: 16,
+    defs: { tilesets: [], layers: [] },
+    levels: [
+      {
+        identifier: 'L',
+        uid: 1,
+        iid: 'iid-1',
+        worldX: 0,
+        worldY: 0,
+        pxWid: 64,
+        pxHei: 16,
+        layerInstances: [layer],
+        ...level,
+      },
+    ],
+  };
+}
+
+// ── Flip-bit constants ──────────────────────────────────────────────────────────
+
+describe('LDtk flip-bit constants', () => {
+  it('have the LDtk-documented values', () => {
+    expect(ldtkFlipNone).toBe(0);
+    expect(ldtkFlipX).toBe(1);
+    expect(ldtkFlipY).toBe(2);
+    expect(ldtkFlipXy).toBe(3);
+  });
+
+  it('compose as an X|Y bitmask', () => {
+    expect(ldtkFlipX | ldtkFlipY).toBe(ldtkFlipXy);
+    expect(ldtkFlipXy & ldtkFlipX).not.toBe(0);
+    expect(ldtkFlipXy & ldtkFlipY).not.toBe(0);
+    expect(ldtkFlipNone & ldtkFlipX).toBe(0);
+    expect(ldtkFlipNone & ldtkFlipY).toBe(0);
+  });
+});
+
+// ── Tile population + flip decoding (Tiles layer, WITH a tileset) ───────────────
+
+describe('ldtkToTileMap — tile population with a tileset', () => {
+  const tileset = makeTileset('Atlas', 4);
+
+  const data = docWithLayer({
+    __identifier: 'Tiles',
+    __type: 'Tiles',
+    __cWid: 4,
+    __cHei: 1,
+    __gridSize: 16,
+    layerDefUid: 101,
+    levelId: 1,
+    visible: true,
+    iid: 'tiles-1',
+    __tilesetDefUid: 1,
+    gridTiles: [
+      { px: [0, 0], src: [16, 0], f: 0, t: 1 }, // tx0, no flip
+      { px: [16, 0], src: [16, 0], f: 1, t: 1 }, // tx1, flipX
+      { px: [32, 0], src: [16, 0], f: 2, t: 1 }, // tx2, flipY
+      { px: [48, 0], src: [16, 0], f: 3, t: 1 }, // tx3, flipX + flipY
+    ],
+    autoLayerTiles: [],
+  });
+
+  function convert() {
+    return ldtkToTileMap(data, { tilesets: new Map([[1, tileset]]) });
+  }
+
+  it('places one tile per gridTiles entry', () => {
+    const layer = convert().levels[0]!.layers[0]!;
+    expect(layer.countNonEmptyTiles()).toBe(4);
+  });
+
+  it('decodes flip bits onto each tile transform', () => {
+    const layer = convert().levels[0]!.layers[0]!;
+
+    const none = layer.getTileAt(0, 0);
+    expect(none).not.toBeNull();
+    expect(none!.transform.flipX).toBe(false);
+    expect(none!.transform.flipY).toBe(false);
+
+    const flipX = layer.getTileAt(1, 0);
+    expect(flipX!.transform.flipX).toBe(true);
+    expect(flipX!.transform.flipY).toBe(false);
+
+    const flipY = layer.getTileAt(2, 0);
+    expect(flipY!.transform.flipX).toBe(false);
+    expect(flipY!.transform.flipY).toBe(true);
+
+    const flipXy = layer.getTileAt(3, 0);
+    expect(flipXy!.transform.flipX).toBe(true);
+    expect(flipXy!.transform.flipY).toBe(true);
+  });
+
+  it('never sets the diagonal transform (LDtk has no anti-diagonal flip)', () => {
+    const layer = convert().levels[0]!.layers[0]!;
+    for (let tx = 0; tx < 4; tx++) {
+      expect(layer.getTileAt(tx, 0)!.transform.diagonal).toBe(false);
+    }
+  });
+
+  it('maps the LDtk tile index `t` to the resolved localTileId and tileset', () => {
+    const tile = convert().levels[0]!.layers[0]!.getTileAt(0, 0)!;
+    expect(tile.localTileId).toBe(1);
+    expect(tile.tileset).toBe(tileset);
+  });
+});
+
+describe('ldtkToTileMap — tile population edge cases', () => {
+  const tileset = makeTileset('Atlas', 4);
+
+  it('skips tiles whose local index is out of the tileset range', () => {
+    const data = docWithLayer({
+      __identifier: 'Tiles',
+      __type: 'Tiles',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 101,
+      levelId: 1,
+      visible: true,
+      iid: 'tiles-1',
+      __tilesetDefUid: 1,
+      gridTiles: [
+        { px: [0, 0], src: [0, 0], f: 0, t: 0 }, // valid
+        { px: [16, 0], src: [0, 0], f: 0, t: 99 }, // t >= tileCount → skipped
+        { px: [32, 0], src: [0, 0], f: 0, t: -1 }, // t < 0 → skipped
+      ],
+      autoLayerTiles: [],
+    });
+
+    const layer = ldtkToTileMap(data, { tilesets: new Map([[1, tileset]]) }).levels[0]!
+      .layers[0]!;
+    expect(layer.countNonEmptyTiles()).toBe(1);
+    expect(layer.getTileAt(1, 0)).toBeNull();
+    expect(layer.getTileAt(2, 0)).toBeNull();
+  });
+
+  it('skips tiles that fall outside the layer grid', () => {
+    const data = docWithLayer({
+      __identifier: 'Tiles',
+      __type: 'Tiles',
+      __cWid: 2,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 101,
+      levelId: 1,
+      visible: true,
+      iid: 'tiles-1',
+      __tilesetDefUid: 1,
+      gridTiles: [
+        { px: [0, 0], src: [0, 0], f: 0, t: 0 }, // tx0, in bounds
+        { px: [48, 0], src: [0, 0], f: 0, t: 0 }, // tx3, out of bounds (width 2)
+      ],
+      autoLayerTiles: [],
+    });
+
+    const layer = ldtkToTileMap(data, { tilesets: new Map([[1, tileset]]) }).levels[0]!
+      .layers[0]!;
+    expect(layer.countNonEmptyTiles()).toBe(1);
+    expect(layer.getTileAt(0, 0)).not.toBeNull();
+  });
+
+  it('places no tiles when the layer references a tileset uid not in the map', () => {
+    const data = docWithLayer({
+      __identifier: 'Tiles',
+      __type: 'Tiles',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 101,
+      levelId: 1,
+      visible: true,
+      iid: 'tiles-1',
+      __tilesetDefUid: 999, // no entry in tilesets map
+      gridTiles: [{ px: [0, 0], src: [0, 0], f: 0, t: 0 }],
+      autoLayerTiles: [],
+    });
+
+    const layer = ldtkToTileMap(data, { tilesets: new Map([[1, tileset]]) }).levels[0]!
+      .layers[0]!;
+    expect(layer.countNonEmptyTiles()).toBe(0);
+  });
+});
+
+// ── AutoLayer + IntGrid render-tile sourcing ────────────────────────────────────
+
+describe('ldtkToTileMap — AutoLayer', () => {
+  const tileset = makeTileset('Atlas', 4);
+
+  it('renders from autoLayerTiles (not gridTiles) into a TileLayer', () => {
+    const data = docWithLayer({
+      __identifier: 'Walls',
+      __type: 'AutoLayer',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 110,
+      levelId: 1,
+      visible: true,
+      iid: 'auto-1',
+      __tilesetDefUid: 1,
+      autoLayerTiles: [{ px: [16, 0], src: [0, 0], f: 1, t: 2 }],
+    });
+
+    const map = ldtkToTileMap(data, { tilesets: new Map([[1, tileset]]) }).levels[0]!;
+    expect(map.layers).toHaveLength(1);
+    expect(map.objectLayers).toHaveLength(0);
+    const tile = map.layers[0]!.getTileAt(1, 0)!;
+    expect(tile.localTileId).toBe(2);
+    expect(tile.transform.flipX).toBe(true);
+  });
+});
+
+describe('ldtkToTileMap — IntGrid', () => {
+  const tileset = makeTileset('Atlas', 4);
+
+  it('renders auto-tiles when an IntGrid layer carries autoLayerTiles + a tileset', () => {
+    const data = docWithLayer({
+      __identifier: 'Collision',
+      __type: 'IntGrid',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 120,
+      levelId: 1,
+      visible: true,
+      iid: 'int-1',
+      __tilesetDefUid: 1,
+      intGridCsv: [1, 0, 0, 0],
+      autoLayerTiles: [{ px: [0, 0], src: [0, 0], f: 0, t: 3 }],
+    });
+
+    const layer = ldtkToTileMap(data, { tilesets: new Map([[1, tileset]]) }).levels[0]!
+      .layers[0]!;
+    expect(layer.countNonEmptyTiles()).toBe(1);
+    expect(layer.getTileAt(0, 0)!.localTileId).toBe(3);
+  });
+
+  it('produces a data-only (empty) TileLayer when IntGrid has no auto-tiles', () => {
+    const data = docWithLayer({
+      __identifier: 'Collision',
+      __type: 'IntGrid',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 120,
+      levelId: 1,
+      visible: true,
+      iid: 'int-1',
+      __tilesetDefUid: 1,
+      intGridCsv: [1, 2, 3, 4],
+    });
+
+    const layer = ldtkToTileMap(data, { tilesets: new Map([[1, tileset]]) }).levels[0]!
+      .layers[0]!;
+    expect(layer.countNonEmptyTiles()).toBe(0);
+    expect(layer.width).toBe(4);
+  });
+});
+
+// ── Grid-size derivation ────────────────────────────────────────────────────────
+
+describe('ldtkToTileMap — level tile size derivation', () => {
+  const tileset = makeTileset('Atlas', 4);
+
+  it('derives the map tile size from the first non-Entities layer', () => {
+    const data = docWithLayer(
+      {
+        __identifier: 'Tiles',
+        __type: 'Tiles',
+        __cWid: 2,
+        __cHei: 1,
+        __gridSize: 32, // differs from defaultGridSize (16)
+        layerDefUid: 101,
+        levelId: 1,
+        visible: true,
+        iid: 'tiles-1',
+        __tilesetDefUid: 1,
+        gridTiles: [],
+        autoLayerTiles: [],
+      },
+      { pxWid: 64, pxHei: 32 },
+    );
+
+    const map = ldtkToTileMap(data, { tilesets: new Map([[1, tileset]]) }).levels[0]!;
+    expect(map.tileWidth).toBe(32);
+    expect(map.tileHeight).toBe(32);
+    // 64 × 32 px at 32 px/tile → 2 × 1 tiles
+    expect(map.width).toBe(2);
+    expect(map.height).toBe(1);
+  });
+
+  it('skips Entities layers and falls back to data.defaultGridSize', () => {
+    const data = docWithLayer(
+      {
+        __identifier: 'Entities',
+        __type: 'Entities',
+        __cWid: 4,
+        __cHei: 4,
+        __gridSize: 16, // ignored: Entities layers do not contribute grid size
+        layerDefUid: 130,
+        levelId: 1,
+        visible: true,
+        iid: 'ent-1',
+        entityInstances: [],
+      },
+      { pxWid: 64, pxHei: 64 },
+    );
+    // Override defaultGridSize to prove the fallback is used (the lone Entities
+    // layer must NOT contribute its own __gridSize).
+    const tuned: LdtkData = { ...data, defaultGridSize: 8 };
+
+    const map = ldtkToTileMap(tuned).levels[0]!;
+    expect(map.tileWidth).toBe(8);
+    expect(map.width).toBe(8); // 64 / 8
+  });
+
+  it('falls back to 16 when defaultGridSize is absent', () => {
+    const data: LdtkData = {
+      jsonVersion: '1.5.3',
+      defs: { tilesets: [], layers: [] },
+      levels: [
+        {
+          identifier: 'L',
+          uid: 1,
+          iid: 'iid-1',
+          worldX: 0,
+          worldY: 0,
+          pxWid: 32,
+          pxHei: 32,
+          layerInstances: [],
+        },
+      ],
+    };
+
+    const map = ldtkToTileMap(data).levels[0]!;
+    expect(map.tileWidth).toBe(16);
+    expect(map.width).toBe(2);
+  });
+
+  it('clamps degenerate level dimensions to a minimum of 1 tile', () => {
+    const data: LdtkData = {
+      jsonVersion: '1.5.3',
+      defaultGridSize: 16,
+      defs: { tilesets: [], layers: [] },
+      levels: [
+        {
+          identifier: 'Tiny',
+          uid: 1,
+          iid: 'iid-1',
+          worldX: 0,
+          worldY: 0,
+          pxWid: 0,
+          pxHei: 8, // ceil(8/16) = 1
+          layerInstances: [],
+        },
+      ],
+    };
+
+    const map = ldtkToTileMap(data).levels[0]!;
+    expect(map.width).toBe(1);
+    expect(map.height).toBe(1);
+  });
+});
+
+// ── Level metadata / properties ─────────────────────────────────────────────────
+
+describe('ldtkToTileMap — level properties', () => {
+  it('stores the LDtk uid and iid alongside world coordinates', () => {
+    const data: LdtkData = {
+      jsonVersion: '1.5.3',
+      defaultGridSize: 16,
+      defs: { tilesets: [], layers: [] },
+      levels: [
+        {
+          identifier: 'L',
+          uid: 42,
+          iid: 'level-iid-42',
+          worldX: 100,
+          worldY: 200,
+          pxWid: 32,
+          pxHei: 32,
+          layerInstances: [],
+        },
+      ],
+    };
+
+    const map = ldtkToTileMap(data).levels[0]!;
+    expect(map.properties['ldtkUid']).toBe(42);
+    expect(map.properties['ldtkIid']).toBe('level-iid-42');
+    expect(map.properties['worldX']).toBe(100);
+    expect(map.properties['worldY']).toBe(200);
+  });
+
+  it('tolerates a level with null layerInstances (unloaded external level)', () => {
+    const data: LdtkData = {
+      jsonVersion: '1.5.3',
+      defaultGridSize: 16,
+      defs: { tilesets: [], layers: [] },
+      levels: [
+        {
+          identifier: 'External',
+          uid: 1,
+          iid: 'iid-1',
+          worldX: 0,
+          worldY: 0,
+          pxWid: 48,
+          pxHei: 16,
+          layerInstances: null,
+        },
+      ],
+    };
+
+    const map = ldtkToTileMap(data).levels[0]!;
+    expect(map.layers).toHaveLength(0);
+    expect(map.objectLayers).toHaveLength(0);
+    expect(map.width).toBe(3); // 48 / 16, default grid
+  });
+});
+
+// ── TileLayer metadata passthrough ──────────────────────────────────────────────
+
+describe('ldtkToTileMap — TileLayer metadata', () => {
+  it('forwards id, grid size, visibility, opacity and offsets to the TileLayer', () => {
+    const data = docWithLayer({
+      __identifier: 'Tiles',
+      __type: 'Tiles',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 101,
+      levelId: 1,
+      visible: false,
+      opacity: 0.25,
+      pxOffsetX: 7,
+      pxOffsetY: 9,
+      iid: 'tiles-1',
+      gridTiles: [],
+      autoLayerTiles: [],
+    });
+
+    const layer = ldtkToTileMap(data).levels[0]!.layers[0]!;
+    expect(layer.id).toBe(101);
+    expect(layer.name).toBe('Tiles');
+    expect(layer.tileWidth).toBe(16);
+    expect(layer.tileHeight).toBe(16);
+    expect(layer.visible).toBe(false);
+    expect(layer.opacity).toBe(0.25);
+    expect(layer.offsetX).toBe(7);
+    expect(layer.offsetY).toBe(9);
+  });
+});
+
+// ── Entity → ObjectLayer conversion ─────────────────────────────────────────────
+
+describe('ldtkToTileMap — entity field projection', () => {
+  it('keeps scalar fields and drops complex (array/object/null) field values', () => {
+    const data = docWithLayer({
+      __identifier: 'Entities',
+      __type: 'Entities',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 130,
+      levelId: 1,
+      visible: true,
+      iid: 'ent-1',
+      entityInstances: [
+        {
+          __identifier: 'NPC',
+          __type: 'NPC',
+          px: [0, 0],
+          width: 16,
+          height: 16,
+          iid: 'npc-1',
+          defUid: 300,
+          fieldInstances: [
+            { __identifier: 'hp', __type: 'Int', __value: 10 },
+            { __identifier: 'label', __type: 'String', __value: 'Bob' },
+            { __identifier: 'hostile', __type: 'Bool', __value: true },
+            { __identifier: 'path', __type: 'Array<Point>', __value: [{ cx: 1, cy: 2 }] },
+            { __identifier: 'meta', __type: 'Object', __value: { k: 1 } },
+            { __identifier: 'nothing', __type: 'String', __value: null },
+          ],
+        },
+      ],
+    });
+
+    const props = ldtkToTileMap(data).levels[0]!.objectLayers[0]!.objects[0]!.properties;
+    expect(props['hp']).toBe(10);
+    expect(props['label']).toBe('Bob');
+    expect(props['hostile']).toBe(true);
+    expect(props['path']).toBeUndefined();
+    expect(props['meta']).toBeUndefined();
+    expect(props['nothing']).toBeUndefined();
+  });
+
+  it('freezes the projected properties bag', () => {
+    const data = docWithLayer({
+      __identifier: 'Entities',
+      __type: 'Entities',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 130,
+      levelId: 1,
+      visible: true,
+      iid: 'ent-1',
+      entityInstances: [
+        {
+          __identifier: 'NPC',
+          __type: 'NPC',
+          px: [0, 0],
+          width: 16,
+          height: 16,
+          iid: 'npc-1',
+          defUid: 300,
+          fieldInstances: [{ __identifier: 'hp', __type: 'Int', __value: 10 }],
+        },
+      ],
+    });
+
+    const props = ldtkToTileMap(data).levels[0]!.objectLayers[0]!.objects[0]!.properties;
+    expect(Object.isFrozen(props)).toBe(true);
+  });
+
+  it('emits a frozen empty bag for entities without fields', () => {
+    const data = docWithLayer({
+      __identifier: 'Entities',
+      __type: 'Entities',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 130,
+      levelId: 1,
+      visible: true,
+      iid: 'ent-1',
+      entityInstances: [
+        {
+          __identifier: 'Marker',
+          __type: 'Marker',
+          px: [0, 0],
+          width: 0,
+          height: 0,
+          iid: 'm-1',
+          defUid: 301,
+          fieldInstances: [],
+        },
+      ],
+    });
+
+    const props = ldtkToTileMap(data).levels[0]!.objectLayers[0]!.objects[0]!.properties;
+    expect(props).toEqual({});
+    expect(Object.isFrozen(props)).toBe(true);
+  });
+
+  it('maps the entity __identifier to both name and type, with rectangle geometry', () => {
+    const data = docWithLayer({
+      __identifier: 'Entities',
+      __type: 'Entities',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 130,
+      levelId: 1,
+      visible: true,
+      iid: 'ent-1',
+      entityInstances: [
+        {
+          __identifier: 'Door',
+          __type: 'Door',
+          px: [3, 5],
+          width: 16,
+          height: 16,
+          iid: 'door-1',
+          defUid: 302,
+          fieldInstances: [],
+        },
+      ],
+    });
+
+    const object = ldtkToTileMap(data).levels[0]!.objectLayers[0]!.objects[0]!;
+    expect(object.name).toBe('Door');
+    expect(object.type).toBe('Door');
+    expect(object.kind).toBe('rectangle');
+    expect(object.rotation).toBe(0);
+    expect(object.visible).toBe(true);
+  });
+});
+
+describe('ldtkToTileMap — ObjectLayer metadata', () => {
+  it('forwards id, visibility, opacity and offsets to the ObjectLayer', () => {
+    const data = docWithLayer({
+      __identifier: 'Entities',
+      __type: 'Entities',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 130,
+      levelId: 1,
+      visible: false,
+      opacity: 0.5,
+      pxOffsetX: 4,
+      pxOffsetY: 6,
+      iid: 'ent-1',
+      entityInstances: [],
+    });
+
+    const objectLayer = ldtkToTileMap(data).levels[0]!.objectLayers[0]!;
+    expect(objectLayer.id).toBe(130);
+    expect(objectLayer.name).toBe('Entities');
+    expect(objectLayer.visible).toBe(false);
+    expect(objectLayer.opacity).toBe(0.5);
+    expect(objectLayer.offsetX).toBe(4);
+    expect(objectLayer.offsetY).toBe(6);
+  });
+});
+
+describe('ldtkToTileMap — entity id assignment across layers and levels', () => {
+  it('accumulates ids across multiple entity layers within one level', () => {
+    const data: LdtkData = {
+      jsonVersion: '1.5.3',
+      defaultGridSize: 16,
+      defs: { tilesets: [], layers: [] },
+      levels: [
+        {
+          identifier: 'L',
+          uid: 1,
+          iid: 'iid-1',
+          worldX: 0,
+          worldY: 0,
+          pxWid: 64,
+          pxHei: 16,
+          layerInstances: [
+            {
+              __identifier: 'EntitiesA',
+              __type: 'Entities',
+              __cWid: 4,
+              __cHei: 1,
+              __gridSize: 16,
+              layerDefUid: 130,
+              levelId: 1,
+              visible: true,
+              iid: 'ent-a',
+              entityInstances: [
+                makeEntity('A0'),
+                makeEntity('A1'),
+              ],
+            },
+            {
+              __identifier: 'EntitiesB',
+              __type: 'Entities',
+              __cWid: 4,
+              __cHei: 1,
+              __gridSize: 16,
+              layerDefUid: 131,
+              levelId: 1,
+              visible: true,
+              iid: 'ent-b',
+              entityInstances: [makeEntity('B0')],
+            },
+          ],
+        },
+      ],
+    };
+
+    const layers = ldtkToTileMap(data).levels[0]!.objectLayers;
+    expect(layers[0]!.objects.map(o => o.id)).toEqual([0, 1]);
+    expect(layers[1]!.objects.map(o => o.id)).toEqual([2]);
+  });
+
+  it('offsets ids by levelIndex * 1_000_000 so they stay globally unique', () => {
+    const data: LdtkData = {
+      jsonVersion: '1.5.3',
+      defaultGridSize: 16,
+      defs: { tilesets: [], layers: [] },
+      levels: [makeEntityLevel('L0', 1), makeEntityLevel('L1', 2)],
+    };
+
+    const result = ldtkToTileMap(data);
+    expect(result.levels[0]!.objectLayers[0]!.objects[0]!.id).toBe(0);
+    expect(result.levels[1]!.objectLayers[0]!.objects[0]!.id).toBe(1_000_000);
+  });
+});
+
+// ── Local builders for the multi-level id fixtures ──────────────────────────────
+
+function makeEntity(identifier: string): LdtkEntityInstance {
+  return {
+    __identifier: identifier,
+    __type: identifier,
+    px: [0, 0],
+    width: 16,
+    height: 16,
+    iid: `iid-${identifier}`,
+    defUid: 0,
+    fieldInstances: [],
+  };
+}
+
+function makeEntityLevel(identifier: string, uid: number): LdtkLevel {
+  return {
+    identifier,
+    uid,
+    iid: `iid-${uid}`,
+    worldX: 0,
+    worldY: 0,
+    pxWid: 64,
+    pxHei: 16,
+    layerInstances: [
+      {
+        __identifier: 'Entities',
+        __type: 'Entities',
+        __cWid: 4,
+        __cHei: 1,
+        __gridSize: 16,
+        layerDefUid: 130,
+        levelId: uid,
+        visible: true,
+        iid: `ent-${uid}`,
+        entityInstances: [makeEntity('E')],
+      },
+    ],
+  };
+}

--- a/packages/exojs-ldtk/test/ldtk-extension.test.ts
+++ b/packages/exojs-ldtk/test/ldtk-extension.test.ts
@@ -1,0 +1,108 @@
+import { ExtensionRegistry } from '@codexo/exojs/extensions';
+import { tilemapExtension } from '@codexo/exojs-tilemap';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { buildSnapshot } from '../../../src/extensions/snapshot';
+import { resetExtensionRegistryForTesting } from '../../../src/extensions/testing';
+import { ldtkMapBinding } from '../src/ldtkBinding';
+import { ldtkExtension } from '../src/ldtkExtension';
+import { LdtkMap } from '../src/LdtkMap';
+
+describe('@codexo/exojs-ldtk extension descriptor', () => {
+  it('has the correct id', () => {
+    expect(ldtkExtension.id).toBe('@codexo/exojs-ldtk');
+  });
+
+  it('declares tilemapExtension as a dependency (same object reference)', () => {
+    expect(ldtkExtension.dependencies).toBeDefined();
+    expect(ldtkExtension.dependencies).toContain(tilemapExtension);
+  });
+
+  it('carries exactly one asset binding (the LdtkMap binding)', () => {
+    expect(ldtkExtension.assets).toBeDefined();
+    expect(ldtkExtension.assets!.length).toBe(1);
+    expect(ldtkExtension.assets![0]).toBe(ldtkMapBinding);
+  });
+
+  it('is a frozen descriptor', () => {
+    expect(Object.isFrozen(ldtkExtension)).toBe(true);
+  });
+});
+
+describe('@codexo/exojs-ldtk asset binding — ldtkMapBinding', () => {
+  it('targets the LdtkMap constructor', () => {
+    expect(ldtkMapBinding.type).toBe(LdtkMap);
+  });
+
+  it('has typeNames ["ldtkMap"]', () => {
+    expect(ldtkMapBinding.typeNames).toEqual(['ldtkMap']);
+  });
+
+  it('claims the .ldtk file extension', () => {
+    expect(ldtkMapBinding.extensions).toEqual(['ldtk']);
+  });
+
+  it('create() returns a handler with a load function', () => {
+    const handler = ldtkMapBinding.create();
+    expect(typeof handler.load).toBe('function');
+  });
+});
+
+describe('buildSnapshot([ldtkExtension])', () => {
+  it('materializes tilemapExtension before ldtkExtension', () => {
+    const snapshot = buildSnapshot([ldtkExtension]);
+    expect(snapshot.extensions.map(e => e.id)).toEqual([
+      '@codexo/exojs-tilemap',
+      '@codexo/exojs-ldtk',
+    ]);
+  });
+
+  it('collects the single LDtk asset binding', () => {
+    const snapshot = buildSnapshot([ldtkExtension]);
+    expect(snapshot.assets).toHaveLength(1);
+    expect(snapshot.assets).toContain(ldtkMapBinding);
+  });
+
+  it('pulls in the tilemap renderer binding (one-extension rendering)', () => {
+    const snapshot = buildSnapshot([ldtkExtension]);
+    // The tilemap dependency contributes its tile chunk renderer binding, so an
+    // LDtk-only setup can both load AND render without manual registration.
+    expect(snapshot.renderers).toHaveLength(1);
+  });
+});
+
+describe('@codexo/exojs-ldtk root entry (side-effect-free)', () => {
+  beforeEach(() => {
+    resetExtensionRegistryForTesting();
+  });
+
+  it('root import does NOT register ldtkExtension in ExtensionRegistry', async () => {
+    await import('../src/index');
+    expect(ExtensionRegistry.has('@codexo/exojs-ldtk')).toBe(false);
+  });
+});
+
+describe('@codexo/exojs-ldtk/register entry', () => {
+  beforeEach(() => {
+    resetExtensionRegistryForTesting();
+  });
+
+  it('registers ldtkExtension on import', async () => {
+    await import('../src/register');
+    expect(ExtensionRegistry.has('@codexo/exojs-ldtk')).toBe(true);
+  });
+});
+
+describe('export parity', () => {
+  it('root and register have the same named exports', async () => {
+    const root = await import('../src/index');
+    const register = await import('../src/register');
+    const rootKeys = Object.keys(root)
+      .filter(k => k !== 'default')
+      .sort();
+    const registerKeys = Object.keys(register)
+      .filter(k => k !== 'default')
+      .sort();
+    expect(rootKeys).toEqual(registerKeys);
+  });
+});

--- a/packages/exojs-ldtk/test/ldtk-map.test.ts
+++ b/packages/exojs-ldtk/test/ldtk-map.test.ts
@@ -1,0 +1,131 @@
+import type { TileMap } from '@codexo/exojs-tilemap';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { LdtkData, LdtkLevel } from '../src/LdtkData';
+import { LdtkMap } from '../src/LdtkMap';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+/** Build a bare LDtk level record with only the fields LdtkMap reads. */
+function makeLevel(identifier: string, uid: number): LdtkLevel {
+  return {
+    identifier,
+    uid,
+    iid: `iid-${uid}`,
+    worldX: 0,
+    worldY: 0,
+    pxWid: 16,
+    pxHei: 16,
+    layerInstances: [],
+  };
+}
+
+/** Build LdtkData carrying the given level identifiers (in order). */
+function makeData(identifiers: readonly string[]): LdtkData {
+  return {
+    jsonVersion: '1.5.3',
+    defaultGridSize: 16,
+    defs: { tilesets: [], layers: [] },
+    levels: identifiers.map((id, i) => makeLevel(id, i + 1)),
+  };
+}
+
+/**
+ * A stand-in TileMap that records destroy() calls. LdtkMap only ever calls
+ * `destroy()` on its levels and otherwise stores the references opaquely, so a
+ * spy object is sufficient and keeps the unit isolated from TileMap internals.
+ */
+function makeFakeTileMap(): TileMap & { destroy: ReturnType<typeof vi.fn> } {
+  return { destroy: vi.fn() } as unknown as TileMap & {
+    destroy: ReturnType<typeof vi.fn>;
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('LdtkMap construction', () => {
+  it('stores source, data, and levels by reference', () => {
+    const data = makeData(['A']);
+    const levels = [makeFakeTileMap()];
+    const map = new LdtkMap('world.ldtk', data, levels);
+
+    expect(map.source).toBe('world.ldtk');
+    expect(map.data).toBe(data);
+    expect(map.levels).toBe(levels);
+  });
+
+  it('keeps levels index-aligned with data.levels', () => {
+    const data = makeData(['First', 'Second']);
+    const first = makeFakeTileMap();
+    const second = makeFakeTileMap();
+    const map = new LdtkMap('', data, [first, second]);
+
+    expect(map.levels[0]).toBe(first);
+    expect(map.levels[1]).toBe(second);
+  });
+});
+
+describe('LdtkMap.getLevelByName', () => {
+  it('returns the runtime TileMap at the matching level index', () => {
+    const data = makeData(['Intro', 'Boss']);
+    const intro = makeFakeTileMap();
+    const boss = makeFakeTileMap();
+    const map = new LdtkMap('', data, [intro, boss]);
+
+    expect(map.getLevelByName('Intro')).toBe(intro);
+    expect(map.getLevelByName('Boss')).toBe(boss);
+  });
+
+  it('returns undefined for an unknown identifier', () => {
+    const map = new LdtkMap('', makeData(['Only']), [makeFakeTileMap()]);
+    expect(map.getLevelByName('Missing')).toBeUndefined();
+  });
+
+  it('resolves to the first level when identifiers are duplicated (findIndex semantics)', () => {
+    const data = makeData(['Dup', 'Dup']);
+    const firstDup = makeFakeTileMap();
+    const secondDup = makeFakeTileMap();
+    const map = new LdtkMap('', data, [firstDup, secondDup]);
+
+    expect(map.getLevelByName('Dup')).toBe(firstDup);
+  });
+
+  it('returns undefined for a level whose TileMap slot was skipped (sparse levels)', () => {
+    // data has two levels but only the first was converted; the second slot is
+    // a hole. getLevelByName resolves the index then reads the (absent) slot.
+    const data = makeData(['Loaded', 'External']);
+    const map = new LdtkMap('', data, [makeFakeTileMap()]);
+
+    expect(map.getLevelByName('External')).toBeUndefined();
+  });
+});
+
+describe('LdtkMap.destroy', () => {
+  it('destroys every owned level exactly once', () => {
+    const a = makeFakeTileMap();
+    const b = makeFakeTileMap();
+    const map = new LdtkMap('', makeData(['A', 'B']), [a, b]);
+
+    map.destroy();
+
+    expect(a.destroy).toHaveBeenCalledTimes(1);
+    expect(b.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards destroy() to each level again on a repeat call (delegates idempotence to TileMap)', () => {
+    // LdtkMap.destroy does not guard itself — it simply forwards to each level,
+    // relying on TileMap.destroy being idempotent. Characterize that forwarding.
+    const a = makeFakeTileMap();
+    const map = new LdtkMap('', makeData(['A']), [a]);
+
+    map.destroy();
+    map.destroy();
+
+    expect(a.destroy).toHaveBeenCalledTimes(2);
+  });
+
+  it('does nothing when there are no levels', () => {
+    const map = new LdtkMap('', makeData([]), []);
+    expect(() => map.destroy()).not.toThrow();
+  });
+});

--- a/packages/exojs-ldtk/test/load-ldtk-map.test.ts
+++ b/packages/exojs-ldtk/test/load-ldtk-map.test.ts
@@ -1,0 +1,260 @@
+import { readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+
+import { type AssetLoaderContext, Texture } from '@codexo/exojs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { LdtkData } from '../src/LdtkData';
+import { LdtkMap } from '../src/LdtkMap';
+import { loadLdtkMap } from '../src/loadLdtkMap';
+
+// ── Fixture loading ───────────────────────────────────────────────────────────
+
+// Support both "pnpm test" (cwd=repo root) and "pnpm --filter ... test" (cwd=package).
+const PKG_DIR =
+  basename(process.cwd()) === 'exojs-ldtk'
+    ? process.cwd()
+    : join(process.cwd(), 'packages', 'exojs-ldtk');
+const FIXTURES_DIR = join(PKG_DIR, 'test', 'fixtures');
+
+function loadFixture(name: string): unknown {
+  return JSON.parse(readFileSync(join(FIXTURES_DIR, name), 'utf-8'));
+}
+
+// ── Mock context factory ────────────────────────────────────────────────────────
+
+// A texture large enough that any fixture's atlas region fits inside it.
+// TextureRegion validates against the *underlying* texture's intrinsic size, so
+// a default-constructed (0x0) Texture would be rejected during tileset assembly.
+function fakeTexture(): Texture {
+  return {
+    width: 4096,
+    height: 4096,
+    uid: 0,
+    label: 'test',
+    destroy: () => {},
+    destroyed: false,
+  } as unknown as Texture;
+}
+
+function makeContext(fixtures: Record<string, unknown>) {
+  const loaderLoad = vi.fn(
+    async (_token: unknown, _url: string): Promise<Texture> => fakeTexture(),
+  );
+
+  const context: AssetLoaderContext = {
+    loader: { load: loaderLoad } as unknown as AssetLoaderContext['loader'],
+    identityKey: 'test',
+    fetchText: vi.fn(),
+    fetchArrayBuffer: vi.fn(),
+    fetchJson: vi.fn(async (source: string): Promise<unknown> => {
+      if (Object.hasOwn(fixtures, source)) return fixtures[source];
+      throw new Error(`load-ldtk-map.test: no fixture registered for source "${source}"`);
+    }),
+  };
+
+  return { context, loaderLoad };
+}
+
+const ABS_SOURCE = 'https://example.com/maps/world.ldtk';
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('loadLdtkMap — happy path (absolute source)', () => {
+  function context() {
+    return makeContext({ [ABS_SOURCE]: loadFixture('world.ldtk') });
+  }
+
+  it('returns an LdtkMap with one TileMap per level', async () => {
+    const map = await loadLdtkMap(ABS_SOURCE, context().context);
+    expect(map).toBeInstanceOf(LdtkMap);
+    expect(map.levels).toHaveLength(1);
+  });
+
+  it('stores the source URL on the returned map', async () => {
+    const map = await loadLdtkMap(ABS_SOURCE, context().context);
+    expect(map.source).toBe(ABS_SOURCE);
+  });
+
+  it('fetches the .ldtk JSON from the source', async () => {
+    const { context: ctx } = context();
+    await loadLdtkMap(ABS_SOURCE, ctx);
+    expect(ctx.fetchJson).toHaveBeenCalledWith(ABS_SOURCE);
+  });
+
+  it('loads the tileset atlas image resolved against the source URL', async () => {
+    const { context: ctx, loaderLoad } = context();
+    await loadLdtkMap(ABS_SOURCE, ctx);
+    // resolveLdtkUrl('tiles.png', 'https://example.com/maps/world.ldtk')
+    expect(loaderLoad).toHaveBeenCalledWith(Texture, 'https://example.com/maps/tiles.png');
+  });
+
+  it('populates the Tiles layer with the gridTiles once the tileset is available', async () => {
+    const map = await loadLdtkMap(ABS_SOURCE, context().context);
+    const tilesLayer = map.levels[0]!.layers.find(l => l.name === 'Tiles')!;
+    // fixture places 2 gridTiles
+    expect(tilesLayer.countNonEmptyTiles()).toBe(2);
+  });
+
+  it('exposes entity layers as ObjectLayers', async () => {
+    const map = await loadLdtkMap(ABS_SOURCE, context().context);
+    const objectLayers = map.levels[0]!.objectLayers;
+    expect(objectLayers).toHaveLength(1);
+    expect(objectLayers[0]!.objects[0]!.type).toBe('Player');
+  });
+});
+
+describe('loadLdtkMap — tilesets without an atlas image', () => {
+  // relPath: null → the tileset is skipped entirely; tiles cannot render.
+  const fixture: LdtkData = {
+    jsonVersion: '1.5.3',
+    defaultGridSize: 16,
+    defs: {
+      tilesets: [
+        {
+          uid: 1,
+          identifier: 'NoImage',
+          relPath: null,
+          tileGridSize: 16,
+          pxWid: 64,
+          pxHei: 64,
+        },
+      ],
+      layers: [{ uid: 101, identifier: 'Tiles', type: 'Tiles', gridSize: 16, tilesetDefUid: 1 }],
+    },
+    levels: [
+      {
+        identifier: 'L',
+        uid: 1,
+        iid: 'iid-1',
+        worldX: 0,
+        worldY: 0,
+        pxWid: 64,
+        pxHei: 16,
+        layerInstances: [
+          {
+            __identifier: 'Tiles',
+            __type: 'Tiles',
+            __cWid: 4,
+            __cHei: 1,
+            __gridSize: 16,
+            layerDefUid: 101,
+            levelId: 1,
+            visible: true,
+            iid: 'tiles-1',
+            __tilesetDefUid: 1,
+            gridTiles: [{ px: [0, 0], src: [0, 0], f: 0, t: 0 }],
+          },
+        ],
+      },
+    ],
+  };
+
+  it('does not call the loader and leaves tile layers empty', async () => {
+    const { context, loaderLoad } = makeContext({ [ABS_SOURCE]: fixture });
+    const map = await loadLdtkMap(ABS_SOURCE, context);
+
+    expect(loaderLoad).not.toHaveBeenCalled();
+    const tilesLayer = map.levels[0]!.layers[0]!;
+    expect(tilesLayer.countNonEmptyTiles()).toBe(0);
+  });
+});
+
+describe('loadLdtkMap — atlas too small for any tile', () => {
+  // pxWid (8) < tileGridSize (16) → columns computes to 0 → tileset is dropped.
+  const fixture: LdtkData = {
+    jsonVersion: '1.5.3',
+    defaultGridSize: 16,
+    defs: {
+      tilesets: [
+        {
+          uid: 1,
+          identifier: 'Tiny',
+          relPath: 'tiny.png',
+          tileGridSize: 16,
+          pxWid: 8,
+          pxHei: 8,
+        },
+      ],
+      layers: [{ uid: 101, identifier: 'Tiles', type: 'Tiles', gridSize: 16, tilesetDefUid: 1 }],
+    },
+    levels: [
+      {
+        identifier: 'L',
+        uid: 1,
+        iid: 'iid-1',
+        worldX: 0,
+        worldY: 0,
+        pxWid: 64,
+        pxHei: 16,
+        layerInstances: [
+          {
+            __identifier: 'Tiles',
+            __type: 'Tiles',
+            __cWid: 4,
+            __cHei: 1,
+            __gridSize: 16,
+            layerDefUid: 101,
+            levelId: 1,
+            visible: true,
+            iid: 'tiles-1',
+            __tilesetDefUid: 1,
+            gridTiles: [{ px: [0, 0], src: [0, 0], f: 0, t: 0 }],
+          },
+        ],
+      },
+    ],
+  };
+
+  it('still loads the texture but drops the tileset (no tiles placed)', async () => {
+    const { context, loaderLoad } = makeContext({ [ABS_SOURCE]: fixture });
+    const map = await loadLdtkMap(ABS_SOURCE, context);
+
+    // The texture load happens before the column check, so it IS requested.
+    expect(loaderLoad).toHaveBeenCalledWith(Texture, 'https://example.com/maps/tiny.png');
+    expect(map.levels[0]!.layers[0]!.countNonEmptyTiles()).toBe(0);
+  });
+});
+
+describe('loadLdtkMap — URL resolution is absolute-base-only (characterization)', () => {
+  // resolveLdtkUrl uses `new URL(relPath, baseUrl)` directly, which throws when
+  // the base URL is relative. Unlike the Tiled adapter, LDtk does NOT tolerate a
+  // relative .ldtk source when a tileset carries a relPath. See report note.
+  const fixture: LdtkData = {
+    jsonVersion: '1.5.3',
+    defaultGridSize: 16,
+    defs: {
+      tilesets: [
+        {
+          uid: 1,
+          identifier: 'Atlas',
+          relPath: 'tiles.png',
+          tileGridSize: 16,
+          pxWid: 64,
+          pxHei: 64,
+        },
+      ],
+      layers: [],
+    },
+    levels: [],
+  };
+
+  it('rejects when the source is a relative URL and a tileset has a relPath', async () => {
+    const { context } = makeContext({ 'world.ldtk': fixture });
+    await expect(loadLdtkMap('world.ldtk', context)).rejects.toThrow(/Invalid URL/);
+  });
+});
+
+describe('loadLdtkMap — no structural validation (characterization)', () => {
+  // loadLdtkMap casts fetched JSON straight to LdtkData with no schema check, so
+  // malformed input surfaces as a raw runtime error during conversion rather than
+  // a typed format error.
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('throws a raw error (not a typed format error) for an empty document', async () => {
+    const { context } = makeContext({ [ABS_SOURCE]: {} });
+    await expect(loadLdtkMap(ABS_SOURCE, context)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## F1 — Test suites for the thin data-format packages

Both packages were near-untested (aseprite: 0 tests; ldtk: 1). These are **characterization tests** for the shipped behaviour — real checked-in fixtures, no behaviour mocks.

### aseprite (3 files, 51 tests)
`AsepriteSheet` parse for both array- and hash-frames forms (frame rekeying, rects, fps from durations + 12fps fallback), `isAsepriteArrayData` guard, clips from `frameTags` (inclusive range, loop, pingpong not expanded), `createAnimatedSprite`, the binding load path (image resolution + sub-load) and every malformed-input `AsepriteFormatError` case, and the extension registration contract (root side-effect-free vs `/register`).

### ldtk (4 new files, +59 tests → 78)
`LdtkMap` accessors + `destroy` forwarding, flip-bit decoding (`ldtkFlipNone/X/Y/Xy`), `ldtkToTileMap` across layer types (Tiles/AutoLayer/IntGrid/Entities) + grid-size derivation + field projection + the entity-id formula, the `loadLdtkMap` loader path, and the extension contract.

### Findings flagged for follow-up (asserted as current behaviour, not fixed here)
- **ldtk `resolveLdtkUrl` throws on a relative `.ldtk` base URL** — Tiled's adapter handles relative bases; real inconsistency worth fixing.
- **ldtk `loadLdtkMap` does no structural validation** — malformed input surfaces as a raw `TypeError` instead of a typed format error (cf. `TiledFormatError`).
- **aseprite parses `slices` into the type model but `AsepriteSheet` never surfaces them** — unimplemented feature, not a bug.

### Verification (local, CI-parity)
- ✅ `exojs-aseprite` + `exojs-ldtk` suites: **129/129** green
- ✅ `verify:quick` passed via pre-push (typecheck ×4 + lint:all + format:check + docs:api:check)

These were written in parallel by two subagents and reviewed/verified before commit.