### PR TITLE
feat: LDtk/Aseprite/Tiled format completeness, AnimatedSprite repeat, WebGPU CI lane

### DIFF
--- a/.github/workflows/_ci-checks.yml
+++ b/.github/workflows/_ci-checks.yml
@@ -232,23 +232,38 @@ jobs:
       - name: Browser tests (Chromium WebGL2, new headless)
         run: pnpm test:browser:webgl
 
-  # Optional, non-blocking lane. Chromium WebGPU new-headless is real coverage
-  # locally, but the GitHub-hosted runner currently drops the device on
-  # custom-material tests; keep non-blocking until runner/driver stability is
-  # solved. A failure here never blocks a merge — the lane still runs and
-  # reports. Run locally via `pnpm test:browser:webgpu`.
+  # Blocking lane. Chromium WebGPU is run against Mesa lavapipe (a real Vulkan
+  # software rasterizer) instead of Chromium's bundled SwiftShader WebGPU
+  # fallback — the three.js-proven recipe for getting actual GPU-path coverage
+  # out of a free `ubuntu-latest` runner (no Docker / self-hosted runner
+  # needed). `mesa-vulkan-drivers` provides the lavapipe ICD, `VK_DRIVER_FILES`
+  # points Chromium's ANGLE Vulkan backend at it, and the launch args in
+  # `vitest.config.ts` (`--enable-features=Vulkan`, `--disable-vulkan-surface`,
+  # `headless: false`) are required for Chromium to actually pick up a Vulkan
+  # adapter instead of silently falling back to SwiftShader — which is why this
+  # runs under `xvfb-run` (a real display is needed for the non-headless
+  # launch). Previously this lane self-skipped almost everything via
+  # `getBackendDeviceOrSkip()` under SwiftShader and was `continue-on-error`,
+  # so it reported green without proving anything; it is now a real, blocking
+  # WebGPU lane. Run locally via `pnpm test:browser:webgpu` (requires a display
+  # or `xvfb-run -a` on a headless dev box, since the project now launches
+  # headed).
   browser-tests-webgpu-chromium:
-    name: Browser Tests (Chromium WebGPU, experimental)
+    name: Browser Tests (Chromium WebGPU)
     needs: [changes]
     if: ${{ needs.changes.outputs.engine == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    continue-on-error: true
+    env:
+      VK_DRIVER_FILES: /usr/share/vulkan/icd.d/lvp_icd.x86_64.json
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.sha }}
+
+      - name: Install Mesa lavapipe + xvfb
+        run: sudo apt-get update && sudo apt-get install -y mesa-vulkan-drivers xvfb
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -278,8 +293,8 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
 
-      - name: Browser tests (Chromium WebGPU, new headless)
-        run: pnpm test:browser:webgpu
+      - name: Browser tests (Chromium WebGPU, Mesa lavapipe via xvfb)
+        run: xvfb-run -a pnpm test:browser:webgpu
 
   # Optional, non-blocking lane. The Ubuntu CI runner does not give headless
   # Firefox a usable WebGL2 context, and Firefox WebGPU adapter availability
@@ -560,7 +575,7 @@ jobs:
   required-ci:
     name: Required CI
     if: ${{ always() }}
-    needs: [changes, typecheck, lint, unit-tests, browser-tests, browser-tests-audio, package-verify, site-build]
+    needs: [changes, typecheck, lint, unit-tests, browser-tests, browser-tests-webgpu-chromium, browser-tests-audio, package-verify, site-build]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -574,6 +589,7 @@ jobs:
           LINT_RESULT: ${{ needs.lint.result }}
           UNIT_TESTS_RESULT: ${{ needs['unit-tests'].result }}
           BROWSER_TESTS_RESULT: ${{ needs['browser-tests'].result }}
+          BROWSER_WEBGPU_RESULT: ${{ needs['browser-tests-webgpu-chromium'].result }}
           BROWSER_AUDIO_RESULT: ${{ needs['browser-tests-audio'].result }}
           PACKAGE_VERIFY_RESULT: ${{ needs['package-verify'].result }}
           SITE_BUILD_RESULT: ${{ needs['site-build'].result }}
@@ -584,6 +600,7 @@ jobs:
           echo "lint: $LINT_RESULT"
           echo "unit-tests: $UNIT_TESTS_RESULT"
           echo "browser-tests: $BROWSER_TESTS_RESULT"
+          echo "browser-tests-webgpu-chromium: $BROWSER_WEBGPU_RESULT"
           echo "browser-tests-audio: $BROWSER_AUDIO_RESULT"
           echo "package-verify: $PACKAGE_VERIFY_RESULT"
           echo "site-build: $SITE_BUILD_RESULT"
@@ -607,6 +624,7 @@ jobs:
             "lint=$LINT_RESULT" \
             "unit-tests=$UNIT_TESTS_RESULT" \
             "browser-tests=$BROWSER_TESTS_RESULT" \
+            "browser-tests-webgpu-chromium=$BROWSER_WEBGPU_RESULT" \
             "browser-tests-audio=$BROWSER_AUDIO_RESULT" \
             "package-verify=$PACKAGE_VERIFY_RESULT" \
             "site-build=$SITE_BUILD_RESULT"; do
@@ -623,10 +641,16 @@ jobs:
           # run. A "skipped" here means the path filter wrongly excluded an
           # impacted change — exactly the defect that let package-only PRs go
           # green while their unit / package / browser lanes were skipped.
+          # `browser-tests-webgpu-chromium` shares the same `engine` gate as
+          # `browser-tests` / `unit-tests` / `package-verify` (see its `if:`
+          # above), so it belongs in this same contract check rather than a
+          # bespoke one like `browser-tests-audio`'s (audio-fx has its own,
+          # narrower path-filter flag).
           if [ "$ENGINE" = "true" ]; then
             for entry in \
               "unit-tests=$UNIT_TESTS_RESULT" \
               "browser-tests=$BROWSER_TESTS_RESULT" \
+              "browser-tests-webgpu-chromium=$BROWSER_WEBGPU_RESULT" \
               "package-verify=$PACKAGE_VERIFY_RESULT"; do
               name="${entry%%=*}"
               result="${entry#*=}"

--- a/.github/workflows/_ci-checks.yml
+++ b/.github/workflows/_ci-checks.yml
@@ -238,16 +238,17 @@ jobs:
   # out of a free `ubuntu-latest` runner (no Docker / self-hosted runner
   # needed). `mesa-vulkan-drivers` provides the lavapipe ICD, `VK_DRIVER_FILES`
   # points Chromium's ANGLE Vulkan backend at it, and the launch args in
-  # `vitest.config.ts` (`--enable-features=Vulkan`, `--disable-vulkan-surface`,
-  # `headless: false`) are required for Chromium to actually pick up a Vulkan
-  # adapter instead of silently falling back to SwiftShader — which is why this
-  # runs under `xvfb-run` (a real display is needed for the non-headless
-  # launch). Previously this lane self-skipped almost everything via
-  # `getBackendDeviceOrSkip()` under SwiftShader and was `continue-on-error`,
-  # so it reported green without proving anything; it is now a real, blocking
-  # WebGPU lane. Run locally via `pnpm test:browser:webgpu` (requires a display
-  # or `xvfb-run -a` on a headless dev box, since the project now launches
-  # headed).
+  # `vitest.config.ts` (`--enable-features=Vulkan`, `--disable-vulkan-surface`)
+  # are required for Chromium to actually pick up a Vulkan adapter instead of
+  # silently falling back to SwiftShader. lavapipe additionally needs a real
+  # display surface to report a usable adapter, so this job sets
+  # `EXOJS_WEBGPU_CI_HEADED=1` (opts the `browser-webgpu` vitest project into
+  # `headless: false`) and runs under `xvfb-run` to supply that display — CI
+  # only; the project stays headless by default so a plain local
+  # `pnpm test:browser:webgpu` never pops a visible browser window. Previously
+  # this lane self-skipped almost everything via `getBackendDeviceOrSkip()`
+  # under SwiftShader and was `continue-on-error`, so it reported green
+  # without proving anything; it is now a real, blocking WebGPU lane.
   browser-tests-webgpu-chromium:
     name: Browser Tests (Chromium WebGPU)
     needs: [changes]
@@ -256,6 +257,10 @@ jobs:
     timeout-minutes: 20
     env:
       VK_DRIVER_FILES: /usr/share/vulkan/icd.d/lvp_icd.x86_64.json
