### PR TITLE
feat(build): shared .worklet.ts build plugin + BitCrusher POC (worklet Phase 1)

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1024,6 +1024,40 @@ export default defineConfig([
     },
   },
 
+  // The bit-crusher worklet source (Phase 1 proof-of-concept for the
+  // `.worklet.ts` → `?worklet` build plugin) runs inside AudioWorkletGlobalScope
+  // — no DOM, no module imports at runtime — and typechecks separately against
+  // packages/exojs-audio-fx/tsconfig.worklets.json (see worklet-globals.d.ts),
+  // not the package's main (DOM-lib) program covered by `projectService`
+  // above. Disable type-aware linting here (matching the test/example
+  // precedent elsewhere in this file) and supply just the AudioWorklet-
+  // specific globals so `no-undef` doesn't false-positive; DOM globals are
+  // explicitly banned via `no-restricted-globals` as a lint-level backstop.
+  {
+    files: ['packages/exojs-audio-fx/src/worklets/bit-crusher.worklet.ts'],
+    ...tseslint.configs.disableTypeChecked,
+  },
+  {
+    files: ['packages/exojs-audio-fx/src/worklets/bit-crusher.worklet.ts'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      parserOptions: { projectService: false, project: null },
+      globals: {
+        ...globals.es2024,
+        AudioWorkletProcessor: 'readonly',
+        AudioParamDescriptor: 'readonly',
+        registerProcessor: 'readonly',
+        sampleRate: 'readonly',
+        currentTime: 'readonly',
+        currentFrame: 'readonly',
+      },
+    },
+    rules: {
+      'no-restricted-globals': ['error', 'window', 'document', 'navigator', 'fetch', 'localStorage', 'sessionStorage', 'alert', 'confirm', 'prompt'],
+    },
+  },
+
   // Physics indexes flat vertex/normal buffers (`number[]`) at provably in-bounds
   // positions; those reads use `arr[i]!` — the same convention core's hot math
   // paths use. Allow the non-null assertion here (packages discourage it by

--- a/packages/exojs-audio-fx/package.json
+++ b/packages/exojs-audio-fx/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "build": "tsx ../../node_modules/rollup/dist/bin/rollup -c --environment EXOJS_ENV:production",
     "build:dev": "tsx ../../node_modules/rollup/dist/bin/rollup -c --environment EXOJS_ENV:development",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.worklets.json",
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "vitest run --root ../.. --project=exojs-audio-fx"
   },

--- a/packages/exojs-audio-fx/src/effects/BitCrusherEffect.ts
+++ b/packages/exojs-audio-fx/src/effects/BitCrusherEffect.ts
@@ -1,6 +1,6 @@
 import { WorkletEffect } from '@codexo/exojs';
 
