### PR TITLE
ci: codecov test analytics + per-package coverage split

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,8 @@
 coverage:
   # Minimum project-wide coverage before Codecov reports a failure.
   # Start permissive; tighten once coverage grows above these floors.
+  # These statuses are informational — the hard regression gate is the
+  # vitest coverage thresholds in vitest.config.ts (fails the CI job itself).
   status:
     project:
       default:
@@ -14,18 +16,56 @@ coverage:
 ignore:
   - 'src/**/*.d.ts'
   - 'src/**/index.ts' # barrel re-exports add noise, not signal
+  - 'packages/*/src/**/*.d.ts'
+  - 'packages/*/src/**/index.ts'
   - 'scripts/**'
   - 'test/**'
+  - 'packages/*/test/**'
   - 'site/**'
 
 comment:
-  layout: 'reach,diff,flags,files'
+  layout: 'reach,diff,flags,components,files'
   behavior: default
   require_changes: true # only comment when coverage actually changes
 
-# Separate flags can be added later for, e.g., rendering vs. audio suites.
+# Upload flags — one per CI lane that uploads (see _ci-checks.yml).
 flags:
   unit:
     paths:
       - src/
+      - packages/
     carryforward: true
+
+# Per-package coverage breakdown in the PR comment and dashboard.
+# Components are pure reporting slices over the single `unit` upload —
+# no extra uploads needed. Untested packages (aseprite, ldtk, react) are
+# not listed yet; add each together with its first test suite (and its
+# vitest coverage.include entry).
+component_management:
+  default_rules:
+    statuses: [] # informational only — no per-component commit statuses
+  individual_components:
+    - component_id: core
+      name: core
+      paths:
+        - src/**
+    - component_id: particles
+      name: particles
+      paths:
+        - packages/exojs-particles/src/**
+    - component_id: tilemap
+      name: tilemap
+      paths:
+        - packages/exojs-tilemap/src/**
+    - component_id: tiled
+      name: tiled
+      paths:
+        - packages/exojs-tiled/src/**
+    - component_id: physics
+      name: physics
+      paths:
+        - packages/exojs-physics/src/**
+    - component_id: audio-fx
+      name: audio-fx
+      paths:
+        - packages/exojs-audio-fx/src/**

--- a/.github/workflows/_ci-checks.yml
+++ b/.github/workflows/_ci-checks.yml
@@ -178,16 +178,29 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Test (with coverage)
-        run: pnpm test:coverage
+        run: pnpm test:coverage -- --reporter=default --reporter=junit --outputFile.junit=./test-results/unit.junit.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6.0.2
         with:
           files: ./coverage/lcov.info
           flags: unit
-          fail_ci_if_error: false
+          # Loud on purpose: the upload failed silently for months (empty token
+          # in the reusable workflow) and nobody noticed.
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: Exoridus/ExoJS
+
+      # Test Analytics (flaky detection, failure rates, slowest tests). Runs
+      # even when the test step failed — capturing failures is the point.
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: ./test-results/unit.junit.xml
+          flags: unit
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   browser-tests:
     name: Browser Tests
@@ -230,7 +243,16 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Browser tests (Chromium WebGL2, new headless)
-        run: pnpm test:browser:webgl
+        run: pnpm test:browser:webgl -- --reporter=default --reporter=junit --outputFile.junit=./test-results/browser-webgl.junit.xml
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: ./test-results/browser-webgl.junit.xml
+          flags: browser-webgl
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   # Blocking lane. Chromium WebGPU is run against Mesa lavapipe (a real Vulkan
   # software rasterizer) instead of Chromium's bundled SwiftShader WebGPU
@@ -299,7 +321,16 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Browser tests (Chromium WebGPU, Mesa lavapipe via xvfb)
-        run: xvfb-run -a pnpm test:browser:webgpu
+        run: xvfb-run -a pnpm test:browser:webgpu -- --reporter=default --reporter=junit --outputFile.junit=./test-results/browser-webgpu.junit.xml
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: ./test-results/browser-webgpu.junit.xml
+          flags: browser-webgpu
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   # Optional, non-blocking lane. The Ubuntu CI runner does not give headless
   # Firefox a usable WebGL2 context, and Firefox WebGPU adapter availability
@@ -402,7 +433,16 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Browser tests (audio, headless Chromium)
-        run: pnpm test:browser:audio
+        run: pnpm test:browser:audio -- --reporter=default --reporter=junit --outputFile.junit=./test-results/browser-audio.junit.xml
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: ./test-results/browser-audio.junit.xml
+          flags: browser-audio
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   # Builds the core package and all extension packages exactly once, then
   # publishes the resulting dist trees as a shared artifact. `package-verify`

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ codexo-bg-*
 !.github/**
 !.husky
 !.husky/**
+
+test-results

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -85,8 +85,19 @@ export default defineConfig({
     coverage: {
       provider: 'istanbul',
       reporter: ['lcov', 'clover', 'text-summary'],
-      include: ['src/**/*.ts'],
-      exclude: ['src/**/*.d.ts'],
+      // Core plus the extension packages that have vitest projects in
+      // `test:coverage`. Untested packages (aseprite, ldtk, react) stay out —
+      // with `all: true` semantics their 0%-covered sources would swamp the
+      // global numbers without adding signal; add each when it gets a suite.
+      include: [
+        'src/**/*.ts',
+        'packages/exojs-particles/src/**/*.ts',
+        'packages/exojs-tilemap/src/**/*.ts',
+        'packages/exojs-tiled/src/**/*.ts',
+        'packages/exojs-physics/src/**/*.ts',
+        'packages/exojs-audio-fx/src/**/*.ts',
+      ],
+      exclude: ['src/**/*.d.ts', 'packages/*/src/**/*.d.ts'],
       // Hard regression gate for the `unit-tests` job (already required in
       // `_ci-checks.yml`) — `.codecov.yml` posts project/patch coverage statuses
       // but they are NOT wired up as required checks, so a coverage drop
@@ -94,11 +105,11 @@ export default defineConfig({
       // itself (the exact command the CI job runs) below the floor.
       //
       // A ratchet floor, not a target: set a few points below the measured
-      // baseline (statements 75.34%, branches 65.43%, functions 74.23%, lines
-      // 75.81% as of 2026-07-03) so normal test-suite churn doesn't flake the
-      // gate, while still catching a real regression. Raise the floor as
-      // coverage grows — never lower it without an explicit reason recorded
-      // here.
+      // baseline (statements 75.25%, branches 65.34%, functions 74.07%, lines
+      // 75.72% as of 2026-07-04, core + the five tested extension packages)
+      // so normal test-suite churn doesn't flake the gate, while still
+      // catching a real regression. Raise the floor as coverage grows — never
+      // lower it without an explicit reason recorded here.
       thresholds: {
         statements: 73,
         branches: 63,


### PR DESCRIPTION
Builds on #246 (working upload path). Coverage now counts the five tested extension packages alongside core (baseline barely moves: 75.25/65.34/74.07/75.72 vs core-only, so the vitest ratchet thresholds stay). Codecov components break coverage down per package in PR comments and the dashboard (config validated via codecov.io/validate). Test Analytics: the unit lane and the three blocking browser lanes emit JUnit XML and upload via codecov/test-results-action — also on failed runs (flaky detection on the GPU lanes). The coverage upload is fail_ci_if_error: true now, so a silent upload failure like the months-long empty-token one can never hide again. This PR is also its own end-to-end test: its coverage job must upload successfully or go red.