### PR TITLE
fix(site): type Monaco onChange value param (clears ts7006)

### DIFF
--- a/site/src/components/EditorCode.tsx
+++ b/site/src/components/EditorCode.tsx
@@ -349,7 +349,7 @@ export const EditorCode = forwardRef<EditorCodeHandle, EditorCodeProps>(function
                         height="100%"
                         language={language}
                         loading={null}
-                        onChange={value => setEditorValue(value ?? '')}
+                        onChange={(value: string | undefined) => setEditorValue(value ?? '')}
                         onMount={onMount}
                         options={{
                             automaticLayout: true,


### PR DESCRIPTION
`onChange={value => setEditorValue(value ?? '')}` left `value` implicitly `any` — the only error `astro check` reported on the site (`EditorCode.tsx:352` ts(7006)). Annotated `value: string | undefined` (the `@monaco-editor/react` `OnChange` signature). No behaviour change; `astro check` now reports 0 errors.

Note: while here I thoroughly investigated the reported "modified-status" bug via Playwright (load / type / delete / undo / run / edit-after-run) — the status is correct in every scenario and the trailing-newline hypothesis doesn't hold (all example sources end with a single consistent `\n`). No reproducible bug, so no speculative dirty-tracking refactor.