-import { bitCrusherWorkletSource } from '../worklets/bit-crusher.worklet';
+import bitCrusherWorkletSource from '../worklets/bit-crusher.worklet.ts?worklet';
 
 export interface BitCrusherEffectOptions {
   /**

--- a/packages/exojs-audio-fx/src/typings.d.ts
+++ b/packages/exojs-audio-fx/src/typings.d.ts
@@ -1,0 +1,12 @@
+// Package-local duplicate of the `?worklet` ambient module declaration in the
+// root `../../src/typings.d.ts` (mirrors how `packages/exojs-particles/src/typings.d.ts`
+// duplicates the `.vert`/`.frag` declarations). `tsc` itself resolves the root
+// copy fine via this package's tsconfig `include`, but `@rollup/plugin-typescript`
+// glob-scans for ambient declarations independently of that `include` list and
+// only finds files inside this package's own `src/` tree — without this local
+// copy, its (non-fatal, but noisy) diagnostics pass reports a spurious
+// `TS2307: Cannot find module` for the `?worklet` import in BitCrusherEffect.ts.
+declare module '*?worklet' {
+  const content: string;
+  export default content;
+}

--- a/packages/exojs-audio-fx/src/worklets/bit-crusher.worklet.ts
+++ b/packages/exojs-audio-fx/src/worklets/bit-crusher.worklet.ts
@@ -1,42 +1,56 @@
-export const bitCrusherWorkletSource = `
+// BitCrusher AudioWorkletProcessor — lo-fi bit-depth + sample-rate reduction.
+//
+// This is the Phase-1 proof-of-concept for the `.worklet.ts` → `?worklet`
+// build plugin (see `@codexo/exojs-config/worklet-plugin`): real, typed
+// TypeScript instead of a template-string constant. It typechecks against the
+// AudioWorkletGlobalScope (see `worklet-globals.d.ts` + `../../tsconfig.worklets.json`),
+// NOT the DOM — this file must stay self-contained (no imports at runtime):
+// `registerAudioWorkletProcessor` (`#audio/worklet/registerWorklet`) loads the
+// build-inlined source via a Blob URL passed to `audioWorklet.addModule()`.
+//
+// Consumed via `import bitCrusherWorkletSource from './bit-crusher.worklet.ts?worklet'`
+// (see `../effects/BitCrusherEffect.ts`) — the `?worklet` query is what routes
+// this file through the transpile-to-string plugin instead of normal
+// TypeScript module resolution.
 class BitCrusherProcessor extends AudioWorkletProcessor {
-    static get parameterDescriptors() {
-        return [
-            { name: 'bits',     defaultValue: 8,   minValue: 1,   maxValue: 16,  automationRate: 'k-rate' },
-            { name: 'normFreq', defaultValue: 0.5, minValue: 0,   maxValue: 1,   automationRate: 'k-rate' },
-        ];
+  public static get parameterDescriptors(): AudioParamDescriptor[] {
+    return [
+      { name: 'bits', defaultValue: 8, minValue: 1, maxValue: 16, automationRate: 'k-rate' },
+      { name: 'normFreq', defaultValue: 0.5, minValue: 0, maxValue: 1, automationRate: 'k-rate' },
+    ];
+  }
+
+  // Phase accumulator for sample-and-hold; `_held` keeps the last latched value.
+  private _phase = 0;
+  private _held = 0;
+
+  public override process(inputs: Float32Array[][], outputs: Float32Array[][], parameters: Record<string, Float32Array>): boolean {
+    const input = inputs[0]?.[0];
+    const output = outputs[0]?.[0];
+    if (!input || !output) return true;
+
+    const bitsParam = parameters['bits']?.[0] ?? 8;
+    const normFreqParam = parameters['normFreq']?.[0] ?? 0.5;
+    const bits = Math.round(Math.max(1, Math.min(16, bitsParam)));
+    const normFreq = Math.max(0, Math.min(1, normFreqParam));
+    // Quantization step: 2 / 2^bits (maps [-1, 1] onto 2^bits levels).
+    const step = 2 / Math.pow(2, bits);
+
+    for (let i = 0; i < input.length; i++) {
+      // Advance the sample-and-hold phase accumulator.
+      this._phase += normFreq;
+      if (this._phase >= 1) {
+        // Wrap phase and latch a fresh, quantized sample.
+        this._phase -= 1;
+        this._held = step * Math.round(input[i]! / step);
+      }
+      // Emit the held (quantized) sample — pure wet, no dry mixing here.
+      output[i] = this._held;
     }
-
-    constructor() {
-        super();
-        // Phase accumulator for sample-and-hold; held keeps the last latched value.
-        this._phase = 0;
-        this._held  = 0;
-    }
-
-    process(inputs, outputs, parameters) {
-        const input  = inputs[0]?.[0];
-        const output = outputs[0]?.[0];
-        if (!input || !output) return true;
-
-        const bits     = Math.round(Math.max(1, Math.min(16, parameters.bits[0])));
-        const normFreq = Math.max(0, Math.min(1, parameters.normFreq[0]));
-        // Quantization step: 2 / 2^bits  (maps [-1, 1] onto 2^bits levels)
-        const step = 2 / Math.pow(2, bits);
-
-        for (let i = 0; i < input.length; i++) {
-            // Advance the sample-and-hold phase accumulator.
-            this._phase += normFreq;
-            if (this._phase >= 1) {
-                // Wrap phase and latch a fresh, quantized sample.
-                this._phase -= 1;
-                this._held = step * Math.round(input[i] / step);
-            }
-            // Emit the held (quantized) sample — pure wet, no dry mixing here.
-            output[i] = this._held;
-        }
-        return true;
-    }
+    return true;
+  }
 }
+
 registerProcessor('exojs-bit-crusher', BitCrusherProcessor);
-`;
+
+export {};

--- a/packages/exojs-audio-fx/src/worklets/worklet-globals.d.ts
+++ b/packages/exojs-audio-fx/src/worklets/worklet-globals.d.ts
@@ -1,0 +1,40 @@
+// Ambient globals for the AudioWorkletGlobalScope. Deliberately hand-rolled and
+// self-contained rather than pulled from `lib.dom`/`lib.webworker` — neither
+// TypeScript lib declares `AudioWorkletProcessor` as a constructible value or
+// `registerProcessor`/`sampleRate`/`currentTime`/`currentFrame` as globals (they
+// only appear in `lib.dom` as JSDoc references on unrelated interfaces), and
+// `dom`/`webworker` cannot be combined in one `lib` array anyway (duplicate
+// globals). Included exclusively by `../../tsconfig.worklets.json`, which
+// typechecks converted `*.worklet.ts` files against just this scope — no DOM —
+// so accidental `window`/`document`/etc. usage is a compile error, not a
+// runtime surprise inside the real AudioWorkletGlobalScope.
+
+interface AudioWorkletProcessorPort {
+  postMessage(message: unknown): void;
+  onmessage: ((event: { data: unknown }) => void) | null;
+}
+
+interface AudioParamDescriptor {
+  name: string;
+  automationRate?: 'a-rate' | 'k-rate';
+  minValue?: number;
+  maxValue?: number;
+  defaultValue?: number;
+}
+
+declare class AudioWorkletProcessor {
+  public constructor(options?: unknown);
+  public readonly port: AudioWorkletProcessorPort;
+  public process(inputs: Float32Array[][], outputs: Float32Array[][], parameters: Record<string, Float32Array>): boolean;
+}
+
+declare function registerProcessor(
+  name: string,
+  processorCtor: (new (options?: unknown) => AudioWorkletProcessor) & {
+    parameterDescriptors?: AudioParamDescriptor[];
+  },
+): void;
+
+declare const sampleRate: number;
+declare const currentTime: number;
+declare const currentFrame: number;

--- a/packages/exojs-audio-fx/test/browser/bit-crusher.audio.test.ts
+++ b/packages/exojs-audio-fx/test/browser/bit-crusher.audio.test.ts
@@ -10,7 +10,7 @@
  *     changes, so the output is a constant-zero buffer.
  */
 
-import { bitCrusherWorkletSource } from '../../src/worklets/bit-crusher.worklet';
+import bitCrusherWorkletSource from '../../src/worklets/bit-crusher.worklet.ts?worklet';
 import { renderWorklet, rms, tail } from './_audio-harness';
 
 describe('BitCrusher worklet — real Web Audio', () => {

--- a/packages/exojs-audio-fx/test/worklets/bit-crusher-processor.test.ts
+++ b/packages/exojs-audio-fx/test/worklets/bit-crusher-processor.test.ts
@@ -12,7 +12,7 @@
  *  - bits=16 is nearly transparent (max quantization error ≤ step/2).
  */
 
-import { bitCrusherWorkletSource } from '../../src/worklets/bit-crusher.worklet';
+import bitCrusherWorkletSource from '../../src/worklets/bit-crusher.worklet.ts?worklet';
 
 // ─── Worklet bootstrap ────────────────────────────────────────────────────────
 

--- a/packages/exojs-audio-fx/tsconfig.json
+++ b/packages/exojs-audio-fx/tsconfig.json
@@ -10,5 +10,13 @@
     }
   },
   "include": ["src/**/*", "src/typings.d.ts", "../../src/typings.d.ts"],
-  "exclude": ["dist", "node_modules", "test"]
+  // `bit-crusher.worklet.ts` typechecks against the AudioWorkletGlobalScope
+  // (no DOM), via the dedicated tsconfig.worklets.json, instead of this
+  // package's main DOM-lib program. It has no importers here — consumers
+  // reach it exclusively through the `?worklet` query, which resolves to the
+  // ambient `*?worklet` module declaration (src/typings.d.ts) rather than
+  // this file — so excluding it from `include` fully removes it from this
+  // program. The other (not yet converted) `*.worklet.ts` files are untouched
+  // and remain part of this program via their direct named-export imports.
+  "exclude": ["dist", "node_modules", "test", "src/worklets/bit-crusher.worklet.ts"]
 }

