### PR TITLE
ci: pass caller secrets to the reusable checks workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,7 @@ concurrency:
 jobs:
   checks:
     uses: ./.github/workflows/_ci-checks.yml
+    # Reusable workflows do NOT see caller secrets by default; without this the
+    # Codecov upload runs tokenless and is rejected ("Token required because
+    # branch is protected").
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,8 @@ jobs:
       node-version: '24.x'
       pnpm-version: '11.4.0'
       ref: ${{ github.event.inputs.tag || github.ref_name }}
+    # Pass caller secrets through (CODECOV_TOKEN) — see ci.yml.
+    secrets: inherit
 
   # ── Stage 1: PREPARE/VERIFY ────────────────────────────────────────────────
   # Build every lockstep package exactly once, then pack/hash/attw/


### PR DESCRIPTION
Reusable workflows do not see caller secrets by default, so `_ci-checks.yml` always received an empty `CODECOV_TOKEN` — the Codecov upload ran tokenless and was rejected with `Token required because branch is protected` on every run (i.e. the upload has never worked). `secrets: inherit` on both call sites (ci.yml, release.yml) fixes the upload path. Verification: after merge, the main run's coverage job should log `processing complete` without the error line, and coverage data appears in Codecov.