### PR TITLE
Fix seven math/text engine bugs, full src/math coverage, example follow-ups

### DIFF
--- a/examples/debug-layer/asset-browser.js
+++ b/examples/debug-layer/asset-browser.js
@@ -129,207 +129,273 @@ class AssetBrowserScene extends Scene {
     txtNoAssets = new Text('globalThis.assets is not available.\nRun this example in the ExoJS playground.', { fillColor: C.dim, fontSize: 16 });
     txtEmptyCat = new Text('(empty)', { fillColor: C.dimDark, fontSize: 13 });
     txtNoSel = new Text('Select an asset from the list.', { fillColor: C.dimDark, fontSize: 14 });
+    txtLoading = new Text('Loading assets…', { fillColor: C.dim, fontSize: 14 });
     txtMeta = new Text('', { fillColor: C.white, fontSize: 13, maxWidth: PREVIEW_W - 80 });
     txtAudioIcon = new Text('', { fillColor: C.white, fontSize: 28 });
     txtAnimPlay = new Text('', { fillColor: C.white, fontSize: 12 });
     txtAnimFrame = new Text('', { fillColor: C.dim, fontSize: 11 });
+    // Lazy per-category loading: only the initial category is fetched up
+    // front; every other one loads on first visit (see ensureCategory), so
+    // the browser becomes interactive quickly instead of downloading the
+    // whole catalog before the first frame.
+    assetLoader = null;
+    loadedCats = new Set();
+    loadingCats = new Set();
     async load(loader) {
-        const texBatch = {};
-        for (const [k, url] of Object.entries(assets.demo.textures ?? {})) {
-            texBatch[`tex_${k}`] = url;
-        }
-        if (Object.keys(texBatch).length)
-            await loader.load(Texture, texBatch);
-        const sprImgBatch = {};
-        const sprJsonBatch = {};
-        for (const [k, entry] of Object.entries(assets.demo.sprites ?? {})) {
-            sprImgBatch[`spr_${k}`] = entry.image;
-            sprJsonBatch[`spr_${k}`] = entry.data;
-        }
-        if (Object.keys(sprImgBatch).length) {
-            await loader.load(Texture, sprImgBatch);
-            await loader.load(Json, sprJsonBatch);
-        }
-        const sshImgBatch = {};
-        const sshJsonBatch = {};
-        for (const [k, entry] of Object.entries(assets.demo.spritesheets ?? {})) {
-            sshImgBatch[`ssh_${k}`] = entry.image;
-            sshJsonBatch[`ssh_${k}`] = entry.data;
-        }
-        if (Object.keys(sshImgBatch).length) {
-            await loader.load(Texture, sshImgBatch);
-            await loader.load(Json, sshJsonBatch);
-        }
-        const svgBatch = {};
-        for (const [k, url] of Object.entries(assets.demo.svg ?? {})) {
-            svgBatch[`svg_${k}`] = url;
-        }
-        if (Object.keys(svgBatch).length)
-            await loader.load(SvgAsset, svgBatch);
-        const inpImgBatch = {};
-        const inpJsonBatch = {};
-        for (const [k, entry] of Object.entries(assets.demo.inputPrompts ?? {})) {
-            inpImgBatch[`inp_${k}`] = entry.image;
-            inpJsonBatch[`inp_${k}`] = entry.data;
-        }
-        if (Object.keys(inpImgBatch).length) {
-            await loader.load(Texture, inpImgBatch);
-            await loader.load(Json, inpJsonBatch);
-        }
-        const audBatch = {};
-        for (const [k, url] of Object.entries(assets.demo.audio ?? {})) {
-            audBatch[`aud_${k}`] = url;
-        }
-        if (Object.keys(audBatch).length)
-            await loader.load(AudioStream, audBatch);
-        const sndBatch = {};
-        for (const [k, url] of Object.entries(assets.demo.sound ?? {})) {
-            sndBatch[`snd_${k}`] = url;
-        }
-        if (Object.keys(sndBatch).length)
-            await loader.load(AudioStream, sndBatch);
-        const musBatch = {};
-        for (const [k, url] of Object.entries(assets.demo.music ?? {})) {
-            musBatch[`mus_${k}`] = url;
-        }
-        if (Object.keys(musBatch).length)
-            await loader.load(AudioStream, musBatch);
-        const sdsBatch = {};
-        const sdsJsonBatch = {};
-        for (const [k, entry] of Object.entries(assets.demo.soundSprites ?? {})) {
-            sdsBatch[`sds_${k}`] = entry.audio;
-            sdsJsonBatch[`sds_${k}`] = entry.data;
-        }
-        if (Object.keys(sdsBatch).length) {
-            await loader.load(AudioStream, sdsBatch);
-            await loader.load(Json, sdsJsonBatch);
-        }
-        for (const [k, url] of Object.entries(assets.demo.fonts ?? {})) {
-            // The fonts category mixes vector fonts (.ttf/.otf) with bitmap-font
-            // sidecars (.fnt/.png) that FontFace cannot parse. Load only the
-            // vector entries — the bitmap ones fall back to a path readout.
-            if (!/\.(ttf|otf|woff2?)$/i.test(url))
-                continue;
-            const family = `assetbrowser_${k}`;
-            await loader.load(FontAsset, { [`fnt_${k}`]: url }, { family });
-        }
-        const techBatch = {};
-        for (const [subcat, items] of Object.entries(assets.technical ?? {})) {
-            for (const [k, u] of Object.entries(items)) {
-                techBatch[`tech_${subcat}_${k}`] = u;
-            }
-        }
-        if (Object.keys(techBatch).length)
-            await loader.load(Texture, techBatch);
-        const bgBatch = {};
-        for (const [k, url] of Object.entries(assets.demo.backgrounds ?? {})) {
-            bgBatch[`bg_${k}`] = url;
-        }
-        if (Object.keys(bgBatch).length)
-            await loader.load(Texture, bgBatch);
-        const curBatch = {};
-        for (const [k, url] of Object.entries(assets.demo.cursors ?? {})) {
-            curBatch[`cur_${k}`] = url;
-        }
-        if (Object.keys(curBatch).length)
-            await loader.load(SvgAsset, curBatch);
-        const tlsBatch = {};
-        for (const [k, entry] of Object.entries(assets.demo.tilesets ?? {})) {
-            tlsBatch[`tls_${k}`] = entry.image;
-        }
-        if (Object.keys(tlsBatch).length)
-            await loader.load(Texture, tlsBatch);
-        const vndBatch = {};
-        for (const [k, url] of Object.entries(assets.demo.vendor ?? {})) {
-            vndBatch[`vnd_${k}`] = url;
-        }
-        if (Object.keys(vndBatch).length)
-            await loader.load(Json, vndBatch);
+        this.assetLoader = loader;
+        await this.ensureCategory(this.cat);
     }
     init(loader) {
-        for (const [k] of Object.entries(assets.demo.textures ?? {})) {
-            const s = new Sprite(loader.get(Texture, `tex_${k}`));
-            s.setAnchor(0.5);
-            this.texSprites.set(k, s);
-        }
-        for (const [k] of Object.entries(assets.demo.sprites ?? {})) {
-            const tex = loader.get(Texture, `spr_${k}`);
-            const data = loader.get(Json, `spr_${k}`);
-            const ss = new Spritesheet(tex, data);
-            this.sprSheets.set(k, ss);
-            for (const s of ss.sprites.values())
-                s.setAnchor(0.5);
-        }
-        for (const [k] of Object.entries(assets.demo.spritesheets ?? {})) {
-            const tex = loader.get(Texture, `ssh_${k}`);
-            const data = loader.get(Json, `ssh_${k}`);
-            const ss = new Spritesheet(tex, data);
-            this.sshSheets.set(k, ss);
-            for (const s of ss.sprites.values())
-                s.setAnchor(0.5);
-        }
-        for (const [k] of Object.entries(assets.demo.svg ?? {})) {
-            const s = new Sprite(new Texture(loader.get(SvgAsset, `svg_${k}`)));
-            s.setAnchor(0.5);
-            this.svgSprites.set(k, s);
-        }
-        for (const [k] of Object.entries(assets.demo.inputPrompts ?? {})) {
-            const tex = loader.get(Texture, `inp_${k}`);
-            const data = loader.get(Json, `inp_${k}`);
-            const ss = new Spritesheet(tex, data);
-            this.inpSheets.set(k, ss);
-            for (const s of ss.sprites.values())
-                s.setAnchor(0.5);
-        }
-        for (const [k] of Object.entries(assets.demo.audio ?? {})) {
-            this.audioMusics.set(k, loader.get(AudioStream, `aud_${k}`));
-        }
-        for (const [k] of Object.entries(assets.demo.sound ?? {})) {
-            this.soundMusics.set(k, loader.get(AudioStream, `snd_${k}`));
-        }
-        for (const [k] of Object.entries(assets.demo.music ?? {})) {
-            this.musicMusics.set(k, loader.get(AudioStream, `mus_${k}`));
-        }
-        for (const [k] of Object.entries(assets.demo.soundSprites ?? {})) {
-            this.soundSpriteAudio.set(k, loader.get(AudioStream, `sds_${k}`));
-            this.soundSpriteData.set(k, loader.get(Json, `sds_${k}`));
-        }
-        for (const [k, url] of Object.entries(assets.demo.fonts ?? {})) {
-            // Match the load() filter: only vector fonts get a registered family;
-            // bitmap-font entries render via the path-readout fallback.
-            if (!/\.(ttf|otf|woff2?)$/i.test(url))
-                continue;
-            this.fontFamilies.set(k, `assetbrowser_${k}`);
-        }
-        for (const [subcat, items] of Object.entries(assets.technical ?? {})) {
-            for (const [k] of Object.entries(items)) {
-                const s = new Sprite(loader.get(Texture, `tech_${subcat}_${k}`));
-                s.setAnchor(0.5);
-                this.techSprites.set(`${subcat}.${k}`, s);
-            }
-        }
-        for (const [k] of Object.entries(assets.demo.backgrounds ?? {})) {
-            const s = new Sprite(loader.get(Texture, `bg_${k}`));
-            s.setAnchor(0.5);
-            this.bgSprites.set(k, s);
-        }
-        for (const [k] of Object.entries(assets.demo.cursors ?? {})) {
-            const s = new Sprite(new Texture(loader.get(SvgAsset, `cur_${k}`)));
-            s.setAnchor(0.5);
-            this.cursorSprites.set(k, s);
-        }
-        for (const [k] of Object.entries(assets.demo.tilesets ?? {})) {
-            const s = new Sprite(loader.get(Texture, `tls_${k}`));
-            s.setAnchor(0.5);
-            this.tilesetSprites.set(k, s);
-        }
-        for (const [k] of Object.entries(assets.demo.vendor ?? {})) {
-            this.vendorData.set(k, loader.get(Json, `vnd_${k}`));
-        }
+        this.assetLoader = loader;
         this.app.input.onPointerTap.add(p => this.onTap(p.x, p.y));
         this.app.input.onPointerMove.add(p => this.onMove(p.x, p.y));
         this.app.input.onMouseWheel.add(v => this.onWheel(v.y));
         this.selectFirstInCategory();
+    }
+    /** Load a category's assets (and build its preview objects) exactly once. */
+    async ensureCategory(catId) {
+        if (this.loadedCats.has(catId) || this.loadingCats.has(catId))
+            return;
+        this.loadingCats.add(catId);
+        try {
+            await this.loadCategory(catId);
+            this.loadedCats.add(catId);
+        }
+        finally {
+            this.loadingCats.delete(catId);
+        }
+    }
+    async loadCategory(catId) {
+        const loader = this.assetLoader;
+        switch (catId) {
+            case 'textures': {
+                const batch = {};
+                for (const [k, url] of Object.entries(assets.demo.textures ?? {})) {
+                    batch[`tex_${k}`] = url;
+                }
+                if (Object.keys(batch).length)
+                    await loader.load(Texture, batch);
+                for (const k of Object.keys(assets.demo.textures ?? {})) {
+                    const s = new Sprite(loader.get(Texture, `tex_${k}`));
+                    s.setAnchor(0.5);
+                    this.texSprites.set(k, s);
+                }
+                break;
+            }
+            case 'sprites': {
+                const imgBatch = {};
+                const jsonBatch = {};
+                for (const [k, entry] of Object.entries(assets.demo.sprites ?? {})) {
+                    imgBatch[`spr_${k}`] = entry.image;
+                    jsonBatch[`spr_${k}`] = entry.data;
+                }
+                if (Object.keys(imgBatch).length) {
+                    await loader.load(Texture, imgBatch);
+                    await loader.load(Json, jsonBatch);
+                }
+                for (const k of Object.keys(assets.demo.sprites ?? {})) {
+                    const ss = new Spritesheet(loader.get(Texture, `spr_${k}`), loader.get(Json, `spr_${k}`));
+                    this.sprSheets.set(k, ss);
+                    for (const s of ss.sprites.values())
+                        s.setAnchor(0.5);
+                }
+                break;
+            }
+            case 'spritesheets': {
+                const imgBatch = {};
+                const jsonBatch = {};
+                for (const [k, entry] of Object.entries(assets.demo.spritesheets ?? {})) {
+                    imgBatch[`ssh_${k}`] = entry.image;
+                    jsonBatch[`ssh_${k}`] = entry.data;
+                }
+                if (Object.keys(imgBatch).length) {
+                    await loader.load(Texture, imgBatch);
+                    await loader.load(Json, jsonBatch);
+                }
+                for (const k of Object.keys(assets.demo.spritesheets ?? {})) {
+                    const ss = new Spritesheet(loader.get(Texture, `ssh_${k}`), loader.get(Json, `ssh_${k}`));
+                    this.sshSheets.set(k, ss);
+                    for (const s of ss.sprites.values())
+                        s.setAnchor(0.5);
+                }
+                break;
+            }
+            case 'svg': {
+                const batch = {};
+                for (const [k, url] of Object.entries(assets.demo.svg ?? {})) {
+                    batch[`svg_${k}`] = url;
+                }
+                if (Object.keys(batch).length)
+                    await loader.load(SvgAsset, batch);
+                for (const k of Object.keys(assets.demo.svg ?? {})) {
+                    const s = new Sprite(new Texture(loader.get(SvgAsset, `svg_${k}`)));
+                    s.setAnchor(0.5);
+                    this.svgSprites.set(k, s);
+                }
+                break;
+            }
+            case 'inputPrompts': {
+                const imgBatch = {};
+                const jsonBatch = {};
+                for (const [k, entry] of Object.entries(assets.demo.inputPrompts ?? {})) {
+                    imgBatch[`inp_${k}`] = entry.image;
+                    jsonBatch[`inp_${k}`] = entry.data;
+                }
+                if (Object.keys(imgBatch).length) {
+                    await loader.load(Texture, imgBatch);
+                    await loader.load(Json, jsonBatch);
+                }
+                for (const k of Object.keys(assets.demo.inputPrompts ?? {})) {
+                    const ss = new Spritesheet(loader.get(Texture, `inp_${k}`), loader.get(Json, `inp_${k}`));
+                    this.inpSheets.set(k, ss);
+                    for (const s of ss.sprites.values())
+                        s.setAnchor(0.5);
+                }
+                break;
+            }
+            case 'audio': {
+                const batch = {};
+                for (const [k, url] of Object.entries(assets.demo.audio ?? {})) {
+                    batch[`aud_${k}`] = url;
+                }
+                if (Object.keys(batch).length)
+                    await loader.load(AudioStream, batch);
+                for (const k of Object.keys(assets.demo.audio ?? {})) {
+                    this.audioMusics.set(k, loader.get(AudioStream, `aud_${k}`));
+                }
+                break;
+            }
+            case 'sound': {
+                const batch = {};
+                for (const [k, url] of Object.entries(assets.demo.sound ?? {})) {
+                    batch[`snd_${k}`] = url;
+                }
+                if (Object.keys(batch).length)
+                    await loader.load(AudioStream, batch);
+                for (const k of Object.keys(assets.demo.sound ?? {})) {
+                    this.soundMusics.set(k, loader.get(AudioStream, `snd_${k}`));
+                }
+                break;
+            }
+            case 'music': {
+                const batch = {};
+                for (const [k, url] of Object.entries(assets.demo.music ?? {})) {
+                    batch[`mus_${k}`] = url;
+                }
+                if (Object.keys(batch).length)
+                    await loader.load(AudioStream, batch);
+                for (const k of Object.keys(assets.demo.music ?? {})) {
+                    this.musicMusics.set(k, loader.get(AudioStream, `mus_${k}`));
+                }
+                break;
+            }
+            case 'soundSprites': {
+                const audioBatch = {};
+                const jsonBatch = {};
+                for (const [k, entry] of Object.entries(assets.demo.soundSprites ?? {})) {
+                    audioBatch[`sds_${k}`] = entry.audio;
+                    jsonBatch[`sds_${k}`] = entry.data;
+                }
+                if (Object.keys(audioBatch).length) {
+                    await loader.load(AudioStream, audioBatch);
+                    await loader.load(Json, jsonBatch);
+                }
+                for (const k of Object.keys(assets.demo.soundSprites ?? {})) {
+                    this.soundSpriteAudio.set(k, loader.get(AudioStream, `sds_${k}`));
+                    this.soundSpriteData.set(k, loader.get(Json, `sds_${k}`));
+                }
+                break;
+            }
+            case 'fonts': {
+                for (const [k, url] of Object.entries(assets.demo.fonts ?? {})) {
+                    // The fonts category mixes vector fonts (.ttf/.otf) with
+                    // bitmap-font sidecars (.fnt/.png) that FontFace cannot
+                    // parse. Load only the vector entries — the bitmap ones
+                    // fall back to a path readout.
+                    if (!/\.(ttf|otf|woff2?)$/i.test(url))
+                        continue;
+                    const family = `assetbrowser_${k}`;
+                    await loader.load(FontAsset, { [`fnt_${k}`]: url }, { family });
+                    this.fontFamilies.set(k, family);
+                }
+                break;
+            }
+            case 'technical': {
+                const batch = {};
+                for (const [subcat, items] of Object.entries(assets.technical ?? {})) {
+                    for (const [k, u] of Object.entries(items)) {
+                        batch[`tech_${subcat}_${k}`] = u;
+                    }
+                }
+                if (Object.keys(batch).length)
+                    await loader.load(Texture, batch);
+                for (const [subcat, items] of Object.entries(assets.technical ?? {})) {
+                    for (const k of Object.keys(items)) {
+                        const s = new Sprite(loader.get(Texture, `tech_${subcat}_${k}`));
+                        s.setAnchor(0.5);
+                        this.techSprites.set(`${subcat}.${k}`, s);
+                    }
+                }
+                break;
+            }
+            case 'backgrounds': {
+                const batch = {};
+                for (const [k, url] of Object.entries(assets.demo.backgrounds ?? {})) {
+                    batch[`bg_${k}`] = url;
+                }
+                if (Object.keys(batch).length)
+                    await loader.load(Texture, batch);
+                for (const k of Object.keys(assets.demo.backgrounds ?? {})) {
+                    const s = new Sprite(loader.get(Texture, `bg_${k}`));
+                    s.setAnchor(0.5);
+                    this.bgSprites.set(k, s);
+                }
+                break;
+            }
+            case 'cursors': {
+                const batch = {};
+                for (const [k, url] of Object.entries(assets.demo.cursors ?? {})) {
+                    batch[`cur_${k}`] = url;
+                }
+                if (Object.keys(batch).length)
+                    await loader.load(SvgAsset, batch);
+                for (const k of Object.keys(assets.demo.cursors ?? {})) {
+                    const s = new Sprite(new Texture(loader.get(SvgAsset, `cur_${k}`)));
+                    s.setAnchor(0.5);
+                    this.cursorSprites.set(k, s);
+                }
+                break;
+            }
+            case 'tilesets': {
+                const batch = {};
+                for (const [k, entry] of Object.entries(assets.demo.tilesets ?? {})) {
+                    batch[`tls_${k}`] = entry.image;
+                }
+                if (Object.keys(batch).length)
+                    await loader.load(Texture, batch);
+                for (const k of Object.keys(assets.demo.tilesets ?? {})) {
+                    const s = new Sprite(loader.get(Texture, `tls_${k}`));
+                    s.setAnchor(0.5);
+                    this.tilesetSprites.set(k, s);
+                }
+                break;
+            }
+            case 'vendor': {
+                const batch = {};
+                for (const [k, url] of Object.entries(assets.demo.vendor ?? {})) {
+                    batch[`vnd_${k}`] = url;
+                }
+                if (Object.keys(batch).length)
+                    await loader.load(Json, batch);
+                for (const k of Object.keys(assets.demo.vendor ?? {})) {
+                    this.vendorData.set(k, loader.get(Json, `vnd_${k}`));
+                }
+                break;
+            }
+            default:
+                // 'video' previews only show the asset URL — nothing to load.
+                break;
+        }
     }
     techFlatKeys() {
         const out = [];
@@ -455,6 +521,7 @@ class AssetBrowserScene extends Scene {
                 if (this.cat !== CATEGORIES_ROW1[i].id) {
                     this.cat = CATEGORIES_ROW1[i].id;
                     this.selectFirstInCategory();
+                    void this.ensureCategory(this.cat);
                 }
                 return;
             }
@@ -465,6 +532,7 @@ class AssetBrowserScene extends Scene {
                 if (this.cat !== CATEGORIES_ROW2[i].id) {
                     this.cat = CATEGORIES_ROW2[i].id;
                     this.selectFirstInCategory();
+                    void this.ensureCategory(this.cat);
                 }
                 return;
             }
@@ -681,6 +749,14 @@ class AssetBrowserScene extends Scene {
         if (!this.key) {
             this.txtNoSel.setPosition(PREVIEW_X + (PREVIEW_W / 2) - 130, H / 2 - 10);
             context.render(this.txtNoSel);
+            this.drawInfoBar(context);
+            return;
+        }
+        // Category still fetching (lazy-load): keep the sidebar interactive
+        // and show a placeholder instead of an empty preview.
+        if (!this.loadedCats.has(this.cat)) {
+            this.txtLoading.setPosition(PREVIEW_X + (PREVIEW_W / 2) - 70, H / 2 - 10);
+            context.render(this.txtLoading);
             this.drawInfoBar(context);
             return;
         }

--- a/examples/debug-layer/asset-browser.ts
+++ b/examples/debug-layer/asset-browser.ts
@@ -157,226 +157,265 @@ class AssetBrowserScene extends Scene {
     );
     txtEmptyCat  = new Text('(empty)', { fillColor: C.dimDark, fontSize: 13 });
     txtNoSel     = new Text('Select an asset from the list.', { fillColor: C.dimDark, fontSize: 14 });
+    txtLoading   = new Text('Loading assets…', { fillColor: C.dim, fontSize: 14 });
     txtMeta      = new Text('', { fillColor: C.white, fontSize: 13, maxWidth: PREVIEW_W - 80 });
     txtAudioIcon = new Text('', { fillColor: C.white, fontSize: 28 });
     txtAnimPlay  = new Text('', { fillColor: C.white, fontSize: 12 });
     txtAnimFrame = new Text('', { fillColor: C.dim,   fontSize: 11 });
 
+    // Lazy per-category loading: only the initial category is fetched up
+    // front; every other one loads on first visit (see ensureCategory), so
+    // the browser becomes interactive quickly instead of downloading the
+    // whole catalog before the first frame.
+    private assetLoader: any = null;
+    loadedCats  = new Set<string>();
+    loadingCats = new Set<string>();
+
     override async load(loader): Promise<void> {
-
-
-        const texBatch: Record<string, string> = {};
-        for (const [k, url] of Object.entries(assets.demo.textures ?? {})) {
-            texBatch[`tex_${k}`] = url as string;
-        }
-        if (Object.keys(texBatch).length) await loader.load(Texture, texBatch);
-
-        const sprImgBatch: Record<string, string> = {};
-        const sprJsonBatch: Record<string, string> = {};
-        for (const [k, entry] of Object.entries(assets.demo.sprites ?? {})) {
-            sprImgBatch[`spr_${k}`]  = (entry as any).image;
-            sprJsonBatch[`spr_${k}`] = (entry as any).data;
-        }
-        if (Object.keys(sprImgBatch).length) {
-            await loader.load(Texture, sprImgBatch);
-            await loader.load(Json, sprJsonBatch);
-        }
-
-        const sshImgBatch: Record<string, string> = {};
-        const sshJsonBatch: Record<string, string> = {};
-        for (const [k, entry] of Object.entries(assets.demo.spritesheets ?? {})) {
-            sshImgBatch[`ssh_${k}`]  = (entry as any).image;
-            sshJsonBatch[`ssh_${k}`] = (entry as any).data;
-        }
-        if (Object.keys(sshImgBatch).length) {
-            await loader.load(Texture, sshImgBatch);
-            await loader.load(Json, sshJsonBatch);
-        }
-
-        const svgBatch: Record<string, string> = {};
-        for (const [k, url] of Object.entries(assets.demo.svg ?? {})) {
-            svgBatch[`svg_${k}`] = url as string;
-        }
-        if (Object.keys(svgBatch).length) await loader.load(SvgAsset, svgBatch);
-
-        const inpImgBatch: Record<string, string> = {};
-        const inpJsonBatch: Record<string, string> = {};
-        for (const [k, entry] of Object.entries(assets.demo.inputPrompts ?? {})) {
-            inpImgBatch[`inp_${k}`]  = (entry as any).image;
-            inpJsonBatch[`inp_${k}`] = (entry as any).data;
-        }
-        if (Object.keys(inpImgBatch).length) {
-            await loader.load(Texture, inpImgBatch);
-            await loader.load(Json, inpJsonBatch);
-        }
-
-        const audBatch: Record<string, string> = {};
-        for (const [k, url] of Object.entries(assets.demo.audio ?? {})) {
-            audBatch[`aud_${k}`] = url as string;
-        }
-        if (Object.keys(audBatch).length) await loader.load(AudioStream, audBatch);
-
-        const sndBatch: Record<string, string> = {};
-        for (const [k, url] of Object.entries(assets.demo.sound ?? {})) {
-            sndBatch[`snd_${k}`] = url as string;
-        }
-        if (Object.keys(sndBatch).length) await loader.load(AudioStream, sndBatch);
-
-        const musBatch: Record<string, string> = {};
-        for (const [k, url] of Object.entries(assets.demo.music ?? {})) {
-            musBatch[`mus_${k}`] = url as string;
-        }
-        if (Object.keys(musBatch).length) await loader.load(AudioStream, musBatch);
-
-        const sdsBatch: Record<string, string> = {};
-        const sdsJsonBatch: Record<string, string> = {};
-        for (const [k, entry] of Object.entries(assets.demo.soundSprites ?? {})) {
-            sdsBatch[`sds_${k}`]     = (entry as any).audio;
-            sdsJsonBatch[`sds_${k}`] = (entry as any).data;
-        }
-        if (Object.keys(sdsBatch).length) {
-            await loader.load(AudioStream, sdsBatch);
-            await loader.load(Json, sdsJsonBatch);
-        }
-
-        for (const [k, url] of Object.entries(assets.demo.fonts ?? {})) {
-            // The fonts category mixes vector fonts (.ttf/.otf) with bitmap-font
-            // sidecars (.fnt/.png) that FontFace cannot parse. Load only the
-            // vector entries — the bitmap ones fall back to a path readout.
-            if (!/\.(ttf|otf|woff2?)$/i.test(url as string)) continue;
-            const family = `assetbrowser_${k}`;
-            await loader.load(FontAsset, { [`fnt_${k}`]: url }, { family });
-        }
-
-        const techBatch: Record<string, string> = {};
-        for (const [subcat, items] of Object.entries(assets.technical ?? {})) {
-            for (const [k, u] of Object.entries(items as Record<string, string>)) {
-                techBatch[`tech_${subcat}_${k}`] = u;
-            }
-        }
-        if (Object.keys(techBatch).length) await loader.load(Texture, techBatch);
-
-        const bgBatch: Record<string, string> = {};
-        for (const [k, url] of Object.entries(assets.demo.backgrounds ?? {})) {
-            bgBatch[`bg_${k}`] = url as string;
-        }
-        if (Object.keys(bgBatch).length) await loader.load(Texture, bgBatch);
-
-        const curBatch: Record<string, string> = {};
-        for (const [k, url] of Object.entries(assets.demo.cursors ?? {})) {
-            curBatch[`cur_${k}`] = url as string;
-        }
-        if (Object.keys(curBatch).length) await loader.load(SvgAsset, curBatch);
-
-        const tlsBatch: Record<string, string> = {};
-        for (const [k, entry] of Object.entries(assets.demo.tilesets ?? {})) {
-            tlsBatch[`tls_${k}`] = (entry as any).image;
-        }
-        if (Object.keys(tlsBatch).length) await loader.load(Texture, tlsBatch);
-
-        const vndBatch: Record<string, string> = {};
-        for (const [k, url] of Object.entries(assets.demo.vendor ?? {})) {
-            vndBatch[`vnd_${k}`] = url as string;
-        }
-        if (Object.keys(vndBatch).length) await loader.load(Json, vndBatch);
+        this.assetLoader = loader;
+        await this.ensureCategory(this.cat);
     }
 
     override init(loader): void {
-        for (const [k] of Object.entries(assets.demo.textures ?? {})) {
-            const s = new Sprite(loader.get(Texture, `tex_${k}`));
-            s.setAnchor(0.5);
-            this.texSprites.set(k, s);
-        }
-
-        for (const [k] of Object.entries(assets.demo.sprites ?? {})) {
-            const tex  = loader.get(Texture, `spr_${k}`);
-            const data = loader.get(Json, `spr_${k}`);
-            const ss   = new Spritesheet(tex, data);
-            this.sprSheets.set(k, ss);
-            for (const s of ss.sprites.values()) s.setAnchor(0.5);
-        }
-
-        for (const [k] of Object.entries(assets.demo.spritesheets ?? {})) {
-            const tex  = loader.get(Texture, `ssh_${k}`);
-            const data = loader.get(Json, `ssh_${k}`);
-            const ss   = new Spritesheet(tex, data);
-            this.sshSheets.set(k, ss);
-            for (const s of ss.sprites.values()) s.setAnchor(0.5);
-        }
-
-        for (const [k] of Object.entries(assets.demo.svg ?? {})) {
-            const s = new Sprite(new Texture(loader.get(SvgAsset, `svg_${k}`)));
-            s.setAnchor(0.5);
-            this.svgSprites.set(k, s);
-        }
-
-        for (const [k] of Object.entries(assets.demo.inputPrompts ?? {})) {
-            const tex  = loader.get(Texture, `inp_${k}`);
-            const data = loader.get(Json, `inp_${k}`);
-            const ss   = new Spritesheet(tex, data);
-            this.inpSheets.set(k, ss);
-            for (const s of ss.sprites.values()) s.setAnchor(0.5);
-        }
-
-        for (const [k] of Object.entries(assets.demo.audio ?? {})) {
-            this.audioMusics.set(k, loader.get(AudioStream, `aud_${k}`));
-        }
-
-        for (const [k] of Object.entries(assets.demo.sound ?? {})) {
-            this.soundMusics.set(k, loader.get(AudioStream, `snd_${k}`));
-        }
-
-        for (const [k] of Object.entries(assets.demo.music ?? {})) {
-            this.musicMusics.set(k, loader.get(AudioStream, `mus_${k}`));
-        }
-
-        for (const [k] of Object.entries(assets.demo.soundSprites ?? {})) {
-            this.soundSpriteAudio.set(k, loader.get(AudioStream, `sds_${k}`));
-            this.soundSpriteData.set(k, loader.get(Json, `sds_${k}`));
-        }
-
-        for (const [k, url] of Object.entries(assets.demo.fonts ?? {})) {
-            // Match the load() filter: only vector fonts get a registered family;
-            // bitmap-font entries render via the path-readout fallback.
-            if (!/\.(ttf|otf|woff2?)$/i.test(url as string)) continue;
-            this.fontFamilies.set(k, `assetbrowser_${k}`);
-        }
-
-        for (const [subcat, items] of Object.entries(assets.technical ?? {})) {
-            for (const [k] of Object.entries(items as Record<string, string>)) {
-                const s = new Sprite(loader.get(Texture, `tech_${subcat}_${k}`));
-                s.setAnchor(0.5);
-                this.techSprites.set(`${subcat}.${k}`, s);
-            }
-        }
-
-        for (const [k] of Object.entries(assets.demo.backgrounds ?? {})) {
-            const s = new Sprite(loader.get(Texture, `bg_${k}`));
-            s.setAnchor(0.5);
-            this.bgSprites.set(k, s);
-        }
-
-        for (const [k] of Object.entries(assets.demo.cursors ?? {})) {
-            const s = new Sprite(new Texture(loader.get(SvgAsset, `cur_${k}`)));
-            s.setAnchor(0.5);
-            this.cursorSprites.set(k, s);
-        }
-
-        for (const [k] of Object.entries(assets.demo.tilesets ?? {})) {
-            const s = new Sprite(loader.get(Texture, `tls_${k}`));
-            s.setAnchor(0.5);
-            this.tilesetSprites.set(k, s);
-        }
-
-        for (const [k] of Object.entries(assets.demo.vendor ?? {})) {
-            this.vendorData.set(k, loader.get(Json, `vnd_${k}`));
-        }
+        this.assetLoader = loader;
 
         this.app.input.onPointerTap.add(p => this.onTap(p.x, p.y));
         this.app.input.onPointerMove.add(p => this.onMove(p.x, p.y));
         this.app.input.onMouseWheel.add(v => this.onWheel(v.y));
 
         this.selectFirstInCategory();
+    }
+
+    /** Load a category's assets (and build its preview objects) exactly once. */
+    private async ensureCategory(catId: string): Promise<void> {
+        if (this.loadedCats.has(catId) || this.loadingCats.has(catId)) return;
+        this.loadingCats.add(catId);
+        try {
+            await this.loadCategory(catId);
+            this.loadedCats.add(catId);
+        } finally {
+            this.loadingCats.delete(catId);
+        }
+    }
+
+    private async loadCategory(catId: string): Promise<void> {
+        const loader = this.assetLoader;
+
+        switch (catId) {
+            case 'textures': {
+                const batch: Record<string, string> = {};
+                for (const [k, url] of Object.entries(assets.demo.textures ?? {})) {
+                    batch[`tex_${k}`] = url as string;
+                }
+                if (Object.keys(batch).length) await loader.load(Texture, batch);
+                for (const k of Object.keys(assets.demo.textures ?? {})) {
+                    const s = new Sprite(loader.get(Texture, `tex_${k}`));
+                    s.setAnchor(0.5);
+                    this.texSprites.set(k, s);
+                }
+                break;
+            }
+            case 'sprites': {
+                const imgBatch: Record<string, string> = {};
+                const jsonBatch: Record<string, string> = {};
+                for (const [k, entry] of Object.entries(assets.demo.sprites ?? {})) {
+                    imgBatch[`spr_${k}`]  = (entry as any).image;
+                    jsonBatch[`spr_${k}`] = (entry as any).data;
+                }
+                if (Object.keys(imgBatch).length) {
+                    await loader.load(Texture, imgBatch);
+                    await loader.load(Json, jsonBatch);
+                }
+                for (const k of Object.keys(assets.demo.sprites ?? {})) {
+                    const ss = new Spritesheet(loader.get(Texture, `spr_${k}`), loader.get(Json, `spr_${k}`));
+                    this.sprSheets.set(k, ss);
+                    for (const s of ss.sprites.values()) s.setAnchor(0.5);
+                }
+                break;
+            }
+            case 'spritesheets': {
+                const imgBatch: Record<string, string> = {};
+                const jsonBatch: Record<string, string> = {};
+                for (const [k, entry] of Object.entries(assets.demo.spritesheets ?? {})) {
+                    imgBatch[`ssh_${k}`]  = (entry as any).image;
+                    jsonBatch[`ssh_${k}`] = (entry as any).data;
+                }
+                if (Object.keys(imgBatch).length) {
+                    await loader.load(Texture, imgBatch);
+                    await loader.load(Json, jsonBatch);
+                }
+                for (const k of Object.keys(assets.demo.spritesheets ?? {})) {
+                    const ss = new Spritesheet(loader.get(Texture, `ssh_${k}`), loader.get(Json, `ssh_${k}`));
+                    this.sshSheets.set(k, ss);
+                    for (const s of ss.sprites.values()) s.setAnchor(0.5);
+                }
+                break;
+            }
+            case 'svg': {
+                const batch: Record<string, string> = {};
+                for (const [k, url] of Object.entries(assets.demo.svg ?? {})) {
+                    batch[`svg_${k}`] = url as string;
+                }
+                if (Object.keys(batch).length) await loader.load(SvgAsset, batch);
+                for (const k of Object.keys(assets.demo.svg ?? {})) {
+                    const s = new Sprite(new Texture(loader.get(SvgAsset, `svg_${k}`)));
+                    s.setAnchor(0.5);
+                    this.svgSprites.set(k, s);
+                }
+                break;
+            }
+            case 'inputPrompts': {
+                const imgBatch: Record<string, string> = {};
+                const jsonBatch: Record<string, string> = {};
+                for (const [k, entry] of Object.entries(assets.demo.inputPrompts ?? {})) {
+                    imgBatch[`inp_${k}`]  = (entry as any).image;
+                    jsonBatch[`inp_${k}`] = (entry as any).data;
+                }
+                if (Object.keys(imgBatch).length) {
+                    await loader.load(Texture, imgBatch);
+                    await loader.load(Json, jsonBatch);
+                }
+                for (const k of Object.keys(assets.demo.inputPrompts ?? {})) {
+                    const ss = new Spritesheet(loader.get(Texture, `inp_${k}`), loader.get(Json, `inp_${k}`));
+                    this.inpSheets.set(k, ss);
+                    for (const s of ss.sprites.values()) s.setAnchor(0.5);
+                }
+                break;
+            }
+            case 'audio': {
+                const batch: Record<string, string> = {};
+                for (const [k, url] of Object.entries(assets.demo.audio ?? {})) {
+                    batch[`aud_${k}`] = url as string;
+                }
+                if (Object.keys(batch).length) await loader.load(AudioStream, batch);
+                for (const k of Object.keys(assets.demo.audio ?? {})) {
+                    this.audioMusics.set(k, loader.get(AudioStream, `aud_${k}`));
+                }
+                break;
+            }
+            case 'sound': {
+                const batch: Record<string, string> = {};
+                for (const [k, url] of Object.entries(assets.demo.sound ?? {})) {
+                    batch[`snd_${k}`] = url as string;
+                }
+                if (Object.keys(batch).length) await loader.load(AudioStream, batch);
+                for (const k of Object.keys(assets.demo.sound ?? {})) {
+                    this.soundMusics.set(k, loader.get(AudioStream, `snd_${k}`));
+                }
+                break;
+            }
+            case 'music': {
+                const batch: Record<string, string> = {};
+                for (const [k, url] of Object.entries(assets.demo.music ?? {})) {
+                    batch[`mus_${k}`] = url as string;
+                }
+                if (Object.keys(batch).length) await loader.load(AudioStream, batch);
+                for (const k of Object.keys(assets.demo.music ?? {})) {
+                    this.musicMusics.set(k, loader.get(AudioStream, `mus_${k}`));
+                }
+                break;
+            }
+            case 'soundSprites': {
+                const audioBatch: Record<string, string> = {};
+                const jsonBatch: Record<string, string> = {};
+                for (const [k, entry] of Object.entries(assets.demo.soundSprites ?? {})) {
+                    audioBatch[`sds_${k}`] = (entry as any).audio;
+                    jsonBatch[`sds_${k}`]  = (entry as any).data;
+                }
+                if (Object.keys(audioBatch).length) {
+                    await loader.load(AudioStream, audioBatch);
+                    await loader.load(Json, jsonBatch);
+                }
+                for (const k of Object.keys(assets.demo.soundSprites ?? {})) {
+                    this.soundSpriteAudio.set(k, loader.get(AudioStream, `sds_${k}`));
+                    this.soundSpriteData.set(k, loader.get(Json, `sds_${k}`));
+                }
+                break;
+            }
+            case 'fonts': {
+                for (const [k, url] of Object.entries(assets.demo.fonts ?? {})) {
+                    // The fonts category mixes vector fonts (.ttf/.otf) with
+                    // bitmap-font sidecars (.fnt/.png) that FontFace cannot
+                    // parse. Load only the vector entries — the bitmap ones
+                    // fall back to a path readout.
+                    if (!/\.(ttf|otf|woff2?)$/i.test(url as string)) continue;
+                    const family = `assetbrowser_${k}`;
+                    await loader.load(FontAsset, { [`fnt_${k}`]: url }, { family });
+                    this.fontFamilies.set(k, family);
+                }
+                break;
+            }
+            case 'technical': {
+                const batch: Record<string, string> = {};
+                for (const [subcat, items] of Object.entries(assets.technical ?? {})) {
+                    for (const [k, u] of Object.entries(items as Record<string, string>)) {
+                        batch[`tech_${subcat}_${k}`] = u;
+                    }
+                }
+                if (Object.keys(batch).length) await loader.load(Texture, batch);
+                for (const [subcat, items] of Object.entries(assets.technical ?? {})) {
+                    for (const k of Object.keys(items as Record<string, string>)) {
+                        const s = new Sprite(loader.get(Texture, `tech_${subcat}_${k}`));
+                        s.setAnchor(0.5);
+                        this.techSprites.set(`${subcat}.${k}`, s);
+                    }
+                }
+                break;
+            }
+            case 'backgrounds': {
+                const batch: Record<string, string> = {};
+                for (const [k, url] of Object.entries(assets.demo.backgrounds ?? {})) {
+                    batch[`bg_${k}`] = url as string;
+                }
+                if (Object.keys(batch).length) await loader.load(Texture, batch);
+                for (const k of Object.keys(assets.demo.backgrounds ?? {})) {
+                    const s = new Sprite(loader.get(Texture, `bg_${k}`));
+                    s.setAnchor(0.5);
+                    this.bgSprites.set(k, s);
+                }
+                break;
+            }
+            case 'cursors': {
+                const batch: Record<string, string> = {};
+                for (const [k, url] of Object.entries(assets.demo.cursors ?? {})) {
+                    batch[`cur_${k}`] = url as string;
+                }
+                if (Object.keys(batch).length) await loader.load(SvgAsset, batch);
+                for (const k of Object.keys(assets.demo.cursors ?? {})) {
+                    const s = new Sprite(new Texture(loader.get(SvgAsset, `cur_${k}`)));
+                    s.setAnchor(0.5);
+                    this.cursorSprites.set(k, s);
+                }
+                break;
+            }
+            case 'tilesets': {
+                const batch: Record<string, string> = {};
+                for (const [k, entry] of Object.entries(assets.demo.tilesets ?? {})) {
+                    batch[`tls_${k}`] = (entry as any).image;
+                }
+                if (Object.keys(batch).length) await loader.load(Texture, batch);
+                for (const k of Object.keys(assets.demo.tilesets ?? {})) {
+                    const s = new Sprite(loader.get(Texture, `tls_${k}`));
+                    s.setAnchor(0.5);
+                    this.tilesetSprites.set(k, s);
+                }
+                break;
+            }
+            case 'vendor': {
+                const batch: Record<string, string> = {};
+                for (const [k, url] of Object.entries(assets.demo.vendor ?? {})) {
+                    batch[`vnd_${k}`] = url as string;
+                }
+                if (Object.keys(batch).length) await loader.load(Json, batch);
+                for (const k of Object.keys(assets.demo.vendor ?? {})) {
+                    this.vendorData.set(k, loader.get(Json, `vnd_${k}`));
+                }
+                break;
+            }
+            default:
+                // 'video' previews only show the asset URL — nothing to load.
+                break;
+        }
     }
 
     private techFlatKeys(): string[] {
@@ -497,6 +536,7 @@ class AssetBrowserScene extends Scene {
                 if (this.cat !== CATEGORIES_ROW1[i].id) {
                     this.cat = CATEGORIES_ROW1[i].id;
                     this.selectFirstInCategory();
+                    void this.ensureCategory(this.cat);
                 }
                 return;
             }
@@ -507,6 +547,7 @@ class AssetBrowserScene extends Scene {
                 if (this.cat !== CATEGORIES_ROW2[i].id) {
                     this.cat = CATEGORIES_ROW2[i].id;
                     this.selectFirstInCategory();
+                    void this.ensureCategory(this.cat);
                 }
                 return;
             }
@@ -743,6 +784,15 @@ class AssetBrowserScene extends Scene {
         if (!this.key) {
             this.txtNoSel.setPosition(PREVIEW_X + (PREVIEW_W / 2) - 130, H / 2 - 10);
             context.render(this.txtNoSel);
+            this.drawInfoBar(context);
+            return;
+        }
+
+        // Category still fetching (lazy-load): keep the sidebar interactive
+        // and show a placeholder instead of an empty preview.
+        if (!this.loadedCats.has(this.cat)) {
+            this.txtLoading.setPosition(PREVIEW_X + (PREVIEW_W / 2) - 70, H / 2 - 10);
+            context.render(this.txtLoading);
             this.drawInfoBar(context);
             return;
         }

--- a/examples/spatial-audio/listener-and-source.js
+++ b/examples/spatial-audio/listener-and-source.js
@@ -37,7 +37,9 @@ class ListenerAndSourceScene extends Scene {
     tapPrompt;
     hud;
     async load(loader) {
-        await loader.load(Sound, { source: 'audio/impact-light.ogg' });
+        // A continuous music loop, not a one-shot: spatialization is only
+        // audible while there is sustained signal to pan/attenuate.
+        await loader.load(Sound, { source: 'audio/demo-loop-main.ogg' });
     }
     init(loader) {
         const { width, height } = this.app.canvas;

--- a/examples/spatial-audio/listener-and-source.ts
+++ b/examples/spatial-audio/listener-and-source.ts
@@ -41,7 +41,9 @@ class ListenerAndSourceScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override async load(loader): Promise<void> {
-        await loader.load(Sound, { source: 'audio/impact-light.ogg' });
+        // A continuous music loop, not a one-shot: spatialization is only
+        // audible while there is sustained signal to pan/attenuate.
+        await loader.load(Sound, { source: 'audio/demo-loop-main.ogg' });
     }
 
     override init(loader): void {

--- a/examples/spatial-audio/moving-source.js
+++ b/examples/spatial-audio/moving-source.js
@@ -35,7 +35,9 @@ class MovingSourceScene extends Scene {
     tapPrompt;
     hud;
     async load(loader) {
-        await loader.load(Sound, { tone: 'audio/impact-light.ogg' });
+        // A continuous music loop, not a one-shot: spatialization is only
+        // audible while there is sustained signal to pan/attenuate.
+        await loader.load(Sound, { tone: 'audio/demo-loop-main.ogg' });
     }
     init(loader) {
         const { width, height } = this.app.canvas;

--- a/examples/spatial-audio/moving-source.ts
+++ b/examples/spatial-audio/moving-source.ts
@@ -39,7 +39,9 @@ class MovingSourceScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override async load(loader): Promise<void> {
-        await loader.load(Sound, { tone: 'audio/impact-light.ogg' });
+        // A continuous music loop, not a one-shot: spatialization is only
+        // audible while there is sustained signal to pan/attenuate.
+        await loader.load(Sound, { tone: 'audio/demo-loop-main.ogg' });
     }
 
     override init(loader): void {

--- a/examples/sprites-textures/video-drawable.js
+++ b/examples/sprites-textures/video-drawable.js
@@ -1,7 +1,15 @@
 // Auto-generated from video-drawable.ts — edit the .ts source, not this file.
-import { Application, Color, Scene, Sprite, Texture, Video } from '@codexo/exojs';
+import { Application, Color, Keyboard, Scene, Sprite, Texture, Video } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
-const VIDEO_URL = assets.demo.video.demoLoop;
+// Every video in the asset catalog, switchable at runtime with the number
+// keys. Only the first entry is fetched up front — the others lazy-load on
+// first selection so startup stays fast.
+const VIDEOS = [
+    { name: 'demoLoop', label: 'Demo loop (webm)', url: assets.demo.video.demoLoop },
+    { name: 'highRes', label: 'High-res (mp4)', url: assets.demo.video.highRes },
+    { name: 'highFps', label: 'High-fps (webm)', url: assets.demo.video.highFps },
+    { name: 'hdr10', label: 'HDR10 (webm)', url: assets.demo.video.hdr10 },
+];
 const app = new Application({
     canvas: {
         width: 1280,
@@ -16,18 +24,20 @@ class VideoDrawableScene extends Scene {
     overlay;
     elapsed = 0;
     hud;
+    assetLoader = null;
+    videoIdx = 0;
+    loadedVideos = new Set();
+    switching = false;
     async load(loader) {
-        await loader.load(Video, { demo: VIDEO_URL });
+        this.assetLoader = loader;
+        await loader.load(Video, { [VIDEOS[0].name]: VIDEOS[0].url });
+        this.loadedVideos.add(VIDEOS[0].name);
         await loader.load(Texture, { ship: assets.demo.textures.shipA });
     }
     init(loader) {
         const { width, height } = this.app.canvas;
-        this.video = loader.get(Video, 'demo');
-        this.video.width = width;
-        this.video.height = height;
-        // Muted playback autoplays reliably under browser autoplay policy without
-        // requiring a user gesture first.
-        this.video.applyOptions({ loop: true, muted: true, volume: 0.5 });
+        this.video = loader.get(Video, VIDEOS[0].name);
+        this.configureVideo();
         // A sprite composited on top of the live video texture — the same scene
         // graph draws video frames and regular sprites side by side.
         this.overlay = new Sprite(loader.get(Texture, 'ship'));
@@ -36,15 +46,57 @@ class VideoDrawableScene extends Scene {
         this.overlay.setPosition(width / 2, height / 2);
         this.hud = mountControls({
             title: 'Video Drawable',
-            controls: [{ keys: 'Tap', action: 'play / pause' }],
-            status: 'Playing',
+            controls: [
+                { keys: 'Tap', action: 'play / pause' },
+                { keys: '1–4', action: 'switch video' },
+            ],
+            status: `Playing — ${VIDEOS[0].label}`,
             hint: 'The video streams as a live GPU texture with a sprite composited over it.',
         });
         this.app.input.onPointerTap.add(() => {
             this.video.toggle();
-            this.hud.setStatus(this.video.playing ? 'Playing' : 'Paused');
+            this.hud.setStatus(this.video.playing ? `Playing — ${VIDEOS[this.videoIdx].label}` : 'Paused');
+        });
+        this.app.input.onKeyDown.add(channel => {
+            const idx = [Keyboard.One, Keyboard.Two, Keyboard.Three, Keyboard.Four].indexOf(channel);
+            if (idx !== -1)
+                void this.switchVideo(idx);
         });
         this.video.play();
+    }
+    /** Sizing + playback options shared by every video the example swaps in. */
+    configureVideo() {
+        const { width, height } = this.app.canvas;
+        this.video.width = width;
+        this.video.height = height;
+        // Muted playback autoplays reliably under browser autoplay policy without
+        // requiring a user gesture first.
+        this.video.applyOptions({ loop: true, muted: true, volume: 0.5 });
+    }
+    async switchVideo(idx) {
+        if (idx === this.videoIdx || this.switching)
+            return;
+        const entry = VIDEOS[idx];
+        this.switching = true;
+        this.hud.setStatus(`Loading — ${entry.label}…`);
+        try {
+            if (!this.loadedVideos.has(entry.name)) {
+                await this.assetLoader.load(Video, { [entry.name]: entry.url });
+                this.loadedVideos.add(entry.name);
+            }
+            this.video.pause();
+            this.videoIdx = idx;
+            this.video = this.assetLoader.get(Video, entry.name);
+            this.configureVideo();
+            this.video.play();
+            this.hud.setStatus(`Playing — ${entry.label}`);
+        }
+        catch {
+            this.hud.setStatus(`Failed to load — ${entry.label}`);
+        }
+        finally {
+            this.switching = false;
+        }
     }
     update(delta) {
         this.elapsed += delta.seconds;

--- a/examples/sprites-textures/video-drawable.ts
+++ b/examples/sprites-textures/video-drawable.ts
@@ -1,7 +1,15 @@
-import { Application, Color, Scene, Sprite, Texture, Video } from '@codexo/exojs';
+import { Application, Color, Keyboard, Scene, Sprite, Texture, Video } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
-const VIDEO_URL = assets.demo.video.demoLoop;
+// Every video in the asset catalog, switchable at runtime with the number
+// keys. Only the first entry is fetched up front — the others lazy-load on
+// first selection so startup stays fast.
+const VIDEOS = [
+    { name: 'demoLoop', label: 'Demo loop (webm)', url: assets.demo.video.demoLoop },
+    { name: 'highRes',  label: 'High-res (mp4)',   url: assets.demo.video.highRes },
+    { name: 'highFps',  label: 'High-fps (webm)',  url: assets.demo.video.highFps },
+    { name: 'hdr10',    label: 'HDR10 (webm)',     url: assets.demo.video.hdr10 },
+];
 
 const app = new Application({
     canvas: {
@@ -18,21 +26,23 @@ class VideoDrawableScene extends Scene {
     private overlay!: Sprite;
     private elapsed = 0;
     private hud!: ReturnType<typeof mountControls>;
+    private assetLoader: any = null;
+    private videoIdx = 0;
+    private readonly loadedVideos = new Set<string>();
+    private switching = false;
 
     override async load(loader): Promise<void> {
-        await loader.load(Video, { demo: VIDEO_URL });
+        this.assetLoader = loader;
+        await loader.load(Video, { [VIDEOS[0].name]: VIDEOS[0].url });
+        this.loadedVideos.add(VIDEOS[0].name);
         await loader.load(Texture, { ship: assets.demo.textures.shipA });
     }
 
     override init(loader): void {
         const { width, height } = this.app.canvas;
 
-        this.video = loader.get(Video, 'demo');
-        this.video.width = width;
-        this.video.height = height;
-        // Muted playback autoplays reliably under browser autoplay policy without
-        // requiring a user gesture first.
-        this.video.applyOptions({ loop: true, muted: true, volume: 0.5 });
+        this.video = loader.get(Video, VIDEOS[0].name);
+        this.configureVideo();
 
         // A sprite composited on top of the live video texture — the same scene
         // graph draws video frames and regular sprites side by side.
@@ -43,17 +53,58 @@ class VideoDrawableScene extends Scene {
 
         this.hud = mountControls({
             title: 'Video Drawable',
-            controls: [{ keys: 'Tap', action: 'play / pause' }],
-            status: 'Playing',
+            controls: [
+                { keys: 'Tap', action: 'play / pause' },
+                { keys: '1–4', action: 'switch video' },
+            ],
+            status: `Playing — ${VIDEOS[0].label}`,
             hint: 'The video streams as a live GPU texture with a sprite composited over it.',
         });
 
         this.app.input.onPointerTap.add(() => {
             this.video.toggle();
-            this.hud.setStatus(this.video.playing ? 'Playing' : 'Paused');
+            this.hud.setStatus(this.video.playing ? `Playing — ${VIDEOS[this.videoIdx].label}` : 'Paused');
+        });
+
+        this.app.input.onKeyDown.add(channel => {
+            const idx = [Keyboard.One, Keyboard.Two, Keyboard.Three, Keyboard.Four].indexOf(channel);
+            if (idx !== -1) void this.switchVideo(idx);
         });
 
         this.video.play();
+    }
+
+    /** Sizing + playback options shared by every video the example swaps in. */
+    private configureVideo(): void {
+        const { width, height } = this.app.canvas;
+        this.video.width = width;
+        this.video.height = height;
+        // Muted playback autoplays reliably under browser autoplay policy without
+        // requiring a user gesture first.
+        this.video.applyOptions({ loop: true, muted: true, volume: 0.5 });
+    }
+
+    private async switchVideo(idx: number): Promise<void> {
+        if (idx === this.videoIdx || this.switching) return;
+        const entry = VIDEOS[idx];
+        this.switching = true;
+        this.hud.setStatus(`Loading — ${entry.label}…`);
+        try {
+            if (!this.loadedVideos.has(entry.name)) {
+                await this.assetLoader.load(Video, { [entry.name]: entry.url });
+                this.loadedVideos.add(entry.name);
+            }
+            this.video.pause();
+            this.videoIdx = idx;
+            this.video = this.assetLoader.get(Video, entry.name);
+            this.configureVideo();
+            this.video.play();
+            this.hud.setStatus(`Playing — ${entry.label}`);
+        } catch {
+            this.hud.setStatus(`Failed to load — ${entry.label}`);
+        } finally {
+            this.switching = false;
+        }
     }
 
     override update(delta): void {

--- a/site/src/content/api/observable-vector.json
+++ b/site/src/content/api/observable-vector.json
@@ -1170,7 +1170,7 @@
       "members": [
         {
           "name": "angle",
-          "signature": "angle: unknown",
+          "signature": "angle: number",
           "signatureTokens": [
             {
               "text": "angle",
@@ -1181,17 +1181,17 @@
               "kind": "punctuation"
             },
             {
-              "text": "unknown",
+              "text": "number",
               "kind": "keyword"
             }
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Angle of this vector in radians, measured from the positive X-axis (the same convention as PolarVector.phi). Setting this rotates the vector to the new angle while preserving its length. Mutates in place."
         },
         {
           "name": "length",
-          "signature": "length: unknown",
+          "signature": "length: number",
           "signatureTokens": [
             {
               "text": "length",
@@ -1202,13 +1202,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "unknown",
+              "text": "number",
               "kind": "keyword"
             }
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Euclidean magnitude of this vector. Setting rescales the vector to magnitude while preserving its angle. Mutates in place."
         },
         {
           "name": "lengthSq",

--- a/site/src/content/api/vector.json
+++ b/site/src/content/api/vector.json
@@ -1746,7 +1746,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Angle of this vector in radians, measured from the positive Y-axis (clockwise). Setting this rotates the vector to the new angle while preserving its length. Mutates in place."
+          "description": "Angle of this vector in radians, measured from the positive X-axis (the same convention as PolarVector.phi). Setting this rotates the vector to the new angle while preserving its length. Mutates in place."
         },
         {
           "name": "length",

--- a/src/math/AbstractVector.ts
+++ b/src/math/AbstractVector.ts
@@ -14,12 +14,13 @@ export abstract class AbstractVector {
   public abstract y: number;
 
   /**
-   * Angle of this vector in radians, measured from the positive Y-axis
-   * (clockwise). Setting this rotates the vector to the new angle while
-   * preserving its {@link length}. Mutates in place.
+   * Angle of this vector in radians, measured from the positive X-axis
+   * (the same convention as `PolarVector.phi`). Setting this rotates the
+   * vector to the new angle while preserving its {@link length}. Mutates in
+   * place.
    */
   public get angle(): number {
-    return Math.atan2(this.x, this.y);
+    return Math.atan2(this.y, this.x);
   }
 
   public set angle(angle: number) {

--- a/src/math/ObservableVector.ts
+++ b/src/math/ObservableVector.ts
@@ -64,10 +64,21 @@ export class ObservableVector extends AbstractVector {
     }
   }
 
+  // The getters must be redeclared alongside the setter overrides: a
+  // setter-only accessor on the subclass prototype would shadow the whole
+  // inherited accessor pair, leaving `get` undefined.
+  public override get angle(): number {
+    return Math.atan2(this._y, this._x);
+  }
+
   public override set angle(angle: number) {
     const length = this.length;
 
     this.set(Math.cos(angle) * length, Math.sin(angle) * length);
+  }
+
+  public override get length(): number {
+    return Math.sqrt(this._x * this._x + this._y * this._y);
   }
 
   public override set length(magnitude: number) {

--- a/src/math/Polygon.ts
+++ b/src/math/Polygon.ts
@@ -231,6 +231,9 @@ export class Polygon implements ShapeLike {
     const nx = axis.x / length;
     const ny = axis.y / length;
 
+    // World-space projection: the polygon's x/y offset shifts every vertex by
+    // the same amount, so it contributes a constant term along the axis.
+    const offset = nx * this._position.x + ny * this._position.y;
     const points = this._points;
     let min = Infinity;
     let max = -Infinity;
@@ -244,7 +247,7 @@ export class Polygon implements ShapeLike {
       if (projection > max) max = projection;
     }
 
-    return result.set(min, max);
+    return result.set(min + offset, max + offset);
   }
 
   public contains(x: number, y: number): boolean {

--- a/src/math/collision-detection.ts
+++ b/src/math/collision-detection.ts
@@ -234,9 +234,14 @@ const shouldExcludeRightVoronoi = (
     return false;
   }
 
-  const region = getVoronoiRegionForPoint(nextEdge.x, nextEdge.y, circleX - nextPoint.x, circleY - nextPoint.y);
+  // In the right region the closest polygon feature is the *next* vertex, so
+  // both the region refinement and the distance test use `circle - nextPoint`
+  // (mirrors the right-region branch of getCollisionPolygonCircle).
+  const positionBx = circleX - nextPoint.x;
+  const positionBy = circleY - nextPoint.y;
+  const region = getVoronoiRegionForPoint(nextEdge.x, nextEdge.y, positionBx, positionBy);
 
-  return region === VoronoiRegion.left && getVectorLength(pointX, pointY) > radius;
+  return region === VoronoiRegion.left && getVectorLength(positionBx, positionBy) > radius;
 };
 
 const shouldExcludeMiddleVoronoi = (pointX: number, pointY: number, radius: number, edgeX: number, edgeY: number): boolean => {
@@ -254,15 +259,10 @@ const shouldExcludeMiddleVoronoi = (pointX: number, pointY: number, radius: numb
 };
 
 const intersectionCirclePoly = ({ x: cx, y: cy, radius }: Circle, { x: px, y: py, points, edges }: Polygon): boolean => {
-  // Frame transform: express the circle's position relative to the polygon's
-  // local space, but with the sign inverted (poly.position - circle.position
-  // rather than the natural circle.position - poly.position). The poly's
-  // `points` are then in their local coordinates and the Voronoi-region tests
-  // below combine them with the negated-offset circle position to reach the
-  // same value as a positively-offset frame would. Don't flip without
-  // re-deriving the Voronoi math.
-  const circleX = px - cx;
-  const circleY = py - cy;
+  // Frame transform: the circle centre expressed in the polygon's local space
+  // (circle.position - poly.position), matching getCollisionPolygonCircle.
+  const circleX = cx - px;
+  const circleY = cy - py;
   const len = points.length;
 
   for (let i = 0; i < len; i++) {
@@ -372,8 +372,8 @@ const getCollisionCircleCircle = (circleA: Circle, circleB: Circle): CollisionRe
     return null;
   }
 
-  const projectionN = difference.clone().normalize();
-  const projectionV = difference.multiply(overlap);
+  const projectionN = difference.normalize();
+  const projectionV = projectionN.clone().multiply(overlap);
 
   return {
     shapeA: circleA,

--- a/src/math/collision-primitives.ts
+++ b/src/math/collision-primitives.ts
@@ -208,7 +208,10 @@ const intersectionPointEllipse = ({ x: x1, y: y1 }: PointLike, { x: x2, y: y2, r
   return normX * normX + normY * normY <= 1;
 };
 
-const intersectionPointPoly = (point: PointLike, { points }: PolygonLikeLike): boolean => polygonContainsPoint(point, points);
+const intersectionPointPoly = (point: PointLike, { x: offsetX, y: offsetY, points }: PolygonLikeLike): boolean =>
+  // Shift the point into the polygon's local space so its x/y position
+  // offset is honoured (the local `points` never carry the offset).
+  polygonContainsPoint({ x: point.x - offsetX, y: point.y - offsetY }, points);
 
 const intersectionLineLineSegments = (a1: PointLike, a2: PointLike, b1: PointLike, b2: PointLike): boolean => {
   const denominator = (a2.x - a1.x) * (b2.y - b1.y) - (b2.x - b1.x) * (a2.y - a1.y);

--- a/src/rendering/text/TextLayout.ts
+++ b/src/rendering/text/TextLayout.ts
@@ -124,13 +124,12 @@ export function layoutText(text: string, style: TextLayoutStyle, layout: LayoutO
       const extraPerGap = (maxLineWidth - line.width) / gaps;
       let wordIdx = -1;
       let prevWasSpace = true;
-      const spaceAdv = provider.getGlyph(' ', fontSize).advance;
 
       for (const entry of line.placements) {
-        if (prevWasSpace && entry.info.advance !== spaceAdv) {
+        if (prevWasSpace && entry.char !== ' ') {
           wordIdx++;
           prevWasSpace = false;
-        } else if (!prevWasSpace && entry.info.advance === spaceAdv) {
+        } else if (!prevWasSpace && entry.char === ' ') {
           prevWasSpace = true;
         }
 

--- a/test/math/circle.test.ts
+++ b/test/math/circle.test.ts
@@ -1,5 +1,23 @@
 import { Circle } from '#math/Circle';
+import type { Collidable } from '#math/Collision';
+import { CollisionType } from '#math/Collision';
+import { Ellipse } from '#math/Ellipse';
+import { Interval } from '#math/Interval';
+import { Line } from '#math/Line';
+import { Polygon } from '#math/Polygon';
+import { Rectangle } from '#math/Rectangle';
 import { Vector } from '#math/Vector';
+
+// A minimal stand-in for a SceneNode, which Circle only ever accesses through
+// `collisionType` + `getBounds()` in its intersectsWith()/collidesWith() switches.
+const fakeSceneNode = (bounds: Rectangle): Collidable => ({ collisionType: CollisionType.SceneNode, getBounds: () => bounds }) as unknown as Collidable;
+
+// A Collidable with a collisionType outside the known enum, to exercise the
+// `default` branch of the intersectsWith()/collidesWith() switches.
+const unknownCollidable = { collisionType: 99 } as unknown as Collidable;
+
+const square = (x: number, y: number, size: number): Polygon =>
+  new Polygon([new Vector(x, y), new Vector(x + size, y), new Vector(x + size, y + size), new Vector(x, y + size)]);
 
 describe('Circle', () => {
   test('projects correctly on an axis', () => {
@@ -128,6 +146,317 @@ describe('Circle', () => {
       const normalsAAfter = circleA.getNormals();
 
       expect(normalsAAfter).toBe(normalsA); // A's reference is stable
+    });
+
+    // getCollisionVertices() (private) guards its own recompute with
+    // `_verticesDirty`, but every public mutator toggles `_verticesDirty` and
+    // `_normalsDirty` together, and getCollisionVertices() is only ever
+    // invoked from inside getNormals()'s `_normalsDirty` guard — so the two
+    // flags are always in lock-step through the public API alone, and the
+    // `_verticesDirty === false` branch can never be observed that way.
+    // Force it directly (bracket-notation access to private fields is an
+    // established convention in this test suite, see e.g.
+    // test/core/focus-visibility.test.ts) to exercise the cache-reuse path.
+    test('getCollisionVertices() reuses the cached vertices when only the normals cache is stale', () => {
+      const circle = new Circle(0, 0, 5);
+
+      // Populate both caches.
+      circle.getNormals();
+
+      // Mark only the normals stale; vertices stay clean.
+      circle['_normalsDirty'] = true;
+
+      expect(() => circle.getNormals()).not.toThrow();
+      expect(circle.getNormals().length).toBe(Circle.collisionSegments);
+    });
+  });
+
+  describe('position, x, y, radius accessors', () => {
+    test('position getter/setter copies coordinates from another vector', () => {
+      const circle = new Circle(1, 2, 3);
+      circle.position = new Vector(10, 20);
+
+      expect(circle.x).toBe(10);
+      expect(circle.y).toBe(20);
+    });
+
+    test('x setter is a no-op when the value is unchanged', () => {
+      const circle = new Circle(5, 0, 1);
+
+      circle.x = 5;
+
+      expect(circle.x).toBe(5);
+    });
+
+    test('x setter updates the value and marks caches dirty when changed', () => {
+      const circle = new Circle(5, 0, 1);
+
+      circle.x = 6;
+
+      expect(circle.x).toBe(6);
+    });
+
+    test('y setter is a no-op when the value is unchanged', () => {
+      const circle = new Circle(0, 5, 1);
+
+      circle.y = 5;
+
+      expect(circle.y).toBe(5);
+    });
+
+    test('y setter updates the value when changed', () => {
+      const circle = new Circle(0, 5, 1);
+
+      circle.y = 8;
+
+      expect(circle.y).toBe(8);
+    });
+
+    test('radius setter is a no-op when the value is unchanged', () => {
+      const circle = new Circle(0, 0, 5);
+
+      circle.radius = 5;
+
+      expect(circle.radius).toBe(5);
+    });
+
+    test('radius setter updates the value when changed', () => {
+      const circle = new Circle(0, 0, 5);
+
+      circle.radius = 9;
+
+      expect(circle.radius).toBe(9);
+    });
+  });
+
+  describe('project() with an explicit result Interval', () => {
+    test('writes into and returns the provided Interval', () => {
+      const circle = new Circle(10, 5, 3);
+      const result = new Interval();
+      const returned = circle.project(new Vector(1, 0), result);
+
+      expect(returned).toBe(result);
+      expect(result.min).toBeCloseTo(7);
+      expect(result.max).toBeCloseTo(13);
+    });
+  });
+
+  describe('getBounds()', () => {
+    test('returns a square rectangle centred on the circle', () => {
+      const circle = new Circle(10, 10, 4);
+      const bounds = circle.getBounds();
+
+      expect(bounds.x).toBe(6);
+      expect(bounds.y).toBe(6);
+      expect(bounds.width).toBe(8);
+      expect(bounds.height).toBe(8);
+    });
+  });
+
+  describe('contains()', () => {
+    test('point inside the circle returns true', () => {
+      const circle = new Circle(0, 0, 5);
+
+      expect(circle.contains(1, 0)).toBe(true);
+    });
+
+    test('point outside the circle returns false', () => {
+      const circle = new Circle(0, 0, 5);
+
+      expect(circle.contains(100, 0)).toBe(false);
+    });
+  });
+
+  describe('equals()', () => {
+    test('returns true when called with no arguments', () => {
+      const circle = new Circle(1, 2, 3);
+
+      expect(circle.equals()).toBe(true);
+      expect(circle.equals({})).toBe(true);
+    });
+
+    test('returns true when all provided fields match', () => {
+      const circle = new Circle(1, 2, 3);
+
+      expect(circle.equals({ x: 1, y: 2, radius: 3 })).toBe(true);
+    });
+
+    test('returns false when x differs', () => {
+      const circle = new Circle(1, 2, 3);
+
+      expect(circle.equals({ x: 99 })).toBe(false);
+    });
+
+    test('returns false when y differs', () => {
+      const circle = new Circle(1, 2, 3);
+
+      expect(circle.equals({ y: 99 })).toBe(false);
+    });
+
+    test('returns false when radius differs', () => {
+      const circle = new Circle(1, 2, 3);
+
+      expect(circle.equals({ radius: 99 })).toBe(false);
+    });
+  });
+
+  describe('set(), copy(), clone(), setPosition(), setRadius()', () => {
+    test('set() updates position and radius and returns this', () => {
+      const circle = new Circle();
+      const result = circle.set(3, 4, 5);
+
+      expect(result).toBe(circle);
+      expect(circle.x).toBe(3);
+      expect(circle.y).toBe(4);
+      expect(circle.radius).toBe(5);
+    });
+
+    test('copy() duplicates another circle state and returns this', () => {
+      const source = new Circle(3, 4, 5);
+      const target = new Circle();
+      const result = target.copy(source);
+
+      expect(result).toBe(target);
+      expect(target.equals(source)).toBe(true);
+    });
+
+    test('clone() returns a new circle with the same state', () => {
+      const circle = new Circle(3, 4, 5);
+      const clone = circle.clone();
+
+      expect(clone).not.toBe(circle);
+      expect(clone.equals(circle)).toBe(true);
+    });
+
+    test('setPosition() updates x/y and returns this', () => {
+      const circle = new Circle();
+      const result = circle.setPosition(7, 8);
+
+      expect(result).toBe(circle);
+      expect(circle.x).toBe(7);
+      expect(circle.y).toBe(8);
+    });
+
+    test('setRadius() updates radius and returns this when changed', () => {
+      const circle = new Circle(0, 0, 5);
+      const result = circle.setRadius(10);
+
+      expect(result).toBe(circle);
+      expect(circle.radius).toBe(10);
+    });
+
+    test('setRadius() is a no-op branch when the radius is unchanged', () => {
+      const circle = new Circle(0, 0, 5);
+      const result = circle.setRadius(5);
+
+      expect(result).toBe(circle);
+      expect(circle.radius).toBe(5);
+    });
+  });
+
+  describe('intersectsWith()', () => {
+    test('SceneNode branch delegates to the rectangle bounds', () => {
+      const circle = new Circle(15, 5, 6);
+
+      expect(circle.intersectsWith(fakeSceneNode(new Rectangle(0, 0, 10, 10)))).toBe(true);
+    });
+
+    test('Rectangle branch', () => {
+      const circle = new Circle(15, 5, 6);
+
+      expect(circle.intersectsWith(new Rectangle(0, 0, 10, 10))).toBe(true);
+    });
+
+    test('Polygon branch', () => {
+      const circle = new Circle(-5, 5, 10);
+
+      expect(circle.intersectsWith(square(0, 0, 10))).toBe(true);
+    });
+
+    test('Circle branch', () => {
+      const circle = new Circle(0, 0, 5);
+
+      expect(circle.intersectsWith(new Circle(6, 0, 5))).toBe(true);
+    });
+
+    test('Ellipse branch', () => {
+      const circle = new Circle(0, 0, 5);
+
+      expect(circle.intersectsWith(new Ellipse(6, 0, 5, 3))).toBe(true);
+    });
+
+    test('Line branch', () => {
+      const circle = new Circle(0, 0, 5);
+
+      expect(circle.intersectsWith(new Line(-10, 0, 10, 0))).toBe(true);
+    });
+
+    test('Point branch', () => {
+      const circle = new Circle(0, 0, 5);
+
+      expect(circle.intersectsWith(new Vector(1, 0))).toBe(true);
+    });
+
+    test('default branch returns false for an unknown collision type', () => {
+      const circle = new Circle(0, 0, 5);
+
+      expect(circle.intersectsWith(unknownCollidable)).toBe(false);
+    });
+  });
+
+  describe('collidesWith()', () => {
+    test('SceneNode branch delegates to the rectangle bounds', () => {
+      const circle = new Circle(13, 5, 5);
+      const response = circle.collidesWith(fakeSceneNode(new Rectangle(0, 0, 10, 10)));
+
+      expect(response).not.toBeNull();
+      expect(response!.projectionN.x).toBeCloseTo(1);
+    });
+
+    test('Rectangle branch', () => {
+      const circle = new Circle(13, 5, 5);
+      const response = circle.collidesWith(new Rectangle(0, 0, 10, 10));
+
+      expect(response).not.toBeNull();
+      expect(response!.overlap).toBeCloseTo(2);
+    });
+
+    test('Polygon branch', () => {
+      const circle = new Circle(5, -0.5, 1);
+      const response = circle.collidesWith(square(0, 0, 10));
+
+      expect(response).not.toBeNull();
+      expect(response!.overlap).toBeGreaterThan(0);
+    });
+
+    test('Circle branch', () => {
+      const circle = new Circle(0, 0, 5);
+      const response = circle.collidesWith(new Circle(8, 0, 5));
+
+      expect(response).not.toBeNull();
+      expect(response!.overlap).toBeCloseTo(2);
+    });
+
+    test('Ellipse branch', () => {
+      const circle = new Circle(6, 0, 2);
+      const response = circle.collidesWith(new Ellipse(0, 0, 5, 3));
+
+      expect(response).not.toBeNull();
+    });
+
+    test('default branch returns null for an unsupported target (e.g. Line)', () => {
+      const circle = new Circle(0, 0, 5);
+
+      expect(circle.collidesWith(new Line(-10, 0, 10, 0))).toBeNull();
+    });
+  });
+
+  describe('static temp', () => {
+    test('returns a shared scratch instance on repeated access', () => {
+      const first = Circle.temp;
+      const second = Circle.temp;
+
+      expect(second).toBe(first);
     });
   });
 });

--- a/test/math/collision-detection.test.ts
+++ b/test/math/collision-detection.test.ts
@@ -45,14 +45,9 @@ const rect = (x: number, y: number, w: number, h: number): Rectangle => new Rect
 const circle = (x: number, y: number, radius: number): Circle => new Circle(x, y, radius);
 const ellipse = (x: number, y: number, rx: number, ry: number): Ellipse => new Ellipse(x, y, rx, ry);
 const line = (x1: number, y1: number, x2: number, y2: number): Line => new Line(x1, y1, x2, y2);
-// NOTE: `Polygon.project()` (src/math/Polygon.ts) reads only the local
-// `points` and never adds the polygon's own `x`/`y` position offset (unlike
-// Circle.project()/Rectangle.project(), which both do). Every SAT-based
-// routine here (getNormals()/project()) is therefore blind to a non-zero
-// Polygon position — see the final report for a repro. To keep these tests
-// exercising *intended* geometry rather than pinning that gap, `square()`
-// bakes its (x, y) directly into the point coordinates and always leaves the
-// Polygon position at the (0, 0) default.
+// `square()` bakes its (x, y) directly into the point coordinates and leaves
+// the Polygon position at the (0, 0) default; positioned-polygon behaviour
+// (x/y offset honoured by project()/the SAT paths) has dedicated tests.
 const square = (x: number, y: number, size: number): Polygon =>
   new Polygon([new Vector(x, y), new Vector(x + size, y), new Vector(x + size, y + size), new Vector(x, y + size)]);
 
@@ -371,16 +366,6 @@ describe('intersectionCircleEllipse', () => {
 // intersectionCirclePoly
 // ---------------------------------------------------------------------------
 
-// NOTE (see final report — suspected bug in intersectionCirclePoly): for a
-// polygon at the default (0, 0) position, this function only reports a hit
-// for circles overlapping through one specific edge/vertex, or once the
-// radius is large enough to reach vertex (0, 0). Circles centred well inside
-// the polygon, or overlapping any of the *other* three edges/corners with a
-// modest radius, are incorrectly reported as *not* intersecting. The sibling
-// getCollisionPolygonCircle() (a separate implementation) does not share this
-// bug — see its describe block below, where the same scenarios pass. Tests
-// below are split into "safe" cases that do not touch the buggy region, and
-// dedicated "BUG" cases that pin the current (incorrect) behaviour.
 describe('intersectionCirclePoly', () => {
   test('circle far away from the polygon does not intersect', () => {
     expect(intersectionCirclePoly(circle(500, 500, 1), square(0, 0, 10))).toBe(false);
@@ -407,20 +392,25 @@ describe('intersectionCirclePoly', () => {
     expect(intersectionCirclePoly(circle(5, 5, 1000), square(0, 0, 10))).toBe(true);
   });
 
-  test('BUG: a circle centred well inside the polygon is incorrectly reported as not intersecting', () => {
-    // Geometrically this must be a hit (the circle centre is inside the
-    // polygon, far from every edge) — getCollisionPolygonCircle agrees it's a
-    // hit for the same shapes. This pins the current, incorrect result.
-    expect(intersectionCirclePoly(circle(5, 5, 1), square(0, 0, 10))).toBe(false);
+  test('a circle centred well inside the polygon intersects', () => {
+    expect(intersectionCirclePoly(circle(5, 5, 1), square(0, 0, 10))).toBe(true);
   });
 
-  test('BUG: a circle clearly overlapping the top edge is incorrectly reported as not intersecting', () => {
-    expect(intersectionCirclePoly(circle(5, -0.5, 1), square(0, 0, 10))).toBe(false);
+  test('a circle clearly overlapping the top edge intersects', () => {
+    expect(intersectionCirclePoly(circle(5, -0.5, 1), square(0, 0, 10))).toBe(true);
   });
 
-  test('BUG: a circle clearly overlapping the (10,10) vertex is incorrectly reported as not intersecting', () => {
+  test('a circle clearly overlapping the (10,10) vertex intersects', () => {
     // Distance from (11, 11) to the corner (10, 10) is sqrt(2) ≈ 1.41 < 2.
-    expect(intersectionCirclePoly(circle(11, 11, 2), square(0, 0, 10))).toBe(false);
+    expect(intersectionCirclePoly(circle(11, 11, 2), square(0, 0, 10))).toBe(true);
+  });
+
+  test('a polygon positioned via its x/y offset is honoured', () => {
+    // Local unit square at position (100, 100) → world square [100..110]².
+    const positioned = new Polygon([new Vector(0, 0), new Vector(10, 0), new Vector(10, 10), new Vector(0, 10)], 100, 100);
+
+    expect(intersectionCirclePoly(circle(105, 105, 1), positioned)).toBe(true);
+    expect(intersectionCirclePoly(circle(5, 5, 1), positioned)).toBe(false);
   });
 });
 
@@ -463,6 +453,14 @@ describe('intersectionPolyPoly', () => {
 
   test('separated polygons do not intersect', () => {
     expect(intersectionPolyPoly(square(0, 0, 10), square(500, 500, 10))).toBe(false);
+  });
+
+  test('a polygon positioned via its x/y offset is honoured by the SAT path', () => {
+    // Local unit square at position (500, 500) → world square [500..510]².
+    const positioned = new Polygon([new Vector(0, 0), new Vector(10, 0), new Vector(10, 10), new Vector(0, 10)], 500, 500);
+
+    expect(intersectionPolyPoly(square(0, 0, 10), positioned)).toBe(false);
+    expect(intersectionPolyPoly(square(495, 495, 10), positioned)).toBe(true);
   });
 });
 
@@ -545,19 +543,12 @@ describe('getCollisionCircleCircle', () => {
     expect(response!.projectionN.y).toBeCloseTo(0);
   });
 
-  // BUG (see final report): CollisionResponse.projectionV is documented as
-  // "projectionN scaled by overlap" (src/math/Collision.ts), and every other
-  // getCollision* implementation builds it that way. getCollisionCircleCircle
-  // instead scales the *unnormalized* centre-to-centre difference vector by
-  // `overlap`, so its magnitude is `distance * overlap`, not `overlap`. Here
-  // distance=8, overlap=2 → projectionV.x comes out to 16, not 2.
-  test('BUG: projectionV magnitude is distance*overlap instead of overlap (unlike every other getCollision*)', () => {
+  test('projectionV is projectionN scaled by overlap, like every other getCollision*', () => {
     const response = getCollisionCircleCircle(circle(0, 0, 5), circle(8, 0, 5));
 
     expect(response).not.toBeNull();
     expect(response!.overlap).toBeCloseTo(2);
-    // Correct MTV would be projectionN(1,0) * overlap(2) = (2, 0).
-    expect(response!.projectionV.x).toBeCloseTo(16); // pins the current (buggy) magnitude
+    expect(response!.projectionV.x).toBeCloseTo(2);
     expect(response!.projectionV.y).toBeCloseTo(0);
   });
 

--- a/test/math/collision-detection.test.ts
+++ b/test/math/collision-detection.test.ts
@@ -427,10 +427,7 @@ describe('intersectionCirclePoly', () => {
     expect(intersectionCirclePoly(circle(5, 5, 1), positioned)).toBe(false);
   });
 
-  // These two pin further internal branches of the same already-buggy sign-inverted
-  // frame (see the describe-level NOTE above), purely for statement/branch coverage
-  // of the current implementation — not additional distinct bugs.
-  test('BUG (coverage): a circle diagonally far from the polygon is excluded via the right-Voronoi check', () => {
+  test('a circle diagonally far from the polygon is excluded via the right-Voronoi check', () => {
     expect(intersectionCirclePoly(circle(-20, -20, 1), square(0, 0, 10))).toBe(false);
   });
 
@@ -505,7 +502,7 @@ describe('intersectionSat', () => {
     expect(intersectionSat(square(0, 0, 10), square(500, 0, 10))).toBe(false);
   });
 
-  test('a separating axis found only among the second shape\'s normals is still detected', () => {
+  test("a separating axis found only among the second shape's normals is still detected", () => {
     // The square's own axes (X/Y) show overlap for both shapes' bounding
     // extents, but the diamond's diagonal edge normals reveal a true
     // separating axis — this can only be found by testing shapeB's normals
@@ -543,7 +540,7 @@ describe('getCollisionRectangleRectangle', () => {
     expect(response!.projectionV.x).toBeCloseTo(2);
   });
 
-  test('smaller X penetration, rectB to the left of rectA\'s centre → normalX = -1', () => {
+  test("smaller X penetration, rectB to the left of rectA's centre → normalX = -1", () => {
     const response = getCollisionRectangleRectangle(rect(0, 0, 10, 10), rect(-8, 0, 10, 10));
 
     expect(response).not.toBeNull();
@@ -551,7 +548,7 @@ describe('getCollisionRectangleRectangle', () => {
     expect(response!.projectionN.y).toBeCloseTo(0);
   });
 
-  test('smaller Y penetration, rectB below rectA\'s centre → normalY = +1', () => {
+  test("smaller Y penetration, rectB below rectA's centre → normalY = +1", () => {
     const response = getCollisionRectangleRectangle(rect(0, 0, 10, 10), rect(0, 8, 10, 10));
 
     expect(response).not.toBeNull();
@@ -976,7 +973,7 @@ describe('getCollisionSat', () => {
     expect(response!.overlap).toBeGreaterThan(0);
   });
 
-  test('a separating axis found only among the second shape\'s normals is still detected', () => {
+  test("a separating axis found only among the second shape's normals is still detected", () => {
     // Same axis-mismatch scenario as intersectionSat above: the square's own
     // axes see overlap everywhere, but the diamond's diagonal normals reveal
     // the true separating axis, which can only be found in the second loop.
@@ -1024,7 +1021,7 @@ describe('getCollisionSat', () => {
     expect(response!.shapeBinA).toBe(false);
   });
 
-  test('a shape with zero normals falls back to the other shape\'s first normal', () => {
+  test("a shape with zero normals falls back to the other shape's first normal", () => {
     // An empty Polygon yields getNormals() === [], so normalsA[0] is
     // undefined and the `(normalsA[0] || normalsB[0])!` fallback must be used
     // instead. It also has no separating axes to test, so the loop over its

--- a/test/math/collision-detection.test.ts
+++ b/test/math/collision-detection.test.ts
@@ -51,6 +51,13 @@ const line = (x1: number, y1: number, x2: number, y2: number): Line => new Line(
 const square = (x: number, y: number, size: number): Polygon =>
   new Polygon([new Vector(x, y), new Vector(x + size, y), new Vector(x + size, y + size), new Vector(x, y + size)]);
 
+// A diamond (rotated square) whose edge normals point along the diagonals
+// instead of the cardinal axes. Used to exercise SAT paths where the
+// separating axis only shows up among one shape's own normals, not the
+// other's — the classic reason SAT must test both shapes' edge normals.
+const diamond = (cx: number, cy: number, r: number): Polygon =>
+  new Polygon([new Vector(cx + r, cy), new Vector(cx, cy + r), new Vector(cx - r, cy), new Vector(cx, cy - r)]);
+
 // ---------------------------------------------------------------------------
 // intersectionPointPoint
 // ---------------------------------------------------------------------------
@@ -243,6 +250,13 @@ describe('intersectionLineEllipse', () => {
     // Horizontal line at y=5 is tangent to an ellipse with ry=5 centred at origin.
     expect(intersectionLineEllipse(line(-20, 5, 20, 5), ellipse(0, 0, 10, 5))).toBe(true);
   });
+
+  test('both quadratic roots lie beyond the segment end (tA > 1) → no intersection', () => {
+    // Segment from (-30,0) to (-20,0): both crossing points of the infinite
+    // line with the ellipse boundary lie at t > 1, past the segment's end,
+    // so this forces evaluation of the tB-range check too (not just tA's).
+    expect(intersectionLineEllipse(line(-30, 0, -20, 0), ellipse(0, 0, 10, 5))).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -412,6 +426,20 @@ describe('intersectionCirclePoly', () => {
     expect(intersectionCirclePoly(circle(105, 105, 1), positioned)).toBe(true);
     expect(intersectionCirclePoly(circle(5, 5, 1), positioned)).toBe(false);
   });
+
+  // These two pin further internal branches of the same already-buggy sign-inverted
+  // frame (see the describe-level NOTE above), purely for statement/branch coverage
+  // of the current implementation — not additional distinct bugs.
+  test('BUG (coverage): a circle diagonally far from the polygon is excluded via the right-Voronoi check', () => {
+    expect(intersectionCirclePoly(circle(-20, -20, 1), square(0, 0, 10))).toBe(false);
+  });
+
+  test('a degenerate polygon with a zero-length edge (duplicate consecutive vertex) does not throw', () => {
+    // Exercises shouldExcludeMiddleVoronoi's normalLength === 0 guard.
+    const degenerate = new Polygon([new Vector(0, 0), new Vector(0, 0), new Vector(10, 0), new Vector(10, 10), new Vector(0, 10)]);
+
+    expect(() => intersectionCirclePoly(circle(0, -5, 1), degenerate)).not.toThrow();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -476,6 +504,14 @@ describe('intersectionSat', () => {
   test('a single separating axis is enough to report no intersection', () => {
     expect(intersectionSat(square(0, 0, 10), square(500, 0, 10))).toBe(false);
   });
+
+  test('a separating axis found only among the second shape\'s normals is still detected', () => {
+    // The square's own axes (X/Y) show overlap for both shapes' bounding
+    // extents, but the diamond's diagonal edge normals reveal a true
+    // separating axis — this can only be found by testing shapeB's normals
+    // (the second loop), which is the entire point of testing both shapes.
+    expect(intersectionSat(square(0, 0, 10), diamond(14, -3, 5))).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -507,6 +543,22 @@ describe('getCollisionRectangleRectangle', () => {
     expect(response!.projectionV.x).toBeCloseTo(2);
   });
 
+  test('smaller X penetration, rectB to the left of rectA\'s centre → normalX = -1', () => {
+    const response = getCollisionRectangleRectangle(rect(0, 0, 10, 10), rect(-8, 0, 10, 10));
+
+    expect(response).not.toBeNull();
+    expect(response!.projectionN.x).toBeCloseTo(-1);
+    expect(response!.projectionN.y).toBeCloseTo(0);
+  });
+
+  test('smaller Y penetration, rectB below rectA\'s centre → normalY = +1', () => {
+    const response = getCollisionRectangleRectangle(rect(0, 0, 10, 10), rect(0, 8, 10, 10));
+
+    expect(response).not.toBeNull();
+    expect(response!.projectionN.x).toBeCloseTo(0);
+    expect(response!.projectionN.y).toBeCloseTo(1);
+  });
+
   test('a big rectangle fully containing a small one reports containment flags', () => {
     const big = rect(0, 0, 100, 100);
     const small = rect(10, 10, 20, 20);
@@ -515,6 +567,13 @@ describe('getCollisionRectangleRectangle', () => {
     expect(response).not.toBeNull();
     expect(response!.shapeBinA).toBe(true); // small (B) is inside big (A)
     expect(response!.shapeAinB).toBe(false);
+  });
+
+  test('the second early-return branch catches rectA positioned entirely past rectB', () => {
+    // rectB.left (0) is not past rectA.right (60) and rectB.top (0) is not past
+    // rectA.bottom (60), so the first check passes; only the second check
+    // (rectA.left > rectB.right) catches this disjoint pair.
+    expect(getCollisionRectangleRectangle(rect(50, 50, 10, 10), rect(0, 0, 10, 10))).toBeNull();
   });
 });
 
@@ -611,6 +670,24 @@ describe('getCollisionCircleRectangle', () => {
     expect(response).not.toBeNull();
     expect(response!.overlap).toBeCloseTo(0);
   });
+
+  test('circle centre exactly inside the rectangle picks the Y exit axis when it is the smaller penetration', () => {
+    // Interior point (5, 2) of rect [0..10]x[0..10]: exitTop=2 is the smallest exit.
+    const response = getCollisionCircleRectangle(circle(5, 2, 1), rect(0, 0, 10, 10));
+
+    expect(response).not.toBeNull();
+    expect(response!.projectionN.x).toBeCloseTo(0);
+    expect(response!.projectionN.y).toBeCloseTo(-1);
+  });
+
+  test('circle centre exactly inside the rectangle, Y exit axis, exitBottom is the smaller exit', () => {
+    // Interior point (5, 8) of rect [0..10]x[0..10]: exitBottom=2 is the smallest exit.
+    const response = getCollisionCircleRectangle(circle(5, 8, 1), rect(0, 0, 10, 10));
+
+    expect(response).not.toBeNull();
+    expect(response!.projectionN.x).toBeCloseTo(0);
+    expect(response!.projectionN.y).toBeCloseTo(1);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -641,6 +718,15 @@ describe('getCollisionEllipseRectangle', () => {
     expect(response!.overlap).toBeCloseTo(5); // minExitX (3) + ellipse.rx (2)
   });
 
+  test('ellipse centre exactly inside the rectangle, X exit axis, exitRight is the smaller exit', () => {
+    const response = getCollisionEllipseRectangle(ellipse(7, 5, 2, 2), rect(0, 0, 10, 10));
+
+    expect(response).not.toBeNull();
+    expect(response!.projectionN.x).toBeCloseTo(1);
+    expect(response!.projectionN.y).toBeCloseTo(0);
+    expect(response!.overlap).toBeCloseTo(5); // minExitX (3) + ellipse.rx (2)
+  });
+
   test('swap=true swaps shapeA/shapeB and flips the normal', () => {
     const e = ellipse(-1, 5, 3, 3);
     const r = rect(0, 0, 10, 10);
@@ -652,6 +738,26 @@ describe('getCollisionEllipseRectangle', () => {
     expect(swapped!.shapeA).toBe(unswapped!.shapeB);
     expect(swapped!.shapeB).toBe(unswapped!.shapeA);
     expect(swapped!.projectionN.x).toBeCloseTo(-unswapped!.projectionN.x);
+  });
+
+  test('ellipse centre exactly inside the rectangle picks the Y exit axis when it is the smaller penetration', () => {
+    // Interior point (5, 2) of rect [0..10]x[0..10]: exitTop=2 is the smallest exit.
+    const response = getCollisionEllipseRectangle(ellipse(5, 2, 2, 2), rect(0, 0, 10, 10));
+
+    expect(response).not.toBeNull();
+    expect(response!.projectionN.x).toBeCloseTo(0);
+    expect(response!.projectionN.y).toBeCloseTo(-1);
+    expect(response!.overlap).toBeCloseTo(4); // minExitY (2) + ellipse.ry (2)
+  });
+
+  test('ellipse centre exactly inside the rectangle, Y exit axis, exitBottom is the smaller exit', () => {
+    // Interior point (5, 8) of rect [0..10]x[0..10]: exitBottom=2 is the smallest exit.
+    const response = getCollisionEllipseRectangle(ellipse(5, 8, 2, 2), rect(0, 0, 10, 10));
+
+    expect(response).not.toBeNull();
+    expect(response!.projectionN.x).toBeCloseTo(0);
+    expect(response!.projectionN.y).toBeCloseTo(1);
+    expect(response!.overlap).toBeCloseTo(4); // minExitY (2) + ellipse.ry (2)
   });
 });
 
@@ -750,6 +856,44 @@ describe('getCollisionPolygonCircle', () => {
     expect(swapped!.shapeA).toBe(unswapped!.shapeB);
     expect(swapped!.shapeB).toBe(unswapped!.shapeA);
   });
+
+  // The next four cases exercise the left/right vertex-Voronoi exclusion
+  // branches directly (a circle near a corner, not a flat edge), each with a
+  // radius just short of / just past the corner distance.
+  test('a circle near the (0,0) vertex, too far to reach it, returns null (left-vertex branch)', () => {
+    // Distance from (-1, -1) to the corner (0, 0) is sqrt(2) ≈ 1.41.
+    expect(getCollisionPolygonCircle(square(0, 0, 10), circle(-1, -1, 1))).toBeNull();
+  });
+
+  test('a circle near the (0,0) vertex, reaching it, computes a response (left-vertex branch)', () => {
+    const response = getCollisionPolygonCircle(square(0, 0, 10), circle(-1, -1, 2));
+
+    expect(response).not.toBeNull();
+    expect(response!.overlap).toBeGreaterThan(0);
+  });
+
+  test('a circle near the (10,0) vertex, too far to reach it, returns null (right-vertex branch)', () => {
+    expect(getCollisionPolygonCircle(square(0, 0, 10), circle(13, -1, 3))).toBeNull();
+  });
+
+  test('a circle near the (10,0) vertex, reaching it, computes a response (right-vertex branch)', () => {
+    const response = getCollisionPolygonCircle(square(0, 0, 10), circle(13, -1, 4));
+
+    expect(response).not.toBeNull();
+    expect(response!.overlap).toBeGreaterThan(0);
+  });
+
+  test('a circle directly in front of a flat edge but far away returns null (middle-region branch)', () => {
+    // Centred under the top edge (x=5 is within the edge's span) but far
+    // enough on the Y axis that no other vertex-region exclusion fires first.
+    expect(getCollisionPolygonCircle(square(0, 0, 10), circle(5, -1000, 1))).toBeNull();
+  });
+
+  test('a degenerate polygon with a zero-length edge does not throw (normalLength === 0 guard)', () => {
+    const degenerate = new Polygon([new Vector(0, 0), new Vector(0, 0), new Vector(10, 0), new Vector(10, 10), new Vector(0, 10)]);
+
+    expect(() => getCollisionPolygonCircle(degenerate, circle(0, -5, 1))).not.toThrow();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -785,6 +929,13 @@ describe('getCollisionEllipseEllipse', () => {
     expect(response!.projectionN.x).toBeCloseTo(1);
     expect(response!.projectionN.y).toBeCloseTo(0);
     expect(response!.overlap).toBeCloseTo(2 + 3); // ellipseA.rx(2) + ellipseB.rx(3)
+  });
+
+  test('ellipses exactly tangent (touching) compute a zero-or-negative overlap and return null', () => {
+    // boundaryA(5) + boundaryB(5) === distance(10) along the connecting axis,
+    // so the computed overlap is <= 0 even though the polygon-approximation
+    // based intersectionEllipseEllipse() reports a (boundary) touch.
+    expect(getCollisionEllipseEllipse(ellipse(0, 0, 5, 3), ellipse(10, 0, 5, 3))).toBeNull();
   });
 });
 
@@ -823,5 +974,63 @@ describe('getCollisionSat', () => {
 
     expect(response).not.toBeNull();
     expect(response!.overlap).toBeGreaterThan(0);
+  });
+
+  test('a separating axis found only among the second shape\'s normals is still detected', () => {
+    // Same axis-mismatch scenario as intersectionSat above: the square's own
+    // axes see overlap everywhere, but the diamond's diagonal normals reveal
+    // the true separating axis, which can only be found in the second loop.
+    expect(getCollisionSat(square(0, 0, 10), diamond(14, -3, 5))).toBeNull();
+  });
+
+  test('shapeAinB stays true through every axis of the first shape, then flips false in the second loop', () => {
+    // Along the square's own axes (X/Y), the diamond's projection always
+    // contains the square's — so shapeAinB survives the entire first loop.
+    // Only the diamond's own (diagonal) axes reveal that containment doesn't
+    // actually hold, flipping shapeAinB to false inside the second loop.
+    const response = getCollisionSat(square(0, 0, 10), diamond(5, 5, 10));
+
+    expect(response).not.toBeNull();
+    expect(response!.shapeAinB).toBe(false);
+    expect(response!.shapeBinA).toBe(false);
+  });
+
+  test('shapeBinA stays true through every axis of the first shape, then flips false in the second loop', () => {
+    // Two irregular overlapping polygons (found by search) where containment
+    // "survives" every axis of the first shape but is disproved by one of the
+    // second shape's own axes — the mirror image of the case above.
+    const shapeA = new Polygon(
+      [
+        [12.3, 0],
+        [2.7, 4.7],
+        [-7.6, 13.2],
+        [-17.4, 0],
+        [-8.3, -14.4],
+        [6.1, -10.5],
+      ].map(([x, y]) => new Vector(x, y)),
+    );
+    const shapeB = new Polygon(
+      [
+        [8.4, 0.4],
+        [-3.8, 11.3],
+        [-15.2, 0.4],
+        [-3.8, -5.5],
+      ].map(([x, y]) => new Vector(x, y)),
+    );
+
+    const response = getCollisionSat(shapeA, shapeB);
+
+    expect(response).not.toBeNull();
+    expect(response!.shapeBinA).toBe(false);
+  });
+
+  test('a shape with zero normals falls back to the other shape\'s first normal', () => {
+    // An empty Polygon yields getNormals() === [], so normalsA[0] is
+    // undefined and the `(normalsA[0] || normalsB[0])!` fallback must be used
+    // instead. It also has no separating axes to test, so the loop over its
+    // (empty) normals never overlaps the other shape and this reports null.
+    const empty = new Polygon([]);
+
+    expect(getCollisionSat(empty, square(0, 0, 10))).toBeNull();
   });
 });

--- a/test/math/collision-primitives.test.ts
+++ b/test/math/collision-primitives.test.ts
@@ -1,0 +1,468 @@
+import {
+  buildCirclePoints,
+  buildEllipsePoints,
+  buildPolygonWorldPoints,
+  buildRectanglePoints,
+  getDotProduct,
+  getVectorLength,
+  getVectorLengthSquared,
+  getVoronoiRegion,
+  intersectionLineLineSegments,
+  intersectionPointCircle,
+  intersectionPointEllipse,
+  intersectionPointLineSegment,
+  intersectionPointPoint,
+  intersectionPointPoly,
+  intersectionPointRect,
+  intersectionRectRect,
+  pointOnSegment,
+  polygonContainsPoint,
+  polygonsIntersect,
+  segmentsIntersect,
+} from '#math/collision-primitives';
+import { VoronoiRegion } from '#math/utils';
+
+// ---------------------------------------------------------------------------
+// buildCirclePoints
+// ---------------------------------------------------------------------------
+
+describe('buildCirclePoints', () => {
+  test('a zero radius produces an empty point list', () => {
+    expect(buildCirclePoints({ x: 0, y: 0, radius: 0 })).toEqual([]);
+  });
+
+  test('a negative radius produces an empty point list', () => {
+    expect(buildCirclePoints({ x: 0, y: 0, radius: -5 })).toEqual([]);
+  });
+
+  test('a positive radius produces points on the circle boundary', () => {
+    const points = buildCirclePoints({ x: 0, y: 0, radius: 10 });
+
+    expect(points.length).toBeGreaterThan(0);
+
+    for (const { x, y } of points) {
+      expect(Math.sqrt(x * x + y * y)).toBeCloseTo(10, 5);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildEllipsePoints
+// ---------------------------------------------------------------------------
+
+describe('buildEllipsePoints', () => {
+  test('rx <= 0 produces an empty point list', () => {
+    expect(buildEllipsePoints({ x: 0, y: 0, rx: 0, ry: 5 })).toEqual([]);
+  });
+
+  test('ry <= 0 produces an empty point list', () => {
+    expect(buildEllipsePoints({ x: 0, y: 0, rx: 5, ry: 0 })).toEqual([]);
+  });
+
+  test('positive radii produce points satisfying the ellipse equation', () => {
+    const points = buildEllipsePoints({ x: 0, y: 0, rx: 10, ry: 5 });
+
+    expect(points.length).toBeGreaterThan(0);
+
+    for (const { x, y } of points) {
+      expect((x / 10) ** 2 + (y / 5) ** 2).toBeCloseTo(1, 5);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRectanglePoints
+// ---------------------------------------------------------------------------
+
+describe('buildRectanglePoints', () => {
+  test('returns the four corners in TL -> TR -> BR -> BL order', () => {
+    expect(buildRectanglePoints({ x: 0, y: 0, width: 10, height: 20 })).toEqual([
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 20 },
+      { x: 0, y: 20 },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildPolygonWorldPoints
+// ---------------------------------------------------------------------------
+
+describe('buildPolygonWorldPoints', () => {
+  test('translates local points by the world offset', () => {
+    const points = buildPolygonWorldPoints({
+      x: 100,
+      y: 200,
+      points: [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ],
+    });
+
+    expect(points).toEqual([
+      { x: 100, y: 200 },
+      { x: 110, y: 200 },
+    ]);
+  });
+
+  test('a zero offset leaves the points unchanged', () => {
+    const points = buildPolygonWorldPoints({ x: 0, y: 0, points: [{ x: 5, y: 5 }] });
+
+    expect(points).toEqual([{ x: 5, y: 5 }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pointOnSegment
+// ---------------------------------------------------------------------------
+
+describe('pointOnSegment', () => {
+  test('a point within the segment bounding box is on the segment', () => {
+    expect(pointOnSegment({ x: 5, y: 0 }, { x: 0, y: 0 }, { x: 10, y: 0 })).toBe(true);
+  });
+
+  test('a point left of the bounding box is not on the segment', () => {
+    expect(pointOnSegment({ x: -5, y: 0 }, { x: 0, y: 0 }, { x: 10, y: 0 })).toBe(false);
+  });
+
+  test('a point right of the bounding box is not on the segment', () => {
+    expect(pointOnSegment({ x: 15, y: 0 }, { x: 0, y: 0 }, { x: 10, y: 0 })).toBe(false);
+  });
+
+  test('a point above the bounding box is not on the segment', () => {
+    expect(pointOnSegment({ x: 5, y: -5 }, { x: 0, y: 0 }, { x: 10, y: 10 })).toBe(false);
+  });
+
+  test('a point below the bounding box is not on the segment', () => {
+    expect(pointOnSegment({ x: 5, y: 15 }, { x: 0, y: 0 }, { x: 10, y: 10 })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// segmentsIntersect
+// ---------------------------------------------------------------------------
+
+describe('segmentsIntersect', () => {
+  test('crossing segments intersect', () => {
+    expect(segmentsIntersect({ x: 0, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }, { x: 10, y: 0 })).toBe(true);
+  });
+
+  test('disjoint, non-collinear segments do not intersect', () => {
+    expect(segmentsIntersect({ x: 0, y: 0 }, { x: 1, y: 1 }, { x: 5, y: 5 }, { x: 10, y: 10 })).toBe(false);
+  });
+
+  test('collinear, overlapping segments intersect (o1 === 0 branch)', () => {
+    // b1 = (5, 0) lies exactly on segment a: (0,0)-(10,0).
+    expect(segmentsIntersect({ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 5, y: 0 }, { x: 20, y: 0 })).toBe(true);
+  });
+
+  test('collinear, non-overlapping segments do not intersect', () => {
+    expect(segmentsIntersect({ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 20, y: 0 }, { x: 30, y: 0 })).toBe(false);
+  });
+
+  test('collinear segment B has its first endpoint outside A and second endpoint inside A (o2 === 0 branch)', () => {
+    // Both segments lie on the same line (all four points collinear), so the
+    // general cross-product test (o1 !== o2 && o3 !== o4) is skipped (o1 ===
+    // o2 === 0 here). b1 = (20, 0) falls outside a's span [0, 10], so the o1
+    // check fails; b2 = (5, 0) falls inside, hitting the o2 check.
+    expect(segmentsIntersect({ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 20, y: 0 }, { x: 5, y: 0 })).toBe(true);
+  });
+
+  test('a small collinear segment fully contained inside a larger one (o3 === 0 branch)', () => {
+    // a = (5,0)-(6,0) is entirely inside b = (0,0)-(10,0)'s span, so neither of
+    // b's endpoints falls inside a's tiny span (o1/o2 both fail), but a1 = (5, 0)
+    // falls inside b's span, hitting the o3 check.
+    expect(segmentsIntersect({ x: 5, y: 0 }, { x: 6, y: 0 }, { x: 0, y: 0 }, { x: 10, y: 0 })).toBe(true);
+  });
+
+  // NOTE: the mirrored o4 branch (`o4 === 0 && pointOnSegment(a2, b1, b2)`) is
+  // unreachable in practice. Reaching it requires o1, o2, and o3 to all fail
+  // while o4 succeeds; for any collinear configuration, o1 === o2 === o3 === o4
+  // together (full collinearity is symmetric — see `orientation()`), so
+  // whichever endpoint-containment check would satisfy o4 always also
+  // satisfies one of the earlier o1/o2/o3 checks first (confirmed by an
+  // exhaustive randomized search over collinear configurations finding no
+  // counterexample). This is dead code from the check ordering, not a bug.
+});
+
+// ---------------------------------------------------------------------------
+// polygonContainsPoint
+// ---------------------------------------------------------------------------
+
+describe('polygonContainsPoint', () => {
+  test('fewer than 3 points always returns false', () => {
+    expect(
+      polygonContainsPoint({ x: 0, y: 0 }, [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ]),
+    ).toBe(false);
+  });
+
+  test('a point inside a triangle returns true', () => {
+    const triangle = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 5, y: 10 },
+    ];
+
+    expect(polygonContainsPoint({ x: 5, y: 3 }, triangle)).toBe(true);
+  });
+
+  test('a point outside a triangle returns false', () => {
+    const triangle = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 5, y: 10 },
+    ];
+
+    expect(polygonContainsPoint({ x: 100, y: 100 }, triangle)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// polygonsIntersect
+// ---------------------------------------------------------------------------
+
+describe('polygonsIntersect', () => {
+  test('an empty first polygon never intersects', () => {
+    expect(polygonsIntersect([], [{ x: 0, y: 0 }])).toBe(false);
+  });
+
+  test('an empty second polygon never intersects', () => {
+    expect(polygonsIntersect([{ x: 0, y: 0 }], [])).toBe(false);
+  });
+
+  test('overlapping polygons (edge crossing) intersect', () => {
+    const a = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 0, y: 10 },
+    ];
+    const b = [
+      { x: 5, y: 5 },
+      { x: 15, y: 5 },
+      { x: 15, y: 15 },
+      { x: 5, y: 15 },
+    ];
+
+    expect(polygonsIntersect(a, b)).toBe(true);
+  });
+
+  test('one polygon fully containing another (no edge crossings) intersects', () => {
+    const outer = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+      { x: 0, y: 100 },
+    ];
+    const inner = [
+      { x: 40, y: 40 },
+      { x: 60, y: 40 },
+      { x: 60, y: 60 },
+      { x: 40, y: 60 },
+    ];
+
+    expect(polygonsIntersect(outer, inner)).toBe(true);
+  });
+
+  test('disjoint polygons do not intersect', () => {
+    const a = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 0, y: 10 },
+    ];
+    const b = [
+      { x: 500, y: 500 },
+      { x: 510, y: 500 },
+      { x: 510, y: 510 },
+      { x: 500, y: 510 },
+    ];
+
+    expect(polygonsIntersect(a, b)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// intersectionPointPoint
+// ---------------------------------------------------------------------------
+
+describe('intersectionPointPoint', () => {
+  test('identical points intersect', () => {
+    expect(intersectionPointPoint({ x: 1, y: 1 }, { x: 1, y: 1 })).toBe(true);
+  });
+
+  test('distinct points beyond the threshold do not intersect', () => {
+    expect(intersectionPointPoint({ x: 0, y: 0 }, { x: 5, y: 0 })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// intersectionPointLineSegment
+// ---------------------------------------------------------------------------
+
+describe('intersectionPointLineSegment', () => {
+  test('a point exactly on the segment intersects', () => {
+    expect(intersectionPointLineSegment({ x: 5, y: 0 }, { x: 0, y: 0 }, { x: 10, y: 0 })).toBe(true);
+  });
+
+  test('a point far from the segment does not intersect', () => {
+    expect(intersectionPointLineSegment({ x: 5, y: 100 }, { x: 0, y: 0 }, { x: 10, y: 0 })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// intersectionPointRect
+// ---------------------------------------------------------------------------
+
+describe('intersectionPointRect', () => {
+  test('a point inside the rectangle intersects', () => {
+    expect(intersectionPointRect({ x: 5, y: 5 }, { x: 0, y: 0, width: 10, height: 10 })).toBe(true);
+  });
+
+  test('a point outside the rectangle does not intersect', () => {
+    expect(intersectionPointRect({ x: 50, y: 50 }, { x: 0, y: 0, width: 10, height: 10 })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// intersectionPointCircle
+// ---------------------------------------------------------------------------
+
+describe('intersectionPointCircle', () => {
+  test('a point inside the circle intersects', () => {
+    expect(intersectionPointCircle({ x: 1, y: 0 }, { x: 0, y: 0, radius: 5 })).toBe(true);
+  });
+
+  test('a point outside the circle does not intersect', () => {
+    expect(intersectionPointCircle({ x: 100, y: 0 }, { x: 0, y: 0, radius: 5 })).toBe(false);
+  });
+
+  test('a zero radius never intersects', () => {
+    expect(intersectionPointCircle({ x: 0, y: 0 }, { x: 0, y: 0, radius: 0 })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// intersectionPointEllipse
+// ---------------------------------------------------------------------------
+
+describe('intersectionPointEllipse', () => {
+  test('rx <= 0 never intersects', () => {
+    expect(intersectionPointEllipse({ x: 0, y: 0 }, { x: 0, y: 0, rx: 0, ry: 5 })).toBe(false);
+  });
+
+  test('ry <= 0 never intersects', () => {
+    expect(intersectionPointEllipse({ x: 0, y: 0 }, { x: 0, y: 0, rx: 5, ry: 0 })).toBe(false);
+  });
+
+  test('a point inside the ellipse intersects', () => {
+    expect(intersectionPointEllipse({ x: 0, y: 0 }, { x: 0, y: 0, rx: 10, ry: 5 })).toBe(true);
+  });
+
+  test('a point outside the ellipse does not intersect', () => {
+    expect(intersectionPointEllipse({ x: 100, y: 100 }, { x: 0, y: 0, rx: 10, ry: 5 })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// intersectionPointPoly
+// ---------------------------------------------------------------------------
+
+describe('intersectionPointPoly', () => {
+  test('a point inside the polygon intersects', () => {
+    const square = {
+      x: 0,
+      y: 0,
+      points: [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 10 },
+        { x: 0, y: 10 },
+      ],
+    };
+
+    expect(intersectionPointPoly({ x: 5, y: 5 }, square)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// intersectionLineLineSegments
+// ---------------------------------------------------------------------------
+
+describe('intersectionLineLineSegments', () => {
+  test('crossing segments intersect', () => {
+    expect(intersectionLineLineSegments({ x: 0, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }, { x: 10, y: 0 })).toBe(true);
+  });
+
+  test('parallel segments (zero denominator) do not intersect', () => {
+    expect(intersectionLineLineSegments({ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 0, y: 5 }, { x: 10, y: 5 })).toBe(false);
+  });
+
+  test('non-parallel segments whose infinite lines cross outside both segments do not intersect', () => {
+    expect(intersectionLineLineSegments({ x: 0, y: 0 }, { x: 1, y: 1 }, { x: 5, y: 0 }, { x: 5, y: -1 })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// intersectionRectRect
+// ---------------------------------------------------------------------------
+
+describe('intersectionRectRect', () => {
+  test('overlapping rectangles intersect', () => {
+    expect(intersectionRectRect({ x: 0, y: 0, width: 10, height: 10 }, { x: 5, y: 5, width: 10, height: 10 })).toBe(true);
+  });
+
+  test('rectB entirely past rectA on X/Y does not intersect (first early-return branch)', () => {
+    expect(intersectionRectRect({ x: 0, y: 0, width: 10, height: 10 }, { x: 50, y: 50, width: 10, height: 10 })).toBe(false);
+  });
+
+  test('rectA entirely past rectB on X does not intersect (second early-return branch)', () => {
+    // rectB.left (0) is NOT past rectA.right (60), so the first check passes;
+    // the second check (rectA.left > rectB.right) is what must catch this case.
+    expect(intersectionRectRect({ x: 50, y: 50, width: 10, height: 10 }, { x: 0, y: 0, width: 10, height: 10 })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Vector helpers
+// ---------------------------------------------------------------------------
+
+describe('getVectorLength', () => {
+  test('computes the Euclidean length of a 2D vector', () => {
+    expect(getVectorLength(3, 4)).toBe(5);
+  });
+});
+
+describe('getVectorLengthSquared', () => {
+  test('computes the squared length without a sqrt', () => {
+    expect(getVectorLengthSquared(3, 4)).toBe(25);
+  });
+});
+
+describe('getDotProduct', () => {
+  test('computes the dot product of two vectors', () => {
+    expect(getDotProduct(1, 2, 3, 4)).toBe(1 * 3 + 2 * 4);
+  });
+
+  test('perpendicular vectors have a zero dot product', () => {
+    expect(getDotProduct(1, 0, 0, 1)).toBe(0);
+  });
+});
+
+describe('getVoronoiRegion (scalar form)', () => {
+  test('point before the edge start classifies as left', () => {
+    expect(getVoronoiRegion(10, 0, -5, 0)).toBe(VoronoiRegion.left);
+  });
+
+  test('point past the edge end classifies as right', () => {
+    expect(getVoronoiRegion(10, 0, 20, 0)).toBe(VoronoiRegion.right);
+  });
+
+  test('point projecting onto the edge classifies as middle', () => {
+    expect(getVoronoiRegion(10, 0, 5, 3)).toBe(VoronoiRegion.middle);
+  });
+});

--- a/test/math/ellipse.test.ts
+++ b/test/math/ellipse.test.ts
@@ -1,4 +1,23 @@
+import { Circle } from '#math/Circle';
+import type { Collidable } from '#math/Collision';
+import { CollisionType } from '#math/Collision';
 import { Ellipse } from '#math/Ellipse';
+import { Interval } from '#math/Interval';
+import { Line } from '#math/Line';
+import { Polygon } from '#math/Polygon';
+import { Rectangle } from '#math/Rectangle';
+import { Vector } from '#math/Vector';
+
+// A minimal stand-in for a SceneNode, which Ellipse only ever accesses through
+// `collisionType` + `getBounds()` in its intersectsWith()/collidesWith() switches.
+const fakeSceneNode = (bounds: Rectangle): Collidable => ({ collisionType: CollisionType.SceneNode, getBounds: () => bounds }) as unknown as Collidable;
+
+// A Collidable with a collisionType outside the known enum, to exercise the
+// `default` branch of the intersectsWith()/collidesWith() switches.
+const unknownCollidable = { collisionType: 99 } as unknown as Collidable;
+
+const square = (x: number, y: number, size: number): Polygon =>
+  new Polygon([new Vector(x, y), new Vector(x + size, y), new Vector(x + size, y + size), new Vector(x, y + size)]);
 
 describe('Ellipse', () => {
   test('returns bounds using diameter', () => {
@@ -17,5 +36,262 @@ describe('Ellipse', () => {
     expect(ellipse.equals({ rx: 12, ry: 14 })).toBe(true);
     expect(ellipse.equals({ rx: 11 })).toBe(false);
     expect(ellipse.equals({ ry: 13 })).toBe(false);
+  });
+
+  describe('equals()', () => {
+    test('returns true when called with no arguments', () => {
+      const ellipse = new Ellipse(4, 8, 12, 14);
+
+      expect(ellipse.equals()).toBe(true);
+      expect(ellipse.equals({})).toBe(true);
+    });
+
+    test('compares x and y correctly', () => {
+      const ellipse = new Ellipse(4, 8, 12, 14);
+
+      expect(ellipse.equals({ x: 4, y: 8 })).toBe(true);
+      expect(ellipse.equals({ x: 99 })).toBe(false);
+      expect(ellipse.equals({ y: 99 })).toBe(false);
+    });
+  });
+
+  describe('position, x, y, radius, rx, ry accessors', () => {
+    test('position getter/setter copies coordinates from another vector', () => {
+      const ellipse = new Ellipse(1, 2, 3, 4);
+      ellipse.position = new Vector(10, 20);
+
+      expect(ellipse.x).toBe(10);
+      expect(ellipse.y).toBe(20);
+    });
+
+    test('x and y setters update the underlying position', () => {
+      const ellipse = new Ellipse();
+      ellipse.x = 5;
+      ellipse.y = 6;
+
+      expect(ellipse.x).toBe(5);
+      expect(ellipse.y).toBe(6);
+    });
+
+    test('radius getter/setter copies from another vector', () => {
+      const ellipse = new Ellipse(0, 0, 1, 1);
+      ellipse.radius = new Vector(7, 9);
+
+      expect(ellipse.rx).toBe(7);
+      expect(ellipse.ry).toBe(9);
+    });
+
+    test('rx and ry setters update independently', () => {
+      const ellipse = new Ellipse();
+      ellipse.rx = 3;
+      ellipse.ry = 4;
+
+      expect(ellipse.rx).toBe(3);
+      expect(ellipse.ry).toBe(4);
+    });
+  });
+
+  describe('setPosition(), setRadius(), set(), copy(), clone()', () => {
+    test('setPosition() updates x/y and returns this', () => {
+      const ellipse = new Ellipse();
+      const result = ellipse.setPosition(7, 8);
+
+      expect(result).toBe(ellipse);
+      expect(ellipse.x).toBe(7);
+      expect(ellipse.y).toBe(8);
+    });
+
+    test('setRadius() with a single argument sets both axes equally', () => {
+      const ellipse = new Ellipse();
+      const result = ellipse.setRadius(5);
+
+      expect(result).toBe(ellipse);
+      expect(ellipse.rx).toBe(5);
+      expect(ellipse.ry).toBe(5);
+    });
+
+    test('setRadius() with two arguments sets each axis independently', () => {
+      const ellipse = new Ellipse();
+      const result = ellipse.setRadius(5, 9);
+
+      expect(result).toBe(ellipse);
+      expect(ellipse.rx).toBe(5);
+      expect(ellipse.ry).toBe(9);
+    });
+
+    test('set() updates position and radius and returns this', () => {
+      const ellipse = new Ellipse();
+      const result = ellipse.set(1, 2, 3, 4);
+
+      expect(result).toBe(ellipse);
+      expect(ellipse.x).toBe(1);
+      expect(ellipse.y).toBe(2);
+      expect(ellipse.rx).toBe(3);
+      expect(ellipse.ry).toBe(4);
+    });
+
+    test('copy() duplicates another ellipse state and returns this', () => {
+      const source = new Ellipse(1, 2, 3, 4);
+      const target = new Ellipse();
+      const result = target.copy(source);
+
+      expect(result).toBe(target);
+      expect(target.equals(source)).toBe(true);
+    });
+
+    test('clone() returns a new ellipse with the same state', () => {
+      const ellipse = new Ellipse(1, 2, 3, 4);
+      const clone = ellipse.clone();
+
+      expect(clone).not.toBe(ellipse);
+      expect(clone.equals(ellipse)).toBe(true);
+    });
+  });
+
+  describe('getNormals()', () => {
+    test('always returns an empty array', () => {
+      const ellipse = new Ellipse(0, 0, 5, 3);
+
+      expect(ellipse.getNormals()).toEqual([]);
+    });
+  });
+
+  describe('project()', () => {
+    test('projects onto the X axis using rx', () => {
+      const ellipse = new Ellipse(10, 5, 3, 2);
+      const result = ellipse.project(new Vector(1, 0));
+
+      expect(result.min).toBeCloseTo(7);
+      expect(result.max).toBeCloseTo(13);
+    });
+
+    test('projects onto the Y axis using ry, writing into a provided Interval', () => {
+      const ellipse = new Ellipse(10, 5, 3, 2);
+      const provided = new Interval();
+      const returned = ellipse.project(new Vector(0, 1), provided);
+
+      expect(returned).toBe(provided);
+      expect(provided.min).toBeCloseTo(3);
+      expect(provided.max).toBeCloseTo(7);
+    });
+  });
+
+  describe('contains()', () => {
+    test('point inside the ellipse returns true', () => {
+      const ellipse = new Ellipse(0, 0, 10, 5);
+
+      expect(ellipse.contains(0, 0)).toBe(true);
+    });
+
+    test('point outside the ellipse returns false', () => {
+      const ellipse = new Ellipse(0, 0, 10, 5);
+
+      expect(ellipse.contains(100, 100)).toBe(false);
+    });
+  });
+
+  describe('intersectsWith()', () => {
+    test('SceneNode branch delegates to the rectangle bounds', () => {
+      const ellipse = new Ellipse(5, 5, 3, 3);
+
+      expect(ellipse.intersectsWith(fakeSceneNode(new Rectangle(0, 0, 10, 10)))).toBe(true);
+    });
+
+    test('Rectangle branch', () => {
+      const ellipse = new Ellipse(5, 5, 3, 3);
+
+      expect(ellipse.intersectsWith(new Rectangle(0, 0, 10, 10))).toBe(true);
+    });
+
+    test('Polygon branch', () => {
+      const ellipse = new Ellipse(5, 5, 3, 3);
+
+      expect(ellipse.intersectsWith(square(0, 0, 10))).toBe(true);
+    });
+
+    test('Circle branch', () => {
+      const ellipse = new Ellipse(6, 0, 5, 3);
+
+      expect(ellipse.intersectsWith(new Circle(0, 0, 5))).toBe(true);
+    });
+
+    test('Ellipse branch', () => {
+      const ellipse = new Ellipse(0, 0, 10, 5);
+
+      expect(ellipse.intersectsWith(new Ellipse(8, 0, 10, 5))).toBe(true);
+    });
+
+    test('Line branch', () => {
+      const ellipse = new Ellipse(0, 0, 10, 5);
+
+      expect(ellipse.intersectsWith(new Line(-20, 0, 20, 0))).toBe(true);
+    });
+
+    test('Point branch', () => {
+      const ellipse = new Ellipse(0, 0, 10, 5);
+
+      expect(ellipse.intersectsWith(new Vector(0, 0))).toBe(true);
+    });
+
+    test('default branch returns false for an unknown collision type', () => {
+      const ellipse = new Ellipse(0, 0, 10, 5);
+
+      expect(ellipse.intersectsWith(unknownCollidable)).toBe(false);
+    });
+  });
+
+  describe('collidesWith()', () => {
+    test('SceneNode branch delegates to the rectangle bounds', () => {
+      const ellipse = new Ellipse(-1, 5, 3, 3);
+      const response = ellipse.collidesWith(fakeSceneNode(new Rectangle(0, 0, 10, 10)));
+
+      expect(response).not.toBeNull();
+      expect(response!.overlap).toBeCloseTo(2);
+    });
+
+    test('Rectangle branch', () => {
+      const ellipse = new Ellipse(-1, 5, 3, 3);
+      const response = ellipse.collidesWith(new Rectangle(0, 0, 10, 10));
+
+      expect(response).not.toBeNull();
+      expect(response!.overlap).toBeCloseTo(2);
+    });
+
+    test('Circle branch', () => {
+      const ellipse = new Ellipse(0, 0, 5, 3);
+      const response = ellipse.collidesWith(new Circle(6, 0, 2));
+
+      expect(response).not.toBeNull();
+    });
+
+    test('Polygon branch (via SAT, using the polygon normals)', () => {
+      const ellipse = new Ellipse(5, 5, 3, 3);
+      const response = ellipse.collidesWith(square(0, 0, 10));
+
+      expect(response).not.toBeNull();
+      expect(response!.overlap).toBeGreaterThan(0);
+    });
+
+    test('Ellipse branch', () => {
+      const ellipse = new Ellipse(0, 0, 5, 3);
+      const response = ellipse.collidesWith(new Ellipse(8, 0, 5, 3));
+
+      expect(response).not.toBeNull();
+      expect(response!.overlap).toBeGreaterThan(0);
+    });
+
+    test('default branch returns null for an unsupported target (e.g. Line)', () => {
+      const ellipse = new Ellipse(0, 0, 10, 5);
+
+      expect(ellipse.collidesWith(new Line(-20, 0, 20, 0))).toBeNull();
+    });
+  });
+
+  describe('destroy()', () => {
+    test('does not throw', () => {
+      const ellipse = new Ellipse(0, 0, 5, 3);
+
+      expect(() => ellipse.destroy()).not.toThrow();
+    });
   });
 });

--- a/test/math/geometry.test.ts
+++ b/test/math/geometry.test.ts
@@ -158,6 +158,24 @@ describe('buildPath', () => {
     expect(box.minY).toBeGreaterThan(-50);
     expect(box.maxY).toBeLessThan(50);
   });
+
+  test('a sharp (but non-collinear) turn also triggers the spike bevel fallback', () => {
+    // Unlike the near-exact-reversal case above (which hits the separate
+    // denom<0.1 near-parallel guard), this turn has a well-defined miter
+    // intersection point that lies far away (pdist > 196 * lineWidth^2),
+    // exercising the perp3-based bevel fallback instead.
+    const points = [0, 0, 100, 0, 5, 5];
+    const data = buildPath(points, 4);
+    const box = bboxOf(data.vertices);
+
+    // The raw (unbevelled) miter intersection for this configuration would
+    // land more than 150 units away from the joint at (100, 0); the bevel
+    // fallback must keep every vertex close to the path instead.
+    expect(box.minX).toBeGreaterThanOrEqual(-10);
+    expect(box.maxX).toBeLessThanOrEqual(110);
+    expect(box.minY).toBeGreaterThanOrEqual(-10);
+    expect(box.maxY).toBeLessThanOrEqual(10);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/math/interval.test.ts
+++ b/test/math/interval.test.ts
@@ -1,0 +1,198 @@
+import { Interval } from '#math/Interval';
+
+describe('Interval', () => {
+  describe('constructor', () => {
+    test('defaults to [0, 0] when no arguments are given', () => {
+      const interval = new Interval();
+
+      expect(interval.min).toBe(0);
+      expect(interval.max).toBe(0);
+    });
+
+    test('defaults max to min when only min is given', () => {
+      const interval = new Interval(5);
+
+      expect(interval.min).toBe(5);
+      expect(interval.max).toBe(5);
+    });
+
+    test('accepts an explicit min and max', () => {
+      const interval = new Interval(2, 8);
+
+      expect(interval.min).toBe(2);
+      expect(interval.max).toBe(8);
+    });
+  });
+
+  describe('set()', () => {
+    test('assigns min/max and returns this for chaining', () => {
+      const interval = new Interval();
+      const returned = interval.set(3, 9);
+
+      expect(returned).toBe(interval);
+      expect(interval.min).toBe(3);
+      expect(interval.max).toBe(9);
+    });
+  });
+
+  describe('copy()', () => {
+    test('copies min/max from another interval', () => {
+      const source = new Interval(1, 4);
+      const target = new Interval();
+      const returned = target.copy(source);
+
+      expect(returned).toBe(target);
+      expect(target.min).toBe(1);
+      expect(target.max).toBe(4);
+    });
+  });
+
+  describe('clone()', () => {
+    test('returns a new interval with the same min/max', () => {
+      const original = new Interval(2, 6);
+      const clone = original.clone();
+
+      expect(clone).not.toBe(original);
+      expect(clone.min).toBe(2);
+      expect(clone.max).toBe(6);
+    });
+  });
+
+  describe('containsInterval()', () => {
+    test('returns true when the argument is strictly inside this interval', () => {
+      const outer = new Interval(0, 10);
+      const inner = new Interval(2, 8);
+
+      expect(outer.containsInterval(inner)).toBe(true);
+    });
+
+    test('returns false when the argument extends past the min bound', () => {
+      const outer = new Interval(0, 10);
+      const notInside = new Interval(-1, 8);
+
+      expect(outer.containsInterval(notInside)).toBe(false);
+    });
+
+    test('returns false when the argument extends past the max bound', () => {
+      const outer = new Interval(0, 10);
+      const notInside = new Interval(2, 11);
+
+      expect(outer.containsInterval(notInside)).toBe(false);
+    });
+
+    test('returns false when both bounds coincide exactly (exclusive comparison)', () => {
+      const a = new Interval(0, 10);
+      const b = new Interval(0, 10);
+
+      expect(a.containsInterval(b)).toBe(false);
+    });
+  });
+
+  describe('includes()', () => {
+    test('returns true for a value strictly inside the interval', () => {
+      const interval = new Interval(0, 10);
+
+      expect(interval.includes(5)).toBe(true);
+    });
+
+    test('returns true for a value exactly on the min bound (inclusive)', () => {
+      const interval = new Interval(0, 10);
+
+      expect(interval.includes(0)).toBe(true);
+    });
+
+    test('returns true for a value exactly on the max bound (inclusive)', () => {
+      const interval = new Interval(0, 10);
+
+      expect(interval.includes(10)).toBe(true);
+    });
+
+    test('returns false for a value below the interval', () => {
+      const interval = new Interval(0, 10);
+
+      expect(interval.includes(-1)).toBe(false);
+    });
+
+    test('returns false for a value above the interval', () => {
+      const interval = new Interval(0, 10);
+
+      expect(interval.includes(11)).toBe(false);
+    });
+  });
+
+  describe('overlaps()', () => {
+    test('returns true for two overlapping intervals', () => {
+      const a = new Interval(0, 10);
+      const b = new Interval(5, 15);
+
+      expect(a.overlaps(b)).toBe(true);
+    });
+
+    test('returns true when intervals touch exactly at a shared boundary', () => {
+      const a = new Interval(0, 10);
+      const b = new Interval(10, 20);
+
+      expect(a.overlaps(b)).toBe(true);
+    });
+
+    test('returns false when this interval lies entirely after the argument', () => {
+      const a = new Interval(20, 30);
+      const b = new Interval(0, 10);
+
+      expect(a.overlaps(b)).toBe(false);
+    });
+
+    test('returns false when this interval lies entirely before the argument', () => {
+      const a = new Interval(0, 10);
+      const b = new Interval(20, 30);
+
+      expect(a.overlaps(b)).toBe(false);
+    });
+  });
+
+  describe('getOverlap()', () => {
+    test('returns this.max - interval.min when this interval ends first', () => {
+      // this = [0, 10], other = [5, 20] -> this.max(10) < other.max(20)
+      const a = new Interval(0, 10);
+      const b = new Interval(5, 20);
+
+      expect(a.getOverlap(b)).toBe(5); // 10 - 5
+    });
+
+    test('returns interval.max - this.min when the argument ends first', () => {
+      // this = [0, 20], other = [5, 10] -> this.max(20) is NOT < other.max(10)
+      const a = new Interval(0, 20);
+      const b = new Interval(5, 10);
+
+      expect(a.getOverlap(b)).toBe(10); // 10 - 0
+    });
+  });
+
+  describe('destroy()', () => {
+    test('is a no-op that does not throw', () => {
+      const interval = new Interval(1, 2);
+
+      expect(() => interval.destroy()).not.toThrow();
+      // Value class — state is untouched by destroy().
+      expect(interval.min).toBe(1);
+      expect(interval.max).toBe(2);
+    });
+  });
+
+  describe('static zero', () => {
+    test('is a [0, 0] sentinel', () => {
+      expect(Interval.zero.min).toBe(0);
+      expect(Interval.zero.max).toBe(0);
+    });
+  });
+
+  describe('static temp', () => {
+    test('lazily allocates and returns the same instance on subsequent calls', () => {
+      const first = Interval.temp;
+      const second = Interval.temp;
+
+      expect(first).toBe(second);
+      expect(first).toBeInstanceOf(Interval);
+    });
+  });
+});

--- a/test/math/line.test.ts
+++ b/test/math/line.test.ts
@@ -1,0 +1,253 @@
+import { Circle } from '#math/Circle';
+import type { Collidable } from '#math/Collision';
+import { CollisionType } from '#math/Collision';
+import { Ellipse } from '#math/Ellipse';
+import { Interval } from '#math/Interval';
+import { Line } from '#math/Line';
+import { Polygon } from '#math/Polygon';
+import { Rectangle } from '#math/Rectangle';
+import { Vector } from '#math/Vector';
+
+// A minimal stand-in for a SceneNode, which Line only ever accesses through
+// `collisionType` + `getBounds()` in its intersectsWith() switch.
+const fakeSceneNode = (bounds: Rectangle): Collidable => ({ collisionType: CollisionType.SceneNode, getBounds: () => bounds }) as unknown as Collidable;
+
+// A Collidable with a collisionType outside the known enum, to exercise the
+// `default` branch of the intersectsWith() switch.
+const unknownCollidable = { collisionType: 99 } as unknown as Collidable;
+
+const square = (x: number, y: number, size: number): Polygon =>
+  new Polygon([new Vector(x, y), new Vector(x + size, y), new Vector(x + size, y + size), new Vector(x, y + size)]);
+
+describe('Line', () => {
+  describe('fromPosition/toPosition and X/Y accessors', () => {
+    test('fromPosition getter/setter copies coordinates from another vector', () => {
+      const line = new Line(0, 0, 1, 1);
+      line.fromPosition = new Vector(5, 6);
+
+      expect(line.fromX).toBe(5);
+      expect(line.fromY).toBe(6);
+    });
+
+    test('toPosition getter/setter copies coordinates from another vector', () => {
+      const line = new Line(0, 0, 1, 1);
+      line.toPosition = new Vector(7, 8);
+
+      expect(line.toX).toBe(7);
+      expect(line.toY).toBe(8);
+    });
+
+    test('fromX/fromY setters update independently', () => {
+      const line = new Line();
+      line.fromX = 3;
+      line.fromY = 4;
+
+      expect(line.fromX).toBe(3);
+      expect(line.fromY).toBe(4);
+    });
+
+    test('toX/toY setters update independently', () => {
+      const line = new Line();
+      line.toX = 9;
+      line.toY = 10;
+
+      expect(line.toX).toBe(9);
+      expect(line.toY).toBe(10);
+    });
+  });
+
+  describe('set(), copy(), clone()', () => {
+    test('set() updates both endpoints and returns this', () => {
+      const line = new Line();
+      const result = line.set(1, 2, 3, 4);
+
+      expect(result).toBe(line);
+      expect(line.fromX).toBe(1);
+      expect(line.fromY).toBe(2);
+      expect(line.toX).toBe(3);
+      expect(line.toY).toBe(4);
+    });
+
+    test('copy() duplicates another line state and returns this', () => {
+      const source = new Line(1, 2, 3, 4);
+      const target = new Line();
+      const result = target.copy(source);
+
+      expect(result).toBe(target);
+      expect(target.equals(source)).toBe(true);
+    });
+
+    test('clone() returns a new line with the same state', () => {
+      const line = new Line(1, 2, 3, 4);
+      const clone = line.clone();
+
+      expect(clone).not.toBe(line);
+      expect(clone.equals(line)).toBe(true);
+    });
+  });
+
+  describe('getBounds()', () => {
+    test('normalizes reversed endpoints into a positive-size rectangle', () => {
+      const line = new Line(10, 10, 0, 0);
+      const bounds = line.getBounds();
+
+      expect(bounds.x).toBe(0);
+      expect(bounds.y).toBe(0);
+      expect(bounds.width).toBe(10);
+      expect(bounds.height).toBe(10);
+    });
+
+    test('works for endpoints already in ascending order', () => {
+      const line = new Line(0, 0, 10, 5);
+      const bounds = line.getBounds();
+
+      expect(bounds.x).toBe(0);
+      expect(bounds.y).toBe(0);
+      expect(bounds.width).toBe(10);
+      expect(bounds.height).toBe(5);
+    });
+  });
+
+  describe('getNormals()', () => {
+    test('always returns an empty array', () => {
+      const line = new Line(0, 0, 10, 0);
+
+      expect(line.getNormals()).toEqual([]);
+    });
+  });
+
+  describe('project()', () => {
+    test('ignores the axis and returns a default Interval unchanged', () => {
+      const line = new Line(0, 0, 10, 0);
+      const result = line.project(new Vector(1, 0));
+
+      expect(result.min).toBe(0);
+      expect(result.max).toBe(0);
+    });
+
+    test('returns the provided Interval unchanged', () => {
+      const line = new Line(0, 0, 10, 0);
+      const provided = new Interval(3, 7);
+      const returned = line.project(new Vector(1, 0), provided);
+
+      expect(returned).toBe(provided);
+      expect(provided.min).toBe(3);
+      expect(provided.max).toBe(7);
+    });
+  });
+
+  describe('contains()', () => {
+    test('point exactly on the segment is contained with the default threshold', () => {
+      const line = new Line(0, 0, 10, 0);
+
+      expect(line.contains(5, 0)).toBe(true);
+    });
+
+    test('point off the segment beyond the default threshold is not contained', () => {
+      const line = new Line(0, 0, 10, 0);
+
+      expect(line.contains(5, 5)).toBe(false);
+    });
+
+    test('a custom threshold expands the hit region', () => {
+      const line = new Line(0, 0, 10, 0);
+
+      expect(line.contains(5, 5, 10)).toBe(true);
+    });
+  });
+
+  describe('equals()', () => {
+    test('returns true when called with no arguments', () => {
+      const line = new Line(1, 2, 3, 4);
+
+      expect(line.equals()).toBe(true);
+      expect(line.equals({})).toBe(true);
+    });
+
+    test('compares each field independently', () => {
+      const line = new Line(1, 2, 3, 4);
+
+      expect(line.equals({ fromX: 1, fromY: 2, toX: 3, toY: 4 })).toBe(true);
+      expect(line.equals({ fromX: 99 })).toBe(false);
+      expect(line.equals({ fromY: 99 })).toBe(false);
+      expect(line.equals({ toX: 99 })).toBe(false);
+      expect(line.equals({ toY: 99 })).toBe(false);
+    });
+  });
+
+  describe('intersectsWith()', () => {
+    test('SceneNode branch delegates to the rectangle bounds', () => {
+      const line = new Line(-5, 5, 15, 5);
+
+      expect(line.intersectsWith(fakeSceneNode(new Rectangle(0, 0, 10, 10)))).toBe(true);
+    });
+
+    test('Rectangle branch', () => {
+      const line = new Line(-5, 5, 15, 5);
+
+      expect(line.intersectsWith(new Rectangle(0, 0, 10, 10))).toBe(true);
+    });
+
+    test('Polygon branch', () => {
+      const line = new Line(-5, 5, 15, 5);
+
+      expect(line.intersectsWith(square(0, 0, 10))).toBe(true);
+    });
+
+    test('Circle branch', () => {
+      const line = new Line(-10, 0, 10, 0);
+
+      expect(line.intersectsWith(new Circle(0, 0, 5))).toBe(true);
+    });
+
+    test('Ellipse branch', () => {
+      const line = new Line(-20, 0, 20, 0);
+
+      expect(line.intersectsWith(new Ellipse(0, 0, 10, 5))).toBe(true);
+    });
+
+    test('Line branch', () => {
+      const line = new Line(0, 0, 10, 10);
+
+      expect(line.intersectsWith(new Line(0, 10, 10, 0))).toBe(true);
+    });
+
+    test('Point branch', () => {
+      const line = new Line(0, 0, 10, 0);
+
+      expect(line.intersectsWith(new Vector(5, 0))).toBe(true);
+    });
+
+    test('default branch returns false for an unknown collision type', () => {
+      const line = new Line(0, 0, 10, 0);
+
+      expect(line.intersectsWith(unknownCollidable)).toBe(false);
+    });
+  });
+
+  describe('collidesWith()', () => {
+    test('always returns null, regardless of the target shape', () => {
+      const line = new Line(-10, 0, 10, 0);
+
+      expect(line.collidesWith(new Circle(0, 0, 5))).toBeNull();
+      expect(line.collidesWith(unknownCollidable)).toBeNull();
+    });
+  });
+
+  describe('destroy()', () => {
+    test('does not throw', () => {
+      const line = new Line(0, 0, 10, 0);
+
+      expect(() => line.destroy()).not.toThrow();
+    });
+  });
+
+  describe('static temp', () => {
+    test('returns a shared scratch instance on repeated access', () => {
+      const first = Line.temp;
+      const second = Line.temp;
+
+      expect(second).toBe(first);
+    });
+  });
+});

--- a/test/math/matrix.test.ts
+++ b/test/math/matrix.test.ts
@@ -58,4 +58,146 @@ describe('Matrix', () => {
 
     expect(inverse.equals(Matrix.identity)).toBe(true);
   });
+
+  test('getInverse() with no argument defaults to in-place inversion (result = this)', () => {
+    const matrix = new Matrix().translate(10, 0);
+    const result = matrix.getInverse();
+
+    expect(result).toBe(matrix);
+    expect(matrix.x).toBeCloseTo(-10);
+  });
+
+  test('set() with no arguments keeps every current component (defaults to this)', () => {
+    const matrix = new Matrix(2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+    matrix.set();
+
+    expect(matrix.equals({ a: 2, b: 3, x: 4, c: 5, d: 6, y: 7, e: 8, f: 9, z: 10 })).toBe(true);
+  });
+
+  test('set() returns this for chaining', () => {
+    const matrix = new Matrix();
+
+    expect(matrix.set(1)).toBe(matrix);
+  });
+
+  test('copy() copies every component from another matrix', () => {
+    const source = new Matrix(2, 3, 4, 5, 6, 7, 8, 9, 10);
+    const target = new Matrix();
+
+    const result = target.copy(source);
+
+    expect(result).toBe(target);
+    expect(target.equals(source)).toBe(true);
+  });
+
+  test('clone() produces an independent Matrix with the same components', () => {
+    const matrix = new Matrix(2, 3, 4, 5, 6, 7, 8, 9, 10);
+    const clone = matrix.clone();
+
+    expect(clone).not.toBe(matrix);
+    expect(clone.equals(matrix)).toBe(true);
+
+    clone.a = 100;
+    expect(matrix.a).toBe(2);
+  });
+
+  describe('equals()', () => {
+    test('called with no arguments matches unconditionally', () => {
+      expect(new Matrix().equals()).toBe(true);
+    });
+
+    test('a single mismatched component fails the comparison', () => {
+      const matrix = new Matrix(1, 0, 0, 0, 1, 0, 0, 0, 1);
+
+      expect(matrix.equals({ a: 999 })).toBe(false);
+      expect(matrix.equals({ b: 999 })).toBe(false);
+      expect(matrix.equals({ x: 999 })).toBe(false);
+      expect(matrix.equals({ c: 999 })).toBe(false);
+      expect(matrix.equals({ d: 999 })).toBe(false);
+      expect(matrix.equals({ y: 999 })).toBe(false);
+      expect(matrix.equals({ e: 999 })).toBe(false);
+      expect(matrix.equals({ f: 999 })).toBe(false);
+      expect(matrix.equals({ z: 999 })).toBe(false);
+    });
+  });
+
+  test('combine() post-multiplies this matrix by another', () => {
+    // Translate then scale — combine() applies `matrix`'s transform after this one's.
+    const matrix = new Matrix().translate(10, 0);
+    const point = new Vector(1, 0).transform(matrix.combine(new Matrix().scale(2, 2)));
+
+    // translate(10,0) then scale(2,2): (1,0) -> (11,0) -> (22,0).
+    expect(point.x).toBeCloseTo(22);
+    expect(point.y).toBeCloseTo(0);
+  });
+
+  describe('translate/rotate/scale default arguments', () => {
+    test('translate() defaults y to x (uniform translation)', () => {
+      const point = new Vector(0, 0).transform(new Matrix().translate(5));
+
+      expect(point.x).toBeCloseTo(5);
+      expect(point.y).toBeCloseTo(5);
+    });
+
+    test('rotate() defaults centerY to centerX', () => {
+      // Rotating 90 degrees around (0, 0) via the single-argument center form.
+      const point = new Vector(1, 0).transform(new Matrix().rotate(90, 0));
+
+      expect(point.x).toBeCloseTo(0, 5);
+      expect(point.y).toBeCloseTo(1, 5);
+    });
+
+    test('scale() defaults scaleY to scaleX and centerY to centerX', () => {
+      const point = new Vector(1, 1).transform(new Matrix().scale(3));
+
+      expect(point.x).toBeCloseTo(3);
+      expect(point.y).toBeCloseTo(3);
+    });
+  });
+
+  describe('toArray()', () => {
+    test('column-major order (default) matches the OpenGL uniform layout', () => {
+      const matrix = new Matrix(2, 3, 4, 5, 6, 7, 8, 9, 10);
+      const array = matrix.toArray();
+
+      expect(Array.from(array)).toEqual([2, 5, 8, 3, 6, 9, 4, 7, 10]);
+    });
+
+    test('row-major order (transpose=true)', () => {
+      const matrix = new Matrix(2, 3, 4, 5, 6, 7, 8, 9, 10);
+      const array = matrix.toArray(true);
+
+      expect(Array.from(array)).toEqual([2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    });
+
+    test('reuses the same underlying Float32Array across calls', () => {
+      const matrix = new Matrix();
+      const first = matrix.toArray();
+      const second = matrix.toArray();
+
+      expect(first).toBe(second);
+    });
+  });
+
+  test('destroy() releases the cached array and is safe to call when none was allocated', () => {
+    const withArray = new Matrix();
+
+    withArray.toArray();
+    expect(() => withArray.destroy()).not.toThrow();
+
+    const withoutArray = new Matrix();
+
+    expect(() => withoutArray.destroy()).not.toThrow();
+  });
+
+  describe('static temp', () => {
+    test('returns a Matrix instance', () => {
+      expect(Matrix.temp).toBeInstanceOf(Matrix);
+    });
+
+    test('returns the same shared instance across accesses', () => {
+      expect(Matrix.temp).toBe(Matrix.temp);
+    });
+  });
 });

--- a/test/math/observable-size.test.ts
+++ b/test/math/observable-size.test.ts
@@ -1,0 +1,303 @@
+import { ObservableSize } from '#math/ObservableSize';
+import { Size } from '#math/Size';
+
+describe('ObservableSize', () => {
+  test('defaults width and height to 0', () => {
+    const callback = vi.fn();
+    const size = new ObservableSize(callback);
+
+    expect(size.width).toBe(0);
+    expect(size.height).toBe(0);
+    expect(callback).not.toHaveBeenCalled();
+
+    size.destroy();
+  });
+
+  test('constructor accepts explicit width and height without firing the callback', () => {
+    const callback = vi.fn();
+    const size = new ObservableSize(callback, 10, 20);
+
+    expect(size.width).toBe(10);
+    expect(size.height).toBe(20);
+    expect(callback).not.toHaveBeenCalled();
+
+    size.destroy();
+  });
+
+  describe('width setter', () => {
+    test('fires the callback when the value changes', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback, 1, 1);
+
+      size.width = 5;
+
+      expect(size.width).toBe(5);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      size.destroy();
+    });
+
+    test('does not fire the callback when set to the same value', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback, 1, 1);
+
+      size.width = 1;
+
+      expect(callback).not.toHaveBeenCalled();
+
+      size.destroy();
+    });
+  });
+
+  describe('height setter', () => {
+    test('fires the callback when the value changes', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback, 1, 1);
+
+      size.height = 5;
+
+      expect(size.height).toBe(5);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      size.destroy();
+    });
+
+    test('does not fire the callback when set to the same value', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback, 1, 1);
+
+      size.height = 1;
+
+      expect(callback).not.toHaveBeenCalled();
+
+      size.destroy();
+    });
+  });
+
+  describe('set()', () => {
+    test('fires the callback at most once for a combined width+height change', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback, 1, 1);
+
+      size.set(5, 6);
+
+      expect(size.width).toBe(5);
+      expect(size.height).toBe(6);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      size.destroy();
+    });
+
+    test('does not fire the callback when both values are unchanged', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback, 5, 6);
+
+      size.set(5, 6);
+
+      expect(callback).not.toHaveBeenCalled();
+
+      size.destroy();
+    });
+
+    test('fires when only width changes', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback, 5, 6);
+
+      size.set(9, 6);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      size.destroy();
+    });
+
+    test('fires when only height changes', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback, 5, 6);
+
+      size.set(5, 9);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      size.destroy();
+    });
+
+    test('defaults to current width/height when called with no arguments', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback, 5, 6);
+
+      size.set();
+
+      expect(size.width).toBe(5);
+      expect(size.height).toBe(6);
+      expect(callback).not.toHaveBeenCalled();
+
+      size.destroy();
+    });
+
+    test('returns this for chaining', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback);
+
+      expect(size.set(1, 1)).toBe(size);
+
+      size.destroy();
+    });
+  });
+
+  describe('add()', () => {
+    test('adds independently for width/height and fires once', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback, 1, 2);
+
+      size.add(3, 4);
+
+      expect(size.width).toBe(4);
+      expect(size.height).toBe(6);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      size.destroy();
+    });
+
+    test('applies a single argument uniformly', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback, 1, 2);
+
+      size.add(3);
+
+      expect(size.width).toBe(4);
+      expect(size.height).toBe(5);
+
+      size.destroy();
+    });
+  });
+
+  describe('subtract()', () => {
+    test('subtracts independently for width/height and fires once', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback, 10, 10);
+
+      size.subtract(3, 4);
+
+      expect(size.width).toBe(7);
+      expect(size.height).toBe(6);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      size.destroy();
+    });
+
+    test('applies a single argument uniformly', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback, 10, 10);
+
+      size.subtract(3);
+
+      expect(size.width).toBe(7);
+      expect(size.height).toBe(7);
+
+      size.destroy();
+    });
+  });
+
+  describe('scale()', () => {
+    test('scales independently for width/height and fires once', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback, 2, 3);
+
+      size.scale(2, 4);
+
+      expect(size.width).toBe(4);
+      expect(size.height).toBe(12);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      size.destroy();
+    });
+
+    test('applies a single argument uniformly', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback, 2, 3);
+
+      size.scale(2);
+
+      expect(size.width).toBe(4);
+      expect(size.height).toBe(6);
+
+      size.destroy();
+    });
+  });
+
+  describe('divide()', () => {
+    test('divides independently for width/height and fires once', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback, 10, 20);
+
+      size.divide(2, 5);
+
+      expect(size.width).toBe(5);
+      expect(size.height).toBe(4);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      size.destroy();
+    });
+
+    test('applies a single argument uniformly', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback, 10, 20);
+
+      size.divide(2);
+
+      expect(size.width).toBe(5);
+      expect(size.height).toBe(10);
+
+      size.destroy();
+    });
+  });
+
+  describe('copy()', () => {
+    test('copies width/height from another Size and fires the callback', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback, 1, 1);
+      const source = new Size(42, 24);
+
+      size.copy(source);
+
+      expect(size.width).toBe(42);
+      expect(size.height).toBe(24);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      size.destroy();
+      source.destroy();
+    });
+
+    test('does not fire the callback when copying identical values', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback, 5, 6);
+      const source = new Size(5, 6);
+
+      size.copy(source);
+
+      expect(callback).not.toHaveBeenCalled();
+
+      size.destroy();
+      source.destroy();
+    });
+  });
+
+  describe('clone()', () => {
+    test('produces an independent ObservableSize with the same callback and values', () => {
+      const callback = vi.fn();
+      const size = new ObservableSize(callback, 7, 9);
+      const clone = size.clone();
+
+      expect(clone).not.toBe(size);
+      expect(clone.width).toBe(7);
+      expect(clone.height).toBe(9);
+
+      clone.width = 100;
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(size.width).toBe(7);
+
+      size.destroy();
+      clone.destroy();
+    });
+  });
+});

--- a/test/math/observable-vector.test.ts
+++ b/test/math/observable-vector.test.ts
@@ -111,62 +111,40 @@ describe('ObservableVector owner notification', () => {
 });
 
 describe('ObservableVector angle/length overrides', () => {
-  // BUG (see final report — the most severe finding of this sweep):
-  // `ObservableVector` overrides only the *setter* for `angle` and `length`
-  // (src/math/ObservableVector.ts), never redeclaring the getter. In native
-  // JS/TS accessor semantics, a subclass that redefines just one half of an
-  // inherited accessor pair replaces the whole property descriptor on its own
-  // prototype — it does NOT fall back to the base class's getter for the
-  // half it didn't redefine. So `ObservableVector.prototype` ends up with an
-  // `angle`/`length` property that has a setter but `get: undefined`, and
-  // reading `v.angle` or `v.length` on any `ObservableVector` returns
-  // `undefined` instead of inheriting `AbstractVector`'s getter. Confirmed
-  // with a minimal repro of the same class shape (plain `get`/`set` pair in a
-  // base class, setter-only override in a subclass) — reading the property on
-  // the subclass instance yields `undefined` before and after invoking the
-  // setter.
-  test('BUG: reading .angle on an ObservableVector returns undefined (setter-only override shadows the inherited getter)', () => {
+  // The subclass must redeclare the getter next to each setter override —
+  // a setter-only accessor on the subclass prototype would shadow the whole
+  // inherited accessor pair and leave `get` undefined.
+  test('reading .angle works like AbstractVector.angle', () => {
     const v = new ObservableVector(null, 0, 0, 5);
 
-    // Expected (per AbstractVector.angle): atan2(0, 5) = 0.
-    expect(v.angle).toBeUndefined();
+    expect(v.angle).toBeCloseTo(Math.PI / 2);
   });
 
-  test('BUG: reading .length on an ObservableVector returns undefined (setter-only override shadows the inherited getter)', () => {
+  test('reading .length works like AbstractVector.length', () => {
     const v = new ObservableVector(null, 0, 3, 4);
 
-    // Expected (per AbstractVector.length): sqrt(3^2 + 4^2) = 5.
-    expect(v.length).toBeUndefined();
+    expect(v.length).toBe(5);
   });
 
-  // The setters themselves still run (only the getter half is shadowed), and
-  // still route through set() for a single notification. They also carry the
-  // same axis-convention mismatch pinned for AbstractVector in
-  // vector.test.ts: the (would-be) getter reads the angle from the Y-axis,
-  // but these setters reconstruct via the X-axis (cos → x, sin → y)
-  // convention. `this.length` inside the angle setter, and `this.angle`
-  // inside the length setter, both resolve to `undefined` per the bug above,
-  // which turns every `Math.cos`/`Math.sin` call into `NaN` — so these
-  // setters don't just use the "wrong" convention, they zero out the vector.
-  test('BUG: angle setter reads the shadowed .length getter and NaNs out the vector (but still notifies once)', () => {
+  test('angle setter rotates the vector, preserving length, and notifies once', () => {
     const onChange = vi.fn();
     const v = new ObservableVector({ _onObservableChange: onChange }, 0, 0, 5);
 
-    v.angle = Math.PI / 2;
+    v.angle = 0;
 
-    expect(v.x).toBeNaN();
-    expect(v.y).toBeNaN();
+    expect(v.x).toBeCloseTo(5);
+    expect(v.y).toBeCloseTo(0);
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 
-  test('BUG: length setter reads the shadowed .angle getter and NaNs out the vector (but still notifies once)', () => {
+  test('length setter rescales the vector, preserving direction, and notifies once', () => {
     const onChange = vi.fn();
     const v = new ObservableVector({ _onObservableChange: onChange }, 0, 3, 4);
 
     v.length = 10;
 
-    expect(v.x).toBeNaN();
-    expect(v.y).toBeNaN();
+    expect(v.x).toBeCloseTo(6);
+    expect(v.y).toBeCloseTo(8);
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/math/observable-vector.test.ts
+++ b/test/math/observable-vector.test.ts
@@ -95,4 +95,219 @@ describe('ObservableVector owner notification', () => {
     expect(v.x).toBe(2);
     expect(v.y).toBe(3);
   });
+
+  // set() without arguments defaults both components to their current values,
+  // so it is a no-op that also does not notify.
+  test('set() with no arguments is a no-op and does not notify', () => {
+    const onChange = vi.fn();
+    const v = new ObservableVector({ _onObservableChange: onChange }, 0, 3, 4);
+
+    v.set();
+
+    expect(v.x).toBe(3);
+    expect(v.y).toBe(4);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('ObservableVector angle/length overrides', () => {
+  // BUG (see final report — the most severe finding of this sweep):
+  // `ObservableVector` overrides only the *setter* for `angle` and `length`
+  // (src/math/ObservableVector.ts), never redeclaring the getter. In native
+  // JS/TS accessor semantics, a subclass that redefines just one half of an
+  // inherited accessor pair replaces the whole property descriptor on its own
+  // prototype — it does NOT fall back to the base class's getter for the
+  // half it didn't redefine. So `ObservableVector.prototype` ends up with an
+  // `angle`/`length` property that has a setter but `get: undefined`, and
+  // reading `v.angle` or `v.length` on any `ObservableVector` returns
+  // `undefined` instead of inheriting `AbstractVector`'s getter. Confirmed
+  // with a minimal repro of the same class shape (plain `get`/`set` pair in a
+  // base class, setter-only override in a subclass) — reading the property on
+  // the subclass instance yields `undefined` before and after invoking the
+  // setter.
+  test('BUG: reading .angle on an ObservableVector returns undefined (setter-only override shadows the inherited getter)', () => {
+    const v = new ObservableVector(null, 0, 0, 5);
+
+    // Expected (per AbstractVector.angle): atan2(0, 5) = 0.
+    expect(v.angle).toBeUndefined();
+  });
+
+  test('BUG: reading .length on an ObservableVector returns undefined (setter-only override shadows the inherited getter)', () => {
+    const v = new ObservableVector(null, 0, 3, 4);
+
+    // Expected (per AbstractVector.length): sqrt(3^2 + 4^2) = 5.
+    expect(v.length).toBeUndefined();
+  });
+
+  // The setters themselves still run (only the getter half is shadowed), and
+  // still route through set() for a single notification. They also carry the
+  // same axis-convention mismatch pinned for AbstractVector in
+  // vector.test.ts: the (would-be) getter reads the angle from the Y-axis,
+  // but these setters reconstruct via the X-axis (cos → x, sin → y)
+  // convention. `this.length` inside the angle setter, and `this.angle`
+  // inside the length setter, both resolve to `undefined` per the bug above,
+  // which turns every `Math.cos`/`Math.sin` call into `NaN` — so these
+  // setters don't just use the "wrong" convention, they zero out the vector.
+  test('BUG: angle setter reads the shadowed .length getter and NaNs out the vector (but still notifies once)', () => {
+    const onChange = vi.fn();
+    const v = new ObservableVector({ _onObservableChange: onChange }, 0, 0, 5);
+
+    v.angle = Math.PI / 2;
+
+    expect(v.x).toBeNaN();
+    expect(v.y).toBeNaN();
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('BUG: length setter reads the shadowed .angle getter and NaNs out the vector (but still notifies once)', () => {
+    const onChange = vi.fn();
+    const v = new ObservableVector({ _onObservableChange: onChange }, 0, 3, 4);
+
+    v.length = 10;
+
+    expect(v.x).toBeNaN();
+    expect(v.y).toBeNaN();
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ObservableVector.add() / subtract() overrides', () => {
+  test('add() notifies once via set()', () => {
+    const onChange = vi.fn();
+    const v = new ObservableVector({ _onObservableChange: onChange }, 0, 1, 1);
+
+    v.add(2, 3);
+
+    expect(v.x).toBe(3);
+    expect(v.y).toBe(4);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('add() defaults y to x when omitted', () => {
+    const v = new ObservableVector(null, 0, 1, 1);
+
+    v.add(5);
+
+    expect(v.x).toBe(6);
+    expect(v.y).toBe(6);
+  });
+
+  test('subtract() notifies once via set()', () => {
+    const onChange = vi.fn();
+    const v = new ObservableVector({ _onObservableChange: onChange }, 0, 5, 5);
+
+    v.subtract(1, 2);
+
+    expect(v.x).toBe(4);
+    expect(v.y).toBe(3);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('subtract() defaults y to x when omitted', () => {
+    const v = new ObservableVector(null, 0, 5, 5);
+
+    v.subtract(2);
+
+    expect(v.x).toBe(3);
+    expect(v.y).toBe(3);
+  });
+});
+
+describe('ObservableVector.scale()', () => {
+  test('multiplies both components explicitly and notifies once', () => {
+    const onChange = vi.fn();
+    const v = new ObservableVector({ _onObservableChange: onChange }, 0, 2, 3);
+
+    v.scale(2, 4);
+
+    expect(v.x).toBe(4);
+    expect(v.y).toBe(12);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('defaults y to x when omitted (uniform scale)', () => {
+    const v = new ObservableVector(null, 0, 2, 3);
+
+    v.scale(2);
+
+    expect(v.x).toBe(4);
+    expect(v.y).toBe(6);
+  });
+});
+
+describe('ObservableVector.divide() override', () => {
+  test('divides both components explicitly and notifies once', () => {
+    const onChange = vi.fn();
+    const v = new ObservableVector({ _onObservableChange: onChange }, 0, 10, 20);
+
+    v.divide(2, 4);
+
+    expect(v.x).toBe(5);
+    expect(v.y).toBe(5);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('defaults y to x when omitted', () => {
+    const v = new ObservableVector(null, 0, 10, 20);
+
+    v.divide(2);
+
+    expect(v.x).toBe(5);
+    expect(v.y).toBe(10);
+  });
+
+  test('skips the division and does not notify when x is zero', () => {
+    const onChange = vi.fn();
+    const v = new ObservableVector({ _onObservableChange: onChange }, 0, 10, 20);
+
+    const result = v.divide(0, 5);
+
+    expect(result).toBe(v);
+    expect(v.x).toBe(10);
+    expect(v.y).toBe(20);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('skips the division and does not notify when y is zero', () => {
+    const onChange = vi.fn();
+    const v = new ObservableVector({ _onObservableChange: onChange }, 0, 10, 20);
+
+    v.divide(2, 0);
+
+    expect(v.x).toBe(10);
+    expect(v.y).toBe(20);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('ObservableVector.clone()', () => {
+  test('returns a distinct instance with the same owner, channel, and components', () => {
+    const onChange = vi.fn();
+    const owner = { _onObservableChange: onChange };
+    const v = new ObservableVector(owner, 3, 1, 2);
+    const clone = v.clone();
+
+    expect(clone).not.toBe(v);
+    expect(clone.x).toBe(1);
+    expect(clone.y).toBe(2);
+
+    // The clone shares the same owner/channel, so mutating it notifies too.
+    clone.x = 9;
+    expect(onChange).toHaveBeenLastCalledWith(3);
+  });
+});
+
+describe('ObservableVector.copy()', () => {
+  test('copies x/y from any AbstractVector and notifies once', () => {
+    const onChange = vi.fn();
+    const v = new ObservableVector({ _onObservableChange: onChange }, 0, 0, 0);
+    const source = new ObservableVector(null, 0, 7, 8);
+
+    const result = v.copy(source);
+
+    expect(result).toBe(v);
+    expect(v.x).toBe(7);
+    expect(v.y).toBe(8);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
 });

--- a/test/math/polar-vector.test.ts
+++ b/test/math/polar-vector.test.ts
@@ -23,7 +23,7 @@ describe('PolarVector.fromVector()', () => {
     const p = PolarVector.fromVector(v);
 
     expect(p.radius).toBeCloseTo(v.length);
-    // AbstractVector.angle is measured from the positive Y-axis, clockwise.
+    // AbstractVector.angle and PolarVector.phi share the X-axis convention.
     expect(p.phi).toBeCloseTo(v.angle);
   });
 
@@ -49,25 +49,15 @@ describe('PolarVector.toVector()', () => {
     expect(p.toVector()).toBe(Vector.temp);
   });
 
-  // BUG (see final report): the class doc comment claims
-  // `PolarVector.fromVector(v).toVector()` reproduces `v` (modulo float
-  // precision). It does not, for any vector where x !== y. `fromVector()`
-  // stores `radius`/`phi` using `AbstractVector.angle`, which is measured from
-  // the positive Y-axis: `phi = atan2(x, y)`. `toVector()` then reconstructs
-  // Cartesian coordinates using the standard X-axis convention:
-  // `x = radius*cos(phi)`, `y = radius*sin(phi)`. Mixing the two conventions
-  // swaps the components instead of round-tripping them: for (3, 4) — length
-  // 5, phi ≈ 0.6435 — `toVector()` yields (4, 3), not (3, 4).
-  test('BUG: fromVector()/toVector() swaps x and y instead of round-tripping', () => {
+  test('fromVector()/toVector() round-trips an asymmetric vector', () => {
     const original = new Vector(3, 4);
     const roundTripped = PolarVector.fromVector(original).toVector();
 
-    // Documented/expected: roundTripped.x ≈ 3, roundTripped.y ≈ 4.
-    expect(roundTripped.x).toBeCloseTo(4);
-    expect(roundTripped.y).toBeCloseTo(3);
+    expect(roundTripped.x).toBeCloseTo(3);
+    expect(roundTripped.y).toBeCloseTo(4);
   });
 
-  test('round-trips correctly on the symmetric x === y case (angle convention mismatch is masked)', () => {
+  test('fromVector()/toVector() round-trips the symmetric x === y case', () => {
     const original = new Vector(5, 5);
     const roundTripped = PolarVector.fromVector(original).toVector();
 

--- a/test/math/polar-vector.test.ts
+++ b/test/math/polar-vector.test.ts
@@ -1,0 +1,77 @@
+import { PolarVector } from '#math/PolarVector';
+import { Vector } from '#math/Vector';
+
+describe('PolarVector construction', () => {
+  test('defaults to radius 0, angle 0', () => {
+    const p = new PolarVector();
+
+    expect(p.radius).toBe(0);
+    expect(p.phi).toBe(0);
+  });
+
+  test('accepts explicit radius and angle', () => {
+    const p = new PolarVector(5, Math.PI / 2);
+
+    expect(p.radius).toBe(5);
+    expect(p.phi).toBe(Math.PI / 2);
+  });
+});
+
+describe('PolarVector.fromVector()', () => {
+  test('preserves magnitude and direction of the source vector', () => {
+    const v = new Vector(3, 4);
+    const p = PolarVector.fromVector(v);
+
+    expect(p.radius).toBeCloseTo(v.length);
+    // AbstractVector.angle is measured from the positive Y-axis, clockwise.
+    expect(p.phi).toBeCloseTo(v.angle);
+  });
+
+  test('handles the zero vector', () => {
+    const p = PolarVector.fromVector(new Vector(0, 0));
+
+    expect(p.radius).toBe(0);
+  });
+});
+
+describe('PolarVector.toVector()', () => {
+  test('converts back to Cartesian coordinates', () => {
+    const p = new PolarVector(5, 0);
+    const v = p.toVector();
+
+    expect(v.x).toBeCloseTo(5);
+    expect(v.y).toBeCloseTo(0);
+  });
+
+  test('returns the shared Vector.temp instance', () => {
+    const p = new PolarVector(1, 0);
+
+    expect(p.toVector()).toBe(Vector.temp);
+  });
+
+  // BUG (see final report): the class doc comment claims
+  // `PolarVector.fromVector(v).toVector()` reproduces `v` (modulo float
+  // precision). It does not, for any vector where x !== y. `fromVector()`
+  // stores `radius`/`phi` using `AbstractVector.angle`, which is measured from
+  // the positive Y-axis: `phi = atan2(x, y)`. `toVector()` then reconstructs
+  // Cartesian coordinates using the standard X-axis convention:
+  // `x = radius*cos(phi)`, `y = radius*sin(phi)`. Mixing the two conventions
+  // swaps the components instead of round-tripping them: for (3, 4) — length
+  // 5, phi ≈ 0.6435 — `toVector()` yields (4, 3), not (3, 4).
+  test('BUG: fromVector()/toVector() swaps x and y instead of round-tripping', () => {
+    const original = new Vector(3, 4);
+    const roundTripped = PolarVector.fromVector(original).toVector();
+
+    // Documented/expected: roundTripped.x ≈ 3, roundTripped.y ≈ 4.
+    expect(roundTripped.x).toBeCloseTo(4);
+    expect(roundTripped.y).toBeCloseTo(3);
+  });
+
+  test('round-trips correctly on the symmetric x === y case (angle convention mismatch is masked)', () => {
+    const original = new Vector(5, 5);
+    const roundTripped = PolarVector.fromVector(original).toVector();
+
+    expect(roundTripped.x).toBeCloseTo(original.x);
+    expect(roundTripped.y).toBeCloseTo(original.y);
+  });
+});

--- a/test/math/polygon.test.ts
+++ b/test/math/polygon.test.ts
@@ -241,9 +241,7 @@ describe('Polygon — points / edges', () => {
   test('setPoints() grows the point/edge arrays when given more points than before', () => {
     const polygon = new Polygon([new Vector(0, 0), new Vector(10, 0)]);
 
-    expect(() =>
-      polygon.setPoints([new Vector(0, 0), new Vector(10, 0), new Vector(10, 10), new Vector(0, 10), new Vector(-5, 5)]),
-    ).not.toThrow();
+    expect(() => polygon.setPoints([new Vector(0, 0), new Vector(10, 0), new Vector(10, 10), new Vector(0, 10), new Vector(-5, 5)])).not.toThrow();
     expect(polygon.points.length).toBe(5);
     expect(polygon.edges.length).toBe(5);
 

--- a/test/math/polygon.test.ts
+++ b/test/math/polygon.test.ts
@@ -63,6 +63,18 @@ describe('Polygon.project()', () => {
   });
 });
 
+describe('Polygon.contains()', () => {
+  test('honours the polygon x/y position offset, like getBounds()', () => {
+    // Local unit square at position (100, 100) → world square [100..110]².
+    const polygon = new Polygon([new Vector(0, 0), new Vector(10, 0), new Vector(10, 10), new Vector(0, 10)], 100, 100);
+
+    expect(polygon.contains(105, 105)).toBe(true);
+    expect(polygon.contains(5, 5)).toBe(false);
+
+    polygon.destroy();
+  });
+});
+
 describe('Polygon', () => {
   test('setPoints handles shrinking point arrays safely', () => {
     const polygon = new Polygon([new Vector(0, 0), new Vector(10, 0), new Vector(10, 10), new Vector(0, 10)]);

--- a/test/math/polygon.test.ts
+++ b/test/math/polygon.test.ts
@@ -46,6 +46,21 @@ describe('Polygon.project()', () => {
 
     polygon.destroy();
   });
+
+  test('(d) the polygon x/y position offsets the projection, like Circle/Rectangle', () => {
+    const polygon = makeSquare();
+    polygon.setPosition(100, 50);
+
+    const onX = polygon.project(new Vector(1, 0));
+    expect(onX.min).toBe(100);
+    expect(onX.max).toBe(110);
+
+    const onY = polygon.project(new Vector(0, 1));
+    expect(onY.min).toBe(50);
+    expect(onY.max).toBe(60);
+
+    polygon.destroy();
+  });
 });
 
 describe('Polygon', () => {

--- a/test/math/polygon.test.ts
+++ b/test/math/polygon.test.ts
@@ -1,5 +1,10 @@
+import { SceneNode } from '#core/SceneNode';
+import { Circle } from '#math/Circle';
+import { Ellipse } from '#math/Ellipse';
 import { Interval } from '#math/Interval';
+import { Line } from '#math/Line';
 import { Polygon } from '#math/Polygon';
+import { Rectangle } from '#math/Rectangle';
 import { Vector } from '#math/Vector';
 
 describe('Polygon.project()', () => {
@@ -61,15 +66,16 @@ describe('Polygon.project()', () => {
 
     polygon.destroy();
   });
-});
 
-describe('Polygon.contains()', () => {
-  test('honours the polygon x/y position offset, like getBounds()', () => {
-    // Local unit square at position (100, 100) → world square [100..110]².
-    const polygon = new Polygon([new Vector(0, 0), new Vector(10, 0), new Vector(10, 10), new Vector(0, 10)], 100, 100);
+  test('(e) a zero-length axis falls back to a length of 1 instead of dividing by zero', () => {
+    const polygon = makeSquare();
+    const result = polygon.project(new Vector(0, 0));
 
-    expect(polygon.contains(105, 105)).toBe(true);
-    expect(polygon.contains(5, 5)).toBe(false);
+    // nx = 0/1 = 0, ny = 0/1 = 0 -> every vertex projects to 0, no NaN.
+    expect(result.min).toBe(0);
+    expect(result.max).toBe(0);
+    expect(Number.isNaN(result.min)).toBe(false);
+    expect(Number.isNaN(result.max)).toBe(false);
 
     polygon.destroy();
   });
@@ -160,5 +166,426 @@ describe('Polygon.getNormals() — dirty-flag cache (0.7.11)', () => {
 
     // Should not throw.
     expect(() => polygon.destroy()).not.toThrow();
+  });
+});
+
+// Positioned-polygon projection matches getBounds() — covered by test (d) in
+// the Polygon.project() describe above.
+
+describe('Polygon — constructor', () => {
+  test('defaults to an empty polygon at the origin', () => {
+    const polygon = new Polygon();
+
+    expect(polygon.points).toEqual([]);
+    expect(polygon.edges).toEqual([]);
+    expect(polygon.x).toBe(0);
+    expect(polygon.y).toBe(0);
+
+    polygon.destroy();
+  });
+
+  test('accepts an explicit position', () => {
+    const polygon = new Polygon([new Vector(0, 0)], 3, 4);
+
+    expect(polygon.x).toBe(3);
+    expect(polygon.y).toBe(4);
+
+    polygon.destroy();
+  });
+});
+
+describe('Polygon — position / x / y', () => {
+  test('position getter returns the internal vector', () => {
+    const polygon = new Polygon([], 1, 2);
+
+    expect(polygon.position.x).toBe(1);
+    expect(polygon.position.y).toBe(2);
+
+    polygon.destroy();
+  });
+
+  test('position setter copies from another vector-like', () => {
+    const polygon = new Polygon([], 0, 0);
+
+    polygon.position = new Vector(9, 8);
+
+    expect(polygon.x).toBe(9);
+    expect(polygon.y).toBe(8);
+
+    polygon.destroy();
+  });
+
+  test('y setter updates y', () => {
+    const polygon = new Polygon([], 0, 0);
+
+    polygon.y = 42;
+
+    expect(polygon.y).toBe(42);
+
+    polygon.destroy();
+  });
+});
+
+describe('Polygon — points / edges', () => {
+  test('points setter delegates to setPoints()', () => {
+    const polygon = new Polygon([new Vector(0, 0), new Vector(10, 0), new Vector(10, 10)]);
+
+    polygon.points = [new Vector(0, 0), new Vector(5, 0), new Vector(5, 5), new Vector(0, 5)];
+
+    expect(polygon.points.length).toBe(4);
+    expect(polygon.edges.length).toBe(4);
+
+    polygon.destroy();
+  });
+
+  test('setPoints() grows the point/edge arrays when given more points than before', () => {
+    const polygon = new Polygon([new Vector(0, 0), new Vector(10, 0)]);
+
+    expect(() =>
+      polygon.setPoints([new Vector(0, 0), new Vector(10, 0), new Vector(10, 10), new Vector(0, 10), new Vector(-5, 5)]),
+    ).not.toThrow();
+    expect(polygon.points.length).toBe(5);
+    expect(polygon.edges.length).toBe(5);
+
+    polygon.destroy();
+  });
+
+  test('setPoints() with an unchanged point count hits neither the growth nor the shrink branch', () => {
+    const polygon = new Polygon([new Vector(0, 0), new Vector(10, 0), new Vector(10, 10)]);
+    const before = polygon.points.length;
+
+    expect(() => polygon.setPoints([new Vector(1, 1), new Vector(11, 1), new Vector(11, 11)])).not.toThrow();
+    expect(polygon.points.length).toBe(before);
+
+    polygon.destroy();
+  });
+
+  test('shrinking after growing without an intervening getNormals() call hits the cache-shorter-than-newLen branch', () => {
+    const polygon = new Polygon([new Vector(0, 0), new Vector(10, 0)]);
+
+    // Warm the cache at length 2.
+    polygon.getNormals();
+
+    // Grow to 5 points without recomputing normals — cache stays at length 2.
+    polygon.setPoints([new Vector(0, 0), new Vector(10, 0), new Vector(10, 10), new Vector(0, 10), new Vector(-5, 5)]);
+
+    // Shrink to 3 points: diff > 0, but the (stale) cache length (2) is not
+    // greater than newLen (3), so the cache-trim branch is skipped.
+    expect(() => polygon.setPoints([new Vector(0, 0), new Vector(10, 0), new Vector(10, 10)])).not.toThrow();
+    expect(polygon.points.length).toBe(3);
+
+    // A subsequent getNormals() call must still work and resync the cache.
+    expect(polygon.getNormals().length).toBe(3);
+
+    polygon.destroy();
+  });
+});
+
+describe('Polygon — set() / copy() / clone() / equals()', () => {
+  const square = () => new Polygon([new Vector(0, 0), new Vector(10, 0), new Vector(10, 10), new Vector(0, 10)]);
+
+  test('set() updates position and points together', () => {
+    const polygon = square();
+    const returned = polygon.set(5, 6, [new Vector(0, 0), new Vector(1, 0), new Vector(1, 1)]);
+
+    expect(returned).toBe(polygon);
+    expect(polygon.x).toBe(5);
+    expect(polygon.y).toBe(6);
+    expect(polygon.points.length).toBe(3);
+
+    polygon.destroy();
+  });
+
+  test('copy() duplicates position and points from another polygon', () => {
+    const source = square();
+
+    source.setPosition(7, 8);
+
+    const target = new Polygon();
+    const returned = target.copy(source);
+
+    expect(returned).toBe(target);
+    expect(target.x).toBe(7);
+    expect(target.y).toBe(8);
+    expect(target.points.length).toBe(source.points.length);
+
+    source.destroy();
+    target.destroy();
+  });
+
+  test('clone() returns an equal but distinct instance', () => {
+    const original = square();
+    const clone = original.clone();
+
+    expect(clone).not.toBe(original);
+    expect(clone.equals(original)).toBe(true);
+
+    original.destroy();
+    clone.destroy();
+  });
+
+  test('equals() returns true when no fields are given', () => {
+    const polygon = square();
+
+    expect(polygon.equals()).toBe(true);
+
+    polygon.destroy();
+  });
+
+  test('equals() returns false when x mismatches', () => {
+    const polygon = square();
+
+    expect(polygon.equals({ x: 999 })).toBe(false);
+
+    polygon.destroy();
+  });
+
+  test('equals() returns false when y mismatches', () => {
+    const polygon = square();
+
+    expect(polygon.equals({ y: 999 })).toBe(false);
+
+    polygon.destroy();
+  });
+
+  test('equals() returns false when the points array length differs', () => {
+    const polygon = square();
+
+    expect(polygon.equals({ points: [new Vector(0, 0)] })).toBe(false);
+
+    polygon.destroy();
+  });
+
+  test('equals() returns false when a point value differs', () => {
+    const polygon = square();
+    const differentPoints = [new Vector(999, 0), new Vector(10, 0), new Vector(10, 10), new Vector(0, 10)];
+
+    expect(polygon.equals({ points: differentPoints })).toBe(false);
+
+    polygon.destroy();
+  });
+
+  test('equals() returns true when x, y and points all match', () => {
+    const polygon = square();
+
+    expect(polygon.equals({ x: 0, y: 0, points: polygon.points })).toBe(true);
+
+    polygon.destroy();
+  });
+});
+
+describe('Polygon.getBounds()', () => {
+  test('computes the axis-aligned bounds including the position offset', () => {
+    const polygon = new Polygon([new Vector(0, 0), new Vector(10, 0), new Vector(10, 10), new Vector(0, 10)], 100, 100);
+    const bounds = polygon.getBounds();
+
+    expect(bounds.left).toBe(100);
+    expect(bounds.top).toBe(100);
+    expect(bounds.width).toBe(10);
+    expect(bounds.height).toBe(10);
+
+    polygon.destroy();
+  });
+});
+
+describe('Polygon.contains()', () => {
+  test('returns true for a point inside a polygon at the default position', () => {
+    const polygon = new Polygon([new Vector(0, 0), new Vector(10, 0), new Vector(10, 10), new Vector(0, 10)]);
+
+    expect(polygon.contains(5, 5)).toBe(true);
+
+    polygon.destroy();
+  });
+
+  test('returns false for a point outside the polygon', () => {
+    const polygon = new Polygon([new Vector(0, 0), new Vector(10, 0), new Vector(10, 10), new Vector(0, 10)]);
+
+    expect(polygon.contains(500, 500)).toBe(false);
+
+    polygon.destroy();
+  });
+
+  test('contains() honours the polygon position offset, like getBounds()', () => {
+    const polygon = new Polygon([new Vector(0, 0), new Vector(10, 0), new Vector(10, 10), new Vector(0, 10)], 100, 100);
+
+    expect(polygon.getBounds().contains(105, 105)).toBe(true);
+    expect(polygon.contains(105, 105)).toBe(true);
+    expect(polygon.contains(5, 5)).toBe(false);
+
+    polygon.destroy();
+  });
+});
+
+describe('Polygon.intersectsWith()', () => {
+  // Kept at the default (0, 0) position with world coordinates baked directly
+  // into the points so these cases exercise only the switch-dispatch logic.
+  const square = (x: number, y: number, size: number) =>
+    new Polygon([new Vector(x, y), new Vector(x + size, y), new Vector(x + size, y + size), new Vector(x, y + size)]);
+
+  test('SceneNode target dispatches to intersectionRectPoly via getBounds()', () => {
+    const node = new SceneNode();
+
+    node.getLocalBounds().set(0, 0, 10, 10);
+    node.updateParentTransform();
+
+    const polygon = square(5, 5, 10);
+
+    expect(polygon.intersectsWith(node)).toBe(true);
+
+    polygon.destroy();
+  });
+
+  test('Rectangle target intersects', () => {
+    const polygon = square(5, 5, 10);
+
+    expect(polygon.intersectsWith(new Rectangle(0, 0, 10, 10))).toBe(true);
+
+    polygon.destroy();
+  });
+
+  test('Polygon target intersects', () => {
+    const a = square(0, 0, 10);
+    const b = square(5, 5, 10);
+
+    expect(a.intersectsWith(b)).toBe(true);
+
+    a.destroy();
+    b.destroy();
+  });
+
+  test('Circle target — far away, unambiguous non-intersection', () => {
+    const polygon = square(0, 0, 10);
+
+    expect(polygon.intersectsWith(new Circle(500, 500, 1))).toBe(false);
+
+    polygon.destroy();
+  });
+
+  test('Ellipse target intersects', () => {
+    const polygon = square(0, 0, 10);
+
+    expect(polygon.intersectsWith(new Ellipse(5, 5, 3, 3))).toBe(true);
+
+    polygon.destroy();
+  });
+
+  test('Line target intersects', () => {
+    const polygon = square(0, 0, 10);
+
+    expect(polygon.intersectsWith(new Line(-5, 5, 15, 5))).toBe(true);
+
+    polygon.destroy();
+  });
+
+  test('Point target intersects', () => {
+    const polygon = square(0, 0, 10);
+
+    expect(polygon.intersectsWith(new Vector(5, 5))).toBe(true);
+
+    polygon.destroy();
+  });
+
+  test('unknown collision type falls through to the default (false)', () => {
+    const polygon = square(0, 0, 10);
+    const unknown = { collisionType: -1 } as unknown as Vector;
+
+    expect(polygon.intersectsWith(unknown)).toBe(false);
+
+    polygon.destroy();
+  });
+});
+
+describe('Polygon.collidesWith()', () => {
+  const square = (x: number, y: number, size: number) =>
+    new Polygon([new Vector(x, y), new Vector(x + size, y), new Vector(x + size, y + size), new Vector(x, y + size)]);
+
+  test('SceneNode target resolves via getCollisionSat', () => {
+    const node = new SceneNode();
+
+    node.getLocalBounds().set(0, 0, 10, 10);
+    node.updateParentTransform();
+
+    const polygon = square(5, 5, 10);
+    const response = polygon.collidesWith(node);
+
+    expect(response).not.toBeNull();
+
+    polygon.destroy();
+  });
+
+  test('Rectangle target resolves via getCollisionSat', () => {
+    const polygon = square(5, 5, 10);
+    const response = polygon.collidesWith(new Rectangle(0, 0, 10, 10));
+
+    expect(response).not.toBeNull();
+
+    polygon.destroy();
+  });
+
+  test('Polygon target resolves via getCollisionSat', () => {
+    const a = square(0, 0, 10);
+    const b = square(5, 5, 10);
+    const response = a.collidesWith(b);
+
+    expect(response).not.toBeNull();
+
+    a.destroy();
+    b.destroy();
+  });
+
+  test('Ellipse target resolves via getCollisionSat', () => {
+    const polygon = square(0, 0, 10);
+    const response = polygon.collidesWith(new Ellipse(5, 5, 3, 3));
+
+    expect(response).not.toBeNull();
+
+    polygon.destroy();
+  });
+
+  test('Circle target resolves via getCollisionPolygonCircle', () => {
+    const polygon = square(0, 0, 10);
+    const response = polygon.collidesWith(new Circle(5, -0.5, 1));
+
+    expect(response).not.toBeNull();
+
+    polygon.destroy();
+  });
+
+  test('disjoint shapes return null', () => {
+    const polygon = square(0, 0, 10);
+    const response = polygon.collidesWith(new Rectangle(500, 500, 10, 10));
+
+    expect(response).toBeNull();
+
+    polygon.destroy();
+  });
+
+  test('unknown collision type falls through to the default (null)', () => {
+    const polygon = square(0, 0, 10);
+    const unknown = { collisionType: -1 } as unknown as Vector;
+
+    expect(polygon.collidesWith(unknown)).toBeNull();
+
+    polygon.destroy();
+  });
+});
+
+describe('Polygon.destroy()', () => {
+  test('does not throw when the normals cache was never populated', () => {
+    const polygon = new Polygon([new Vector(0, 0), new Vector(10, 0), new Vector(10, 10)]);
+
+    expect(() => polygon.destroy()).not.toThrow();
+    expect(polygon.points.length).toBe(0);
+    expect(polygon.edges.length).toBe(0);
+  });
+});
+
+describe('Polygon.temp', () => {
+  test('lazily allocates and returns the same instance on subsequent calls', () => {
+    const first = Polygon.temp;
+    const second = Polygon.temp;
+
+    expect(first).toBe(second);
+    expect(first).toBeInstanceOf(Polygon);
   });
 });

--- a/test/math/quadtree.test.ts
+++ b/test/math/quadtree.test.ts
@@ -1,0 +1,233 @@
+import type { QuadtreeItem } from '#math/Quadtree';
+import { Quadtree } from '#math/Quadtree';
+import { Rectangle } from '#math/Rectangle';
+
+function makeItem(x: number, y: number, width: number, height: number, payload = `${x},${y},${width},${height}`): QuadtreeItem<string> {
+  return { bounds: new Rectangle(x, y, width, height), payload };
+}
+
+describe('Quadtree', () => {
+  describe('insert()', () => {
+    test('stores items directly while under capacity', () => {
+      const tree = new Quadtree<string>(new Rectangle(0, 0, 100, 100), 8, 5);
+      const item = makeItem(10, 10, 5, 5);
+
+      tree.insert(item);
+
+      const results = tree.queryPoint(12, 12);
+
+      expect(results).toContain(item);
+    });
+
+    test('subdivides once maxItems is exceeded and routes items into a fully-containing child', () => {
+      const tree = new Quadtree<string>(new Rectangle(0, 0, 100, 100), 2, 5);
+
+      // Three overlapping items, all fully inside the NW quadrant [0,50)x[0,50):
+      // inserting the third exceeds maxItems(2) and forces a subdivision.
+      tree.insert(makeItem(1, 1, 4, 4, 'a'));
+      tree.insert(makeItem(2, 2, 4, 4, 'b'));
+      tree.insert(makeItem(3, 3, 4, 4, 'c'));
+
+      // (3, 3) falls inside all three overlapping bounds.
+      const results = tree.queryPoint(3, 3);
+
+      expect(results.map(item => item.payload).sort()).toEqual(['a', 'b', 'c']);
+    });
+
+    test('an item spanning multiple quadrants is kept at the current node rather than duplicated', () => {
+      const tree = new Quadtree<string>(new Rectangle(0, 0, 100, 100), 1, 5);
+
+      tree.insert(makeItem(10, 10, 2, 2, 'first'));
+      // This item straddles the NW/NE quadrant boundary (x=50) and cannot be
+      // fully contained by any single child.
+      tree.insert(makeItem(45, 10, 20, 2, 'spanning'));
+
+      const results = tree.queryRect(new Rectangle(0, 0, 100, 100));
+
+      expect(results.map(item => item.payload).sort()).toEqual(['first', 'spanning']);
+    });
+
+    test('does not subdivide past maxDepth — items accumulate at the deepest node', () => {
+      const tree = new Quadtree<string>(new Rectangle(0, 0, 100, 100), 1, 0);
+
+      tree.insert(makeItem(1, 1, 4, 4, 'a'));
+      tree.insert(makeItem(2, 2, 4, 4, 'b'));
+      tree.insert(makeItem(3, 3, 4, 4, 'c'));
+
+      // maxDepth=0 means the root never subdivides (depth 0 is not < maxDepth 0).
+      const results = tree.queryPoint(3, 3);
+
+      expect(results.map(item => item.payload).sort()).toEqual(['a', 'b', 'c']);
+    });
+  });
+
+  describe('queryPoint()', () => {
+    test('returns an empty array when the point is outside the tree bounds', () => {
+      const tree = new Quadtree<string>(new Rectangle(0, 0, 100, 100));
+
+      expect(tree.queryPoint(-10, -10)).toEqual([]);
+    });
+
+    test('only returns items whose bounds actually contain the point', () => {
+      const tree = new Quadtree<string>(new Rectangle(0, 0, 100, 100));
+      const inside = makeItem(0, 0, 10, 10, 'inside');
+      const outside = makeItem(50, 50, 10, 10, 'outside');
+
+      tree.insert(inside);
+      tree.insert(outside);
+
+      const results = tree.queryPoint(5, 5);
+
+      expect(results).toContain(inside);
+      expect(results).not.toContain(outside);
+    });
+
+    test('recurses into children and appends into a provided results buffer', () => {
+      const tree = new Quadtree<string>(new Rectangle(0, 0, 100, 100), 1, 5);
+
+      tree.insert(makeItem(1, 1, 2, 2, 'a'));
+      tree.insert(makeItem(2, 2, 2, 2, 'b'));
+
+      const buffer: Array<QuadtreeItem<string>> = [];
+      const returned = tree.queryPoint(2, 2, buffer);
+
+      expect(returned).toBe(buffer);
+      expect(buffer.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('queryRect()', () => {
+    test('returns an empty array when the rect does not overlap the tree bounds', () => {
+      const tree = new Quadtree<string>(new Rectangle(0, 0, 100, 100));
+
+      expect(tree.queryRect(new Rectangle(500, 500, 10, 10))).toEqual([]);
+    });
+
+    test('only returns items whose bounds overlap the query rect', () => {
+      const tree = new Quadtree<string>(new Rectangle(0, 0, 100, 100));
+      const overlapping = makeItem(5, 5, 10, 10, 'overlap');
+      const disjoint = makeItem(90, 90, 5, 5, 'disjoint');
+
+      tree.insert(overlapping);
+      tree.insert(disjoint);
+
+      const results = tree.queryRect(new Rectangle(0, 0, 20, 20));
+
+      expect(results).toContain(overlapping);
+      expect(results).not.toContain(disjoint);
+    });
+
+    test('recurses into children', () => {
+      const tree = new Quadtree<string>(new Rectangle(0, 0, 100, 100), 1, 5);
+
+      tree.insert(makeItem(1, 1, 2, 2, 'a'));
+      tree.insert(makeItem(60, 60, 2, 2, 'b'));
+
+      const results = tree.queryRect(new Rectangle(0, 0, 100, 100));
+
+      expect(results.map(item => item.payload).sort()).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('remove()', () => {
+    test('removes an item found at the root and returns true', () => {
+      const tree = new Quadtree<string>(new Rectangle(0, 0, 100, 100));
+      const item = makeItem(10, 10, 5, 5);
+
+      tree.insert(item);
+
+      expect(tree.remove(item)).toBe(true);
+      expect(tree.queryPoint(12, 12)).toEqual([]);
+    });
+
+    test('removes an item found in a descendant and returns true', () => {
+      const tree = new Quadtree<string>(new Rectangle(0, 0, 100, 100), 1, 5);
+      const a = makeItem(1, 1, 2, 2, 'a');
+      const b = makeItem(2, 2, 2, 2, 'b');
+
+      tree.insert(a);
+      tree.insert(b); // triggers subdivision, both land in a child
+
+      expect(tree.remove(b)).toBe(true);
+
+      const results = tree.queryPoint(2, 2);
+
+      expect(results).not.toContain(b);
+      expect(results).toContain(a);
+    });
+
+    test('returns false when the item is not present anywhere in the tree', () => {
+      const tree = new Quadtree<string>(new Rectangle(0, 0, 100, 100), 1, 5);
+
+      tree.insert(makeItem(1, 1, 2, 2, 'a'));
+      tree.insert(makeItem(2, 2, 2, 2, 'b'));
+
+      expect(tree.remove(makeItem(99, 99, 1, 1, 'ghost'))).toBe(false);
+    });
+  });
+
+  describe('clear()', () => {
+    test('removes all items and collapses child nodes', () => {
+      const tree = new Quadtree<string>(new Rectangle(0, 0, 100, 100), 1, 5);
+
+      tree.insert(makeItem(1, 1, 2, 2, 'a'));
+      tree.insert(makeItem(2, 2, 2, 2, 'b'));
+      tree.insert(makeItem(60, 60, 2, 2, 'c'));
+
+      tree.clear();
+
+      expect(tree.queryRect(new Rectangle(0, 0, 100, 100))).toEqual([]);
+    });
+
+    test('is safe to call on an already-empty tree', () => {
+      const tree = new Quadtree<string>(new Rectangle(0, 0, 100, 100));
+
+      expect(() => tree.clear()).not.toThrow();
+    });
+  });
+
+  describe('_walkBounds()', () => {
+    test('visits the root and every subdivided child rectangle', () => {
+      const tree = new Quadtree<string>(new Rectangle(0, 0, 100, 100), 1, 5);
+
+      tree.insert(makeItem(1, 1, 2, 2, 'a'));
+      tree.insert(makeItem(2, 2, 2, 2, 'b')); // forces one subdivision
+
+      const visited: Rectangle[] = [];
+
+      tree._walkBounds(rect => visited.push(rect));
+
+      // Root + 4 children.
+      expect(visited.length).toBe(5);
+      expect(visited[0]!.equals({ x: 0, y: 0, width: 100, height: 100 })).toBe(true);
+    });
+
+    test('visits only the root when the tree never subdivided', () => {
+      const tree = new Quadtree<string>(new Rectangle(0, 0, 100, 100));
+      const visited: Rectangle[] = [];
+
+      tree._walkBounds(rect => visited.push(rect));
+
+      expect(visited).toHaveLength(1);
+    });
+  });
+
+  describe('destroy()', () => {
+    test('does not throw for a leaf tree', () => {
+      const tree = new Quadtree<string>(new Rectangle(0, 0, 100, 100));
+
+      tree.insert(makeItem(1, 1, 2, 2));
+
+      expect(() => tree.destroy()).not.toThrow();
+    });
+
+    test('recursively destroys subdivided children', () => {
+      const tree = new Quadtree<string>(new Rectangle(0, 0, 100, 100), 1, 5);
+
+      tree.insert(makeItem(1, 1, 2, 2, 'a'));
+      tree.insert(makeItem(2, 2, 2, 2, 'b')); // forces subdivision
+
+      expect(() => tree.destroy()).not.toThrow();
+    });
+  });
+});

--- a/test/math/rectangle.test.ts
+++ b/test/math/rectangle.test.ts
@@ -1,0 +1,525 @@
+import { SceneNode } from '#core/SceneNode';
+import { Circle } from '#math/Circle';
+import { Ellipse } from '#math/Ellipse';
+import { Interval } from '#math/Interval';
+import { Line } from '#math/Line';
+import { Matrix } from '#math/Matrix';
+import { Polygon } from '#math/Polygon';
+import { Rectangle } from '#math/Rectangle';
+import { Size } from '#math/Size';
+import { Vector } from '#math/Vector';
+
+describe('Rectangle', () => {
+  describe('constructor', () => {
+    test('defaults to a zero-sized rectangle at the origin', () => {
+      const rectangle = new Rectangle();
+
+      expect(rectangle.x).toBe(0);
+      expect(rectangle.y).toBe(0);
+      expect(rectangle.width).toBe(0);
+      expect(rectangle.height).toBe(0);
+    });
+
+    test('a single argument fills x, y, width and height uniformly', () => {
+      const rectangle = new Rectangle(5);
+
+      expect(rectangle.x).toBe(5);
+      expect(rectangle.y).toBe(5);
+      expect(rectangle.width).toBe(0);
+      expect(rectangle.height).toBe(0);
+    });
+
+    test('a width argument without height fills height uniformly', () => {
+      const rectangle = new Rectangle(1, 2, 10);
+
+      expect(rectangle.x).toBe(1);
+      expect(rectangle.y).toBe(2);
+      expect(rectangle.width).toBe(10);
+      expect(rectangle.height).toBe(10);
+    });
+
+    test('accepts explicit x, y, width, height', () => {
+      const rectangle = new Rectangle(1, 2, 3, 4);
+
+      expect(rectangle.x).toBe(1);
+      expect(rectangle.y).toBe(2);
+      expect(rectangle.width).toBe(3);
+      expect(rectangle.height).toBe(4);
+    });
+  });
+
+  describe('position', () => {
+    test('position getter returns the internal vector', () => {
+      const rectangle = new Rectangle(1, 2, 3, 4);
+
+      expect(rectangle.position.x).toBe(1);
+      expect(rectangle.position.y).toBe(2);
+    });
+
+    test('position setter copies from another vector-like and marks normals dirty', () => {
+      const rectangle = new Rectangle(0, 0, 10, 10);
+
+      rectangle.getNormals(); // warm the cache
+      rectangle.position = new Vector(5, 6);
+
+      expect(rectangle.x).toBe(5);
+      expect(rectangle.y).toBe(6);
+    });
+  });
+
+  describe('x / y', () => {
+    test('x setter updates x and marks normals dirty', () => {
+      const rectangle = new Rectangle(0, 0, 10, 10);
+
+      rectangle.x = 7;
+      expect(rectangle.x).toBe(7);
+    });
+
+    test('y setter updates y and marks normals dirty', () => {
+      const rectangle = new Rectangle(0, 0, 10, 10);
+
+      rectangle.y = 8;
+      expect(rectangle.y).toBe(8);
+    });
+  });
+
+  describe('size', () => {
+    test('size getter returns the internal Size', () => {
+      const rectangle = new Rectangle(0, 0, 3, 4);
+
+      expect(rectangle.size.width).toBe(3);
+      expect(rectangle.size.height).toBe(4);
+    });
+
+    test('size setter copies from another Size', () => {
+      const rectangle = new Rectangle(0, 0, 3, 4);
+
+      rectangle.size = new Size(9, 9);
+
+      expect(rectangle.width).toBe(9);
+      expect(rectangle.height).toBe(9);
+    });
+  });
+
+  describe('width / height', () => {
+    test('width setter updates width and marks normals dirty', () => {
+      const rectangle = new Rectangle(0, 0, 3, 4);
+
+      rectangle.width = 20;
+      expect(rectangle.width).toBe(20);
+    });
+
+    test('height setter updates height and marks normals dirty', () => {
+      const rectangle = new Rectangle(0, 0, 3, 4);
+
+      rectangle.height = 30;
+      expect(rectangle.height).toBe(30);
+    });
+  });
+
+  describe('left / top / right / bottom', () => {
+    test('derive from x/y/width/height', () => {
+      const rectangle = new Rectangle(2, 3, 10, 20);
+
+      expect(rectangle.left).toBe(2);
+      expect(rectangle.top).toBe(3);
+      expect(rectangle.right).toBe(12);
+      expect(rectangle.bottom).toBe(23);
+    });
+  });
+
+  describe('setPosition() / setSize() / set()', () => {
+    test('setPosition() updates x/y and returns this', () => {
+      const rectangle = new Rectangle();
+      const returned = rectangle.setPosition(4, 5);
+
+      expect(returned).toBe(rectangle);
+      expect(rectangle.x).toBe(4);
+      expect(rectangle.y).toBe(5);
+    });
+
+    test('setSize() updates width/height and returns this', () => {
+      const rectangle = new Rectangle();
+      const returned = rectangle.setSize(6, 7);
+
+      expect(returned).toBe(rectangle);
+      expect(rectangle.width).toBe(6);
+      expect(rectangle.height).toBe(7);
+    });
+
+    test('set() updates all four fields and returns this', () => {
+      const rectangle = new Rectangle();
+      const returned = rectangle.set(1, 2, 3, 4);
+
+      expect(returned).toBe(rectangle);
+      expect(rectangle.x).toBe(1);
+      expect(rectangle.y).toBe(2);
+      expect(rectangle.width).toBe(3);
+      expect(rectangle.height).toBe(4);
+    });
+  });
+
+  describe('copy() / clone()', () => {
+    test('copy() duplicates position and size from another rectangle', () => {
+      const source = new Rectangle(1, 2, 3, 4);
+      const target = new Rectangle();
+      const returned = target.copy(source);
+
+      expect(returned).toBe(target);
+      expect(target.equals(source)).toBe(true);
+    });
+
+    test('clone() returns an equal but distinct instance', () => {
+      const original = new Rectangle(1, 2, 3, 4);
+      const clone = original.clone();
+
+      expect(clone).not.toBe(original);
+      expect(clone.equals(original)).toBe(true);
+    });
+  });
+
+  describe('equals()', () => {
+    test('returns true when no fields are given', () => {
+      const rectangle = new Rectangle(1, 2, 3, 4);
+
+      expect(rectangle.equals()).toBe(true);
+    });
+
+    test('returns false when x mismatches', () => {
+      const rectangle = new Rectangle(1, 2, 3, 4);
+
+      expect(rectangle.equals({ x: 99 })).toBe(false);
+    });
+
+    test('returns false when y mismatches', () => {
+      const rectangle = new Rectangle(1, 2, 3, 4);
+
+      expect(rectangle.equals({ y: 99 })).toBe(false);
+    });
+
+    test('returns false when width mismatches', () => {
+      const rectangle = new Rectangle(1, 2, 3, 4);
+
+      expect(rectangle.equals({ width: 99 })).toBe(false);
+    });
+
+    test('returns false when height mismatches', () => {
+      const rectangle = new Rectangle(1, 2, 3, 4);
+
+      expect(rectangle.equals({ height: 99 })).toBe(false);
+    });
+
+    test('returns true when all given fields match', () => {
+      const rectangle = new Rectangle(1, 2, 3, 4);
+
+      expect(rectangle.equals({ x: 1, y: 2, width: 3, height: 4 })).toBe(true);
+    });
+  });
+
+  describe('getBounds()', () => {
+    test('returns a clone of itself', () => {
+      const rectangle = new Rectangle(1, 2, 3, 4);
+      const bounds = rectangle.getBounds();
+
+      expect(bounds).not.toBe(rectangle);
+      expect(bounds.equals(rectangle)).toBe(true);
+    });
+  });
+
+  describe('getNormals()', () => {
+    test('returns 4 unit normals for an axis-aligned rectangle', () => {
+      const rectangle = new Rectangle(0, 0, 10, 20);
+      const normals = rectangle.getNormals();
+
+      expect(normals).toHaveLength(4);
+      // Each normal is the right-perpendicular of an edge vector, normalized:
+      // top edge (10,0) -> rperp (0,-10) -> (0,-1); right edge (0,20) -> (20,0) -> (1,0);
+      // bottom edge (-10,0) -> (0,10) -> (0,1); left edge (0,-20) -> (-20,0) -> (-1,0).
+      // (toBeCloseTo, not toMatchObject: -0 vs 0 differ under Object.is.)
+      const expected = [
+        [0, -1],
+        [1, 0],
+        [0, 1],
+        [-1, 0],
+      ];
+
+      for (const [i, [ex, ey]] of expected.entries()) {
+        expect(normals[i]!.x).toBeCloseTo(ex);
+        expect(normals[i]!.y).toBeCloseTo(ey);
+      }
+    });
+
+    test('returns the same array reference on consecutive calls (cache hit)', () => {
+      const rectangle = new Rectangle(0, 0, 10, 20);
+      const first = rectangle.getNormals();
+      const second = rectangle.getNormals();
+
+      expect(second).toBe(first);
+    });
+
+    test('recomputes in place after a mutation marks the cache dirty', () => {
+      const rectangle = new Rectangle(0, 0, 10, 20);
+      const first = rectangle.getNormals();
+
+      rectangle.width = 999; // triggers _onObservableChange indirectly via width setter
+      const second = rectangle.getNormals();
+
+      expect(second).toBe(first); // same array, values recomputed in place
+    });
+  });
+
+  describe('project()', () => {
+    test('projects onto the X axis', () => {
+      const rectangle = new Rectangle(0, 0, 10, 20);
+      const interval = rectangle.project(new Vector(1, 0));
+
+      expect(interval.min).toBe(0);
+      expect(interval.max).toBe(10);
+    });
+
+    test('projects onto the Y axis', () => {
+      const rectangle = new Rectangle(0, 0, 10, 20);
+      const interval = rectangle.project(new Vector(0, 1));
+
+      expect(interval.min).toBe(0);
+      expect(interval.max).toBe(20);
+    });
+
+    test('writes into a provided result interval and returns it', () => {
+      const rectangle = new Rectangle(0, 0, 10, 20);
+      const result = new Interval();
+      const returned = rectangle.project(new Vector(1, 0), result);
+
+      expect(returned).toBe(result);
+    });
+  });
+
+  describe('transform()', () => {
+    test('a translation matrix shifts the rectangle bounds and mutates this by default', () => {
+      const rectangle = new Rectangle(0, 0, 10, 20);
+      const matrix = new Matrix(1, 0, 5, 0, 1, 7);
+      const returned = rectangle.transform(matrix);
+
+      expect(returned).toBe(rectangle);
+      expect(rectangle.x).toBe(5);
+      expect(rectangle.y).toBe(7);
+      expect(rectangle.width).toBe(10);
+      expect(rectangle.height).toBe(20);
+    });
+
+    test('a 90-degree rotation matrix produces the rotated AABB', () => {
+      // Rotate (a=0,b=1,c=-1,d=0) is a 90° CCW rotation in this row-major layout:
+      // transform() computes (x*a + y*b, x*c + y*d) -> (y, -x).
+      const rectangle = new Rectangle(0, 0, 10, 20);
+      const matrix = new Matrix(0, 1, 0, -1, 0, 0);
+      const bounds = rectangle.transform(matrix, new Rectangle());
+
+      // Corners (0,0),(10,0),(10,20),(0,20) map to (0,0),(0,-10),(20,-10),(20,0).
+      expect(bounds.x).toBeCloseTo(0);
+      expect(bounds.y).toBeCloseTo(-10);
+      expect(bounds.width).toBeCloseTo(20);
+      expect(bounds.height).toBeCloseTo(10);
+    });
+
+    test('writing into a separate result rectangle leaves the source untouched', () => {
+      const rectangle = new Rectangle(0, 0, 10, 20);
+      const matrix = new Matrix(1, 0, 3, 0, 1, 4);
+      const result = new Rectangle();
+      const returned = rectangle.transform(matrix, result);
+
+      expect(returned).toBe(result);
+      expect(rectangle.x).toBe(0);
+      expect(rectangle.y).toBe(0);
+      expect(result.x).toBe(3);
+      expect(result.y).toBe(4);
+    });
+  });
+
+  describe('contains()', () => {
+    test('returns true for a point inside the rectangle', () => {
+      const rectangle = new Rectangle(0, 0, 10, 10);
+
+      expect(rectangle.contains(5, 5)).toBe(true);
+    });
+
+    test('returns false for a point outside the rectangle', () => {
+      const rectangle = new Rectangle(0, 0, 10, 10);
+
+      expect(rectangle.contains(50, 50)).toBe(false);
+    });
+  });
+
+  describe('containsRect()', () => {
+    const outer = () => new Rectangle(0, 0, 100, 100);
+
+    test('returns true when rect is entirely inside', () => {
+      expect(outer().containsRect(new Rectangle(10, 10, 20, 20))).toBe(true);
+    });
+
+    test('returns false when rect extends past the left edge', () => {
+      expect(outer().containsRect(new Rectangle(-5, 10, 20, 20))).toBe(false);
+    });
+
+    test('returns false when rect extends past the right edge', () => {
+      expect(outer().containsRect(new Rectangle(90, 10, 20, 20))).toBe(false);
+    });
+
+    test('returns false when rect extends past the top edge', () => {
+      expect(outer().containsRect(new Rectangle(10, -5, 20, 20))).toBe(false);
+    });
+
+    test('returns false when rect extends past the bottom edge', () => {
+      expect(outer().containsRect(new Rectangle(10, 90, 20, 20))).toBe(false);
+    });
+  });
+
+  describe('intersectsWith()', () => {
+    const base = () => new Rectangle(0, 0, 10, 10);
+
+    test('SceneNode target, axis-aligned: delegates to intersectionRectRect via getBounds()', () => {
+      const node = new SceneNode();
+
+      node.getLocalBounds().set(0, 0, 10, 10);
+      node.setPosition(5, 5);
+      node.updateParentTransform();
+
+      expect(node.isAlignedBox).toBe(true);
+      expect(base().intersectsWith(node)).toBe(true);
+    });
+
+    test('SceneNode target, rotated: delegates to full SAT', () => {
+      const node = new SceneNode();
+
+      node.getLocalBounds().set(0, 0, 10, 10);
+      node.setPosition(5, 5);
+      node.setRotation(45);
+      node.updateParentTransform();
+
+      expect(node.isAlignedBox).toBe(false);
+      // Boolean result only matters for branch coverage; both outcomes are valid geometry.
+      expect(typeof base().intersectsWith(node)).toBe('boolean');
+    });
+
+    test('Rectangle target intersects', () => {
+      expect(base().intersectsWith(new Rectangle(5, 5, 10, 10))).toBe(true);
+    });
+
+    test('Polygon target intersects', () => {
+      const polygon = new Polygon([new Vector(5, 5), new Vector(15, 5), new Vector(15, 15), new Vector(5, 15)]);
+
+      expect(base().intersectsWith(polygon)).toBe(true);
+    });
+
+    test('Circle target intersects', () => {
+      expect(base().intersectsWith(new Circle(15, 5, 6))).toBe(true);
+    });
+
+    test('Ellipse target intersects', () => {
+      expect(base().intersectsWith(new Ellipse(5, 5, 3, 3))).toBe(true);
+    });
+
+    test('Line target intersects', () => {
+      expect(base().intersectsWith(new Line(-5, 5, 15, 5))).toBe(true);
+    });
+
+    test('Point target intersects', () => {
+      expect(base().intersectsWith(new Vector(5, 5))).toBe(true);
+    });
+
+    test('unknown collision type falls through to the default (false)', () => {
+      const unknown = { collisionType: -1 } as unknown as Vector;
+
+      expect(base().intersectsWith(unknown)).toBe(false);
+    });
+  });
+
+  describe('collidesWith()', () => {
+    const base = () => new Rectangle(0, 0, 10, 10);
+
+    test('SceneNode target, axis-aligned: delegates to getCollisionRectangleRectangle', () => {
+      const node = new SceneNode();
+
+      node.getLocalBounds().set(0, 0, 10, 10);
+      node.setPosition(5, 5);
+      node.updateParentTransform();
+
+      expect(node.isAlignedBox).toBe(true);
+      expect(base().collidesWith(node)).not.toBeNull();
+    });
+
+    test('SceneNode target, rotated: delegates to getCollisionSat', () => {
+      const node = new SceneNode();
+
+      node.getLocalBounds().set(0, 0, 10, 10);
+      node.setPosition(5, 5);
+      node.setRotation(45);
+      node.updateParentTransform();
+
+      expect(node.isAlignedBox).toBe(false);
+      // Either a response or null is valid geometry — this exercises the SAT branch.
+      const response = base().collidesWith(node);
+
+      expect(response === null || typeof response.overlap === 'number').toBe(true);
+    });
+
+    test('Rectangle target returns a collision response', () => {
+      const response = base().collidesWith(new Rectangle(5, 5, 10, 10));
+
+      expect(response).not.toBeNull();
+      expect(response!.overlap).toBeGreaterThan(0);
+    });
+
+    test('Polygon target returns a collision response via SAT', () => {
+      const polygon = new Polygon([new Vector(5, 5), new Vector(15, 5), new Vector(15, 15), new Vector(5, 15)]);
+      const response = base().collidesWith(polygon);
+
+      expect(response).not.toBeNull();
+    });
+
+    test('Circle target returns a collision response with swap=true (rect calling into circle logic)', () => {
+      const response = base().collidesWith(new Circle(9, 5, 5));
+
+      expect(response).not.toBeNull();
+      expect(response!.shapeA).toBeInstanceOf(Rectangle);
+    });
+
+    test('Ellipse target returns a collision response with swap=true', () => {
+      const response = base().collidesWith(new Ellipse(9, 5, 3, 3));
+
+      expect(response).not.toBeNull();
+      expect(response!.shapeA).toBeInstanceOf(Rectangle);
+    });
+
+    test('unknown collision type falls through to the default (null)', () => {
+      const unknown = { collisionType: -1 } as unknown as Vector;
+
+      expect(base().collidesWith(unknown)).toBeNull();
+    });
+  });
+
+  describe('destroy()', () => {
+    test('does not throw and releases the normals cache', () => {
+      const rectangle = new Rectangle(0, 0, 10, 10);
+
+      rectangle.getNormals(); // populate the cache first
+
+      expect(() => rectangle.destroy()).not.toThrow();
+    });
+
+    test('does not throw when the normals cache was never populated', () => {
+      const rectangle = new Rectangle(0, 0, 10, 10);
+
+      expect(() => rectangle.destroy()).not.toThrow();
+    });
+  });
+
+  describe('static temp', () => {
+    test('lazily allocates and returns the same instance on subsequent calls', () => {
+      const first = Rectangle.temp;
+      const second = Rectangle.temp;
+
+      expect(first).toBe(second);
+      expect(first).toBeInstanceOf(Rectangle);
+    });
+  });
+});

--- a/test/math/segment.test.ts
+++ b/test/math/segment.test.ts
@@ -1,0 +1,106 @@
+import { Segment } from '#math/Segment';
+import { Vector } from '#math/Vector';
+
+describe('Segment', () => {
+  describe('startPoint/endPoint and X/Y accessors', () => {
+    test('startPoint getter/setter copies coordinates from another vector', () => {
+      const segment = new Segment(0, 0, 1, 1);
+      segment.startPoint = new Vector(5, 6);
+
+      expect(segment.startX).toBe(5);
+      expect(segment.startY).toBe(6);
+    });
+
+    test('endPoint getter/setter copies coordinates from another vector', () => {
+      const segment = new Segment(0, 0, 1, 1);
+      segment.endPoint = new Vector(7, 8);
+
+      expect(segment.endX).toBe(7);
+      expect(segment.endY).toBe(8);
+    });
+
+    test('startX/startY setters update independently', () => {
+      const segment = new Segment();
+      segment.startX = 3;
+      segment.startY = 4;
+
+      expect(segment.startX).toBe(3);
+      expect(segment.startY).toBe(4);
+    });
+
+    test('endX/endY setters update independently', () => {
+      const segment = new Segment();
+      segment.endX = 9;
+      segment.endY = 10;
+
+      expect(segment.endX).toBe(9);
+      expect(segment.endY).toBe(10);
+    });
+  });
+
+  describe('set(), copy(), clone()', () => {
+    test('set() updates both endpoints and returns this', () => {
+      const segment = new Segment();
+      const result = segment.set(1, 2, 3, 4);
+
+      expect(result).toBe(segment);
+      expect(segment.startX).toBe(1);
+      expect(segment.startY).toBe(2);
+      expect(segment.endX).toBe(3);
+      expect(segment.endY).toBe(4);
+    });
+
+    test('copy() duplicates another segment state and returns this', () => {
+      const source = new Segment(1, 2, 3, 4);
+      const target = new Segment();
+      const result = target.copy(source);
+
+      expect(result).toBe(target);
+      expect(target.equals(source)).toBe(true);
+    });
+
+    test('clone() returns a new segment with the same state', () => {
+      const segment = new Segment(1, 2, 3, 4);
+      const clone = segment.clone();
+
+      expect(clone).not.toBe(segment);
+      expect(clone.equals(segment)).toBe(true);
+    });
+  });
+
+  describe('equals()', () => {
+    test('returns true when called with no arguments', () => {
+      const segment = new Segment(1, 2, 3, 4);
+
+      expect(segment.equals()).toBe(true);
+      expect(segment.equals({})).toBe(true);
+    });
+
+    test('compares each field independently', () => {
+      const segment = new Segment(1, 2, 3, 4);
+
+      expect(segment.equals({ startX: 1, startY: 2, endX: 3, endY: 4 })).toBe(true);
+      expect(segment.equals({ startX: 99 })).toBe(false);
+      expect(segment.equals({ startY: 99 })).toBe(false);
+      expect(segment.equals({ endX: 99 })).toBe(false);
+      expect(segment.equals({ endY: 99 })).toBe(false);
+    });
+  });
+
+  describe('destroy()', () => {
+    test('does not throw', () => {
+      const segment = new Segment(0, 0, 1, 1);
+
+      expect(() => segment.destroy()).not.toThrow();
+    });
+  });
+
+  describe('static temp', () => {
+    test('returns a shared scratch instance on repeated access', () => {
+      const first = Segment.temp;
+      const second = Segment.temp;
+
+      expect(second).toBe(first);
+    });
+  });
+});

--- a/test/math/size.test.ts
+++ b/test/math/size.test.ts
@@ -1,0 +1,259 @@
+import { Size } from '#math/Size';
+
+describe('Size', () => {
+  test('defaults width and height to 0', () => {
+    const size = new Size();
+
+    expect(size.width).toBe(0);
+    expect(size.height).toBe(0);
+
+    size.destroy();
+  });
+
+  test('constructor accepts explicit width and height', () => {
+    const size = new Size(10, 20);
+
+    expect(size.width).toBe(10);
+    expect(size.height).toBe(20);
+
+    size.destroy();
+  });
+
+  test('width/height setters mutate independently', () => {
+    const size = new Size();
+
+    size.width = 5;
+    size.height = 8;
+
+    expect(size.width).toBe(5);
+    expect(size.height).toBe(8);
+
+    size.destroy();
+  });
+
+  test('set() with both arguments sets width and height independently', () => {
+    const size = new Size();
+
+    size.set(3, 7);
+
+    expect(size.width).toBe(3);
+    expect(size.height).toBe(7);
+
+    size.destroy();
+  });
+
+  test('set() with a single argument applies it uniformly', () => {
+    const size = new Size();
+
+    size.set(4);
+
+    expect(size.width).toBe(4);
+    expect(size.height).toBe(4);
+
+    size.destroy();
+  });
+
+  test('set() returns this for chaining', () => {
+    const size = new Size();
+
+    expect(size.set(1, 1)).toBe(size);
+
+    size.destroy();
+  });
+
+  test('add() with both arguments adds independently', () => {
+    const size = new Size(1, 2);
+
+    size.add(3, 4);
+
+    expect(size.width).toBe(4);
+    expect(size.height).toBe(6);
+
+    size.destroy();
+  });
+
+  test('add() with a single argument adds uniformly', () => {
+    const size = new Size(1, 2);
+
+    size.add(3);
+
+    expect(size.width).toBe(4);
+    expect(size.height).toBe(5);
+
+    size.destroy();
+  });
+
+  test('subtract() with both arguments subtracts independently', () => {
+    const size = new Size(10, 10);
+
+    size.subtract(3, 4);
+
+    expect(size.width).toBe(7);
+    expect(size.height).toBe(6);
+
+    size.destroy();
+  });
+
+  test('subtract() with a single argument subtracts uniformly', () => {
+    const size = new Size(10, 10);
+
+    size.subtract(3);
+
+    expect(size.width).toBe(7);
+    expect(size.height).toBe(7);
+
+    size.destroy();
+  });
+
+  test('scale() with both arguments scales independently', () => {
+    const size = new Size(2, 3);
+
+    size.scale(2, 4);
+
+    expect(size.width).toBe(4);
+    expect(size.height).toBe(12);
+
+    size.destroy();
+  });
+
+  test('scale() with a single argument scales uniformly', () => {
+    const size = new Size(2, 3);
+
+    size.scale(2);
+
+    expect(size.width).toBe(4);
+    expect(size.height).toBe(6);
+
+    size.destroy();
+  });
+
+  test('divide() with both arguments divides independently', () => {
+    const size = new Size(10, 20);
+
+    size.divide(2, 5);
+
+    expect(size.width).toBe(5);
+    expect(size.height).toBe(4);
+
+    size.destroy();
+  });
+
+  test('divide() with a single argument divides uniformly', () => {
+    const size = new Size(10, 20);
+
+    size.divide(2);
+
+    expect(size.width).toBe(5);
+    expect(size.height).toBe(10);
+
+    size.destroy();
+  });
+
+  test('copy() copies width/height from a plain object', () => {
+    const size = new Size();
+
+    size.copy({ width: 42, height: 24 });
+
+    expect(size.width).toBe(42);
+    expect(size.height).toBe(24);
+
+    size.destroy();
+  });
+
+  test('copy() returns this for chaining', () => {
+    const size = new Size();
+
+    expect(size.copy({ width: 1, height: 1 })).toBe(size);
+
+    size.destroy();
+  });
+
+  test('clone() produces an independent Size with the same values', () => {
+    const size = new Size(7, 9);
+    const clone = size.clone();
+
+    expect(clone).not.toBe(size);
+    expect(clone.width).toBe(7);
+    expect(clone.height).toBe(9);
+
+    clone.width = 100;
+    expect(size.width).toBe(7);
+
+    size.destroy();
+    clone.destroy();
+  });
+
+  describe('equals()', () => {
+    test('matches when both width and height are equal', () => {
+      const size = new Size(5, 6);
+
+      expect(size.equals({ width: 5, height: 6 })).toBe(true);
+
+      size.destroy();
+    });
+
+    test('does not match when width differs', () => {
+      const size = new Size(5, 6);
+
+      expect(size.equals({ width: 999, height: 6 })).toBe(false);
+
+      size.destroy();
+    });
+
+    test('does not match when height differs', () => {
+      const size = new Size(5, 6);
+
+      expect(size.equals({ width: 5, height: 999 })).toBe(false);
+
+      size.destroy();
+    });
+
+    test('an omitted width is treated as a wildcard (matches any value)', () => {
+      const size = new Size(5, 6);
+
+      expect(size.equals({ height: 6 })).toBe(true);
+
+      size.destroy();
+    });
+
+    test('an omitted height is treated as a wildcard (matches any value)', () => {
+      const size = new Size(5, 6);
+
+      expect(size.equals({ width: 5 })).toBe(true);
+
+      size.destroy();
+    });
+
+    test('called with no arguments matches unconditionally', () => {
+      const size = new Size(5, 6);
+
+      expect(size.equals()).toBe(true);
+
+      size.destroy();
+    });
+  });
+
+  test('destroy() does not throw (no-op)', () => {
+    const size = new Size(1, 2);
+
+    expect(() => size.destroy()).not.toThrow();
+  });
+
+  test('static zero is a (0, 0) sentinel', () => {
+    expect(Size.zero.width).toBe(0);
+    expect(Size.zero.height).toBe(0);
+  });
+
+  describe('static temp', () => {
+    test('returns a Size instance', () => {
+      expect(Size.temp).toBeInstanceOf(Size);
+    });
+
+    test('returns the same shared instance across accesses', () => {
+      const first = Size.temp;
+      const second = Size.temp;
+
+      expect(first).toBe(second);
+    });
+  });
+});

--- a/test/math/swept-collision.test.ts
+++ b/test/math/swept-collision.test.ts
@@ -128,6 +128,62 @@ describe('sweepRectangle', () => {
     expect(hit!.x).toBeCloseTo(10, 10); // 0 + 20 * 0.5
     expect(hit!.y).toBe(0);
   });
+
+  test('moving box approaches static box from above (deltaY < 0)', () => {
+    // moving: y in [20..30], target: y in [0..10]. Moving upward (negative Y).
+    const moving = rect(0, 20, 10, 10);
+    const target = rect(0, 0, 10, 10);
+    const hit = sweepRectangle(moving, 0, -20, target);
+
+    expect(hit).not.toBeNull();
+    expect(hit!.t).toBeCloseTo(0.5, 10);
+    expect(hit!.normalY).toBe(1);
+  });
+
+  test('no movement on Y and no static Y overlap → null', () => {
+    // deltaY === 0 and the boxes never overlap on the Y axis, regardless of X.
+    const moving = rect(0, 0, 10, 10);
+    const target = rect(0, 100, 10, 10);
+    const hit = sweepRectangle(moving, 5, 0, target);
+
+    expect(hit).toBeNull();
+  });
+
+  test('already overlapping with a smaller X penetration picks normal via movMinX < tarMinX (-1)', () => {
+    // moving straddles target's left edge → overlapX < overlapY, moving's min-X is left of target's.
+    const moving = rect(-5, 0, 10, 20);
+    const target = rect(0, 0, 20, 20);
+    const hit = sweepRectangle(moving, 0, 0, target);
+
+    expect(hit).not.toBeNull();
+    expect(hit!.t).toBe(0);
+    expect(hit!.normalX).toBe(-1);
+    expect(hit!.normalY).toBe(0);
+  });
+
+  test('already overlapping with a smaller X penetration picks normal via movMinX >= tarMinX (+1)', () => {
+    // moving straddles target's right edge → overlapX < overlapY, moving's min-X is right of target's.
+    const moving = rect(15, 0, 10, 20);
+    const target = rect(0, 0, 20, 20);
+    const hit = sweepRectangle(moving, 0, 0, target);
+
+    expect(hit).not.toBeNull();
+    expect(hit!.t).toBe(0);
+    expect(hit!.normalX).toBe(1);
+    expect(hit!.normalY).toBe(0);
+  });
+
+  test('already overlapping with a smaller Y penetration picks normal via movMinY < tarMinY (-1)', () => {
+    // moving straddles target's top edge → overlapY < overlapX, moving's min-Y is above target's.
+    const moving = rect(0, -5, 20, 10);
+    const target = rect(0, 0, 20, 20);
+    const hit = sweepRectangle(moving, 0, 0, target);
+
+    expect(hit).not.toBeNull();
+    expect(hit!.t).toBe(0);
+    expect(hit!.normalX).toBe(0);
+    expect(hit!.normalY).toBe(-1);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -142,6 +198,20 @@ describe('sweepCircleVsCircle', () => {
 
     expect(hit).not.toBeNull();
     expect(hit!.t).toBe(0);
+  });
+
+  test('already overlapping but not coincident computes a real (dist > 0) normal', () => {
+    // distance (3) < combined radius (10), and the centres are offset — unlike
+    // the coincident-centre case above, this exercises the dist > 0 branch.
+    const moving = circle(0, 0, 5);
+    const target = circle(3, 0, 5);
+    const hit = sweepCircleVsCircle(moving, 0, 0, target);
+
+    expect(hit).not.toBeNull();
+    expect(hit!.t).toBe(0);
+    // dx = moving.x - target.x = 0 - 3 = -3, dist = 3 > 0 → normal = dx/dist = -1.
+    expect(hit!.normalX).toBeCloseTo(-1);
+    expect(hit!.normalY).toBeCloseTo(0);
   });
 
   test('circle approaches on collision course → correct t', () => {
@@ -208,6 +278,15 @@ describe('sweepCircleVsCircle', () => {
 
     expect(hit).toBeNull();
   });
+
+  test('moving toward the target, but not far enough to ever reach it → t > 1 → null', () => {
+    // combined radius = 4, gap = 100 - 4 = 96; delta of 10 only covers t = 9.6.
+    const moving = circle(0, 0, 2);
+    const target = circle(100, 0, 2);
+    const hit = sweepCircleVsCircle(moving, 10, 0, target);
+
+    expect(hit).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -256,6 +335,120 @@ describe('sweepCircleVsRectangle', () => {
 
     expect(hit).toBeNull();
   });
+
+  test('already overlapping from outside the rect (dist > 0 branch)', () => {
+    // Circle centred to the right of the rect's right edge, close enough that
+    // its boundary already overlaps — the closest rect point is not the
+    // circle's own centre, so `dist > 0`.
+    const moving = circle(25, 5, 6);
+    const target = rect(0, 0, 20, 10);
+    const hit = sweepCircleVsRectangle(moving, 0, 0, target);
+
+    expect(hit).not.toBeNull();
+    expect(hit!.t).toBe(0);
+    expect(hit!.normalX).toBeCloseTo(1);
+    expect(hit!.normalY).toBeCloseTo(0);
+  });
+
+  test('circle centre inside the rect picks the Y exit axis when it is the smaller penetration', () => {
+    const moving = circle(10, 2, 1);
+    const target = rect(0, 0, 20, 20);
+    const hit = sweepCircleVsRectangle(moving, 0, 0, target);
+
+    expect(hit).not.toBeNull();
+    expect(hit!.t).toBe(0);
+    expect(hit!.normalX).toBe(0);
+    expect(hit!.normalY).toBe(-1);
+  });
+
+  test('circle centre inside the rect, X exit axis, exitRight is the smaller exit', () => {
+    const moving = circle(15, 10, 1);
+    const target = rect(0, 0, 20, 20);
+    const hit = sweepCircleVsRectangle(moving, 0, 0, target);
+
+    expect(hit).not.toBeNull();
+    expect(hit!.normalX).toBe(1);
+    expect(hit!.normalY).toBe(0);
+  });
+
+  test('circle centre inside the rect, X exit axis, exitLeft is the smaller exit', () => {
+    const moving = circle(3, 10, 1);
+    const target = rect(0, 0, 20, 20);
+    const hit = sweepCircleVsRectangle(moving, 0, 0, target);
+
+    expect(hit).not.toBeNull();
+    expect(hit!.normalX).toBe(-1);
+    expect(hit!.normalY).toBe(0);
+  });
+
+  test('moving toward the top face but not far enough to reach the bottom face time-wise', () => {
+    // tT lands in [0, 1] (hit), but tB overshoots past t = 1 — exercises the
+    // tB-range check's false outcome (unlike the full-traverse top/bottom tests
+    // above, which happen to satisfy both time windows at once).
+    const moving = circle(10, -30, 5);
+    const target = rect(0, 0, 20, 20);
+    const hit = sweepCircleVsRectangle(moving, 0, 40, target);
+
+    expect(hit).not.toBeNull();
+    expect(hit!.t).toBeCloseTo(0.625, 5);
+    expect(hit!.normalY).toBe(-1);
+  });
+
+  test('moving toward the rect too slowly — neither the top nor bottom face time window is reached', () => {
+    const moving = circle(10, -100, 5);
+    const target = rect(0, 0, 20, 20);
+    const hit = sweepCircleVsRectangle(moving, 0, 10, target);
+
+    expect(hit).toBeNull();
+  });
+
+  test('circle centre inside the rect, Y exit axis, exitBottom is the smaller exit', () => {
+    const moving = circle(10, 18, 1);
+    const target = rect(0, 0, 20, 20);
+    const hit = sweepCircleVsRectangle(moving, 0, 0, target);
+
+    expect(hit).not.toBeNull();
+    expect(hit!.normalX).toBe(0);
+    expect(hit!.normalY).toBe(1);
+  });
+
+  test('not overlapping and no movement → null', () => {
+    const moving = circle(100, 100, 1);
+    const target = rect(0, 0, 10, 10);
+    const hit = sweepCircleVsRectangle(moving, 0, 0, target);
+
+    expect(hit).toBeNull();
+  });
+
+  test('circle approaching the right face moving left (flat-face tR branch)', () => {
+    const moving = circle(30, 10, 5);
+    const target = rect(0, 0, 20, 20);
+    const hit = sweepCircleVsRectangle(moving, -100, 0, target);
+
+    expect(hit).not.toBeNull();
+    expect(hit!.normalX).toBe(1);
+    expect(hit!.normalY).toBe(0);
+  });
+
+  test('circle approaching the top face moving down (flat-face tT branch)', () => {
+    const moving = circle(10, -30, 5);
+    const target = rect(0, 0, 20, 20);
+    const hit = sweepCircleVsRectangle(moving, 0, 100, target);
+
+    expect(hit).not.toBeNull();
+    expect(hit!.normalX).toBe(0);
+    expect(hit!.normalY).toBe(-1);
+  });
+
+  test('circle approaching the bottom face moving up (flat-face tB branch)', () => {
+    const moving = circle(10, 50, 5);
+    const target = rect(0, 0, 20, 20);
+    const hit = sweepCircleVsRectangle(moving, 0, -100, target);
+
+    expect(hit).not.toBeNull();
+    expect(hit!.normalX).toBe(0);
+    expect(hit!.normalY).toBe(1);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -296,6 +489,18 @@ describe('sweepRectangleAgainst', () => {
     expect(hit).not.toBeNull();
     expect(hit!.t).toBeCloseTo(0.5, 5);
   });
+
+  test('a later target with a later hit time does not replace the current earliest', () => {
+    const moving = rect(0, 0, 10, 10);
+    const near = rect(20, 0, 10, 10);
+    const far = rect(60, 0, 10, 10);
+    // near listed first this time, so the "far" candidate must fail the
+    // hit.t < earliest.t check instead of setting it.
+    const hit = sweepRectangleAgainst(moving, 100, 0, [near, far]);
+
+    expect(hit).not.toBeNull();
+    expect(hit!.t).toBeCloseTo(0.1, 5);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -335,6 +540,16 @@ describe('sweepCircleAgainst', () => {
 
     expect(hit).not.toBeNull();
     expect(hit!.t).toBeCloseTo(0.5, 5);
+  });
+
+  test('a later target with a later hit time does not replace the current earliest', () => {
+    const moving = circle(0, 0, 2);
+    const near = circle(10, 0, 2);
+    const far = circle(50, 0, 2);
+    const hit = sweepCircleAgainst(moving, 100, 0, [near, far]);
+
+    expect(hit).not.toBeNull();
+    expect(hit!.t).toBeCloseTo(6 / 100, 5);
   });
 });
 

--- a/test/math/triangulate.test.ts
+++ b/test/math/triangulate.test.ts
@@ -188,6 +188,47 @@ test('always returns Uint32Array', () => {
 });
 
 // ---------------------------------------------------------------------------
+// 10. Concave pentagon where the first ear candidate is rejected
+// ---------------------------------------------------------------------------
+
+test('concave arrowhead pentagon → an ear candidate spanning the reflex vertex is rejected, still triangulates', () => {
+  // (0,0) -> (10,0) -> (10,10) -> (5,3) [reflex, points inward] -> (0,10).
+  // The "obvious" ear at (10,0) (triangle (0,0)-(10,0)-(10,10)) is locally
+  // convex (CCW) but contains the reflex vertex (5,3), so isEar() must reject
+  // it and the algorithm must move on to find a valid ear elsewhere.
+  const verts = [0, 0, 10, 0, 10, 10, 5, 3, 0, 10];
+  const result = triangulate(verts);
+
+  expect(result).toBeInstanceOf(Uint32Array);
+  expect(result.length % 3).toBe(0);
+  expect(result.length).toBe(9); // 3 triangles
+  expectAllCcw(verts, result);
+});
+
+// ---------------------------------------------------------------------------
+// 11. Irregular concave decagon exercising pointInTriangle's "sole d3 positive" path
+// ---------------------------------------------------------------------------
+
+test('irregular concave decagon (found via search) still triangulates cleanly', () => {
+  // pointInTriangle()'s `hasPos = d1 > 0 || d2 > 0 || d3 > 0` short-circuits
+  // whenever d1 or d2 alone already determines the outcome; this specific
+  // (deliberately irregular) 10-vertex polygon was found by a randomized
+  // search over concave shapes to be one where d1 <= 0 and d2 <= 0 for some
+  // ear candidate, forcing d3 to be evaluated and be the sole positive term.
+  const verts = [
+    5.389492029971207, 0, 6.212573802756832, 4.513699076074827, 4.274168271560207, 13.154537324497655, -6.140227506262378, 18.897677110534385,
+    -15.71425141785387, 11.41707195083938, -9.86079931485504, 1.2075996317971638e-15, -15.638609760820472, -11.362115070115815, -2.3784531256734933,
+    -7.320126028828331, 4.1528337407457485, -12.781108036519122, 9.465984076706368, -6.87744000114874,
+  ];
+  const result = triangulate(verts);
+
+  expect(result).toBeInstanceOf(Uint32Array);
+  expect(result.length % 3).toBe(0);
+  expect(result.length).toBe(24); // 8 triangles
+  expectAllCcw(verts, result);
+});
+
+// ---------------------------------------------------------------------------
 // 9. Length is always a multiple of 3
 // ---------------------------------------------------------------------------
 

--- a/test/math/utils.test.ts
+++ b/test/math/utils.test.ts
@@ -1,0 +1,325 @@
+import {
+  bezierCurveTo,
+  clamp,
+  DEGREES_PER_RADIAN,
+  degreesToRadians,
+  getDistance,
+  getVoronoiRegion,
+  inRange,
+  isPowerOfTwo,
+  lerp,
+  MathUtils,
+  quadraticCurveTo,
+  RADIANS_PER_DEGREE,
+  radiansToDegrees,
+  sign,
+  TAU,
+  trimRotation,
+  VoronoiRegion,
+} from '#math/utils';
+import { Vector } from '#math/Vector';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+describe('constants', () => {
+  test('TAU is 2*PI', () => {
+    expect(TAU).toBeCloseTo(Math.PI * 2);
+  });
+
+  test('RADIANS_PER_DEGREE / DEGREES_PER_RADIAN are inverse factors', () => {
+    expect(RADIANS_PER_DEGREE * DEGREES_PER_RADIAN).toBeCloseTo(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// trimRotation
+// ---------------------------------------------------------------------------
+
+describe('trimRotation', () => {
+  test('a value already in [0, 360) is unchanged', () => {
+    expect(trimRotation(45)).toBe(45);
+  });
+
+  test('a value >= 360 wraps into range', () => {
+    expect(trimRotation(400)).toBe(40);
+  });
+
+  test('a negative value wraps into the positive range', () => {
+    expect(trimRotation(-90)).toBe(270);
+  });
+
+  test('exactly 360 wraps to 0', () => {
+    expect(trimRotation(360)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// degreesToRadians / radiansToDegrees
+// ---------------------------------------------------------------------------
+
+describe('degreesToRadians', () => {
+  test('180 degrees is PI radians', () => {
+    expect(degreesToRadians(180)).toBeCloseTo(Math.PI);
+  });
+
+  test('0 degrees is 0 radians', () => {
+    expect(degreesToRadians(0)).toBe(0);
+  });
+});
+
+describe('radiansToDegrees', () => {
+  test('PI radians is 180 degrees', () => {
+    expect(radiansToDegrees(Math.PI)).toBeCloseTo(180);
+  });
+
+  test('0 radians is 0 degrees', () => {
+    expect(radiansToDegrees(0)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clamp
+// ---------------------------------------------------------------------------
+
+describe('clamp', () => {
+  test('value within range is unchanged', () => {
+    expect(clamp(5, 0, 10)).toBe(5);
+  });
+
+  test('value below min is clamped to min', () => {
+    expect(clamp(-5, 0, 10)).toBe(0);
+  });
+
+  test('value above max is clamped to max', () => {
+    expect(clamp(15, 0, 10)).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sign
+// ---------------------------------------------------------------------------
+
+describe('sign', () => {
+  test('positive value returns 1', () => {
+    expect(sign(5)).toBe(1);
+  });
+
+  test('negative value returns -1', () => {
+    expect(sign(-5)).toBe(-1);
+  });
+
+  test('strict zero returns 0', () => {
+    expect(sign(0)).toBe(0);
+  });
+
+  test('negative zero short-circuits through the falsy `value &&` guard (stays -0, not -1)', () => {
+    // `value && (value < 0 ? -1 : 1)` short-circuits on any falsy `value`
+    // (0 or -0) and returns that value as-is, rather than -1 or 1.
+    expect(Object.is(sign(-0), -0)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lerp
+// ---------------------------------------------------------------------------
+
+describe('lerp', () => {
+  test('ratio 0 returns the start value', () => {
+    expect(lerp(10, 20, 0)).toBe(10);
+  });
+
+  test('ratio 1 returns the end value', () => {
+    expect(lerp(10, 20, 1)).toBe(20);
+  });
+
+  test('ratio 0.5 returns the midpoint', () => {
+    expect(lerp(10, 20, 0.5)).toBeCloseTo(15);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isPowerOfTwo
+// ---------------------------------------------------------------------------
+
+describe('isPowerOfTwo', () => {
+  test('powers of two return true', () => {
+    expect(isPowerOfTwo(1)).toBe(true);
+    expect(isPowerOfTwo(2)).toBe(true);
+    expect(isPowerOfTwo(1024)).toBe(true);
+  });
+
+  test('non-powers of two return false', () => {
+    expect(isPowerOfTwo(3)).toBe(false);
+    expect(isPowerOfTwo(100)).toBe(false);
+  });
+
+  test('zero returns false', () => {
+    expect(isPowerOfTwo(0)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inRange
+// ---------------------------------------------------------------------------
+
+describe('inRange', () => {
+  test('value within [min, max] returns true', () => {
+    expect(inRange(5, 0, 10)).toBe(true);
+  });
+
+  test('value outside [min, max] returns false', () => {
+    expect(inRange(50, 0, 10)).toBe(false);
+  });
+
+  test('works when min > max (reversed bounds)', () => {
+    expect(inRange(5, 10, 0)).toBe(true);
+    expect(inRange(50, 10, 0)).toBe(false);
+  });
+
+  test('boundary values are inclusive', () => {
+    expect(inRange(0, 0, 10)).toBe(true);
+    expect(inRange(10, 0, 10)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getDistance
+// ---------------------------------------------------------------------------
+
+describe('getDistance', () => {
+  test('computes the Euclidean distance between two points', () => {
+    expect(getDistance(0, 0, 3, 4)).toBe(5);
+  });
+
+  test('distance between identical points is 0', () => {
+    expect(getDistance(1, 1, 1, 1)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bezierCurveTo
+// ---------------------------------------------------------------------------
+
+describe('bezierCurveTo', () => {
+  test('pushes the starting point first, then len samples (default len=20)', () => {
+    const path = bezierCurveTo(0, 0, 5, 10, 15, 10, 20, 0);
+
+    // 1 start point + 20 sampled points = 21 (x, y) pairs.
+    expect(path.length).toBe(21 * 2);
+    expect(path[0]).toBe(0);
+    expect(path[1]).toBe(0);
+  });
+
+  test('the final sampled point matches the curve endpoint', () => {
+    const path = bezierCurveTo(0, 0, 5, 10, 15, 10, 20, 0);
+
+    expect(path[path.length - 2]).toBeCloseTo(20);
+    expect(path[path.length - 1]).toBeCloseTo(0);
+  });
+
+  test('appends to a provided path array instead of creating a new one', () => {
+    const existing = [1, 2];
+    const path = bezierCurveTo(0, 0, 5, 10, 15, 10, 20, 0, existing, 5);
+
+    expect(path).toBe(existing);
+    expect(path[0]).toBe(1);
+    expect(path[1]).toBe(2);
+    // 2 existing + 1 start pair (2) + 5 sampled pairs (10) = 14 values.
+    expect(path.length).toBe(14);
+  });
+
+  test('respects a custom sample count', () => {
+    const path = bezierCurveTo(0, 0, 5, 10, 15, 10, 20, 0, [], 4);
+
+    // 1 start + 4 samples = 5 pairs.
+    expect(path.length).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// quadraticCurveTo
+// ---------------------------------------------------------------------------
+
+describe('quadraticCurveTo', () => {
+  test('produces len + 1 samples (default len=20), including both endpoints', () => {
+    const path = quadraticCurveTo(0, 0, 10, 10, 20, 0);
+
+    // 21 (x, y) pairs.
+    expect(path.length).toBe(21 * 2);
+    expect(path[0]).toBeCloseTo(0);
+    expect(path[1]).toBeCloseTo(0);
+    expect(path[path.length - 2]).toBeCloseTo(20);
+    expect(path[path.length - 1]).toBeCloseTo(0);
+  });
+
+  test('appends to a provided path array instead of creating a new one', () => {
+    const existing = [7, 8];
+    const path = quadraticCurveTo(0, 0, 10, 10, 20, 0, existing, 4);
+
+    expect(path).toBe(existing);
+    expect(path[0]).toBe(7);
+    expect(path[1]).toBe(8);
+    // 2 existing + 5 pairs (len+1=5) = 12 values.
+    expect(path.length).toBe(12);
+  });
+
+  test('respects a custom sample count', () => {
+    const path = quadraticCurveTo(0, 0, 10, 10, 20, 0, [], 2);
+
+    // len + 1 = 3 pairs.
+    expect(path.length).toBe(6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getVoronoiRegion
+// ---------------------------------------------------------------------------
+
+describe('getVoronoiRegion', () => {
+  test('point before the line start classifies as left', () => {
+    const line = new Vector(10, 0);
+    const point = new Vector(-5, 0);
+
+    expect(getVoronoiRegion(line, point)).toBe(VoronoiRegion.left);
+
+    line.destroy();
+    point.destroy();
+  });
+
+  test('point past the line end classifies as right', () => {
+    const line = new Vector(10, 0);
+    const point = new Vector(20, 0);
+
+    expect(getVoronoiRegion(line, point)).toBe(VoronoiRegion.right);
+
+    line.destroy();
+    point.destroy();
+  });
+
+  test('point projecting onto the segment classifies as middle', () => {
+    const line = new Vector(10, 0);
+    const point = new Vector(5, 3);
+
+    expect(getVoronoiRegion(line, point)).toBe(VoronoiRegion.middle);
+
+    line.destroy();
+    point.destroy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MathUtils facade
+// ---------------------------------------------------------------------------
+
+describe('MathUtils', () => {
+  test('exposes the angle/curve/geometry helpers by reference', () => {
+    expect(MathUtils.distance).toBe(getDistance);
+    expect(MathUtils.trimRotation).toBe(trimRotation);
+    expect(MathUtils.degreesToRadians).toBe(degreesToRadians);
+    expect(MathUtils.radiansToDegrees).toBe(radiansToDegrees);
+    expect(MathUtils.bezierCurveTo).toBe(bezierCurveTo);
+    expect(MathUtils.quadraticCurveTo).toBe(quadraticCurveTo);
+  });
+});

--- a/test/math/vector.test.ts
+++ b/test/math/vector.test.ts
@@ -1,0 +1,516 @@
+import { Circle } from '#math/Circle';
+import { CollisionType } from '#math/Collision';
+import { Ellipse } from '#math/Ellipse';
+import { Interval } from '#math/Interval';
+import { Line } from '#math/Line';
+import { Matrix } from '#math/Matrix';
+import { Polygon } from '#math/Polygon';
+import { Rectangle } from '#math/Rectangle';
+import { Vector } from '#math/Vector';
+
+describe('Vector construction', () => {
+  test('defaults to (0, 0)', () => {
+    const v = new Vector();
+
+    expect(v.x).toBe(0);
+    expect(v.y).toBe(0);
+  });
+
+  test('accepts explicit x/y', () => {
+    const v = new Vector(3, 4);
+
+    expect(v.x).toBe(3);
+    expect(v.y).toBe(4);
+  });
+
+  test('collisionType is Point', () => {
+    expect(new Vector().collisionType).toBe(CollisionType.Point);
+  });
+});
+
+describe('Vector.clone()', () => {
+  test('returns a distinct instance with equal components', () => {
+    const v = new Vector(1, 2);
+    const c = v.clone();
+
+    expect(c).not.toBe(v);
+    expect(c.x).toBe(1);
+    expect(c.y).toBe(2);
+  });
+});
+
+describe('Vector.copy()', () => {
+  test('copies x/y from another vector', () => {
+    const v = new Vector(0, 0);
+    const source = new Vector(9, 8);
+
+    const result = v.copy(source);
+
+    expect(v.x).toBe(9);
+    expect(v.y).toBe(8);
+    expect(result).toBe(v);
+  });
+});
+
+describe('Vector.intersectsWith()', () => {
+  test('dispatches to SceneNode handling via getBounds()', () => {
+    const point = new Vector(5, 5);
+    const fakeSceneNode = {
+      collisionType: CollisionType.SceneNode,
+      getBounds: (): Rectangle => new Rectangle(0, 0, 10, 10),
+    };
+
+    expect(point.intersectsWith(fakeSceneNode as never)).toBe(true);
+    expect(new Vector(50, 50).intersectsWith(fakeSceneNode as never)).toBe(false);
+  });
+
+  test('dispatches to Rectangle handling', () => {
+    expect(new Vector(5, 5).intersectsWith(new Rectangle(0, 0, 10, 10))).toBe(true);
+    expect(new Vector(50, 50).intersectsWith(new Rectangle(0, 0, 10, 10))).toBe(false);
+  });
+
+  test('dispatches to Polygon handling', () => {
+    const square = new Polygon([new Vector(0, 0), new Vector(10, 0), new Vector(10, 10), new Vector(0, 10)]);
+
+    expect(new Vector(5, 5).intersectsWith(square)).toBe(true);
+    expect(new Vector(50, 50).intersectsWith(square)).toBe(false);
+  });
+
+  test('dispatches to Circle handling', () => {
+    expect(new Vector(1, 0).intersectsWith(new Circle(0, 0, 5))).toBe(true);
+    expect(new Vector(100, 0).intersectsWith(new Circle(0, 0, 5))).toBe(false);
+  });
+
+  test('dispatches to Ellipse handling', () => {
+    expect(new Vector(0, 0).intersectsWith(new Ellipse(0, 0, 10, 5))).toBe(true);
+    expect(new Vector(100, 100).intersectsWith(new Ellipse(0, 0, 10, 5))).toBe(false);
+  });
+
+  test('dispatches to Line handling', () => {
+    expect(new Vector(5, 0).intersectsWith(new Line(0, 0, 10, 0))).toBe(true);
+    expect(new Vector(5, 5).intersectsWith(new Line(0, 0, 10, 0))).toBe(false);
+  });
+
+  test('dispatches to Point handling', () => {
+    expect(new Vector(1, 1).intersectsWith(new Vector(1, 1))).toBe(true);
+    expect(new Vector(0, 0).intersectsWith(new Vector(1, 0))).toBe(false);
+  });
+
+  test('unknown collisionType falls through to the default false branch', () => {
+    const unknown = { collisionType: -1 as CollisionType };
+
+    expect(new Vector(0, 0).intersectsWith(unknown as never)).toBe(false);
+  });
+});
+
+describe('Vector.collidesWith()', () => {
+  test('always returns null (points carry no penetration/response data)', () => {
+    expect(new Vector(0, 0).collidesWith(new Vector(0, 0))).toBeNull();
+  });
+});
+
+describe('Vector.getBounds()', () => {
+  test('returns a zero-sized rectangle at the point', () => {
+    const bounds = new Vector(3, 4).getBounds();
+
+    expect(bounds.x).toBe(3);
+    expect(bounds.y).toBe(4);
+    expect(bounds.width).toBe(0);
+    expect(bounds.height).toBe(0);
+  });
+});
+
+describe('Vector.contains()', () => {
+  test('true when (x, y) equals the point', () => {
+    expect(new Vector(2, 3).contains(2, 3)).toBe(true);
+  });
+
+  test('false when (x, y) differs from the point', () => {
+    expect(new Vector(2, 3).contains(5, 5)).toBe(false);
+  });
+});
+
+describe('Vector.getNormals()', () => {
+  test('returns a single unit-length normal', () => {
+    const normals = new Vector(3, 4).getNormals();
+
+    expect(normals).toHaveLength(1);
+    expect(normals[0].length).toBeCloseTo(1);
+  });
+});
+
+describe('Vector.project()', () => {
+  test('returns the interval unchanged (a point has no extent)', () => {
+    const interval = new Interval(1, 2);
+    const result = new Vector(5, 5).project(new Vector(1, 0), interval);
+
+    expect(result).toBe(interval);
+    expect(result.min).toBe(1);
+    expect(result.max).toBe(2);
+  });
+
+  test('defaults to a fresh Interval when none is supplied', () => {
+    const result = new Vector(5, 5).project(new Vector(1, 0));
+
+    expect(result).toBeInstanceOf(Interval);
+  });
+});
+
+describe('Vector.destroy()', () => {
+  test('is a no-op and never throws', () => {
+    const v = new Vector(1, 1);
+
+    expect(() => v.destroy()).not.toThrow();
+  });
+});
+
+describe('Vector.temp', () => {
+  test('returns the same shared instance across calls', () => {
+    const a = Vector.temp;
+    const b = Vector.temp;
+
+    expect(a).toBe(b);
+  });
+
+  test('is mutable scratch storage', () => {
+    Vector.temp.set(7, 8);
+
+    expect(Vector.temp.x).toBe(7);
+    expect(Vector.temp.y).toBe(8);
+  });
+});
+
+describe('Vector static sentinels', () => {
+  test('zero is (0, 0)', () => {
+    expect(Vector.zero.x).toBe(0);
+    expect(Vector.zero.y).toBe(0);
+  });
+
+  test('one is (1, 1)', () => {
+    expect(Vector.one.x).toBe(1);
+    expect(Vector.one.y).toBe(1);
+  });
+});
+
+describe('Vector static factories', () => {
+  test('add() returns a new vector without mutating operands', () => {
+    const a = new Vector(1, 2);
+    const b = new Vector(3, 4);
+    const result = Vector.add(a, b);
+
+    expect(result).not.toBe(a);
+    expect(result).not.toBe(b);
+    expect(result.x).toBe(4);
+    expect(result.y).toBe(6);
+    expect(a.x).toBe(1);
+    expect(b.x).toBe(3);
+  });
+
+  test('subtract() returns a new vector without mutating operands', () => {
+    const result = Vector.subtract(new Vector(5, 7), new Vector(2, 3));
+
+    expect(result.x).toBe(3);
+    expect(result.y).toBe(4);
+  });
+
+  test('multiply() returns the component-wise product without mutating operands', () => {
+    const result = Vector.multiply(new Vector(2, 3), new Vector(4, 5));
+
+    expect(result.x).toBe(8);
+    expect(result.y).toBe(15);
+  });
+
+  test('divide() returns the component-wise quotient without mutating operands', () => {
+    const result = Vector.divide(new Vector(10, 9), new Vector(2, 3));
+
+    expect(result.x).toBe(5);
+    expect(result.y).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AbstractVector — exercised through the concrete Vector subclass, since
+// AbstractVector itself cannot be instantiated.
+// ---------------------------------------------------------------------------
+
+describe('AbstractVector.angle', () => {
+  test('getter measures the angle from the positive Y-axis, clockwise', () => {
+    expect(new Vector(0, 1).angle).toBeCloseTo(0);
+    expect(new Vector(1, 0).angle).toBeCloseTo(Math.PI / 2);
+  });
+
+  // BUG (see final report): the getter measures the angle from the positive
+  // Y-axis (`atan2(x, y)`, per the class doc comment), but the setter
+  // reconstructs components using the standard X-axis convention
+  // (`x = cos(angle) * length`, `y = sin(angle) * length`). The two use
+  // incompatible conventions, so the setter does not rotate the vector to the
+  // angle its own getter would report — for a vector at getter-angle 0 (i.e.
+  // pointing along +Y), setting `.angle = Math.PI / 2` should rotate it to
+  // point along +X (5, 0) but instead leaves it at (0, 5), unchanged.
+  test('BUG: angle setter uses a different axis convention than the angle getter, so it does not rotate as documented', () => {
+    const v = new Vector(0, 5);
+
+    expect(v.angle).toBeCloseTo(0); // pointing along +Y reads as angle 0
+
+    v.angle = Math.PI / 2;
+
+    expect(v.length).toBeCloseTo(5); // length is preserved...
+    // ...but expected x=5, y=0 (rotated to point along +X); instead unchanged.
+    expect(v.x).toBeCloseTo(0);
+    expect(v.y).toBeCloseTo(5);
+  });
+});
+
+describe('AbstractVector.length', () => {
+  test('getter returns the Euclidean magnitude', () => {
+    expect(new Vector(3, 4).length).toBe(5);
+  });
+
+  // BUG (see final report): same root cause as the angle-setter bug above.
+  // The length setter reads `this.angle` (Y-axis convention) then
+  // reconstructs via the X-axis convention (`cos` → x, `sin` → y), so
+  // rescaling does not preserve the vector's own angle/direction — for (3, 4)
+  // scaled to length 10, the expected direction-preserving result is (6, 8),
+  // but the setter instead produces (8, 6) (x/y swapped).
+  test('BUG: length setter uses a different axis convention than the angle getter, so it does not preserve direction as documented', () => {
+    const v = new Vector(3, 4);
+
+    v.length = 10;
+
+    expect(v.length).toBeCloseTo(10);
+    // Expected (direction-preserving): x=6, y=8. Actual: swapped.
+    expect(v.x).toBeCloseTo(8);
+    expect(v.y).toBeCloseTo(6);
+  });
+});
+
+describe('AbstractVector.lengthSq', () => {
+  test('getter returns the squared magnitude', () => {
+    expect(new Vector(3, 4).lengthSq).toBe(25);
+  });
+
+  test('setter rescales via the square root of the given value', () => {
+    const v = new Vector(3, 4);
+
+    v.lengthSq = 100;
+
+    expect(v.length).toBeCloseTo(10);
+  });
+});
+
+describe('AbstractVector.set()', () => {
+  test('sets both components explicitly', () => {
+    const v = new Vector();
+
+    expect(v.set(1, 2)).toBe(v);
+    expect(v.x).toBe(1);
+    expect(v.y).toBe(2);
+  });
+
+  test('defaults y to x when omitted', () => {
+    const v = new Vector().set(7);
+
+    expect(v.x).toBe(7);
+    expect(v.y).toBe(7);
+  });
+});
+
+describe('AbstractVector.equals()', () => {
+  test('true when both components match', () => {
+    expect(new Vector(1, 2).equals({ x: 1, y: 2 })).toBe(true);
+  });
+
+  test('false when a component differs', () => {
+    expect(new Vector(1, 2).equals({ x: 1, y: 3 })).toBe(false);
+  });
+
+  test('checks only x when y is omitted', () => {
+    expect(new Vector(1, 2).equals({ x: 1 })).toBe(true);
+    expect(new Vector(1, 2).equals({ x: 5 })).toBe(false);
+  });
+
+  test('checks only y when x is omitted', () => {
+    expect(new Vector(1, 2).equals({ y: 2 })).toBe(true);
+    expect(new Vector(1, 2).equals({ y: 5 })).toBe(false);
+  });
+
+  test('defaults to an empty object, matching any vector', () => {
+    expect(new Vector(1, 2).equals()).toBe(true);
+  });
+});
+
+describe('AbstractVector.add()', () => {
+  test('adds both components explicitly', () => {
+    const v = new Vector(1, 1);
+
+    expect(v.add(2, 3)).toBe(v);
+    expect(v.x).toBe(3);
+    expect(v.y).toBe(4);
+  });
+
+  test('defaults y to x when omitted', () => {
+    const v = new Vector(1, 1).add(5);
+
+    expect(v.x).toBe(6);
+    expect(v.y).toBe(6);
+  });
+});
+
+describe('AbstractVector.subtract()', () => {
+  test('subtracts both components explicitly', () => {
+    const v = new Vector(5, 5);
+
+    expect(v.subtract(1, 2)).toBe(v);
+    expect(v.x).toBe(4);
+    expect(v.y).toBe(3);
+  });
+
+  test('defaults y to x when omitted', () => {
+    const v = new Vector(5, 5).subtract(2);
+
+    expect(v.x).toBe(3);
+    expect(v.y).toBe(3);
+  });
+});
+
+describe('AbstractVector.multiply()', () => {
+  test('multiplies both components explicitly', () => {
+    const v = new Vector(2, 3);
+
+    expect(v.multiply(2, 4)).toBe(v);
+    expect(v.x).toBe(4);
+    expect(v.y).toBe(12);
+  });
+
+  test('defaults y to x when omitted (uniform scale)', () => {
+    const v = new Vector(2, 3).multiply(2);
+
+    expect(v.x).toBe(4);
+    expect(v.y).toBe(6);
+  });
+});
+
+describe('AbstractVector.divide()', () => {
+  test('divides both components explicitly', () => {
+    const v = new Vector(10, 20);
+
+    expect(v.divide(2, 4)).toBe(v);
+    expect(v.x).toBe(5);
+    expect(v.y).toBe(5);
+  });
+
+  test('defaults y to x when omitted', () => {
+    const v = new Vector(10, 20).divide(2);
+
+    expect(v.x).toBe(5);
+    expect(v.y).toBe(10);
+  });
+
+  test('skips the division silently when x is zero', () => {
+    const v = new Vector(10, 20);
+
+    v.divide(0, 5);
+
+    expect(v.x).toBe(10);
+    expect(v.y).toBe(20);
+  });
+
+  test('skips the division silently when y is zero', () => {
+    const v = new Vector(10, 20);
+
+    v.divide(2, 0);
+
+    expect(v.x).toBe(10);
+    expect(v.y).toBe(20);
+  });
+});
+
+describe('AbstractVector.normalize()', () => {
+  test('scales the vector to unit length', () => {
+    const v = new Vector(3, 4).normalize();
+
+    expect(v.length).toBeCloseTo(1);
+  });
+
+  test('is a no-op on the zero vector (avoids division by zero)', () => {
+    const v = new Vector(0, 0).normalize();
+
+    expect(v.x).toBe(0);
+    expect(v.y).toBe(0);
+  });
+});
+
+describe('AbstractVector.invert()', () => {
+  test('negates both components', () => {
+    const v = new Vector(3, -4).invert();
+
+    expect(v.x).toBe(-3);
+    expect(v.y).toBe(4);
+  });
+});
+
+describe('AbstractVector.transform() / transformInverse()', () => {
+  test('applies an affine matrix to the vector', () => {
+    const matrix = new Matrix(2, 0, 10, 0, 2, 20);
+    const v = new Vector(3, 4).transform(matrix);
+
+    expect(v.x).toBe(2 * 3 + 0 * 4 + 10);
+    expect(v.y).toBe(0 * 3 + 2 * 4 + 20);
+  });
+
+  test('transformInverse() undoes transform() for an invertible matrix', () => {
+    const matrix = new Matrix(2, 0, 10, 0, 2, 20);
+    const original = new Vector(3, 4);
+    const roundTripped = original.clone().transform(matrix).transformInverse(matrix);
+
+    expect(roundTripped.x).toBeCloseTo(original.x);
+    expect(roundTripped.y).toBeCloseTo(original.y);
+  });
+});
+
+describe('AbstractVector.perp() / rperp()', () => {
+  test('perp() rotates 90 degrees counter-clockwise: (-y, x)', () => {
+    const v = new Vector(3, 4).perp();
+
+    expect(v.x).toBe(-4);
+    expect(v.y).toBe(3);
+  });
+
+  test('rperp() rotates 90 degrees clockwise: (y, -x)', () => {
+    const v = new Vector(3, 4).rperp();
+
+    expect(v.x).toBe(4);
+    expect(v.y).toBe(-3);
+  });
+});
+
+describe('AbstractVector.min() / max()', () => {
+  test('min() returns the smaller component', () => {
+    expect(new Vector(3, 7).min()).toBe(3);
+    expect(new Vector(7, 3).min()).toBe(3);
+  });
+
+  test('max() returns the larger component', () => {
+    expect(new Vector(3, 7).max()).toBe(7);
+    expect(new Vector(7, 3).max()).toBe(7);
+  });
+});
+
+describe('AbstractVector.dot()', () => {
+  test('computes the dot product with explicit components', () => {
+    expect(new Vector(2, 3).dot(4, 5)).toBe(2 * 4 + 3 * 5);
+  });
+});
+
+describe('AbstractVector.cross()', () => {
+  test('computes the 2D cross product (scalar z-component)', () => {
+    expect(new Vector(1, 0).cross(new Vector(0, 1))).toBe(1);
+    expect(new Vector(0, 1).cross(new Vector(1, 0))).toBe(-1);
+  });
+});
+
+describe('AbstractVector.distanceTo()', () => {
+  test('computes the Euclidean distance between two vectors', () => {
+    expect(new Vector(0, 0).distanceTo(new Vector(3, 4))).toBe(5);
+  });
+});

--- a/test/math/vector.test.ts
+++ b/test/math/vector.test.ts
@@ -234,30 +234,21 @@ describe('Vector static factories', () => {
 // ---------------------------------------------------------------------------
 
 describe('AbstractVector.angle', () => {
-  test('getter measures the angle from the positive Y-axis, clockwise', () => {
-    expect(new Vector(0, 1).angle).toBeCloseTo(0);
-    expect(new Vector(1, 0).angle).toBeCloseTo(Math.PI / 2);
+  test('getter measures the angle from the positive X-axis, like PolarVector.phi', () => {
+    expect(new Vector(1, 0).angle).toBeCloseTo(0);
+    expect(new Vector(0, 1).angle).toBeCloseTo(Math.PI / 2);
   });
 
-  // BUG (see final report): the getter measures the angle from the positive
-  // Y-axis (`atan2(x, y)`, per the class doc comment), but the setter
-  // reconstructs components using the standard X-axis convention
-  // (`x = cos(angle) * length`, `y = sin(angle) * length`). The two use
-  // incompatible conventions, so the setter does not rotate the vector to the
-  // angle its own getter would report — for a vector at getter-angle 0 (i.e.
-  // pointing along +Y), setting `.angle = Math.PI / 2` should rotate it to
-  // point along +X (5, 0) but instead leaves it at (0, 5), unchanged.
-  test('BUG: angle setter uses a different axis convention than the angle getter, so it does not rotate as documented', () => {
+  test('setter rotates the vector to the new angle while preserving length', () => {
     const v = new Vector(0, 5);
 
-    expect(v.angle).toBeCloseTo(0); // pointing along +Y reads as angle 0
+    expect(v.angle).toBeCloseTo(Math.PI / 2); // pointing along +Y
 
-    v.angle = Math.PI / 2;
+    v.angle = 0;
 
-    expect(v.length).toBeCloseTo(5); // length is preserved...
-    // ...but expected x=5, y=0 (rotated to point along +X); instead unchanged.
-    expect(v.x).toBeCloseTo(0);
-    expect(v.y).toBeCloseTo(5);
+    expect(v.length).toBeCloseTo(5);
+    expect(v.x).toBeCloseTo(5);
+    expect(v.y).toBeCloseTo(0);
   });
 });
 
@@ -266,21 +257,14 @@ describe('AbstractVector.length', () => {
     expect(new Vector(3, 4).length).toBe(5);
   });
 
-  // BUG (see final report): same root cause as the angle-setter bug above.
-  // The length setter reads `this.angle` (Y-axis convention) then
-  // reconstructs via the X-axis convention (`cos` → x, `sin` → y), so
-  // rescaling does not preserve the vector's own angle/direction — for (3, 4)
-  // scaled to length 10, the expected direction-preserving result is (6, 8),
-  // but the setter instead produces (8, 6) (x/y swapped).
-  test('BUG: length setter uses a different axis convention than the angle getter, so it does not preserve direction as documented', () => {
+  test('setter rescales the vector while preserving its direction', () => {
     const v = new Vector(3, 4);
 
     v.length = 10;
 
     expect(v.length).toBeCloseTo(10);
-    // Expected (direction-preserving): x=6, y=8. Actual: swapped.
-    expect(v.x).toBeCloseTo(8);
-    expect(v.y).toBeCloseTo(6);
+    expect(v.x).toBeCloseTo(6);
+    expect(v.y).toBeCloseTo(8);
   });
 });
 

--- a/test/rendering/text/text-layout.test.ts
+++ b/test/rendering/text/text-layout.test.ts
@@ -284,10 +284,6 @@ describe('layoutText', () => {
   });
 
   test('align "justify" distributes extra space across inter-word gaps on non-last lines', () => {
-    // The source detects "start of a new word" by comparing a glyph's advance
-    // to the space glyph's advance — so the mock atlas must give the space a
-    // *different* advance than letters, or every character looks like a word
-    // start (uniform-advance atlases can't exercise this branch).
     const letterAdvance = 10;
     const spaceAdvance = 5;
     const atlas = {
@@ -322,6 +318,30 @@ describe('layoutText', () => {
     expect(firstLine).toHaveLength(3);
     const bPlacement = firstLine.at(-1)!;
     expect(bPlacement.x).toBe(40); // 15 natural + 25 stretch (extraPerGap = (50 - 25) / 1)
+  });
+
+  test('align "justify" works with a uniform-advance (monospace) atlas', () => {
+    // Word boundaries must be detected from the characters themselves, not by
+    // comparing advances against the space glyph — with a monospace atlas every
+    // glyph shares the space's advance, which used to defeat gap detection.
+    const advance = 10;
+    const atlas = makeAtlas(advance);
+    const style = new TextStyle({ fontSize: 16, align: 'justify' });
+
+    // _wrapLine (maxWidth 30): "A B" (30px) fits on line 0; "CCCCC" (50px,
+    // over budget but unbreakable without breakWords) becomes line 1 — the
+    // widest realized line, so line 0 has slack to distribute.
+    const placements = layoutText('A B CCCCC', style, { maxWidth: 30 }, atlas);
+
+    const lineYs = [...new Set(placements.map(p => p.y))];
+    expect(lineYs).toHaveLength(2);
+
+    // First line contains 'A', ' ', 'B' — the justified gap must stretch "B"
+    // beyond its natural position of 20px: extraPerGap = (50 - 30) / 1 = 20.
+    const firstLine = placements.filter(p => p.y === lineYs[0]);
+    expect(firstLine).toHaveLength(3);
+    expect(firstLine[0]!.x).toBe(0); // first word stays anchored at the left edge
+    expect(firstLine.at(-1)!.x).toBe(40);
   });
 
   test('align "justify" does not stretch the last line', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -108,17 +108,17 @@ export default defineConfig({
       // itself (the exact command the CI job runs) below the floor.
       //
       // A ratchet floor, not a target: set a few points below the measured
-      // baseline (statements 79.46%, branches 70.00%, functions 78.87%, lines
-      // 79.84% as of 2026-07-04 after the coverage-fleet pass, core + all
-      // extension packages) so normal test-suite churn doesn't flake the
+      // baseline (statements 80.83%, branches 72.28%, functions 81.88%, lines
+      // 81.24% as of 2026-07-04 after the src/math full-coverage pass, core +
+      // all extension packages) so normal test-suite churn doesn't flake the
       // gate, while still catching a real regression. Raise the floor as
       // coverage grows — never lower it without an explicit reason recorded
       // here.
       thresholds: {
-        statements: 77,
-        branches: 67,
-        functions: 76,
-        lines: 77,
+        statements: 78,
+        branches: 70,
+        functions: 79,
+        lines: 79,
       },
     },
     projects: [


### PR DESCRIPTION
## Engine bug fixes

**The four pinned from PR #250:**
- `intersectionCirclePoly`: the circle frame transform was sign-inverted (`poly - circle` instead of `circle - poly`), so circles deep inside a polygon or overlapping most edges/vertices reported no hit; a second defect in the right-Voronoi exclusion measured the distance to the *current* vertex instead of the *next* one. Both now mirror the correct sibling `getCollisionPolygonCircle`.
- `getCollisionCircleCircle`: `projectionV` was the unnormalized center delta scaled by overlap (magnitude `distance*overlap`); now `projectionN * overlap` like every other `getCollision*`.
- `Polygon.project()`: honours the polygon x/y position, fixing all SAT paths for positioned polygons.
- `TextLayout` justify: word boundaries via `char === '' ''` instead of advance comparison with the space glyph (broken for monospace atlases).

**Three more found by the coverage fleet:**
- `intersectionPointPoly` ignored the polygon x/y offset → `Polygon.contains()` wrong for positioned polygons.
- `AbstractVector.angle` getter used `atan2(x, y)` (Y-axis convention) while all consumers (angle/length setters, `PolarVector`) use the X-axis convention → getter now `atan2(y, x)`, restoring the documented `PolarVector.fromVector(v).toVector()` round-trip. Pre-1.0 clean break; API docs regenerated.
- `ObservableVector` overrode only the *setters* of `angle`/`length`, shadowing the inherited getters (reads returned `undefined`, setters NaNed the vector). Getters are now redeclared alongside the overrides.

## src/math full coverage

Four worktree-isolated agents brought all 24 `src/math` files to 100% lines/branches/functions (three files have individually documented unreachable defensive branches, proven via randomized search or structural argument). `test/math` grows from 236 to 784 tests; suite total 5,690. Coverage ratchet raised 77/67/76/77 → **78/70/79/79** (measured: 80.83/72.28/81.88/81.24).

## Example follow-ups (user acceptance from #249)

- **spatial-audio ×2**: instrumented measurement (channel-split RMS on the master tap in headless Chromium) proved the spatial chain works — the inaudibility was the source material (`impact-light.ogg`: 0.16s one-shot, 67% silence). Both examples now use `demo-loop-main.ogg` (5s continuous loop); the orbit sweep shows continuous RMS on the correct channel throughout.
- **asset-browser**: lazy per-category loading (only the initial category fetched before first frame, loading placeholder for the rest).
- **video-drawable**: all four catalog videos switchable via keys 1–4, lazy-loaded on first selection.

All examples verified interactively in headless Chromium through the preview harness.