--- a/packages/exojs-audio-fx/tsconfig.worklets.json
+++ b/packages/exojs-audio-fx/tsconfig.worklets.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "_comment": "Typechecks *.worklet.ts source against the AudioWorkletGlobalScope, not the package's main (DOM-lib) program: `lib` drops `dom`/`dom.iterable` entirely and relies on the hand-rolled ambient globals in src/worklets/worklet-globals.d.ts. These files are excluded from tsconfig.json's `include` (see its comment) and typechecked here instead; `pnpm typecheck` runs both.",
+  "extends": "@codexo/exojs-config/typescript/base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "types": [],
+    "noEmit": true,
+    "rootDir": "src/worklets"
+  },
+  "include": ["src/worklets/bit-crusher.worklet.ts", "src/worklets/worklet-globals.d.ts"]
+}

--- a/packages/exojs-config/package.json
+++ b/packages/exojs-config/package.json
@@ -9,6 +9,7 @@
     "./prettier": "./prettier/index.js",
     "./vitest": "./vitest/index.js",
     "./rollup": "./rollup/index.js",
+    "./worklet-plugin": "./worklet-plugin.js",
     "./build-defines": "./build-defines/index.js",
     "./package-policy": "./package-policy/index.js",
     "./typescript/base.json": "./typescript/base.json",
