### PR TITLE
fix: physics dead-option cleanup + WheelJoint limit, particles/react/audio-fx audit fixes, DE locale fallback

### DIFF
--- a/packages/exojs-audio-fx/src/effects/LimiterEffect.ts
+++ b/packages/exojs-audio-fx/src/effects/LimiterEffect.ts
@@ -22,6 +22,17 @@ export interface LimiterEffectOptions {
    * processing workflows.
    */
   wet?: number;
+  /**
+   * Input-to-output dB ratio above the threshold. Range 1..20, default 20
+   * (brick-wall). Lower it for a softer, more compressor-like limiter.
+   */
+  ratio?: number;
+  /**
+   * Width in dB of the transition region around the threshold (soft knee).
+   * Range 0..40, default 0 (hard knee). Raise it for a gentler transition
+   * into limiting.
+   */
+  knee?: number;
 }
 
 interface LimiterEffectSetup {
@@ -38,10 +49,14 @@ interface LimiterEffectSetup {
  * fast attack. Use it as a final-chain safety net to prevent clipping and
  * protect downstream output.
  *
- * The compressor `ratio` (20) and `knee` (0) are fixed internally and are not
- * user-configurable options. The effect exposes a dry/wet mix for API
- * consistency and parallel processing workflows, though a fully-wet signal
- * (`wet = 1`) is the typical configuration.
+ * The compressor `ratio` and `knee` default to brick-wall values (20 and 0
+ * respectively) but remain configurable, unlike a truly fixed limiter,
+ * because callers occasionally want a softer, more compressor-like limiting
+ * curve (lower ratio) or a gentler transition into limiting (larger knee)
+ * without switching to {@link CompressorEffect} and losing the dry/wet mix.
+ * The effect also exposes a dry/wet mix for API consistency and parallel
+ * processing workflows, though a fully-wet signal (`wet = 1`) is the typical
+ * configuration.
  *
  * Node graph:
  * ```
@@ -62,6 +77,8 @@ export class LimiterEffect extends AudioEffect {
   private _attack: number;
   private _release: number;
   private _wet: number;
+  private _ratio: number;
+  private _knee: number;
   private readonly _onAudioContextReady = (ctx: AudioContext): void => {
     onAudioContextReady.remove(this._onAudioContextReady);
     this._setupNodes(ctx);
@@ -73,6 +90,8 @@ export class LimiterEffect extends AudioEffect {
     this._attack = Math.max(0, Math.min(1, options.attack ?? 0.003));
     this._release = Math.max(0, Math.min(1, options.release ?? 0.25));
     this._wet = Math.max(0, Math.min(1, options.wet ?? 1));
+    this._ratio = Math.max(1, Math.min(20, options.ratio ?? 20));
+    this._knee = Math.max(0, Math.min(40, options.knee ?? 0));
     if (isAudioContextReady()) {
       this._setupNodes(getAudioContext());
     } else {
@@ -156,6 +175,38 @@ export class LimiterEffect extends AudioEffect {
   }
 
   /**
+   * Input-to-output dB ratio above the threshold. Range 1..20, default 20
+   * (brick-wall). Lower for a softer, more compressor-like limiter.
+   * Changes are ramped smoothly via `setTargetAtTime`.
+   */
+  public get ratio(): number {
+    return this._ratio;
+  }
+
+  public set ratio(value: number) {
+    this._ratio = Math.max(1, Math.min(20, value));
+    if (this._setup) {
+      this._setup.compressor.ratio.setTargetAtTime(this._ratio, this._setup.compressor.context.currentTime, 0.01);
+    }
+  }
+
+  /**
+   * Width in dB of the transition region around the threshold (soft knee).
+   * Range 0..40, default 0 (hard knee). Raise for a gentler transition into
+   * limiting. Changes are ramped smoothly via `setTargetAtTime`.
+   */
+  public get knee(): number {
+    return this._knee;
+  }
+
+  public set knee(value: number) {
+    this._knee = Math.max(0, Math.min(40, value));
+    if (this._setup) {
+      this._setup.compressor.knee.setTargetAtTime(this._knee, this._setup.compressor.context.currentTime, 0.01);
+    }
+  }
+
+  /**
    * Dry/wet mix level, 0..1. The dry level is automatically `1 - wet`.
    * Changes are ramped smoothly via `setTargetAtTime`. Default 1.0.
    */
@@ -196,9 +247,10 @@ export class LimiterEffect extends AudioEffect {
     dryGain.gain.setValueAtTime(1 - this._wet, ctx.currentTime);
     wetGain.gain.setValueAtTime(this._wet, ctx.currentTime);
 
-    // Fixed limiter settings: high ratio for brick-wall behaviour, hard knee (0).
-    compressor.ratio.setValueAtTime(20, ctx.currentTime);
-    compressor.knee.setValueAtTime(0, ctx.currentTime);
+    // Defaults to brick-wall behaviour (high ratio, hard knee) but both remain
+    // configurable — see LimiterEffectOptions.ratio / .knee.
+    compressor.ratio.setValueAtTime(this._ratio, ctx.currentTime);
+    compressor.knee.setValueAtTime(this._knee, ctx.currentTime);
     compressor.threshold.setValueAtTime(this._threshold, ctx.currentTime);
     compressor.attack.setValueAtTime(this._attack, ctx.currentTime);
     compressor.release.setValueAtTime(this._release, ctx.currentTime);

--- a/packages/exojs-audio-fx/test/effects/limiter-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/limiter-effect.test.ts
@@ -52,6 +52,18 @@ describe('LimiterEffect', () => {
       effect.destroy();
     });
 
+    it('uses default ratio of 20', () => {
+      const effect = new LimiterEffect();
+      expect(effect.ratio).toBe(20);
+      effect.destroy();
+    });
+
+    it('uses default knee of 0', () => {
+      const effect = new LimiterEffect();
+      expect(effect.knee).toBe(0);
+      effect.destroy();
+    });
+
     it('accepts custom threshold option', () => {
       const effect = new LimiterEffect({ threshold: -6 });
       expect(effect.threshold).toBe(-6);
@@ -76,6 +88,18 @@ describe('LimiterEffect', () => {
       effect.destroy();
     });
 
+    it('accepts custom ratio option', () => {
+      const effect = new LimiterEffect({ ratio: 8 });
+      expect(effect.ratio).toBe(8);
+      effect.destroy();
+    });
+
+    it('accepts custom knee option', () => {
+      const effect = new LimiterEffect({ knee: 6 });
+      expect(effect.knee).toBe(6);
+      effect.destroy();
+    });
+
     it('clamps threshold to -60 minimum on construction', () => {
       const effect = new LimiterEffect({ threshold: -100 });
       expect(effect.threshold).toBe(-60);
@@ -97,6 +121,30 @@ describe('LimiterEffect', () => {
     it('clamps wet to 1 maximum on construction', () => {
       const effect = new LimiterEffect({ wet: 2 });
       expect(effect.wet).toBe(1);
+      effect.destroy();
+    });
+
+    it('clamps ratio to 1 minimum on construction', () => {
+      const effect = new LimiterEffect({ ratio: 0 });
+      expect(effect.ratio).toBe(1);
+      effect.destroy();
+    });
+
+    it('clamps ratio to 20 maximum on construction', () => {
+      const effect = new LimiterEffect({ ratio: 30 });
+      expect(effect.ratio).toBe(20);
+      effect.destroy();
+    });
+
+    it('clamps knee to 0 minimum on construction', () => {
+      const effect = new LimiterEffect({ knee: -5 });
+      expect(effect.knee).toBe(0);
+      effect.destroy();
+    });
+
+    it('clamps knee to 40 maximum on construction', () => {
+      const effect = new LimiterEffect({ knee: 50 });
+      expect(effect.knee).toBe(40);
       effect.destroy();
     });
   });
@@ -198,7 +246,7 @@ describe('LimiterEffect', () => {
       compressorSpy.mockRestore();
     });
 
-    it('sets fixed ratio of 20 on compressor', () => {
+    it('sets default ratio of 20 on compressor', () => {
       const ctx = getAudioContext();
       const { compressor, gainSpy, compressorSpy } = wireAll(ctx);
       const effect = new LimiterEffect();
@@ -208,11 +256,31 @@ describe('LimiterEffect', () => {
       compressorSpy.mockRestore();
     });
 
-    it('sets fixed knee of 0 on compressor', () => {
+    it('sets default knee of 0 on compressor', () => {
       const ctx = getAudioContext();
       const { compressor, gainSpy, compressorSpy } = wireAll(ctx);
       const effect = new LimiterEffect();
       expect(compressor.knee.setValueAtTime).toHaveBeenCalledWith(0, expect.anything());
+      effect.destroy();
+      gainSpy.mockRestore();
+      compressorSpy.mockRestore();
+    });
+
+    it('sets ratio on compressor from option', () => {
+      const ctx = getAudioContext();
+      const { compressor, gainSpy, compressorSpy } = wireAll(ctx);
+      const effect = new LimiterEffect({ ratio: 8 });
+      expect(compressor.ratio.setValueAtTime).toHaveBeenCalledWith(8, expect.anything());
+      effect.destroy();
+      gainSpy.mockRestore();
+      compressorSpy.mockRestore();
+    });
+
+    it('sets knee on compressor from option', () => {
+      const ctx = getAudioContext();
+      const { compressor, gainSpy, compressorSpy } = wireAll(ctx);
+      const effect = new LimiterEffect({ knee: 6 });
+      expect(compressor.knee.setValueAtTime).toHaveBeenCalledWith(6, expect.anything());
       effect.destroy();
       gainSpy.mockRestore();
       compressorSpy.mockRestore();
@@ -345,6 +413,74 @@ describe('LimiterEffect', () => {
       const effect = new LimiterEffect();
       effect.release = 0.3;
       expect(compressor.release.setTargetAtTime).toHaveBeenCalledWith(0.3, expect.anything(), expect.anything());
+      effect.destroy();
+      gainSpy.mockRestore();
+      compressorSpy.mockRestore();
+    });
+  });
+
+  describe('ratio setter', () => {
+    it('ratio setter clamps to 1 minimum', () => {
+      const effect = new LimiterEffect();
+      effect.ratio = 0;
+      expect(effect.ratio).toBe(1);
+      effect.destroy();
+    });
+
+    it('ratio setter clamps to 20 maximum', () => {
+      const effect = new LimiterEffect();
+      effect.ratio = 30;
+      expect(effect.ratio).toBe(20);
+      effect.destroy();
+    });
+
+    it('ratio setter ramps compressor ratio', () => {
+      const ctx = getAudioContext();
+      const compressor = makeCompressorNode(ctx);
+      const gains = [makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx)];
+      let i = 0;
+      const gainSpy = vi.spyOn(ctx, 'createGain').mockImplementation(() => gains[i++] as unknown as GainNode);
+      const compressorSpy = vi
+        .spyOn(ctx, 'createDynamicsCompressor')
+        .mockReturnValue(compressor as unknown as DynamicsCompressorNode);
+
+      const effect = new LimiterEffect();
+      effect.ratio = 8;
+      expect(compressor.ratio.setTargetAtTime).toHaveBeenCalledWith(8, expect.anything(), expect.anything());
+      effect.destroy();
+      gainSpy.mockRestore();
+      compressorSpy.mockRestore();
+    });
+  });
+
+  describe('knee setter', () => {
+    it('knee setter clamps to 0 minimum', () => {
+      const effect = new LimiterEffect();
+      effect.knee = -5;
+      expect(effect.knee).toBe(0);
+      effect.destroy();
+    });
+
+    it('knee setter clamps to 40 maximum', () => {
+      const effect = new LimiterEffect();
+      effect.knee = 50;
+      expect(effect.knee).toBe(40);
+      effect.destroy();
+    });
+
+    it('knee setter ramps compressor knee', () => {
+      const ctx = getAudioContext();
+      const compressor = makeCompressorNode(ctx);
+      const gains = [makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx)];
+      let i = 0;
+      const gainSpy = vi.spyOn(ctx, 'createGain').mockImplementation(() => gains[i++] as unknown as GainNode);
+      const compressorSpy = vi
+        .spyOn(ctx, 'createDynamicsCompressor')
+        .mockReturnValue(compressor as unknown as DynamicsCompressorNode);
+
+      const effect = new LimiterEffect();
+      effect.knee = 6;
+      expect(compressor.knee.setTargetAtTime).toHaveBeenCalledWith(6, expect.anything(), expect.anything());
       effect.destroy();
       gainSpy.mockRestore();
       compressorSpy.mockRestore();

--- a/packages/exojs-particles/src/ParticleSystem.ts
+++ b/packages/exojs-particles/src/ParticleSystem.ts
@@ -112,7 +112,6 @@ export interface ParticleSystemOptions {
  * // Backend-agnostic — runs CPU on WebGL2, GPU on WebGPU automatically.
  * const system = new ParticleSystem(loader.get(Texture, 'spark'), {
  *     capacity: 8192,
- *     backend: app.backend,
  * });
  *
  * system.addSpawnModule(new RateSpawn({ rate: new Constant(60), ... }));

--- a/packages/exojs-particles/src/modules/ScaleOverLifetime.ts
+++ b/packages/exojs-particles/src/modules/ScaleOverLifetime.ts
@@ -10,9 +10,8 @@ const lookupSize = 256;
 
 /**
  * Sets every live particle's scale to a curve sampled at the particle's
- * current lifetime ratio. Both axes share one curve — for non-uniform
- * scaling layer two ScaleOverLifetime modules with separate `axis` filters
- * (or extend with a per-axis variant).
+ * current lifetime ratio. Both axes share one curve; non-uniform per-axis
+ * scaling isn't supported by this module.
  *
  * Common patterns: shrink-to-zero (start at 1, end at 0), pulse (sine-like
  * curve up to peak then down), slow-grow (linear ramp).

--- a/packages/exojs-particles/test/particle-system.test.ts
+++ b/packages/exojs-particles/test/particle-system.test.ts
@@ -1,8 +1,12 @@
 import { Color, Texture, Time } from '@codexo/exojs';
 
+import { BoxArea } from '../src/distributions/BoxArea';
+import { CircleArea } from '../src/distributions/CircleArea';
 import { ColorGradient } from '../src/distributions/ColorGradient';
+import { ConeDirection } from '../src/distributions/ConeDirection';
 import { Constant } from '../src/distributions/Constant';
 import { Curve } from '../src/distributions/Curve';
+import { LineSegment } from '../src/distributions/LineSegment';
 import { Range } from '../src/distributions/Range';
 import { VectorRange } from '../src/distributions/VectorRange';
 import { AlphaFadeOverLifetime } from '../src/modules/AlphaFadeOverLifetime';
@@ -160,6 +164,95 @@ describe('Distribution', () => {
 
     expect(g.evaluateRgba(0)).toBe(0);
   });
+
+  test('BoxArea volume mode stays within the box', () => {
+    const box = new BoxArea(10, 20, -5, 5, 'volume');
+
+    for (let i = 0; i < 50; i++) {
+      const v = box.sample();
+      expect(v.x).toBeGreaterThanOrEqual(10);
+      expect(v.x).toBeLessThanOrEqual(20);
+      expect(v.y).toBeGreaterThanOrEqual(-5);
+      expect(v.y).toBeLessThanOrEqual(5);
+    }
+  });
+
+  test('BoxArea edge mode lands on the perimeter', () => {
+    const box = new BoxArea(0, 10, 0, 20, 'edge');
+
+    for (let i = 0; i < 50; i++) {
+      const v = box.sample();
+      const onVerticalEdge = v.x === 0 || v.x === 10;
+      const onHorizontalEdge = v.y === 0 || v.y === 20;
+
+      expect(onVerticalEdge || onHorizontalEdge).toBe(true);
+      expect(v.x).toBeGreaterThanOrEqual(0);
+      expect(v.x).toBeLessThanOrEqual(10);
+      expect(v.y).toBeGreaterThanOrEqual(0);
+      expect(v.y).toBeLessThanOrEqual(20);
+    }
+  });
+
+  test('CircleArea volume mode stays within the radius', () => {
+    const circle = new CircleArea(100, 50, 25, 'volume');
+
+    for (let i = 0; i < 50; i++) {
+      const v = circle.sample();
+      const dist = Math.hypot(v.x - 100, v.y - 50);
+
+      expect(dist).toBeLessThanOrEqual(25);
+    }
+  });
+
+  test('CircleArea edge mode lands exactly on the circumference', () => {
+    const circle = new CircleArea(0, 0, 10, 'edge');
+
+    for (let i = 0; i < 50; i++) {
+      const v = circle.sample();
+      const dist = Math.hypot(v.x, v.y);
+
+      expect(dist).toBeCloseTo(10);
+    }
+  });
+
+  test('LineSegment stays on the line between the endpoints', () => {
+    const line = new LineSegment(0, 0, 10, 10);
+
+    for (let i = 0; i < 50; i++) {
+      const v = line.sample();
+
+      expect(v.x).toBeGreaterThanOrEqual(0);
+      expect(v.x).toBeLessThanOrEqual(10);
+      // Diagonal 45° segment: y must track x exactly.
+      expect(v.y).toBeCloseTo(v.x);
+    }
+  });
+
+  test('ConeDirection stays within the angular spread and speed range', () => {
+    const cone = new ConeDirection(0, Math.PI / 6, 50, 100);
+
+    for (let i = 0; i < 50; i++) {
+      const v = cone.sample();
+      const speed = Math.hypot(v.x, v.y);
+      const angle = Math.atan2(v.y, v.x);
+
+      expect(speed).toBeGreaterThanOrEqual(50);
+      expect(speed).toBeLessThanOrEqual(100);
+      expect(Math.abs(angle)).toBeLessThanOrEqual(Math.PI / 6 + 1e-9);
+    }
+  });
+
+  test('ConeDirection.omni produces full-circle directions within the speed range', () => {
+    const cone = ConeDirection.omni(10, 20);
+
+    for (let i = 0; i < 50; i++) {
+      const v = cone.sample();
+      const speed = Math.hypot(v.x, v.y);
+
+      expect(speed).toBeGreaterThanOrEqual(10);
+      expect(speed).toBeLessThanOrEqual(20);
+    }
+  });
 });
 
 describe('SpawnModule', () => {
@@ -228,6 +321,50 @@ describe('SpawnModule', () => {
     // Tick past t=0.5 fires the second burst.
     system.update(tick(0.5));
     expect(system.liveCount).toBe(15);
+  });
+
+  test('BurstSpawn loop repeats the schedule once exhausted', () => {
+    const system = new ParticleSystem(makeTexture(), { capacity: 128 });
+
+    system.addSpawnModule(
+      new BurstSpawn({
+        schedule: [{ time: 0, count: 5 }],
+        lifetime: new Constant(10),
+        loop: true,
+      }),
+    );
+
+    // First tick fires the t=0 burst, then wraps back to t=0 since the
+    // 1-entry schedule is immediately exhausted.
+    system.update(tick(0.1));
+    expect(system.liveCount).toBe(5);
+
+    // Wrapped schedule fires again on the next tick.
+    system.update(tick(0.1));
+    expect(system.liveCount).toBe(10);
+  });
+
+  test('BurstSpawn.reset() restarts the schedule from t=0', () => {
+    const system = new ParticleSystem(makeTexture(), { capacity: 128 });
+
+    const burst = new BurstSpawn({
+      schedule: [{ time: 0, count: 5 }],
+      lifetime: new Constant(10),
+    });
+
+    system.addSpawnModule(burst);
+
+    // Fires once; without looping, the schedule stays exhausted afterwards.
+    system.update(tick(0.1));
+    expect(system.liveCount).toBe(5);
+
+    system.update(tick(1));
+    expect(system.liveCount).toBe(5);
+
+    // Explicit reset rewinds the schedule so the t=0 burst can fire again.
+    burst.reset();
+    system.update(tick(0.1));
+    expect(system.liveCount).toBe(10);
   });
 });
 
@@ -412,6 +549,36 @@ describe('UpdateModule', () => {
 
     expect(system.velX[slot]).toBeGreaterThan(0);
     expect(Math.abs(system.velY[slot])).toBeLessThan(0.001);
+  });
+
+  test('AttractToPoint falloff softens the pull inside the falloff radius', () => {
+    const strength = 1000;
+
+    // Unsoftened (falloff=0, the default): full strength regardless of distance.
+    const unsoftened = new ParticleSystem(makeTexture(), { capacity: 4 });
+    const unsoftenedSlot = unsoftened.spawn();
+
+    unsoftened.lifetime[unsoftenedSlot] = 10;
+    unsoftened.posX[unsoftenedSlot] = 90;
+    unsoftened.posY[unsoftenedSlot] = 0;
+    unsoftened.addUpdateModule(new AttractToPoint(100, 0, strength));
+
+    // Softened: particle is at dist=10 from the target, inside falloff=50,
+    // so k = min(1, dist / falloff) = 0.2 scales the acceleration down.
+    const softened = new ParticleSystem(makeTexture(), { capacity: 4 });
+    const softenedSlot = softened.spawn();
+
+    softened.lifetime[softenedSlot] = 10;
+    softened.posX[softenedSlot] = 90;
+    softened.posY[softenedSlot] = 0;
+    softened.addUpdateModule(new AttractToPoint(100, 0, strength, 50));
+
+    unsoftened.update(tick(1));
+    softened.update(tick(1));
+
+    expect(unsoftened.velX[unsoftenedSlot]).toBeCloseTo(1000);
+    expect(softened.velX[softenedSlot]).toBeCloseTo(200);
+    expect(softened.velX[softenedSlot]).toBeLessThan(unsoftened.velX[unsoftenedSlot]);
   });
 
   test('RepelFromPoint pushes particle away from source', () => {

--- a/packages/exojs-physics/src/PhysicsWorld.ts
+++ b/packages/exojs-physics/src/PhysicsWorld.ts
@@ -5,7 +5,7 @@ import type { Aabb } from './Aabb';
 import { NativePhysicsBackend } from './backend/NativePhysicsBackend';
 import type { PhysicsBackend } from './backend/PhysicsBackend';
 import { BindingRegistry } from './binding/BindingRegistry';
-import type { BindingOptions, PhysicsBinding } from './binding/PhysicsBinding';
+import type { PhysicsBinding } from './binding/PhysicsBinding';
 import { Collider } from './Collider';
 import type { CollisionEvent, SensorEvent } from './events';
 import type { Joint } from './joints/Joint';
@@ -41,8 +41,6 @@ export interface PhysicsWorldOptions {
   contactHertz?: number;
   /** Soft-contact damping ratio (≥ 1 keeps contacts from oscillating). Default `10`. */
   dampingRatio?: number;
-  /** Interpolate bound nodes between fixed steps (reserved; no effect yet). Default `true`. */
-  interpolation?: boolean;
   /** Put resting bodies to sleep so they skip integration and solving. Default `true`. */
   enableSleeping?: boolean;
   /** Linear speed at or below which a body is a sleep candidate, px/s. Default `5`. */
@@ -84,8 +82,6 @@ export interface AttachOptions {
   isSensor?: boolean;
   /** Category/mask/group collision filter; partials merge over the defaults. */
   filter?: Partial<CollisionFilter>;
-  /** Binding options forwarded to {@link PhysicsWorld.bind}. */
-  binding?: BindingOptions;
 }
 
 /**
@@ -135,8 +131,6 @@ export class PhysicsWorld implements BodyOwner {
   public readonly gravity: Vector;
   /** The fixed-step accumulator. */
   public readonly timeStepper: TimeStepper;
-  /** Whether bound nodes interpolate between fixed steps (reserved; no effect yet). */
-  public readonly interpolation: boolean;
   /** TGS-Soft sub-steps per fixed step. */
   public readonly subStepCount: number;
   /** Soft-contact stiffness in Hz. */
@@ -179,7 +173,6 @@ export class PhysicsWorld implements BodyOwner {
       ...(options.fixedDelta !== undefined && { fixedDelta: options.fixedDelta }),
       ...(options.maxSubSteps !== undefined && { maxSubSteps: options.maxSubSteps }),
     });
-    this.interpolation = options.interpolation ?? true;
 
     const subStepCount = options.subStepCount ?? 4;
 
@@ -266,7 +259,7 @@ export class PhysicsWorld implements BodyOwner {
     });
 
     this.add(body);
-    this.bind(body, node, options.binding);
+    this.bind(body, node);
 
     return body;
   }
@@ -427,8 +420,8 @@ export class PhysicsWorld implements BodyOwner {
   // ── binding ────────────────────────────────────────────────────────────
 
   /** Link a body to a scene node; the node tracks the body after each step. */
-  public bind(body: PhysicsBody, node: SceneNode, options?: BindingOptions): PhysicsBinding {
-    return this._bindings.bind(body, node, options);
+  public bind(body: PhysicsBody, node: SceneNode): PhysicsBinding {
+    return this._bindings.bind(body, node);
   }
 
   /** Remove a body↔node link. */

--- a/packages/exojs-physics/src/binding/BindingRegistry.ts
+++ b/packages/exojs-physics/src/binding/BindingRegistry.ts
@@ -1,7 +1,6 @@
 import type { SceneNode } from '@codexo/exojs';
 
 import type { PhysicsBody } from '../PhysicsBody';
-import type { BindingOptions } from './PhysicsBinding';
 import { PhysicsBinding } from './PhysicsBinding';
 
 /**
@@ -12,12 +11,12 @@ export class BindingRegistry {
   private readonly _bindings = new Map<PhysicsBody, PhysicsBinding>();
 
   /** Link `body` to `node`. Rejects nodes with non-zero skew; runtime scale is ignored. */
-  public bind(body: PhysicsBody, node: SceneNode, options?: BindingOptions): PhysicsBinding {
+  public bind(body: PhysicsBody, node: SceneNode): PhysicsBinding {
     if (node.skewX !== 0 || node.skewY !== 0) {
       throw new Error(`PhysicsBinding: the bound node has non-zero skew (${node.skewX}°, ${node.skewY}°); skewed nodes are not supported.`);
     }
 
-    const binding = new PhysicsBinding(body, node, options?.drive ?? 'body-to-node');
+    const binding = new PhysicsBinding(body, node);
 
     this._bindings.set(body, binding);
     binding.sync();

--- a/packages/exojs-physics/src/binding/PhysicsBinding.ts
+++ b/packages/exojs-physics/src/binding/PhysicsBinding.ts
@@ -2,17 +2,6 @@ import { MathUtils, type SceneNode } from '@codexo/exojs';
 
 import type { PhysicsBody } from '../PhysicsBody';
 
-/** Options for {@link PhysicsWorld.bind}. */
-export interface BindingOptions {
-  /**
-   * Which way the transform flows. `'body-to-node'` (default) writes the body's
-   * transform onto the node each step — for dynamic and kinematic-position
-   * bodies. `'node-to-body'` (read the node, drive the body) is reserved for the
-   * kinematic-velocity follow-up and currently behaves like `'body-to-node'`.
-   */
-  drive?: 'body-to-node' | 'node-to-body';
-}
-
 /**
  * A link between a {@link PhysicsBody} and a {@link SceneNode}. After each
  * {@link PhysicsWorld.step}, the body's world position **and rotation** are
@@ -24,7 +13,6 @@ export class PhysicsBinding {
   public constructor(
     public readonly body: PhysicsBody,
     public readonly node: SceneNode,
-    public readonly drive: 'body-to-node' | 'node-to-body' = 'body-to-node',
   ) {}
 
   /** Write the body's current transform (position + rotation) onto the bound node. */

--- a/packages/exojs-physics/src/joints/WheelJoint.ts
+++ b/packages/exojs-physics/src/joints/WheelJoint.ts
@@ -23,6 +23,12 @@ export interface WheelJointOptions {
   motorSpeed?: number;
   /** Maximum motor torque. Default `0`. */
   maxMotorTorque?: number;
+  /** Enable the suspension-travel limit (keeps the axis translation in `[lowerTranslation, upperTranslation]`). Default `false`. */
+  enableLimit?: boolean;
+  /** Lower suspension-travel limit along the axis (relative to the creation position). Default `0`. */
+  lowerTranslation?: number;
+  /** Upper suspension-travel limit along the axis. Default `0`. */
+  upperTranslation?: number;
 }
 
 /** Reused output sink — physics steps single-threaded, so a shared scratch is safe. */
@@ -32,7 +38,8 @@ const scratch: Mutable2D = { x: 0, y: 0 };
  * A wheel attached to a chassis: free to **spin** (no rotation lock) and sprung
  * along a **suspension axis** (a soft spring), but locked **laterally** (it
  * cannot slide perpendicular to the axis). Optionally driven by a rotation
- * motor. Used for vehicles. Solved in the sub-step loop, warm-started.
+ * motor and/or bounded by a suspension-travel limit. Used for vehicles. Solved
+ * in the sub-step loop, warm-started.
  */
 export class WheelJoint extends Joint {
   /** Suspension spring frequency in Hz (`0` = rigid axis). */
@@ -45,6 +52,12 @@ export class WheelJoint extends Joint {
   public motorSpeed: number;
   /** Maximum motor torque. */
   public maxMotorTorque: number;
+  /** When `true`, the axis translation is constrained to `[lowerTranslation, upperTranslation]`. */
+  public enableLimit: boolean;
+  /** Lower suspension-travel limit along the axis. */
+  public lowerTranslation: number;
+  /** Upper suspension-travel limit along the axis. */
+  public upperTranslation: number;
 
   private readonly _localAnchorAx: number;
   private readonly _localAnchorAy: number;
@@ -74,6 +87,8 @@ export class WheelJoint extends Joint {
   private _perpImpulse = 0;
   private _springImpulse = 0;
   private _motorImpulse = 0;
+  private _lowerImpulse = 0;
+  private _upperImpulse = 0;
 
   public constructor(options: WheelJointOptions) {
     super(options.bodyA, options.bodyB);
@@ -95,6 +110,9 @@ export class WheelJoint extends Joint {
     this.enableMotor = options.enableMotor ?? false;
     this.motorSpeed = options.motorSpeed ?? 0;
     this.maxMotorTorque = options.maxMotorTorque ?? 0;
+    this.enableLimit = options.enableLimit ?? false;
+    this.lowerTranslation = options.lowerTranslation ?? 0;
+    this.upperTranslation = options.upperTranslation ?? 0;
   }
 
   public override _prepare(h: number): void {
@@ -171,6 +189,11 @@ export class WheelJoint extends Joint {
     if (!this.enableMotor) {
       this._motorImpulse = 0;
     }
+
+    if (!this.enableLimit) {
+      this._lowerImpulse = 0;
+      this._upperImpulse = 0;
+    }
   }
 
   public override _warmStart(): void {
@@ -185,7 +208,7 @@ export class WheelJoint extends Joint {
     bodyA.angularVelocity -= bodyA.invInertia * this._motorImpulse;
     bodyB.angularVelocity += bodyB.invInertia * this._motorImpulse;
 
-    this._applyAxial(this._springImpulse);
+    this._applyAxial(this._springImpulse + this._lowerImpulse - this._upperImpulse);
     this._applyPerp(this._perpImpulse);
   }
 
@@ -217,6 +240,37 @@ export class WheelJoint extends Joint {
 
     this._springImpulse += springImpulse;
     this._applyAxial(springImpulse);
+
+    // Suspension-travel limits along the axis.
+    if (this.enableLimit) {
+      // Lower limit (translation ≥ lowerTranslation): positive impulse pushes along +axis.
+      const cLower = this._translation - this.lowerTranslation;
+      let biasLower = 0;
+
+      if (cLower > 0) {
+        biasLower = cLower * this._invH;
+      } else if (useBias) {
+        biasLower = 0.2 * this._invH * cLower;
+      }
+
+      const oldLower = this._lowerImpulse;
+      this._lowerImpulse = Math.max(0, oldLower - this._axialMass * (this._axisVelocity() + biasLower));
+      this._applyAxial(this._lowerImpulse - oldLower);
+
+      // Upper limit (translation ≤ upperTranslation): impulse pushes along −axis.
+      const cUpper = this.upperTranslation - this._translation;
+      let biasUpper = 0;
+
+      if (cUpper > 0) {
+        biasUpper = cUpper * this._invH;
+      } else if (useBias) {
+        biasUpper = 0.2 * this._invH * cUpper;
+      }
+
+      const oldUpper = this._upperImpulse;
+      this._upperImpulse = Math.max(0, oldUpper - this._axialMass * (-this._axisVelocity() + biasUpper));
+      this._applyAxial(-(this._upperImpulse - oldUpper));
+    }
 
     // Lateral lock (perpendicular, rigid).
     const cdotPerp = this._perpVelocity();

--- a/packages/exojs-physics/src/public.ts
+++ b/packages/exojs-physics/src/public.ts
@@ -4,7 +4,6 @@
 // extension. The tree-shakeable debug overlay lives at `@codexo/exojs-physics/debug`.
 
 export type { Aabb } from './Aabb';
-export type { BindingOptions } from './binding/PhysicsBinding';
 export { PhysicsBinding } from './binding/PhysicsBinding';
 export type { ColliderOptions } from './Collider';
 export { Collider } from './Collider';

--- a/packages/exojs-physics/test/joints.test.ts
+++ b/packages/exojs-physics/test/joints.test.ts
@@ -321,4 +321,64 @@ describe('SG-J — joints', () => {
     expect(heavy.x).toBeGreaterThan(0); // it did move toward the target
     expect(heavy.x).toBeLessThan(200); // but maxForce kept it from reaching the far target
   });
+
+  it('SG-J19: a motorized wheel joint reaches and holds its target spin speed', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const chassis = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    const wheel = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 30 }, colliders: [{ shape: new CircleShape(10) }] }));
+
+    world.addJoint(
+      new WheelJoint({ bodyA: chassis, bodyB: wheel, anchor: { x: 0, y: 30 }, axis: { x: 0, y: 1 }, enableMotor: true, motorSpeed: 5, maxMotorTorque: 1e8 }),
+    );
+
+    advance(world, 1);
+
+    expect(wheel.angularVelocity).toBeCloseTo(5, 0); // driven to the target rad/s and held
+  });
+
+  it('SG-J20: a wheel suspension spring settles to a bounded rest sag under gravity', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const chassis = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    // Suspension axis vertical (0,1) = gravity: an unloaded soft spring sags then settles.
+    const wheel = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 30 }, colliders: [{ shape: new CircleShape(10) }] }));
+
+    world.addJoint(new WheelJoint({ bodyA: chassis, bodyB: wheel, anchor: { x: 0, y: 30 }, axis: { x: 0, y: 1 }, hertz: 1, dampingRatio: 1 }));
+
+    advance(world, 3);
+
+    const settledY = wheel.y;
+    expect(settledY).toBeGreaterThan(40); // sagged down under gravity
+    expect(settledY).toBeLessThan(90); // but bounded by the spring, not free fall
+    expect(Math.abs(wheel.x)).toBeLessThan(1); // lateral still locked
+
+    advance(world, 0.5);
+    expect(Math.abs(wheel.y - settledY)).toBeLessThan(1); // at rest — no longer moving
+  });
+
+  it('SG-J21: a wheel suspension-travel limit caps how far the spring compresses', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const chassis = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    // The same spring as SG-J20 would sag to ~55 (translation ~25) under gravity
+    // alone, but the travel limit caps the compression at upperTranslation (20).
+    const wheel = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 30 }, colliders: [{ shape: new CircleShape(10) }] }));
+
+    world.addJoint(
+      new WheelJoint({
+        bodyA: chassis,
+        bodyB: wheel,
+        anchor: { x: 0, y: 30 },
+        axis: { x: 0, y: 1 },
+        hertz: 1,
+        dampingRatio: 1,
+        enableLimit: true,
+        lowerTranslation: -20,
+        upperTranslation: 20,
+      }),
+    );
+
+    advance(world, 3);
+
+    expect(wheel.y).toBeGreaterThan(45); // pulled down to the limit
+    expect(wheel.y).toBeLessThan(51); // capped at upperTranslation (30 + 20)
+  });
 });

--- a/packages/exojs-react/README.md
+++ b/packages/exojs-react/README.md
@@ -37,7 +37,7 @@ function Game() {
       options={{ canvas: { width: 1280, height: 720 }, clearColor: someColor }}
       style={{ width: 1280, height: 720 }}
     >
-      <Scenes active="game" transition={{ type: 'fade', duration: 0.3 }}>
+      <Scenes active="game" transition={{ type: 'fade', duration: 300 }}>
         <Scene name="title" component={TitleScene} />
         <Scene name="game" component={GameScene}>
           <Hud /> {/* absolutely-positioned React overlay, over the canvas */}
@@ -72,14 +72,15 @@ function Game() {
 
 | Export | Kind | Purpose |
 |---|---|---|
-| `ExoCanvas` | component | Batteries-included canvas host (wrapper div + canvas + context). |
-| `useExoApplication(options?, onReady?)` | hook | Headless: owns the `Application`, returns `{ app, canvasRef }`. |
+| `ExoCanvas` | component | Batteries-included canvas host (wrapper div + canvas + context). Accepts `onReady`/`onError`. |
+| `useExoApplication(options?, onReady?, onError?)` | hook | Headless: owns the `Application`, returns `{ app, canvasRef }`. `onError` mirrors `Application.onError`. |
 | `useExoApp()` | hook | The `Application` from the nearest `<ExoCanvas>`/provider. Throws if absent. |
 | `useExoContext()` | hook | Like `useExoApp` but returns `Application \| null` (no throw). |
 | `ExoContext` | context | The underlying context (advanced / testing). |
-| `useScene(SceneClass, deps?)` | hook | Instantiate + activate a single scene; returns it once live. |
-| `Scenes` / `Scene` | components | Declarative scene switch over the one-active-scene model. |
+| `useScene(SceneClass, deps?)` | hook | Instantiate + activate a single scene; returns it once live. Load failures route to `app.onError`. |
+| `Scenes` / `Scene` | components | Declarative scene switch over the one-active-scene model. Load failures route to `app.onError`. |
 | `useActiveScene()` | hook | The active scene instance from the nearest `<Scenes>`. |
+| `useSignal(signal, getSnapshot)` | hook | Subscribes to an engine `Signal` and re-renders on every dispatch (e.g. `app.onFrame`). |
 
 ### Reactivity model
 

--- a/packages/exojs-react/src/ExoCanvas.tsx
+++ b/packages/exojs-react/src/ExoCanvas.tsx
@@ -22,6 +22,13 @@ export interface ExoCanvasProps extends HTMLAttributes<HTMLDivElement> {
    */
   onReady?: (app: Application) => void;
   /**
+   * Called for every {@link Application.onError} dispatch — async init or
+   * scene-load failures (including the ones surfaced by
+   * {@link import('./useScene').useScene} and {@link import('./Scenes').Scenes}
+   * descendants) — while an Application exists.
+   */
+  onError?: (error: unknown) => void;
+  /**
    * Props forwarded to the inner `<canvas>` (e.g. its own `style`/`className`).
    * `ref`, `width` and `height` are managed by the engine and cannot be set.
    */
@@ -47,8 +54,8 @@ export interface ExoCanvasProps extends HTMLAttributes<HTMLDivElement> {
  * </ExoCanvas>
  * ```
  */
-export function ExoCanvas({ options, onReady, canvasProps, children, style, ...divProps }: ExoCanvasProps): ReactElement {
-  const { app, canvasRef } = useExoApplication(options, onReady);
+export function ExoCanvas({ options, onReady, onError, canvasProps, children, style, ...divProps }: ExoCanvasProps): ReactElement {
+  const { app, canvasRef } = useExoApplication(options, onReady, onError);
 
   const { style: canvasStyle, ...restCanvasProps } = canvasProps ?? {};
   const wrapperStyle: CSSProperties = { position: 'relative', ...style };

--- a/packages/exojs-react/src/Scenes.tsx
+++ b/packages/exojs-react/src/Scenes.tsx
@@ -63,6 +63,11 @@ export interface ScenesProps {
  * (HUD overlay) render alongside, and can read the instance via
  * {@link useActiveScene}.
  *
+ * A failure in `app.start()`/`app.scene.setScene()` (e.g. a scene's `onLoad`
+ * rejects) is caught and routed to {@link Application.onError} rather than
+ * left as an unhandled promise rejection — subscribe via `app.onError.add(...)`
+ * or the {@link import('./ExoCanvas').ExoCanvas} `onError` prop to observe it.
+ *
  * @example
  * ```tsx
  * <ExoCanvas>
@@ -97,7 +102,9 @@ export function Scenes({ active, transition, children }: ScenesProps): ReactElem
   useEffect(() => {
     if (SceneClass === null) {
       setInstance(null);
-      void app.scene.setScene(null);
+      void app.scene.setScene(null).catch((error: unknown) => {
+        app.onError.dispatch(error instanceof Error ? error : new Error(String(error)));
+      });
       return;
     }
 
@@ -105,15 +112,22 @@ export function Scenes({ active, transition, children }: ScenesProps): ReactElem
     const scene = new SceneClass();
 
     const apply = async (): Promise<void> => {
-      if (app.status === ApplicationStatus.Stopped) {
-        // First activation initializes the backend and starts the frame loop;
-        // transitions only apply to subsequent switches.
-        await app.start(scene);
-      } else {
-        await app.scene.setScene(scene, transition !== undefined ? { transition } : {});
-      }
-      if (!cancelled) {
-        setInstance(scene);
+      try {
+        if (app.status === ApplicationStatus.Stopped) {
+          // First activation initializes the backend and starts the frame loop;
+          // transitions only apply to subsequent switches.
+          await app.start(scene);
+        } else {
+          await app.scene.setScene(scene, transition !== undefined ? { transition } : {});
+        }
+        if (!cancelled) {
+          setInstance(scene);
+        }
+      } catch (error) {
+        // Route to Application.onError instead of leaving an unhandled
+        // rejection — app.start()/setScene() reject rather than dispatching
+        // onError themselves.
+        app.onError.dispatch(error instanceof Error ? error : new Error(String(error)));
       }
     };
 

--- a/packages/exojs-react/src/index.ts
+++ b/packages/exojs-react/src/index.ts
@@ -7,3 +7,4 @@ export { useExoApp } from './useExoApp';
 export type { ExoApplicationOptions, UseExoApplicationResult } from './useExoApplication';
 export { useExoApplication } from './useExoApplication';
 export { useScene } from './useScene';
+export { useSignal } from './useSignal';

--- a/packages/exojs-react/src/useExoApp.ts
+++ b/packages/exojs-react/src/useExoApp.ts
@@ -9,11 +9,17 @@ import { useExoContext } from './ExoContext';
  *
  * @throws {Error} When no `<ExoCanvas>` ancestor is present.
  *
+ * `app.frameCount` is a plain getter updated by the engine's own frame loop —
+ * reading it here does not, on its own, make `HudOverlay` re-render. Pair it
+ * with {@link import('./useSignal').useSignal} to subscribe to `app.onFrame`
+ * and re-render on every dispatch.
+ *
  * @example
  * ```tsx
  * function HudOverlay() {
  *   const app = useExoApp();
- *   return <span>Frame: {app.frameCount}</span>;
+ *   const frameCount = useSignal(app.onFrame, () => app.frameCount);
+ *   return <span>Frame: {frameCount}</span>;
  * }
  * ```
  */

--- a/packages/exojs-react/src/useExoApplication.ts
+++ b/packages/exojs-react/src/useExoApplication.ts
@@ -61,10 +61,14 @@ function colorKey(color: Color | undefined): string | undefined {
  *
  * @param options - Application options (the canvas element is the one you render).
  * @param onReady - Called once each time an Application is created.
+ * @param onError - Called for every {@link Application.onError} dispatch (async
+ *   init/scene-load failures) while an Application exists. Re-subscribed
+ *   automatically whenever the Application is (re)created.
  */
 export function useExoApplication(
   options?: ExoApplicationOptions,
   onReady?: (app: Application) => void,
+  onError?: (error: unknown) => void,
 ): UseExoApplicationResult {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [app, setApp] = useState<Application | null>(null);
@@ -74,6 +78,12 @@ export function useExoApplication(
   const onReadyRef = useRef(onReady);
   useEffect(() => {
     onReadyRef.current = onReady;
+  });
+
+  // Latest onError without retriggering the subscribe effect below.
+  const onErrorRef = useRef(onError);
+  useEffect(() => {
+    onErrorRef.current = onError;
   });
 
   // Identity: only the backend type forces a full recreation.
@@ -105,6 +115,23 @@ export function useExoApplication(
     // by the effects below. `options` is intentionally read at (re)create time.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [backendKey]);
+
+  // ── Live sync: error reporting ─────────────────────────────────────────────
+  useEffect(() => {
+    if (app === null) {
+      return;
+    }
+
+    const handleError = (error: Error): void => {
+      onErrorRef.current?.(error);
+    };
+
+    app.onError.add(handleError);
+
+    return () => {
+      app.onError.remove(handleError);
+    };
+  }, [app]);
 
   // ── Live sync: size ───────────────────────────────────────────────────────
   const width = options?.canvas?.width;

--- a/packages/exojs-react/src/useScene.ts
+++ b/packages/exojs-react/src/useScene.ts
@@ -15,6 +15,12 @@ import { useExoApp } from './useExoApp';
  * The scene is cleared (`setScene(null)`) when the component unmounts or
  * when `deps` change — mirroring `useEffect` semantics.
  *
+ * A failure in `app.start()`/`app.scene.setScene()` (e.g. a scene's `onLoad`
+ * rejects) is caught and routed to {@link Application.onError} rather than
+ * left as an unhandled promise rejection — subscribe via
+ * `app.onError.add(...)` or the {@link import('./ExoCanvas').ExoCanvas}
+ * `onError` prop to observe it.
+ *
  * @param SceneClass - Constructor for the scene to instantiate.
  * @param deps - Extra deps that trigger scene replacement when changed, in
  *   addition to the stable `app` reference (same semantics as `useEffect`).
@@ -39,16 +45,23 @@ export function useScene<T extends Scene>(SceneClass: new () => T, deps: Depende
     const s = new SceneClass();
 
     const apply = async (): Promise<void> => {
-      if (app.status === ApplicationStatus.Stopped) {
-        // First activation — initialize the backend and start the frame loop.
-        await app.start(s);
-      } else {
-        // Engine already running — switch scenes without restarting.
-        await app.scene.setScene(s);
-      }
+      try {
+        if (app.status === ApplicationStatus.Stopped) {
+          // First activation — initialize the backend and start the frame loop.
+          await app.start(s);
+        } else {
+          // Engine already running — switch scenes without restarting.
+          await app.scene.setScene(s);
+        }
 
-      if (!cancelled) {
-        setScene(s);
+        if (!cancelled) {
+          setScene(s);
+        }
+      } catch (error) {
+        // Route to Application.onError instead of leaving an unhandled
+        // rejection — app.start()/setScene() reject rather than dispatching
+        // onError themselves.
+        app.onError.dispatch(error instanceof Error ? error : new Error(String(error)));
       }
     };
 
@@ -59,7 +72,9 @@ export function useScene<T extends Scene>(SceneClass: new () => T, deps: Depende
       setScene(null);
       // Best-effort scene clear; the Application.destroy() called by
       // ExoCanvas cleanup will also handle any remaining active scene.
-      void app.scene.setScene(null);
+      void app.scene.setScene(null).catch((error: unknown) => {
+        app.onError.dispatch(error instanceof Error ? error : new Error(String(error)));
+      });
     };
     // SceneClass is intentionally excluded from deps: a new class reference
     // (e.g. inline arrow class) on every render would recreate the scene

--- a/packages/exojs-react/src/useSignal.ts
+++ b/packages/exojs-react/src/useSignal.ts
@@ -1,0 +1,47 @@
+import type { Signal } from '@codexo/exojs';
+import { useCallback, useSyncExternalStore } from 'react';
+
+/**
+ * Subscribes to an ExoJS {@link Signal} and returns the latest value computed by
+ * `getSnapshot`, re-rendering the component every time the signal dispatches.
+ * Built on `useSyncExternalStore`, so reads stay tear-free under concurrent
+ * rendering.
+ *
+ * The signal itself is only used to know *when* to re-read — `getSnapshot` is
+ * responsible for producing the actual value (usually a getter on the engine
+ * object the signal lives on).
+ *
+ * @example
+ * ```tsx
+ * function FrameCounter() {
+ *   const app = useExoApp();
+ *   // Re-renders on every `onFrame` dispatch (i.e. every engine frame).
+ *   const frameCount = useSignal(app.onFrame, () => app.frameCount);
+ *   return <span>Frame: {frameCount}</span>;
+ * }
+ * ```
+ *
+ * @param signal - The signal to subscribe to. `null`/`undefined` is accepted
+ *   (e.g. before an `Application` exists) — the hook simply does not subscribe
+ *   to anything and `getSnapshot` still runs on every render.
+ * @param getSnapshot - Reads the current value. Called on mount and again after
+ *   every dispatch of `signal`.
+ */
+export function useSignal<Args extends unknown[], T>(signal: Signal<Args> | null | undefined, getSnapshot: () => T): T {
+  const subscribe = useCallback(
+    (onStoreChange: () => void): (() => void) => {
+      if (!signal) {
+        return () => {};
+      }
+
+      signal.add(onStoreChange);
+
+      return () => {
+        signal.remove(onStoreChange);
+      };
+    },
+    [signal],
+  );
+
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/packages/exojs-react/src/useSignal.ts
+++ b/packages/exojs-react/src/useSignal.ts
@@ -32,6 +32,7 @@ export function useSignal<Args extends unknown[], T>(signal: Signal<Args> | null
     (onStoreChange: () => void): (() => void) => {
       if (!signal) {
         // No signal to subscribe to (e.g. before an Application exists) — nothing to unsubscribe either.
+        // eslint-disable-next-line @typescript-eslint/no-empty-function -- intentional no-op unsubscribe
         return () => {};
       }
 

--- a/packages/exojs-react/src/useSignal.ts
+++ b/packages/exojs-react/src/useSignal.ts
@@ -31,6 +31,7 @@ export function useSignal<Args extends unknown[], T>(signal: Signal<Args> | null
   const subscribe = useCallback(
     (onStoreChange: () => void): (() => void) => {
       if (!signal) {
+        // No signal to subscribe to (e.g. before an Application exists) — nothing to unsubscribe either.
         return () => {};
       }
 

--- a/packages/exojs-react/test/ExoCanvas.test.tsx
+++ b/packages/exojs-react/test/ExoCanvas.test.tsx
@@ -85,4 +85,16 @@ describe('<ExoCanvas>', () => {
     const hud = getByTestId('hud');
     expect(hud.textContent).toBe('has-app');
   });
+
+  it('forwards Application.onError dispatches to the onError prop', () => {
+    const onError = vi.fn();
+    render(<ExoCanvas options={{ canvas: { width: 800, height: 600 } }} onError={onError} />);
+
+    const app = MockApplication.instances[0]!;
+    const error = new Error('boom');
+    app.onError.dispatch(error);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(error);
+  });
 });

--- a/packages/exojs-react/test/Scenes.test.tsx
+++ b/packages/exojs-react/test/Scenes.test.tsx
@@ -99,4 +99,33 @@ describe('<Scenes> / <Scene> / useActiveScene', () => {
     await waitFor(() => expect(app.scene.setScene).toHaveBeenCalledWith(null));
     expect(view.queryByTestId('hud')).toBeNull();
   });
+
+  it('routes a rejected app.start() to app.onError instead of an unhandled rejection', async () => {
+    const app = makeApp();
+    const onError = vi.fn();
+    app.onError.add(onError);
+    const failure = new Error('scene failed to load');
+    app.start.mockRejectedValueOnce(failure);
+
+    const view = render(<Tree app={app} active="title" />);
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(failure));
+    // The overlay never appears — no active scene was ever installed.
+    expect(view.queryByTestId('hud')).toBeNull();
+  });
+
+  it('routes a rejected app.scene.setScene() (scene switch) to app.onError', async () => {
+    const app = makeApp();
+    const view = render(<Tree app={app} active="title" />);
+    await view.findByTestId('active');
+
+    const onError = vi.fn();
+    app.onError.add(onError);
+    const failure = new Error('switch failed');
+    app.scene.setScene.mockRejectedValueOnce(failure);
+
+    view.rerender(<Tree app={app} active="game" />);
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(failure));
+  });
 });

--- a/packages/exojs-react/test/support/mock-application.ts
+++ b/packages/exojs-react/test/support/mock-application.ts
@@ -30,6 +30,41 @@ interface MockApplicationOptions {
 }
 
 /**
+ * Minimal `Signal`-alike (add/remove/dispatch/count) for `MockApplication.onError`.
+ * Deliberately NOT the real `Signal` from `@codexo/exojs` — this module is
+ * dynamically imported from inside the `vi.mock('@codexo/exojs', …)` factory
+ * (see `configureApplicationStatus` above for the same reasoning), so a
+ * top-level `import { Signal } from '@codexo/exojs'` here would re-enter the
+ * still-resolving mock factory and deadlock the module loader.
+ */
+class MockSignal<Args extends unknown[]> {
+  private readonly _handlers: ((...args: Args) => void)[] = [];
+
+  public get count(): number {
+    return this._handlers.length;
+  }
+
+  public add(handler: (...args: Args) => void): void {
+    if (!this._handlers.includes(handler)) {
+      this._handlers.push(handler);
+    }
+  }
+
+  public remove(handler: (...args: Args) => void): void {
+    const index = this._handlers.indexOf(handler);
+    if (index !== -1) {
+      this._handlers.splice(index, 1);
+    }
+  }
+
+  public dispatch(...args: Args): void {
+    for (const handler of [...this._handlers]) {
+      handler(...args);
+    }
+  }
+}
+
+/**
  * Minimal stand-in for the engine {@link Application}. It owns no GPU backend;
  * it only records the calls the React glue makes (construction, resize,
  * sizingMode / clearColor assignment, start / setScene, destroy) so the tests
@@ -59,6 +94,9 @@ export class MockApplication {
   public readonly clearColorAssignments: unknown[] = [];
 
   public readonly resize = vi.fn();
+
+  /** Tests dispatch through this exactly like the engine's `Application.onError`. */
+  public readonly onError = new MockSignal<[error: Error]>();
 
   public readonly destroy = vi.fn((): void => {
     this.destroyed = true;

--- a/packages/exojs-react/test/useExoApplication.test.tsx
+++ b/packages/exojs-react/test/useExoApplication.test.tsx
@@ -20,6 +20,7 @@ vi.mock('@codexo/exojs', async importActual => {
 interface HarnessProps {
   options?: ExoApplicationOptions;
   onReady?: (app: Application) => void;
+  onError?: (error: unknown) => void;
   expose: (result: UseExoApplicationResult) => void;
 }
 
@@ -29,8 +30,8 @@ interface HarnessProps {
  * Application (it bails out when `canvasRef.current` is null). `expose` hands the
  * latest hook result back to the test on every render.
  */
-function Harness({ options, onReady, expose }: HarnessProps): ReactElement {
-  const result = useExoApplication(options, onReady);
+function Harness({ options, onReady, onError, expose }: HarnessProps): ReactElement {
+  const result = useExoApplication(options, onReady, onError);
   expose(result);
 
   return <canvas ref={result.canvasRef} data-testid="exo-canvas" />;
@@ -160,5 +161,53 @@ describe('useExoApplication — teardown', () => {
 
     expect(app.destroy).toHaveBeenCalledTimes(1);
     expect(app.destroyed).toBe(true);
+  });
+});
+
+describe('useExoApplication — onError', () => {
+  it('forwards Application.onError dispatches to the onError callback', () => {
+    const onError = vi.fn();
+    mount({ options: { canvas: { width: 800, height: 600 } }, onError });
+    const app = onlyInstance();
+
+    const error = new Error('boom');
+    app.onError.dispatch(error);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(error);
+  });
+
+  it('always calls the LATEST onError without resubscribing on every render', () => {
+    const onErrorFirst = vi.fn();
+    const onErrorSecond = vi.fn();
+    const harness = mount({ options: { canvas: { width: 800, height: 600 } }, onError: onErrorFirst });
+    const app = onlyInstance();
+
+    harness.rerender({ options: { canvas: { width: 800, height: 600 } }, onError: onErrorSecond });
+
+    app.onError.dispatch(new Error('boom'));
+
+    expect(onErrorFirst).not.toHaveBeenCalled();
+    expect(onErrorSecond).toHaveBeenCalledTimes(1);
+    // A live prop change must not tear down and rebuild the Application.
+    expect(MockApplication.instances).toHaveLength(1);
+  });
+
+  it('unsubscribes from onError when the component unmounts', () => {
+    const onError = vi.fn();
+    const harness = mount({ options: { canvas: { width: 800, height: 600 } }, onError });
+    const app = onlyInstance();
+
+    expect(app.onError.count).toBe(1);
+    harness.unmount();
+
+    expect(app.onError.count).toBe(0);
+  });
+
+  it('does not throw when no onError callback is supplied', () => {
+    mount({ options: { canvas: { width: 800, height: 600 } } });
+    const app = onlyInstance();
+
+    expect(() => app.onError.dispatch(new Error('boom'))).not.toThrow();
   });
 });

--- a/packages/exojs-react/test/useScene.test.tsx
+++ b/packages/exojs-react/test/useScene.test.tsx
@@ -67,4 +67,33 @@ describe('useScene', () => {
 
     expect(app.scene.setScene).toHaveBeenCalledWith(null);
   });
+
+  it('routes a rejected app.start() to app.onError instead of an unhandled rejection', async () => {
+    const app = makeApp();
+    const onError = vi.fn();
+    app.onError.add(onError);
+    const failure = new Error('scene failed to load');
+    app.start.mockRejectedValueOnce(failure);
+
+    const { findByText } = render(provide(app, <SceneProbe sceneClass={LevelScene} />));
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(failure));
+    // The probe never receives a scene — it stays in the loading state.
+    expect(await findByText('loading')).toBeTruthy();
+  });
+
+  it('routes a rejected app.scene.setScene() (dep-change switch) to app.onError', async () => {
+    const app = makeApp();
+    const view = render(provide(app, <SceneProbe sceneClass={LevelScene} deps={[1]} />));
+    await view.findByText('LevelScene');
+
+    const onError = vi.fn();
+    app.onError.add(onError);
+    const failure = new Error('switch failed');
+    app.scene.setScene.mockRejectedValueOnce(failure);
+
+    view.rerender(provide(app, <SceneProbe sceneClass={LevelScene} deps={[2]} />));
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(failure));
+  });
 });

--- a/packages/exojs-react/test/useSignal.test.tsx
+++ b/packages/exojs-react/test/useSignal.test.tsx
@@ -1,0 +1,71 @@
+import { Signal } from '@codexo/exojs';
+import { act, render } from '@testing-library/react';
+import { type ReactElement } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { useSignal } from '../src/useSignal';
+
+/** Reads a live counter through `useSignal` and renders it as text. */
+function Counter({ signal, getValue }: { signal: Signal<[number]> | null; getValue: () => number }): ReactElement {
+  const value = useSignal(signal, getValue);
+
+  return <span data-testid="value">{value}</span>;
+}
+
+describe('useSignal', () => {
+  it('returns the initial snapshot on first render without any dispatch', () => {
+    const signal = new Signal<[number]>();
+    let counter = 0;
+    const { getByTestId } = render(<Counter signal={signal} getValue={() => counter} />);
+
+    expect(getByTestId('value').textContent).toBe('0');
+    counter = 5; // Mutating the closed-over value alone must not update the render.
+    expect(getByTestId('value').textContent).toBe('0');
+  });
+
+  it('re-renders with the new snapshot every time the signal dispatches', () => {
+    const signal = new Signal<[number]>();
+    let counter = 0;
+    const { getByTestId } = render(<Counter signal={signal} getValue={() => counter} />);
+
+    counter = 1;
+    act(() => {
+      signal.dispatch(1);
+    });
+    expect(getByTestId('value').textContent).toBe('1');
+
+    counter = 2;
+    act(() => {
+      signal.dispatch(2);
+    });
+    expect(getByTestId('value').textContent).toBe('2');
+  });
+
+  it('unsubscribes the internal listener on unmount', () => {
+    const signal = new Signal<[number]>();
+    const { unmount } = render(<Counter signal={signal} getValue={() => 0} />);
+
+    expect(signal.count).toBe(1);
+    unmount();
+    expect(signal.count).toBe(0);
+  });
+
+  it('resubscribes when the signal identity changes', () => {
+    const signalA = new Signal<[number]>();
+    const signalB = new Signal<[number]>();
+    const { rerender } = render(<Counter signal={signalA} getValue={() => 0} />);
+
+    expect(signalA.count).toBe(1);
+
+    rerender(<Counter signal={signalB} getValue={() => 0} />);
+
+    expect(signalA.count).toBe(0);
+    expect(signalB.count).toBe(1);
+  });
+
+  it('tolerates a null signal (e.g. before the Application exists) and still reads getSnapshot', () => {
+    const { getByTestId } = render(<Counter signal={null} getValue={() => 42} />);
+
+    expect(getByTestId('value').textContent).toBe('42');
+  });
+});

--- a/site/src/components/EnglishFallbackNotice.astro
+++ b/site/src/components/EnglishFallbackNotice.astro
@@ -1,0 +1,24 @@
+---
+// Unobtrusive banner shown above real content on `de/` routes that do not
+// have a German translation yet. Unlike TranslationNotice, this does NOT
+// replace the content — the actual (English) page renders normally below it,
+// so visitors get the real thing immediately instead of a "coming soon" stub.
+---
+
+<p class="english-fallback-notice" role="status">
+    Showing the English version — German translation is not available yet.
+</p>
+
+<style>
+    .english-fallback-notice {
+        margin: 0 0 1rem;
+        padding: 0.5rem 0.85rem;
+        border: 1px solid var(--line-soft);
+        border-left: 3px solid var(--accent);
+        border-radius: var(--r-2);
+        background: var(--bg-elevated);
+        color: var(--fg-muted);
+        font-size: 0.8rem;
+        line-height: 1.5;
+    }
+</style>

--- a/site/src/content/api/limiter-effect.mdx
+++ b/site/src/content/api/limiter-effect.mdx
@@ -1,15 +1,15 @@
 ---
 title: "LimiterEffect"
-description: "Brick-wall limiter backed by a Web Audio `DynamicsCompressorNode` configured for hard limiting: a fixed high ratio (~20), zero knee (hard knee), and a fast attack. Use it as a final-chain safety net to prevent clipping and protect downstream output. The compressor `ratio` (20) and `knee` (0) are fixed internally and are not user-configurable options. The effect exposes a dry/wet mix for API consistency and parallel processing workflows, though a fully-wet signal (`wet = 1`) is the typical configuration. Node graph: ``` input(GainNode) → dryGain → output(GainNode) input → compressor → wetGain → output ``` Gains: `dryGain.gain = 1 - wet`; `wetGain.gain = wet`."
+description: "Brick-wall limiter backed by a Web Audio `DynamicsCompressorNode` configured for hard limiting: a fixed high ratio (~20), zero knee (hard knee), and a fast attack. Use it as a final-chain safety net to prevent clipping and protect downstream output. The compressor `ratio` and `knee` default to brick-wall values (20 and 0 respectively) but remain configurable, unlike a truly fixed limiter, because callers occasionally want a softer, more compressor-like limiting curve (lower ratio) or a gentler transition into limiting (larger knee) without switching to CompressorEffect and losing the dry/wet mix. The effect also exposes a dry/wet mix for API consistency and parallel processing workflows, though a fully-wet signal (`wet = 1`) is the typical configuration. Node graph: ``` input(GainNode) → dryGain → output(GainNode) input → compressor → wetGain → output ``` Gains: `dryGain.gain = 1 - wet`; `wetGain.gain = wet`."
 symbol: "LimiterEffect"
 kind: "class"
 subsystem: "audio"
 importPath: "@codexo/exojs-audio-fx"
-memberCount: 9
+memberCount: 11
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "packages/exojs-audio-fx/src/effects/LimiterEffect.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-audio-fx/src/effects/LimiterEffect.ts#L59"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-audio-fx/src/effects/LimiterEffect.ts#L74"
 ---
 ## Import
 
@@ -20,10 +20,14 @@ for hard limiting: a fixed high ratio (~20), zero knee (hard knee), and a
 fast attack. Use it as a final-chain safety net to prevent clipping and
 protect downstream output.
 
-The compressor `ratio` (20) and `knee` (0) are fixed internally and are not
-user-configurable options. The effect exposes a dry/wet mix for API
-consistency and parallel processing workflows, though a fully-wet signal
-(`wet = 1`) is the typical configuration.
+The compressor `ratio` and `knee` default to brick-wall values (20 and 0
+respectively) but remain configurable, unlike a truly fixed limiter,
+because callers occasionally want a softer, more compressor-like limiting
+curve (lower ratio) or a gentler transition into limiting (larger knee)
+without switching to CompressorEffect and losing the dry/wet mix.
+The effect also exposes a dry/wet mix for API consistency and parallel
+processing workflows, though a fully-wet signal (`wet = 1`) is the typical
+configuration.
 
 Node graph:
 ```
@@ -44,7 +48,9 @@ Gains: `dryGain.gain = 1 - wet`; `wetGain.gain = wet`.
 
 - `attack: number`
 - `inputNode: AudioNode`
+- `knee: number`
 - `outputNode: AudioNode`
+- `ratio: number`
 - `ready: Promise<void>`
 - `release: number`
 - `threshold: number`
@@ -52,4 +58,4 @@ Gains: `dryGain.gain = 1 - wet`; `wetGain.gain = wet`.
 
 ## Source
 
-[packages/exojs-audio-fx/src/effects/LimiterEffect.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-audio-fx/src/effects/LimiterEffect.ts#L59)
+[packages/exojs-audio-fx/src/effects/LimiterEffect.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-audio-fx/src/effects/LimiterEffect.ts#L74)

--- a/site/src/content/api/particle-system.mdx
+++ b/site/src/content/api/particle-system.mdx
@@ -9,7 +9,7 @@ memberCount: 120
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "packages/exojs-particles/src/ParticleSystem.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/ParticleSystem.ts#L123"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/ParticleSystem.ts#L122"
 ---
 ## Import
 
@@ -197,4 +197,4 @@ to `(0, 0)`.
 
 ## Source
 
-[packages/exojs-particles/src/ParticleSystem.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/ParticleSystem.ts#L123)
+[packages/exojs-particles/src/ParticleSystem.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/ParticleSystem.ts#L122)

--- a/site/src/content/api/physics-binding.mdx
+++ b/site/src/content/api/physics-binding.mdx
@@ -5,11 +5,11 @@ symbol: "PhysicsBinding"
 kind: "class"
 subsystem: "physics"
 importPath: "@codexo/exojs-physics"
-memberCount: 5
+memberCount: 4
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "packages/exojs-physics/src/binding/PhysicsBinding.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/binding/PhysicsBinding.ts#L23"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/binding/PhysicsBinding.ts#L12"
 ---
 ## Import
 
@@ -23,7 +23,7 @@ non-zero skew is rejected at bind time.
 
 ## Constructors
 
-- `new(body: PhysicsBody, node: SceneNode, drive: "body-to-node" | "node-to-body"): PhysicsBinding`
+- `new(body: PhysicsBody, node: SceneNode): PhysicsBinding`
 
 ## Methods
 
@@ -32,9 +32,8 @@ non-zero skew is rejected at bind time.
 ## Properties
 
 - `body: PhysicsBody`
-- `drive: "body-to-node" | "node-to-body"`
 - `node: SceneNode`
 
 ## Source
 
-[packages/exojs-physics/src/binding/PhysicsBinding.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/binding/PhysicsBinding.ts#L23)
+[packages/exojs-physics/src/binding/PhysicsBinding.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/binding/PhysicsBinding.ts#L12)

--- a/site/src/content/api/physics-world.mdx
+++ b/site/src/content/api/physics-world.mdx
@@ -5,11 +5,11 @@ symbol: "PhysicsWorld"
 kind: "class"
 subsystem: "physics"
 importPath: "@codexo/exojs-physics"
-memberCount: 37
+memberCount: 36
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "packages/exojs-physics/src/PhysicsWorld.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/PhysicsWorld.ts#L124"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/PhysicsWorld.ts#L120"
 ---
 ## Import
 
@@ -58,7 +58,7 @@ each is pinned by a gate in `dynamics.test.ts`:
 - `add(body: PhysicsBody): PhysicsBody`
 - `addJoint(joint: T): T`
 - `attach(node: SceneNode, options: AttachOptions): PhysicsBody`
-- `bind(body: PhysicsBody, node: SceneNode, options?: BindingOptions): PhysicsBinding`
+- `bind(body: PhysicsBody, node: SceneNode): PhysicsBinding`
 - `destroy(): void`
 - `destroyBody(body: PhysicsBody): void`
 - `destroyCollider(collider: Collider): void`
@@ -78,7 +78,6 @@ each is pinned by a gate in `dynamics.test.ts`:
 - `dampingRatio: number`
 - `enableSleeping: boolean`
 - `gravity: Vector`
-- `interpolation: boolean`
 - `sleepAngularVelocity: number`
 - `sleepLinearVelocity: number`
 - `subStepCount: number`
@@ -98,4 +97,4 @@ each is pinned by a gate in `dynamics.test.ts`:
 
 ## Source
 
-[packages/exojs-physics/src/PhysicsWorld.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/PhysicsWorld.ts#L124)
+[packages/exojs-physics/src/PhysicsWorld.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/PhysicsWorld.ts#L120)

--- a/site/src/content/api/scale-over-lifetime.mdx
+++ b/site/src/content/api/scale-over-lifetime.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ScaleOverLifetime"
-description: "Sets every live particle's scale to a curve sampled at the particle's current lifetime ratio. Both axes share one curve — for non-uniform scaling layer two ScaleOverLifetime modules with separate `axis` filters (or extend with a per-axis variant). Common patterns: shrink-to-zero (start at 1, end at 0), pulse (sine-like curve up to peak then down), slow-grow (linear ramp). GPU-eligible: the curve is uploaded once as a 256-tap 1D R32F texture and sampled with linear filtering on the GPU — no curve evaluation cost in the inner loop."
+description: "Sets every live particle's scale to a curve sampled at the particle's current lifetime ratio. Both axes share one curve; non-uniform per-axis scaling isn't supported by this module. Common patterns: shrink-to-zero (start at 1, end at 0), pulse (sine-like curve up to peak then down), slow-grow (linear ramp). GPU-eligible: the curve is uploaded once as a 256-tap 1D R32F texture and sampled with linear filtering on the GPU — no curve evaluation cost in the inner loop."
 symbol: "ScaleOverLifetime"
 kind: "class"
 subsystem: "particles"
@@ -9,16 +9,15 @@ memberCount: 7
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Source"]
 sourcePath: "packages/exojs-particles/src/modules/ScaleOverLifetime.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/modules/ScaleOverLifetime.ts#L24"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/modules/ScaleOverLifetime.ts#L23"
 ---
 ## Import
 
 `import { ScaleOverLifetime } from '@codexo/exojs-particles'`
 
 Sets every live particle's scale to a curve sampled at the particle's
-current lifetime ratio. Both axes share one curve — for non-uniform
-scaling layer two ScaleOverLifetime modules with separate `axis` filters
-(or extend with a per-axis variant).
+current lifetime ratio. Both axes share one curve; non-uniform per-axis
+scaling isn't supported by this module.
 
 Common patterns: shrink-to-zero (start at 1, end at 0), pulse (sine-like
 curve up to peak then down), slow-grow (linear ramp).
@@ -45,4 +44,4 @@ the inner loop.
 
 ## Source
 
-[packages/exojs-particles/src/modules/ScaleOverLifetime.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/modules/ScaleOverLifetime.ts#L24)
+[packages/exojs-particles/src/modules/ScaleOverLifetime.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/modules/ScaleOverLifetime.ts#L23)

--- a/site/src/content/api/wheel-joint.mdx
+++ b/site/src/content/api/wheel-joint.mdx
@@ -1,15 +1,15 @@
 ---
 title: "WheelJoint"
-description: "A wheel attached to a chassis: free to **spin** (no rotation lock) and sprung along a **suspension axis** (a soft spring), but locked **laterally** (it cannot slide perpendicular to the axis). Optionally driven by a rotation motor. Used for vehicles. Solved in the sub-step loop, warm-started."
+description: "A wheel attached to a chassis: free to **spin** (no rotation lock) and sprung along a **suspension axis** (a soft spring), but locked **laterally** (it cannot slide perpendicular to the axis). Optionally driven by a rotation motor and/or bounded by a suspension-travel limit. Used for vehicles. Solved in the sub-step loop, warm-started."
 symbol: "WheelJoint"
 kind: "class"
 subsystem: "physics"
 importPath: "@codexo/exojs-physics"
-memberCount: 9
+memberCount: 12
 tier: "stable"
 sections: ["Import", "Constructors", "Properties", "Source"]
 sourcePath: "packages/exojs-physics/src/joints/WheelJoint.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/joints/WheelJoint.ts#L37"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/joints/WheelJoint.ts#L44"
 ---
 ## Import
 
@@ -18,7 +18,8 @@ sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/s
 A wheel attached to a chassis: free to **spin** (no rotation lock) and sprung
 along a **suspension axis** (a soft spring), but locked **laterally** (it
 cannot slide perpendicular to the axis). Optionally driven by a rotation
-motor. Used for vehicles. Solved in the sub-step loop, warm-started.
+motor and/or bounded by a suspension-travel limit. Used for vehicles. Solved
+in the sub-step loop, warm-started.
 
 ## Constructors
 
@@ -30,11 +31,14 @@ motor. Used for vehicles. Solved in the sub-step loop, warm-started.
 - `bodyB: PhysicsBody`
 - `dampingRatio: number`
 - `enabled: boolean`
+- `enableLimit: boolean`
 - `enableMotor: boolean`
 - `hertz: number`
+- `lowerTranslation: number`
 - `maxMotorTorque: number`
 - `motorSpeed: number`
+- `upperTranslation: number`
 
 ## Source
 
-[packages/exojs-physics/src/joints/WheelJoint.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/joints/WheelJoint.ts#L37)
+[packages/exojs-physics/src/joints/WheelJoint.ts](https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/joints/WheelJoint.ts#L44)

--- a/site/src/content/guide/effects/particles.mdx
+++ b/site/src/content/guide/effects/particles.mdx
@@ -108,6 +108,9 @@ Distributions let each spawned particle get a different value. The most commonly
 | `VectorRange(xMin, xMax, yMin, yMax)` | Independent uniform random per axis |
 | `ConeDirection(angle, halfAngle, minSpeed, maxSpeed)` | Velocity vector within a directional cone |
 | `ConeDirection.omni(minSpeed, maxSpeed)` | Full 360° omnidirectional velocity |
+| `BoxArea(minX, maxX, minY, maxY, mode)` | Random point in an axis-aligned box — `'volume'` (default) fills the area, `'edge'` sticks to the perimeter |
+| `CircleArea(centerX, centerY, radius, mode)` | Random point in a circle — `'volume'` (default) fills the disk with uniform area density, `'edge'` sticks to the circumference |
+| `LineSegment(x0, y0, x1, y1)` | Random point uniformly distributed along a line segment |
 | `Curve(keys)` | Piecewise-linear spline evaluated over a particle's lifetime normalised progress (0..1) |
 | `ColorGradient(keys)` | Same as `Curve` but interpolates `Color` values |
 

--- a/site/src/content/guide/integrations/react.mdx
+++ b/site/src/content/guide/integrations/react.mdx
@@ -184,12 +184,17 @@ Any component rendered inside `<ExoCanvas>` can read the running app:
 - `ExoContext` is the underlying context object, exported for advanced use (testing, custom
   providers).
 
+`app.frameCount` is a plain getter the engine updates on its own frame loop — reading it
+alone does not make a component re-render. Pair `useExoApp()` with `useSignal()` to subscribe
+to `app.onFrame` and re-render on every dispatch:
+
 ```tsx no-check
-import { useExoApp } from '@codexo/exojs-react';
+import { useExoApp, useSignal } from '@codexo/exojs-react';
 
 function FrameCounter() {
   const app = useExoApp(); // throws if rendered outside <ExoCanvas>
-  return <span>Frame: {app.frameCount}</span>;
+  const frameCount = useSignal(app.onFrame, () => app.frameCount);
+  return <span>Frame: {frameCount}</span>;
 }
 ```
 

--- a/site/src/pages/de/api/[symbol].astro
+++ b/site/src/pages/de/api/[symbol].astro
@@ -2,9 +2,136 @@
 import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
 import DocsLayout from '../../../layouts/DocsLayout.astro';
-import TranslationNotice from '../../../components/TranslationNotice.astro';
+import DocsSidebar from '../../../components/DocsSidebar.astro';
+import EnglishFallbackNotice from '../../../components/EnglishFallbackNotice.astro';
+import { API_SUBSYSTEM_META, API_SUBSYSTEM_ORDER, toApiHref } from '../../../lib/api-reference';
 
 type ApiEntry = CollectionEntry<'api'>;
+
+type ApiRow = {
+    signature: string;
+    description: string;
+};
+
+type ParsedSection = {
+    id: string;
+    title: string;
+    rows: ApiRow[];
+    paragraphs: string[];
+    importLine: string | null;
+    sourceLink: { label: string; href: string } | null;
+};
+
+type ApiMobileTab = {
+    id: string;
+    title: string;
+    count: number | null;
+};
+
+const toAnchor = (value: string): string =>
+    value
+        .toLowerCase()
+        .replace(/[^a-z0-9\s-]/g, '')
+        .trim()
+        .replace(/\s+/g, '-');
+
+const cleanText = (value: string): string => value.replace(/\\([{}])/g, '$1');
+
+const parseParagraphs = (lines: string[]): string[] => {
+    const paragraphs: string[] = [];
+    let buffer: string[] = [];
+
+    const flush = () => {
+        if (buffer.length === 0) return;
+        paragraphs.push(cleanText(buffer.join(' ').trim()));
+        buffer = [];
+    };
+
+    for (const rawLine of lines) {
+        const line = rawLine.trim();
+        if (!line) {
+            flush();
+            continue;
+        }
+        if (line.startsWith('- `')) {
+            flush();
+            continue;
+        }
+        if (/^`[^`]+`$/.test(line)) {
+            flush();
+            continue;
+        }
+        if (/^\[[^\]]+\]\(([^)]+)\)$/.test(line)) {
+            flush();
+            continue;
+        }
+        buffer.push(line);
+    }
+
+    flush();
+    return paragraphs;
+};
+
+const parseSections = (body: string): ParsedSection[] => {
+    const sections: Array<{ title: string; lines: string[] }> = [];
+    let active: { title: string; lines: string[] } | null = null;
+
+    for (const rawLine of body.split('\n')) {
+        const headingMatch = /^##\s+(.+)$/.exec(rawLine.trim());
+        if (headingMatch) {
+            if (active) sections.push(active);
+            active = { title: headingMatch[1].trim(), lines: [] };
+            continue;
+        }
+        if (active) active.lines.push(rawLine);
+    }
+
+    if (active) sections.push(active);
+
+    return sections.map(section => {
+        const rows: ApiRow[] = [];
+        let importLine: string | null = null;
+        let sourceLink: { label: string; href: string } | null = null;
+
+        for (const rawLine of section.lines) {
+            const line = rawLine.trim();
+            if (!line) continue;
+
+            if (!importLine) {
+                const importMatch = /^`([^`]+)`$/.exec(line);
+                if (importMatch) {
+                    importLine = cleanText(importMatch[1]);
+                    continue;
+                }
+            }
+
+            if (!sourceLink) {
+                const sourceMatch = /^\[([^\]]+)\]\(([^)]+)\)$/.exec(line);
+                if (sourceMatch) {
+                    sourceLink = { label: cleanText(sourceMatch[1]), href: sourceMatch[2] };
+                    continue;
+                }
+            }
+
+            const rowMatch = /^-\s+`([^`]+)`(?:\s*[-:]\s*(.+))?$/.exec(line);
+            if (rowMatch) {
+                rows.push({
+                    signature: cleanText(rowMatch[1]),
+                    description: cleanText(rowMatch[2] ?? ''),
+                });
+            }
+        }
+
+        return {
+            id: toAnchor(section.title),
+            title: section.title,
+            rows,
+            paragraphs: parseParagraphs(section.lines),
+            importLine,
+            sourceLink,
+        };
+    });
+};
 
 export async function getStaticPaths() {
     const apiEntries = await getCollection('api');
@@ -12,30 +139,757 @@ export async function getStaticPaths() {
 }
 
 const symbol = (Astro.params as Record<string, string | undefined>).symbol ?? '';
+const apiEntries = await getCollection('api');
+const entry = apiEntries.find((item: ApiEntry) => item.id === symbol);
+if (!entry) {
+    throw new Error(`Unknown API symbol: ${symbol}`);
+}
+
+const parsedSections = parseSections(entry.body ?? '');
+const sectionByTitle = new Map(parsedSections.map(section => [section.title.toLowerCase(), section]));
+const methodsCount = sectionByTitle.get('methods')?.rows.length ?? 0;
+const propertiesCount = sectionByTitle.get('properties')?.rows.length ?? 0;
+const eventsCount = sectionByTitle.get('events')?.rows.length ?? 0;
+const currentSubsystem = entry.data.subsystem as keyof typeof API_SUBSYSTEM_META;
+
+const kindGlyph = entry.data.kind === 'enum' ? 'E' : entry.data.kind === 'class' ? 'C' : entry.data.kind.slice(0, 1).toUpperCase();
+const kindLabel = entry.data.kind.toLowerCase();
+
+const toMobileTabCount = (section: ParsedSection): number | null => {
+    const sectionKey = section.title.toLowerCase();
+    if (sectionKey === 'constructor' || sectionKey === 'constructors') return section.rows.length;
+    if (sectionKey === 'methods') return section.rows.length;
+    if (sectionKey === 'properties') return section.rows.length;
+    if (sectionKey === 'events') return section.rows.length;
+    if (sectionKey === 'examples') return section.rows.length > 0 ? section.rows.length : null;
+    return section.rows.length > 0 ? section.rows.length : null;
+};
+
+const mobileTabs: ApiMobileTab[] = [
+    { id: 'overview', title: 'Overview', count: null },
+    ...parsedSections.map(section => ({
+        id: section.id,
+        title: section.title,
+        count: toMobileTabCount(section),
+    })),
+];
+
+const currentSubsystemEntries = apiEntries
+    .filter((item: ApiEntry) => item.data.subsystem === currentSubsystem)
+    .sort((a: ApiEntry, b: ApiEntry) => a.data.title.localeCompare(b.data.title));
+
+const sidebarGroups = [
+    {
+        title: 'API',
+        items: [
+            { href: `${import.meta.env.BASE_URL}en/api/`, label: 'Overview' },
+            { href: `${import.meta.env.BASE_URL}en/api/all/`, label: 'All symbols A-Z' },
+        ],
+    },
+    {
+        title: 'Subsystems',
+        items: API_SUBSYSTEM_ORDER.map(subsystem => ({
+            href: `${import.meta.env.BASE_URL}en/api/#subsystem-${subsystem}`,
+            label: API_SUBSYSTEM_META[subsystem].label,
+        })),
+    },
+    {
+        title: `${API_SUBSYSTEM_META[currentSubsystem].label}`,
+        items: currentSubsystemEntries.map((item: ApiEntry) => ({
+            href: toApiHref(import.meta.env.BASE_URL, item.id),
+            label: item.data.title,
+        })),
+    },
+];
 ---
 
-<DocsLayout title={`API Symbol (DE)`} description="German localization placeholder for this API symbol page.">
-    <section class="de-api-symbol">
-        <h1>{symbol}</h1>
-        <p>This API page is not translated to German yet.</p>
-        <TranslationNotice englishHref={`${import.meta.env.BASE_URL}en/api/${symbol}/`} />
-    </section>
+<DocsLayout title={`${entry.data.title} | ExoJS API`} description={entry.data.description} variant="api">
+    <DocsSidebar slot="sidebar" groups={sidebarGroups} />
+    <aside slot="rail" class="toc" aria-label="API symbol page table of contents">
+        <h6>On this page</h6>
+        <ul data-api-toc>
+            {
+                parsedSections.map((section, index) => (
+                    <li>
+                        <a href={`#${section.id}`} data-api-toc-link data-active={index === 0 ? 'true' : 'false'}>
+                            {section.title}
+                        </a>
+                    </li>
+                ))
+            }
+        </ul>
+        <div class="toc__resources">
+            <h6>Tools</h6>
+            <ul>
+                <li><a href={`${import.meta.env.BASE_URL}en/api/`}>API index</a></li>
+                <li><a href={`${import.meta.env.BASE_URL}en/api/all/`}>All symbols A-Z</a></li>
+                <li><a href={`${import.meta.env.BASE_URL}en/guide/`}>Read Guide</a></li>
+                <li><a href={`${import.meta.env.BASE_URL}en/playground/`}>Try Playground</a></li>
+                {entry.data.sourceUrl && <li><a href={entry.data.sourceUrl} rel="noreferrer noopener" target="_blank">Source link</a></li>}
+            </ul>
+        </div>
+    </aside>
+
+    <div class="prose api-prose">
+        <EnglishFallbackNotice />
+        <div class="api-head">
+            <div>
+                <h1>API reference</h1>
+                <p>
+                    Every public class, method, and event in <code class="inline">@codexo/exojs</code>. Generated from source.
+                </p>
+            </div>
+        </div>
+
+        <nav class="api-mobile-tabs" data-api-mobile-tabs aria-label="API detail sections">
+            {mobileTabs.map((tab, index) => (
+                <button
+                    type="button"
+                    class="api-mobile-tabs__tab"
+                    data-api-mobile-tab={tab.id}
+                    data-active={index === 0 ? 'true' : 'false'}
+                    aria-current={index === 0 ? 'true' : undefined}
+                >
+                    <span>{tab.title}</span>
+                    {tab.count !== null && <span class="count">{tab.count}</span>}
+                </button>
+            ))}
+        </nav>
+
+        <article class="api-class">
+            <section id="overview" class="api-section api-section--overview" data-api-mobile-section data-api-mobile-key="overview">
+                <header class="api-class-head">
+                    <span class="icon">{kindGlyph}</span>
+                    <div class="api-class-head__main">
+                        <h2><span class="keyword">{kindLabel}</span>{entry.data.title}</h2>
+                        <div class="extends">
+                            <span>{entry.data.importPath}</span>
+                            <span> / {entry.data.subsystem}</span>
+                            <span> / stable</span>
+                        </div>
+                        <p>{entry.data.description}</p>
+                    </div>
+                    <div class="stats">
+                        <div class="s">
+                            <div class="n">{propertiesCount}</div>
+                            <div class="l">props</div>
+                        </div>
+                        <div class="s">
+                            <div class="n">{methodsCount}</div>
+                            <div class="l">methods</div>
+                        </div>
+                        <div class="s">
+                            <div class="n">{eventsCount}</div>
+                            <div class="l">events</div>
+                        </div>
+                    </div>
+                </header>
+            </section>
+
+            {
+                parsedSections.map(section => (
+                    <section id={section.id} class="api-section" data-api-mobile-section data-api-mobile-key={section.id}>
+                        <div class="api-section-head">
+                            <span>{section.title}</span>
+                            <span class="line"></span>
+                            <span>{section.rows.length > 0 ? section.rows.length : ''}</span>
+                        </div>
+
+                        {section.importLine && (
+                            <div class="api-inline-code">
+                                <code>{section.importLine}</code>
+                            </div>
+                        )}
+
+                        {section.rows.length > 0 &&
+                            section.rows.map(row => (
+                                <div class="api-row">
+                                    <div class="sig">
+                                        <div class="name">
+                                            <code>{row.signature}</code>
+                                        </div>
+                                    </div>
+                                    <div class="desc">{row.description}</div>
+                                </div>
+                            ))}
+
+                        {section.paragraphs.length > 0 && (
+                            <div class="api-paragraphs">
+                                {section.paragraphs.map(paragraph => (
+                                    <p>{paragraph}</p>
+                                ))}
+                            </div>
+                        )}
+
+                        {section.sourceLink && (
+                            <div class="api-source">
+                                <a href={section.sourceLink.href} rel="noreferrer noopener" target="_blank">
+                                    {section.sourceLink.label}
+                                </a>
+                            </div>
+                        )}
+                    </section>
+                ))
+            }
+        </article>
+    </div>
+
+    <script is:inline>
+        (() => {
+            const links = Array.from(document.querySelectorAll('[data-api-toc-link]'));
+            const mobileTabs = Array.from(document.querySelectorAll('[data-api-mobile-tab]'));
+            const mobileSections = Array.from(document.querySelectorAll('[data-api-mobile-section]'));
+            const mobileMediaQuery = window.matchMedia('(max-width: 760px)');
+            const reduceMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+            const revealAllMobileSections = () => {
+                for (const section of mobileSections) {
+                    if (section instanceof HTMLElement) {
+                        section.hidden = false;
+                    }
+                }
+            };
+
+            const setActiveMobileTab = id => {
+                for (const button of mobileTabs) {
+                    if (!(button instanceof HTMLButtonElement)) continue;
+                    const isActive = (button.dataset.apiMobileTab ?? '') === id;
+                    button.setAttribute('data-active', isActive ? 'true' : 'false');
+                    if (isActive) button.setAttribute('aria-current', 'true');
+                    else button.removeAttribute('aria-current');
+                }
+            };
+
+            const setMobileSection = (id, options = {}) => {
+                const sectionId = typeof id === 'string' && id.length > 0 ? id : 'overview';
+                const shouldScroll = options.scroll === true;
+                setActiveMobileTab(sectionId);
+
+                if (!mobileMediaQuery.matches) {
+                    revealAllMobileSections();
+                    return;
+                }
+
+                for (const section of mobileSections) {
+                    if (!(section instanceof HTMLElement)) continue;
+                    section.hidden = (section.dataset.apiMobileKey ?? '') !== sectionId;
+                }
+
+                if (!shouldScroll) return;
+                const target = mobileSections.find(node => node instanceof HTMLElement && (node.dataset.apiMobileKey ?? '') === sectionId);
+                if (!(target instanceof HTMLElement)) return;
+                target.scrollIntoView({
+                    block: 'start',
+                    behavior: reduceMotionQuery.matches ? 'auto' : 'smooth',
+                });
+            };
+
+            mobileTabs.forEach(button => {
+                if (!(button instanceof HTMLButtonElement)) return;
+                button.addEventListener('click', () => {
+                    const id = button.dataset.apiMobileTab ?? 'overview';
+                    setMobileSection(id, { scroll: true });
+                });
+            });
+
+            mobileMediaQuery.addEventListener('change', event => {
+                if (event.matches) {
+                    const active = mobileTabs.find(node => node instanceof HTMLButtonElement && node.getAttribute('data-active') === 'true');
+                    const id = active instanceof HTMLButtonElement ? (active.dataset.apiMobileTab ?? 'overview') : 'overview';
+                    setMobileSection(id, { scroll: false });
+                    return;
+                }
+                revealAllMobileSections();
+            });
+
+            if (mobileMediaQuery.matches) {
+                setMobileSection('overview', { scroll: false });
+            } else {
+                revealAllMobileSections();
+            }
+
+            if (links.length === 0) return;
+
+            const targets = links
+                .map(link => {
+                    if (!(link instanceof HTMLAnchorElement)) return null;
+                    const id = link.getAttribute('href')?.replace(/^#/, '');
+                    if (!id) return null;
+                    const target = document.getElementById(id);
+                    if (!(target instanceof HTMLElement)) return null;
+                    return { link, target };
+                })
+                .filter(Boolean);
+
+            if (targets.length === 0) return;
+
+            const setActive = activeLink => {
+                for (const node of links) {
+                    if (node instanceof HTMLAnchorElement) node.setAttribute('data-active', node === activeLink ? 'true' : 'false');
+                }
+            };
+
+            const observer = new IntersectionObserver(
+                entries => {
+                    const visible = entries
+                        .filter(entry => entry.isIntersecting)
+                        .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+                    const first = visible[0];
+                    if (!first) return;
+                    const match = targets.find(item => item.target === first.target);
+                    if (!match) return;
+                    setActive(match.link);
+                    if (mobileMediaQuery.matches) {
+                        setActiveMobileTab(match.target.id);
+                    }
+                },
+                { rootMargin: '-20% 0px -65% 0px', threshold: [0, 1] },
+            );
+
+            for (const item of targets) observer.observe(item.target);
+            setActive(targets[0].link);
+        })();
+    </script>
 </DocsLayout>
 
 <style>
-    .de-api-symbol {
-        display: grid;
-        gap: 0.9rem;
+    .api-prose {
+        max-width: none;
     }
 
-    .de-api-symbol h1 {
-        margin: 0;
-        font-size: clamp(1.6rem, 3.5vw, 2.3rem);
+    .api-head {
+        margin-bottom: var(--s-5);
     }
 
-    .de-api-symbol p {
+    .api-head h1 {
+        margin: 0 0 4px;
+        font-size: 32px;
+        font-weight: 600;
+        letter-spacing: -0.02em;
+    }
+
+    .api-head p {
         margin: 0;
         color: var(--fg-muted);
+        max-width: 72ch;
+    }
+
+    .api-mobile-tabs {
+        display: none;
+    }
+
+    .api-class {
+        background: var(--bg-elevated);
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-4);
+        overflow: hidden;
+    }
+
+    .api-class-head {
+        padding: var(--s-5) var(--s-6);
+        border-bottom: 1px solid var(--line-soft);
+        display: flex;
+        gap: var(--s-4);
+        align-items: start;
+        background: var(--bg-elevated);
+    }
+
+    .api-class-head .icon {
+        width: 36px;
+        height: 36px;
+        flex-shrink: 0;
+        display: grid;
+        place-items: center;
+        border-radius: var(--r-2);
+        background: var(--accent-soft);
+        color: var(--accent);
+        font-family: var(--f-mono);
+        font-weight: 600;
+        font-size: 14px;
+    }
+
+    .api-class-head__main {
+        min-width: 0;
+        flex: 1;
+    }
+
+    .api-class-head h2 {
+        margin: 0;
+        font-size: 20px;
+        font-family: var(--f-mono);
+        font-weight: 600;
+        letter-spacing: -0.01em;
+        overflow-wrap: anywhere;
+    }
+
+    .api-class-head h2 .keyword {
+        color: var(--fg-faint);
+        font-weight: 400;
+        margin-right: 6px;
+        text-transform: lowercase;
+    }
+
+    .api-class-head .extends {
+        font-family: var(--f-mono);
+        font-size: 12.5px;
+        color: var(--fg-muted);
+        margin-top: 2px;
+        overflow-wrap: anywhere;
+    }
+
+    .api-class-head p {
+        margin: 6px 0 0;
+        color: var(--fg-muted);
+        font-size: 14px;
+        max-width: 760px;
+    }
+
+    .api-class-head .stats {
+        display: flex;
+        gap: var(--s-4);
+        margin-left: auto;
+        flex-shrink: 0;
+    }
+
+    .api-class-head .stats .s {
+        text-align: right;
+    }
+
+    .api-class-head .stats .s .n {
+        font-family: var(--f-mono);
+        font-size: 14px;
+        color: var(--fg);
+    }
+
+    .api-class-head .stats .s .l {
+        font-size: 10.5px;
+        color: var(--fg-faint);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+    }
+
+    .api-section {
+        padding: var(--s-3) 0;
+    }
+
+    .api-section + .api-section {
+        margin-top: var(--s-7);
+    }
+
+    .api-section-head {
+        padding: var(--s-3) var(--s-6);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--fg-faint);
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: var(--s-2);
+    }
+
+    .api-section-head .line {
+        flex: 1;
+        height: 1px;
+        background: var(--line-soft);
+    }
+
+    .api-inline-code {
+        padding: 0 var(--s-6) var(--s-3);
+    }
+
+    .api-inline-code code {
+        display: inline-flex;
+        align-items: center;
+        border-radius: var(--r-2);
+        border: 1px solid var(--line-soft);
+        background: var(--bg-canvas);
+        font-family: var(--f-mono);
+        font-size: 12.5px;
+        color: var(--fg);
+        padding: 4px 9px;
+        overflow-wrap: anywhere;
+    }
+
+    .api-row {
+        display: grid;
+        grid-template-columns: 320px minmax(0, 1fr);
+        gap: var(--s-5);
+        padding: var(--s-4) var(--s-6);
+        border-top: 1px dashed var(--line-soft);
+        align-items: start;
+    }
+
+    .api-row .sig {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+    }
+
+    .api-row .sig .name code {
+        font-family: var(--f-mono);
+        font-size: 13.5px;
+        color: var(--fg);
+        line-height: 1.7;
+        overflow-wrap: anywhere;
+        white-space: normal;
+    }
+
+    .api-row .desc {
+        color: var(--fg-muted);
+        font-size: 14px;
+        line-height: 1.65;
         max-width: 64ch;
+    }
+
+    .api-paragraphs {
+        padding: 0 var(--s-6);
+        margin-top: var(--s-2);
+    }
+
+    .api-paragraphs p {
+        margin: var(--s-3) 0;
+        color: var(--fg-muted);
+        line-height: 1.65;
+        max-width: 74ch;
+    }
+
+    .api-source {
+        padding: var(--s-3) var(--s-6) 0;
+    }
+
+    .api-source a {
+        color: var(--accent);
+        text-decoration: none;
+        border-bottom: 1px solid var(--accent-line);
+        font-family: var(--f-mono);
+        font-size: 12.5px;
+    }
+
+    .toc h6 {
+        margin: 0;
+        font-family: var(--f-mono);
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--fg-faint);
+    }
+
+    .toc ul {
+        list-style: none;
+        margin: var(--s-3) 0 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .toc a {
+        display: block;
+        border-left: 2px solid transparent;
+        padding: 4px 0 4px var(--s-3);
+        margin-left: -10px;
+        color: var(--fg-muted);
+        text-decoration: none;
+        font-size: 13px;
+    }
+
+    .toc a:hover,
+    .toc a:focus-visible {
+        color: var(--fg);
+        outline: none;
+    }
+
+    .toc a[data-active='true'] {
+        color: var(--accent);
+        border-left-color: var(--accent);
+    }
+
+    .toc__resources {
+        margin-top: 1.5rem;
+        padding-top: 0.75rem;
+        border-top: 1px solid var(--line-soft);
+    }
+
+    @media (max-width: 1120px) {
+        .api-row {
+            grid-template-columns: 1fr;
+            gap: var(--s-2);
+        }
+    }
+
+    @media (max-width: 760px) {
+        .api-head {
+            margin-bottom: var(--s-3);
+        }
+
+        .api-head h1 {
+            font-size: 1.7rem;
+            line-height: 1.14;
+        }
+
+        .api-mobile-tabs {
+            display: flex;
+            gap: 0.4rem;
+            overflow-x: auto;
+            overflow-y: hidden;
+            position: sticky;
+            top: calc(3.2rem + env(safe-area-inset-top));
+            z-index: 9;
+            margin: 0 0 var(--s-3);
+            padding: 0.4rem 0 0.25rem;
+            background: color-mix(in oklab, var(--bg-canvas), transparent 8%);
+            scrollbar-width: thin;
+            -webkit-overflow-scrolling: touch;
+            backdrop-filter: blur(6px);
+            border-bottom: 1px solid var(--line-soft);
+        }
+
+        .api-mobile-tabs__tab {
+            min-height: 44px;
+            flex: 0 0 auto;
+            border: 1px solid var(--line-soft);
+            border-radius: var(--r-pill);
+            background: var(--bg-elevated);
+            color: var(--fg-muted);
+            padding: 0 0.75rem;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.42rem;
+            font-size: 0.74rem;
+            font-family: var(--f-mono);
+            cursor: pointer;
+            white-space: nowrap;
+        }
+
+        .api-mobile-tabs__tab .count {
+            color: var(--fg-faint);
+        }
+
+        .api-mobile-tabs__tab[data-active='true'] {
+            border-color: var(--accent-line);
+            background: var(--accent-soft);
+            color: var(--accent);
+            box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--accent-line), transparent 35%);
+        }
+
+        .api-mobile-tabs__tab[data-active='true'] .count {
+            color: var(--accent);
+        }
+
+        .api-mobile-tabs__tab:focus-visible {
+            outline: 2px solid var(--focus-ring);
+            outline-offset: 2px;
+        }
+
+        .api-class-head {
+            padding: var(--s-4) var(--s-3);
+            gap: var(--s-3);
+            flex-wrap: wrap;
+        }
+
+        .api-class-head .icon {
+            width: 32px;
+            height: 32px;
+            font-size: 13px;
+        }
+
+        .api-class-head h2 {
+            font-size: 1.02rem;
+        }
+
+        .api-class-head .extends {
+            font-size: 0.7rem;
+            overflow-wrap: anywhere;
+        }
+
+        .api-class-head p {
+            margin-top: 0.45rem;
+            font-size: 0.84rem;
+            line-height: 1.62;
+        }
+
+        .api-class-head .stats {
+            gap: var(--s-3);
+            margin-left: 0;
+            width: 100%;
+            justify-content: flex-start;
+            padding-top: 0.1rem;
+        }
+
+        .api-class-head .stats .s {
+            text-align: left;
+        }
+
+        .api-section {
+            padding: var(--s-2) 0;
+            scroll-margin-top: calc(4.2rem + env(safe-area-inset-top));
+        }
+
+        .api-section + .api-section {
+            margin-top: var(--s-4);
+        }
+
+        .api-section-head {
+            padding: var(--s-2) var(--s-3);
+            font-size: 0.64rem;
+        }
+
+        .api-inline-code {
+            padding: 0 var(--s-3) var(--s-2);
+            overflow-x: auto;
+        }
+
+        .api-inline-code code {
+            min-height: 36px;
+            white-space: nowrap;
+            max-width: max-content;
+            min-width: max-content;
+        }
+
+        .api-row {
+            padding: var(--s-3) var(--s-3);
+            gap: var(--s-1);
+        }
+
+        .api-row .sig .name {
+            overflow-x: auto;
+            overflow-y: hidden;
+            scrollbar-width: thin;
+            -webkit-overflow-scrolling: touch;
+        }
+
+        .api-row .sig .name code {
+            display: inline-block;
+            min-width: max-content;
+            white-space: nowrap;
+            font-size: 0.78rem;
+            line-height: 1.5;
+        }
+
+        .api-row .desc {
+            font-size: 0.82rem;
+            line-height: 1.6;
+            max-width: none;
+            overflow-wrap: anywhere;
+        }
+
+        .api-paragraphs {
+            padding: 0 var(--s-3);
+            margin-top: var(--s-1);
+        }
+
+        .api-paragraphs p {
+            margin: var(--s-2) 0;
+            font-size: 0.83rem;
+            line-height: 1.68;
+            max-width: none;
+        }
+
+        .api-source {
+            padding: var(--s-2) var(--s-3) 0;
+        }
     }
 </style>

--- a/site/src/pages/de/api/index.astro
+++ b/site/src/pages/de/api/index.astro
@@ -1,30 +1,627 @@
 ---
+import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
 import DocsLayout from '../../../layouts/DocsLayout.astro';
-import TranslationNotice from '../../../components/TranslationNotice.astro';
+import DocsSidebar from '../../../components/DocsSidebar.astro';
+import EnglishFallbackNotice from '../../../components/EnglishFallbackNotice.astro';
+import { API_SUBSYSTEM_META, API_SUBSYSTEM_ORDER, FEATURED_SYMBOLS, compactDescription, parseMemberCounts, toApiHref } from '../../../lib/api-reference';
+
+type ApiListItem = {
+    entry: CollectionEntry<'api'>;
+    href: string;
+    kind: string;
+    shortDescription: string;
+    counts: ReturnType<typeof parseMemberCounts>;
+};
+
+const apiEntries = await getCollection('api');
+const sortedEntries = [...apiEntries].sort((a, b) => a.data.title.localeCompare(b.data.title));
+
+const items: ApiListItem[] = sortedEntries.map(entry => ({
+    entry,
+    href: toApiHref(import.meta.env.BASE_URL, entry.id),
+    kind: entry.data.kind.toLowerCase(),
+    shortDescription: compactDescription(entry.data.description ?? '', 138),
+    counts: parseMemberCounts(entry.body ?? ''),
+}));
+
+const grouped = API_SUBSYSTEM_ORDER.map(subsystem => ({
+    subsystem,
+    label: API_SUBSYSTEM_META[subsystem].label,
+    description: API_SUBSYSTEM_META[subsystem].description,
+    entries: items.filter(item => item.entry.data.subsystem === subsystem),
+}));
+
+const featured = FEATURED_SYMBOLS.map(id => items.find(item => item.entry.id === id)).filter((item): item is ApiListItem => Boolean(item));
+
+const totalSymbols = items.length;
+const classCount = items.filter(item => item.kind === 'class').length;
+const enumCount = items.filter(item => item.kind === 'enum').length;
+
+const sidebarGroups = [
+    {
+        title: 'Getting Started',
+        items: featured.map(item => ({
+            href: item.href,
+            label: item.entry.data.title,
+        })),
+    },
+    {
+        title: 'Subsystems',
+        items: [
+            ...grouped.map(group => ({
+                href: `#subsystem-${group.subsystem}`,
+                label: `${group.label} (${group.entries.length})`,
+            })),
+            {
+                href: `${import.meta.env.BASE_URL}en/api/all/`,
+                label: 'All symbols A-Z',
+            },
+        ],
+    },
+];
 ---
 
-<DocsLayout title="ExoJS API (DE)" description="German localization placeholder for the ExoJS API reference.">
-    <section class="de-api">
-        <h1>API reference</h1>
-        <p>The API reference is currently available in English only.</p>
-        <TranslationNotice englishHref={`${import.meta.env.BASE_URL}en/api/`} />
-    </section>
+<DocsLayout title="ExoJS API" description="Public API for @codexo/exojs, organized by subsystem." variant="api">
+    <DocsSidebar slot="sidebar" groups={sidebarGroups} />
+
+    <aside slot="rail" class="toc" aria-label="API overview table of contents">
+        <h6>On this page</h6>
+        <ul>
+            <li><a href="#featured" data-active="true">Featured</a></li>
+            <li><a href="#subsystems">Subsystems</a></li>
+            <li><a href="#all-symbols">All symbols</a></li>
+        </ul>
+        <div class="toc__resources">
+            <h6>Tools</h6>
+            <ul>
+                <li><a href={`${import.meta.env.BASE_URL}en/api/all/`}>All symbols A-Z</a></li>
+                <li><a href={`${import.meta.env.BASE_URL}en/guide/`}>Read Guide</a></li>
+                <li><a href={`${import.meta.env.BASE_URL}en/playground/`}>Try Playground</a></li>
+            </ul>
+        </div>
+    </aside>
+
+    <div class="prose api-prose">
+        <EnglishFallbackNotice />
+        <header class="api-head">
+            <div>
+                <h1>API reference</h1>
+                <p>Public API for <code class="inline">@codexo/exojs</code>, organized by subsystem.</p>
+            </div>
+            <form class="api-search" action={`${import.meta.env.BASE_URL}en/api/all/`} method="get" role="search">
+                <span class="api-search__icon" aria-hidden="true">/</span>
+                <input type="search" name="q" placeholder="Find Application, Scene, Sprite..." autocomplete="off" />
+                <button type="submit">Search</button>
+            </form>
+        </header>
+
+        <div class="api-counts" aria-label="API totals">
+            <span>Symbols <strong>{totalSymbols}</strong></span>
+            <span>Classes <strong>{classCount}</strong></span>
+            <span>Enums <strong>{enumCount}</strong></span>
+            <span>Subsystems <strong>{grouped.length}</strong></span>
+        </div>
+
+        <section id="featured" class="api-featured">
+            <div class="api-section-head">
+                <span>Featured</span>
+                <span class="line"></span>
+                <span>{featured.length}</span>
+            </div>
+            <div class="api-featured-grid">
+                {featured.map(item => (
+                    <a class="api-feature-card" href={item.href}>
+                        <div class="api-feature-card__head">
+                            <span class:list={['api-kind', `kind-${item.kind}`]}>{item.kind}</span>
+                            <code>{item.entry.data.title}</code>
+                        </div>
+                        <div class="api-feature-card__import">{item.entry.data.importPath}</div>
+                        <p>{item.shortDescription}</p>
+                    </a>
+                ))}
+            </div>
+        </section>
+
+        <section id="subsystems" class="api-subsystems">
+            <div class="api-section-head">
+                <span>Subsystems</span>
+                <span class="line"></span>
+                <span>{grouped.length}</span>
+            </div>
+
+            <div class="api-subsystem-grid">
+                {grouped.map(group => {
+                    const preview = group.entries.slice(0, 5);
+                    return (
+                        <article id={`subsystem-${group.subsystem}`} class="api-subsystem-card">
+                            <header>
+                                <h2>{group.label}</h2>
+                                <span class="count">{group.entries.length} symbols</span>
+                            </header>
+                            <p>{group.description}</p>
+                            <ul>
+                                {preview.map(item => (
+                                    <li>
+                                        <a href={item.href}>
+                                            <code>{item.entry.data.title}</code>
+                                            <span>{item.kind}</span>
+                                        </a>
+                                    </li>
+                                ))}
+                            </ul>
+                            <a class="view-all" href={`${import.meta.env.BASE_URL}en/api/all/?subsystem=${group.subsystem}`}>View all in {group.label}</a>
+                        </article>
+                    );
+                })}
+            </div>
+        </section>
+
+        <section id="all-symbols" class="api-all-link">
+            <div class="api-section-head">
+                <span>All symbols</span>
+                <span class="line"></span>
+                <span>A-Z</span>
+            </div>
+            <p>Use the full lookup page for alphabetical browsing and filters.</p>
+            <a class="api-all-link__cta" href={`${import.meta.env.BASE_URL}en/api/all/`}>Open all symbols A-Z</a>
+        </section>
+    </div>
 </DocsLayout>
 
 <style>
-    .de-api {
-        display: grid;
-        gap: 0.9rem;
+    .api-prose {
+        max-width: none;
     }
 
-    .de-api h1 {
-        margin: 0;
-        font-size: clamp(1.8rem, 4vw, 2.5rem);
+    .api-head {
+        display: flex;
+        align-items: end;
+        justify-content: space-between;
+        gap: var(--s-5);
+        margin-bottom: var(--s-4);
+        flex-wrap: wrap;
     }
 
-    .de-api p {
+    .api-head h1 {
+        margin: 0 0 4px;
+        font-size: 32px;
+        font-weight: 600;
+        letter-spacing: -0.02em;
+    }
+
+    .api-head p {
         margin: 0;
         color: var(--fg-muted);
-        max-width: 64ch;
+        max-width: 68ch;
+    }
+
+    .api-search {
+        display: flex;
+        align-items: center;
+        gap: var(--s-2);
+        width: 420px;
+        max-width: 100%;
+        padding: 8px 10px;
+        border-radius: var(--r-3);
+        background: var(--bg-elevated);
+        border: 1px solid var(--line);
+    }
+
+    .api-search__icon {
+        color: var(--fg-faint);
+        font-family: var(--f-mono);
+        font-size: 12px;
+    }
+
+    .api-search input {
+        background: transparent;
+        border: none;
+        outline: none;
+        flex: 1;
+        font-size: 14px;
+        color: var(--fg);
+        min-width: 0;
+    }
+
+    .api-search button {
+        border: 1px solid var(--line-soft);
+        background: var(--bg-canvas);
+        color: var(--fg-muted);
+        border-radius: var(--r-pill);
+        font-family: var(--f-mono);
+        font-size: 11px;
+        padding: 4px 9px;
+    }
+
+    .api-search button:hover,
+    .api-search button:focus-visible {
+        color: var(--fg);
+        border-color: var(--accent-line);
+        background: var(--accent-soft);
+        outline: none;
+    }
+
+    .api-counts {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-bottom: var(--s-6);
+    }
+
+    .api-counts span {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 5px 10px;
+        border-radius: var(--r-pill);
+        background: var(--bg-elevated);
+        border: 1px solid var(--line-soft);
+        font-size: 12px;
+        color: var(--fg-muted);
+        font-family: var(--f-mono);
+    }
+
+    .api-counts strong {
+        color: var(--fg);
+        font-weight: 600;
+    }
+
+    .api-section-head {
+        margin-bottom: var(--s-3);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--fg-faint);
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: var(--s-2);
+    }
+
+    .api-section-head .line {
+        flex: 1;
+        height: 1px;
+        background: var(--line-soft);
+    }
+
+    .api-featured {
+        margin-bottom: var(--s-7);
+    }
+
+    .api-featured-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: var(--s-3);
+    }
+
+    .api-feature-card {
+        display: block;
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-3);
+        background: var(--bg-elevated);
+        padding: 0.75rem;
+        color: inherit;
+        text-decoration: none;
+    }
+
+    .api-feature-card:hover,
+    .api-feature-card:focus-visible {
+        border-color: var(--accent-line);
+        background: color-mix(in oklab, var(--bg-canvas), transparent 55%);
+        outline: none;
+    }
+
+    .api-feature-card__head {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+    }
+
+    .api-feature-card__head code {
+        font-family: var(--f-mono);
+        font-size: 13px;
+        color: var(--fg);
+    }
+
+    .api-feature-card__import {
+        margin-top: 0.3rem;
+        font-family: var(--f-mono);
+        font-size: 11px;
+        color: var(--sky);
+    }
+
+    .api-feature-card p {
+        margin: 0.4rem 0 0;
+        font-size: 12.5px;
+        color: var(--fg-muted);
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+
+    .api-subsystem-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: var(--s-4);
+    }
+
+    .api-subsystem-card {
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-3);
+        background: var(--bg-elevated);
+        padding: 0.9rem;
+    }
+
+    .api-subsystem-card header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: var(--s-3);
+        margin-bottom: 0.3rem;
+    }
+
+    .api-subsystem-card h2 {
+        margin: 0;
+        font-size: 15px;
+        letter-spacing: -0.01em;
+    }
+
+    .api-subsystem-card .count {
+        font-family: var(--f-mono);
+        font-size: 11px;
+        color: var(--fg-faint);
+    }
+
+    .api-subsystem-card > p {
+        margin: 0;
+        font-size: 13px;
+        color: var(--fg-muted);
+    }
+
+    .api-subsystem-card ul {
+        list-style: none;
+        margin: 0.7rem 0 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+    }
+
+    .api-subsystem-card li a {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        padding: 0.3rem 0.45rem;
+        border-radius: var(--r-2);
+        color: var(--fg-muted);
+        text-decoration: none;
+    }
+
+    .api-subsystem-card li a:hover,
+    .api-subsystem-card li a:focus-visible {
+        background: var(--bg-canvas);
+        color: var(--fg);
+        outline: none;
+    }
+
+    .api-subsystem-card li code {
+        font-family: var(--f-mono);
+        font-size: 12px;
+        color: inherit;
+    }
+
+    .api-subsystem-card li span {
+        font-size: 11px;
+        font-family: var(--f-mono);
+        color: var(--fg-faint);
+        text-transform: uppercase;
+    }
+
+    .api-subsystem-card .view-all {
+        margin-top: 0.7rem;
+        display: inline-flex;
+        font-size: 12px;
+        color: var(--accent);
+        text-decoration: none;
+        border-bottom: 1px solid var(--accent-line);
+    }
+
+    .api-all-link {
+        margin-top: var(--s-7);
+    }
+
+    .api-all-link p {
+        margin: 0;
+        color: var(--fg-muted);
+    }
+
+    .api-all-link__cta {
+        margin-top: var(--s-3);
+        display: inline-flex;
+        padding: 8px 12px;
+        border-radius: var(--r-2);
+        border: 1px solid var(--line-soft);
+        background: var(--bg-elevated);
+        color: var(--fg);
+        text-decoration: none;
+        font-size: 13px;
+        font-weight: 500;
+    }
+
+    .api-all-link__cta:hover,
+    .api-all-link__cta:focus-visible {
+        border-color: var(--accent-line);
+        background: var(--accent-soft);
+        outline: none;
+    }
+
+    .api-kind {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        border: 1px solid var(--line-soft);
+        padding: 1px 6px;
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        line-height: 1.3;
+    }
+
+    .api-kind.kind-class {
+        color: var(--accent);
+        border-color: var(--accent-line);
+        background: var(--accent-soft);
+    }
+
+    .api-kind.kind-enum {
+        color: var(--rose);
+        border-color: color-mix(in oklab, var(--rose), transparent 65%);
+        background: color-mix(in oklab, var(--rose), transparent 88%);
+    }
+
+    .toc h6 {
+        margin: 0;
+        font-family: var(--f-mono);
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--fg-faint);
+    }
+
+    .toc ul {
+        list-style: none;
+        margin: var(--s-3) 0 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .toc a {
+        display: block;
+        border-left: 2px solid transparent;
+        padding: 4px 0 4px var(--s-3);
+        margin-left: -10px;
+        color: var(--fg-muted);
+        text-decoration: none;
+        font-size: 13px;
+    }
+
+    .toc a:hover,
+    .toc a:focus-visible {
+        color: var(--fg);
+        outline: none;
+    }
+
+    .toc li:first-child a,
+    .toc a[data-active='true'] {
+        color: var(--accent);
+        border-left-color: var(--accent);
+    }
+
+    .toc__resources {
+        margin-top: 1.5rem;
+        padding-top: 0.75rem;
+        border-top: 1px solid var(--line-soft);
+    }
+
+    @media (max-width: 1120px) {
+        .api-featured-grid,
+        .api-subsystem-grid {
+            grid-template-columns: 1fr;
+        }
+    }
+
+    @media (max-width: 760px) {
+        .api-head {
+            gap: var(--s-3);
+            margin-bottom: var(--s-3);
+        }
+
+        .api-head h1 {
+            font-size: 1.75rem;
+            line-height: 1.15;
+        }
+
+        .api-head p {
+            line-height: 1.58;
+        }
+
+        .api-search {
+            width: 100%;
+            min-height: 44px;
+            padding: 0.55rem 0.62rem;
+        }
+
+        .api-search input {
+            min-height: 32px;
+        }
+
+        .api-search button {
+            min-height: 32px;
+            white-space: nowrap;
+        }
+
+        .api-counts {
+            margin-bottom: var(--s-4);
+        }
+
+        .api-featured {
+            margin-bottom: var(--s-5);
+        }
+
+        .api-feature-card {
+            padding: 0.72rem;
+        }
+
+        .api-feature-card p {
+            line-height: 1.58;
+        }
+
+        .api-subsystem-grid {
+            grid-template-columns: 1fr;
+            gap: var(--s-3);
+        }
+
+        .api-subsystem-card {
+            padding: 0.75rem;
+        }
+
+        .api-subsystem-card h2 {
+            font-size: 0.92rem;
+        }
+
+        .api-subsystem-card .count {
+            font-size: 0.65rem;
+        }
+
+        .api-subsystem-card li a {
+            min-height: 44px;
+            padding: 0.45rem 0.52rem;
+        }
+
+        .api-subsystem-card li code {
+            overflow-wrap: anywhere;
+            min-width: 0;
+        }
+
+        .api-subsystem-card .view-all {
+            min-height: 44px;
+            align-items: center;
+            padding: 0.5rem 0;
+        }
+
+        .api-all-link {
+            margin-top: var(--s-5);
+        }
+
+        .api-all-link__cta {
+            min-height: 44px;
+            align-items: center;
+        }
     }
 </style>

--- a/site/src/pages/de/guide/[part]/[chapter]/index.astro
+++ b/site/src/pages/de/guide/[part]/[chapter]/index.astro
@@ -1,9 +1,13 @@
 ---
-import { getCollection } from 'astro:content';
+import { getCollection, render } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
 import DocsLayout from '../../../../../layouts/DocsLayout.astro';
-import TranslationNotice from '../../../../../components/TranslationNotice.astro';
-import { GUIDE_PARTS, GUIDE_CHAPTER_BY_PATH } from '../../../../../lib/guide-structure';
+import DocsSidebar from '../../../../../components/DocsSidebar.astro';
+import EnglishFallbackNotice from '../../../../../components/EnglishFallbackNotice.astro';
+import GuideMeta from '../../../../../components/GuideMeta.astro';
+import GuidePager from '../../../../../components/GuidePager.astro';
+import { GUIDE_PARTS, GUIDE_CHAPTER_BY_PATH, getAdjacentChapters } from '../../../../../lib/guide-structure';
+import { toApiHref } from '../../../../../lib/api-reference';
 
 export function getStaticPaths() {
     return GUIDE_PARTS.flatMap(part =>
@@ -26,32 +30,474 @@ if (!chapterMeta) {
 }
 
 const guideEntries = await getCollection('guide');
-const entry = guideEntries.find((item: CollectionEntry<'guide'>) => item.id.replace(/\.(md|mdx)$/, '') === chapterPath);
-const chapterTitle = entry?.data.title ?? chapterSlug;
+const entryByPath = new Map<string, CollectionEntry<'guide'>>(
+    guideEntries.map((entry: CollectionEntry<'guide'>) => [entry.id.replace(/\.(md|mdx)$/, ''), entry]),
+);
+const entry = entryByPath.get(chapterPath);
+
+if (!entry) {
+    throw new Error(`Missing guide content entry: ${chapterPath}`);
+}
+
+const titleByPath = (path: string): string => entryByPath.get(path)?.data.title ?? path;
+const guideHref = (path: string): string => `${import.meta.env.BASE_URL}en/guide/${path}/`;
+
+// Reading-time estimate from the prose: strip code fences and component tags so
+// the number reflects what a reader actually reads, then 200 words/minute.
+const proseWords = entry.body
+    ? entry.body
+        .replace(/```[\s\S]*?```/g, ' ')
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/[#>*_`|-]/g, ' ')
+        .split(/\s+/)
+        .filter(Boolean).length
+    : 0;
+const readingMinutes = proseWords > 0 ? Math.max(1, Math.round(proseWords / 200)) : undefined;
+
+const prerequisites = chapterMeta.prerequisites.map(path => ({
+    label: titleByPath(path),
+    href: guideHref(path),
+}));
+
+type TocHeading = { depth: number; slug: string; text: string };
+const { Content, headings } = await render(entry);
+const tocItems = (headings as TocHeading[]).filter((heading: TocHeading) => heading.depth >= 2 && heading.depth <= 3);
+const primaryExample = chapterMeta.examples[0] ?? null;
+const partTitle = chapterMeta.partTitle;
+const chapterTitle = entry.data.title;
+
+const { previous, next } = getAdjacentChapters(chapterPath);
+const previousLink = previous
+    ? { label: titleByPath(previous.path), href: guideHref(previous.path), context: previous.partTitle }
+    : null;
+const nextLink = next
+    ? { label: titleByPath(next.path), href: guideHref(next.path), context: next.partTitle }
+    : null;
+
+// Surface the chapter's curated spine apiLinks as a compact "Related API"
+// section. Slugs resolve against the generated api collection, so a stale slug
+// fails the build (and the guide-structure test) rather than shipping a dead
+// link — the same contract TryIt uses.
+const apiEntries = await getCollection('api');
+const apiEntryById = new Map<string, CollectionEntry<'api'>>(
+    apiEntries.map((item: CollectionEntry<'api'>) => [item.id, item] as [string, CollectionEntry<'api'>]),
+);
+const relatedApi = chapterMeta.apiLinks.map(slug => {
+    const apiEntry = apiEntryById.get(slug);
+    if (!apiEntry) {
+        throw new Error(`Unknown API page "${slug}" referenced by guide chapter ${chapterPath}`);
+    }
+    return { label: apiEntry.data.symbol || apiEntry.data.title, href: toApiHref(import.meta.env.BASE_URL, slug) };
+});
+
+const getFirstChapterHref = (part: (typeof GUIDE_PARTS)[number]) => {
+    const firstChapter = part.chapters[0];
+    return firstChapter
+        ? `${import.meta.env.BASE_URL}en/guide/${part.slug}/${firstChapter.slug}/`
+        : `${import.meta.env.BASE_URL}en/guide/${part.slug}/`;
+};
+const sidebarParts = GUIDE_PARTS.map(part => ({
+    slug: part.slug,
+    title: part.title,
+    href: getFirstChapterHref(part),
+    baseHref: `${import.meta.env.BASE_URL}en/guide/${part.slug}/`,
+    chapters: part.chapters.map(chapter => ({
+        slug: chapter.slug,
+        title: titleByPath(chapter.path),
+        href: `${import.meta.env.BASE_URL}en/guide/${part.slug}/${chapter.slug}/`,
+    })),
+}));
 ---
 
-<DocsLayout title={`${chapterTitle} (DE)`} description="German localization placeholder for this guide chapter.">
-    <section class="de-guide-chapter">
+<DocsLayout title={`${chapterTitle} | ExoJS Guide`} description={entry.data.description} variant="guide">
+    <DocsSidebar slot="sidebar" parts={sidebarParts} />
+    <aside slot="rail" class="toc" aria-label="On this page">
+        <h6>On this page</h6>
+        {tocItems.length > 0 && (
+            <ul data-guide-toc>
+                {tocItems.map((item: TocHeading) => (
+                    <li>
+                        <a href={`#${item.slug}`} data-guide-toc-link class:list={[item.depth === 3 && 'lvl-3']}>
+                            {item.text}
+                        </a>
+                    </li>
+                ))}
+            </ul>
+        )}
+        <div class="toc__resources">
+            <h6>Open in</h6>
+            <ul>
+                {primaryExample && (
+                    <li>
+                        <a href={`${import.meta.env.BASE_URL}en/playground/?example=${primaryExample}`}>↗ Playground</a>
+                    </li>
+                )}
+                <li>
+                    <a href={`${import.meta.env.BASE_URL}en/api/`}>↗ API reference</a>
+                </li>
+            </ul>
+        </div>
+    </aside>
+
+    <article class="prose chapter-prose">
+        <EnglishFallbackNotice />
+        <div class="crumbs">
+                <a href={`${import.meta.env.BASE_URL}en/guide/`}>Guide</a>
+                <span class="sep" aria-hidden="true">/</span>
+                <a href={`${import.meta.env.BASE_URL}en/guide/${chapterMeta.partSlug}/`}>{partTitle}</a>
+                <span class="sep" aria-hidden="true">/</span>
+                <span>{chapterTitle}</span>
+        </div>
         <h1>{chapterTitle}</h1>
-        <p>This chapter is not translated to German yet.</p>
-        <TranslationNotice englishHref={`${import.meta.env.BASE_URL}en/guide/${partSlug}/${chapterSlug}/`} />
-    </section>
+        <p class="lead">{entry.data.description}</p>
+
+        <GuideMeta
+            level={chapterMeta.level}
+            readingMinutes={readingMinutes}
+            learningGoals={chapterMeta.learningGoals}
+            prerequisites={prerequisites}
+        />
+
+        <div class="chapter-content">
+            <Content />
+        </div>
+
+        {relatedApi.length > 0 && (
+            <nav class="related-api" aria-label="Related API">
+                <p class="related-api__heading">Related API</p>
+                <ul class="related-api__list">
+                    {relatedApi.map(link => (
+                        <li>
+                            <a href={link.href}><code>{link.label}</code></a>
+                        </li>
+                    ))}
+                </ul>
+            </nav>
+        )}
+
+        <GuidePager previous={previousLink} next={nextLink} />
+    </article>
 </DocsLayout>
 
+<script is:inline>
+    (() => {
+        const toc = document.querySelector('[data-guide-toc]');
+        if (!(toc instanceof HTMLElement)) return;
+        const links = Array.from(toc.querySelectorAll('[data-guide-toc-link]'));
+        if (links.length === 0) return;
+
+        const map = new Map();
+        for (const link of links) {
+            if (!(link instanceof HTMLAnchorElement)) continue;
+            const id = link.getAttribute('href')?.replace(/^#/, '');
+            if (!id) continue;
+            const target = document.getElementById(id);
+            if (target) map.set(target, link);
+        }
+        if (map.size === 0) return;
+
+        const headings = [...map.keys()];
+        if (headings.length === 0) return;
+
+        const setActive = (link) => {
+            links.forEach(node => node.setAttribute('data-active', String(node === link)));
+        };
+
+        // Active = the last heading whose top has crossed a line ~28% down the
+        // viewport. A rootMargin "band" can't do this: headings near the page
+        // bottom never scroll high enough to enter the band, so the final
+        // section(s) would never activate. At the very bottom we force the last
+        // heading, since it can sit below the line with nothing left to scroll.
+        const LINE = 0.28;
+        const update = () => {
+            const line = window.innerHeight * LINE;
+            let active = headings[0];
+            for (const heading of headings) {
+                if (heading.getBoundingClientRect().top <= line) active = heading;
+                else break;
+            }
+            const atBottom = window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 4;
+            if (atBottom) active = headings[headings.length - 1];
+            setActive(map.get(active));
+        };
+
+        let ticking = false;
+        const onScroll = () => {
+            if (ticking) return;
+            ticking = true;
+            requestAnimationFrame(() => {
+                ticking = false;
+                update();
+            });
+        };
+        window.addEventListener('scroll', onScroll, { passive: true });
+        window.addEventListener('resize', onScroll, { passive: true });
+
+        // Clicking a link jumps to its heading. Activate it immediately so the
+        // rail reflects the click right away — independent of where the scroll
+        // settles (a jumped-to heading lands at the very top, which the scroll
+        // heuristic alone may attribute to the next section).
+        for (const [target, link] of map) {
+            link.addEventListener('click', () => setActive(link));
+            void target;
+        }
+
+        update();
+    })();
+</script>
+
 <style>
-    .de-guide-chapter {
-        display: grid;
-        gap: 0.9rem;
+    .chapter-prose {
+        max-width: 720px;
     }
 
-    .de-guide-chapter h1 {
-        margin: 0;
-        font-size: clamp(1.5rem, 3.2vw, 2.2rem);
+    .chapter-prose .crumbs {
+        display: flex;
+        align-items: center;
+        gap: var(--s-2);
+        margin-bottom: var(--s-4);
+        font-size: 12.5px;
+        color: var(--fg-faint);
+        font-family: var(--f-mono);
+        flex-wrap: wrap;
     }
 
-    .de-guide-chapter p {
-        margin: 0;
+    .chapter-prose .crumbs .sep {
+        opacity: 0.5;
+    }
+
+    .chapter-prose .crumbs a:hover {
+        color: var(--fg);
+    }
+
+    .chapter-prose h1 {
+        margin: 0 0 var(--s-4);
+        font-size: 36px;
+        font-weight: 600;
+        letter-spacing: -0.02em;
+        line-height: 1.1;
+    }
+
+    .chapter-prose .lead {
+        margin: 0 0 var(--s-6);
+        font-size: 17px;
         color: var(--fg-muted);
-        max-width: 64ch;
+        line-height: 1.55;
+        text-wrap: pretty;
+    }
+
+    /* The MDX body repeats the title as a leading H1; the layout already renders
+       the title above, so hide the in-content one. */
+    .chapter-prose :global(.chapter-content > h1:first-child) {
+        display: none;
+    }
+
+    /* Typographic rules are scoped to .chapter-content (the rendered MDX body),
+       not .chapter-prose (the whole article). The article also wraps layout
+       chrome — GuideMeta, Related API, the pager — which carry their own styles;
+       scoping to the body keeps the prose h2 (#-prefix, 56px lead), list, and
+       link styles from bleeding into those boxes. */
+    .chapter-content :global(h2) {
+        font-size: 22px;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+        margin: var(--s-9) 0 var(--s-3);
+        padding-top: var(--s-3);
+        border: 0;
+        position: relative;
+    }
+
+    .chapter-content :global(h2)::before {
+        content: '#';
+        font-family: var(--f-mono);
+        color: var(--fg-faint);
+        font-weight: 400;
+        font-size: 14px;
+        margin-right: 8px;
+    }
+
+    .chapter-content :global(h3) {
+        font-size: 16px;
+        font-weight: 600;
+        margin: var(--s-7) 0 var(--s-3);
+    }
+
+    .chapter-content :global(p) {
+        margin: var(--s-3) 0;
+        line-height: 1.65;
+        color: var(--fg);
+        text-wrap: pretty;
+    }
+
+    .chapter-content :global(li) {
+        margin: 4px 0;
+        line-height: 1.65;
+    }
+
+    .chapter-content :global(ul, ol) {
+        margin: var(--s-3) 0;
+        padding-left: var(--s-5);
+        line-height: 1.65;
+    }
+
+    .chapter-content :global(p.muted) {
+        color: var(--fg-muted);
+    }
+
+    .chapter-content :global(pre.astro-code) {
+        margin: var(--s-4) 0;
+        border-color: var(--line-soft);
+    }
+
+    .chapter-content :global(hr) {
+        border: none;
+        border-top: 1px solid var(--line-soft);
+        margin: var(--s-9) 0;
+    }
+
+    /* Underline prose links only — component links (TryIt, NextStep, pager,
+       example/source embeds) keep their own styling. */
+    .chapter-content :global(p a),
+    .chapter-content :global(li a) {
+        color: var(--fg);
+        text-decoration: underline;
+        text-decoration-color: color-mix(in oklab, var(--accent), transparent 55%);
+        text-underline-offset: 0.2em;
+    }
+
+    .chapter-content :global(p a:hover),
+    .chapter-content :global(li a:hover) {
+        color: var(--accent);
+        text-decoration-color: var(--accent);
+    }
+
+    .toc h6 {
+        margin: 0;
+        font-family: var(--f-mono);
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--fg-faint);
+    }
+
+    .toc ul {
+        list-style: none;
+        margin: var(--s-3) 0 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .toc a {
+        display: block;
+        border-left: 2px solid transparent;
+        padding: 4px 0 4px var(--s-3);
+        margin-left: -10px;
+        color: var(--fg-muted);
+        text-decoration: none;
+        font-size: 13px;
+    }
+
+    .toc a.lvl-3 {
+        padding-left: var(--s-5);
+        font-size: 12.5px;
+        color: var(--fg-faint);
+    }
+
+    .toc a:hover,
+    .toc a:focus-visible {
+        color: var(--fg);
+        outline: none;
+    }
+
+    .toc a[data-active='true'] {
+        color: var(--accent);
+        border-left-color: var(--accent);
+    }
+
+    .toc__resources {
+        margin-top: 1.5rem;
+        padding-top: 0.75rem;
+        border-top: 1px solid var(--line-soft);
+    }
+
+    /* Spine-curated apiLinks, surfaced as a compact chip row below the chapter
+       body. Selectors are nested under .related-api so the prose link/code rules
+       above do not bleed in. */
+    .related-api {
+        margin: var(--s-9) 0 0;
+        padding-top: var(--s-5);
+        border-top: 1px solid var(--line-soft);
+    }
+
+    .related-api .related-api__heading {
+        margin: 0 0 var(--s-3);
+        padding: 0;
+        border: 0;
+        font-family: var(--f-mono);
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--fg-faint);
+    }
+
+    .related-api .related-api__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--s-2);
+    }
+
+    .related-api .related-api__list li {
+        margin: 0;
+    }
+
+    .related-api .related-api__list a {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.25rem 0.65rem;
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-pill);
+        background: var(--bg-elevated);
+        color: var(--fg-muted);
+        text-decoration: none;
+        font-size: 13px;
+        line-height: 1.4;
+        transition: color 0.15s ease, border-color 0.15s ease;
+    }
+
+    .related-api .related-api__list a::before {
+        content: '↗';
+        color: var(--fg-faint);
+        font-size: 11px;
+    }
+
+    .related-api .related-api__list a:hover {
+        color: var(--accent);
+        border-color: var(--accent-line);
+    }
+
+    .related-api .related-api__list a:hover::before {
+        color: var(--accent);
+    }
+
+    .related-api .related-api__list a:focus-visible {
+        outline: 2px solid var(--focus-ring);
+        outline-offset: 2px;
+        color: var(--accent);
+    }
+
+    .related-api .related-api__list code {
+        border: 0;
+        background: transparent;
+        padding: 0;
+        font-size: 13px;
+        color: inherit;
     }
 </style>

--- a/site/src/pages/de/guide/index.astro
+++ b/site/src/pages/de/guide/index.astro
@@ -1,30 +1,553 @@
 ---
+import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
 import DocsLayout from '../../../layouts/DocsLayout.astro';
-import TranslationNotice from '../../../components/TranslationNotice.astro';
+import DocsSidebar from '../../../components/DocsSidebar.astro';
+import EnglishFallbackNotice from '../../../components/EnglishFallbackNotice.astro';
+import { GUIDE_PARTS, GUIDE_LEARNING_PATH, GUIDE_TOPICS } from '../../../lib/guide-structure';
+
+const base = import.meta.env.BASE_URL;
+const guideHref = (path: string): string => `${base}en/guide/${path}/`;
+const playgroundHref = (example: string): string => `${base}en/playground/?example=${example}`;
+
+const guideEntries = await getCollection('guide');
+const dataByPath = new Map<string, CollectionEntry<'guide'>['data']>(
+    guideEntries.map((entry: CollectionEntry<'guide'>) => [entry.id.replace(/\.(md|mdx)$/, ''), entry.data]),
+);
+const titleOf = (path: string): string => dataByPath.get(path)?.title ?? path;
+const descriptionOf = (path: string): string => dataByPath.get(path)?.description ?? '';
+
+const chapterCount = GUIDE_PARTS.reduce((sum, part) => sum + part.chapters.length, 0);
+
+const learningPath = GUIDE_LEARNING_PATH;
+const topics = GUIDE_TOPICS;
+
+const getFirstChapterHref = (part: (typeof GUIDE_PARTS)[number]) => {
+    const firstChapter = part.chapters[0];
+    return firstChapter ? guideHref(`${part.slug}/${firstChapter.slug}`) : `${base}en/guide/${part.slug}/`;
+};
+const sidebarParts = GUIDE_PARTS.map(part => ({
+    slug: part.slug,
+    title: part.title,
+    href: getFirstChapterHref(part),
+    baseHref: `${base}en/guide/${part.slug}/`,
+    chapters: part.chapters.map(chapter => ({
+        slug: chapter.slug,
+        title: titleOf(chapter.path),
+        href: guideHref(chapter.path),
+    })),
+}));
 ---
 
-<DocsLayout title="ExoJS Guide (DE)" description="German localization placeholder for the ExoJS guide.">
-    <section class="de-guide">
-        <h1>Guide</h1>
-        <p>The German guide is not translated yet. Use the English guide while localization is in progress.</p>
-        <TranslationNotice englishHref={`${import.meta.env.BASE_URL}en/guide/`} />
-    </section>
+<DocsLayout title="ExoJS Guide" description="Learn ExoJS from your first project to a complete, deployable game." variant="guide">
+    <DocsSidebar slot="sidebar" parts={sidebarParts} />
+    <aside slot="rail" class="toc" aria-label="Guide index shortcuts">
+        <h6>On this page</h6>
+        <ul>
+            <li><a href="#start">Start here</a></li>
+            <li><a href="#path">Learning path</a></li>
+            <li><a href="#topics">Browse by topic</a></li>
+            <li><a href="#all">All chapters</a></li>
+        </ul>
+        <div class="toc__resources">
+            <h6>Resources</h6>
+            <ul>
+                <li><a href={`${base}en/api/`}>API reference</a></li>
+                <li><a href={`${base}en/playground/`}>Playground</a></li>
+            </ul>
+        </div>
+    </aside>
+
+    <div class="prose guide-index-prose">
+        <EnglishFallbackNotice />
+        <section class="guide-hero" id="start">
+            <h1>Build your first ExoJS project</h1>
+            <p>
+                Start with a TypeScript project, learn the Scene and rendering model, then move into input, audio,
+                effects, debugging, and deployment.
+            </p>
+            <div class="guide-hero__cmd">
+                <code>npm create exo-app@latest my-game</code>
+            </div>
+            <div class="guide-hero__actions">
+                <a class="act act--primary" href={guideHref('introduction/setup')}>Create a project</a>
+                <a class="act" href={guideHref('introduction/what-is-exojs')}>Start the first guide</a>
+                <a class="act" href={`${base}en/playground/`}>Open the Playground</a>
+            </div>
+        </section>
+
+        <section class="guide-section" id="path" aria-labelledby="path-title">
+            <h2 class="guide-section__title" id="path-title">Recommended learning path</h2>
+            <p class="guide-section__lead">Follow these in order to go from an empty folder to a deployable game.</p>
+            <ol class="path">
+                {learningPath.map((step, index) => (
+                    <li class="path__step">
+                        <span class="path__num" aria-hidden="true">{index + 1}</span>
+                        <div class="path__body">
+                            <a class="path__title" href={guideHref(step.path)}>{titleOf(step.path)}</a>
+                            <p class="path__goal">{step.goal}</p>
+                            {step.example && (
+                                <a class="path__example" href={playgroundHref(step.example)}>Open example ↗</a>
+                            )}
+                        </div>
+                    </li>
+                ))}
+            </ol>
+        </section>
+
+        <section class="guide-section" id="topics" aria-labelledby="topics-title">
+            <h2 class="guide-section__title" id="topics-title">Browse by topic</h2>
+            <div class="topic-grid">
+                {topics.map(topic => (
+                    <a class="topic-card" href={guideHref(topic.path)}>
+                        <h3>{topic.title}</h3>
+                        <p>{topic.description}</p>
+                    </a>
+                ))}
+            </div>
+        </section>
+
+        <section class="guide-section orient" aria-labelledby="orient-title">
+            <h2 class="guide-section__title" id="orient-title">Guides, Playground, and API</h2>
+            <div class="orient-grid">
+                <div class="orient-card">
+                    <p class="orient-card__k">Guides</p>
+                    <p class="orient-card__v">Explain concepts and workflows, step by step.</p>
+                </div>
+                <span class="orient-arrow" aria-hidden="true">→</span>
+                <div class="orient-card">
+                    <p class="orient-card__k">Playground</p>
+                    <p class="orient-card__v">Run and edit every example live in the browser.</p>
+                </div>
+                <span class="orient-arrow" aria-hidden="true">→</span>
+                <div class="orient-card">
+                    <p class="orient-card__k">API reference</p>
+                    <p class="orient-card__v">Documents every class, method, and option.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="guide-section" id="all" aria-labelledby="all-title">
+            <h2 class="guide-section__title" id="all-title">All chapters</h2>
+            <p class="guide-section__lead">{chapterCount} chapters across {GUIDE_PARTS.length} parts.</p>
+            {GUIDE_PARTS.map(part => (
+                <section class="part-block" id={`part-${part.slug}`}>
+                    <h3 class="part-block__title">
+                        <span>{String(part.part).padStart(2, '0')}</span>
+                        <span>{part.title}</span>
+                    </h3>
+                    <div class="chapter-grid">
+                        {part.chapters.map(chapter => (
+                            <a class="chapter-card" href={guideHref(chapter.path)}>
+                                <h4>{titleOf(chapter.path)}</h4>
+                                <p>{descriptionOf(chapter.path)}</p>
+                            </a>
+                        ))}
+                    </div>
+                </section>
+            ))}
+        </section>
+    </div>
 </DocsLayout>
 
 <style>
-    .de-guide {
-        display: grid;
-        gap: 0.9rem;
+    .guide-index-prose {
+        max-width: none;
     }
 
-    .de-guide h1 {
-        margin: 0;
-        font-size: clamp(1.8rem, 4vw, 2.5rem);
+    .guide-hero {
+        position: relative;
+        overflow: hidden;
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-5);
+        padding: var(--s-9) var(--s-7);
+        background: var(--bg-elevated);
+        margin-bottom: var(--s-8);
     }
 
-    .de-guide p {
+    .guide-hero::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-image:
+            linear-gradient(var(--grid-line) 1px, transparent 1px),
+            linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
+        background-size: 32px 32px;
+        opacity: 0.6;
+        mask-image: radial-gradient(60% 100% at 100% 0%, #000, transparent 70%);
+        pointer-events: none;
+    }
+
+    .guide-hero > * {
+        position: relative;
+    }
+
+    .guide-hero h1 {
         margin: 0;
+        font-size: 36px;
+        line-height: 1.1;
+        letter-spacing: -0.02em;
+    }
+
+    .guide-hero p {
+        margin: 0.75rem 0 0;
+        max-width: 56ch;
+        color: var(--fg-muted);
+        line-height: 1.6;
+    }
+
+    .guide-hero__cmd {
+        margin-top: var(--s-5);
+    }
+
+    .guide-hero__cmd code {
+        display: inline-block;
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-2);
+        background: var(--bg-canvas);
+        padding: 0.5rem 0.8rem;
+        font-family: var(--f-mono);
+        font-size: 13.5px;
+        color: var(--fg);
+    }
+
+    .guide-hero__actions {
+        margin-top: var(--s-5);
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--s-3);
+    }
+
+    .act {
+        display: inline-flex;
+        align-items: center;
+        min-height: 40px;
+        padding: 0 var(--s-4);
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-2);
+        background: var(--bg-canvas);
+        color: var(--fg);
+        text-decoration: none;
+        font-size: 14px;
+        font-weight: 600;
+    }
+
+    .act--primary {
+        border-color: var(--accent-line);
+        background: var(--accent-soft);
+    }
+
+    .act:hover {
+        border-color: var(--accent-line);
+        color: var(--accent);
+    }
+
+    .act:focus-visible {
+        outline: 2px solid var(--focus-ring);
+        outline-offset: 2px;
+    }
+
+    .guide-section {
+        margin-top: var(--s-8);
+    }
+
+    .guide-section__title {
+        display: flex;
+        align-items: baseline;
+        gap: 0.6rem;
+        margin: 0 0 var(--s-2);
+        font-size: 20px;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+        border: 0;
+        padding: 0;
+    }
+
+    .guide-section__lead {
+        margin: 0 0 var(--s-5);
         color: var(--fg-muted);
         max-width: 64ch;
+    }
+
+    .path {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: var(--s-3);
+    }
+
+    .path__step {
+        display: flex;
+        gap: var(--s-4);
+        align-items: flex-start;
+        padding: var(--s-4);
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-4);
+        background: var(--bg-elevated);
+    }
+
+    .path__num {
+        flex: none;
+        display: inline-grid;
+        place-items: center;
+        width: 28px;
+        height: 28px;
+        border-radius: var(--r-pill);
+        border: 1px solid var(--accent-line);
+        background: var(--accent-soft);
+        color: var(--accent);
+        font-family: var(--f-mono);
+        font-size: 13px;
+        font-weight: 600;
+    }
+
+    .path__body {
+        min-width: 0;
+    }
+
+    .path__title {
+        font-size: 16px;
+        font-weight: 600;
+        color: var(--fg);
+        text-decoration: none;
+    }
+
+    .path__title:hover {
+        color: var(--accent);
+    }
+
+    .path__goal {
+        margin: 4px 0 0;
+        color: var(--fg-muted);
+        font-size: 14px;
+        line-height: 1.5;
+        max-width: none;
+    }
+
+    .path__example {
+        display: inline-block;
+        margin-top: var(--s-2);
+        font-family: var(--f-mono);
+        font-size: 12px;
+        color: var(--fg-faint);
+        text-decoration: none;
+    }
+
+    .path__example:hover {
+        color: var(--accent);
+    }
+
+    .topic-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: var(--s-3);
+    }
+
+    .topic-card {
+        display: block;
+        padding: var(--s-5);
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-4);
+        background: var(--bg-elevated);
+        text-decoration: none;
+        color: inherit;
+        transition:
+            border-color var(--transition-fast),
+            transform var(--transition-fast);
+    }
+
+    .topic-card:hover {
+        border-color: var(--accent-line);
+        transform: translateY(-2px);
+    }
+
+    .topic-card:focus-visible {
+        outline: 2px solid var(--focus-ring);
+        outline-offset: 2px;
+    }
+
+    .topic-card h3 {
+        margin: 0;
+        font-size: 16px;
+        color: var(--fg);
+    }
+
+    .topic-card p {
+        margin: var(--s-2) 0 0;
+        font-size: 13.5px;
+        line-height: 1.5;
+        color: var(--fg-muted);
+        max-width: none;
+    }
+
+    .orient-grid {
+        display: flex;
+        align-items: stretch;
+        gap: var(--s-3);
+    }
+
+    .orient-card {
+        flex: 1;
+        padding: var(--s-4);
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-4);
+        background: var(--bg-elevated);
+    }
+
+    .orient-card__k {
+        margin: 0;
+        font-family: var(--f-mono);
+        font-size: 12px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--accent);
+    }
+
+    .orient-card__v {
+        margin: var(--s-2) 0 0;
+        font-size: 13.5px;
+        line-height: 1.5;
+        color: var(--fg-muted);
+        max-width: none;
+    }
+
+    .orient-arrow {
+        display: flex;
+        align-items: center;
+        color: var(--fg-faint);
+        font-family: var(--f-mono);
+    }
+
+    .part-block + .part-block {
+        margin-top: var(--s-6);
+    }
+
+    .part-block__title {
+        display: inline-flex;
+        align-items: baseline;
+        gap: 0.6rem;
+        margin: 0 0 var(--s-3);
+        font-family: var(--f-mono);
+        font-size: 14px;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        border: 0;
+        padding: 0;
+    }
+
+    .part-block__title span:first-child {
+        color: var(--accent);
+    }
+
+    .part-block__title span:last-child {
+        color: var(--fg-muted);
+    }
+
+    .chapter-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: var(--s-3);
+    }
+
+    .chapter-card {
+        display: flex;
+        flex-direction: column;
+        gap: var(--s-2);
+        padding: var(--s-4);
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-4);
+        background: var(--bg-elevated);
+        text-decoration: none;
+        color: inherit;
+        transition:
+            border-color var(--transition-fast),
+            transform var(--transition-fast);
+    }
+
+    .chapter-card:hover {
+        border-color: var(--accent-line);
+        transform: translateY(-2px);
+    }
+
+    .chapter-card:focus-visible {
+        outline: 2px solid var(--focus-ring);
+        outline-offset: 2px;
+    }
+
+    .chapter-card h4 {
+        margin: 0;
+        font-size: 15px;
+        color: var(--fg);
+    }
+
+    .chapter-card p {
+        margin: 0;
+        font-size: 13px;
+        line-height: 1.5;
+        color: var(--fg-muted);
+        max-width: none;
+    }
+
+    .toc h6 {
+        margin: 0;
+        font-family: var(--f-mono);
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--fg-faint);
+    }
+
+    .toc ul {
+        list-style: none;
+        margin: var(--s-3) 0 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .toc a {
+        display: block;
+        border-left: 2px solid transparent;
+        padding: 4px 0 4px var(--s-3);
+        margin-left: -10px;
+        color: var(--fg-muted);
+        text-decoration: none;
+        font-size: 13px;
+    }
+
+    .toc a:hover,
+    .toc a:focus-visible {
+        color: var(--fg);
+        outline: none;
+    }
+
+    .toc ul li:first-child a {
+        color: var(--accent);
+        border-left-color: var(--accent);
+    }
+
+    .toc__resources {
+        margin-top: 1.5rem;
+        padding-top: 0.75rem;
+        border-top: 1px solid var(--line-soft);
+    }
+
+    @media (max-width: 900px) {
+        .topic-grid,
+        .chapter-grid {
+            grid-template-columns: 1fr;
+        }
+
+        .orient-grid {
+            flex-direction: column;
+        }
+
+        .orient-arrow {
+            transform: rotate(90deg);
+            justify-content: center;
+        }
     }
 </style>

--- a/site/src/pages/de/index.astro
+++ b/site/src/pages/de/index.astro
@@ -1,30 +1,1011 @@
 ---
-import DocsLayout from '../../layouts/DocsLayout.astro';
-import TranslationNotice from '../../components/TranslationNotice.astro';
+import AppShell from '../../layouts/AppShell.astro';
+import { Code } from 'astro:components';
+import EnglishFallbackNotice from '../../components/EnglishFallbackNotice.astro';
+import ExampleThumb from '../../components/ExampleThumb.astro';
+import { GuideExamplePreview } from '../../components/GuideExamplePreview';
+import { appInfo } from '../../lib/app-info';
+import { getAllExamples, getExamplesForChapter } from '../../lib/examples-catalog';
+import { getExampleExecutionSource } from '../../lib/example-sources';
+import { GUIDE_PARTS } from '../../lib/guide-structure';
+
+const majorVersion = Number.parseInt(appInfo.version.split('.')[0] ?? '0', 10);
+const releaseStage = Number.isFinite(majorVersion) && majorVersion < 1 ? 'Pre-1.0' : 'Stable';
+const chapterCount = GUIDE_PARTS.reduce((sum, part) => sum + part.chapters.length, 0);
+const demoCount = getAllExamples().length;
+
+// Live hero example — an ambient particle showcase that runs everywhere
+// (WebGL2, no input or audio gesture needed) so the landing shows the real
+// engine rendering in the page, not a video.
+const heroExample = getExamplesForChapter('particles').find(entry => entry.slug === 'bonfire');
+const heroExampleTitle = heroExample?.title ?? 'Bonfire';
+const heroExampleSource = getExampleExecutionSource('particles', 'bonfire');
+
+const heroSnippet = `import { Application, Color, Scene, Sprite, Texture } from '@codexo/exojs';
+
+class HeroScene extends Scene {
+  private ship!: Sprite;
+
+  async load(loader) {
+    this.ship = new Sprite(await loader.load(Texture, 'ship.png'));
+  }
+
+  init() {
+    const { width, height } = this.app.canvas;
+    this.ship.setAnchor(0.5).setPosition(width / 2, height / 2);
+
+    // Pulse and spin — two tweens running in parallel.
+    this.app.tweens.create(this.ship.scale)
+      .to({ x: 1.4, y: 1.4 }, 0.9).yoyo(true).repeat(-1).start();
+    this.app.tweens.create(this.ship)
+      .to({ rotation: Math.PI }, 1.8).yoyo(true).repeat(-1).start();
+  }
+
+  draw(context) {
+    context.backend.clear();
+    context.render(this.ship);
+  }
+}
+
+const app = new Application({
+  canvas: { width: 960, height: 540 },
+  clearColor: Color.black,
+});
+
+app.start(new HeroScene());`;
+
+const quickstartSnippet = `import { Application, Scene } from '@codexo/exojs';
+
+class HelloScene extends Scene {
+  draw(context) {
+    context.backend.clear();
+  }
+}
+
+const app = new Application({ canvas: { width: 800, height: 600 } });
+app.start(new HelloScene());`;
+
+const examples = [
+    {
+        title: 'Bonfire',
+        description: 'Per-frame particle emitter with falloff and color ramp.',
+        chapter: 'Particles',
+        tags: ['particles', 'color'],
+        anim: 'particles' as const,
+        href: `${import.meta.env.BASE_URL}en/playground/?example=particles/bonfire`,
+    },
+    {
+        title: 'Chromatic Aberration',
+        description: 'Stack two filters on a layer for analog feel.',
+        chapter: 'Filters',
+        tags: ['filter', 'blend'],
+        anim: 'chroma' as const,
+        href: `${import.meta.env.BASE_URL}en/playground/?example=filters/chromatic-aberration`,
+    },
+    {
+        title: 'Beat Sync Pulse',
+        description: 'Drive scene scale from FFT bands.',
+        chapter: 'Audio FX',
+        tags: ['audio', 'fft'],
+        anim: 'fft' as const,
+        href: `${import.meta.env.BASE_URL}en/playground/?example=beat-detection/beat-sync-pulse`,
+    },
+    {
+        title: 'Sprite Sheet',
+        description: 'Animate from a strip with frame timing.',
+        chapter: 'Sprites & Textures',
+        tags: ['sprite', 'anim'],
+        anim: 'frames' as const,
+        href: `${import.meta.env.BASE_URL}en/playground/?example=sprites-textures/spritesheet-frames`,
+    },
+    {
+        title: 'Easing Curves',
+        description: 'Tween any numeric property with built-in easings.',
+        chapter: 'Tweens & Animation',
+        tags: ['tween', 'easing'],
+        anim: 'easing' as const,
+        href: `${import.meta.env.BASE_URL}en/playground/?example=tweens-animation/easing-curves`,
+    },
+    {
+        title: 'Camera And View',
+        description: 'Pan and zoom with View; world vs screen coords.',
+        chapter: 'Application & Scenes',
+        tags: ['scene', 'view'],
+        anim: 'camera' as const,
+        href: `${import.meta.env.BASE_URL}en/playground/?example=application-scenes/camera-and-view`,
+    },
+];
 ---
 
-<DocsLayout title="ExoJS" description="German localization placeholder for ExoJS documentation.">
-    <section class="de-home">
-        <h1>ExoJS</h1>
-        <p>The German homepage is in progress. You can use the English docs and playground right now.</p>
-        <TranslationNotice englishHref={`${import.meta.env.BASE_URL}en/`} />
-    </section>
-</DocsLayout>
+<AppShell title="ExoJS" description="A TypeScript-first 2D runtime for games and interactive apps.">
+    <EnglishFallbackNotice />
+    <div class="home">
+        <section class="hero">
+            <div class="hero-inner">
+                <div class="hero-copy">
+                    <span class="hero-eyebrow">
+                        <span class="pip"><span class="dot"></span>v{appInfo.version}</span>
+                        <span>{releaseStage} / TypeScript / {appInfo.license}</span>
+                    </span>
+                    <h1><span class="nowrap">A TypeScript-first</span><br />2D runtime for<br /><span class="hero-token-wrap"><span class="hero-token" id="hero-token">arcade games</span></span></h1>
+                    <p class="lead">
+                        ExoJS gives you scenes, sprites, graphics, input, audio, effects, assets, and rendering primitives — without turning your project into a full game-engine workflow.
+                    </p>
+                    <div class="hero-cta">
+                        <a class="btn btn-primary" href={`${import.meta.env.BASE_URL}en/guide/`}>Read the Guide</a>
+                        <a class="btn btn-ghost" href={`${import.meta.env.BASE_URL}en/playground/`}>Open Playground</a>
+                        <a class="btn btn-link" href={`${import.meta.env.BASE_URL}en/api/`}>Browse API</a>
+                        <span class="meta">npm i @codexo/exojs</span>
+                    </div>
+                </div>
+                <div class="hero-snippet">
+                    <div class="head">
+                        <span class="dot3"></span><span class="dot3"></span><span class="dot3"></span>
+                        <span class="file">game.ts</span>
+                        <span class="caps"><span class="cap cap-accent">scene</span><span class="cap">tweens</span></span>
+                    </div>
+                    <Code code={heroSnippet} lang="ts" themes={{ light: 'github-light', dark: 'one-dark-pro' }} />
+                </div>
+            </div>
+        </section>
+
+        <section class="live-hero" aria-label="Live example">
+            <img
+                class="hero-companion"
+                src={`${import.meta.env.BASE_URL}brand/companion-hero.webp`}
+                alt=""
+                aria-hidden="true"
+                width="208"
+                height="208"
+                loading="lazy"
+                decoding="async"
+            />
+            <div class="live-hero-head">
+                <span class="live-tag"><span class="live-dot"></span>Live — rendering in your browser</span>
+                <h2>{heroExampleTitle}</h2>
+                <p>Not a video or a GIF — this is the engine running in the page. Hit play, then open it in the Playground and edit it live.</p>
+            </div>
+            <div class="live-hero-stage">
+                <GuideExamplePreview
+                    client:visible
+                    chapter="particles"
+                    slug="bonfire"
+                    title={heroExampleTitle}
+                    sourceCode={heroExampleSource}
+                    capabilities={heroExample?.capabilities ?? []}
+                />
+            </div>
+            <div class="live-hero-actions">
+                <a class="btn btn-ghost" href={`${import.meta.env.BASE_URL}en/playground/?example=particles/bonfire`}>Open in Playground</a>
+                <a class="btn btn-link" href={`${import.meta.env.BASE_URL}en/playground/`}>Browse all {demoCount} demos</a>
+            </div>
+        </section>
+
+        <div class="cap-strip">
+            <article class="cap">
+                <span class="cap-icon">SCN</span>
+                <h4>Scenes & lifecycle</h4>
+                <p>Compose scenes from sprites, graphics, and text. Lifecycle hooks make state predictable.</p>
+            </article>
+            <article class="cap">
+                <span class="cap-icon">INP</span>
+                <h4>Unified input</h4>
+                <p>Keyboard, pointer, and gamepad behind one action mapping API.</p>
+            </article>
+            <article class="cap">
+                <span class="cap-icon">AUD</span>
+                <h4>Spatial audio</h4>
+                <p>Buses, effects, and listener-source positioning built on Web Audio.</p>
+            </article>
+            <article class="cap">
+                <span class="cap-icon">FX</span>
+                <h4>Filters & particles</h4>
+                <p>Post-processing, bloom, blur, particles — composable and GPU-accelerated.</p>
+            </article>
+        </div>
+
+        <section class="section">
+            <div class="section-head">
+                <div class="l">
+                    <h2>Live examples.</h2>
+                    <p>Open any of these in the Playground. The code and preview stay in sync with the running example.</p>
+                </div>
+                <div class="r">examples / {chapterCount} chapters / {demoCount} demos</div>
+            </div>
+            <div class="examples">
+                {examples.map((example, index) => (
+                    <a class="ex-card" href={example.href}>
+                        <ExampleThumb anim={example.anim} title={example.title} tone={index % 6} />
+                        <div class="ex-meta">
+                            <div class="row">
+                                {example.tags.map(tag => (
+                                    <span class="badge">{tag}</span>
+                                ))}
+                            </div>
+                            <h4>{example.title}</h4>
+                            <p>{example.description}</p>
+                            <div class="chapter">{example.chapter}</div>
+                        </div>
+                    </a>
+                ))}
+            </div>
+        </section>
+
+        <section class="quickstart">
+            <div class="quickstart-inner">
+                <div>
+                    <h3>Install once, use anywhere.</h3>
+                    <p>ExoJS ships as plain ES modules. Drop it into Vite, esbuild, or whatever you already use.</p>
+                    <a class="btn btn-ghost" href={`${import.meta.env.BASE_URL}en/guide/getting-started/setup/`}>Open Getting Started</a>
+                </div>
+                <div>
+                    <div class="install-tabs">
+                        <button type="button" data-active="true">npm</button>
+                        <button type="button">pnpm</button>
+                        <button type="button">yarn</button>
+                        <button type="button">bun</button>
+                    </div>
+                    <div class="install-line">
+                        <span class="dollar">$</span>
+                        <span><span class="key">npm</span> install <span class="pkg">@codexo/exojs</span></span>
+                        <span class="copy">COPY</span>
+                    </div>
+                    <div class="snippet">
+                        <Code code={quickstartSnippet} lang="ts" themes={{ light: 'github-light', dark: 'github-dark' }} />
+                    </div>
+                </div>
+            </div>
+        </section>
+    </div>
+</AppShell>
 
 <style>
-    .de-home {
+    .home {
+        position: relative;
+        isolation: isolate;
+    }
+
+    .hero {
+        position: relative;
+        padding: var(--s-12) var(--s-7) var(--s-11);
+        overflow: hidden;
+        border-bottom: 1px solid var(--line-soft);
+    }
+
+    .hero::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-image:
+            linear-gradient(var(--grid-line) 1px, transparent 1px),
+            linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
+        background-size: 64px 64px;
+        background-position: -1px -1px;
+        mask-image: radial-gradient(120% 80% at 70% 0%, #000 35%, transparent 75%);
+        pointer-events: none;
+        z-index: -1;
+        animation: hero-grid-drift 26s linear infinite;
+    }
+
+    /* Slowly drift the grid by exactly one cell so the loop is seamless. */
+    @keyframes hero-grid-drift {
+        to {
+            background-position: 63px 63px;
+        }
+    }
+
+    .hero::after {
+        content: '';
+        position: absolute;
+        right: -160px;
+        top: -120px;
+        width: 520px;
+        height: 520px;
+        background: radial-gradient(closest-side, var(--accent-soft), transparent 70%);
+        pointer-events: none;
+        z-index: -1;
+        animation: hero-glow-breathe 9s ease-in-out infinite;
+    }
+
+    @keyframes hero-glow-breathe {
+        0%,
+        100% {
+            opacity: 0.8;
+            transform: scale(1);
+        }
+        50% {
+            opacity: 1;
+            transform: scale(1.09);
+        }
+    }
+
+    .hero-inner {
+        position: relative;
+        max-width: 1180px;
+        margin: 0 auto;
         display: grid;
-        gap: 0.9rem;
+        grid-template-columns: 1fr 1.1fr;
+        gap: var(--s-10);
+        align-items: center;
     }
 
-    .de-home h1 {
+    .hero-copy {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    /* Companion mascot — a waving greeter presenting the live example, perched in
+       the top-right of the live-hero section. Decorative (aria-hidden). */
+    .hero-companion {
+        position: absolute;
+        top: -58px;
+        right: var(--s-4);
+        z-index: 3;
+        width: clamp(120px, 13vw, 172px);
+        height: auto;
+        pointer-events: none;
+        filter: drop-shadow(0 14px 26px rgba(0, 0, 0, 0.4));
+        animation: companion-float 4.6s ease-in-out infinite;
+    }
+
+    @keyframes companion-float {
+        0%,
+        100% {
+            transform: translateY(0) rotate(-0.6deg);
+        }
+        50% {
+            transform: translateY(-10px) rotate(0.6deg);
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .hero-companion,
+        .hero::before,
+        .hero::after,
+        .cap-icon {
+            animation: none;
+        }
+    }
+
+    .hero-eyebrow {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--s-2);
+        margin-bottom: var(--s-5);
+        padding: 4px 10px 4px 4px;
+        border-radius: var(--r-pill);
+        background: var(--bg-elevated);
+        border: 1px solid var(--line-soft);
+        font-size: 12px;
+        color: var(--fg-muted);
+        font-family: var(--f-mono);
+    }
+
+    .hero-eyebrow .pip {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        padding: 2px 8px;
+        background: var(--accent-soft);
+        color: var(--accent);
+        border-radius: var(--r-pill);
+        font-weight: 600;
+    }
+
+    .hero-eyebrow .dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: var(--accent);
+        box-shadow: 0 0 0 3px var(--accent-soft);
+    }
+
+    .hero h1 {
+        font-size: clamp(40px, 5.4vw, 68px);
+        font-weight: 600;
+        line-height: 1.02;
+        letter-spacing: -0.025em;
+        margin: 0 0 var(--s-5);
+        color: var(--fg);
+    }
+
+    .nowrap {
+        white-space: nowrap;
+    }
+
+    .hero-token-wrap {
+        display: block;
+    }
+
+    .hero-token {
+        display: inline-block;
+        color: var(--accent);
+        font-style: italic;
+        font-weight: 500;
+        white-space: nowrap;
+        will-change: transform, opacity;
+    }
+
+    @keyframes token-exit {
+        to {
+            opacity: 0;
+            transform: translateY(-0.28em);
+        }
+    }
+
+    @keyframes token-enter {
+        from {
+            opacity: 0;
+            transform: translateY(0.32em);
+        }
+    }
+
+    .hero-token.is-exiting {
+        animation: token-exit 240ms cubic-bezier(0.7, 0, 0.84, 0) forwards;
+    }
+
+    .hero-token.is-entering {
+        animation: token-enter 460ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    }
+
+    .hero p.lead {
+        font-size: 18px;
+        color: var(--fg-muted);
+        max-width: 540px;
+        margin: 0 0 var(--s-7);
+        line-height: 1.55;
+        text-wrap: pretty;
+    }
+
+    .hero-cta {
+        display: flex;
+        gap: var(--s-3);
+        flex-wrap: wrap;
+        align-items: center;
+    }
+
+    .hero-cta .meta {
+        color: var(--fg-faint);
+        font-size: 13px;
+        font-family: var(--f-mono);
+        margin-left: var(--s-3);
+    }
+
+    .home .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--s-2);
+        padding: 9px 14px;
+        border-radius: var(--r-3);
+        font-size: 14px;
+        font-weight: 500;
+        transition:
+            background var(--transition-fast),
+            border-color var(--transition-fast),
+            color var(--transition-fast),
+            transform var(--transition-fast);
+        border: 1px solid transparent;
+        white-space: nowrap;
+        text-decoration: none;
+    }
+
+    .home .btn:active {
+        transform: translateY(1px);
+    }
+
+    .home .btn-primary {
+        background: var(--accent);
+        color: var(--accent-fg);
+    }
+
+    .home .btn-primary:hover {
+        background: color-mix(in oklab, var(--accent), white 8%);
+    }
+
+    .home .btn-ghost {
+        background: transparent;
+        border-color: var(--line);
+        color: var(--fg);
+    }
+
+    .home .btn-ghost:hover {
+        background: var(--bg-elevated);
+        border-color: var(--fg-faint);
+    }
+
+    .home .btn-link {
+        padding: 0;
+        color: var(--accent);
+        border-bottom: 1px solid var(--accent-line);
+        border-radius: 0;
+    }
+
+    .hero-snippet {
+        background: var(--bg-code);
+        border: 1px solid var(--line);
+        border-radius: var(--r-4);
+        box-shadow: var(--shadow-2);
+        overflow: hidden;
+        position: relative;
+    }
+
+    .hero-snippet .head {
+        display: flex;
+        align-items: center;
+        gap: var(--s-2);
+        padding: 10px 14px;
+        border-bottom: 1px solid oklch(30% 0.014 245);
+        background: oklch(18% 0.012 245);
+        color: oklch(70% 0.012 245);
+        font-family: var(--f-mono);
+        font-size: 12px;
+    }
+
+    .hero-snippet .dot3 {
+        width: 9px;
+        height: 9px;
+        border-radius: 50%;
+        background: oklch(35% 0.014 245);
+    }
+
+    .hero-snippet .file {
+        margin-left: var(--s-2);
+    }
+
+    .hero-snippet .caps {
+        margin-left: auto;
+        display: flex;
+        gap: 6px;
+    }
+
+    .hero-snippet .cap {
+        display: inline-flex;
+        align-items: center;
+        border-radius: var(--r-pill);
+        border: 1px solid var(--line-soft);
+        padding: 2px 8px;
+        font-size: 11px;
+        color: oklch(78% 0.012 245);
+        background: oklch(20% 0.012 245);
+    }
+
+    .hero-snippet .cap-accent {
+        color: oklch(82% 0.13 142);
+        border-color: oklch(58% 0.16 142 / 0.42);
+        background: oklch(22% 0.014 142 / 0.32);
+    }
+
+    .hero-snippet :global(pre.astro-code) {
         margin: 0;
-        font-size: clamp(1.8rem, 4vw, 2.6rem);
+        padding: var(--s-5) !important;
+        border: 0 !important;
+        border-radius: 0 !important;
+        background: transparent !important;
+        box-shadow: none !important;
+        font-size: 13px;
+        line-height: 1.7;
     }
 
-    .de-home p {
+    .live-hero {
+        position: relative;
+        max-width: 1180px;
+        margin: var(--s-10) auto 0;
+        padding: 0 var(--s-7);
+    }
+
+    .live-hero-head {
+        margin-bottom: var(--s-5);
+    }
+
+    .live-tag {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        margin-bottom: var(--s-3);
+        font-family: var(--f-mono);
+        font-size: 12px;
+        color: var(--accent);
+    }
+
+    .live-dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: var(--accent);
+        box-shadow: 0 0 0 3px var(--accent-soft);
+    }
+
+    .live-hero-head h2 {
+        margin: 0 0 6px;
+        font-size: 28px;
+        font-weight: 600;
+        letter-spacing: -0.015em;
+    }
+
+    .live-hero-head p {
         margin: 0;
         color: var(--fg-muted);
-        max-width: 64ch;
+        max-width: 640px;
+        line-height: 1.55;
+    }
+
+    .live-hero-stage {
+        border: 1px solid var(--line);
+        border-radius: var(--r-4);
+        overflow: hidden;
+        box-shadow: var(--shadow-2);
+        background: var(--bg-code);
+    }
+
+    .live-hero-actions {
+        display: flex;
+        gap: var(--s-3);
+        align-items: center;
+        margin-top: var(--s-4);
+    }
+
+    .cap-strip {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: var(--s-4);
+        max-width: 1180px;
+        margin: var(--s-10) auto 0;
+        padding: 0 var(--s-7);
+    }
+
+    .cap {
+        padding: var(--s-5);
+        border-radius: var(--r-3);
+        background: var(--bg-elevated);
+        border: 1px solid var(--line-soft);
+        display: flex;
+        flex-direction: column;
+        gap: var(--s-2);
+    }
+
+    .cap-icon {
+        width: 32px;
+        height: 32px;
+        display: grid;
+        place-items: center;
+        border-radius: var(--r-2);
+        background: var(--accent-soft);
+        color: var(--accent);
+        margin-bottom: var(--s-2);
+        font-size: 13px;
+        font-family: var(--f-mono);
+        font-weight: 700;
+        animation: cap-pulse 4.8s ease-in-out infinite;
+    }
+
+    /* Staggered glow travelling across the four feature icons. */
+    .cap:nth-child(2) .cap-icon {
+        animation-delay: 1.2s;
+    }
+    .cap:nth-child(3) .cap-icon {
+        animation-delay: 2.4s;
+    }
+    .cap:nth-child(4) .cap-icon {
+        animation-delay: 3.6s;
+    }
+
+    @keyframes cap-pulse {
+        0%,
+        100% {
+            box-shadow: 0 0 0 0 transparent;
+        }
+        50% {
+            box-shadow: 0 0 16px 1px var(--accent-soft);
+        }
+    }
+
+    .cap h4 {
+        margin: 0;
+        font-size: 14px;
+        font-weight: 600;
+    }
+
+    .cap p {
+        margin: 0;
+        font-size: 13px;
+        color: var(--fg-muted);
+        line-height: 1.5;
+    }
+
+    .section {
+        padding: var(--s-11) var(--s-7);
+        max-width: 1180px;
+        margin: 0 auto;
+    }
+
+    .section-head {
+        display: flex;
+        align-items: end;
+        justify-content: space-between;
+        margin-bottom: var(--s-7);
+        gap: var(--s-5);
+    }
+
+    .section-head .l h2 {
+        margin: 0 0 6px;
+        font-size: 28px;
+        font-weight: 600;
+        letter-spacing: -0.015em;
+    }
+
+    .section-head .l p {
+        margin: 0;
+        color: var(--fg-muted);
+    }
+
+    .section-head .r {
+        color: var(--fg-faint);
+        font-family: var(--f-mono);
+        font-size: 12px;
+        white-space: nowrap;
+    }
+
+    .examples {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--s-4);
+    }
+
+    .ex-card {
+        background: var(--bg-elevated);
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-4);
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        transition:
+            border-color var(--transition-fast),
+            transform var(--transition-fast);
+        color: inherit;
+        text-decoration: none;
+    }
+
+    .ex-card:hover {
+        border-color: var(--line);
+        transform: translateY(-2px);
+    }
+
+    .ex-meta {
+        padding: var(--s-4) var(--s-5);
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+    }
+
+    .ex-meta .row {
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+    }
+
+    .ex-meta h4 {
+        margin: 0;
+        font-size: 15px;
+        font-weight: 600;
+    }
+
+    .ex-meta p {
+        margin: 0;
+        font-size: 13px;
+        color: var(--fg-muted);
+        max-width: none;
+    }
+
+    .ex-meta .chapter {
+        color: var(--fg-faint);
+        font-family: var(--f-mono);
+        font-size: 11px;
+        margin-top: 4px;
+    }
+
+    .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 3px 8px;
+        border-radius: var(--r-pill);
+        font-size: 11px;
+        font-family: var(--f-mono);
+        font-weight: 500;
+        letter-spacing: 0.02em;
+        background: var(--bg-elevated);
+        color: var(--fg-muted);
+        border: 1px solid var(--line-soft);
+        white-space: nowrap;
+    }
+
+    .quickstart {
+        border-top: 1px solid var(--line-soft);
+        background: var(--bg-elevated);
+    }
+
+    .quickstart-inner {
+        display: grid;
+        grid-template-columns: 1fr 1.2fr;
+        gap: var(--s-10);
+        padding: var(--s-11) var(--s-7);
+        max-width: 1180px;
+        margin: 0 auto;
+    }
+
+    .quickstart h3 {
+        margin: 0 0 var(--s-3);
+        font-size: 24px;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+    }
+
+    .quickstart p {
+        margin: 0 0 var(--s-5);
+        color: var(--fg-muted);
+        max-width: 460px;
+    }
+
+    .install-tabs {
+        display: flex;
+        gap: 4px;
+        padding: 4px;
+        background: var(--bg-canvas);
+        border: 1px solid var(--line-soft);
+        border-radius: var(--r-2);
+        width: max-content;
+        margin-bottom: var(--s-3);
+    }
+
+    .install-tabs button {
+        padding: 4px 10px;
+        border-radius: 4px;
+        font-size: 12px;
+        font-family: var(--f-mono);
+        color: var(--fg-muted);
+        border: 0;
+        background: transparent;
+    }
+
+    .install-tabs button[data-active='true'] {
+        background: var(--bg-elevated);
+        color: var(--fg);
+    }
+
+    .install-line {
+        display: flex;
+        align-items: center;
+        gap: var(--s-2);
+        background: var(--bg-code);
+        border: 1px solid var(--line);
+        border-radius: var(--r-2);
+        padding: 10px 14px;
+        font-family: var(--f-mono);
+        font-size: 13px;
+        color: oklch(92% 0.02 245);
+    }
+
+    .install-line .dollar {
+        color: oklch(70% 0.012 245);
+    }
+
+    .install-line .copy {
+        margin-left: auto;
+        color: oklch(70% 0.012 245);
+    }
+
+    .install-line .key {
+        color: oklch(78% 0.16 95);
+    }
+
+    .install-line .pkg {
+        color: oklch(80% 0.14 30);
+    }
+
+    .snippet {
+        margin-top: 12px;
+    }
+
+    .snippet :global(pre.astro-code) {
+        margin: 0;
+    }
+
+    @media (max-width: 1000px) {
+        .hero-inner {
+            grid-template-columns: 1fr;
+        }
+    }
+
+    @media (max-width: 900px) {
+        .cap-strip {
+            grid-template-columns: repeat(2, 1fr);
+        }
+
+        .examples {
+            grid-template-columns: 1fr;
+        }
+
+        .quickstart-inner {
+            grid-template-columns: 1fr;
+        }
+    }
+
+    @media (max-width: 760px) {
+        .hero {
+            padding: var(--s-8) var(--s-4) var(--s-7);
+        }
+
+        /* Shrink the live-hero greeter so it never crowds the heading on phones. */
+        .hero-companion {
+            width: 92px;
+            top: -32px;
+            right: var(--s-3);
+        }
+
+        .hero-inner {
+            gap: var(--s-6);
+        }
+
+        .hero h1 {
+            font-size: clamp(2rem, 11vw, 2.8rem);
+            margin-bottom: var(--s-4);
+        }
+
+        .hero p.lead {
+            font-size: 0.96rem;
+            margin-bottom: var(--s-5);
+        }
+
+        .hero-snippet .head {
+            padding: 8px 11px;
+        }
+
+        .hero-snippet .caps {
+            display: none;
+        }
+
+        .hero-snippet :global(pre.astro-code) {
+            padding: var(--s-3) var(--s-4) !important;
+            max-height: 15.5rem;
+            overflow: auto;
+            font-size: 12px;
+            line-height: 1.6;
+        }
+
+        .cap-strip {
+            margin-top: var(--s-7);
+            padding: 0 var(--s-4);
+            grid-template-columns: 1fr;
+        }
+
+        .section {
+            padding: var(--s-8) var(--s-4);
+        }
+
+        .quickstart-inner {
+            padding: var(--s-8) var(--s-4);
+        }
     }
 </style>
+
+<script>
+    const TOKENS = ['arcade games', 'interactive apps', 'audio visualizers', 'particle effects', 'motion graphics', 'creative tools'];
+    const INTERVAL = 3200;
+    const DURATION = 240;
+
+    const el = document.getElementById('hero-token');
+    if (el && !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        let idx = 0;
+        setInterval(() => {
+            el.classList.add('is-exiting');
+            setTimeout(() => {
+                idx = (idx + 1) % TOKENS.length;
+                el.textContent = TOKENS[idx] ?? '';
+                el.classList.remove('is-exiting');
+                el.classList.add('is-entering');
+                el.addEventListener('animationend', () => el.classList.remove('is-entering'), { once: true });
+            }, DURATION);
+        }, INTERVAL);
+    }
+</script>

--- a/site/src/pages/de/playground/index.astro
+++ b/site/src/pages/de/playground/index.astro
@@ -1,30 +1,13 @@
 ---
-import DocsLayout from '../../../layouts/DocsLayout.astro';
-import TranslationNotice from '../../../components/TranslationNotice.astro';
+import Layout from '../../../layouts/Layout.astro';
+import { ExampleBrowser } from '../../../components/ExampleBrowser';
 ---
 
-<DocsLayout title="ExoJS Playground (DE)" description="German localization placeholder for the ExoJS playground.">
-    <section class="de-playground">
-        <h1>Playground</h1>
-        <p>The playground experience is currently maintained in English only.</p>
-        <TranslationNotice englishHref={`${import.meta.env.BASE_URL}en/playground/`} />
-    </section>
-</DocsLayout>
-
-<style>
-    .de-playground {
-        display: grid;
-        gap: 0.9rem;
-    }
-
-    .de-playground h1 {
-        margin: 0;
-        font-size: clamp(1.8rem, 4vw, 2.5rem);
-    }
-
-    .de-playground p {
-        margin: 0;
-        color: var(--fg-muted);
-        max-width: 64ch;
-    }
-</style>
+<Layout title="ExoJS Playground">
+    <!-- Skip-link target — light-DOM wrapper that's focusable so Skip-to-main-content
+         actually lands on something keyboard-traversable. Focus then tabs into the
+         shadow tree of <example-browser> as normal. -->
+    <div class="playground-main">
+        <ExampleBrowser client:load baseUrl={import.meta.env.BASE_URL} />
+    </div>
+</Layout>


### PR DESCRIPTION
## Summary

Fixes from a package-wide quality audit, bundled into one PR (disjoint files across 5 unrelated packages):

- **Physics**: deleted `PhysicsWorldOptions.interpolation` and `BindingOptions.drive:'node-to-body'` — both documented as "reserved, no effect yet" and referenced nowhere. Added a suspension-travel limit (`enableLimit`/`lowerTranslation`/`upperTranslation`) to `WheelJoint`, matching `PrismaticJoint`'s existing limit; added motor/spring-settling/limit tests (WheelJoint was previously the least-tested joint in the family).
- **Particles**: fixed two doc/example drifts (`ScaleOverLifetime`'s nonexistent `axis` mention, `ParticleSystem`'s nonexistent `backend` option in its `@example`). Added missing test coverage for `BoxArea`/`CircleArea`/`LineSegment`/`ConeDirection` distributions and `BurstSpawn.loop`/`.reset()`/`AttractToPoint.falloff`. Documented the three previously-guide-omitted distributions.
- **React**: built a real `useSignal` hook (bridges an engine `Signal` into React via `useSyncExternalStore`) and fixed the previously-broken `FrameCounter` example (`app.frameCount` never re-rendered — nothing subscribed to it). Added an `onError` counterpart to `onReady` on `ExoCanvas`/`useExoApplication`, wired to `Application.onError`; wrapped the previously-fire-and-forget scene-activation `await`s in `useScene`/`Scenes` in try/catch. Fixed a wrong duration unit in the package README (`0.3` → `300`, ms not seconds).
- **Audio-fx**: made `LimiterEffect.ratio`/`.knee` configurable (previously hardcoded), matching sibling `CompressorEffect` — defaults unchanged (20/0).
- **Site**: German (`de/`) locale pages now render the real English content directly instead of a "Translation coming soon" stub (no German content exists yet, so this removes an unnecessary click-through). A small unobtrusive banner replaces the old boxed notice; the playground page gets a silent fallback (layout constraints).

Continues on top of `main`; independent of PR #222 (LDtk/Aseprite/Tiled/animation-repeat work).

## Test plan

- [x] `pnpm typecheck` (root + all 8 extension packages)
- [x] `pnpm test` (jsdom, all default projects) — 4415 passed, 1 skipped
- [x] `pnpm vitest run --project exojs-ldtk --project exojs-aseprite --project exojs-react` — 167 passed
- [x] `pnpm lint:all` — 0 errors
- [x] `pnpm format:check` — clean
- [x] `pnpm typecheck:guides` — clean
- [x] `pnpm docs:api:check` — in sync (regenerated 6 pages)
- [x] `pnpm build` + `pnpm site:build` — 700 pages built, spot-checked `de/guide/rendering/animation/` renders real content (no "coming soon" text, page size matches the English original)