### PR TITLE
fix(site): code blocks readable in the light theme

### DIFF
--- a/site/src/styles/global.scss
+++ b/site/src/styles/global.scss
@@ -81,15 +81,13 @@ kbd {
     line-height: 1.68;
 }
 
+// Code blocks always sit on the dark `--color-code-bg` surface (dark in both
+// themes, see the background rule above), so the syntax colours must always be
+// the dark-theme set — `--shiki-light` is the light-on-light variant and would
+// render dark text on the dark panel (unreadable in the light site theme).
+// Dual-theme `<Code>`/markdown output still defines `--shiki-dark`; we just pin
+// to it regardless of the site's data-theme.
 :where(pre.astro-code, pre.astro-code span) {
-    color: var(--shiki-dark) !important;
-}
-
-html[data-theme='light'] :where(pre.astro-code, pre.astro-code span) {
-    color: var(--shiki-light) !important;
-}
-
-html[data-theme='dark'] :where(pre.astro-code, pre.astro-code span) {
     color: var(--shiki-dark) !important;
 }
 


### PR DESCRIPTION
Code blocks always render on the dark `--color-code-bg` surface (dark in **both** themes), but the syntax colour was bridged to the site's `data-theme`: `html[data-theme='light']` forced `--shiki-light` (the light-on-light variant) → dark text on the dark panel, i.e. **unreadable in the light theme**.

This hit every code surface site-wide: the home hero/quickstart panels, guide MDX code blocks, and `SourceSnippet`s.

Fix: pin syntax colours to `--shiki-dark` regardless of site theme, matching the always-dark surface. Dual-theme `<Code>`/markdown output still defines the variable.

Verified via Playwright in light theme: home hero, quickstart, and a guide code block all readable; dark theme unchanged.