### PR TITLE
chore(ci): coverage gate + nightly full-matrix + create-exo-app version check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,18 @@
 version: 2
 updates:
+  # Single npm entry for the whole pnpm workspace: Dependabot's npm ecosystem is
+  # pnpm-workspace-aware from the root manifest + pnpm-lock.yaml + pnpm-
+  # workspace.yaml, so this one entry already covers every workspace member's
+  # package.json — every packages/exojs-* extension, packages/create-exo-app,
+  # AND site/ (the Astro examples app). No per-package or per-`site` entry is
+  # needed or wanted (it would just double-PR the same dependency).
+  #
+  # There used to be a second entry here for `/examples`, added in #127
+  # (2026-06-13) — but examples/package.json was deleted over a month earlier
+  # when examples/ was split into examples/ (pure sources, no manifest) +
+  # site/ (the Astro app) (commit a11264e6, 2026-05-08). That entry pointed at a
+  # directory with no manifest and produced nothing but a failed Dependabot job
+  # every week; removed. `site/` needs no entry of its own — see above.
   - package-ecosystem: npm
     directory: '/'
     schedule:
@@ -29,29 +42,6 @@ updates:
           - 'typescript-eslint'
           - 'eslint-plugin-*'
           - 'eslint-config-*'
-      patch-only:
-        update-types:
-          - patch
-    ignore:
-      - dependency-name: '*'
-        update-types:
-          - version-update:semver-major
-
-  - package-ecosystem: npm
-    directory: '/examples'
-    schedule:
-      interval: weekly
-      day: monday
-      time: '06:15'
-      timezone: 'Europe/Berlin'
-    open-pull-requests-limit: 10
-    cooldown:
-      semver-patch-days: 3
-      semver-minor-days: 7
-    labels:
-      - dependencies
-      - examples
-    groups:
       patch-only:
         update-types:
           - patch

--- a/.github/workflows/nightly-full-ci.yml
+++ b/.github/workflows/nightly-full-ci.yml
@@ -1,0 +1,46 @@
+name: Nightly Full CI
+
+# Full-matrix backstop, independent of PR path-filtering.
+#
+# `ci.yml` gates PRs through `scripts/ci/select-lanes.mjs`, which skips lanes
+# whose path-to-area mapping doesn't classify a change as engine/site/audioFx
+# impacting. That classification is itself just a heuristic maintained by hand
+# in select-lanes.mjs; a bug there (a mis-scoped path, a new lane nobody wired
+# into RUNTIME_PACKAGES, etc.) can make a PR skip a lane it should have run —
+# exactly the class of defect `required-ci`'s in-PR contract checks (see
+# _ci-checks.yml) cannot catch, because they only assert the CONTRACT between
+# the detector's own output and which jobs ran, not whether the detector itself
+# classified the change correctly.
+#
+# select-lanes.mjs already runs every lane unconditionally on any non-
+# `pull_request` event (see its `main()`): "a push to main, a tag release ... or
+# a manual dispatch is always validated in full, never partially." A scheduled
+# (`schedule`) trigger is likewise not `pull_request`, so calling the same
+# reusable `_ci-checks.yml` workflow here — with no changed-file list, no path
+# filter — genuinely exercises every lane every night regardless of what the
+# select-lanes heuristic would have decided for any given PR. A red run here
+# with no corresponding red PR is the signal that select-lanes drifted from
+# reality.
+#
+# Deliberately minimal: no Slack/issue-filing wiring, no artifact retention
+# beyond what _ci-checks.yml already does. A red scheduled run shows up in the
+# Actions tab and email notifications on failure; that is the whole point.
+
+on:
+  schedule:
+    # 03:17 UTC daily — off the hour, avoiding the stampede of jobs scheduled
+    # exactly on the hour across GitHub Actions.
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: nightly-full-ci
+  cancel-in-progress: false
+
+jobs:
+  checks:
+    uses: ./.github/workflows/_ci-checks.yml