@@ -20,6 +21,7 @@
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-replace": "^6.0.3",
     "@rollup/plugin-typescript": "^12.3.0",
+    "esbuild": "^0.25.0",
     "rollup-plugin-string": "^3.0.0"
   },
   "license": "MIT"

--- a/packages/exojs-config/rollup/index.js
+++ b/packages/exojs-config/rollup/index.js
@@ -7,6 +7,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import { createBuildDefinesFromRepo } from '../build-defines/index.js';
+import { createWorkletPlugin } from '../worklet-plugin.js';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import typescript from '@rollup/plugin-typescript';
@@ -60,6 +61,10 @@ export function createExtensionConfig(opts) {
       // skipped when the package has no internal `#` imports.
       ...(sourceCondition ? [nodeResolve({ exportConditions: [sourceCondition, 'browser', 'module', 'import', 'default'], extensions: ['.ts', '.js'] })] : []),
       string({ include: ['**/*.vert', '**/*.frag'] }),
+      // Real, typed AudioWorklet sources imported via `?worklet` (see
+      // `../worklet-plugin.js`); untouched worklets keep exporting a plain
+      // template-string constant and are unaffected.
+      createWorkletPlugin(),
       typescript({
         compilerOptions: {
           incremental: false,

--- a/packages/exojs-config/vitest/index.js
+++ b/packages/exojs-config/vitest/index.js
@@ -1,8 +1,9 @@
 // Shared Vitest building blocks for the ExoJS monorepo. The browser (WebGL2/
 // WebGPU) projects stay repository-local because they need repo path knowledge
 // and the playwright provider; this module centralizes the parts every project
-// shares: the package source conditions, the shader-stub plugin, and a jsdom
-// unit-test project factory.
+// shares: the package source conditions, the shader-stub plugin, the AudioWorklet
+// `?worklet` transform plugin, and a jsdom unit-test project factory.
+import { createWorkletPlugin } from '../worklet-plugin.js';
 
 /**
  * Conditions that activate each package's package-private `@codexo/…-source`
@@ -22,6 +23,18 @@ export const shaderStubPlugin = {
 };
 
 /**
+ * Transpiles `*.worklet.ts?worklet` imports to a real, functioning JS string
+ * (mirroring the production Rollup build — see `../rollup/index.js`) instead
+ * of stubbing them: unlike GLSL, worklet source is actually executed by tests
+ * (DSP-level `eval()` harnesses and the real-Web-Audio browser suite), so a
+ * stub would defeat the point. Shared across every jsdom test project via
+ * `createJsdomTestProject` below, and wired directly into the repo-root
+ * browser projects (`vitest.config.ts`) since those are not built from this
+ * factory.
+ */
+export const workletTransformPlugin = createWorkletPlugin();
+
+/**
  * A jsdom unit/integration test project. Used for Core and each extension.
  * @param {{ name: string, include: string[], exclude?: string[], setupFiles?: string[], alias?: unknown }} opts
  */
@@ -30,7 +43,7 @@ export function createJsdomTestProject(opts) {
   return {
     resolve: { alias, conditions: srcConditions },
     ssr: { resolve: { conditions: srcConditions } },
-    plugins: [shaderStubPlugin],
+    plugins: [shaderStubPlugin, workletTransformPlugin],
     define: { __DEV__: JSON.stringify(true), __VERSION__: JSON.stringify('0.0.0'), __REVISION__: JSON.stringify('test') },
     test: {
       name,

--- a/packages/exojs-config/worklet-plugin.js
+++ b/packages/exojs-config/worklet-plugin.js
@@ -1,0 +1,72 @@
+// Shared Rollup/Vite plugin that turns a real, typed `*.worklet.ts` module
+// into an inlined JS-string import — the AudioWorklet analogue of the GLSL
+// `*.vert`/`*.frag` → string mechanism (see `rollup/index.js`'s `string({
+// include: ['**/*.vert', '**/*.frag'] })` and `vitest/index.js`'s
+// `shaderStubPlugin`). GLSL sources are already plain text, so that mechanism
+// only needs to inline raw file contents; AudioWorklet code is authored as
+// TypeScript, so this plugin additionally transpiles it (via esbuild) before
+// inlining.
+//
+// Adoption is incremental and opt-in via an explicit `?worklet` import query
+// — e.g. `import src from './x.worklet.ts?worklet'` — rather than by matching
+// the `.worklet.ts` filename itself. Worklet files that are not yet converted
+// keep exporting a plain template-string constant and are imported without
+// the query, so they never reach this plugin and are completely unaffected
+// by its presence.
+//
+// AudioWorklet code runs in its own global scope (no bundler, no runtime
+// imports — `registerAudioWorkletProcessor` loads it via a Blob URL passed to
+// `audioWorklet.addModule()`), so the source must be self-contained. Transpiling
+// with esbuild's `iife` format guarantees the emitted string contains no
+// `import`/`export` tokens, which keeps it valid in BOTH runtime shapes the
+// codebase evaluates worklet source in: as a real ES module (`addModule()`
+// always parses worklet scripts as modules) and as a plain script (the
+// DSP-level unit tests `eval()` the source directly outside any module context,
+// where `import`/`export` syntax would throw a SyntaxError).
+//
+// Implemented with only the two hooks (`resolveId`, `load`) that Rollup and
+// Vite/Vitest plugins share identically, so one implementation serves all
+// three build/test contexts: the production Rollup build (via
+// `createExtensionConfig` in `rollup/index.js`), and Vitest — both the shared
+// jsdom project factory (`createJsdomTestProject`) and the repo-root browser
+// projects, which wire it in directly since they are not built from that
+// factory.
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+import { transformSync } from 'esbuild';
+
+const WORKLET_QUERY = '?worklet';
+
+/**
+ * @returns {import('rollup').Plugin}
+ */
+export function createWorkletPlugin() {
+  return {
+    name: 'exojs-worklet-transform',
+    // Vite-only: makes sure this plugin's `resolveId`/`load` run before Vite's
+    // core resolver/esbuild-TS pipeline would otherwise try to handle the
+    // `.ts` id itself. Rollup ignores unknown plugin properties, so this is
+    // harmless there.
+    enforce: 'pre',
+    resolveId(source, importer) {
+      if (!source.endsWith(WORKLET_QUERY)) return null;
+      const target = source.slice(0, -WORKLET_QUERY.length);
+      const importerPath = importer ? importer.split('?')[0] : undefined;
+      const resolved = importerPath ? resolve(dirname(importerPath), target) : resolve(target);
+      return `${resolved}${WORKLET_QUERY}`;
+    },
+    load(id) {
+      if (!id.endsWith(WORKLET_QUERY)) return null;
+      const filePath = id.slice(0, -WORKLET_QUERY.length);
+      const source = readFileSync(filePath, 'utf8');
+      const { code } = transformSync(source, {
+        loader: 'ts',
+        format: 'iife',
+        target: 'es2022',
+        sourcefile: filePath,
+      });
+      return `export default ${JSON.stringify(code)};`;
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       '@rollup/plugin-typescript':
         specifier: ^12.3.0
         version: 12.3.0(rollup@4.62.2)(tslib@2.8.1)(typescript@6.0.3)
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
       rollup-plugin-string:
         specifier: ^3.0.0
         version: 3.0.0

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -8,6 +8,16 @@ declare module '*.frag' {
   export default content;
 }
 
+// A real, typed AudioWorklet module (`*.worklet.ts`) transpiled and inlined as
+// a JS string — the AudioWorklet analogue of the two shader declarations
+// above. Matches the `?worklet` import query (not the `.worklet.ts` filename)
+// so unconverted worklets, still imported without the query, are unaffected.
+// See `@codexo/exojs-config/worklet-plugin` for the build/test-side mechanism.
+declare module '*?worklet' {
+  const content: string;
+  export default content;
+}
+
 declare const __DEV__: boolean;
 declare const __VERSION__: string;
 declare const __REVISION__: string;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url';
 
-import { createJsdomTestProject, shaderStubPlugin, srcConditions } from '@codexo/exojs-config/vitest';
+import { createJsdomTestProject, shaderStubPlugin, srcConditions, workletTransformPlugin } from '@codexo/exojs-config/vitest';
 import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vitest/config';
 
@@ -39,7 +39,10 @@ const aliasConfig = [
 const browserBase = {
   resolve: { alias: aliasConfig, conditions: srcConditions },
   ssr: { resolve: { conditions: srcConditions } },
-  plugins: [shaderStubPlugin],
+  // `workletTransformPlugin` is the real (non-stub) transform — the browser-
+  // audio-chromium project below renders converted worklets through a genuine
+  // AudioContext, so it needs functioning DSP, not an empty string.
+  plugins: [shaderStubPlugin, workletTransformPlugin],
   define: { __DEV__: JSON.stringify(true), __VERSION__: JSON.stringify('0.0.0'), __REVISION__: JSON.stringify('test') },
 } as const;
 


### PR DESCRIPTION
Phase 1 of the `.worklet.ts` → typed-TS build plugin. **Phase 2** = convert the remaining 4 worklets incl. the beat-detector flagship (carefully, against its golden baseline).

Adds a **shared, core-level** build plugin so ANY package can author AudioWorklet code as real, typed `.ts` (imported via a `?worklet` query) instead of an inline template string — the AudioWorklet analogue of the GLSL `.vert`/`.frag` → string mechanism.

**Shared infra (reusable by every package):**
- `@codexo/exojs-config/worklet-plugin.js` — esbuild-transpiles `*.ts?worklet` → inlined JS string (`format: 'iife'`, so valid for both `AudioWorklet.addModule()` and the DSP unit tests' `eval()`). Only `resolveId`+`load`, so one impl serves Rollup + Vitest.
- Wired into the shared Rollup config, the shared Vitest jsdom factory, and the root browser Vitest projects.
- `declare module '*?worklet'` in the shared root `src/typings.d.ts` — every package's tsconfig picks it up (verified with a throwaway import in `exojs-particles`, a non-audio-fx package).

**Incremental & opt-in:** the plugin matches the `?worklet` *query*, not the `.worklet.ts` filename — the other 4 worklets keep their string-const form, completely untouched.

**POC:** `bit-crusher.worklet.ts` converted to a typed `AudioWorkletProcessor` class, typechecked against a dedicated `tsconfig.worklets.json` (AudioWorklet globals, no DOM) + worklet-scoped eslint. Behavior verified identical (unit + real-Chromium AudioContext tests).

Verify: typecheck (×all), lint (0 errors), format, `pnpm build` + audio-fx build (dist spot-checked for the inlined IIFE), full test (4473), `browser-audio-chromium` (19/19), docs:api:check in sync.