### PR TITLE
docs: v0.15 guide coverage catch-up (blend modes, UI widgets, fixed-update, more)

### DIFF
--- a/site/src/content/guide/assets/loading-and-resources.mdx
+++ b/site/src/content/guide/assets/loading-and-resources.mdx
@@ -226,6 +226,48 @@ async load(loader) {
 }
 ```
 
+## Signals for a global loading screen
+
+`LoadingQueue.onProgress` and `onBundleProgress` (above) are scoped to one call or one bundle. When you want a single loading screen that reflects *everything* the loader is doing — regardless of how many separate `loader.load(...)` calls triggered it — subscribe to the loader instance's own signals instead: `onLoadStart`, `onLoadProgress`, `onLoadComplete`, and `onLoadError`. These track one shared, loader-wide batch: as long as any foreground load is in flight, new loads join the same batch instead of starting a new one.
+
+| Signal | Payload | Fires |
+|--------|---------|-------|
+| `onLoadStart` | `(key, url)` | Once, when the loader goes from idle to active. `key`/`url` identify the asset that triggered it. |
+| `onLoadProgress` | `(loaded, total, key)` | After every asset in the batch settles (success or failure). `loaded`/`total` are running counts across the whole batch; `key` is the asset that just settled. |
+| `onLoadComplete` | — | Once, when every in-flight foreground load has settled and the batch returns to idle. |
+| `onLoadError` | `(key, error)` | For each asset that fails. Does not prevent `onLoadComplete` from firing afterward. |
+
+Because the batch is shared, `total` can grow mid-flight: if a new `loader.load(...)` call starts while others are still pending, its assets are added to the same running total rather than starting a fresh count at 0. That is exactly what you want for a boot screen — one progress bar that stays accurate no matter how many scenes or systems kick off loads concurrently.
+
+```js
+class BootScene extends Scene {
+    init(loader) {
+        loader.onLoadStart.add((key, url) => {
+            this.progressBar.visible = true;
+        });
+
+        loader.onLoadProgress.add((loaded, total, key) => {
+            this.progressBar.value = loaded / total;
+        });
+
+        loader.onLoadError.add((key, error) => {
+            console.warn(`Failed to load "${key}":`, error);
+            // onLoadComplete still fires once the rest of the batch settles
+        });
+
+        loader.onLoadComplete.add(() => {
+            this.progressBar.visible = false;
+            this._enterGame();
+        });
+
+        // Trigger loads from anywhere — the signals above see all of them
+        loader.load(TitleAssets);
+    }
+}
+```
+
+Unlike `LoadingQueue.onProgress`, which you attach to the return value of one `loader.load(...)` call, these four are properties on the `Loader` itself — subscribe once (for example in your boot scene's `init`) and they report every foreground load for the lifetime of that loader.
+
 ## Aliases and identity
 
 Aliases come from the keys you supply in a record or `Assets` container. The same `Asset<T>` reference can appear under multiple aliases — the loader issues only one network request and stores the result under each alias independently:

--- a/site/src/content/guide/debugging/debugging-and-inspection.mdx
+++ b/site/src/content/guide/debugging/debugging-and-inspection.mdx
@@ -76,6 +76,48 @@ All debug layers live on `DebugOverlay.layers`. The overlay subscribes to applic
 
 Debug layers have zero overhead when their `visible` flag is `false` — `DebugOverlay._onFrame` skips invisible layers entirely. You can leave the overlay constructed for a full development session without worrying about perf impact on profiling.
 
+## Logging
+
+Separately from the visual overlays above, ExoJS ships a channel-based [`Logger`](/ExoJS/en/api/logger/) in the core module — no special entrypoint required. The engine uses it internally (for example, `Application` logs unexpected failures on the `'core'` channel), and it's available for your own code too. A ready-to-use default instance, `logger`, is exported alongside the class:
+
+```js
+import { logger } from '@codexo/exojs';
+
+logger.debug('assets', 'Bundle "level-1" queued');
+logger.info('scene', 'Entered gameplay scene');
+logger.warn('audio', 'AudioContext resumed after a user gesture');
+logger.error('physics', 'Simulation step threw', new Error('physics step failed'));
+```
+
+Each call takes a `channel` — one of the built-in channels (`'core'`, `'rendering'`, `'audio'`, `'input'`, `'assets'`, `'physics'`, `'ui'`, `'animation'`, `'scene'`) or any custom string — plus a `message`, and either an optional `data` object (`debug`/`info`/`warn`) or an optional `Error` (`error`). Filter or route by channel in your own tooling to focus on one subsystem at a time.
+
+Severity follows `LogSeverity`: `Debug < Info < Warning < Error`. In production builds, `Debug`/`Info`/`Warning` calls are compiled out entirely — only `Error` survives — so it's safe to leave `logger.debug`/`logger.info` calls in shipped code without gating them yourself. In development builds, a console handler is registered by default and prefixes every line with `[ExoJS:<channel>]`.
+
+To capture log entries yourself — for an in-game console, telemetry, or a custom debug panel — register a handler with `addHandler`. It returns an unsubscribe function:
+
+```js
+import { logger, LogSeverity } from '@codexo/exojs';
+
+const unsubscribe = logger.addHandler((entry) => {
+    if (entry.severity >= LogSeverity.Warning) {
+        console.warn(entry.channel, entry.message, entry.data ?? entry.error);
+    }
+});
+
+// later
+unsubscribe();
+```
+
+For warnings that could otherwise repeat every frame (a stale asset reference checked in `update`, say), use `warnOnce` — it logs the first time for a given key and silently skips every call after:
+
+```js
+update(delta) {
+    if (this.texture.width > 4096) {
+        logger.warnOnce('huge-texture', 'rendering', 'Texture exceeds 4096px — this may hurt performance on mobile GPUs.');
+    }
+}
+```
+
 ## Inspecting the render pipeline
 
 Every filter attached to a drawable costs at least one extra render pass. A stack of three filters on a container means the container renders to an off-screen target, the first filter reads and writes a target, the second does the same, and the third composites the result — four passes for one element. When your frame budget tightens, knowing who is adding passes and why matters.

--- a/site/src/content/guide/debugging/performance.mdx
+++ b/site/src/content/guide/debugging/performance.mdx
@@ -72,6 +72,42 @@ Updating a texture source (e.g. a canvas, video frame, or `DataTexture` buffer) 
 
 Nodes that fall entirely outside the current `View`'s viewport are skipped by the renderer. This is automatic and per-node. The culling check is AABB-based rather than exact shape, so nodes near the viewport edge may still be rendered even if partially outside. For large scrolling worlds, this is a significant performance multiplier — only the visible subset of your scene graph incurs draw cost.
 
+### Overriding the cull check with `cullArea`
+
+The automatic check calls `getBounds()`, which for a `Container` walks every visible child and unions their bounds — for a complex `Graphics` node or a container with hundreds of children, that walk runs every frame even when the node's on-screen footprint is trivial to reason about. Set `cullArea` to a `Rectangle` and the cull check uses it directly instead of computing bounds:
+
+```js
+import { Color, Container, Graphics, Rectangle } from '@codexo/exojs';
+
+// A debris field built from hundreds of small Graphics children — walking
+// all of them for getBounds() every frame is wasted work once we already
+// know the field never exceeds a 200x200 footprint at its spawn position.
+const debris = new Container();
+
+for (let i = 0; i < 300; i++) {
+  const shard = new Graphics();
+  shard.fillColor = Color.slateGray;
+  shard.drawCircle(0, 0, 2);
+  shard.x = Math.random() * 200;
+  shard.y = Math.random() * 200;
+  debris.addChild(shard);
+}
+
+debris.x = 400;
+debris.y = 300;
+
+// cullArea is compared directly against the view's bounds, in the same
+// world-space coordinates getBounds() would otherwise produce — it is not
+// re-transformed by the node's own position/scale/rotation. Since `debris`
+// is positioned once and never moves, a static rectangle here stays correct.
+debris.cullArea = new Rectangle(debris.x, debris.y, 200, 200);
+```
+
+Two things to keep in mind:
+
+- `cullArea` replaces `getBounds()` only in the `inView()` check — it has no effect on hit-testing, collision, or rendering, and it's ignored entirely when `cullable = false`.
+- Because the rectangle is used as-is (not transformed), a `cullArea` on a node that moves, rotates, or scales after it's set will go stale. Either recompute it when the node's position changes, or reserve it for nodes whose world placement is fixed once configured — e.g. static level decoration, or particle-heavy effects anchored to a known spawn point.
+
 ## Not a checklist
 
 The most useful performance practice is measurement. Turn on the performance layer, watch the numbers, change one thing, measure again. The engine's behavior under your specific scene — your sprite counts, your texture layout, your filter stacks — matters more than any general guideline.

--- a/site/src/content/guide/getting-started/resize-dpr-and-canvas.mdx
+++ b/site/src/content/guide/getting-started/resize-dpr-and-canvas.mdx
@@ -62,6 +62,37 @@ init() {
 
 Either approach works — poll in `update` for small scenes, react to `onResize` when re-layout is expensive.
 
+## Sizing modes
+
+The manual `app.resize` + `onResize` pattern above works well when you compute the size yourself. For the common cases — filling a container, scaling a fixed-resolution canvas to fit, or letterboxing — pass `canvas.sizingMode` instead and let the application manage the CSS and `ResizeObserver` for you:
+
+```js
+import { Application } from '@codexo/exojs';
+
+const app = new Application({
+    canvas: { width: 320, height: 240, sizingMode: 'letterbox' },
+});
+```
+
+- `'fixed'` (default) — exact pixel size, no responsive behavior.
+- `'fill'` — observes the parent element and calls `app.resize(...)` to match its size exactly.
+- `'fit'` / `'shrink'` — CSS-scales the fixed-resolution canvas to fit its container via `object-fit: contain`; `'fit'` always fills the available space, `'shrink'` never scales up past 100%.
+- `'letterbox'` — keeps the design-space render target fixed and centers it in the parent at native resolution, with the parent background showing through as bars around it.
+
+`sizingMode` is also a live, runtime-settable property — not just a constructor option. Assigning `app.sizingMode` re-applies the strategy immediately: it disconnects any previous `ResizeObserver` and installs the new mode's CSS/observer. That makes it easy to switch strategies in response to user actions, for example filling the screen on fullscreen entry and returning to a fixed size on exit:
+
+```js
+import { Application } from '@codexo/exojs';
+
+const app = new Application({
+    canvas: { width: 800, height: 600 },
+});
+
+document.addEventListener('fullscreenchange', () => {
+    app.sizingMode = document.fullscreenElement ? 'fill' : 'fixed';
+});
+```
+
 ## Example
 
 <ExamplePreview chapter="getting-started" slug="resize-and-dpr" />

--- a/site/src/content/guide/rendering/sprites.mdx
+++ b/site/src/content/guide/rendering/sprites.mdx
@@ -98,7 +98,7 @@ Call `resetTextureFrame()` to restore the full texture.
 
 ## Blend modes
 
-`sprite.blendMode` controls how the sprite composites with pixels already in the framebuffer. The default is normal alpha blending. Alternative modes (`additive`, `subtract`, `multiply`, `screen`) are available via `BlendModes`:
+`sprite.blendMode` controls how the sprite composites with pixels already in the framebuffer. The default is `BlendModes.Normal` (standard alpha blending):
 
 ```js
 import { BlendModes } from '@codexo/exojs';
