### PR TITLE
refactor(core): route raw console.* through DEV-gated logger/warnOnce/assert

### DIFF
--- a/site/src/content/api/application-status.mdx
+++ b/site/src/content/api/application-status.mdx
@@ -9,7 +9,7 @@ memberCount: 4
 tier: "stable"
 sections: ["Import", "Members", "Source"]
 sourcePath: "src/core/Application.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L38"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L39"
 ---
 ## Import
 
@@ -24,4 +24,4 @@ sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#
 
 ## Source
 
-[src/core/Application.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L38)
+[src/core/Application.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L39)

--- a/site/src/content/api/application.mdx
+++ b/site/src/content/api/application.mdx
@@ -9,7 +9,7 @@ memberCount: 48
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/core/Application.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L227"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L228"
 ---
 ## Import
 
@@ -99,4 +99,4 @@ background-active simulations.
 
 ## Source
 
-[src/core/Application.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L227)
+[src/core/Application.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L228)

--- a/site/src/content/api/htmltext.mdx
+++ b/site/src/content/api/htmltext.mdx
@@ -9,7 +9,7 @@ memberCount: 99
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/rendering/text/HTMLText.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/text/HTMLText.ts#L61"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/text/HTMLText.ts#L62"
 ---
 ## Import
 
@@ -146,4 +146,4 @@ because it is embedded inside an XML document.
 
 ## Source
 
