### PR TITLE
fix: playground example sweep — text/gamepad/render fixes

### DIFF
--- a/examples/assets/svg/rune-mark.svg
+++ b/examples/assets/svg/rune-mark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="#7af5a8">
   <path d="M5 2h8l-2 3H3z"/>
   <path d="M4.5 6.5h6l-2 3H2.5z"/>
   <path d="M4 11h8l-2 3H2z"/>

--- a/examples/debug-layer/asset-browser.js
+++ b/examples/debug-layer/asset-browser.js
@@ -591,18 +591,21 @@ class AssetBrowserScene extends Scene {
         for (let i = 0; i < CATEGORIES_ROW1.length; i++) {
             const bx = CAT_BTN_X0 + i * (CAT_BTN_W + 4);
             const t = this.catBtnTexts[i];
+            t.text = CATEGORIES_ROW1[i].label;
             t.setPosition(bx + (CAT_BTN_W - 22) / 2, CAT_BTN_Y1 + 12);
             context.render(t);
         }
         for (let i = 0; i < CATEGORIES_ROW2.length; i++) {
             const bx = CAT_BTN_X0 + i * (CAT_BTN_W + 4);
             const t = this.catBtnTexts[CATEGORIES_ROW1.length + i];
+            t.text = CATEGORIES_ROW2[i].label;
             t.setPosition(bx + (CAT_BTN_W - 22) / 2, CAT_BTN_Y2 + 12);
             context.render(t);
         }
         for (let i = 0; i < BG_OPTIONS.length; i++) {
             const bx = BG_BTN_X0 + i * (BG_BTN_SIZE + 5);
             const t = this.bgBtnTexts[i];
+            t.text = BG_OPTIONS[i].label;
             t.style.fillColor = i === 1 ? C.white : C.dim;
             t.setPosition(bx + 7, BG_BTN_Y + 7);
             context.render(t);

--- a/examples/debug-layer/asset-browser.ts
+++ b/examples/debug-layer/asset-browser.ts
@@ -647,6 +647,7 @@ class AssetBrowserScene extends Scene {
         for (let i = 0; i < CATEGORIES_ROW1.length; i++) {
             const bx = CAT_BTN_X0 + i * (CAT_BTN_W + 4);
             const t = this.catBtnTexts[i];
+            t.text = CATEGORIES_ROW1[i].label;
             t.setPosition(bx + (CAT_BTN_W - 22) / 2, CAT_BTN_Y1 + 12);
             context.render(t);
         }
@@ -654,6 +655,7 @@ class AssetBrowserScene extends Scene {
         for (let i = 0; i < CATEGORIES_ROW2.length; i++) {
             const bx = CAT_BTN_X0 + i * (CAT_BTN_W + 4);
             const t = this.catBtnTexts[CATEGORIES_ROW1.length + i];
+            t.text = CATEGORIES_ROW2[i].label;
             t.setPosition(bx + (CAT_BTN_W - 22) / 2, CAT_BTN_Y2 + 12);
             context.render(t);
         }
@@ -661,6 +663,7 @@ class AssetBrowserScene extends Scene {
         for (let i = 0; i < BG_OPTIONS.length; i++) {
             const bx = BG_BTN_X0 + i * (BG_BTN_SIZE + 5);
             const t = this.bgBtnTexts[i];
+            t.text = BG_OPTIONS[i].label;
             t.style.fillColor = i === 1 ? C.white : C.dim;
             t.setPosition(bx + 7, BG_BTN_Y + 7);
             context.render(t);

--- a/examples/physics/tiled-map-physics-actor.js
+++ b/examples/physics/tiled-map-physics-actor.js
@@ -3,8 +3,8 @@ import { Application, Color, Json, Scene, Spritesheet, Texture, TextureRegion, V
 import { BoxShape, PhysicsWorld } from '@codexo/exojs-physics';
 import { PhysicsDebugDraw } from '@codexo/exojs-physics/debug';
 import { ObjectKind, ObjectLayer, TILE_TRANSFORM_IDENTITY, TileLayer, TileMap, tilemapExtension, TileMapNode, TileSet } from '@codexo/exojs-tilemap';
+import { buildCollidersFromObjectLayer } from '@examples/physics-tilemap';
 import { mountControls } from '@examples/runtime';
-import { buildCollidersFromObjectLayer } from '../shared/physics-tilemap.js';
 // Combined Tiled + physics demo.
 //
 //   1. A hand-built `TileMap` is rendered with a `TileMapNode` (tilemap

--- a/examples/physics/tiled-map-physics-actor.ts
+++ b/examples/physics/tiled-map-physics-actor.ts
@@ -2,9 +2,8 @@ import { Application, Color, Json, Scene, Sprite, Spritesheet, type SpritesheetD
 import { BoxShape, type PhysicsBody, PhysicsWorld } from '@codexo/exojs-physics';
 import { PhysicsDebugDraw } from '@codexo/exojs-physics/debug';
 import { ObjectKind, ObjectLayer, type RectangleObject, TILE_TRANSFORM_IDENTITY, TileLayer, TileMap, tilemapExtension, TileMapNode, TileSet } from '@codexo/exojs-tilemap';
+import { buildCollidersFromObjectLayer } from '@examples/physics-tilemap';
 import { mountControls } from '@examples/runtime';
-
-import { buildCollidersFromObjectLayer } from '../shared/physics-tilemap.js';
 
 // Combined Tiled + physics demo.
 //

--- a/examples/render-targets/mini-map.js
+++ b/examples/render-targets/mini-map.js
@@ -1,5 +1,5 @@
 // Auto-generated from mini-map.ts — edit the .ts source, not this file.
-import { Application, CallbackRenderPass, Color, Graphics, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite } from '@codexo/exojs';
+import { Application, Color, Container, Graphics, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite, View } from '@codexo/exojs';
 const app = new Application({
     canvas: {
         width: 1280,
@@ -13,46 +13,57 @@ const app = new Application({
     },
 });
 class MiniMapScene extends Scene {
+    worldContainer;
     world;
     player;
     miniRt;
     miniSprite;
     miniFrame;
+    overlay;
+    miniView;
     pipeline;
     time = 0;
     init() {
-        const { width } = this.app.canvas;
+        const { width, height } = this.app.canvas;
         const miniX = width - 220 - 20;
         const miniY = 20;
+        // Grid + player live in one container so the same subtree can be drawn at
+        // full size to the canvas and shrunk into the minimap texture.
+        this.worldContainer = new Container();
         this.world = new Graphics();
         this.player = new Graphics();
+        this.worldContainer.addChild(this.world);
+        this.worldContainer.addChild(this.player);
         this.miniRt = new RenderTexture(220, 160);
         this.miniSprite = new Sprite(this.miniRt).setPosition(miniX, miniY);
         this.miniFrame = new Graphics();
         this.miniFrame.lineWidth = 2;
         this.miniFrame.lineColor = Color.white;
         this.miniFrame.drawRectangle(miniX, miniY, 220, 160);
-        // The "world" is immediate-mode (grid + player) — a context-aware callback, drawn once
-        // into the minimap texture and once to the screen. The sprite + frame are scene nodes.
+        // Sprite + frame in one overlay subtree, composited in a single pass. The
+        // frame is added first so the RenderTexture-sampling sprite stays the LAST
+        // draw of the frame: sampling a render target only reads back correctly
+        // when no further draw follows the sampling sprite.
+        this.overlay = new Container();
+        this.overlay.addChild(this.miniFrame);
+        this.overlay.addChild(this.miniSprite);
+        // A dedicated view that frames the whole world, scaled down into the
+        // 220×160 minimap texture so the entire grid stays visible.
+        this.miniView = new View(width / 2, height / 2, width, height);
+        // Every stage is a RenderNodePass so the off-screen target redirect and
+        // its clear stay inside the pass machinery — mixing in a manual
+        // `context.backend.clear()` (immediate-mode) here leaks the off-screen
+        // pass's clear onto the canvas and leaves the texture empty.
         this.pipeline = new RenderPipeline()
-            .addPass(new CallbackRenderPass((context) => {
-            context.backend.clear();
-            this.renderWorld(context.backend);
-        }, { target: this.miniRt }))
-            .addPass(new CallbackRenderPass((context) => {
-            context.backend.clear();
-            this.renderWorld(context.backend);
-        }))
-            .addPass(new RenderNodePass(this.miniSprite))
-            .addPass(new RenderNodePass(this.miniFrame));
+            .addPass(new RenderNodePass(this.worldContainer, { target: this.miniRt, view: this.miniView, clear: Color.black }))
+            .addPass(new RenderNodePass(this.worldContainer, { clear: Color.black }))
+            .addPass(new RenderNodePass(this.overlay));
     }
     update(delta) {
-        this.time += delta.seconds;
-    }
-    renderWorld(backend) {
         const { width, height } = this.app.canvas;
         const marginX = 80;
         const marginY = 60;
+        this.time += delta.seconds;
         this.world.clear();
         this.world.lineWidth = 2;
         this.world.lineColor = new Color(60, 70, 90);
@@ -60,21 +71,20 @@ class MiniMapScene extends Scene {
             this.world.drawLine(x, marginY, x, height - marginY);
         for (let y = marginY; y <= height - marginY; y += 80)
             this.world.drawLine(marginX, y, width - marginX, y);
-        this.world.render(backend);
-        const x = width / 2 + Math.cos(this.time) * (width * 0.4);
-        const y = height / 2 + Math.sin(this.time * 1.3) * (height * 0.4);
+        const px = width / 2 + Math.cos(this.time) * (width * 0.4);
+        const py = height / 2 + Math.sin(this.time * 1.3) * (height * 0.4);
         this.player.clear();
         this.player.fillColor = new Color(255, 180, 100);
-        this.player.drawCircle(x, y, 18);
-        this.player.render(backend);
+        this.player.drawCircle(px, py, 18);
     }
     draw(context) {
         this.pipeline.execute(context);
     }
     destroy() {
-        // Pipeline cascades destroy() to its passes; the caller-owned minimap target is freed here.
+        // Pipeline cascades destroy() to its passes; the caller-owned target/view it created are freed here.
         this.pipeline.destroy();
         this.miniRt.destroy();
+        this.miniView.destroy();
         super.destroy();
     }
 }

--- a/examples/render-targets/mini-map.ts
+++ b/examples/render-targets/mini-map.ts
@@ -1,4 +1,4 @@
-import { Application, CallbackRenderPass, Color, Graphics, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite } from '@codexo/exojs';
+import { Application, Color, Container, Graphics, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite, View } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -14,21 +14,30 @@ const app = new Application({
 });
 
 class MiniMapScene extends Scene {
+    private worldContainer!: Container;
     private world!: Graphics;
     private player!: Graphics;
     private miniRt!: RenderTexture;
     private miniSprite!: Sprite;
     private miniFrame!: Graphics;
+    private overlay!: Container;
+    private miniView!: View;
     private pipeline!: RenderPipeline;
     private time = 0;
 
     override init(): void {
-        const { width } = this.app.canvas;
+        const { width, height } = this.app.canvas;
         const miniX = width - 220 - 20;
         const miniY = 20;
 
+        // Grid + player live in one container so the same subtree can be drawn at
+        // full size to the canvas and shrunk into the minimap texture.
+        this.worldContainer = new Container();
         this.world = new Graphics();
         this.player = new Graphics();
+        this.worldContainer.addChild(this.world);
+        this.worldContainer.addChild(this.player);
+
         this.miniRt = new RenderTexture(220, 160);
         this.miniSprite = new Sprite(this.miniRt).setPosition(miniX, miniY);
         this.miniFrame = new Graphics();
@@ -36,50 +45,46 @@ class MiniMapScene extends Scene {
         this.miniFrame.lineColor = Color.white;
         this.miniFrame.drawRectangle(miniX, miniY, 220, 160);
 
-        // The "world" is immediate-mode (grid + player) — a context-aware callback, drawn once
-        // into the minimap texture and once to the screen. The sprite + frame are scene nodes.
+        // Sprite + frame in one overlay subtree, composited in a single pass. The
+        // frame is added first so the RenderTexture-sampling sprite stays the LAST
+        // draw of the frame: sampling a render target only reads back correctly
+        // when no further draw follows the sampling sprite.
+        this.overlay = new Container();
+        this.overlay.addChild(this.miniFrame);
+        this.overlay.addChild(this.miniSprite);
+
+        // A dedicated view that frames the whole world, scaled down into the
+        // 220×160 minimap texture so the entire grid stays visible.
+        this.miniView = new View(width / 2, height / 2, width, height);
+
+        // Every stage is a RenderNodePass so the off-screen target redirect and
+        // its clear stay inside the pass machinery — mixing in a manual
+        // `context.backend.clear()` (immediate-mode) here leaks the off-screen
+        // pass's clear onto the canvas and leaves the texture empty.
         this.pipeline = new RenderPipeline()
-            .addPass(
-                new CallbackRenderPass(
-                    (context) => {
-                        context.backend.clear();
-                        this.renderWorld(context.backend);
-                    },
-                    { target: this.miniRt },
-                ),
-            )
-            .addPass(
-                new CallbackRenderPass((context) => {
-                    context.backend.clear();
-                    this.renderWorld(context.backend);
-                }),
-            )
-            .addPass(new RenderNodePass(this.miniSprite))
-            .addPass(new RenderNodePass(this.miniFrame));
+            .addPass(new RenderNodePass(this.worldContainer, { target: this.miniRt, view: this.miniView, clear: Color.black }))
+            .addPass(new RenderNodePass(this.worldContainer, { clear: Color.black }))
+            .addPass(new RenderNodePass(this.overlay));
     }
 
     override update(delta): void {
-        this.time += delta.seconds;
-    }
-
-    private renderWorld(backend): void {
         const { width, height } = this.app.canvas;
         const marginX = 80;
         const marginY = 60;
+
+        this.time += delta.seconds;
 
         this.world.clear();
         this.world.lineWidth = 2;
         this.world.lineColor = new Color(60, 70, 90);
         for (let x = marginX; x <= width - marginX; x += 80) this.world.drawLine(x, marginY, x, height - marginY);
         for (let y = marginY; y <= height - marginY; y += 80) this.world.drawLine(marginX, y, width - marginX, y);
-        this.world.render(backend);
 
-        const x = width / 2 + Math.cos(this.time) * (width * 0.4);
-        const y = height / 2 + Math.sin(this.time * 1.3) * (height * 0.4);
+        const px = width / 2 + Math.cos(this.time) * (width * 0.4);
+        const py = height / 2 + Math.sin(this.time * 1.3) * (height * 0.4);
         this.player.clear();
         this.player.fillColor = new Color(255, 180, 100);
-        this.player.drawCircle(x, y, 18);
-        this.player.render(backend);
+        this.player.drawCircle(px, py, 18);
     }
 
     override draw(context): void {
@@ -87,9 +92,10 @@ class MiniMapScene extends Scene {
     }
 
     override destroy(): void {
-        // Pipeline cascades destroy() to its passes; the caller-owned minimap target is freed here.
+        // Pipeline cascades destroy() to its passes; the caller-owned target/view it created are freed here.
         this.pipeline.destroy();
         this.miniRt.destroy();
+        this.miniView.destroy();
         super.destroy();
     }
 }

--- a/examples/render-targets/trail-feedback.js
+++ b/examples/render-targets/trail-feedback.js
@@ -13,29 +13,46 @@ const app = new Application({
     },
 });
 class TrailFeedbackScene extends Scene {
-    rt;
-    decay;
+    // Two render targets, ping-ponged each frame. Reading from and writing to
+    // the SAME render target forms a GL feedback loop (INVALID_OPERATION), so we
+    // read the faded previous frame from one target and write the new
+    // accumulation into the other, then swap.
+    rtA;
+    rtB;
     bunny;
-    final;
-    pipeline;
+    pipeAtoB;
+    pipeBtoA;
+    forward = true;
     time = 0;
     async load(loader) {
         await loader.load(Texture, { bunny: 'image/ship-a.png' });
     }
     init(loader) {
         const { width, height } = this.app.canvas;
-        this.rt = new RenderTexture(width, height);
-        this.decay = new Sprite(this.rt).setTint(new Color(255, 255, 255, 0.93));
+        this.rtA = new RenderTexture(width, height);
+        this.rtB = new RenderTexture(width, height);
         this.bunny = new Sprite(loader.get(Texture, 'bunny')).setAnchor(0.5);
-        this.final = new Sprite(this.rt);
-        // Feedback: the off-screen target is deliberately NOT cleared, so the decayed previous frame
-        // plus the bunny accumulate into a trail; the final sprite composites it to the screen.
-        this.pipeline = new RenderPipeline()
+        // A 93%-alpha copy of the source target = the decaying trail.
+        const decayA = new Sprite(this.rtA).setTint(new Color(255, 255, 255, 0.93));
+        const decayB = new Sprite(this.rtB).setTint(new Color(255, 255, 255, 0.93));
+        const showA = new Sprite(this.rtA);
+        const showB = new Sprite(this.rtB);
+        // Read A → write B → show B.
+        this.pipeAtoB = new RenderPipeline()
             .addPass(new CallbackRenderPass((context) => {
-            context.render(this.decay);
+            context.backend.clear();
+            context.render(decayA);
             context.render(this.bunny);
-        }, { target: this.rt }))
-            .addPass(new RenderNodePass(this.final, { clear: Color.black }));
+        }, { target: this.rtB }))
+            .addPass(new RenderNodePass(showB, { clear: Color.black }));
+        // Read B → write A → show A.
+        this.pipeBtoA = new RenderPipeline()
+            .addPass(new CallbackRenderPass((context) => {
+            context.backend.clear();
+            context.render(decayB);
+            context.render(this.bunny);
+        }, { target: this.rtA }))
+            .addPass(new RenderNodePass(showA, { clear: Color.black }));
     }
     update(delta) {
         const { width, height } = this.app.canvas;
@@ -43,12 +60,14 @@ class TrailFeedbackScene extends Scene {
         this.bunny.setPosition(width / 2 + Math.cos(this.time * 2.0) * (width * 0.36), height / 2 + Math.sin(this.time * 2.7) * (height * 0.34));
     }
     draw(context) {
-        this.pipeline.execute(context);
+        (this.forward ? this.pipeAtoB : this.pipeBtoA).execute(context);
+        this.forward = !this.forward;
     }
     destroy() {
-        // Pipeline cascades destroy() to its passes; the caller-owned feedback target is freed here.
-        this.pipeline.destroy();
-        this.rt.destroy();
+        this.pipeAtoB.destroy();
+        this.pipeBtoA.destroy();
+        this.rtA.destroy();
+        this.rtB.destroy();
         super.destroy();
     }
 }

--- a/examples/render-targets/trail-feedback.ts
+++ b/examples/render-targets/trail-feedback.ts
@@ -14,11 +14,16 @@ const app = new Application({
 });
 
 class TrailFeedbackScene extends Scene {
-    private rt!: RenderTexture;
-    private decay!: Sprite;
+    // Two render targets, ping-ponged each frame. Reading from and writing to
+    // the SAME render target forms a GL feedback loop (INVALID_OPERATION), so we
+    // read the faded previous frame from one target and write the new
+    // accumulation into the other, then swap.
+    private rtA!: RenderTexture;
+    private rtB!: RenderTexture;
     private bunny!: Sprite;
-    private final!: Sprite;
-    private pipeline!: RenderPipeline;
+    private pipeAtoB!: RenderPipeline;
+    private pipeBtoA!: RenderPipeline;
+    private forward = true;
     private time = 0;
 
     override async load(loader): Promise<void> {
@@ -28,24 +33,43 @@ class TrailFeedbackScene extends Scene {
     override init(loader): void {
         const { width, height } = this.app.canvas;
 
-        this.rt = new RenderTexture(width, height);
-        this.decay = new Sprite(this.rt).setTint(new Color(255, 255, 255, 0.93));
+        this.rtA = new RenderTexture(width, height);
+        this.rtB = new RenderTexture(width, height);
         this.bunny = new Sprite(loader.get(Texture, 'bunny')).setAnchor(0.5);
-        this.final = new Sprite(this.rt);
 
-        // Feedback: the off-screen target is deliberately NOT cleared, so the decayed previous frame
-        // plus the bunny accumulate into a trail; the final sprite composites it to the screen.
-        this.pipeline = new RenderPipeline()
+        // A 93%-alpha copy of the source target = the decaying trail.
+        const decayA = new Sprite(this.rtA).setTint(new Color(255, 255, 255, 0.93));
+        const decayB = new Sprite(this.rtB).setTint(new Color(255, 255, 255, 0.93));
+        const showA = new Sprite(this.rtA);
+        const showB = new Sprite(this.rtB);
+
+        // Read A → write B → show B.
+        this.pipeAtoB = new RenderPipeline()
             .addPass(
                 new CallbackRenderPass(
                     (context) => {
-                        context.render(this.decay);
+                        context.backend.clear();
+                        context.render(decayA);
                         context.render(this.bunny);
                     },
-                    { target: this.rt },
+                    { target: this.rtB },
                 ),
             )
-            .addPass(new RenderNodePass(this.final, { clear: Color.black }));
+            .addPass(new RenderNodePass(showB, { clear: Color.black }));
+
+        // Read B → write A → show A.
+        this.pipeBtoA = new RenderPipeline()
+            .addPass(
+                new CallbackRenderPass(
+                    (context) => {
+                        context.backend.clear();
+                        context.render(decayB);
+                        context.render(this.bunny);
+                    },
+                    { target: this.rtA },
+                ),
+            )
+            .addPass(new RenderNodePass(showA, { clear: Color.black }));
     }
 
     override update(delta): void {
@@ -55,13 +79,15 @@ class TrailFeedbackScene extends Scene {
     }
 
     override draw(context): void {
-        this.pipeline.execute(context);
+        (this.forward ? this.pipeAtoB : this.pipeBtoA).execute(context);
+        this.forward = !this.forward;
     }
 
     override destroy(): void {
-        // Pipeline cascades destroy() to its passes; the caller-owned feedback target is freed here.
-        this.pipeline.destroy();
-        this.rt.destroy();
+        this.pipeAtoB.destroy();
+        this.pipeBtoA.destroy();
+        this.rtA.destroy();
+        this.rtB.destroy();
         super.destroy();
     }
 }

--- a/examples/sprites-textures/svg-drawable.js
+++ b/examples/sprites-textures/svg-drawable.js
@@ -16,7 +16,10 @@ class SvgDrawableScene extends Scene {
     texture;
     sprite;
     async load(loader) {
-        await loader.load(SvgAsset, { mark: 'svg/rune-mark.svg' });
+        // rune-mark.svg carries only a viewBox (no width/height), so it would
+        // rasterise to a 0x0 image. Request an explicit pixel size — the SVG is
+        // vector, so it stays crisp scaled up to 256x256.
+        await loader.load(SvgAsset, { mark: 'svg/rune-mark.svg' }, { width: 256, height: 256 });
     }
     init(loader) {
         const { width, height } = this.app.canvas;

--- a/examples/sprites-textures/svg-drawable.ts
+++ b/examples/sprites-textures/svg-drawable.ts
@@ -18,7 +18,10 @@ class SvgDrawableScene extends Scene {
     private sprite!: Sprite;
 
     override async load(loader): Promise<void> {
-        await loader.load(SvgAsset, { mark: 'svg/rune-mark.svg' });
+        // rune-mark.svg carries only a viewBox (no width/height), so it would
+        // rasterise to a 0x0 image. Request an explicit pixel size — the SVG is
+        // vector, so it stays crisp scaled up to 256x256.
+        await loader.load(SvgAsset, { mark: 'svg/rune-mark.svg' }, { width: 256, height: 256 });
     }
 
     override init(loader): void {

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "test:browser:webgpu": "vitest run --project=browser-webgpu",
     "test:browser:webgpu:chromium": "pnpm run test:browser:webgpu",
     "test:browser:webgpu:firefox": "vitest run --project=browser-webgpu-firefox",
+    "webgpu:probe": "node scripts/webgpu-probe.mjs",
     "bench": "vitest bench",
     "bench:run": "vitest bench --run",
     "site:install": "pnpm bootstrap",

--- a/packages/exojs-audio-fx/src/effects/DuckingEffect.ts
+++ b/packages/exojs-audio-fx/src/effects/DuckingEffect.ts
@@ -6,8 +6,12 @@ class DuckingProcessor extends AudioWorkletProcessor {
         return [
             { name: 'threshold', defaultValue: -20, minValue: -100, maxValue: 0, automationRate: 'k-rate' },
             { name: 'ratio', defaultValue: 4, minValue: 1, maxValue: 20, automationRate: 'k-rate' },
-            { name: 'attack', defaultValue: 0.03, minValue: 0.001, maxValue: 1, automationRate: 'k-rate' },
-            { name: 'release', defaultValue: 0.3, minValue: 0.001, maxValue: 5, automationRate: 'k-rate' },
+            // attack/release are one-pole smoothing coefficients (1 - exp(-1/tau)),
+            // not times — their value lives in [0, 1]. A 0.001 floor clipped the
+            // small coefficients of typical attack/release times (e.g. 30 ms at
+            // 48 kHz ≈ 0.0007), so the browser clamped them and logged a warning.
+            { name: 'attack', defaultValue: 0.03, minValue: 0, maxValue: 1, automationRate: 'k-rate' },
+            { name: 'release', defaultValue: 0.3, minValue: 0, maxValue: 1, automationRate: 'k-rate' },
         ];
     }
 

--- a/packages/exojs-audio-fx/src/worklets/vocoder.worklet.ts
+++ b/packages/exojs-audio-fx/src/worklets/vocoder.worklet.ts
@@ -80,7 +80,11 @@ class VocoderProcessor extends AudioWorkletProcessor {
                 bandSum += carBand * this._envelopes[b];
             }
 
-            output[i] = (1 - wet) * carrierSample + wet * bandSum;
+            // Multiply bandSum by bandCount: for a broadband carrier the energy is
+            // split across N bands, so the raw product (carBand × envelope) is
+            // O(1/N) of the carrier amplitude. Scaling by N restores unity gain
+            // for typical broadband carrier + voice modulator inputs.
+            output[i] = (1 - wet) * carrierSample + wet * bandSum * bandCount;
         }
         return true;
     }

--- a/packages/exojs-audio-fx/test/worklets/vocoder-processor.test.ts
+++ b/packages/exojs-audio-fx/test/worklets/vocoder-processor.test.ts
@@ -1,0 +1,282 @@
+/**
+ * DSP-level regression tests for the VocoderProcessor worklet.
+ *
+ * These tests directly instantiate the processor class (by evaluating the
+ * worklet source string with minimal stubs) and verify the DSP output — RMS,
+ * spectral envelope shaping, and the bandCount make-up gain — without needing
+ * a real AudioContext or browser.
+ */
+
+import { vocoderWorkletSource } from '../../src/worklets/vocoder.worklet';
+
+// ─── Worklet bootstrap helpers ────────────────────────────────────────────────
+
+const SAMPLE_RATE = 48000;
+const BLOCK = 128;
+
+// The processor constructor and class (captured via registerProcessor stub).
+interface BandCoef {
+  b0: number;
+  b1: number;
+  b2: number;
+  a1: number;
+  a2: number;
+  centerHz: number;
+}
+interface BiquadState {
+  x1: number;
+  x2: number;
+  y1: number;
+  y2: number;
+}
+
+interface VocoderProcessorLike {
+  process(
+    inputs: Float32Array[][],
+    outputs: Float32Array[][],
+    parameters: Record<string, number[]>,
+  ): boolean;
+  getBandInfo(): BandCoef[];
+  getEnvelopes(): Float32Array;
+}
+
+type VocoderProcessorConstructor = new (options: { processorOptions?: Record<string, number> }) => VocoderProcessorLike;
+
+function buildProcessorClass(numBands: number): VocoderProcessorConstructor {
+  let klass: VocoderProcessorConstructor | null = null;
+
+  const savedSampleRate = (globalThis as Record<string, unknown>)['sampleRate'];
+
+  // Install stubs expected by the worklet source.
+  (globalThis as Record<string, unknown>)['sampleRate'] = SAMPLE_RATE;
+  (globalThis as Record<string, unknown>)['AudioWorkletProcessor'] = class {
+    constructor() {}
+  };
+  (globalThis as Record<string, unknown>)['registerProcessor'] = (_name: string, cls: VocoderProcessorConstructor): void => {
+    klass = cls;
+  };
+
+  eval(vocoderWorkletSource);
+
+  // Restore globals.
+  (globalThis as Record<string, unknown>)['sampleRate'] = savedSampleRate;
+  delete (globalThis as Record<string, unknown>)['AudioWorkletProcessor'];
+  delete (globalThis as Record<string, unknown>)['registerProcessor'];
+
+  if (!klass) throw new Error('registerProcessor was not called — worklet source malformed');
+  return klass;
+}
+
+// ─── Signal helpers ───────────────────────────────────────────────────────────
+
+function makeSawtooth(freq: number, amplitude: number, n: number): Float32Array {
+  const buf = new Float32Array(n);
+  let phase = 0;
+  const inc = freq / SAMPLE_RATE;
+  for (let i = 0; i < n; i++) {
+    buf[i] = amplitude * (2 * phase - 1);
+    phase = (phase + inc) % 1.0;
+  }
+  return buf;
+}
+
+function makeSine(freq: number, amplitude: number, n: number): Float32Array {
+  const buf = new Float32Array(n);
+  for (let i = 0; i < n; i++) {
+    buf[i] = amplitude * Math.sin(2 * Math.PI * freq * i / SAMPLE_RATE);
+  }
+  return buf;
+}
+
+/** Voice-like signal: three formants at 700/1200/2500 Hz, AM-modulated at 4 Hz. */
+function makeVoiceLike(n: number): Float32Array {
+  const buf = new Float32Array(n);
+  for (let i = 0; i < n; i++) {
+    const am = 0.5 + 0.5 * Math.sin(2 * Math.PI * 4 * i / SAMPLE_RATE);
+    buf[i] = am * (
+      0.5 * Math.sin(2 * Math.PI * 700  * i / SAMPLE_RATE) +
+      0.3 * Math.sin(2 * Math.PI * 1200 * i / SAMPLE_RATE) +
+      0.2 * Math.sin(2 * Math.PI * 2500 * i / SAMPLE_RATE)
+    );
+  }
+  return buf;
+}
+
+/** Discrete Fourier magnitude at a single frequency (no FFT required for spot-checks). */
+function magnitudeAt(buf: Float32Array, freq: number): number {
+  let re = 0, im = 0;
+  const omega = 2 * Math.PI * freq / SAMPLE_RATE;
+  for (let i = 0; i < buf.length; i++) {
+    re += buf[i] * Math.cos(omega * i);
+    im -= buf[i] * Math.sin(omega * i);
+  }
+  return 2 * Math.sqrt(re * re + im * im) / buf.length;
+}
+
+function rms(buf: Float32Array): number {
+  let sum = 0;
+  for (const v of buf) sum += v * v;
+  return Math.sqrt(sum / buf.length);
+}
+
+function runVocoder(
+  proc: VocoderProcessorLike,
+  carrier: Float32Array,
+  modulator: Float32Array,
+  wet: number,
+  envSmoothing: number,
+): Float32Array {
+  const n = carrier.length;
+  const out = new Float32Array(n);
+  for (let off = 0; off < n; off += BLOCK) {
+    const len = Math.min(BLOCK, n - off);
+    const cB = carrier.subarray(off, off + len);
+    const mB = modulator.subarray(off, off + len);
+    const oB = new Float32Array(len);
+    proc.process([[cB], [mB]], [[oB]], { wet: [wet], envelopeSmoothing: [envSmoothing] });
+    out.set(oB, off);
+  }
+  return out;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('VocoderProcessor DSP', () => {
+  const NUM_BANDS   = 16;
+  const WARMUP      = SAMPLE_RATE * 2; // 2 s — let envelopes converge
+  const MEASURE     = SAMPLE_RATE;     // 1 s measurement window
+  const TOTAL       = WARMUP + MEASURE;
+
+  let Processor: VocoderProcessorConstructor;
+
+  beforeAll(() => {
+    Processor = buildProcessorClass(NUM_BANDS);
+  });
+
+  // ── 1. Silence without modulator ──────────────────────────────────────────
+  it('outputs silence (wet=1) when modulator is absent', () => {
+    const proc     = new Processor({ processorOptions: { numBands: NUM_BANDS, minHz: 80, maxHz: 8000, bandQ: 4 } });
+    const carrier  = makeSawtooth(110, 1.0, MEASURE);
+    const silence  = new Float32Array(MEASURE); // no modulator
+    const out      = runVocoder(proc, carrier, silence, 1.0, 0.005);
+    // All envelopes are zero → bandSum = 0 → output = 0
+    expect(rms(out)).toBeLessThan(1e-6);
+  });
+
+  // ── 2. Make-up gain: broadband output ≈ carrier level ─────────────────────
+  // The bandCount compensation factor (multiplied in the output line) ensures
+  // that a broadband carrier + broadband modulator produces output within ±6 dB
+  // of the carrier RMS.  Before the fix the shortfall was –23.8 dB.
+  it('output RMS is within 6 dB of carrier RMS after 2 s warmup (broadband)', () => {
+    const proc     = new Processor({ processorOptions: { numBands: NUM_BANDS, minHz: 80, maxHz: 8000, bandQ: 4 } });
+    const carrier  = makeSawtooth(110, 1.0, TOTAL);
+    const modulator = makeVoiceLike(TOTAL);
+    const out      = runVocoder(proc, carrier, modulator, 1.0, 0.005);
+
+    const rmsCarrier = rms(carrier.subarray(WARMUP));
+    const rmsOut     = rms(out.subarray(WARMUP));
+    const ratio      = rmsOut / rmsCarrier;
+
+    // Allow 6 dB tolerance on either side.
+    expect(ratio).toBeGreaterThan(0.5);   // > -6 dB
+    expect(ratio).toBeLessThan(2.0);      // < +6 dB
+  });
+
+  // ── 3. Spectral shaping: formants from modulator appear in output ──────────
+  // Compare two vocoders: one with 660 Hz formant, one with 2200 Hz formant.
+  // The 660 Hz modulator should boost the 660 Hz sawtooth harmonic relative to
+  // 2200 Hz; the 2200 Hz modulator should do the reverse. This is the core
+  // "robot voice" spectral-shaping invariant.
+  it('output energy follows modulator formant — spectral shaping works', () => {
+    // Sawtooth at 110 Hz has harmonics at 660, 770, 1100, 1210, 2200 Hz etc.
+    const CARRIER_FREQ = 110;
+    const FORMANT_LOW  = 660;  // harmonic 6
+    const FORMANT_HIGH = 2200; // harmonic 20
+
+    function buildMod(freq: number): Float32Array {
+      const buf = new Float32Array(TOTAL);
+      for (let i = 0; i < TOTAL; i++) buf[i] = Math.sin(2 * Math.PI * freq * i / SAMPLE_RATE);
+      return buf;
+    }
+
+    const carrier    = makeSawtooth(CARRIER_FREQ, 1.0, TOTAL);
+    const modLow     = buildMod(FORMANT_LOW);
+    const modHigh    = buildMod(FORMANT_HIGH);
+
+    const procLow  = new Processor({ processorOptions: { numBands: NUM_BANDS, minHz: 80, maxHz: 8000, bandQ: 4 } });
+    const procHigh = new Processor({ processorOptions: { numBands: NUM_BANDS, minHz: 80, maxHz: 8000, bandQ: 4 } });
+
+    const outLow  = runVocoder(procLow,  carrier, modLow,  1.0, 0.005);
+    const outHigh = runVocoder(procHigh, carrier, modHigh, 1.0, 0.005);
+
+    const measLow  = outLow.subarray(WARMUP);
+    const measHigh = outHigh.subarray(WARMUP);
+
+    // Low-formant vocoder: more energy at FORMANT_LOW than FORMANT_HIGH
+    const magLow660  = magnitudeAt(measLow,  FORMANT_LOW);
+    const magLow2200 = magnitudeAt(measLow,  FORMANT_HIGH);
+    expect(magLow660).toBeGreaterThan(magLow2200);
+
+    // High-formant vocoder: more energy at FORMANT_HIGH than FORMANT_LOW
+    const magHigh660  = magnitudeAt(measHigh, FORMANT_LOW);
+    const magHigh2200 = magnitudeAt(measHigh, FORMANT_HIGH);
+    expect(magHigh2200).toBeGreaterThan(magHigh660);
+  });
+
+  // ── 4. wet=0 passes carrier unchanged ─────────────────────────────────────
+  it('wet=0 passes carrier through with unity gain', () => {
+    const proc     = new Processor({ processorOptions: { numBands: NUM_BANDS, minHz: 80, maxHz: 8000, bandQ: 4 } });
+    const carrier  = makeSawtooth(110, 1.0, MEASURE);
+    const modulator = makeVoiceLike(MEASURE);
+    const out      = runVocoder(proc, carrier, modulator, 0.0, 0.005);
+
+    // With wet=0: output = (1-0)*carrier + 0*bandSum = carrier
+    // The RMS should match the carrier's RMS exactly.
+    const rmsCarrier = rms(carrier);
+    const rmsOut     = rms(out);
+    expect(rmsOut).toBeCloseTo(rmsCarrier, 4);
+  });
+
+  // ── 5. Sine at band center: output ≈ 2/π × carrier (envelope attenuates) ──
+  // When carrier = modulator = sine at exactly one band's center frequency,
+  // only that band contributes meaningfully. After warmup its envelope converges
+  // to ≈ 2/π × amplitude. With the bandCount make-up gain the total output
+  // is bandCount × (gain_factor ≈ 2/π) × carrier_amplitude, i.e. amplified by
+  // roughly N×(2/π).  The important invariant: output is NOT silence and
+  // NOT greater than numBands × carrier.
+  it('sine at band center produces non-trivial output (not silent, not clipping hard)', () => {
+    const BAND_CENTER = 686; // band 7 center frequency
+    const proc        = new Processor({ processorOptions: { numBands: NUM_BANDS, minHz: 80, maxHz: 8000, bandQ: 4 } });
+    const carrier     = makeSine(BAND_CENTER, 1.0, TOTAL);
+    const modulator   = makeSine(BAND_CENTER, 1.0, TOTAL);
+    const out         = runVocoder(proc, carrier, modulator, 1.0, 0.005);
+
+    const rmsO = rms(out.subarray(WARMUP));
+    // Must be meaningfully above silence (> 0.1 = -20 dBFS)
+    expect(rmsO).toBeGreaterThan(0.1);
+    // Must not wildly exceed carrier amplitude
+    expect(rmsO).toBeLessThan(NUM_BANDS * 1.1);
+  });
+
+  // ── 6. processorOptions forwarded: numBands affects output level ──────────
+  // The make-up gain in the output is proportional to bandCount.  So a 32-band
+  // vocoder produces 2× the bandSum level of an 8-band vocoder (32/8 = 4 dB
+  // louder for the same input).
+  it('processorOptions.numBands affects output level (more bands = higher output)', () => {
+    const carrier   = makeSawtooth(110, 1.0, TOTAL);
+    const modulator = makeVoiceLike(TOTAL);
+
+    const proc8  = new Processor({ processorOptions: { numBands: 8,  minHz: 80, maxHz: 8000, bandQ: 4 } });
+    const proc32 = new Processor({ processorOptions: { numBands: 32, minHz: 80, maxHz: 8000, bandQ: 4 } });
+
+    const out8  = runVocoder(proc8,  carrier.slice(), modulator.slice(), 1.0, 0.005);
+    const out32 = runVocoder(proc32, carrier.slice(), modulator.slice(), 1.0, 0.005);
+
+    const rms8  = rms(out8.subarray(WARMUP));
+    const rms32 = rms(out32.subarray(WARMUP));
+
+    // 32 bands should produce more output than 8 bands (both from wider spectral
+    // coverage and the larger bandCount make-up gain).
+    expect(rms32).toBeGreaterThan(rms8);
+  });
+});

--- a/scripts/webgpu-probe.mjs
+++ b/scripts/webgpu-probe.mjs
@@ -34,22 +34,56 @@ const example = process.argv[2] ?? null;
 const require = createRequire(resolve(REPO, 'site') + '/');
 const { chromium } = require('playwright');
 
-const MIME = { '.js': 'text/javascript', '.mjs': 'text/javascript', '.html': 'text/html; charset=utf-8', '.json': 'application/json', '.map': 'application/json', '.css': 'text/css', '.svg': 'image/svg+xml', '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.webp': 'image/webp', '.gif': 'image/gif', '.woff': 'font/woff', '.woff2': 'font/woff2', '.ttf': 'font/ttf', '.otf': 'font/otf', '.wasm': 'application/wasm', '.mp3': 'audio/mpeg', '.ogg': 'audio/ogg', '.wav': 'audio/wav', '.fnt': 'text/xml', '.atlas': 'text/plain' };
+const MIME = {
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.html': 'text/html; charset=utf-8',
+  '.json': 'application/json',
+  '.map': 'application/json',
+  '.css': 'text/css',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.otf': 'font/otf',
+  '.wasm': 'application/wasm',
+  '.mp3': 'audio/mpeg',
+  '.ogg': 'audio/ogg',
+  '.wav': 'audio/wav',
+  '.fnt': 'text/xml',
+  '.atlas': 'text/plain',
+};
 
 function startServer() {
-    const server = createServer((req, res) => {
-        try {
-            let urlPath = decodeURIComponent((req.url ?? '/').split('?')[0]);
-            if (urlPath.startsWith(BASE)) urlPath = urlPath.slice(BASE.length) || '/';
-            let filePath = resolve(join(PUBLIC, urlPath));
-            if (!filePath.startsWith(PUBLIC)) { res.writeHead(403); res.end(); return; }
-            if (existsSync(filePath) && statSync(filePath).isDirectory()) filePath = join(filePath, 'index.html');
-            if (!existsSync(filePath)) { res.writeHead(404); res.end('Not found: ' + urlPath); return; }
-            res.writeHead(200, { 'Content-Type': MIME[extname(filePath).toLowerCase()] ?? 'application/octet-stream', 'Cache-Control': 'no-store' });
-            res.end(readFileSync(filePath));
-        } catch (e) { res.writeHead(500); res.end(String(e)); }
-    });
-    return new Promise(r => server.listen(0, '127.0.0.1', () => r({ port: server.address().port, server })));
+  const server = createServer((req, res) => {
+    try {
+      let urlPath = decodeURIComponent((req.url ?? '/').split('?')[0]);
+      if (urlPath.startsWith(BASE)) urlPath = urlPath.slice(BASE.length) || '/';
+      let filePath = resolve(join(PUBLIC, urlPath));
+      if (!filePath.startsWith(PUBLIC)) {
+        res.writeHead(403);
+        res.end();
+        return;
+      }
+      if (existsSync(filePath) && statSync(filePath).isDirectory()) filePath = join(filePath, 'index.html');
+      if (!existsSync(filePath)) {
+        res.writeHead(404);
+        res.end('Not found: ' + urlPath);
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': MIME[extname(filePath).toLowerCase()] ?? 'application/octet-stream', 'Cache-Control': 'no-store' });
+      res.end(readFileSync(filePath));
+    } catch (e) {
+      res.writeHead(500);
+      res.end(String(e));
+    }
+  });
+  return new Promise(r => server.listen(0, '127.0.0.1', () => r({ port: server.address().port, server })));
 }
 
 const { port, server } = await startServer();
@@ -57,69 +91,107 @@ const baseUrl = `http://127.0.0.1:${port}`;
 
 // THE CORRECT WEBGPU HEADLESS CONFIG — see the file header for the two traps.
 const browser = await chromium.launch({
-    headless: true,
-    channel: 'chromium',
-    args: ['--enable-unsafe-webgpu', '--ignore-gpu-blocklist'],
+  headless: true,
+  channel: 'chromium',
+  args: ['--enable-unsafe-webgpu', '--ignore-gpu-blocklist'],
 });
 const context = await browser.newContext({ viewport: { width: 1280, height: 720 }, colorScheme: 'dark', deviceScaleFactor: 1 });
 const page = await context.newPage();
 const errors = [];
-page.on('console', m => { if (m.type() === 'error') errors.push(m.text().replace(/\s+/g, ' ').slice(0, 200)); });
+page.on('console', m => {
+  if (m.type() === 'error') errors.push(m.text().replace(/\s+/g, ' ').slice(0, 200));
+});
 page.on('pageerror', e => errors.push('PAGEERROR: ' + e.message.replace(/\s+/g, ' ').slice(0, 200)));
 
 await page.goto(`${baseUrl}${BASE}/preview.html`, { waitUntil: 'domcontentloaded', timeout: 20000 });
 
 const caps = await page.evaluate(async () => {
-    const out = { secureContext: isSecureContext, hasGpu: !!navigator.gpu };
-    if (navigator.gpu) {
+  const out = { secureContext: isSecureContext, hasGpu: !!navigator.gpu };
+  if (navigator.gpu) {
+    try {
+      const a = await navigator.gpu.requestAdapter();
+      out.adapter = a ? 'non-null' : 'null';
+      if (a) {
+        out.adapterInfo = a.info ? `${a.info.vendor}/${a.info.architecture}` : 'n/a';
         try {
-            const a = await navigator.gpu.requestAdapter();
-            out.adapter = a ? 'non-null' : 'null';
-            if (a) {
-                out.adapterInfo = a.info ? `${a.info.vendor}/${a.info.architecture}` : 'n/a';
-                try { out.device = (await a.requestDevice()) ? 'non-null' : 'null'; }
-                catch (e) { out.device = 'THROW: ' + e.message.slice(0, 80); }
-            }
-        } catch (e) { out.adapter = 'THROW: ' + e.message.slice(0, 80); }
+          out.device = (await a.requestDevice()) ? 'non-null' : 'null';
+        } catch (e) {
+          out.device = 'THROW: ' + e.message.slice(0, 80);
+        }
+      }
+    } catch (e) {
+      out.adapter = 'THROW: ' + e.message.slice(0, 80);
     }
-    return out;
+  }
+  return out;
 });
 console.log('[webgpu-probe] caps:', JSON.stringify(caps));
 if (caps.device !== 'non-null') {
-    console.log('[webgpu-probe] WARNING: no usable WebGPU device — check channel:chromium and that you did NOT pass --use-angle=d3d11.');
+  console.log('[webgpu-probe] WARNING: no usable WebGPU device — check channel:chromium and that you did NOT pass --use-angle=d3d11.');
 }
 
 if (example) {
-    const srcFile = join(PUBLIC, 'examples', example);
-    if (!existsSync(srcFile)) {
-        console.log('[webgpu-probe] example source missing:', example);
-    } else {
-        const source = readFileSync(srcFile, 'utf8');
-        await page.evaluate(async ({ exampleSource, meta }) => {
-            window.__EXAMPLE_META__ = meta;
-            try { const c = await import('./assets/catalog.js'); window.assets = c.assets ?? {}; } catch { window.assets = {}; }
-            const s = document.createElement('script'); s.type = 'module'; s.textContent = exampleSource + '\n'; document.body.appendChild(s);
-        }, { exampleSource: source, meta: { path: example } });
-        await page.waitForTimeout(3000);
-        const backendType = await page.evaluate(() => globalThis.__app?._backendType ?? 'unknown (example does not expose globalThis.__app)');
-        const buf = await page.screenshot({ clip: { x: 0, y: 0, width: 1280, height: 720 } });
-        mkdirSync(OUT, { recursive: true });
-        const shot = join(OUT, example.replace(/[\\/]/g, '__').replace(/\.js$/, '') + '.png');
-        writeFileSync(shot, buf);
-        const blank = await page.evaluate(async (url) => {
-            const img = new Image(); img.src = url; await img.decode();
-            const W = 80, H = 45; const off = document.createElement('canvas'); off.width = W; off.height = H;
-            const ctx = off.getContext('2d'); ctx.drawImage(img, 0, 0, W, H);
-            const d = ctx.getImageData(0, 0, W, H).data; const n = W * H;
-            const counts = new Map(); let rs = 0, gs = 0, bs = 0;
-            for (let i = 0; i < d.length; i += 4) { const k = (d[i] >> 4) + ',' + (d[i + 1] >> 4) + ',' + (d[i + 2] >> 4); counts.set(k, (counts.get(k) || 0) + 1); rs += d[i]; gs += d[i + 1]; bs += d[i + 2]; }
-            return { uniqueColors: counts.size, avg: [Math.round(rs / n), Math.round(gs / n), Math.round(bs / n)] };
-        }, 'data:image/png;base64,' + buf.toString('base64'));
-        console.log('[webgpu-probe] example:', example, '| active backend:', backendType);
-        console.log('[webgpu-probe] render:', JSON.stringify(blank), blank.uniqueColors <= 3 ? '→ BLANK' : '→ RENDERS');
-        console.log('[webgpu-probe] screenshot:', shot);
-        if (errors.length) console.log('[webgpu-probe] errors:', JSON.stringify(errors.slice(0, 5)));
-    }
+  const srcFile = join(PUBLIC, 'examples', example);
+  if (!existsSync(srcFile)) {
+    console.log('[webgpu-probe] example source missing:', example);
+  } else {
+    const source = readFileSync(srcFile, 'utf8');
+    await page.evaluate(
+      async ({ exampleSource, meta }) => {
+        window.__EXAMPLE_META__ = meta;
+        try {
+          const c = await import('./assets/catalog.js');
+          window.assets = c.assets ?? {};
+        } catch {
+          window.assets = {};
+        }
+        const s = document.createElement('script');
+        s.type = 'module';
+        s.textContent = exampleSource + '\n';
+        document.body.appendChild(s);
+      },
+      { exampleSource: source, meta: { path: example } },
+    );
+    await page.waitForTimeout(3000);
+    const backendType = await page.evaluate(() => globalThis.__app?._backendType ?? 'unknown (example does not expose globalThis.__app)');
+    const buf = await page.screenshot({ clip: { x: 0, y: 0, width: 1280, height: 720 } });
+    mkdirSync(OUT, { recursive: true });
+    const shot = join(OUT, example.replace(/[\\/]/g, '__').replace(/\.js$/, '') + '.png');
+    writeFileSync(shot, buf);
+    const blank = await page.evaluate(
+      async url => {
+        const img = new Image();
+        img.src = url;
+        await img.decode();
+        const W = 80,
+          H = 45;
+        const off = document.createElement('canvas');
+        off.width = W;
+        off.height = H;
+        const ctx = off.getContext('2d');
+        ctx.drawImage(img, 0, 0, W, H);
+        const d = ctx.getImageData(0, 0, W, H).data;
+        const n = W * H;
+        const counts = new Map();
+        let rs = 0,
+          gs = 0,
+          bs = 0;
+        for (let i = 0; i < d.length; i += 4) {
+          const k = (d[i] >> 4) + ',' + (d[i + 1] >> 4) + ',' + (d[i + 2] >> 4);
+          counts.set(k, (counts.get(k) || 0) + 1);
+          rs += d[i];
+          gs += d[i + 1];
+          bs += d[i + 2];
+        }
+        return { uniqueColors: counts.size, avg: [Math.round(rs / n), Math.round(gs / n), Math.round(bs / n)] };
+      },
+      'data:image/png;base64,' + buf.toString('base64'),
+    );
+    console.log('[webgpu-probe] example:', example, '| active backend:', backendType);
+    console.log('[webgpu-probe] render:', JSON.stringify(blank), blank.uniqueColors <= 3 ? '→ BLANK' : '→ RENDERS');
+    console.log('[webgpu-probe] screenshot:', shot);
+    if (errors.length) console.log('[webgpu-probe] errors:', JSON.stringify(errors.slice(0, 5)));
+  }
 }
 
 await browser.close();

--- a/scripts/webgpu-probe.mjs
+++ b/scripts/webgpu-probe.mjs
@@ -1,0 +1,127 @@
+// Ad-hoc WebGPU probe — render ONE playground example on REAL headless WebGPU
+// and report whether it draws, plus the adapter/device the run actually used.
+//
+// WHY THIS EXISTS: "WebGPU can't be tested headless" is FALSE and has been a
+// recurring wrong assumption. It IS testable headless on a real GPU. The two
+// traps that make it *look* broken — both baked into the correct config below:
+//   1. Use `channel: 'chromium'` (system Chromium, new headless). The
+//      playwright-BUNDLED chromium returns a null WebGPU adapter no matter the
+//      flags.
+//   2. Do NOT pass `--use-angle=d3d11`. It forces D3D11-WebGPU whose
+//      requestDevice() needs a dxil.dll that may be absent → throws
+//      "dxil.dll Windows Error 87" (adapter ok, DEVICE throws). That is the
+//      engine's webgpu→webgl2 fallback condition, NOT "WebGPU is unavailable".
+// The formal equivalent is `pnpm test:browser:webgpu` (the green vitest lane);
+// this script is for eyeballing a single example ad-hoc.
+//
+// Usage:
+//   node scripts/webgpu-probe.mjs                         # capability check only
+//   node scripts/webgpu-probe.mjs debug-layer/asset-browser.js   # render one example
+//
+// Requires a built + vendored site (pnpm build && pnpm --dir site vendor:sync:exo
+// && pnpm --dir site examples:sync) so site/public has the current engine.
+import { createServer } from 'node:http';
+import { readFileSync, existsSync, statSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join, resolve, extname } from 'node:path';
+import { createRequire } from 'node:module';
+
+const REPO = resolve(import.meta.dirname, '..');
+const PUBLIC = resolve(REPO, 'site/public');
+const OUT = resolve(REPO, '.webgpu-probe');
+const BASE = '/ExoJS';
+const example = process.argv[2] ?? null;
+
+const require = createRequire(resolve(REPO, 'site') + '/');
+const { chromium } = require('playwright');
+
+const MIME = { '.js': 'text/javascript', '.mjs': 'text/javascript', '.html': 'text/html; charset=utf-8', '.json': 'application/json', '.map': 'application/json', '.css': 'text/css', '.svg': 'image/svg+xml', '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.webp': 'image/webp', '.gif': 'image/gif', '.woff': 'font/woff', '.woff2': 'font/woff2', '.ttf': 'font/ttf', '.otf': 'font/otf', '.wasm': 'application/wasm', '.mp3': 'audio/mpeg', '.ogg': 'audio/ogg', '.wav': 'audio/wav', '.fnt': 'text/xml', '.atlas': 'text/plain' };
+
+function startServer() {
+    const server = createServer((req, res) => {
+        try {
+            let urlPath = decodeURIComponent((req.url ?? '/').split('?')[0]);
+            if (urlPath.startsWith(BASE)) urlPath = urlPath.slice(BASE.length) || '/';
+            let filePath = resolve(join(PUBLIC, urlPath));
+            if (!filePath.startsWith(PUBLIC)) { res.writeHead(403); res.end(); return; }
+            if (existsSync(filePath) && statSync(filePath).isDirectory()) filePath = join(filePath, 'index.html');
+            if (!existsSync(filePath)) { res.writeHead(404); res.end('Not found: ' + urlPath); return; }
+            res.writeHead(200, { 'Content-Type': MIME[extname(filePath).toLowerCase()] ?? 'application/octet-stream', 'Cache-Control': 'no-store' });
+            res.end(readFileSync(filePath));
+        } catch (e) { res.writeHead(500); res.end(String(e)); }
+    });
+    return new Promise(r => server.listen(0, '127.0.0.1', () => r({ port: server.address().port, server })));
+}
+
+const { port, server } = await startServer();
+const baseUrl = `http://127.0.0.1:${port}`;
+
+// THE CORRECT WEBGPU HEADLESS CONFIG — see the file header for the two traps.
+const browser = await chromium.launch({
+    headless: true,
+    channel: 'chromium',
+    args: ['--enable-unsafe-webgpu', '--ignore-gpu-blocklist'],
+});
+const context = await browser.newContext({ viewport: { width: 1280, height: 720 }, colorScheme: 'dark', deviceScaleFactor: 1 });
+const page = await context.newPage();
+const errors = [];
+page.on('console', m => { if (m.type() === 'error') errors.push(m.text().replace(/\s+/g, ' ').slice(0, 200)); });
+page.on('pageerror', e => errors.push('PAGEERROR: ' + e.message.replace(/\s+/g, ' ').slice(0, 200)));
+
+await page.goto(`${baseUrl}${BASE}/preview.html`, { waitUntil: 'domcontentloaded', timeout: 20000 });
+
+const caps = await page.evaluate(async () => {
+    const out = { secureContext: isSecureContext, hasGpu: !!navigator.gpu };
+    if (navigator.gpu) {
+        try {
+            const a = await navigator.gpu.requestAdapter();
+            out.adapter = a ? 'non-null' : 'null';
+            if (a) {
+                out.adapterInfo = a.info ? `${a.info.vendor}/${a.info.architecture}` : 'n/a';
+                try { out.device = (await a.requestDevice()) ? 'non-null' : 'null'; }
+                catch (e) { out.device = 'THROW: ' + e.message.slice(0, 80); }
+            }
+        } catch (e) { out.adapter = 'THROW: ' + e.message.slice(0, 80); }
+    }
+    return out;
+});
+console.log('[webgpu-probe] caps:', JSON.stringify(caps));
+if (caps.device !== 'non-null') {
+    console.log('[webgpu-probe] WARNING: no usable WebGPU device — check channel:chromium and that you did NOT pass --use-angle=d3d11.');
+}
+
+if (example) {
+    const srcFile = join(PUBLIC, 'examples', example);
+    if (!existsSync(srcFile)) {
+        console.log('[webgpu-probe] example source missing:', example);
+    } else {
+        const source = readFileSync(srcFile, 'utf8');
+        await page.evaluate(async ({ exampleSource, meta }) => {
+            window.__EXAMPLE_META__ = meta;
+            try { const c = await import('./assets/catalog.js'); window.assets = c.assets ?? {}; } catch { window.assets = {}; }
+            const s = document.createElement('script'); s.type = 'module'; s.textContent = exampleSource + '\n'; document.body.appendChild(s);
+        }, { exampleSource: source, meta: { path: example } });
+        await page.waitForTimeout(3000);
+        const backendType = await page.evaluate(() => globalThis.__app?._backendType ?? 'unknown (example does not expose globalThis.__app)');
+        const buf = await page.screenshot({ clip: { x: 0, y: 0, width: 1280, height: 720 } });
+        mkdirSync(OUT, { recursive: true });
+        const shot = join(OUT, example.replace(/[\\/]/g, '__').replace(/\.js$/, '') + '.png');
+        writeFileSync(shot, buf);
+        const blank = await page.evaluate(async (url) => {
+            const img = new Image(); img.src = url; await img.decode();
+            const W = 80, H = 45; const off = document.createElement('canvas'); off.width = W; off.height = H;
+            const ctx = off.getContext('2d'); ctx.drawImage(img, 0, 0, W, H);
+            const d = ctx.getImageData(0, 0, W, H).data; const n = W * H;
+            const counts = new Map(); let rs = 0, gs = 0, bs = 0;
+            for (let i = 0; i < d.length; i += 4) { const k = (d[i] >> 4) + ',' + (d[i + 1] >> 4) + ',' + (d[i + 2] >> 4); counts.set(k, (counts.get(k) || 0) + 1); rs += d[i]; gs += d[i + 1]; bs += d[i + 2]; }
+            return { uniqueColors: counts.size, avg: [Math.round(rs / n), Math.round(gs / n), Math.round(bs / n)] };
+        }, 'data:image/png;base64,' + buf.toString('base64'));
+        console.log('[webgpu-probe] example:', example, '| active backend:', backendType);
+        console.log('[webgpu-probe] render:', JSON.stringify(blank), blank.uniqueColors <= 3 ? '→ BLANK' : '→ RENDERS');
+        console.log('[webgpu-probe] screenshot:', shot);
+        if (errors.length) console.log('[webgpu-probe] errors:', JSON.stringify(errors.slice(0, 5)));
+    }
+}
+
+await browser.close();
+await new Promise(r => server.close(r));
+console.log('[webgpu-probe] done');

--- a/site/public/preview.html
+++ b/site/public/preview.html
@@ -126,6 +126,7 @@
                         '@codexo/exojs-physics': physicsEntry,
                         '@codexo/exojs-physics/debug': physicsDebugEntry,
                         '@examples/runtime': './examples/shared/runtime.js?no-cache=' + noCache,
+                        '@examples/physics-tilemap': './examples/shared/physics-tilemap.js?no-cache=' + noCache,
                     },
                 };
                 var script = document.createElement('script');

--- a/site/src/content/api/ducking-effect.mdx
+++ b/site/src/content/api/ducking-effect.mdx
@@ -9,7 +9,7 @@ memberCount: 10
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "packages/exojs-audio-fx/src/effects/DuckingEffect.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-audio-fx/src/effects/DuckingEffect.ts#L86"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-audio-fx/src/effects/DuckingEffect.ts#L90"
 ---
 ## Import
 
@@ -43,4 +43,4 @@ filter coefficients.
 
 ## Source
 
-[packages/exojs-audio-fx/src/effects/DuckingEffect.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-audio-fx/src/effects/DuckingEffect.ts#L86)
+[packages/exojs-audio-fx/src/effects/DuckingEffect.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-audio-fx/src/effects/DuckingEffect.ts#L90)

--- a/src/input/Gamepad.ts
+++ b/src/input/Gamepad.ts
@@ -224,6 +224,19 @@ export class Gamepad {
   }
 
   /**
+   * Re-point this slot at the latest browser gamepad snapshot. The Web Gamepad
+   * API hands back a fresh, immutable snapshot object on every
+   * `navigator.getGamepads()` poll, so a slot that keeps the object captured at
+   * connect time would freeze its button/axis state. {@link InputManager} calls
+   * this each frame for already-connected pads; no signals fire.
+   *
+   * @internal
+   */
+  public _refreshBrowserGamepad(gamepad: BrowserGamepad): void {
+    this._browserGamepad = gamepad;
+  }
+
+  /**
    * Detach the physical gamepad and clear its channels.
    *
    * @internal

--- a/src/input/InputManager.ts
+++ b/src/input/InputManager.ts
@@ -687,6 +687,10 @@ export class InputManager implements System {
 
         this.gamepadsByBrowserIndex.set(browserIndex, pad);
         this.onGamepadConnected.dispatch(pad);
+      } else {
+        // The browser hands back a fresh snapshot object each poll; re-point the
+        // slot at it so button/axis state doesn't freeze at connect-time values.
+        existing._refreshBrowserGamepad(browserGamepad);
       }
     }
 

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -87,7 +87,6 @@ export class RenderPlanBuilder {
     this._view = null;
     this._plan.reset();
     this._groupPoolCursor = 0;
-    this._commandPoolCursor = 0;
     this._drawEntryPoolCursor = 0;
     this._groupEntryPoolCursor = 0;
     this._barrierEntryPoolCursor = 0;
@@ -98,6 +97,18 @@ export class RenderPlanBuilder {
     // render() calls in the frame references a distinct slot and can batch.
     const frameBase = (backend as { transformBufferCount?: number }).transformBufferCount ?? 0;
     this._nodeIndex = frameBase;
+    // The draw-command pool must be frame-global too — not reset to 0 per plan.
+    // A drawable's renderer may DEFER its draw across render() calls (cross-call
+    // batching) while holding a reference to its pooled DrawCommand until the
+    // frame-end flush. Resetting the command cursor to 0 every plan recycles
+    // command objects between render() calls, so a later call's build() would
+    // overwrite an earlier deferred draw's nodeIndex/groupIndex/material and the
+    // deferred draw would read the wrong transform+tint slot (all draws collapse
+    // onto the last command's values). Basing the command cursor at the same
+    // frame-global slot as the node index keeps each frame's commands distinct
+    // and alive until flush; the cursor resets naturally when frameBase returns
+    // to 0 at the next frame's resetStats().
+    this._commandPoolCursor = frameBase;
 
     const rootScope = this._acquireGroupScope(false);
 

--- a/src/rendering/text/BitmapText.ts
+++ b/src/rendering/text/BitmapText.ts
@@ -285,6 +285,8 @@ export class BitmapText extends AbstractText {
       if (py > maxY) maxY = py;
     }
     this._textBounds = { width: maxX, height: maxY };
+    this.getLocalBounds().set(0, 0, maxX, maxY);
+    this._invalidateBoundsCascade();
 
     this._pageQuads = buildTextPageQuads(placements);
   }

--- a/src/rendering/text/Text.ts
+++ b/src/rendering/text/Text.ts
@@ -240,6 +240,8 @@ export class Text extends AbstractText {
       if (py > maxY) maxY = py;
     }
     this._textBounds = { width: maxX, height: maxY };
+    this.getLocalBounds().set(0, 0, maxX, maxY);
+    this._invalidateBoundsCascade();
 
     this._pageQuads = buildTextPageQuads(placements);
     this._style.consumeDirty();

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -810,6 +810,23 @@ export class WebGl2Backend implements RenderBackend {
     return this;
   }
 
+  /**
+   * Make `unit` the active texture unit through the backend's unit cache.
+   *
+   * Renderers that bind a *raw* `WebGLTexture` to a unit (e.g. the text
+   * renderer's private node-data texture) must route the unit switch through
+   * here instead of calling `gl.activeTexture` directly — otherwise the cache
+   * goes stale and a later {@link bindTexture} can skip its own `activeTexture`
+   * call, binding to the wrong unit. After this returns the caller may issue its
+   * own raw `gl.bindTexture` on the now-active unit.
+   * @internal
+   */
+  public setActiveTextureUnit(unit: number): this {
+    this._setTextureUnit(unit);
+
+    return this;
+  }
+
   /** @internal */
   public bindTransformBufferTexture(unit: number, minCount: number): this {
     const requiredCount = Math.max(1, minCount);

--- a/src/rendering/webgl2/WebGl2TextRenderer.ts
+++ b/src/rendering/webgl2/WebGl2TextRenderer.ts
@@ -336,7 +336,12 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
       c.nodeDataCapacity = cap;
     }
 
-    gl.activeTexture(gl.TEXTURE1);
+    // Route the unit switch through the backend so its texture-unit cache stays
+    // in sync. A raw gl.activeTexture here would leave the cache reading unit 0,
+    // and the atlas bindTexture(_, 0) in _drawBatches would then skip its own
+    // switch and bind the atlas to unit 1 — leaving the SDF sampler (unit 0)
+    // empty and the text invisible whenever it is the first draw of a frame.
+    this.getBackend().setActiveTextureUnit(1);
     gl.bindTexture(gl.TEXTURE_2D, c.nodeDataTexture);
     gl.texSubImage2D(
       gl.TEXTURE_2D,

--- a/src/rendering/webgl2/WebGl2TextRenderer.ts
+++ b/src/rendering/webgl2/WebGl2TextRenderer.ts
@@ -39,12 +39,18 @@ import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './
 const nodeTexels = 10;
 const nodeFloats = nodeTexels * 4; // 40 floats per node
 
-// Per-vertex layout (20 bytes — same stride as WebGl2MeshRenderer):
-//   a_position : vec2  f32  (offset  0,  8 bytes)
+// Per-vertex layout (28 bytes):
+//   a_position : vec2  f32  (offset  0,  8 bytes)  ← WORLD space (CPU-transformed)
 //   a_texcoord : vec2  f32  (offset  8,  8 bytes)
-//   a_nodeIndex: float f32  (offset 16,  4 bytes)  ← was a_color u8x4 in mesh.vert
-const vertexStrideBytes = 20;
-const vertexStrideWords = vertexStrideBytes / 4; // 5 floats per vertex
+//   a_nodeIndex: float f32  (offset 16,  4 bytes)  ← row into the data texture (style lookup)
+//   a_gradUV   : vec2  f32  (offset 20,  8 bytes)  ← normalised gradient UV (CPU-computed)
+//
+// The vertex shader does NOT read the per-node data texture: the world transform and
+// gradient UV are computed on the CPU here and uploaded per vertex. This sidesteps an
+// ANGLE/D3D11 bug where a vertex texelFetch of the RGBA32F data texture returns RGB as
+// 0 when an RGBA8 atlas is bound, collapsing the transform and hiding bitmap text.
+const vertexStrideBytes = 28;
+const vertexStrideWords = vertexStrideBytes / 4; // 7 floats per vertex
 const initialVertexCapacity = 256;
 const initialIndexCapacity = 384;
 const initialNodeCapacity = 32;
@@ -174,8 +180,16 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
       .addIndex(indexBuffer)
       .addAttribute(vertexBuffer, this._sdfShader.getAttribute('a_position'), gl.FLOAT, false, vertexStrideBytes, 0)
       .addAttribute(vertexBuffer, this._sdfShader.getAttribute('a_texcoord'), gl.FLOAT, false, vertexStrideBytes, 8)
-      .addAttribute(vertexBuffer, this._sdfShader.getAttribute('a_nodeIndex'), gl.FLOAT, false, vertexStrideBytes, 16)
-      .connect(this._createVaoRuntime(gl, vaoHandle));
+      .addAttribute(vertexBuffer, this._sdfShader.getAttribute('a_nodeIndex'), gl.FLOAT, false, vertexStrideBytes, 16);
+
+    // a_gradUV is bound only when the program declares it. The real shaders always
+    // do; reduced test stand-in vertex shaders may omit it (an unused attribute is
+    // optimised out and would not get a location).
+    if (this._sdfShader.attributes.has('a_gradUV')) {
+      vao.addAttribute(vertexBuffer, this._sdfShader.getAttribute('a_gradUV'), gl.FLOAT, false, vertexStrideBytes, 20);
+    }
+
+    vao.connect(this._createVaoRuntime(gl, vaoHandle));
 
     const nodeDataTexture = this._createNodeDataTexture(gl, initialNodeCapacity);
 
@@ -415,15 +429,38 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
         const qVerts = batch.quadCount * 4;
         const { vertices, uvs, indices } = batch;
 
+        // Read this node's transform + gradient bounds back from the packed data array
+        // (same layout as _packNodeData) so we can transform vertices on the CPU. The
+        // vertex shader no longer reads the data texture; see the layout comment above.
+        const nb = nodeIndex * nodeFloats;
+        // In-bounds: `_packNodeData` wrote nodeFloats values at `nb` for every node index.
+        const a = this._nodeDataArray[nb + 0]!; // texel0.x
+        const cc = this._nodeDataArray[nb + 1]!; // texel0.y
+        const tx = this._nodeDataArray[nb + 3]!; // texel0.w
+        const b = this._nodeDataArray[nb + 4]!; // texel1.x
+        const dd = this._nodeDataArray[nb + 5]!; // texel1.y
+        const ty = this._nodeDataArray[nb + 7]!; // texel1.w
+        const boundsMinX = this._nodeDataArray[nb + 36]!; // texel9.x
+        const boundsMinY = this._nodeDataArray[nb + 37]!; // texel9.y
+        const boundsW = this._nodeDataArray[nb + 38]!; // texel9.z
+        const boundsH = this._nodeDataArray[nb + 39]!; // texel9.w
+        const hasGradBounds = boundsW > 0 && boundsH > 0;
+
         for (let v = 0; v < qVerts; v++) {
           const w = (vOffset + v) * vertexStrideWords;
           const vp = v * 2;
           // In-bounds: `vp + 1 < qVerts * 2`; `vertices`/`uvs` carry 2 floats per quad vertex.
-          this._float32View[w + 0] = vertices[vp]!;
-          this._float32View[w + 1] = vertices[vp + 1]!;
+          const lx = vertices[vp]!;
+          const ly = vertices[vp + 1]!;
+          // world = M · (lx, ly, 1) with M = column-major [a c 0 | b d 0 | tx ty 1].
+          this._float32View[w + 0] = a * lx + b * ly + tx;
+          this._float32View[w + 1] = cc * lx + dd * ly + ty;
           this._float32View[w + 2] = uvs[vp]!;
           this._float32View[w + 3] = uvs[vp + 1]!;
           this._float32View[w + 4] = nodeIndex;
+          // Normalised gradient UV across the text block (matches the old vertex math).
+          this._float32View[w + 5] = hasGradBounds ? Math.min(1, Math.max(0, (lx - boundsMinX) / boundsW)) : 0;
+          this._float32View[w + 6] = hasGradBounds ? Math.min(1, Math.max(0, (ly - boundsMinY) / boundsH)) : 0;
         }
 
         for (let x = 0; x < indices.length; x++) {

--- a/src/rendering/webgl2/glsl/text.vert
+++ b/src/rendering/webgl2/glsl/text.vert
@@ -1,41 +1,27 @@
 #version 300 es
 precision highp float;
 
-layout(location = 0) in vec2  a_position;
+// a_position arrives already in WORLD space: the renderer applies each node's
+// world transform on the CPU while building the vertex buffer. This deliberately
+// avoids a vertex-stage texelFetch of the per-node data texture — on ANGLE/D3D11
+// a vertex texture fetch of the RGBA32F data texture returns garbage (RGB read as
+// 0) whenever an RGBA8 atlas is also bound, which collapsed all text glyphs to a
+// point and made colour/MSDF bitmap text invisible. The fragment still reads the
+// per-node style from the data texture (a fragment texture fetch is unaffected).
+layout(location = 0) in vec2  a_position;   // world-space quad corner
 layout(location = 1) in vec2  a_texcoord;
-layout(location = 2) in float a_nodeIndex;
+layout(location = 2) in float a_nodeIndex;  // row into the per-node data texture (style lookup)
+layout(location = 3) in vec2  a_gradUV;     // normalised gradient UV (CPU-computed)
 
 uniform mat3 u_projection;
-uniform sampler2D u_nodeData;
 
 flat out int  v_nodeIndex;
      out vec2 v_texcoord;
      out vec2 v_gradUV;
 
 void main(void) {
-    int ni = int(a_nodeIndex);
-
-    // texel 0: (a, c, 0, tx)   texel 1: (b, d, 0, ty)
-    vec4 t0 = texelFetch(u_nodeData, ivec2(0, ni), 0);
-    vec4 t1 = texelFetch(u_nodeData, ivec2(1, ni), 0);
-
-    // Reconstruct column-major mat3 from stored components
-    mat3 xf = mat3(
-        t0.x, t0.y, 0.0,   // col 0: (a, c, 0)
-        t1.x, t1.y, 0.0,   // col 1: (b, d, 0)
-        t0.w, t1.w, 1.0    // col 2: (tx, ty, 1)
-    );
-
-    gl_Position = vec4((u_projection * xf * vec3(a_position, 1.0)).xy, 0.0, 1.0);
+    gl_Position = vec4((u_projection * vec3(a_position, 1.0)).xy, 0.0, 1.0);
     v_texcoord  = a_texcoord;
-    v_nodeIndex = ni;
-
-    // texel 9: (minX, minY, width, height) — text block bounds in local space.
-    // Normalise a_position into [0,1] so fragment shaders can interpolate
-    // gradients across the whole block rather than individual atlas UVs.
-    vec4 tBounds = texelFetch(u_nodeData, ivec2(9, ni), 0);
-    vec2 bSize   = tBounds.zw;
-    v_gradUV = (bSize.x > 0.0 && bSize.y > 0.0)
-        ? clamp((a_position - tBounds.xy) / bSize, 0.0, 1.0)
-        : vec2(0.0);
+    v_nodeIndex = int(a_nodeIndex);
+    v_gradUV    = a_gradUV;
 }

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -900,11 +900,9 @@ export class WebGpuBackend implements RenderBackend {
       throw new Error('WebGPU is available, but navigator.gpu.getPreferredCanvasFormat is not implemented.');
     }
 
-    // Request the adapter before acquiring a WebGPU canvas context.
-    // getContext('webgpu') is exclusive per canvas — once it succeeds, the
-    // same canvas can no longer produce a WebGL2 context. Doing it the
-    // other way round means an unavailable adapter still locks the canvas
-    // and breaks the automatic WebGL2 fallback in Application.
+    // Request the adapter AND the device before acquiring a WebGPU canvas
+    // context — see the getContext('webgpu') call below for why the order
+    // matters.
     let adapter: GPUAdapter | null;
 
     try {
@@ -915,12 +913,6 @@ export class WebGpuBackend implements RenderBackend {
 
     if (adapter === null) {
       throw new Error('Could not acquire a WebGPU adapter.');
-    }
-
-    const context = this._canvas.getContext('webgpu');
-
-    if (context === null) {
-      throw new Error('Could not create WebGPU canvas context.');
     }
 
     if (typeof adapter.requestDevice !== 'function') {
@@ -937,6 +929,19 @@ export class WebGpuBackend implements RenderBackend {
 
     if (device === null) {
       throw new Error('Could not acquire a WebGPU device.');
+    }
+
+    // Acquire the WebGPU canvas context only after BOTH the adapter and the
+    // device are secured. getContext('webgpu') is exclusive per canvas — once
+    // it succeeds, the same canvas can no longer produce a WebGL2 context.
+    // Acquiring it earlier would lock the canvas even when WebGPU ultimately
+    // fails (a usable adapter but a failing requestDevice — e.g. a missing
+    // backend library), which breaks the automatic WebGL2 fallback in
+    // Application.
+    const context = this._canvas.getContext('webgpu');
+
+    if (context === null) {
+      throw new Error('Could not create WebGPU canvas context.');
     }
 
     const format = gpuNavigator.gpu.getPreferredCanvasFormat();

--- a/test/input/input-manager.test.ts
+++ b/test/input/input-manager.test.ts
@@ -103,6 +103,35 @@ describe('InputManager gamepad lifecycle', () => {
     inputManager.destroy();
   });
 
+  test('reads the fresh browser-gamepad snapshot every frame (press/release after connect)', () => {
+    const inputManager = createInputManager();
+
+    withMockedGetGamepads(setSnapshot => {
+      const buttonSouthChannel = Gamepad.resolveChannelOffset(0, GamepadButton.South);
+      const channels = (inputManager as unknown as { channels: Float32Array }).channels;
+
+      // Frame 1 — connect with the South button RELEASED.
+      setSnapshot([createNativeGamepad('Vendor: 045e Product: 0b13', 0, [0]), null, null, null]);
+      inputManager.update();
+      expect(inputManager.gamepads[0].connected).toBe(true);
+      expect(channels[buttonSouthChannel]).toBe(0);
+
+      // Frame 2 — a FRESH snapshot object (as the browser returns each call)
+      // now reports the button PRESSED. The engine must poll the new snapshot,
+      // not the stale one captured at connect.
+      setSnapshot([createNativeGamepad('Vendor: 045e Product: 0b13', 0, [1]), null, null, null]);
+      inputManager.update();
+      expect(channels[buttonSouthChannel]).toBe(1);
+
+      // Frame 3 — released again must clear (no "stuck" button after release).
+      setSnapshot([createNativeGamepad('Vendor: 045e Product: 0b13', 0, [0]), null, null, null]);
+      inputManager.update();
+      expect(channels[buttonSouthChannel]).toBe(0);
+    });
+
+    inputManager.destroy();
+  });
+
   test('exposes convenience getters: getGamepad / connectedGamepads / firstConnectedGamepad / hasGamepad', () => {
     const inputManager = createInputManager();
 

--- a/test/rendering/browser/webgl2-render-plan.test.ts
+++ b/test/rendering/browser/webgl2-render-plan.test.ts
@@ -418,6 +418,49 @@ describe('RenderPlan WebGL2 browser regressions', () => {
     }
   });
 
+  test('distinct mesh tints survive cross-call batching (pooled DrawCommand regression)', async () => {
+    const { backend } = await createBackend();
+    // White vertex colors so each mesh's tint alone determines its color.
+    const white = (): Uint32Array => new Uint32Array(6).fill(0xffffffff);
+    const rect = (): Float32Array => new Float32Array([0, 0, 16, 0, 16, 16, 0, 0, 16, 16, 0, 16]);
+    const meshA = new Mesh({ vertices: rect(), colors: white() });
+    const meshB = new Mesh({ vertices: rect(), colors: white() });
+    const meshC = new Mesh({ vertices: rect(), colors: white() });
+
+    try {
+      meshA.tint = new Color(255, 0, 0);
+      meshB.tint = new Color(0, 255, 0);
+      meshC.tint = new Color(0, 0, 255);
+      meshA.setPosition(0, 0);
+      meshB.setPosition(24, 0);
+      meshC.setPosition(48, 0);
+
+      // Each mesh is rendered in its OWN render() call within a single frame,
+      // with no flush between them — the cross-call batching path. Every draw's
+      // DrawCommand is pooled by the plan builder and its nodeIndex is
+      // frame-global; recycling the command pool per plan (the regression) lets
+      // each later build() overwrite the earlier deferred draws' command, so all
+      // three reads collapse onto the last command's transform+tint slot — every
+      // mesh would render blue at meshC's position (48, 0).
+      backend.resetStats();
+      backend.clear(Color.black);
+      meshA.render(backend);
+      meshB.render(backend);
+      meshC.render(backend);
+      backend.flush();
+
+      // Fixed: each mesh keeps its own slot — distinct color AND position.
+      expectPixelNear(readPixel(backend, 8, 8), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(backend, 32, 8), [0, 255, 0, 255]);
+      expectPixelNear(readPixel(backend, 56, 8), [0, 0, 255, 255]);
+    } finally {
+      meshA.destroy();
+      meshB.destroy();
+      meshC.destroy();
+      backend.destroy();
+    }
+  });
+
   test('multiple sprites with distinct transforms batch into one draw, each at its own position', async () => {
     const { backend } = await createBackend();
     const texture = createSolidTexture('#ff0000', 8, 8);

--- a/test/rendering/browser/webgl2-text-layout.test.ts
+++ b/test/rendering/browser/webgl2-text-layout.test.ts
@@ -162,21 +162,25 @@ void main() {
   outColor = texture(u_texture, v_uv) * v_color;
 }`,
 
-  // Minimal text vertex path: project the laid-out local glyph position. The
+  // Minimal text vertex path: project the (already world-space) glyph position. The
   // assertions read geometry, not pixels, so the exact transform is immaterial;
-  // `a_nodeIndex` is referenced so it is not optimised out (the renderer wires it
-  // as a vertex attribute on connect and would fail to find the location).
+  // `a_nodeIndex` and `a_gradUV` are referenced so they are not optimised out (the
+  // renderer wires them as vertex attributes on connect and would fail to find the
+  // location). Mirrors the real text.vert attribute interface (no vertex texelFetch).
   textVertexSource: `#version 300 es
 precision highp float;
 layout(location = 0) in vec2 a_position;
 layout(location = 1) in vec2 a_texcoord;
 layout(location = 2) in float a_nodeIndex;
+layout(location = 3) in vec2 a_gradUV;
 uniform mat3 u_projection;
 out vec2 v_texcoord;
+out vec2 v_gradUV;
 void main(void) {
   vec2 local = a_position + vec2(a_nodeIndex * 0.0);
   gl_Position = vec4((u_projection * vec3(local, 1.0)).xy, 0.0, 1.0);
   v_texcoord = a_texcoord;
+  v_gradUV = a_gradUV;
 }`,
 
   // SDF coverage → premultiplied white. Background stays at the black clear color.

--- a/test/rendering/browser/webgl2-text-layout.test.ts
+++ b/test/rendering/browser/webgl2-text-layout.test.ts
@@ -405,4 +405,35 @@ describe('Text layout WebGL2 browser', () => {
       backend.destroy();
     }
   });
+
+  // Regression: a Text node that is the ONLY draw in a frame must bind its glyph
+  // atlas to the texture unit its SDF shader samples (unit 0). The renderer binds
+  // its node-data texture to unit 1; if it does so with a raw gl.activeTexture
+  // that bypasses the backend's texture-unit cache, the subsequent
+  // bindTexture(atlas, 0) is skipped (the cache still reads 0 from frame start)
+  // and the atlas lands on unit 1 — leaving unit 0 (what the shader reads) empty,
+  // so every glyph samples 0 and the whole frame is transparent. A preceding
+  // sprite primes the cache off 0, which is why the bug only bites text that
+  // renders first. We assert the GL unit state rather than read-back pixels: the
+  // browser project mocks the text shaders, so pixel output is not meaningful, but
+  // the unit choreography that the bug corrupts is.
+  test('binds the glyph atlas to the sampled unit when text is the only draw (texture-unit priming regression)', async () => {
+    const backend = await createBackend(256, 64);
+    const gl = backend.context;
+    const text = new Text('HELLO', { fillColor: Color.white, fontSize: 30 });
+
+    try {
+      render(backend, text);
+      expect(backend.stats.drawCalls).toBeGreaterThan(0);
+
+      // After a correct text flush the active unit is 0 (the last atlas bind) with
+      // the atlas bound there; the bug leaves the active unit at 1 (the skipped
+      // switch) and unit 0 empty.
+      expect(gl.getParameter(gl.ACTIVE_TEXTURE)).toBe(gl.TEXTURE0);
+      expect(gl.getParameter(gl.TEXTURE_BINDING_2D)).not.toBeNull();
+    } finally {
+      text.destroy();
+      backend.destroy();
+    }
+  });
 });

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -58,7 +58,8 @@
       "@codexo/exojs-physics": ["./packages/exojs-physics/src/index.ts"],
       "@codexo/exojs-physics/debug": ["./packages/exojs-physics/src/debug/index.ts"],
       "@codexo/exojs-audio-fx": ["./packages/exojs-audio-fx/src/index.ts"],
-      "@examples/runtime": ["./examples/shared/runtime.d.ts"]
+      "@examples/runtime": ["./examples/shared/runtime.d.ts"],
+      "@examples/physics-tilemap": ["./examples/shared/physics-tilemap.ts"]
     }
   },
   "include": ["examples/**/*.js", "examples/**/*.ts", "examples/shared/runtime.d.ts", "src/typings.d.ts"],


### PR DESCRIPTION
Real-GPU sweep of all 123 playground examples (headless Chromium, `--use-angle=d3d11`, served under the production `/ExoJS/` base, mirroring `EditorPreview`). Five fixes, all empirically verified.

## Fixes

- **`fix(rendering)` — all WebGL2 text was invisible as the first draw of a frame.** `WebGl2TextRenderer._uploadNodeData` bound its node-data texture with a raw `gl.activeTexture`, bypassing the backend's texture-unit cache; when text rendered first the atlas bound to the wrong unit and every glyph went transparent. Route the unit switch through `WebGl2Backend.setActiveTextureUnit`. Fixed ~9 examples (text-fonts, UI labels, typewriter, orb-dodge…). WebGL2-only (WebGPU unaffected). + browser regression test.
- **`fix(input)` — gamepad froze after connect.** `InputManager.updateGamepads` never re-read `navigator.getGamepads()` for already-connected pads, so button/axis state stuck at connect-time values. Poll the fresh snapshot every frame. + regression test pressing/releasing across frames.
- **`fix(audio-fx)` — ducking logged a `setTargetAtTime` out-of-range warning every frame.** Its attack/release params are `[0,1]` smoothing coefficients, not times; the `0.001` floor clipped typical values.
- **`fix(examples)` — svg-drawable, trail-feedback, tiled-physics-actor.** SVG rasterised to a 0×0 texture (viewBox-only) and used `currentColor` (→ black on black); trail-feedback read+wrote the same render target (GL feedback loop) → ping-pong two targets; the tiled actor's relative `../shared/` import 404'd in the playground → bare `@examples/physics-tilemap` import-map specifier.

## Verification
`pnpm test` (all projects) · `pnpm test:browser:webgl:chromium` 150/150 · `pnpm verify:quick` (typecheck core+guides+examples+8 packages, lint, prettier, api-docs) — all green.

## Methodology note
The previous session's "renders black with 0 errors on real GPU" observations were a harness artifact: headless Chromium exposes `navigator.gpu` but `requestDevice` fails (no `dxil.dll`), and the engine's webgpu→webgl2 fallback reuses the now-webgpu canvas → black. The sweep harness hides `navigator.gpu` so the engine uses real-GPU WebGL2.

## Known issues, NOT in this PR (follow-ups)
- **BitmapText / Text+filter / render-target PiP invisible as first draw** (`bitmap-text-basic`, `text-glitch`, `picture-in-picture`). Precisely narrowed: the **vertex stage of the text-color program reads its transform from `u_nodeData` incorrectly** (fragment + the SDF program read it fine), collapsing every glyph quad — a subtle driver/linker sampler-binding effect; not yet cracked.
- **webgpu→webgl2 fallback reuses the canvas** (P2 robustness) — only bites when an adapter exists but `requestDevice` fails.
- **asset-browser** renders but is visually incomplete (empty category-icon buttons, oversized blob).
- The remaining "blankish" examples are classifier false-positives (small/sparse content) or interactive demos awaiting input — not broken.