@@ -107,6 +107,31 @@ this.glow.blendMode = BlendModes.Additive;
 ```
 
 Blend modes are per-sprite. Combined with tinting they cover common glow, shadow, and knock-out compositing without needing custom shaders.
+
+`BlendModes` implements the full W3C compositing/blending set. `Normal`, `Additive`, `Subtract`, `Multiply`, and `Screen` are fixed-function GPU blends with no extra draw cost. The remaining "advanced" modes go through a backdrop-aware compositor that copies the current render target before drawing each sprite, so they carry a small per-draw backdrop-copy cost — reach for them deliberately in draw-call-heavy scenes. `isAdvancedBlendMode(mode)` reports which category a given mode falls into.
+
+| Mode | Visual effect |
+| --- | --- |
+| `Normal` | Standard alpha compositing — source drawn over the backdrop. |
+| `Additive` | Adds source and backdrop colors; brightens. Good for glows, light, fire, particles. |
+| `Subtract` | Subtracts source from backdrop; darkens toward black. |
+| `Multiply` | Multiplies channel values; darkens, like stacking transparencies. |
+| `Screen` | Inverse of multiply; lightens, like projecting two images onto the same surface. |
+| `Darken` * | Keeps the darker of source and backdrop, per channel. |
+| `Lighten` * | Keeps the lighter of source and backdrop, per channel. |
+| `Overlay` * | Multiplies dark backdrop areas and screens light ones; boosts contrast. |
+| `ColorDodge` * | Brightens the backdrop to reflect the source color; intense highlights. |
+| `ColorBurn` * | Darkens the backdrop to reflect the source color; intense shadows. |
+| `HardLight` * | Overlay with source and backdrop roles swapped; harsh, directional lighting. |
+| `SoftLight` * | Softer version of Overlay; subtle, diffused lighting. |
+| `Difference` * | Absolute value of the channel difference; inversion / comparison effects. |
+| `Exclusion` * | Lower-contrast variant of Difference. |
+| `Hue` * | Source hue with backdrop saturation and luminosity. |
+| `Saturation` * | Source saturation with backdrop hue and luminosity. |
+| `Color` * | Source hue and saturation with backdrop luminosity; recolors while preserving shading. |
+| `Luminosity` * | Source luminosity with backdrop hue and saturation; inverse of `Color`. |
+
+\* Advanced mode — routed through the backdrop-aware compositor (`isAdvancedBlendMode` returns `true`).
 
 ## Spritesheets
 

--- a/site/src/content/guide/runtime/application.mdx
+++ b/site/src/content/guide/runtime/application.mdx
@@ -46,9 +46,10 @@ Options are organised into groups:
 - `backend` — `{ type: 'auto' }` (default), or pin to `'webgl2'` / `'webgpu'`.
 
 `clearColor` is not just a construction-time default — `app.clearColor` returns the render
-backend's live {@link Color} instance, so it stays readable and writable for the whole life of
-the application. Assigning a new `Color` copies its channels into the backend (effective from the
-next frame), which makes it a convenient way to react to game state without touching draw code:
+backend's live [`Color`](/ExoJS/en/api/color/) instance, so it stays readable and writable for the
+whole life of the application. Assigning a new `Color` copies its channels into the backend
+(effective from the next frame), which makes it a convenient way to react to game state without
+touching draw code:
 
 ```js
 import { Application, Color } from '@codexo/exojs';

