### PR TITLE
fix(ci): align main to 0.15.1, gate unit lane on root changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 # ExoJS
 
 [![Latest](https://img.shields.io/github/v/release/Exoridus/ExoJS?style=for-the-badge&label=Latest&logo=github&color=44cc11)](https://github.com/Exoridus/ExoJS/releases/latest)
-[![npm](https://img.shields.io/npm/v/%40codexo%2Fexojs?style=for-the-badge&logo=npm&label=npm&color=cb3837)](https://www.npmjs.com/package/@codexo/exojs)
+[![npm](https://img.shields.io/npm/v/%40codexo%2Fexojs?style=for-the-badge&logo=npm&label=npm&color=44cc11)](https://www.npmjs.com/package/@codexo/exojs)
 [![CI](https://img.shields.io/github/actions/workflow/status/Exoridus/ExoJS/ci.yml?branch=main&style=for-the-badge&logo=githubactions&logoColor=fff&label=CI)](https://github.com/Exoridus/ExoJS/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/codecov/c/github/Exoridus/ExoJS?style=for-the-badge&logo=codecov&logoColor=fff&label=Coverage)](https://app.codecov.io/gh/Exoridus/ExoJS)
-[![License](https://img.shields.io/github/license/Exoridus/ExoJS?style=for-the-badge&color=1a1e23)](https://github.com/Exoridus/ExoJS/blob/main/LICENSE)
+[![License](https://img.shields.io/github/license/Exoridus/ExoJS?style=for-the-badge&color=44cc11)](https://github.com/Exoridus/ExoJS/blob/main/LICENSE)
 
 A TypeScript-first 2D engine for games and interactive apps. Explicit scene graph, WebGPU/WebGL2 rendering, native physics, spatial audio, and a strict type system — measured and verified, not just claimed.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@codexo/exojs",
   "description": "A TypeScript-first browser 2D runtime for games and interactive apps.",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "type": "module",
   "packageManager": "pnpm@11.4.0",
   "files": [

--- a/packages/exojs-aseprite/package.json
+++ b/packages/exojs-aseprite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexo/exojs-aseprite",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Aseprite sprite sheet asset extension for ExoJS.",
   "repository": {
     "type": "git",

--- a/packages/exojs-audio-fx/package.json
+++ b/packages/exojs-audio-fx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexo/exojs-audio-fx",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Audio effects, DSP, beat detection and analysis for ExoJS.",
   "repository": {
     "type": "git",

--- a/packages/exojs-ldtk/package.json
+++ b/packages/exojs-ldtk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexo/exojs-ldtk",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "LDtk level format asset extension for ExoJS.",
   "repository": {
     "type": "git",

--- a/packages/exojs-particles/package.json
+++ b/packages/exojs-particles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexo/exojs-particles",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Particle system extension for ExoJS.",
   "repository": {
     "type": "git",

--- a/packages/exojs-physics/package.json
+++ b/packages/exojs-physics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexo/exojs-physics",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Native 2D collision, query and sensor runtime for ExoJS.",
   "repository": {
     "type": "git",

--- a/packages/exojs-react/package.json
+++ b/packages/exojs-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexo/exojs-react",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "React integration for ExoJS.",
   "repository": {
     "type": "git",

--- a/packages/exojs-tiled/package.json
+++ b/packages/exojs-tiled/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexo/exojs-tiled",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Tiled map format asset extension for ExoJS.",
   "repository": {
     "type": "git",

--- a/packages/exojs-tilemap/package.json
+++ b/packages/exojs-tilemap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexo/exojs-tilemap",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Generic, format-independent tilemap runtime for ExoJS.",
   "repository": {
     "type": "git",

--- a/scripts/ci/select-lanes.mjs
+++ b/scripts/ci/select-lanes.mjs
@@ -96,6 +96,10 @@ const isEnginePath = file => {
   if (file === 'tsconfig.json' || file === 'tsconfig.test.json' || file === 'tsconfig.eslint.json') return true;
   // Root manifest + lockfile + workspace topology all affect the whole build.
   if (file === 'package.json' || file === 'pnpm-lock.yaml' || file === 'pnpm-workspace.yaml') return true;
+  // The release version-coherence tests derive expectations from the root
+  // CHANGELOG, so a changelog-only PR must still run the unit lane (a docs-only
+  // changelog edit once skipped it and the mismatch only failed on main).
+  if (file === 'CHANGELOG.md') return true;
   // Runtime-package CODE (source, tests, build config, manifest) — but not docs.
   for (const pkg of RUNTIME_PACKAGES) {
     if (file.startsWith(`packages/${pkg}/`) && !isPackageDocPath(file)) return true;

--- a/test/ci/select-lanes.test.ts
+++ b/test/ci/select-lanes.test.ts
@@ -86,6 +86,10 @@ describe('CI lane selection — engine/site areas', () => {
     expect(selectAreas(['packages/exojs-particles/CHANGELOG.md'])).toEqual({ engine: false, site: true, audioFx: false });
   });
 
+  it('the ROOT changelog gates the engine lane (release version-coherence tests read it)', () => {
+    expect(selectAreas(['CHANGELOG.md']).engine).toBe(true);
+  });
+
   it('core engine SOURCE change keeps existing behavior (engine lanes, no site)', () => {
     const { areas, lanes } = decide('src/rendering/Drawable.ts');
     expect(areas).toEqual({ engine: true, site: false, audioFx: false });


### PR DESCRIPTION
Repairs the failing CI on main after the 0.15.1 hotfix release:

- The hotfix was cut on `release/0.15.x`, so main kept `0.15.0` package versions while #252 ported the `[0.15.1]` changelog section. The version-coherence release tests (changelog head vs. root package.json) failed on the main push — the docs-only PR run had skipped the unit lane because `CHANGELOG.md` did not gate it.
- Cherry-picks the lockstep bump (`chore(release): bump to 0.15.1`) onto main.
- `select-lanes.mjs`: the ROOT changelog now gates the engine lane, with a regression test, so changelog PRs run the coherence tests before merging.
- README: npm/license badges switched to green — brand-red npm reads as a failing badge in a status row (user feedback).

Verified locally: `test/ci` + `test/release` green (94 tests), `verify:lockstep` reports all 9 packages at 0.15.1.