### PR TITLE
fix(core): guard scene-graph cycles + post-destroy Application reuse

### DIFF
--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -25,6 +25,7 @@ import { Loader, type LoaderOptions } from '#resources/Loader';
 import { Capabilities } from './capabilities';
 import { Clock } from './Clock';
 import { Color } from './Color';
+import { assert, invariant } from './dev';
 import { FixedTimestep } from './FixedTimestep';
 import { computeLetterboxLayout } from './letterbox';
 import { hello, logger } from './logging';
@@ -288,6 +289,7 @@ export class Application {
   private _frameAlpha = 0;
 
   private _status: ApplicationStatus = ApplicationStatus.Stopped;
+  private _destroyed = false;
   private _pixelRatio: number = defaultCanvasSettings.pixelRatio;
   private _designWidth: number = defaultCanvasSettings.width;
   private _designHeight: number = defaultCanvasSettings.height;
@@ -314,6 +316,9 @@ export class Application {
 
     const logicalWidth = canvasOptions.width ?? defaultCanvasSettings.width;
     const logicalHeight = canvasOptions.height ?? defaultCanvasSettings.height;
+
+    assert(logicalWidth > 0 && logicalHeight > 0, `Application canvas dimensions must be positive (got ${logicalWidth}×${logicalHeight}).`);
+
     this._pixelRatio = canvasOptions.pixelRatio ?? resolveAutoPixelRatio();
     this._designWidth = logicalWidth;
     this._designHeight = logicalHeight;
@@ -606,6 +611,8 @@ export class Application {
    * status returns to `Stopped` and the error propagates.
    */
   public async start(scene: Scene): Promise<this> {
+    invariant(!this._destroyed, 'Application.start() was called after destroy(). Construct a new Application instead of reusing a destroyed one.');
+
     if (this._status === ApplicationStatus.Stopped) {
       this._status = ApplicationStatus.Loading;
 
@@ -743,6 +750,8 @@ export class Application {
    * notified.
    */
   public resize(width: number, height: number): this {
+    assert(width > 0 && height > 0, `Application.resize() dimensions must be positive (got ${width}×${height}).`);
+
     this._designWidth = width;
     this._designHeight = height;
     this._applyCanvasSize(width, height);
@@ -900,6 +909,8 @@ export class Application {
    * unusable after this call.
    */
   public destroy(): void {
+    this._destroyed = true;
+
     if (typeof document !== 'undefined') {
       document.removeEventListener('visibilitychange', this._visibilityChangeHandler);
     }

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -1,3 +1,4 @@
+import { invariant } from '#core/dev';
 import type { Stage } from '#core/Stage';
 import { removeArrayItems } from '#core/utils';
 import type { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
@@ -85,6 +86,17 @@ export class Container extends RenderNode {
 
     if (child === this) {
       return this;
+    }
+
+    // Reject reparenting an ancestor of this container as a child: it would
+    // close a cycle in the scene graph, and every recursive walk over it
+    // (bounds cascade, updateParentTransform, subtree destroy) would loop
+    // forever instead of terminating at the root.
+    for (let ancestor = this.parent; ancestor !== null; ancestor = ancestor.parent) {
+      invariant(
+        ancestor !== child,
+        'Container.addChild(): cannot add an ancestor of this container as a child — that would create a cycle in the scene graph.',
+      );
     }
 
     if (child.parent) {


### PR DESCRIPTION
The conservative "asserts/warnings pass" — 4 high-value contract checks at core public-API boundaries, using the repaired always-on `invariant` + dev-only `assert`.

- **`Container.addChild`** — `invariant` rejecting reparenting an ancestor of `this` as a child: it would close a cycle in the scene graph, and every recursive walk (bounds cascade, transform update, subtree destroy) would then loop forever (hang / stack overflow, not a caught error). Public entry, O(depth), must hold in production.
- **`Application.start`** — `invariant(!this._destroyed, …)` (new `_destroyed` flag): `destroy()` resets status to `Stopped`, indistinguishable from "never started", so restarting after destroy silently re-inits against a destroyed Loader/backend and crashes deep in an unrelated subsystem. This throws a clear message at the real misuse site instead.
- **`Application` constructor + `resize()`** — dev-only `assert` that canvas dimensions are positive (a zero/negative canvas renders nothing with no error — a silent-corruption footgun), mirroring the existing `RenderTexture` precedent.

Deliberately conservative: the pass's "considered but deliberately skipped" set (destroyed-node reuse — no `_destroyed` on SceneNode; double-destroy — already idempotent codebase-wide; NaN transforms — hot path / out of scope; etc.) was evaluated and left out to avoid speculative spray. No public API-surface change.

Verify: typecheck · lint 0 errors · format · test (4473 passed).