--- a/site/src/content/guide/runtime/application.mdx
+++ b/site/src/content/guide/runtime/application.mdx
@@ -45,6 +45,27 @@ Options are organised into groups:
 - `clearColor` — what `context.backend.clear()` paints each frame.
 - `backend` — `{ type: 'auto' }` (default), or pin to `'webgl2'` / `'webgpu'`.
 
+`clearColor` is not just a construction-time default — `app.clearColor` returns the render
+backend's live {@link Color} instance, so it stays readable and writable for the whole life of
+the application. Assigning a new `Color` copies its channels into the backend (effective from the
+next frame), which makes it a convenient way to react to game state without touching draw code:
+
+```js
+import { Application, Color } from '@codexo/exojs';
+
+const app = new Application();
+
+function onLowHealth(isLow) {
+    app.clearColor = isLow ? Color.darkRed : Color.cornflowerBlue;
+}
+```
+
+You can also mutate the existing instance in place instead of allocating a new `Color` each time:
+
+```js
+app.clearColor.set(20, 20, 40, 1); // dusk
+```
+
 ## Choosing the canvas
 
 By default the application creates its own canvas. Read it from `app.canvas` and place it in your page wherever your layout needs it:

--- a/site/src/content/guide/runtime/scenes-and-lifecycle.mdx
+++ b/site/src/content/guide/runtime/scenes-and-lifecycle.mdx
@@ -136,13 +136,14 @@ The first time a scene starts:
 
 Then, every frame while the scene is active:
 