-[src/rendering/text/HTMLText.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/text/HTMLText.ts#L61)
+[src/rendering/text/HTMLText.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/text/HTMLText.ts#L62)

--- a/site/src/content/api/scene-manager.mdx
+++ b/site/src/content/api/scene-manager.mdx
@@ -9,7 +9,7 @@ memberCount: 10
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/core/SceneManager.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/SceneManager.ts#L70"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/SceneManager.ts#L71"
 ---
 ## Import
 
@@ -49,4 +49,4 @@ while it keeps rendering).
 
 ## Source
 
-[src/core/SceneManager.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/SceneManager.ts#L70)
+[src/core/SceneManager.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/SceneManager.ts#L71)

--- a/site/src/content/api/tween.mdx
+++ b/site/src/content/api/tween.mdx
@@ -9,7 +9,7 @@ memberCount: 19
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/animation/Tween.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/animation/Tween.ts#L39"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/animation/Tween.ts#L41"
 ---
 ## Import
 
@@ -62,4 +62,4 @@ properties listed in Tween.to emit a console warning and are skipped.
 
 ## Source
 
-[src/animation/Tween.ts](https://github.com/Exoridus/ExoJS/blob/main/src/animation/Tween.ts#L39)
+[src/animation/Tween.ts](https://github.com/Exoridus/ExoJS/blob/main/src/animation/Tween.ts#L41)

--- a/src/animation/Tween.ts
+++ b/src/animation/Tween.ts
@@ -1,3 +1,5 @@
+import { warnOnce } from '#core/dev';
+
 import { Ease } from './Easing';
 import type { TweenManager } from './TweenManager';
 import type { EasingFunction, TweenLifecycleCallback, TweenUpdateCallback } from './types';
@@ -359,7 +361,10 @@ export class Tween<T extends object = object> {
       const val = this._target[key];
 
       if (typeof val !== 'number') {
-        console.warn(`Tween: property "${String(key)}" is not a number on target ` + `(got ${typeof val}). It will be skipped.`);
+        warnOnce(
+          `tween:non-numeric-prop:${String(key)}`,
+          `Tween: property "${String(key)}" is not a number on target (got ${typeof val}). It will be skipped.`,
+        );
         continue;
       }
 

--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -27,6 +27,7 @@ import { Clock } from './Clock';
 import { Color } from './Color';
 import { FixedTimestep } from './FixedTimestep';
 import { computeLetterboxLayout } from './letterbox';
+import { logger } from './logging';
 import type { Scene } from './Scene';
 import { SceneManager } from './SceneManager';
 import { defaultSerializationRegistry, SerializationRegistry } from './serialization/SerializationRegistry';
@@ -690,7 +691,7 @@ export class Application {
       this._status = ApplicationStatus.Halting;
       cancelAnimationFrame(this._frameRequest);
       void this.scene.setScene(null).catch((error: unknown) => {
-        console.error('Application.stop() failed to unload the active scene.', error);
+        logger.error('core', 'Application.stop() failed to unload the active scene.', error instanceof Error ? error : undefined);
         this.onError?.dispatch(error instanceof Error ? error : new Error(String(error)));
       });
       this._activeClock.stop();

--- a/src/core/SceneManager.ts
+++ b/src/core/SceneManager.ts
@@ -3,6 +3,7 @@ import type { RenderBackend } from '#rendering/RenderBackend';
 
 import type { Application } from './Application';
 import { Color } from './Color';
+import { logger } from './logging';
 import { Scene } from './Scene';
 import { Signal } from './Signal';
 import type { Time } from './Time';
@@ -150,8 +151,9 @@ export class SceneManager {
 
         if (!this._asyncUpdateWarned.has(scene) && (updateResult as unknown) instanceof Promise) {
           this._asyncUpdateWarned.add(scene);
-          console.warn(
-            `[ExoJS] Scene.update() returned a Promise. update() must be synchronous — async logic here breaks frame timing and silently drops errors. Move async work into load() or init() instead.`,
+          logger.warn(
+            'scene',
+            `Scene.update() returned a Promise. update() must be synchronous — async logic here breaks frame timing and silently drops errors. Move async work into load() or init() instead.`,
           );
         }
 
@@ -164,8 +166,9 @@ export class SceneManager {
 
       if (!this._asyncDrawWarned.has(scene) && (drawResult as unknown) instanceof Promise) {
         this._asyncDrawWarned.add(scene);
-        console.warn(
-          `[ExoJS] Scene.draw() returned a Promise. draw() must be synchronous — an async draw() produces incomplete frames and silently drops errors.`,
+        logger.warn(
+          'scene',
+          `Scene.draw() returned a Promise. draw() must be synchronous — an async draw() produces incomplete frames and silently drops errors.`,
         );
       }
 
@@ -228,8 +231,9 @@ export class SceneManager {
       await scene.init(this._app.loader);
 
       if (scene.root.children.length > 0 && scene.draw === Scene.prototype.draw) {
-        console.warn(
-          `[ExoJS] Scene.root has ${scene.root.children.length} child(ren) after init() but draw() is not overridden. Scene.root is not auto-rendered — call context.render(this.root) inside draw().`,
+        logger.warn(
+          'scene',
+          `Scene.root has ${scene.root.children.length} child(ren) after init() but draw() is not overridden. Scene.root is not auto-rendered — call context.render(this.root) inside draw().`,
         );
       }
 
@@ -303,7 +307,7 @@ export class SceneManager {
     try {
       await this._disposeScene(scene);
     } catch (error) {
-      console.error('SceneManager.destroy() failed to unload the active scene.', error);
+      logger.error('scene', 'SceneManager.destroy() failed to unload the active scene.', error instanceof Error ? error : undefined);
     }
   }
 

--- a/src/rendering/text/HTMLText.ts
+++ b/src/rendering/text/HTMLText.ts
@@ -1,3 +1,4 @@
+import { logger, LogSeverity } from '#core/logging';
 import { Container } from '#rendering/Container';
 import { Mesh } from '#rendering/mesh/Mesh';
 import { Texture } from '#rendering/texture/Texture';
@@ -218,8 +219,7 @@ export class HTMLText extends Container {
   private _schedule(): void {
     const version = ++this._renderVersion;
     this._activeRender = this._render(version).catch(error => {
-      // eslint-disable-next-line no-console -- SVG/HTML render failures are meaningful dev-time diagnostics
-      console.warn('[ExoJS] HTMLText render failed.', error);
+      logger.log(LogSeverity.Warning, 'rendering', 'HTMLText render failed.', error instanceof Error ? { error } : undefined);
     });
   }
 

--- a/test/core/application.test.ts
+++ b/test/core/application.test.ts
@@ -518,7 +518,7 @@ describe('Application', () => {
     expect(activeClock.stop).toHaveBeenCalledTimes(1);
     expect(frameClock.stop).toHaveBeenCalledTimes(1);
     expect(app.status).toBe(ApplicationStatus.Stopped);
-    expect(consoleErrorSpy).toHaveBeenCalledWith('Application.stop() failed to unload the active scene.', sceneTeardownError);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('[ExoJS:core]', 'Application.stop() failed to unload the active scene.', sceneTeardownError);
 
     cancelSpy.mockRestore();
     consoleErrorSpy.mockRestore();

--- a/test/core/scene-manager.test.ts
+++ b/test/core/scene-manager.test.ts
@@ -184,7 +184,7 @@ describe('SceneManager', () => {
     await Promise.resolve();
 
     expect(unload).toHaveBeenCalledTimes(1);
-    expect(consoleErrorSpy).toHaveBeenCalledWith('SceneManager.destroy() failed to unload the active scene.', expect.any(Error));
+    expect(consoleErrorSpy).toHaveBeenCalledWith('[ExoJS:scene]', 'SceneManager.destroy() failed to unload the active scene.', expect.any(Error));
     consoleErrorSpy.mockRestore();
   });
 


### PR DESCRIPTION
Routes raw `console.*` calls in the engine source through the existing DEV-gated logging mechanism so they no longer ship in the production build (#4 logger hygiene from the render-engine follow-up).

## Changes
- **`Tween.ts`**: `console.warn` (non-numeric tween property) → `warnOnce(key, msg)` — once per property name, stripped in production.
- **`Application.ts`**: `console.error` (cleanup path in `stop()`) → `logger.error('core', …, error)`; the `onError` dispatch stays as a fallback.
- **`SceneManager.ts`** (4×): async `Scene.update`/`draw` warnings + root-not-rendered warning + destroy error → `logger.warn/error('scene', …)`. The existing `_asyncUpdateWarned`/`_asyncDrawWarned` dedup stays; the `[ExoJS]` prefix is dropped (the logger prepends `[ExoJS:scene]` itself).
- **`HTMLText.ts`**: `console.warn` (render failure) → `logger.log(LogSeverity.Warning, 'rendering', …, { error })`; the `eslint-disable no-console` is gone.
- Two unit tests updated (`application`/`scene-manager`): the `console.error` spy now expects the 3-arg, channel-prefixed shape.

`WebGl2Backend` GL-call trace is intentionally **not** here — it lands in the render PR (same file, to avoid a conflict).

## Verify
- `pnpm build` + `pnpm typecheck` + `pnpm lint` green.
- `vitest run test/animation test/core test/build-defines` → 489 tests green.

## Note (intentional semantic change)
`logger.warn` is a no-op in production (severity filter); the original `console.warn` calls ran there — which is exactly the goal (keep them out of the production build). `logger.error` is routed to registered handlers in production (no default console output).
