### PR TITLE
feat(audio): WorkletEffect dry/wet gain-staging primitive + dry-latency compensation

### DIFF
--- a/packages/exojs-audio-fx/src/effects/GranularEffect.ts
+++ b/packages/exojs-audio-fx/src/effects/GranularEffect.ts
@@ -45,7 +45,6 @@ export class GranularEffect extends WorkletEffect {
   private _spread: number;
   private _pitchMin: number;
   private _pitchMax: number;
-  private _wet: number;
   private readonly _bufferSeconds: number;
   private readonly _normalizeGain: boolean;
 
@@ -56,9 +55,9 @@ export class GranularEffect extends WorkletEffect {
     this._spread = Math.max(0, Math.min(1, options.spread ?? 0.5));
     this._pitchMin = Math.max(0.25, Math.min(4, options.pitchMin ?? 1));
     this._pitchMax = Math.max(0.25, Math.min(4, options.pitchMax ?? 1));
-    this._wet = Math.max(0, Math.min(1, options.wet ?? 1));
     this._bufferSeconds = options.bufferSeconds ?? 2;
     this._normalizeGain = options.normalizeGain ?? false;
+    this.wet = options.wet ?? 1;
   }
 
   protected get _workletName(): string {
@@ -81,7 +80,6 @@ export class GranularEffect extends WorkletEffect {
     this._setAudioParam('spread', this._spread);
     this._setAudioParam('pitchMin', this._pitchMin);
     this._setAudioParam('pitchMax', this._pitchMax);
-    this._setAudioParam('wet', this._wet);
   }
 
   /** Duration of each grain in seconds. Range 0.005..0.5, default 0.05. */
@@ -127,14 +125,5 @@ export class GranularEffect extends WorkletEffect {
   public set pitchMax(value: number) {
     this._pitchMax = Math.max(0.25, Math.min(4, value));
     this._setAudioParam('pitchMax', this._pitchMax);
-  }
-
-  /** Wet (granular) mix level, 0..1. Default 1.0. */
-  public get wet(): number {
-    return this._wet;
-  }
-  public set wet(value: number) {
-    this._wet = Math.max(0, Math.min(1, value));
-    this._setAudioParam('wet', this._wet);
   }
 }

--- a/packages/exojs-audio-fx/src/effects/PitchShiftEffect.ts
+++ b/packages/exojs-audio-fx/src/effects/PitchShiftEffect.ts
@@ -36,14 +36,13 @@ export interface PitchShiftEffectOptions {
  */
 export class PitchShiftEffect extends WorkletEffect {
   private _pitch: number;
-  private _wet: number;
   private readonly _grainSize: number;
 
   public constructor(options: PitchShiftEffectOptions = {}) {
     super();
     this._pitch = Math.max(0.25, Math.min(4, options.pitch ?? 1));
-    this._wet = Math.max(0, Math.min(1, options.wet ?? 1));
     this._grainSize = options.grainSize ?? 1024;
+    this.wet = options.wet ?? 1;
   }
 
   protected get _workletName(): string {
@@ -64,7 +63,6 @@ export class PitchShiftEffect extends WorkletEffect {
 
   protected override _onWorkletReady(): void {
     this._setAudioParam('pitch', this._pitch);
-    this._setAudioParam('wet', this._wet);
   }
 
   /** Pitch ratio relative to the original. 1.0 = no change, 0.5 = one octave down, 2.0 = one octave up. Range 0.25..4.0, default 1.0. */
@@ -74,14 +72,5 @@ export class PitchShiftEffect extends WorkletEffect {
   public set pitch(value: number) {
     this._pitch = Math.max(0.25, Math.min(4, value));
     this._setAudioParam('pitch', this._pitch);
-  }
-
-  /** Wet (pitch-shifted) mix level, 0..1. Default 1.0 (full wet). */
-  public get wet(): number {
-    return this._wet;
-  }
-  public set wet(value: number) {
-    this._wet = Math.max(0, Math.min(1, value));
-    this._setAudioParam('wet', this._wet);
   }
 }

--- a/packages/exojs-audio-fx/src/effects/PitchShiftEffect.ts
+++ b/packages/exojs-audio-fx/src/effects/PitchShiftEffect.ts
@@ -53,6 +53,12 @@ export class PitchShiftEffect extends WorkletEffect {
     return pitchShiftWorkletSource;
   }
 
+  protected override get _dryLatencySeconds(): number {
+    // SOLA algorithmic latency ≈ one analysis frame + the correlation search
+    // radius (grainSize/4). Tuned against the wet=0.5 comb-filter test below.
+    return (this._grainSize + (this._grainSize >> 2)) / this._sampleRate;
+  }
+
   protected override get _workletOptions(): AudioWorkletNodeOptions {
     return {
       numberOfInputs: 1,

--- a/packages/exojs-audio-fx/src/effects/VocoderEffect.ts
+++ b/packages/exojs-audio-fx/src/effects/VocoderEffect.ts
@@ -38,7 +38,6 @@ export class VocoderEffect extends WorkletEffect {
   private readonly _minHz: number;
   private readonly _maxHz: number;
   private readonly _bandQ: number;
-  private _wet: number;
   private _envelopeSmoothing: number;
 
   public constructor(options: VocoderEffectOptions) {
@@ -51,8 +50,8 @@ export class VocoderEffect extends WorkletEffect {
     this._minHz = options.minHz ?? 80;
     this._maxHz = options.maxHz ?? 8000;
     this._bandQ = options.bandQ ?? 4;
-    this._wet = Math.max(0, Math.min(1, options.wet ?? 1));
     this._envelopeSmoothing = Math.max(0.0001, Math.min(0.1, options.envelopeSmoothing ?? 0.005));
+    this.wet = options.wet ?? 1;
   }
 
   protected get _workletName(): string {
@@ -78,7 +77,6 @@ export class VocoderEffect extends WorkletEffect {
     // Guard against partially-constructed instances (constructor threw after super()).
     if (!this._modulator) return;
 
-    this._setAudioParam('wet', this._wet);
     this._setAudioParam('envelopeSmoothing', this._envelopeSmoothing);
 
     // Wire modulator bus output to input 1 of the worklet
@@ -94,15 +92,6 @@ export class VocoderEffect extends WorkletEffect {
         }
       });
     }
-  }
-
-  /** Wet (vocoded) mix level, 0..1. Default 1.0. */
-  public get wet(): number {
-    return this._wet;
-  }
-  public set wet(value: number) {
-    this._wet = Math.max(0, Math.min(1, value));
-    this._setAudioParam('wet', this._wet);
   }
 
   /** One-pole envelope follower coefficient. Smaller values produce slower, smoother envelope tracking. Range 0.0001..0.1, default 0.005. */

--- a/packages/exojs-audio-fx/src/worklets/granular.worklet.ts
+++ b/packages/exojs-audio-fx/src/worklets/granular.worklet.ts
@@ -9,7 +9,6 @@ class GranularProcessor extends AudioWorkletProcessor {
             { name: 'spread', defaultValue: 0.5, minValue: 0, maxValue: 1.0, automationRate: 'k-rate' },
             { name: 'pitchMin', defaultValue: 1.0, minValue: 0.25, maxValue: 4.0, automationRate: 'k-rate' },
             { name: 'pitchMax', defaultValue: 1.0, minValue: 0.25, maxValue: 4.0, automationRate: 'k-rate' },
-            { name: 'wet', defaultValue: 1.0, minValue: 0, maxValue: 1.0, automationRate: 'k-rate' },
         ];
     }
 
@@ -35,8 +34,6 @@ class GranularProcessor extends AudioWorkletProcessor {
         const spread = parameters.spread[0];
         const pitchMin = parameters.pitchMin[0];
         const pitchMax = parameters.pitchMax[0];
-        const wet = parameters.wet[0];
-
         const grainSizeSamples = Math.max(8, Math.floor(grainSize * sampleRate));
         const samplesPerGrain = sampleRate / Math.max(1, density);
 
@@ -89,7 +86,7 @@ class GranularProcessor extends AudioWorkletProcessor {
                 grain.ageSamples++;
             }
 
-            output[i] = (1 - wet) * input[i] + wet * grainSum * normFactor;
+            output[i] = grainSum * normFactor;
         }
         return true;
     }

--- a/packages/exojs-audio-fx/src/worklets/pitch-shift.worklet.ts
+++ b/packages/exojs-audio-fx/src/worklets/pitch-shift.worklet.ts
@@ -3,7 +3,6 @@ class PitchShiftProcessor extends AudioWorkletProcessor {
     static get parameterDescriptors() {
         return [
             { name: 'pitch', defaultValue: 1.0, minValue: 0.25, maxValue: 4.0, automationRate: 'k-rate' },
-            { name: 'wet', defaultValue: 1.0, minValue: 0, maxValue: 1.0, automationRate: 'k-rate' },
         ];
     }
 
@@ -96,7 +95,6 @@ class PitchShiftProcessor extends AudioWorkletProcessor {
         if (!input || !output) return true;
 
         const pitch = parameters.pitch[0];
-        const wet = parameters.wet[0];
         const ob = this._outBuf, oL = this._outLen;
 
         for (let i = 0; i < input.length; i++) {
@@ -119,8 +117,7 @@ class PitchShiftProcessor extends AudioWorkletProcessor {
                 this._readPos += pitch;
             }
 
-            // Dry stays latency-free: wet=0 is an exact bypass, wet=1 a full shift.
-            output[i] = (1 - wet) * input[i] + wet * shifted;
+            output[i] = shifted;
         }
         return true;
     }

--- a/packages/exojs-audio-fx/src/worklets/vocoder.worklet.ts
+++ b/packages/exojs-audio-fx/src/worklets/vocoder.worklet.ts
@@ -4,7 +4,6 @@ const sampleRate = globalThis.sampleRate;
 class VocoderProcessor extends AudioWorkletProcessor {
     static get parameterDescriptors() {
         return [
-            { name: 'wet', defaultValue: 1.0, minValue: 0, maxValue: 1.0, automationRate: 'k-rate' },
             { name: 'envelopeSmoothing', defaultValue: 0.005, minValue: 0.0001, maxValue: 0.1, automationRate: 'k-rate' },
         ];
     }
@@ -58,7 +57,6 @@ class VocoderProcessor extends AudioWorkletProcessor {
         const output = outputs[0]?.[0];
         if (!carrier || !output) return true;
 
-        const wet = parameters.wet[0];
         const envSmoothing = parameters.envelopeSmoothing[0];
         const bandCount = this._bands.length;
 
@@ -84,7 +82,7 @@ class VocoderProcessor extends AudioWorkletProcessor {
             // split across N bands, so the raw product (carBand × envelope) is
             // O(1/N) of the carrier amplitude. Scaling by N restores unity gain
             // for typical broadband carrier + voice modulator inputs.
-            output[i] = (1 - wet) * carrierSample + wet * bandSum * bandCount;
+            output[i] = bandSum * bandCount;
         }
         return true;
     }

--- a/packages/exojs-audio-fx/test/browser/granular.audio.test.ts
+++ b/packages/exojs-audio-fx/test/browser/granular.audio.test.ts
@@ -11,12 +11,12 @@ import { granularWorkletSource } from '../../src/worklets/granular.worklet';
 import { renderWorklet, rms, tail } from './_audio-harness';
 
 describe('Granular worklet — real Web Audio', () => {
-  async function granularRms(opts: { density: number; normalizeGain: boolean; wet?: number }): Promise<number> {
+  async function granularRms(opts: { density: number; normalizeGain: boolean }): Promise<number> {
     const out = await renderWorklet({
       source: granularWorkletSource,
       processorName: 'exojs-granular',
       processorOptions: { bufferSeconds: 2, normalizeGain: opts.normalizeGain },
-      params: { grainSize: 0.05, density: opts.density, spread: 0.5, pitchMin: 1, pitchMax: 1, wet: opts.wet ?? 1 },
+      params: { grainSize: 0.05, density: opts.density, spread: 0.5, pitchMin: 1, pitchMax: 1 },
       inputFreq: 440,
       durationSeconds: 2,
     });
@@ -31,12 +31,5 @@ describe('Granular worklet — real Web Audio', () => {
     const normalized = await granularRms({ density: 200, normalizeGain: true });
     const raw = await granularRms({ density: 200, normalizeGain: false });
     expect(normalized).toBeLessThan(raw);
-  });
-
-  it('wet=0 passes the input through (level preserved)', async () => {
-    const r = await granularRms({ density: 100, normalizeGain: false, wet: 0 });
-    // dry 440 Hz oscillator at unit amplitude -> RMS ≈ 1/sqrt(2)
-    expect(r).toBeGreaterThan(0.6);
-    expect(r).toBeLessThan(0.8);
   });
 });

--- a/packages/exojs-audio-fx/test/browser/pitch-shift.audio.test.ts
+++ b/packages/exojs-audio-fx/test/browser/pitch-shift.audio.test.ts
@@ -86,7 +86,9 @@ describe('PitchShift worklet — real Web Audio', () => {
       candidates.push({ delay: d, level: rms(tail(combine(d), 0.5)) });
     }
     const best = candidates.reduce((a, b) => (b.level > a.level ? b : a));
-    void best; // sweep validated L=1280; result unused at runtime
+    // The empirical best delay must land within ±64 samples of the tuned constant.
+    expect(best.delay).toBeGreaterThanOrEqual(L - 64);
+    expect(best.delay).toBeLessThanOrEqual(L + 64);
 
     const fromS = 0.5; // skip warmup
     const levelComp = rms(tail(combine(L), fromS));

--- a/packages/exojs-audio-fx/test/browser/pitch-shift.audio.test.ts
+++ b/packages/exojs-audio-fx/test/browser/pitch-shift.audio.test.ts
@@ -103,13 +103,11 @@ describe('PitchShift worklet — real Web Audio', () => {
       candidates.push({ delay: d, level: rms(tail(combine(d), 0.5)) });
     }
     const best = candidates.reduce((a, b) => (b.level > a.level ? b : a));
-    console.log(`PitchShift dry-latency sweep: best=${best.delay} samples (L=${L}), level=${best.level.toFixed(4)}`);
+    void best; // sweep validated L=1280; result unused at runtime
 
     const fromS = 0.5; // skip warmup
     const levelComp = rms(tail(combine(L), fromS));
     const levelNoComp = rms(tail(combine(0), fromS));
-
-    console.log(`levelComp=${levelComp.toFixed(4)}, levelNoComp=${levelNoComp.toFixed(4)}, ratio=${(levelComp / levelNoComp).toFixed(3)}`);
 
     // The compensated mix must be clearly louder at 440 Hz than the naive mix,
     // and close to the dry tone's own level (0.5 amplitude → rms ≈ 0.5/√2 ≈ 0.354,

--- a/packages/exojs-audio-fx/test/browser/pitch-shift.audio.test.ts
+++ b/packages/exojs-audio-fx/test/browser/pitch-shift.audio.test.ts
@@ -81,7 +81,7 @@ describe('PitchShift worklet — real Web Audio', () => {
     };
 
     // Sweep a window around L to find the empirical best delay (tunes the constant).
-    const candidates: Array<{ delay: number; level: number }> = [];
+    const candidates: { delay: number; level: number }[] = [];
     for (let d = Math.max(0, L - 256); d <= L + 256; d += 32) {
       candidates.push({ delay: d, level: rms(tail(combine(d), 0.5)) });
     }

--- a/packages/exojs-audio-fx/test/browser/pitch-shift.audio.test.ts
+++ b/packages/exojs-audio-fx/test/browser/pitch-shift.audio.test.ts
@@ -17,7 +17,7 @@ describe('PitchShift worklet — real Web Audio', () => {
       source: pitchShiftWorkletSource,
       processorName: 'exojs-pitch-shift',
       processorOptions: { grainSize: 1024 },
-      params: { pitch, wet: 1.0 },
+      params: { pitch },
       inputFreq: INPUT,
       durationSeconds: 2,
     });
@@ -46,23 +46,6 @@ describe('PitchShift worklet — real Web Audio', () => {
     const f = await shiftedFreq(2.0);
     expect(f).toBeGreaterThan(880 * 0.97);
     expect(f).toBeLessThan(880 * 1.03);
-  });
-
-  it('wet=0 passes the input through (level preserved)', async () => {
-    const out = await renderWorklet({
-      source: pitchShiftWorkletSource,
-      processorName: 'exojs-pitch-shift',
-      processorOptions: { grainSize: 1024 },
-      params: { pitch: 2.0, wet: 0.0 },
-      inputFreq: INPUT,
-      durationSeconds: 1,
-    });
-    const meas = tail(out, 0.25);
-    // dry oscillator at unit amplitude -> RMS ≈ 1/sqrt(2)
-    expect(rms(meas)).toBeGreaterThan(0.6);
-    const f = dominantFreq(meas);
-    expect(f).toBeGreaterThan(INPUT * 0.97);
-    expect(f).toBeLessThan(INPUT * 1.03);
   });
 
   it('wet=0.5 with dry-latency compensation keeps the tone level (no comb cancellation)', async () => {

--- a/packages/exojs-audio-fx/test/browser/pitch-shift.audio.test.ts
+++ b/packages/exojs-audio-fx/test/browser/pitch-shift.audio.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { pitchShiftWorkletSource } from '../../src/worklets/pitch-shift.worklet';
-import { dominantFreq, renderWorklet, rms, tail } from './_audio-harness';
+import { dominantFreq, renderWorklet, rms, SAMPLE_RATE, tail } from './_audio-harness';
 
 describe('PitchShift worklet — real Web Audio', () => {
   const INPUT = 440;
@@ -63,5 +63,58 @@ describe('PitchShift worklet — real Web Audio', () => {
     const f = dominantFreq(meas);
     expect(f).toBeGreaterThan(INPUT * 0.97);
     expect(f).toBeLessThan(INPUT * 1.03);
+  });
+
+  it('wet=0.5 with dry-latency compensation keeps the tone level (no comb cancellation)', async () => {
+    const freq = 440;
+    const grain = 1024;
+    const seconds = 1.5;
+    const n = Math.floor(seconds * SAMPLE_RATE);
+
+    // Known input sine so we control phase exactly.
+    const input = new Float32Array(n);
+    for (let i = 0; i < n; i++) input[i] = 0.5 * Math.sin((2 * Math.PI * freq * i) / SAMPLE_RATE);
+
+    // Pure wet from the worklet at pitch=1.0 (output is the input delayed by the
+    // SOLA latency). After cleanup the worklet has no `wet` param; passing extra
+    // params is harmless.
+    const wet = await renderWorklet({
+      source: pitchShiftWorkletSource,
+      processorName: 'exojs-pitch-shift',
+      processorOptions: { grainSize: grain },
+      params: { pitch: 1.0 },
+      inputBuffer: input,
+      durationSeconds: seconds,
+    });
+
+    const L = grain + (grain >> 2); // the effect's dry-latency in samples
+    const combine = (delaySamples: number): Float32Array => {
+      const out = new Float32Array(n);
+      for (let i = 0; i < n; i++) {
+        const dry = i - delaySamples >= 0 ? input[i - delaySamples] : 0;
+        out[i] = 0.5 * dry + 0.5 * wet[i];
+      }
+      return out;
+    };
+
+    // Sweep a window around L to find the empirical best delay (tunes the constant).
+    const candidates: Array<{ delay: number; level: number }> = [];
+    for (let d = Math.max(0, L - 256); d <= L + 256; d += 32) {
+      candidates.push({ delay: d, level: rms(tail(combine(d), 0.5)) });
+    }
+    const best = candidates.reduce((a, b) => (b.level > a.level ? b : a));
+    console.log(`PitchShift dry-latency sweep: best=${best.delay} samples (L=${L}), level=${best.level.toFixed(4)}`);
+
+    const fromS = 0.5; // skip warmup
+    const levelComp = rms(tail(combine(L), fromS));
+    const levelNoComp = rms(tail(combine(0), fromS));
+
+    console.log(`levelComp=${levelComp.toFixed(4)}, levelNoComp=${levelNoComp.toFixed(4)}, ratio=${(levelComp / levelNoComp).toFixed(3)}`);
+
+    // The compensated mix must be clearly louder at 440 Hz than the naive mix,
+    // and close to the dry tone's own level (0.5 amplitude → rms ≈ 0.5/√2 ≈ 0.354,
+    // halved by the 0.5 mix weight on each path when aligned ≈ 0.354).
+    expect(levelComp).toBeGreaterThan(levelNoComp * 1.15);
+    expect(levelComp).toBeGreaterThan(0.2);
   });
 });

--- a/packages/exojs-audio-fx/test/browser/vocoder.audio.test.ts
+++ b/packages/exojs-audio-fx/test/browser/vocoder.audio.test.ts
@@ -7,13 +7,12 @@
  */
 
 import { vocoderWorkletSource } from '../../src/worklets/vocoder.worklet';
-import { dominantFreq, rms, SAMPLE_RATE,tail } from './_audio-harness';
+import { rms, SAMPLE_RATE, tail } from './_audio-harness';
 
 interface VocoderRenderOptions {
   carrierType: OscillatorType;
   carrierFreq: number;
   modFreq: number;
-  wet: number;
   durationSeconds: number;
 }
 
@@ -30,7 +29,6 @@ async function renderVocoder(opts: VocoderRenderOptions): Promise<Float32Array> 
     numberOfOutputs: 1,
     processorOptions: { numBands: 16, minHz: 80, maxHz: 8000, bandQ: 4 },
   });
-  node.parameters.get('wet')!.value = opts.wet;
   node.parameters.get('envelopeSmoothing')!.value = 0.005;
 
   const carrier = ctx.createOscillator();
@@ -67,7 +65,6 @@ describe('Vocoder worklet — real Web Audio', () => {
       carrierType: 'sawtooth',
       carrierFreq: 110,
       modFreq: 700,
-      wet: 1.0,
       durationSeconds: 3,
     });
     // after 2 s the band envelopes have converged; -20 dBFS is the floor below
@@ -78,8 +75,8 @@ describe('Vocoder worklet — real Web Audio', () => {
   it('spectral envelope follows the modulator formant', async () => {
     // Sawtooth at 110 Hz has harmonics at 660 and 2200 Hz; a 660 Hz modulator
     // should boost the 660 Hz region relative to a 2200 Hz modulator.
-    const low = tail(await renderVocoder({ carrierType: 'sawtooth', carrierFreq: 110, modFreq: 660, wet: 1, durationSeconds: 3 }), 2.0);
-    const high = tail(await renderVocoder({ carrierType: 'sawtooth', carrierFreq: 110, modFreq: 2200, wet: 1, durationSeconds: 3 }), 2.0);
+    const low = tail(await renderVocoder({ carrierType: 'sawtooth', carrierFreq: 110, modFreq: 660, durationSeconds: 3 }), 2.0);
+    const high = tail(await renderVocoder({ carrierType: 'sawtooth', carrierFreq: 110, modFreq: 2200, durationSeconds: 3 }), 2.0);
 
     const lowRatio = magnitudeAt(low, 660) / (magnitudeAt(low, 2200) + 1e-9);
     const highRatio = magnitudeAt(high, 660) / (magnitudeAt(high, 2200) + 1e-9);
@@ -87,10 +84,4 @@ describe('Vocoder worklet — real Web Audio', () => {
     expect(lowRatio).toBeGreaterThan(highRatio);
   });
 
-  it('wet=0 passes the carrier through', async () => {
-    const out = await renderVocoder({ carrierType: 'sine', carrierFreq: 440, modFreq: 700, wet: 0, durationSeconds: 1 });
-    const meas = tail(out, 0.25);
-    expect(dominantFreq(meas)).toBeGreaterThan(440 * 0.97);
-    expect(dominantFreq(meas)).toBeLessThan(440 * 1.03);
-  });
 });

--- a/packages/exojs-audio-fx/test/effects/granular-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/granular-effect.test.ts
@@ -100,7 +100,7 @@ describe('GranularEffect', () => {
       filter.destroy();
     });
 
-    it('after await filter.ready: all 6 worklet params are set', async () => {
+    it('after await filter.ready: all 5 worklet params are set', async () => {
       const filter = new GranularEffect({
         grainSize: 0.1,
         density: 30,
@@ -122,7 +122,8 @@ describe('GranularEffect', () => {
       check('spread', 0.8);
       check('pitchMin', 0.5);
       check('pitchMax', 1.5);
-      check('wet', 0.9);
+      // wet is now managed by the WorkletEffect base gain nodes, not the worklet param
+      expect(filter.wet).toBe(0.9);
       filter.destroy();
     });
 
@@ -312,15 +313,15 @@ describe('GranularEffect', () => {
       filter.destroy();
     });
 
-    it('setting wet updates worklet param', async () => {
+    it('setting wet updates base gain nodes', async () => {
       const filter = new GranularEffect();
       await filter.ready;
-      const node = filter['_workletNode']!;
-      const param = node.parameters.get('wet') as unknown as { setTargetAtTime: MockInstance };
-      param.setTargetAtTime.mockClear();
+      vi.spyOn(filter['_dryGain']!.gain, 'setTargetAtTime');
+      vi.spyOn(filter['_wetGain']!.gain, 'setTargetAtTime');
       filter.wet = 0.6;
       expect(filter.wet).toBe(0.6);
-      expect(param.setTargetAtTime).toHaveBeenCalledWith(0.6, expect.anything(), expect.anything());
+      expect(filter['_dryGain']!.gain.setTargetAtTime).toHaveBeenCalledWith(0.4, expect.anything(), expect.anything());
+      expect(filter['_wetGain']!.gain.setTargetAtTime).toHaveBeenCalledWith(0.6, expect.anything(), expect.anything());
       filter.destroy();
     });
 

--- a/packages/exojs-audio-fx/test/effects/pitch-shift-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/pitch-shift-effect.test.ts
@@ -122,13 +122,13 @@ describe('PitchShiftEffect', () => {
       filter.destroy();
     });
 
-    it('worklet parameters pitch and wet are set on ready', async () => {
+    it('pitch is set on ready; wet applies to the base mix', async () => {
       const filter = new PitchShiftEffect({ pitch: 1.5, wet: 0.8 });
       await filter.ready;
       const node = filter['_workletNode']!;
       const pitchParam = node.parameters.get('pitch') as unknown as { setTargetAtTime: MockInstance };
       expect(pitchParam.setTargetAtTime).toHaveBeenCalledWith(1.5, expect.anything(), expect.anything());
-      // wet is now managed by the WorkletEffect base gain nodes, not the worklet param
+      // wet is managed by the WorkletEffect base gain nodes, not a worklet param
       expect(filter.wet).toBe(0.8);
       filter.destroy();
     });
@@ -159,6 +159,29 @@ describe('PitchShiftEffect', () => {
       await filter.ready;
       expect(capturedOptions?.processorOptions?.grainSize).toBe(1024);
       filter.destroy();
+    });
+
+    it('_dryDelay is created after worklet-ready with the correct SOLA latency', async () => {
+      // Regression test for the field-order bug: _grainSize is assigned after
+      // super() in PitchShiftEffect, so _dryLatencySeconds must NOT be read
+      // synchronously in _setup() — it must be deferred to the worklet-ready
+      // callback (which is always async, guaranteeing the constructor finished).
+      //
+      // On the pre-fix code this test would FAIL because _dryDelay would be null:
+      // _dryLatencySeconds returned NaN (this._grainSize was undefined at _setup
+      // time), so the if (dryLatency > 0) branch was never taken.
+      const fx = new PitchShiftEffect(); // default grainSize = 1024
+      await fx.ready;
+
+      // The delay node must exist.
+      expect(fx['_dryDelay']).not.toBeNull();
+
+      // delayTime must match the SOLA latency formula: (grainSize + grainSize>>2) / sampleRate.
+      const sampleRate = fx['_dryDelay']!.context.sampleRate; // 44100 from mock
+      const expectedLatency = (1024 + (1024 >> 2)) / sampleRate; // 1280 / 44100
+      expect(fx['_dryDelay']!.delayTime.value).toBeCloseTo(expectedLatency, 5);
+
+      fx.destroy();
     });
   });
 

--- a/packages/exojs-audio-fx/test/effects/pitch-shift-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/pitch-shift-effect.test.ts
@@ -127,9 +127,9 @@ describe('PitchShiftEffect', () => {
       await filter.ready;
       const node = filter['_workletNode']!;
       const pitchParam = node.parameters.get('pitch') as unknown as { setTargetAtTime: MockInstance };
-      const wetParam = node.parameters.get('wet') as unknown as { setTargetAtTime: MockInstance };
       expect(pitchParam.setTargetAtTime).toHaveBeenCalledWith(1.5, expect.anything(), expect.anything());
-      expect(wetParam.setTargetAtTime).toHaveBeenCalledWith(0.8, expect.anything(), expect.anything());
+      // wet is now managed by the WorkletEffect base gain nodes, not the worklet param
+      expect(filter.wet).toBe(0.8);
       filter.destroy();
     });
 
@@ -175,15 +175,15 @@ describe('PitchShiftEffect', () => {
       filter.destroy();
     });
 
-    it('setting wet updates worklet param', async () => {
+    it('setting wet updates base gain nodes', async () => {
       const filter = new PitchShiftEffect();
       await filter.ready;
-      const node = filter['_workletNode']!;
-      const param = node.parameters.get('wet') as unknown as { setTargetAtTime: MockInstance };
-      param.setTargetAtTime.mockClear();
+      vi.spyOn(filter['_dryGain']!.gain, 'setTargetAtTime');
+      vi.spyOn(filter['_wetGain']!.gain, 'setTargetAtTime');
       filter.wet = 0.5;
       expect(filter.wet).toBe(0.5);
-      expect(param.setTargetAtTime).toHaveBeenCalledWith(0.5, expect.anything(), expect.anything());
+      expect(filter['_dryGain']!.gain.setTargetAtTime).toHaveBeenCalledWith(0.5, expect.anything(), expect.anything());
+      expect(filter['_wetGain']!.gain.setTargetAtTime).toHaveBeenCalledWith(0.5, expect.anything(), expect.anything());
       filter.destroy();
     });
   });

--- a/packages/exojs-audio-fx/test/effects/vocoder-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/vocoder-effect.test.ts
@@ -126,15 +126,15 @@ describe('VocoderEffect', () => {
       filter.destroy();
     });
 
-    it('after await filter.ready: wet and envelopeSmoothing params are set', async () => {
+    it('after await filter.ready: envelopeSmoothing worklet param and wet base gain are set', async () => {
       const modulator = makeModulatorBus();
       const filter = new VocoderEffect({ modulator, wet: 0.7, envelopeSmoothing: 0.01 });
       await filter.ready;
       const node = filter['_workletNode']!;
-      const wetParam = node.parameters.get('wet') as unknown as { setTargetAtTime: MockInstance };
       const esParam = node.parameters.get('envelopeSmoothing') as unknown as { setTargetAtTime: MockInstance };
-      expect(wetParam.setTargetAtTime).toHaveBeenCalledWith(0.7, expect.anything(), expect.anything());
       expect(esParam.setTargetAtTime).toHaveBeenCalledWith(0.01, expect.anything(), expect.anything());
+      // wet is now managed by the WorkletEffect base gain nodes, not the worklet param
+      expect(filter.wet).toBe(0.7);
       filter.destroy();
     });
 
@@ -207,16 +207,16 @@ describe('VocoderEffect', () => {
   // 5. Runtime setters
   // -------------------------------------------------------------------------
   describe('setters after ready', () => {
-    it('setting wet updates worklet param', async () => {
+    it('setting wet updates base gain nodes', async () => {
       const modulator = makeModulatorBus();
       const filter = new VocoderEffect({ modulator });
       await filter.ready;
-      const node = filter['_workletNode']!;
-      const param = node.parameters.get('wet') as unknown as { setTargetAtTime: MockInstance };
-      param.setTargetAtTime.mockClear();
+      vi.spyOn(filter['_dryGain']!.gain, 'setTargetAtTime');
+      vi.spyOn(filter['_wetGain']!.gain, 'setTargetAtTime');
       filter.wet = 0.4;
       expect(filter.wet).toBe(0.4);
-      expect(param.setTargetAtTime).toHaveBeenCalledWith(0.4, expect.anything(), expect.anything());
+      expect(filter['_dryGain']!.gain.setTargetAtTime).toHaveBeenCalledWith(0.6, expect.anything(), expect.anything());
+      expect(filter['_wetGain']!.gain.setTargetAtTime).toHaveBeenCalledWith(0.4, expect.anything(), expect.anything());
       filter.destroy();
     });
 

--- a/packages/exojs-audio-fx/test/worklets/granular-processor.test.ts
+++ b/packages/exojs-audio-fx/test/worklets/granular-processor.test.ts
@@ -80,7 +80,7 @@ describe('GranularProcessor normalizeGain DSP', () => {
     randomSpy.mockRestore();
   });
 
-  function rmsRatio(opts: { density: number; grainSize: number; normalizeGain?: boolean; wet?: number }): number {
+  function rmsRatio(opts: { density: number; grainSize: number; normalizeGain?: boolean }): number {
     const proc = new Processor({ processorOptions: { bufferSeconds: 2, normalizeGain: opts.normalizeGain ?? false } });
     const n = SAMPLE_RATE * 3;
     const input = makeSine(440, 0.5, n);
@@ -94,7 +94,6 @@ describe('GranularProcessor normalizeGain DSP', () => {
         spread: [0.5],
         pitchMin: [1],
         pitchMax: [1],
-        wet: [opts.wet ?? 1],
       });
       out.set(oB, off);
     }
@@ -120,23 +119,5 @@ describe('GranularProcessor normalizeGain DSP', () => {
     const r = rmsRatio({ density: 100, grainSize: 0.05, normalizeGain: true });
     expect(r).toBeGreaterThan(0.5);
     expect(r).toBeLessThan(2.0);
-  });
-
-  // ── Bypass holds regardless of normalizeGain ───────────────────────────────
-  it('wet=0 passes the input through unchanged', () => {
-    const proc = new Processor({ processorOptions: { bufferSeconds: 2, normalizeGain: true } });
-    const input = makeSine(440, 0.5, BLOCK * 8);
-    const out = new Float32Array(input.length);
-    for (let off = 0; off < input.length; off += BLOCK) {
-      const len = Math.min(BLOCK, input.length - off);
-      const oB = new Float32Array(len);
-      proc.process([[input.subarray(off, off + len)]], [[oB]], {
-        grainSize: [0.05], density: [100], spread: [0.5], pitchMin: [1], pitchMax: [1], wet: [0],
-      });
-      out.set(oB, off);
-    }
-    let maxDiff = 0;
-    for (let i = 0; i < input.length; i++) maxDiff = Math.max(maxDiff, Math.abs(input[i] - out[i]));
-    expect(maxDiff).toBeLessThan(1e-6);
   });
 });

--- a/packages/exojs-audio-fx/test/worklets/pitch-shift-processor.test.ts
+++ b/packages/exojs-audio-fx/test/worklets/pitch-shift-processor.test.ts
@@ -82,7 +82,7 @@ function dominantFreq(buf: Float32Array, lo = 50, hi = 4000): { freq: number; ma
 function runWorklet(
   Processor: PitchProcessorConstructor,
   input: Float32Array,
-  opts: { pitch: number; wet: number; grainSize: number },
+  opts: { pitch: number; grainSize: number },
 ): Float32Array {
   const proc = new Processor({ processorOptions: { grainSize: opts.grainSize } });
   const n = input.length;
@@ -91,7 +91,7 @@ function runWorklet(
     const len = Math.min(BLOCK, n - off);
     const iB = input.subarray(off, off + len);
     const oB = new Float32Array(len);
-    proc.process([[iB]], [[oB]], { pitch: [opts.pitch], wet: [opts.wet] });
+    proc.process([[iB]], [[oB]], { pitch: [opts.pitch] });
     out.set(oB, off);
   }
   return out;
@@ -112,7 +112,7 @@ describe('PitchShiftProcessor DSP', () => {
 
   function measureShift(pitch: number): { freq: number; purity: number; ratioRms: number } {
     const input = makeSine(INPUT_FREQ, 0.5, TOTAL);
-    const out = runWorklet(Processor, input, { pitch, wet: 1.0, grainSize: GRAIN });
+    const out = runWorklet(Processor, input, { pitch, grainSize: GRAIN });
     const meas = out.subarray(WARMUP);
     const { freq, mag } = dominantFreq(meas);
     const purity = mag / (Math.SQRT2 * (rms(meas) || 1e-9));
@@ -161,14 +161,5 @@ describe('PitchShiftProcessor DSP', () => {
     const { ratioRms } = measureShift(2.0);
     expect(ratioRms).toBeGreaterThan(0.25); // > -12 dB
     expect(ratioRms).toBeLessThan(2.0); // < +6 dB
-  });
-
-  // ── Bypass: wet=0 is the dry signal, unchanged ─────────────────────────────
-  it('wet=0 passes the input through unchanged', () => {
-    const input = makeSine(INPUT_FREQ, 0.5, GRAIN * 4);
-    const out = runWorklet(Processor, input, { pitch: 2.0, wet: 0.0, grainSize: GRAIN });
-    let maxDiff = 0;
-    for (let i = 0; i < input.length; i++) maxDiff = Math.max(maxDiff, Math.abs(input[i] - out[i]));
-    expect(maxDiff).toBeLessThan(1e-6);
   });
 });

--- a/packages/exojs-audio-fx/test/worklets/vocoder-processor.test.ts
+++ b/packages/exojs-audio-fx/test/worklets/vocoder-processor.test.ts
@@ -123,7 +123,6 @@ function runVocoder(
   proc: VocoderProcessorLike,
   carrier: Float32Array,
   modulator: Float32Array,
-  wet: number,
   envSmoothing: number,
 ): Float32Array {
   const n = carrier.length;
@@ -133,7 +132,7 @@ function runVocoder(
     const cB = carrier.subarray(off, off + len);
     const mB = modulator.subarray(off, off + len);
     const oB = new Float32Array(len);
-    proc.process([[cB], [mB]], [[oB]], { wet: [wet], envelopeSmoothing: [envSmoothing] });
+    proc.process([[cB], [mB]], [[oB]], { envelopeSmoothing: [envSmoothing] });
     out.set(oB, off);
   }
   return out;
@@ -154,11 +153,11 @@ describe('VocoderProcessor DSP', () => {
   });
 
   // ── 1. Silence without modulator ──────────────────────────────────────────
-  it('outputs silence (wet=1) when modulator is absent', () => {
+  it('outputs silence when modulator is absent', () => {
     const proc     = new Processor({ processorOptions: { numBands: NUM_BANDS, minHz: 80, maxHz: 8000, bandQ: 4 } });
     const carrier  = makeSawtooth(110, 1.0, MEASURE);
     const silence  = new Float32Array(MEASURE); // no modulator
-    const out      = runVocoder(proc, carrier, silence, 1.0, 0.005);
+    const out      = runVocoder(proc, carrier, silence, 0.005);
     // All envelopes are zero → bandSum = 0 → output = 0
     expect(rms(out)).toBeLessThan(1e-6);
   });
@@ -171,7 +170,7 @@ describe('VocoderProcessor DSP', () => {
     const proc     = new Processor({ processorOptions: { numBands: NUM_BANDS, minHz: 80, maxHz: 8000, bandQ: 4 } });
     const carrier  = makeSawtooth(110, 1.0, TOTAL);
     const modulator = makeVoiceLike(TOTAL);
-    const out      = runVocoder(proc, carrier, modulator, 1.0, 0.005);
+    const out      = runVocoder(proc, carrier, modulator, 0.005);
 
     const rmsCarrier = rms(carrier.subarray(WARMUP));
     const rmsOut     = rms(out.subarray(WARMUP));
@@ -206,8 +205,8 @@ describe('VocoderProcessor DSP', () => {
     const procLow  = new Processor({ processorOptions: { numBands: NUM_BANDS, minHz: 80, maxHz: 8000, bandQ: 4 } });
     const procHigh = new Processor({ processorOptions: { numBands: NUM_BANDS, minHz: 80, maxHz: 8000, bandQ: 4 } });
 
-    const outLow  = runVocoder(procLow,  carrier, modLow,  1.0, 0.005);
-    const outHigh = runVocoder(procHigh, carrier, modHigh, 1.0, 0.005);
+    const outLow  = runVocoder(procLow,  carrier, modLow,  0.005);
+    const outHigh = runVocoder(procHigh, carrier, modHigh, 0.005);
 
     const measLow  = outLow.subarray(WARMUP);
     const measHigh = outHigh.subarray(WARMUP);
@@ -223,21 +222,7 @@ describe('VocoderProcessor DSP', () => {
     expect(magHigh2200).toBeGreaterThan(magHigh660);
   });
 
-  // ── 4. wet=0 passes carrier unchanged ─────────────────────────────────────
-  it('wet=0 passes carrier through with unity gain', () => {
-    const proc     = new Processor({ processorOptions: { numBands: NUM_BANDS, minHz: 80, maxHz: 8000, bandQ: 4 } });
-    const carrier  = makeSawtooth(110, 1.0, MEASURE);
-    const modulator = makeVoiceLike(MEASURE);
-    const out      = runVocoder(proc, carrier, modulator, 0.0, 0.005);
-
-    // With wet=0: output = (1-0)*carrier + 0*bandSum = carrier
-    // The RMS should match the carrier's RMS exactly.
-    const rmsCarrier = rms(carrier);
-    const rmsOut     = rms(out);
-    expect(rmsOut).toBeCloseTo(rmsCarrier, 4);
-  });
-
-  // ── 5. Sine at band center: output ≈ 2/π × carrier (envelope attenuates) ──
+  // ── 4. Sine at band center: output ≈ 2/π × carrier (envelope attenuates) ──
   // When carrier = modulator = sine at exactly one band's center frequency,
   // only that band contributes meaningfully. After warmup its envelope converges
   // to ≈ 2/π × amplitude. With the bandCount make-up gain the total output
@@ -249,7 +234,7 @@ describe('VocoderProcessor DSP', () => {
     const proc        = new Processor({ processorOptions: { numBands: NUM_BANDS, minHz: 80, maxHz: 8000, bandQ: 4 } });
     const carrier     = makeSine(BAND_CENTER, 1.0, TOTAL);
     const modulator   = makeSine(BAND_CENTER, 1.0, TOTAL);
-    const out         = runVocoder(proc, carrier, modulator, 1.0, 0.005);
+    const out         = runVocoder(proc, carrier, modulator, 0.005);
 
     const rmsO = rms(out.subarray(WARMUP));
     // Must be meaningfully above silence (> 0.1 = -20 dBFS)
@@ -269,8 +254,8 @@ describe('VocoderProcessor DSP', () => {
     const proc8  = new Processor({ processorOptions: { numBands: 8,  minHz: 80, maxHz: 8000, bandQ: 4 } });
     const proc32 = new Processor({ processorOptions: { numBands: 32, minHz: 80, maxHz: 8000, bandQ: 4 } });
 
-    const out8  = runVocoder(proc8,  carrier.slice(), modulator.slice(), 1.0, 0.005);
-    const out32 = runVocoder(proc32, carrier.slice(), modulator.slice(), 1.0, 0.005);
+    const out8  = runVocoder(proc8,  carrier.slice(), modulator.slice(), 0.005);
+    const out32 = runVocoder(proc32, carrier.slice(), modulator.slice(), 0.005);
 
     const rms8  = rms(out8.subarray(WARMUP));
     const rms32 = rms(out32.subarray(WARMUP));

--- a/site/src/content/api/ducking-effect.mdx
+++ b/site/src/content/api/ducking-effect.mdx
@@ -5,7 +5,7 @@ symbol: "DuckingEffect"
 kind: "class"
 subsystem: "audio"
 importPath: "@codexo/exojs-audio-fx"
-memberCount: 10
+memberCount: 11
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "packages/exojs-audio-fx/src/effects/DuckingEffect.ts"
@@ -40,6 +40,7 @@ filter coefficients.
 - `ready: Promise<void>`
 - `releaseMs: number`
 - `threshold: number`
+- `wet: number`
 
 ## Source
 

--- a/site/src/content/api/worklet-effect.mdx
+++ b/site/src/content/api/worklet-effect.mdx
@@ -1,32 +1,30 @@
 ---
 title: "WorkletEffect"
-description: "Base class for filters implemented as AudioWorkletProcessors. Subclasses declare the worklet's name, source code, and node options; this class handles the async lifecycle. Stable input/output nodes (GainNodes) are created immediately on setup. While the worklet loads asynchronously, audio passes through directly (effectively bypassing the filter for ~10-50ms during initial load). Once the worklet loads, it's inserted into the chain and audio routes through it. Subclasses can override `_onWorkletReady` to perform additional wiring (e.g., sidechain inputs)."
+description: "Base class for filters implemented as AudioWorkletProcessors. Subclasses declare the worklet's name, source code, and node options; this class owns the async lifecycle AND the dry/wet gain staging. Stable input/output nodes are created immediately. The worklet emits a pure wet signal; the base mixes it against the dry signal via `_dryGain`/`_wetGain` (`dryGain = 1 - wet`, `wetGain = wet * _wetMakeupGain`). An optional `_dryDelay` time-aligns the dry path with the worklet's algorithmic latency. While the worklet loads, the wet path is silent and dry passes at unity, so the effect is a clean passthrough (no volume dip) until it is ready."
 symbol: "WorkletEffect"
 kind: "class"
 subsystem: "audio"
 importPath: "@codexo/exojs"
-memberCount: 6
+memberCount: 7
 tier: "advanced"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "src/audio/WorkletEffect.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/audio/WorkletEffect.ts#L20"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/audio/WorkletEffect.ts#L18"
 ---
 ## Import
 
 `import { WorkletEffect } from '@codexo/exojs'`
 
 Base class for filters implemented as AudioWorkletProcessors. Subclasses
-declare the worklet's name, source code, and node options; this class
-handles the async lifecycle.
+declare the worklet's name, source code, and node options; this class owns
+the async lifecycle AND the dry/wet gain staging.
 
-Stable input/output nodes (GainNodes) are created immediately on setup.
-While the worklet loads asynchronously, audio passes through directly
-(effectively bypassing the filter for ~10-50ms during initial load).
-Once the worklet loads, it's inserted into the chain and audio routes
-through it.
-
-Subclasses can override `_onWorkletReady` to perform additional wiring
-(e.g., sidechain inputs).
+Stable input/output nodes are created immediately. The worklet emits a pure
+wet signal; the base mixes it against the dry signal via `_dryGain`/`_wetGain`
+(`dryGain = 1 - wet`, `wetGain = wet * _wetMakeupGain`). An optional
+`_dryDelay` time-aligns the dry path with the worklet's algorithmic latency.
+While the worklet loads, the wet path is silent and dry passes at unity, so
+the effect is a clean passthrough (no volume dip) until it is ready.
 
 ## Constructors
 
@@ -42,7 +40,8 @@ Subclasses can override `_onWorkletReady` to perform additional wiring
 - `inputNode: AudioNode`
 - `outputNode: AudioNode`
 - `ready: Promise<void>`
+- `wet: number`
 
 ## Source
 
-[src/audio/WorkletEffect.ts](https://github.com/Exoridus/ExoJS/blob/main/src/audio/WorkletEffect.ts#L20)
+[src/audio/WorkletEffect.ts](https://github.com/Exoridus/ExoJS/blob/main/src/audio/WorkletEffect.ts#L18)

--- a/src/audio/WorkletEffect.ts
+++ b/src/audio/WorkletEffect.ts
@@ -4,24 +4,26 @@ import { registerAudioWorkletProcessor } from '#audio/worklet/registerWorklet';
 
 /**
  * Base class for filters implemented as AudioWorkletProcessors. Subclasses
- * declare the worklet's name, source code, and node options; this class
- * handles the async lifecycle.
+ * declare the worklet's name, source code, and node options; this class owns
+ * the async lifecycle AND the dry/wet gain staging.
  *
- * Stable input/output nodes (GainNodes) are created immediately on setup.
- * While the worklet loads asynchronously, audio passes through directly
- * (effectively bypassing the filter for ~10-50ms during initial load).
- * Once the worklet loads, it's inserted into the chain and audio routes
- * through it.
- *
- * Subclasses can override `_onWorkletReady` to perform additional wiring
- * (e.g., sidechain inputs).
+ * Stable input/output nodes are created immediately. The worklet emits a pure
+ * wet signal; the base mixes it against the dry signal via `_dryGain`/`_wetGain`
+ * (`dryGain = 1 - wet`, `wetGain = wet * _wetMakeupGain`). An optional
+ * `_dryDelay` time-aligns the dry path with the worklet's algorithmic latency.
+ * While the worklet loads, the wet path is silent and dry passes at unity, so
+ * the effect is a clean passthrough (no volume dip) until it is ready.
  * @advanced
  */
 export abstract class WorkletEffect extends AudioEffect {
   protected _inputGain: GainNode | null = null;
   protected _outputGain: GainNode | null = null;
+  protected _dryGain: GainNode | null = null;
+  protected _wetGain: GainNode | null = null;
+  protected _dryDelay: DelayNode | null = null;
   protected _workletNode: AudioWorkletNode | null = null;
   protected _ready: Promise<void> | null = null;
+  protected _wet = 1;
   private readonly _onAudioContextReady = (ctx: AudioContext): void => {
     onAudioContextReady.remove(this._onAudioContextReady);
     this._setup(ctx);
@@ -34,6 +36,20 @@ export abstract class WorkletEffect extends AudioEffect {
   /** AudioWorkletNode constructor options. Default: 1 input, 1 output. */
   protected get _workletOptions(): AudioWorkletNodeOptions {
     return { numberOfInputs: 1, numberOfOutputs: 1 };
+  }
+
+  /**
+   * Dry-path delay in seconds, time-aligning the dry signal with the worklet's
+   * algorithmic latency so intermediate `wet` values do not comb-filter.
+   * Default 0 (no delay). Override in subclasses with buffering latency.
+   */
+  protected get _dryLatencySeconds(): number {
+    return 0;
+  }
+
+  /** Static makeup multiplier folded into the wet path (`wetGain = wet * this`). Default 1. */
+  protected get _wetMakeupGain(): number {
+    return 1;
   }
 
   public constructor() {
@@ -59,11 +75,21 @@ export abstract class WorkletEffect extends AudioEffect {
     return this._outputGain;
   }
 
-  /**
-   * Resolves once the underlying worklet is loaded and inserted into the
-   * audio chain. Use this if you need to wait before applying parameters
-   * that depend on the worklet node.
-   */
+  /** Wet (processed) mix level, 0..1. The dry level is automatically `1 - wet`. Ramped smoothly. */
+  public get wet(): number {
+    return this._wet;
+  }
+
+  public set wet(value: number) {
+    this._wet = Math.max(0, Math.min(1, value));
+    if (this._dryGain && this._wetGain) {
+      const ctx = this._wetGain.context;
+      this._dryGain.gain.setTargetAtTime(1 - this._wet, ctx.currentTime, 0.01);
+      this._wetGain.gain.setTargetAtTime(this._wet * this._wetMakeupGain, ctx.currentTime, 0.01);
+    }
+  }
+
+  /** Resolves once the worklet is loaded and inserted into the wet path. */
   public override get ready(): Promise<void> {
     return this._ready ?? Promise.resolve();
   }
@@ -74,22 +100,27 @@ export abstract class WorkletEffect extends AudioEffect {
     this._workletNode?.disconnect();
     this._inputGain?.disconnect();
     this._outputGain?.disconnect();
+    this._dryGain?.disconnect();
+    this._wetGain?.disconnect();
+    this._dryDelay?.disconnect();
     this._workletNode = null;
     this._inputGain = null;
     this._outputGain = null;
+    this._dryGain = null;
+    this._wetGain = null;
+    this._dryDelay = null;
     this._ready = null;
   }
 
   /**
-   * Subclass hook — called once when the worklet has loaded and the
-   * AudioWorkletNode is inserted into the chain. Use this for additional
-   * wiring (e.g., connecting a sidechain input).
+   * Subclass hook — called once the worklet is loaded and inserted into the
+   * wet path. Use for additional wiring (e.g. a sidechain input).
    */
   protected _onWorkletReady?(audioContext: AudioContext): void;
 
   /**
-   * Ramps an `AudioParam` on the underlying `AudioWorkletNode` to `value`
-   * using a short exponential ramp. No-ops if the worklet is not yet loaded.
+   * Ramps an `AudioParam` on the underlying `AudioWorkletNode` to `value` using
+   * a short exponential ramp. No-ops if the worklet is not yet loaded.
    * @internal
    */
   protected _setAudioParam(name: string, value: number): void {
@@ -101,26 +132,49 @@ export abstract class WorkletEffect extends AudioEffect {
   }
 
   private _setup(audioContext: AudioContext): void {
-    // Create stable input/output gains immediately (bus can wire them now).
     const inputGain = audioContext.createGain();
     const outputGain = audioContext.createGain();
-    // Bypass: input → output until worklet loads.
-    inputGain.connect(outputGain);
+    const dryGain = audioContext.createGain();
+    const wetGain = audioContext.createGain();
+
+    // Dry path: input → [dryDelay] → dryGain → output. The delay aligns dry with
+    // the worklet's latency so intermediate wet values stay phase-coherent.
+    const dryLatency = this._dryLatencySeconds;
+    let dryDelay: DelayNode | null = null;
+    if (dryLatency > 0) {
+      dryDelay = audioContext.createDelay(Math.max(1, dryLatency * 2));
+      dryDelay.delayTime.setValueAtTime(dryLatency, audioContext.currentTime);
+      inputGain.connect(dryDelay);
+      dryDelay.connect(dryGain);
+    } else {
+      inputGain.connect(dryGain);
+    }
+    dryGain.connect(outputGain);
+
+    // Wet path output stage exists immediately but is silent until the worklet
+    // loads. Dry passes at unity meanwhile → clean passthrough, no volume dip.
+    dryGain.gain.setValueAtTime(1, audioContext.currentTime);
+    wetGain.gain.setValueAtTime(0, audioContext.currentTime);
+    wetGain.connect(outputGain);
 
     this._inputGain = inputGain;
     this._outputGain = outputGain;
+    this._dryGain = dryGain;
+    this._wetGain = wetGain;
+    this._dryDelay = dryDelay;
 
-    // Async-load the worklet, then re-route through it.
     this._ready = registerAudioWorkletProcessor(audioContext, this._workletName, this._workletSource).then(() => {
-      if (!this._inputGain || !this._outputGain) return; // destroyed during load
+      if (!this._inputGain || !this._dryGain || !this._wetGain) return; // destroyed during load
 
       const node = new AudioWorkletNode(audioContext, this._workletName, this._workletOptions);
       this._workletNode = node;
 
-      // Re-route: input → worklet → output
-      this._inputGain.disconnect();
+      // Wet path: input → worklet → wetGain.
       this._inputGain.connect(node);
-      node.connect(this._outputGain);
+      node.connect(this._wetGain);
+
+      // Apply the configured mix now that the wet path carries signal.
+      this.wet = this._wet;
 
       this._onWorkletReady?.(audioContext);
     });

--- a/src/audio/WorkletEffect.ts
+++ b/src/audio/WorkletEffect.ts
@@ -146,13 +146,18 @@ export abstract class WorkletEffect extends AudioEffect {
     const dryGain = audioContext.createGain();
     const wetGain = audioContext.createGain();
 
+    // Assign the gain references immediately so _sampleRate (which reads
+    // this._outputGain.context.sampleRate) is populated before subclasses
+    // compute _dryLatencySeconds below.
+    this._inputGain = inputGain;
+    this._outputGain = outputGain;
+
     // Dry path: input → [dryDelay] → dryGain → output. The delay aligns dry with
     // the worklet's latency so intermediate wet values stay phase-coherent.
     const dryLatency = this._dryLatencySeconds;
     let dryDelay: DelayNode | null = null;
     if (dryLatency > 0) {
       dryDelay = audioContext.createDelay(Math.max(1, dryLatency * 2));
-      dryDelay.delayTime.value = dryLatency;
       dryDelay.delayTime.setValueAtTime(dryLatency, audioContext.currentTime);
       inputGain.connect(dryDelay);
       dryDelay.connect(dryGain);
@@ -167,8 +172,6 @@ export abstract class WorkletEffect extends AudioEffect {
     wetGain.gain.setValueAtTime(0, audioContext.currentTime);
     wetGain.connect(outputGain);
 
-    this._inputGain = inputGain;
-    this._outputGain = outputGain;
     this._dryGain = dryGain;
     this._wetGain = wetGain;
     this._dryDelay = dryDelay;

--- a/src/audio/WorkletEffect.ts
+++ b/src/audio/WorkletEffect.ts
@@ -54,8 +54,8 @@ export abstract class WorkletEffect extends AudioEffect {
 
   /**
    * The audio context's sample rate in Hz, or 48000 if the context is not yet
-   * available. Used by subclasses to compute `_dryLatencySeconds` before the
-   * worklet loads.
+   * available. Populated as soon as the audio context is ready (i.e. once
+   * `_setup` runs). Safe to read from `_dryLatencySeconds`.
    */
   protected get _sampleRate(): number {
     return this._outputGain?.context.sampleRate ?? 48000;
@@ -146,24 +146,18 @@ export abstract class WorkletEffect extends AudioEffect {
     const dryGain = audioContext.createGain();
     const wetGain = audioContext.createGain();
 
-    // Assign the gain references immediately so _sampleRate (which reads
-    // this._outputGain.context.sampleRate) is populated before subclasses
-    // compute _dryLatencySeconds below.
+    // Assign gain references immediately so inputNode/outputNode are accessible
+    // and _sampleRate (which reads this._outputGain.context.sampleRate) returns
+    // the real context rate for subclass use in _dryLatencySeconds.
     this._inputGain = inputGain;
     this._outputGain = outputGain;
 
-    // Dry path: input → [dryDelay] → dryGain → output. The delay aligns dry with
-    // the worklet's latency so intermediate wet values stay phase-coherent.
-    const dryLatency = this._dryLatencySeconds;
-    let dryDelay: DelayNode | null = null;
-    if (dryLatency > 0) {
-      dryDelay = audioContext.createDelay(Math.max(1, dryLatency * 2));
-      dryDelay.delayTime.setValueAtTime(dryLatency, audioContext.currentTime);
-      inputGain.connect(dryDelay);
-      dryDelay.connect(dryGain);
-    } else {
-      inputGain.connect(dryGain);
-    }
+    // Dry path: input → dryGain → output. A time-alignment DelayNode is
+    // inserted in the worklet-ready callback below once _dryLatencySeconds is
+    // safe to read. The addModule Promise always settles asynchronously, so the
+    // subclass constructor is fully done by then (post-super() fields such as
+    // PitchShiftEffect._grainSize are guaranteed initialized).
+    inputGain.connect(dryGain);
     dryGain.connect(outputGain);
 
     // Wet path output stage exists immediately but is silent until the worklet
@@ -174,10 +168,25 @@ export abstract class WorkletEffect extends AudioEffect {
 
     this._dryGain = dryGain;
     this._wetGain = wetGain;
-    this._dryDelay = dryDelay;
 
     this._ready = registerAudioWorkletProcessor(audioContext, this._workletName, this._workletSource).then(() => {
       if (!this._inputGain || !this._dryGain || !this._wetGain) return; // destroyed during load
+
+      // Read _dryLatencySeconds here, not in _setup(), because the addModule
+      // Promise always resolves asynchronously — by this point the subclass
+      // constructor has fully run and any post-super() fields are valid.
+      const dryLatency = this._dryLatencySeconds;
+      if (dryLatency > 0) {
+        const dryDelay = audioContext.createDelay(Math.max(1, dryLatency * 2));
+        dryDelay.delayTime.setValueAtTime(dryLatency, audioContext.currentTime);
+        this._dryDelay = dryDelay;
+        // Re-route dry path to insert the delay: inputGain → dryDelay → dryGain.
+        // Use the destination-argument form of disconnect so only this edge is
+        // moved; the inputGain → worklet connection (added below) is unaffected.
+        this._inputGain.disconnect(this._dryGain);
+        this._inputGain.connect(dryDelay);
+        dryDelay.connect(this._dryGain);
+      }
 
       const node = new AudioWorkletNode(audioContext, this._workletName, this._workletOptions);
       this._workletNode = node;

--- a/src/audio/WorkletEffect.ts
+++ b/src/audio/WorkletEffect.ts
@@ -52,6 +52,15 @@ export abstract class WorkletEffect extends AudioEffect {
     return 1;
   }
 
+  /**
+   * The audio context's sample rate in Hz, or 48000 if the context is not yet
+   * available. Used by subclasses to compute `_dryLatencySeconds` before the
+   * worklet loads.
+   */
+  protected get _sampleRate(): number {
+    return this._outputGain?.context.sampleRate ?? 48000;
+  }
+
   public constructor() {
     super();
     if (isAudioContextReady()) {
@@ -143,6 +152,7 @@ export abstract class WorkletEffect extends AudioEffect {
     let dryDelay: DelayNode | null = null;
     if (dryLatency > 0) {
       dryDelay = audioContext.createDelay(Math.max(1, dryLatency * 2));
+      dryDelay.delayTime.value = dryLatency;
       dryDelay.delayTime.setValueAtTime(dryLatency, audioContext.currentTime);
       inputGain.connect(dryDelay);
       dryDelay.connect(dryGain);

--- a/test/audio/filters/worklet-effect.test.ts
+++ b/test/audio/filters/worklet-effect.test.ts
@@ -252,4 +252,32 @@ describe('WorkletEffect', () => {
     expect(wetGainNode!.gain.setTargetAtTime as unknown as MockInstance).toHaveBeenCalledWith(1, expect.anything(), expect.anything());
     filter.destroy();
   });
+
+  // ---------------------------------------------------------------------------
+  // Dry-latency compensation (Task 2)
+  // ---------------------------------------------------------------------------
+
+  it('inserts a dry-path DelayNode when _dryLatencySeconds > 0', () => {
+    const ctx = getAudioContext();
+    const delaySpy = vi.spyOn(ctx, 'createDelay');
+    class DelayedFilter extends TestWorkletEffect {
+      protected override get _dryLatencySeconds(): number {
+        return 0.02;
+      }
+    }
+    const filter = new DelayedFilter();
+    expect(delaySpy).toHaveBeenCalled();
+    expect(filter['_dryDelay']).not.toBeNull();
+    expect(filter['_dryDelay']!.delayTime.value).toBeCloseTo(0.02, 5);
+    filter.destroy();
+  });
+
+  it('does not create a DelayNode when _dryLatencySeconds is 0 (default)', () => {
+    const ctx = getAudioContext();
+    const delaySpy = vi.spyOn(ctx, 'createDelay');
+    const filter = new TestWorkletEffect();
+    expect(delaySpy).not.toHaveBeenCalled();
+    expect(filter['_dryDelay']).toBeNull();
+    filter.destroy();
+  });
 });

--- a/test/audio/filters/worklet-effect.test.ts
+++ b/test/audio/filters/worklet-effect.test.ts
@@ -179,4 +179,77 @@ describe('WorkletEffect', () => {
     filter1.destroy();
     filter2.destroy();
   });
+
+  // ---------------------------------------------------------------------------
+  // Dry/wet gain staging (Task 1)
+  // ---------------------------------------------------------------------------
+
+  it('creates dry and wet gains; wet path is silent before the worklet loads', () => {
+    const ctx = getAudioContext();
+    const originalCreateGain = ctx.createGain.bind(ctx);
+    let callCount = 0;
+    let dryGainNode: GainNode | null = null;
+    let wetGainNode: GainNode | null = null;
+
+    vi.spyOn(ctx, 'createGain').mockImplementation(() => {
+      const node = originalCreateGain();
+      vi.spyOn(node.gain, 'setValueAtTime');
+      callCount++;
+      if (callCount === 3) dryGainNode = node;
+      if (callCount === 4) wetGainNode = node;
+      return node;
+    });
+
+    const filter = new TestWorkletEffect();
+    // input, output, dry, wet — at least 4 gains
+    expect(callCount).toBeGreaterThanOrEqual(4);
+    expect(filter['_dryGain']).not.toBeNull();
+    expect(filter['_wetGain']).not.toBeNull();
+    // dry initialized to 1, wet initialized to 0 (silent until worklet loads)
+    expect(dryGainNode!.gain.setValueAtTime as unknown as MockInstance).toHaveBeenCalledWith(1, expect.anything());
+    expect(wetGainNode!.gain.setValueAtTime as unknown as MockInstance).toHaveBeenCalledWith(0, expect.anything());
+    filter.destroy();
+  });
+
+  it('wet setter clamps to [0,1] and is reflected once the worklet is ready', async () => {
+    const filter = new TestWorkletEffect();
+    await filter.ready;
+
+    vi.spyOn(filter['_dryGain']!.gain, 'setTargetAtTime');
+    vi.spyOn(filter['_wetGain']!.gain, 'setTargetAtTime');
+
+    filter.wet = 0.25;
+    expect(filter.wet).toBe(0.25);
+    expect(filter['_dryGain']!.gain.setTargetAtTime).toHaveBeenCalledWith(0.75, expect.anything(), expect.anything());
+    expect(filter['_wetGain']!.gain.setTargetAtTime).toHaveBeenCalledWith(0.25, expect.anything(), expect.anything());
+    filter.wet = 5;
+    expect(filter.wet).toBe(1);
+    filter.wet = -1;
+    expect(filter.wet).toBe(0);
+    filter.destroy();
+  });
+
+  it('after the worklet loads, the configured wet mix is applied (default wet=1)', async () => {
+    const ctx = getAudioContext();
+    const originalCreateGain = ctx.createGain.bind(ctx);
+    let callCount = 0;
+    let dryGainNode: GainNode | null = null;
+    let wetGainNode: GainNode | null = null;
+
+    vi.spyOn(ctx, 'createGain').mockImplementation(() => {
+      const node = originalCreateGain();
+      vi.spyOn(node.gain, 'setTargetAtTime');
+      callCount++;
+      if (callCount === 3) dryGainNode = node;
+      if (callCount === 4) wetGainNode = node;
+      return node;
+    });
+
+    const filter = new TestWorkletEffect();
+    await filter.ready;
+    // Default wet=1: dryGain.setTargetAtTime(0, ...), wetGain.setTargetAtTime(1, ...)
+    expect(dryGainNode!.gain.setTargetAtTime as unknown as MockInstance).toHaveBeenCalledWith(0, expect.anything(), expect.anything());
+    expect(wetGainNode!.gain.setTargetAtTime as unknown as MockInstance).toHaveBeenCalledWith(1, expect.anything(), expect.anything());
+    filter.destroy();
+  });
 });

--- a/test/audio/filters/worklet-effect.test.ts
+++ b/test/audio/filters/worklet-effect.test.ts
@@ -299,7 +299,7 @@ describe('WorkletEffect', () => {
     const filter = new SampleRateFilter();
     await filter.ready;
     const expected = 1000 / 44100; // ~0.022676
-    const wrong = 1000 / 48000;    // ~0.020833
+    const wrong = 1000 / 48000; // ~0.020833
     expect(filter['_dryDelay']).not.toBeNull();
     // Must be close to the 44100-based value, not the 48000 fallback.
     expect(filter['_dryDelay']!.delayTime.value).toBeCloseTo(expected, 5);

--- a/test/audio/filters/worklet-effect.test.ts
+++ b/test/audio/filters/worklet-effect.test.ts
@@ -280,4 +280,23 @@ describe('WorkletEffect', () => {
     expect(filter['_dryDelay']).toBeNull();
     filter.destroy();
   });
+
+  it('_sampleRate uses the real context rate (not the 48000 fallback) when _dryLatencySeconds is read in _setup', () => {
+    // The mock AudioContext has sampleRate=44100 (not 48000). A subclass that
+    // derives _dryLatencySeconds from this._sampleRate must see 44100, so the
+    // resulting delayTime reflects 1000/44100, NOT the wrong 1000/48000.
+    class SampleRateFilter extends TestWorkletEffect {
+      protected override get _dryLatencySeconds(): number {
+        return 1000 / this._sampleRate;
+      }
+    }
+    const filter = new SampleRateFilter();
+    const expected = 1000 / 44100; // ~0.022676
+    const wrong = 1000 / 48000;    // ~0.020833
+    expect(filter['_dryDelay']).not.toBeNull();
+    // Must be close to the 44100-based value, not the 48000 fallback.
+    expect(filter['_dryDelay']!.delayTime.value).toBeCloseTo(expected, 5);
+    expect(filter['_dryDelay']!.delayTime.value).not.toBeCloseTo(wrong, 5);
+    filter.destroy();
+  });
 });

--- a/test/audio/filters/worklet-effect.test.ts
+++ b/test/audio/filters/worklet-effect.test.ts
@@ -257,7 +257,7 @@ describe('WorkletEffect', () => {
   // Dry-latency compensation (Task 2)
   // ---------------------------------------------------------------------------
 
-  it('inserts a dry-path DelayNode when _dryLatencySeconds > 0', () => {
+  it('inserts a dry-path DelayNode when _dryLatencySeconds > 0', async () => {
     const ctx = getAudioContext();
     const delaySpy = vi.spyOn(ctx, 'createDelay');
     class DelayedFilter extends TestWorkletEffect {
@@ -266,31 +266,38 @@ describe('WorkletEffect', () => {
       }
     }
     const filter = new DelayedFilter();
+    // Delay is created in the worklet-ready callback, not synchronously.
+    expect(delaySpy).not.toHaveBeenCalled();
+    await filter.ready;
     expect(delaySpy).toHaveBeenCalled();
     expect(filter['_dryDelay']).not.toBeNull();
     expect(filter['_dryDelay']!.delayTime.value).toBeCloseTo(0.02, 5);
     filter.destroy();
   });
 
-  it('does not create a DelayNode when _dryLatencySeconds is 0 (default)', () => {
+  it('does not create a DelayNode when _dryLatencySeconds is 0 (default)', async () => {
     const ctx = getAudioContext();
     const delaySpy = vi.spyOn(ctx, 'createDelay');
     const filter = new TestWorkletEffect();
+    await filter.ready;
     expect(delaySpy).not.toHaveBeenCalled();
     expect(filter['_dryDelay']).toBeNull();
     filter.destroy();
   });
 
-  it('_sampleRate uses the real context rate (not the 48000 fallback) when _dryLatencySeconds is read in _setup', () => {
+  it('_sampleRate uses the real context rate (not the 48000 fallback) when _dryLatencySeconds is read at worklet-ready', async () => {
     // The mock AudioContext has sampleRate=44100 (not 48000). A subclass that
     // derives _dryLatencySeconds from this._sampleRate must see 44100, so the
     // resulting delayTime reflects 1000/44100, NOT the wrong 1000/48000.
+    // _dryLatencySeconds is now read in the worklet-ready callback (async),
+    // where _outputGain.context.sampleRate is already 44100.
     class SampleRateFilter extends TestWorkletEffect {
       protected override get _dryLatencySeconds(): number {
         return 1000 / this._sampleRate;
       }
     }
     const filter = new SampleRateFilter();
+    await filter.ready;
     const expected = 1000 / 44100; // ~0.022676
     const wrong = 1000 / 48000;    // ~0.020833
     expect(filter['_dryDelay']).not.toBeNull();

--- a/test/setup-env.vitest.ts
+++ b/test/setup-env.vitest.ts
@@ -293,15 +293,20 @@ class MockAudioContext {
   }
 
   public createDelay(_maxDelayTime?: number): DelayNode {
+    const delayTime = {
+      value: 0,
+      // Syncs .value so tests can read the scheduled value without a direct
+      // .value assignment in production code (the real AudioParam does this too).
+      setValueAtTime(v: number) {
+        this.value = v;
+      },
+      setTargetAtTime: () => undefined,
+    };
     return {
       connect: () => undefined,
       disconnect: () => undefined,
       context: this,
-      delayTime: {
-        setValueAtTime: () => undefined,
-        setTargetAtTime: () => undefined,
-        value: 0,
-      },
+      delayTime,
     } as unknown as DelayNode;
   }
 


### PR DESCRIPTION
## Summary
Stufe 2 of the audio-fx gain audit: pulls dry/wet mixing out of the worklet effects into the `WorkletEffect` base class, adds dry-latency compensation, and migrates the three worklets to emit pure wet.

## What changed
- **Base gain staging** (`src/audio/WorkletEffect.ts`): dry/wet fan-out around the worklet node (`input → dryGain → output`, `input → worklet → wetGain → output`), a `wet` getter/setter (linear mix, ramped), and `_dryLatencySeconds` / `_wetMakeupGain` hooks. Bypass-before-load is preserved as a clean unity passthrough.
- **Dry-latency compensation**: a dry-path `DelayNode` time-aligns the dry signal with the worklet's algorithmic latency, fixing PitchShift intermediate-`wet` comb-filtering. The delay is created at worklet-ready (after the subclass constructor has run) so subclass-derived latency (PitchShift ≈ 1280 samples) engages correctly on every construction path.
- **Worklet migration**: the PitchShift / Granular / Vocoder worklets drop their `wet` param + internal mix and emit pure wet; the three effect classes route `wet` through the base. No behavior change (each worklet defaulted to `wet=1.0`). Granular's dynamic `normalizeGain` and Vocoder's `× bandCount` stay in the worklet.

## Tests
- Base structural tests: dry/wet/delay wiring, bypass-before-load, `wet` ramps, `_sampleRate` resolution.
- Browser-audio acoustic contracts (OfflineAudioContext + FFT): a `wet=0.5` dry-alignment proof (comb-filter compensation) with the latency constant verified as the empirical argmax, plus a real-`PitchShiftEffect` regression test asserting the dry delay actually engages.
- Updated worklet eval tests to assert pure-wet output.

No version bump.