+      # Opts the `browser-webgpu` vitest project into `headless: false` (see
+      # vitest.config.ts). Unset locally, so `pnpm test:browser:webgpu` stays
+      # headless by default and never pops a visible browser window on a dev box.
+      EXOJS_WEBGPU_CI_HEADED: '1'
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/examples/tweens-animation/frame-animation.ts
+++ b/examples/tweens-animation/frame-animation.ts
@@ -35,7 +35,7 @@ class FrameAnimationScene extends Scene {
         const walkFrames = ['character_beige_walk_a', 'character_beige_walk_b'].map(name => sheet.getFrame(name));
 
         this.frameCount = walkFrames.length;
-        this.sprite = new AnimatedSprite(texture, { walk: { frames: walkFrames, fps: walkFps, loop: true } });
+        this.sprite = new AnimatedSprite(texture, { walk: { frames: walkFrames, fps: walkFps } });
         this.sprite.setAnchor(0.5).setScale(3).setPosition(width / 2, height / 2);
 
         this.hud = mountControls({

--- a/packages/exojs-aseprite/src/AsepriteData.ts
+++ b/packages/exojs-aseprite/src/AsepriteData.ts
@@ -43,6 +43,11 @@ export interface AsepriteFrameTag {
   /** Inclusive start frame index. */
   readonly from: number;
   readonly name: string;
+  /**
+   * Number of times the tag plays before stopping, as a numeric string
+   * (e.g. `"1"`, `"2"`). Absent means the tag loops indefinitely.
+   */
+  readonly repeat?: string;
 }
 
 /** A single layer entry in the Aseprite JSON metadata. */

--- a/packages/exojs-aseprite/src/AsepriteSheet.ts
+++ b/packages/exojs-aseprite/src/AsepriteSheet.ts
@@ -145,9 +145,11 @@ export class AsepriteSheet {
    * clip — `forward` and `reverse` play the `[from, to]` range in order or
    * in reverse, while `pingpong`/`pingpong_reverse` append a backward pass
    * (excluding both endpoints) so the bounce plays back correctly on the
-   * engine's forward-only {@link AnimatedSprite} playback. A clip loops
-   * (`loop: true`) unless the tag's `repeat` is exactly `"1"`, in which case
-   * it plays once (`loop: false`).
+   * engine's forward-only {@link AnimatedSprite} playback. The tag's
+   * `repeat` field maps directly onto {@link AnimatedSpriteClipDefinition.repeat}:
+   * absent means the clip loops indefinitely (`repeat: -1`); a numeric
+   * string (`"1"`, `"2"`, …) means it plays exactly that many full cycles
+   * before stopping.
    *
    * Each clip's `frameDurations` carries the real per-frame `duration` from
    * the export (falling back to the tag's average when a frame's duration is
@@ -186,9 +188,10 @@ export class AsepriteSheet {
         continue;
       }
 
-      // `repeat === '1'` is an explicit one-shot. Any other finite N (e.g. '2',
-      // '3') falls back to an infinite loop pending engine `loopCount` support.
-      const loop = tag.repeat !== '1';
+      // Aseprite's `tag.repeat` (a numeric string, `'1'` through any N) maps
+      // directly onto the engine's `repeat` count. Absent means the tag
+      // loops indefinitely, the engine's `-1` sentinel.
+      const repeat = tag.repeat !== undefined ? Number(tag.repeat) : -1;
       const fps = avgFps(frameArray, validIndices);
 
       // Per-frame hold duration (Aseprite "duration"), so uneven hold-frames
@@ -218,7 +221,7 @@ export class AsepriteSheet {
       clips.set(tag.name, {
         fps,
         frames,
-        loop,
+        repeat,
         frameDurations,
         ...(frameOffsets ? { frameOffsets } : {}),
       });

--- a/packages/exojs-aseprite/src/AsepriteSheet.ts
+++ b/packages/exojs-aseprite/src/AsepriteSheet.ts
@@ -152,7 +152,11 @@ export class AsepriteSheet {
    * Each clip's `frameDurations` carries the real per-frame `duration` from
    * the export (falling back to the tag's average when a frame's duration is
    * non-positive), so uneven hold-frames survive into playback instead of
-   * being flattened to a uniform fps.
+   * being flattened to a uniform fps. `frameOffsets` carries each frame's
+   * `spriteSourceSize` `{x,y}` — its trimmed content's offset within the
+   * untrimmed canvas — whenever any frame in the tag is trimmed, so frames
+   * trimmed by different amounts stay anchored instead of jittering; it's
+   * omitted entirely for tags with no trimmed frames.
    */
   public static parse(data: AsepriteData, texture: Texture): AsepriteSheet {
     const frameArray = normaliseFrames(data);
@@ -174,7 +178,7 @@ export class AsepriteSheet {
     for (const tag of frameTags) {
       // Out-of-range indices are silently skipped; `validIndices` parallels
       // `frames` exactly, so it's the basis for every other per-frame array
-      // (durations) built below.
+      // (durations, offsets) built below.
       const validIndices = expandFrameIndices(tag).filter(i => i >= 0 && i < frameArray.length);
       const frames = validIndices.map(i => spritesheet.getFrame(String(i)));
 
@@ -198,11 +202,25 @@ export class AsepriteSheet {
         return duration > 0 ? duration : avgDurationFallback;
       });
 
+      // Per-frame trim offset (Aseprite "spriteSourceSize"), so frames trimmed
+      // by different amounts stay anchored to the same point in the untrimmed
+      // canvas instead of jittering frame to frame. Omitted entirely when no
+      // frame in the tag is trimmed, to avoid noise on untrimmed sheets.
+      const anyTrimmed = validIndices.some(i => frameArray[i]!.trimmed);
+      const frameOffsets = anyTrimmed
+        ? validIndices.map(i => {
+            const { x, y } = frameArray[i]!.spriteSourceSize;
+
+            return { x, y };
+          })
+        : undefined;
+
       clips.set(tag.name, {
         fps,
         frames,
         loop,
         frameDurations,
+        ...(frameOffsets ? { frameOffsets } : {}),
       });
     }
 

--- a/packages/exojs-aseprite/src/AsepriteSheet.ts
+++ b/packages/exojs-aseprite/src/AsepriteSheet.ts
@@ -1,6 +1,6 @@
 import { AnimatedSprite, type AnimatedSpriteClipDefinition, type Rectangle, Spritesheet, type Texture } from '@codexo/exojs';
 
-import { type AsepriteData, type AsepriteFrameData, type AsepriteFrameTag,isAsepriteArrayData } from './AsepriteData';
+import { type AsepriteData, type AsepriteFrameData, type AsepriteFrameTag, type AsepriteSlice,isAsepriteArrayData } from './AsepriteData';
 
 /**
  * Normalises an {@link AsepriteData} document into an ordered array of
@@ -113,13 +113,24 @@ export class AsepriteSheet {
   public readonly clips: ReadonlyMap<string, AnimatedSpriteClipDefinition>;
 
   /**
+   * Named slices from the Aseprite `meta.slices` metadata, keyed by slice
+   * name. Slices describe editor-defined regions — hitboxes, nine-patch
+   * borders, UI anchor points — that aren't part of the frame/animation
+   * data itself. Each {@link AsepriteSlice} carries one {@link AsepriteSliceKey}
+   * per frame at which its bounds change; consumers resolve the applicable
+   * key for a given frame index themselves.
+   */
+  public readonly slices: ReadonlyMap<string, AsepriteSlice>;
+
+  /**
    * @internal — use {@link AsepriteSheet.parse} to create instances.
    * The public modifier is required for the Loader's `AssetConstructor` token
    * contract; users should call `parse()` instead of constructing directly.
    */
-  public constructor(spritesheet: Spritesheet, clips: ReadonlyMap<string, AnimatedSpriteClipDefinition>) {
+  public constructor(spritesheet: Spritesheet, clips: ReadonlyMap<string, AnimatedSpriteClipDefinition>, slices: ReadonlyMap<string, AsepriteSlice>) {
     this.spritesheet = spritesheet;
     this.clips = clips;
+    this.slices = slices;
   }
 
   /**
@@ -180,7 +191,14 @@ export class AsepriteSheet {
       });
     }
 
-    return new AsepriteSheet(spritesheet, clips);
+    // Build the slices map from meta.slices, keyed by slice name.
+    const slices = new Map<string, AsepriteSlice>();
+
+    for (const slice of data.meta.slices ?? []) {
+      slices.set(slice.name, slice);
+    }
+
+    return new AsepriteSheet(spritesheet, clips, slices);
   }
 
   /**

--- a/packages/exojs-aseprite/src/AsepriteSheet.ts
+++ b/packages/exojs-aseprite/src/AsepriteSheet.ts
@@ -1,6 +1,6 @@
 import { AnimatedSprite, type AnimatedSpriteClipDefinition, type Rectangle, Spritesheet, type Texture } from '@codexo/exojs';
 
-import { type AsepriteData, type AsepriteFrameData,isAsepriteArrayData } from './AsepriteData';
+import { type AsepriteData, type AsepriteFrameData, type AsepriteFrameTag,isAsepriteArrayData } from './AsepriteData';
 
 /**
  * Normalises an {@link AsepriteData} document into an ordered array of
@@ -16,19 +16,67 @@ function normaliseFrames(data: AsepriteData): AsepriteFrameData[] {
 }
 
 /**
- * Calculates the average frames-per-second for a subset of frames, based on
- * the per-frame `duration` field (milliseconds per frame) exported by Aseprite.
- * Falls back to `12` fps when all durations are zero or the slice is empty.
+ * Expands a frame tag's inclusive `[from, to]` range into the ordered
+ * sequence of frame indices it actually plays, according to its
+ * {@link AsepriteDirection}. Indices are not bounds-checked against the
+ * frame array here; callers filter out-of-range entries separately.
+ *
+ * - `forward`: `[from, from+1, ..., to]`.
+ * - `reverse`: `[to, to-1, ..., from]`.
+ * - `pingpong`: a forward pass followed by a backward pass that excludes
+ *   both endpoints, e.g. `[0,1,2]` becomes `[0,1,2,1]`.
+ * - `pingpong_reverse`: the mirrored shape, starting from `to`.
+ * - A single-frame tag (`from === to`) always yields just that one frame.
  */
-function avgFps(frames: AsepriteFrameData[], from: number, to: number): number {
-  const slice = frames.slice(from, to + 1);
+function expandFrameIndices(tag: AsepriteFrameTag): number[] {
+  const { from, to } = tag;
 
-  if (slice.length === 0) {
+  if (from === to) {
+    return [from];
+  }
+
+  const indices: number[] = [];
+
+  switch (tag.direction) {
+    case 'reverse':
+      for (let i = to; i >= from; i--) indices.push(i);
+      break;
+
+    case 'pingpong':
+      for (let i = from; i <= to; i++) indices.push(i);
+      for (let i = to - 1; i > from; i--) indices.push(i);
+      break;
+
+    case 'pingpong_reverse':
+      for (let i = to; i >= from; i--) indices.push(i);
+      for (let i = from + 1; i < to; i++) indices.push(i);
+      break;
+
+    case 'forward':
+    default:
+      for (let i = from; i <= to; i++) indices.push(i);
+      break;
+  }
+
+  return indices;
+}
+
+/**
+ * Calculates the average frames-per-second for a sequence of frame indices,
+ * based on the per-frame `duration` field (milliseconds per frame) exported
+ * by Aseprite. Every occurrence of an index counts toward the average — for
+ * ping-pong sequences that means repeated (bounced) frames are weighted twice.
+ * Falls back to `12` fps when all durations are zero or the sequence is empty.
+ */
+function avgFps(frameArray: AsepriteFrameData[], indices: number[]): number {
+  const durations = indices.filter(i => i >= 0 && i < frameArray.length).map(i => frameArray[i]!.duration);
+
+  if (durations.length === 0) {
     return 12;
   }
 
-  const totalMs = slice.reduce((sum, f) => sum + f.duration, 0);
-  const avgMs = totalMs / slice.length;
+  const totalMs = durations.reduce((sum, d) => sum + d, 0);
+  const avgMs = totalMs / durations.length;
 
   return avgMs > 0 ? 1000 / avgMs : 12;
 }
@@ -82,9 +130,11 @@ export class AsepriteSheet {
    * `frameTags` are resolved against the ordered frame array; out-of-range
    * indices are silently skipped.
    *
-   * Ping-pong directions (`pingpong`, `pingpong_reverse`) are recorded with
-   * `loop: true` but the reversed segment is not automatically appended —
-   * the clip plays only the declared `from`→`to` range.
+   * A tag's `direction` determines the expanded frame sequence fed into the
+   * clip — `forward` and `reverse` play the `[from, to]` range in order or
+   * in reverse, while `pingpong`/`pingpong_reverse` append a backward pass
+   * (excluding both endpoints) so the bounce plays back correctly on the
+   * engine's forward-only {@link AnimatedSprite} playback.
    */
   public static parse(data: AsepriteData, texture: Texture): AsepriteSheet {
     const frameArray = normaliseFrames(data);
@@ -104,9 +154,10 @@ export class AsepriteSheet {
     const frameTags = data.meta.frameTags ?? [];
 
     for (const tag of frameTags) {
+      const indices = expandFrameIndices(tag);
       const frames: Rectangle[] = [];
 
-      for (let i = tag.from; i <= tag.to; i++) {
+      for (const i of indices) {
         if (i >= 0 && i < frameArray.length) {
           frames.push(spritesheet.getFrame(String(i)));
         }
@@ -117,7 +168,7 @@ export class AsepriteSheet {
       }
 
       clips.set(tag.name, {
-        fps: avgFps(frameArray, tag.from, tag.to),
+        fps: avgFps(frameArray, indices),
         frames,
         loop: true,
       });

--- a/packages/exojs-aseprite/src/AsepriteSheet.ts
+++ b/packages/exojs-aseprite/src/AsepriteSheet.ts
@@ -1,4 +1,4 @@
-import { AnimatedSprite, type AnimatedSpriteClipDefinition, type Rectangle, Spritesheet, type Texture } from '@codexo/exojs';
+import { AnimatedSprite, type AnimatedSpriteClipDefinition, Spritesheet, type Texture } from '@codexo/exojs';
 
 import { type AsepriteData, type AsepriteFrameData, type AsepriteFrameTag, type AsepriteSlice,isAsepriteArrayData } from './AsepriteData';
 
@@ -148,6 +148,11 @@ export class AsepriteSheet {
    * engine's forward-only {@link AnimatedSprite} playback. A clip loops
    * (`loop: true`) unless the tag's `repeat` is exactly `"1"`, in which case
    * it plays once (`loop: false`).
+   *
+   * Each clip's `frameDurations` carries the real per-frame `duration` from
+   * the export (falling back to the tag's average when a frame's duration is
+   * non-positive), so uneven hold-frames survive into playback instead of
+   * being flattened to a uniform fps.
    */
   public static parse(data: AsepriteData, texture: Texture): AsepriteSheet {
     const frameArray = normaliseFrames(data);
@@ -167,14 +172,11 @@ export class AsepriteSheet {
     const frameTags = data.meta.frameTags ?? [];
 
     for (const tag of frameTags) {
-      const indices = expandFrameIndices(tag);
-      const frames: Rectangle[] = [];
-
-      for (const i of indices) {
-        if (i >= 0 && i < frameArray.length) {
-          frames.push(spritesheet.getFrame(String(i)));
-        }
-      }
+      // Out-of-range indices are silently skipped; `validIndices` parallels
+      // `frames` exactly, so it's the basis for every other per-frame array
+      // (durations) built below.
+      const validIndices = expandFrameIndices(tag).filter(i => i >= 0 && i < frameArray.length);
+      const frames = validIndices.map(i => spritesheet.getFrame(String(i)));
 
       if (frames.length === 0) {
         continue;
@@ -183,11 +185,24 @@ export class AsepriteSheet {
       // `repeat === '1'` is an explicit one-shot. Any other finite N (e.g. '2',
       // '3') falls back to an infinite loop pending engine `loopCount` support.
       const loop = tag.repeat !== '1';
+      const fps = avgFps(frameArray, validIndices);
+
+      // Per-frame hold duration (Aseprite "duration"), so uneven hold-frames
+      // (e.g. a lingering idle frame) survive into playback instead of being
+      // flattened to the tag's average fps. A non-positive duration (same
+      // degenerate case `avgFps` guards against) falls back to the average.
+      const avgDurationFallback = 1000 / fps;
+      const frameDurations = validIndices.map(i => {
+        const duration = frameArray[i]!.duration;
+
+        return duration > 0 ? duration : avgDurationFallback;
+      });
 
       clips.set(tag.name, {
-        fps: avgFps(frameArray, indices),
+        fps,
         frames,
         loop,
+        frameDurations,
       });
     }
 

--- a/packages/exojs-aseprite/src/AsepriteSheet.ts
+++ b/packages/exojs-aseprite/src/AsepriteSheet.ts
@@ -134,7 +134,9 @@ export class AsepriteSheet {
    * clip — `forward` and `reverse` play the `[from, to]` range in order or
    * in reverse, while `pingpong`/`pingpong_reverse` append a backward pass
    * (excluding both endpoints) so the bounce plays back correctly on the
-   * engine's forward-only {@link AnimatedSprite} playback.
+   * engine's forward-only {@link AnimatedSprite} playback. A clip loops
+   * (`loop: true`) unless the tag's `repeat` is exactly `"1"`, in which case
+   * it plays once (`loop: false`).
    */
   public static parse(data: AsepriteData, texture: Texture): AsepriteSheet {
     const frameArray = normaliseFrames(data);
@@ -167,10 +169,14 @@ export class AsepriteSheet {
         continue;
       }
 
+      // `repeat === '1'` is an explicit one-shot. Any other finite N (e.g. '2',
+      // '3') falls back to an infinite loop pending engine `loopCount` support.
+      const loop = tag.repeat !== '1';
+
       clips.set(tag.name, {
         fps: avgFps(frameArray, indices),
         frames,
-        loop: true,
+        loop,
       });
     }
 

--- a/packages/exojs-aseprite/test/aseprite-sheet.test.ts
+++ b/packages/exojs-aseprite/test/aseprite-sheet.test.ts
@@ -213,6 +213,87 @@ describe('AsepriteSheet.parse — direction expansion', () => {
   });
 });
 
+// ── AsepriteSheet.parse — per-frame durations (hold frames) ────────────────────
+
+describe('AsepriteSheet.parse — per-frame durations', () => {
+  it('populates frameDurations with each expanded frame index real duration', () => {
+    const data: AsepriteData = {
+      frames: [100, 100, 300].map((duration, i) => ({
+        duration,
+        frame: { x: i * 16, y: 0, w: 16, h: 16 },
+        rotated: false,
+        trimmed: false,
+        sourceSize: { w: 16, h: 16 },
+        spriteSourceSize: { x: 0, y: 0, w: 16, h: 16 },
+      })),
+      meta: {
+        app: 'aseprite',
+        version: '1.3',
+        image: 'x.png',
+        format: 'RGBA8888',
+        size: { w: 48, h: 16 },
+        scale: '1',
+        frameTags: [{ name: 'idle', from: 0, to: 2, direction: 'forward' }],
+      },
+    };
+    const sheet = AsepriteSheet.parse(data, newTexture());
+    expect(sheet.clips.get('idle')!.frameDurations).toEqual([100, 100, 300]);
+    // fps stays the computed average, unaffected by the per-frame durations.
+    expect(sheet.clips.get('idle')!.fps).toBeCloseTo(1000 / ((100 + 100 + 300) / 3));
+  });
+
+  it('expands frameDurations to match a pingpong sequence, repeating bounced indices', () => {
+    const data: AsepriteData = {
+      frames: [100, 300, 100].map((duration, i) => ({
+        duration,
+        frame: { x: i * 16, y: 0, w: 16, h: 16 },
+        rotated: false,
+        trimmed: false,
+        sourceSize: { w: 16, h: 16 },
+        spriteSourceSize: { x: 0, y: 0, w: 16, h: 16 },
+      })),
+      meta: {
+        app: 'aseprite',
+        version: '1.3',
+        image: 'x.png',
+        format: 'RGBA8888',
+        size: { w: 48, h: 16 },
+        scale: '1',
+        frameTags: [{ name: 'clip', from: 0, to: 2, direction: 'pingpong' }],
+      },
+    };
+    const sheet = AsepriteSheet.parse(data, newTexture());
+    // Expanded sequence is [0,1,2,1] -> durations [100, 300, 100, 300].
+    expect(sheet.clips.get('clip')!.frameDurations).toEqual([100, 300, 100, 300]);
+  });
+
+  it('falls back to the average duration for a non-positive per-frame duration', () => {
+    const data: AsepriteData = {
+      frames: [100, 0, 100].map((duration, i) => ({
+        duration,
+        frame: { x: i * 16, y: 0, w: 16, h: 16 },
+        rotated: false,
+        trimmed: false,
+        sourceSize: { w: 16, h: 16 },
+        spriteSourceSize: { x: 0, y: 0, w: 16, h: 16 },
+      })),
+      meta: {
+        app: 'aseprite',
+        version: '1.3',
+        image: 'x.png',
+        format: 'RGBA8888',
+        size: { w: 48, h: 16 },
+        scale: '1',
+        frameTags: [{ name: 'clip', from: 0, to: 2, direction: 'forward' }],
+      },
+    };
+    const sheet = AsepriteSheet.parse(data, newTexture());
+    const clip = sheet.clips.get('clip')!;
+    const avgMs = 1000 / clip.fps!;
+    expect(clip.frameDurations).toEqual([100, avgMs, 100]);
+  });
+});
+
 // ── AsepriteSheet.parse — repeat (one-shot vs looping) ─────────────────────────
 
 describe('AsepriteSheet.parse — repeat', () => {

--- a/packages/exojs-aseprite/test/aseprite-sheet.test.ts
+++ b/packages/exojs-aseprite/test/aseprite-sheet.test.ts
@@ -254,6 +254,50 @@ describe('AsepriteSheet.parse — repeat', () => {
   });
 });
 
+// ── AsepriteSheet.parse — slices ────────────────────────────────────────────────
+
+describe('AsepriteSheet.parse — slices', () => {
+  it('populates the slices map keyed by slice name', () => {
+    const sheet = AsepriteSheet.parse(arrayData, newTexture());
+    expect(sheet.slices.has('hitbox')).toBe(true);
+  });
+
+  it('preserves the slice bounds/keys/color from the Aseprite JSON', () => {
+    const sheet = AsepriteSheet.parse(arrayData, newTexture());
+    const hitbox = sheet.slices.get('hitbox')!;
+    expect(hitbox.name).toBe('hitbox');
+    expect(hitbox.color).toBe('#0000ffff');
+    expect(hitbox.keys).toHaveLength(1);
+    expect(hitbox.keys[0]!.frame).toBe(0);
+    expect(hitbox.keys[0]!.bounds).toEqual({ x: 2, y: 2, w: 12, h: 12 });
+  });
+
+  it('produces an empty slices map when meta.slices is absent', () => {
+    const data: AsepriteData = {
+      frames: [
+        {
+          duration: 100,
+          frame: { x: 0, y: 0, w: 16, h: 16 },
+          rotated: false,
+          trimmed: false,
+          sourceSize: { w: 16, h: 16 },
+          spriteSourceSize: { x: 0, y: 0, w: 16, h: 16 },
+        },
+      ],
+      meta: {
+        app: 'aseprite',
+        version: '1.3',
+        image: 'x.png',
+        format: 'RGBA8888',
+        size: { w: 16, h: 16 },
+        scale: '1',
+      },
+    };
+    const sheet = AsepriteSheet.parse(data, newTexture());
+    expect(sheet.slices.size).toBe(0);
+  });
+});
+
 // ── AsepriteSheet.parse — fps averaging and fallbacks ──────────────────────────
 
 describe('AsepriteSheet.parse — fps derivation', () => {

--- a/packages/exojs-aseprite/test/aseprite-sheet.test.ts
+++ b/packages/exojs-aseprite/test/aseprite-sheet.test.ts
@@ -99,10 +99,10 @@ describe('AsepriteSheet.parse — clips from frameTags', () => {
     expect(sheet.clips.get('walk')!.frames[1]).toBe(sheet.spritesheet.getFrame('1'));
   });
 
-  it('marks every clip as looping by default regardless of direction', () => {
+  it('marks every clip as looping indefinitely (repeat: -1) by default regardless of direction', () => {
     const sheet = AsepriteSheet.parse(arrayData, newTexture());
-    expect(sheet.clips.get('walk')!.loop).toBe(true);
-    expect(sheet.clips.get('bounce')!.loop).toBe(true);
+    expect(sheet.clips.get('walk')!.repeat).toBe(-1);
+    expect(sheet.clips.get('bounce')!.repeat).toBe(-1);
   });
 
   it('a two-frame pingpong tag has no middle frame to repeat, so it plays like forward', () => {
@@ -341,7 +341,7 @@ describe('AsepriteSheet.parse — trimmed-frame offsets', () => {
   });
 });
 
-// ── AsepriteSheet.parse — repeat (one-shot vs looping) ─────────────────────────
+// ── AsepriteSheet.parse — repeat (one-shot vs finite vs infinite) ──────────────
 
 describe('AsepriteSheet.parse — repeat', () => {
   function makeData(repeat: string | undefined): AsepriteData {
@@ -366,19 +366,19 @@ describe('AsepriteSheet.parse — repeat', () => {
     };
   }
 
-  it('repeat: "1" marks the clip as one-shot (loop: false)', () => {
+  it('repeat: "1" maps to repeatCount 1 (one-shot)', () => {
     const sheet = AsepriteSheet.parse(makeData('1'), newTexture());
-    expect(sheet.clips.get('clip')!.loop).toBe(false);
+    expect(sheet.clips.get('clip')!.repeat).toBe(1);
   });
 
-  it('no repeat field means infinite loop (loop: true)', () => {
-    const sheet = AsepriteSheet.parse(makeData(undefined), newTexture());
-    expect(sheet.clips.get('clip')!.loop).toBe(true);
-  });
-
-  it('repeat: "3" (finite N-times) falls back to infinite loop (loopCount not yet supported)', () => {
+  it('repeat: "3" maps to repeatCount 3', () => {
     const sheet = AsepriteSheet.parse(makeData('3'), newTexture());
-    expect(sheet.clips.get('clip')!.loop).toBe(true);
+    expect(sheet.clips.get('clip')!.repeat).toBe(3);
+  });
+
+  it('no repeat field means infinite loop (repeat: -1)', () => {
+    const sheet = AsepriteSheet.parse(makeData(undefined), newTexture());
+    expect(sheet.clips.get('clip')!.repeat).toBe(-1);
   });
 });
 
@@ -561,13 +561,13 @@ describe('AsepriteSheet.createAnimatedSprite', () => {
     expect(() => sprite.play('bounce')).not.toThrow();
   });
 
-  it('play() activates the named clip and adopts its looping flag', () => {
+  it('play() activates the named clip and adopts its repeat setting', () => {
     const sheet = AsepriteSheet.parse(arrayData, newTexture());
     const sprite = sheet.createAnimatedSprite();
     sprite.play('walk');
     expect(sprite.currentClip).toBe('walk');
     expect(sprite.playing).toBe(true);
-    expect(sprite.loop).toBe(true);
+    expect(sprite.repeat).toBe(-1);
   });
 
   it('throws when playing a clip that has no matching tag', () => {

--- a/packages/exojs-aseprite/test/aseprite-sheet.test.ts
+++ b/packages/exojs-aseprite/test/aseprite-sheet.test.ts
@@ -4,7 +4,7 @@ import { basename, join } from 'node:path';
 import { AnimatedSprite, Spritesheet, Texture } from '@codexo/exojs';
 import { describe, expect, it } from 'vitest';
 
-import type { AsepriteData } from '../src/AsepriteData';
+import type { AsepriteData, AsepriteDirection } from '../src/AsepriteData';
 import { isAsepriteArrayData } from '../src/AsepriteData';
 import { AsepriteSheet } from '../src/AsepriteSheet';
 
@@ -105,15 +105,111 @@ describe('AsepriteSheet.parse — clips from frameTags', () => {
     expect(sheet.clips.get('bounce')!.loop).toBe(true);
   });
 
-  it('does NOT expand a pingpong tag into a reversed segment (plays only from->to)', () => {
+  it('a two-frame pingpong tag has no middle frame to repeat, so it plays like forward', () => {
     const sheet = AsepriteSheet.parse(arrayData, newTexture());
-    // bounce: from 1 to 2 pingpong -> 2 frames (1, 2), not 3 (1, 2, 1).
+    // bounce: from 1 to 2 pingpong -> forward pass [1,2], backward pass excludes
+    // both endpoints, and there is no frame strictly between 1 and 2 -> [1, 2].
     expect(sheet.clips.get('bounce')!.frames).toHaveLength(2);
+    expect(sheet.clips.get('bounce')!.frames[0]).toBe(sheet.spritesheet.getFrame('1'));
+    expect(sheet.clips.get('bounce')!.frames[1]).toBe(sheet.spritesheet.getFrame('2'));
   });
 
   it('derives clip fps from the average frame duration (100ms -> 10fps)', () => {
     const sheet = AsepriteSheet.parse(arrayData, newTexture());
     expect(sheet.clips.get('walk')!.fps).toBe(10);
+  });
+});
+
+// ── AsepriteSheet.parse — direction expansion ──────────────────────────────────
+
+describe('AsepriteSheet.parse — direction expansion', () => {
+  function makeData(tag: { from: number; to: number; direction: AsepriteDirection }): AsepriteData {
+    return {
+      frames: [0, 1, 2].map(i => ({
+        duration: 100,
+        frame: { x: i * 16, y: 0, w: 16, h: 16 },
+        rotated: false,
+        trimmed: false,
+        sourceSize: { w: 16, h: 16 },
+        spriteSourceSize: { x: 0, y: 0, w: 16, h: 16 },
+      })),
+      meta: {
+        app: 'aseprite',
+        version: '1.3',
+        image: 'x.png',
+        format: 'RGBA8888',
+        size: { w: 48, h: 16 },
+        scale: '1',
+        frameTags: [{ name: 'clip', from: tag.from, to: tag.to, direction: tag.direction }],
+      },
+    };
+  }
+
+  function indicesOf(sheet: AsepriteSheet): number[] {
+    const frames = sheet.clips.get('clip')!.frames;
+
+    return frames.map(rect => {
+      for (let i = 0; i < 3; i++) {
+        if (rect === sheet.spritesheet.getFrame(String(i))) {
+          return i;
+        }
+      }
+
+      throw new Error('frame not found');
+    });
+  }
+
+  it('forward (default) expands to [from..to] unchanged', () => {
+    const sheet = AsepriteSheet.parse(makeData({ from: 0, to: 2, direction: 'forward' }), newTexture());
+    expect(indicesOf(sheet)).toEqual([0, 1, 2]);
+  });
+
+  it('reverse expands to [to..from]', () => {
+    const sheet = AsepriteSheet.parse(makeData({ from: 0, to: 2, direction: 'reverse' }), newTexture());
+    expect(indicesOf(sheet)).toEqual([2, 1, 0]);
+  });
+
+  it('pingpong expands to a forward pass then a backward pass excluding both endpoints', () => {
+    const sheet = AsepriteSheet.parse(makeData({ from: 0, to: 2, direction: 'pingpong' }), newTexture());
+    expect(indicesOf(sheet)).toEqual([0, 1, 2, 1]);
+  });
+
+  it('pingpong_reverse expands starting from the reverse end', () => {
+    const sheet = AsepriteSheet.parse(makeData({ from: 0, to: 2, direction: 'pingpong_reverse' }), newTexture());
+    expect(indicesOf(sheet)).toEqual([2, 1, 0, 1]);
+  });
+
+  it('a single-frame tag (from === to) emits just that frame for any direction', () => {
+    for (const direction of ['forward', 'reverse', 'pingpong', 'pingpong_reverse'] as const) {
+      const sheet = AsepriteSheet.parse(makeData({ from: 1, to: 1, direction }), newTexture());
+      expect(indicesOf(sheet)).toEqual([1]);
+    }
+  });
+
+  it('averages duration across the full expanded pingpong sequence, weighting repeated frames', () => {
+    const data: AsepriteData = {
+      frames: [100, 300, 100].map((duration, i) => ({
+        duration,
+        frame: { x: i * 16, y: 0, w: 16, h: 16 },
+        rotated: false,
+        trimmed: false,
+        sourceSize: { w: 16, h: 16 },
+        spriteSourceSize: { x: 0, y: 0, w: 16, h: 16 },
+      })),
+      meta: {
+        app: 'aseprite',
+        version: '1.3',
+        image: 'x.png',
+        format: 'RGBA8888',
+        size: { w: 48, h: 16 },
+        scale: '1',
+        frameTags: [{ name: 'clip', from: 0, to: 2, direction: 'pingpong' }],
+      },
+    };
+    const sheet = AsepriteSheet.parse(data, newTexture());
+    // Expanded sequence is [100, 300, 100, 300] (frame 1's duration counted twice)
+    // -> avg 200ms -> 5fps. A naive from..to average (100+300+100)/3 would give 6fps.
+    expect(sheet.clips.get('clip')!.fps).toBe(5);
   });
 });
 

--- a/packages/exojs-aseprite/test/aseprite-sheet.test.ts
+++ b/packages/exojs-aseprite/test/aseprite-sheet.test.ts
@@ -99,7 +99,7 @@ describe('AsepriteSheet.parse — clips from frameTags', () => {
     expect(sheet.clips.get('walk')!.frames[1]).toBe(sheet.spritesheet.getFrame('1'));
   });
 
-  it('marks every clip as looping regardless of direction', () => {
+  it('marks every clip as looping by default regardless of direction', () => {
     const sheet = AsepriteSheet.parse(arrayData, newTexture());
     expect(sheet.clips.get('walk')!.loop).toBe(true);
     expect(sheet.clips.get('bounce')!.loop).toBe(true);
@@ -210,6 +210,47 @@ describe('AsepriteSheet.parse — direction expansion', () => {
     // Expanded sequence is [100, 300, 100, 300] (frame 1's duration counted twice)
     // -> avg 200ms -> 5fps. A naive from..to average (100+300+100)/3 would give 6fps.
     expect(sheet.clips.get('clip')!.fps).toBe(5);
+  });
+});
+
+// ── AsepriteSheet.parse — repeat (one-shot vs looping) ─────────────────────────
+
+describe('AsepriteSheet.parse — repeat', () => {
+  function makeData(repeat: string | undefined): AsepriteData {
+    return {
+      frames: [0, 1].map(i => ({
+        duration: 100,
+        frame: { x: i * 16, y: 0, w: 16, h: 16 },
+        rotated: false,
+        trimmed: false,
+        sourceSize: { w: 16, h: 16 },
+        spriteSourceSize: { x: 0, y: 0, w: 16, h: 16 },
+      })),
+      meta: {
+        app: 'aseprite',
+        version: '1.3',
+        image: 'x.png',
+        format: 'RGBA8888',
+        size: { w: 32, h: 16 },
+        scale: '1',
+        frameTags: [{ name: 'clip', from: 0, to: 1, direction: 'forward', repeat }],
+      },
+    };
+  }
+
+  it('repeat: "1" marks the clip as one-shot (loop: false)', () => {
+    const sheet = AsepriteSheet.parse(makeData('1'), newTexture());
+    expect(sheet.clips.get('clip')!.loop).toBe(false);
+  });
+
+  it('no repeat field means infinite loop (loop: true)', () => {
+    const sheet = AsepriteSheet.parse(makeData(undefined), newTexture());
+    expect(sheet.clips.get('clip')!.loop).toBe(true);
+  });
+
+  it('repeat: "3" (finite N-times) falls back to infinite loop (loopCount not yet supported)', () => {
+    const sheet = AsepriteSheet.parse(makeData('3'), newTexture());
+    expect(sheet.clips.get('clip')!.loop).toBe(true);
   });
 });
 

--- a/packages/exojs-aseprite/test/aseprite-sheet.test.ts
+++ b/packages/exojs-aseprite/test/aseprite-sheet.test.ts
@@ -294,6 +294,53 @@ describe('AsepriteSheet.parse — per-frame durations', () => {
   });
 });
 
+// ── AsepriteSheet.parse — trimmed-frame offsets ─────────────────────────────────
+
+describe('AsepriteSheet.parse — trimmed-frame offsets', () => {
+  it('populates frameOffsets from spriteSourceSize when any frame in the tag is trimmed', () => {
+    const data: AsepriteData = {
+      frames: [
+        {
+          duration: 100,
+          frame: { x: 0, y: 0, w: 12, h: 14 },
+          rotated: false,
+          trimmed: true,
+          sourceSize: { w: 16, h: 16 },
+          spriteSourceSize: { x: 2, y: 3, w: 12, h: 14 },
+        },
+        {
+          duration: 100,
+          frame: { x: 16, y: 0, w: 16, h: 16 },
+          rotated: false,
+          trimmed: false,
+          sourceSize: { w: 16, h: 16 },
+          spriteSourceSize: { x: 0, y: 0, w: 16, h: 16 },
+        },
+      ],
+      meta: {
+        app: 'aseprite',
+        version: '1.3',
+        image: 'x.png',
+        format: 'RGBA8888',
+        size: { w: 32, h: 16 },
+        scale: '1',
+        frameTags: [{ name: 'clip', from: 0, to: 1, direction: 'forward' }],
+      },
+    };
+    const sheet = AsepriteSheet.parse(data, newTexture());
+    const clip = sheet.clips.get('clip')!;
+    expect(clip.frameOffsets).toEqual([
+      { x: 2, y: 3 },
+      { x: 0, y: 0 },
+    ]);
+  });
+
+  it('omits frameOffsets entirely when no frame in the tag is trimmed', () => {
+    const sheet = AsepriteSheet.parse(arrayData, newTexture());
+    expect(sheet.clips.get('walk')!.frameOffsets).toBeUndefined();
+  });
+});
+
 // ── AsepriteSheet.parse — repeat (one-shot vs looping) ─────────────────────────
 
 describe('AsepriteSheet.parse — repeat', () => {

--- a/packages/exojs-ldtk/src/LdtkData.ts
+++ b/packages/exojs-ldtk/src/LdtkData.ts
@@ -219,6 +219,37 @@ export interface LdtkLevel {
   readonly externalRelPath?: string;
 }
 
+// ── Worlds ────────────────────────────────────────────────────────────────────
+
+/**
+ * How a {@link LdtkWorldData}'s levels are spatially organised. `null` is a
+ * valid LDtk value (unset), same as the other nullable enum-ish fields in
+ * this file.
+ */
+export type LdtkWorldLayout = 'Free' | 'GridVania' | 'LinearHorizontal' | 'LinearVertical' | null;
+
+/**
+ * A single world in a multi-world LDtk project (`root.worlds[]`, populated
+ * when the project has "Multi-Worlds" enabled in its advanced settings).
+ * Each world owns its own {@link levels}; `defs` (tilesets/layers/entity
+ * definitions) is declared once at the document root and shared by every
+ * world rather than duplicated per-world — see {@link LdtkData.defs}.
+ */
+export interface LdtkWorldData {
+  /** Human-readable world identifier (unique within the project). */
+  readonly identifier: string;
+  /** Globally unique instance id (UUID string). */
+  readonly iid: string;
+  /** Width of the world grid in pixels. */
+  readonly worldGridWidth: number;
+  /** Height of the world grid in pixels. */
+  readonly worldGridHeight: number;
+  /** How this world's levels are spatially organised. */
+  readonly worldLayout: LdtkWorldLayout;
+  /** Levels belonging to this world, in document order. */
+  readonly levels: readonly LdtkLevel[];
+}
+
 // ── Definitions ───────────────────────────────────────────────────────────────
 
 /** Tileset definition from `defs.tilesets`. */
@@ -278,5 +309,22 @@ export interface LdtkData {
   readonly defaultGridSize?: number;
   readonly bgColor?: string;
   readonly defs: LdtkDefs;
+  /**
+   * Levels not organised into worlds. Always populated for pre-multi-world
+   * documents; kept EMPTY (per the LDtk spec's backward-compatibility rule)
+   * when {@link worlds} is used instead — read levels via `worlds[].levels`
+   * in that case, or use {@link import('./ldtkLevelEntries').getLdtkLevelEntries}
+   * (or simply {@link import('./LdtkMap').LdtkMap.levels} /
+   * {@link import('./LdtkMap').LdtkMap.getLevelByName}) to get "all levels,
+   * in order" regardless of which shape the document uses.
+   */
   readonly levels: readonly LdtkLevel[];
+  /**
+   * Worlds, present and non-empty only when the project has "Multi-Worlds"
+   * enabled in its advanced settings. Absent or empty for the (overwhelmingly
+   * common) single-world case, in which levels live directly in the root
+   * {@link levels} array instead. `defs` is NOT duplicated per-world — it
+   * stays declared once at the document root regardless of this field.
+   */
+  readonly worlds?: readonly LdtkWorldData[];
 }

--- a/packages/exojs-ldtk/src/LdtkData.ts
+++ b/packages/exojs-ldtk/src/LdtkData.ts
@@ -50,10 +50,20 @@ export interface LdtkEntityInstance {
   readonly __identifier: string;
   /** Alias of `__identifier`, mirrors the entity definition type. */
   readonly __type: string;
-  /** Pixel position `[x, y]` of the entity origin. */
+  /**
+   * Pixel position `[x, y]` of the entity's pivot-adjusted anchor — NOT the
+   * top-left corner. Combine with {@link __pivot} to recover the bounding
+   * box's top-left corner: `topLeftX = px[0] - width * __pivot[0]`.
+   */
   readonly px: readonly [number, number];
   readonly width: number;
   readonly height: number;
+  /**
+   * Normalised `[x, y]` anchor point within the entity's bounding box, each
+   * in `[0, 1]`. `[0, 0]` = top-left, `[0.5, 0.5]` = center, `[1, 1]` =
+   * bottom-right. Determines how {@link px} relates to the bounding box.
+   */
+  readonly __pivot: readonly [number, number];
   readonly fieldInstances: readonly LdtkFieldInstance[];
   /** Globally unique instance id (UUID string). */
   readonly iid: string;

--- a/packages/exojs-ldtk/src/LdtkData.ts
+++ b/packages/exojs-ldtk/src/LdtkData.ts
@@ -10,6 +10,8 @@
 
 /* eslint-disable @typescript-eslint/naming-convention -- LDtk uses __ prefix for runtime fields */
 
+import type { TilePropertyPoint, TilePropertyTileRef } from '@codexo/exojs-tilemap';
+
 // ── Tile data ─────────────────────────────────────────────────────────────────
 
 /** Flip-bit constants for {@link LdtkTileData.f}. */
@@ -37,12 +39,81 @@ export interface LdtkTileData {
 
 // ── Entity data ───────────────────────────────────────────────────────────────
 
-/** A field value on an entity or level instance. */
-export interface LdtkFieldInstance {
-  readonly __identifier: string;
-  readonly __type: string;
-  readonly __value: unknown;
+/**
+ * LDtk field types whose `__value` is a bare scalar (or `null`, when the
+ * field has no value set).
+ */
+export type LdtkFieldScalarType =
+  | 'Int'
+  | 'Float'
+  | 'Bool'
+  | 'String'
+  | 'Multilines'
+  | 'Color'
+  | 'FilePath'
+  | 'Enum';
+
+/**
+ * Raw `__value` shape for a `Point`-typed field. Structurally identical to
+ * {@link TilePropertyPoint} minus its `kind` tag, so the canonical shape is
+ * reused directly rather than duplicated.
+ */
+export type LdtkFieldPointValue = Omit<TilePropertyPoint, 'kind'>;
+
+/**
+ * Raw `__value` shape for an `EntityRef`-typed field: the referenced
+ * entity's own iid plus LDtk's navigation context (owning layer/level/world).
+ * Maps to {@link import('@codexo/exojs-tilemap').TilePropertyObjectRef} —
+ * `entityIid` becomes `id`.
+ */
+export interface LdtkFieldEntityRefValue {
+  readonly entityIid: string;
+  readonly layerIid: string;
+  readonly levelIid: string;
+  readonly worldIid: string;
 }
+
+/**
+ * Raw `__value` shape for a `Tile`-typed field. Structurally identical to
+ * {@link TilePropertyTileRef} minus its `kind` tag, so the canonical shape is
+ * reused directly rather than duplicated.
+ */
+export type LdtkFieldTileValue = Omit<TilePropertyTileRef, 'kind'>;
+
+/**
+ * A field value on an entity or level instance, discriminated by `__type`.
+ * `Array<T>` fields (e.g. `Array<Int>`, `Array<Point>`) carry a raw element
+ * array whose per-element shape matches the corresponding non-array
+ * `__value` shape above; see {@link import('./ldtkToTileMap').ldtkToTileMap}'s
+ * field conversion for the exhaustive mapping into the canonical
+ * {@link import('@codexo/exojs-tilemap').TilePropertyValue}.
+ */
+export type LdtkFieldInstance =
+  | {
+      readonly __identifier: string;
+      readonly __type: LdtkFieldScalarType;
+      readonly __value: string | number | boolean | null;
+    }
+  | {
+      readonly __identifier: string;
+      readonly __type: 'Point';
+      readonly __value: LdtkFieldPointValue | null;
+    }
+  | {
+      readonly __identifier: string;
+      readonly __type: 'EntityRef';
+      readonly __value: LdtkFieldEntityRefValue | null;
+    }
+  | {
+      readonly __identifier: string;
+      readonly __type: 'Tile';
+      readonly __value: LdtkFieldTileValue | null;
+    }
+  | {
+      readonly __identifier: string;
+      readonly __type: `Array<${string}>`;
+      readonly __value: readonly unknown[] | null;
+    };
 
 /** An entity instance placed in an Entities layer. */
 export interface LdtkEntityInstance {

--- a/packages/exojs-ldtk/src/LdtkMap.ts
+++ b/packages/exojs-ldtk/src/LdtkMap.ts
@@ -1,6 +1,7 @@
 import type { TileMap } from '@codexo/exojs-tilemap';
 
 import type { LdtkData } from './LdtkData';
+import { getLdtkLevelEntries } from './ldtkLevelEntries';
 
 /**
  * A parsed LDtk world document: holds the raw JSON data and the converted
@@ -38,10 +39,17 @@ export class LdtkMap {
    * Find a level's runtime {@link TileMap} by the LDtk level `identifier`,
    * or `undefined` when no level with that name exists.
    *
+   * Searches across {@link import('./ldtkLevelEntries').getLdtkLevelEntries}'s
+   * flattened level set rather than `data.levels` directly, so this works for
+   * both single-world and multi-world documents — `data.levels` alone is
+   * empty for the latter.
+   *
    * The lookup is O(n) in the number of levels.
    */
   public getLevelByName(identifier: string): TileMap | undefined {
-    const index = this.data.levels.findIndex(level => level.identifier === identifier);
+    const index = getLdtkLevelEntries(this.data).findIndex(
+      entry => entry.level.identifier === identifier,
+    );
     if (index === -1) return undefined;
     return this.levels[index];
   }

--- a/packages/exojs-ldtk/src/LdtkMap.ts
+++ b/packages/exojs-ldtk/src/LdtkMap.ts
@@ -23,9 +23,12 @@ export class LdtkMap {
   /**
    * Runtime TileMaps — one per LDtk level, in document order.
    *
-   * The index here corresponds to `data.levels[i]`. Levels for which
-   * conversion was skipped (e.g. external `.ldtkl` files not yet loaded)
-   * are `undefined` at that position.
+   * The index here corresponds to
+   * {@link import('./ldtkLevelEntries').getLdtkLevelEntries}`(data)[i]`, not
+   * `data.levels[i]` — the latter is empty for multi-world documents, where
+   * levels live under `data.worlds[].levels` instead. `loadLdtkMap` fully
+   * resolves external `.ldtkl` levels before conversion, so every entry here
+   * is always a fully converted `TileMap`.
    */
   public readonly levels: readonly TileMap[];
 

--- a/packages/exojs-ldtk/src/ldtkLevelEntries.ts
+++ b/packages/exojs-ldtk/src/ldtkLevelEntries.ts
@@ -1,0 +1,41 @@
+import type { LdtkData, LdtkLevel } from './LdtkData';
+
+/**
+ * One level from a (possibly multi-world) {@link LdtkData} document, paired
+ * with the {@link import('./LdtkData').LdtkWorldData.iid} of the world it
+ * belongs to. `worldIid` is `undefined` when the document uses the legacy
+ * single-world shape (`data.levels`, no `worlds[]`) — the overwhelmingly
+ * common case.
+ */
+export interface LdtkLevelEntry {
+  readonly level: LdtkLevel;
+  readonly worldIid: string | undefined;
+}
+
+/**
+ * Flatten a {@link LdtkData} document's levels into one ordered list,
+ * abstracting over LDtk's two root shapes: single-world (levels live in the
+ * root {@link LdtkData.levels}) and multi-world (levels live in
+ * `data.worlds[].levels`, each tagged here with its owning world's `iid`;
+ * per the LDtk spec the root `levels` array is kept but EMPTY in this shape).
+ *
+ * This is the single place that decides which shape a document uses — every
+ * consumer that needs "all levels, in document order" ({@link import('./loadLdtkMap').loadLdtkMap}'s
+ * external `.ldtkl` resolution, {@link import('./ldtkToTileMap').ldtkToTileMap}'s
+ * conversion, and {@link import('./LdtkMap').LdtkMap.getLevelByName}'s lookup)
+ * goes through this function rather than re-deriving the single/multi-world
+ * detection independently.
+ */
+export function getLdtkLevelEntries(data: LdtkData): readonly LdtkLevelEntry[] {
+  if (data.worlds && data.worlds.length > 0) {
+    const entries: LdtkLevelEntry[] = [];
+    for (const world of data.worlds) {
+      for (const level of world.levels) {
+        entries.push({ level, worldIid: world.iid });
+      }
+    }
+    return entries;
+  }
+
+  return data.levels.map(level => ({ level, worldIid: undefined }));
+}

--- a/packages/exojs-ldtk/src/ldtkToTileMap.ts
+++ b/packages/exojs-ldtk/src/ldtkToTileMap.ts
@@ -11,6 +11,7 @@ import type {
   LdtkTileData,
 } from './LdtkData';
 import { ldtkFlipX, ldtkFlipY } from './LdtkData';
+import { getLdtkLevelEntries } from './ldtkLevelEntries';
 import { LdtkMap } from './LdtkMap';
 
 // ── Public API ────────────────────────────────────────────────────────────────
@@ -49,13 +50,18 @@ export interface LdtkToTileMapOptions {
  *
  * Pass `options.tilesets` to populate tile data; omit it for structure-only
  * conversion (useful in unit tests that do not need textures).
+ *
+ * Transparently handles both LDtk root shapes via {@link getLdtkLevelEntries}:
+ * single-world (`data.levels`) and multi-world (`data.worlds[].levels`) — in
+ * the latter case every converted level's `TileMap.properties` is additionally
+ * tagged with its owning world's iid under the reserved `ldtkWorldIid` key.
  */
 export function ldtkToTileMap(data: LdtkData, options?: LdtkToTileMapOptions): LdtkMap {
   const source = options?.source ?? '';
   const tilesets = options?.tilesets ?? new Map<number, TileSet>();
 
-  const levels = data.levels.map((level, levelIndex) =>
-    convertLevel(level, levelIndex, data, tilesets),
+  const levels = getLdtkLevelEntries(data).map((entry, levelIndex) =>
+    convertLevel(entry.level, entry.worldIid, levelIndex, data, tilesets),
   );
 
   return new LdtkMap(source, data, levels);
@@ -66,6 +72,7 @@ export function ldtkToTileMap(data: LdtkData, options?: LdtkToTileMapOptions): L
 // eslint-disable-next-line complexity
 function convertLevel(
   level: LdtkLevel,
+  worldIid: string | undefined,
   levelIndex: number,
   data: LdtkData,
   tilesets: ReadonlyMap<number, TileSet>,
@@ -156,13 +163,17 @@ function convertLevel(
     layers: runtimeLayers,
     objectLayers: runtimeObjectLayers,
     // Convert user-defined level fields first, then apply the reserved keys
-    // last so a same-named user field can never clobber them.
+    // last so a same-named user field can never clobber them. ldtkWorldIid is
+    // only added for multi-world documents (worldIid !== undefined) — a
+    // single-world document's properties must stay exactly as they were
+    // before multi-world support existed.
     properties: {
       ...convertFieldInstances(level.fieldInstances ?? []),
       ldtkUid: level.uid,
       ldtkIid: level.iid,
       worldX: level.worldX,
       worldY: level.worldY,
+      ...(worldIid !== undefined && { ldtkWorldIid: worldIid }),
     },
   });
 }

--- a/packages/exojs-ldtk/src/ldtkToTileMap.ts
+++ b/packages/exojs-ldtk/src/ldtkToTileMap.ts
@@ -155,7 +155,10 @@ function convertLevel(
     tilesets: runtimeTilesets,
     layers: runtimeLayers,
     objectLayers: runtimeObjectLayers,
+    // Convert user-defined level fields first, then apply the reserved keys
+    // last so a same-named user field can never clobber them.
     properties: {
+      ...convertFieldInstances(level.fieldInstances ?? []),
       ldtkUid: level.uid,
       ldtkIid: level.iid,
       worldX: level.worldX,

--- a/packages/exojs-ldtk/src/ldtkToTileMap.ts
+++ b/packages/exojs-ldtk/src/ldtkToTileMap.ts
@@ -1,5 +1,5 @@
 import type { TileMapObject, TileProperties, TilePropertyValue, TileSet } from '@codexo/exojs-tilemap';
-import { ObjectLayer, TILE_TRANSFORM_IDENTITY, TileLayer, TileMap } from '@codexo/exojs-tilemap';
+import { ObjectLayer, TILE_TRANSFORM_IDENTITY, TileLayer, TileMap, TilePropertyKind } from '@codexo/exojs-tilemap';
 
 import type {
   LdtkData,
@@ -336,19 +336,123 @@ function convertEntity(entity: LdtkEntityInstance, id: number): TileMapObject {
 
 /**
  * Project LDtk field instances to a flat {@link TileProperties} bag.
- * Only scalar values (string, number, boolean) are forwarded; complex types
- * (arrays, colours, enums-as-objects) are silently skipped.
+ * Every LDtk field type maps to a canonical {@link TilePropertyValue}
+ * (scalars pass through; `Point`/`EntityRef`/`Tile` become their tagged
+ * structured variants; `Array<T>` fields recursively convert each element).
+ * A field whose raw `__value` is `null` (LDtk's "not set" convention) is
+ * omitted from the bag entirely, matching the property-absent case rather
+ * than a present-but-null value.
  */
 function convertFieldInstances(fields: readonly LdtkFieldInstance[]): TileProperties {
   if (fields.length === 0) return Object.freeze({});
   const out: Record<string, TilePropertyValue> = {};
   for (const field of fields) {
-    const v = field.__value;
-    if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
-      out[field.__identifier] = v;
+    const value = convertField(field);
+    if (value !== undefined) {
+      out[field.__identifier] = value;
     }
   }
   return Object.freeze(out);
+}
+
+/**
+ * Type guard narrowing to the `Array<T>` member of {@link LdtkFieldInstance}.
+ * `String.prototype.startsWith` alone does not narrow a template-literal
+ * union member for the compiler; a predicate on `field` itself does.
+ */
+function isLdtkArrayField(
+  field: LdtkFieldInstance,
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- LDtk uses __ prefix for runtime fields
+): field is Extract<LdtkFieldInstance, { readonly __type: `Array<${string}>` }> {
+  return field.__type.startsWith('Array<');
+}
+
+/** Convert one {@link LdtkFieldInstance} to its canonical {@link TilePropertyValue}, or `undefined` for a `null` (unset) field. */
+function convertField(field: LdtkFieldInstance): TilePropertyValue | undefined {
+  switch (field.__type) {
+    case 'Int':
+    case 'Float':
+    case 'Bool':
+    case 'String':
+    case 'Multilines':
+    case 'Color':
+    case 'FilePath':
+    case 'Enum':
+    case 'Point':
+    case 'EntityRef':
+    case 'Tile':
+      return mapLdtkFieldValue(field.__type, field.__value);
+
+    default:
+      break;
+  }
+
+  if (isLdtkArrayField(field)) {
+    if (field.__value === null) return undefined;
+    const elementType = field.__type.slice('Array<'.length, -1);
+    const elements: TilePropertyValue[] = [];
+    for (const raw of field.__value) {
+      const converted = mapLdtkFieldValue(elementType, raw);
+      if (converted !== undefined) elements.push(converted);
+    }
+    return Object.freeze(elements);
+  }
+
+  // Exhaustiveness check: if LDtk ever adds a new field type, `field` will
+  // fail to narrow to `never` here and tsc will error.
+  const _exhaustive: never = field;
+  void _exhaustive;
+  throw new Error(`convertFieldInstances: unrecognised LDtk field type "${(field as LdtkFieldInstance).__type}".`);
+}
+
+/**
+ * Map a single raw LDtk field value (or array element) to its canonical
+ * {@link TilePropertyValue}, given the LDtk type name it was declared with.
+ * Shared by {@link convertField} (top-level fields) and array-element
+ * conversion (`typeName` is the `T` extracted from an `Array<T>` field).
+ * Returns `undefined` for a `null` value or an unrecognised `typeName`.
+ */
+function mapLdtkFieldValue(typeName: string, value: unknown): TilePropertyValue | undefined {
+  if (value === null || value === undefined) return undefined;
+
+  switch (typeName) {
+    case 'Int':
+    case 'Float':
+    case 'Bool':
+    case 'String':
+    case 'Multilines':
+    case 'Color':
+    case 'FilePath':
+    case 'Enum':
+      return value as string | number | boolean;
+
+    case 'Point': {
+      const v = value as { cx: number; cy: number };
+      return { kind: TilePropertyKind.Point, cx: v.cx, cy: v.cy };
+    }
+
+    case 'EntityRef': {
+      const v = value as { entityIid: string; layerIid: string; levelIid: string; worldIid: string };
+      return {
+        kind: TilePropertyKind.ObjectRef,
+        id: v.entityIid,
+        layerIid: v.layerIid,
+        levelIid: v.levelIid,
+        worldIid: v.worldIid,
+      };
+    }
+
+    case 'Tile': {
+      const v = value as { tilesetUid: number; x: number; y: number; w: number; h: number };
+      return { kind: TilePropertyKind.TileRef, tilesetUid: v.tilesetUid, x: v.x, y: v.y, w: v.w, h: v.h };
+    }
+
+    default:
+      // Unknown/unsupported array element type (e.g. a future LDtk type
+      // inside Array<T>) — skip rather than throw, since this path is not
+      // compiler-exhaustive (element types are plain runtime strings).
+      return undefined;
+  }
 }
 
 // ── Helpers: grid size ────────────────────────────────────────────────────────

--- a/packages/exojs-ldtk/src/ldtkToTileMap.ts
+++ b/packages/exojs-ldtk/src/ldtkToTileMap.ts
@@ -5,6 +5,7 @@ import type {
   LdtkData,
   LdtkEntityInstance,
   LdtkFieldInstance,
+  LdtkIntGridValueDef,
   LdtkLayerInstance,
   LdtkLevel,
   LdtkTileData,
@@ -106,9 +107,11 @@ function convertLevel(
       }
 
       case 'IntGrid': {
-        const rLayer = makeTileLayer(layerInst, layerId, runtimeTilesets);
+        const intGridProperties = buildIntGridProperties(layerInst, data);
+        const rLayer = makeTileLayer(layerInst, layerId, runtimeTilesets, intGridProperties);
         // IntGrid layers may carry auto-tiles when "Auto-layer" rules are
-        // configured. Use those for rendering; raw intGridCsv is data-only.
+        // configured. Use those for rendering; raw intGridCsv is exposed as
+        // data-only layer properties (see buildIntGridProperties).
         const autoTiles = layerInst.autoLayerTiles ?? [];
         const tsUid = layerInst.__tilesetDefUid;
         if (autoTiles.length > 0 && tsUid !== undefined) {
@@ -167,6 +170,7 @@ function makeTileLayer(
   layerInst: LdtkLayerInstance,
   layerId: number,
   tilesets: readonly TileSet[],
+  properties?: TileProperties,
 ): TileLayer {
   return new TileLayer({
     id: layerId,
@@ -180,6 +184,7 @@ function makeTileLayer(
     opacity: layerInst.opacity ?? 1,
     offsetX: layerInst.pxOffsetX ?? 0,
     offsetY: layerInst.pxOffsetY ?? 0,
+    ...(properties && { properties }),
   });
 }
 
@@ -208,6 +213,80 @@ function populateTileLayer(
       },
     });
   }
+}
+
+// ── Helpers: IntGrid ──────────────────────────────────────────────────────────
+
+/**
+ * Reserved {@link TileLayer.properties} key holding the JSON-encoded raw
+ * IntGrid CSV array (`readonly number[]`) for a `TileLayer` converted from an
+ * LDtk `IntGrid` layer instance. Index = `y * layer.width + x`; `0` = empty.
+ * Prefer {@link getLdtkIntGridValueAt} over reading this directly.
+ */
+export const ldtkIntGridCsvProperty = 'ldtkIntGridCsv';
+
+/**
+ * Reserved {@link TileLayer.properties} key holding the JSON-encoded
+ * {@link LdtkIntGridValueDef} array for a `TileLayer` converted from an LDtk
+ * `IntGrid` layer instance — the raw-int → named/coloured mapping declared on
+ * the owning layer definition (`data.defs.layers[].intGridValues`).
+ * Prefer {@link getLdtkIntGridValueAt} over reading this directly.
+ */
+export const ldtkIntGridValuesProperty = 'ldtkIntGridValues';
+
+/**
+ * Build the reserved IntGrid properties for a `TileLayer` from an LDtk
+ * `IntGrid` layer instance, or `undefined` when the layer carries no
+ * `intGridCsv` data (nothing to expose).
+ *
+ * {@link TileLayer.properties} values are scalar-only, so the raw CSV array
+ * and the value-definition mapping are JSON-encoded into two reserved string
+ * properties rather than stored as nested structures — the same
+ * `properties`-bag mechanism the Tiled adapter already uses for per-layer
+ * metadata, just serialized to fit its scalar-only value type.
+ */
+function buildIntGridProperties(
+  layerInst: LdtkLayerInstance,
+  data: LdtkData,
+): TileProperties | undefined {
+  const csv = layerInst.intGridCsv;
+  if (!csv || csv.length === 0) return undefined;
+
+  const layerDef = data.defs.layers.find(def => def.uid === layerInst.layerDefUid);
+  const values = layerDef?.intGridValues ?? [];
+
+  return Object.freeze({
+    [ldtkIntGridCsvProperty]: JSON.stringify(csv),
+    [ldtkIntGridValuesProperty]: JSON.stringify(values),
+  });
+}
+
+/**
+ * Look up the named/coloured {@link LdtkIntGridValueDef} at a tile coordinate
+ * on a `TileLayer` converted from an LDtk `IntGrid` layer instance.
+ *
+ * Returns `undefined` when the coordinate is out of bounds, the cell's raw
+ * value is `0` (empty), the raw value has no matching definition, or `layer`
+ * was not converted from an IntGrid layer instance (no IntGrid data attached
+ * via {@link ldtkIntGridCsvProperty} / {@link ldtkIntGridValuesProperty}).
+ */
+export function getLdtkIntGridValueAt(
+  layer: TileLayer,
+  x: number,
+  y: number,
+): LdtkIntGridValueDef | undefined {
+  if (!layer.inBounds(x, y)) return undefined;
+
+  const csvRaw = layer.properties[ldtkIntGridCsvProperty];
+  const valuesRaw = layer.properties[ldtkIntGridValuesProperty];
+  if (typeof csvRaw !== 'string' || typeof valuesRaw !== 'string') return undefined;
+
+  const csv = JSON.parse(csvRaw) as readonly number[];
+  const raw = csv[y * layer.width + x];
+  if (raw === undefined || raw === 0) return undefined;
+
+  const values = JSON.parse(valuesRaw) as readonly LdtkIntGridValueDef[];
+  return values.find(v => v.value === raw);
 }
 
 // ── Helpers: ObjectLayer ──────────────────────────────────────────────────────

--- a/packages/exojs-ldtk/src/ldtkToTileMap.ts
+++ b/packages/exojs-ldtk/src/ldtkToTileMap.ts
@@ -275,6 +275,45 @@ function buildIntGridProperties(
   });
 }
 
+/** Parsed, cached form of a `TileLayer`'s {@link ldtkIntGridCsvProperty} / {@link ldtkIntGridValuesProperty}. */
+interface ParsedIntGridData {
+  readonly csv: readonly number[];
+  readonly values: readonly LdtkIntGridValueDef[];
+}
+
+/**
+ * Per-`TileLayer` cache of parsed IntGrid CSV/value-defs data, populated
+ * lazily on first {@link getLdtkIntGridValueAt} lookup for a given layer.
+ *
+ * Keyed by the `TileLayer` instance itself (`WeakMap`), so an entry is
+ * naturally garbage-collected once the layer it was derived from is no
+ * longer referenced — no manual invalidation needed since
+ * {@link TileLayer.properties} is frozen and copied at construction time and
+ * can never change afterwards.
+ */
+const intGridCache = new WeakMap<TileLayer, ParsedIntGridData>();
+
+/**
+ * Parse (or retrieve from {@link intGridCache}) the IntGrid CSV/value-defs
+ * data attached to `layer`, or `undefined` when `layer` carries no such data
+ * (not converted from an IntGrid layer instance).
+ */
+function getParsedIntGridData(layer: TileLayer): ParsedIntGridData | undefined {
+  const cached = intGridCache.get(layer);
+  if (cached) return cached;
+
+  const csvRaw = layer.properties[ldtkIntGridCsvProperty];
+  const valuesRaw = layer.properties[ldtkIntGridValuesProperty];
+  if (typeof csvRaw !== 'string' || typeof valuesRaw !== 'string') return undefined;
+
+  const parsed: ParsedIntGridData = {
+    csv: JSON.parse(csvRaw) as readonly number[],
+    values: JSON.parse(valuesRaw) as readonly LdtkIntGridValueDef[],
+  };
+  intGridCache.set(layer, parsed);
+  return parsed;
+}
+
 /**
  * Look up the named/coloured {@link LdtkIntGridValueDef} at a tile coordinate
  * on a `TileLayer` converted from an LDtk `IntGrid` layer instance.
@@ -283,6 +322,10 @@ function buildIntGridProperties(
  * value is `0` (empty), the raw value has no matching definition, or `layer`
  * was not converted from an IntGrid layer instance (no IntGrid data attached
  * via {@link ldtkIntGridCsvProperty} / {@link ldtkIntGridValuesProperty}).
+ *
+ * The underlying JSON-encoded CSV/value-defs properties are parsed once per
+ * layer and cached (see {@link getParsedIntGridData}) — safe to call from a
+ * hot path (e.g. per-cell or per-frame collision/classification checks).
  */
 export function getLdtkIntGridValueAt(
   layer: TileLayer,
@@ -291,16 +334,13 @@ export function getLdtkIntGridValueAt(
 ): LdtkIntGridValueDef | undefined {
   if (!layer.inBounds(x, y)) return undefined;
 
-  const csvRaw = layer.properties[ldtkIntGridCsvProperty];
-  const valuesRaw = layer.properties[ldtkIntGridValuesProperty];
-  if (typeof csvRaw !== 'string' || typeof valuesRaw !== 'string') return undefined;
+  const parsed = getParsedIntGridData(layer);
+  if (!parsed) return undefined;
 
-  const csv = JSON.parse(csvRaw) as readonly number[];
-  const raw = csv[y * layer.width + x];
+  const raw = parsed.csv[y * layer.width + x];
   if (raw === undefined || raw === 0) return undefined;
 
-  const values = JSON.parse(valuesRaw) as readonly LdtkIntGridValueDef[];
-  return values.find(v => v.value === raw);
+  return parsed.values.find(v => v.value === raw);
 }
 
 // ── Helpers: ObjectLayer ──────────────────────────────────────────────────────

--- a/packages/exojs-ldtk/src/ldtkToTileMap.ts
+++ b/packages/exojs-ldtk/src/ldtkToTileMap.ts
@@ -315,13 +315,17 @@ function convertEntityLayer(
 }
 
 function convertEntity(entity: LdtkEntityInstance, id: number): TileMapObject {
+  // entity.px is the pivot-adjusted anchor, not the bounding box's top-left
+  // corner — undo the pivot offset to recover the corner TileMapObject expects.
+  const x = entity.px[0] - entity.width * entity.__pivot[0];
+  const y = entity.px[1] - entity.height * entity.__pivot[1];
   return {
     kind: 'rectangle',
     id,
     name: entity.__identifier,
     type: entity.__identifier,
-    x: entity.px[0],
-    y: entity.px[1],
+    x,
+    y,
     width: entity.width,
     height: entity.height,
     rotation: 0,

--- a/packages/exojs-ldtk/src/loadLdtkMap.ts
+++ b/packages/exojs-ldtk/src/loadLdtkMap.ts
@@ -1,7 +1,7 @@
 import { type AssetLoaderContext, Texture, TextureRegion } from '@codexo/exojs';
 import { TileSet } from '@codexo/exojs-tilemap';
 
-import type { LdtkData, LdtkTilesetDef } from './LdtkData';
+import type { LdtkData, LdtkLevel, LdtkTilesetDef } from './LdtkData';
 import type { LdtkMap } from './LdtkMap';
 import { ldtkToTileMap } from './ldtkToTileMap';
 
@@ -64,12 +64,46 @@ async function loadLdtkTileset(
   });
 }
 
+// ── External level loading ───────────────────────────────────────────────────
+
+/**
+ * Resolve a level's external `.ldtkl` payload and merge its layer/field data
+ * into the level record.
+ *
+ * LDtk's "Save levels to separate files" project option nulls out
+ * `layerInstances` on the root document; the real layer data lives in a
+ * sibling `<levelIdentifier>.ldtkl` file referenced by {@link LdtkLevel.externalRelPath}.
+ * That file also carries its own `fieldInstances`, which is authoritative —
+ * the root document's copy is typically stripped or stale for externalized
+ * levels. Levels that already carry `layerInstances` (not externalized) are
+ * returned unchanged.
+ */
+async function loadExternalLevel(
+  level: LdtkLevel,
+  ldtkSource: string,
+  context: AssetLoaderContext,
+): Promise<LdtkLevel> {
+  if (level.layerInstances !== null || !level.externalRelPath) return level;
+
+  const externalUrl = resolveLdtkUrl(level.externalRelPath, ldtkSource);
+  // Cast without deep validation, matching the root document's fetch below —
+  // structural errors surface as runtime exceptions during conversion.
+  const external = (await context.fetchJson(externalUrl)) as LdtkLevel;
+  const fieldInstances = external.fieldInstances ?? level.fieldInstances;
+
+  return {
+    ...level,
+    layerInstances: external.layerInstances,
+    ...(fieldInstances !== undefined && { fieldInstances }),
+  };
+}
+
 // ── Public loader ─────────────────────────────────────────────────────────────
 
 /**
- * Fetch a `.ldtk` file, load all referenced tileset images, and return a
- * fully assembled {@link LdtkMap} with one runtime {@link import('@codexo/exojs-tilemap').TileMap}
- * per level.
+ * Fetch a `.ldtk` file, load all referenced tileset images, resolve any
+ * externalized (`.ldtkl`) levels, and return a fully assembled {@link LdtkMap}
+ * with one runtime {@link import('@codexo/exojs-tilemap').TileMap} per level.
  *
  * Tilesets without an atlas image (`relPath = null`) are silently skipped;
  * their tiles will not appear in the rendered output.
@@ -84,18 +118,21 @@ export async function loadLdtkMap(
   // exceptions when we access fields during conversion.
   const data = raw as LdtkData;
 
-  // Load all referenced tilesets concurrently.
-  const tilesetEntries = await Promise.all(
-    data.defs.tilesets.map(async (def) => {
-      const ts = await loadLdtkTileset(def, source, context);
-      return [def.uid, ts] as const;
-    }),
-  );
+  // Load all referenced tilesets and resolve externalized levels concurrently.
+  const [tilesetEntries, levels] = await Promise.all([
+    Promise.all(
+      data.defs.tilesets.map(async (def) => {
+        const ts = await loadLdtkTileset(def, source, context);
+        return [def.uid, ts] as const;
+      }),
+    ),
+    Promise.all(data.levels.map((level) => loadExternalLevel(level, source, context))),
+  ]);
 
   const tilesets = new Map<number, TileSet>();
   for (const [uid, ts] of tilesetEntries) {
     if (ts !== null) tilesets.set(uid, ts);
   }
 
-  return ldtkToTileMap(data, { source, tilesets });
+  return ldtkToTileMap({ ...data, levels }, { source, tilesets });
 }

--- a/packages/exojs-ldtk/src/loadLdtkMap.ts
+++ b/packages/exojs-ldtk/src/loadLdtkMap.ts
@@ -2,6 +2,7 @@ import { type AssetLoaderContext, Texture, TextureRegion } from '@codexo/exojs';
 import { TileSet } from '@codexo/exojs-tilemap';
 
 import type { LdtkData, LdtkLevel, LdtkTilesetDef } from './LdtkData';
+import { getLdtkLevelEntries } from './ldtkLevelEntries';
 import type { LdtkMap } from './LdtkMap';
 import { ldtkToTileMap } from './ldtkToTileMap';
 
@@ -98,6 +99,32 @@ async function loadExternalLevel(
   };
 }
 
+/**
+ * Rebuild an {@link LdtkData} document with its levels replaced by
+ * `resolvedLevels` (external `.ldtkl` payloads merged in via
+ * {@link loadExternalLevel}), preserving whichever root shape the source
+ * document used — single-world (`levels`) or multi-world (`worlds[].levels`).
+ *
+ * `resolvedLevels` must be in the same flattened order
+ * {@link getLdtkLevelEntries} produced for `data` — each world's slice is
+ * recovered by walking `data.worlds` in that same order, so a second pass
+ * through {@link getLdtkLevelEntries} (performed inside {@link ldtkToTileMap})
+ * reproduces an identical flattened list, now with external levels resolved.
+ */
+function withResolvedLevels(data: LdtkData, resolvedLevels: readonly LdtkLevel[]): LdtkData {
+  if (data.worlds && data.worlds.length > 0) {
+    let cursor = 0;
+    const worlds = data.worlds.map((world) => {
+      const levels = resolvedLevels.slice(cursor, cursor + world.levels.length);
+      cursor += world.levels.length;
+      return { ...world, levels };
+    });
+    return { ...data, worlds };
+  }
+
+  return { ...data, levels: resolvedLevels };
+}
+
 // ── Public loader ─────────────────────────────────────────────────────────────
 
 /**
@@ -119,14 +146,19 @@ export async function loadLdtkMap(
   const data = raw as LdtkData;
 
   // Load all referenced tilesets and resolve externalized levels concurrently.
-  const [tilesetEntries, levels] = await Promise.all([
+  // Iterate the flattened level list (not raw data.levels) so multi-world
+  // documents — whose levels live under worlds[].levels, with an empty root
+  // levels[] — still get their external .ldtkl files resolved.
+  const [tilesetEntries, resolvedLevels] = await Promise.all([
     Promise.all(
       data.defs.tilesets.map(async (def) => {
         const ts = await loadLdtkTileset(def, source, context);
         return [def.uid, ts] as const;
       }),
     ),
-    Promise.all(data.levels.map((level) => loadExternalLevel(level, source, context))),
+    Promise.all(
+      getLdtkLevelEntries(data).map((entry) => loadExternalLevel(entry.level, source, context)),
+    ),
   ]);
 
   const tilesets = new Map<number, TileSet>();
@@ -134,5 +166,5 @@ export async function loadLdtkMap(
     if (ts !== null) tilesets.set(uid, ts);
   }
 
-  return ldtkToTileMap({ ...data, levels }, { source, tilesets });
+  return ldtkToTileMap(withResolvedLevels(data, resolvedLevels), { source, tilesets });
 }

--- a/packages/exojs-ldtk/src/public.ts
+++ b/packages/exojs-ldtk/src/public.ts
@@ -58,6 +58,9 @@ export type {
   TileMapViewOptions,
   TileObject,
   TileProperties,
+  TilePropertyObjectRef,
+  TilePropertyPoint,
+  TilePropertyTileRef,
   TilePropertyValue,
   TileSetOptions,
   TileTransform,
@@ -70,6 +73,7 @@ export {
   TileMap,
   tilemapExtension,
   TileMapView,
+  TilePropertyKind,
   TileSet,
 } from '@codexo/exojs-tilemap';
 

--- a/packages/exojs-ldtk/src/public.ts
+++ b/packages/exojs-ldtk/src/public.ts
@@ -28,6 +28,8 @@ export type {
   LdtkLevel,
   LdtkTileData,
   LdtkTilesetDef,
+  LdtkWorldData,
+  LdtkWorldLayout,
 } from './LdtkData';
 export { ldtkFlipNone, ldtkFlipX, ldtkFlipXy, ldtkFlipY } from './LdtkData';
 

--- a/packages/exojs-ldtk/src/public.ts
+++ b/packages/exojs-ldtk/src/public.ts
@@ -8,7 +8,12 @@ export { ldtkExtension } from './ldtkExtension';
 // ── Parsed source model ───────────────────────────────────────────────────────
 export { LdtkMap } from './LdtkMap';
 export type { LdtkToTileMapOptions } from './ldtkToTileMap';
-export { ldtkToTileMap } from './ldtkToTileMap';
+export {
+  getLdtkIntGridValueAt,
+  ldtkIntGridCsvProperty,
+  ldtkIntGridValuesProperty,
+  ldtkToTileMap,
+} from './ldtkToTileMap';
 
 // ── Raw LDtk JSON types ───────────────────────────────────────────────────────
 export type {

--- a/packages/exojs-ldtk/test/fixtures/multi-world.ldtk
+++ b/packages/exojs-ldtk/test/fixtures/multi-world.ldtk
@@ -1,0 +1,115 @@
+{
+  "jsonVersion": "1.5.3",
+  "defaultGridSize": 16,
+  "defs": {
+    "tilesets": [
+      {
+        "uid": 1,
+        "identifier": "Atlas",
+        "relPath": "tiles.png",
+        "tileGridSize": 16,
+        "pxWid": 64,
+        "pxHei": 64,
+        "spacing": 0,
+        "padding": 0
+      }
+    ],
+    "layers": [
+      { "uid": 101, "identifier": "Tiles", "type": "Tiles", "gridSize": 16, "tilesetDefUid": 1 },
+      { "uid": 102, "identifier": "Entities", "type": "Entities", "gridSize": 16 }
+    ]
+  },
+  "levels": [],
+  "worlds": [
+    {
+      "identifier": "WorldA",
+      "iid": "world-a-iid",
+      "worldGridWidth": 256,
+      "worldGridHeight": 256,
+      "worldLayout": "GridVania",
+      "levels": [
+        {
+          "identifier": "A_Level1",
+          "uid": 1,
+          "iid": "aaaaaaaa-0000-0000-0000-000000000001",
+          "worldX": 0,
+          "worldY": 0,
+          "pxWid": 64,
+          "pxHei": 64,
+          "layerInstances": [
+            {
+              "__identifier": "Tiles",
+              "__type": "Tiles",
+              "__cWid": 4,
+              "__cHei": 4,
+              "__gridSize": 16,
+              "layerDefUid": 101,
+              "levelId": 1,
+              "visible": true,
+              "iid": "bbbbbbbb-0000-0000-0000-000000000001",
+              "__tilesetDefUid": 1,
+              "gridTiles": [
+                { "px": [0, 0], "src": [0, 0], "f": 0, "t": 0 },
+                { "px": [16, 0], "src": [16, 0], "f": 1, "t": 1 }
+              ],
+              "autoLayerTiles": []
+            },
+            {
+              "__identifier": "Entities",
+              "__type": "Entities",
+              "__cWid": 4,
+              "__cHei": 4,
+              "__gridSize": 16,
+              "layerDefUid": 102,
+              "levelId": 1,
+              "visible": true,
+              "iid": "bbbbbbbb-0000-0000-0000-000000000002",
+              "entityInstances": [
+                {
+                  "__identifier": "Player",
+                  "__type": "Player",
+                  "px": [8, 8],
+                  "width": 16,
+                  "height": 16,
+                  "__pivot": [0, 0],
+                  "fieldInstances": [],
+                  "iid": "cccccccc-0000-0000-0000-000000000001",
+                  "defUid": 200
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "identifier": "A_Level2",
+          "uid": 2,
+          "iid": "aaaaaaaa-0000-0000-0000-000000000002",
+          "worldX": 64,
+          "worldY": 0,
+          "pxWid": 32,
+          "pxHei": 32,
+          "layerInstances": []
+        }
+      ]
+    },
+    {
+      "identifier": "WorldB",
+      "iid": "world-b-iid",
+      "worldGridWidth": 128,
+      "worldGridHeight": 128,
+      "worldLayout": "Free",
+      "levels": [
+        {
+          "identifier": "B_Level1",
+          "uid": 3,
+          "iid": "dddddddd-0000-0000-0000-000000000003",
+          "worldX": 0,
+          "worldY": 0,
+          "pxWid": 16,
+          "pxHei": 16,
+          "layerInstances": []
+        }
+      ]
+    }
+  ]
+}

--- a/packages/exojs-ldtk/test/fixtures/world.ldtk
+++ b/packages/exojs-ldtk/test/fixtures/world.ldtk
@@ -63,6 +63,7 @@
               "px": [8, 8],
               "width": 16,
               "height": 16,
+              "__pivot": [0, 0],
               "fieldInstances": [],
               "iid": "cccccccc-0000-0000-0000-000000000001",
               "defUid": 200

--- a/packages/exojs-ldtk/test/ldtk-conversion.test.ts
+++ b/packages/exojs-ldtk/test/ldtk-conversion.test.ts
@@ -9,7 +9,7 @@ import type {
   LdtkLevel,
 } from '../src/LdtkData';
 import { ldtkFlipNone, ldtkFlipX, ldtkFlipXy, ldtkFlipY } from '../src/LdtkData';
-import { ldtkToTileMap } from '../src/ldtkToTileMap';
+import { getLdtkIntGridValueAt, ldtkToTileMap } from '../src/ldtkToTileMap';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -294,6 +294,132 @@ describe('ldtkToTileMap — IntGrid', () => {
       .layers[0]!;
     expect(layer.countNonEmptyTiles()).toBe(0);
     expect(layer.width).toBe(4);
+  });
+});
+
+describe('ldtkToTileMap — IntGrid value exposure', () => {
+  it('exposes the named/coloured IntGrid value at a tile coordinate', () => {
+    const data = docWithLayer({
+      __identifier: 'Collision',
+      __type: 'IntGrid',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 120,
+      levelId: 1,
+      visible: true,
+      iid: 'int-1',
+      intGridCsv: [1, 0, 2, 1],
+    });
+    const withDefs: LdtkData = {
+      ...data,
+      defs: {
+        tilesets: [],
+        layers: [
+          {
+            uid: 120,
+            identifier: 'Collision',
+            type: 'IntGrid',
+            gridSize: 16,
+            intGridValues: [
+              { value: 1, identifier: 'Wall', color: '#ff0000' },
+              { value: 2, identifier: 'Water', color: '#0000ff' },
+            ],
+          },
+        ],
+      },
+    };
+
+    const layer = ldtkToTileMap(withDefs).levels[0]!.layers[0]!;
+    expect(getLdtkIntGridValueAt(layer, 0, 0)).toEqual({
+      value: 1,
+      identifier: 'Wall',
+      color: '#ff0000',
+    });
+    expect(getLdtkIntGridValueAt(layer, 2, 0)).toEqual({
+      value: 2,
+      identifier: 'Water',
+      color: '#0000ff',
+    });
+    expect(getLdtkIntGridValueAt(layer, 3, 0)).toEqual({
+      value: 1,
+      identifier: 'Wall',
+      color: '#ff0000',
+    });
+  });
+
+  it('returns undefined for empty cells (raw value 0)', () => {
+    const data = docWithLayer({
+      __identifier: 'Collision',
+      __type: 'IntGrid',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 120,
+      levelId: 1,
+      visible: true,
+      iid: 'int-1',
+      intGridCsv: [1, 0, 2, 1],
+    });
+
+    const layer = ldtkToTileMap(data).levels[0]!.layers[0]!;
+    expect(getLdtkIntGridValueAt(layer, 1, 0)).toBeUndefined();
+  });
+
+  it('returns undefined for out-of-bounds coordinates', () => {
+    const data = docWithLayer({
+      __identifier: 'Collision',
+      __type: 'IntGrid',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 120,
+      levelId: 1,
+      visible: true,
+      iid: 'int-1',
+      intGridCsv: [1, 0, 2, 1],
+    });
+
+    const layer = ldtkToTileMap(data).levels[0]!.layers[0]!;
+    expect(getLdtkIntGridValueAt(layer, -1, 0)).toBeUndefined();
+    expect(getLdtkIntGridValueAt(layer, 99, 99)).toBeUndefined();
+  });
+
+  it('returns undefined for a layer with no IntGrid data attached (e.g. a Tiles layer)', () => {
+    const data = docWithLayer({
+      __identifier: 'Tiles',
+      __type: 'Tiles',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 101,
+      levelId: 1,
+      visible: true,
+      iid: 'tiles-1',
+      gridTiles: [],
+      autoLayerTiles: [],
+    });
+
+    const layer = ldtkToTileMap(data).levels[0]!.layers[0]!;
+    expect(getLdtkIntGridValueAt(layer, 0, 0)).toBeUndefined();
+  });
+
+  it('returns undefined for a raw value with no matching definition', () => {
+    const data = docWithLayer({
+      __identifier: 'Collision',
+      __type: 'IntGrid',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 120,
+      levelId: 1,
+      visible: true,
+      iid: 'int-1',
+      intGridCsv: [5, 0, 0, 0], // 5 has no defs.layers[].intGridValues entry
+    });
+
+    const layer = ldtkToTileMap(data).levels[0]!.layers[0]!;
+    expect(getLdtkIntGridValueAt(layer, 0, 0)).toBeUndefined();
   });
 });
 

--- a/packages/exojs-ldtk/test/ldtk-conversion.test.ts
+++ b/packages/exojs-ldtk/test/ldtk-conversion.test.ts
@@ -513,6 +513,104 @@ describe('ldtkToTileMap — level field instances', () => {
   });
 });
 
+// ── Entity pivot correction ────────────────────────────────────────────────────
+
+describe('ldtkToTileMap — entity pivot correction', () => {
+  it('adjusts px by the pivot to compute the bounding-box top-left corner', () => {
+    const data = docWithLayer({
+      __identifier: 'Entities',
+      __type: 'Entities',
+      __cWid: 4,
+      __cHei: 4,
+      __gridSize: 16,
+      layerDefUid: 130,
+      levelId: 1,
+      visible: true,
+      iid: 'ent-1',
+      entityInstances: [
+        {
+          __identifier: 'Torch',
+          __type: 'Torch',
+          px: [40, 64],
+          width: 16,
+          height: 32,
+          __pivot: [0.5, 1],
+          iid: 'torch-1',
+          defUid: 400,
+          fieldInstances: [],
+        },
+      ],
+    });
+
+    const object = ldtkToTileMap(data).levels[0]!.objectLayers[0]!.objects[0]!;
+    // x = 40 - 16 * 0.5 = 32; y = 64 - 32 * 1 = 32
+    expect(object.x).toBe(32);
+    expect(object.y).toBe(32);
+  });
+
+  it('leaves position unchanged for a default top-left pivot [0, 0]', () => {
+    const data = docWithLayer({
+      __identifier: 'Entities',
+      __type: 'Entities',
+      __cWid: 4,
+      __cHei: 4,
+      __gridSize: 16,
+      layerDefUid: 130,
+      levelId: 1,
+      visible: true,
+      iid: 'ent-1',
+      entityInstances: [
+        {
+          __identifier: 'Torch',
+          __type: 'Torch',
+          px: [40, 64],
+          width: 16,
+          height: 32,
+          __pivot: [0, 0],
+          iid: 'torch-1',
+          defUid: 400,
+          fieldInstances: [],
+        },
+      ],
+    });
+
+    const object = ldtkToTileMap(data).levels[0]!.objectLayers[0]!.objects[0]!;
+    expect(object.x).toBe(40);
+    expect(object.y).toBe(64);
+  });
+
+  it('adjusts by the full width/height for a bottom-right pivot [1, 1]', () => {
+    const data = docWithLayer({
+      __identifier: 'Entities',
+      __type: 'Entities',
+      __cWid: 4,
+      __cHei: 4,
+      __gridSize: 16,
+      layerDefUid: 130,
+      levelId: 1,
+      visible: true,
+      iid: 'ent-1',
+      entityInstances: [
+        {
+          __identifier: 'Torch',
+          __type: 'Torch',
+          px: [40, 64],
+          width: 16,
+          height: 32,
+          __pivot: [1, 1],
+          iid: 'torch-1',
+          defUid: 400,
+          fieldInstances: [],
+        },
+      ],
+    });
+
+    const object = ldtkToTileMap(data).levels[0]!.objectLayers[0]!.objects[0]!;
+    expect(object.x).toBe(24); // 40 - 16
+    expect(object.y).toBe(32); // 64 - 32
+  });
+});
+
 // ── Grid-size derivation ────────────────────────────────────────────────────────
 
 describe('ldtkToTileMap — level tile size derivation', () => {
@@ -727,6 +825,7 @@ describe('ldtkToTileMap — entity field projection', () => {
           px: [0, 0],
           width: 16,
           height: 16,
+          __pivot: [0, 0],
           iid: 'npc-1',
           defUid: 300,
           fieldInstances: [
@@ -768,6 +867,7 @@ describe('ldtkToTileMap — entity field projection', () => {
           px: [0, 0],
           width: 16,
           height: 16,
+          __pivot: [0, 0],
           iid: 'npc-1',
           defUid: 300,
           fieldInstances: [{ __identifier: 'hp', __type: 'Int', __value: 10 }],
@@ -797,6 +897,7 @@ describe('ldtkToTileMap — entity field projection', () => {
           px: [0, 0],
           width: 0,
           height: 0,
+          __pivot: [0, 0],
           iid: 'm-1',
           defUid: 301,
           fieldInstances: [],
@@ -827,6 +928,7 @@ describe('ldtkToTileMap — entity field projection', () => {
           px: [3, 5],
           width: 16,
           height: 16,
+          __pivot: [0, 0],
           iid: 'door-1',
           defUid: 302,
           fieldInstances: [],
@@ -947,6 +1049,7 @@ function makeEntity(identifier: string): LdtkEntityInstance {
     px: [0, 0],
     width: 16,
     height: 16,
+    __pivot: [0, 0],
     iid: `iid-${identifier}`,
     defUid: 0,
     fieldInstances: [],

--- a/packages/exojs-ldtk/test/ldtk-conversion.test.ts
+++ b/packages/exojs-ldtk/test/ldtk-conversion.test.ts
@@ -1,7 +1,7 @@
 import { type Texture, TextureRegion } from '@codexo/exojs';
 import type { TileProperties } from '@codexo/exojs-tilemap';
 import { TileSet } from '@codexo/exojs-tilemap';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type {
   LdtkData,
@@ -454,6 +454,72 @@ describe('ldtkToTileMap — IntGrid value exposure', () => {
 
     const layer = ldtkToTileMap(data).levels[0]!.layers[0]!;
     expect(getLdtkIntGridValueAt(layer, 0, 0)).toBeUndefined();
+  });
+
+  it('parses the CSV/value-defs JSON only once per layer, regardless of call count', () => {
+    const data = docWithLayer({
+      __identifier: 'Collision',
+      __type: 'IntGrid',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 120,
+      levelId: 1,
+      visible: true,
+      iid: 'int-1',
+      intGridCsv: [1, 0, 2, 1],
+    });
+    const withDefs: LdtkData = {
+      ...data,
+      defs: {
+        tilesets: [],
+        layers: [
+          {
+            uid: 120,
+            identifier: 'Collision',
+            type: 'IntGrid',
+            gridSize: 16,
+            intGridValues: [
+              { value: 1, identifier: 'Wall', color: '#ff0000' },
+              { value: 2, identifier: 'Water', color: '#0000ff' },
+            ],
+          },
+        ],
+      },
+    };
+
+    const layer = ldtkToTileMap(withDefs).levels[0]!.layers[0]!;
+
+    const parseSpy = vi.spyOn(JSON, 'parse');
+    try {
+      // Repeated lookups across the whole layer, several times over — a
+      // naive implementation would re-parse both JSON-encoded properties on
+      // every single call.
+      for (let pass = 0; pass < 5; pass++) {
+        expect(getLdtkIntGridValueAt(layer, 0, 0)).toEqual({
+          value: 1,
+          identifier: 'Wall',
+          color: '#ff0000',
+        });
+        expect(getLdtkIntGridValueAt(layer, 1, 0)).toBeUndefined();
+        expect(getLdtkIntGridValueAt(layer, 2, 0)).toEqual({
+          value: 2,
+          identifier: 'Water',
+          color: '#0000ff',
+        });
+        expect(getLdtkIntGridValueAt(layer, 3, 0)).toEqual({
+          value: 1,
+          identifier: 'Wall',
+          color: '#ff0000',
+        });
+      }
+
+      // One parse for the CSV array, one for the value-defs array — cached
+      // after the first lookup and reused for every subsequent call.
+      expect(parseSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      parseSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/exojs-ldtk/test/ldtk-conversion.test.ts
+++ b/packages/exojs-ldtk/test/ldtk-conversion.test.ts
@@ -423,6 +423,96 @@ describe('ldtkToTileMap — IntGrid value exposure', () => {
   });
 });
 
+// ── Level field instances ────────────────────────────────────────────────────────
+
+describe('ldtkToTileMap — level field instances', () => {
+  it('merges scalar level field instances into TileMap.properties', () => {
+    const data: LdtkData = {
+      jsonVersion: '1.5.3',
+      defaultGridSize: 16,
+      defs: { tilesets: [], layers: [] },
+      levels: [
+        {
+          identifier: 'L',
+          uid: 7,
+          iid: 'iid-7',
+          worldX: 0,
+          worldY: 0,
+          pxWid: 32,
+          pxHei: 32,
+          layerInstances: [],
+          fieldInstances: [
+            { __identifier: 'difficulty', __type: 'String', __value: 'hard' },
+            { __identifier: 'timeLimit', __type: 'Int', __value: 60 },
+          ],
+        },
+      ],
+    };
+
+    const map = ldtkToTileMap(data).levels[0]!;
+    expect(map.properties['difficulty']).toBe('hard');
+    expect(map.properties['timeLimit']).toBe(60);
+    expect(map.properties['ldtkUid']).toBe(7);
+    expect(map.properties['ldtkIid']).toBe('iid-7');
+  });
+
+  it('never lets a user-defined field clobber a reserved key (reserved keys win)', () => {
+    const data: LdtkData = {
+      jsonVersion: '1.5.3',
+      defaultGridSize: 16,
+      defs: { tilesets: [], layers: [] },
+      levels: [
+        {
+          identifier: 'L',
+          uid: 7,
+          iid: 'iid-7',
+          worldX: 0,
+          worldY: 0,
+          pxWid: 32,
+          pxHei: 32,
+          layerInstances: [],
+          fieldInstances: [
+            { __identifier: 'ldtkUid', __type: 'Int', __value: 999 },
+            { __identifier: 'worldX', __type: 'Int', __value: -1 },
+          ],
+        },
+      ],
+    };
+
+    const map = ldtkToTileMap(data).levels[0]!;
+    expect(map.properties['ldtkUid']).toBe(7);
+    expect(map.properties['worldX']).toBe(0);
+  });
+
+  it('produces only the reserved keys when fieldInstances is absent', () => {
+    const data: LdtkData = {
+      jsonVersion: '1.5.3',
+      defaultGridSize: 16,
+      defs: { tilesets: [], layers: [] },
+      levels: [
+        {
+          identifier: 'L',
+          uid: 1,
+          iid: 'iid-1',
+          worldX: 0,
+          worldY: 0,
+          pxWid: 32,
+          pxHei: 32,
+          layerInstances: [],
+        },
+      ],
+    };
+
+    const map = ldtkToTileMap(data).levels[0]!;
+    expect(Object.keys(map.properties).sort()).toEqual([
+      'ldtkIid',
+      'ldtkUid',
+      'worldX',
+      'worldY',
+    ]);
+  });
+});
+
 // ── Grid-size derivation ────────────────────────────────────────────────────────
 
 describe('ldtkToTileMap — level tile size derivation', () => {

--- a/packages/exojs-ldtk/test/ldtk-conversion.test.ts
+++ b/packages/exojs-ldtk/test/ldtk-conversion.test.ts
@@ -1,10 +1,12 @@
 import { type Texture, TextureRegion } from '@codexo/exojs';
+import type { TileProperties } from '@codexo/exojs-tilemap';
 import { TileSet } from '@codexo/exojs-tilemap';
 import { describe, expect, it } from 'vitest';
 
 import type {
   LdtkData,
   LdtkEntityInstance,
+  LdtkFieldInstance,
   LdtkLayerInstance,
   LdtkLevel,
 } from '../src/LdtkData';
@@ -54,6 +56,38 @@ function docWithLayer(layer: LdtkLayerInstance, level: Partial<LdtkLevel> = {}):
       },
     ],
   };
+}
+
+/**
+ * Convert a document with one Entities layer holding exactly one entity with
+ * exactly one field, returning that entity's converted properties bag.
+ */
+function convertSingleField(field: LdtkFieldInstance): TileProperties {
+  const data = docWithLayer({
+    __identifier: 'Entities',
+    __type: 'Entities',
+    __cWid: 4,
+    __cHei: 1,
+    __gridSize: 16,
+    layerDefUid: 130,
+    levelId: 1,
+    visible: true,
+    iid: 'ent-1',
+    entityInstances: [
+      {
+        __identifier: 'E',
+        __type: 'E',
+        px: [0, 0],
+        width: 16,
+        height: 16,
+        __pivot: [0, 0],
+        iid: 'e-1',
+        defUid: 0,
+        fieldInstances: [field],
+      },
+    ],
+  });
+  return ldtkToTileMap(data).levels[0]!.objectLayers[0]!.objects[0]!.properties;
 }
 
 // ── Flip-bit constants ──────────────────────────────────────────────────────────
@@ -807,7 +841,7 @@ describe('ldtkToTileMap — TileLayer metadata', () => {
 // ── Entity → ObjectLayer conversion ─────────────────────────────────────────────
 
 describe('ldtkToTileMap — entity field projection', () => {
-  it('keeps scalar fields and drops complex (array/object/null) field values', () => {
+  it('keeps scalar fields, maps structured/array fields, and omits null-valued fields', () => {
     const data = docWithLayer({
       __identifier: 'Entities',
       __type: 'Entities',
@@ -833,7 +867,6 @@ describe('ldtkToTileMap — entity field projection', () => {
             { __identifier: 'label', __type: 'String', __value: 'Bob' },
             { __identifier: 'hostile', __type: 'Bool', __value: true },
             { __identifier: 'path', __type: 'Array<Point>', __value: [{ cx: 1, cy: 2 }] },
-            { __identifier: 'meta', __type: 'Object', __value: { k: 1 } },
             { __identifier: 'nothing', __type: 'String', __value: null },
           ],
         },
@@ -844,8 +877,7 @@ describe('ldtkToTileMap — entity field projection', () => {
     expect(props['hp']).toBe(10);
     expect(props['label']).toBe('Bob');
     expect(props['hostile']).toBe(true);
-    expect(props['path']).toBeUndefined();
-    expect(props['meta']).toBeUndefined();
+    expect(props['path']).toEqual([{ kind: 'point', cx: 1, cy: 2 }]);
     expect(props['nothing']).toBeUndefined();
   });
 
@@ -943,6 +975,144 @@ describe('ldtkToTileMap — entity field projection', () => {
     expect(object.rotation).toBe(0);
     expect(object.visible).toBe(true);
   });
+});
+
+// ── Structured field types (Point / EntityRef / Tile / Array) ───────────────────
+
+describe('ldtkToTileMap — Point field conversion', () => {
+  it('maps a Point field to a TilePropertyPoint', () => {
+    const props = convertSingleField({
+      __identifier: 'spawn',
+      __type: 'Point',
+      __value: { cx: 3, cy: 4 },
+    });
+
+    expect(props['spawn']).toEqual({ kind: 'point', cx: 3, cy: 4 });
+  });
+
+  it('omits a null-valued Point field', () => {
+    const props = convertSingleField({
+      __identifier: 'spawn',
+      __type: 'Point',
+      __value: null,
+    });
+
+    expect(props['spawn']).toBeUndefined();
+    expect('spawn' in props).toBe(false);
+  });
+});
+
+describe('ldtkToTileMap — EntityRef field conversion', () => {
+  it('maps an EntityRef field to a TilePropertyObjectRef, threading all 4 source fields through', () => {
+    const props = convertSingleField({
+      __identifier: 'target',
+      __type: 'EntityRef',
+      __value: {
+        entityIid: 'target-entity-iid',
+        layerIid: 'target-layer-iid',
+        levelIid: 'target-level-iid',
+        worldIid: 'target-world-iid',
+      },
+    });
+
+    expect(props['target']).toEqual({
+      kind: 'objectRef',
+      id: 'target-entity-iid',
+      layerIid: 'target-layer-iid',
+      levelIid: 'target-level-iid',
+      worldIid: 'target-world-iid',
+    });
+  });
+
+  it('omits a null-valued EntityRef field', () => {
+    const props = convertSingleField({
+      __identifier: 'target',
+      __type: 'EntityRef',
+      __value: null,
+    });
+
+    expect('target' in props).toBe(false);
+  });
+});
+
+describe('ldtkToTileMap — Tile field conversion', () => {
+  it('maps a Tile field to a TilePropertyTileRef', () => {
+    const props = convertSingleField({
+      __identifier: 'icon',
+      __type: 'Tile',
+      __value: { tilesetUid: 7, x: 16, y: 32, w: 16, h: 16 },
+    });
+
+    expect(props['icon']).toEqual({ kind: 'tileRef', tilesetUid: 7, x: 16, y: 32, w: 16, h: 16 });
+  });
+
+  it('omits a null-valued Tile field', () => {
+    const props = convertSingleField({
+      __identifier: 'icon',
+      __type: 'Tile',
+      __value: null,
+    });
+
+    expect('icon' in props).toBe(false);
+  });
+});
+
+describe('ldtkToTileMap — Array field conversion', () => {
+  it('maps an Array<Int> field to a plain array of numbers', () => {
+    const props = convertSingleField({
+      __identifier: 'scores',
+      __type: 'Array<Int>',
+      __value: [1, 2, 3],
+    });
+
+    expect(props['scores']).toEqual([1, 2, 3]);
+  });
+
+  it('maps an Array<Point> field to an array of TilePropertyPoint (nested complex conversion)', () => {
+    const props = convertSingleField({
+      __identifier: 'path',
+      __type: 'Array<Point>',
+      __value: [
+        { cx: 0, cy: 0 },
+        { cx: 1, cy: 2 },
+      ],
+    });
+
+    expect(props['path']).toEqual([
+      { kind: 'point', cx: 0, cy: 0 },
+      { kind: 'point', cx: 1, cy: 2 },
+    ]);
+  });
+
+  it('omits a null-valued Array field', () => {
+    const props = convertSingleField({
+      __identifier: 'scores',
+      __type: 'Array<Int>',
+      __value: null,
+    });
+
+    expect('scores' in props).toBe(false);
+  });
+
+  it('maps an empty array to an empty array (still present, not omitted)', () => {
+    const props = convertSingleField({
+      __identifier: 'scores',
+      __type: 'Array<Int>',
+      __value: [],
+    });
+
+    expect(props['scores']).toEqual([]);
+  });
+});
+
+describe('ldtkToTileMap — null-valued scalar fields (all scalar types)', () => {
+  it.each(['Int', 'Float', 'Bool', 'String', 'Multilines', 'Color', 'FilePath', 'Enum'] as const)(
+    'omits a null-valued %s field',
+    __type => {
+      const props = convertSingleField({ __identifier: 'x', __type, __value: null });
+      expect('x' in props).toBe(false);
+    },
+  );
 });
 
 describe('ldtkToTileMap — ObjectLayer metadata', () => {

--- a/packages/exojs-ldtk/test/ldtk-map.test.ts
+++ b/packages/exojs-ldtk/test/ldtk-map.test.ts
@@ -1,7 +1,7 @@
 import type { TileMap } from '@codexo/exojs-tilemap';
 import { describe, expect, it, vi } from 'vitest';
 
-import type { LdtkData, LdtkLevel } from '../src/LdtkData';
+import type { LdtkData, LdtkLevel, LdtkWorldData } from '../src/LdtkData';
 import { LdtkMap } from '../src/LdtkMap';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -27,6 +27,38 @@ function makeData(identifiers: readonly string[]): LdtkData {
     defaultGridSize: 16,
     defs: { tilesets: [], layers: [] },
     levels: identifiers.map((id, i) => makeLevel(id, i + 1)),
+  };
+}
+
+/** Build a bare LDtk world record carrying the given level identifiers. */
+function makeWorld(worldIid: string, identifiers: readonly string[], uidStart: number): LdtkWorldData {
+  return {
+    identifier: worldIid,
+    iid: worldIid,
+    worldGridWidth: 256,
+    worldGridHeight: 256,
+    worldLayout: 'Free',
+    levels: identifiers.map((id, i) => makeLevel(id, uidStart + i)),
+  };
+}
+
+/**
+ * Build multi-world LdtkData: root `levels` stays empty (per the LDtk spec's
+ * backward-compatibility shape) and every level lives under `worlds[].levels`.
+ */
+function makeMultiWorldData(worlds: ReadonlyMap<string, readonly string[]>): LdtkData {
+  let uidCursor = 1;
+  const worldEntries: LdtkWorldData[] = [];
+  for (const [worldIid, identifiers] of worlds) {
+    worldEntries.push(makeWorld(worldIid, identifiers, uidCursor));
+    uidCursor += identifiers.length;
+  }
+  return {
+    jsonVersion: '1.5.3',
+    defaultGridSize: 16,
+    defs: { tilesets: [], layers: [] },
+    levels: [],
+    worlds: worldEntries,
   };
 }
 
@@ -97,6 +129,36 @@ describe('LdtkMap.getLevelByName', () => {
     const map = new LdtkMap('', data, [makeFakeTileMap()]);
 
     expect(map.getLevelByName('External')).toBeUndefined();
+  });
+
+  describe('multi-world documents (data.worlds present)', () => {
+    it('finds levels across every world, not just the (empty) root levels array', () => {
+      const data = makeMultiWorldData(
+        new Map([
+          ['world-a', ['A1', 'A2']],
+          ['world-b', ['B1']],
+        ]),
+      );
+      const a1 = makeFakeTileMap();
+      const a2 = makeFakeTileMap();
+      const b1 = makeFakeTileMap();
+      const map = new LdtkMap('', data, [a1, a2, b1]);
+
+      // Regression guard: root `data.levels` is empty in the multi-world
+      // shape — a naive `data.levels.findIndex(...)` lookup would silently
+      // fail to find any of these.
+      expect(data.levels).toHaveLength(0);
+      expect(map.getLevelByName('A1')).toBe(a1);
+      expect(map.getLevelByName('A2')).toBe(a2);
+      expect(map.getLevelByName('B1')).toBe(b1);
+    });
+
+    it('returns undefined for an identifier that exists in no world', () => {
+      const data = makeMultiWorldData(new Map([['world-a', ['A1']]]));
+      const map = new LdtkMap('', data, [makeFakeTileMap()]);
+
+      expect(map.getLevelByName('Missing')).toBeUndefined();
+    });
   });
 });
 

--- a/packages/exojs-ldtk/test/ldtkToTileMap.test.ts
+++ b/packages/exojs-ldtk/test/ldtkToTileMap.test.ts
@@ -163,6 +163,69 @@ const layeredData: LdtkData = {
   ],
 };
 
+/** Multi-world document: two worlds, each owning its own `levels[]`. */
+const multiWorldData: LdtkData = {
+  jsonVersion: '1.5.3',
+  defaultGridSize: 16,
+  defs: {
+    tilesets: [],
+    layers: [],
+  },
+  // Root `levels` is kept empty per the LDtk spec's backward-compat shape
+  // when `worlds` is used.
+  levels: [],
+  worlds: [
+    {
+      identifier: 'WorldA',
+      iid: 'world-a-iid',
+      worldGridWidth: 256,
+      worldGridHeight: 256,
+      worldLayout: 'GridVania',
+      levels: [
+        {
+          identifier: 'A_Level1',
+          uid: 20,
+          iid: 'aaaaaaaa-0000-0000-0000-000000000020',
+          worldX: 0,
+          worldY: 0,
+          pxWid: 64,
+          pxHei: 64,
+          layerInstances: [],
+        },
+        {
+          identifier: 'A_Level2',
+          uid: 21,
+          iid: 'aaaaaaaa-0000-0000-0000-000000000021',
+          worldX: 64,
+          worldY: 0,
+          pxWid: 32,
+          pxHei: 32,
+          layerInstances: [],
+        },
+      ],
+    },
+    {
+      identifier: 'WorldB',
+      iid: 'world-b-iid',
+      worldGridWidth: 128,
+      worldGridHeight: 128,
+      worldLayout: 'Free',
+      levels: [
+        {
+          identifier: 'B_Level1',
+          uid: 30,
+          iid: 'bbbbbbbb-0000-0000-0000-000000000030',
+          worldX: 0,
+          worldY: 0,
+          pxWid: 16,
+          pxHei: 16,
+          layerInstances: [],
+        },
+      ],
+    },
+  ],
+};
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('ldtkToTileMap', () => {
@@ -304,6 +367,45 @@ describe('ldtkToTileMap', () => {
       const result = ldtkToTileMap(minimalData);
       // Just ensure destroy() does not throw
       expect(() => result.destroy()).not.toThrow();
+    });
+  });
+
+  describe('multi-world documents (data.worlds present)', () => {
+    it('flattens every world into result.levels, in world order', () => {
+      const result = ldtkToTileMap(multiWorldData);
+      expect(result.levels).toHaveLength(3);
+      expect(result.levels.map(l => l.name)).toEqual(['A_Level1', 'A_Level2', 'B_Level1']);
+    });
+
+    it("tags each level's properties with its owning world's iid", () => {
+      const result = ldtkToTileMap(multiWorldData);
+      expect(result.levels[0]?.properties['ldtkWorldIid']).toBe('world-a-iid');
+      expect(result.levels[1]?.properties['ldtkWorldIid']).toBe('world-a-iid');
+      expect(result.levels[2]?.properties['ldtkWorldIid']).toBe('world-b-iid');
+    });
+
+    it('finds levels across worlds via getLevelByName', () => {
+      const result = ldtkToTileMap(multiWorldData);
+      expect(result.getLevelByName('A_Level2')).toBe(result.levels[1]);
+      expect(result.getLevelByName('B_Level1')).toBe(result.levels[2]);
+      expect(result.getLevelByName('Missing')).toBeUndefined();
+    });
+
+    it('still records ordinary reserved level metadata alongside ldtkWorldIid', () => {
+      const result = ldtkToTileMap(multiWorldData);
+      const map = result.levels[1];
+      expect(map?.properties['ldtkUid']).toBe(21);
+      expect(map?.properties['worldX']).toBe(64);
+      expect(map?.properties['worldY']).toBe(0);
+    });
+  });
+
+  describe('single-world backward compatibility (no data.worlds)', () => {
+    it('never adds an ldtkWorldIid property key when the document has no worlds', () => {
+      const result = ldtkToTileMap(multiLevelData);
+      for (const level of result.levels) {
+        expect(Object.hasOwn(level.properties, 'ldtkWorldIid')).toBe(false);
+      }
     });
   });
 });

--- a/packages/exojs-ldtk/test/ldtkToTileMap.test.ts
+++ b/packages/exojs-ldtk/test/ldtkToTileMap.test.ts
@@ -137,6 +137,7 @@ const layeredData: LdtkData = {
               px: [32, 48],
               width: 16,
               height: 16,
+              __pivot: [0, 0],
               fieldInstances: [
                 { __identifier: 'speed', __type: 'Float', __value: 1.5 },
                 { __identifier: 'name', __type: 'String', __value: 'Hero' },
@@ -150,6 +151,7 @@ const layeredData: LdtkData = {
               px: [64, 32],
               width: 8,
               height: 8,
+              __pivot: [0, 0],
               fieldInstances: [],
               iid: 'cccccccc-0000-0000-0000-000000000002',
               defUid: 201,

--- a/packages/exojs-ldtk/test/load-ldtk-map.test.ts
+++ b/packages/exojs-ldtk/test/load-ldtk-map.test.ts
@@ -104,6 +104,103 @@ describe('loadLdtkMap — happy path (absolute source)', () => {
   });
 });
 
+describe('loadLdtkMap — external levels (.ldtkl)', () => {
+  // "Save levels to separate files" projects null out layerInstances on the
+  // root document and store the real layer data in a sibling `<id>.ldtkl`
+  // file referenced by externalRelPath.
+  const EXTERNAL_URL = 'https://example.com/maps/levels/Level_0.ldtkl';
+
+  const rootFixture: LdtkData = {
+    jsonVersion: '1.5.3',
+    defaultGridSize: 16,
+    defs: {
+      tilesets: [],
+      layers: [{ uid: 101, identifier: 'Entities', type: 'Entities', gridSize: 16 }],
+    },
+    levels: [
+      {
+        identifier: 'Level_0',
+        uid: 1,
+        iid: 'iid-1',
+        worldX: 0,
+        worldY: 0,
+        pxWid: 64,
+        pxHei: 16,
+        layerInstances: null,
+        externalRelPath: 'levels/Level_0.ldtkl',
+        // The root doc's own fieldInstances copy is stale/stripped once a
+        // level is externalized; the .ldtkl file's copy is authoritative.
+        fieldInstances: [{ __identifier: 'stale', __type: 'String', __value: 'root' }],
+      },
+    ],
+  };
+
+  const externalFixture = {
+    identifier: 'Level_0',
+    uid: 1,
+    iid: 'iid-1',
+    worldX: 0,
+    worldY: 0,
+    pxWid: 64,
+    pxHei: 16,
+    fieldInstances: [{ __identifier: 'difficulty', __type: 'String', __value: 'hard' }],
+    layerInstances: [
+      {
+        __identifier: 'Entities',
+        __type: 'Entities',
+        __cWid: 4,
+        __cHei: 1,
+        __gridSize: 16,
+        layerDefUid: 101,
+        levelId: 1,
+        visible: true,
+        iid: 'ent-1',
+        entityInstances: [
+          {
+            __identifier: 'Player',
+            __type: 'Player',
+            px: [8, 8],
+            width: 16,
+            height: 16,
+            __pivot: [0, 0],
+            fieldInstances: [],
+            iid: 'player-1',
+            defUid: 200,
+          },
+        ],
+      },
+    ],
+  };
+
+  function context() {
+    return makeContext({
+      [ABS_SOURCE]: rootFixture,
+      [EXTERNAL_URL]: externalFixture,
+    });
+  }
+
+  it('fetches the external .ldtkl file for a level with null layerInstances', async () => {
+    const { context: ctx } = context();
+    await loadLdtkMap(ABS_SOURCE, ctx);
+    expect(ctx.fetchJson).toHaveBeenCalledWith(EXTERNAL_URL);
+  });
+
+  it('merges the external layerInstances into the level before conversion (no longer empty)', async () => {
+    const map = await loadLdtkMap(ABS_SOURCE, context().context);
+    const level = map.levels[0]!;
+    expect(level.objectLayers).toHaveLength(1);
+    expect(level.objectLayers[0]!.objects).toHaveLength(1);
+    expect(level.objectLayers[0]!.objects[0]!.type).toBe('Player');
+  });
+
+  it('prefers the external fieldInstances over the stale root copy', async () => {
+    const map = await loadLdtkMap(ABS_SOURCE, context().context);
+    const level = map.levels[0]!;
+    expect(level.properties['difficulty']).toBe('hard');
+    expect(level.properties['stale']).toBeUndefined();
+  });
+});
+
 describe('loadLdtkMap — tilesets without an atlas image', () => {
   // relPath: null → the tileset is skipped entirely; tiles cannot render.
   const fixture: LdtkData = {

--- a/packages/exojs-ldtk/test/load-ldtk-map.test.ts
+++ b/packages/exojs-ldtk/test/load-ldtk-map.test.ts
@@ -102,6 +102,172 @@ describe('loadLdtkMap — happy path (absolute source)', () => {
     expect(objectLayers).toHaveLength(1);
     expect(objectLayers[0]!.objects[0]!.type).toBe('Player');
   });
+
+  it('never adds an ldtkWorldIid property key for a single-world document (backward-compat guard)', async () => {
+    const map = await loadLdtkMap(ABS_SOURCE, context().context);
+    expect(Object.hasOwn(map.levels[0]!.properties, 'ldtkWorldIid')).toBe(false);
+  });
+});
+
+describe('loadLdtkMap — multi-world (worlds[] present)', () => {
+  const MULTI_WORLD_SOURCE = 'https://example.com/maps/multi-world.ldtk';
+
+  function context() {
+    return makeContext({ [MULTI_WORLD_SOURCE]: loadFixture('multi-world.ldtk') });
+  }
+
+  it('flattens every world into map.levels, in world order', async () => {
+    const map = await loadLdtkMap(MULTI_WORLD_SOURCE, context().context);
+    expect(map.levels).toHaveLength(3);
+    expect(map.levels.map(l => l.name)).toEqual(['A_Level1', 'A_Level2', 'B_Level1']);
+  });
+
+  it("tags each level's properties with its owning world's iid", async () => {
+    const map = await loadLdtkMap(MULTI_WORLD_SOURCE, context().context);
+    expect(map.levels[0]!.properties['ldtkWorldIid']).toBe('world-a-iid');
+    expect(map.levels[1]!.properties['ldtkWorldIid']).toBe('world-a-iid');
+    expect(map.levels[2]!.properties['ldtkWorldIid']).toBe('world-b-iid');
+  });
+
+  it('finds levels across worlds via getLevelByName', async () => {
+    const map = await loadLdtkMap(MULTI_WORLD_SOURCE, context().context);
+    expect(map.getLevelByName('A_Level1')).toBe(map.levels[0]);
+    expect(map.getLevelByName('B_Level1')).toBe(map.levels[2]);
+    expect(map.getLevelByName('Missing')).toBeUndefined();
+  });
+
+  it('populates tile/entity data for a level nested inside a world (defs shared at root)', async () => {
+    const map = await loadLdtkMap(MULTI_WORLD_SOURCE, context().context);
+    const tilesLayer = map.levels[0]!.layers.find(l => l.name === 'Tiles')!;
+    expect(tilesLayer.countNonEmptyTiles()).toBe(2);
+    expect(map.levels[0]!.objectLayers[0]!.objects[0]!.type).toBe('Player');
+  });
+});
+
+describe('loadLdtkMap — multi-world with an external (.ldtkl) level', () => {
+  // Combines Task 2's world-flattening with the existing external-level
+  // resolution: one level in World A is externalized; World B's level is
+  // stored inline. Both must resolve correctly through the same flattened
+  // pass.
+  const MULTI_SOURCE = 'https://example.com/maps/multi-external.ldtk';
+  const EXTERNAL_URL = 'https://example.com/maps/levels/A_External.ldtkl';
+
+  const rootFixture: LdtkData = {
+    jsonVersion: '1.5.3',
+    defaultGridSize: 16,
+    defs: {
+      tilesets: [],
+      layers: [{ uid: 101, identifier: 'Entities', type: 'Entities', gridSize: 16 }],
+    },
+    levels: [],
+    worlds: [
+      {
+        identifier: 'WorldA',
+        iid: 'world-a-iid',
+        worldGridWidth: 256,
+        worldGridHeight: 256,
+        worldLayout: 'Free',
+        levels: [
+          {
+            identifier: 'A_External',
+            uid: 1,
+            iid: 'iid-a-external',
+            worldX: 0,
+            worldY: 0,
+            pxWid: 64,
+            pxHei: 16,
+            layerInstances: null,
+            externalRelPath: 'levels/A_External.ldtkl',
+          },
+        ],
+      },
+      {
+        identifier: 'WorldB',
+        iid: 'world-b-iid',
+        worldGridWidth: 128,
+        worldGridHeight: 128,
+        worldLayout: 'Free',
+        levels: [
+          {
+            identifier: 'B_Inline',
+            uid: 2,
+            iid: 'iid-b-inline',
+            worldX: 0,
+            worldY: 0,
+            pxWid: 16,
+            pxHei: 16,
+            layerInstances: [],
+          },
+        ],
+      },
+    ],
+  };
+
+  const externalFixture = {
+    identifier: 'A_External',
+    uid: 1,
+    iid: 'iid-a-external',
+    worldX: 0,
+    worldY: 0,
+    pxWid: 64,
+    pxHei: 16,
+    fieldInstances: [],
+    layerInstances: [
+      {
+        __identifier: 'Entities',
+        __type: 'Entities',
+        __cWid: 4,
+        __cHei: 1,
+        __gridSize: 16,
+        layerDefUid: 101,
+        levelId: 1,
+        visible: true,
+        iid: 'ent-a-external',
+        entityInstances: [
+          {
+            __identifier: 'Player',
+            __type: 'Player',
+            px: [8, 8],
+            width: 16,
+            height: 16,
+            __pivot: [0, 0],
+            fieldInstances: [],
+            iid: 'player-a-external',
+            defUid: 200,
+          },
+        ],
+      },
+    ],
+  };
+
+  function context() {
+    return makeContext({
+      [MULTI_SOURCE]: rootFixture,
+      [EXTERNAL_URL]: externalFixture,
+    });
+  }
+
+  it('fetches the external .ldtkl file for the level nested inside a world', async () => {
+    const { context: ctx } = context();
+    await loadLdtkMap(MULTI_SOURCE, ctx);
+    expect(ctx.fetchJson).toHaveBeenCalledWith(EXTERNAL_URL);
+  });
+
+  it('merges the resolved external level into map.levels alongside the inline one', async () => {
+    const map = await loadLdtkMap(MULTI_SOURCE, context().context);
+    expect(map.levels).toHaveLength(2);
+    expect(map.levels.map(l => l.name)).toEqual(['A_External', 'B_Inline']);
+
+    const external = map.levels[0]!;
+    expect(external.objectLayers).toHaveLength(1);
+    expect(external.objectLayers[0]!.objects[0]!.type).toBe('Player');
+  });
+
+  it("still tags the externally-resolved level with its owning world's iid", async () => {
+    const map = await loadLdtkMap(MULTI_SOURCE, context().context);
+    expect(map.levels[0]!.properties['ldtkWorldIid']).toBe('world-a-iid');
+    expect(map.levels[1]!.properties['ldtkWorldIid']).toBe('world-b-iid');
+  });
 });
 
 describe('loadLdtkMap — external levels (.ldtkl)', () => {

--- a/packages/exojs-tiled/src/TiledMap.ts
+++ b/packages/exojs-tiled/src/TiledMap.ts
@@ -1,8 +1,8 @@
 import { type Texture, TextureRegion } from '@codexo/exojs';
 import type { ObjectPoint, ResolvedTile, TextStyle, TileAnimationFrame, TileDefinition, TileMapObject, TileProperties, TilePropertyValue, TileTransform } from '@codexo/exojs-tilemap';
-import { ImageLayer, ObjectLayer, TileLayer, TileMap, TileSet } from '@codexo/exojs-tilemap';
+import { ImageLayer, ObjectLayer, TileLayer, TileMap, TilePropertyKind, TileSet } from '@codexo/exojs-tilemap';
 
-import type { TiledMapData, TiledObjectData, TiledOrientation, TiledPropertyData, TiledRenderOrder, TiledTileData } from './data';
+import type { TiledClassPropertyValueData, TiledMapData, TiledObjectData, TiledOrientation, TiledPropertyData, TiledRenderOrder, TiledTileData } from './data';
 import {
   maskTiledGid,
   TILED_FLIPPED_DIAGONALLY_FLAG,
@@ -504,17 +504,64 @@ function convertCollisionObject(obj: TiledObjectData): TileMapObject | null {
 }
 
 /**
- * Project Tiled custom properties to the generic flat property bag. Class /
- * object-valued properties are not representable and are skipped.
+ * Project Tiled custom properties to the generic flat property bag.
+ * `object`-typed properties become a {@link TilePropertyKind.ObjectRef}
+ * (the wire value is already the referenced object's numeric id — Tiled has
+ * no LDtk-style navigation fields, so those stay `undefined`). `class`-typed
+ * properties recursively convert their nested member bag into a
+ * {@link TileProperties}.
  */
 function convertProperties(properties: readonly TiledPropertyData[]): TileProperties {
   if (properties.length === 0) return Object.freeze({});
   const out: Record<string, TilePropertyValue> = {};
   for (const property of properties) {
-    const value = property.value;
-    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    const value = convertPropertyValue(property);
+    if (value !== undefined) {
       out[property.name] = value;
     }
+  }
+  return Object.freeze(out);
+}
+
+/** Convert one {@link TiledPropertyData} to its canonical {@link TilePropertyValue}. */
+function convertPropertyValue(property: TiledPropertyData): TilePropertyValue | undefined {
+  switch (property.type) {
+    case 'string':
+    case 'int':
+    case 'float':
+    case 'bool':
+    case 'color':
+    case 'file':
+      return property.value;
+
+    case 'object':
+      return { kind: TilePropertyKind.ObjectRef, id: property.value as number };
+
+    case 'class':
+      return convertClassPropertyValue(property.value as TiledClassPropertyValueData);
+
+    default: {
+      // Exhaustiveness check: if a new TiledPropertyType is ever added,
+      // `property.type` will fail to narrow to `never` here and tsc will error.
+      const _exhaustive: never = property.type;
+      void _exhaustive;
+      throw new Error(`convertProperties: unrecognised Tiled property type "${property.type as string}".`);
+    }
+  }
+}
+
+/**
+ * Recursively convert a `class`-typed property's nested member bag into a
+ * {@link TileProperties}. Scalar members pass through; nested-class members
+ * recurse (Tiled classes may nest arbitrarily deep).
+ */
+function convertClassPropertyValue(value: TiledClassPropertyValueData): TileProperties {
+  const out: Record<string, TilePropertyValue> = {};
+  for (const [name, member] of Object.entries(value)) {
+    out[name] =
+      typeof member === 'string' || typeof member === 'number' || typeof member === 'boolean'
+        ? member
+        : convertClassPropertyValue(member);
   }
   return Object.freeze(out);
 }

--- a/packages/exojs-tiled/src/TiledMap.ts
+++ b/packages/exojs-tiled/src/TiledMap.ts
@@ -540,7 +540,7 @@ function convertPropertyValue(property: TiledPropertyData): TilePropertyValue | 
       return { kind: TilePropertyKind.ObjectRef, id: property.value as number };
 
     case 'class':
-      return convertClassPropertyValue(property.value as TiledClassPropertyValueData);
+      return convertClassPropertyValue(property.value as TiledClassPropertyValueData, property.propertytype);
 
     default: {
       // Exhaustiveness check: if a new TiledPropertyType is ever added,
@@ -553,17 +553,35 @@ function convertPropertyValue(property: TiledPropertyData): TilePropertyValue | 
 }
 
 /**
+ * Reserved key under which a `class`-typed property's Tiled custom-class name
+ * ({@link TiledPropertyData.propertytype}, e.g. `"Stats"`) is stored inside the
+ * converted nested {@link TileProperties} bag, mirroring the `ldtkUid`/
+ * `ldtkWorldIid`-style reserved-metadata-key convention used by the LDtk
+ * adapter (`packages/exojs-ldtk/src/ldtkToTileMap.ts`). Only set on the
+ * top-level converted bag for a class-typed property that has a
+ * `propertytype` — nested-class members carry no `propertytype` of their own
+ * in Tiled's data model, so recursive calls never set it.
+ */
+const tiledClassNameProperty = 'tiledClassName';
+
+/**
  * Recursively convert a `class`-typed property's nested member bag into a
  * {@link TileProperties}. Scalar members pass through; nested-class members
- * recurse (Tiled classes may nest arbitrarily deep).
+ * recurse (Tiled classes may nest arbitrarily deep). When `propertytype` is
+ * given (the Tiled custom-class name), it is tagged onto the bag under the
+ * reserved {@link tiledClassNameProperty} key, applied last so it can never
+ * be clobbered by a same-named member.
  */
-function convertClassPropertyValue(value: TiledClassPropertyValueData): TileProperties {
+function convertClassPropertyValue(value: TiledClassPropertyValueData, propertytype?: string): TileProperties {
   const out: Record<string, TilePropertyValue> = {};
   for (const [name, member] of Object.entries(value)) {
     out[name] =
       typeof member === 'string' || typeof member === 'number' || typeof member === 'boolean'
         ? member
         : convertClassPropertyValue(member);
+  }
+  if (propertytype !== undefined) {
+    out[tiledClassNameProperty] = propertytype;
   }
   return Object.freeze(out);
 }

--- a/packages/exojs-tiled/src/TiledMap.ts
+++ b/packages/exojs-tiled/src/TiledMap.ts
@@ -242,6 +242,7 @@ export class TiledMap {
             tintColor: parseTiledColor(layer.tintColor),
             repeatX: layer.repeatX,
             repeatY: layer.repeatY,
+            properties: convertProperties(layer.properties),
           }));
         }
       }

--- a/packages/exojs-tiled/src/TiledMap.ts
+++ b/packages/exojs-tiled/src/TiledMap.ts
@@ -262,6 +262,7 @@ export class TiledMap {
       class: this.class,
       backgroundColor: parseTiledColor(this.backgroundColor),
       renderOrder: this.renderOrder ?? 'right-down',
+      properties: convertProperties(this.properties),
     });
   }
 

--- a/packages/exojs-tiled/test/TiledMap.test.ts
+++ b/packages/exojs-tiled/test/TiledMap.test.ts
@@ -363,7 +363,41 @@ describe('TiledMap.toTileMap — object/class property conversion', () => {
       locked: true,
       label: 'Vault',
       access: { level: 2, tags: { vip: true } },
+      tiledClassName: 'DoorConfig',
     });
+  });
+
+  it('tags a class-typed property with its Tiled propertytype under the reserved tiledClassName key', () => {
+    const tm = makeObjectPropsMap([{
+      name: 'stats',
+      type: 'class',
+      propertytype: 'Stats',
+      value: { hp: 10 },
+    }]);
+    const obj = tm.objectLayers[0]!.objects[0]!;
+    expect(obj.properties['stats']).toMatchObject({ hp: 10, tiledClassName: 'Stats' });
+  });
+
+  it('omits the reserved tiledClassName key on nested class members, which carry no propertytype of their own', () => {
+    const tm = makeObjectPropsMap([{
+      name: 'config',
+      type: 'class',
+      propertytype: 'DoorConfig',
+      value: { access: { level: 2 } },
+    }]);
+    const obj = tm.objectLayers[0]!.objects[0]!;
+    const config = obj.properties['config'] as Record<string, unknown>;
+    expect(config['access']).toEqual({ level: 2 });
+  });
+
+  it('omits the reserved tiledClassName key when the class-typed property has no propertytype', () => {
+    const tm = makeObjectPropsMap([{
+      name: 'config',
+      type: 'class',
+      value: { locked: true },
+    }]);
+    const obj = tm.objectLayers[0]!.objects[0]!;
+    expect(obj.properties['config']).toEqual({ locked: true });
   });
 
   it('keeps scalar properties unaffected alongside object/class properties', () => {

--- a/packages/exojs-tiled/test/TiledMap.test.ts
+++ b/packages/exojs-tiled/test/TiledMap.test.ts
@@ -377,6 +377,26 @@ describe('TiledMap.toTileMap — object/class property conversion', () => {
   });
 });
 
+describe('TiledMap.toTileMap — map-level property conversion', () => {
+  it('carries map-level custom properties into TileMap.properties', () => {
+    const data = validateTiledMapData({
+      ...RAW_MINIMAL,
+      properties: [
+        { name: 'biome', type: 'string', value: 'forest' },
+        { name: 'maxPlayers', type: 'int', value: 4 },
+      ],
+    }, 'mapprops.tmj');
+    const tm = new TiledMap('mapprops.tmj', data, [ATLAS_TILESET]).toTileMap();
+    expect(tm.properties['biome']).toBe('forest');
+    expect(tm.properties['maxPlayers']).toBe(4);
+  });
+
+  it('defaults TileMap.properties to an empty bag when the map has no custom properties', () => {
+    const tm = makeAtlasMap().toTileMap();
+    expect(tm.properties).toEqual({});
+  });
+});
+
 describe('TiledMap.toTileMap — error cases', () => {
   it('throws TiledFormatError for a collection-of-images tileset', () => {
     const collectionTs = new TiledTileset(

--- a/packages/exojs-tiled/test/TiledMap.test.ts
+++ b/packages/exojs-tiled/test/TiledMap.test.ts
@@ -323,6 +323,60 @@ describe('TiledMap.toTileMap — multi-tileset', () => {
   });
 });
 
+describe('TiledMap.toTileMap — object/class property conversion', () => {
+  function makeObjectPropsMap(properties: readonly { name: string; type: string; value: unknown; propertytype?: string }[]): TileMap {
+    const data = validateTiledMapData({
+      type: 'map', version: '1.10', orientation: 'orthogonal', renderorder: 'right-down',
+      width: 1, height: 1, tilewidth: 16, tileheight: 16, infinite: false,
+      layers: [{
+        id: 1, name: 'Objects', type: 'objectgroup', visible: true, x: 0, y: 0, opacity: 1,
+        draworder: 'topdown',
+        objects: [{
+          id: 1, name: 'door', type: '', x: 0, y: 0, width: 16, height: 16,
+          rotation: 0, visible: true, properties,
+        }],
+      }],
+      tilesets: [],
+    }, 'objprops.tmj');
+    return new TiledMap('objprops.tmj', data, []).toTileMap();
+  }
+
+  it('maps an object-typed property to a TilePropertyObjectRef by numeric id', () => {
+    const tm = makeObjectPropsMap([{ name: 'target', type: 'object', value: 42 }]);
+    const obj = tm.objectLayers[0]!.objects[0]!;
+    expect(obj.properties['target']).toEqual({ kind: 'objectRef', id: 42 });
+  });
+
+  it('recursively maps a class-typed property to a nested TileProperties bag, including 2-level nesting', () => {
+    const tm = makeObjectPropsMap([{
+      name: 'config',
+      type: 'class',
+      propertytype: 'DoorConfig',
+      value: {
+        locked: true,
+        label: 'Vault',
+        access: { level: 2, tags: { vip: true } },
+      },
+    }]);
+    const obj = tm.objectLayers[0]!.objects[0]!;
+    expect(obj.properties['config']).toEqual({
+      locked: true,
+      label: 'Vault',
+      access: { level: 2, tags: { vip: true } },
+    });
+  });
+
+  it('keeps scalar properties unaffected alongside object/class properties', () => {
+    const tm = makeObjectPropsMap([
+      { name: 'label', type: 'string', value: 'north gate' },
+      { name: 'target', type: 'object', value: 7 },
+    ]);
+    const obj = tm.objectLayers[0]!.objects[0]!;
+    expect(obj.properties['label']).toBe('north gate');
+    expect(obj.properties['target']).toEqual({ kind: 'objectRef', id: 7 });
+  });
+});
+
 describe('TiledMap.toTileMap — error cases', () => {
   it('throws TiledFormatError for a collection-of-images tileset', () => {
     const collectionTs = new TiledTileset(

--- a/packages/exojs-tiled/test/fixtures/orthogonal-rich.tmj
+++ b/packages/exojs-tiled/test/fixtures/orthogonal-rich.tmj
@@ -75,7 +75,10 @@
       "y": 0,
       "image": "bg.png",
       "repeatx": true,
-      "repeaty": false
+      "repeaty": false,
+      "properties": [
+        { "name": "parallaxLayer", "type": "string", "value": "sky" }
+      ]
     },
     {
       "id": 4,

--- a/packages/exojs-tiled/test/toTileMap.test.ts
+++ b/packages/exojs-tiled/test/toTileMap.test.ts
@@ -420,6 +420,14 @@ describe('TiledMap.toTileMap() — image layers', () => {
     expect(layer?.repeatY).toBe(false);
     expect(layer?.texture).not.toBeNull();
   });
+
+  it('carries the image layer custom properties through toTileMap()', async () => {
+    const tiled = await loadTiledMap('orthogonal-rich.tmj', context);
+    const runtime = tiled.toTileMap();
+
+    const layer = runtime.getImageLayer('Background');
+    expect(layer?.properties.parallaxLayer).toBe('sky');
+  });
 });
 
 // ── Parallax forwarding ──────────────────────────────────────────────────────

--- a/packages/exojs-tilemap/src/ImageLayer.ts
+++ b/packages/exojs-tilemap/src/ImageLayer.ts
@@ -1,5 +1,7 @@
 import type { Texture } from '@codexo/exojs';
 
+import type { TileProperties } from './types';
+
 /** Construction options for an {@link ImageLayer}. */
 export interface ImageLayerOptions {
   /** Layer id (unique within the map). */
@@ -30,6 +32,8 @@ export interface ImageLayerOptions {
   readonly repeatX?: boolean;
   /** Whether the image repeats vertically. Default `false`. */
   readonly repeatY?: boolean;
+  /** Layer properties (copied and frozen). */
+  readonly properties?: TileProperties;
 }
 
 /**
@@ -75,6 +79,8 @@ export class ImageLayer {
   public readonly repeatX: boolean;
   /** Whether the image repeats vertically. */
   public readonly repeatY: boolean;
+  /** Immutable layer properties. */
+  public readonly properties: TileProperties;
 
   public constructor(options: ImageLayerOptions) {
     this.id = options.id;
@@ -91,5 +97,8 @@ export class ImageLayer {
     this.tintColor = options.tintColor ?? null;
     this.repeatX = options.repeatX ?? false;
     this.repeatY = options.repeatY ?? false;
+    this.properties = options.properties
+      ? Object.freeze({ ...options.properties })
+      : Object.freeze({});
   }
 }

--- a/packages/exojs-tilemap/src/ObjectLayer.ts
+++ b/packages/exojs-tilemap/src/ObjectLayer.ts
@@ -1,4 +1,5 @@
-import type { ResolvedTile, TileProperties, TilePropertyValue } from './types';
+import type { ResolvedTile, TileProperties, TilePropertyObjectRef, TilePropertyValue } from './types';
+import { TilePropertyKind } from './types';
 
 /**
  * Geometry kinds for a {@link TileMapObject}, as an `as const` value object.
@@ -194,6 +195,38 @@ export interface ObjectQuery {
   readonly value?: TilePropertyValue;
 }
 
+/**
+ * Type guard for the {@link TilePropertyObjectRef} variant of
+ * {@link TilePropertyValue}.
+ * @internal
+ */
+function isTilePropertyObjectRef(value: TilePropertyValue): value is TilePropertyObjectRef {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    (value as { kind?: unknown }).kind === TilePropertyKind.ObjectRef
+  );
+}
+
+/**
+ * Equality used by {@link ObjectLayer.query}'s `value` filter.
+ *
+ * Scalars and `null` compare with `===`. `objectRef` values compare by `id`
+ * alone — the one genuinely common "find all objects referencing X" query
+ * need — regardless of differing LDtk navigation fields. Every other
+ * structured shape (`point`, `tileRef`, arrays, nested property bags) has no
+ * obvious value-equality semantics (exact float coordinates? array order?)
+ * and only matches when reference-identical; use `query({ property })`
+ * (presence-only) for those.
+ * @internal
+ */
+function tilePropertyValueEquals(a: TilePropertyValue, b: TilePropertyValue): boolean {
+  if (a === b) return true;
+  if (isTilePropertyObjectRef(a) && isTilePropertyObjectRef(b)) return a.id === b.id;
+  return false;
+}
+
 /** Construction options for an {@link ObjectLayer}. */
 export interface ObjectLayerOptions {
   /** Layer id (unique within the map). */
@@ -299,11 +332,15 @@ export class ObjectLayer<S extends ObjectSchema = ObjectSchema> {
       }
 
       if (filter.property !== undefined) {
-        if (!(filter.property in object.properties)) {
+        // TilePropertyValue never includes `undefined`, so an `undefined`
+        // read is a reliable "key absent" signal (equivalent to, but avoids
+        // re-indexing after, an `in` check).
+        const value = object.properties[filter.property];
+        if (value === undefined) {
           return false;
         }
 
-        if (filter.value !== undefined && object.properties[filter.property] !== filter.value) {
+        if (filter.value !== undefined && !tilePropertyValueEquals(value, filter.value)) {
           return false;
         }
       }

--- a/packages/exojs-tilemap/src/TileLayer.ts
+++ b/packages/exojs-tilemap/src/TileLayer.ts
@@ -79,8 +79,8 @@ const DEFAULT_CHUNK_SIZE = 32;
  * changes. Direct chunk mutation is not supported — the layer owns chunk
  * storage and exposes only a {@link ReadonlyTileChunk} view.
  *
- * The layer is NOT a SceneNode — that integration lives in the future
- * renderer slice.
+ * The layer is NOT a SceneNode — that integration lives in
+ * {@link import('./TileLayerNode').TileLayerNode}.
  *
  * @advanced
  */

--- a/packages/exojs-tilemap/src/TileMap.ts
+++ b/packages/exojs-tilemap/src/TileMap.ts
@@ -55,7 +55,8 @@ export interface TileMapOptions {
  * Tile data is stored in compact chunked arrays — no per-tile heap objects.
  *
  * The map does NOT own tileset textures (those are Loader-owned) and does
- * NOT own SceneNode children (the future TileMapNode will own those).
+ * NOT own SceneNode children — see {@link import('./TileMapNode').TileMapNode},
+ * which owns those.
  *
  * Multiple tilesets are supported: each cell stores a packed tileset index
  * and local tile ID, so different tilesets may have different tile dimensions.

--- a/packages/exojs-tilemap/src/TileMap.ts
+++ b/packages/exojs-tilemap/src/TileMap.ts
@@ -271,6 +271,29 @@ export class TileMap {
     return this._objectLayers.find(layer => layer.name === name) as ObjectLayer<S> | undefined;
   }
 
+  /**
+   * Get an object layer by ID.
+   *
+   * Supply an {@link ObjectSchema} type argument `S` to obtain a typed view of
+   * the layer, as with {@link getObjectLayer}.
+   */
+  public getObjectLayerById<S extends ObjectSchema = ObjectSchema>(id: number): ObjectLayer<S> | undefined {
+    return this._objectLayers.find(layer => layer.id === id) as ObjectLayer<S> | undefined;
+  }
+
+  /**
+   * Remove an object layer by ID.
+   * @returns true if the layer was found and removed.
+   */
+  public removeObjectLayer(id: number): boolean {
+    this._checkDestroyed();
+    const index = this._objectLayers.findIndex(layer => layer.id === id);
+    if (index === -1) return false;
+    this._objectLayers.splice(index, 1);
+    this._revision++;
+    return true;
+  }
+
   // ── Image layers (data-only) ──────────────────────────────────────────
 
   /** Immutable snapshot of image layers (insertion order). */
@@ -283,6 +306,26 @@ export class TileMap {
    */
   public getImageLayer(name: string): ImageLayer | undefined {
     return this._imageLayers.find(layer => layer.name === name);
+  }
+
+  /**
+   * Get an image layer by ID.
+   */
+  public getImageLayerById(id: number): ImageLayer | undefined {
+    return this._imageLayers.find(layer => layer.id === id);
+  }
+
+  /**
+   * Remove an image layer by ID.
+   * @returns true if the layer was found and removed.
+   */
+  public removeImageLayer(id: number): boolean {
+    this._checkDestroyed();
+    const index = this._imageLayers.findIndex(layer => layer.id === id);
+    if (index === -1) return false;
+    this._imageLayers.splice(index, 1);
+    this._revision++;
+    return true;
   }
 
   // ── Scene composition ─────────────────────────────────────────────────

--- a/packages/exojs-tilemap/src/public.ts
+++ b/packages/exojs-tilemap/src/public.ts
@@ -57,11 +57,15 @@ export type {
   TileAnimationFrame,
   TileDefinition,
   TileProperties,
+  TilePropertyObjectRef,
+  TilePropertyPoint,
+  TilePropertyTileRef,
   TilePropertyValue,
   TileTransform,
 } from './types';
 export {
   TILE_TRANSFORM_IDENTITY,
+  TilePropertyKind,
   tileToChunkCoord,
   tileToLocalInChunk,
 } from './types';

--- a/packages/exojs-tilemap/src/types.ts
+++ b/packages/exojs-tilemap/src/types.ts
@@ -4,23 +4,91 @@ import type { TileSet } from './TileSet';
 // ── Properties ────────────────────────────────────────────────────────────
 
 /**
+ * Discriminant for the three structured, non-scalar {@link TilePropertyValue}
+ * variants: {@link TilePropertyPoint}, {@link TilePropertyObjectRef}, and
+ * {@link TilePropertyTileRef}.
+ *
+ * Modelled as a frozen string map (not a TS `enum`) so the values stay
+ * wire-stable, survive `verbatimModuleSyntax` (no emitted runtime helper),
+ * and follow the package convention for enum-like constants (see
+ * {@link import('./ObjectLayer').ObjectKind}).
+ * @stable
+ */
+export const TilePropertyKind = {
+  Point: 'point',
+  ObjectRef: 'objectRef',
+  TileRef: 'tileRef',
+} as const;
+
+/** Structured-value discriminant for {@link TilePropertyValue}. */
+export type TilePropertyKind = (typeof TilePropertyKind)[keyof typeof TilePropertyKind];
+
+/** A 2D point-valued tile property (e.g. an LDtk `Point` field). */
+export interface TilePropertyPoint {
+  readonly kind: typeof TilePropertyKind.Point;
+  readonly cx: number;
+  readonly cy: number;
+}
+
+/**
+ * A reference to another object/entity. `id` is the referenced object's
+ * identity — Tiled's numeric object id, or LDtk's `entityIid`. The extra
+ * fields are LDtk-only navigation context (`undefined` for Tiled-sourced
+ * refs) that lets a consumer resolve the reference without searching the
+ * whole level tree.
+ */
+export interface TilePropertyObjectRef {
+  readonly kind: typeof TilePropertyKind.ObjectRef;
+  readonly id: string | number;
+  readonly layerIid?: string;
+  readonly levelIid?: string;
+  readonly worldIid?: string;
+}
+
+/** A reference into a tileset region (e.g. an LDtk `Tile`-typed field). */
+export interface TilePropertyTileRef {
+  readonly kind: typeof TilePropertyKind.TileRef;
+  readonly tilesetUid: number;
+  readonly x: number;
+  readonly y: number;
+  readonly w: number;
+  readonly h: number;
+}
+
+/**
  * Union of legal tile-property value types in the generic runtime.
- * Format-neutral; adapters map their native property systems into this set.
+ * Format-neutral; adapters map their native property systems into this set —
+ * including the structured {@link TilePropertyPoint}, {@link TilePropertyObjectRef},
+ * and {@link TilePropertyTileRef} variants, arrays of any of the above, and
+ * nested property bags (e.g. Tiled `class`-typed properties).
  * @advanced
  */
 export type TilePropertyValue =
   | null
   | boolean
   | number
-  | string;
+  | string
+  | TilePropertyPoint
+  | TilePropertyObjectRef
+  | TilePropertyTileRef
+  | readonly TilePropertyValue[]
+  | TileProperties;
 
 /**
  * An immutable, flat key-value bag of generic tile properties.
  * Adapters copy and freeze source properties; the runtime never retains
  * a caller-owned mutable object.
+ *
+ * Declared as an interface (not a `Record<...>` type alias) so it can
+ * mutually recurse with {@link TilePropertyValue} — a nested-bag member of
+ * that union — without TypeScript's "circularly references itself" alias
+ * restriction; structurally it behaves exactly like
+ * `Readonly<Record<string, TilePropertyValue>>`.
  * @advanced
  */
-export type TileProperties = Readonly<Record<string, TilePropertyValue>>;
+export interface TileProperties {
+  readonly [key: string]: TilePropertyValue;
+}
 
 // ── Tile orientation / transform ──────────────────────────────────────────
 

--- a/packages/exojs-tilemap/test/ImageLayer.test.ts
+++ b/packages/exojs-tilemap/test/ImageLayer.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import { ImageLayer } from '../src/index';
+
+describe('ImageLayer', () => {
+  it('applies defaults for optional fields', () => {
+    const layer = new ImageLayer({ id: 1, image: 'bg.png' });
+
+    expect(layer.kind).toBe('image');
+    expect(layer.id).toBe(1);
+    expect(layer.name).toBe('');
+    expect(layer.class).toBe('');
+    expect(layer.image).toBe('bg.png');
+    expect(layer.texture).toBeNull();
+    expect(layer.visible).toBe(true);
+    expect(layer.opacity).toBe(1);
+    expect(layer.offsetX).toBe(0);
+    expect(layer.offsetY).toBe(0);
+    expect(layer.parallaxX).toBe(1);
+    expect(layer.parallaxY).toBe(1);
+    expect(layer.tintColor).toBeNull();
+    expect(layer.repeatX).toBe(false);
+    expect(layer.repeatY).toBe(false);
+  });
+
+  it('carries explicit construction options', () => {
+    const layer = new ImageLayer({
+      id: 2,
+      name: 'Background',
+      class: 'parallaxLayer',
+      image: 'sky.png',
+      visible: false,
+      opacity: 0.5,
+      offsetX: 8,
+      offsetY: -4,
+      parallaxX: 0.5,
+      parallaxY: 0.25,
+      tintColor: 0xff8800,
+      repeatX: true,
+      repeatY: true,
+    });
+
+    expect(layer.name).toBe('Background');
+    expect(layer.class).toBe('parallaxLayer');
+    expect(layer.image).toBe('sky.png');
+    expect(layer.visible).toBe(false);
+    expect(layer.opacity).toBe(0.5);
+    expect(layer.offsetX).toBe(8);
+    expect(layer.offsetY).toBe(-4);
+    expect(layer.parallaxX).toBe(0.5);
+    expect(layer.parallaxY).toBe(0.25);
+    expect(layer.tintColor).toBe(0xff8800);
+    expect(layer.repeatX).toBe(true);
+    expect(layer.repeatY).toBe(true);
+  });
+
+  it('properties default to a frozen empty object', () => {
+    const layer = new ImageLayer({ id: 1, image: 'bg.png' });
+
+    expect(layer.properties).toEqual({});
+    expect(Object.isFrozen(layer.properties)).toBe(true);
+  });
+
+  it('accepts a provided properties bag, copied and frozen', () => {
+    const properties = { depth: 'far', parallax: true };
+    const layer = new ImageLayer({ id: 1, image: 'bg.png', properties });
+
+    expect(layer.properties).toEqual({ depth: 'far', parallax: true });
+    expect(layer.properties).not.toBe(properties);
+    expect(Object.isFrozen(layer.properties)).toBe(true);
+
+    // Mutating the source object after construction must not affect the layer.
+    (properties as Record<string, unknown>).depth = 'near';
+    expect(layer.properties.depth).toBe('far');
+  });
+});

--- a/packages/exojs-tilemap/test/object-layer.test.ts
+++ b/packages/exojs-tilemap/test/object-layer.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
-import type { TileMapObject } from '../src/index';
-import { ObjectKind, ObjectLayer, TileMap } from '../src/index';
+import type {
+  TileMapObject,
+  TilePropertyObjectRef,
+  TilePropertyPoint,
+  TilePropertyTileRef,
+  TilePropertyValue,
+} from '../src/index';
+import { ObjectKind, ObjectLayer, TileMap, TilePropertyKind } from '../src/index';
 
-const rectangle = (id: number, name: string, type: string, properties: Record<string, string> = {}): TileMapObject => ({
+const rectangle = (id: number, name: string, type: string, properties: Record<string, TilePropertyValue> = {}): TileMapObject => ({
   kind: 'rectangle',
   id,
   name,
@@ -83,6 +89,113 @@ describe('ObjectLayer', () => {
     expect(layer.getObjectByName('hero')?.id).toBe(7);
     expect(layer.getObjectById(99)).toBeUndefined();
     expect(layer.getObjectByName('missing')).toBeUndefined();
+  });
+});
+
+describe('ObjectLayer query() value-matching for structured TilePropertyValue kinds', () => {
+  const objectRefA: TilePropertyObjectRef = {
+    kind: TilePropertyKind.ObjectRef,
+    id: 'entity-1',
+    layerIid: 'layer-a',
+    levelIid: 'level-a',
+    worldIid: 'world-a',
+  };
+  // Same `id`, every nav field differs — must still match by id alone.
+  const objectRefASameId: TilePropertyObjectRef = {
+    kind: TilePropertyKind.ObjectRef,
+    id: 'entity-1',
+    layerIid: 'layer-b',
+    levelIid: 'level-b',
+    worldIid: 'world-b',
+  };
+  const objectRefB: TilePropertyObjectRef = {
+    kind: TilePropertyKind.ObjectRef,
+    id: 'entity-2',
+  };
+  const pointValue: TilePropertyPoint = { kind: TilePropertyKind.Point, cx: 1, cy: 2 };
+  const tileRef: TilePropertyTileRef = {
+    kind: TilePropertyKind.TileRef,
+    tilesetUid: 1,
+    x: 0,
+    y: 0,
+    w: 16,
+    h: 16,
+  };
+  const nested = { a: 1 };
+  const array = [1, 2, 3] as const;
+
+  it('scalar value equality is unchanged', () => {
+    const layer = new ObjectLayer({
+      id: 1,
+      objects: [
+        rectangle(1, 'a', 'spawn', { team: 'red' }),
+        rectangle(2, 'b', 'spawn', { team: 'blue' }),
+      ],
+    });
+
+    expect(layer.query({ property: 'team', value: 'red' })).toHaveLength(1);
+    expect(layer.query({ property: 'team', value: 'red' })[0]!.id).toBe(1);
+    expect(layer.query({ property: 'team', value: 'green' })).toHaveLength(0);
+  });
+
+  it('matches objectRef values by id, regardless of differing nav fields', () => {
+    const layer = new ObjectLayer({
+      id: 1,
+      objects: [
+        rectangle(1, 'a', 'ref', { target: objectRefA }),
+        rectangle(2, 'b', 'ref', { target: objectRefASameId }),
+        rectangle(3, 'c', 'ref', { target: objectRefB }),
+      ],
+    });
+
+    const matches = layer.query({ property: 'target', value: objectRefA });
+    expect(matches.map(o => o.id)).toEqual([1, 2]);
+  });
+
+  it('point values match by reference identity (=== fast path), never structurally', () => {
+    const layer = new ObjectLayer({
+      id: 1,
+      objects: [rectangle(1, 'a', 'p', { at: pointValue })],
+    });
+
+    expect(layer.query({ property: 'at' })).toHaveLength(1);
+    // Same reference as stored -> hits the === fast path.
+    expect(layer.query({ property: 'at', value: pointValue })).toHaveLength(1);
+    // Structurally identical but a distinct object -> never matches.
+    expect(layer.query({ property: 'at', value: { ...pointValue } })).toHaveLength(0);
+  });
+
+  it('tileRef values match by reference identity, never structurally', () => {
+    const layer = new ObjectLayer({
+      id: 1,
+      objects: [rectangle(1, 'a', 't', { region: tileRef })],
+    });
+
+    expect(layer.query({ property: 'region' })).toHaveLength(1);
+    expect(layer.query({ property: 'region', value: tileRef })).toHaveLength(1);
+    expect(layer.query({ property: 'region', value: { ...tileRef } })).toHaveLength(0);
+  });
+
+  it('array values match by reference identity, never structurally', () => {
+    const layer = new ObjectLayer({
+      id: 1,
+      objects: [rectangle(1, 'a', 'arr', { list: array })],
+    });
+
+    expect(layer.query({ property: 'list' })).toHaveLength(1);
+    expect(layer.query({ property: 'list', value: array })).toHaveLength(1);
+    expect(layer.query({ property: 'list', value: [1, 2, 3] })).toHaveLength(0);
+  });
+
+  it('nested property bags match by reference identity, never structurally', () => {
+    const layer = new ObjectLayer({
+      id: 1,
+      objects: [rectangle(1, 'a', 'n', { meta: nested })],
+    });
+
+    expect(layer.query({ property: 'meta' })).toHaveLength(1);
+    expect(layer.query({ property: 'meta', value: nested })).toHaveLength(1);
+    expect(layer.query({ property: 'meta', value: { ...nested } })).toHaveLength(0);
   });
 });
 

--- a/packages/exojs-tilemap/test/tilemap.test.ts
+++ b/packages/exojs-tilemap/test/tilemap.test.ts
@@ -2,6 +2,8 @@ import { TextureRegion } from '@codexo/exojs';
 import { type Texture } from '@codexo/exojs';
 import { describe, expect, it } from 'vitest';
 
+import { ImageLayer } from '../src/ImageLayer';
+import { ObjectLayer } from '../src/ObjectLayer';
 import { TileChunk } from '../src/TileChunk';
 import { TileLayer } from '../src/TileLayer';
 import { TileMap } from '../src/TileMap';
@@ -1023,6 +1025,74 @@ describe('TileMap', () => {
       tilesets: [ts],
     });
     expect(map.removeLayer(999)).toBe(false);
+  });
+
+  it('getObjectLayerById finds an object layer by ID', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      objectLayers: [
+        new ObjectLayer({ id: 1, name: 'spawns' }),
+        new ObjectLayer({ id: 2, name: 'triggers' }),
+      ],
+    });
+    expect(map.getObjectLayerById(1)!.name).toBe('spawns');
+    expect(map.getObjectLayerById(2)!.name).toBe('triggers');
+    expect(map.getObjectLayerById(999)).toBeUndefined();
+  });
+
+  it('removeObjectLayer removes the layer by ID', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+    });
+    const layer = new ObjectLayer({ id: 1, name: 'removable' });
+    map.addObjectLayer(layer);
+    expect(map.removeObjectLayer(1)).toBe(true);
+    expect(map.getObjectLayerById(1)).toBeUndefined();
+    expect(map.objectLayers).toHaveLength(0);
+  });
+
+  it('removeObjectLayer returns false for non-existent ID', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+    });
+    expect(map.removeObjectLayer(999)).toBe(false);
+  });
+
+  it('getImageLayerById finds an image layer by ID', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      imageLayers: [
+        new ImageLayer({ id: 1, name: 'bg', image: 'bg.png' }),
+        new ImageLayer({ id: 2, name: 'fg', image: 'fg.png' }),
+      ],
+    });
+    expect(map.getImageLayerById(1)!.name).toBe('bg');
+    expect(map.getImageLayerById(2)!.name).toBe('fg');
+    expect(map.getImageLayerById(999)).toBeUndefined();
+  });
+
+  it('removeImageLayer removes the layer by ID', () => {
+    const layer = new ImageLayer({ id: 1, name: 'removable', image: 'bg.png' });
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      imageLayers: [layer],
+    });
+    expect(map.removeImageLayer(1)).toBe(true);
+    expect(map.getImageLayerById(1)).toBeUndefined();
+    expect(map.imageLayers).toHaveLength(0);
+  });
+
+  it('removeImageLayer returns false for non-existent ID', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+    });
+    expect(map.removeImageLayer(999)).toBe(false);
   });
 
   it('getLayerByName returns first match', () => {

--- a/site/src/content/api/animated-sprite.mdx
+++ b/site/src/content/api/animated-sprite.mdx
@@ -1,6 +1,6 @@
 ---
 title: "AnimatedSprite"
-description: "A Sprite that advances through a sequence of texture-frame Rectangles over time to produce frame-based animation. Multiple named clips can be registered via defineClip or the constructor. Call play to start a clip; call update each frame with the elapsed delta (seconds or a `Time` object) to advance playback. The `onFrame` signal fires on every frame advance and `onComplete` fires when a non-looping clip reaches its last frame. Use AnimatedSprite.fromSpritesheet to create an instance directly from a Spritesheet's named animations."
+description: "A Sprite that advances through a sequence of texture-frame Rectangles over time to produce frame-based animation. Multiple named clips can be registered via defineClip or the constructor. Call play to start a clip; call update each frame with the elapsed delta (seconds or a `Time` object) to advance playback. The `onFrame` signal fires on every frame advance and `onComplete` fires when a clip completes its final AnimatedSpriteClipDefinition.repeat cycle. Use AnimatedSprite.fromSpritesheet to create an instance directly from a Spritesheet's named animations."
 symbol: "AnimatedSprite"
 kind: "class"
 subsystem: "rendering"
@@ -9,7 +9,7 @@ memberCount: 105
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/rendering/sprite/AnimatedSprite.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/sprite/AnimatedSprite.ts#L44"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/sprite/AnimatedSprite.ts#L86"
 ---
 ## Import
 
@@ -22,7 +22,7 @@ Multiple named clips can be registered via defineClip or the
 constructor. Call play to start a clip; call update each
 frame with the elapsed delta (seconds or a `Time` object) to advance
 playback. The `onFrame` signal fires on every frame advance and
-`onComplete` fires when a non-looping clip reaches its last frame.
+`onComplete` fires when a clip completes its final AnimatedSpriteClipDefinition.repeat cycle.
 
 Use AnimatedSprite.fromSpritesheet to create an instance directly
 from a Spritesheet's named animations.
@@ -103,7 +103,6 @@ from a Spritesheet's named animations.
 - `height: number`
 - `interactive: boolean`
 - `isAlignedBox: boolean`
-- `loop: boolean`
 - `mask: MaskSource`
 - `material: SpriteMaterial | null`
 - `origin: ObservableVector`
@@ -111,6 +110,7 @@ from a Spritesheet's named animations.
 - `pixelSnapMode: PixelSnapMode`
 - `playing: boolean`
 - `position: ObservableVector`
+- `repeat: number`
 - `rotation: number`
 - `scale: ObservableVector`
 - `skewX: number`
@@ -146,4 +146,4 @@ from a Spritesheet's named animations.
 
 ## Source
 
-[src/rendering/sprite/AnimatedSprite.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/sprite/AnimatedSprite.ts#L44)
+[src/rendering/sprite/AnimatedSprite.ts](https://github.com/Exoridus/ExoJS/blob/main/src/rendering/sprite/AnimatedSprite.ts#L86)

--- a/site/src/content/api/aseprite-sheet.mdx
+++ b/site/src/content/api/aseprite-sheet.mdx
@@ -5,11 +5,11 @@ symbol: "AsepriteSheet"
 kind: "class"
 subsystem: "aseprite"
 importPath: "@codexo/exojs-aseprite"
-memberCount: 5
+memberCount: 6
 tier: "stable"
 sections: ["Import", "Methods", "Properties", "Source"]
 sourcePath: "packages/exojs-aseprite/src/AsepriteSheet.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-aseprite/src/AsepriteSheet.ts#L56"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-aseprite/src/AsepriteSheet.ts#L104"
 ---
 ## Import
 
@@ -35,8 +35,9 @@ AnimatedSprite with all clips pre-registered.
 ## Properties
 
 - `clips: ReadonlyMap<string, AnimatedSpriteClipDefinition>`
+- `slices: ReadonlyMap<string, AsepriteSlice>`
 - `spritesheet: Spritesheet`
 
 ## Source
 
-[packages/exojs-aseprite/src/AsepriteSheet.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-aseprite/src/AsepriteSheet.ts#L56)
+[packages/exojs-aseprite/src/AsepriteSheet.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-aseprite/src/AsepriteSheet.ts#L104)

--- a/site/src/content/api/image-layer.mdx
+++ b/site/src/content/api/image-layer.mdx
@@ -5,11 +5,11 @@ symbol: "ImageLayer"
 kind: "class"
 subsystem: "tilemap"
 importPath: "@codexo/exojs-tilemap"
-memberCount: 16
+memberCount: 17
 tier: "advanced"
 sections: ["Import", "Constructors", "Properties", "Source"]
 sourcePath: "packages/exojs-tilemap/src/ImageLayer.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/ImageLayer.ts#L46"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/ImageLayer.ts#L50"
 ---
 ## Import
 
@@ -39,6 +39,7 @@ source Tiled map.
 - `opacity: number`
 - `parallaxX: number`
 - `parallaxY: number`
+- `properties: TileProperties`
 - `repeatX: boolean`
 - `repeatY: boolean`
 - `texture: Texture | null`
@@ -47,4 +48,4 @@ source Tiled map.
 
 ## Source
 
-[packages/exojs-tilemap/src/ImageLayer.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/ImageLayer.ts#L46)
+[packages/exojs-tilemap/src/ImageLayer.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/ImageLayer.ts#L50)

--- a/site/src/content/api/ldtk-map.mdx
+++ b/site/src/content/api/ldtk-map.mdx
@@ -9,7 +9,7 @@ memberCount: 6
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "packages/exojs-ldtk/src/LdtkMap.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-ldtk/src/LdtkMap.ts#L17"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-ldtk/src/LdtkMap.ts#L18"
 ---
 ## Import
 
@@ -43,4 +43,4 @@ Construction is cheap — the runtime `TileMap[]` is supplied externally
 
 ## Source
 
-[packages/exojs-ldtk/src/LdtkMap.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-ldtk/src/LdtkMap.ts#L17)
+[packages/exojs-ldtk/src/LdtkMap.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-ldtk/src/LdtkMap.ts#L18)

--- a/site/src/content/api/object-layer.mdx
+++ b/site/src/content/api/object-layer.mdx
@@ -9,7 +9,7 @@ memberCount: 18
 tier: "advanced"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "packages/exojs-tilemap/src/ObjectLayer.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/ObjectLayer.ts#L248"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/ObjectLayer.ts#L281"
 ---
 ## Import
 
@@ -33,11 +33,11 @@ parameter reproduces the original untyped behaviour, so
 
 ## Methods
 
-- `byKind(kind: K): Extract<RectangleObject<Readonly<Record<string, TilePropertyValue>>>, object> | Extract<EllipseObject<Readonly<Record<string, TilePropertyValue>>>, object> | Extract<PointObject<Readonly<Record<string, TilePropertyValue>>>, object> | Extract<PolygonObject<Readonly<Record<string, TilePropertyValue>>>, object> | Extract<PolylineObject<Readonly<Record<string, TilePropertyValue>>>, object> | Extract<TileObject<Readonly<Record<string, TilePropertyValue>>>, object> | Extract<TextObject<Readonly<Record<string, TilePropertyValue>>>, object>[]`
+- `byKind(kind: K): Extract<RectangleObject<TileProperties>, object> | Extract<EllipseObject<TileProperties>, object> | Extract<PointObject<TileProperties>, object> | Extract<PolygonObject<TileProperties>, object> | Extract<PolylineObject<TileProperties>, object> | Extract<TileObject<TileProperties>, object> | Extract<TextObject<TileProperties>, object>[]`
 - `byType(type: T): TypedObject<S, T>[]`
-- `getObjectById(id: number): TileMapObject<Readonly<Record<string, TilePropertyValue>>> | undefined`
-- `getObjectByName(name: string): TileMapObject<Readonly<Record<string, TilePropertyValue>>> | undefined`
-- `query(filter: ObjectQuery): TileMapObject<Readonly<Record<string, TilePropertyValue>>>[]`
+- `getObjectById(id: number): TileMapObject<TileProperties> | undefined`
+- `getObjectByName(name: string): TileMapObject<TileProperties> | undefined`
+- `query(filter: ObjectQuery): TileMapObject<TileProperties>[]`
 - `where(type: T, predicate: object): TypedObject<S, T>[]`
 
 ## Properties
@@ -47,7 +47,7 @@ parameter reproduces the original untyped behaviour, so
 - `id: number`
 - `kind: "object"`
 - `name: string`
-- `objects: readonly TileMapObject<Readonly<Record<string, TilePropertyValue>>>[]`
+- `objects: readonly TileMapObject<TileProperties>[]`
 - `offsetX: number`
 - `offsetY: number`
 - `opacity: number`
@@ -56,4 +56,4 @@ parameter reproduces the original untyped behaviour, so
 
 ## Source
 
-[packages/exojs-tilemap/src/ObjectLayer.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/ObjectLayer.ts#L248)
+[packages/exojs-tilemap/src/ObjectLayer.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/ObjectLayer.ts#L281)

--- a/site/src/content/api/tile-layer.mdx
+++ b/site/src/content/api/tile-layer.mdx
@@ -1,6 +1,6 @@
 ---
 title: "TileLayer"
-description: "A generic, format-independent tile layer with chunk-first storage. Tile data is stored in fixed-size TileChunks indexed by signed chunk coordinates. For finite maps, only chunks that intersect the layer bounds exist. **Mutation must go through the layer's public APIs only.** `setTileAt` / `clearTileAt` validate coordinates, tileset references, and increment revision counters only when the stored value actually changes. Direct chunk mutation is not supported — the layer owns chunk storage and exposes only a ReadonlyTileChunk view. The layer is NOT a SceneNode — that integration lives in the future renderer slice."
+description: "A generic, format-independent tile layer with chunk-first storage. Tile data is stored in fixed-size TileChunks indexed by signed chunk coordinates. For finite maps, only chunks that intersect the layer bounds exist. **Mutation must go through the layer's public APIs only.** `setTileAt` / `clearTileAt` validate coordinates, tileset references, and increment revision counters only when the stored value actually changes. Direct chunk mutation is not supported — the layer owns chunk storage and exposes only a ReadonlyTileChunk view. The layer is NOT a SceneNode — that integration lives in import('./TileLayerNode').TileLayerNode."
 symbol: "TileLayer"
 kind: "class"
 subsystem: "tilemap"
@@ -27,8 +27,8 @@ and increment revision counters only when the stored value actually
 changes. Direct chunk mutation is not supported — the layer owns chunk
 storage and exposes only a ReadonlyTileChunk view.
 
-The layer is NOT a SceneNode — that integration lives in the future
-renderer slice.
+The layer is NOT a SceneNode — that integration lives in
+import('./TileLayerNode').TileLayerNode.
 
 ## Constructors
 

--- a/site/src/content/api/tile-map.mdx
+++ b/site/src/content/api/tile-map.mdx
@@ -1,15 +1,15 @@
 ---
 title: "TileMap"
-description: "A generic, format-independent tile map. Owns a finite grid of TileLayers and a shared set of TileSets. Tile data is stored in compact chunked arrays — no per-tile heap objects. The map does NOT own tileset textures (those are Loader-owned) and does NOT own SceneNode children (the future TileMapNode will own those). Multiple tilesets are supported: each cell stores a packed tileset index and local tile ID, so different tilesets may have different tile dimensions."
+description: "A generic, format-independent tile map. Owns a finite grid of TileLayers and a shared set of TileSets. Tile data is stored in compact chunked arrays — no per-tile heap objects. The map does NOT own tileset textures (those are Loader-owned) and does NOT own SceneNode children — see import('./TileMapNode').TileMapNode, which owns those. Multiple tilesets are supported: each cell stores a packed tileset index and local tile ID, so different tilesets may have different tile dimensions."
 symbol: "TileMap"
 kind: "class"
 subsystem: "tilemap"
 importPath: "@codexo/exojs-tilemap"
-memberCount: 37
+memberCount: 41
 tier: "advanced"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "packages/exojs-tilemap/src/TileMap.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/TileMap.ts#L65"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/TileMap.ts#L66"
 ---
 ## Import
 
@@ -21,7 +21,8 @@ Owns a finite grid of TileLayers and a shared set of TileSets.
 Tile data is stored in compact chunked arrays — no per-tile heap objects.
 
 The map does NOT own tileset textures (those are Loader-owned) and does
-NOT own SceneNode children (the future TileMapNode will own those).
+NOT own SceneNode children — see import('./TileMapNode').TileMapNode,
+which owns those.
 
 Multiple tilesets are supported: each cell stores a packed tileset index
 and local tile ID, so different tilesets may have different tile dimensions.
@@ -39,14 +40,18 @@ and local tile ID, so different tilesets may have different tile dimensions.
 - `createView(options?: TileMapViewOptions): TileMapView`
 - `destroy(): void`
 - `getImageLayer(name: string): ImageLayer | undefined`
+- `getImageLayerById(id: number): ImageLayer | undefined`
 - `getLayerById(id: number): TileLayer | undefined`
 - `getLayerByName(name: string): TileLayer | undefined`
 - `getObjectLayer(name: string): ObjectLayer<S> | undefined`
+- `getObjectLayerById(id: number): ObjectLayer<S> | undefined`
 - `getTileAt(layerId: number, tx: number, ty: number): ResolvedTile | null`
 - `getTileLayer(name: string): TileLayer | undefined`
 - `getTileset(name: string): TileSet | undefined`
 - `pixelToTile(px: number, py: number): object`
+- `removeImageLayer(id: number): boolean`
 - `removeLayer(id: number): boolean`
+- `removeObjectLayer(id: number): boolean`
 - `setTileAt(layerId: number, tx: number, ty: number, tile: ResolvedTile): void`
 - `tileToPixel(tx: number, ty: number): object`
 
@@ -74,4 +79,4 @@ and local tile ID, so different tilesets may have different tile dimensions.
 
 ## Source
 
-[packages/exojs-tilemap/src/TileMap.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/TileMap.ts#L65)
+[packages/exojs-tilemap/src/TileMap.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/TileMap.ts#L66)

--- a/site/src/content/guide/assets/aseprite.mdx
+++ b/site/src/content/guide/assets/aseprite.mdx
@@ -130,24 +130,137 @@ sheet.clips.keys();        // iterate tag names
 sheet.spritesheet;         // the underlying Spritesheet (frames keyed by index string)
 ```
 
-## Frame timing (fps)
+## Playback direction (reverse & ping-pong tags)
 
-Each clip's `fps` is derived from the per-frame `duration` values Aseprite exports (milliseconds per
-frame), averaged across the tag's `from`→`to` range:
+Aseprite frame tags carry a `direction`: `forward` (the default), `reverse`, `pingpong`, or
+`pingpong_reverse`. `AsepriteSheet.parse()` expands a tag's declared `from`→`to` range into the
+actual sequence of frame indices before building the clip, since `AnimatedSprite` itself always
+plays forward through whatever frame list it's given:
+
+- `forward` — unchanged: `[from, from+1, …, to]`.
+- `reverse` — the range played backwards: `[to, to-1, …, from]`.
+- `pingpong` — a forward pass followed by a backward pass that excludes both endpoints, e.g. a tag
+  with `from: 0, to: 2` expands to `[0, 1, 2, 1]`.
+- `pingpong_reverse` — the mirrored shape, starting from `to`: `[2, 1, 0, 1]`.
+- A single-frame tag (`from === to`) always yields just that one frame, regardless of `direction`.
+
+One consequence: a ping-pong tag's resulting clip has **more frames than `to - from + 1`** — the
+bounce frames are appended, not looped separately — so `sheet.clips.get(name).frames.length` (and
+the tag's average fps, see below) already reflect the expanded sequence, not the raw tag range:
+
+```ts no-check
+// Aseprite tag: { name: 'idle', from: 0, to: 2, direction: 'pingpong' }
+sheet.clips.get('idle').frames.length; // 4 — plays [0, 1, 2, 1], not the 3 declared source frames
+```
+
+## One-shot playback (repeat)
+
+Aseprite frame tags can also carry a `repeat` field — a numeric string (`"1"`, `"2"`, …) set from the
+Tag Properties panel — specifying how many full cycles the tag plays before stopping. `AsepriteSheet.parse()`
+maps it directly onto [`AnimatedSpriteClipDefinition.repeat`](/ExoJS/en/api/animated-sprite/):
+
+- No `repeat` on the tag → the clip's `repeat` is `-1` (loop indefinitely) — the same behaviour as
+  before.
+- `repeat: "1"` → the clip plays exactly once; `AnimatedSprite.onComplete` then fires and playback
+  stops on the last frame instead of looping.
+- `repeat: "3"` → the clip plays exactly three full cycles through its (possibly direction-expanded)
+  frame sequence, then stops.
+
+```ts no-check
+import { AsepriteSheet } from '@codexo/exojs-aseprite';
+
+const sheet = await loader.load(AsepriteSheet, 'sprites/hero.json');
+const player = sheet.createAnimatedSprite();
+
+player.onComplete.add(clip => {
+    if (clip === 'attack') {
+        player.play('idle'); // the 'attack' tag has repeat: "1" — plays once, then this fires
+    }
+});
+
+player.play('attack');
+```
+
+`AnimatedSprite.repeat` can be read back at any time and overridden per-call via
+`play(name, { repeat })` — see the [`AnimatedSprite`](/ExoJS/en/api/animated-sprite/) API reference
+for the full playback surface.
+
+## Frame timing
+
+Each clip still exposes an `fps` derived from the per-frame `duration` values Aseprite exports
+(milliseconds per frame), averaged across the tag's *expanded* frame sequence — for ping-pong tags
+that means bounced frames count toward the average twice, since they play twice:
 
 - A tag whose frames are all 100 ms produces **10 fps**; mixed durations are averaged (100/200/300 ms
   → 200 ms → **5 fps**).
 - When every frame duration in the tag is zero, the clip falls back to **12 fps**.
 
-Every clip is created with `loop: true`. Aseprite's ping-pong directions are recorded as looping but
-are **not** expanded into a reversed segment — a ping-pong tag plays only its declared `from`→`to`
-range. Frame indices in a tag that fall outside the frame array are skipped, and a tag whose entire
-range is out of bounds produces no clip.
+`fps` alone can't represent uneven timing, though — an artist holding one "impact" frame twice as
+long as the rest would get flattened to a single average interval. Each clip therefore also carries
+`frameDurations`, a per-frame hold-time array (`AnimatedSpriteClipDefinition.frameDurations`) taken
+directly from Aseprite's per-frame `duration` field. When present, `frameDurations` is authoritative
+during playback; `fps` is retained only as a display-only average. A non-positive frame duration
+falls back to the tag's average, the same degenerate case the `fps` calculation itself guards
+against.
+
+```ts no-check
+sheet.clips.get('walk').fps;             // 5 — display-only average
+sheet.clips.get('walk').frameDurations;  // [100, 200, 300] — authoritative per-frame hold times
+```
+
+Frame indices in a tag that fall outside the frame array are skipped, and a tag whose entire
+(expanded) range is out of bounds produces no clip.
+
+## Trimmed frames (frameOffsets)
+
+Exporting with Aseprite's *Trim* option removes transparent padding from each frame and records how
+much was trimmed via `spriteSourceSize` — different frames in the same animation are often trimmed by
+different amounts. Naively rendering trimmed frames at a fixed origin makes the sprite visibly jitter
+frame to frame.
+
+When any frame in a tag is trimmed, `AsepriteSheet.parse()` populates
+`AnimatedSpriteClipDefinition.frameOffsets` with each frame's `spriteSourceSize` `{x, y}` — its
+trimmed content's offset within the untrimmed canvas. `AnimatedSprite` applies that offset as a local
+translation on top of the sprite's own position/origin as it advances frames, keeping every frame
+anchored to the same point instead of jittering. `frameOffsets` is omitted entirely for tags with no
+trimmed frames, so untrimmed sheets are unaffected.
+
+This is transparent — nothing to opt into beyond exporting with *Trim* enabled in Aseprite and
+consuming clips the normal way through `createAnimatedSprite()` or `sheet.clips`.
+
+## Slices
+
+Aseprite's editor lets you define named **slices** — hitboxes, nine-patch borders, UI anchor
+points — independently of the frame/animation data. `AsepriteSheet.parse()` reads `meta.slices` into
+`AsepriteSheet.slices: ReadonlyMap<string, AsepriteSlice>`, keyed by slice name:
+
+```ts no-check
+sheet.slices.size;                 // number of named slices
+sheet.slices.has('hitbox');        // true when the 'hitbox' slice exists
+sheet.slices.get('hitbox').keys;   // AsepriteSliceKey[] — bounds per frame
+```
+
+A slice's bounds can change per frame — each `AsepriteSlice` carries one `AsepriteSliceKey` per frame
+at which its bounds change, not one key per rendered frame. Resolve the key that applies to a given
+frame index yourself by taking the last key whose `frame` is at or before it:
+
+```ts
+import type { AsepriteSlice } from '@codexo/exojs-aseprite';
+
+function resolveSliceBounds(slice: AsepriteSlice, frameIndex: number) {
+    let bounds = slice.keys[0]?.bounds;
+
+    for (const key of slice.keys) {
+        if (key.frame > frameIndex) break;
+        bounds = key.bounds;
+    }
+
+    return bounds;
+}
+```
 
 ## Not yet supported
 
-- **Slices** — slice data (`AsepriteSlice` / `AsepriteSliceKey`) is parsed into the raw document
-  types but is **not** yet surfaced as a runtime API; there is no slice accessor on `AsepriteSheet`.
 - **Layers / nested tags** — Aseprite layer metadata is preserved in the parsed data but is not
   interpreted into clips.
 
@@ -161,10 +274,11 @@ texture through the loader's own unload path when nothing else needs it.
 
 - **Package README:** [`@codexo/exojs-aseprite`](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-aseprite/README.md)
   — install, entry points, and the supported-format matrix.
-- **API reference:** [`AsepriteSheet`](/ExoJS/en/api/aseprite-sheet/) documents `clips`,
+- **API reference:** [`AsepriteSheet`](/ExoJS/en/api/aseprite-sheet/) documents `clips`, `slices`,
   `spritesheet`, and `createAnimatedSprite()`; [`AnimatedSprite`](/ExoJS/en/api/animated-sprite/)
-  documents clip definition and playback; [`Loader`](/ExoJS/en/api/loader/) documents `load(...)`
-  and the `'asepriteSheet'` config-map type name.
+  documents clip definition (`repeat`, `frameDurations`, `frameOffsets`) and playback;
+  [`Loader`](/ExoJS/en/api/loader/) documents `load(...)` and the `'asepriteSheet'` config-map type
+  name.
 - **Guides:** [Sprites](/ExoJS/en/guide/rendering/sprites/) and
   [Loading & resources](/ExoJS/en/guide/assets/loading-and-resources/) cover the rendering and asset
   model the sheet plugs into.

--- a/site/src/content/guide/assets/ldtk.mdx
+++ b/site/src/content/guide/assets/ldtk.mdx
@@ -96,6 +96,13 @@ const fromConfig = await loader.load({
 > an absolute `https://…` URL, or set `loader.basePath` to an absolute origin so relative map paths
 > resolve to absolute URLs. A bare relative or root-relative path will fail tileset resolution.
 
+> **Note:** LDtk's "Save levels to separate files" project option stores each level's layers and
+> fields in a sibling `<identifier>.ldtkl` file instead of inline in the `.ldtk` document —
+> `loadLdtkMap()` detects and fetches these external level files automatically as part of the load,
+> so there is nothing extra to do on your end. If you call [`ldtkToTileMap`](#converting-manually-advanced)
+> directly on a raw document whose external levels have not been resolved, those levels convert with
+> empty layers instead (`layerInstances` is `null` until resolved).
+
 ## The LdtkMap result
 
 A loaded `LdtkMap` exposes one runtime `TileMap` per LDtk level, plus the raw parsed document:
@@ -107,8 +114,37 @@ world.data;                        // the raw parsed LdtkData document
 ```
 
 Each level's `TileMap` carries the LDtk tile layers (as `TileLayer`s) and entity layers (as data-only
-`ObjectLayer`s, with each entity's position, size, and scalar fields preserved as object
-properties). World-space placement is stored in `TileMap.properties` (`worldX` / `worldY`).
+`ObjectLayer`s, with each entity's position, size, and fields preserved as object properties). Entity
+positions are corrected for LDtk's per-entity `__pivot` anchor, so an object's `x`/`y` always give the
+bounding box's top-left corner, regardless of which pivot the entity definition uses in the editor.
+See [Entity field values](#entity-field-values) below for how individual field values convert.
+
+World-space placement is stored in `TileMap.properties` (`worldX` / `worldY`), alongside `ldtkUid` /
+`ldtkIid` identifiers and any custom fields set on the **level itself** in the LDtk editor (the
+level's own "Custom fields" tab — distinct from fields on the entities placed inside it), merged in
+under their own field identifier:
+
+```js no-check
+level.properties.worldX;       // number — level's world-space X position in pixels
+level.properties.musicTrack;   // whatever value the level's own custom field carries
+```
+
+## Multi-world projects
+
+LDtk projects can enable "Multi-Worlds" (an advanced project setting) to hold several independent
+worlds — each with its own set of levels — in one `.ldtk` file. When that setting is on, levels live
+under `data.worlds[].levels` instead of the root `data.levels`, which LDtk's format then keeps empty.
+
+The overwhelming majority of projects use a single world and never touch this setting — for those,
+nothing below applies and `world.levels` behaves exactly as shown above. When multi-world **is** in
+use, ExoJS handles it transparently: `LdtkMap.levels` and `getLevelByName()` flatten every world's
+levels into the same single ordered list, so the rest of this guide's API is unchanged either way.
+The only difference is that each converted level's `TileMap.properties` additionally carries the
+owning world's id under the reserved `ldtkWorldIid` key:
+
+```js no-check
+level.properties.ldtkWorldIid; // string | undefined — set only for multi-world projects
+```
 
 ## Rendering a level
 
@@ -133,6 +169,82 @@ for (const level of world.levels) {
 `TileMapNode` handles per-chunk culling and renders the level's layers in document order. For
 interleaving actors between tile layers, use `TileMap.createView()` to obtain independently
 placeable layer nodes — see the [`TileMapView`](/ExoJS/en/api/tile-map-view/) API.
+
+## Entity field values
+
+Every custom field an entity carries in the LDtk editor ends up as a property on that entity's
+`TileMapObject` (found on the entity layer's `ObjectLayer`). Scalar field types — Int, Float, Bool,
+String, Multilines, Color, FilePath, Enum — convert directly to their JS scalar. Three structured
+field types — **Point**, **EntityRef**, and **Tile** — convert into the tagged `TilePropertyValue`
+variants from `@codexo/exojs-tilemap`, discriminated by a `kind` string:
+
+```ts no-check
+import { TilePropertyKind } from '@codexo/exojs-tilemap';
+
+const entities = level.getObjectLayer('Entities');
+const chest = entities?.objects.find((object) => object.type === 'Chest');
+const linkedSwitch = chest?.properties.linkedSwitch;
+
+if (linkedSwitch && typeof linkedSwitch === 'object' && 'kind' in linkedSwitch) {
+    switch (linkedSwitch.kind) {
+        case TilePropertyKind.Point:
+            linkedSwitch.cx; // grid-cell X — a Point field
+            linkedSwitch.cy;
+            break;
+        case TilePropertyKind.ObjectRef:
+            linkedSwitch.id;       // the referenced entity's entityIid — an EntityRef field
+            linkedSwitch.levelIid; // LDtk navigation context, when set
+            break;
+        case TilePropertyKind.TileRef:
+            linkedSwitch.tilesetUid; // a Tile field: region within a tileset, in pixels
+            linkedSwitch.x;
+            linkedSwitch.y;
+            break;
+    }
+}
+```
+
+- **Point** fields (`{ kind: 'point', cx, cy }`) give the field's grid-cell coordinates.
+- **EntityRef** fields (`{ kind: 'objectRef', id, layerIid?, levelIid?, worldIid? }`) reference
+  another entity — `id` is that entity's `entityIid`, matched against `iid`-based lookups rather than
+  the numeric `TileMapObject.id` ExoJS assigns during conversion. The optional `layerIid` /
+  `levelIid` / `worldIid` are LDtk's own navigation context for locating the reference without
+  searching the whole project.
+- **Tile** fields (`{ kind: 'tileRef', tilesetUid, x, y, w, h }`) reference a pixel region within a
+  tileset — useful for entities whose "icon" is picked from a tileset in the editor.
+
+`Array<T>` fields (`Array<Int>`, `Array<Point>`, and so on) convert to a `readonly` array of the same
+per-element conversion — an `Array<Point>` field becomes `readonly TilePropertyPoint[]`, for example.
+Unset (`null`) fields, and unset elements within an array field, are omitted entirely rather than
+carried through as `null` properties.
+
+## IntGrid values
+
+IntGrid layers classify each grid cell with a small integer you assign meaning to in the LDtk editor
+(e.g. `1` = Wall, `2` = Water). Query a converted IntGrid layer's classification with
+`getLdtkIntGridValueAt(layer, x, y)`:
+
+```ts no-check
+import { getLdtkIntGridValueAt } from '@codexo/exojs-ldtk';
+
+const collision = level.getLayerByName('Collision');
+const cell = collision && getLdtkIntGridValueAt(collision, 3, 5);
+
+if (cell) {
+    cell.value;       // the raw integer assigned in the editor
+    cell.identifier;  // the name given to that value in the editor, or null
+    cell.color;       // the editor's swatch colour, as a CSS hex string
+}
+```
+
+`getLdtkIntGridValueAt` returns `undefined` for an out-of-bounds coordinate, an empty cell (raw value
+`0`), a raw value with no matching definition, or a `TileLayer` that was not converted from an IntGrid
+layer in the first place — you don't need to special-case any of those yourself.
+
+Under the hood, the raw per-cell data is stored as JSON-encoded strings under two reserved
+`TileLayer.properties` keys — `ldtkIntGridCsv` (the flat `number[]` CSV, index `y * layer.width + x`)
+and `ldtkIntGridValues` (the layer's raw-value → name/colour definitions). Both exist for advanced
+consumers that want the unprocessed data; prefer `getLdtkIntGridValueAt` for everyday lookups.
 
 ## Converting manually (advanced)
 

--- a/site/src/content/guide/assets/tiled-maps.mdx
+++ b/site/src/content/guide/assets/tiled-maps.mdx
@@ -159,6 +159,150 @@ Before this conversion existed, `object`- and `class`-typed properties were indi
 a plain number or silently dropped; both are now tagged (`TilePropertyObjectRef`) or preserved
 (nested `TileProperties`) so you can tell them apart from real scalars at runtime.
 
+## Text objects
+
+An object drawn with Tiled's text tool converts to a `TextObject` — a `TileMapObject` whose
+`kind` is `'text'` and whose `text` field carries the styled content:
+
+```js no-check
+import { ObjectKind } from '@codexo/exojs-tilemap';
+
+const tileMap = map.toTileMap();
+const [captionLayer] = tileMap.objectLayers;
+const [caption] = captionLayer.byKind(ObjectKind.Text);
+
+caption.text.text;       // the text content
+caption.text.color;      // 0xRRGGBB, or null for the default colour
+caption.text.fontFamily; // e.g. 'sans-serif'
+caption.text.pixelSize;  // font size in px
+caption.text.bold;
+caption.text.italic;
+caption.text.wrap;       // wrap within the object's [width, height] bounds
+caption.text.halign;     // 'left' | 'center' | 'right' | 'justify'
+caption.text.valign;     // 'top' | 'center' | 'bottom'
+```
+
+`caption.x`, `caption.y`, `caption.width`, and `caption.height` (inherited from the common
+`TileMapObject` fields) give the text box's placement and bounds; ExoJS does not lay out or draw
+the text for you — pair `caption.text` with a [`Text`](/ExoJS/en/guide/rendering/text/) node or
+your own renderer.
+
+## Image layers
+
+A Tiled image layer converts to an `ImageLayer` — a data-only layer holding a single resolved
+image, alongside the same offset/parallax/tint/opacity/`properties` fields tile and object layers
+carry:
+
+```js no-check
+const tileMap = map.toTileMap();
+const [background] = tileMap.imageLayers;
+
+background.texture;   // the resolved Texture (Loader-owned), or null if the image failed to load
+background.repeatX;   // tiles the image horizontally when true
+background.repeatY;   // tiles the image vertically when true
+background.parallaxX; // horizontal parallax factor
+background.parallaxY; // vertical parallax factor
+background.properties.fogDensity; // custom properties — same TileProperties bag as other layers
+```
+
+Like `ObjectLayer`, `ImageLayer` is not a `Drawable` — it exposes the resolved image and its
+placement so a renderer or scene node can draw it; there is no built-in image-layer renderer.
+
+## Per-tile collision shapes
+
+Shapes drawn in Tiled's tile collision editor (the `objectgroup` on an individual tile within a
+tileset) survive the trip through `toTileMap()` as `TileDefinition.collision` — a list of
+`TileMapObject`s in tile-local pixel space (origin at the top-left of the cell):
+
+```js no-check
+const tileMap = map.toTileMap();
+const [ground] = tileMap.layers;
+const tile = ground.getTileAt(3, 5);
+const definition = tile?.tileset.getTileDefinition(tile.localTileId);
+
+for (const shape of definition?.collision ?? []) {
+  shape.kind;   // 'rectangle' | 'ellipse' | 'polygon' | 'polyline' | 'point'
+  shape.x;      // tile-local pixel space
+  shape.y;
+  shape.width;
+  shape.height;
+}
+```
+
+`collision` is only present on definitions for tiles that actually declare shapes in Tiled;
+`getTileDefinition` returns `undefined` for a tile with no per-tile metadata at all. Combine the
+shape's local coordinates with the cell's world position (`tx * tileWidth`, `ty * tileHeight`) to
+place it in map space.
+
+## Base64 and compressed tile data
+
+Tiled can write a tile layer's `data` as a plain CSV array, or as a base64 string that's
+optionally gzip- or zlib-compressed. `@codexo/exojs-tiled` decodes both transparently during the
+async load phase — by the time you read `map.layers`, every layer's data is a plain GID array
+regardless of which encoding the map was exported with. There's no user-facing API for this step;
+it just works.
+
+The one exception is `zstd`: Tiled's zstd tile-layer compression has no native decoder in this
+extension and throws `TiledFormatError`. Re-export the map with gzip, zlib, or uncompressed CSV
+data instead.
+
+## Wang and autotile sets
+
+Wang sets — Tiled's terrain/auto-tile definitions — parse onto `TiledTileset.wangSets` as raw
+`TiledWangSetData`. Convert one with `tiledWangSetToWangSet` into a runtime `WangSet`, then apply
+it to a layer with `autoTile` (a full-layer pass) or `refreshCell` (an incremental, single-cell
+update) from `@codexo/exojs-tilemap`:
+
+```js no-check
+import { tiledWangSetToWangSet } from '@codexo/exojs-tiled';
+import { autoTile, refreshCell } from '@codexo/exojs-tilemap';
+
+const tileMap = map.toTileMap();
+const [ground] = tileMap.layers;
+
+// wangSets live on the parsed TiledTileset, keyed by the runtime tileset's
+// index within `layer.tilesets` (0 here — the layer's only tileset).
+const [wangSetData] = map.tilesets[0].wangSets;
+const wangSet = tiledWangSetToWangSet(wangSetData, 0);
+
+// Re-derive every autotiled variant across the whole layer, e.g. after
+// generating terrain procedurally:
+autoTile(ground, wangSet);
+
+// Or, after painting a single cell, refresh just that cell and its eight
+// neighbours instead of re-running autoTile over the whole layer:
+refreshCell(ground, tx, ty, wangSet);
+```
+
+`tiledWangSetToWangSet` handles Tiled's `'corner'` (blob-style, 8-neighbour) and `'edge'`
+(4-neighbour) wangset types; `'mixed'` wangsets interleave both semantics in a way that can't be
+faithfully represented by a single mask and convert to `null`. This conversion is a deliberate
+manual step (not run automatically by `toTileMap()`) — you decide which layers get autotiled and
+when.
+
+## Per-tile animation
+
+Tiled's tile editor lets you give a tile an animation: a sequence of frames, each showing a
+different local tile ID for a set duration. `toTileMap()` carries these frames into
+`TileDefinition.animation`; `@codexo/exojs-tilemap` ships `TileAnimator` to drive them at runtime,
+RPG-Maker style — advancing every animated cell across one or more layers on a shared clock:
+
+```js no-check
+import { TileAnimator } from '@codexo/exojs-tilemap';
+
+const tileMap = map.toTileMap();
+const animator = new TileAnimator(tileMap.layers);
+
+// Somewhere in your update loop:
+scene.systems.add({ update: (t) => animator.update(t.deltaSeconds) });
+```
+
+`TileAnimator` only rewrites a cell — and rebuilds the chunk that contains it — on the frame it
+actually changes; static tiles, and animated tiles between frame boundaries, are left untouched.
+Call `animator.reset()` to snap every animated cell back to its first frame (useful before
+serialising or pausing), and `animator.rescan()` after structural edits that add or remove
+animated tiles.
+
 ## Tileset texture ownership
 
 The tileset textures a `TiledMap` exposes are loaded through the `Loader` and owned by the
@@ -174,23 +318,33 @@ the loader's own unload path when nothing else needs them — never from the map
 
 ## Supported scope
 
-The initial extension covers the common orthogonal workflow:
+The extension covers the common orthogonal workflow, including format details beyond the basics:
 
 - Orthogonal orientation
-- Tile layers (the tile-index grid)
-- Image-based tilesets (each tileset's `image` is resolved to a `Texture`)
-- Basic object layers (object metadata is preserved in `map.data`)
+- Tile layers, including base64 and gzip/zlib-compressed `data`
+- Image-based (atlas) tilesets, embedded in the map or referenced externally (`.tsj`)
+- Object layers — rectangle, ellipse, point, polygon, polyline, tile, and text objects
+- Image layers
+- Per-tile collision shapes, animation frames, and custom properties
+- Wang/autotile sets, via the `tiledWangSetToWangSet` conversion step (see
+  [Wang and autotile sets](#wang-and-autotile-sets) above)
 
 ## Not supported
 
-These raise a clear error or are intentionally absent in the initial scope:
+These raise a clear error or are intentionally absent from this release:
 
-- **`.tmx` / XML maps** — only the JSON `.tmj` format is parsed. Export from Tiled as JSON.
+- **`.tmx` maps and `.tsx` tilesets (XML)** — only the JSON format is parsed: `.tmj` for maps,
+  `.tsj` for external tilesets. Export from Tiled as JSON.
 - **Infinite maps** — chunked/infinite maps throw; use a fixed-size map.
 - **Non-orthogonal orientations** — isometric, staggered, and hexagonal throw.
-- **Advanced editor features** — external tilesets (`.tsx`), embedded image collections,
-  per-tile animations, and Wang/terrain sets are not interpreted (data may still be present in
-  `map.data` but is not resolved by the handler).
+- **Collection-of-images tilesets** — a tileset built from one image per tile, rather than a
+  single atlas, throws in `toTileMap()`. Use an atlas tileset.
+- **`zstd`-compressed tile data** — no native decoder is wired up; re-export with gzip, zlib, or
+  uncompressed CSV data instead.
+- **Object templates (`.tx`)** — an object's template path is preserved on `TiledObject.template`
+  but not fetched or merged into the object. Avoid templates, or resolve them yourself.
+- **Text kerning** — Tiled's per-text `kerning` flag is parsed (`TiledTextData.kerning`) but
+  dropped during `toTileMap()`; it isn't carried into `TextStyle`.
 
 ## Where to look next
 

--- a/site/src/content/guide/assets/tiled-maps.mdx
+++ b/site/src/content/guide/assets/tiled-maps.mdx
@@ -110,6 +110,55 @@ map.data;             // the raw parsed TiledMapData
 textures; you decide how to render them (for example, by building a `Mesh` or batching `Sprite`s
 per visible tile). A built-in tilemap renderer is out of this extension's initial scope.
 
+## Custom properties
+
+Tiled's custom properties (on maps, layers, tiles, and objects) survive the trip through
+`map.toTileMap()`. Every runtime `ObjectLayer`, `TileMapObject`, and `TileDefinition` carries a
+`properties` bag — a flat, frozen `Readonly<Record<string, TilePropertyValue>>` built from the
+map's Tiled property list. Plain-scalar Tiled types (`string`, `int`, `float`, `bool`, `color`,
+`file`) come through as their equivalent JS value:
+
+```js no-check
+const tileMap = map.toTileMap();
+const [spawnLayer] = tileMap.objectLayers;
+const spawn = spawnLayer.objects.find(object => object.name === 'PlayerSpawn');
+
+spawn.properties.maxHealth; // number, e.g. 100
+spawn.properties.label;     // string
+spawn.properties.locked;    // boolean
+```
+
+Two Tiled property types aren't plain scalars and convert to structured values instead:
+
+- **`object`-typed properties** — a reference to another Tiled object by numeric id — convert to
+  a `TilePropertyObjectRef`: `{ kind: 'objectRef', id }`. Resolve it by matching `id` against
+  another object's `id` in the same map:
+
+  ```js no-check
+  import { TilePropertyKind } from '@codexo/exojs-tilemap';
+
+  const door = spawnLayer.objects.find(object => object.name === 'Door');
+  const target = door.properties.linkedSwitch;
+
+  if (target?.kind === TilePropertyKind.ObjectRef) {
+    const linkedSwitch = spawnLayer.objects.find(object => object.id === target.id);
+  }
+  ```
+
+- **`class`-typed properties** — Tiled's nested custom-property groups — recursively convert into
+  their own `properties`-shaped bag instead of being dropped. Nesting can be arbitrarily deep, and
+  each nested bag reads the same way as the top-level one:
+
+  ```js no-check
+  const stats = spawn.properties.stats; // a nested TileProperties bag
+  stats.health; // number
+  stats.resistances.fire; // further nesting reads the same way
+  ```
+
+Before this conversion existed, `object`- and `class`-typed properties were indistinguishable from
+a plain number or silently dropped; both are now tagged (`TilePropertyObjectRef`) or preserved
+(nested `TileProperties`) so you can tell them apart from real scalars at runtime.
+
 ## Tileset texture ownership
 
 The tileset textures a `TiledMap` exposes are loaded through the `Loader` and owned by the

--- a/site/src/content/guide/rendering/animation.mdx
+++ b/site/src/content/guide/rendering/animation.mdx
@@ -150,7 +150,7 @@ Tween interpolation is purely numeric. Attempting to tween a non-number property
 
 ## Animated sprites
 
-[`AnimatedSprite`](/ExoJS/en/api/animated-sprite/) extends `Sprite` with frame-based animation playback from named clips. Each clip is a sequence of texture-frame rectangles with a playback speed.
+[`AnimatedSprite`](/ExoJS/en/api/animated-sprite/) extends `Sprite` with frame-based animation playback from named clips. Each clip is a sequence of texture-frame rectangles with a playback speed and repeat count.
 
 ### Defining clips
 
@@ -167,32 +167,51 @@ player.defineClip('walk', {
         new Rectangle(96, 0, 32, 32),
     ],
     fps: 10,       // frames per second (default 12)
-    loop: true,    // default true
+    repeat: -1,    // full cycles to play; -1 loops indefinitely (default)
 });
 ```
+
+`repeat` counts full cycles through every frame: `-1` (the default when omitted) loops indefinitely, `1` plays the clip once and stops on its last frame, and any other positive integer plays exactly that many cycles before `onComplete` fires. This is the same `-1` = infinite convention [`Tween.repeat()`](#tweens) uses above — `AnimatedSprite.repeat` now agrees with `Tween` on what "loop forever" means.
 
 Multiple clips can be registered on the same `AnimatedSprite`:
 
 ```js
-player.defineClip('idle', { frames: [new Rectangle(0, 32, 32, 32)], fps: 1, loop: true });
-player.defineClip('jump', { frames: [new Rectangle(128, 0, 32, 32)], fps: 1, loop: false });
+player.defineClip('idle', { frames: [new Rectangle(0, 32, 32, 32)], fps: 1 });              // repeat: -1 (default) — loops forever
+player.defineClip('jump', { frames: [new Rectangle(128, 0, 32, 32)], fps: 1, repeat: 1 });  // plays once
 ```
 
 Call `setClips()` to replace all clips at once with a map.
+
+### Per-frame timing and offsets
+
+Two optional clip fields cover cases a single `fps` value can't express:
+
+- **`frameDurations`** — a per-frame hold time in milliseconds, parallel to `frames`. When present it drives playback timing directly and `fps` is ignored while advancing frames (still accepted as a display-only average). Use it for clips with intentionally uneven pacing, such as an impact frame that lingers longer than the rest.
+- **`frameOffsets`** — a per-frame local draw offset (`{ x, y }` in local pixels), parallel to `frames`. Use it to keep frames anchored to a stable point when the source frames are trimmed to different sizes — without it, differently-trimmed frames jitter around their own top-left corner.
+
+```js
+player.defineClip('hit', {
+    frames: [frame0, frame1, frame2],
+    frameDurations: [80, 40, 200],                                    // ms per frame — frame1 is a quick flash, frame2 lingers
+    frameOffsets: [{ x: 0, y: 0 }, { x: -2, y: 1 }, { x: 0, y: 0 }],   // keep the trimmed frame1 anchored
+});
+```
+
+Both arrays are usually populated automatically rather than written by hand: the [Aseprite guide](/ExoJS/en/guide/assets/aseprite/) (`@codexo/exojs-aseprite`) fills `frameDurations` from each tag's per-frame export duration and `frameOffsets` from trimmed `spriteSourceSize` data. Set them yourself when building clips directly from a `Spritesheet` or raw `Rectangle`s and you need the same fidelity.
 
 ### Playback control
 
 ```js
 player.play('walk');                        // start from frame 0
 player.play('walk', { restart: false });    // resume if same clip
-player.play('walk', { loop: false });       // override loop setting for this play
+player.play('walk', { repeat: 1 });         // override repeat count for this play
 
 player.pause();    // freeze playback
 player.resume();   // continue
 player.stop();     // stop and rewind to frame 0
 ```
 
-The `onFrame` signal fires on every frame advance; `onComplete` fires when a non-looping clip reaches its last frame:
+The `onFrame` signal fires on every frame advance; `onComplete` fires when the clip completes its final `repeat` cycle:
 
 ```js
 player.onFrame.add((clip, frame) => {
@@ -224,11 +243,11 @@ const hero = AnimatedSprite.fromSpritesheet(sheet);
 hero.play('walk');
 ```
 
-The spritesheet's `animations` map — ordered lists of frame names — becomes named `AnimatedSprite` clips, each frame rectangle sourced from the spritesheet's `frames` map.
+The spritesheet's `animations` map — ordered lists of frame names — becomes named `AnimatedSprite` clips (repeating indefinitely, since `repeat` isn't set), each frame rectangle sourced from the spritesheet's `frames` map.
 
 ### When to use
 
-Use `AnimatedSprite` when you have frame strips from a texture atlas and want clip-based playback with names, speeds, and looping. Use manual `sprite.setTextureFrame()` calls in `update` when you need per-frame logic beyond simple clip playback — responsive frame selection based on game state, for example.
+Use `AnimatedSprite` when you have frame strips from a texture atlas and want clip-based playback with names, speeds, and repeat counts. Use manual `sprite.setTextureFrame()` calls in `update` when you need per-frame logic beyond simple clip playback — responsive frame selection based on game state, for example.
 
 ## Standing tween vs. frame-loop animation
 

--- a/site/src/content/guide/rendering/animation.mdx
+++ b/site/src/content/guide/rendering/animation.mdx
@@ -131,6 +131,40 @@ first.start();
 
 Only the first tween in the chain needs a `start()` call — each chained tween automatically starts when its predecessor completes.
 
+### Sequencing with TweenSequencer
+
+`chain()` links exactly one tween to exactly one successor — fine for a short relay, but it can't express "run these two tweens together, then move on" or "pause for a beat between steps" without extra bookkeeping. [`TweenSequencer`](/ExoJS/en/api/tween-sequencer/) covers those cases. Create one with `app.tweens.createSequencer()` and build it up with `.then()` and `.wait()`:
+
+```js
+const fadeIn = this.app.tweens.create(sprite)
+    .to({ alpha: 1 }, 0.4);
+
+const moveLeft = this.app.tweens.create(sprite.position)
+    .to({ x: 200 }, 0.6)
+    .easing(Ease.cubicOut);
+
+const scaleUp = this.app.tweens.create(sprite.scale)
+    .to({ x: 1.2, y: 1.2 }, 0.6)
+    .easing(Ease.cubicOut);
+
+const fadeOut = this.app.tweens.create(sprite)
+    .to({ alpha: 0 }, 0.4);
+
+this.app.tweens.createSequencer()
+    .then(fadeIn)
+    .wait(0.5)
+    .then([moveLeft, scaleUp])
+    .then(fadeOut)
+    .onComplete(() => console.log('sequence done'))
+    .start();
+```
+
+Each `.then()` call adds a stage. Pass a single tween to run it alone, or an array of tweens to run them in parallel — the stage only advances once every tween in it has completed, which is how `moveLeft` and `scaleUp` above end up running side by side before `fadeOut` begins. `.wait(seconds)` inserts a timed pause as its own stage, without needing a dummy tween to hold up the sequence.
+
+The sequencer also has lifecycle controls of its own, independent of any individual tween's: `.repeat(count)` and `.yoyo()` replay the whole stage sequence (optionally reversed), `.onStart()` / `.onComplete()` fire once for the sequence as a whole, and `.pause()` / `.resume()` / `.stop()` act on whichever stage is currently active. `createSequencer()` binds the sequencer to `app.tweens`, so — like tweens created via `app.tweens.create()` — it's ticked automatically once `start()` is called; no manual `update()` calls needed.
+
+Reach for `.chain()` when you already have two tween references and just need one to follow the other. Reach for `TweenSequencer` when a step in the sequence involves multiple simultaneous tweens, needs a timed gap, or the sequence itself needs repeat/yoyo/callback control.
+
 ### Interruption and replacement
 
 Calling `start()` on an active tween restarts it from zero. To replace a running animation cleanly, stop the old tween and start a new one on the same target:

--- a/src/core/serialization/renderingSerializers.ts
+++ b/src/core/serialization/renderingSerializers.ts
@@ -13,7 +13,7 @@ import { Texture } from '#rendering/texture/Texture';
 import { Video } from '#rendering/video/Video';
 
 import type { NodeSerializer } from './NodeSerializer';
-import { asNumberArray, asObject, asSerializedNode, readBoolean, readEnum, REPEAT_FITS, REPEAT_MODES } from './read';
+import { asNumberArray, asObject, asSerializedNode, readEnum, REPEAT_FITS, REPEAT_MODES } from './read';
 import type { SerializationRegistry } from './SerializationRegistry';
 import { compact, deserializeStyleOptions, readLayoutOptions, serializeStyle } from './serializerHelpers';
 
@@ -224,7 +224,7 @@ const animatedSpriteSerializer: NodeSerializer<AnimatedSprite> = {
       clips[name] = compact({
         frames: clip.frames.map(frame => [frame.x, frame.y, frame.width, frame.height]),
         fps: clip.fps,
-        loop: clip.loop,
+        repeat: clip.repeat,
         frameDurations: clip.frameDurations ? [...clip.frameDurations] : undefined,
         frameOffsets: clip.frameOffsets ? clip.frameOffsets.map(offset => [offset.x, offset.y]) : undefined,
       });
@@ -270,7 +270,7 @@ const animatedSpriteSerializer: NodeSerializer<AnimatedSprite> = {
             })
           : undefined;
 
-        clips[name] = compact({ frames, fps: num(clip.fps), loop: readBoolean(clip, 'loop'), frameDurations, frameOffsets });
+        clips[name] = compact({ frames, fps: num(clip.fps), repeat: num(clip.repeat), frameDurations, frameOffsets });
       }
     }
 

--- a/src/core/serialization/renderingSerializers.ts
+++ b/src/core/serialization/renderingSerializers.ts
@@ -226,6 +226,7 @@ const animatedSpriteSerializer: NodeSerializer<AnimatedSprite> = {
         fps: clip.fps,
         loop: clip.loop,
         frameDurations: clip.frameDurations ? [...clip.frameDurations] : undefined,
+        frameOffsets: clip.frameOffsets ? clip.frameOffsets.map(offset => [offset.x, offset.y]) : undefined,
       });
     }
 
@@ -261,7 +262,15 @@ const animatedSpriteSerializer: NodeSerializer<AnimatedSprite> = {
 
         const frameDurations = Array.isArray(clip.frameDurations) ? (asNumberArray(clip.frameDurations) ?? undefined) : undefined;
 
-        clips[name] = compact({ frames, fps: num(clip.fps), loop: readBoolean(clip, 'loop'), frameDurations });
+        const frameOffsets = Array.isArray(clip.frameOffsets)
+          ? clip.frameOffsets.map(entry => {
+              const values = asNumberArray(entry) ?? [];
+
+              return { x: values[0] ?? 0, y: values[1] ?? 0 };
+            })
+          : undefined;
+
+        clips[name] = compact({ frames, fps: num(clip.fps), loop: readBoolean(clip, 'loop'), frameDurations, frameOffsets });
       }
     }
 

--- a/src/core/serialization/renderingSerializers.ts
+++ b/src/core/serialization/renderingSerializers.ts
@@ -221,11 +221,12 @@ const animatedSpriteSerializer: NodeSerializer<AnimatedSprite> = {
     const clips: Record<string, unknown> = {};
 
     for (const [name, clip] of Object.entries(node._getClipDefinitions())) {
-      clips[name] = {
+      clips[name] = compact({
         frames: clip.frames.map(frame => [frame.x, frame.y, frame.width, frame.height]),
         fps: clip.fps,
         loop: clip.loop,
-      };
+        frameDurations: clip.frameDurations ? [...clip.frameDurations] : undefined,
+      });
     }
 
     out.clips = clips;
@@ -258,7 +259,9 @@ const animatedSpriteSerializer: NodeSerializer<AnimatedSprite> = {
             })
           : [];
 
-        clips[name] = compact({ frames, fps: num(clip.fps), loop: readBoolean(clip, 'loop') });
+        const frameDurations = Array.isArray(clip.frameDurations) ? (asNumberArray(clip.frameDurations) ?? undefined) : undefined;
+
+        clips[name] = compact({ frames, fps: num(clip.fps), loop: readBoolean(clip, 'loop'), frameDurations });
       }
     }
 

--- a/src/rendering/sprite/AnimatedSprite.ts
+++ b/src/rendering/sprite/AnimatedSprite.ts
@@ -20,6 +20,14 @@ export interface AnimatedSpriteClipDefinition {
    * export where one frame intentionally lingers longer than the rest.
    */
   readonly frameDurations?: readonly number[];
+  /**
+   * Per-frame local translation in local (pre-scale) pixels, indexed the
+   * same as `frames`, applied on top of the sprite's own position/origin.
+   * Use this to keep frames anchored to a stable point when a source atlas
+   * trims frames to different sizes (Aseprite's `spriteSourceSize`) — without
+   * it, differently-trimmed frames would jitter around their own top-left.
+   */
+  readonly frameOffsets?: ReadonlyArray<{ readonly x: number; readonly y: number }>;
 }
 
 /** Per-call options passed to {@link AnimatedSprite.play}. */
@@ -32,6 +40,7 @@ interface NormalizedAnimatedSpriteClip {
   readonly frames: readonly Rectangle[];
   readonly frameDurationMs: number;
   readonly frameDurations: readonly number[] | null;
+  readonly frameOffsets: ReadonlyArray<{ readonly x: number; readonly y: number }> | null;
   readonly loop: boolean;
 }
 
@@ -149,10 +158,27 @@ export class AnimatedSprite extends Sprite {
       frameDurations = [...clip.frameDurations];
     }
 
+    let frameOffsets: ReadonlyArray<{ readonly x: number; readonly y: number }> | null = null;
+
+    if (clip.frameOffsets) {
+      if (clip.frameOffsets.length !== frames.length) {
+        throw new Error(`AnimatedSprite clip "${name}" frameOffsets length (${clip.frameOffsets.length}) must match its frame count (${frames.length}).`);
+      }
+
+      for (const offset of clip.frameOffsets) {
+        if (!Number.isFinite(offset.x) || !Number.isFinite(offset.y)) {
+          throw new Error(`AnimatedSprite clip "${name}" has an invalid frameOffsets value (${JSON.stringify(offset)}).`);
+        }
+      }
+
+      frameOffsets = clip.frameOffsets.map(offset => ({ x: offset.x, y: offset.y }));
+    }
+
     this._clips.set(name, {
       frames: frames.map(frame => frame.clone()),
       frameDurationMs: 1000 / fps,
       frameDurations,
+      frameOffsets,
       loop: clip.loop ?? true,
     });
 
@@ -161,9 +187,9 @@ export class AnimatedSprite extends Sprite {
 
   /**
    * Returns the registered clips as serializable definitions (frames as
-   * {@link Rectangle}s, `fps`, `loop`, and `frameDurations` when the clip has
-   * one). Used by scene serialization to read back clip state the normalized
-   * internal store no longer exposes directly.
+   * {@link Rectangle}s, `fps`, `loop`, and `frameDurations`/`frameOffsets`
+   * when the clip has them). Used by scene serialization to read back clip
+   * state the normalized internal store no longer exposes directly.
    * @internal
    */
   public _getClipDefinitions(): Record<string, Required<Pick<AnimatedSpriteClipDefinition, 'frames' | 'loop'>> & AnimatedSpriteClipDefinition> {
@@ -175,6 +201,7 @@ export class AnimatedSprite extends Sprite {
         fps: 1000 / clip.frameDurationMs,
         loop: clip.loop,
         ...(clip.frameDurations ? { frameDurations: [...clip.frameDurations] } : {}),
+        ...(clip.frameOffsets ? { frameOffsets: clip.frameOffsets.map(offset => ({ x: offset.x, y: offset.y })) } : {}),
       };
     }
 
@@ -212,7 +239,7 @@ export class AnimatedSprite extends Sprite {
       this._currentFrameIndex = 0;
       this._elapsedFrameTimeMs = 0;
       // Normalized clips always hold at least one frame.
-      this._applyFrame(clip.frames[0]!);
+      this._applyFrame(clip, 0);
       this.onFrame.dispatch(name, 0);
     }
 
@@ -236,7 +263,7 @@ export class AnimatedSprite extends Sprite {
     if (clip && clip.frames.length > 0) {
       this._currentFrameIndex = 0;
       // Guarded non-empty above.
-      this._applyFrame(clip.frames[0]!);
+      this._applyFrame(clip, 0);
       this.onFrame.dispatch(this._currentClipName, 0);
     }
 
@@ -297,7 +324,7 @@ export class AnimatedSprite extends Sprite {
         if (this.loop) {
           this._currentFrameIndex = 0;
           // clip has > 1 frame here (early-returned otherwise).
-          this._applyFrame(clip.frames[0]!);
+          this._applyFrame(clip, 0);
           this.onFrame.dispatch(this._currentClipName, 0);
           thresholdMs = clip.frameDurations?.[this._currentFrameIndex] ?? clip.frameDurationMs;
           continue;
@@ -305,7 +332,7 @@ export class AnimatedSprite extends Sprite {
 
         this._currentFrameIndex = clip.frames.length - 1;
         // In-bounds: last frame index.
-        this._applyFrame(clip.frames[this._currentFrameIndex]!);
+        this._applyFrame(clip, this._currentFrameIndex);
         this._playing = false;
         this.onComplete.dispatch(this._currentClipName);
 
@@ -314,7 +341,7 @@ export class AnimatedSprite extends Sprite {
 
       this._currentFrameIndex = nextFrame;
       // In-bounds: nextFrame < frames.length.
-      this._applyFrame(clip.frames[this._currentFrameIndex]!);
+      this._applyFrame(clip, this._currentFrameIndex);
       this.onFrame.dispatch(this._currentClipName, this._currentFrameIndex);
       thresholdMs = clip.frameDurations?.[this._currentFrameIndex] ?? clip.frameDurationMs;
     }
@@ -355,7 +382,23 @@ export class AnimatedSprite extends Sprite {
     return new AnimatedSprite(spritesheet.texture, clips);
   }
 
-  private _applyFrame(frame: Rectangle): void {
-    this.setTextureFrame(frame, false);
+  /**
+   * Apply the clip's frame at `frameIndex` to the sprite's texture region,
+   * and — when the clip defines `frameOffsets` — translate the local quad by
+   * that frame's `{x,y}` on top of the sprite's own position/origin. The
+   * offset lives entirely in local (pre-scale) space via {@link getLocalBounds},
+   * so it composes correctly under rotation/scale and never mutates the
+   * public `x`/`y`/`origin` a caller set.
+   */
+  private _applyFrame(clip: NormalizedAnimatedSpriteClip, frameIndex: number): void {
+    // In-bounds by every call site's own guard.
+    this.setTextureFrame(clip.frames[frameIndex]!, false);
+
+    const offset = clip.frameOffsets?.[frameIndex];
+
+    if (offset) {
+      this.getLocalBounds().setPosition(offset.x, offset.y);
+      this._invalidateBoundsCascade();
+    }
   }
 }

--- a/src/rendering/sprite/AnimatedSprite.ts
+++ b/src/rendering/sprite/AnimatedSprite.ts
@@ -12,6 +12,14 @@ export interface AnimatedSpriteClipDefinition {
   readonly frames: readonly Rectangle[];
   readonly fps?: number;
   readonly loop?: boolean;
+  /**
+   * Per-frame hold duration in milliseconds, indexed the same as `frames`.
+   * When provided it is authoritative for playback timing and `fps` is
+   * ignored while advancing frames (still accepted as a display-only
+   * average). Use this to preserve uneven hold-frames — e.g. an Aseprite
+   * export where one frame intentionally lingers longer than the rest.
+   */
+  readonly frameDurations?: readonly number[];
 }
 
 /** Per-call options passed to {@link AnimatedSprite.play}. */
@@ -23,6 +31,7 @@ export interface AnimatedSpritePlayOptions {
 interface NormalizedAnimatedSpriteClip {
   readonly frames: readonly Rectangle[];
   readonly frameDurationMs: number;
+  readonly frameDurations: readonly number[] | null;
   readonly loop: boolean;
 }
 
@@ -124,9 +133,26 @@ export class AnimatedSprite extends Sprite {
       throw new Error(`AnimatedSprite clip "${name}" has an invalid fps value (${fps}).`);
     }
 
+    let frameDurations: readonly number[] | null = null;
+
+    if (clip.frameDurations) {
+      if (clip.frameDurations.length !== frames.length) {
+        throw new Error(`AnimatedSprite clip "${name}" frameDurations length (${clip.frameDurations.length}) must match its frame count (${frames.length}).`);
+      }
+
+      for (const duration of clip.frameDurations) {
+        if (!Number.isFinite(duration) || duration <= 0) {
+          throw new Error(`AnimatedSprite clip "${name}" has an invalid frameDurations value (${duration}).`);
+        }
+      }
+
+      frameDurations = [...clip.frameDurations];
+    }
+
     this._clips.set(name, {
       frames: frames.map(frame => frame.clone()),
       frameDurationMs: 1000 / fps,
+      frameDurations,
       loop: clip.loop ?? true,
     });
 
@@ -135,15 +161,21 @@ export class AnimatedSprite extends Sprite {
 
   /**
    * Returns the registered clips as serializable definitions (frames as
-   * {@link Rectangle}s, `fps`, `loop`). Used by scene serialization to read
-   * back clip state the normalized internal store no longer exposes directly.
+   * {@link Rectangle}s, `fps`, `loop`, and `frameDurations` when the clip has
+   * one). Used by scene serialization to read back clip state the normalized
+   * internal store no longer exposes directly.
    * @internal
    */
-  public _getClipDefinitions(): Record<string, { frames: Rectangle[]; fps: number; loop: boolean }> {
-    const out: Record<string, { frames: Rectangle[]; fps: number; loop: boolean }> = {};
+  public _getClipDefinitions(): Record<string, Required<Pick<AnimatedSpriteClipDefinition, 'frames' | 'loop'>> & AnimatedSpriteClipDefinition> {
+    const out: Record<string, Required<Pick<AnimatedSpriteClipDefinition, 'frames' | 'loop'>> & AnimatedSpriteClipDefinition> = {};
 
     for (const [name, clip] of this._clips) {
-      out[name] = { frames: clip.frames.map(frame => frame.clone()), fps: 1000 / clip.frameDurationMs, loop: clip.loop };
+      out[name] = {
+        frames: clip.frames.map(frame => frame.clone()),
+        fps: 1000 / clip.frameDurationMs,
+        loop: clip.loop,
+        ...(clip.frameDurations ? { frameDurations: [...clip.frameDurations] } : {}),
+      };
     }
 
     return out;
@@ -249,8 +281,15 @@ export class AnimatedSprite extends Sprite {
 
     this._elapsedFrameTimeMs += deltaMs;
 
-    while (this._elapsedFrameTimeMs >= clip.frameDurationMs) {
-      this._elapsedFrameTimeMs -= clip.frameDurationMs;
+    // The hold duration for the frame CURRENTLY displayed determines how long
+    // it takes to advance past it. `frameDurations`, when present, overrides
+    // the clip's uniform `frameDurationMs` per frame — re-read after every
+    // index change below rather than cached once, since it depends on
+    // `_currentFrameIndex`.
+    let thresholdMs = clip.frameDurations?.[this._currentFrameIndex] ?? clip.frameDurationMs;
+
+    while (this._elapsedFrameTimeMs >= thresholdMs) {
+      this._elapsedFrameTimeMs -= thresholdMs;
 
       const nextFrame = this._currentFrameIndex + 1;
 
@@ -260,6 +299,7 @@ export class AnimatedSprite extends Sprite {
           // clip has > 1 frame here (early-returned otherwise).
           this._applyFrame(clip.frames[0]!);
           this.onFrame.dispatch(this._currentClipName, 0);
+          thresholdMs = clip.frameDurations?.[this._currentFrameIndex] ?? clip.frameDurationMs;
           continue;
         }
 
@@ -276,6 +316,7 @@ export class AnimatedSprite extends Sprite {
       // In-bounds: nextFrame < frames.length.
       this._applyFrame(clip.frames[this._currentFrameIndex]!);
       this.onFrame.dispatch(this._currentClipName, this._currentFrameIndex);
+      thresholdMs = clip.frameDurations?.[this._currentFrameIndex] ?? clip.frameDurationMs;
     }
 
     return this;

--- a/src/rendering/sprite/AnimatedSprite.ts
+++ b/src/rendering/sprite/AnimatedSprite.ts
@@ -11,7 +11,15 @@ import type { Spritesheet } from './Spritesheet';
 export interface AnimatedSpriteClipDefinition {
   readonly frames: readonly Rectangle[];
   readonly fps?: number;
-  readonly loop?: boolean;
+  /**
+   * How many full cycles (advancing through every frame once counts as one
+   * cycle) the clip plays before stopping and dispatching `onComplete`.
+   * `-1` (the default when omitted) loops indefinitely; `1` plays once; any
+   * other positive integer plays exactly that many times. Use this to
+   * preserve Aseprite's frame-tag `repeat` count (e.g. an attack that should
+   * play exactly twice, not once or forever).
+   */
+  readonly repeat?: number;
   /**
    * Per-frame hold duration in milliseconds, indexed the same as `frames`.
    * When provided it is authoritative for playback timing and `fps` is
@@ -32,7 +40,8 @@ export interface AnimatedSpriteClipDefinition {
 
 /** Per-call options passed to {@link AnimatedSprite.play}. */
 export interface AnimatedSpritePlayOptions {
-  loop?: boolean;
+  /** Per-call override of the clip's {@link AnimatedSpriteClipDefinition.repeat}, for the duration of this `play()` call. */
+  repeat?: number;
   restart?: boolean;
 }
 
@@ -41,10 +50,25 @@ interface NormalizedAnimatedSpriteClip {
   readonly frameDurationMs: number;
   readonly frameDurations: readonly number[] | null;
   readonly frameOffsets: ReadonlyArray<{ readonly x: number; readonly y: number }> | null;
-  readonly loop: boolean;
+  readonly repeat: number;
 }
 
 const defaultClipFps = 12;
+
+/** Sentinel {@link AnimatedSpriteClipDefinition.repeat}/{@link AnimatedSprite.repeat} value meaning "loop indefinitely"; also the default when `repeat` is omitted. */
+const infiniteRepeat = -1;
+
+/**
+ * Throws if `repeat` is not `infiniteRepeat` (`-1`) or a positive integer.
+ * Shared by {@link AnimatedSprite.defineClip}, the {@link AnimatedSprite.repeat}
+ * setter, and {@link AnimatedSprite.play}'s `options.repeat` so every entry
+ * point rejects the same invalid values consistently.
+ */
+function assertValidRepeat(context: string, repeat: number): void {
+  if (!Number.isInteger(repeat) || (repeat !== infiniteRepeat && repeat < 1)) {
+    throw new Error(`AnimatedSprite ${context} has an invalid repeat value (${repeat}). Must be ${infiniteRepeat} (infinite) or a positive integer.`);
+  }
+}
 
 /**
  * A {@link Sprite} that advances through a sequence of texture-frame
@@ -54,7 +78,7 @@ const defaultClipFps = 12;
  * constructor. Call {@link play} to start a clip; call {@link update} each
  * frame with the elapsed delta (seconds or a `Time` object) to advance
  * playback. The `onFrame` signal fires on every frame advance and
- * `onComplete` fires when a non-looping clip reaches its last frame.
+ * `onComplete` fires when a clip completes its final {@link AnimatedSpriteClipDefinition.repeat} cycle.
  *
  * Use {@link AnimatedSprite.fromSpritesheet} to create an instance directly
  * from a {@link Spritesheet}'s named animations.
@@ -64,8 +88,9 @@ export class AnimatedSprite extends Sprite {
   private _currentClipName: string | null = null;
   private _currentFrameIndex = 0;
   private _playing = false;
-  private _loopOverride: boolean | null = null;
+  private _repeatOverride: number | null = null;
   private _elapsedFrameTimeMs = 0;
+  private _completedCycles = 0;
 
   public readonly onComplete = new Signal<[clip: string]>();
   public readonly onFrame = new Signal<[clip: string, frame: number]>();
@@ -91,23 +116,26 @@ export class AnimatedSprite extends Sprite {
   }
 
   /**
-   * Whether the current clip loops. Returns the per-call loop override if set,
-   * otherwise the clip's own `loop` flag.
+   * How many cycles the current clip plays before stopping. Returns the
+   * per-call override if set via {@link play} or this setter, otherwise the
+   * clip's own `repeat` value (or `-1` if no clip is active).
    */
-  public get loop(): boolean {
-    if (this._loopOverride !== null) {
-      return this._loopOverride;
+  public get repeat(): number {
+    if (this._repeatOverride !== null) {
+      return this._repeatOverride;
     }
 
     if (!this._currentClipName) {
-      return false;
+      return infiniteRepeat;
     }
 
-    return this._clips.get(this._currentClipName)?.loop ?? false;
+    return this._clips.get(this._currentClipName)?.repeat ?? infiniteRepeat;
   }
 
-  public set loop(loop: boolean) {
-    this._loopOverride = loop;
+  public set repeat(repeat: number) {
+    assertValidRepeat('repeat', repeat);
+
+    this._repeatOverride = repeat;
   }
 
   /** Replace all registered clips with the provided map. Clears any previously registered clips first. */
@@ -141,6 +169,10 @@ export class AnimatedSprite extends Sprite {
     if (!Number.isFinite(fps) || fps <= 0) {
       throw new Error(`AnimatedSprite clip "${name}" has an invalid fps value (${fps}).`);
     }
+
+    const repeat = clip.repeat ?? infiniteRepeat;
+
+    assertValidRepeat(`clip "${name}"`, repeat);
 
     let frameDurations: readonly number[] | null = null;
 
@@ -179,7 +211,7 @@ export class AnimatedSprite extends Sprite {
       frameDurationMs: 1000 / fps,
       frameDurations,
       frameOffsets,
-      loop: clip.loop ?? true,
+      repeat,
     });
 
     return this;
@@ -187,19 +219,19 @@ export class AnimatedSprite extends Sprite {
 
   /**
    * Returns the registered clips as serializable definitions (frames as
-   * {@link Rectangle}s, `fps`, `loop`, and `frameDurations`/`frameOffsets`
+   * {@link Rectangle}s, `fps`, `repeat`, and `frameDurations`/`frameOffsets`
    * when the clip has them). Used by scene serialization to read back clip
    * state the normalized internal store no longer exposes directly.
    * @internal
    */
-  public _getClipDefinitions(): Record<string, Required<Pick<AnimatedSpriteClipDefinition, 'frames' | 'loop'>> & AnimatedSpriteClipDefinition> {
-    const out: Record<string, Required<Pick<AnimatedSpriteClipDefinition, 'frames' | 'loop'>> & AnimatedSpriteClipDefinition> = {};
+  public _getClipDefinitions(): Record<string, Required<Pick<AnimatedSpriteClipDefinition, 'frames' | 'repeat'>> & AnimatedSpriteClipDefinition> {
+    const out: Record<string, Required<Pick<AnimatedSpriteClipDefinition, 'frames' | 'repeat'>> & AnimatedSpriteClipDefinition> = {};
 
     for (const [name, clip] of this._clips) {
       out[name] = {
         frames: clip.frames.map(frame => frame.clone()),
         fps: 1000 / clip.frameDurationMs,
-        loop: clip.loop,
+        repeat: clip.repeat,
         ...(clip.frameDurations ? { frameDurations: [...clip.frameDurations] } : {}),
         ...(clip.frameOffsets ? { frameOffsets: clip.frameOffsets.map(offset => ({ x: offset.x, y: offset.y })) } : {}),
       };
@@ -222,13 +254,17 @@ export class AnimatedSprite extends Sprite {
   /**
    * Start playing the named clip. By default restarts from frame 0; pass
    * `{ restart: false }` to resume from the current frame if the same clip
-   * is already active. Optionally overrides the clip's loop setting.
+   * is already active. Optionally overrides the clip's `repeat` setting.
    */
   public play(name: string, options: AnimatedSpritePlayOptions = {}): this {
     const clip = this._clips.get(name);
 
     if (!clip) {
       throw new Error(`AnimatedSprite clip "${name}" is not defined.`);
+    }
+
+    if (options.repeat !== undefined) {
+      assertValidRepeat('play() options.repeat', options.repeat);
     }
 
     const isSameClip = this._currentClipName === name;
@@ -238,12 +274,13 @@ export class AnimatedSprite extends Sprite {
       this._currentClipName = name;
       this._currentFrameIndex = 0;
       this._elapsedFrameTimeMs = 0;
+      this._completedCycles = 0;
       // Normalized clips always hold at least one frame.
       this._applyFrame(clip, 0);
       this.onFrame.dispatch(name, 0);
     }
 
-    this._loopOverride = options.loop ?? this._loopOverride;
+    this._repeatOverride = options.repeat ?? this._repeatOverride;
     this._playing = true;
 
     return this;
@@ -287,7 +324,8 @@ export class AnimatedSprite extends Sprite {
   /**
    * Advance playback by `delta` milliseconds (or a `Time` object). Call once
    * per frame from the game loop. Dispatches `onFrame` for each frame
-   * boundary crossed and `onComplete` when a non-looping clip ends.
+   * boundary crossed and `onComplete` when the clip completes its final
+   * {@link AnimatedSpriteClipDefinition.repeat} cycle.
    */
   public update(delta: Time | number): this {
     if (!this._playing || this._currentClipName === null) {
@@ -321,7 +359,20 @@ export class AnimatedSprite extends Sprite {
       const nextFrame = this._currentFrameIndex + 1;
 
       if (nextFrame >= clip.frames.length) {
-        if (this.loop) {
+        // `repeat` is the single source of truth for whether playback wraps.
+        // Infinite always wraps; a finite count wraps until it has completed
+        // that many full cycles, then stops on the same path play-once used to.
+        const activeRepeat = this._repeatOverride ?? clip.repeat;
+        let shouldWrap: boolean;
+
+        if (activeRepeat === infiniteRepeat) {
+          shouldWrap = true;
+        } else {
+          this._completedCycles++;
+          shouldWrap = this._completedCycles < activeRepeat;
+        }
+
+        if (shouldWrap) {
           this._currentFrameIndex = 0;
           // clip has > 1 frame here (early-returned otherwise).
           this._applyFrame(clip, 0);
@@ -366,8 +417,9 @@ export class AnimatedSprite extends Sprite {
 
   /**
    * Construct an {@link AnimatedSprite} from the named animations defined on
-   * a {@link Spritesheet}. Each animation becomes a looping clip whose frames
-   * are the spritesheet frame rectangles in declaration order.
+   * a {@link Spritesheet}. Each animation becomes an indefinitely-looping
+   * clip whose frames are the spritesheet frame rectangles in declaration
+   * order.
    */
   public static fromSpritesheet(spritesheet: Spritesheet): AnimatedSprite {
     const clips: Record<string, AnimatedSpriteClipDefinition> = {};
@@ -375,7 +427,6 @@ export class AnimatedSprite extends Sprite {
     for (const [clipName, frameNames] of spritesheet.animations) {
       clips[clipName] = {
         frames: frameNames.map(frameName => spritesheet.getFrame(frameName)),
-        loop: true,
       };
     }
 

--- a/src/rendering/webgpu/WebGpuBackdropBlendCompositor.ts
+++ b/src/rendering/webgpu/WebGpuBackdropBlendCompositor.ts
@@ -9,7 +9,8 @@ import type { WebGpuBackend } from './WebGpuBackend';
 import { getWebGpuBlendState } from './WebGpuBlendState';
 import { stencilContentDepthStencilState } from './WebGpuStencilState';
 
-const compositorShaderSource = `
+/** WGSL source for the backdrop-blend compositor pipeline. @internal */
+export const compositorShaderSource = `
 struct ProjectionUniforms {
     matrix: mat4x4<f32>,
 };

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -59,6 +59,50 @@ const managedTextureFormat: GPUTextureFormat = 'rgba8unorm';
 // Managed content + render textures use rgba8unorm = 4 bytes/px.
 const MANAGED_TEXTURE_BYTES_PER_PIXEL = 4;
 
+/** WGSL source for the box-filter mipmap-generation pipeline. @internal */
+export const mipmapWgsl = `
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) texcoord: vec2<f32>,
+};
+
+@group(0) @binding(0)
+var sourceTexture: texture_2d<f32>;
+@group(0) @binding(1)
+var sourceSampler: sampler;
+
+@vertex
+fn vertexMain(@builtin(vertex_index) vertexIndex: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, -1.0),
+        vec2<f32>(3.0, -1.0),
+        vec2<f32>(-1.0, 3.0)
+    );
+    // Y is flipped vs the position array: NDC Y points up, but texture UV
+    // Y points down (UV (0,0) is the top-left of the source). Matching the
+    // two ensures that the output texture's top-left pixel samples from the
+    // source's top-left, so every mip level has the same orientation as the
+    // level above it. Prior to this, odd mip levels were rendered upside
+    // down, producing visible texture flips at view-size doublings.
+    var texcoords = array<vec2<f32>, 3>(
+        vec2<f32>(0.0, 1.0),
+        vec2<f32>(2.0, 1.0),
+        vec2<f32>(0.0, -1.0)
+    );
+    var output: VertexOutput;
+
+    output.position = vec4<f32>(positions[vertexIndex], 0.0, 1.0);
+    output.texcoord = texcoords[vertexIndex];
+
+    return output;
+}
+
+@fragment
+fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(sourceTexture, sourceSampler, input.texcoord);
+}
+`;
+
 /**
  * WebGPU implementation of {@link RenderBackend}. Manages the GPU device,
  * canvas context configuration, format selection, managed-texture cache
@@ -1554,48 +1598,7 @@ export class WebGpuBackend implements RenderBackend {
       this._mipmapSampler === null
     ) {
       this._mipmapShaderModule = this.device.createShaderModule({
-        code: `
-struct VertexOutput {
-    @builtin(position) position: vec4<f32>,
-    @location(0) texcoord: vec2<f32>,
-};
-
-@group(0) @binding(0)
-var sourceTexture: texture_2d<f32>;
-@group(0) @binding(1)
-var sourceSampler: sampler;
-
-@vertex
-fn vertexMain(@builtin(vertex_index) vertexIndex: u32) -> VertexOutput {
-    var positions = array<vec2<f32>, 3>(
-        vec2<f32>(-1.0, -1.0),
-        vec2<f32>(3.0, -1.0),
-        vec2<f32>(-1.0, 3.0)
-    );
-    // Y is flipped vs the position array: NDC Y points up, but texture UV
-    // Y points down (UV (0,0) is the top-left of the source). Matching the
-    // two ensures that the output texture's top-left pixel samples from the
-    // source's top-left, so every mip level has the same orientation as the
-    // level above it. Prior to this, odd mip levels were rendered upside
-    // down, producing visible texture flips at view-size doublings.
-    var texcoords = array<vec2<f32>, 3>(
-        vec2<f32>(0.0, 1.0),
-        vec2<f32>(2.0, 1.0),
-        vec2<f32>(0.0, -1.0)
-    );
-    var output: VertexOutput;
-
-    output.position = vec4<f32>(positions[vertexIndex], 0.0, 1.0);
-    output.texcoord = texcoords[vertexIndex];
-
-    return output;
-}
-
-@fragment
-fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
-    return textureSample(sourceTexture, sourceSampler, input.texcoord);
-}
-`,
+        code: mipmapWgsl,
       });
       this._mipmapBindGroupLayout = this.device.createBindGroupLayout({
         entries: [

--- a/src/rendering/webgpu/WebGpuMaskCompositor.ts
+++ b/src/rendering/webgpu/WebGpuMaskCompositor.ts
@@ -9,7 +9,8 @@ import type { WebGpuBackend } from './WebGpuBackend';
 import { getWebGpuBlendState } from './WebGpuBlendState';
 import { stencilContentDepthStencilState } from './WebGpuStencilState';
 
-const compositorShaderSource = `
+/** WGSL source for the mask compositor pipeline. @internal */
+export const compositorShaderSource = `
 struct ProjectionUniforms {
     matrix: mat4x4<f32>,
 };

--- a/src/rendering/webgpu/WebGpuMeshRenderer.ts
+++ b/src/rendering/webgpu/WebGpuMeshRenderer.ts
@@ -16,7 +16,8 @@ import type { WebGpuBackend } from './WebGpuBackend';
 import { getWebGpuBlendState } from './WebGpuBlendState';
 import { stencilContentDepthStencilState } from './WebGpuStencilState';
 
-const meshShaderSource = `
+/** WGSL source for the default (non-instanced) mesh pipeline. @internal */
+export const meshShaderSource = `
 struct VertexInput {
     @location(0) position: vec2<f32>,
     @location(1) texcoord: vec2<f32>,
@@ -59,7 +60,8 @@ fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
 }
 `;
 
-const instancedMeshShaderSource = `
+/** WGSL source for the instanced mesh pipeline. @internal */
+export const instancedMeshShaderSource = `
 struct VertexInput {
     @location(0) position: vec2<f32>,
     @location(1) texcoord: vec2<f32>,

--- a/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
@@ -11,7 +11,8 @@ import type { WebGpuBackend } from './WebGpuBackend';
 import { getWebGpuBlendState } from './WebGpuBlendState';
 import { stencilContentDepthStencilState } from './WebGpuStencilState';
 
-const nineSliceShaderSource = `
+/** WGSL source for the nine-slice sprite pipeline. @internal */
+export const nineSliceShaderSource = `
 struct ProjectionUniforms {
     matrix: mat4x4<f32>,
 };

--- a/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
@@ -18,7 +18,8 @@ import { stencilContentDepthStencilState } from './WebGpuStencilState';
 // both the shader path and the geometry path entry points.
 // ---------------------------------------------------------------------------
 
-const commonWgsl = `
+/** Shared WGSL structs/bindings used by both repeating-sprite entry points. @internal */
+export const commonWgsl = `
 struct ProjectionUniforms {
     matrix: mat4x4<f32>,
 };
@@ -44,7 +45,8 @@ struct VOut {
 // Shader path WGSL — one quad per sprite, UVs computed in vertex shader.
 // ---------------------------------------------------------------------------
 
-const shaderPathEntries = `
+/** WGSL entry points for the shader (one-quad-per-sprite) repeating-sprite path. @internal */
+export const shaderPathEntries = `
 struct ShaderVIn {
     @location(0) quadBounds: vec4<f32>,  // x0,y0,x1,y1
     @location(1) uvParams:   vec4<f32>,  // tilingX, tilingY, offsetU, offsetV
@@ -85,7 +87,8 @@ fn shaderFrag(input: VOut) -> @location(0) vec4<f32> {
 // Geometry path WGSL — N quads per sprite, UVs pre-computed in CPU.
 // ---------------------------------------------------------------------------
 
-const geoPathEntries = `
+/** WGSL entry points for the geometry (N-quads-per-sprite) repeating-sprite path. @internal */
+export const geoPathEntries = `
 struct GeoVIn {
     @location(0) quadBounds: vec4<f32>,  // x0,y0,x1,y1
     @location(1) uvBounds:   vec4<f32>,  // u0,v0,u1,v1 (normalised, flipY pre-applied)

--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -14,7 +14,8 @@ import type { WebGpuBackend } from './WebGpuBackend';
 import { getWebGpuBlendState } from './WebGpuBlendState';
 import { stencilContentDepthStencilState } from './WebGpuStencilState';
 
-const spriteShaderSource = `
+/** WGSL source for the default sprite pipeline. @internal */
+export const spriteShaderSource = `
 struct ProjectionUniforms {
     matrix: mat4x4<f32>,
 };

--- a/src/rendering/webgpu/WebGpuStencilClipper.ts
+++ b/src/rendering/webgpu/WebGpuStencilClipper.ts
@@ -11,7 +11,8 @@ export const stencilAttachmentFormat: GPUTextureFormat = 'depth24plus-stencil8';
 const positionNames = new Set<string>(['a_position', 'position']);
 const matrixByteLength = 64; // mat4x4<f32>
 
-const stencilWriteShaderSource = `
+/** WGSL source for the stencil-write pipeline. @internal */
+export const stencilWriteShaderSource = `
 struct Uniforms {
     matrix: mat4x4<f32>,
 };

--- a/src/rendering/webgpu/WebGpuTextRenderer.ts
+++ b/src/rendering/webgpu/WebGpuTextRenderer.ts
@@ -57,7 +57,8 @@ interface BatchDraw {
 }
 
 // ── WGSL: shared vertex + three fragment entry points ────────────────────────
-const textShaderSource = `
+/** WGSL source for the text pipeline (shared vertex + color/SDF/MSDF fragment entry points). @internal */
+export const textShaderSource = `
 struct FrameUniforms {
     projCol0 : vec4<f32>,
     projCol1 : vec4<f32>,

--- a/test/core/serialization.test.ts
+++ b/test/core/serialization.test.ts
@@ -533,6 +533,30 @@ describe('serialization — AnimatedSprite', () => {
     expect(restored.playing).toBe(true);
     expect(() => restored.play('run')).not.toThrow();
   });
+
+  it('round-trips per-frame frameDurations', () => {
+    const texture = createTexture(64, 16);
+    const loader = fakeLoader([{ type: Texture, source: 'hero.png', resource: texture }]);
+    const sprite = new AnimatedSprite(texture, {
+      idle: {
+        frames: [new Rectangle(0, 0, 16, 16), new Rectangle(16, 0, 16, 16)],
+        loop: true,
+        frameDurations: [100, 300],
+      },
+    });
+
+    const data = serializeTree(sprite, loader);
+    const restored = deserializeTree(data, loader) as AnimatedSprite;
+
+    restored.play('idle');
+    restored.update(100);
+    expect(restored.currentFrame).toBe(1);
+
+    // Frame 1 holds 300ms (frameDurations), not the 100ms it would hold at
+    // the default 12fps if frameDurations had been lost in the round-trip.
+    restored.update(100);
+    expect(restored.currentFrame).toBe(1);
+  });
 });
 
 describe('serialization — BitmapText', () => {

--- a/test/core/serialization.test.ts
+++ b/test/core/serialization.test.ts
@@ -557,6 +557,32 @@ describe('serialization — AnimatedSprite', () => {
     restored.update(100);
     expect(restored.currentFrame).toBe(1);
   });
+
+  it('round-trips per-frame frameOffsets', () => {
+    const texture = createTexture(64, 16);
+    const loader = fakeLoader([{ type: Texture, source: 'hero.png', resource: texture }]);
+    const sprite = new AnimatedSprite(texture, {
+      punch: {
+        frames: [new Rectangle(0, 0, 16, 16), new Rectangle(16, 0, 16, 16)],
+        loop: true,
+        frameOffsets: [
+          { x: 0, y: 0 },
+          { x: 4, y: -2 },
+        ],
+      },
+    });
+
+    const data = serializeTree(sprite, loader);
+    const restored = deserializeTree(data, loader) as AnimatedSprite;
+
+    restored.play('punch');
+    expect(restored.getLocalBounds().x).toBe(0);
+
+    restored.update(100);
+    expect(restored.currentFrame).toBe(1);
+    expect(restored.getLocalBounds().x).toBe(4);
+    expect(restored.getLocalBounds().y).toBe(-2);
+  });
 });
 
 describe('serialization — BitmapText', () => {

--- a/test/core/serialization.test.ts
+++ b/test/core/serialization.test.ts
@@ -516,7 +516,7 @@ describe('serialization — AnimatedSprite', () => {
     const texture = createTexture(64, 16);
     const loader = fakeLoader([{ type: Texture, source: 'hero.png', resource: texture }]);
     const sprite = new AnimatedSprite(texture, {
-      run: { frames: [new Rectangle(0, 0, 16, 16), new Rectangle(16, 0, 16, 16)], fps: 10, loop: true },
+      run: { frames: [new Rectangle(0, 0, 16, 16), new Rectangle(16, 0, 16, 16)], fps: 10 },
     });
 
     sprite.play('run');
@@ -540,7 +540,6 @@ describe('serialization — AnimatedSprite', () => {
     const sprite = new AnimatedSprite(texture, {
       idle: {
         frames: [new Rectangle(0, 0, 16, 16), new Rectangle(16, 0, 16, 16)],
-        loop: true,
         frameDurations: [100, 300],
       },
     });
@@ -564,7 +563,6 @@ describe('serialization — AnimatedSprite', () => {
     const sprite = new AnimatedSprite(texture, {
       punch: {
         frames: [new Rectangle(0, 0, 16, 16), new Rectangle(16, 0, 16, 16)],
-        loop: true,
         frameOffsets: [
           { x: 0, y: 0 },
           { x: 4, y: -2 },
@@ -582,6 +580,34 @@ describe('serialization — AnimatedSprite', () => {
     expect(restored.currentFrame).toBe(1);
     expect(restored.getLocalBounds().x).toBe(4);
     expect(restored.getLocalBounds().y).toBe(-2);
+  });
+
+  it('round-trips a finite repeat count', () => {
+    const texture = createTexture(64, 16);
+    const loader = fakeLoader([{ type: Texture, source: 'hero.png', resource: texture }]);
+    const sprite = new AnimatedSprite(texture, {
+      triple: {
+        frames: [new Rectangle(0, 0, 16, 16), new Rectangle(16, 0, 16, 16)],
+        fps: 10,
+        repeat: 2,
+      },
+    });
+
+    const data = serializeTree(sprite, loader);
+    const restored = deserializeTree(data, loader) as AnimatedSprite;
+    const completeSpy = vi.fn();
+
+    restored.onComplete.add(completeSpy);
+    restored.play('triple');
+
+    // 2 frames @ 10fps = 100ms/frame; one full cycle is 200ms.
+    restored.update(200);
+    expect(restored.playing).toBe(true);
+    expect(completeSpy).not.toHaveBeenCalled();
+
+    restored.update(200);
+    expect(restored.playing).toBe(false);
+    expect(completeSpy).toHaveBeenCalledWith('triple');
   });
 });
 

--- a/test/rendering/animated-sprite.test.ts
+++ b/test/rendering/animated-sprite.test.ts
@@ -177,4 +177,81 @@ describe('AnimatedSprite', () => {
     expect(sprite.currentClip).toBe('idle');
     expect(sprite.currentFrame).toBe(1);
   });
+
+  test('frameOffsets translate the local quad so trimmed frames stay anchored to the untrimmed canvas', () => {
+    const frames = createFrames();
+    const sprite = new AnimatedSprite(null, {
+      punch: {
+        frames,
+        fps: 10,
+        loop: true,
+        frameOffsets: [
+          { x: 0, y: 0 },
+          { x: 4, y: -2 },
+          { x: 0, y: 0 },
+        ],
+      },
+    });
+
+    sprite.play('punch');
+    expect(sprite.getLocalBounds().x).toBe(0);
+    expect(sprite.getLocalBounds().y).toBe(0);
+
+    sprite.update(100);
+    expect(sprite.currentFrame).toBe(1);
+    expect(sprite.getLocalBounds().x).toBe(4);
+    expect(sprite.getLocalBounds().y).toBe(-2);
+
+    sprite.update(100);
+    expect(sprite.currentFrame).toBe(2);
+    expect(sprite.getLocalBounds().x).toBe(0);
+    expect(sprite.getLocalBounds().y).toBe(0);
+  });
+
+  test('frameOffsets do not affect a sprite without any offset data (pixel-identical to today)', () => {
+    const frames = createFrames();
+    const sprite = new AnimatedSprite(null, {
+      walk: {
+        frames,
+        fps: 10,
+        loop: true,
+      },
+    });
+
+    sprite.play('walk');
+    sprite.update(100);
+
+    expect(sprite.getLocalBounds().x).toBe(0);
+    expect(sprite.getLocalBounds().y).toBe(0);
+    expect(sprite.getLocalBounds().width).toBe(16);
+    expect(sprite.getLocalBounds().height).toBe(16);
+  });
+
+  test('frameOffsets length must match the frame count', () => {
+    const frames = createFrames();
+    const sprite = new AnimatedSprite(null);
+
+    expect(() =>
+      sprite.defineClip('bad', {
+        frames,
+        frameOffsets: [{ x: 0, y: 0 }],
+      }),
+    ).toThrow(/frameOffsets/);
+  });
+
+  test('frameOffsets entries must have finite x/y', () => {
+    const frames = createFrames();
+    const sprite = new AnimatedSprite(null);
+
+    expect(() =>
+      sprite.defineClip('bad', {
+        frames,
+        frameOffsets: [
+          { x: 0, y: 0 },
+          { x: Number.NaN, y: 0 },
+          { x: 0, y: 0 },
+        ],
+      }),
+    ).toThrow(/frameOffsets/);
+  });
 });

--- a/test/rendering/animated-sprite.test.ts
+++ b/test/rendering/animated-sprite.test.ts
@@ -1,4 +1,4 @@
-﻿import { Rectangle } from '#math/Rectangle';
+import { Rectangle } from '#math/Rectangle';
 import { AnimatedSprite } from '#rendering/sprite/AnimatedSprite';
 import { Spritesheet } from '#rendering/sprite/Spritesheet';
 import type { Texture } from '#rendering/texture/Texture';
@@ -20,7 +20,6 @@ describe('AnimatedSprite', () => {
       walk: {
         frames,
         fps: 10,
-        loop: true,
       },
     });
 
@@ -43,7 +42,7 @@ describe('AnimatedSprite', () => {
       looped: {
         frames,
         fps: 10,
-        loop: true,
+        repeat: -1,
       },
     });
 
@@ -54,13 +53,13 @@ describe('AnimatedSprite', () => {
     expect(sprite.playing).toBe(true);
   });
 
-  test('non-looping clip completes and dispatches onComplete', () => {
+  test('non-looping clip (repeat: 1) completes and dispatches onComplete', () => {
     const frames = createFrames();
     const sprite = new AnimatedSprite(null, {
       burst: {
         frames,
         fps: 10,
-        loop: false,
+        repeat: 1,
       },
     });
     const completeSpy = vi.fn();
@@ -80,7 +79,6 @@ describe('AnimatedSprite', () => {
       move: {
         frames,
         fps: 10,
-        loop: true,
       },
     });
 
@@ -113,7 +111,6 @@ describe('AnimatedSprite', () => {
       idle: {
         frames,
         frameDurations: [100, 100, 300],
-        loop: true,
       },
     });
 
@@ -184,7 +181,6 @@ describe('AnimatedSprite', () => {
       punch: {
         frames,
         fps: 10,
-        loop: true,
         frameOffsets: [
           { x: 0, y: 0 },
           { x: 4, y: -2 },
@@ -214,7 +210,6 @@ describe('AnimatedSprite', () => {
       walk: {
         frames,
         fps: 10,
-        loop: true,
       },
     });
 
@@ -253,5 +248,204 @@ describe('AnimatedSprite', () => {
         ],
       }),
     ).toThrow(/frameOffsets/);
+  });
+
+  describe('repeat', () => {
+    test('repeat: 3 stops after exactly 3 full cycles and dispatches onComplete on the 3rd', () => {
+      const frames = createFrames();
+      const sprite = new AnimatedSprite(null, {
+        triple: {
+          frames,
+          fps: 10,
+          repeat: 3,
+        },
+      });
+      const completeSpy = vi.fn();
+
+      sprite.onComplete.add(completeSpy);
+      sprite.play('triple');
+
+      // Each cycle is 3 frames @ 10fps = 300ms. Advance through 2 full
+      // cycles first — playback should still be running, no onComplete yet.
+      sprite.update(300);
+      expect(sprite.playing).toBe(true);
+      expect(completeSpy).not.toHaveBeenCalled();
+
+      sprite.update(300);
+      expect(sprite.playing).toBe(true);
+      expect(completeSpy).not.toHaveBeenCalled();
+
+      // Third cycle: stops on the last frame and fires onComplete exactly once.
+      sprite.update(300);
+      expect(sprite.playing).toBe(false);
+      expect(sprite.currentFrame).toBe(2);
+      expect(completeSpy).toHaveBeenCalledTimes(1);
+      expect(completeSpy).toHaveBeenCalledWith('triple');
+
+      // Further updates are a no-op once stopped.
+      sprite.update(300);
+      expect(sprite.playing).toBe(false);
+      expect(completeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('repeat overrides an infinite default (repeat omitted means -1) for the clip it is set on', () => {
+      const frames = createFrames();
+      const sprite = new AnimatedSprite(null, {
+        // No `repeat` set: defaults to -1 (infinite), same as before.
+        infinite: { frames, fps: 10 },
+        // `repeat: 2` takes full precedence — stops after 2 cycles regardless
+        // of what an infinite default would otherwise do.
+        finite: { frames, fps: 10, repeat: 2 },
+      });
+
+      sprite.play('finite');
+      sprite.update(300);
+      sprite.update(300);
+
+      expect(sprite.playing).toBe(false);
+      expect(sprite.currentFrame).toBe(2);
+    });
+
+    test('play() resets the cycle counter, so playing the same clip twice in a row both complete after N cycles', () => {
+      const frames = createFrames();
+      const sprite = new AnimatedSprite(null, {
+        twice: {
+          frames,
+          fps: 10,
+          repeat: 2,
+        },
+      });
+      const completeSpy = vi.fn();
+
+      sprite.onComplete.add(completeSpy);
+      sprite.play('twice');
+      sprite.update(300);
+      sprite.update(300);
+
+      expect(sprite.playing).toBe(false);
+      expect(completeSpy).toHaveBeenCalledTimes(1);
+
+      // Replaying the same clip must complete after another 2 cycles, not
+      // immediately (which would happen if the cycle counter leaked across
+      // plays instead of being reset).
+      sprite.play('twice');
+      expect(sprite.playing).toBe(true);
+
+      sprite.update(300);
+      expect(sprite.playing).toBe(true);
+      expect(completeSpy).toHaveBeenCalledTimes(1);
+
+      sprite.update(300);
+      expect(sprite.playing).toBe(false);
+      expect(completeSpy).toHaveBeenCalledTimes(2);
+    });
+
+    test('per-call options.repeat overrides the clip repeat for the duration of that play() call', () => {
+      const frames = createFrames();
+      const sprite = new AnimatedSprite(null, {
+        // Clip defaults to infinite.
+        walk: { frames, fps: 10 },
+      });
+      const completeSpy = vi.fn();
+
+      sprite.onComplete.add(completeSpy);
+      sprite.play('walk', { repeat: 1 });
+      sprite.update(300);
+
+      expect(sprite.playing).toBe(false);
+      expect(completeSpy).toHaveBeenCalledWith('walk');
+    });
+
+    test('repeat must be -1 or a positive integer', () => {
+      const frames = createFrames();
+      const sprite = new AnimatedSprite(null);
+
+      expect(() => sprite.defineClip('bad', { frames, repeat: 0 })).toThrow(/repeat/);
+      expect(() => sprite.defineClip('bad', { frames, repeat: -2 })).toThrow(/repeat/);
+      expect(() => sprite.defineClip('bad', { frames, repeat: 1.5 })).toThrow(/repeat/);
+    });
+
+    test("repeat honors each frame's own frameDurations hold time on every cycle, not an averaged/uniform value", () => {
+      const frames = createFrames();
+      const sprite = new AnimatedSprite(null, {
+        combo: {
+          frames,
+          // Deliberately uneven: frame 2 lingers for 300ms. No `fps` given, so
+          // if a cycle ever fell back to the uniform default (1000/12 ≈ 83.3ms)
+          // instead of re-reading `frameDurations`, these exact-boundary
+          // assertions would drift and fail.
+          frameDurations: [100, 100, 300],
+          repeat: 2,
+        },
+      });
+      const completeSpy = vi.fn();
+
+      sprite.onComplete.add(completeSpy);
+      sprite.play('combo');
+
+      // ── Cycle 1 ──
+      sprite.update(100); // frame 0 -> 1
+      expect(sprite.currentFrame).toBe(1);
+
+      sprite.update(100); // frame 1 -> 2
+      expect(sprite.currentFrame).toBe(2);
+
+      // Frame 2 holds 300ms; short of that must not wrap yet.
+      sprite.update(299);
+      expect(sprite.currentFrame).toBe(2);
+      expect(sprite.playing).toBe(true);
+      expect(completeSpy).not.toHaveBeenCalled();
+
+      // The remaining 1ms completes frame 2's 300ms hold and wraps into cycle 2.
+      sprite.update(1);
+      expect(sprite.currentFrame).toBe(0);
+      expect(sprite.playing).toBe(true);
+      expect(completeSpy).not.toHaveBeenCalled();
+
+      // ── Cycle 2 — same per-frame durations must apply again ──
+      sprite.update(100); // frame 0 -> 1
+      expect(sprite.currentFrame).toBe(1);
+
+      sprite.update(100); // frame 1 -> 2
+      expect(sprite.currentFrame).toBe(2);
+
+      // Short of frame 2's 300ms hold on the final cycle: still not complete.
+      sprite.update(299);
+      expect(sprite.currentFrame).toBe(2);
+      expect(sprite.playing).toBe(true);
+      expect(completeSpy).not.toHaveBeenCalled();
+
+      // The final 1ms genuinely completes the 2nd full cycle (500ms of real
+      // per-frame hold time each, 1000ms total) and fires onComplete exactly once.
+      sprite.update(1);
+      expect(sprite.currentFrame).toBe(2);
+      expect(sprite.playing).toBe(false);
+      expect(completeSpy).toHaveBeenCalledTimes(1);
+      expect(completeSpy).toHaveBeenCalledWith('combo');
+    });
+
+    // Pre-existing behavior, not introduced by `repeat`: `update()` early-returns
+    // for single-frame clips (`frames.length <= 1`) before it ever reaches the
+    // frame-wrap logic that counts cycles and dispatches `onComplete`. A
+    // single-frame clip therefore never completes on its own, even with a
+    // finite `repeat` — `onComplete` only fires via the multi-frame wrap path.
+    test('a single-frame clip with a finite repeat never advances or completes (pre-existing early-return, not a repeat regression)', () => {
+      const sprite = new AnimatedSprite(null, {
+        still: {
+          frames: [new Rectangle(0, 0, 16, 16)],
+          fps: 10,
+          repeat: 1,
+        },
+      });
+      const completeSpy = vi.fn();
+
+      sprite.onComplete.add(completeSpy);
+      sprite.play('still');
+      sprite.update(1000);
+
+      expect(sprite.currentFrame).toBe(0);
+      expect(sprite.playing).toBe(true);
+      expect(completeSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/test/rendering/animated-sprite.test.ts
+++ b/test/rendering/animated-sprite.test.ts
@@ -107,6 +107,58 @@ describe('AnimatedSprite', () => {
     expect(() => sprite.play('missing')).toThrow('AnimatedSprite clip "missing" is not defined.');
   });
 
+  test('per-frame frameDurations hold each frame for its own duration instead of the uniform fps rate', () => {
+    const frames = createFrames();
+    const sprite = new AnimatedSprite(null, {
+      idle: {
+        frames,
+        frameDurations: [100, 100, 300],
+        loop: true,
+      },
+    });
+
+    sprite.play('idle');
+
+    // Frame 0 holds 100ms.
+    sprite.update(100);
+    expect(sprite.currentFrame).toBe(1);
+
+    // Frame 1 holds 100ms.
+    sprite.update(100);
+    expect(sprite.currentFrame).toBe(2);
+
+    // Frame 2 holds 300ms; 100ms is not enough to advance yet.
+    sprite.update(100);
+    expect(sprite.currentFrame).toBe(2);
+
+    sprite.update(200);
+    expect(sprite.currentFrame).toBe(0);
+  });
+
+  test('frameDurations length must match the frame count', () => {
+    const frames = createFrames();
+    const sprite = new AnimatedSprite(null);
+
+    expect(() =>
+      sprite.defineClip('bad', {
+        frames,
+        frameDurations: [100, 100],
+      }),
+    ).toThrow(/frameDurations/);
+  });
+
+  test('frameDurations entries must be finite positive numbers', () => {
+    const frames = createFrames();
+    const sprite = new AnimatedSprite(null);
+
+    expect(() =>
+      sprite.defineClip('bad', {
+        frames,
+        frameDurations: [100, 0, 100],
+      }),
+    ).toThrow(/frameDurations/);
+  });
+
   test('can build clips from spritesheet animation metadata', () => {
     const spritesheet = new Spritesheet(createTextureStub(), {
       frames: {

--- a/test/rendering/browser/webgpu-backdrop-blend.test.ts
+++ b/test/rendering/browser/webgpu-backdrop-blend.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="@webgpu/types" />
+
 /**
  * WebGPU backdrop-aware blend SPIKE — proves the advanced-blend primitive
  * (`WebGpuBackdropBlendCompositor`) end-to-end in isolation, before any
@@ -13,6 +15,12 @@
  *     right place (a vertically-split backdrop under an opaque white source comes
  *     back unflipped — copyTextureToTexture preserves top-left order, unlike the
  *     WebGL2 framebuffer blit).
+ *
+ * Pixel readback is real GPU-side readback (`copyTextureToBuffer` +
+ * `mapAsync`), NOT `ctx.drawImage(webgpuCanvas)` into a 2D canvas — the
+ * drawImage path silently reads back all-zero on the software (SwiftShader /
+ * lavapipe) adapters CI runs on, which would make this spike pass without
+ * proving anything.
  *
  * All tests skip gracefully when WebGPU is unavailable or the software adapter
  * drops the device mid-test.
@@ -86,27 +94,56 @@ const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException 
 const fullQuadVertices = (): Float32Array => new Float32Array([0, 0, canvasSize, 0, canvasSize, canvasSize, 0, 0, canvasSize, canvasSize, 0, canvasSize]);
 const fullQuadUvs = (): Float32Array => new Float32Array([0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1]);
 
-// Read the presented WebGPU canvas back through a 2D canvas (drawImage accepts a
-// WebGPU-configured canvas as an image source), giving CPU-side pixel access.
-const readCanvas = (backend: WebGpuBackend): ((x: number, y: number) => RgbaTuple) => {
-  const source = backend.context.canvas as HTMLCanvasElement;
-  const readback = document.createElement('canvas');
+// GPU-side row alignment: copyTextureToBuffer requires bytesPerRow to be a
+// multiple of 256. A 64x64 RGBA8 canvas is already 256 bytes/row (64 * 4), but
+// this is computed generically so a future canvasSize change doesn't silently
+// break the readback.
+const bytesPerRowAligned = (widthPx: number, bytesPerPixel: number): number => Math.ceil((widthPx * bytesPerPixel) / 256) * 256;
 
-  readback.width = canvasSize;
-  readback.height = canvasSize;
+// Read the presented WebGPU canvas back via a real GPU-side readback:
+// copyTextureToBuffer -> mapAsync -> getMappedRange, mirroring
+// `WebGpuStorageBuffer.read`. `ctx.drawImage(webgpuCanvas)` into a 2D canvas
+// looks like a readback but returns all-zero on the software (SwiftShader /
+// lavapipe) adapters CI runs the WebGPU lane on — it never actually exercises
+// the GPU-visible pixel data, so a real regression there would go undetected.
+const readGpuCanvas = async (backend: WebGpuBackend): Promise<(x: number, y: number) => RgbaTuple> => {
+  const device = backend.device;
+  const texture = backend.context.getCurrentTexture();
+  const bytesPerPixel = 4; // canvas context is always an 8-bit-per-channel RGBA format (rgba8unorm / bgra8unorm).
+  const bytesPerRow = bytesPerRowAligned(canvasSize, bytesPerPixel);
+  const bufferSize = bytesPerRow * canvasSize;
 
-  const ctx = readback.getContext('2d');
+  const readbackBuffer = device.createBuffer({
+    label: 'webgpu-backdrop-blend-test-readback',
+    size: bufferSize,
+    usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
+  });
 
-  if (!ctx) {
-    throw new Error('2D context is required for canvas readback.');
-  }
+  const encoder = device.createCommandEncoder({ label: 'webgpu-backdrop-blend-test-readback-copy' });
 
-  ctx.drawImage(source, 0, 0);
+  encoder.copyTextureToBuffer({ texture }, { buffer: readbackBuffer, bytesPerRow, rowsPerImage: canvasSize }, { width: canvasSize, height: canvasSize });
+  device.queue.submit([encoder.finish()]);
+
+  await readbackBuffer.mapAsync(GPUMapMode.READ);
+
+  // Copy out of the mapped range before unmap() detaches its backing buffer.
+  const pixels = new Uint8Array(readbackBuffer.getMappedRange().slice(0));
+
+  readbackBuffer.unmap();
+  readbackBuffer.destroy();
+
+  // The preferred canvas format is commonly `bgra8unorm` on Chromium; swap
+  // channels back to RGBA so callers don't need to know the swizzle.
+  const swapRedBlue = backend.format === 'bgra8unorm';
 
   return (x: number, y: number): RgbaTuple => {
-    const { data } = ctx.getImageData(Math.floor(x), Math.floor(y), 1, 1);
+    const offset = Math.floor(y) * bytesPerRow + Math.floor(x) * bytesPerPixel;
+    const c0 = pixels[offset];
+    const c1 = pixels[offset + 1];
+    const c2 = pixels[offset + 2];
+    const c3 = pixels[offset + 3];
 
-    return [data[0], data[1], data[2], data[3]];
+    return swapRedBlue ? [c2, c1, c0, c3] : [c0, c1, c2, c3];
   };
 };
 
@@ -166,7 +203,7 @@ describe('WebGPU backdrop-aware blend (Darken spike)', () => {
       backend.clear(new Color(60, 120, 200)); // backdrop (deferred; compose flushes it)
       composeBackdropBlend(backend, source, BlendModes.Darken);
 
-      const readPixel = readCanvas(backend);
+      const readPixel = await readGpuCanvas(backend);
 
       // Left (red over blue, Darken): min((60,120,200),(255,0,0)) = (60,0,0).
       expectRgbNear(readPixel(16, 32), [60, 0, 0]);
@@ -216,7 +253,7 @@ describe('WebGPU backdrop-aware blend (Darken spike)', () => {
       drawBackdrop(backend, backdrop);
       composeBackdropBlend(backend, white, BlendModes.Darken);
 
-      const readPixel = readCanvas(backend);
+      const readPixel = await readGpuCanvas(backend);
 
       expectRgbNear(readPixel(32, 8), [200, 40, 40]); // top
       expectRgbNear(readPixel(32, 56), [40, 40, 200]); // bottom
@@ -264,7 +301,9 @@ describe('WebGPU backdrop-aware blend (Darken spike)', () => {
         drawBackdrop(backend, backdrop);
         compositor.compose(backend, source, 0, 0, canvasSize, canvasSize, mode);
 
-        expectRgbNear(readCanvas(backend)(32, 32), expectedOpaqueBlend(mode, backdropColor, sourceColor), 5);
+        const readPixel = await readGpuCanvas(backend);
+
+        expectRgbNear(readPixel(32, 32), expectedOpaqueBlend(mode, backdropColor, sourceColor), 5);
       }
     } catch (error) {
       if (isDeviceLoss(error)) {

--- a/test/rendering/browser/webgpu-shader-compile.test.ts
+++ b/test/rendering/browser/webgpu-shader-compile.test.ts
@@ -98,7 +98,10 @@ const compileWgsl = async (device: GPUDevice, code: string): Promise<CompileResu
   const module = device.createShaderModule({ code });
   const info = await module.getCompilationInfo();
   const errors = info.messages.filter(message => message.type === 'error');
-  const log = info.messages.length > 0 ? info.messages.map(message => `${message.type} ${message.lineNum}:${message.linePos} ${message.message}`).join('\n') : '<no messages>';
+  const log =
+    info.messages.length > 0
+      ? info.messages.map(message => `${message.type} ${message.lineNum}:${message.linePos} ${message.message}`).join('\n')
+      : '<no messages>';
 
   return { errorCount: errors.length, log };
 };

--- a/test/rendering/browser/webgpu-shader-compile.test.ts
+++ b/test/rendering/browser/webgpu-shader-compile.test.ts
@@ -1,0 +1,200 @@
+/// <reference types="@webgpu/types" />
+
+/**
+ * Real WGSL shader compile coverage.
+ *
+ * Mirrors `webgl2-shader-compile.test.ts` (real GLSL compile coverage) for the
+ * WebGPU renderer path. Unlike `gl.compileShader`, WGSL compilation is async
+ * and non-throwing: `device.createShaderModule({ code })` never throws on a
+ * syntax error — the error only surfaces later, off the main thread, via
+ * `shaderModule.getCompilationInfo()`. Nothing else in the test suite calls
+ * that API, so a WGSL syntax error anywhere in the WebGPU renderer path would
+ * ship completely silently.
+ *
+ * The sources under test are the actual module-level WGSL string constants
+ * feeding each renderer's `createShaderModule` call (exported — and, for the
+ * one call site that had it inline, hoisted — specifically so this spec can
+ * import them directly instead of duplicating the WGSL text). A source edit
+ * in any of those files is automatically covered here; no `.wgsl` files or
+ * `import.meta.glob` are involved because these are TS string constants, not
+ * separate assets.
+ *
+ * Two `createShaderModule` call sites are intentionally NOT covered:
+ *  - `WebGpuComputePipeline.create` takes an arbitrary caller-supplied `wgsl`
+ *    string as an option; it has no fixed source of its own, and currently no
+ *    caller inside `src/` (it is exported SDK surface for extension authors).
+ *  - `WebGpuSpriteRenderer`'s custom-material path and
+ *    `WebGpuMeshRenderer._getOrCreateCustomShaderResources` compile
+ *    user-authored `material.shader.wgsl` at runtime — there is no
+ *    engine-owned fixed string to assert against. `spriteVertexWgsl`, the
+ *    fixed prelude those custom-material shaders are prepended with, IS
+ *    covered below.
+ *
+ * Skips gracefully when WebGPU is unavailable, matching every other browser
+ * spec in this directory. Run via: pnpm test:browser:webgpu
+ */
+
+import { spriteVertexWgsl } from '#rendering/sprite/spriteMaterialSources';
+import { compositorShaderSource as backdropBlendCompositorWgsl } from '#rendering/webgpu/WebGpuBackdropBlendCompositor';
+import { mipmapWgsl } from '#rendering/webgpu/WebGpuBackend';
+import { compositorShaderSource as maskCompositorWgsl } from '#rendering/webgpu/WebGpuMaskCompositor';
+import { instancedMeshShaderSource, meshShaderSource } from '#rendering/webgpu/WebGpuMeshRenderer';
+import { nineSliceShaderSource } from '#rendering/webgpu/WebGpuNineSliceSpriteRenderer';
+import { commonWgsl, geoPathEntries, shaderPathEntries } from '#rendering/webgpu/WebGpuRepeatingSpriteRenderer';
+import { spriteShaderSource } from '#rendering/webgpu/WebGpuSpriteRenderer';
+import { stencilWriteShaderSource } from '#rendering/webgpu/WebGpuStencilClipper';
+import { textShaderSource } from '#rendering/webgpu/WebGpuTextRenderer';
+
+interface ShaderEntry {
+  readonly name: string;
+  readonly source: string;
+}
+
+const shaders: readonly ShaderEntry[] = [
+  { name: 'WebGpuBackend mipmap pipeline', source: mipmapWgsl },
+  { name: 'WebGpuBackdropBlendCompositor', source: backdropBlendCompositorWgsl },
+  { name: 'WebGpuMaskCompositor', source: maskCompositorWgsl },
+  { name: 'WebGpuMeshRenderer (default)', source: meshShaderSource },
+  { name: 'WebGpuMeshRenderer (instanced)', source: instancedMeshShaderSource },
+  { name: 'WebGpuNineSliceSpriteRenderer', source: nineSliceShaderSource },
+  // Combined exactly as `onConnect` feeds `createShaderModule`: shared struct/
+  // binding declarations + both entry-point sets in one module.
+  { name: 'WebGpuRepeatingSpriteRenderer (combined)', source: commonWgsl + shaderPathEntries + geoPathEntries },
+  { name: 'WebGpuSpriteRenderer', source: spriteShaderSource },
+  { name: 'WebGpuStencilClipper', source: stencilWriteShaderSource },
+  { name: 'WebGpuTextRenderer', source: textShaderSource },
+  { name: 'spriteMaterialSources spriteVertexWgsl (custom-material vertex prelude)', source: spriteVertexWgsl },
+];
+
+// On the software (swiftshader / lavapipe) adapter the WebGPU device can drop
+// mid-test; treat that as an unavailable-adapter skip rather than a failure,
+// matching every other WebGPU browser spec in this directory.
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+const requestDeviceOrSkip = async (ctx: { skip: (reason: string) => void }): Promise<GPUDevice | null> => {
+  if (!navigator.gpu) {
+    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
+
+    return null;
+  }
+
+  const adapter = await navigator.gpu.requestAdapter();
+
+  if (!adapter) {
+    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
+
+    return null;
+  }
+
+  return adapter.requestDevice();
+};
+
+interface CompileResult {
+  readonly errorCount: number;
+  readonly log: string;
+}
+
+const compileWgsl = async (device: GPUDevice, code: string): Promise<CompileResult> => {
+  const module = device.createShaderModule({ code });
+  const info = await module.getCompilationInfo();
+  const errors = info.messages.filter(message => message.type === 'error');
+  const log = info.messages.length > 0 ? info.messages.map(message => `${message.type} ${message.lineNum}:${message.linePos} ${message.message}`).join('\n') : '<no messages>';
+
+  return { errorCount: errors.length, log };
+};
+
+describe('WebGPU WGSL shader sources', () => {
+  test('imports non-empty WGSL sources for every fixed createShaderModule call site', () => {
+    // 9 renderer/compositor sources + the shared custom-material vertex
+    // prelude; grows if a new WebGPU renderer is added.
+    expect(shaders.length).toBeGreaterThanOrEqual(10);
+
+    for (const { name, source } of shaders) {
+      expect(source.length, `${name} is empty`).toBeGreaterThan(0);
+    }
+  });
+
+  // One shader compile per `test()` call (rather than `test.each`) so each
+  // gets its own device — matching the isolation-per-test pattern the other
+  // WebGPU browser specs in this directory use (see `setupBackend` in
+  // `webgpu-backdrop-blend.test.ts`), and keeping `ctx.skip` unambiguous.
+  for (const { name, source } of shaders) {
+    test(`compiles ${name}`, async ctx => {
+      const device = await requestDeviceOrSkip(ctx);
+
+      if (!device) {
+        return;
+      }
+
+      try {
+        const { errorCount, log } = await compileWgsl(device, source);
+
+        expect(errorCount, `${name} failed to compile:\n${log}`).toBe(0);
+      } catch (error) {
+        if (isDeviceLoss(error)) {
+          ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+          return;
+        }
+
+        throw error;
+      } finally {
+        device.destroy();
+      }
+    });
+  }
+
+  // ── Best-effort adapter-identity diagnostic ─────────────────────────────
+  //
+  // Closes (partially) an open uncertainty about the lavapipe CI wiring: does
+  // `VK_DRIVER_FILES` actually reach the Playwright-launched Chromium child
+  // process, or does Chromium silently fall back to its bundled SwiftShader
+  // software adapter? `GPUAdapter.info` (and the deprecated async
+  // `requestAdapterInfo()` it replaced) are the only APIs that could answer
+  // this from inside a test, but support/content is inconsistent across
+  // Chromium versions and can be intentionally opaque for fingerprinting
+  // reasons — so this is diagnostic logging only, not a hard pass/fail gate.
+  // A human should read this log line in the CI run to confirm the adapter
+  // description does not say "SwiftShader".
+  test('logs the requested adapter identity (informational, non-blocking)', async ctx => {
+    if (!navigator.gpu) {
+      ctx.skip('WebGPU unavailable: navigator.gpu is absent');
+
+      return;
+    }
+
+    const adapter = await navigator.gpu.requestAdapter();
+
+    if (!adapter) {
+      ctx.skip('WebGPU unavailable: requestAdapter() returned null');
+
+      return;
+    }
+
+    const info = (adapter as GPUAdapter & { info?: GPUAdapterInfo }).info;
+
+    if (info) {
+      console.info(
+        `[webgpu-shader-compile] adapter.info: vendor="${info.vendor}" architecture="${info.architecture}" device="${info.device}" description="${info.description}"`,
+      );
+
+      return;
+    }
+
+    const legacyRequestInfo = (adapter as GPUAdapter & { requestAdapterInfo?: () => Promise<GPUAdapterInfo> }).requestAdapterInfo;
+
+    if (typeof legacyRequestInfo === 'function') {
+      const legacyInfo = await legacyRequestInfo.call(adapter);
+
+      console.info(
+        `[webgpu-shader-compile] adapter.requestAdapterInfo(): vendor="${legacyInfo.vendor}" architecture="${legacyInfo.architecture}" device="${legacyInfo.device}" description="${legacyInfo.description}"`,
+      );
+
+      return;
+    }
+
+    console.info(
+      '[webgpu-shader-compile] adapter identity: neither adapter.info nor requestAdapterInfo() is available on this browser/version — cannot verify from inside the test whether lavapipe or SwiftShader served this run.',
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -192,26 +192,23 @@ export default defineConfig({
         },
       },
 
-      // ── browser-webgpu — WebGPU via Chromium + Mesa lavapipe (Vulkan software
-      // rasterizer) ─────────────────────────────────────────────────────────
-      // The `--use-angle=vulkan` / `--enable-features=Vulkan` / `--disable-vulkan-surface`
-      // flags are the exact recipe from Chrome for Developers' headless-WebGPU
-      // guide for getting a REAL (non-SwiftShader) Vulkan adapter out of Chromium
-      // on a free `ubuntu-latest` runner. NOTE: an earlier revision of this recipe
-      // also expanded `--enable-features` to `Vulkan,VulkanFromANGLE,DefaultANGLEVulkan`
-      // per an anecdotal report in gpuweb/gpuweb#5022 — that combination was
-      // measured against this CI's xvfb-headed (not `--headless=new`) lavapipe
-      // setup and made things *worse*: `requestAdapter()` started returning
-      // `null` outright (WebGPU browser suite dropped from 100/100 tests
-      // actually exercised down to 4/100, the rest skip-passing), instead of
-      // the pre-existing SwiftShader fallback. Reverted to the plain,
-      // officially-documented single feature flag. Locally these args are
-      // harmless (verified against a real Windows/NVIDIA adapter). `headless`
-      // stays true by default so local dev never pops a visible browser window;
-      // CI opts into `headless: false` via `EXOJS_WEBGPU_CI_HEADED=1` because Mesa
-      // lavapipe needs a real display surface to report a real Vulkan adapter
-      // instead of silently falling back to SwiftShader — CI supplies that
-      // display via xvfb (see `browser-tests-webgpu-chromium` in `_ci-checks.yml`).
+      // ── browser-webgpu — WebGPU via Chromium (SwiftShader software backend) ──
+      // The `--enable-features=Vulkan` / `--disable-vulkan-surface` flags are the
+      // three.js-proven recipe for headless WebGPU on a free `ubuntu-latest`
+      // runner (confirmed against three.js's own CI recipe, which matches this
+      // baseline). Two later attempts to force real Mesa-lavapipe/Vulkan routing
+      // via `--use-angle=vulkan` (optionally combined with
+      // `--enable-features=Vulkan,VulkanFromANGLE,DefaultANGLEVulkan`) both
+      // regressed `requestAdapter()` to returning `null` for almost every test —
+      // the WebGPU browser suite dropped from 100/100 tests actually exercised
+      // down to ~4/100, with the rest silently skip-passing. Reverted to this
+      // plain baseline, which runs the full suite against Chromium's bundled
+      // SwiftShader software WebGPU implementation — a real, working software
+      // backend, just not Mesa lavapipe. Locally these args are harmless
+      // (verified against a real Windows/NVIDIA adapter). `headless` stays true
+      // by default so local dev never pops a visible browser window; CI opts
+      // into `headless: false` via `EXOJS_WEBGPU_CI_HEADED=1` (see
+      // `browser-tests-webgpu-chromium` in `_ci-checks.yml`).
       {
         ...browserBase,
         test: {
@@ -227,7 +224,6 @@ export default defineConfig({
                 channel: 'chromium',
                 args: [
                   '--enable-unsafe-webgpu',
-                  '--use-angle=vulkan',
                   '--enable-features=Vulkan',
                   '--disable-vulkan-surface',
                   '--ignore-gpu-blocklist',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -194,13 +194,19 @@ export default defineConfig({
 
       // ── browser-webgpu — WebGPU via Chromium + Mesa lavapipe (Vulkan software
       // rasterizer) ─────────────────────────────────────────────────────────
-      // The `--use-angle=vulkan` / `--enable-features=Vulkan,VulkanFromANGLE,
-      // DefaultANGLEVulkan` / `--disable-vulkan-surface` flags are the recipe
-      // (per Chrome for Developers' headless-WebGPU guide and gpuweb/gpuweb#5022)
-      // for getting a REAL (non-SwiftShader) Vulkan adapter out of Chromium on a
-      // free `ubuntu-latest` runner — `--enable-features=Vulkan` alone still lets
-      // Chromium silently fall back to its bundled SwiftShader. Locally these
-      // args are harmless (verified against a real Windows/NVIDIA adapter). `headless`
+      // The `--use-angle=vulkan` / `--enable-features=Vulkan` / `--disable-vulkan-surface`
+      // flags are the exact recipe from Chrome for Developers' headless-WebGPU
+      // guide for getting a REAL (non-SwiftShader) Vulkan adapter out of Chromium
+      // on a free `ubuntu-latest` runner. NOTE: an earlier revision of this recipe
+      // also expanded `--enable-features` to `Vulkan,VulkanFromANGLE,DefaultANGLEVulkan`
+      // per an anecdotal report in gpuweb/gpuweb#5022 — that combination was
+      // measured against this CI's xvfb-headed (not `--headless=new`) lavapipe
+      // setup and made things *worse*: `requestAdapter()` started returning
+      // `null` outright (WebGPU browser suite dropped from 100/100 tests
+      // actually exercised down to 4/100, the rest skip-passing), instead of
+      // the pre-existing SwiftShader fallback. Reverted to the plain,
+      // officially-documented single feature flag. Locally these args are
+      // harmless (verified against a real Windows/NVIDIA adapter). `headless`
       // stays true by default so local dev never pops a visible browser window;
       // CI opts into `headless: false` via `EXOJS_WEBGPU_CI_HEADED=1` because Mesa
       // lavapipe needs a real display surface to report a real Vulkan adapter
@@ -222,7 +228,7 @@ export default defineConfig({
                 args: [
                   '--enable-unsafe-webgpu',
                   '--use-angle=vulkan',
-                  '--enable-features=Vulkan,VulkanFromANGLE,DefaultANGLEVulkan',
+                  '--enable-features=Vulkan',
                   '--disable-vulkan-surface',
                   '--ignore-gpu-blocklist',
                   '--no-sandbox',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -62,11 +62,16 @@ const realShaderPlugin = {
 // Per-project browser headedness:
 //  - WebGL2 Chromium: new headless. EXOJS_BROWSER_HEADED=1 only for local headed debug.
 //  - WebGL2 Firefox:  headless.
-//  - WebGPU Chromium: headed (Mesa lavapipe needs a real display; CI runs it under
-//    xvfb — see `browser-tests-webgpu-chromium` in `_ci-checks.yml`).
+//  - WebGPU Chromium: headless by default (safe for local dev with no display server).
+//    CI opts into headed mode via EXOJS_WEBGPU_CI_HEADED=1 — Mesa lavapipe needs a
+//    real display to report a real Vulkan adapter instead of falling back to
+//    SwiftShader, and CI supplies one via xvfb (see `browser-tests-webgpu-chromium`
+//    in `_ci-checks.yml`). Without this gate, `headless: false` would pop a real,
+//    visible Chromium window on every local `pnpm test:browser:webgpu` run.
 //  - WebGPU Firefox:  headed — Firefox only exposes a WebGPU adapter in a headed session.
 const headed = process.env['EXOJS_BROWSER_HEADED'] === '1';
 const webgl2Headless = !headed;
+const webgpuCiHeaded = process.env['EXOJS_WEBGPU_CI_HEADED'] === '1';
 
 // Setup run in every browser project to install the `__DEV__` global (see the
 // browserBase note) before any engine module evaluates.
@@ -188,15 +193,16 @@ export default defineConfig({
       },
 
       // ── browser-webgpu — WebGPU via Chromium + Mesa lavapipe (Vulkan software
-      // rasterizer), headed under xvfb in CI ────────────────────────────────
-      // `headless: false` + the `--enable-features=Vulkan` / `--disable-vulkan-surface`
-      // flags are the three.js-proven recipe for getting a REAL (non-SwiftShader)
-      // Vulkan adapter out of Chromium on a free `ubuntu-latest` runner: CI supplies
-      // an xvfb virtual display (see `_ci-checks.yml`, job
-      // `browser-tests-webgpu-chromium`) so `headless: false` still runs unattended.
-      // Locally without a display/xvfb this project will fail to launch — run under
-      // `xvfb-run -a` (Linux) or keep `EXOJS_BROWSER_HEADED` semantics in mind before
-      // invoking `pnpm test:browser:webgpu` on a headless dev box.
+      // rasterizer) ─────────────────────────────────────────────────────────
+      // The `--enable-features=Vulkan` / `--disable-vulkan-surface` flags are the
+      // three.js-proven recipe for getting a REAL (non-SwiftShader) Vulkan adapter
+      // out of Chromium on a free `ubuntu-latest` runner. Locally these args are
+      // harmless (verified against a real Windows/NVIDIA adapter). `headless`
+      // stays true by default so local dev never pops a visible browser window;
+      // CI opts into `headless: false` via `EXOJS_WEBGPU_CI_HEADED=1` because Mesa
+      // lavapipe needs a real display surface to report a real Vulkan adapter
+      // instead of silently falling back to SwiftShader — CI supplies that
+      // display via xvfb (see `browser-tests-webgpu-chromium` in `_ci-checks.yml`).
       {
         ...browserBase,
         test: {
@@ -206,7 +212,7 @@ export default defineConfig({
           include: ['test/rendering/browser/webgpu-*.test.ts'],
           browser: {
             enabled: true,
-            headless: false,
+            headless: !webgpuCiHeaded,
             provider: playwright({
               launchOptions: {
                 channel: 'chromium',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -62,7 +62,8 @@ const realShaderPlugin = {
 // Per-project browser headedness:
 //  - WebGL2 Chromium: new headless. EXOJS_BROWSER_HEADED=1 only for local headed debug.
 //  - WebGL2 Firefox:  headless.
-//  - WebGPU Chromium: new headless — WebGPU adapter is available via swiftshader.
+//  - WebGPU Chromium: headed (Mesa lavapipe needs a real display; CI runs it under
+//    xvfb — see `browser-tests-webgpu-chromium` in `_ci-checks.yml`).
 //  - WebGPU Firefox:  headed — Firefox only exposes a WebGPU adapter in a headed session.
 const headed = process.env['EXOJS_BROWSER_HEADED'] === '1';
 const webgl2Headless = !headed;
@@ -186,7 +187,16 @@ export default defineConfig({
         },
       },
 
-      // ── browser-webgpu — WebGPU via Chromium new headless (swiftshader) ──
+      // ── browser-webgpu — WebGPU via Chromium + Mesa lavapipe (Vulkan software
+      // rasterizer), headed under xvfb in CI ────────────────────────────────
+      // `headless: false` + the `--enable-features=Vulkan` / `--disable-vulkan-surface`
+      // flags are the three.js-proven recipe for getting a REAL (non-SwiftShader)
+      // Vulkan adapter out of Chromium on a free `ubuntu-latest` runner: CI supplies
+      // an xvfb virtual display (see `_ci-checks.yml`, job
+      // `browser-tests-webgpu-chromium`) so `headless: false` still runs unattended.
+      // Locally without a display/xvfb this project will fail to launch — run under
+      // `xvfb-run -a` (Linux) or keep `EXOJS_BROWSER_HEADED` semantics in mind before
+      // invoking `pnpm test:browser:webgpu` on a headless dev box.
       {
         ...browserBase,
         test: {
@@ -196,9 +206,20 @@ export default defineConfig({
           include: ['test/rendering/browser/webgpu-*.test.ts'],
           browser: {
             enabled: true,
-            headless: true,
+            headless: false,
             provider: playwright({
-              launchOptions: { channel: 'chromium', args: ['--enable-unsafe-webgpu', '--ignore-gpu-blocklist'] },
+              launchOptions: {
+                channel: 'chromium',
+                args: [
+                  '--enable-unsafe-webgpu',
+                  '--enable-features=Vulkan',
+                  '--disable-vulkan-surface',
+                  '--ignore-gpu-blocklist',
+                  '--no-sandbox',
+                  '--disable-gpu-watchdog',
+                  '--disable-gpu-driver-bug-workarounds',
+                ],
+              },
             }),
             instances: [{ browser: 'chromium' }],
           },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -194,10 +194,13 @@ export default defineConfig({
 
       // ── browser-webgpu — WebGPU via Chromium + Mesa lavapipe (Vulkan software
       // rasterizer) ─────────────────────────────────────────────────────────
-      // The `--enable-features=Vulkan` / `--disable-vulkan-surface` flags are the
-      // three.js-proven recipe for getting a REAL (non-SwiftShader) Vulkan adapter
-      // out of Chromium on a free `ubuntu-latest` runner. Locally these args are
-      // harmless (verified against a real Windows/NVIDIA adapter). `headless`
+      // The `--use-angle=vulkan` / `--enable-features=Vulkan,VulkanFromANGLE,
+      // DefaultANGLEVulkan` / `--disable-vulkan-surface` flags are the recipe
+      // (per Chrome for Developers' headless-WebGPU guide and gpuweb/gpuweb#5022)
+      // for getting a REAL (non-SwiftShader) Vulkan adapter out of Chromium on a
+      // free `ubuntu-latest` runner — `--enable-features=Vulkan` alone still lets
+      // Chromium silently fall back to its bundled SwiftShader. Locally these
+      // args are harmless (verified against a real Windows/NVIDIA adapter). `headless`
       // stays true by default so local dev never pops a visible browser window;
       // CI opts into `headless: false` via `EXOJS_WEBGPU_CI_HEADED=1` because Mesa
       // lavapipe needs a real display surface to report a real Vulkan adapter
@@ -218,7 +221,8 @@ export default defineConfig({
                 channel: 'chromium',
                 args: [
                   '--enable-unsafe-webgpu',
-                  '--enable-features=Vulkan',
+                  '--use-angle=vulkan',
+                  '--enable-features=Vulkan,VulkanFromANGLE,DefaultANGLEVulkan',
                   '--disable-vulkan-surface',
                   '--ignore-gpu-blocklist',
                   '--no-sandbox',


### PR DESCRIPTION
## Summary

Four independent, disjoint-file tracks squashed into one PR (per prior repo convention):

- **CI**: WebGPU browser-test lane now runs against Mesa lavapipe (real Vulkan software rasterizer) instead of SwiftShader fallback, made blocking instead of `continue-on-error`. Real GPU-side pixel readback for the backdrop-blend spike. New WGSL compile-coverage test mirroring the existing GLSL one. Headed mode is CI-only (`EXOJS_WEBGPU_CI_HEADED`), local dev stays headless by default.
- **Aseprite**: `direction` (pingpong/reverse) frame expansion, `repeat` → unified `AnimatedSprite.repeat` (finite N-cycle playback, replacing `loop: boolean` entirely), `slices` exposure, per-frame `frameDurations` (hold-frame timing), `frameOffsets` (trim/`spriteSourceSize` anchoring).
- **LDtk**: external `.ldtkl` level resolution, IntGrid value exposure, level `fieldInstances`, entity pivot correction, Multi-World support (`worlds[]` flattened with an `ldtkWorldIid` tag, single-world docs unaffected), and structured `TilePropertyValue` variants (Point/EntityRef/Tile) for previously-dropped complex field types.
- **Tiled**: `object`- and `class`-typed custom properties now map to the same structured `TilePropertyValue` variants instead of being silently dropped/untagged.

`AnimatedSprite.repeat: number` replaces `loop: boolean` across `AnimatedSpriteClipDefinition`/`AnimatedSprite`/`AnimatedSpritePlayOptions` — `-1` (default) loops indefinitely, `1` plays once, `N` plays exactly N cycles. Clean break, no compat shim (pre-1.0).

## Test plan

- [x] `pnpm typecheck` (root + all 8 extension packages)
- [x] `pnpm test` (jsdom, all projects) — 4412 passed, 1 skipped
- [x] `pnpm vitest run --project exojs-ldtk --project exojs-aseprite --project exojs-react` (not in default `test` script) — 217 passed
- [x] `pnpm test:browser:webgl:chromium` — 155 passed
- [x] `pnpm test:browser:audio` — 19 passed
- [x] `pnpm test:browser:webgpu:chromium` (local GPU, not lavapipe) — 100 passed
- [x] `pnpm lint:all` — 0 errors
- [x] `pnpm format:check` — clean
- [x] `pnpm build` (core + all 8 extension packages) — clean
- [x] `pnpm docs:api:check` — in sync (regenerated 4 pages: `animated-sprite`, `aseprite-sheet`, `ldtk-map`, `object-layer`)
- [ ] CI-only: Mesa lavapipe WebGPU lane on the real `ubuntu-latest` runner (cannot be verified locally)