--- a/packages/exojs-physics/test/perf.test.ts
+++ b/packages/exojs-physics/test/perf.test.ts
@@ -134,6 +134,17 @@ describe('physics dynamics performance', () => {
     // Baseline: the identical field with sleeping disabled stays fully active.
     const awake = buildField(1000, 5, { enableSleeping: false });
 
+    // Skipped entirely under istanbul coverage: instrumentation inflates the
+    // per-step cost enough (see the identical `cov_` guard above) that the full
+    // 840-step awake+sleeping budget across two 5,000-body fields blows even the
+    // 60s timeout below. The sharp gate runs in the normal `pnpm test` run +
+    // `verify:ci`.
+    if (awake.world.step.toString().includes('cov_')) {
+      console.log('sleeping-vs-awake perf gate skipped under coverage (instrumentation slows the measurement past the timeout)');
+
+      return;
+    }
+
     for (let i = 0; i < 240; i++) {
       awake.world.step(FRAME);
     }

--- a/test/core/application-import.test.ts
+++ b/test/core/application-import.test.ts
@@ -8,11 +8,18 @@ describe('@/core/Application import behavior', () => {
     vi.resetModules();
   });
 
+  // Explicit timeout above the project default (15s): under istanbul coverage
+  // instrumentation this dynamic `import()` compiles the full Application
+  // module graph on demand (nothing is pre-transformed/cached at file-load
+  // time, unlike a static top-level import), which measured consistently at
+  // 14-18s under `pnpm test:coverage` — right at the default budget's edge.
+  // Functionally instant without coverage (~3s); this only widens the margin
+  // for the one-time instrumentation cost.
   it('does not create a canvas on import', async () => {
     const createElementSpy = vi.spyOn(document, 'createElement');
 
     await import('#core/Application');
 
     expect(createElementSpy).not.toHaveBeenCalled();
-  });
+  }, 25_000);
 });

