### PR TITLE
chore(webgpu): add debug labels to WebGPU objects

### DIFF
--- a/src/rendering/webgpu/WebGpuBackdropBlendCompositor.ts
+++ b/src/rendering/webgpu/WebGpuBackdropBlendCompositor.ts
@@ -237,13 +237,15 @@ export class WebGpuBackdropBlendCompositor {
     }
 
     this._device = device;
-    this._shaderModule = device.createShaderModule({ code: compositorShaderSource });
+    this._shaderModule = device.createShaderModule({ label: 'backdrop-blend:shader', code: compositorShaderSource });
 
     this._projectionBindGroupLayout = device.createBindGroupLayout({
+      label: 'backdrop-blend:bind-group-layout:projection',
       entries: [{ binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform' } }],
     });
 
     this._textureBindGroupLayout = device.createBindGroupLayout({
+      label: 'backdrop-blend:bind-group-layout:texture',
       entries: [
         { binding: 0, visibility: GPUShaderStage.FRAGMENT, texture: {} },
         { binding: 1, visibility: GPUShaderStage.FRAGMENT, sampler: {} },
@@ -253,19 +255,23 @@ export class WebGpuBackdropBlendCompositor {
     });
 
     this._blendBindGroupLayout = device.createBindGroupLayout({
+      label: 'backdrop-blend:bind-group-layout:blend',
       entries: [{ binding: 0, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } }],
     });
 
     this._pipelineLayout = device.createPipelineLayout({
+      label: 'backdrop-blend:pipeline-layout',
       bindGroupLayouts: [this._projectionBindGroupLayout, this._textureBindGroupLayout, this._blendBindGroupLayout],
     });
 
     this._vertexBuffer = device.createBuffer({
+      label: 'backdrop-blend:vertex-buffer',
       size: 4 * vertexStrideBytes,
       usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
     });
 
     this._indexBuffer = device.createBuffer({
+      label: 'backdrop-blend:index-buffer',
       size: 6 * Uint16Array.BYTES_PER_ELEMENT,
       usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
     });
@@ -273,16 +279,19 @@ export class WebGpuBackdropBlendCompositor {
     device.queue.writeBuffer(this._indexBuffer, 0, this._indexData);
 
     this._projectionBuffer = device.createBuffer({
+      label: 'backdrop-blend:uniform-buffer:projection',
       size: projectionUniformBytes,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
 
     this._blendBuffer = device.createBuffer({
+      label: 'backdrop-blend:uniform-buffer:blend',
       size: blendUniformBytes,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
 
     this._backdropSampler = device.createSampler({
+      label: 'backdrop-blend:sampler',
       magFilter: 'nearest',
       minFilter: 'nearest',
       addressModeU: 'clamp-to-edge',
@@ -290,11 +299,13 @@ export class WebGpuBackdropBlendCompositor {
     });
 
     this._projectionBindGroup = device.createBindGroup({
+      label: 'backdrop-blend:bind-group:projection',
       layout: this._projectionBindGroupLayout,
       entries: [{ binding: 0, resource: { buffer: this._projectionBuffer } }],
     });
 
     this._blendBindGroup = device.createBindGroup({
+      label: 'backdrop-blend:bind-group:blend',
       layout: this._blendBindGroupLayout,
       entries: [{ binding: 0, resource: { buffer: this._blendBuffer } }],
     });
@@ -373,7 +384,7 @@ export class WebGpuBackdropBlendCompositor {
 
     // Capture the target region into the backdrop on a standalone encoder; a copy
     // cannot run inside a render pass (the coordinator's passes self-submit).
-    const encoder = device.createCommandEncoder();
+    const encoder = device.createCommandEncoder({ label: 'backdrop-blend:command-encoder' });
 
     encoder.copyTextureToTexture(
       { texture: manager._renderTargetTexture(target), origin: { x: ox, y: oy, z: 0 } },
@@ -390,6 +401,7 @@ export class WebGpuBackdropBlendCompositor {
     if (this._backdropTexture === null || this._backdropWidth !== width || this._backdropHeight !== height || this._backdropFormat !== format) {
       this._backdropTexture?.destroy();
       this._backdropTexture = device.createTexture({
+        label: 'backdrop-blend:texture',
         size: { width, height },
         format,
         usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
@@ -429,6 +441,7 @@ export class WebGpuBackdropBlendCompositor {
     const sourceBinding = manager.getTextureBinding(source);
 
     const textureBindGroup = device.createBindGroup({
+      label: 'backdrop-blend:bind-group:texture',
       layout: this._textureBindGroupLayout!,
       entries: [
         { binding: 0, resource: sourceBinding.view },
@@ -474,6 +487,7 @@ export class WebGpuBackdropBlendCompositor {
 
     const device = this._device!;
     const descriptor: GPURenderPipelineDescriptor = {
+      label: 'backdrop-blend:render-pipeline',
       layout: this._pipelineLayout!,
       vertex: {
         module: this._shaderModule!,

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -1220,6 +1220,7 @@ export class WebGpuBackend implements RenderBackend {
 
     if (!state) {
       const gpuTexture = this.device.createTexture({
+        label: 'backend:texture',
         size: {
           width: Math.max(texture.width, 1),
           height: Math.max(texture.height, 1),
@@ -1271,6 +1272,7 @@ export class WebGpuBackend implements RenderBackend {
         state.texture.destroy();
 
         const resizedTexture = this.device.createTexture({
+          label: 'backend:texture:resize',
           size: {
             width: texture.width,
             height: texture.height,
@@ -1455,6 +1457,7 @@ export class WebGpuBackend implements RenderBackend {
     const filter: GPUFilterMode = isFloatData ? 'nearest' : this._getFilterMode(texture.scaleMode);
 
     return this.device.createSampler({
+      label: 'backend:sampler',
       addressModeU: this._getAddressMode(texture.wrapMode),
       addressModeV: this._getAddressMode(texture.wrapMode),
       magFilter: filter,
@@ -1554,10 +1557,11 @@ export class WebGpuBackend implements RenderBackend {
     }
 
     const resources = this._getMipmapResources();
-    const encoder = this.device.createCommandEncoder();
+    const encoder = this.device.createCommandEncoder({ label: 'backend:command-encoder' });
 
     for (let mipLevel = 1; mipLevel < mipLevelCount; mipLevel++) {
       const bindGroup = this.device.createBindGroup({
+        label: 'backend:bind-group',
         layout: resources.bindGroupLayout,
         entries: [
           {
@@ -1574,6 +1578,7 @@ export class WebGpuBackend implements RenderBackend {
         ],
       });
       const pass = encoder.beginRenderPass({
+        label: 'backend:render-pass',
         colorAttachments: [
           {
             view: texture.createView({
@@ -1609,9 +1614,11 @@ export class WebGpuBackend implements RenderBackend {
       this._mipmapSampler === null
     ) {
       this._mipmapShaderModule = this.device.createShaderModule({
+        label: 'backend:mipmap-shader',
         code: mipmapWgsl,
       });
       this._mipmapBindGroupLayout = this.device.createBindGroupLayout({
+        label: 'backend:mipmap-bind-group-layout',
         entries: [
           {
             binding: 0,
@@ -1630,9 +1637,11 @@ export class WebGpuBackend implements RenderBackend {
         ],
       });
       this._mipmapPipelineLayout = this.device.createPipelineLayout({
+        label: 'backend:mipmap-pipeline-layout',
         bindGroupLayouts: [this._mipmapBindGroupLayout],
       });
       this._mipmapPipeline = this.device.createRenderPipeline({
+        label: 'backend:mipmap-pipeline',
         layout: this._mipmapPipelineLayout,
         vertex: {
           module: this._mipmapShaderModule,
@@ -1653,6 +1662,7 @@ export class WebGpuBackend implements RenderBackend {
         },
       });
       this._mipmapSampler = this.device.createSampler({
+        label: 'backend:mipmap-sampler',
         minFilter: 'linear',
         magFilter: 'linear',
         mipmapFilter: 'nearest',

--- a/src/rendering/webgpu/WebGpuMaskCompositor.ts
+++ b/src/rendering/webgpu/WebGpuMaskCompositor.ts
@@ -96,9 +96,10 @@ export class WebGpuMaskCompositor {
     }
 
     this._device = device;
-    this._shaderModule = device.createShaderModule({ code: compositorShaderSource });
+    this._shaderModule = device.createShaderModule({ label: 'mask:shader', code: compositorShaderSource });
 
     this._projectionBindGroupLayout = device.createBindGroupLayout({
+      label: 'mask:bind-group-layout:projection',
       entries: [
         {
           binding: 0,
@@ -109,6 +110,7 @@ export class WebGpuMaskCompositor {
     });
 
     this._textureBindGroupLayout = device.createBindGroupLayout({
+      label: 'mask:bind-group-layout:texture',
       entries: [
         { binding: 0, visibility: GPUShaderStage.FRAGMENT, texture: {} },
         { binding: 1, visibility: GPUShaderStage.FRAGMENT, sampler: {} },
@@ -118,15 +120,18 @@ export class WebGpuMaskCompositor {
     });
 
     this._pipelineLayout = device.createPipelineLayout({
+      label: 'mask:pipeline-layout',
       bindGroupLayouts: [this._projectionBindGroupLayout, this._textureBindGroupLayout],
     });
 
     this._vertexBuffer = device.createBuffer({
+      label: 'mask:vertex-buffer',
       size: 4 * vertexStrideBytes,
       usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
     });
 
     this._indexBuffer = device.createBuffer({
+      label: 'mask:index-buffer',
       size: 6 * Uint16Array.BYTES_PER_ELEMENT,
       usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
     });
@@ -134,11 +139,13 @@ export class WebGpuMaskCompositor {
     device.queue.writeBuffer(this._indexBuffer, 0, this._indexData);
 
     this._projectionBuffer = device.createBuffer({
+      label: 'mask:uniform-buffer:projection',
       size: projectionUniformBytes,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
 
     this._projectionBindGroup = device.createBindGroup({
+      label: 'mask:bind-group:projection',
       layout: this._projectionBindGroupLayout,
       entries: [{ binding: 0, resource: { buffer: this._projectionBuffer } }],
     });
@@ -195,6 +202,7 @@ export class WebGpuMaskCompositor {
     const maskBinding = manager.getTextureBinding(mask);
 
     const textureBindGroup = device.createBindGroup({
+      label: 'mask:bind-group:texture',
       layout: this._textureBindGroupLayout!,
       entries: [
         { binding: 0, resource: contentBinding.view },
@@ -239,6 +247,7 @@ export class WebGpuMaskCompositor {
 
     const device = this._device!;
     const descriptor: GPURenderPipelineDescriptor = {
+      label: 'mask:render-pipeline',
       layout: this._pipelineLayout!,
       vertex: {
         module: this._shaderModule!,

--- a/src/rendering/webgpu/WebGpuMeshRenderer.ts
+++ b/src/rendering/webgpu/WebGpuMeshRenderer.ts
@@ -774,10 +774,11 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
     }
 
     this._device = backend.device;
-    this._shaderModule = this._device.createShaderModule({ code: meshShaderSource });
-    this._instancedShaderModule = this._device.createShaderModule({ code: instancedMeshShaderSource });
+    this._shaderModule = this._device.createShaderModule({ label: 'mesh:shader', code: meshShaderSource });
+    this._instancedShaderModule = this._device.createShaderModule({ label: 'mesh:instanced-shader', code: instancedMeshShaderSource });
 
     this._uniformBindGroupLayout = this._device.createBindGroupLayout({
+      label: 'mesh:bind-group-layout:uniform',
       entries: [
         {
           binding: 0,
@@ -787,6 +788,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
       ],
     });
     this._textureBindGroupLayout = this._device.createBindGroupLayout({
+      label: 'mesh:bind-group-layout:texture',
       entries: [
         {
           binding: 0,
@@ -801,9 +803,11 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
       ],
     });
     this._pipelineLayout = this._device.createPipelineLayout({
+      label: 'mesh:pipeline-layout',
       bindGroupLayouts: [this._uniformBindGroupLayout, this._textureBindGroupLayout],
     });
     this._instancedTransformBindGroupLayout = this._device.createBindGroupLayout({
+      label: 'mesh:instanced-bind-group-layout:transform',
       entries: [
         {
           binding: 0,
@@ -818,6 +822,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
       ],
     });
     this._instancedPipelineLayout = this._device.createPipelineLayout({
+      label: 'mesh:instanced-pipeline-layout',
       bindGroupLayouts: [this._instancedTransformBindGroupLayout, this._textureBindGroupLayout],
     });
   }
@@ -939,6 +944,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
 
   private _buildPipelineDescriptor(blendMode: BlendModes, format: GPUTextureFormat, stencil = false): GPURenderPipelineDescriptor {
     const descriptor: GPURenderPipelineDescriptor = {
+      label: 'mesh:render-pipeline',
       layout: this._pipelineLayout!,
       vertex: {
         module: this._shaderModule!,
@@ -994,6 +1000,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
     }
 
     const group = this._device!.createBindGroup({
+      label: 'mesh:bind-group',
       layout: this._textureBindGroupLayout!,
       entries: [
         { binding: 0, resource: binding.view },
@@ -1108,6 +1115,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
       this._instancedNodeIndexBuffer?.destroy();
       this._instancedNodeIndexBufferCapacity = Math.max(requiredBytes, this._instancedNodeIndexBufferCapacity * 2 || Uint32Array.BYTES_PER_ELEMENT);
       this._instancedNodeIndexBuffer = this._device!.createBuffer({
+        label: 'mesh:instanced-node-index-buffer',
         size: this._instancedNodeIndexBufferCapacity,
         usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
       });
@@ -1125,6 +1133,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
       this._instancedUniformBuffer?.destroy();
       this._instancedUniformBufferCapacity = Math.max(requiredBytes, this._instancedUniformBufferCapacity * 2 || this._uniformAlignment);
       this._instancedUniformBuffer = this._device!.createBuffer({
+        label: 'mesh:instanced-uniform-buffer',
         size: this._instancedUniformBufferCapacity,
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
       });
@@ -1157,6 +1166,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
 
     this._instancedTransformStorageBuffer = storageBuffer;
     this._instancedTransformBindGroup = this._device!.createBindGroup({
+      label: 'mesh:instanced-transform-bind-group',
       layout: this._instancedTransformBindGroupLayout!,
       entries: [
         {
@@ -1192,6 +1202,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
 
   private _buildInstancedPipelineDescriptor(blendMode: BlendModes, format: GPUTextureFormat, stencil = false): GPURenderPipelineDescriptor {
     const descriptor: GPURenderPipelineDescriptor = {
+      label: 'mesh:instanced-render-pipeline',
       layout: this._instancedPipelineLayout!,
       vertex: {
         module: this._instancedShaderModule!,
@@ -1272,10 +1283,12 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
     const alignedIndexByteLen = (indexByteLen + 3) & ~3;
 
     const vertexBuffer = this._device!.createBuffer({
+      label: 'mesh:static-geometry-vertex-buffer',
       size: vertexData.byteLength,
       usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
     });
     const indexBuffer = this._device!.createBuffer({
+      label: 'mesh:static-geometry-index-buffer',
       size: alignedIndexByteLen,
       usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
     });
@@ -1324,6 +1337,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
       this._vertexBuffer?.destroy();
       this._vertexBufferCapacity = Math.max(requiredBytes, this._vertexBufferCapacity === 0 ? vertexStrideBytes : this._vertexBufferCapacity * 2);
       this._vertexBuffer = this._device!.createBuffer({
+        label: 'mesh:vertex-buffer',
         size: this._vertexBufferCapacity,
         usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
       });
@@ -1346,6 +1360,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
       this._indexBuffer?.destroy();
       this._indexBufferCapacity = Math.max(requiredBytes, this._indexBufferCapacity === 0 ? 4 : this._indexBufferCapacity * 2);
       this._indexBuffer = this._device!.createBuffer({
+        label: 'mesh:index-buffer',
         size: this._indexBufferCapacity,
         usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
       });
@@ -1363,10 +1378,12 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
       this._uniformBuffer?.destroy();
       this._uniformBufferCapacity = Math.max(requiredBytes, this._uniformBufferCapacity === 0 ? this._uniformAlignment : this._uniformBufferCapacity * 2);
       this._uniformBuffer = this._device!.createBuffer({
+        label: 'mesh:uniform-buffer',
         size: this._uniformBufferCapacity,
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
       });
       this._uniformBindGroup = this._device!.createBindGroup({
+        label: 'mesh:uniform-bind-group',
         layout: this._uniformBindGroupLayout!,
         entries: [
           {
@@ -1414,9 +1431,10 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
     }
 
     const device = this._device;
-    const shaderModule = device.createShaderModule({ code: material.shader.wgsl });
+    const shaderModule = device.createShaderModule({ label: 'mesh:material-shader', code: material.shader.wgsl });
 
     const meshUniformLayout = device.createBindGroupLayout({
+      label: 'mesh:material-bind-group-layout:uniform',
       entries: [
         {
           binding: 0,
@@ -1427,6 +1445,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
     });
 
     const meshTextureLayout = device.createBindGroupLayout({
+      label: 'mesh:material-bind-group-layout:texture',
       entries: [
         { binding: 0, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } },
         { binding: 1, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' } },
@@ -1436,10 +1455,12 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
     const userLayout = this._buildUserBindGroupLayout(device, material);
 
     const pipelineLayout = device.createPipelineLayout({
+      label: 'mesh:material-pipeline-layout',
       bindGroupLayouts: [meshUniformLayout, meshTextureLayout, userLayout],
     });
 
     const sampler = device.createSampler({
+      label: 'mesh:material-sampler',
       magFilter: 'linear',
       minFilter: 'linear',
       addressModeU: 'clamp-to-edge',
@@ -1506,6 +1527,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
       resources.vertexBuffer?.destroy();
       resources.vertexBufferCapacity = Math.max(vertexBytes, resources.vertexBufferCapacity * 2 || vertexStrideBytes);
       resources.vertexBuffer = device.createBuffer({
+        label: 'mesh:material-vertex-buffer',
         size: resources.vertexBufferCapacity,
         usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
       });
@@ -1520,6 +1542,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
       resources.indexBuffer?.destroy();
       resources.indexBufferCapacity = Math.max(indexBytes, resources.indexBufferCapacity * 2 || 4);
       resources.indexBuffer = device.createBuffer({
+        label: 'mesh:material-index-buffer',
         size: resources.indexBufferCapacity,
         usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
       });
@@ -1531,10 +1554,12 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
       resources.meshUniformBuffer?.destroy();
       resources.meshUniformBufferCapacity = Math.max(meshUniformBytes, resources.meshUniformBufferCapacity * 2 || meshUniformAlignment);
       resources.meshUniformBuffer = device.createBuffer({
+        label: 'mesh:material-uniform-buffer',
         size: resources.meshUniformBufferCapacity,
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
       });
       resources.meshUniformBindGroup = device.createBindGroup({
+        label: 'mesh:material-bind-group:uniform',
         layout: resources.meshUniformLayout,
         entries: [
           {
@@ -1635,6 +1660,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
 
     if (pipeline === undefined) {
       const descriptor: GPURenderPipelineDescriptor = {
+        label: 'mesh:material-render-pipeline',
         layout: resources.pipelineLayout,
         vertex: {
           module: resources.shaderModule,
@@ -1694,6 +1720,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
     }
 
     const group = this._device!.createBindGroup({
+      label: 'mesh:material-bind-group:texture',
       layout: resources.meshTextureLayout,
       entries: [
         { binding: 0, resource: binding.view },
@@ -1740,7 +1767,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
       bindingIndex++;
     }
 
-    return device.createBindGroupLayout({ entries });
+    return device.createBindGroupLayout({ label: 'mesh:material-bind-group-layout:user', entries });
   }
 
   private _uploadUserUniforms(material: Material, resources: CustomShaderResources): void {
@@ -1756,6 +1783,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
       resources.userUniformBuffer?.destroy();
       resources.userUniformBufferCapacity = bufferBytes;
       resources.userUniformBuffer = device.createBuffer({
+        label: 'mesh:material-user-uniform-buffer',
         size: bufferBytes,
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
       });
@@ -1805,6 +1833,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
     }
 
     return device.createBindGroup({
+      label: 'mesh:material-user-bind-group',
       layout: resources.userLayout,
       entries,
     });

--- a/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
@@ -117,9 +117,10 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     }
 
     this._device = backend.device;
-    this._shaderModule = this._device.createShaderModule({ code: nineSliceShaderSource });
+    this._shaderModule = this._device.createShaderModule({ label: 'nine-slice:shader', code: nineSliceShaderSource });
 
     this._uniformBindGroupLayout = this._device.createBindGroupLayout({
+      label: 'nine-slice:bind-group-layout:uniform',
       entries: [
         { binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform' } },
         { binding: 1, visibility: GPUShaderStage.VERTEX, buffer: { type: 'read-only-storage' } },
@@ -127,6 +128,7 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     });
 
     this._textureBindGroupLayout = this._device.createBindGroupLayout({
+      label: 'nine-slice:bind-group-layout:texture',
       entries: [
         { binding: 0, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } },
         { binding: 1, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' } },
@@ -134,15 +136,18 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     });
 
     this._pipelineLayout = this._device.createPipelineLayout({
+      label: 'nine-slice:pipeline-layout',
       bindGroupLayouts: [this._uniformBindGroupLayout, this._textureBindGroupLayout],
     });
 
     this._uniformBuffer = this._device.createBuffer({
+      label: 'nine-slice:uniform-buffer',
       size: projectionByteLength,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
 
     this._indexBuffer = this._device.createBuffer({
+      label: 'nine-slice:index-buffer',
       size: quadIndices.byteLength,
       usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
     });
@@ -325,6 +330,7 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
 
     this._transformStorageBuffer = storageBuffer;
     this._transformBindGroup = device.createBindGroup({
+      label: 'nine-slice:transform-bind-group',
       layout: this._uniformBindGroupLayout!,
       entries: [
         { binding: 0, resource: { buffer: uniformBuffer } },
@@ -339,6 +345,7 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     const binding = backend.getTextureBinding(texture);
 
     return device.createBindGroup({
+      label: 'nine-slice:texture-bind-group',
       layout: this._textureBindGroupLayout!,
       entries: [
         { binding: 0, resource: binding.view },
@@ -360,6 +367,7 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     }
 
     const descriptor: GPURenderPipelineDescriptor = {
+      label: 'nine-slice:render-pipeline',
       layout: this._pipelineLayout,
       vertex: {
         module: this._shaderModule,
@@ -424,6 +432,7 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     }
 
     const instanceBuffer = this._device.createBuffer({
+      label: 'nine-slice:instance-buffer',
       size: instanceData.byteLength,
       usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
     });

--- a/src/rendering/webgpu/WebGpuPassCoordinator.ts
+++ b/src/rendering/webgpu/WebGpuPassCoordinator.ts
@@ -138,6 +138,7 @@ export class WebGpuPassCoordinator implements RenderPassCoordinator {
     const backend = this._backend;
     const stencilEnabled = this.stencilActive;
     const descriptor: GPURenderPassDescriptor = {
+      label: 'pass-coordinator:render-pass',
       colorAttachments: [backend.createColorAttachment()],
     };
 
@@ -145,7 +146,7 @@ export class WebGpuPassCoordinator implements RenderPassCoordinator {
       descriptor.depthStencilAttachment = this._createStencilAttachment(backend.renderTarget);
     }
 
-    const encoder = backend.device.createCommandEncoder();
+    const encoder = backend.device.createCommandEncoder({ label: 'pass-coordinator:command-encoder' });
     const pass = encoder.beginRenderPass(descriptor);
 
     backend.stats.renderPasses++;

--- a/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
@@ -191,9 +191,13 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     const device = backend.device;
     this._device = device;
 
-    this._shaderModule = device.createShaderModule({ code: commonWgsl + shaderPathEntries + geoPathEntries });
+    this._shaderModule = device.createShaderModule({
+      label: 'repeating-sprite:shader',
+      code: commonWgsl + shaderPathEntries + geoPathEntries,
+    });
 
     this._uniformBindGroupLayout = device.createBindGroupLayout({
+      label: 'repeating-sprite:bind-group-layout:uniform',
       entries: [
         { binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform' } },
         { binding: 1, visibility: GPUShaderStage.VERTEX, buffer: { type: 'read-only-storage' } },
@@ -201,6 +205,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     });
 
     this._textureBindGroupLayout = device.createBindGroupLayout({
+      label: 'repeating-sprite:bind-group-layout:texture',
       entries: [
         { binding: 0, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } },
         { binding: 1, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' } },
@@ -208,11 +213,13 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     });
 
     this._uniformBuffer = device.createBuffer({
+      label: 'repeating-sprite:uniform-buffer',
       size: projectionByteLength,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
 
     this._indexBuffer = device.createBuffer({
+      label: 'repeating-sprite:index-buffer',
       size: quadIndices.byteLength,
       usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
     });
@@ -452,6 +459,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     const sampler = this._getOrCreateSampler(device, modeX, modeY);
     const texView = backend.getTextureBinding(this._currentTexture).view;
     const textureBindGroup = device.createBindGroup({
+      label: 'repeating-sprite:texture-bind-group:shader',
       layout: this._textureBindGroupLayout!,
       entries: [
         { binding: 0, resource: texView },
@@ -483,6 +491,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     // Geometry path: use backend's default (clamp) sampler.
     const binding = backend.getTextureBinding(this._currentTexture);
     const textureBindGroup = device.createBindGroup({
+      label: 'repeating-sprite:texture-bind-group:geo',
       layout: this._textureBindGroupLayout!,
       entries: [
         { binding: 0, resource: binding.view },
@@ -517,6 +526,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     if (existing) return existing;
 
     const sampler = device.createSampler({
+      label: 'repeating-sprite:sampler',
       addressModeU: repeatModeToAddressMode(modeX),
       addressModeV: repeatModeToAddressMode(modeY),
       magFilter: 'linear',
@@ -532,6 +542,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     }
     this._transformStorageBuf = storageBuf;
     this._transformBindGroup = device.createBindGroup({
+      label: 'repeating-sprite:transform-bind-group',
       layout: this._uniformBindGroupLayout!,
       entries: [
         { binding: 0, resource: { buffer: uniformBuf } },
@@ -551,6 +562,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     }
 
     const layout = this._device.createPipelineLayout({
+      label: 'repeating-sprite:pipeline-layout',
       bindGroupLayouts: [this._uniformBindGroupLayout, this._textureBindGroupLayout],
     });
 
@@ -584,6 +596,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
         ];
 
     const desc: GPURenderPipelineDescriptor = {
+      label: 'repeating-sprite:render-pipeline',
       layout,
       vertex: {
         module: this._shaderModule,
@@ -618,6 +631,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     this._shaderInstU32 = new Uint32Array(this._shaderInstData);
     this._shaderInstBuf?.destroy();
     this._shaderInstBuf = this._device.createBuffer({
+      label: 'repeating-sprite:shader-instance-buffer',
       size: this._shaderInstData.byteLength,
       usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
     });
@@ -634,6 +648,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     this._geoInstU32 = new Uint32Array(this._geoInstData);
     this._geoInstBuf?.destroy();
     this._geoInstBuf = this._device.createBuffer({
+      label: 'repeating-sprite:geo-instance-buffer',
       size: this._geoInstData.byteLength,
       usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
     });

--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -238,9 +238,10 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     }
 
     this._device = backend.device;
-    this._shaderModule = this._device.createShaderModule({ code: spriteShaderSource });
+    this._shaderModule = this._device.createShaderModule({ label: 'sprite:shader', code: spriteShaderSource });
 
     this._uniformBindGroupLayout = this._device.createBindGroupLayout({
+      label: 'sprite:bind-group-layout:uniform',
       entries: [
         {
           binding: 0,
@@ -259,6 +260,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
       ],
     });
     this._textureBindGroupLayout = this._device.createBindGroupLayout({
+      label: 'sprite:bind-group-layout:texture',
       entries: [
         ...Array.from({ length: maxBatchTextures }, (_, index) => ({
           binding: index,
@@ -277,16 +279,19 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
       ],
     });
     this._pipelineLayout = this._device.createPipelineLayout({
+      label: 'sprite:pipeline-layout',
       bindGroupLayouts: [this._uniformBindGroupLayout, this._textureBindGroupLayout],
     });
     // Single base-texture layout for the custom-material path (group 1).
     this._customBaseTextureLayout = this._device.createBindGroupLayout({
+      label: 'sprite:bind-group-layout:custom-base-texture',
       entries: [
         { binding: 0, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } },
         { binding: 1, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' } },
       ],
     });
     this._uniformBuffer = this._device.createBuffer({
+      label: 'sprite:uniform-buffer',
       size: projectionByteLength,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
@@ -297,6 +302,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     // Static index buffer for the quad. Allocated once at connect; its
     // contents never change.
     this._indexBuffer = this._device.createBuffer({
+      label: 'sprite:index-buffer',
       size: quadIndices.byteLength,
       usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
     });
@@ -539,6 +545,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
 
     this._transformStorageBuffer = storageBuffer;
     this._transformBindGroup = device.createBindGroup({
+      label: 'sprite:transform-bind-group',
       layout: this._uniformBindGroupLayout!,
       entries: [
         { binding: 0, resource: { buffer: uniformBuffer } },
@@ -677,6 +684,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     }
 
     const instanceBuffer = this._device.createBuffer({
+      label: 'sprite:instance-buffer',
       size: instanceData.byteLength,
       usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
     });
@@ -734,6 +742,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     }
 
     return device.createBindGroup({
+      label: 'sprite:texture-bind-group',
       layout: this._textureBindGroupLayout!,
       entries,
     });
@@ -764,6 +773,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     }
 
     const descriptor: GPURenderPipelineDescriptor = {
+      label: 'sprite:render-pipeline',
       layout: this._pipelineLayout,
       vertex: {
         module: this._shaderModule,
@@ -870,9 +880,10 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     // The engine owns the vertex stage: prepend the canonical sprite vertex
     // module (VertexInput/VertexOutput, group(0) projection + transform storage,
     // group(1) base texture + sampler) to the material's fragment WGSL.
-    const shaderModule = device.createShaderModule({ code: `${spriteVertexWgsl}\n${wgsl}` });
+    const shaderModule = device.createShaderModule({ label: 'sprite:material-shader', code: `${spriteVertexWgsl}\n${wgsl}` });
     const userLayout = this._buildUserBindGroupLayout(device, material);
     const pipelineLayout = device.createPipelineLayout({
+      label: 'sprite:material-pipeline-layout',
       bindGroupLayouts: [this._uniformBindGroupLayout!, this._customBaseTextureLayout!, userLayout],
     });
 
@@ -915,6 +926,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     }
 
     const descriptor: GPURenderPipelineDescriptor = {
+      label: 'sprite:material-render-pipeline',
       layout: resources.pipelineLayout,
       vertex: {
         module: resources.shaderModule,
@@ -977,6 +989,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     }
 
     const group = device.createBindGroup({
+      label: 'sprite:material-base-texture-bind-group',
       layout: this._customBaseTextureLayout!,
       entries: [
         { binding: 0, resource: binding.view },
@@ -1015,7 +1028,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
       bindingIndex++;
     }
 
-    return device.createBindGroupLayout({ entries });
+    return device.createBindGroupLayout({ label: 'sprite:material-bind-group-layout', entries });
   }
 
   private _uploadUserUniforms(material: SpriteMaterial, resources: CustomSpriteResources, device: GPUDevice): void {
@@ -1030,6 +1043,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
       resources.userUniformBuffer?.destroy();
       resources.userUniformBufferCapacity = bufferBytes;
       resources.userUniformBuffer = device.createBuffer({
+        label: 'sprite:material-user-uniform-buffer',
         size: bufferBytes,
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
       });
@@ -1079,7 +1093,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
       bindingIndex++;
     }
 
-    return device.createBindGroup({ layout: resources.userLayout, entries });
+    return device.createBindGroup({ label: 'sprite:material-user-bind-group', layout: resources.userLayout, entries });
   }
 
   private _releaseCustomResources(resources: CustomSpriteResources): void {

--- a/src/rendering/webgpu/WebGpuStencilClipper.ts
+++ b/src/rendering/webgpu/WebGpuStencilClipper.ts
@@ -74,16 +74,19 @@ export class WebGpuStencilClipper {
     }
 
     this._device = device;
-    this._shaderModule = device.createShaderModule({ code: stencilWriteShaderSource });
+    this._shaderModule = device.createShaderModule({ label: 'stencil:shader', code: stencilWriteShaderSource });
     this._bindGroupLayout = device.createBindGroupLayout({
+      label: 'stencil:bind-group-layout',
       entries: [{ binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform' } }],
     });
-    this._pipelineLayout = device.createPipelineLayout({ bindGroupLayouts: [this._bindGroupLayout] });
+    this._pipelineLayout = device.createPipelineLayout({ label: 'stencil:pipeline-layout', bindGroupLayouts: [this._bindGroupLayout] });
     this._uniformBuffer = device.createBuffer({
+      label: 'stencil:uniform-buffer',
       size: matrixByteLength,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
     this._bindGroup = device.createBindGroup({
+      label: 'stencil:bind-group',
       layout: this._bindGroupLayout,
       entries: [{ binding: 0, resource: { buffer: this._uniformBuffer } }],
     });
@@ -137,6 +140,7 @@ export class WebGpuStencilClipper {
     existing?.texture.destroy();
 
     const texture = device.createTexture({
+      label: 'stencil:texture',
       size: { width: safeWidth, height: safeHeight },
       format: stencilAttachmentFormat,
       usage: GPUTextureUsage.RENDER_ATTACHMENT,
@@ -203,6 +207,7 @@ export class WebGpuStencilClipper {
     const stencilFace: GPUStencilFaceState = { compare: 'equal', failOp: 'keep', depthFailOp: 'keep', passOp: stencilOp };
 
     const pipeline = device.createRenderPipeline({
+      label: increment ? 'stencil:increment-pipeline' : 'stencil:decrement-pipeline',
       layout: this._pipelineLayout!,
       vertex: {
         module: this._shaderModule!,
@@ -311,6 +316,7 @@ export class WebGpuStencilClipper {
       this._vertexBuffer?.destroy();
       this._vertexBufferCapacity = Math.max(requiredBytes, this._vertexBufferCapacity * 2 || 512);
       this._vertexBuffer = this._device!.createBuffer({
+        label: 'stencil:vertex-buffer',
         size: this._vertexBufferCapacity,
         usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
       });

--- a/src/rendering/webgpu/WebGpuTextRenderer.ts
+++ b/src/rendering/webgpu/WebGpuTextRenderer.ts
@@ -765,6 +765,7 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
       return this._frameBindGroup;
     }
     this._frameBindGroup = device.createBindGroup({
+      label: 'WebGpuTextRenderer/frame-bind-group',
       layout: this._frameBindGroupLayout!,
       entries: [
         { binding: 0, resource: { buffer: this._projBuffer! } },
@@ -787,6 +788,7 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     if (cached?.view === view) return cached.group;
 
     const group = device.createBindGroup({
+      label: 'WebGpuTextRenderer/texture-bind-group',
       layout: this._textureBindGroupLayout!,
       entries: [
         { binding: 0, resource: view },

--- a/src/rendering/webgpu/WebGpuTransformStorage.ts
+++ b/src/rendering/webgpu/WebGpuTransformStorage.ts
@@ -166,6 +166,7 @@ export class WebGpuTransformStorage {
 
     this._storageBuffer?.destroy();
     this._storageBuffer = device.createBuffer({
+      label: 'transform:storage-buffer',
       size: nextCapacity,
       usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
     });


### PR DESCRIPTION
Adds **124 debug `label` fields** to WebGPU object/pass creations across 11 files in `src/rendering/webgpu/**` — buffers, textures, samplers, shader modules, bind-group (layouts), pipeline (layouts), and render/compute passes.

WebGPU surfaces `label`s in validation-error messages (`"Buffer 'sprite:vertex' ..."`) and in tooling → free, high-value debugging. **Label-only change: no logic, arguments, or behavior modified** (verified line-by-line).

**Naming:** `<context>:<role>` (lowercase, static string literals — no per-frame allocation). Contexts: `sprite`, `mesh`, `text`, `nine-slice`, `repeating-sprite`, `mask`, `stencil`, `backdrop-blend`, `backend`, `pass-coordinator`, `transform`.

Note: `WebGpuTextRenderer` had pre-existing labels in a `WebGpuTextRenderer/<role>` scheme — kept as-is (not mixing two schemes in one file); a minor, low-stakes convention inconsistency that could be normalized later.