### PR TITLE
fix(rendering): WebGpuShaderFilter black screen from pipeline/target format mismatch

### DIFF
--- a/src/rendering/filters/WebGpuShaderFilter.ts
+++ b/src/rendering/filters/WebGpuShaderFilter.ts
@@ -263,7 +263,7 @@ export class WebGpuShaderFilter extends Filter {
   // Private helpers
   // ---------------------------------------------------------------------------
 
-  private _ensureConnected(backend: WebGpuBackend, _output: RenderTexture): void {
+  private _ensureConnected(backend: WebGpuBackend, output: RenderTexture): void {
     if (this._connection !== null) {
       return;
     }
@@ -304,7 +304,14 @@ export class WebGpuShaderFilter extends Filter {
     });
 
     // ---- Render pipeline ----
-    const targetFormat = backend.renderTargetFormat;
+    // `output` is always a temporary offscreen RenderTexture (see Filter.apply
+    // docs) — never the canvas/root target directly — and this pipeline is
+    // built and cached before BackendTargetPass redirects rendering into it.
+    // Reading `backend.renderTargetFormat` here would reflect whatever target
+    // is *currently* bound (typically still the canvas), not the format
+    // `output` will actually have, producing a permanent color-target format
+    // mismatch that WebGPU validation silently rejects on every draw.
+    const targetFormat = backend.getTextureFormat(output);
     const pipeline = device.createRenderPipeline({
       layout: pipelineLayout,
       vertex: {

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -817,6 +817,18 @@ export class WebGpuBackend implements RenderBackend {
     };
   }
 
+  /**
+   * The `GPUTextureFormat` a given `Texture`/`RenderTexture` is (or will be)
+   * backed by. Unlike {@link renderTargetFormat} (which reflects whatever
+   * target is *currently bound*), this is keyed off the texture itself, so
+   * callers that build a pipeline for a specific offscreen target — before
+   * that target is bound as the active render target — can match its format
+   * exactly instead of reading unrelated, possibly-stale backend state.
+   */
+  public getTextureFormat(texture: Texture | RenderTexture): GPUTextureFormat {
+    return this._getGpuTextureFormat(texture);
+  }
+
   public shouldPremultiplyTextureSample(texture: Texture | RenderTexture): boolean {
     return !(texture instanceof RenderTexture) && texture.premultiplyAlpha;
   }

--- a/test/rendering/browser/webgpu-shader-filter.test.ts
+++ b/test/rendering/browser/webgpu-shader-filter.test.ts
@@ -1,0 +1,181 @@
+/**
+ * WebGpuShaderFilter browser test — opt-in, capability-aware, real GPU.
+ *
+ * Reproduces the black-screen bug (crt-scanlines / chromatic-aberration
+ * examples on the WebGPU backend): `WebGpuShaderFilter._ensureConnected`
+ * builds and permanently caches its `GPURenderPipeline` against
+ * `backend.renderTargetFormat` — which reflects whatever render target is
+ * *currently bound* (still the canvas/root target at the moment the
+ * pipeline is built) rather than the filter's own offscreen `output`
+ * RenderTexture the pipeline will actually render into. Offscreen render
+ * textures are always allocated in the fixed managed format
+ * (`rgba8unorm`), so whenever the canvas' preferred format differs (e.g.
+ * `bgra8unorm`), every draw through the mismatched pipeline is silently
+ * rejected by WebGPU validation and the filter's `output` never receives
+ * any pixels — it stays cleared to transparent black.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { WebGpuShaderFilter } from '#rendering/filters/WebGpuShaderFilter';
+import { Mesh } from '#rendering/mesh/Mesh';
+import { RenderTexture } from '#rendering/texture/RenderTexture';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+
+const canvasSize = 64;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: {
+      canvas: { width: canvasSize, height: canvasSize },
+      clearColor: Color.black,
+    },
+  }) as unknown as Application;
+
+const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<WebGpuBackend | null> => {
+  if (!navigator.gpu) {
+    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
+
+    return null;
+  }
+
+  const adapter = await navigator.gpu.requestAdapter();
+
+  if (!adapter) {
+    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
+
+    return null;
+  }
+
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  await backend.initialize();
+  wireCoreRenderers(backend);
+
+  return backend;
+};
+
+// On the software (swiftshader/lavapipe) adapter the WebGPU device can drop
+// mid-test; treat that as an unavailable-adapter skip rather than a failure
+// (mirrors every other webgpu-*.test.ts in this suite).
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+// Ignores the input texture entirely and paints solid opaque red — so the
+// only way `output` ends up as anything other than red is the draw through
+// this pipeline being silently dropped (the bug under test), not a sampling
+// or UV mistake in the test shader itself.
+const solidRedFragSrc = `
+@group(0) @binding(0) var<uniform> uResolution: vec2<f32>;
+@group(0) @binding(1) var uTexture: texture_2d<f32>;
+@group(0) @binding(2) var uSampler: sampler;
+
+@fragment
+fn main(@location(0) vUv: vec2<f32>) -> @location(0) vec4<f32> {
+    return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+}
+`;
+
+const fullQuadVertices = (): Float32Array => new Float32Array([0, 0, canvasSize, 0, canvasSize, canvasSize, 0, 0, canvasSize, canvasSize, 0, canvasSize]);
+const fullQuadUvs = (): Float32Array => new Float32Array([0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1]);
+
+// `output` is an offscreen RenderTexture, never presented directly — draw it
+// onto the (still-root) canvas through the real mesh path, then sample the
+// presented canvas via a 2D context to get CPU-side pixel access.
+const readTexturePixel = (backend: WebGpuBackend, texture: RenderTexture, x: number, y: number): readonly [number, number, number, number] => {
+  const mesh = new Mesh({ vertices: fullQuadVertices(), uvs: fullQuadUvs(), texture });
+
+  try {
+    backend.resetStats();
+    backend.clear(Color.black);
+    mesh.render(backend);
+    backend.flush();
+  } finally {
+    mesh.destroy();
+  }
+
+  const readback = document.createElement('canvas');
+
+  readback.width = canvasSize;
+  readback.height = canvasSize;
+
+  const ctx2d = readback.getContext('2d');
+
+  if (!ctx2d) {
+    throw new Error('2D context is required for canvas readback.');
+  }
+
+  ctx2d.drawImage(backend.context.canvas as HTMLCanvasElement, 0, 0);
+
+  const { data } = ctx2d.getImageData(x, y, 1, 1);
+
+  return [data[0], data[1], data[2], data[3]];
+};
+
+describe('WebGpuShaderFilter (real GPU)', () => {
+  test('apply() writes non-black pixels into output — pipeline format matches the offscreen target', async ctx => {
+    const backend = await setupBackend(ctx);
+
+    if (!backend) {
+      return;
+    }
+
+    const device = getBackendDeviceOrSkip(ctx, backend);
+
+    if (!device) {
+      return;
+    }
+
+    const input = new RenderTexture(canvasSize, canvasSize);
+    const output = new RenderTexture(canvasSize, canvasSize);
+    const filter = new WebGpuShaderFilter({ fragmentSource: solidRedFragSrc });
+
+    try {
+      device.pushErrorScope('validation');
+
+      let validationError: GPUError | null;
+
+      try {
+        // `backend.renderTarget` is still the root canvas target here — this
+        // is exactly the state Filter.apply()/RenderEffectExecutor invoke the
+        // filter in, before BackendTargetPass redirects into `output`.
+        filter.apply(backend, input, output);
+        validationError = await device.popErrorScope();
+      } catch (error) {
+        if (isDeviceLoss(error)) {
+          ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+          return;
+        }
+
+        throw error;
+      }
+
+      // Confirms the exact mechanism: a color-target format mismatch between
+      // the cached pipeline and the render pass targeting `output`.
+      expect(validationError).toBeNull();
+
+      const [r, g, b, a] = readTexturePixel(backend, output, canvasSize / 2, canvasSize / 2);
+
+      expect([r, g, b, a]).not.toEqual([0, 0, 0, 0]);
+      expect(r).toBeGreaterThan(200);
+      expect(g).toBeLessThan(20);
+      expect(b).toBeLessThan(20);
+    } finally {
+      filter.destroy();
+      input.destroy();
+      output.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/filters/web-gpu-shader-filter.test.ts
+++ b/test/rendering/filters/web-gpu-shader-filter.test.ts
@@ -147,6 +147,7 @@ function createMockWebGpuEnv(): MockWebGpuEnv {
 interface MockWebGpuBackendExtras {
   execute: MockInstance;
   getTextureBinding: MockInstance;
+  getTextureFormat: MockInstance;
   device: GPUDevice;
   renderTargetFormat: GPUTextureFormat;
   createColorAttachment: MockInstance;
@@ -167,6 +168,7 @@ function makeWebGpuBackend(env: MockWebGpuEnv): RenderBackend & WebGpuBackend & 
     view: {} as GPUTextureView,
     sampler: {} as GPUSampler,
   }));
+  const getTextureFormat = vi.fn(() => 'rgba8unorm' as GPUTextureFormat);
   const createColorAttachment = vi.fn(() => ({
     view: {} as GPUTextureView,
     clearValue: { r: 0, g: 0, b: 0, a: 0 },
@@ -246,6 +248,7 @@ function makeWebGpuBackend(env: MockWebGpuEnv): RenderBackend & WebGpuBackend & 
     },
     execute,
     getTextureBinding,
+    getTextureFormat,
     createColorAttachment,
     submit,
   } as unknown as RenderBackend & WebGpuBackend & MockWebGpuBackendExtras;


### PR DESCRIPTION
## Symptom

On the WebGPU backend, the `crt-scanlines` and `chromatic-aberration` filter examples render a **black screen** — the filtered sprite never appears. WebGL2 is unaffected.

## Root cause

`WebGpuShaderFilter._ensureConnected` builds and permanently caches its `GPURenderPipeline` the first time the filter runs, reading `backend.renderTargetFormat` to pick the fragment color-target format. That getter reflects whichever render target is **currently bound** on the backend — which, at the moment the pipeline is built, is still the canvas/root target, because `BackendTargetPass` only redirects rendering into the filter's own offscreen `output` texture *after* `_ensureConnected` runs.

Every offscreen `RenderTexture` (a `Filter`'s `output` is always one — see `Filter.apply` docs) is allocated in a fixed managed format (`rgba8unorm` in `WebGpuBackend`). Whenever the canvas' preferred format differs (typically `bgra8unorm`), the cached pipeline is permanently built against the wrong color-target format. Every subsequent draw through it is silently rejected by WebGPU validation:

```
Attachment state of [RenderPipeline (unlabeled)] is not compatible with [RenderPassEncoder (unlabeled)].
[RenderPassEncoder (unlabeled)] expects an attachment state of { colorTargets: [0={format:TextureFormat::RGBA8Unorm}], ... }.
[RenderPipeline (unlabeled)] has an attachment state of { colorTargets: [0={format:TextureFormat::BGRA8Unorm}], ... }.
```

`output` stays cleared to transparent black, and that's what gets composited back onto the sprite.

The stock `BlurFilter`/`ColorFilter` are unaffected: they render through the generic `WebGpuSpriteRenderer`, which reads the render-target format fresh on every draw and keys its own pipeline cache by format (`_getPipeline(blendMode, backend.renderTargetFormat, stencil)`), so it always matches whatever target is currently bound.

## Fix

- `src/rendering/webgpu/WebGpuBackend.ts`: add a public `getTextureFormat(texture)`, a texture-keyed counterpart to `renderTargetFormat` that wraps the existing private `_getGpuTextureFormat`.
- `src/rendering/filters/WebGpuShaderFilter.ts`: in `_ensureConnected`, build the pipeline against `backend.getTextureFormat(output)` instead of `backend.renderTargetFormat`. The `output` parameter (previously unused and prefixed `_output`) is now used and renamed.

This is a single targeted change — no caching/architecture redesign; the pipeline is still built once and cached, just against the correct format.

## Test

Added `test/rendering/browser/webgpu-shader-filter.test.ts` — a real-GPU (headless Chromium) test that applies a solid-color `WebGpuShaderFilter` directly (mirroring how `RenderEffectExecutor` invokes `Filter.apply` while the previous target is still bound), wraps the call in `device.pushErrorScope('validation')`, and asserts:
1. no validation error is raised, and
2. reading the `output` texture back (drawn onto the canvas via a real `Mesh`) yields the filter's solid red, not black/transparent.

Before the fix this test fails with the exact `GPUValidationError` above (confirmed by temporarily logging `validationError.message`) and a black/transparent pixel read-back. After the fix it passes.

Also updated the existing mock-based unit suite (`test/rendering/filters/web-gpu-shader-filter.test.ts`) to stub the new `getTextureFormat` method on its mock backend.

## Verification

- New test: fails on unfixed code with the exact validation error, passes after the fix.
- `pnpm vitest run --project=browser-webgpu test/rendering/browser/` — 20 files / 88 tests pass.
- `test/rendering/filters/*`, `test/rendering/render-effects.test.ts`, `test/rendering/webgpu-backend.test.ts` — all pass.
- `tsc --noEmit`, `eslint` on touched files — clean (no new errors; pre-existing `vitest/no-disabled-tests` warning pattern shared with every other `webgpu-*.test.ts` in the suite).
- Full local `pnpm push` pre-push gate (`verify:quick`: typecheck/typecheck:guides/typecheck:examples/typecheck:packages/lint:all/format:check/docs:api:check) passes.

## Test plan

- [x] New WebGPU browser test reproduces the bug and passes after the fix
- [x] Existing filter/render-effects/webgpu-backend tests still pass
- [x] Typecheck + lint clean
- [ ] Manual example verification (crt-scanlines / chromatic-aberration in the playground) not run in this environment; the browser test exercises the identical code path (`Filter.apply` invoked while the previous render target is still bound) that `RenderEffectExecutor` uses for `sprite.filters`