### PR TITLE
feat(audio-fx): add ConvolutionEffect for real impulse-response convolution

### DIFF
--- a/packages/exojs-audio-fx/src/effects/ConvolutionEffect.ts
+++ b/packages/exojs-audio-fx/src/effects/ConvolutionEffect.ts
@@ -1,0 +1,241 @@
+import { AudioEffect, getAudioContext, isAudioContextReady, onAudioContextReady, Sound } from '@codexo/exojs';
+
+/** Construction options for {@link ConvolutionEffect}. */
+export interface ConvolutionEffectOptions {
+  /**
+   * Impulse response. Accepts a decoded `AudioBuffer` or a `Sound` (its
+   * `audioBuffer` is used). If omitted the effect runs dry (passthrough) until
+   * {@link ConvolutionEffect.setImpulse} is called.
+   */
+  impulse?: AudioBuffer | Sound;
+  /**
+   * Dry/wet mix, 0..1. The dry level is automatically `1 - wet`. Default 1.0.
+   */
+  wet?: number;
+  /**
+   * Maps to `ConvolverNode.normalize`. When `true` the browser applies an
+   * equal-power normalization pass on the IR so different IRs play at a
+   * consistent perceived loudness. Default `true` (the Web Audio spec default).
+   *
+   * **Note:** the Web Audio spec only respects `normalize` if it is set
+   * *before* `buffer` is assigned. This class always writes `normalize` first.
+   * Changing `normalize` at runtime while an IR is loaded re-assigns the
+   * buffer so the new value takes effect.
+   */
+  normalize?: boolean;
+  /**
+   * Optional makeup gain multiplier applied to the wet path. Useful when the
+   * IR is very quiet or very loud and `normalize` is off. Range 0..4,
+   * default 1.
+   */
+  gain?: number;
+}
+
+interface ConvolutionEffectSetup {
+  readonly inputGain: GainNode;
+  readonly outputGain: GainNode;
+  readonly convolver: ConvolverNode;
+  readonly dryGain: GainNode;
+  readonly wetGain: GainNode;
+}
+
+/**
+ * Convolution effect that convolves the input signal with a user-supplied
+ * impulse response (IR). Unlike {@link ReverbEffect}, which generates a
+ * procedural noise-based IR, `ConvolutionEffect` accepts a *real* decoded IR —
+ * enabling convolution reverb from acoustic-space captures, cabinet/speaker
+ * simulations, telephone/pipe character filtering, and any other linear
+ * time-invariant transformation.
+ *
+ * Pass the IR as an `AudioBuffer` (typically decoded via
+ * `AudioContext.decodeAudioData`) or as a `Sound` (its `audioBuffer` is used).
+ * Omitting the IR leaves `convolver.buffer` as `null`, making the wet path
+ * silent and the effect act as a passthrough until {@link setImpulse} is
+ * called — safe to add to a bus before an IR is available.
+ *
+ * Node graph:
+ * ```
+ * input(GainNode) → dryGain → output(GainNode)
+ * input           → convolver → wetGain → output
+ * ```
+ * Gains: `dryGain.gain = 1 - wet`; `wetGain.gain = wet × gain`.
+ *
+ * @example
+ * ```ts
+ * const ir = await audioManager.load('hall.wav');
+ * const reverb = new ConvolutionEffect({ impulse: ir, wet: 0.6 });
+ * bus.addEffect(reverb);
+ * ```
+ */
+export class ConvolutionEffect extends AudioEffect {
+  private _setup: ConvolutionEffectSetup | null = null;
+  private _wet: number;
+  private _normalize: boolean;
+  private _gain: number;
+  private _pendingImpulse: AudioBuffer | Sound | null;
+  private readonly _onAudioContextReady = (ctx: AudioContext): void => {
+    onAudioContextReady.remove(this._onAudioContextReady);
+    this._setupNodes(ctx);
+  };
+
+  public constructor(options: ConvolutionEffectOptions = {}) {
+    super();
+    this._wet = Math.max(0, Math.min(1, options.wet ?? 1));
+    this._normalize = options.normalize ?? true;
+    this._gain = Math.max(0, Math.min(4, options.gain ?? 1));
+    this._pendingImpulse = options.impulse ?? null;
+    if (isAudioContextReady()) {
+      this._setupNodes(getAudioContext());
+    } else {
+      onAudioContextReady.add(this._onAudioContextReady);
+    }
+  }
+
+  /**
+   * The node where audio enters this effect. Throws if the audio context is
+   * not yet initialized.
+   */
+  public get inputNode(): AudioNode {
+    if (!this._setup) throw new Error('ConvolutionEffect not yet initialized.');
+    return this._setup.inputGain;
+  }
+
+  /**
+   * The node where audio exits this effect. Throws if the audio context is
+   * not yet initialized.
+   */
+  public get outputNode(): AudioNode {
+    if (!this._setup) throw new Error('ConvolutionEffect not yet initialized.');
+    return this._setup.outputGain;
+  }
+
+  /**
+   * Wet (convolved) mix level, 0..1. The dry level is automatically `1 - wet`.
+   * Changes are ramped smoothly via `setTargetAtTime`. Default 1.0.
+   */
+  public get wet(): number {
+    return this._wet;
+  }
+
+  public set wet(value: number) {
+    this._wet = Math.max(0, Math.min(1, value));
+    if (this._setup) {
+      const ctx = this._setup.wetGain.context;
+      this._setup.wetGain.gain.setTargetAtTime(this._wet * this._gain, ctx.currentTime, 0.01);
+      this._setup.dryGain.gain.setTargetAtTime(1 - this._wet, ctx.currentTime, 0.01);
+    }
+  }
+
+  /**
+   * Whether the browser normalizes the IR for equal-power loudness. Mirrors
+   * `ConvolverNode.normalize`. Default `true`.
+   *
+   * Changing this at runtime re-assigns the current buffer so the new value
+   * takes effect (a Web Audio requirement: `normalize` is only applied on
+   * buffer assignment).
+   */
+  public get normalize(): boolean {
+    return this._normalize;
+  }
+
+  public set normalize(value: boolean) {
+    this._normalize = value;
+    if (this._setup) {
+      const { convolver } = this._setup;
+      convolver.normalize = this._normalize;
+      if (convolver.buffer !== null) {
+        // Re-assign so the new normalize value takes effect immediately.
+        // (The Web Audio spec only applies normalize on buffer assignment.)
+        const current = convolver.buffer;
+        convolver.buffer = current;
+      }
+    }
+  }
+
+  /**
+   * Makeup gain multiplier applied to the wet path. Range 0..4, default 1.
+   * Adjusting this changes the wet-path amplitude without altering the
+   * dry/wet balance ratio.
+   */
+  public get gain(): number {
+    return this._gain;
+  }
+
+  public set gain(value: number) {
+    this._gain = Math.max(0, Math.min(4, value));
+    if (this._setup) {
+      const ctx = this._setup.wetGain.context;
+      this._setup.wetGain.gain.setTargetAtTime(this._wet * this._gain, ctx.currentTime, 0.01);
+    }
+  }
+
+  /**
+   * Set or replace the impulse response. Accepts a decoded `AudioBuffer`, a
+   * `Sound` (its `audioBuffer` is used), or `null` to clear the IR (wet path
+   * goes silent). Safe to call before the audio context is ready — the impulse
+   * is stored and applied once nodes are created.
+   *
+   * **Web Audio note:** `normalize` is written to the convolver *before*
+   * `buffer` is assigned, as required by the spec for the value to take effect.
+   */
+  public setImpulse(ir: AudioBuffer | Sound | null): void {
+    const resolved = this._resolveBuffer(ir);
+    if (this._setup) {
+      const { convolver } = this._setup;
+      convolver.normalize = this._normalize;
+      convolver.buffer = resolved;
+    } else {
+      // Store for application in _setupNodes once the context is ready.
+      this._pendingImpulse = ir;
+    }
+  }
+
+  public override destroy(): void {
+    onAudioContextReady.remove(this._onAudioContextReady);
+    if (this._setup) {
+      this._setup.inputGain.disconnect();
+      this._setup.convolver.disconnect();
+      this._setup.dryGain.disconnect();
+      this._setup.wetGain.disconnect();
+      this._setup.outputGain.disconnect();
+      this._setup = null;
+    }
+  }
+
+  private _resolveBuffer(ir: AudioBuffer | Sound | null): AudioBuffer | null {
+    if (ir === null) return null;
+    if (ir instanceof Sound) return ir.audioBuffer;
+    return ir;
+  }
+
+  private _setupNodes(ctx: AudioContext): void {
+    const inputGain = ctx.createGain();
+    const outputGain = ctx.createGain();
+    const convolver = ctx.createConvolver();
+    const dryGain = ctx.createGain();
+    const wetGain = ctx.createGain();
+
+    inputGain.gain.setValueAtTime(1, ctx.currentTime);
+    outputGain.gain.setValueAtTime(1, ctx.currentTime);
+    dryGain.gain.setValueAtTime(1 - this._wet, ctx.currentTime);
+    wetGain.gain.setValueAtTime(this._wet * this._gain, ctx.currentTime);
+
+    // Web Audio requirement: set normalize BEFORE assigning buffer.
+    convolver.normalize = this._normalize;
+    if (this._pendingImpulse !== null) {
+      convolver.buffer = this._resolveBuffer(this._pendingImpulse);
+      this._pendingImpulse = null;
+    }
+
+    // Dry path: input → dryGain → output
+    inputGain.connect(dryGain);
+    dryGain.connect(outputGain);
+
+    // Wet path: input → convolver → wetGain → output
+    inputGain.connect(convolver);
+    convolver.connect(wetGain);
+    wetGain.connect(outputGain);
+
+    this._setup = { inputGain, outputGain, convolver, dryGain, wetGain };
+  }
+}

