### PR TITLE
ci: run the CI gate on merge_group (enable merge-queue support)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Run the same gate on merge-queue entries so the queue can require it. On a
+  # merge_group event select-lanes.mjs (non-PR path) runs every lane, so the
+  # queued merge is checked against the full matrix.
+  merge_group:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Adds the `merge_group` trigger to `ci.yml` so a GitHub merge queue can require the `checks / Required CI` aggregate. On a `merge_group` event `select-lanes.mjs` takes the non-PR path and runs every lane, so a queued merge is validated against the full matrix. **Inert** until the `merge_queue` ruleset rule is enabled (done separately once no auto-merges are in flight).