### PR TITLE
fix(site): unblock build (subsystem enum) + guide box spacing

### DIFF
--- a/site/src/components/TryIt.astro
+++ b/site/src/components/TryIt.astro
@@ -132,7 +132,9 @@ if (api.length > 0) {
         padding: 0;
         display: flex;
         flex-direction: column;
-        gap: var(--s-1);
+        /* s-2, not s-1: links can wrap to two lines, and a 4px gap lets wrapped
+           items visually merge. 8px keeps each entry distinct. */
+        gap: var(--s-2);
     }
 
     .tryit li {

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -2,6 +2,8 @@ import { glob } from 'astro/loaders';
 import { z } from 'astro/zod';
 import { defineCollection } from 'astro:content';
 
+import { API_SUBSYSTEM_ORDER } from './lib/api-reference';
+
 // Guide ordering, grouping, and learning metadata live in
 // src/lib/guide-structure.ts (the single source of truth, reconciled with these
 // files by test/site/guide-structure.test.ts). Frontmatter only carries the
@@ -21,7 +23,10 @@ const api = defineCollection({
         description: z.string().default(''),
         symbol: z.string(),
         kind: z.enum(['class', 'enum', 'interface', 'type']),
-        subsystem: z.enum(['animation', 'audio', 'core', 'debug', 'input', 'math', 'particles', 'rendering', 'resources', 'tiled', 'tilemap']),
+        // Single source of truth: api-reference.ts owns the subsystem list (order
+        // + labels). Deriving the validation enum from it keeps the two in sync,
+        // so adding a package's subsystem there can't silently break the build.
+        subsystem: z.enum(API_SUBSYSTEM_ORDER),
         importPath: z.string(),
         memberCount: z.number().int().min(0).default(0),
         sections: z.array(z.string()).default([]),

--- a/site/src/pages/en/guide/[part]/[chapter]/index.astro
+++ b/site/src/pages/en/guide/[part]/[chapter]/index.astro
@@ -265,7 +265,12 @@ const sidebarParts = GUIDE_PARTS.map(part => ({
         display: none;
     }
 
-    .chapter-prose :global(h2) {
+    /* Typographic rules are scoped to .chapter-content (the rendered MDX body),
+       not .chapter-prose (the whole article). The article also wraps layout
+       chrome — GuideMeta, Related API, the pager — which carry their own styles;
+       scoping to the body keeps the prose h2 (#-prefix, 56px lead), list, and
+       link styles from bleeding into those boxes. */
+    .chapter-content :global(h2) {
         font-size: 22px;
         font-weight: 600;
         letter-spacing: -0.01em;
@@ -275,7 +280,7 @@ const sidebarParts = GUIDE_PARTS.map(part => ({
         position: relative;
     }
 
-    .chapter-prose :global(h2)::before {
+    .chapter-content :global(h2)::before {
         content: '#';
         font-family: var(--f-mono);
         color: var(--fg-faint);
@@ -284,40 +289,40 @@ const sidebarParts = GUIDE_PARTS.map(part => ({
         margin-right: 8px;
     }
 
-    .chapter-prose :global(h3) {
+    .chapter-content :global(h3) {
         font-size: 16px;
         font-weight: 600;
         margin: var(--s-7) 0 var(--s-3);
     }
 
-    .chapter-prose :global(p) {
+    .chapter-content :global(p) {
         margin: var(--s-3) 0;
         line-height: 1.65;
         color: var(--fg);
         text-wrap: pretty;
     }
 
-    .chapter-prose :global(li) {
+    .chapter-content :global(li) {
         margin: 4px 0;
         line-height: 1.65;
     }
 
-    .chapter-prose :global(ul, ol) {
+    .chapter-content :global(ul, ol) {
         margin: var(--s-3) 0;
         padding-left: var(--s-5);
         line-height: 1.65;
     }
 
-    .chapter-prose :global(p.muted) {
+    .chapter-content :global(p.muted) {
         color: var(--fg-muted);
     }
 
-    .chapter-prose :global(pre.astro-code) {
+    .chapter-content :global(pre.astro-code) {
         margin: var(--s-4) 0;
         border-color: var(--line-soft);
     }
 
-    .chapter-prose :global(hr) {
+    .chapter-content :global(hr) {
         border: none;
         border-top: 1px solid var(--line-soft);
         margin: var(--s-9) 0;
@@ -325,16 +330,16 @@ const sidebarParts = GUIDE_PARTS.map(part => ({
 
     /* Underline prose links only — component links (TryIt, NextStep, pager,
        example/source embeds) keep their own styling. */
-    .chapter-prose :global(p a),
-    .chapter-prose :global(li a) {
+    .chapter-content :global(p a),
+    .chapter-content :global(li a) {
         color: var(--fg);
         text-decoration: underline;
         text-decoration-color: color-mix(in oklab, var(--accent), transparent 55%);
         text-underline-offset: 0.2em;
     }
 
-    .chapter-prose :global(p a:hover),
-    .chapter-prose :global(li a:hover) {
+    .chapter-content :global(p a:hover),
+    .chapter-content :global(li a:hover) {
         color: var(--accent);
         text-decoration-color: var(--accent);
     }


### PR DESCRIPTION
Two related site fixes found while doing the Guide-Polish-CSS pass.

## 1. Build blocker — `subsystem` enum drift
The `subsystem` Zod enum in `content.config.ts` never gained `physics` (v0.14), `aseprite`, or `ldtk` (#199), but the generated API pages for those packages carry exactly those values. This broke the **entire** Astro build on the branch — `astro dev`, `astro build`, and `astro check` all failed validating the content collection (first error on `aseprite-format-error.mdx`, with every physics page behind it).

`api-reference.ts` already lists every subsystem in `API_SUBSYSTEM_ORDER`. The enum is now derived from it, so the schema can't fall out of sync with the package list again.

## 2. "Empty box spacing" in GuideMeta — prose-rule bleed
The chapter layout scoped its typographic rules (`h2`/`h3`/`p`/`li`/links) to `.chapter-prose`, which wraps the whole article including the GuideMeta boxes ("What you'll learn" / "Before you start"). Those boxes' `<h2>` headings inherited the prose-h2 styling: a 56px top margin, top padding, and a `#` `::before` glyph — a large empty gap + a stray `#` in each box; `<li>` picked up an extra margin, loosening the bullets.

Fix: scope the prose rules to `.chapter-content` (the rendered MDX body). GuideMeta sits outside it, so the bleed is gone — specificity-proof, without touching `GuideMeta.astro`. Body / lead / related-api / pager are unaffected.

Also bumps the TryIt list gap 4px → 8px so wrapped two-line links stay distinct.

## Verification
- Playwright element screenshots before/after across 4 guide pages: GuideMeta box clean (no top gap, no `#`, tight bullets), TryIt links distinct, body prose + lead + Callout + TryIt unregressed.
- `pre-push` `verify:quick` green (typecheck core/guides/examples/packages, lint:all, format:check, docs:api:check).
- `astro check`: the only error is pre-existing and unrelated (`EditorCode.tsx:352` implicit-any, part of the open syntax-highlighting track).