--- a/packages/exojs-audio-fx/src/effects/ConvolutionEffect.ts
+++ b/packages/exojs-audio-fx/src/effects/ConvolutionEffect.ts
@@ -62,8 +62,8 @@ interface ConvolutionEffectSetup {
  *
  * @example
  * ```ts
- * const ir = await audioManager.load('hall.wav');
- * const reverb = new ConvolutionEffect({ impulse: ir, wet: 0.6 });
+ * await loader.load(Sound, { hall: 'hall.wav' });
+ * const reverb = new ConvolutionEffect({ impulse: loader.get(Sound, 'hall'), wet: 0.6 });
  * bus.addEffect(reverb);
  * ```
  */

--- a/packages/exojs-audio-fx/src/index.ts
+++ b/packages/exojs-audio-fx/src/index.ts
@@ -17,6 +17,7 @@ export type {
 export { BeatDetector } from './BeatDetector';
 export { ChorusEffect, type ChorusEffectOptions } from './effects/ChorusEffect';
 export { CompressorEffect, type CompressorEffectOptions } from './effects/CompressorEffect';
+export { ConvolutionEffect, type ConvolutionEffectOptions } from './effects/ConvolutionEffect';
 export { DelayEffect, type DelayEffectOptions } from './effects/DelayEffect';
 export { DuckingEffect, type DuckingEffectOptions } from './effects/DuckingEffect';
 export { EqualizerEffect, type EqualizerEffectOptions } from './effects/EqualizerEffect';

--- a/packages/exojs-audio-fx/test/browser/convolution.audio.test.ts
+++ b/packages/exojs-audio-fx/test/browser/convolution.audio.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Acoustic contract for convolution via a real OfflineAudioContext +
+ * ConvolverNode in headless Chromium. Verifies two mathematical properties of
+ * the ConvolverNode that underpin ConvolutionEffect's correctness:
+ *
+ * 1. A single-sample unit-impulse IR [1.0] is the identity of convolution —
+ *    the output must equal the input (within floating-point tolerance).
+ * 2. A 2-tap IR [1, 1] sums the input with a 1-sample-delayed copy, producing
+ *    a louder-than-dry output for a steady sinusoidal input.
+ *
+ * Tests use raw Web Audio (OfflineAudioContext + ConvolverNode) rather than
+ * the ConvolutionEffect class, because the class relies on the engine's
+ * AudioContext lifecycle (isAudioContextReady / onAudioContextReady) which is
+ * not wired in the browser-audio test environment.
+ */
+
+import { rms, SAMPLE_RATE } from './_audio-harness';
+
+interface ConvolutionRenderOptions {
+  /** Impulse response samples (normalize=false always). */
+  irSamples: number[];
+  /** Render duration in seconds. */
+  durationSeconds: number;
+  /** Wet level 0..1 (dry = 1-wet). Default 1. */
+  wet?: number;
+}
+
+/**
+ * Render a 440 Hz sine through a wet/dry ConvolverNode graph using a real
+ * OfflineAudioContext and return the mono output samples.
+ *
+ * Graph:  oscillator → inputGain → dryGain → outputGain → destination
+ *                                → convolver → wetGain → outputGain
+ */
+async function renderConvolution(opts: ConvolutionRenderOptions): Promise<Float32Array> {
+  const sr = SAMPLE_RATE;
+  const length = Math.floor(opts.durationSeconds * sr);
+  const wet = opts.wet ?? 1;
+  const dry = 1 - wet;
+
+  const ctx = new OfflineAudioContext(1, length, sr);
+
+  // Build the IR buffer (normalize=false — we want exact arithmetic).
+  const irBuffer = ctx.createBuffer(1, opts.irSamples.length, sr);
+  irBuffer.getChannelData(0).set(new Float32Array(opts.irSamples));
+
+  const convolver = ctx.createConvolver();
+  convolver.normalize = false;
+  convolver.buffer = irBuffer;
+
+  // Graph nodes.
+  const inputGain = ctx.createGain();
+  const dryGain = ctx.createGain();
+  const wetGain = ctx.createGain();
+  const outputGain = ctx.createGain();
+
+  dryGain.gain.value = dry;
+  wetGain.gain.value = wet;
+  outputGain.gain.value = 1;
+
+  // Wiring.
+  const osc = ctx.createOscillator();
+  osc.type = 'sine';
+  osc.frequency.value = 440;
+
+  osc.connect(inputGain);
+  inputGain.connect(dryGain);
+  dryGain.connect(outputGain);
+  inputGain.connect(convolver);
+  convolver.connect(wetGain);
+  wetGain.connect(outputGain);
+  outputGain.connect(ctx.destination);
+
+  osc.start(0);
+
+  const rendered = await ctx.startRendering();
+  return rendered.getChannelData(0).slice();
+}
+
+describe('ConvolutionEffect — acoustic contract (real Web Audio)', () => {
+  it('unit-impulse IR [1] is the identity of convolution (output ≈ input)', async () => {
+    // With normalize=false, a single-sample IR of value 1.0 is the unit
+    // impulse δ[n]. Convolution with δ[n] is the identity: y = x * δ = x.
+    const withConv = await renderConvolution({ irSamples: [1.0], durationSeconds: 0.3, wet: 1 });
+    const dryOnly = await renderConvolution({ irSamples: [1.0], durationSeconds: 0.3, wet: 0 });
+
+    // Drop the first 256 samples to skip the convolver's initial latency.
+    const skip = 256;
+    const convSamples = withConv.subarray(skip);
+    const drySamples = dryOnly.subarray(skip);
+
+    // Measure SNR: signal power / difference power.
+    let diffPower = 0;
+    let refPower = 0;
+    const count = Math.min(convSamples.length, drySamples.length);
+    for (let i = 0; i < count; i++) {
+      diffPower += (convSamples[i]! - drySamples[i]!) ** 2;
+      refPower += drySamples[i]! ** 2;
+    }
+    const snr = refPower / (diffPower + 1e-12);
+    // Require > 20 dB SNR (SNR > 100) — the identity property holds in floating point.
+    expect(snr).toBeGreaterThan(100);
+  });
+
+  it('2-tap IR [1, 1] produces louder output than dry (sums x[n] + x[n-1])', async () => {
+    // With normalize=false and IR=[1, 1], the convolver computes y[n]=x[n]+x[n-1].
+    // For a 440 Hz sine at 48000 Hz the 1-sample phase difference is
+    // 2π·440/48000 ≈ 0.0576 rad, so the two samples add nearly constructively:
+    // amplitude ≈ 2·cos(0.0288) ≈ 1.999 — roughly √2 more RMS than the dry signal.
+    const withConv = await renderConvolution({ irSamples: [1.0, 1.0], durationSeconds: 0.3, wet: 1 });
+    const dryOnly = await renderConvolution({ irSamples: [1.0, 1.0], durationSeconds: 0.3, wet: 0 });
+
+    // Skip leading transient.
+    const skip = 512;
+    const wetRms = rms(withConv.subarray(skip));
+    const dryRms = rms(dryOnly.subarray(skip));
+
+    // Convolved RMS should be appreciably larger than dry (expect ≈ 1.4× or more).
+    expect(wetRms).toBeGreaterThan(dryRms * 1.2);
+  });
+
+  it('wet=0 passes the input through unmodified', async () => {
+    // With wet=0 the convolver path is gated off (wetGain=0) and the dry
+    // gain is 1 — so the output equals the raw oscillator signal.
+    const out = await renderConvolution({ irSamples: [1.0], durationSeconds: 0.3, wet: 0 });
+    const skip = 256;
+    const meas = out.subarray(skip);
+    // 440 Hz sine at unit amplitude: RMS ≈ 1/√2 ≈ 0.707.
+    expect(rms(meas)).toBeGreaterThan(0.6);
+    expect(rms(meas)).toBeLessThan(0.8);
+  });
+});

--- a/packages/exojs-audio-fx/test/effects/convolution-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/convolution-effect.test.ts
@@ -1,0 +1,442 @@
+import { getAudioContext, Sound } from '@codexo/exojs';
+
+import { ConvolutionEffect } from '../../src/effects/ConvolutionEffect';
+
+const makeAudioParam = (initial: number) => ({
+  setValueAtTime: vi.fn(),
+  setTargetAtTime: vi.fn(),
+  value: initial,
+});
+
+const makeGainNode = (ctx: AudioContext) => ({
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  context: ctx,
+  gain: makeAudioParam(1),
+});
+
+const makeConvolverNode = () => ({
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  buffer: null as AudioBuffer | null,
+  normalize: true,
+  context: null as AudioContext | null,
+});
+
+describe('ConvolutionEffect', () => {
+  describe('construction', () => {
+    it('uses default wet of 1.0', () => {
+      const effect = new ConvolutionEffect();
+      expect(effect.wet).toBe(1.0);
+      effect.destroy();
+    });
+
+    it('uses default normalize of true', () => {
+      const effect = new ConvolutionEffect();
+      expect(effect.normalize).toBe(true);
+      effect.destroy();
+    });
+
+    it('uses default gain of 1', () => {
+      const effect = new ConvolutionEffect();
+      expect(effect.gain).toBe(1);
+      effect.destroy();
+    });
+
+    it('accepts custom wet option', () => {
+      const effect = new ConvolutionEffect({ wet: 0.5 });
+      expect(effect.wet).toBe(0.5);
+      effect.destroy();
+    });
+
+    it('accepts custom normalize option', () => {
+      const effect = new ConvolutionEffect({ normalize: false });
+      expect(effect.normalize).toBe(false);
+      effect.destroy();
+    });
+
+    it('accepts custom gain option', () => {
+      const effect = new ConvolutionEffect({ gain: 2 });
+      expect(effect.gain).toBe(2);
+      effect.destroy();
+    });
+  });
+
+  describe('node setup', () => {
+    // Calling getAudioContext() here ensures isAudioContextReady() returns true
+    // for all tests in this describe block and below, so the constructor calls
+    // _setupNodes() immediately rather than deferring via onAudioContextReady.
+
+    const wireAll = (ctx: AudioContext) => {
+      const convolver = makeConvolverNode();
+      convolver.context = ctx;
+      const gains = [makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx)];
+      let i = 0;
+      // _setupNodes createGain order: inputGain, outputGain, dryGain, wetGain
+      const gainSpy = vi.spyOn(ctx, 'createGain').mockImplementation(() => gains[i++] as unknown as GainNode);
+      const convolverSpy = vi.spyOn(ctx, 'createConvolver').mockReturnValue(convolver as unknown as ConvolverNode);
+      const [inputGain, outputGain, dryGain, wetGain] = gains;
+      return { convolver, gains, inputGain, outputGain, dryGain, wetGain, gainSpy, convolverSpy };
+    };
+
+    it('inputNode and outputNode are different nodes', () => {
+      const ctx = getAudioContext();
+      const effect = new ConvolutionEffect();
+      expect(effect.inputNode).not.toBe(effect.outputNode);
+      effect.destroy();
+    });
+
+    it('inputNode is the input gain node', () => {
+      const ctx = getAudioContext();
+      const { inputGain, gainSpy, convolverSpy } = wireAll(ctx);
+      const effect = new ConvolutionEffect();
+      expect(effect.inputNode).toBe(inputGain);
+      effect.destroy();
+      gainSpy.mockRestore();
+      convolverSpy.mockRestore();
+    });
+
+    it('outputNode is the output gain node', () => {
+      const ctx = getAudioContext();
+      const { outputGain, gainSpy, convolverSpy } = wireAll(ctx);
+      const effect = new ConvolutionEffect();
+      expect(effect.outputNode).toBe(outputGain);
+      effect.destroy();
+      gainSpy.mockRestore();
+      convolverSpy.mockRestore();
+    });
+
+    it('throws before context is ready', () => {
+      const effect = new ConvolutionEffect();
+      effect.destroy();
+      expect(() => effect.inputNode).toThrow('ConvolutionEffect not yet initialized.');
+      expect(() => effect.outputNode).toThrow('ConvolutionEffect not yet initialized.');
+    });
+
+    it('connects dry path: input → dryGain → output', () => {
+      const ctx = getAudioContext();
+      const { inputGain, outputGain, dryGain, gainSpy, convolverSpy } = wireAll(ctx);
+      const effect = new ConvolutionEffect();
+      expect(inputGain.connect).toHaveBeenCalledWith(dryGain);
+      expect(dryGain.connect).toHaveBeenCalledWith(outputGain);
+      effect.destroy();
+      gainSpy.mockRestore();
+      convolverSpy.mockRestore();
+    });
+
+    it('connects wet path: input → convolver → wetGain → output', () => {
+      const ctx = getAudioContext();
+      const { inputGain, outputGain, convolver, wetGain, gainSpy, convolverSpy } = wireAll(ctx);
+      const effect = new ConvolutionEffect();
+      expect(inputGain.connect).toHaveBeenCalledWith(convolver);
+      expect(convolver.connect).toHaveBeenCalledWith(wetGain);
+      expect(wetGain.connect).toHaveBeenCalledWith(outputGain);
+      effect.destroy();
+      gainSpy.mockRestore();
+      convolverSpy.mockRestore();
+    });
+
+    it('sets complementary dry/wet gains on construction (wet=1 → dry=0, wet=1*gain=1)', () => {
+      const ctx = getAudioContext();
+      const { dryGain, wetGain, gainSpy, convolverSpy } = wireAll(ctx);
+      const effect = new ConvolutionEffect({ wet: 1.0, gain: 1 });
+      expect(dryGain.gain.setValueAtTime).toHaveBeenCalledWith(0, expect.anything());
+      expect(wetGain.gain.setValueAtTime).toHaveBeenCalledWith(1, expect.anything());
+      effect.destroy();
+      gainSpy.mockRestore();
+      convolverSpy.mockRestore();
+    });
+
+    it('sets complementary dry/wet gains for custom wet', () => {
+      const ctx = getAudioContext();
+      const { dryGain, wetGain, gainSpy, convolverSpy } = wireAll(ctx);
+      const effect = new ConvolutionEffect({ wet: 0.75, gain: 1 });
+      expect(dryGain.gain.setValueAtTime).toHaveBeenCalledWith(0.25, expect.anything());
+      expect(wetGain.gain.setValueAtTime).toHaveBeenCalledWith(0.75, expect.anything());
+      effect.destroy();
+      gainSpy.mockRestore();
+      convolverSpy.mockRestore();
+    });
+
+    it('wetGain includes gain multiplier (wet=0.5, gain=2 → wetGain=1.0)', () => {
+      const ctx = getAudioContext();
+      const { wetGain, gainSpy, convolverSpy } = wireAll(ctx);
+      const effect = new ConvolutionEffect({ wet: 0.5, gain: 2 });
+      expect(wetGain.gain.setValueAtTime).toHaveBeenCalledWith(1.0, expect.anything());
+      effect.destroy();
+      gainSpy.mockRestore();
+      convolverSpy.mockRestore();
+    });
+
+    it('sets normalize on convolver before assigning buffer', () => {
+      const ctx = getAudioContext();
+      const convolver = makeConvolverNode();
+      convolver.context = ctx;
+      const gains = [makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx)];
+      let i = 0;
+      const gainSpy = vi.spyOn(ctx, 'createGain').mockImplementation(() => gains[i++] as unknown as GainNode);
+      const convolverSpy = vi.spyOn(ctx, 'createConvolver').mockReturnValue(convolver as unknown as ConvolverNode);
+
+      const ab = ctx.createBuffer(1, 1, 44100);
+      const effect = new ConvolutionEffect({ normalize: false, impulse: ab });
+      // normalize=false should have been applied
+      expect(convolver.normalize).toBe(false);
+      // buffer should be the provided AudioBuffer
+      expect(convolver.buffer).toBe(ab);
+      effect.destroy();
+      gainSpy.mockRestore();
+      convolverSpy.mockRestore();
+    });
+  });
+
+  describe('wet setter', () => {
+    const wireAll = (ctx: AudioContext) => {
+      const convolver = makeConvolverNode();
+      convolver.context = ctx;
+      const gains = [makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx)];
+      let i = 0;
+      const gainSpy = vi.spyOn(ctx, 'createGain').mockImplementation(() => gains[i++] as unknown as GainNode);
+      const convolverSpy = vi.spyOn(ctx, 'createConvolver').mockReturnValue(convolver as unknown as ConvolverNode);
+      const [, , dryGain, wetGain] = gains;
+      return { dryGain, wetGain, gainSpy, convolverSpy };
+    };
+
+    it('wet setter clamps to 0 minimum', () => {
+      const effect = new ConvolutionEffect();
+      effect.wet = -1;
+      expect(effect.wet).toBe(0);
+      effect.destroy();
+    });
+
+    it('wet setter clamps to 1 maximum', () => {
+      const effect = new ConvolutionEffect();
+      effect.wet = 2;
+      expect(effect.wet).toBe(1);
+      effect.destroy();
+    });
+
+    it('wet setter ramps complementary dry/wet gains', () => {
+      const ctx = getAudioContext();
+      const { dryGain, wetGain, gainSpy, convolverSpy } = wireAll(ctx);
+      const effect = new ConvolutionEffect({ gain: 1 });
+      effect.wet = 0.6;
+      expect(wetGain.gain.setTargetAtTime).toHaveBeenCalledWith(expect.closeTo(0.6), expect.anything(), expect.anything());
+      expect(dryGain.gain.setTargetAtTime).toHaveBeenCalledWith(expect.closeTo(0.4), expect.anything(), expect.anything());
+      effect.destroy();
+      gainSpy.mockRestore();
+      convolverSpy.mockRestore();
+    });
+
+    it('wet setter applies gain multiplier to wetGain', () => {
+      const ctx = getAudioContext();
+      const { wetGain, gainSpy, convolverSpy } = wireAll(ctx);
+      const effect = new ConvolutionEffect({ gain: 2 });
+      effect.wet = 0.5;
+      // wetGain = 0.5 * 2 = 1.0
+      expect(wetGain.gain.setTargetAtTime).toHaveBeenCalledWith(expect.closeTo(1.0), expect.anything(), expect.anything());
+      effect.destroy();
+      gainSpy.mockRestore();
+      convolverSpy.mockRestore();
+    });
+  });
+
+  describe('gain setter', () => {
+    const wireAll = (ctx: AudioContext) => {
+      const convolver = makeConvolverNode();
+      convolver.context = ctx;
+      const gains = [makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx)];
+      let i = 0;
+      const gainSpy = vi.spyOn(ctx, 'createGain').mockImplementation(() => gains[i++] as unknown as GainNode);
+      const convolverSpy = vi.spyOn(ctx, 'createConvolver').mockReturnValue(convolver as unknown as ConvolverNode);
+      const [, , , wetGain] = gains;
+      return { wetGain, gainSpy, convolverSpy };
+    };
+
+    it('gain setter clamps to 0 minimum', () => {
+      const effect = new ConvolutionEffect();
+      effect.gain = -1;
+      expect(effect.gain).toBe(0);
+      effect.destroy();
+    });
+
+    it('gain setter clamps to 4 maximum', () => {
+      const effect = new ConvolutionEffect();
+      effect.gain = 10;
+      expect(effect.gain).toBe(4);
+      effect.destroy();
+    });
+
+    it('gain setter updates wetGain (wet=0.5, gain=2 → wetGain=1.0)', () => {
+      const ctx = getAudioContext();
+      const { wetGain, gainSpy, convolverSpy } = wireAll(ctx);
+      const effect = new ConvolutionEffect({ wet: 0.5 });
+      effect.gain = 2;
+      expect(wetGain.gain.setTargetAtTime).toHaveBeenCalledWith(expect.closeTo(1.0), expect.anything(), expect.anything());
+      effect.destroy();
+      gainSpy.mockRestore();
+      convolverSpy.mockRestore();
+    });
+  });
+
+  describe('normalize setter', () => {
+    it('normalize setter stores the value', () => {
+      const effect = new ConvolutionEffect({ normalize: true });
+      effect.normalize = false;
+      expect(effect.normalize).toBe(false);
+      effect.destroy();
+    });
+
+    it('normalize setter applies to convolver', () => {
+      const ctx = getAudioContext();
+      const convolver = makeConvolverNode();
+      convolver.context = ctx;
+      const gains = [makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx)];
+      let i = 0;
+      const gainSpy = vi.spyOn(ctx, 'createGain').mockImplementation(() => gains[i++] as unknown as GainNode);
+      const convolverSpy = vi.spyOn(ctx, 'createConvolver').mockReturnValue(convolver as unknown as ConvolverNode);
+
+      const effect = new ConvolutionEffect({ normalize: true });
+      effect.normalize = false;
+      expect(convolver.normalize).toBe(false);
+      effect.destroy();
+      gainSpy.mockRestore();
+      convolverSpy.mockRestore();
+    });
+
+    it('normalize setter re-assigns buffer when one is loaded', () => {
+      const ctx = getAudioContext();
+      const convolver = makeConvolverNode();
+      convolver.context = ctx;
+      const gains = [makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx)];
+      let i = 0;
+      const gainSpy = vi.spyOn(ctx, 'createGain').mockImplementation(() => gains[i++] as unknown as GainNode);
+      const convolverSpy = vi.spyOn(ctx, 'createConvolver').mockReturnValue(convolver as unknown as ConvolverNode);
+
+      const ab = ctx.createBuffer(1, 1, 44100);
+      convolver.buffer = ab; // pre-load a buffer
+
+      const effect = new ConvolutionEffect({ normalize: true });
+      effect.normalize = false;
+      // buffer should have been re-assigned so normalize takes effect
+      expect(convolver.buffer).toBe(ab);
+      effect.destroy();
+      gainSpy.mockRestore();
+      convolverSpy.mockRestore();
+    });
+  });
+
+  describe('setImpulse', () => {
+    const wireConvolver = (ctx: AudioContext) => {
+      const convolver = makeConvolverNode();
+      convolver.context = ctx;
+      const gains = [makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx)];
+      let i = 0;
+      const gainSpy = vi.spyOn(ctx, 'createGain').mockImplementation(() => gains[i++] as unknown as GainNode);
+      const convolverSpy = vi.spyOn(ctx, 'createConvolver').mockReturnValue(convolver as unknown as ConvolverNode);
+      return { convolver, gainSpy, convolverSpy };
+    };
+
+    it('setImpulse assigns an AudioBuffer to the convolver', () => {
+      const ctx = getAudioContext();
+      const { convolver, gainSpy, convolverSpy } = wireConvolver(ctx);
+      const ab = ctx.createBuffer(1, 44100, 44100);
+      const effect = new ConvolutionEffect();
+      effect.setImpulse(ab);
+      expect(convolver.buffer).toBe(ab);
+      effect.destroy();
+      gainSpy.mockRestore();
+      convolverSpy.mockRestore();
+    });
+
+    it('setImpulse resolves a Sound to its audioBuffer', () => {
+      const ctx = getAudioContext();
+      const { convolver, gainSpy, convolverSpy } = wireConvolver(ctx);
+      const ab = ctx.createBuffer(1, 44100, 44100);
+      const sound = new Sound(ab);
+      const effect = new ConvolutionEffect();
+      effect.setImpulse(sound);
+      expect(convolver.buffer).toBe(ab);
+      effect.destroy();
+      gainSpy.mockRestore();
+      convolverSpy.mockRestore();
+    });
+
+    it('setImpulse(null) clears the convolver buffer', () => {
+      const ctx = getAudioContext();
+      const { convolver, gainSpy, convolverSpy } = wireConvolver(ctx);
+      const ab = ctx.createBuffer(1, 44100, 44100);
+      const effect = new ConvolutionEffect({ impulse: ab });
+      effect.setImpulse(null);
+      expect(convolver.buffer).toBeNull();
+      effect.destroy();
+      gainSpy.mockRestore();
+      convolverSpy.mockRestore();
+    });
+
+    it('setImpulse sets normalize before buffer (Web Audio order)', () => {
+      const ctx = getAudioContext();
+      const normalizeOrder: boolean[] = [];
+      const convolver = makeConvolverNode();
+      convolver.context = ctx;
+
+      // Intercept normalize writes and buffer writes in order.
+      let lastNormalizeBeforeBuffer: boolean | undefined;
+      const proxy = new Proxy(convolver, {
+        set(target, prop, value) {
+          if (prop === 'normalize') {
+            lastNormalizeBeforeBuffer = value as boolean;
+          }
+          if (prop === 'buffer') {
+            normalizeOrder.push(lastNormalizeBeforeBuffer ?? target.normalize);
+          }
+          (target as Record<string | symbol, unknown>)[prop] = value;
+          return true;
+        },
+      });
+
+      const gains = [makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx)];
+      let i = 0;
+      const gainSpy = vi.spyOn(ctx, 'createGain').mockImplementation(() => gains[i++] as unknown as GainNode);
+      const convolverSpy = vi.spyOn(ctx, 'createConvolver').mockReturnValue(proxy as unknown as ConvolverNode);
+
+      const ab = ctx.createBuffer(1, 44100, 44100);
+      const effect = new ConvolutionEffect({ normalize: false });
+      effect.setImpulse(ab);
+      // normalize=false should have been set before the buffer assignment
+      expect(normalizeOrder).toEqual([false]);
+      effect.destroy();
+      gainSpy.mockRestore();
+      convolverSpy.mockRestore();
+    });
+  });
+
+  describe('destroy', () => {
+    it('disconnects all internal nodes', () => {
+      const ctx = getAudioContext();
+      const convolver = makeConvolverNode();
+      convolver.context = ctx as unknown as AudioContext;
+      const gains = [makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx)];
+      let gainCallCount = 0;
+      const gainSpy = vi.spyOn(ctx, 'createGain').mockImplementation(() => {
+        return gains[gainCallCount++] as unknown as GainNode;
+      });
+      const convolverSpy = vi.spyOn(ctx, 'createConvolver').mockReturnValue(convolver as unknown as ConvolverNode);
+
+      const effect = new ConvolutionEffect();
+      effect.destroy();
+
+      expect(convolver.disconnect).toHaveBeenCalled();
+      for (const gain of gains) {
+        expect(gain.disconnect).toHaveBeenCalled();
+      }
+      gainSpy.mockRestore();
+      convolverSpy.mockRestore();
+    });
+
+    it('throws after destroy', () => {
+      const effect = new ConvolutionEffect();
+      effect.destroy();
+      expect(() => effect.inputNode).toThrow('ConvolutionEffect not yet initialized.');
+    });
+  });
+});

