### PR TITLE
feat(core): instrument per-frame phases with User Timing API (dev-only)

### DIFF
--- a/site/src/content/api/application-status.mdx
+++ b/site/src/content/api/application-status.mdx
@@ -9,7 +9,7 @@ memberCount: 4
 tier: "stable"
 sections: ["Import", "Members", "Source"]
 sourcePath: "src/core/Application.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L39"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L40"
 ---
 ## Import
 
@@ -24,4 +24,4 @@ sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#
 
 ## Source
 
-[src/core/Application.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L39)
+[src/core/Application.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L40)

--- a/site/src/content/api/application.mdx
+++ b/site/src/content/api/application.mdx
@@ -9,7 +9,7 @@ memberCount: 48
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/core/Application.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L235"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L244"
 ---
 ## Import
 
@@ -99,4 +99,4 @@ background-active simulations.
 
 ## Source
 
-[src/core/Application.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L235)
+[src/core/Application.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/Application.ts#L244)

--- a/site/src/content/api/scene-manager.mdx
+++ b/site/src/content/api/scene-manager.mdx
@@ -9,7 +9,7 @@ memberCount: 10
 tier: "stable"
 sections: ["Import", "Constructors", "Methods", "Properties", "Events", "Source"]
 sourcePath: "src/core/SceneManager.ts"
-sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/SceneManager.ts#L71"
+sourceUrl: "https://github.com/Exoridus/ExoJS/blob/main/src/core/SceneManager.ts#L84"
 ---
 ## Import
 
@@ -49,4 +49,4 @@ while it keeps rendering).
 
 ## Source
 
