### PR TITLE
test(webgpu): drop availability skips so a missing adapter fails the CI lane

### DIFF
--- a/test/rendering/browser/webgpu-backdrop-blend.test.ts
+++ b/test/rendering/browser/webgpu-backdrop-blend.test.ts
@@ -22,8 +22,9 @@
  * lavapipe) adapters CI runs on, which would make this spike pass without
  * proving anything.
  *
- * All tests skip gracefully when WebGPU is unavailable or the software adapter
- * drops the device mid-test.
+ * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
+ * against Mesa lavapipe); tests only skip when the software adapter drops the
+ * device mid-test.
  *
  * Run via:  pnpm test:browser:webgpu
  */
@@ -38,7 +39,6 @@ import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { ADVANCED_BLEND_MODES, expectedOpaqueBlend } from './_blendReference';
 import { wireCoreRenderers } from './_coreRenderers';
-import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
 
 type RgbaTuple = readonly [number, number, number, number];
 
@@ -62,17 +62,7 @@ const makeApp = (canvas: HTMLCanvasElement): Application =>
     },
   }) as unknown as Application;
 
-const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<WebGpuBackend> => {
-  if (!navigator.gpu) {
-    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-
-  if (!adapter) {
-    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-  }
-
+const setupBackend = async (): Promise<WebGpuBackend> => {
   const canvas = document.createElement('canvas');
 
   canvas.width = canvasSize;
@@ -184,11 +174,7 @@ const composeBackdropBlend = (backend: WebGpuBackend, source: DataTexture, mode:
 
 describe('WebGPU backdrop-aware blend (Darken spike)', () => {
   test('transparent source region shows the backdrop; covered region is min(backdrop, source)', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!getBackendDeviceOrSkip(ctx, backend)) {
-      return;
-    }
+    const backend = await setupBackend();
 
     // Source: opaque red (texel 0, left half) then transparent (texel 1, right).
     const source = new DataTexture({
@@ -211,6 +197,7 @@ describe('WebGPU backdrop-aware blend (Darken spike)', () => {
       expectRgbNear(readPixel(48, 32), [60, 120, 200]);
     } catch (error) {
       if (isDeviceLoss(error)) {
+        // eslint-disable-next-line vitest/no-disabled-tests -- intentional runtime guard: the software WebGPU adapter can drop the device mid-test
         ctx.skip('WebGPU device lost mid-test — unstable software adapter');
 
         return;
@@ -224,11 +211,7 @@ describe('WebGPU backdrop-aware blend (Darken spike)', () => {
   });
 
   test('backdrop is captured and composited unflipped (vertical split survives)', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!getBackendDeviceOrSkip(ctx, backend)) {
-      return;
-    }
+    const backend = await setupBackend();
 
     // Backdrop: red top row, blue bottom row (top-left origin → top of canvas).
     const backdrop = new DataTexture({
@@ -259,6 +242,7 @@ describe('WebGPU backdrop-aware blend (Darken spike)', () => {
       expectRgbNear(readPixel(32, 56), [40, 40, 200]); // bottom
     } catch (error) {
       if (isDeviceLoss(error)) {
+        // eslint-disable-next-line vitest/no-disabled-tests -- intentional runtime guard: the software WebGPU adapter can drop the device mid-test
         ctx.skip('WebGPU device lost mid-test — unstable software adapter');
 
         return;
@@ -273,11 +257,7 @@ describe('WebGPU backdrop-aware blend (Darken spike)', () => {
   });
 
   test('every advanced blend mode matches the W3C reference (opaque over opaque)', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!getBackendDeviceOrSkip(ctx, backend)) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const backdropColor: [number, number, number] = [180, 110, 60];
     const sourceColor: [number, number, number] = [90, 200, 150];
@@ -307,6 +287,7 @@ describe('WebGPU backdrop-aware blend (Darken spike)', () => {
       }
     } catch (error) {
       if (isDeviceLoss(error)) {
+        // eslint-disable-next-line vitest/no-disabled-tests -- intentional runtime guard: the software WebGPU adapter can drop the device mid-test
         ctx.skip('WebGPU device lost mid-test — unstable software adapter');
 
         return;

--- a/test/rendering/browser/webgpu-custom-mesh-material.test.ts
+++ b/test/rendering/browser/webgpu-custom-mesh-material.test.ts
@@ -1,8 +1,8 @@
 /**
  * WebGPU custom-MeshMaterial browser test — opt-in, capability-aware.
  *
- * Skips gracefully when WebGPU is unavailable (navigator.gpu absent or no
- * adapter), matching webgpu-smoke.test.ts. When WebGPU IS available it drives a
+ * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
+ * against Mesa lavapipe), so this test drives a
  * custom {@link MeshMaterial} (user uniform + user texture) through the real
  * {@link WebGpuMeshRenderer} and asserts the migrated WGSL custom path (group
  * 0 mesh-uniforms, group 1 mesh texture, group 2 user UBO + texture) issues a
@@ -22,7 +22,7 @@ import { Texture } from '#rendering/texture/Texture';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { wireCoreRenderers } from './_coreRenderers';
-import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+import { getBackendDevice } from './webgpu-test-helpers';
 
 // Custom WGSL honouring the mesh contract: group(0) auto-bound mesh uniforms,
 // group(1) the mesh's own texture+sampler, group(2) the user UBO followed by
@@ -147,16 +147,6 @@ const createQuadGeometry = (size: number): Geometry => {
 
 describe('custom MeshMaterial WebGPU browser', () => {
   test('issues a custom-material draw with user uniform + texture and no validation error', async ctx => {
-    if (!navigator.gpu) {
-      ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-    }
-
-    const adapter = await navigator.gpu.requestAdapter();
-
-    if (!adapter) {
-      ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-    }
-
     const canvas = document.createElement('canvas');
     canvas.width = 64;
     canvas.height = 64;
@@ -166,13 +156,7 @@ describe('custom MeshMaterial WebGPU browser', () => {
     await backend.initialize();
     wireCoreRenderers(backend);
 
-    const device = getBackendDeviceOrSkip(ctx, backend);
-
-    if (!device) {
-      backend.destroy();
-
-      return;
-    }
+    const device = getBackendDevice(backend);
 
     const pattern = createPatternTexture();
     const material = new MeshMaterial({
@@ -203,6 +187,7 @@ describe('custom MeshMaterial WebGPU browser', () => {
         material.destroy();
         pattern.destroy();
         backend.destroy();
+        // eslint-disable-next-line vitest/no-disabled-tests -- intentional runtime guard: the software WebGPU adapter can drop the device mid-test
         ctx.skip('WebGPU device lost mid-test — unstable software adapter');
 
         return;
@@ -222,17 +207,7 @@ describe('custom MeshMaterial WebGPU browser', () => {
     }
   });
 
-  test('batches compatible static-geometry mesh draws with default material', async ctx => {
-    if (!navigator.gpu) {
-      ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-    }
-
-    const adapter = await navigator.gpu.requestAdapter();
-
-    if (!adapter) {
-      ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-    }
-
+  test('batches compatible static-geometry mesh draws with default material', async () => {
     const canvas = document.createElement('canvas');
     canvas.width = 64;
     canvas.height = 64;
@@ -266,17 +241,7 @@ describe('custom MeshMaterial WebGPU browser', () => {
     }
   });
 
-  test('does not batch default static-geometry meshes across different groupIndex values', async ctx => {
-    if (!navigator.gpu) {
-      ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-    }
-
-    const adapter = await navigator.gpu.requestAdapter();
-
-    if (!adapter) {
-      ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-    }
-
+  test('does not batch default static-geometry meshes across different groupIndex values', async () => {
     const canvas = document.createElement('canvas');
     canvas.width = 64;
     canvas.height = 64;

--- a/test/rendering/browser/webgpu-custom-sprite-material.test.ts
+++ b/test/rendering/browser/webgpu-custom-sprite-material.test.ts
@@ -1,8 +1,8 @@
 /**
  * WebGPU custom-SpriteMaterial browser test — opt-in, capability-aware.
  *
- * Skips gracefully when WebGPU is unavailable (navigator.gpu absent or no
- * adapter), matching webgpu-smoke.test.ts. When WebGPU IS available it drives a
+ * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
+ * against Mesa lavapipe), so this test drives a
  * custom {@link SpriteMaterial} (user uniform) through the real
  * {@link WebGpuSpriteRenderer} and asserts the custom path (group 0 projection +
  * shared transform storage, group 1 base texture, group 2 user UBO) issues an
@@ -22,7 +22,7 @@ import { Texture } from '#rendering/texture/Texture';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { wireCoreRenderers } from './_coreRenderers';
-import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+import { getBackendDevice } from './webgpu-test-helpers';
 
 // Fragment-only WGSL: the engine prepends the canonical sprite vertex module
 // (spriteVertexWgsl), which declares VertexOutput, the group(0) projection, and
@@ -74,16 +74,6 @@ const createMaterial = (): SpriteMaterial =>
 
 describe('custom SpriteMaterial WebGPU browser', () => {
   test('issues an instanced custom-material draw with a user uniform and no validation error', async ctx => {
-    if (!navigator.gpu) {
-      ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-    }
-
-    const adapter = await navigator.gpu.requestAdapter();
-
-    if (!adapter) {
-      ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-    }
-
     const canvas = document.createElement('canvas');
     canvas.width = 64;
     canvas.height = 64;
@@ -93,13 +83,7 @@ describe('custom SpriteMaterial WebGPU browser', () => {
     await backend.initialize();
     wireCoreRenderers(backend);
 
-    const device = getBackendDeviceOrSkip(ctx, backend);
-
-    if (!device) {
-      backend.destroy();
-
-      return;
-    }
+    const device = getBackendDevice(backend);
 
     const texture = createSolidTexture(128, 128, 128);
     const material = createMaterial();
@@ -131,6 +115,7 @@ describe('custom SpriteMaterial WebGPU browser', () => {
         material.destroy();
         texture.destroy();
         backend.destroy();
+        // eslint-disable-next-line vitest/no-disabled-tests -- intentional runtime guard: the software WebGPU adapter can drop the device mid-test
         ctx.skip('WebGPU device lost mid-test — unstable software adapter');
 
         return;

--- a/test/rendering/browser/webgpu-dpr-resolution.test.ts
+++ b/test/rendering/browser/webgpu-dpr-resolution.test.ts
@@ -6,7 +6,9 @@
  * content fills every device pixel (crisp) and logical positions land at the
  * matching physical pixel.
  *
- * Skips gracefully when WebGPU is unavailable or the software adapter drops.
+ * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
+ * against Mesa lavapipe); this only skips when the software adapter drops the
+ * device mid-test.
  *
  * Run via:  pnpm test:browser:webgpu
  */
@@ -18,7 +20,7 @@ import { Texture } from '#rendering/texture/Texture';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { wireCoreRenderers } from './_coreRenderers';
-import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+import { getBackendDevice } from './webgpu-test-helpers';
 
 type RgbaTuple = readonly [number, number, number, number];
 
@@ -31,17 +33,7 @@ const makeApp = (canvas: HTMLCanvasElement, logical: number, pixelRatio: number)
     },
   }) as unknown as Application;
 
-const setupBackend = async (ctx: { skip: (reason: string) => void }, logical: number, pixelRatio: number): Promise<WebGpuBackend> => {
-  if (!navigator.gpu) {
-    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-
-  if (!adapter) {
-    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-  }
-
+const setupBackend = async (logical: number, pixelRatio: number): Promise<WebGpuBackend> => {
   const canvas = document.createElement('canvas');
 
   canvas.width = logical * pixelRatio;
@@ -114,12 +106,8 @@ const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 6):
 describe('WebGPU device-pixel-ratio resolution', () => {
   test('pixelRatio 2 scales the root viewport to fill the full backing store', async ctx => {
     const logical = 64;
-    const backend = await setupBackend(ctx, logical, 2);
-    const device = getBackendDeviceOrSkip(ctx, backend);
-
-    if (!device) {
-      return;
-    }
+    const backend = await setupBackend(logical, 2);
+    const device = getBackendDevice(backend);
 
     const white = createSolidTexture('#ffffff');
     const sprite = createLeftHalfSprite(white, logical);
@@ -140,6 +128,7 @@ describe('WebGPU device-pixel-ratio resolution', () => {
         validationError = await device.popErrorScope();
       } catch (error) {
         if (isDeviceLoss(error)) {
+          // eslint-disable-next-line vitest/no-disabled-tests -- intentional runtime guard: the software WebGPU adapter can drop the device mid-test
           ctx.skip('WebGPU device lost mid-test — unstable software adapter');
 
           return;

--- a/test/rendering/browser/webgpu-draw-geometry.test.ts
+++ b/test/rendering/browser/webgpu-draw-geometry.test.ts
@@ -6,7 +6,9 @@
  * transform seam. Confirms the geometry renders at its world position, that the
  * raw transform is applied verbatim, and that a tint modulates the vertex color.
  *
- * All tests skip gracefully when WebGPU is unavailable.
+ * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
+ * against Mesa lavapipe); `drawGeometries` only skips when the software adapter
+ * drops the device mid-test.
  *
  * Run via:  pnpm test:browser:webgpu
  */
@@ -21,7 +23,7 @@ import { View } from '#rendering/View';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { wireCoreRenderers } from './_coreRenderers';
-import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+import { getBackendDevice } from './webgpu-test-helpers';
 
 type RgbaTuple = readonly [number, number, number, number];
 
@@ -36,17 +38,7 @@ const makeApp = (canvas: HTMLCanvasElement): Application =>
     },
   }) as unknown as Application;
 
-const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<WebGpuBackend> => {
-  if (!navigator.gpu) {
-    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-
-  if (!adapter) {
-    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-  }
-
+const setupBackend = async (): Promise<WebGpuBackend> => {
   const canvas = document.createElement('canvas');
 
   canvas.width = canvasSize;
@@ -147,11 +139,7 @@ const drawGeometries = async (
   context: RenderingContext,
   calls: readonly DrawCall[],
 ): Promise<boolean> => {
-  const device = getBackendDeviceOrSkip(ctx, backend);
-
-  if (!device) {
-    return false;
-  }
+  const device = getBackendDevice(backend);
 
   device.pushErrorScope('validation');
 
@@ -184,7 +172,7 @@ const drawGeometries = async (
 
 describe('WebGPU RenderingContext.drawGeometry', () => {
   test('renders a colored geometry quad at its world position', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const context = new RenderingContext(backend);
     const geometry = coloredQuad(16, 16, 48, 48, [255, 0, 0, 255]);
 
@@ -205,7 +193,7 @@ describe('WebGPU RenderingContext.drawGeometry', () => {
   });
 
   test('applies the raw transform verbatim (translation)', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const context = new RenderingContext(backend);
     const geometry = coloredQuad(0, 0, 32, 32, [0, 255, 0, 255]);
 
@@ -227,7 +215,7 @@ describe('WebGPU RenderingContext.drawGeometry', () => {
   });
 
   test('modulates the geometry color by the tint', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const context = new RenderingContext(backend);
     // White geometry × a fractional tint resolves to the tint color.
     const geometry = coloredQuad(16, 16, 48, 48, [255, 255, 255, 255]);
@@ -246,7 +234,7 @@ describe('WebGPU RenderingContext.drawGeometry', () => {
   });
 
   test('drawBatch draws N instances of one geometry as a single instanced draw call', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const context = new RenderingContext(backend);
     // A 16×16 white quad at the local origin, instanced to three positions/tints.
     const geometry = coloredQuad(0, 0, 16, 16, [255, 255, 255, 255]);
@@ -256,11 +244,7 @@ describe('WebGPU RenderingContext.drawGeometry', () => {
       .add(new Matrix(1, 0, 0, 0, 1, 32), new Color(0, 0, 255));
 
     try {
-      const device = getBackendDeviceOrSkip(ctx, backend);
-
-      if (!device) {
-        return;
-      }
+      const device = getBackendDevice(backend);
 
       device.pushErrorScope('validation');
 
@@ -273,6 +257,7 @@ describe('WebGPU RenderingContext.drawGeometry', () => {
         validationError = await device.popErrorScope();
       } catch (error) {
         if (isDeviceLoss(error)) {
+          // eslint-disable-next-line vitest/no-disabled-tests -- intentional runtime guard: the software WebGPU adapter can drop the device mid-test
           ctx.skip('WebGPU device lost mid-test — unstable software adapter');
 
           return;

--- a/test/rendering/browser/webgpu-graphics-gradient.test.ts
+++ b/test/rendering/browser/webgpu-graphics-gradient.test.ts
@@ -9,7 +9,9 @@
  * gradient samples through the real Graphics `fillStyle` / `strokeStyle`
  * API path.
  *
- * All tests skip gracefully when WebGPU is unavailable.
+ * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
+ * against Mesa lavapipe); `renderAndValidate` only skips when the software
+ * adapter drops the device mid-test.
  *
  * Run via:  pnpm test:browser:webgpu
  */
@@ -23,7 +25,7 @@ import type { RenderNode } from '#rendering/RenderNode';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { wireCoreRenderers } from './_coreRenderers';
-import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+import { getBackendDevice } from './webgpu-test-helpers';
 
 type RgbaTuple = readonly [number, number, number, number];
 
@@ -38,17 +40,7 @@ const makeApp = (canvas: HTMLCanvasElement): Application =>
     },
   }) as unknown as Application;
 
-const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<WebGpuBackend> => {
-  if (!navigator.gpu) {
-    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-
-  if (!adapter) {
-    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-  }
-
+const setupBackend = async (): Promise<WebGpuBackend> => {
   const canvas = document.createElement('canvas');
 
   canvas.width = canvasSize;
@@ -70,11 +62,7 @@ const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException 
 // assert it produced valid GPU work. Returns false when the device dropped
 // mid-test (the caller should bail).
 const renderAndValidate = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
-  const device = getBackendDeviceOrSkip(ctx, backend);
-
-  if (!device) {
-    return false;
-  }
+  const device = getBackendDevice(backend);
 
   device.pushErrorScope('validation');
 
@@ -136,7 +124,7 @@ const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 4):
 
 describe('WebGPU Graphics gradient fills', () => {
   test('linear gradient fill renders a red-to-blue ramp across the shape', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const graphics = new Graphics();
 
     graphics.fillStyle = new LinearGradient(
@@ -179,7 +167,7 @@ describe('WebGPU Graphics gradient fills', () => {
   });
 
   test('radial gradient fill distinguishes center from edge', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const graphics = new Graphics();
 
     graphics.fillStyle = new RadialGradient(
@@ -213,7 +201,7 @@ describe('WebGPU Graphics gradient fills', () => {
   });
 
   test('linear gradient stroke renders a red-to-blue ramp across the line', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const graphics = new Graphics();
 
     graphics.lineWidth = 8;
@@ -250,7 +238,7 @@ describe('WebGPU Graphics gradient fills', () => {
   });
 
   test('transformed Graphics gradient appears at the translated location', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const graphics = new Graphics();
 
     graphics.fillStyle = new LinearGradient(

--- a/test/rendering/browser/webgpu-mesh-tint.test.ts
+++ b/test/rendering/browser/webgpu-mesh-tint.test.ts
@@ -14,7 +14,9 @@
  * These tests therefore cover DataTexture, canvas-sourced Texture, a rasterized
  * Gradient, and a fractional tint, all through the default mesh path.
  *
- * All tests skip gracefully when WebGPU is unavailable.
+ * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
+ * against Mesa lavapipe); `renderMesh` only skips when the software adapter
+ * drops the device mid-test.
  *
  * Run via:  pnpm test:browser:webgpu
  */
@@ -29,7 +31,7 @@ import { ScaleModes } from '#rendering/types';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { wireCoreRenderers } from './_coreRenderers';
-import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+import { getBackendDevice } from './webgpu-test-helpers';
 
 type RgbaTuple = readonly [number, number, number, number];
 
@@ -44,17 +46,7 @@ const makeApp = (canvas: HTMLCanvasElement): Application =>
     },
   }) as unknown as Application;
 
-const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<WebGpuBackend> => {
-  if (!navigator.gpu) {
-    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-
-  if (!adapter) {
-    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-  }
-
+const setupBackend = async (): Promise<WebGpuBackend> => {
   const canvas = document.createElement('canvas');
 
   canvas.width = canvasSize;
@@ -112,11 +104,7 @@ const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException 
 // Render a single mesh through the real flush path inside a validation error
 // scope. Returns false when the device dropped mid-test (caller should bail).
 const renderMesh = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, mesh: Mesh): Promise<boolean> => {
-  const device = getBackendDeviceOrSkip(ctx, backend);
-
-  if (!device) {
-    return false;
-  }
+  const device = getBackendDevice(backend);
 
   device.pushErrorScope('validation');
 
@@ -146,7 +134,7 @@ const renderMesh = async (ctx: { skip: (reason: string) => void }, backend: WebG
 
 describe('WebGPU mesh tint and texture sampling', () => {
   test('samples intermediate DataTexture grayscale levels without saturating', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const levels = [32, 96, 160, 224];
     const width = levels.length;
     const data = new Uint8Array(width * 4);
@@ -178,7 +166,7 @@ describe('WebGPU mesh tint and texture sampling', () => {
   });
 
   test('samples a 2x2 rgba8 DataTexture into the correct quadrants', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     // Row-major, top-left origin: row 0 = red, green; row 1 = blue, white.
     const texture = new DataTexture({
       width: 2,
@@ -208,7 +196,7 @@ describe('WebGPU mesh tint and texture sampling', () => {
   });
 
   test('samples an intermediate canvas-sourced Texture without saturating', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const source = document.createElement('canvas');
 
     source.width = 2;
@@ -240,7 +228,7 @@ describe('WebGPU mesh tint and texture sampling', () => {
   });
 
   test('renders a rasterized linear gradient DataTexture across the quad', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const gradient = new LinearGradient(
       [
         { offset: 0, color: Color.red },
@@ -272,7 +260,7 @@ describe('WebGPU mesh tint and texture sampling', () => {
   });
 
   test('applies a fractional mesh tint to a white texture without saturating', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const texture = new DataTexture({
       width: 1,
       height: 1,
@@ -306,7 +294,7 @@ describe('WebGPU mesh tint and texture sampling', () => {
   // never change after the first draw. The fix re-resolves the binding each draw
   // (reusing the bind group only while the view is unchanged).
   test('re-uploads a DataTexture mutated between draws (no stale mesh bind-group cache)', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const texture = new DataTexture({
       width: 1,
       height: 1,

--- a/test/rendering/browser/webgpu-pixel-snap.test.ts
+++ b/test/rendering/browser/webgpu-pixel-snap.test.ts
@@ -8,12 +8,10 @@
  * seam-free geometry, stays deterministic, and downgrades gracefully under
  * rotation.
  *
- * All WebGPU tests skip gracefully when WebGPU is unavailable (no adapter or
- * software adapter lost mid-test). The double-skip contract ensures no false
- * failures on headless CI or machines without --enable-unsafe-webgpu:
- *  1. `setupBackend` skips when navigator.gpu / requestAdapter() is absent.
- *  2. `renderScene` calls `getBackendDeviceOrSkip` (device-gone guard) and
- *     catches DOMException device-loss mid-test.
+ * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
+ * against Mesa lavapipe), so these tests do not skip on a missing adapter —
+ * `renderScene` only skips when the software adapter drops the device
+ * mid-test (a DOMException device-loss caught during rendering).
  *
  * Run via:  pnpm test:browser:webgpu
  */
@@ -28,7 +26,7 @@ import { Texture } from '#rendering/texture/Texture';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { wireCoreRenderers } from './_coreRenderers';
-import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+import { getBackendDevice } from './webgpu-test-helpers';
 
 type RgbaTuple = readonly [number, number, number, number];
 
@@ -57,21 +55,7 @@ const createSolidTexture = (color: string, width = 16, height = 16): Texture => 
   return new Texture(src);
 };
 
-const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<WebGpuBackend | null> => {
-  if (!navigator.gpu) {
-    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-
-    return null;
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-
-  if (!adapter) {
-    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-
-    return null;
-  }
-
+const setupBackend = async (): Promise<WebGpuBackend> => {
   const canvas = document.createElement('canvas');
 
   canvas.width = canvasSize;
@@ -117,11 +101,7 @@ const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException 
 // Render a scene inside a validation error scope.
 // Returns false when the device dropped mid-test (caller should bail).
 const renderScene = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
-  const device = getBackendDeviceOrSkip(ctx, backend);
-
-  if (!device) {
-    return false;
-  }
+  const device = getBackendDevice(backend);
 
   device.pushErrorScope('validation');
 
@@ -154,11 +134,7 @@ const renderScene = async (ctx: { skip: (reason: string) => void }, backend: Web
 
 describe('WebGPU pixel snapping — Sprite position mode', () => {
   test('renders correctly at a fractional position and leaves logical state untouched', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#ff0000', 16, 16);
     const root = new Container();
@@ -197,11 +173,7 @@ describe('WebGPU pixel snapping — Sprite position mode', () => {
   });
 
   test('unsnapped baseline renders the same interior color', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#ff0000', 16, 16);
     const root = new Container();
@@ -227,11 +199,7 @@ describe('WebGPU pixel snapping — Sprite position mode', () => {
   });
 
   test('snapped rendering is deterministic across frames', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#00ff00', 16, 16);
     const root = new Container();
@@ -282,11 +250,7 @@ describe('WebGPU pixel snapping — Sprite position mode', () => {
 
 describe('WebGPU pixel snapping — NineSlice geometry mode', () => {
   test('produces no interior seams at a fractional placement', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#ff0000', 32, 32);
     const root = new Container();
@@ -318,11 +282,7 @@ describe('WebGPU pixel snapping — NineSlice geometry mode', () => {
   });
 
   test('geometry mode under rotation downgrades without error and keeps logical transform', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#0000ff', 32, 32);
     const root = new Container();

--- a/test/rendering/browser/webgpu-render-pipeline.test.ts
+++ b/test/rendering/browser/webgpu-render-pipeline.test.ts
@@ -2,10 +2,11 @@
  * WebGPU RenderPipeline browser test — opt-in, capability-aware.
  *
  * Runs under the `browser-webgpu` project: new headless Chromium exposes a WebGPU
- * adapter via swiftshader (`--enable-unsafe-webgpu --ignore-gpu-blocklist`). Skips
- * gracefully when WebGPU is unavailable (no `navigator.gpu` / no adapter / no
- * device) AND when the software adapter drops the device mid-test (the canonical
- * `isDeviceLoss` + `withValidation` model shared by every webgpu-*.test.ts).
+ * adapter via swiftshader (`--enable-unsafe-webgpu --ignore-gpu-blocklist`). CI
+ * guarantees a real adapter (the required Chromium-WebGPU lane runs against Mesa
+ * lavapipe); `withValidation` only skips when the software adapter drops the
+ * device mid-test (the canonical `isDeviceLoss` model shared by every
+ * webgpu-*.test.ts).
  *
  * It drives a RenderPipeline (including a nested pipeline) whose CallbackRenderPass
  * redirects into an off-screen target via the BackendTargetPass/coordinator path,
@@ -24,7 +25,7 @@ import { RenderTexture } from '#rendering/texture/RenderTexture';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { wireCoreRenderers } from './_coreRenderers';
-import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+import { getBackendDevice } from './webgpu-test-helpers';
 
 const makeApp = (canvas: HTMLCanvasElement): Application =>
   ({
@@ -35,21 +36,7 @@ const makeApp = (canvas: HTMLCanvasElement): Application =>
     },
   }) as unknown as Application;
 
-const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<WebGpuBackend | null> => {
-  if (!navigator.gpu) {
-    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-
-    return null;
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-
-  if (!adapter) {
-    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-
-    return null;
-  }
-
+const setupBackend = async (): Promise<WebGpuBackend> => {
   const canvas = document.createElement('canvas');
   canvas.width = 64;
   canvas.height = 64;
@@ -64,11 +51,7 @@ const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<We
 const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
 
 const withValidation = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, run: () => void): Promise<void> => {
-  const device = getBackendDeviceOrSkip(ctx, backend);
-
-  if (!device) {
-    return;
-  }
+  const device = getBackendDevice(backend);
 
   device.pushErrorScope('validation');
 
@@ -92,11 +75,7 @@ const withValidation = async (ctx: { skip: (reason: string) => void }, backend: 
 
 describe('RenderPipeline WebGPU browser', () => {
   test('a nested pipeline redirecting into a target raises no validation error', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const context = new RenderingContext(backend);
     const target = new RenderTexture(64, 64);

--- a/test/rendering/browser/webgpu-render-to-texture.test.ts
+++ b/test/rendering/browser/webgpu-render-to-texture.test.ts
@@ -1,9 +1,8 @@
 /**
  * WebGPU browser tests for renderTo — opt-in, capability-aware.
  *
- * All tests skip gracefully when WebGPU is unavailable. The WebGPU
- * backend supports all operations used by renderTo (setRenderTarget,
- * clear, draw, flush) so the facade delegates correctly.
+ * The WebGPU backend supports all operations used by renderTo
+ * (setRenderTarget, clear, draw, flush) so the facade delegates correctly.
  *
  * Run via:  pnpm test:browser:webgpu
  */
@@ -15,17 +14,7 @@ import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { wireCoreRenderers } from './_coreRenderers';
 
-const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<WebGpuBackend> => {
-  if (!navigator.gpu) {
-    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-
-  if (!adapter) {
-    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-  }
-
+const setupBackend = async (): Promise<WebGpuBackend> => {
   const canvas = document.createElement('canvas');
 
   canvas.width = 64;
@@ -48,8 +37,8 @@ const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<We
 };
 
 describe('RenderTo WebGPU browser', () => {
-  test('backend initializes and accepts render target changes', async ctx => {
-    const backend = await setupBackend(ctx);
+  test('backend initializes and accepts render target changes', async () => {
+    const backend = await setupBackend();
     const rtSize = 32;
     const target = new RenderTexture(rtSize, rtSize);
 
@@ -66,8 +55,8 @@ describe('RenderTo WebGPU browser', () => {
     backend.destroy();
   });
 
-  test('renderTo pattern correctly sets and restores render target', async ctx => {
-    const backend = await setupBackend(ctx);
+  test('renderTo pattern correctly sets and restores render target', async () => {
+    const backend = await setupBackend();
     const rtSize = 32;
     const target = new RenderTexture(rtSize, rtSize);
 

--- a/test/rendering/browser/webgpu-repeating-sprite.test.ts
+++ b/test/rendering/browser/webgpu-repeating-sprite.test.ts
@@ -8,8 +8,9 @@
  *    built on the CPU with clamped UVs.
  *
  * All WebGPU renderers use inline WGSL — no shader file mocks are needed.
- * Tests skip gracefully when WebGPU is unavailable (software adapter or
- * headless CI without --enable-unsafe-webgpu).
+ * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
+ * against Mesa lavapipe); `renderScene` only skips when the software adapter
+ * drops the device mid-test.
  *
  * Run via:  pnpm test:browser:webgpu
  */
@@ -24,7 +25,7 @@ import { TextureRegion } from '#rendering/texture/TextureRegion';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { wireCoreRenderers } from './_coreRenderers';
-import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+import { getBackendDevice } from './webgpu-test-helpers';
 
 // ---------------------------------------------------------------------------
 // Infrastructure helpers
@@ -43,21 +44,7 @@ const makeApp = (canvas: HTMLCanvasElement): Application =>
     },
   }) as unknown as Application;
 
-const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<WebGpuBackend | null> => {
-  if (!navigator.gpu) {
-    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-
-    return null;
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-
-  if (!adapter) {
-    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-
-    return null;
-  }
-
+const setupBackend = async (): Promise<WebGpuBackend> => {
   const canvas = document.createElement('canvas');
 
   canvas.width = canvasSize;
@@ -113,11 +100,7 @@ const createSolidTexture = (color: string, size = 16): Texture => {
 const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
 
 const renderScene = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
-  const device = getBackendDeviceOrSkip(ctx, backend);
-
-  if (!device) {
-    return false;
-  }
+  const device = getBackendDevice(backend);
 
   device.pushErrorScope('validation');
 
@@ -150,11 +133,7 @@ const renderScene = async (ctx: { skip: (reason: string) => void }, backend: Web
 
 describe('WebGPU RepeatingSprite — shader path', () => {
   test('solid-color texture fills destination', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#ff0000');
     const root = new Container();
@@ -180,11 +159,7 @@ describe('WebGPU RepeatingSprite — shader path', () => {
   });
 
   test('stretch mode fills destination', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#00ff00', 8);
     const root = new Container();
@@ -215,11 +190,7 @@ describe('WebGPU RepeatingSprite — shader path', () => {
   });
 
   test('mirror-repeat mode does not crash', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#0000ff', 16);
     const root = new Container();
@@ -250,11 +221,7 @@ describe('WebGPU RepeatingSprite — shader path', () => {
   });
 
   test('tint is applied', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#ffffff');
     const root = new Container();
@@ -283,11 +250,7 @@ describe('WebGPU RepeatingSprite — shader path', () => {
   });
 
   test('zero-size does not crash', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#ff0000');
     const root = new Container();
@@ -312,11 +275,7 @@ describe('WebGPU RepeatingSprite — shader path', () => {
   });
 
   test('node transform (position) is applied', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#ff0000', 16);
     const root = new Container();
@@ -348,11 +307,7 @@ describe('WebGPU RepeatingSprite — shader path', () => {
 
 describe('WebGPU RepeatingSprite — geometry path', () => {
   test('solid-color atlas region fills destination', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#0000ff', 32);
     const region = new TextureRegion(texture, { x: 0, y: 0, width: 16, height: 16 });
@@ -379,11 +334,7 @@ describe('WebGPU RepeatingSprite — geometry path', () => {
   });
 
   test('tint is applied on geometry path', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#ffffff');
     const region = new TextureRegion(texture, { x: 0, y: 0, width: 16, height: 16 });
@@ -413,11 +364,7 @@ describe('WebGPU RepeatingSprite — geometry path', () => {
   });
 
   test('zero-size geometry path does not crash', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#ff0000');
     const region = new TextureRegion(texture, { x: 0, y: 0, width: 16, height: 16 });
@@ -443,11 +390,7 @@ describe('WebGPU RepeatingSprite — geometry path', () => {
   });
 
   test('mirror-repeat geometry path does not crash', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#ff0000', 16);
     const region = new TextureRegion(texture, { x: 0, y: 0, width: 16, height: 16 });

--- a/test/rendering/browser/webgpu-shader-compile.test.ts
+++ b/test/rendering/browser/webgpu-shader-compile.test.ts
@@ -30,8 +30,9 @@
  *    fixed prelude those custom-material shaders are prepended with, IS
  *    covered below.
  *
- * Skips gracefully when WebGPU is unavailable, matching every other browser
- * spec in this directory. Run via: pnpm test:browser:webgpu
+ * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
+ * against Mesa lavapipe); tests only skip when the software adapter drops the
+ * device mid-test. Run via: pnpm test:browser:webgpu
  */
 
 import { spriteVertexWgsl } from '#rendering/sprite/spriteMaterialSources';
@@ -71,22 +72,10 @@ const shaders: readonly ShaderEntry[] = [
 // matching every other WebGPU browser spec in this directory.
 const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
 
-const requestDeviceOrSkip = async (ctx: { skip: (reason: string) => void }): Promise<GPUDevice | null> => {
-  if (!navigator.gpu) {
-    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-
-    return null;
-  }
-
+const requestTestDevice = async (): Promise<GPUDevice> => {
   const adapter = await navigator.gpu.requestAdapter();
 
-  if (!adapter) {
-    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-
-    return null;
-  }
-
-  return adapter.requestDevice();
+  return adapter!.requestDevice();
 };
 
 interface CompileResult {
@@ -123,11 +112,7 @@ describe('WebGPU WGSL shader sources', () => {
   // `webgpu-backdrop-blend.test.ts`), and keeping `ctx.skip` unambiguous.
   for (const { name, source } of shaders) {
     test(`compiles ${name}`, async ctx => {
-      const device = await requestDeviceOrSkip(ctx);
-
-      if (!device) {
-        return;
-      }
+      const device = await requestTestDevice();
 
       try {
         const { errorCount, log } = await compileWgsl(device, source);
@@ -135,6 +120,7 @@ describe('WebGPU WGSL shader sources', () => {
         expect(errorCount, `${name} failed to compile:\n${log}`).toBe(0);
       } catch (error) {
         if (isDeviceLoss(error)) {
+          // eslint-disable-next-line vitest/no-disabled-tests -- intentional runtime guard: the software WebGPU adapter can drop the device mid-test
           ctx.skip('WebGPU device lost mid-test — unstable software adapter');
 
           return;
@@ -159,21 +145,8 @@ describe('WebGPU WGSL shader sources', () => {
   // reasons — so this is diagnostic logging only, not a hard pass/fail gate.
   // A human should read this log line in the CI run to confirm the adapter
   // description does not say "SwiftShader".
-  test('logs the requested adapter identity (informational, non-blocking)', async ctx => {
-    if (!navigator.gpu) {
-      ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-
-      return;
-    }
-
+  test('logs the requested adapter identity (informational, non-blocking)', async () => {
     const adapter = await navigator.gpu.requestAdapter();
-
-    if (!adapter) {
-      ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-
-      return;
-    }
-
     const info = (adapter as GPUAdapter & { info?: GPUAdapterInfo }).info;
 
     if (info) {

--- a/test/rendering/browser/webgpu-shader-filter.test.ts
+++ b/test/rendering/browser/webgpu-shader-filter.test.ts
@@ -14,6 +14,10 @@
  * rejected by WebGPU validation and the filter's `output` never receives
  * any pixels — it stays cleared to transparent black.
  *
+ * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
+ * against Mesa lavapipe); this only skips when the software adapter drops the
+ * device mid-test.
+ *
  * Run via:  pnpm test:browser:webgpu
  */
 
@@ -25,7 +29,7 @@ import { RenderTexture } from '#rendering/texture/RenderTexture';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { wireCoreRenderers } from './_coreRenderers';
-import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+import { getBackendDevice } from './webgpu-test-helpers';
 
 const canvasSize = 64;
 
@@ -38,21 +42,7 @@ const makeApp = (canvas: HTMLCanvasElement): Application =>
     },
   }) as unknown as Application;
 
-const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<WebGpuBackend | null> => {
-  if (!navigator.gpu) {
-    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-
-    return null;
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-
-  if (!adapter) {
-    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-
-    return null;
-  }
-
+const setupBackend = async (): Promise<WebGpuBackend> => {
   const canvas = document.createElement('canvas');
 
   canvas.width = canvasSize;
@@ -67,8 +57,8 @@ const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<We
 };
 
 // On the software (swiftshader/lavapipe) adapter the WebGPU device can drop
-// mid-test; treat that as an unavailable-adapter skip rather than a failure
-// (mirrors every other webgpu-*.test.ts in this suite).
+// mid-test; treat that as a device-lost skip rather than a failure (mirrors
+// every other webgpu-*.test.ts in this suite).
 const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
 
 // Ignores the input texture entirely and paints solid opaque red — so the
@@ -124,17 +114,8 @@ const readTexturePixel = (backend: WebGpuBackend, texture: RenderTexture, x: num
 
 describe('WebGpuShaderFilter (real GPU)', () => {
   test('apply() writes non-black pixels into output — pipeline format matches the offscreen target', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
-
-    const device = getBackendDeviceOrSkip(ctx, backend);
-
-    if (!device) {
-      return;
-    }
+    const backend = await setupBackend();
+    const device = getBackendDevice(backend);
 
     const input = new RenderTexture(canvasSize, canvasSize);
     const output = new RenderTexture(canvasSize, canvasSize);
@@ -153,6 +134,7 @@ describe('WebGpuShaderFilter (real GPU)', () => {
         validationError = await device.popErrorScope();
       } catch (error) {
         if (isDeviceLoss(error)) {
+          // eslint-disable-next-line vitest/no-disabled-tests -- intentional runtime guard: the software WebGPU adapter can drop the device mid-test
           ctx.skip('WebGPU device lost mid-test — unstable software adapter');
 
           return;

--- a/test/rendering/browser/webgpu-smoke.test.ts
+++ b/test/rendering/browser/webgpu-smoke.test.ts
@@ -1,9 +1,10 @@
 /**
- * WebGPU browser smoke tests — opt-in, capability-aware.
+ * WebGPU browser smoke tests.
  *
- * All tests skip gracefully when WebGPU is unavailable (navigator.gpu absent,
- * adapter null, or device request rejected). This keeps normal CI green even
- * on hosts without a usable GPU adapter.
+ * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
+ * against Mesa lavapipe), so these tests exercise the API directly rather
+ * than skipping when it looks unavailable — a missing adapter here is a
+ * genuine failure, not an environment gap.
  *
  * Run via:  pnpm test:browser:webgpu
  */
@@ -42,19 +43,11 @@ import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 // ── Section 1: raw WebGPU API availability ────────────────────────────────
 
 describe('WebGPU API — navigator.gpu', () => {
-  test('navigator.gpu is present', ctx => {
-    if (!navigator.gpu) {
-      ctx.skip('WebGPU unavailable: navigator.gpu is absent in this Chromium instance');
-    }
-
+  test('navigator.gpu is present', () => {
     expect(navigator.gpu).toBeDefined();
   });
 
-  test('getPreferredCanvasFormat() returns a known format', ctx => {
-    if (!navigator.gpu) {
-      ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-    }
-
+  test('getPreferredCanvasFormat() returns a known format', () => {
     const format = navigator.gpu.getPreferredCanvasFormat();
 
     expect(['bgra8unorm', 'rgba8unorm']).toContain(format);
@@ -64,31 +57,14 @@ describe('WebGPU API — navigator.gpu', () => {
 // ── Section 2: adapter & device ───────────────────────────────────────────
 
 describe('WebGPU API — adapter and device', () => {
-  test('requestAdapter() resolves to a non-null GPUAdapter', async ctx => {
-    if (!navigator.gpu) {
-      ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-    }
-
+  test('requestAdapter() resolves to a non-null GPUAdapter', async () => {
     const adapter = await navigator.gpu.requestAdapter();
-
-    if (!adapter) {
-      ctx.skip('WebGPU unavailable: requestAdapter() returned null — no compatible GPU adapter (no hardware GPU or software fallback)');
-    }
 
     expect(adapter).not.toBeNull();
   });
 
-  test('requestDevice() returns a GPUDevice and can be destroyed', async ctx => {
-    if (!navigator.gpu) {
-      ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-    }
-
+  test('requestDevice() returns a GPUDevice and can be destroyed', async () => {
     const adapter = await navigator.gpu.requestAdapter();
-
-    if (!adapter) {
-      ctx.skip('WebGPU unavailable: no adapter');
-    }
-
     const device = await adapter!.requestDevice();
 
     expect(device).toBeDefined();
@@ -97,17 +73,8 @@ describe('WebGPU API — adapter and device', () => {
     device.destroy();
   });
 
-  test('GPUDevice.lost promise resolves to a GPUDeviceLostInfo when device is destroyed', async ctx => {
-    if (!navigator.gpu) {
-      ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-    }
-
+  test('GPUDevice.lost promise resolves to a GPUDeviceLostInfo when device is destroyed', async () => {
     const adapter = await navigator.gpu.requestAdapter();
-
-    if (!adapter) {
-      ctx.skip('WebGPU unavailable: no adapter');
-    }
-
     const device = await adapter!.requestDevice();
     const lostPromise = device.lost;
 
@@ -131,28 +98,14 @@ describe('WebGpuBackend — real GPU initialization', () => {
       },
     }) as unknown as Application;
 
-  test('backendType is RenderBackendType.WebGpu', ctx => {
-    if (!navigator.gpu) {
-      ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-    }
-
+  test('backendType is RenderBackendType.WebGpu', () => {
     const canvas = document.createElement('canvas');
     const backend = new WebGpuBackend(makeApp(canvas));
 
     expect(backend.backendType).toBe(RenderBackendType.WebGpu);
   });
 
-  test('initialize() resolves with the backend instance', async ctx => {
-    if (!navigator.gpu) {
-      ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-    }
-
-    const adapter = await navigator.gpu.requestAdapter();
-
-    if (!adapter) {
-      ctx.skip('WebGPU unavailable: no adapter — initialize() would throw');
-    }
-
+  test('initialize() resolves with the backend instance', async () => {
     const canvas = document.createElement('canvas');
     canvas.width = 64;
     canvas.height = 64;
@@ -163,17 +116,7 @@ describe('WebGpuBackend — real GPU initialization', () => {
     backend.destroy();
   });
 
-  test('stats object is defined after initialize()', async ctx => {
-    if (!navigator.gpu) {
-      ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-    }
-
-    const adapter = await navigator.gpu.requestAdapter();
-
-    if (!adapter) {
-      ctx.skip('WebGPU unavailable: no adapter');
-    }
-
+  test('stats object is defined after initialize()', async () => {
     const canvas = document.createElement('canvas');
     const backend = new WebGpuBackend(makeApp(canvas));
 
@@ -185,17 +128,7 @@ describe('WebGpuBackend — real GPU initialization', () => {
     backend.destroy();
   });
 
-  test('clear() and flush() complete without throwing after initialize()', async ctx => {
-    if (!navigator.gpu) {
-      ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-    }
-
-    const adapter = await navigator.gpu.requestAdapter();
-
-    if (!adapter) {
-      ctx.skip('WebGPU unavailable: no adapter');
-    }
-
+  test('clear() and flush() complete without throwing after initialize()', async () => {
     const canvas = document.createElement('canvas');
     canvas.width = 64;
     canvas.height = 64;

--- a/test/rendering/browser/webgpu-sprite-transform.test.ts
+++ b/test/rendering/browser/webgpu-sprite-transform.test.ts
@@ -15,7 +15,9 @@
  *  - Pixels: the presented WebGPU canvas is read back via drawImage onto a 2D
  *    canvas (a standard cross-context read) and sampled.
  *
- * All tests skip gracefully when WebGPU is unavailable.
+ * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
+ * against Mesa lavapipe); `renderScene` only skips when the software adapter
+ * drops the device mid-test.
  *
  * Run via:  pnpm test:browser:webgpu
  */
@@ -30,7 +32,7 @@ import { BlendModes } from '#rendering/types';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { wireCoreRenderers } from './_coreRenderers';
-import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+import { getBackendDevice } from './webgpu-test-helpers';
 
 type RgbaTuple = readonly [number, number, number, number];
 
@@ -63,17 +65,7 @@ const createSolidTexture = (color: string, size: number): Texture => {
   return new Texture(source);
 };
 
-const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<WebGpuBackend> => {
-  if (!navigator.gpu) {
-    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-
-  if (!adapter) {
-    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-  }
-
+const setupBackend = async (): Promise<WebGpuBackend> => {
   const canvas = document.createElement('canvas');
 
   canvas.width = canvasSize;
@@ -119,18 +111,14 @@ const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 12)
 };
 
 // On the software (swiftshader) adapter used in CI the WebGPU device can be
-// dropped mid-test ("Instance dropped in popErrorScope"). Treat that as an
-// unavailable-adapter skip rather than a failure, matching setupBackend().
+// dropped mid-test ("Instance dropped in popErrorScope"). Treat that as a
+// device-lost skip rather than a failure.
 const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
 
 // Render a scene through the real plan path inside a validation error scope.
 // Returns false when the device dropped mid-test (the caller should bail).
 const renderScene = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
-  const device = getBackendDeviceOrSkip(ctx, backend);
-
-  if (!device) {
-    return false;
-  }
+  const device = getBackendDevice(backend);
 
   device.pushErrorScope('validation');
 
@@ -159,7 +147,7 @@ const renderScene = async (ctx: { skip: (reason: string) => void }, backend: Web
 
 describe('WebGPU sprite transform storage', () => {
   test('a translated sprite lands at its buffer-resolved position', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const texture = createSolidTexture('#ff0000', 16);
     const root = new Container();
     const sprite = new Sprite(texture);
@@ -188,7 +176,7 @@ describe('WebGPU sprite transform storage', () => {
   });
 
   test('a scaled sprite stretches to its scaled bounds via the buffer transform', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const texture = createSolidTexture('#ff0000', 8);
     const root = new Container();
     const sprite = new Sprite(texture);
@@ -218,7 +206,7 @@ describe('WebGPU sprite transform storage', () => {
   });
 
   test('multiple sprites with distinct transforms batch into one draw, each at its own position', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const texture = createSolidTexture('#ff0000', 8);
     const root = new Container();
     const a = new Sprite(texture);
@@ -263,7 +251,7 @@ describe('WebGPU sprite transform storage', () => {
     // command buffer still referenced the old one, causing WebGPU validation
     // errors. With reserve() called in _beginDrawPlan the buffer is sized for
     // the full plan once, so no reallocation happens between flushes.
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const textureA = createSolidTexture('#ff0000', 12);
     const textureB = createSolidTexture('#0000ff', 12);
     const root = new Container();
@@ -319,7 +307,7 @@ describe('WebGPU sprite transform storage', () => {
     // because it tracks blend-mode / texture / material — not render-group
     // boundaries. Each sprite fetches its own transform row independently via
     // its stable nodeIndex, so non-contiguous slots are handled correctly.
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const texture = createSolidTexture('#ff0000', 8);
     const root = new Container();
     const a = new Sprite(texture);

--- a/test/rendering/browser/webgpu-stencil-clip.test.ts
+++ b/test/rendering/browser/webgpu-stencil-clip.test.ts
@@ -13,7 +13,9 @@
  *  - Pixels: the presented WebGPU canvas is read back via drawImage onto a 2D
  *    canvas (a standard cross-context read) and sampled.
  *
- * All tests skip gracefully when WebGPU is unavailable.
+ * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
+ * against Mesa lavapipe); `renderClipped` only skips when the software adapter
+ * drops the device mid-test.
  *
  * Run via:  pnpm test:browser:webgpu
  */
@@ -36,7 +38,7 @@ import { Texture } from '#rendering/texture/Texture';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { wireCoreRenderers } from './_coreRenderers';
-import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+import { getBackendDevice } from './webgpu-test-helpers';
 
 type RgbaTuple = readonly [number, number, number, number];
 
@@ -172,17 +174,7 @@ fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
 }
 `.trim();
 
-const setupBackend = async (ctx: { skip: (reason: string) => void }, logicalSize = canvasSize): Promise<WebGpuBackend> => {
-  if (!navigator.gpu) {
-    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-
-  if (!adapter) {
-    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-  }
-
+const setupBackend = async (logicalSize = canvasSize): Promise<WebGpuBackend> => {
   const canvas = document.createElement('canvas');
 
   // The physical backing store is always canvasSize. A logicalSize < canvasSize
@@ -231,16 +223,12 @@ const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 12)
 };
 
 // On the software (swiftshader) adapter used in CI the WebGPU device can be
-// dropped mid-test ("Instance dropped in popErrorScope"). Treat that as an
-// unavailable-adapter skip rather than a failure, matching setupBackend().
+// dropped mid-test ("Instance dropped in popErrorScope"). Treat that as a
+// device-lost skip rather than a failure.
 const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
 
 const renderClipped = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<void> => {
-  const device = getBackendDeviceOrSkip(ctx, backend);
-
-  if (!device) {
-    return;
-  }
+  const device = getBackendDevice(backend);
 
   device.pushErrorScope('validation');
 
@@ -267,7 +255,7 @@ const renderClipped = async (ctx: { skip: (reason: string) => void }, backend: W
 
 describe('WebGPU geometric (stencil) clipping', () => {
   test('Geometry clipShape discards fragments outside the shape', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const texture = createSolidTexture('#ff0000');
     const root = new Container();
     const clipped = new Container();
@@ -299,7 +287,7 @@ describe('WebGPU geometric (stencil) clipping', () => {
   });
 
   test('nested stencil clips render only the intersection', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const texture = createSolidTexture('#ff0000');
     const root = new Container();
     const outer = new Container();
@@ -339,7 +327,7 @@ describe('WebGPU geometric (stencil) clipping', () => {
   });
 
   test('stencil clip composes with a scissor rect (intersection)', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const texture = createSolidTexture('#ff0000');
     const root = new Container();
     const clipped = new Container();
@@ -375,7 +363,7 @@ describe('WebGPU geometric (stencil) clipping', () => {
   });
 
   test('a clipped container clips multiple children', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const redTexture = createSolidTexture('#ff0000');
     const greenTexture = createSolidTexture('#00ff00');
     const root = new Container();
@@ -415,7 +403,7 @@ describe('WebGPU geometric (stencil) clipping', () => {
   });
 
   test('scene without clip renders unchanged (stencil attachment inert)', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const texture = createSolidTexture('#ff0000');
     const root = new Container();
     const sprite = new Sprite(texture);
@@ -440,7 +428,7 @@ describe('WebGPU geometric (stencil) clipping', () => {
   });
 
   test('balanced clips do not throw', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const texture = createSolidTexture('#ff0000');
     const root = new Container();
     const clipped = new Container();
@@ -464,7 +452,7 @@ describe('WebGPU geometric (stencil) clipping', () => {
   });
 
   test('Rectangle clipShape still uses the scissor path (no throw)', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const texture = createSolidTexture('#ff0000');
     const root = new Container();
     const clipped = new Container();
@@ -492,7 +480,7 @@ describe('WebGPU geometric (stencil) clipping', () => {
   });
 
   test('a default-material Mesh renders inside a Geometry stencil clip', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const root = new Container();
     const clipped = new Container();
     const mesh = createQuadMesh(48, Color.red);
@@ -519,7 +507,7 @@ describe('WebGPU geometric (stencil) clipping', () => {
   });
 
   test('a Graphics shape renders inside a Geometry stencil clip', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const root = new Container();
     const clipped = new Container();
     const graphics = new Graphics();
@@ -548,7 +536,7 @@ describe('WebGPU geometric (stencil) clipping', () => {
   });
 
   test('a Mesh stencil clip composes with a scissor rect (intersection)', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const root = new Container();
     const clipped = new Container();
     const mesh = createQuadMesh(64, Color.red);
@@ -579,7 +567,7 @@ describe('WebGPU geometric (stencil) clipping', () => {
   });
 
   test('a custom-material Mesh renders inside a Geometry stencil clip', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const root = new Container();
     const clipped = new Container();
     const material = new MeshMaterial({ shader: new ShaderSource({ wgsl: customMeshWgsl }) });
@@ -612,7 +600,7 @@ describe('WebGPU geometric (stencil) clipping', () => {
   });
 
   test('a custom-material Mesh stencil clip composes with a scissor rect (intersection)', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const root = new Container();
     const clipped = new Container();
     const material = new MeshMaterial({ shader: new ShaderSource({ wgsl: customMeshWgsl }) });
@@ -649,7 +637,7 @@ describe('WebGPU geometric (stencil) clipping', () => {
   });
 
   test('a custom-material Mesh renders only the intersection under nested clips', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const root = new Container();
     const outer = new Container();
     const inner = new Container();
@@ -690,7 +678,7 @@ describe('WebGPU geometric (stencil) clipping', () => {
   });
 
   test('a custom-material Sprite renders inside a Geometry stencil clip', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const root = new Container();
     const clipped = new Container();
     const material = new SpriteMaterial({
@@ -729,7 +717,7 @@ describe('WebGPU geometric (stencil) clipping', () => {
     // Logical render target 32×32, physical canvas 64×64 → pixelRatio 2. Before the
     // physical-sizing fix the root stencil attachment (logical 32) mismatched the
     // physical colour attachment (64) and the clip pass raised a validation error.
-    const backend = await setupBackend(ctx, 32);
+    const backend = await setupBackend(32);
     const texture = createSolidTexture('#ff0000');
     const root = new Container();
     const clipped = new Container();
@@ -761,7 +749,7 @@ describe('WebGPU geometric (stencil) clipping', () => {
   });
 
   test('a BitmapText renders inside a Geometry stencil clip', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const root = new Container();
     const clipped = new Container();
     const { text, texture } = createSolidBitmapText('#ff0000', 64);
@@ -798,7 +786,7 @@ describe('WebGPU geometric (stencil) clipping', () => {
     // RenderEffectExecutor pushes the Geometry clip outermost, so the mask
     // compositor draws into the stencil-enabled pass. Without a stencil pipeline
     // variant on the compositor this raised a WebGPU validation error.
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const contentTexture = createSolidTexture('#ff0000');
     const maskTexture = createSolidTexture('#ffffff');
     const root = new Container();

--- a/test/rendering/browser/webgpu-stencil-composition.test.ts
+++ b/test/rendering/browser/webgpu-stencil-composition.test.ts
@@ -10,6 +10,10 @@
  * Pixels are read back via drawImage onto a 2D canvas, and every render runs
  * inside pushErrorScope('validation') to catch any GPU validation error.
  *
+ * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
+ * against Mesa lavapipe); `withValidation` only skips when the software
+ * adapter drops the device mid-test.
+ *
  * Run via:  pnpm test:browser:webgpu
  */
 
@@ -24,7 +28,7 @@ import { Texture } from '#rendering/texture/Texture';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { wireCoreRenderers } from './_coreRenderers';
-import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+import { getBackendDevice } from './webgpu-test-helpers';
 
 type RgbaTuple = readonly [number, number, number, number];
 
@@ -65,17 +69,7 @@ const createQuadGeometry = (x: number, y: number, width: number, height: number)
     stride: 8,
   });
 
-const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<WebGpuBackend> => {
-  if (!navigator.gpu) {
-    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-
-  if (!adapter) {
-    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-  }
-
+const setupBackend = async (): Promise<WebGpuBackend> => {
   const canvas = document.createElement('canvas');
 
   canvas.width = canvasSize;
@@ -118,16 +112,12 @@ const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 12)
 };
 
 // On the software (swiftshader) adapter used in CI the WebGPU device can be
-// dropped mid-test ("Instance dropped in popErrorScope"). Treat that as an
-// unavailable-adapter skip rather than a failure, matching setupBackend().
+// dropped mid-test ("Instance dropped in popErrorScope"). Treat that as a
+// device-lost skip rather than a failure.
 const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
 
 const withValidation = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, run: () => void): Promise<void> => {
-  const device = getBackendDeviceOrSkip(ctx, backend);
-
-  if (!device) {
-    return;
-  }
+  const device = getBackendDevice(backend);
 
   device.pushErrorScope('validation');
 
@@ -151,7 +141,7 @@ const withValidation = async (ctx: { skip: (reason: string) => void }, backend: 
 
 describe('WebGPU stencil composition', () => {
   test('clip into a RenderTexture, then sample it back as a Sprite', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const context = new RenderingContext(backend);
     const texture = createSolidTexture('#ff0000');
     const clipped = new Container();
@@ -181,7 +171,7 @@ describe('WebGPU stencil composition', () => {
   });
 
   test('a cacheAsBitmap node renders correctly inside a stencil clip', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const texture = createSolidTexture('#ff0000');
     const root = new Container();
     const clipped = new Container();
@@ -222,7 +212,7 @@ describe('WebGPU stencil composition', () => {
   });
 
   test('a pooled RenderTexture reused after a clip carries no stale stencil', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     const context = new RenderingContext(backend);
     const texture = createSolidTexture('#00ff00');
 

--- a/test/rendering/browser/webgpu-test-helpers.ts
+++ b/test/rendering/browser/webgpu-test-helpers.ts
@@ -1,30 +1,11 @@
 import type { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
-export interface BrowserWebGpuTestContext {
-  skip: (reason: string) => void;
-}
-
-const missingDeviceReason = 'WebGPU unavailable: backend has no device';
-const uninitializedDeviceMessage = 'WebGPU device is not initialized yet.';
-
-export const getBackendDeviceOrSkip = (ctx: BrowserWebGpuTestContext, backend: WebGpuBackend): GPUDevice | null => {
-  try {
-    const device = backend.device as GPUDevice | undefined;
-
-    if (!device) {
-      ctx.skip(missingDeviceReason);
-
-      return null;
-    }
-
-    return device;
-  } catch (error) {
-    if (error instanceof Error && error.message === uninitializedDeviceMessage) {
-      ctx.skip(missingDeviceReason);
-
-      return null;
-    }
-
-    throw error;
-  }
-};
+/**
+ * Returns the backend's WebGPU device.
+ *
+ * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
+ * against Mesa lavapipe), so a missing device is a genuine test failure, not
+ * an environment gap — this throws (via the `device` getter) rather than
+ * skipping.
+ */
+export const getBackendDevice = (backend: WebGpuBackend): GPUDevice => backend.device;

--- a/test/rendering/browser/webgpu-text-atlas-upload.test.ts
+++ b/test/rendering/browser/webgpu-text-atlas-upload.test.ts
@@ -17,7 +17,9 @@
  * atlas is freshly created and fully uploaded every time — the partial,
  * post-cache upload path never runs.
  *
- * Skips gracefully when WebGPU is unavailable. Run via: pnpm test:browser:webgpu
+ * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
+ * against Mesa lavapipe); `renderText` only skips when the software adapter
+ * drops the device mid-test. Run via: pnpm test:browser:webgpu
  */
 
 import type { Application } from '#core/Application';
@@ -27,7 +29,7 @@ import { Text } from '#rendering/text/Text';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { wireCoreRenderers } from './_coreRenderers';
-import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+import { getBackendDevice } from './webgpu-test-helpers';
 
 const canvasSize = 128;
 
@@ -40,17 +42,7 @@ const makeApp = (canvas: HTMLCanvasElement): Application =>
     },
   }) as unknown as Application;
 
-const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<WebGpuBackend> => {
-  if (!navigator.gpu) {
-    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-
-  if (!adapter) {
-    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-  }
-
+const setupBackend = async (): Promise<WebGpuBackend> => {
   const canvas = document.createElement('canvas');
 
   canvas.width = canvasSize;
@@ -70,11 +62,7 @@ const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException 
 
 /** Render one node through the real flush path inside a validation error scope. */
 const renderText = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, node: Text): Promise<boolean> => {
-  const device = getBackendDeviceOrSkip(ctx, backend);
-
-  if (!device) {
-    return false;
-  }
+  const device = getBackendDevice(backend);
 
   device.pushErrorScope('validation');
 
@@ -109,7 +97,7 @@ describe('WebGPU text atlas upload', () => {
   afterEach(() => resetDefaultGlyphAtlasPool());
 
   test('re-resolves the atlas binding when a later Text adds new glyphs (no stale bind-group cache)', async ctx => {
-    const backend = await setupBackend(ctx);
+    const backend = await setupBackend();
     // The Text constructor rasterizes eagerly, so the second Text must be
     // created only after the first upload — only then are its (disjoint) glyphs
     // new to the shared atlas, exercising the post-cache re-sync path.

--- a/test/rendering/browser/webgpu-tilemap-interleave.test.ts
+++ b/test/rendering/browser/webgpu-tilemap-interleave.test.ts
@@ -4,8 +4,9 @@
  * `webgl2-tilemap-interleave.test.ts`: an application-owned sibling node placed
  * BETWEEN two `TileMapView` bands composites in document order (over the band
  * below, under the band above) on a real WebGPU backend. All WebGPU renderers
- * use inline WGSL — no shader mocks. Tests skip gracefully when WebGPU is
- * unavailable (no adapter) or the software adapter is lost mid-test.
+ * use inline WGSL — no shader mocks. CI guarantees a real WebGPU adapter (the
+ * required Chromium-WebGPU lane runs against Mesa lavapipe); `renderScene`
+ * only skips when the software adapter drops the device mid-test.
  *
  * Run via:  pnpm test:browser:webgpu
  */
@@ -19,7 +20,7 @@ import type { RenderNode } from '#rendering/RenderNode';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { createSolidTexture, makeTileset, singleTileMap, wireTilemapRenderers } from './_tilemapScene';
-import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+import { getBackendDevice } from './webgpu-test-helpers';
 
 type RgbaTuple = readonly [number, number, number, number];
 
@@ -31,21 +32,7 @@ const makeApp = (canvas: HTMLCanvasElement): Application =>
     options: { canvas: { width: canvasSize, height: canvasSize }, clearColor: Color.black },
   }) as unknown as Application;
 
-const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<WebGpuBackend | null> => {
-  if (!navigator.gpu) {
-    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-
-    return null;
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-
-  if (!adapter) {
-    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-
-    return null;
-  }
-
+const setupBackend = async (): Promise<WebGpuBackend> => {
   const canvas = document.createElement('canvas');
 
   canvas.width = canvasSize;
@@ -86,11 +73,7 @@ const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 18)
 const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
 
 const renderScene = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
-  const device = getBackendDeviceOrSkip(ctx, backend);
-
-  if (!device) {
-    return false;
-  }
+  const device = getBackendDevice(backend);
 
   device.pushErrorScope('validation');
 
@@ -168,11 +151,7 @@ const makeInterleaveScene = () => {
 
 describe('WebGPU tilemap — actor interleaving (G-INTERLEAVE)', () => {
   test('an actor sibling composites between the ground and roof bands', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const { worldRoot, dispose } = makeInterleaveScene();
 

--- a/test/rendering/browser/webgpu-tilemap-snap.test.ts
+++ b/test/rendering/browser/webgpu-tilemap-snap.test.ts
@@ -6,11 +6,10 @@
  * at a fractional world position produces no background/clear-colour gaps
  * across a chunk boundary in the rendered output.
  *
- * All WebGPU tests skip gracefully when WebGPU is unavailable (no adapter or
- * software adapter lost mid-test). The double-skip contract:
- *  1. `setupBackend` skips when navigator.gpu / requestAdapter() is absent.
- *  2. `renderScene` calls `getBackendDeviceOrSkip` (device-gone guard) and
- *     catches DOMException device-loss mid-test.
+ * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
+ * against Mesa lavapipe), so these tests do not skip on a missing adapter —
+ * `renderScene` only skips when the software adapter drops the device
+ * mid-test (a DOMException device-loss caught during rendering).
  *
  * Run via:  pnpm test:browser:webgpu
  */
@@ -23,7 +22,7 @@ import type { RenderNode } from '#rendering/RenderNode';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { createSolidTexture, makeTileset, wireTilemapRenderers } from './_tilemapScene';
-import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+import { getBackendDevice } from './webgpu-test-helpers';
 
 type RgbaTuple = readonly [number, number, number, number];
 
@@ -35,21 +34,7 @@ const makeApp = (canvas: HTMLCanvasElement): Application =>
     options: { canvas: { width: canvasSize, height: canvasSize }, clearColor: Color.black },
   }) as unknown as Application;
 
-const setupBackend = async (ctx: { skip: (reason: string) => void }): Promise<WebGpuBackend | null> => {
-  if (!navigator.gpu) {
-    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-
-    return null;
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-
-  if (!adapter) {
-    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-
-    return null;
-  }
-
+const setupBackend = async (): Promise<WebGpuBackend> => {
   const canvas = document.createElement('canvas');
 
   canvas.width = canvasSize;
@@ -95,11 +80,7 @@ const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException 
 // Render a scene inside a validation error scope.
 // Returns false when the device dropped mid-test (caller should bail).
 const renderScene = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
-  const device = getBackendDeviceOrSkip(ctx, backend);
-
-  if (!device) {
-    return false;
-  }
+  const device = getBackendDevice(backend);
 
   device.pushErrorScope('validation');
 
@@ -165,11 +146,7 @@ function buildSeamMap(texture: ReturnType<typeof createSolidTexture>): TileMap {
 
 describe('WebGPU tilemap pixel snapping — chunk seam', () => {
   test('geometry mode: no clear-colour gap across chunk boundary at fractional position', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#ff0000');
     const node = new TileMapNode(buildSeamMap(texture));
@@ -203,11 +180,7 @@ describe('WebGPU tilemap pixel snapping — chunk seam', () => {
   });
 
   test('pixelSnapMode is render-only: logical position is unchanged after render', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#00ff00');
     const node = new TileMapNode(buildSeamMap(texture));
@@ -231,11 +204,7 @@ describe('WebGPU tilemap pixel snapping — chunk seam', () => {
   });
 
   test('snapped tilemap rendering is deterministic across frames', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#0000ff');
     const node = new TileMapNode(buildSeamMap(texture));
@@ -278,11 +247,7 @@ describe('WebGPU tilemap pixel snapping — chunk seam', () => {
   });
 
   test('position mode also produces no seam gap across chunk boundary', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#ff0000');
     const node = new TileMapNode(buildSeamMap(texture));
@@ -312,11 +277,7 @@ describe('WebGPU tilemap pixel snapping — chunk seam', () => {
   });
 
   test('unsnapped tilemap at integer position renders without gaps', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#ff0000');
     const node = new TileMapNode(buildSeamMap(texture));

--- a/test/rendering/browser/webgpu-tilemap.test.ts
+++ b/test/rendering/browser/webgpu-tilemap.test.ts
@@ -4,8 +4,9 @@
  * The parity counterpart of `webgl2-tilemap.test.ts`: single/multi-tileset
  * rendering, all 8 tile orientations, culling, layer opacity, and one-extension
  * Tiled wiring on a real WebGPU backend. All WebGPU renderers use inline WGSL —
- * no shader mocks. Tests skip gracefully when WebGPU is unavailable (no adapter)
- * or the software adapter is lost mid-test.
+ * no shader mocks. CI guarantees a real WebGPU adapter (the required
+ * Chromium-WebGPU lane runs against Mesa lavapipe); `renderScene` only skips
+ * when the software adapter drops the device mid-test.
  *
  * Run via:  pnpm test:browser:webgpu
  */
@@ -18,7 +19,7 @@ import type { RenderNode } from '#rendering/RenderNode';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { createQuadrantTexture, createSolidTexture, makeTileset, singleTileMap, wireTilemapRenderers, wireViaTiledExtension } from './_tilemapScene';
-import { getBackendDeviceOrSkip } from './webgpu-test-helpers';
+import { getBackendDevice } from './webgpu-test-helpers';
 
 type RgbaTuple = readonly [number, number, number, number];
 
@@ -30,24 +31,7 @@ const makeApp = (canvas: HTMLCanvasElement): Application =>
     options: { canvas: { width: canvasSize, height: canvasSize }, clearColor: Color.black },
   }) as unknown as Application;
 
-const setupBackend = async (
-  ctx: { skip: (reason: string) => void },
-  wire: (backend: WebGpuBackend) => void = wireTilemapRenderers,
-): Promise<WebGpuBackend | null> => {
-  if (!navigator.gpu) {
-    ctx.skip('WebGPU unavailable: navigator.gpu is absent');
-
-    return null;
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-
-  if (!adapter) {
-    ctx.skip('WebGPU unavailable: requestAdapter() returned null');
-
-    return null;
-  }
-
+const setupBackend = async (wire: (backend: WebGpuBackend) => void = wireTilemapRenderers): Promise<WebGpuBackend> => {
   const canvas = document.createElement('canvas');
 
   canvas.width = canvasSize;
@@ -88,11 +72,7 @@ const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 18)
 const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
 
 const renderScene = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
-  const device = getBackendDeviceOrSkip(ctx, backend);
-
-  if (!device) {
-    return false;
-  }
+  const device = getBackendDevice(backend);
 
   device.pushErrorScope('validation');
 
@@ -123,11 +103,7 @@ const renderScene = async (ctx: { skip: (reason: string) => void }, backend: Web
 
 describe('WebGPU tilemap — single tile', () => {
   test('renders one tile at the node position', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#ff0000');
     const node = new TileMapNode(singleTileMap(texture));
@@ -152,11 +128,7 @@ describe('WebGPU tilemap — single tile', () => {
 
 describe('WebGPU tilemap — multiple tilesets', () => {
   test('renders adjacent tiles from two different tileset textures', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const red = createSolidTexture('#ff0000');
     const blue = createSolidTexture('#0000ff');
@@ -191,11 +163,7 @@ describe('WebGPU tilemap — multiple tilesets', () => {
 
 describe('WebGPU tilemap — tile orientation', () => {
   test('all 8 flip/diagonal orientations permute the source quadrants correctly', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createQuadrantTexture();
 
@@ -263,11 +231,7 @@ describe('WebGPU tilemap — tile orientation', () => {
 
 describe('WebGPU tilemap — chunk culling', () => {
   test('culls off-screen chunks and draws on-screen ones', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#ff0000');
     const tileset = makeTileset(texture);
@@ -308,11 +272,7 @@ describe('WebGPU tilemap — chunk culling', () => {
 
 describe('WebGPU tilemap — layer opacity', () => {
   test('applies layer opacity to the rendered tile', async ctx => {
-    const backend = await setupBackend(ctx);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend();
 
     const texture = createSolidTexture('#ffffff');
     const tileset = makeTileset(texture);
@@ -343,11 +303,7 @@ describe('WebGPU tilemap — layer opacity', () => {
 
 describe('WebGPU tilemap — one-extension Tiled wiring', () => {
   test('extensions: [tiledExtension] makes TileMapNode render via the tilemap dependency', async ctx => {
-    const backend = await setupBackend(ctx, wireViaTiledExtension);
-
-    if (!backend) {
-      return;
-    }
+    const backend = await setupBackend(wireViaTiledExtension);
 
     const texture = createSolidTexture('#00ff00');
     const node = new TileMapNode(singleTileMap(texture));


### PR DESCRIPTION
The blocking Chromium-WebGPU CI lane runs against Mesa lavapipe (real Vulkan software rasterizer), so WebGPU is guaranteed there. The per-test *availability* skips (`navigator.gpu absent` / `requestAdapter() returned null`) can therefore only mask a real regression as a silent green — a missing adapter should FAIL the lane, not skip.

- Removed every availability `ctx.skip(...)` + its guard across all 22 `test/rendering/browser/webgpu-*.test.ts` files.
- Shared helper: `getBackendDeviceOrSkip(ctx, backend)` → `getBackendDevice(backend)` (plain pass-through); `setupBackend` now returns `Promise<WebGpuBackend>` (no skip-then-null). `WebGpuBackend.initialize()` already throws on a missing adapter/device, so a genuine failure now surfaces.
- **Kept** the `device lost mid-test — unstable software adapter` skips (legitimate flakiness guards); the 9 that trip `vitest/no-disabled-tests` got a scoped `eslint-disable-next-line` with justification (the 13 inside shared helpers don't trip the rule).

Verify: `typecheck` · `lint:all` 0 errors · `format:check` clean. The browser-WebGPU behaviour is validated by the CI lavapipe lane (no local adapter available).