--- a/site/src/content/api/convolution-effect.mdx
+++ b/site/src/content/api/convolution-effect.mdx
@@ -1,0 +1,58 @@
+---
+title: "ConvolutionEffect"
+description: "Convolution effect that convolves the input signal with a user-supplied impulse response (IR). Unlike ReverbEffect, which generates a procedural noise-based IR, `ConvolutionEffect` accepts a *real* decoded IR — enabling convolution reverb from acoustic-space captures, cabinet/speaker simulations, telephone/pipe character filtering, and any other linear time-invariant transformation. Pass the IR as an `AudioBuffer` (typically decoded via `AudioContext.decodeAudioData`) or as a `Sound` (its `audioBuffer` is used). Omitting the IR leaves `convolver.buffer` as `null`, making the wet path silent and the effect act as a passthrough until setImpulse is called — safe to add to a bus before an IR is available. Node graph: ``` input(GainNode) → dryGain → output(GainNode) input → convolver → wetGain → output ``` Gains: `dryGain.gain = 1 - wet`; `wetGain.gain = wet × gain`."
+symbol: "ConvolutionEffect"
+kind: "class"
+subsystem: "audio"
+importPath: "@codexo/exojs-audio-fx"
+memberCount: 9
+tier: "stable"
+sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
+sourcePath: "packages/exojs-audio-fx/src/effects/ConvolutionEffect.ts"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-audio-fx/src/effects/ConvolutionEffect.ts#L70"
+---
+## Import
+
+`import { ConvolutionEffect } from '@codexo/exojs-audio-fx'`
+
+Convolution effect that convolves the input signal with a user-supplied
+impulse response (IR). Unlike ReverbEffect, which generates a
+procedural noise-based IR, `ConvolutionEffect` accepts a *real* decoded IR —
+enabling convolution reverb from acoustic-space captures, cabinet/speaker
+simulations, telephone/pipe character filtering, and any other linear
+time-invariant transformation.
+
+Pass the IR as an `AudioBuffer` (typically decoded via
+`AudioContext.decodeAudioData`) or as a `Sound` (its `audioBuffer` is used).
+Omitting the IR leaves `convolver.buffer` as `null`, making the wet path
+silent and the effect act as a passthrough until setImpulse is
+called — safe to add to a bus before an IR is available.
+
+Node graph:
+```
+input(GainNode) → dryGain → output(GainNode)
+input           → convolver → wetGain → output
+```
+Gains: `dryGain.gain = 1 - wet`; `wetGain.gain = wet × gain`.
+
+## Constructors
+
+- `new(options: ConvolutionEffectOptions): ConvolutionEffect`
+
+## Methods
+
+- `destroy(): void`
+- `setImpulse(ir: AudioBuffer | Sound | null): void`
+
+## Properties
+
+- `gain: number`
+- `inputNode: AudioNode`
+- `normalize: boolean`
+- `outputNode: AudioNode`
+- `ready: Promise<void>`
+- `wet: number`
+
+## Source
+
+[packages/exojs-audio-fx/src/effects/ConvolutionEffect.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-audio-fx/src/effects/ConvolutionEffect.ts#L70)


### PR DESCRIPTION
## Summary
Adds `ConvolutionEffect` to `@codexo/exojs-audio-fx`: a convolution effect backed by a native Web Audio `ConvolverNode` that convolves the input with a user-supplied impulse response (IR). Unlike the existing procedural `ReverbEffect`, this accepts a *real* decoded IR — enabling convolution reverb from acoustic-space captures, cabinet/speaker simulation, and telephone/pipe character filtering.

## Details
- Accepts the IR as an `AudioBuffer` or a `Sound` (uses its `audioBuffer`); omitting it leaves the effect a dry passthrough until `setImpulse()` is called — safe to add to a bus before an IR is available.
- Mirrors the proven `ReverbEffect`/`DelayEffect` dry/wet node topology (`input → dryGain → output`, `input → convolver → wetGain → output`).
- `normalize` maps to the native `ConvolverNode.normalize` and is always written *before* the buffer (a Web Audio requirement); runtime changes re-assign the buffer so the new value takes effect.
- `wet` (dry/wet mix) and `gain` (wet-path makeup) with smooth `setTargetAtTime` ramps; stable input/output gains created on audio-context-ready with bypass until an IR is set.

## Tests
- jsdom structural tests (`test/effects/convolution-effect.test.ts`).
- Browser-audio acoustic-contract tests (`test/browser/convolution.audio.test.ts`): a unit-impulse IR is the convolution identity; a 2-tap IR sums adjacent samples.

## Notes
- No version bump, no new top-level directories.
- The dedicated `ImpulseResponse` asset type is intentionally deferred to v0.16 (the package currently has no extension/`register` infrastructure); `ConvolutionEffect` already supports IR loading today via `loader.get(Sound, …)`.