--- a/test/release/create-exo-app-templates.test.ts
+++ b/test/release/create-exo-app-templates.test.ts
@@ -1,0 +1,112 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+// Version-agnostic guard for packages/create-exo-app/templates/*/package.json:
+// every scaffolded app depends on `@codexo/exojs` (and, if a template ever grows
+// one, an `@codexo/exojs-*` extension), and that dependency range must never be
+// allowed to silently drift from the package it actually resolves against —
+// otherwise `npm create exo-app` hands out a project that breaks on install or
+// at runtime. Nothing here is hard-coded to a version number; both the current
+// version and the templates are read from disk so this test never goes stale on
+// a version bump (mirrors `release-coherence.test.ts`).
+const repoRoot = resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+
+interface Manifest {
+  name?: string;
+  version?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+const readManifest = (path: string): Manifest => JSON.parse(readFileSync(path, 'utf8')) as Manifest;
+
+const templatesDir = resolve(repoRoot, 'packages', 'create-exo-app', 'templates');
+const templateDirs = readdirSync(templatesDir, { withFileTypes: true })
+  .filter(entry => entry.isDirectory())
+  .map(entry => entry.name)
+  .sort();
+
+// name -> version for every package that a template could plausibly depend on
+// (Core plus every extension under packages/*). Read from disk, not hard-coded,
+// so a new extension package (or a version bump of an existing one) is picked
+// up automatically.
+const corePkg = readManifest(resolve(repoRoot, 'package.json'));
+const packagesDir = resolve(repoRoot, 'packages');
+const publishedVersions = new Map<string, string>();
+if (corePkg.name !== undefined && corePkg.version !== undefined) {
+  publishedVersions.set(corePkg.name, corePkg.version);
+}
+for (const dir of readdirSync(packagesDir, { withFileTypes: true })) {
+  if (!dir.isDirectory()) continue;
+  try {
+    const manifest = readManifest(resolve(packagesDir, dir.name, 'package.json'));
+    if (manifest.name !== undefined && manifest.version !== undefined) {
+      publishedVersions.set(manifest.name, manifest.version);
+    }
+  } catch {
+    // No package.json (or unreadable) — not a package directory, skip.
+  }
+}
+
+/**
+ * A dependency range on an `@codexo/exojs*` package is considered in sync with
+ * `version` when it is:
+ *   - the literal `latest` dist-tag (the documented create-exo-app convention —
+ *     see scripts/verify-create-exo-app.ts — which by construction can never
+ *     drift, since it always resolves to whatever is newest on npm); or
+ *   - an exact match of `version` (optionally caret-prefixed); or
+ *   - the lockstep `<major>.<minor>.x` form used elsewhere in the repo (see
+ *     scripts/verify-lockstep-versions.ts) for the same major.minor as `version`.
+ * Anything else (a stale pin, a mismatched major/minor, a `workspace:` protocol
+ * range that would break a published scaffold) fails.
+ */
+function isInSyncRange(range: string, version: string): boolean {
+  if (range === 'latest') return true;
+  if (range === version || range === `^${version}`) return true;
+
+  const [major, minor] = version.split('.');
+  return range === `${major}.${minor}.x` || range === `^${major}.${minor}.0`;
+}
+
+describe('create-exo-app template version sync', () => {
+  it('discovers at least one template', () => {
+    expect(templateDirs.length).toBeGreaterThan(0);
+  });
+
+  it('every published @codexo/exojs* package resolved from disk has a version', () => {
+    expect(publishedVersions.size).toBeGreaterThan(0);
+    expect(publishedVersions.get('@codexo/exojs')).toBe(corePkg.version);
+  });
+
+  for (const template of templateDirs) {
+    const manifest = readManifest(resolve(templatesDir, template, 'package.json'));
+    const deps = { ...manifest.dependencies, ...manifest.devDependencies };
+    const exoDeps = Object.entries(deps).filter(([name]) => name === '@codexo/exojs' || name.startsWith('@codexo/exojs-'));
+
+    it(`${template}: declares a @codexo/exojs dependency`, () => {
+      expect(manifest.dependencies?.['@codexo/exojs']).toBeDefined();
+    });
+
+    it(`${template}: never uses the workspace: protocol (not publishable)`, () => {
+      for (const [, range] of exoDeps) {
+        expect(range.startsWith('workspace:')).toBe(false);
+      }
+    });
+
+    for (const [name, range] of exoDeps) {
+      it(`${template}: ${name}@"${range}" is in sync with the published version`, () => {
+        const publishedVersion = publishedVersions.get(name);
+        expect(publishedVersion, `no package under packages/ (or root) publishes "${name}"`).toBeDefined();
+        expect(isInSyncRange(range, publishedVersion!), `"${range}" is not in sync with ${name}@${publishedVersion} — update the template`).toBe(true);
+      });
+    }
+  }
+
+  it('every template agrees on the same @codexo/exojs range (no partial-update drift)', () => {
+    const ranges = new Set(templateDirs.map(template => readManifest(resolve(templatesDir, template, 'package.json')).dependencies?.['@codexo/exojs']));
+    expect([...ranges]).toHaveLength(1);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -87,6 +87,24 @@ export default defineConfig({
       reporter: ['lcov', 'clover', 'text-summary'],
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.d.ts'],
+      // Hard regression gate for the `unit-tests` job (already required in
+      // `_ci-checks.yml`) — `.codecov.yml` posts project/patch coverage statuses
+      // but they are NOT wired up as required checks, so a coverage drop
+      // currently merges silently. These thresholds fail `pnpm test:coverage`
+      // itself (the exact command the CI job runs) below the floor.
+      //
+      // A ratchet floor, not a target: set a few points below the measured
+      // baseline (statements 75.34%, branches 65.43%, functions 74.23%, lines
+      // 75.81% as of 2026-07-03) so normal test-suite churn doesn't flake the
+      // gate, while still catching a real regression. Raise the floor as
+      // coverage grows — never lower it without an explicit reason recorded
+      // here.
+      thresholds: {
+        statements: 73,
+        branches: 63,
+        functions: 72,
+        lines: 73,
+      },
     },
     projects: [
       // ── jsdom unit/integration projects (Core + extensions) ──────────────


### PR DESCRIPTION
CI/config hardening (four items).

**Coverage gate (#7):** added `coverage.thresholds` to `vitest.config.ts` (statements 73 / branches 63 / functions 72 / lines 73 — a ratchet floor a few points below current). The already-required `unit-tests` job now fails on a real coverage regression (`.codecov.yml` statuses are informational only, not required checks).

**Nightly full-matrix (#8):** `.github/workflows/nightly-full-ci.yml` (`schedule` + `workflow_dispatch`) calls the reusable `_ci-checks.yml`; on a non-PR event `select-lanes.mjs` forces every lane, so the nightly exercises the full matrix regardless of path-filter classification — a backstop for a select-lanes bug that the in-PR contract checks can't catch. actionlint-clean.

**create-exo-app version-sync (#10):** new version-agnostic `test/release/create-exo-app-templates.test.ts` asserting each template's `@codexo/exojs`* range is `latest` or an in-sync `^x.y.z`/`x.y.x` range (rejects `workspace:`), running in normal CI — the existing scaffold check only ran at tag-push.

**Dependabot (#12):** removed a dead `/examples` npm entry (it pointed at a `package.json` deleted in the examples/site split) — the root `/` entry already covers the whole pnpm workspace. github-actions coverage already adequate.

Also: two pre-existing tests that only fail under istanbul instrumentation got the standard `cov_`-skip guard / a timeout bump (physics perf bench, application-import) so `test:coverage` is green.

Verify: typecheck · lint 0 errors · format · `test:coverage` (4474 passed, above thresholds).