-[src/core/SceneManager.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/SceneManager.ts#L71)
+[src/core/SceneManager.ts](https://github.com/Exoridus/ExoJS/blob/main/src/core/SceneManager.ts#L84)

--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -28,6 +28,7 @@ import { Color } from './Color';
 import { FixedTimestep } from './FixedTimestep';
 import { computeLetterboxLayout } from './letterbox';
 import { hello, logger } from './logging';
+import { Perf } from './Perf';
 import type { Scene } from './Scene';
 import { SceneManager } from './SceneManager';
 import { defaultSerializationRegistry, SerializationRegistry } from './serialization/SerializationRegistry';
@@ -155,6 +156,14 @@ const maxDeltaMs = 100;
 const defaultFixedStepMs = 1000 / 60;
 /** Max fixed steps run in one frame — the spiral-of-death guard. */
 const maxFixedSteps = 5;
+
+// User Timing mark/measure names for the per-frame loop (dev-only, see `update()`).
+// Constant strings so the Performance panel groups every frame's entries
+// under a stable label instead of one row per frame.
+const frameStartMark = 'exojs:frame:start';
+const frameMeasure = 'exojs:frame';
+const systemsStartMark = 'exojs:systems:start';
+const systemsMeasure = 'exojs:systems';
 
 const createDefaultCanvas = (): HTMLCanvasElement => document.createElement('canvas');
 
@@ -666,10 +675,14 @@ export class Application {
       const frameDelta = Time.temp.set(clampedDeltaMs);
       const frameStart = performance.now();
 
+      if (__DEV__) Perf.mark(frameStartMark);
+
       this.backend.resetStats();
       this.backend.stats.rawFrameDeltaMs = rawDeltaMs;
 
+      if (__DEV__) Perf.mark(systemsStartMark);
       this.systems._tick(frameDelta);
+      if (__DEV__) Perf.measure(systemsMeasure, systemsStartMark);
 
       // Fixed-timestep steps (0..N) for deterministic logic/physics, after input
       // so they see this frame's input and before the variable update/draw.
@@ -686,6 +699,15 @@ export class Application {
       this.onFrame.dispatch(frameDelta);
       this.backend.flush();
       this.backend.stats.frameTimeMs = performance.now() - frameStart;
+
+      if (__DEV__) {
+        Perf.measure(frameMeasure, frameStartMark);
+        Perf.clearMarks(frameStartMark);
+        Perf.clearMarks(systemsStartMark);
+        Perf.clearMeasures(frameMeasure);
+        Perf.clearMeasures(systemsMeasure);
+      }
+
       this._frameRequest = requestAnimationFrame(this._updateHandler);
       this._frameClock.restart();
       this._frameCount++;

--- a/src/core/SceneManager.ts
+++ b/src/core/SceneManager.ts
@@ -4,6 +4,7 @@ import type { RenderBackend } from '#rendering/RenderBackend';
 import type { Application } from './Application';
 import { Color } from './Color';
 import { logger } from './logging';
+import { Perf } from './Perf';
 import { Scene } from './Scene';
 import { Signal } from './Signal';
 import type { Time } from './Time';
@@ -56,6 +57,18 @@ const createOverlayMesh = (): TransitionOverlayMesh =>
   });
 
 const defaultFadeTransitionDuration = 220;
+
+// User Timing mark/measure names for the scene sub-phases of `update()`
+// (dev-only). Constant strings so the Performance panel groups every frame's
+// entries under a stable label instead of one row per frame.
+const sceneUpdateStartMark = 'exojs:scene-update:start';
+const sceneUpdateMeasure = 'exojs:scene-update';
+const sceneTickStartMark = 'exojs:scene-tick:start';
+const sceneTickMeasure = 'exojs:scene-tick';
+const drawStartMark = 'exojs:draw:start';
+const drawMeasure = 'exojs:draw';
+const uiStartMark = 'exojs:ui:start';
+const uiMeasure = 'exojs:ui';
 
 /**
  * Single-active-scene controller owned by {@link Application}. Holds at most one
@@ -146,8 +159,10 @@ export class SceneManager {
 
     if (scene !== null) {
       if (!scene.paused) {
+        if (__DEV__) Perf.mark(sceneUpdateStartMark);
         // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
         const updateResult = scene.update(delta);
+        if (__DEV__) Perf.measure(sceneUpdateMeasure, sceneUpdateStartMark);
 
         if (!this._asyncUpdateWarned.has(scene) && (updateResult as unknown) instanceof Promise) {
           this._asyncUpdateWarned.add(scene);
@@ -158,11 +173,15 @@ export class SceneManager {
         }
 
         // Tick the scene's systems (e.g. a physics world) after its update().
+        if (__DEV__) Perf.mark(sceneTickStartMark);
         scene._tickSystems(delta);
+        if (__DEV__) Perf.measure(sceneTickMeasure, sceneTickStartMark);
       }
 
+      if (__DEV__) Perf.mark(drawStartMark);
       // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
       const drawResult = scene.draw(this._app.rendering);
+      if (__DEV__) Perf.measure(drawMeasure, drawStartMark);
 
       if (!this._asyncDrawWarned.has(scene) && (drawResult as unknown) instanceof Promise) {
         this._asyncDrawWarned.add(scene);
@@ -172,7 +191,9 @@ export class SceneManager {
       }
 
       // Auto-render the scene's screen-fixed UI layer above its content.
+      if (__DEV__) Perf.mark(uiStartMark);
       scene._peekUI()?._render(this._app.rendering);
+      if (__DEV__) Perf.measure(uiMeasure, uiStartMark);
     }
 
     const transitionAlpha = this._getTransitionAlpha();
@@ -183,6 +204,17 @@ export class SceneManager {
 
     if (scene !== null) {
       this.onUpdateScene.dispatch(scene);
+    }
+
+    if (__DEV__) {
+      Perf.clearMarks(sceneUpdateStartMark);
+      Perf.clearMarks(sceneTickStartMark);
+      Perf.clearMarks(drawStartMark);
+      Perf.clearMarks(uiStartMark);
+      Perf.clearMeasures(sceneUpdateMeasure);
+      Perf.clearMeasures(sceneTickMeasure);
+      Perf.clearMeasures(drawMeasure);
+      Perf.clearMeasures(uiMeasure);
     }
 
     return this;


### PR DESCRIPTION
Adds User Timing (`performance.mark`/`measure` via the `Perf` helper) around the per-frame lifecycle phases, **`__DEV__`-gated** (fully stripped in production), so the phases annotate Chrome's Performance panel (Timings track / flame chart) when a dev records a profile.

**Phases:** `exojs:frame`, `exojs:systems` (Application loop), `exojs:scene-update`, `exojs:scene-tick`, `exojs:draw`, `exojs:ui` (SceneManager).

Constant mark/measure names (no per-frame allocation); the Performance buffer is cleared each frame to bound retained size while still letting an active recording capture every measure. The existing unconditional `performance.now()` frame-stat timing (`backend.stats.frameTimeMs`) is untouched. No behavior change, no overlay/console output.