-3. `update(delta)` — advance state. `delta.seconds` is the elapsed time since the last frame.
-4. `draw(context)` — render the current state.
+3. `fixedUpdate(delta)` — zero or more deterministic steps with a constant `delta`, run before `update`.
+4. `update(delta)` — advance state. `delta.seconds` is the elapsed time since the last frame.
+5. `draw(context)` — render the current state.
 
 When the scene is replaced or the application shuts down:
 
-5. `async unload(loader)` — release scene-private assets that aren't needed by the next scene.
-6. `destroy()` — drop scene-graph references and cancel input bindings.
+6. `async unload(loader)` — release scene-private assets that aren't needed by the next scene.
+7. `destroy()` — drop scene-graph references and cancel input bindings.
 
 You override the hooks you need. Empty hooks like `update` and `draw` do nothing by default, so there is no setup ceremony for scenes that only need one or two phases. Cleanup hooks are different: if you override `destroy`, keep the built-in cleanup path intact unless the API reference for your version says otherwise.
 
@@ -179,6 +180,49 @@ init(loader) {
 ```
 
 The `init` hook runs once per scene-start. If you start the scene again later it runs again on the new instance, not on the old one.
+
+## fixedUpdate: deterministic steps
+
+`update` runs once per real frame, so its `delta` varies with the display's refresh rate and any hitches. `fixedUpdate` is the other logic hook: the engine runs it a constant number of times per second — independent of frame rate — before `update`:
+
+```js
+fixedUpdate(delta) {
+    this.world.step(delta.seconds);
+}
+```
+
+Behind the scenes, the application accumulates each frame's elapsed time and drains it in fixed-size chunks — `1 / 60` s by default, configurable via `fixedTimeStep` (seconds) on the `Application` constructor options:
+
+```js
+const app = new Application({ fixedTimeStep: 1 / 30 });
+```
+
+At 60 fps, that is one `fixedUpdate` call per frame, tracking `update` one-to-one. At 144 fps, some frames get zero calls and others get one, averaging out to the configured rate. On a stalled frame (a GC pause, a dropped tab), it can run several calls back-to-back so simulation time is never silently lost — capped at an internal maximum so a single long freeze cannot spiral into minutes of catch-up.
+
+Because the step size never changes, `fixedUpdate` is the right place for anything that must behave identically regardless of frame rate — physics stepping is the headline case; see [Physics basics](/ExoJS/en/guide/physics/physics-basics/) for a full `world.step(delta.seconds)` walkthrough. Leave camera movement, UI, and anything purely visual in `update`: running those at a fixed rate would make them look choppy on high-refresh-rate displays instead of smoother.
+
+### frameAlpha: smoothing between steps
+
+Because `fixedUpdate` calls don't line up one-to-one with rendered frames, there is always a small unrendered remainder — the fraction of the current fixed step already elapsed since the last one ran. The application exposes it as `app.frameAlpha`, a value in `[0, 1)`.
+
+**`frameAlpha` is not applied automatically** — the scene graph never interpolates itself. It exists for you to read and use if you want smooth visual motion between fixed steps: keep the previous and current fixed-step positions and lerp between them by `frameAlpha` when you draw.
+
+```js
+fixedUpdate() {
+    this.hero.prevX = this.hero.x;
+    this.world.step(1 / 60); // moves the body; the binding updates this.hero.x
+}
+
+draw(context) {
+    const alpha = this.app.frameAlpha;
+    const renderX = this.hero.prevX + (this.hero.x - this.hero.prevX) * alpha;
+    this.hero.setPosition(renderX, this.hero.y);
+    context.backend.clear();
+    context.render(this.root);
+}
+```
+
+If you don't need buttery-smooth motion, ignore `frameAlpha` — most scenes never touch it. It matters once the fixed step is coarser than the display's frame rate (say `fixedTimeStep: 1 / 30` on a 144 Hz screen), where skipping interpolation shows up as visible stutter on fast-moving objects.
 
 ## update: per-frame logic
 

--- a/site/src/content/guide/runtime/ui-and-widgets.mdx
+++ b/site/src/content/guide/runtime/ui-and-widgets.mdx
@@ -10,7 +10,7 @@ import TryIt from '../../../components/TryIt.astro';
 
 Every scene owns a screen-fixed UI layer, [`scene.ui`](/ExoJS/en/api/uiroot/), that is rendered automatically on top of the world. It lives in screen space (origin top-left, `0..width` × `0..height`), so its contents never scroll or zoom with the camera. Add anything to it with `scene.ui.addChild(...)`.
 
-On top of that layer, ExoJS ships a small set of widgets — [`Panel`](/ExoJS/en/api/panel/), [`Button`](/ExoJS/en/api/button/), [`Label`](/ExoJS/en/api/label/), [`ProgressBar`](/ExoJS/en/api/progress-bar/), and a [`Stack`](/ExoJS/en/api/stack/) layout container — for HUDs, menus, and pause screens without hand-built hit-tests.
+On top of that layer, ExoJS ships a small set of widgets — [`Panel`](/ExoJS/en/api/panel/), [`Button`](/ExoJS/en/api/button/), [`Label`](/ExoJS/en/api/label/), [`ProgressBar`](/ExoJS/en/api/progress-bar/), a [`Stack`](/ExoJS/en/api/stack/) layout container, a [`ScrollContainer`](/ExoJS/en/api/scroll-container/) for overflowing content, and a hover [`Tooltip`](/ExoJS/en/api/tooltip/) helper — for HUDs, menus, and pause screens without hand-built hit-tests.
 
 ## Building blocks
 
@@ -78,6 +78,31 @@ class MenuScene extends Scene {
 }
 ```
 
+## Scrolling content
+
+A `ScrollContainer` clips its content to a fixed `width` × `height` and scrolls it with the mouse wheel — useful for inventories, logs, or any list longer than its box. Add children to `scroll.content`, not to the container itself:
+
+```js
+import { Label, Scene, ScrollContainer } from '@codexo/exojs';
+
+class InventoryScene extends Scene {
+    init() {
+        const scroll = new ScrollContainer({ width: 280, height: 320, direction: 'vertical' });
+        scroll.anchorIn(this.ui, 'center');
+
+        for (let i = 0; i < 20; i++) {
+            const item = new Label(`Item ${i}`, { fontSize: 16 });
+            item.setPosition(12, i * 28);
+            scroll.content.addChild(item);
+        }
+
+        this.ui.addChild(scroll);
+    }
+}
+```
+
+`scroll.scrollTo(x, y)` and `scroll.scrollBy(dx, dy)` move the content programmatically, clamped so it never scrolls past its edges; `direction` restricts the wheel to `'vertical'`, `'horizontal'`, or `'both'`.
+
 ## Clicks and keyboard focus
 
 UI nodes are hit-tested in screen space *before* the world, so a `Button` on `scene.ui` is clickable even under a panned or zoomed camera. Listen to `button.onClick`:
@@ -113,6 +138,27 @@ field.onKeyDown.add(event => {
 
 The per-application focus service, [`app.focus`](/ExoJS/en/api/focus-manager/), tracks the focused node, moves focus with `Tab` / `Shift+Tab`, activates a focused button on `Enter` / `Space`, and exposes `app.focus.focus(node)` to focus programmatically.
 
+## Tooltips
+
+A `Tooltip` attaches to any `interactive` node and shows a small text label near the pointer after a short delay, hiding again as soon as the pointer leaves. It parents itself to the nearest `UIRoot` ancestor of its target, so it always renders above other content — the target just needs to already be in the scene tree:
+
+```js
+import { Button, Scene, Tooltip } from '@codexo/exojs';
+
+class ShopScene extends Scene {
+    init() {
+        const upgrade = new Button({ label: 'Upgrade', width: 160, height: 44 });
+        upgrade.interactive = true;
+        upgrade.anchorIn(this.ui, 'top-left', 24, 20);
+        this.ui.addChild(upgrade);
+
+        this.tooltip = new Tooltip(upgrade, { text: 'Costs 50 gold', delay: 0.3 });
+    }
+}
+```
+
+Options cover the delay before showing (`delay`, in seconds), the offset from the pointer (`offsetX` / `offsetY`), and basic styling (`background`, `textColor`, `padding`, `fontSize`). Call `tooltip.destroy()` to remove the listeners it attached to its target — e.g. when the target itself is destroyed.
+
 ## Pause overlays
 
 A pause menu is the canonical combination: freeze the world with `scene.paused = true` — which skips `update` and the scene's systems while it keeps drawing — and show an overlay built from widgets on `scene.ui`:
@@ -147,5 +193,5 @@ class GameScene extends Scene {
 
 <TryIt
     examples={['ui/hud-and-widgets', 'application-scenes/hud-overlay-scene']}
-    api={['uiroot', 'button', 'panel', 'label', 'progress-bar']}
+    api={['uiroot', 'button', 'panel', 'label', 'progress-bar', 'scroll-container', 'tooltip']}
 />

--- a/site/src/content/guide/shipping/deployment.mdx
+++ b/site/src/content/guide/shipping/deployment.mdx
@@ -122,7 +122,9 @@ await loader.load(Texture, { bunny: 'assets/bunny.png' }); // correct
 
 ## CDN and release bundle usage
 
-If you want to use ExoJS from a CDN or include the release bundle directly (without npm), use ES module imports with a `<script type="module">` tag.
+If you want to use ExoJS from a CDN or include the release bundle directly (without npm), there are two bundle formats to choose from: an ES module bundle for use with `<script type="module">`, or a plain-script IIFE bundle for use with a regular `<script>` tag. Both are published with the npm package and available from any CDN that mirrors it (unpkg, jsDelivr).
+
+### ES module bundle
 
 For the core engine bundle:
 
@@ -156,6 +158,23 @@ For the debug bundle (`exo.debug.esm.js`), note that it is an **external-core** 
 Without the import map, `exo.debug.esm.js` cannot resolve `@codexo/exojs` and will fail with a module not found error. The debug bundle is not a standalone engine; it extends the core bundle.
 
 Import maps are supported in all modern browsers. If you need to support older environments, use the npm + Vite workflow instead.
+
+### Script-tag (IIFE) bundle
+
+If you don't have any module-aware setup — no bundler, no import maps, just a plain HTML file with `<script>` tags — use the IIFE bundle instead. It is a classic (non-module) script that attaches every export as a property of a single global variable, `Exo`:
+
+```html
+<script src="./dist/exo.iife.js"></script>
+<script>
+    const { Application, Scene } = Exo;
+
+    const app = new Application({ canvas: { width: 800, height: 600 } });
+</script>
+```
+
+There is no `import` statement anywhere in this path — `Exo` is already in scope by the time the second `<script>` block runs, as long as it comes after the bundle's `<script>` tag. A minified build for production is available at `dist/exo.iife.min.js`; swap the `src` to use it.
+
+Prefer the ES module bundle when your host supports import maps and you want the browser to load only what you use. Prefer the IIFE bundle when you need a true zero-build setup — for example a single static HTML file, a CMS or forum post that only allows pasting a `<script>` tag, or any environment without import-map support.
 
 ## MIME types
 


### PR DESCRIPTION
## Summary

Closes the remaining gaps found by a guide-vs-shipped-feature coverage audit — every v0.15-era feature that had no guide coverage at all, minus the Tiled/TweenSequencer items (those landed in #222 since they touch files already modified there).

- **Blend modes** (`rendering/sprites.mdx`): documented the full 18-mode W3C suite (was 4).
- **UI widgets** (`runtime/ui-and-widgets.mdx`): added `Tooltip` and `ScrollContainer`.
- **Loader signals + Logger** (`assets/loading-and-resources.mdx`, `debugging/debugging-and-inspection.mdx`): documented `onLoadStart`/`onLoadProgress`/`onLoadComplete`/`onLoadError` and the `Logger` class.
- **Live `sizingMode`/`clearColor`** (`getting-started/resize-dpr-and-canvas.mdx`, `runtime/application.mdx`): documented as runtime-settable, not just constructor options.
- **`cullArea`** (`debugging/performance.mdx`): documented the manual cull-rect override, including that it's world-space and not auto-transformed.
- **`fixedUpdate`/`frameAlpha`** (`runtime/scenes-and-lifecycle.mdx`): documented the fixed-timestep lifecycle hook and manual interpolation; also fixed a pre-existing false cross-reference claim in the physics guide.
- **IIFE/CDN bundle** (`shipping/deployment.mdx`): documented the `<script>`-tag bundle (global `Exo`) alongside the existing ESM path.

## Test plan

- [x] `pnpm typecheck:guides` — clean
- [x] Docs-only change, no source touched