### PR TITLE
Fleet 4: +440 tests across all extension packages, three package bugs fixed

### DIFF
--- a/packages/exojs-aseprite/test/aseprite-binding.test.ts
+++ b/packages/exojs-aseprite/test/aseprite-binding.test.ts
@@ -109,6 +109,20 @@ describe('asepriteBinding.load — array fixture', () => {
     const sheet = await handler.load({ source: 'sprites/hero.json' }, context);
     expect(sheet.spritesheet.frames.size).toBe(3);
   });
+
+  it('resolves a relative image ref against an absolute (scheme-qualified) source URL', async () => {
+    const { context, loaderLoad } = makeContext({ 'https://cdn.example.com/sprites/hero.json': loadFixture('hero.array.json') });
+    const handler = asepriteBinding.create();
+    await handler.load({ source: 'https://cdn.example.com/sprites/hero.json' }, context);
+    expect(loaderLoad).toHaveBeenCalledWith(Texture, 'https://cdn.example.com/sprites/hero.png');
+  });
+
+  it('resolves a relative image ref against a root-relative source, preserving the leading slash', async () => {
+    const { context, loaderLoad } = makeContext({ '/assets/sprites/hero.json': loadFixture('hero.array.json') });
+    const handler = asepriteBinding.create();
+    await handler.load({ source: '/assets/sprites/hero.json' }, context);
+    expect(loaderLoad).toHaveBeenCalledWith(Texture, '/assets/sprites/hero.png');
+  });
 });
 
 // ── load() — validation / AsepriteFormatError ───────────────────────────────────

--- a/packages/exojs-audio-fx/test/audio-analyser.test.ts
+++ b/packages/exojs-audio-fx/test/audio-analyser.test.ts
@@ -18,6 +18,54 @@ function makeMediaStream(): MediaStream {
   return { getTracks: () => [] } as unknown as MediaStream;
 }
 
+/**
+ * Runs `run` against a fresh copy of the `@codexo/exojs` module registry (via
+ * `vi.resetModules()` + dynamic import) backed by an `AudioContext` that starts
+ * `'suspended'` instead of the shared mock's default `'running'`.
+ *
+ * The shared mock AudioContext (see `test/setup-env.vitest.ts`) starts
+ * `'running'` immediately, which means `onAudioContextReady.add()`/`.once()`
+ * dispatch synchronously the very first time anything touches the context —
+ * there is no way to observe an intermediate "still pending" state, and no way
+ * to have multiple deferred registrations accumulate before the ready signal
+ * fires. A real browser starts `'suspended'` under the autoplay policy and only
+ * reaches `'running'` later (asynchronously, after a user gesture), giving a
+ * genuine window where several `onAudioContextReady` handlers can be queued.
+ * This helper reproduces that window deterministically: nothing dispatches
+ * until `flipToReady()` is called, which flips `.state` to `'running'` and
+ * re-triggers the module's monitoring so every handler registered so far fires
+ * in registration order.
+ */
+async function withSuspendedContext<T>(
+  run: (mod: {
+    fresh: typeof import('@codexo/exojs');
+    FreshAudioAnalyser: typeof AudioAnalyser;
+    flipToReady: () => void;
+  }) => T | Promise<T>,
+): Promise<T> {
+  const OriginalAudioContext = globalThis.AudioContext;
+  class SuspendedMockAudioContext extends (OriginalAudioContext as unknown as new () => AudioContext) {
+    public constructor() {
+      super();
+      (this as unknown as { state: AudioContextState }).state = 'suspended';
+    }
+  }
+  Object.defineProperty(globalThis, 'AudioContext', { configurable: true, value: SuspendedMockAudioContext });
+  try {
+    vi.resetModules();
+    const fresh = await import('@codexo/exojs');
+    const { AudioAnalyser: FreshAudioAnalyser } = await import('../src/AudioAnalyser');
+    const flipToReady = (): void => {
+      const ctx = fresh.getAudioContext();
+      (ctx as unknown as { state: AudioContextState }).state = 'running';
+      fresh.getAudioContext(); // re-trigger monitoring — dispatches ready to every pending handler
+    };
+    return await run({ fresh, FreshAudioAnalyser, flipToReady });
+  } finally {
+    Object.defineProperty(globalThis, 'AudioContext', { configurable: true, value: OriginalAudioContext });
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -95,6 +143,28 @@ describe('AudioAnalyser', () => {
       a.maxDecibels = -20;
       expect(a.maxDecibels).toBeCloseTo(-20);
       a.destroy();
+    });
+
+    it('smoothingTimeConstant/minDecibels/maxDecibels fall back to the stored option before the analyser exists', async () => {
+      await withSuspendedContext(({ FreshAudioAnalyser }) => {
+        const a = new FreshAudioAnalyser({ smoothingTimeConstant: 0.6, minDecibels: -90, maxDecibels: -25 });
+        // Getters read the analyser node when present, falling back to the
+        // stored option otherwise (`this._analyser?.x ?? this._options.x`).
+        expect(a.smoothingTimeConstant).toBe(0.6);
+        expect(a.minDecibels).toBe(-90);
+        expect(a.maxDecibels).toBe(-25);
+        // Setters store the option unconditionally and only touch the
+        // analyser node when it exists — no-ops (but do not throw) here.
+        expect(() => {
+          a.smoothingTimeConstant = 0.9;
+          a.minDecibels = -70;
+          a.maxDecibels = -10;
+        }).not.toThrow();
+        expect(a.smoothingTimeConstant).toBe(0.9);
+        expect(a.minDecibels).toBe(-70);
+        expect(a.maxDecibels).toBe(-10);
+        a.destroy();
+      });
     });
   });
 
@@ -409,6 +479,18 @@ describe('AudioAnalyser', () => {
       a.destroy();
     });
 
+    it('caches the log ranges — repeated calls with the same params do not rebuild', () => {
+      const a = new AudioAnalyser({ source: makeAudioNode(), fftSize: 512 });
+      a.getSpectrumLog(undefined, { bands: 16 });
+      const cacheBefore = (a as unknown as { _logCache: Map<string, unknown> })._logCache.size;
+      a.getSpectrumLog(undefined, { bands: 16 });
+      a.getSpectrumLog(undefined, { bands: 16 });
+      const cacheAfter = (a as unknown as { _logCache: Map<string, unknown> })._logCache.size;
+      expect(cacheBefore).toBe(1);
+      expect(cacheAfter).toBe(1);
+      a.destroy();
+    });
+
     it('caches the log ranges separately from the mel filterbank', () => {
       const a = new AudioAnalyser({ source: makeAudioNode(), fftSize: 512 });
       a.getSpectrumMel(undefined, { bands: 16 });
@@ -425,6 +507,238 @@ describe('AudioAnalyser', () => {
       const result = a.getSpectrumLogFloat(undefined, { bands: 24 });
       expect(result).toBeInstanceOf(Float32Array);
       expect(result.length).toBe(24);
+      a.destroy();
+    });
+  });
+
+  // ---- Source setter — idempotence ----
+
+  describe('source setter — same value twice', () => {
+    it('is a no-op when assigning the same source again (no re-tap)', () => {
+      const a = new AudioAnalyser();
+      const node = makeAudioNode();
+      a.source = node;
+      const connectSpy = vi.spyOn(node, 'connect');
+      a.source = node;
+      expect(connectSpy).not.toHaveBeenCalled();
+      a.destroy();
+    });
+  });
+
+  // ---- Data getters before the analyser exists ----
+
+  describe('data getters before the analyser has been set up', () => {
+    it('all return safe fallback values (zero-filled / 0) instead of throwing', async () => {
+      await withSuspendedContext(({ FreshAudioAnalyser }) => {
+        const a = new FreshAudioAnalyser({ fftSize: 512 });
+
+        const byteSpec = a.getSpectrum();
+        expect(Array.from(byteSpec).every(v => v === 0)).toBe(true);
+
+        const floatSpec = a.getSpectrumFloat();
+        expect(Array.from(floatSpec).every(v => v === 0)).toBe(true);
+
+        const byteWave = a.getWaveform();
+        expect(Array.from(byteWave).every(v => v === 0)).toBe(true);
+
+        const floatWave = a.getWaveformFloat();
+        expect(Array.from(floatWave).every(v => v === 0)).toBe(true);
+
+        expect(a.getBandEnergy(100, 1000)).toBe(0);
+        expect(a.getRms()).toBe(0);
+
+        expect(Array.from(a.getSpectrumMel()).every(v => v === 0)).toBe(true);
+        expect(Array.from(a.getSpectrumMelFloat()).every(v => v === 0)).toBe(true);
+        expect(Array.from(a.getSpectrumLog()).every(v => v === 0)).toBe(true);
+        expect(Array.from(a.getSpectrumLogFloat()).every(v => v === 0)).toBe(true);
+
+        a.destroy();
+      });
+    });
+  });
+
+  // ---- Deferred construction / source connection (context not yet ready) ----
+
+  describe('deferred setup when constructed before the context is ready', () => {
+    it('registers via onAudioContextReady and sets up the analyser once ready', async () => {
+      await withSuspendedContext(({ FreshAudioAnalyser, flipToReady }) => {
+        const a = new FreshAudioAnalyser();
+        // Still pending: getSpectrum uses the zero-fill fallback (no analyser yet).
+        expect(Array.from(a.getSpectrum()).every(v => v === 0)).toBe(true);
+        flipToReady();
+        expect(a.fftSize).toBe(2048);
+        a.destroy();
+      });
+    });
+
+    it('connects a source assigned before the context is ready once it becomes ready', async () => {
+      await withSuspendedContext(({ FreshAudioAnalyser, flipToReady }) => {
+        const a = new FreshAudioAnalyser();
+        const node = { connect: vi.fn(), disconnect: vi.fn() } as unknown as AudioNode;
+        a.source = node;
+        expect(a.source).toBe(node);
+        expect(node.connect).not.toHaveBeenCalled();
+        flipToReady();
+        expect(node.connect).toHaveBeenCalled();
+        a.destroy();
+      });
+    });
+
+    it('replacing a pending source cancels the previous deferred handler', async () => {
+      await withSuspendedContext(({ FreshAudioAnalyser, flipToReady }) => {
+        const a = new FreshAudioAnalyser();
+        const node1 = { connect: vi.fn(), disconnect: vi.fn() } as unknown as AudioNode;
+        const node2 = { connect: vi.fn(), disconnect: vi.fn() } as unknown as AudioNode;
+        a.source = node1;
+        a.source = node2;
+        flipToReady();
+        expect(node2.connect).toHaveBeenCalled();
+        expect(node1.connect).not.toHaveBeenCalled();
+        a.destroy();
+      });
+    });
+
+    it('destroying while a source connection is still pending cancels the deferred handler', async () => {
+      await withSuspendedContext(({ FreshAudioAnalyser, flipToReady }) => {
+        const a = new FreshAudioAnalyser();
+        const node = { connect: vi.fn(), disconnect: vi.fn() } as unknown as AudioNode;
+        a.source = node;
+        a.destroy();
+        expect(() => flipToReady()).not.toThrow();
+        expect(node.connect).not.toHaveBeenCalled();
+      });
+    });
+
+    it('connecting the same pending MediaStream source via both the constructor and setter callbacks replaces the first tap', async () => {
+      // When constructed with the context not yet ready, the constructor's own
+      // deferred callback (_setupAnalyser, which itself calls _connectSource
+      // for any already-assigned source) and the source setter's own deferred
+      // handler both fire in the same onAudioContextReady dispatch, both
+      // calling _connectSource for the same MediaStream — exercising the
+      // "already had a stream source" replace-and-disconnect path.
+      await withSuspendedContext(({ fresh, FreshAudioAnalyser, flipToReady }) => {
+        const a = new FreshAudioAnalyser();
+        const ctx = fresh.getAudioContext();
+        const createdNodes: { connect: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> }[] = [];
+        vi.spyOn(ctx, 'createMediaStreamSource').mockImplementation(() => {
+          const node = { connect: vi.fn(), disconnect: vi.fn() };
+          createdNodes.push(node);
+          return node as unknown as MediaStreamAudioSourceNode;
+        });
+        const stream = { getTracks: () => [] } as unknown as MediaStream;
+        a.source = stream;
+        flipToReady();
+        expect(createdNodes.length).toBe(2);
+        expect(createdNodes[0]!.disconnect).toHaveBeenCalled();
+        a.destroy();
+      });
+    });
+  });
+
+  // ---- Bus deferred connection (AudioBus not yet internally set up) ----
+
+  describe('source setter — AudioBus not yet internally set up', () => {
+    it('defers via the bus onceSetup hook and connects once the bus becomes available', () => {
+      const bus = new AudioBus('deferred-bus');
+      const outputNode = bus._getOutputNode();
+      const onceSetupSpy = vi.spyOn(bus, 'onceSetup');
+      vi.spyOn(bus, '_getOutputNode').mockReturnValueOnce(null);
+
+      expect(outputNode).not.toBeNull();
+      const connectSpy = vi.spyOn(outputNode!, 'connect');
+
+      const a = new AudioAnalyser();
+      a.source = bus;
+
+      expect(onceSetupSpy).toHaveBeenCalled();
+      expect(connectSpy).toHaveBeenCalled();
+      a.destroy();
+      bus.destroy();
+    });
+
+    it('the bus onceSetup callback is a no-op if the source changed before it fired', () => {
+      const bus = new AudioBus('deferred-bus-2');
+      vi.spyOn(bus, '_getOutputNode').mockReturnValue(null);
+      let capturedCallback: (() => void) | undefined;
+      vi.spyOn(bus, 'onceSetup').mockImplementation(cb => {
+        capturedCallback = cb;
+      });
+
+      const a = new AudioAnalyser();
+      a.source = bus;
+      expect(capturedCallback).toBeDefined();
+
+      // Re-assign the source before the deferred callback fires — the
+      // callback's `this._source === source` guard must now be false.
+      const node = makeAudioNode();
+      a.source = node;
+
+      expect(() => capturedCallback!()).not.toThrow();
+      a.destroy();
+      bus.destroy();
+    });
+  });
+
+  // ---- Non-bus deferred connection fallback ----
+
+  describe('source setter — unrecognised source type deferred fallback', () => {
+    it('_deferConnectionViaBus falls back to onAudioContextReady.once and resolves once ready', async () => {
+      // _connectSource (and therefore _deferConnectionViaBus) is only ever
+      // reached once isAudioContextReady() is true, but onAudioContextReady is
+      // a one-shot latch (see src/audio/audio-context.ts's `readyDispatched`) —
+      // a *new* registration made after the ready event already fired can never
+      // fire again. The "otherwise" fallback branch is therefore only
+      // observably exercised by invoking the private method directly while the
+      // context is still genuinely pending, then letting it resolve normally.
+      await withSuspendedContext(({ FreshAudioAnalyser, flipToReady }) => {
+        const a = new FreshAudioAnalyser();
+        const unrecognised = {} as unknown as AudioNode;
+        (a as unknown as { _source: unknown })._source = unrecognised;
+        (a as unknown as { _deferConnectionViaBus: (s: unknown) => void })._deferConnectionViaBus(unrecognised);
+        expect(() => flipToReady()).not.toThrow();
+        a.destroy();
+      });
+    });
+
+    it('the once() fallback callback is a no-op if the source changed before it fired', async () => {
+      await withSuspendedContext(({ FreshAudioAnalyser, flipToReady }) => {
+        const a = new FreshAudioAnalyser();
+        const unrecognised = {} as unknown as AudioNode;
+        (a as unknown as { _source: unknown })._source = unrecognised;
+        (a as unknown as { _deferConnectionViaBus: (s: unknown) => void })._deferConnectionViaBus(unrecognised);
+        // Change the source before the deferred once() callback fires so its
+        // `this._source === source` guard evaluates false.
+        (a as unknown as { _source: unknown })._source = null;
+        expect(() => flipToReady()).not.toThrow();
+        a.destroy();
+      });
+    });
+  });
+
+  // ---- Private defensive guards (reached only via direct invocation — see note) ----
+
+  describe('private defensive guards', () => {
+    it('_connectSource is a no-op once the analyser has been released (post-destroy)', () => {
+      const a = new AudioAnalyser();
+      a.destroy();
+      const node = makeAudioNode();
+      const connectSpy = vi.spyOn(node, 'connect');
+      expect(() => {
+        (a as unknown as { _connectSource: (s: unknown, ctx: unknown) => void })._connectSource(node, getAudioContext());
+      }).not.toThrow();
+      expect(connectSpy).not.toHaveBeenCalled();
+    });
+
+    it('_resolveToAudioNode returns null for a null source', () => {
+      // _connectSource never passes null (the public `source` setter already
+      // returns early for `value === null`), so this guard is unreachable via
+      // the public API; invoked directly here purely for coverage of the
+      // defensive branch, matching this test file's existing convention of
+      // reaching into private state (see _melCache/_logCache above).
+      const a = new AudioAnalyser();
+      const ctx = getAudioContext();
+      const result = (a as unknown as { _resolveToAudioNode: (s: unknown, c: unknown) => unknown })._resolveToAudioNode(null, ctx);
+      expect(result).toBeNull();
       a.destroy();
     });
   });

--- a/packages/exojs-audio-fx/test/beat-detector.test.ts
+++ b/packages/exojs-audio-fx/test/beat-detector.test.ts
@@ -44,6 +44,49 @@ function makeVoiceLike(): Voice {
   return { output: ctx.createGain() } as unknown as Voice;
 }
 
+/**
+ * Runs `run` against a fresh copy of the `@codexo/exojs` module registry (via
+ * `vi.resetModules()` + dynamic import) backed by an `AudioContext` that starts
+ * `'suspended'` instead of the shared mock's default `'running'`.
+ *
+ * The shared mock AudioContext starts `'running'` immediately, so
+ * `onAudioContextReady.add()`/`.once()` dispatch synchronously the first time
+ * anything touches the context — there is no window to observe a genuinely
+ * pending state, nor to have several deferred registrations queue up before
+ * the ready signal fires. A real browser starts `'suspended'` under the
+ * autoplay policy; this helper reproduces that deterministically. Nothing
+ * dispatches until `flipToReady()` is called.
+ */
+async function withSuspendedBeatDetectorContext<T>(
+  run: (mod: {
+    fresh: typeof import('@codexo/exojs');
+    FreshBeatDetector: typeof BeatDetector;
+    flipToReady: () => void;
+  }) => T | Promise<T>,
+): Promise<T> {
+  const OriginalAudioContext = globalThis.AudioContext;
+  class SuspendedMockAudioContext extends (OriginalAudioContext as unknown as new () => AudioContext) {
+    public constructor() {
+      super();
+      (this as unknown as { state: AudioContextState }).state = 'suspended';
+    }
+  }
+  Object.defineProperty(globalThis, 'AudioContext', { configurable: true, value: SuspendedMockAudioContext });
+  try {
+    vi.resetModules();
+    const fresh = await import('@codexo/exojs');
+    const { BeatDetector: FreshBeatDetector } = await import('../src/BeatDetector');
+    const flipToReady = (): void => {
+      const ctx = fresh.getAudioContext();
+      (ctx as unknown as { state: AudioContextState }).state = 'running';
+      fresh.getAudioContext(); // re-trigger monitoring — dispatches ready to every pending handler
+    };
+    return await run({ fresh, FreshBeatDetector, flipToReady });
+  } finally {
+    Object.defineProperty(globalThis, 'AudioContext', { configurable: true, value: OriginalAudioContext });
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -703,6 +746,409 @@ describe('BeatDetector', () => {
       expect(() => {
         (la as UpcomingBeat[]).push({ audioTime: 99, tempo: 999, isDownbeat: false, beatInBar: 2 });
       }).toThrow();
+      d.destroy();
+    });
+  });
+
+  // ---- Additional stage 1/2 state accessors ----
+
+  describe('additional state accessors', () => {
+    it('exposes beatPhase, nextBeatTime, gridStability, rms, onsetStrength, bandEnergy, nextDownbeatTime from state messages', async () => {
+      const d = new BeatDetector();
+      await d.ready;
+      simulateMessage(d, {
+        type: 'state',
+        tempo: 120,
+        beatPhase: 0.25,
+        confidence: 0.5,
+        gridStability: 0.75,
+        tempoCandidates: [],
+        rms: 0.4,
+        onsetStrength: 0.9,
+        bandEnergy: { low: 0.1, mid: 0.2, high: 0.3 },
+        barPosition: 1,
+        barLength: 4,
+        timeSignature: { numerator: 4, denominator: 4 },
+        lookahead: [],
+        nextBeatTime: 1.25,
+        nextDownbeatTime: 3.0,
+      });
+      expect(d.beatPhase).toBeCloseTo(0.25);
+      expect(d.nextBeatTime).toBeCloseTo(1.25);
+      expect(d.gridStability).toBeCloseTo(0.75);
+      expect(d.rms).toBeCloseTo(0.4);
+      expect(d.onsetStrength).toBeCloseTo(0.9);
+      expect(d.bandEnergy).toEqual({ low: 0.1, mid: 0.2, high: 0.3 });
+      expect(d.nextDownbeatTime).toBeCloseTo(3.0);
+      d.destroy();
+    });
+
+    it('falls back to documented defaults for every field a state message omits', async () => {
+      const d = new BeatDetector();
+      await d.ready;
+      simulateMessage(d, { type: 'state' });
+      expect(d.tempo).toBe(0);
+      expect(d.beatPhase).toBe(0);
+      expect(d.nextBeatTime).toBe(0);
+      expect(d.nextDownbeatTime).toBe(0);
+      expect(d.confidence).toBe(0);
+      expect(d.gridStability).toBe(0);
+      expect(d.tempoCandidates).toEqual([]);
+      expect(d.rms).toBe(0);
+      expect(d.onsetStrength).toBe(0);
+      expect(d.bandEnergy).toEqual({ low: 0, mid: 0, high: 0 });
+      expect(d.barPosition).toBe(1);
+      expect(d.barLength).toBe(4);
+      expect(d.timeSignature).toEqual({ numerator: 4, denominator: 4 });
+      expect(d.lookahead).toEqual([]);
+      d.destroy();
+    });
+  });
+
+  // ---- Visual derived state — pure getters for per-frame polling ----
+
+  describe('visual derived state', () => {
+    it('secondsSinceLastBeat, pulse, barPulse, and justBeat are all 0/false before any tempo is known', () => {
+      const d = new BeatDetector();
+      expect(d.secondsSinceLastBeat).toBe(0);
+      expect(d.pulse).toBe(0);
+      expect(d.barPulse).toBe(0);
+      expect(d.justBeat).toBe(false);
+      d.destroy();
+    });
+
+    it('secondsSinceLastBeat and pulse compute from tempo and beatPhase once known', async () => {
+      const d = new BeatDetector();
+      await d.ready;
+      simulateMessage(d, {
+        type: 'state',
+        tempo: 120,
+        beatPhase: 0.5,
+        confidence: 0.8,
+        gridStability: 0.8,
+        tempoCandidates: [],
+        rms: 0,
+        onsetStrength: 0,
+        bandEnergy: { low: 0, mid: 0, high: 0 },
+        barPosition: 1,
+        barLength: 4,
+        timeSignature: { numerator: 4, denominator: 4 },
+        lookahead: [],
+        nextBeatTime: 0,
+        nextDownbeatTime: 2,
+      });
+      // secondsSinceLastBeat = beatPhase * (60 / tempo) = 0.5 * 0.5 = 0.25
+      expect(d.secondsSinceLastBeat).toBeCloseTo(0.25);
+      expect(d.pulse).toBeCloseTo(Math.pow(0.5, 0.25 / d.pulseHalfLife));
+      expect(d.justBeat).toBe(0.25 < d.justBeatWindow);
+      d.destroy();
+    });
+
+    it('barPulse is 0 when barLength is 0 even if tempo is known', async () => {
+      const d = new BeatDetector();
+      await d.ready;
+      simulateMessage(d, {
+        type: 'state',
+        tempo: 120,
+        beatPhase: 0,
+        confidence: 0.8,
+        gridStability: 0.8,
+        tempoCandidates: [],
+        rms: 0,
+        onsetStrength: 0,
+        bandEnergy: { low: 0, mid: 0, high: 0 },
+        barPosition: 1,
+        barLength: 0,
+        timeSignature: { numerator: 4, denominator: 4 },
+        lookahead: [],
+        nextBeatTime: 0,
+        nextDownbeatTime: 0,
+      });
+      expect(d.barPulse).toBe(0);
+      d.destroy();
+    });
+
+    it('barPulse computes a decay envelope in [0, 1] once tempo and barLength are known', async () => {
+      const d = new BeatDetector();
+      await d.ready;
+      simulateMessage(d, {
+        type: 'state',
+        tempo: 120,
+        beatPhase: 0,
+        confidence: 0.8,
+        gridStability: 0.8,
+        tempoCandidates: [],
+        rms: 0,
+        onsetStrength: 0,
+        bandEnergy: { low: 0, mid: 0, high: 0 },
+        barPosition: 1,
+        barLength: 4,
+        timeSignature: { numerator: 4, denominator: 4 },
+        lookahead: [],
+        nextBeatTime: 0,
+        nextDownbeatTime: 2,
+      });
+      expect(d.barPulse).toBeGreaterThanOrEqual(0);
+      expect(d.barPulse).toBeLessThanOrEqual(1);
+      d.destroy();
+    });
+
+    it('subdivisionPhase returns 0 for a non-finite or non-positive division', () => {
+      const d = new BeatDetector();
+      expect(d.subdivisionPhase(0)).toBe(0);
+      expect(d.subdivisionPhase(-2)).toBe(0);
+      expect(d.subdivisionPhase(Number.NaN)).toBe(0);
+      expect(d.subdivisionPhase(Number.POSITIVE_INFINITY)).toBe(0);
+      d.destroy();
+    });
+
+    it('subdivisionPhase computes (beatPhase * division) % 1', async () => {
+      const d = new BeatDetector();
+      await d.ready;
+      simulateMessage(d, {
+        type: 'state',
+        tempo: 120,
+        beatPhase: 0.6,
+        confidence: 0.8,
+        gridStability: 0.8,
+        tempoCandidates: [],
+        rms: 0,
+        onsetStrength: 0,
+        bandEnergy: { low: 0, mid: 0, high: 0 },
+        barPosition: 1,
+        barLength: 4,
+        timeSignature: { numerator: 4, denominator: 4 },
+        lookahead: [],
+        nextBeatTime: 0,
+        nextDownbeatTime: 0,
+      });
+      // 0.6 * 4 = 2.4 -> % 1 = 0.4 (approximately, floating point)
+      expect(d.subdivisionPhase(4)).toBeCloseTo(0.4, 10);
+      d.destroy();
+    });
+  });
+
+  // ---- Constructor source option / source setter idempotence ----
+
+  describe('constructor source option', () => {
+    it('accepts a source via the constructor option and connects it once ready', async () => {
+      const node = getAudioContext().createGain() as unknown as AudioNode;
+      const connectSpy = vi.spyOn(node, 'connect');
+      const d = new BeatDetector({ source: node });
+      await d.ready;
+      expect(d.source).toBe(node);
+      expect(connectSpy).toHaveBeenCalled();
+      d.destroy();
+    });
+  });
+
+  describe('source setter — same value twice', () => {
+    it('is a no-op when assigning the same source again (no re-tap)', async () => {
+      const d = new BeatDetector();
+      await d.ready;
+      const node = getAudioContext().createGain() as unknown as AudioNode;
+      d.source = node;
+      const connectSpy = vi.spyOn(node, 'connect');
+      d.source = node;
+      expect(connectSpy).not.toHaveBeenCalled();
+      d.destroy();
+    });
+  });
+
+  // ---- Deferred construction / source connection (context not yet ready) ----
+
+  describe('deferred setup when constructed before the context is ready', () => {
+    it('registers via onAudioContextReady and resolves the worklet once ready', async () => {
+      await withSuspendedBeatDetectorContext(async ({ FreshBeatDetector, flipToReady }) => {
+        const d = new FreshBeatDetector();
+        expect(d.tempo).toBe(0);
+        // Before _setup() has ever run, `_ready` is still null — the `ready`
+        // getter falls back to an already-resolved promise (`?? Promise.resolve()`).
+        await expect(d.ready).resolves.toBeUndefined();
+        flipToReady();
+        await expect(d.ready).resolves.toBeUndefined();
+        d.destroy();
+      });
+    });
+
+    it('connects a source assigned before the context is ready once the worklet resolves', async () => {
+      await withSuspendedBeatDetectorContext(async ({ FreshBeatDetector, flipToReady }) => {
+        const d = new FreshBeatDetector();
+        const node = { connect: vi.fn(), disconnect: vi.fn() } as unknown as AudioNode;
+        d.source = node;
+        expect(node.connect).not.toHaveBeenCalled();
+        flipToReady();
+        // At this exact synchronous point the source setter's own deferred
+        // handler (registered after the constructor's) may already have fired
+        // and no-opped, because _workletNode is still null — the worklet
+        // registration promise resolves asynchronously. _setup()'s own
+        // pending-source check (once the promise resolves) is what actually
+        // connects it.
+        await d.ready;
+        expect(node.connect).toHaveBeenCalled();
+        d.destroy();
+      });
+    });
+
+    it('replacing a pending source cancels the previous deferred handler', async () => {
+      await withSuspendedBeatDetectorContext(async ({ FreshBeatDetector, flipToReady }) => {
+        const d = new FreshBeatDetector();
+        const node1 = { connect: vi.fn(), disconnect: vi.fn() } as unknown as AudioNode;
+        const node2 = { connect: vi.fn(), disconnect: vi.fn() } as unknown as AudioNode;
+        d.source = node1;
+        d.source = node2;
+        flipToReady();
+        await d.ready;
+        expect(node2.connect).toHaveBeenCalled();
+        expect(node1.connect).not.toHaveBeenCalled();
+        d.destroy();
+      });
+    });
+
+    it('destroying while a source connection is still pending cancels the deferred handler', async () => {
+      await withSuspendedBeatDetectorContext(({ FreshBeatDetector, flipToReady }) => {
+        const d = new FreshBeatDetector();
+        const node = { connect: vi.fn(), disconnect: vi.fn() } as unknown as AudioNode;
+        d.source = node;
+        d.destroy();
+        expect(() => flipToReady()).not.toThrow();
+        expect(node.connect).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  // ---- Bus deferred connection (AudioBus not yet internally set up) ----
+
+  describe('source setter — AudioBus not yet internally set up', () => {
+    it('defers via the bus onceSetup hook and connects once the bus becomes available', async () => {
+      const bus = new AudioBus('bd-deferred-bus');
+      const outputNode = bus._getOutputNode();
+      expect(outputNode).not.toBeNull();
+      const onceSetupSpy = vi.spyOn(bus, 'onceSetup');
+      vi.spyOn(bus, '_getOutputNode').mockReturnValueOnce(null);
+      const connectSpy = vi.spyOn(outputNode!, 'connect');
+
+      const d = new BeatDetector();
+      await d.ready;
+      d.source = bus;
+
+      expect(onceSetupSpy).toHaveBeenCalled();
+      expect(connectSpy).toHaveBeenCalled();
+      d.destroy();
+      bus.destroy();
+    });
+
+    it('the bus onceSetup callback is a no-op if the source changed before it fired', async () => {
+      const bus = new AudioBus('bd-deferred-bus-2');
+      vi.spyOn(bus, '_getOutputNode').mockReturnValue(null);
+      let capturedCallback: (() => void) | undefined;
+      vi.spyOn(bus, 'onceSetup').mockImplementation(cb => {
+        capturedCallback = cb;
+      });
+
+      const d = new BeatDetector();
+      await d.ready;
+      d.source = bus;
+      expect(capturedCallback).toBeDefined();
+
+      const node = getAudioContext().createGain() as unknown as AudioNode;
+      d.source = node;
+
+      expect(() => capturedCallback!()).not.toThrow();
+      d.destroy();
+      bus.destroy();
+    });
+  });
+
+  // ---- Non-bus deferred connection fallback ----
+
+  describe('source setter — unrecognised source type', () => {
+    it('resolves to null and falls through to the deferred fallback without throwing', async () => {
+      const d = new BeatDetector();
+      await d.ready;
+      const unrecognised = {} as unknown as AudioNode;
+      expect(() => {
+        d.source = unrecognised;
+      }).not.toThrow();
+      expect(d.source).toBe(unrecognised);
+      d.destroy();
+    });
+
+    // NOTE: _deferConnectionViaBus's non-bus "otherwise" fallback registers
+    // onAudioContextReady.once(...). That callback can only ever fire
+    // synchronously as part of the SAME onAudioContextReady dispatch that also
+    // kicks off _setup()'s async worklet registration (registerAudioWorkletProcessor(...).then(...))
+    // — reaching _connectSource while the context is *not yet* ready requires
+    // this method to be invoked directly (see below), since through the public
+    // API isAudioContextReady() is always true by the time _connectSource is
+    // ever called. Because the worklet-ready promise can only resolve in a
+    // *later* microtask than this synchronous dispatch, `this._workletNode` is
+    // provably still null at the exact moment this callback runs — so the
+    // "reconnect" branch inside it (`this._workletNode && isAudioContextReady()`
+    // both true) is structurally unreachable for this fallback path specifically,
+    // unlike the AudioBus onceSetup path above (whose readiness is independent
+    // of the worklet's async setup). The two tests below still exercise the
+    // callback body itself (both the "still applicable" and "source changed"
+    // no-op cases), just not the inner `_connectSource` call.
+    it('_deferConnectionViaBus falls back to onAudioContextReady.once and runs its callback once ready', async () => {
+      await withSuspendedBeatDetectorContext(async ({ FreshBeatDetector, flipToReady }) => {
+        const d = new FreshBeatDetector();
+        const unrecognised = {} as unknown as AudioNode;
+        (d as unknown as { _source: unknown })._source = unrecognised;
+        (d as unknown as { _deferConnectionViaBus: (s: unknown) => void })._deferConnectionViaBus(unrecognised);
+        expect(() => flipToReady()).not.toThrow();
+        await expect(d.ready).resolves.toBeUndefined();
+        d.destroy();
+      });
+    });
+
+    it('the once() fallback callback is a no-op if the source changed before it fired', async () => {
+      await withSuspendedBeatDetectorContext(async ({ FreshBeatDetector, flipToReady }) => {
+        const d = new FreshBeatDetector();
+        const unrecognised = {} as unknown as AudioNode;
+        (d as unknown as { _source: unknown })._source = unrecognised;
+        (d as unknown as { _deferConnectionViaBus: (s: unknown) => void })._deferConnectionViaBus(unrecognised);
+        (d as unknown as { _source: unknown })._source = null;
+        expect(() => flipToReady()).not.toThrow();
+        await expect(d.ready).resolves.toBeUndefined();
+        d.destroy();
+      });
+    });
+  });
+
+  // ---- MediaStream re-resolution (private guard) ----
+
+  describe('private defensive guards', () => {
+    it('_resolveToAudioNode replaces an existing stream tap when resolved again without an intervening disconnect', async () => {
+      // Through the public `.source =` setter this is unreachable — _disconnectTap()
+      // always runs first and clears `_streamSource`. Calling the private method
+      // directly (consistent with this file's existing convention of reaching
+      // into internal state, e.g. getMockWorkletNode) exercises the "already had
+      // a stream source" replace-and-disconnect branch directly.
+      const d = new BeatDetector();
+      await d.ready;
+      const stream = { getTracks: () => [] } as unknown as MediaStream;
+      const ctx = getAudioContext();
+      const resolve = (
+        d as unknown as { _resolveToAudioNode: (s: unknown, c: unknown) => AudioNode | null }
+      )._resolveToAudioNode.bind(d);
+      const first = resolve(stream, ctx);
+      expect(first).not.toBeNull();
+      const disconnectSpy = vi.spyOn(first!, 'disconnect');
+      const second = resolve(stream, ctx);
+      expect(disconnectSpy).toHaveBeenCalled();
+      expect(second).not.toBe(first);
+      d.destroy();
+    });
+
+    it('_resolveToAudioNode returns null for a null source', () => {
+      // _connectSource never passes null (the public `source` setter already
+      // returns early for `value === null`), so this guard is unreachable via
+      // the public API; invoked directly here purely for coverage.
+      const d = new BeatDetector();
+      const ctx = getAudioContext();
+      const result = (d as unknown as { _resolveToAudioNode: (s: unknown, c: unknown) => unknown })._resolveToAudioNode(null, ctx);
+      expect(result).toBeNull();
       d.destroy();
     });
   });

--- a/packages/exojs-audio-fx/test/dsp/mel.test.ts
+++ b/packages/exojs-audio-fx/test/dsp/mel.test.ts
@@ -68,4 +68,25 @@ describe('computeMelBands', () => {
     computeMelBands(mag, fb, out);
     for (const v of out) expect(v).toBeCloseTo(0, 3);
   });
+
+  it('allocates its own output array when none is supplied', () => {
+    const fb = buildMelFilterbank(8, 80, 8000, 2048, 48000);
+    const mag = new Float32Array(1024).fill(1);
+    const out = computeMelBands(mag, fb);
+    expect(out).toBeInstanceOf(Float32Array);
+    expect(out.length).toBe(8);
+  });
+});
+
+describe('buildMelFilterbank — degenerate bands', () => {
+  it('falls back to a unit weight when startBin === peakBin === endBin', () => {
+    // A large band count over a tiny FFT / narrow frequency range collapses
+    // several consecutive mel points onto the same rounded FFT bin, producing
+    // a degenerate single-bin band whose weight is forced to 1.
+    const fb = buildMelFilterbank(64, 100, 200, 64, 8000);
+    const degenerate = fb.find(band => band.startBin === band.peakBin && band.peakBin === band.endBin);
+    expect(degenerate).toBeDefined();
+    expect(degenerate!.weights.length).toBe(1);
+    expect(degenerate!.weights[0]).toBe(1);
+  });
 });

--- a/packages/exojs-audio-fx/test/dsp/tempogram.test.ts
+++ b/packages/exojs-audio-fx/test/dsp/tempogram.test.ts
@@ -3,6 +3,8 @@ import {
   computeTempoCandidates,
   findTempoPeaks,
   isOctaveRelated,
+  scoreTempoHypotheses,
+  tempoPrior,
 } from '../../src/dsp/tempogram';
 
 const SAMPLE_RATE = 48000;
@@ -204,5 +206,119 @@ describe('isOctaveRelated', () => {
   it('does not flag a nearby non-octave tempo', () => {
     expect(isOctaveRelated(130, 120)).toBe(false);
     expect(isOctaveRelated(140, 120)).toBe(false); // 1.17 — legitimate drift, not metrical
+  });
+
+  it('returns false for a non-positive reference (guards divide-by-zero)', () => {
+    expect(isOctaveRelated(120, 0)).toBe(false);
+    expect(isOctaveRelated(120, -60)).toBe(false);
+  });
+});
+
+describe('computeAcf — empty input', () => {
+  it('returns all zeros for an empty flux array (n === 0 guards)', () => {
+    const acf = computeAcf(new Float32Array(0), 1, 5);
+    expect(acf.length).toBe(5);
+    for (const v of acf) expect(v).toBe(0);
+  });
+});
+
+describe('findTempoPeaks — endpoint peaks and defaults', () => {
+  it('returns no peaks for a single-sample ACF (acf.length > 1 guard is false)', () => {
+    const peaks = findTempoPeaks(new Float32Array([5]), 10, HOP_SIZE, SAMPLE_RATE);
+    expect(peaks).toEqual([]);
+  });
+
+  it('detects a leading-endpoint peak (lag === minLag beats its only neighbour)', () => {
+    const acf = new Float32Array([5, 1, 2, 1]);
+    const peaks = findTempoPeaks(acf, 10, HOP_SIZE, SAMPLE_RATE, 10);
+    const leading = peaks.find(p => p.lag === 10);
+    expect(leading).toBeDefined();
+    expect(leading!.score).toBe(5);
+  });
+
+  it('detects a trailing-endpoint peak (lag === maxLag beats its only neighbour)', () => {
+    const acf = new Float32Array([1, 2, 1, 5]);
+    const peaks = findTempoPeaks(acf, 10, HOP_SIZE, SAMPLE_RATE, 10);
+    const trailing = peaks.find(p => p.lag === 13);
+    expect(trailing).toBeDefined();
+    expect(trailing!.score).toBe(5);
+  });
+
+  // NOTE on two lines that remain uncovered in `parabolicPeakOffset` after this test:
+  // - `if (denom >= 0) return 0;` — mathematically unreachable through `findTempoPeaks`'
+  //   strict peak-selection gate (`acf[i] > acf[i-1] && acf[i] > acf[i+1]`): if yMid is
+  //   strictly greater than both neighbours, `yPrev + yNext < 2*yMid` always holds (adding
+  //   the two strict inequalities), so `denom = yPrev - 2*yMid + yNext` is always negative.
+  //   A randomized search of >230M float32 triples satisfying the strict-peak invariant
+  //   (spanning the full float32 dynamic range, including extreme-magnitude mismatches that
+  //   trigger catastrophic cancellation) found zero counterexamples — confirming this is a
+  //   pure defensive guard against a case that cannot occur via the public API, not merely a
+  //   rare one. Left uncovered as documented unreachable code.
+  // - `if (d < -0.5) d = -0.5;` — the mirror-image clamp of the `d > 0.5` case covered by the
+  //   test below. The `d > 0.5` clamp WAS found (below) via floating-point cancellation with
+  //   an extreme-magnitude yPrev; an equally extensive randomized search (>500M triples,
+  //   including deliberately mirroring the found +0.5 triple) for the symmetric `d < -0.5`
+  //   case found none — the two branches of this expression are not perfectly symmetric under
+  //   floating-point rounding (`p - 2*m + q` evaluates left-to-right, so swapping p/q changes
+  //   intermediate rounding). Left uncovered; treated as practically unreachable rather than
+  //   forcing an artificial non-representative test.
+  it('clamps the parabolic interpolation offset to +0.5 on extreme floating-point asymmetry', () => {
+    // These three values are a strict interior local maximum (the middle sample
+    // is greater than both neighbours and positive, satisfying findTempoPeaks'
+    // peak-selection gate), but their magnitudes are so mismatched that the
+    // catastrophic cancellation inside the parabolic-fit formula
+    // `0.5 * (yPrev - yNext) / (yPrev - 2*yMid + yNext)` rounds to a hair
+    // above 0.5 in double precision, exercising the `d > 0.5` clamp.
+    const acf = new Float32Array([-7335888027648, 0.03963751718401909, 0.03963751345872879]);
+    const minLag = 10;
+    const peaks = findTempoPeaks(acf, minLag, HOP_SIZE, SAMPLE_RATE, 10);
+    const interior = peaks.find(p => p.lag > minLag && p.lag < minLag + 2);
+    expect(interior).toBeDefined();
+    // lag = minLag + i + offset, i = 1, offset clamped to exactly 0.5.
+    expect(interior!.lag).toBeCloseTo(minLag + 1.5, 10);
+  });
+
+  it('uses the default topK of 3 when omitted', () => {
+    // Five independent single-neighbour "peaks" alternating up/down so every
+    // interior sample plus both endpoints qualify — without the default topK
+    // cap this would return more than 3 candidates.
+    const acf = new Float32Array([5, 1, 5, 1, 5, 1, 5]);
+    const peaks = findTempoPeaks(acf, 10, HOP_SIZE, SAMPLE_RATE);
+    expect(peaks.length).toBeLessThanOrEqual(3);
+  });
+});
+
+describe('tempoPrior — defaults', () => {
+  it('is 1 at the default prior centre (140 BPM) when mu/sigma are omitted', () => {
+    expect(tempoPrior(140)).toBeCloseTo(1, 10);
+  });
+
+  it('decays away from the default centre', () => {
+    expect(tempoPrior(280)).toBeLessThan(tempoPrior(140));
+  });
+});
+
+describe('scoreTempoHypotheses — defaults and boundary lag', () => {
+  it('accepts an omitted options argument (all defaults)', () => {
+    const acf = new Float32Array(20).fill(0.1);
+    const scored = scoreTempoHypotheses([{ bpm: 120, score: 0, lag: 24 }], acf, 10);
+    expect(scored.length).toBe(1);
+    expect(scored[0]!.bpm).toBe(120);
+  });
+
+  it('samples the ACF exactly at its last representable lag (boundary interpolation)', () => {
+    // acf has 5 samples for lags 10..14 (minLag=10, length=5, maxIndex=4).
+    // A candidate at lag=7 makes its super-multiple lag*2 === 14, landing
+    // exactly on the last ACF sample — the interpolator's "at the last index,
+    // no right neighbour" boundary path.
+    const acf = new Float32Array([0.1, 0.2, 0.3, 0.4, 0.5]);
+    expect(() => scoreTempoHypotheses([{ bpm: 100, score: 0, lag: 7 }], acf, 10, { maxBpm: 300 })).not.toThrow();
+  });
+});
+
+describe('computeTempoCandidates — omitted options', () => {
+  it('accepts an omitted options argument (uses all documented defaults)', () => {
+    const flux = syntheticNovelty(120, 400);
+    expect(() => computeTempoCandidates(flux, MIN_LAG, MAX_LAG, HOP_SIZE, SAMPLE_RATE)).not.toThrow();
   });
 });

--- a/packages/exojs-audio-fx/test/effects/auto-wah-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/auto-wah-effect.test.ts
@@ -335,6 +335,15 @@ describe('AutoWahEffect', () => {
       effect.destroy();
     });
 
+    it('updates the internal value without throwing when called after destroy', () => {
+      const effect = new AutoWahEffect();
+      effect.destroy();
+      expect(() => {
+        effect.baseFrequency = 500;
+      }).not.toThrow();
+      expect(effect.baseFrequency).toBe(500);
+    });
+
     it('ramps wahFilter.frequency via setTargetAtTime', () => {
       const ctx = getAudioContext();
       const wahFilter = makeBiquadFilterNode(ctx);
@@ -359,6 +368,15 @@ describe('AutoWahEffect', () => {
       effect.sensitivity = 9999;
       expect(effect.sensitivity).toBe(6000);
       effect.destroy();
+    });
+
+    it('updates the internal value without throwing when called after destroy', () => {
+      const effect = new AutoWahEffect();
+      effect.destroy();
+      expect(() => {
+        effect.sensitivity = 1000;
+      }).not.toThrow();
+      expect(effect.sensitivity).toBe(1000);
     });
 
     it('ramps sensitivityGain.gain via setTargetAtTime', () => {
@@ -392,6 +410,15 @@ describe('AutoWahEffect', () => {
       effect.destroy();
     });
 
+    it('updates the internal value without throwing when called after destroy', () => {
+      const effect = new AutoWahEffect();
+      effect.destroy();
+      expect(() => {
+        effect.q = 10;
+      }).not.toThrow();
+      expect(effect.q).toBe(10);
+    });
+
     it('ramps wahFilter.Q via setTargetAtTime', () => {
       const ctx = getAudioContext();
       const wahFilter = makeBiquadFilterNode(ctx);
@@ -416,6 +443,15 @@ describe('AutoWahEffect', () => {
       effect.responseMs = 9999;
       expect(effect.responseMs).toBe(500);
       effect.destroy();
+    });
+
+    it('updates the internal value without throwing when called after destroy', () => {
+      const effect = new AutoWahEffect();
+      effect.destroy();
+      expect(() => {
+        effect.responseMs = 50;
+      }).not.toThrow();
+      expect(effect.responseMs).toBe(50);
     });
 
     it('ramps smoothingLowpass.frequency via setTargetAtTime', () => {
@@ -447,6 +483,15 @@ describe('AutoWahEffect', () => {
       effect.wet = 2;
       expect(effect.wet).toBe(1);
       effect.destroy();
+    });
+
+    it('updates the internal value without throwing when called after destroy', () => {
+      const effect = new AutoWahEffect();
+      effect.destroy();
+      expect(() => {
+        effect.wet = 0.3;
+      }).not.toThrow();
+      expect(effect.wet).toBe(0.3);
     });
 
     it('ramps complementary dry/wet gains via setTargetAtTime', () => {

--- a/packages/exojs-audio-fx/test/effects/bit-crusher-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/bit-crusher-effect.test.ts
@@ -1,0 +1,312 @@
+import { getAudioContext } from '@codexo/exojs';
+
+import { BitCrusherEffect } from '../../src/effects/BitCrusherEffect';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeMockAudioParam = () => ({
+  setValueAtTime: vi.fn(),
+  setTargetAtTime: vi.fn(),
+  cancelScheduledValues: vi.fn(),
+  linearRampToValueAtTime: vi.fn(),
+  value: 0,
+});
+
+// The shared global AudioWorkletNode mock (test/setup-env.vitest.ts) only
+// pre-populates a fixed set of param names that does not include BitCrusher's
+// `bits`/`normFreq` AudioParams. Provide a local mock (scoped to this file
+// only) that exposes exactly the params BitCrusherEffect's worklet declares.
+class MockBitCrusherWorkletNode {
+  public readonly connect: MockInstance = vi.fn();
+  public readonly disconnect: MockInstance = vi.fn();
+  public readonly context: AudioContext;
+  public readonly parameters: Map<string, AudioParam>;
+  public readonly port = {
+    postMessage: vi.fn(),
+    onmessage: null as ((event: { data: unknown }) => void) | null,
+  };
+
+  public constructor(context: AudioContext, _name: string, _options?: AudioWorkletNodeOptions) {
+    this.context = context;
+    this.parameters = new Map<string, AudioParam>();
+    this.parameters.set('bits', makeMockAudioParam() as unknown as AudioParam);
+    this.parameters.set('normFreq', makeMockAudioParam() as unknown as AudioParam);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('BitCrusherEffect', () => {
+  let OriginalAudioWorkletNode: typeof AudioWorkletNode;
+
+  beforeEach(() => {
+    const ctx = getAudioContext();
+    const addModuleMock = vi.fn().mockResolvedValue(undefined);
+    (ctx as unknown as { audioWorklet: { addModule: MockInstance } }).audioWorklet.addModule = addModuleMock;
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:bit-crusher-url');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+
+    OriginalAudioWorkletNode = globalThis.AudioWorkletNode;
+    (globalThis as unknown as { AudioWorkletNode: unknown }).AudioWorkletNode = MockBitCrusherWorkletNode;
+  });
+
+  afterEach(() => {
+    (globalThis as unknown as { AudioWorkletNode: unknown }).AudioWorkletNode = OriginalAudioWorkletNode;
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Construction with defaults
+  // -------------------------------------------------------------------------
+  describe('construction with defaults', () => {
+    it('uses default bits of 8', () => {
+      const filter = new BitCrusherEffect();
+      expect(filter.bits).toBe(8);
+      filter.destroy();
+    });
+
+    it('uses default frequencyReduction of 0.5', () => {
+      const filter = new BitCrusherEffect();
+      expect(filter.frequencyReduction).toBe(0.5);
+      filter.destroy();
+    });
+
+    it('uses default wet of 1', () => {
+      const filter = new BitCrusherEffect();
+      expect(filter.wet).toBe(1);
+      filter.destroy();
+    });
+
+    it('constructs without arguments', () => {
+      expect(() => new BitCrusherEffect()).not.toThrow();
+      const filter = new BitCrusherEffect();
+      filter.destroy();
+    });
+
+    it('creates input and output nodes on construction', () => {
+      const filter = new BitCrusherEffect();
+      expect(filter.inputNode).toBeDefined();
+      expect(filter.outputNode).toBeDefined();
+      filter.destroy();
+    });
+
+    it('accepts custom options', () => {
+      const filter = new BitCrusherEffect({ bits: 4, frequencyReduction: 0.3, wet: 0.8 });
+      expect(filter.bits).toBe(4);
+      expect(filter.frequencyReduction).toBe(0.3);
+      expect(filter.wet).toBe(0.8);
+      filter.destroy();
+    });
+
+    it('rounds a fractional bits option', () => {
+      const filter = new BitCrusherEffect({ bits: 4.6 });
+      expect(filter.bits).toBe(5);
+      filter.destroy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Option clamping on construction
+  // -------------------------------------------------------------------------
+  describe('constructor clamping', () => {
+    it('clamps bits to 1 minimum', () => {
+      const filter = new BitCrusherEffect({ bits: 0 });
+      expect(filter.bits).toBe(1);
+      filter.destroy();
+    });
+
+    it('clamps bits to 16 maximum', () => {
+      const filter = new BitCrusherEffect({ bits: 99 });
+      expect(filter.bits).toBe(16);
+      filter.destroy();
+    });
+
+    it('clamps frequencyReduction to 0 minimum', () => {
+      const filter = new BitCrusherEffect({ frequencyReduction: -1 });
+      expect(filter.frequencyReduction).toBe(0);
+      filter.destroy();
+    });
+
+    it('clamps frequencyReduction to 1 maximum', () => {
+      const filter = new BitCrusherEffect({ frequencyReduction: 5 });
+      expect(filter.frequencyReduction).toBe(1);
+      filter.destroy();
+    });
+
+    it('clamps wet to 0 minimum', () => {
+      const filter = new BitCrusherEffect({ wet: -1 });
+      expect(filter.wet).toBe(0);
+      filter.destroy();
+    });
+
+    it('clamps wet to 1 maximum', () => {
+      const filter = new BitCrusherEffect({ wet: 2 });
+      expect(filter.wet).toBe(1);
+      filter.destroy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Worklet lifecycle
+  // -------------------------------------------------------------------------
+  describe('worklet lifecycle', () => {
+    it('after await filter.ready: workletNode is not null', async () => {
+      const filter = new BitCrusherEffect();
+      await filter.ready;
+      expect(filter['_workletNode']).not.toBeNull();
+      filter.destroy();
+    });
+
+    it('after await filter.ready: bits and normFreq worklet params are set', async () => {
+      const filter = new BitCrusherEffect({ bits: 4, frequencyReduction: 0.3 });
+      await filter.ready;
+      const node = filter['_workletNode']!;
+
+      const bitsParam = node.parameters.get('bits') as unknown as { setTargetAtTime: MockInstance };
+      const normFreqParam = node.parameters.get('normFreq') as unknown as { setTargetAtTime: MockInstance };
+      expect(bitsParam.setTargetAtTime).toHaveBeenCalledWith(4, expect.anything(), expect.anything());
+      expect(normFreqParam.setTargetAtTime).toHaveBeenCalledWith(0.3, expect.anything(), expect.anything());
+      filter.destroy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Setters after ready
+  // -------------------------------------------------------------------------
+  describe('setters after ready', () => {
+    it('setting bits updates the worklet param', async () => {
+      const filter = new BitCrusherEffect();
+      await filter.ready;
+      const node = filter['_workletNode']!;
+      const param = node.parameters.get('bits') as unknown as { setTargetAtTime: MockInstance };
+      param.setTargetAtTime.mockClear();
+      filter.bits = 12;
+      expect(filter.bits).toBe(12);
+      expect(param.setTargetAtTime).toHaveBeenCalledWith(12, expect.anything(), expect.anything());
+      filter.destroy();
+    });
+
+    it('bits setter rounds fractional values', async () => {
+      const filter = new BitCrusherEffect();
+      await filter.ready;
+      filter.bits = 6.5;
+      expect(filter.bits).toBe(7);
+      filter.destroy();
+    });
+
+    it('bits setter clamps to 1 minimum', async () => {
+      const filter = new BitCrusherEffect();
+      await filter.ready;
+      filter.bits = -5;
+      expect(filter.bits).toBe(1);
+      filter.destroy();
+    });
+
+    it('bits setter clamps to 16 maximum', async () => {
+      const filter = new BitCrusherEffect();
+      await filter.ready;
+      filter.bits = 999;
+      expect(filter.bits).toBe(16);
+      filter.destroy();
+    });
+
+    it('setting frequencyReduction updates the worklet param', async () => {
+      const filter = new BitCrusherEffect();
+      await filter.ready;
+      const node = filter['_workletNode']!;
+      const param = node.parameters.get('normFreq') as unknown as { setTargetAtTime: MockInstance };
+      param.setTargetAtTime.mockClear();
+      filter.frequencyReduction = 0.2;
+      expect(filter.frequencyReduction).toBe(0.2);
+      expect(param.setTargetAtTime).toHaveBeenCalledWith(0.2, expect.anything(), expect.anything());
+      filter.destroy();
+    });
+
+    it('frequencyReduction setter clamps to 0 minimum', async () => {
+      const filter = new BitCrusherEffect();
+      await filter.ready;
+      filter.frequencyReduction = -1;
+      expect(filter.frequencyReduction).toBe(0);
+      filter.destroy();
+    });
+
+    it('frequencyReduction setter clamps to 1 maximum', async () => {
+      const filter = new BitCrusherEffect();
+      await filter.ready;
+      filter.frequencyReduction = 5;
+      expect(filter.frequencyReduction).toBe(1);
+      filter.destroy();
+    });
+
+    it('setting wet updates base gain nodes', async () => {
+      const filter = new BitCrusherEffect();
+      await filter.ready;
+      vi.spyOn(filter['_dryGain']!.gain, 'setTargetAtTime');
+      vi.spyOn(filter['_wetGain']!.gain, 'setTargetAtTime');
+      filter.wet = 0.6;
+      expect(filter.wet).toBe(0.6);
+      expect(filter['_dryGain']!.gain.setTargetAtTime).toHaveBeenCalledWith(0.4, expect.anything(), expect.anything());
+      expect(filter['_wetGain']!.gain.setTargetAtTime).toHaveBeenCalledWith(0.6, expect.anything(), expect.anything());
+      filter.destroy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Setters before ready (worklet node not yet created — _setAudioParam no-ops)
+  // -------------------------------------------------------------------------
+  describe('setters before worklet is ready', () => {
+    it('bits setter updates the internal value without throwing', () => {
+      const filter = new BitCrusherEffect();
+      expect(() => {
+        filter.bits = 3;
+      }).not.toThrow();
+      expect(filter.bits).toBe(3);
+      filter.destroy();
+    });
+
+    it('frequencyReduction setter updates the internal value without throwing', () => {
+      const filter = new BitCrusherEffect();
+      expect(() => {
+        filter.frequencyReduction = 0.9;
+      }).not.toThrow();
+      expect(filter.frequencyReduction).toBe(0.9);
+      filter.destroy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // destroy
+  // -------------------------------------------------------------------------
+  describe('destroy', () => {
+    it('destroy cleans up without throwing', async () => {
+      const filter = new BitCrusherEffect();
+      await filter.ready;
+      expect(() => filter.destroy()).not.toThrow();
+    });
+
+    it('after destroy, inputNode throws', async () => {
+      const filter = new BitCrusherEffect();
+      await filter.ready;
+      filter.destroy();
+      expect(() => filter.inputNode).toThrow();
+    });
+
+    it('after destroy, outputNode throws', async () => {
+      const filter = new BitCrusherEffect();
+      await filter.ready;
+      filter.destroy();
+      expect(() => filter.outputNode).toThrow();
+    });
+
+    it('double destroy is safe', async () => {
+      const filter = new BitCrusherEffect();
+      await filter.ready;
+      filter.destroy();
+      expect(() => filter.destroy()).not.toThrow();
+    });
+  });
+});

--- a/packages/exojs-audio-fx/test/effects/chorus-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/chorus-effect.test.ts
@@ -187,6 +187,50 @@ describe('ChorusEffect', () => {
       expect(filter.delayMs).toBe(0);
       filter.destroy();
     });
+
+    it('updates the internal value without throwing when called after destroy', () => {
+      const filter = new ChorusEffect();
+      filter.destroy();
+      expect(() => {
+        filter.delayMs = 15;
+      }).not.toThrow();
+      expect(filter.delayMs).toBe(15);
+    });
+  });
+
+  describe('depthMs setter', () => {
+    it('updates lfoGain.gain via setTargetAtTime', () => {
+      const ctx = getAudioContext();
+      const lfoGain = makeGainNode(ctx);
+      let gainCallCount = 0;
+      // ChorusEffect._setupNodes createGain order: inputGain, outputGain, dryGain, wetGain, lfoGain
+      const gains = [makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx), makeGainNode(ctx), lfoGain];
+      vi.spyOn(ctx, 'createGain').mockImplementation(() => {
+        return gains[gainCallCount++] as unknown as GainNode;
+      });
+
+      const filter = new ChorusEffect({ depthMs: 5 });
+      filter.depthMs = 10;
+      expect(filter.depthMs).toBe(10);
+      expect(lfoGain.gain.setTargetAtTime).toHaveBeenCalledWith(0.01, expect.anything(), expect.anything());
+      filter.destroy();
+    });
+
+    it('clamps depthMs to minimum of 0', () => {
+      const filter = new ChorusEffect();
+      filter.depthMs = -10;
+      expect(filter.depthMs).toBe(0);
+      filter.destroy();
+    });
+
+    it('updates the internal value without throwing when called after destroy', () => {
+      const filter = new ChorusEffect();
+      filter.destroy();
+      expect(() => {
+        filter.depthMs = 8;
+      }).not.toThrow();
+      expect(filter.depthMs).toBe(8);
+    });
   });
 
   describe('rateHz setter', () => {
@@ -211,6 +255,15 @@ describe('ChorusEffect', () => {
       filter.rateHz = -1;
       expect(filter.rateHz).toBe(0);
       filter.destroy();
+    });
+
+    it('updates the internal value without throwing when called after destroy', () => {
+      const filter = new ChorusEffect();
+      filter.destroy();
+      expect(() => {
+        filter.rateHz = 2;
+      }).not.toThrow();
+      expect(filter.rateHz).toBe(2);
     });
   });
 
@@ -243,6 +296,15 @@ describe('ChorusEffect', () => {
       filter.wet = 2;
       expect(filter.wet).toBe(1);
       filter.destroy();
+    });
+
+    it('updates the internal value without throwing when called after destroy', () => {
+      const filter = new ChorusEffect();
+      filter.destroy();
+      expect(() => {
+        filter.wet = 0.9;
+      }).not.toThrow();
+      expect(filter.wet).toBe(0.9);
     });
   });
 
@@ -284,6 +346,12 @@ describe('ChorusEffect', () => {
       const filter = new ChorusEffect();
       filter.destroy();
       expect(() => filter.inputNode).toThrow('ChorusEffect not yet initialized.');
+    });
+
+    it('throws after destroy when accessing outputNode', () => {
+      const filter = new ChorusEffect();
+      filter.destroy();
+      expect(() => filter.outputNode).toThrow('ChorusEffect not yet initialized.');
     });
 
     it('double destroy is safe', () => {

--- a/packages/exojs-audio-fx/test/effects/compressor-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/compressor-effect.test.ts
@@ -85,10 +85,34 @@ describe('CompressorEffect', () => {
       filter.destroy();
     });
 
-    it('throws after destroy', () => {
+    it('throws after destroy (inputNode)', () => {
       const filter = new CompressorEffect();
       filter.destroy();
       expect(() => filter.inputNode).toThrow('CompressorEffect not yet initialized.');
+    });
+
+    it('throws after destroy (outputNode)', () => {
+      const filter = new CompressorEffect();
+      filter.destroy();
+      expect(() => filter.outputNode).toThrow('CompressorEffect not yet initialized.');
+    });
+  });
+
+  describe('construction before the audio context is ready', () => {
+    it('registers a deferred onAudioContextReady setup and _onAudioContextReady wires the node', async () => {
+      // The shared mock AudioContext is always 'running', so
+      // onAudioContextReady.add() synchronously creates the context and
+      // dispatches ready inside the constructor call itself — the deferred
+      // callback (and the constructor's else-branch registration) both
+      // execute before `new` returns. Using a fresh module registry via
+      // vi.resetModules() guarantees the internal audio-context singleton
+      // starts in its virgin (not-ready) state for this one test, regardless
+      // of what earlier tests in this file already did with getAudioContext().
+      vi.resetModules();
+      const { CompressorEffect: FreshCompressorEffect } = await import('../../src/effects/CompressorEffect');
+      const effect = new FreshCompressorEffect();
+      expect(effect.inputNode).toBeDefined();
+      effect.destroy();
     });
   });
 
@@ -138,6 +162,51 @@ describe('CompressorEffect', () => {
       filter.destroy();
     });
 
+    it('threshold setter updates the internal value without throwing after destroy', () => {
+      const filter = new CompressorEffect();
+      filter.destroy();
+      expect(() => {
+        filter.threshold = -10;
+      }).not.toThrow();
+      expect(filter.threshold).toBe(-10);
+    });
+
+    it('knee setter updates the internal value without throwing after destroy', () => {
+      const filter = new CompressorEffect();
+      filter.destroy();
+      expect(() => {
+        filter.knee = 15;
+      }).not.toThrow();
+      expect(filter.knee).toBe(15);
+    });
+
+    it('ratio setter updates the internal value without throwing after destroy', () => {
+      const filter = new CompressorEffect();
+      filter.destroy();
+      expect(() => {
+        filter.ratio = 8;
+      }).not.toThrow();
+      expect(filter.ratio).toBe(8);
+    });
+
+    it('attack setter updates the internal value without throwing after destroy', () => {
+      const filter = new CompressorEffect();
+      filter.destroy();
+      expect(() => {
+        filter.attack = 0.2;
+      }).not.toThrow();
+      expect(filter.attack).toBe(0.2);
+    });
+
+    it('release setter updates the internal value without throwing after destroy', () => {
+      const filter = new CompressorEffect();
+      filter.destroy();
+      expect(() => {
+        filter.release = 0.6;
+      }).not.toThrow();
+      expect(filter.release).toBe(0.6);
+    });
+
     it('setters call setTargetAtTime on the underlying audio param', () => {
       const ctx = getAudioContext();
       const mockNode = createMockCompressor(ctx);
@@ -155,6 +224,25 @@ describe('CompressorEffect', () => {
       expect(mockNode.release.setTargetAtTime).toHaveBeenCalledWith(0.5, 0, 0.01);
       filter.destroy();
       spy.mockRestore();
+    });
+  });
+
+  describe('reduction', () => {
+    it('reflects the underlying node.reduction value', () => {
+      const ctx = getAudioContext();
+      const mockNode = createMockCompressor(ctx);
+      mockNode.reduction = -6.5;
+      const spy = vi.spyOn(ctx, 'createDynamicsCompressor').mockReturnValue(mockNode as unknown as DynamicsCompressorNode);
+      const filter = new CompressorEffect();
+      expect(filter.reduction).toBe(-6.5);
+      filter.destroy();
+      spy.mockRestore();
+    });
+
+    it('falls back to 0 after destroy (node reference cleared)', () => {
+      const filter = new CompressorEffect();
+      filter.destroy();
+      expect(filter.reduction).toBe(0);
     });
   });
 

--- a/packages/exojs-audio-fx/test/effects/convolution-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/convolution-effect.test.ts
@@ -227,6 +227,15 @@ describe('ConvolutionEffect', () => {
       convolverSpy.mockRestore();
     });
 
+    it('wet setter updates the internal value without throwing when called after destroy', () => {
+      const effect = new ConvolutionEffect();
+      effect.destroy();
+      expect(() => {
+        effect.wet = 0.3;
+      }).not.toThrow();
+      expect(effect.wet).toBe(0.3);
+    });
+
     it('wet setter applies gain multiplier to wetGain', () => {
       const ctx = getAudioContext();
       const { wetGain, gainSpy, convolverSpy } = wireAll(ctx);
@@ -266,6 +275,15 @@ describe('ConvolutionEffect', () => {
       effect.destroy();
     });
 
+    it('gain setter updates the internal value without throwing when called after destroy', () => {
+      const effect = new ConvolutionEffect();
+      effect.destroy();
+      expect(() => {
+        effect.gain = 3;
+      }).not.toThrow();
+      expect(effect.gain).toBe(3);
+    });
+
     it('gain setter updates wetGain (wet=0.5, gain=2 → wetGain=1.0)', () => {
       const ctx = getAudioContext();
       const { wetGain, gainSpy, convolverSpy } = wireAll(ctx);
@@ -284,6 +302,15 @@ describe('ConvolutionEffect', () => {
       effect.normalize = false;
       expect(effect.normalize).toBe(false);
       effect.destroy();
+    });
+
+    it('normalize setter updates the internal value without throwing when called after destroy', () => {
+      const effect = new ConvolutionEffect();
+      effect.destroy();
+      expect(() => {
+        effect.normalize = false;
+      }).not.toThrow();
+      expect(effect.normalize).toBe(false);
     });
 
     it('normalize setter applies to convolver', () => {
@@ -373,6 +400,44 @@ describe('ConvolutionEffect', () => {
       convolverSpy.mockRestore();
     });
 
+    it('stores a pending impulse when called before the audio context is ready', async () => {
+      // The shared mock AudioContext is always constructed with state
+      // 'running', so by the time any effect's constructor returns, its
+      // internal _setup has already been synchronously assigned (see the
+      // onAudioContextReady dispatch mechanism in src/audio/audio-context.ts).
+      // To genuinely exercise ConvolutionEffect.setImpulse's `else` branch
+      // (storing `_pendingImpulse` for later application in `_setupNodes`),
+      // the underlying AudioContext must still be 'suspended' when
+      // setImpulse is called. We simulate that real-world scenario (a
+      // context awaiting a user-interaction gesture per browser autoplay
+      // policy) by swapping in an AudioContext subclass that starts
+      // 'suspended', combined with vi.resetModules() so the module-level
+      // audio-context singleton starts virgin for this one test.
+      const OriginalAudioContext = globalThis.AudioContext;
+      class SuspendedAudioContext extends (OriginalAudioContext as unknown as new () => AudioContext) {
+        public constructor() {
+          super();
+          (this as unknown as { state: AudioContextState }).state = 'suspended';
+        }
+      }
+      Object.defineProperty(globalThis, 'AudioContext', { configurable: true, value: SuspendedAudioContext });
+
+      vi.resetModules();
+      const { ConvolutionEffect: FreshConvolutionEffect } = await import('../../src/effects/ConvolutionEffect');
+
+      const effect = new FreshConvolutionEffect();
+      // _setup must genuinely be null here — the context never reached 'running'.
+      expect(effect['_setup']).toBeNull();
+
+      const ir = { length: 1 } as unknown as AudioBuffer;
+      effect.setImpulse(ir);
+      // The else branch stores the impulse for later application in _setupNodes.
+      expect(effect['_pendingImpulse']).toBe(ir);
+
+      effect.destroy();
+      Object.defineProperty(globalThis, 'AudioContext', { configurable: true, value: OriginalAudioContext });
+    });
+
     it('setImpulse sets normalize before buffer (Web Audio order)', () => {
       const ctx = getAudioContext();
       const normalizeOrder: boolean[] = [];
@@ -437,6 +502,12 @@ describe('ConvolutionEffect', () => {
       const effect = new ConvolutionEffect();
       effect.destroy();
       expect(() => effect.inputNode).toThrow('ConvolutionEffect not yet initialized.');
+    });
+
+    it('double destroy is safe', () => {
+      const effect = new ConvolutionEffect();
+      effect.destroy();
+      expect(() => effect.destroy()).not.toThrow();
     });
   });
 });

--- a/packages/exojs-audio-fx/test/effects/delay-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/delay-effect.test.ts
@@ -151,6 +151,15 @@ describe('DelayEffect', () => {
       expect(filter.feedback).toBe(0.6);
       filter.destroy();
     });
+
+    it('updates the internal value without throwing when called after destroy', () => {
+      const filter = new DelayEffect();
+      filter.destroy();
+      expect(() => {
+        filter.feedback = 0.5;
+      }).not.toThrow();
+      expect(filter.feedback).toBe(0.5);
+    });
   });
 
   describe('delaySeconds setter', () => {
@@ -167,6 +176,15 @@ describe('DelayEffect', () => {
       expect(filter.delaySeconds).toBe(5);
       filter.destroy();
     });
+
+    it('updates the internal value without throwing when called after destroy', () => {
+      const filter = new DelayEffect();
+      filter.destroy();
+      expect(() => {
+        filter.delaySeconds = 1.5;
+      }).not.toThrow();
+      expect(filter.delaySeconds).toBe(1.5);
+    });
   });
 
   describe('wet setter', () => {
@@ -177,6 +195,15 @@ describe('DelayEffect', () => {
       filter.wet = 2;
       expect(filter.wet).toBe(1);
       filter.destroy();
+    });
+
+    it('updates the internal value without throwing when called after destroy', () => {
+      const filter = new DelayEffect();
+      filter.destroy();
+      expect(() => {
+        filter.wet = 0.9;
+      }).not.toThrow();
+      expect(filter.wet).toBe(0.9);
     });
   });
 
@@ -201,10 +228,22 @@ describe('DelayEffect', () => {
       delaySpy.mockRestore();
     });
 
-    it('throws after destroy', () => {
+    it('throws after destroy (inputNode)', () => {
       const filter = new DelayEffect();
       filter.destroy();
       expect(() => filter.inputNode).toThrow('DelayEffect not yet initialized.');
+    });
+
+    it('throws after destroy (outputNode)', () => {
+      const filter = new DelayEffect();
+      filter.destroy();
+      expect(() => filter.outputNode).toThrow('DelayEffect not yet initialized.');
+    });
+
+    it('double destroy is safe', () => {
+      const filter = new DelayEffect();
+      filter.destroy();
+      expect(() => filter.destroy()).not.toThrow();
     });
   });
 });

--- a/packages/exojs-audio-fx/test/effects/distortion-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/distortion-effect.test.ts
@@ -320,6 +320,15 @@ describe('DistortionEffect', () => {
       waveShaperSpy.mockRestore();
       biquadSpy.mockRestore();
     });
+
+    it('updates the internal value without throwing when called after destroy', () => {
+      const effect = new DistortionEffect();
+      effect.destroy();
+      expect(() => {
+        effect.drive = 0.6;
+      }).not.toThrow();
+      expect(effect.drive).toBe(0.6);
+    });
   });
 
   describe('wet setter', () => {
@@ -357,6 +366,15 @@ describe('DistortionEffect', () => {
       waveShaperSpy.mockRestore();
       biquadSpy.mockRestore();
     });
+
+    it('updates the internal value without throwing when called after destroy', () => {
+      const effect = new DistortionEffect();
+      effect.destroy();
+      expect(() => {
+        effect.wet = 0.3;
+      }).not.toThrow();
+      expect(effect.wet).toBe(0.3);
+    });
   });
 
   describe('oversample setter', () => {
@@ -377,6 +395,15 @@ describe('DistortionEffect', () => {
       gainSpy.mockRestore();
       waveShaperSpy.mockRestore();
       biquadSpy.mockRestore();
+    });
+
+    it('updates the internal value without throwing when called after destroy', () => {
+      const effect = new DistortionEffect();
+      effect.destroy();
+      expect(() => {
+        effect.oversample = '4x';
+      }).not.toThrow();
+      expect(effect.oversample).toBe('4x');
     });
   });
 
@@ -411,6 +438,15 @@ describe('DistortionEffect', () => {
       waveShaperSpy.mockRestore();
       biquadSpy.mockRestore();
     });
+
+    it('updates the internal value without throwing when called after destroy', () => {
+      const effect = new DistortionEffect();
+      effect.destroy();
+      expect(() => {
+        effect.tone = 0.2;
+      }).not.toThrow();
+      expect(effect.tone).toBe(0.2);
+    });
   });
 
   describe('destroy', () => {
@@ -433,6 +469,12 @@ describe('DistortionEffect', () => {
       const effect = new DistortionEffect();
       effect.destroy();
       expect(() => effect.inputNode).toThrow('DistortionEffect not yet initialized.');
+    });
+
+    it('double destroy is safe', () => {
+      const effect = new DistortionEffect();
+      effect.destroy();
+      expect(() => effect.destroy()).not.toThrow();
     });
   });
 });

--- a/packages/exojs-audio-fx/test/effects/ducking-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/ducking-effect.test.ts
@@ -148,6 +148,43 @@ describe('DuckingEffect', () => {
         filter.destroy();
       }
     });
+
+    it('defers the cross-connection via onceSetup when sidechain output is not yet available', async () => {
+      const fakeConnect = vi.fn();
+      const fakeOutputNode = { connect: fakeConnect, disconnect: vi.fn() } as unknown as GainNode;
+
+      // First call (inside _onWorkletReady) returns null so the else/onceSetup branch is
+      // taken; subsequent calls (inside the deferred callback) return a real node.
+      let callCount = 0;
+      const getOutputNodeSpy = vi.spyOn(sidechain, '_getOutputNode').mockImplementation(() => {
+        callCount++;
+        return callCount === 1 ? null : fakeOutputNode;
+      });
+      const onceSetupSpy = vi.spyOn(sidechain, 'onceSetup');
+
+      const filter = new DuckingEffect({ sidechain });
+      await filter.ready;
+
+      // The AudioBus is already set up (AudioContext ready), so onceSetup's real
+      // implementation invokes the deferred callback synchronously within this call.
+      expect(onceSetupSpy).toHaveBeenCalledTimes(1);
+      expect(getOutputNodeSpy).toHaveBeenCalledTimes(2);
+      expect(fakeConnect).toHaveBeenCalledWith(filter['_workletNode'], 0, 1);
+      filter.destroy();
+    });
+
+    it('deferred onceSetup callback is a no-op if the sidechain output is still unavailable', async () => {
+      // Always returns null: neither the immediate check nor the deferred callback
+      // ever obtains a real output node, so `.connect` must never be called.
+      vi.spyOn(sidechain, '_getOutputNode').mockReturnValue(null);
+      const onceSetupSpy = vi.spyOn(sidechain, 'onceSetup');
+
+      const filter = new DuckingEffect({ sidechain });
+      await filter.ready;
+
+      expect(onceSetupSpy).toHaveBeenCalledTimes(1);
+      filter.destroy();
+    });
   });
 
   describe('setters after ready', () => {

--- a/packages/exojs-audio-fx/test/effects/equalizer-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/equalizer-effect.test.ts
@@ -19,6 +19,16 @@ const makeBiquadFilterNode = (ctx: AudioContext, filterType: BiquadFilterType) =
 });
 
 describe('EqualizerEffect', () => {
+  describe('deferred setup before AudioContext exists', () => {
+    it('registers a deferred onAudioContextReady setup when constructed before any AudioContext exists', async () => {
+      vi.resetModules();
+      const { EqualizerEffect: FreshEqualizerEffect } = await import('../../src/effects/EqualizerEffect');
+      const effect = new FreshEqualizerEffect();
+      expect(effect.inputNode).toBeDefined();
+      effect.destroy();
+    });
+  });
+
   describe('construction', () => {
     it('creates three BiquadFilterNodes', () => {
       const ctx = getAudioContext();
@@ -211,6 +221,164 @@ describe('EqualizerEffect', () => {
       const filter = new EqualizerEffect();
       filter.destroy();
       expect(() => filter.inputNode).toThrow('EqualizerEffect not yet initialized.');
+      expect(() => filter.outputNode).toThrow('EqualizerEffect not yet initialized.');
+    });
+
+    it('double destroy is safe', () => {
+      const filter = new EqualizerEffect();
+      filter.destroy();
+      expect(() => filter.destroy()).not.toThrow();
+    });
+  });
+
+  describe('frequency getters and setters', () => {
+    let ctx: AudioContext;
+    let lowShelf: ReturnType<typeof makeBiquadFilterNode>;
+    let peaking: ReturnType<typeof makeBiquadFilterNode>;
+    let highShelf: ReturnType<typeof makeBiquadFilterNode>;
+    let spy: MockInstance;
+
+    beforeEach(() => {
+      ctx = getAudioContext();
+      lowShelf = makeBiquadFilterNode(ctx, 'lowshelf');
+      peaking = makeBiquadFilterNode(ctx, 'peaking');
+      highShelf = makeBiquadFilterNode(ctx, 'highshelf');
+      const nodes = [lowShelf, peaking, highShelf];
+      let nodeCallCount = 0;
+      spy = vi.spyOn(ctx, 'createBiquadFilter').mockImplementation(() => {
+        return nodes[nodeCallCount++] as unknown as BiquadFilterNode;
+      });
+    });
+
+    afterEach(() => {
+      spy.mockRestore();
+    });
+
+    it('uses default lowFrequency of 250', () => {
+      const filter = new EqualizerEffect();
+      expect(filter.lowFrequency).toBe(250);
+      filter.destroy();
+    });
+
+    it('uses default midFrequency of 1500', () => {
+      const filter = new EqualizerEffect();
+      expect(filter.midFrequency).toBe(1500);
+      filter.destroy();
+    });
+
+    it('uses default highFrequency of 6000', () => {
+      const filter = new EqualizerEffect();
+      expect(filter.highFrequency).toBe(6000);
+      filter.destroy();
+    });
+
+    it('accepts custom frequency options', () => {
+      const filter = new EqualizerEffect({ lowFrequency: 100, midFrequency: 2000, highFrequency: 8000 });
+      expect(filter.lowFrequency).toBe(100);
+      expect(filter.midFrequency).toBe(2000);
+      expect(filter.highFrequency).toBe(8000);
+      filter.destroy();
+    });
+
+    it('lowFrequency setter ramps lowShelf.frequency via setTargetAtTime', () => {
+      const filter = new EqualizerEffect();
+      filter.lowFrequency = 300;
+      expect(filter.lowFrequency).toBe(300);
+      expect(lowShelf.frequency.setTargetAtTime).toHaveBeenCalledWith(300, 0, 0.01);
+      filter.destroy();
+    });
+
+    it('midFrequency setter ramps peaking.frequency via setTargetAtTime', () => {
+      const filter = new EqualizerEffect();
+      filter.midFrequency = 2500;
+      expect(filter.midFrequency).toBe(2500);
+      expect(peaking.frequency.setTargetAtTime).toHaveBeenCalledWith(2500, 0, 0.01);
+      filter.destroy();
+    });
+
+    it('highFrequency setter ramps highShelf.frequency via setTargetAtTime', () => {
+      const filter = new EqualizerEffect();
+      filter.highFrequency = 9000;
+      expect(filter.highFrequency).toBe(9000);
+      expect(highShelf.frequency.setTargetAtTime).toHaveBeenCalledWith(9000, 0, 0.01);
+      filter.destroy();
+    });
+
+    it('lowFrequency setter clamps to a minimum of 0', () => {
+      const filter = new EqualizerEffect();
+      filter.lowFrequency = -50;
+      expect(filter.lowFrequency).toBe(0);
+      filter.destroy();
+    });
+
+    it('midFrequency setter clamps to a minimum of 0', () => {
+      const filter = new EqualizerEffect();
+      filter.midFrequency = -50;
+      expect(filter.midFrequency).toBe(0);
+      filter.destroy();
+    });
+
+    it('highFrequency setter clamps to a minimum of 0', () => {
+      const filter = new EqualizerEffect();
+      filter.highFrequency = -50;
+      expect(filter.highFrequency).toBe(0);
+      filter.destroy();
+    });
+
+    it('lowFrequency setter is a no-op on the node graph after destroy but still updates the field', () => {
+      const filter = new EqualizerEffect();
+      filter.destroy();
+      expect(() => {
+        filter.lowFrequency = 400;
+      }).not.toThrow();
+      expect(filter.lowFrequency).toBe(400);
+    });
+
+    it('midFrequency setter is a no-op on the node graph after destroy but still updates the field', () => {
+      const filter = new EqualizerEffect();
+      filter.destroy();
+      expect(() => {
+        filter.midFrequency = 1800;
+      }).not.toThrow();
+      expect(filter.midFrequency).toBe(1800);
+    });
+
+    it('highFrequency setter is a no-op on the node graph after destroy but still updates the field', () => {
+      const filter = new EqualizerEffect();
+      filter.destroy();
+      expect(() => {
+        filter.highFrequency = 7000;
+      }).not.toThrow();
+      expect(filter.highFrequency).toBe(7000);
+    });
+  });
+
+  describe('gain setters after destroy', () => {
+    it('low setter is a no-op on the node graph after destroy but still updates the field', () => {
+      const filter = new EqualizerEffect();
+      filter.destroy();
+      expect(() => {
+        filter.low = 10;
+      }).not.toThrow();
+      expect(filter.low).toBe(10);
+    });
+
+    it('mid setter is a no-op on the node graph after destroy but still updates the field', () => {
+      const filter = new EqualizerEffect();
+      filter.destroy();
+      expect(() => {
+        filter.mid = -10;
+      }).not.toThrow();
+      expect(filter.mid).toBe(-10);
+    });
+
+    it('high setter is a no-op on the node graph after destroy but still updates the field', () => {
+      const filter = new EqualizerEffect();
+      filter.destroy();
+      expect(() => {
+        filter.high = 20;
+      }).not.toThrow();
+      expect(filter.high).toBe(20);
     });
   });
 });

--- a/packages/exojs-audio-fx/test/effects/flanger-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/flanger-effect.test.ts
@@ -264,6 +264,15 @@ describe('FlangerEffect', () => {
       expect(delayNode.delayTime.setTargetAtTime).toHaveBeenCalledWith(0.01, expect.anything(), expect.anything());
       effect.destroy();
     });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new FlangerEffect();
+      effect.destroy();
+      expect(() => {
+        effect.delayMs = 10;
+      }).not.toThrow();
+      expect(effect.delayMs).toBe(10);
+    });
   });
 
   describe('depthMs setter', () => {
@@ -304,6 +313,15 @@ describe('FlangerEffect', () => {
       expect(lfoGain.gain.setTargetAtTime).toHaveBeenCalledWith(0.004, expect.anything(), expect.anything());
       effect.destroy();
     });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new FlangerEffect();
+      effect.destroy();
+      expect(() => {
+        effect.depthMs = 5;
+      }).not.toThrow();
+      expect(effect.depthMs).toBe(5);
+    });
   });
 
   describe('rateHz setter', () => {
@@ -335,6 +353,15 @@ describe('FlangerEffect', () => {
       expect(effect.rateHz).toBe(2);
       expect(lfoOscillator.frequency.setTargetAtTime).toHaveBeenCalledWith(2, expect.anything(), expect.anything());
       effect.destroy();
+    });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new FlangerEffect();
+      effect.destroy();
+      expect(() => {
+        effect.rateHz = 3;
+      }).not.toThrow();
+      expect(effect.rateHz).toBe(3);
     });
   });
 
@@ -375,6 +402,15 @@ describe('FlangerEffect', () => {
       expect(effect.feedback).toBe(0.8);
       expect(feedbackGain.gain.setTargetAtTime).toHaveBeenCalledWith(0.8, expect.anything(), expect.anything());
       effect.destroy();
+    });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new FlangerEffect();
+      effect.destroy();
+      expect(() => {
+        effect.feedback = 0.6;
+      }).not.toThrow();
+      expect(effect.feedback).toBe(0.6);
     });
   });
 
@@ -417,6 +453,15 @@ describe('FlangerEffect', () => {
       expect(wetGain.gain.setTargetAtTime).toHaveBeenCalledWith(0.8, expect.anything(), expect.anything());
       expect(dryGain.gain.setTargetAtTime).toHaveBeenCalledWith(expect.closeTo(0.2, 5), expect.anything(), expect.anything());
       effect.destroy();
+    });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new FlangerEffect();
+      effect.destroy();
+      expect(() => {
+        effect.wet = 0.3;
+      }).not.toThrow();
+      expect(effect.wet).toBe(0.3);
     });
   });
 

--- a/packages/exojs-audio-fx/test/effects/limiter-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/limiter-effect.test.ts
@@ -349,6 +349,15 @@ describe('LimiterEffect', () => {
       gainSpy.mockRestore();
       compressorSpy.mockRestore();
     });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new LimiterEffect();
+      effect.destroy();
+      expect(() => {
+        effect.threshold = -20;
+      }).not.toThrow();
+      expect(effect.threshold).toBe(-20);
+    });
   });
 
   describe('attack setter', () => {
@@ -382,6 +391,15 @@ describe('LimiterEffect', () => {
       effect.destroy();
       gainSpy.mockRestore();
       compressorSpy.mockRestore();
+    });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new LimiterEffect();
+      effect.destroy();
+      expect(() => {
+        effect.attack = 0.02;
+      }).not.toThrow();
+      expect(effect.attack).toBe(0.02);
     });
   });
 
@@ -417,6 +435,15 @@ describe('LimiterEffect', () => {
       gainSpy.mockRestore();
       compressorSpy.mockRestore();
     });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new LimiterEffect();
+      effect.destroy();
+      expect(() => {
+        effect.release = 0.4;
+      }).not.toThrow();
+      expect(effect.release).toBe(0.4);
+    });
   });
 
   describe('ratio setter', () => {
@@ -451,6 +478,15 @@ describe('LimiterEffect', () => {
       gainSpy.mockRestore();
       compressorSpy.mockRestore();
     });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new LimiterEffect();
+      effect.destroy();
+      expect(() => {
+        effect.ratio = 10;
+      }).not.toThrow();
+      expect(effect.ratio).toBe(10);
+    });
   });
 
   describe('knee setter', () => {
@@ -484,6 +520,15 @@ describe('LimiterEffect', () => {
       effect.destroy();
       gainSpy.mockRestore();
       compressorSpy.mockRestore();
+    });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new LimiterEffect();
+      effect.destroy();
+      expect(() => {
+        effect.knee = 12;
+      }).not.toThrow();
+      expect(effect.knee).toBe(12);
     });
   });
 
@@ -525,6 +570,15 @@ describe('LimiterEffect', () => {
       gainSpy.mockRestore();
       compressorSpy.mockRestore();
     });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new LimiterEffect();
+      effect.destroy();
+      expect(() => {
+        effect.wet = 0.3;
+      }).not.toThrow();
+      expect(effect.wet).toBe(0.3);
+    });
   });
 
   describe('destroy', () => {
@@ -555,6 +609,12 @@ describe('LimiterEffect', () => {
       const effect = new LimiterEffect();
       effect.destroy();
       expect(() => effect.inputNode).toThrow('LimiterEffect not yet initialized.');
+    });
+
+    it('double destroy is safe', () => {
+      const effect = new LimiterEffect();
+      effect.destroy();
+      expect(() => effect.destroy()).not.toThrow();
     });
   });
 });

--- a/packages/exojs-audio-fx/test/effects/phaser-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/phaser-effect.test.ts
@@ -445,6 +445,15 @@ describe('PhaserEffect', () => {
       expect(effect.rateHz).toBe(20);
       effect.destroy();
     });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new PhaserEffect();
+      effect.destroy();
+      expect(() => {
+        effect.rateHz = 3;
+      }).not.toThrow();
+      expect(effect.rateHz).toBe(3);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -489,6 +498,15 @@ describe('PhaserEffect', () => {
       expect(effect.baseFrequency).toBe(5000);
       effect.destroy();
     });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new PhaserEffect();
+      effect.destroy();
+      expect(() => {
+        effect.baseFrequency = 700;
+      }).not.toThrow();
+      expect(effect.baseFrequency).toBe(700);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -521,6 +539,15 @@ describe('PhaserEffect', () => {
       expect(effect.depth).toBe(1);
       effect.destroy();
     });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new PhaserEffect();
+      effect.destroy();
+      expect(() => {
+        effect.depth = 0.2;
+      }).not.toThrow();
+      expect(effect.depth).toBe(0.2);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -551,6 +578,15 @@ describe('PhaserEffect', () => {
       effect.feedback = 2;
       expect(effect.feedback).toBe(0.9);
       effect.destroy();
+    });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new PhaserEffect();
+      effect.destroy();
+      expect(() => {
+        effect.feedback = 0.5;
+      }).not.toThrow();
+      expect(effect.feedback).toBe(0.5);
     });
   });
 
@@ -583,6 +619,15 @@ describe('PhaserEffect', () => {
       effect.wet = 2;
       expect(effect.wet).toBe(1);
       effect.destroy();
+    });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new PhaserEffect();
+      effect.destroy();
+      expect(() => {
+        effect.wet = 0.3;
+      }).not.toThrow();
+      expect(effect.wet).toBe(0.3);
     });
   });
 

--- a/packages/exojs-audio-fx/test/effects/ping-pong-delay-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/ping-pong-delay-effect.test.ts
@@ -371,6 +371,15 @@ describe('PingPongDelayEffect', () => {
       delaySpy.mockRestore();
       pannerSpy.mockRestore();
     });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new PingPongDelayEffect();
+      effect.destroy();
+      expect(() => {
+        effect.delayTime = 0.6;
+      }).not.toThrow();
+      expect(effect.delayTime).toBe(0.6);
+    });
   });
 
   describe('feedback setter', () => {
@@ -423,6 +432,15 @@ describe('PingPongDelayEffect', () => {
       gainSpy.mockRestore();
       delaySpy.mockRestore();
       pannerSpy.mockRestore();
+    });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new PingPongDelayEffect();
+      effect.destroy();
+      expect(() => {
+        effect.feedback = 0.5;
+      }).not.toThrow();
+      expect(effect.feedback).toBe(0.5);
     });
   });
 
@@ -478,6 +496,15 @@ describe('PingPongDelayEffect', () => {
       delaySpy.mockRestore();
       pannerSpy.mockRestore();
     });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new PingPongDelayEffect();
+      effect.destroy();
+      expect(() => {
+        effect.wet = 0.3;
+      }).not.toThrow();
+      expect(effect.wet).toBe(0.3);
+    });
   });
 
   describe('destroy', () => {
@@ -518,6 +545,12 @@ describe('PingPongDelayEffect', () => {
       const effect = new PingPongDelayEffect();
       effect.destroy();
       expect(() => effect.inputNode).toThrow('PingPongDelayEffect not yet initialized.');
+    });
+
+    it('double destroy is safe', () => {
+      const effect = new PingPongDelayEffect();
+      effect.destroy();
+      expect(() => effect.destroy()).not.toThrow();
     });
   });
 });

--- a/packages/exojs-audio-fx/test/effects/reverb-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/reverb-effect.test.ts
@@ -153,6 +153,15 @@ describe('ReverbEffect', () => {
       expect(filter.durationSeconds).toBe(5);
       filter.destroy();
     });
+
+    it('updates the internal value without throwing when called after destroy', () => {
+      const filter = new ReverbEffect();
+      filter.destroy();
+      expect(() => {
+        filter.durationSeconds = 1.5;
+      }).not.toThrow();
+      expect(filter.durationSeconds).toBe(1.5);
+    });
   });
 
   describe('decay setter', () => {
@@ -169,6 +178,15 @@ describe('ReverbEffect', () => {
       expect(filter.decay).toBe(10);
       filter.destroy();
     });
+
+    it('updates the internal value without throwing when called after destroy', () => {
+      const filter = new ReverbEffect();
+      filter.destroy();
+      expect(() => {
+        filter.decay = 3;
+      }).not.toThrow();
+      expect(filter.decay).toBe(3);
+    });
   });
 
   describe('inputNode / outputNode', () => {
@@ -178,10 +196,16 @@ describe('ReverbEffect', () => {
       filter.destroy();
     });
 
-    it('throws after destroy', () => {
+    it('throws after destroy (inputNode)', () => {
       const filter = new ReverbEffect();
       filter.destroy();
       expect(() => filter.inputNode).toThrow('ReverbEffect not yet initialized.');
+    });
+
+    it('throws after destroy (outputNode)', () => {
+      const filter = new ReverbEffect();
+      filter.destroy();
+      expect(() => filter.outputNode).toThrow('ReverbEffect not yet initialized.');
     });
   });
 
@@ -219,6 +243,15 @@ describe('ReverbEffect', () => {
       gainSpy.mockRestore();
       convolverSpy.mockRestore();
     });
+
+    it('wet setter updates the internal value without throwing when called after destroy', () => {
+      const filter = new ReverbEffect();
+      filter.destroy();
+      expect(() => {
+        filter.wet = 0.9;
+      }).not.toThrow();
+      expect(filter.wet).toBe(0.9);
+    });
   });
 
   describe('destroy', () => {
@@ -240,6 +273,12 @@ describe('ReverbEffect', () => {
       }
       gainSpy.mockRestore();
       convolverSpy.mockRestore();
+    });
+
+    it('double destroy is safe', () => {
+      const filter = new ReverbEffect();
+      filter.destroy();
+      expect(() => filter.destroy()).not.toThrow();
     });
   });
 });

--- a/packages/exojs-audio-fx/test/effects/ring-modulator-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/ring-modulator-effect.test.ts
@@ -251,6 +251,15 @@ describe('RingModulatorEffect', () => {
       expect(effect.frequency).toBe(20000);
       effect.destroy();
     });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new RingModulatorEffect();
+      effect.destroy();
+      expect(() => {
+        effect.frequency = 660;
+      }).not.toThrow();
+      expect(effect.frequency).toBe(660);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -274,6 +283,15 @@ describe('RingModulatorEffect', () => {
       const effect = new RingModulatorEffect({ waveform: 'sawtooth' });
       expect(effect.waveform).toBe('sawtooth');
       effect.destroy();
+    });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new RingModulatorEffect();
+      effect.destroy();
+      expect(() => {
+        effect.waveform = 'square';
+      }).not.toThrow();
+      expect(effect.waveform).toBe('square');
     });
   });
 
@@ -319,6 +337,15 @@ describe('RingModulatorEffect', () => {
       effect.wet = 2;
       expect(effect.wet).toBe(1);
       effect.destroy();
+    });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new RingModulatorEffect();
+      effect.destroy();
+      expect(() => {
+        effect.wet = 0.3;
+      }).not.toThrow();
+      expect(effect.wet).toBe(0.3);
     });
   });
 

--- a/packages/exojs-audio-fx/test/effects/tremolo-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/tremolo-effect.test.ts
@@ -358,6 +358,15 @@ describe('TremoloEffect', () => {
       expect(lfoOscillator.frequency.setTargetAtTime).toHaveBeenCalledWith(10, expect.anything(), expect.anything());
       effect.destroy();
     });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new TremoloEffect();
+      effect.destroy();
+      expect(() => {
+        effect.rateHz = 3;
+      }).not.toThrow();
+      expect(effect.rateHz).toBe(3);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -426,6 +435,15 @@ describe('TremoloEffect', () => {
       expect(panGain.gain.setTargetAtTime).toHaveBeenCalledWith(expect.closeTo(0.4), expect.anything(), expect.anything());
       effect.destroy();
     });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new TremoloEffect();
+      effect.destroy();
+      expect(() => {
+        effect.depth = 0.2;
+      }).not.toThrow();
+      expect(effect.depth).toBe(0.2);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -469,6 +487,15 @@ describe('TremoloEffect', () => {
       expect(wetGain.gain.setTargetAtTime).toHaveBeenCalledWith(expect.closeTo(0.6), expect.anything(), expect.anything());
       expect(dryGain.gain.setTargetAtTime).toHaveBeenCalledWith(expect.closeTo(0.4), expect.anything(), expect.anything());
       effect.destroy();
+    });
+
+    it('is a no-op on the node graph after destroy but still updates the field', () => {
+      const effect = new TremoloEffect();
+      effect.destroy();
+      expect(() => {
+        effect.wet = 0.3;
+      }).not.toThrow();
+      expect(effect.wet).toBe(0.3);
     });
   });
 

--- a/packages/exojs-audio-fx/test/effects/vocoder-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/vocoder-effect.test.ts
@@ -201,6 +201,45 @@ describe('VocoderEffect', () => {
       expect(modOutputConnectSpy).toHaveBeenCalledWith(filter['_workletNode'], 0, 1);
       filter.destroy();
     });
+
+    it('defers the cross-connection via onceSetup when modulator output is not yet available', async () => {
+      const modulator = makeModulatorBus();
+      const fakeConnect = vi.fn();
+      const fakeOutputNode = { connect: fakeConnect, disconnect: vi.fn() } as unknown as GainNode;
+
+      // First call (inside _onWorkletReady) returns null so the else/onceSetup branch is
+      // taken; subsequent calls (inside the deferred callback) return a real node.
+      let callCount = 0;
+      const getOutputNodeSpy = vi.spyOn(modulator, '_getOutputNode').mockImplementation(() => {
+        callCount++;
+        return callCount === 1 ? null : fakeOutputNode;
+      });
+      const onceSetupSpy = vi.spyOn(modulator, 'onceSetup');
+
+      const filter = new VocoderEffect({ modulator });
+      await filter.ready;
+
+      // The AudioBus is already set up (AudioContext ready), so onceSetup's real
+      // implementation invokes the deferred callback synchronously within this call.
+      expect(onceSetupSpy).toHaveBeenCalledTimes(1);
+      expect(getOutputNodeSpy).toHaveBeenCalledTimes(2);
+      expect(fakeConnect).toHaveBeenCalledWith(filter['_workletNode'], 0, 1);
+      filter.destroy();
+    });
+
+    it('deferred onceSetup callback is a no-op if the modulator output is still unavailable', async () => {
+      const modulator = makeModulatorBus();
+      // Always returns null: neither the immediate check nor the deferred callback
+      // ever obtains a real output node, so `.connect` must never be called.
+      vi.spyOn(modulator, '_getOutputNode').mockReturnValue(null);
+      const onceSetupSpy = vi.spyOn(modulator, 'onceSetup');
+
+      const filter = new VocoderEffect({ modulator });
+      await filter.ready;
+
+      expect(onceSetupSpy).toHaveBeenCalledTimes(1);
+      filter.destroy();
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/exojs-ldtk/test/ldtk-conversion.test.ts
+++ b/packages/exojs-ldtk/test/ldtk-conversion.test.ts
@@ -1292,6 +1292,245 @@ function makeEntity(identifier: string): LdtkEntityInstance {
   };
 }
 
+// ── Coverage-closing edge cases ─────────────────────────────────────────────
+
+describe('ldtkToTileMap — grid size skips a non-Entities layer with an invalid grid size', () => {
+  it('continues past a layer whose __gridSize is 0 and uses the next valid layer', () => {
+    // A layer type outside the LdtkLayerType union (cast) is used here so the
+    // gridSize<=0 layer is never routed through the Tiles/IntGrid/AutoLayer
+    // switch cases in convertLevel (which would otherwise try to build a
+    // TileLayer from its own invalid __gridSize and throw). This isolates
+    // pickLevelGridSize's `__gridSize > 0` guard for the non-Entities branch.
+    const invalidGridSizeLayer = {
+      __identifier: 'Unsupported',
+      __type: 'Unsupported',
+      __cWid: 2,
+      __cHei: 1,
+      __gridSize: 0, // invalid — must be skipped, not treated as the map's grid size
+      layerDefUid: 102,
+      levelId: 1,
+      visible: true,
+      iid: 'unsupported-0',
+    } as unknown as LdtkLayerInstance;
+
+    const validTilesLayer: LdtkLayerInstance = {
+      __identifier: 'Tiles',
+      __type: 'Tiles',
+      __cWid: 2,
+      __cHei: 1,
+      __gridSize: 24,
+      layerDefUid: 101,
+      levelId: 1,
+      visible: true,
+      iid: 'tiles-0',
+      gridTiles: [],
+      autoLayerTiles: [],
+    };
+
+    const data: LdtkData = {
+      jsonVersion: '1.5.3',
+      defaultGridSize: 16,
+      defs: { tilesets: [], layers: [] },
+      levels: [
+        {
+          identifier: 'L',
+          uid: 1,
+          iid: 'iid-1',
+          worldX: 0,
+          worldY: 0,
+          pxWid: 48,
+          pxHei: 24,
+          layerInstances: [invalidGridSizeLayer, validTilesLayer],
+        },
+      ],
+    };
+
+    const map = ldtkToTileMap(data).levels[0]!;
+    expect(map.tileWidth).toBe(24);
+    expect(map.tileHeight).toBe(24);
+  });
+});
+
+describe('ldtkToTileMap — Tiles/AutoLayer tile-source fallback when the field is absent', () => {
+  const tileset = makeTileset('Atlas', 4);
+
+  it('falls back to an empty tile list for a Tiles layer with no gridTiles field', () => {
+    const data = docWithLayer({
+      __identifier: 'Tiles',
+      __type: 'Tiles',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 101,
+      levelId: 1,
+      visible: true,
+      iid: 'tiles-1',
+      __tilesetDefUid: 1,
+      // gridTiles intentionally omitted
+    });
+
+    const layer = ldtkToTileMap(data, { tilesets: new Map([[1, tileset]]) }).levels[0]!
+      .layers[0]!;
+    expect(layer.countNonEmptyTiles()).toBe(0);
+  });
+
+  it('falls back to an empty tile list for an AutoLayer layer with no autoLayerTiles field', () => {
+    const data = docWithLayer({
+      __identifier: 'Walls',
+      __type: 'AutoLayer',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 110,
+      levelId: 1,
+      visible: true,
+      iid: 'auto-1',
+      __tilesetDefUid: 1,
+      // autoLayerTiles intentionally omitted
+    });
+
+    const layer = ldtkToTileMap(data, { tilesets: new Map([[1, tileset]]) }).levels[0]!
+      .layers[0]!;
+    expect(layer.countNonEmptyTiles()).toBe(0);
+  });
+});
+
+describe('ldtkToTileMap — IntGrid auto-tiles reference a tileset uid missing from the tilesets map', () => {
+  it('leaves the layer without tiles instead of throwing', () => {
+    const tileset = makeTileset('Atlas', 4);
+    const data = docWithLayer({
+      __identifier: 'Collision',
+      __type: 'IntGrid',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 120,
+      levelId: 1,
+      visible: true,
+      iid: 'int-1',
+      __tilesetDefUid: 999, // not present in the tilesets map below
+      intGridCsv: [1, 0, 0, 0],
+      autoLayerTiles: [{ px: [0, 0], src: [0, 0], f: 0, t: 3 }],
+    });
+
+    const layer = ldtkToTileMap(data, { tilesets: new Map([[1, tileset]]) }).levels[0]!
+      .layers[0]!;
+    expect(layer.countNonEmptyTiles()).toBe(0);
+  });
+});
+
+describe('ldtkToTileMap — IntGrid layer with no intGridCsv data', () => {
+  it('exposes no IntGrid properties when intGridCsv is absent', () => {
+    const data = docWithLayer({
+      __identifier: 'Collision',
+      __type: 'IntGrid',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 120,
+      levelId: 1,
+      visible: true,
+      iid: 'int-1',
+      // intGridCsv intentionally omitted
+    });
+
+    const layer = ldtkToTileMap(data).levels[0]!.layers[0]!;
+    expect(getLdtkIntGridValueAt(layer, 0, 0)).toBeUndefined();
+  });
+
+  it('exposes no IntGrid properties when intGridCsv is an empty array', () => {
+    const data = docWithLayer({
+      __identifier: 'Collision',
+      __type: 'IntGrid',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 120,
+      levelId: 1,
+      visible: true,
+      iid: 'int-1',
+      intGridCsv: [],
+    });
+
+    const layer = ldtkToTileMap(data).levels[0]!.layers[0]!;
+    expect(getLdtkIntGridValueAt(layer, 0, 0)).toBeUndefined();
+  });
+});
+
+describe('ldtkToTileMap — Entities layer fallback / defensive entries', () => {
+  it('produces an empty ObjectLayer for an Entities layer with no entityInstances field', () => {
+    const data = docWithLayer({
+      __identifier: 'Entities',
+      __type: 'Entities',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 130,
+      levelId: 1,
+      visible: true,
+      iid: 'ent-1',
+      // entityInstances intentionally omitted
+    });
+
+    const objectLayer = ldtkToTileMap(data).levels[0]!.objectLayers[0]!;
+    expect(objectLayer.objects).toHaveLength(0);
+  });
+
+  it('skips a hole (undefined entry) in entityInstances while keeping surrounding entities and their index-derived ids', () => {
+    // entityInstances is typed as a dense array, but the conversion loop
+    // defensively guards against a sparse/holey array — construct one via a
+    // cast to exercise that guard.
+    const holeyInstances = [
+      makeEntity('First'),
+      undefined,
+      makeEntity('Second'),
+    ] as unknown as readonly LdtkEntityInstance[];
+
+    const data = docWithLayer({
+      __identifier: 'Entities',
+      __type: 'Entities',
+      __cWid: 4,
+      __cHei: 1,
+      __gridSize: 16,
+      layerDefUid: 130,
+      levelId: 1,
+      visible: true,
+      iid: 'ent-1',
+      entityInstances: holeyInstances,
+    });
+
+    const objects = ldtkToTileMap(data).levels[0]!.objectLayers[0]!.objects;
+    expect(objects.map(o => o.name)).toEqual(['First', 'Second']);
+    // index 1 (the hole) was skipped, so the surviving ids are 0 and 2.
+    expect(objects.map(o => o.id)).toEqual([0, 2]);
+  });
+});
+
+describe('ldtkToTileMap — unrecognised field types (exhaustiveness guard)', () => {
+  it('throws when a top-level field carries an unrecognised, non-Array __type', () => {
+    // Constructing this requires a cast — the LdtkFieldInstance union only
+    // permits known __type values, so this exercises the runtime guard
+    // against malformed/future LDtk data rather than a reachable-by-types path.
+    const bogusField = {
+      __identifier: 'x',
+      __type: 'FutureType',
+      __value: 'whatever',
+    } as unknown as LdtkFieldInstance;
+
+    expect(() => convertSingleField(bogusField)).toThrow(/unrecognised LDtk field type "FutureType"/);
+  });
+
+  it('drops an Array<T> element whose element type is unrecognised, yielding an empty array', () => {
+    const props = convertSingleField({
+      __identifier: 'mystery',
+      __type: 'Array<FutureType>',
+      __value: [1, 2, 3],
+    });
+
+    expect(props['mystery']).toEqual([]);
+  });
+});
+
 function makeEntityLevel(identifier: string, uid: number): LdtkLevel {
   return {
     identifier,

--- a/packages/exojs-ldtk/test/ldtk-extension.test.ts
+++ b/packages/exojs-ldtk/test/ldtk-extension.test.ts
@@ -1,10 +1,12 @@
+import type { AssetLoaderContext } from '@codexo/exojs';
 import { ExtensionRegistry } from '@codexo/exojs/extensions';
 import { tilemapExtension } from '@codexo/exojs-tilemap';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildSnapshot } from '../../../src/extensions/snapshot';
 import { resetExtensionRegistryForTesting } from '../../../src/extensions/testing';
 import { ldtkMapBinding } from '../src/ldtkBinding';
+import type { LdtkData } from '../src/LdtkData';
 import { ldtkExtension } from '../src/ldtkExtension';
 import { LdtkMap } from '../src/LdtkMap';
 
@@ -45,6 +47,44 @@ describe('@codexo/exojs-ldtk asset binding — ldtkMapBinding', () => {
   it('create() returns a handler with a load function', () => {
     const handler = ldtkMapBinding.create();
     expect(typeof handler.load).toBe('function');
+  });
+
+  it("load() delegates to loadLdtkMap, passing through the request's source and the context", async () => {
+    const fixture: LdtkData = {
+      jsonVersion: '1.5.3',
+      defaultGridSize: 16,
+      defs: { tilesets: [], layers: [] },
+      levels: [
+        {
+          identifier: 'L',
+          uid: 1,
+          iid: 'iid-1',
+          worldX: 0,
+          worldY: 0,
+          pxWid: 16,
+          pxHei: 16,
+          layerInstances: [],
+        },
+      ],
+    };
+    const source = 'https://example.com/world.ldtk';
+    const context: AssetLoaderContext = {
+      loader: { load: vi.fn() } as unknown as AssetLoaderContext['loader'],
+      identityKey: 'test',
+      fetchText: vi.fn(),
+      fetchArrayBuffer: vi.fn(),
+      fetchJson: vi.fn(async (requested: string) => {
+        expect(requested).toBe(source);
+        return fixture;
+      }),
+    };
+
+    const handler = ldtkMapBinding.create();
+    const result = await handler.load({ source }, context);
+
+    expect(result).toBeInstanceOf(LdtkMap);
+    expect(result.source).toBe(source);
+    expect(context.fetchJson).toHaveBeenCalledWith(source);
   });
 });
 

--- a/packages/exojs-ldtk/test/load-ldtk-map.test.ts
+++ b/packages/exojs-ldtk/test/load-ldtk-map.test.ts
@@ -367,6 +367,61 @@ describe('loadLdtkMap — external levels (.ldtkl)', () => {
   });
 });
 
+describe('loadLdtkMap — external level omits fieldInstances entirely', () => {
+  // Distinct from the "prefers the external fieldInstances" case above: here the
+  // external payload does not carry the key at all (undefined, not `[]`), so
+  // loadExternalLevel's `external.fieldInstances ?? level.fieldInstances` must
+  // fall back to the root level's own fieldInstances rather than dropping them.
+  const EXTERNAL_URL = 'https://example.com/maps/levels/Level_0.ldtkl';
+
+  const rootFixture: LdtkData = {
+    jsonVersion: '1.5.3',
+    defaultGridSize: 16,
+    defs: {
+      tilesets: [],
+      layers: [{ uid: 101, identifier: 'Entities', type: 'Entities', gridSize: 16 }],
+    },
+    levels: [
+      {
+        identifier: 'Level_0',
+        uid: 1,
+        iid: 'iid-1',
+        worldX: 0,
+        worldY: 0,
+        pxWid: 64,
+        pxHei: 16,
+        layerInstances: null,
+        externalRelPath: 'levels/Level_0.ldtkl',
+        fieldInstances: [{ __identifier: 'kept', __type: 'String', __value: 'root-value' }],
+      },
+    ],
+  };
+
+  const externalFixture = {
+    identifier: 'Level_0',
+    uid: 1,
+    iid: 'iid-1',
+    worldX: 0,
+    worldY: 0,
+    pxWid: 64,
+    pxHei: 16,
+    // fieldInstances intentionally omitted (not even an empty array).
+    layerInstances: [],
+  };
+
+  function context() {
+    return makeContext({
+      [ABS_SOURCE]: rootFixture,
+      [EXTERNAL_URL]: externalFixture,
+    });
+  }
+
+  it("falls back to the root level's fieldInstances when the external payload has none", async () => {
+    const map = await loadLdtkMap(ABS_SOURCE, context().context);
+    expect(map.levels[0]!.properties['kept']).toBe('root-value');
+  });
+});
+
 describe('loadLdtkMap — tilesets without an atlas image', () => {
   // relPath: null → the tileset is skipped entirely; tiles cannot render.
   const fixture: LdtkData = {

--- a/packages/exojs-particles/test/particle-default-texture.test.ts
+++ b/packages/exojs-particles/test/particle-default-texture.test.ts
@@ -1,0 +1,38 @@
+import { ParticleSystem } from '../src/ParticleSystem';
+
+// ParticleSystem falls back to a lazily-initialised, module-level 1x1 white
+// texture when constructed without one. That singleton is created at most
+// once per module instance (`defaultWhiteTexture` lives at module scope) —
+// this file is dedicated to it so its *first* access in this module's
+// lifetime is deterministic (a fresh test file gets a fresh module graph),
+// letting us exercise both the "not yet created" and "already created"
+// branches, plus the defensive `getContext('2d') === null` fallback.
+
+describe('ParticleSystem default white texture singleton', () => {
+  test('falls back to a 1x1 texture even when 2D canvas context creation fails', () => {
+    const original = HTMLCanvasElement.prototype.getContext;
+
+    // Force the very first `getDefaultWhiteTexture()` call in this module's
+    // lifetime down the `ctx === null` path (no fillRect performed).
+    HTMLCanvasElement.prototype.getContext = (() => null) as typeof original;
+
+    try {
+      const system = new ParticleSystem({ capacity: 1 });
+
+      expect(system.texture.width).toBe(1);
+      expect(system.texture.height).toBe(1);
+    } finally {
+      HTMLCanvasElement.prototype.getContext = original;
+    }
+  });
+
+  test('reuses the already-created singleton on a later construction', () => {
+    // The previous test already created and cached `defaultWhiteTexture` at
+    // module scope; this second textureless construction must hit the
+    // "already initialised" branch instead of creating a new canvas.
+    const first = new ParticleSystem({ capacity: 1 }).texture;
+    const second = new ParticleSystem({ capacity: 1 }).texture;
+
+    expect(second).toBe(first);
+  });
+});

--- a/packages/exojs-particles/test/particle-gpu.test.ts
+++ b/packages/exojs-particles/test/particle-gpu.test.ts
@@ -1,15 +1,21 @@
 /// <reference types="@webgpu/types" />
 
 import { Color, Rectangle, Texture, Time } from '@codexo/exojs';
+import type { RenderPlanBuilder } from '@codexo/exojs/renderer-sdk';
 import { WebGpuBackend } from '@codexo/exojs/renderer-sdk';
 
 import { ColorGradient } from '../src/distributions/ColorGradient';
+import { Constant } from '../src/distributions/Constant';
 import { Curve } from '../src/distributions/Curve';
+import { ParticleGpuState } from '../src/gpu/ParticleGpuState';
 import { ApplyForce } from '../src/modules/ApplyForce';
+import { BurstSpawn } from '../src/modules/BurstSpawn';
 import { ColorOverLifetime } from '../src/modules/ColorOverLifetime';
 import { Drag } from '../src/modules/Drag';
 import { RotateOverLifetime } from '../src/modules/RotateOverLifetime';
 import { ScaleOverLifetime } from '../src/modules/ScaleOverLifetime';
+import { SpawnOnDeath } from '../src/modules/SpawnOnDeath';
+import { Turbulence } from '../src/modules/Turbulence';
 import { UpdateModule } from '../src/modules/UpdateModule';
 import { ParticleSystem } from '../src/ParticleSystem';
 
@@ -127,6 +133,18 @@ const makeMockDevice = () => {
 
   return { device, encoder, pass, queue, buffers, textures, computePipelineDescriptors, shaderSources };
 };
+
+/** Finds the mock GPUBuffer created with a given `label`, by call order. */
+const findBufferByLabel = (env: ReturnType<typeof makeMockDevice>, label: string): { destroy: MockInstance } => {
+  const calls = (env.device.createBuffer as unknown as MockInstance).mock.calls as [GPUBufferDescriptor][];
+  const index = calls.findIndex(([descriptor]) => descriptor.label === label);
+
+  if (index === -1) throw new Error(`No buffer created with label "${label}"`);
+
+  return env.buffers[index]!;
+};
+
+const makeBuilder = (device: GPUDevice | null): RenderPlanBuilder => ({ backend: { device } }) as unknown as RenderPlanBuilder;
 
 describe('ParticleSystem GPU mode — auto-routing', () => {
   let restoreGlobals: () => void;
@@ -402,5 +420,438 @@ describe('ParticleSystem render-inject backend detection', () => {
 
     system.update(tick(0.016));
     expect(system.gpuMode).toBe(true);
+  });
+});
+
+describe('ParticleSystem._collect backend-change detection', () => {
+  let restoreGlobals: () => void;
+
+  beforeEach(() => {
+    restoreGlobals = installGlobals();
+  });
+
+  afterEach(() => {
+    restoreGlobals();
+  });
+
+  test('re-collecting on the same backend is a no-op; a changed backend tears down GPU state', () => {
+    const env = makeMockDevice();
+    const system = new ParticleSystem(makeTexture(), { capacity: 4 });
+
+    // visible=false makes the inherited RenderNode._collect() return
+    // immediately after ParticleSystem's own backend-tracking logic runs,
+    // so we can drive `_collect` directly without a full render-plan builder.
+    system.visible = false;
+    system.addUpdateModule(new ApplyForce(0, 0));
+
+    const builderA = makeBuilder(env.device);
+
+    system._collect(builderA);
+    expect(system.gpuState).toBeNull();
+
+    const slot = system.spawn();
+    system.lifetime[slot] = 10;
+    system.update(tick(0.016));
+    expect(system.gpuMode).toBe(true);
+
+    const gpuStateAfterCompile = system.gpuState;
+    expect(gpuStateAfterCompile).not.toBeNull();
+
+    // Same backend reference again — must not touch the existing GPU state.
+    system._collect(builderA);
+    expect(system.gpuState).toBe(gpuStateAfterCompile);
+
+    // A different backend forces a teardown of the existing GPU state.
+    const env2 = makeMockDevice();
+    const builderB = makeBuilder(env2.device);
+
+    system._collect(builderB);
+    expect(system.gpuState).toBeNull();
+  });
+});
+
+describe('ParticleSystem._compile pre-existing dead slots', () => {
+  let restoreGlobals: () => void;
+
+  beforeEach(() => {
+    restoreGlobals = installGlobals();
+  });
+
+  afterEach(() => {
+    restoreGlobals();
+  });
+
+  test('slots killed directly (not via natural expiry) before the first update are not marked dirty at compile time', () => {
+    const env = makeMockDevice();
+    const system = new ParticleSystem(makeTexture(), { capacity: 4, device: env.device });
+
+    // Two slots spawned in dense CPU fashion before any update() call (the
+    // system is still in CPU mode at this point — _compile() hasn't run).
+    const a = system.spawn();
+    const b = system.spawn();
+
+    system.lifetime[a] = 10;
+    system.lifetime[b] = 10;
+    // Kill slot b directly, bypassing recycling — it's still within
+    // [0, liveCount) when _compile() runs on the first update().
+    system.alive[b] = 0;
+
+    system.addUpdateModule(new ApplyForce(0, 0));
+    system.update(tick(0.016));
+
+    expect(system.gpuMode).toBe(true);
+
+    const positionsBuffer = findBufferByLabel(env, 'particle-positions');
+    const offsets = (env.queue.writeBuffer as unknown as MockInstance).mock.calls
+      .filter(([buffer]) => buffer === positionsBuffer)
+      .map(([, offset]) => offset);
+
+    // Slot a (alive) is uploaded at byte offset 0; slot b (dead pre-compile)
+    // must be skipped, so its byte offset (8) never appears.
+    expect(offsets).toContain(0);
+    expect(offsets).not.toContain(8);
+  });
+});
+
+describe('ParticleSystem._spawnGpu wrap-around search', () => {
+  let restoreGlobals: () => void;
+
+  beforeEach(() => {
+    restoreGlobals = installGlobals();
+  });
+
+  afterEach(() => {
+    restoreGlobals();
+  });
+
+  test('wraps past the hint to find a dead slot below it, skipping still-alive slots along the way', () => {
+    const env = makeMockDevice();
+    const system = new ParticleSystem(makeTexture(), { capacity: 4, device: env.device });
+
+    system.addUpdateModule(new ApplyForce(0, 0));
+    system.update(tick(0));
+    expect(system.gpuMode).toBe(true);
+
+    // Fill all 4 slots — the round-robin hint wraps back to 0.
+    const a = system.spawn();
+    const b = system.spawn();
+    const c = system.spawn();
+    const d = system.spawn();
+
+    expect([a, b, c, d]).toEqual([0, 1, 2, 3]);
+
+    // Free slot 2 — found by the forward-scan first loop, hint becomes 3.
+    system.alive[2] = 0;
+    expect(system.spawn()).toBe(2);
+
+    // Free slot 1 (but leave slot 0 alive). The forward-scan loop
+    // (hint(3)..capacity-1) finds nothing since slot 3 is still alive, so
+    // the wrap-around loop (0..hint) must run: it skips over still-alive
+    // slot 0 before finding dead slot 1.
+    system.alive[1] = 0;
+    expect(system.spawn()).toBe(1);
+  });
+
+  test('returns -1 once every slot is alive and no gap exists to wrap into', () => {
+    const env = makeMockDevice();
+    const system = new ParticleSystem(makeTexture(), { capacity: 2, device: env.device });
+
+    system.addUpdateModule(new ApplyForce(0, 0));
+    system.update(tick(0));
+    expect(system.gpuMode).toBe(true);
+
+    expect(system.spawn()).toBe(0);
+    expect(system.spawn()).toBe(1);
+    expect(system.spawn()).toBe(-1);
+  });
+});
+
+describe('ParticleSystem._updateGpu dead-slot skipping', () => {
+  let restoreGlobals: () => void;
+
+  beforeEach(() => {
+    restoreGlobals = installGlobals();
+  });
+
+  afterEach(() => {
+    restoreGlobals();
+  });
+
+  test('slots killed directly within the live range are skipped by the elapsed-increment loop', () => {
+    const env = makeMockDevice();
+    const system = new ParticleSystem(makeTexture(), { capacity: 4, device: env.device });
+
+    system.addUpdateModule(new ApplyForce(0, 0));
+
+    const a = system.spawn();
+    const b = system.spawn();
+
+    system.lifetime[a] = 10;
+    system.lifetime[b] = 10;
+    system.update(tick(0));
+    expect(system.gpuMode).toBe(true);
+
+    // Kill b directly — not via natural expiry — while it's still within
+    // [0, liveCount).
+    system.alive[b] = 0;
+    system.update(tick(0.1));
+
+    expect(system.elapsed[a]).toBeCloseTo(0.1);
+    // b was skipped by the `if (alive[i] === 0) continue;` guard, so its
+    // elapsed time is untouched.
+    expect(system.elapsed[b]).toBe(0);
+  });
+});
+
+describe('ParticleSystem GPU mode — natural expiry death modules', () => {
+  let restoreGlobals: () => void;
+
+  beforeEach(() => {
+    restoreGlobals = installGlobals();
+  });
+
+  afterEach(() => {
+    restoreGlobals();
+  });
+
+  test('fires death modules when a particle expires naturally (elapsed >= lifetime) in GPU mode', () => {
+    const env = makeMockDevice();
+    const parent = new ParticleSystem(makeTexture(), { capacity: 4, device: env.device });
+    const child = new ParticleSystem(makeTexture(), { capacity: 4 });
+
+    parent.addUpdateModule(new ApplyForce(0, 0));
+    parent.addDeathModule(new SpawnOnDeath(child, new BurstSpawn({ schedule: [{ time: 0, count: 1 }], lifetime: new Constant(5) })));
+
+    const slot = parent.spawn();
+    parent.lifetime[slot] = 0.05;
+
+    parent.update(tick(0));
+    expect(parent.gpuMode).toBe(true);
+
+    // elapsed (integrated in _updateGpu) reaches 0.1 >= lifetime 0.05 -> natural expiry.
+    parent.update(tick(0.1));
+
+    expect(parent.alive[slot]).toBe(0);
+    expect(parent.lifetime[slot]).toBe(-1);
+    expect(child.liveCount).toBe(1);
+  });
+});
+
+describe('ParticleGpuState direct construction', () => {
+  let restoreGlobals: () => void;
+
+  beforeEach(() => {
+    restoreGlobals = installGlobals();
+  });
+
+  afterEach(() => {
+    restoreGlobals();
+  });
+
+  test('throws if a registered module lacks wgsl(), bypassing ParticleSystem\'s own eligibility guard', () => {
+    const env = makeMockDevice();
+
+    class NoWgslModule extends UpdateModule {
+      public override apply(): void {
+        /* no-op */
+      }
+    }
+
+    expect(() => new ParticleGpuState(env.device, 4, [new NoWgslModule()], [], makeTexture())).toThrow(/has no wgsl/);
+  });
+
+  test('uploadTextures loop tolerates a module that implements uploadTextures() without declaring any wgsl() textures', () => {
+    const env = makeMockDevice();
+
+    let uploadCalls = 0;
+
+    class UploaderWithoutTextures extends UpdateModule {
+      public override apply(): void {
+        /* no-op */
+      }
+
+      public override wgsl() {
+        return { key: 'NoTex', body: '// noop' };
+      }
+
+      public override uploadTextures(_device: GPUDevice, textures: ReadonlyMap<string, GPUTexture>): void {
+        uploadCalls++;
+        expect(textures.size).toBe(0);
+      }
+    }
+
+    expect(() => new ParticleGpuState(env.device, 4, [new UploaderWithoutTextures()], [], makeTexture())).not.toThrow();
+    expect(uploadCalls).toBe(1);
+  });
+
+  test('destroy() releases every module-owned lookup texture', () => {
+    const env = makeMockDevice();
+    const system = new ParticleSystem(makeTexture(), { capacity: 4, device: env.device });
+
+    system.addUpdateModule(
+      new ScaleOverLifetime(
+        new Curve([
+          { t: 0, v: 1 },
+          { t: 1, v: 0 },
+        ]),
+      ),
+    );
+
+    const slot = system.spawn();
+    system.lifetime[slot] = 10;
+    system.update(tick(0.016));
+
+    expect(system.gpuMode).toBe(true);
+    expect(env.textures.length).toBeGreaterThan(0);
+
+    system.destroy();
+
+    expect(env.textures.every(t => t.destroy.mock.calls.length > 0)).toBe(true);
+  });
+});
+
+describe('ParticleGpuState frame-UV packing (_writeFrames)', () => {
+  let restoreGlobals: () => void;
+
+  beforeEach(() => {
+    restoreGlobals = installGlobals();
+  });
+
+  afterEach(() => {
+    restoreGlobals();
+  });
+
+  const readFramesUniforms = (env: ReturnType<typeof makeMockDevice>): Float32Array => {
+    const framesBuffer = findBufferByLabel(env, 'particle-frames-uniforms');
+    const call = (env.queue.writeBuffer as unknown as MockInstance).mock.calls.find(([buffer]) => buffer === framesBuffer);
+
+    if (!call) throw new Error('frames uniform buffer was never written');
+
+    return new Float32Array(call[2] as ArrayBuffer);
+  };
+
+  test('atlas frames (non-flipped) pack per-frame UV bounds via the loop path', () => {
+    const env = makeMockDevice();
+    const tex = makeTexture(); // 16x16
+    const frames = [new Rectangle(0, 0, 8, 8), new Rectangle(8, 0, 8, 8)];
+    const system = new ParticleSystem(tex, frames, { capacity: 4, device: env.device });
+
+    system.addUpdateModule(new ApplyForce(0, 0));
+    const slot = system.spawn();
+    system.lifetime[slot] = 10;
+    system.update(tick(0.016));
+
+    expect(system.gpuMode).toBe(true);
+
+    const view = readFramesUniforms(env);
+
+    // Frame 0: (0,0)-(8,8) on a 16x16 texture -> UV (0,0)-(0.5,0.5).
+    expect(view[0]).toBeCloseTo(0);
+    expect(view[1]).toBeCloseTo(0);
+    expect(view[2]).toBeCloseTo(0.5);
+    expect(view[3]).toBeCloseTo(0.5);
+    // Frame 1: (8,0)-(16,8) -> UV (0.5,0)-(1,0.5).
+    expect(view[4]).toBeCloseTo(0.5);
+    expect(view[5]).toBeCloseTo(0);
+    expect(view[6]).toBeCloseTo(1);
+    expect(view[7]).toBeCloseTo(0.5);
+  });
+
+  test('atlas frames on a flipY texture swap the V bounds via the loop path', () => {
+    const env = makeMockDevice();
+    const tex = makeTexture();
+    tex.flipY = true;
+    const frames = [new Rectangle(0, 0, 8, 8)];
+    const system = new ParticleSystem(tex, frames, { capacity: 4, device: env.device });
+
+    system.addUpdateModule(new ApplyForce(0, 0));
+    const slot = system.spawn();
+    system.lifetime[slot] = 10;
+    system.update(tick(0.016));
+
+    const view = readFramesUniforms(env);
+
+    // flipY swaps topV/bottomV: minV becomes bottomV(0), maxV becomes topV(0.5).
+    expect(view[1]).toBeCloseTo(0.5);
+    expect(view[3]).toBeCloseTo(0);
+  });
+
+  test('flipY texture without an atlas packs the single-frame fallback with V bounds swapped', () => {
+    const env = makeMockDevice();
+    const tex = makeTexture();
+    tex.flipY = true;
+    const system = new ParticleSystem(tex, { capacity: 4, device: env.device });
+
+    system.addUpdateModule(new ApplyForce(0, 0));
+    const slot = system.spawn();
+    system.lifetime[slot] = 10;
+    system.update(tick(0.016));
+
+    const view = readFramesUniforms(env);
+
+    expect(view[0]).toBe(0);
+    expect(view[1]).toBe(1);
+    expect(view[2]).toBe(1);
+    expect(view[3]).toBe(0);
+  });
+});
+
+describe('ParticleGpuState prelude deduplication', () => {
+  let restoreGlobals: () => void;
+
+  beforeEach(() => {
+    restoreGlobals = installGlobals();
+  });
+
+  afterEach(() => {
+    restoreGlobals();
+  });
+
+  test('two modules sharing a wgsl() key emit the prelude helper block only once', () => {
+    const env = makeMockDevice();
+    const system = new ParticleSystem(makeTexture(), { capacity: 4, device: env.device });
+
+    // Two Turbulence instances share the same wgsl() `key` ("Turbulence") —
+    // documented as unsupported ("Two ApplyForce instances on one system
+    // aren't supported — combine into one", WgslContribution.key) but not
+    // rejected at runtime. This is the only way to reach the prelude
+    // deduplication branch, so we use it purely to exercise that path.
+    system.addUpdateModule(new Turbulence(50));
+    system.addUpdateModule(new Turbulence(30));
+
+    const slot = system.spawn();
+    system.lifetime[slot] = 10;
+    system.update(tick(0.016));
+
+    expect(system.gpuMode).toBe(true);
+
+    const shaderSource = env.shaderSources[0]!;
+    const preludeOccurrences = shaderSource.match(/fn exojs_turbulence_hash21/g) ?? [];
+
+    expect(preludeOccurrences.length).toBe(1);
+  });
+});
+
+describe('UpdateModule.uploadTextures — missing map entry', () => {
+  test('ColorOverLifetime.uploadTextures no-ops when the gradient texture is absent from the map', () => {
+    const module = new ColorOverLifetime(
+      new ColorGradient([
+        { t: 0, color: new Color(0, 0, 0, 1) },
+        { t: 1, color: new Color(255, 255, 255, 1) },
+      ]),
+    );
+
+    expect(() => module.uploadTextures({} as GPUDevice, new Map())).not.toThrow();
+  });
+
+  test('ScaleOverLifetime.uploadTextures no-ops when the curve texture is absent from the map', () => {
+    const module = new ScaleOverLifetime(
+      new Curve([
+        { t: 0, v: 1 },
+        { t: 1, v: 0 },
+      ]),
+    );
+
+    expect(() => module.uploadTextures({} as GPUDevice, new Map())).not.toThrow();
   });
 });

--- a/packages/exojs-particles/test/particle-system-lifecycle.test.ts
+++ b/packages/exojs-particles/test/particle-system-lifecycle.test.ts
@@ -43,6 +43,32 @@ describe('ParticleSystem construction shapes', () => {
     expect(system.hasAtlas).toBe(false);
   });
 
+  test('texture + frames overload without a trailing options bag uses the default capacity', () => {
+    const tex = makeTexture();
+    const frames = [new Rectangle(0, 0, 8, 8), new Rectangle(8, 0, 8, 8)];
+    const system = new ParticleSystem(tex, frames);
+
+    expect(system.capacity).toBe(4096);
+    expect(system.frames.length).toBe(2);
+    expect(system.hasAtlas).toBe(true);
+  });
+
+  test('Spritesheet overload without a trailing options bag uses the default capacity', () => {
+    const tex = makeTexture(32, 32);
+    const sheet = new Spritesheet(tex, {
+      frames: {
+        a: { frame: { x: 0, y: 0, w: 16, h: 16 } },
+        b: { frame: { x: 16, y: 0, w: 16, h: 16 } },
+      },
+    });
+
+    const system = new ParticleSystem(sheet);
+
+    expect(system.capacity).toBe(4096);
+    expect(system.texture).toBe(tex);
+    expect(system.frames.length).toBe(2);
+  });
+
   test('Spritesheet overload pulls texture and frames from the sheet', () => {
     const tex = makeTexture(32, 32);
     const sheet = new Spritesheet(tex, {
@@ -114,6 +140,19 @@ describe('ParticleSystem texture / frame accessors', () => {
     expect(top).toBeCloseTo(-5);
     expect(right).toBeCloseTo(10);
     expect(bottom).toBeCloseTo(5);
+  });
+
+  test('vertices getter reuses the cached value on a second access without recomputing', () => {
+    const system = new ParticleSystem(makeTexture(20, 10), { capacity: 4 });
+
+    const first = system.vertices;
+    const second = system.vertices;
+
+    // Same underlying Float32Array instance, with unchanged values — the
+    // cache-hit branch must skip the recompute block entirely.
+    expect(second).toBe(first);
+    expect(second[0]).toBeCloseTo(-10);
+    expect(second[1]).toBeCloseTo(-5);
   });
 
   test('texCoords ordering flips when the texture has flipY set', () => {
@@ -199,6 +238,23 @@ describe('ParticleSystem module registries', () => {
 
     expect(destroySpy).toHaveBeenCalledTimes(1);
     expect(system.deathModules.length).toBe(0);
+  });
+});
+
+describe('ParticleSystem.aliveCount', () => {
+  test('counts only slots flagged alive within [0, liveCount), distinct from liveCount itself', () => {
+    const system = new ParticleSystem(makeTexture(), { capacity: 8 });
+
+    system.spawn();
+    system.spawn();
+    system.spawn();
+
+    // Directly clear one slot's alive flag without going through the
+    // normal compaction path (simulates a GPU-mode dead hole).
+    system.alive[1] = 0;
+
+    expect(system.liveCount).toBe(3);
+    expect(system.aliveCount).toBe(2);
   });
 });
 

--- a/packages/exojs-particles/test/particle-system.test.ts
+++ b/packages/exojs-particles/test/particle-system.test.ts
@@ -165,6 +165,19 @@ describe('Distribution', () => {
     expect(g.evaluateRgba(0)).toBe(0);
   });
 
+  test('BoxArea defaults to volume mode when no mode is given', () => {
+    const box = new BoxArea(10, 20, -5, 5);
+
+    expect(box.mode).toBe('volume');
+
+    for (let i = 0; i < 50; i++) {
+      const v = box.sample();
+
+      expect(v.x).toBeGreaterThanOrEqual(10);
+      expect(v.x).toBeLessThanOrEqual(20);
+    }
+  });
+
   test('BoxArea volume mode stays within the box', () => {
     const box = new BoxArea(10, 20, -5, 5, 'volume');
 
@@ -190,6 +203,19 @@ describe('Distribution', () => {
       expect(v.x).toBeLessThanOrEqual(10);
       expect(v.y).toBeGreaterThanOrEqual(0);
       expect(v.y).toBeLessThanOrEqual(20);
+    }
+  });
+
+  test('CircleArea defaults to volume mode when no mode is given', () => {
+    const circle = new CircleArea(100, 50, 25);
+
+    expect(circle.mode).toBe('volume');
+
+    for (let i = 0; i < 50; i++) {
+      const v = circle.sample();
+      const dist = Math.hypot(v.x - 100, v.y - 50);
+
+      expect(dist).toBeLessThanOrEqual(25);
     }
   });
 
@@ -256,6 +282,39 @@ describe('Distribution', () => {
 });
 
 describe('SpawnModule', () => {
+  test('RateSpawn skips spawning while the accumulated fraction is below one whole particle', () => {
+    const system = new ParticleSystem(makeTexture(), { capacity: 8 });
+
+    system.addSpawnModule(
+      new RateSpawn({
+        rate: new Constant(1),
+        lifetime: new Constant(10),
+      }),
+    );
+
+    // 1 particle/s * 0.01s = 0.01 accumulated — rounds down to 0, so the
+    // module must return early without spawning or throwing.
+    system.update(tick(0.01));
+
+    expect(system.liveCount).toBe(0);
+  });
+
+  test('RateSpawn defaults spawned particles to a 1-second lifetime when omitted', () => {
+    const system = new ParticleSystem(makeTexture(), { capacity: 8 });
+
+    system.addSpawnModule(new RateSpawn({ rate: new Constant(100) }));
+
+    // A short tick — a full 1s tick would make elapsed (integrated in the
+    // same frame) equal the default lifetime, expiring particles instantly.
+    system.update(tick(0.1));
+
+    expect(system.liveCount).toBeGreaterThan(0);
+
+    for (let i = 0; i < system.liveCount; i++) {
+      expect(system.lifetime[i]).toBe(1);
+    }
+  });
+
   test('RateSpawn emits at configured rate', () => {
     const system = new ParticleSystem(makeTexture(), { capacity: 1024 });
 
@@ -298,6 +357,30 @@ describe('SpawnModule', () => {
       expect(system.scaleX[i]).toBeCloseTo(2);
       // rotation = rotationSpeed * dt = 45 * 0.1 = 4.5
       expect(system.rotations[i]).toBeCloseTo(4.5);
+    }
+  });
+
+  test('BurstSpawn with an empty schedule never fires and never throws', () => {
+    const system = new ParticleSystem(makeTexture(), { capacity: 8 });
+
+    system.addSpawnModule(new BurstSpawn({ schedule: [], lifetime: new Constant(10) }));
+
+    system.update(tick(1));
+
+    expect(system.liveCount).toBe(0);
+  });
+
+  test('BurstSpawn defaults spawned particles to a 1-second lifetime when omitted', () => {
+    const system = new ParticleSystem(makeTexture(), { capacity: 8 });
+
+    system.addSpawnModule(new BurstSpawn({ schedule: [{ time: 0, count: 3 }] }));
+
+    system.update(tick(0.1));
+
+    expect(system.liveCount).toBe(3);
+
+    for (let i = 0; i < system.liveCount; i++) {
+      expect(system.lifetime[i]).toBe(1);
     }
   });
 
@@ -534,6 +617,30 @@ describe('UpdateModule', () => {
     expect(Math.abs(system.velX[slot])).toBeGreaterThan(20);
   });
 
+  test('VelocityOverLifetime treats an exact-zero curve sample as a near-zero sentinel', () => {
+    const system = new ParticleSystem(makeTexture(), { capacity: 4 });
+    const slot = system.spawn();
+
+    system.lifetime[slot] = 1;
+    system.velX[slot] = 100;
+    system.velY[slot] = 0;
+    system.addUpdateModule(
+      new VelocityOverLifetime(
+        new Curve([
+          { t: 0, v: 1 },
+          { t: 1, v: 0 },
+        ]),
+      ),
+    );
+
+    // A single 1s tick advances elapsed to exactly lifetime (t=1), where the
+    // curve evaluates to exactly 0 — the module must not store a literal 0
+    // (which would divide-by-zero on a later frame) but a tiny sentinel.
+    system.update(tick(1));
+
+    expect(system.velX[slot]).toBeCloseTo(0);
+  });
+
   test('AttractToPoint pulls particle toward target', () => {
     const system = new ParticleSystem(makeTexture(), { capacity: 4 });
     const slot = system.spawn();
@@ -579,6 +686,62 @@ describe('UpdateModule', () => {
     expect(unsoftened.velX[unsoftenedSlot]).toBeCloseTo(1000);
     expect(softened.velX[softenedSlot]).toBeCloseTo(200);
     expect(softened.velX[softenedSlot]).toBeLessThan(unsoftened.velX[unsoftenedSlot]);
+  });
+
+  test('AttractToPoint ignores a particle sitting exactly on the target (avoids a divide-by-zero)', () => {
+    const system = new ParticleSystem(makeTexture(), { capacity: 4 });
+    const slot = system.spawn();
+
+    system.lifetime[slot] = 10;
+    system.posX[slot] = 100;
+    system.posY[slot] = 0;
+    // Zero velocity so integration doesn't move the particle off the exact
+    // target position before the module runs.
+    system.velX[slot] = 0;
+    system.velY[slot] = 0;
+    system.addUpdateModule(new AttractToPoint(100, 0, 1000));
+
+    system.update(tick(1));
+
+    // dist === 0 < epsilon guard — the module must skip this particle
+    // entirely rather than dividing by zero (which would produce NaN/Infinity).
+    expect(system.velX[slot]).toBe(0);
+    expect(system.velY[slot]).toBe(0);
+  });
+
+  test('RepelFromPoint ignores a particle sitting exactly on the source (avoids a divide-by-zero)', () => {
+    const system = new ParticleSystem(makeTexture(), { capacity: 4 });
+    const slot = system.spawn();
+
+    system.lifetime[slot] = 10;
+    system.posX[slot] = 0;
+    system.posY[slot] = 0;
+    system.velX[slot] = 0;
+    system.velY[slot] = 0;
+    system.addUpdateModule(new RepelFromPoint(0, 0, 500));
+
+    system.update(tick(1));
+
+    expect(system.velX[slot]).toBe(0);
+    expect(system.velY[slot]).toBe(0);
+  });
+
+  test('RepelFromPoint softens the push with a linear falloff inside the radius', () => {
+    const system = new ParticleSystem(makeTexture(), { capacity: 4 });
+    const slot = system.spawn();
+
+    system.lifetime[slot] = 10;
+    system.posX[slot] = 10;
+    system.posY[slot] = 0;
+    system.velX[slot] = 0;
+    system.velY[slot] = 0;
+    // dist=10, radius=50 (in range) -> falloff = 1 - 10/50 = 0.8
+    // a = strength * falloff * dt / dist = 1000 * 0.8 * 1 / 10 = 80
+    system.addUpdateModule(new RepelFromPoint(0, 0, 1000, 50));
+
+    system.update(tick(1));
+
+    expect(system.velX[slot]).toBeCloseTo(800);
   });
 
   test('RepelFromPoint pushes particle away from source', () => {
@@ -630,6 +793,13 @@ describe('UpdateModule', () => {
     expect(Math.abs(system.velX[slot])).toBeLessThan(0.001);
   });
 
+  test('Turbulence defaults frequency and timeScale when omitted', () => {
+    const turbulence = new Turbulence(50);
+
+    expect(turbulence.frequency).toBe(0.01);
+    expect(turbulence.timeScale).toBe(1);
+  });
+
   test('Turbulence perturbs particle velocity', () => {
     const system = new ParticleSystem(makeTexture(), { capacity: 4 });
     const slot = system.spawn();
@@ -676,6 +846,15 @@ describe('UpdateModule', () => {
 });
 
 describe('DeathModule', () => {
+  test('SpawnOnDeath defaults count to 1 when omitted', () => {
+    const child = new ParticleSystem(makeTexture(), { capacity: 4 });
+    const burst = new BurstSpawn({ schedule: [{ time: 0, count: 1 }], lifetime: new Constant(5) });
+
+    const death = new SpawnOnDeath(child, burst);
+
+    expect(death.count).toBe(1);
+  });
+
   test('SpawnOnDeath fires when particle expires and copies position', () => {
     const parent = new ParticleSystem(makeTexture(), { capacity: 4 });
     const child = new ParticleSystem(makeTexture(), { capacity: 16 });

--- a/packages/exojs-physics/src/joints/PrismaticJoint.ts
+++ b/packages/exojs-physics/src/joints/PrismaticJoint.ts
@@ -91,7 +91,12 @@ export class PrismaticJoint extends Joint {
     this._localAnchorBx = scratch.x;
     this._localAnchorBy = scratch.y;
 
-    const axisLength = Math.hypot(options.axis.x, options.axis.y) || 1;
+    const axisLength = Math.hypot(options.axis.x, options.axis.y);
+
+    if (!Number.isFinite(axisLength) || axisLength === 0) {
+      throw new RangeError(`PrismaticJoint: axis must be a non-zero finite vector, received (${options.axis.x}, ${options.axis.y}).`);
+    }
+
     applyInverseRotation(options.bodyA.transform, options.axis.x / axisLength, options.axis.y / axisLength, scratch);
     this._localAxisAx = scratch.x;
     this._localAxisAy = scratch.y;

--- a/packages/exojs-physics/src/joints/WheelJoint.ts
+++ b/packages/exojs-physics/src/joints/WheelJoint.ts
@@ -100,7 +100,12 @@ export class WheelJoint extends Joint {
     this._localAnchorBx = scratch.x;
     this._localAnchorBy = scratch.y;
 
-    const axisLength = Math.hypot(options.axis.x, options.axis.y) || 1;
+    const axisLength = Math.hypot(options.axis.x, options.axis.y);
+
+    if (!Number.isFinite(axisLength) || axisLength === 0) {
+      throw new RangeError(`WheelJoint: axis must be a non-zero finite vector, received (${options.axis.x}, ${options.axis.y}).`);
+    }
+
     applyInverseRotation(options.bodyA.transform, options.axis.x / axisLength, options.axis.y / axisLength, scratch);
     this._localAxisAx = scratch.x;
     this._localAxisAy = scratch.y;

--- a/packages/exojs-physics/test/binding.test.ts
+++ b/packages/exojs-physics/test/binding.test.ts
@@ -1,6 +1,9 @@
 import type { SceneNode } from '@codexo/exojs';
 import { describe, expect, it } from 'vitest';
 
+import { NativePhysicsBackend } from '../src/backend/NativePhysicsBackend';
+import { BindingRegistry } from '../src/binding/BindingRegistry';
+import { Collider } from '../src/Collider';
 import { BoxShape, PhysicsBody, PhysicsWorld } from '../src/index';
 
 interface FakeNode {
@@ -84,5 +87,51 @@ describe('SceneNode binding', () => {
     world.step(1 / 60);
     expect(node.x).toBe(0);
     expect(node.y).toBe(0);
+  });
+});
+
+describe('BindingRegistry', () => {
+  it('tracks the number of active bindings via size', () => {
+    const registry = new BindingRegistry();
+    const bodyA = new PhysicsBody({ type: 'kinematic', position: { x: 0, y: 0 }, colliders: [{ shape: new BoxShape(10, 10) }] });
+    const bodyB = new PhysicsBody({ type: 'kinematic', position: { x: 0, y: 0 }, colliders: [{ shape: new BoxShape(10, 10) }] });
+
+    expect(registry.size).toBe(0);
+
+    registry.bind(bodyA, fakeNode() as unknown as SceneNode);
+    expect(registry.size).toBe(1);
+
+    registry.bind(bodyB, fakeNode() as unknown as SceneNode);
+    expect(registry.size).toBe(2);
+
+    registry.unbind(bodyA);
+    expect(registry.size).toBe(1);
+
+    registry.clear();
+    expect(registry.size).toBe(0);
+  });
+});
+
+describe('NativePhysicsBackend', () => {
+  it('exposes the latest broad-phase candidate pairs', () => {
+    // A real PhysicsWorld is used only to attach + synchronize the colliders (assign
+    // ids, compute their AABBs) — the backend under test is a fresh, standalone instance,
+    // not the world's own backend.
+    const world = new PhysicsWorld();
+    const colliderA = new Collider({ shape: new BoxShape(10, 10) });
+    const colliderB = new Collider({ shape: new BoxShape(10, 10) });
+
+    world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 }, colliders: [colliderA] }));
+    world.add(new PhysicsBody({ type: 'static', position: { x: 5, y: 0 }, colliders: [colliderB] }));
+
+    const backend = new NativePhysicsBackend();
+
+    expect(backend.candidatePairs.length).toBe(0);
+
+    backend.detect([colliderA, colliderB]);
+
+    expect(backend.candidatePairs.length).toBe(1);
+    expect(backend.candidatePairs[0]?.a).toBe(colliderA);
+    expect(backend.candidatePairs[0]?.b).toBe(colliderB);
   });
 });

--- a/packages/exojs-physics/test/ccd.test.ts
+++ b/packages/exojs-physics/test/ccd.test.ts
@@ -139,4 +139,45 @@ describe('continuous collision (bullet mode)', () => {
     // would have dead-stopped it at vy ≈ 0.
     expect(ball.linearVelocityY).toBeGreaterThan(1000);
   });
+
+  it('a bullet with negligible motion this step is skipped by the sweep (near-zero distance)', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const ball = new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [{ shape: new CircleShape(6) }] });
+    ball.isBullet = true;
+    world.add(ball);
+
+    // No velocity, no gravity — the body barely moves (well below the sweep's
+    // 1e-6 distance floor), so `_advanceBullets` must bail out via the
+    // near-zero-distance guard instead of normalizing a ~zero-length direction.
+    expect(() => world.step(FRAME)).not.toThrow();
+    expect(ball.x).toBe(0);
+    expect(ball.y).toBe(0);
+  });
+
+  it('a slow bullet impact below the restitution threshold does not bounce', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    // The CCD sweep tracks the centre point only (documented limitation — see
+    // `_advanceBullets`), targeting the wall's true surface at x = 198,
+    // independent of the ball's own radius. A normal-sized ball's *actual*
+    // shape would already overlap the wall from this close (radius 6 ≫ the
+    // 0.005px gap), so the ordinary discrete solver — not CCD — would resolve
+    // it first. Using a tiny radius (0.002, smaller than this step's ~0.0083px
+    // travel) keeps the real shapes apart at the step's start while still
+    // letting the centre-only sweep register the crossing, so CCD (not the
+    // discrete solver) is what responds here. At vx = 0.5 px/s the impact speed
+    // is well below `ccdRestitutionThreshold` (1 px/s), so the response must be
+    // a pure slide (restitution 0), not a bounce.
+    world.add(new PhysicsBody({ type: 'static', position: { x: 200, y: 0 }, colliders: [{ shape: new BoxShape(4, 400) }] }));
+    const ball = new PhysicsBody({ type: 'dynamic', position: { x: 198 - 0.005, y: 0 }, colliders: [{ shape: new CircleShape(0.002) }] });
+    ball.isBullet = true;
+    world.add(ball);
+    ball.linearVelocityX = 0.5;
+
+    world.step(FRAME);
+
+    expect(ball.x).toBeLessThan(198); // clamped short of the wall surface, did not tunnel
+    // A bounce (restitution > 0) would reverse the velocity to a negative value;
+    // a slide (restitution 0) cancels the inward velocity to ~0, not past it.
+    expect(ball.linearVelocityX).toBeCloseTo(0, 6);
+  });
 });

--- a/packages/exojs-physics/test/debug.test.ts
+++ b/packages/exojs-physics/test/debug.test.ts
@@ -1,10 +1,48 @@
 import type { Application } from '@codexo/exojs';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { PhysicsDebugDraw } from '../src/debug/PhysicsDebugDraw';
-import { PhysicsWorld } from '../src/index';
+import { BoxShape, CircleShape, DistanceJoint, PhysicsBody, PhysicsWorld } from '../src/index';
+import { colliderAt } from './support';
 
 const fakeApp = {} as Application;
+
+const FRAME = 1 / 60;
+
+const advance = (world: PhysicsWorld, seconds: number): void => {
+  const frames = Math.round(seconds / FRAME);
+
+  for (let frame = 0; frame < frames; frame++) {
+    world.step(FRAME);
+  }
+};
+
+/** Minimal fake render backend — never a real WebGL2/WebGPU backend (jsdom project). */
+const makeBackend = () => ({
+  stats: {
+    frameTimeMs: 0,
+    drawCalls: 0,
+    culledNodes: 0,
+    submittedNodes: 0,
+    batches: 0,
+    renderPasses: 0,
+    renderTargetChanges: 0,
+    frame: 0,
+  },
+  view: { width: 800, height: 600, getBounds: () => ({ intersectsWith: () => true }) },
+  setView: vi.fn().mockReturnThis(),
+  draw: vi.fn().mockReturnThis(),
+  flush: vi.fn().mockReturnThis(),
+});
+
+/** Render `debug` against a fresh fake backend and return it for assertions. */
+const renderWith = (debug: PhysicsDebugDraw) => {
+  const backend = makeBackend();
+
+  debug.render(backend as unknown as Parameters<typeof debug.render>[0]);
+
+  return backend;
+};
 
 describe('PhysicsDebugDraw', () => {
   it('defaults to drawing shapes only, in world space', () => {
@@ -35,5 +73,204 @@ describe('PhysicsDebugDraw', () => {
 
     expect(() => debug.update()).not.toThrow();
     expect(() => debug.destroy()).not.toThrow();
+  });
+
+  describe('render() option gating', () => {
+    it('renders an empty world with every flag off without throwing', () => {
+      const world = new PhysicsWorld();
+      const debug = new PhysicsDebugDraw(fakeApp, world, {
+        drawShapes: false,
+        drawAabb: false,
+        drawContacts: false,
+        drawNormals: false,
+        drawCenters: false,
+        drawBroadphase: false,
+        drawJoints: false,
+      });
+
+      expect(() => renderWith(debug)).not.toThrow();
+    });
+
+    it('draws shapes for static, kinematic and dynamic colliders (default options)', () => {
+      const world = new PhysicsWorld();
+      colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 }, 0, 'static');
+      colliderAt(world, new BoxShape(10, 10), { x: 100, y: 0 }, 0, 'kinematic');
+      colliderAt(world, new CircleShape(5), { x: 200, y: 0 }, 0.3, 'dynamic');
+
+      const debug = new PhysicsDebugDraw(fakeApp, world);
+      const backend = renderWith(debug);
+
+      // Shape strokes were flushed through the fake backend.
+      expect(backend.draw).toHaveBeenCalled();
+    });
+
+    it('draws AABBs when drawAabb is enabled', () => {
+      const world = new PhysicsWorld();
+      colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
+
+      const debug = new PhysicsDebugDraw(fakeApp, world, { drawAabb: true, drawShapes: false });
+
+      expect(() => renderWith(debug)).not.toThrow();
+    });
+
+    it('draws centre crosses for every body when drawCenters is enabled', () => {
+      const world = new PhysicsWorld();
+      colliderAt(world, new BoxShape(10, 10), { x: 5, y: 7 });
+
+      const debug = new PhysicsDebugDraw(fakeApp, world, { drawCenters: true, drawShapes: false });
+
+      expect(() => renderWith(debug)).not.toThrow();
+    });
+
+    it('draws broad-phase links for overlapping colliders when drawBroadphase is enabled', () => {
+      const world = new PhysicsWorld();
+      colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
+      colliderAt(world, new BoxShape(10, 10), { x: 5, y: 0 });
+
+      const debug = new PhysicsDebugDraw(fakeApp, world, { drawBroadphase: true, drawShapes: false });
+
+      expect(() => renderWith(debug)).not.toThrow();
+    });
+
+    it('drawBroadphase with a single collider produces no pairs but still renders', () => {
+      const world = new PhysicsWorld();
+      colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
+
+      const debug = new PhysicsDebugDraw(fakeApp, world, { drawBroadphase: true, drawShapes: false });
+
+      expect(() => renderWith(debug)).not.toThrow();
+    });
+  });
+
+  describe('_renderJoints', () => {
+    it('draws a line between the two bodies of a joint when drawJoints is enabled', () => {
+      const world = new PhysicsWorld();
+      const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+      const bob = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 100 }, colliders: [{ shape: new BoxShape(16, 16) }] }));
+
+      world.addJoint(new DistanceJoint({ bodyA: anchor, bodyB: bob, length: 100 }));
+
+      const debug = new PhysicsDebugDraw(fakeApp, world, { drawJoints: true, drawShapes: false });
+
+      expect(() => renderWith(debug)).not.toThrow();
+    });
+
+    it('is a no-op loop when drawJoints is enabled but the world has no joints', () => {
+      const world = new PhysicsWorld();
+      const debug = new PhysicsDebugDraw(fakeApp, world, { drawJoints: true, drawShapes: false });
+
+      expect(() => renderWith(debug)).not.toThrow();
+    });
+  });
+
+  describe('_outlineColor / _strokeShape', () => {
+    it('uses the sensor colour for a sensor collider regardless of drawSleeping', () => {
+      const world = new PhysicsWorld();
+      colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 }, 0, 'static', { isSensor: true });
+
+      const debug = new PhysicsDebugDraw(fakeApp, world, { drawSleeping: true });
+
+      expect(() => renderWith(debug)).not.toThrow();
+    });
+
+    it('falls through to the body-type colour when drawSleeping is on but the body is awake', () => {
+      const world = new PhysicsWorld();
+      colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 }, 0, 'dynamic');
+
+      const debug = new PhysicsDebugDraw(fakeApp, world, { drawSleeping: true });
+
+      expect(() => renderWith(debug)).not.toThrow();
+    });
+
+    it('uses the sleeping colour once drawSleeping is on and the body has fallen asleep', () => {
+      const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+      world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 320 }, colliders: [{ shape: new BoxShape(1200, 40) }] }));
+      const box = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 284 }, colliders: [{ shape: new BoxShape(32, 32) }] }));
+
+      advance(world, 2); // longer than the default timeToSleep
+      expect(box.isSleeping).toBe(true);
+
+      const debug = new PhysicsDebugDraw(fakeApp, world, { drawSleeping: true });
+
+      expect(() => renderWith(debug)).not.toThrow();
+    });
+
+    it('strokes a circle shape including its orientation spoke', () => {
+      const world = new PhysicsWorld();
+      colliderAt(world, new CircleShape(6), { x: 3, y: 4 }, 0.5, 'dynamic');
+
+      const debug = new PhysicsDebugDraw(fakeApp, world);
+
+      expect(() => renderWith(debug)).not.toThrow();
+    });
+
+    it('strokes a polygon shape, wrapping the last edge back to the first vertex', () => {
+      const world = new PhysicsWorld();
+      colliderAt(world, new BoxShape(20, 12), { x: -3, y: 2 }, 0.2, 'kinematic');
+
+      const debug = new PhysicsDebugDraw(fakeApp, world);
+
+      expect(() => renderWith(debug)).not.toThrow();
+    });
+  });
+
+  describe('_renderContacts', () => {
+    it('draws a two-point manifold (face-to-face boxes) with drawContacts enabled', () => {
+      const world = new PhysicsWorld();
+      colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
+      colliderAt(world, new BoxShape(10, 10), { x: 8, y: 0 });
+
+      const debug = new PhysicsDebugDraw(fakeApp, world, { drawShapes: false, drawContacts: true, drawNormals: false });
+
+      expect(() => renderWith(debug)).not.toThrow();
+    });
+
+    it('draws a single-point manifold (overlapping circles) with drawNormals enabled', () => {
+      const world = new PhysicsWorld();
+      colliderAt(world, new CircleShape(5), { x: 0, y: 0 });
+      colliderAt(world, new CircleShape(5), { x: 8, y: 0 });
+
+      const debug = new PhysicsDebugDraw(fakeApp, world, { drawShapes: false, drawContacts: false, drawNormals: true });
+
+      expect(() => renderWith(debug)).not.toThrow();
+    });
+
+    it('skips a pair where either collider is a sensor', () => {
+      const world = new PhysicsWorld();
+      colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
+      colliderAt(world, new BoxShape(10, 10), { x: 8, y: 0 }, 0, 'static', { isSensor: true });
+
+      const debug = new PhysicsDebugDraw(fakeApp, world, { drawShapes: false, drawContacts: true });
+
+      expect(() => renderWith(debug)).not.toThrow();
+    });
+
+    it('skips a broad-phase pair whose AABBs overlap but whose narrow phase reports no collision', () => {
+      // Two circles offset diagonally: both AABBs overlap on each axis independently
+      // (|dx|=8 < r1+r2=10 and |dy|=8 < r1+r2=10), but the actual centre distance
+      // (~11.3) exceeds the summed radii, so narrowphase `collide()` returns false
+      // even though the broad-phase produced the pair.
+      const world = new PhysicsWorld();
+      colliderAt(world, new CircleShape(5), { x: 0, y: 0 });
+      colliderAt(world, new CircleShape(5), { x: 8, y: 8 });
+
+      const debug = new PhysicsDebugDraw(fakeApp, world, { drawShapes: false, drawContacts: true, drawNormals: true });
+
+      expect(() => renderWith(debug)).not.toThrow();
+    });
+  });
+
+  describe('destroy()', () => {
+    it('releases the Graphics primitive created by render(), and a second destroy() is a no-op', () => {
+      const world = new PhysicsWorld();
+      colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
+
+      const debug = new PhysicsDebugDraw(fakeApp, world);
+
+      renderWith(debug);
+
+      expect(() => debug.destroy()).not.toThrow();
+      expect(() => debug.destroy()).not.toThrow();
+    });
   });
 });

--- a/packages/exojs-physics/test/dynamics.test.ts
+++ b/packages/exojs-physics/test/dynamics.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
+import { Manifold } from '../src/collision/Manifold';
+import type { ContactRecord } from '../src/ContactGraph';
 import { BoxShape, CircleShape, PhysicsWorld } from '../src/index';
 import { PhysicsBody } from '../src/PhysicsBody';
+import { ContactSolver } from '../src/solver/ContactSolver';
+import { colliderAt } from './support';
 
 /**
  * The Solver Correctness & Stability matrix, exercised over the
@@ -621,6 +625,62 @@ describe('failure safety', () => {
     // is a v0.16 CCD / bullet-mode item (see the operating-envelope note).
     expectAllFinite(world);
     expect(bullet.y).toBeGreaterThan(floorTop); // tunnelled through (documented limitation)
+  });
+});
+
+// ── ContactSolver internals ─────────────────────────────────────────
+
+describe('ContactSolver internals', () => {
+  it('contactHertz=0 takes the rigid (non-soft) branch and still settles a resting box', () => {
+    // Default worlds use contactHertz=30 (soft); this exercises the `contactHertz > 0`
+    // false side of ContactSolver.prepare's soft-factor computation (biasRate=0,
+    // massScale=1, impulseScale=0 — the hard-constraint fallback).
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY }, contactHertz: 0 });
+    const floorTop = 300;
+
+    addFloor(world, floorTop);
+    const box = addBox(world, 0, floorTop - 16 - 0.5, 32);
+
+    advance(world, 2);
+
+    expectAllFinite(world);
+    expect(Math.abs(box.linearVelocityY)).toBeLessThanOrEqual(1);
+  });
+
+  it('prepare() skips a contact whose manifold reports zero points', () => {
+    // ContactGraph only ever pushes a record into solidContacts when the narrow
+    // phase reports `touching` (which requires pointCount ≥ 1), so this path is not
+    // reachable through PhysicsWorld — it is exercised here by calling the solver
+    // directly with a hand-built record whose manifold was never populated.
+    const world = new PhysicsWorld();
+    const colliderA = colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
+    const colliderB = colliderAt(world, new BoxShape(10, 10), { x: 5, y: 0 }, 0, 'dynamic');
+
+    const record: ContactRecord = {
+      a: colliderA,
+      b: colliderB,
+      isSensor: false,
+      touching: true,
+      seen: true,
+      manifold: new Manifold(), // freshly constructed — pointCount stays 0
+      normalImpulse: [0, 0],
+      tangentImpulse: [0, 0],
+      pointIds: [0, 0],
+    };
+
+    const solver = new ContactSolver();
+    const bodyB = colliderB.body;
+    const vyBefore = bodyB.linearVelocityY;
+
+    solver.prepare([record], 1 / 240, 30, 10);
+    solver.warmStart();
+    solver.solveVelocities(true);
+    solver.solveVelocities(false);
+    solver.applyRestitution();
+
+    // pointCount === 0 → the contact is skipped entirely: no constraint is built, so
+    // none of the solve passes touch bodyB's velocity.
+    expect(bodyB.linearVelocityY).toBe(vyBefore);
   });
 });
 

--- a/packages/exojs-physics/test/events.test.ts
+++ b/packages/exojs-physics/test/events.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { CollisionEvent, SensorEvent } from '../src/index';
+import type { Collider, CollisionEvent, SensorEvent } from '../src/index';
 import { BoxShape, PhysicsBody, PhysicsWorld } from '../src/index';
 import { colliderAt } from './support';
 
@@ -88,6 +88,48 @@ describe('contact events', () => {
     expect(world.bodies).not.toContain(projectile);
   });
 
+  it('a body added and destroyed within the same dispatch is never pushed to the live list', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
+    world.add(new PhysicsBody({ type: 'kinematic', position: { x: 8, y: 0 }, colliders: [{ shape: new BoxShape(10, 10) }] }));
+
+    let created: PhysicsBody | null = null;
+    world.onCollisionStart.add(() => {
+      // Both the body push (world.add) and the collider registration it triggers
+      // are deferred while dispatching; marking it destroyed before commands
+      // drain must suppress that deferred push (PhysicsWorld._registerCollider /
+      // the body-add command's `!body.destroyed` guard).
+      created = world.add(new PhysicsBody({ type: 'dynamic', colliders: [{ shape: new BoxShape(5, 5) }] }));
+      created._markDestroyed();
+    });
+
+    expect(() => world.step(DT)).not.toThrow();
+    const body = created as unknown as PhysicsBody;
+    expect(body).not.toBeNull();
+    expect(world.bodies).not.toContain(body);
+  });
+
+  it('a collider added and destroyed within the same dispatch is never registered', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
+    world.add(new PhysicsBody({ type: 'kinematic', position: { x: 8, y: 0 }, colliders: [{ shape: new BoxShape(10, 10) }] }));
+
+    let addedCollider: Collider | null = null;
+    world.onCollisionStart.add(() => {
+      // An already-attached body's addCollider defers registration through
+      // PhysicsWorld._registerCollider while dispatching; destroying the
+      // collider immediately must suppress that deferred push.
+      const body = world.add(new PhysicsBody({ type: 'static', position: { x: 100, y: 100 } }));
+      addedCollider = body.addCollider({ shape: new BoxShape(5, 5) });
+      addedCollider._markDestroyed();
+    });
+
+    expect(() => world.step(DT)).not.toThrow();
+    const collider = addedCollider as unknown as Collider;
+    expect(collider).not.toBeNull();
+    expect(world.colliders).not.toContain(collider);
+  });
+
   it('does not fire events for filtered-out pairs', () => {
     const world = new PhysicsWorld();
     colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 }, 0, 'static', { filter: { category: 0x0001, mask: 0x0001 } });
@@ -100,5 +142,107 @@ describe('contact events', () => {
     world.step(DT);
 
     expect(start).not.toHaveBeenCalled();
+  });
+
+  it('fires a sensor event where the sensor is the higher-id collider', () => {
+    const world = new PhysicsWorld();
+    // Solid collider added first → lower id; sensor added second → higher id.
+    const solid = colliderAt(world, new BoxShape(20, 20), { x: 0, y: 0 });
+    const sensorBody = world.add(new PhysicsBody({ type: 'static', position: { x: 5, y: 0 }, colliders: [{ shape: new BoxShape(20, 20), isSensor: true }] }));
+    const sensor = sensorBody.colliders[0]!;
+
+    const enters: SensorEvent[] = [];
+    world.onSensorEnter.add(e => enters.push(e));
+    world.step(DT);
+
+    expect(enters).toHaveLength(1);
+    expect(enters[0].sensor).toBe(sensor);
+    expect(enters[0].other).toBe(solid);
+  });
+
+  it('fires one sensor event (with the lower-id collider as sensor) when both overlapping colliders are sensors', () => {
+    const world = new PhysicsWorld();
+    const first = colliderAt(world, new BoxShape(20, 20), { x: 0, y: 0 }, 0, 'static', { isSensor: true });
+    const secondBody = world.add(new PhysicsBody({ type: 'static', position: { x: 5, y: 0 }, colliders: [{ shape: new BoxShape(20, 20), isSensor: true }] }));
+    const second = secondBody.colliders[0]!;
+
+    const enters: SensorEvent[] = [];
+    world.onSensorEnter.add(e => enters.push(e));
+    world.step(DT);
+
+    expect(enters).toHaveLength(1);
+    expect(enters[0].sensor).toBe(first); // added first → lower id → wins the tie-break
+    expect(enters[0].other).toBe(second);
+  });
+
+  it('sorts sensorEnter events by (sensor.id, other.id), including a tie on the same sensor', () => {
+    const world = new PhysicsWorld();
+    // sensorA overlaps two different bodies (ties on sensor.id, so the sort must
+    // fall through to comparing other.id) while a second, distinct sensor
+    // overlaps a third body (differing sensor.id) — all entering on the first step.
+    colliderAt(world, new BoxShape(40, 40), { x: 0, y: 0 }, 0, 'static', { isSensor: true });
+    world.add(new PhysicsBody({ type: 'kinematic', position: { x: 5, y: 0 }, colliders: [{ shape: new BoxShape(10, 10) }] }));
+    world.add(new PhysicsBody({ type: 'kinematic', position: { x: -5, y: 0 }, colliders: [{ shape: new BoxShape(10, 10) }] }));
+    colliderAt(world, new BoxShape(10, 10), { x: 100, y: 0 }, 0, 'static', { isSensor: true });
+    world.add(new PhysicsBody({ type: 'kinematic', position: { x: 100, y: 0 }, colliders: [{ shape: new BoxShape(10, 10) }] }));
+
+    const enters: SensorEvent[] = [];
+    world.onSensorEnter.add(e => enters.push(e));
+    world.step(DT);
+
+    expect(enters.length).toBe(3);
+
+    for (let i = 1; i < enters.length; i++) {
+      const prev = enters[i - 1]!;
+      const cur = enters[i]!;
+
+      expect(prev.sensor.id < cur.sensor.id || (prev.sensor.id === cur.sensor.id && prev.other.id < cur.other.id)).toBe(true);
+    }
+
+    // Confirm a genuine tie on `sensor.id` occurred (the two bodies overlapping
+    // the same big sensor), otherwise the loop above would pass trivially.
+    expect(enters.some((e, i) => i > 0 && enters[i - 1]!.sensor.id === e.sensor.id)).toBe(true);
+  });
+});
+
+describe('collision filter group override', () => {
+  it('a positive shared group always collides, overriding an otherwise-blocking mask', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 }, 0, 'static', { filter: { group: 5, category: 0x0001, mask: 0x0000 } });
+    world.add(
+      new PhysicsBody({ type: 'kinematic', position: { x: 5, y: 0 }, colliders: [{ shape: new BoxShape(10, 10), filter: { group: 5, mask: 0x0000 } }] }),
+    );
+
+    const start = vi.fn();
+    world.onCollisionStart.add(start);
+    world.step(DT);
+
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  it('a shared negative group never collides, overriding an otherwise-matching mask', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 }, 0, 'static', { filter: { group: -3 } });
+    world.add(new PhysicsBody({ type: 'kinematic', position: { x: 5, y: 0 }, colliders: [{ shape: new BoxShape(10, 10), filter: { group: -3 } }] }));
+
+    const start = vi.fn();
+    world.onCollisionStart.add(start);
+    world.step(DT);
+
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it('different non-zero groups fall through to the normal category/mask check', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 }, 0, 'static', { filter: { group: 5 } });
+    world.add(new PhysicsBody({ type: 'kinematic', position: { x: 5, y: 0 }, colliders: [{ shape: new BoxShape(10, 10), filter: { group: 7 } }] }));
+
+    const start = vi.fn();
+    world.onCollisionStart.add(start);
+    world.step(DT);
+
+    // Groups differ (no override) — default category/mask (0x0001 / 0xffff) still
+    // matches, so it collides via the fallback path.
+    expect(start).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/exojs-physics/test/joints.test.ts
+++ b/packages/exojs-physics/test/joints.test.ts
@@ -381,4 +381,231 @@ describe('joints', () => {
     expect(wheel.y).toBeGreaterThan(45); // pulled down to the limit
     expect(wheel.y).toBeLessThan(51); // capped at upperTranslation (30 + 20)
   });
+
+  // ── Edge-case coverage: joint limits at their boundary, zero-length axes,
+  // soft-spring branches and fixed-rotation degenerate-mass paths ───────────
+
+  it('a distance joint with minLength acts as a strut — stops a body from crushing into the anchor', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    // Bob starts well above the anchor and falls toward it under gravity; the strut
+    // (minLength only — maxLength defaults to Infinity) stops it at minLength instead
+    // of letting it crush through to the anchor.
+    const bob = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: -300 }, colliders: [{ shape: new BoxShape(16, 16) }] }));
+
+    world.addJoint(new DistanceJoint({ bodyA: anchor, bodyB: bob, minLength: 100 }));
+
+    advance(world, 3);
+
+    const distance = Math.hypot(bob.x - anchor.x, bob.y - anchor.y);
+    expect(distance).toBeGreaterThan(95); // never crushed below minLength
+    expect(distance).toBeLessThan(160); // and not flung far past it either
+    expect(bob.y).toBeLessThan(0); // still above the anchor — never crossed through
+  });
+
+  it('handles coincident anchors at prepare time (zero-length axis) without producing NaN', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const a = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [{ shape: new BoxShape(16, 16) }] }));
+    const b = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [{ shape: new BoxShape(16, 16) }] }));
+
+    // Both anchors default to their body's position — identical points, so the
+    // connecting axis has zero length at the first _prepare().
+    world.addJoint(new DistanceJoint({ bodyA: a, bodyB: b, length: 50 }));
+
+    world.step(1 / 60);
+
+    expect(Number.isFinite(a.x)).toBe(true);
+    expect(Number.isFinite(a.y)).toBe(true);
+    expect(Number.isFinite(b.x)).toBe(true);
+    expect(Number.isFinite(b.y)).toBe(true);
+  });
+
+  it('uses default hertz/dampingRatio/maxForce when omitted, and target reads back the current point', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const body = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [{ shape: new BoxShape(20, 20) }] }));
+
+    const joint = world.addJoint(new MouseJoint({ body, target: { x: 0, y: 0 } }));
+
+    expect(joint.hertz).toBe(5);
+    expect(joint.dampingRatio).toBe(0.7);
+    expect(joint.maxForce).toBe(Infinity);
+    expect(joint.target).toEqual({ x: 0, y: 0 });
+
+    joint.target = { x: 30, y: 0 }; // move the target away — the default soft spring pulls the body toward it
+    expect(joint.target).toEqual({ x: 30, y: 0 });
+
+    advance(world, 1);
+
+    expect(body.x).toBeGreaterThan(20); // still converges toward the target with the defaults
+  });
+
+  it('BUG: a zero-length axis in a prismatic joint yields a degenerate joint with no lock in any direction', () => {
+    // `Math.hypot(0, 0) || 1` (PrismaticJoint.ts, constructor) only guards the division
+    // — it does not turn (0,0) into a *unit* vector. The local axis stays (0,0), so both
+    // the axis and its perpendicular end up as zero vectors in `_prepare`; `_applyAxial`/
+    // `_applyBlock` scale every impulse by axisX/axisY/perpX/perpY (all 0), so no force is
+    // ever applied in any direction. Expected correct behavior: reject a zero-length axis
+    // (throw) or fall back to a sane default unit axis (e.g. (1, 0)) instead of silently
+    // creating a no-op joint.
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    const slider = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [{ shape: new BoxShape(20, 20) }] }));
+
+    world.addJoint(new PrismaticJoint({ bodyA: anchor, bodyB: slider, anchor: { x: 0, y: 0 }, axis: { x: 0, y: 0 } }));
+
+    advance(world, 1);
+
+    // Current (buggy) behavior: free fall under gravity — the joint constrained nothing.
+    expect(slider.y).toBeGreaterThan(400);
+  });
+
+  it('a prismatic joint with a fixed-rotation slider keeps the perpendicular lock solvable (k22 fallback)', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    // Both bodies are rotation-locked (static anchor + fixedRotation slider): iA+iB=0,
+    // which would make the perpendicular+angular block matrix singular without the
+    // `_k22 = 1` fallback.
+    const slider = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, fixedRotation: true, colliders: [{ shape: new BoxShape(20, 20) }] }));
+
+    world.addJoint(new PrismaticJoint({ bodyA: anchor, bodyB: slider, anchor: { x: 0, y: 0 }, axis: { x: 1, y: 0 } }));
+
+    advance(world, 2);
+
+    expect(Math.abs(slider.y)).toBeLessThan(1); // perpendicular still locked with both bodies rotation-locked
+    expect(slider.angle).toBe(0);
+  });
+
+  it('a soft revolute joint (hertz>0) settles bounded near the pivot radius', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    const bob = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 70, y: 0 }, colliders: [{ shape: new BoxShape(16, 16) }] }));
+
+    world.addJoint(new RevoluteJoint({ bodyA: anchor, bodyB: bob, anchor: { x: 0, y: 0 }, hertz: 3, dampingRatio: 1 }));
+
+    advance(world, 2);
+
+    // A soft pin lets the anchor point drift a little under load but stays bounded.
+    const radius = Math.hypot(bob.x, bob.y);
+    expect(radius).toBeGreaterThan(60);
+    expect(radius).toBeLessThan(140);
+    expect(Number.isFinite(bob.angle)).toBe(true);
+  });
+
+  it('an angular motor on a fixed-rotation body does nothing (zero angular effective mass)', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    const bob = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 50, y: 0 }, fixedRotation: true, colliders: [{ shape: new BoxShape(16, 16) }] }));
+
+    world.addJoint(new RevoluteJoint({ bodyA: anchor, bodyB: bob, anchor: { x: 0, y: 0 }, enableMotor: true, motorSpeed: 10, maxMotorTorque: 1e8 }));
+
+    advance(world, 1);
+
+    expect(bob.angularVelocity).toBe(0); // fixed rotation — zero angular mass, the motor can't spin it
+  });
+
+  it('a revolute lower-angle limit engages its Baumgarte push-back when violently overshot', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    const bar = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 50, y: 0 }, colliders: [{ shape: new BoxShape(100, 10) }] }));
+
+    world.addJoint(new RevoluteJoint({ bodyA: anchor, bodyB: bar, anchor: { x: 0, y: 0 }, enableLimit: true, lowerAngle: -0.2, upperAngle: 0.2 }));
+
+    bar.angularVelocity = -50; // slam it hard into the lower limit, forcing a real overshoot
+
+    advance(world, 0.5);
+
+    expect(bar.angle).toBeGreaterThanOrEqual(-0.3); // the limit + push-back stopped it near lowerAngle
+    expect(Number.isFinite(bar.angle)).toBe(true);
+  });
+
+  it('a soft weld joint (linearHertz/angularHertz>0) holds bounded near the anchor pose', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    const box = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 50, y: 30 }, colliders: [{ shape: new BoxShape(20, 20) }] }));
+
+    world.addJoint(new WeldJoint({ bodyA: anchor, bodyB: box, linearHertz: 3, angularHertz: 3, dampingRatio: 1 }));
+
+    advance(world, 1);
+
+    // A soft weld is compliant under load (it can sag/rotate noticeably, unlike the
+    // rigid weld above) but still bounded — not flung away or blown up to NaN/Inf.
+    expect(Number.isFinite(box.x)).toBe(true);
+    expect(Number.isFinite(box.y)).toBe(true);
+    expect(Number.isFinite(box.angle)).toBe(true);
+    expect(Math.hypot(box.x, box.y)).toBeLessThan(300);
+  });
+
+  it('a weld joint between fixed-rotation bodies still locks position (zero angular effective mass)', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    const box = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 50, y: 0 }, fixedRotation: true, colliders: [{ shape: new BoxShape(20, 20) }] }));
+
+    world.addJoint(new WeldJoint({ bodyA: anchor, bodyB: box }));
+
+    advance(world, 2);
+
+    expect(box.x).toBeCloseTo(50, 0);
+    expect(box.angle).toBe(0); // fixed rotation — never rotates regardless of the angular constraint
+  });
+
+  it('BUG: a zero-length axis in a wheel joint yields a degenerate joint with no suspension or lateral lock', () => {
+    // Same root cause as the prismatic joint above: `Math.hypot(0, 0) || 1` only guards
+    // the division — the local axis stays (0,0), so the axis, its perpendicular, the
+    // suspension spring and the lateral lock all end up applying zero force. Expected
+    // correct behavior: reject a zero-length axis (throw) or default to a unit axis.
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const chassis = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    const wheel = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 30 }, colliders: [{ shape: new CircleShape(10) }] }));
+
+    world.addJoint(new WheelJoint({ bodyA: chassis, bodyB: wheel, anchor: { x: 0, y: 30 }, axis: { x: 0, y: 0 }, hertz: 5, dampingRatio: 1 }));
+
+    advance(world, 1);
+
+    // Current (buggy) behavior: free fall under gravity — nothing was constrained.
+    expect(wheel.y).toBeGreaterThan(400);
+  });
+
+  it('a wheel motor on a fixed-rotation wheel does nothing (zero angular effective mass)', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const chassis = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    const wheel = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 30 }, fixedRotation: true, colliders: [{ shape: new CircleShape(10) }] }));
+
+    world.addJoint(
+      new WheelJoint({ bodyA: chassis, bodyB: wheel, anchor: { x: 0, y: 30 }, axis: { x: 0, y: 1 }, enableMotor: true, motorSpeed: 20, maxMotorTorque: 1e8 }),
+    );
+
+    advance(world, 1);
+
+    expect(wheel.angularVelocity).toBe(0); // fixed rotation — zero angular mass, the motor can't spin it
+  });
+
+  it('a wheel lower-translation limit engages its Baumgarte push-back when violently overshot', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const chassis = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+    const wheel = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 30 }, colliders: [{ shape: new CircleShape(10) }] }));
+
+    // A soft suspension (hertz>0) actually allows axis travel — with hertz=0 (rigid)
+    // the axial "spring" alone holds the translation near 0, so the limit would never
+    // see a violation to push back from.
+    world.addJoint(
+      new WheelJoint({
+        bodyA: chassis,
+        bodyB: wheel,
+        anchor: { x: 0, y: 30 },
+        axis: { x: 0, y: 1 },
+        hertz: 1,
+        dampingRatio: 1,
+        enableLimit: true,
+        lowerTranslation: -15,
+        upperTranslation: 15,
+      }),
+    );
+
+    wheel.linearVelocityY = -3000; // slam it hard away from the chassis, past lowerTranslation
+
+    advance(world, 0.3);
+
+    expect(wheel.y).toBeGreaterThan(0); // the lower limit + push-back stopped the overshoot before it ran away
+    expect(Number.isFinite(wheel.y)).toBe(true);
+  });
 });

--- a/packages/exojs-physics/test/joints.test.ts
+++ b/packages/exojs-physics/test/joints.test.ts
@@ -439,24 +439,15 @@ describe('joints', () => {
     expect(body.x).toBeGreaterThan(20); // still converges toward the target with the defaults
   });
 
-  it('BUG: a zero-length axis in a prismatic joint yields a degenerate joint with no lock in any direction', () => {
-    // `Math.hypot(0, 0) || 1` (PrismaticJoint.ts, constructor) only guards the division
-    // — it does not turn (0,0) into a *unit* vector. The local axis stays (0,0), so both
-    // the axis and its perpendicular end up as zero vectors in `_prepare`; `_applyAxial`/
-    // `_applyBlock` scale every impulse by axisX/axisY/perpX/perpY (all 0), so no force is
-    // ever applied in any direction. Expected correct behavior: reject a zero-length axis
-    // (throw) or fall back to a sane default unit axis (e.g. (1, 0)) instead of silently
-    // creating a no-op joint.
+  it('a zero-length axis in a prismatic joint is rejected at construction', () => {
+    // A (0,0) axis cannot be normalized into a direction — silently creating a
+    // joint that constrains nothing would let the body free-fall.
     const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
     const anchor = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
     const slider = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [{ shape: new BoxShape(20, 20) }] }));
 
-    world.addJoint(new PrismaticJoint({ bodyA: anchor, bodyB: slider, anchor: { x: 0, y: 0 }, axis: { x: 0, y: 0 } }));
-
-    advance(world, 1);
-
-    // Current (buggy) behavior: free fall under gravity — the joint constrained nothing.
-    expect(slider.y).toBeGreaterThan(400);
+    expect(() => new PrismaticJoint({ bodyA: anchor, bodyB: slider, anchor: { x: 0, y: 0 }, axis: { x: 0, y: 0 } })).toThrow(RangeError);
+    expect(() => new PrismaticJoint({ bodyA: anchor, bodyB: slider, anchor: { x: 0, y: 0 }, axis: { x: Number.NaN, y: 0 } })).toThrow(RangeError);
   });
 
   it('a prismatic joint with a fixed-rotation slider keeps the perpendicular lock solvable (k22 fallback)', () => {
@@ -548,21 +539,14 @@ describe('joints', () => {
     expect(box.angle).toBe(0); // fixed rotation — never rotates regardless of the angular constraint
   });
 
-  it('BUG: a zero-length axis in a wheel joint yields a degenerate joint with no suspension or lateral lock', () => {
-    // Same root cause as the prismatic joint above: `Math.hypot(0, 0) || 1` only guards
-    // the division — the local axis stays (0,0), so the axis, its perpendicular, the
-    // suspension spring and the lateral lock all end up applying zero force. Expected
-    // correct behavior: reject a zero-length axis (throw) or default to a unit axis.
+  it('a zero-length axis in a wheel joint is rejected at construction', () => {
+    // Same rationale as the prismatic joint above: a (0,0) axis cannot be
+    // normalized, so suspension spring and lateral lock would apply zero force.
     const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
     const chassis = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
     const wheel = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 30 }, colliders: [{ shape: new CircleShape(10) }] }));
 
-    world.addJoint(new WheelJoint({ bodyA: chassis, bodyB: wheel, anchor: { x: 0, y: 30 }, axis: { x: 0, y: 0 }, hertz: 5, dampingRatio: 1 }));
-
-    advance(world, 1);
-
-    // Current (buggy) behavior: free fall under gravity — nothing was constrained.
-    expect(wheel.y).toBeGreaterThan(400);
+    expect(() => new WheelJoint({ bodyA: chassis, bodyB: wheel, anchor: { x: 0, y: 30 }, axis: { x: 0, y: 0 }, hertz: 5, dampingRatio: 1 })).toThrow(RangeError);
   });
 
   it('a wheel motor on a fixed-rotation wheel does nothing (zero angular effective mass)', () => {

--- a/packages/exojs-physics/test/manifold.test.ts
+++ b/packages/exojs-physics/test/manifold.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { Manifold } from '../src/collision/Manifold';
-import { collide } from '../src/collision/narrowphase';
+import { collide, testOverlap } from '../src/collision/narrowphase';
 import { BoxShape, CircleShape, PhysicsBody, PhysicsWorld } from '../src/index';
 import { colliderAt } from './support';
 
@@ -106,5 +106,89 @@ describe('narrow phase — manifold generation', () => {
 
     expect(previousIds).not.toBeNull();
     expect(previousIds).toHaveLength(2);
+  });
+
+  it('circle vs circle: coincident centres fall back to a stable arbitrary normal', () => {
+    const world = new PhysicsWorld();
+    const a = colliderAt(world, new CircleShape(5), { x: 3, y: 3 });
+    const b = colliderAt(world, new CircleShape(5), { x: 3, y: 3 });
+
+    // Zero-length separation vector: the normal direction is undefined, so the
+    // implementation picks a fixed (0, 1) fallback rather than dividing by zero.
+    expect(collide(a, b, manifold)).toBe(true);
+    expect(manifold.normalX).toBe(0);
+    expect(manifold.normalY).toBe(1);
+    expect(manifold.points[0].penetration).toBeCloseTo(10, 6);
+  });
+
+  it('circle vs box (vertex v2 Voronoi region): separated past the corner returns false', () => {
+    const world = new PhysicsWorld();
+    const box = colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
+    const circle = colliderAt(world, new CircleShape(1), { x: 5.3, y: -6 });
+
+    // (5.3, -6) is closest to the box's (5, -5) corner as the *end* vertex of
+    // its reference edge (the "v2" branch), and just outside radius 1.
+    expect(collide(circle, box, manifold)).toBe(false);
+  });
+
+  it('circle vs box (vertex v2 Voronoi region): touching the corner produces a single point', () => {
+    const world = new PhysicsWorld();
+    const box = colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
+    const circle = colliderAt(world, new CircleShape(1.5), { x: 5.3, y: -6 });
+
+    expect(collide(circle, box, manifold)).toBe(true);
+    expect(manifold.pointCount).toBe(1);
+  });
+});
+
+describe('testOverlap — boolean overlap without a manifold', () => {
+  it('circle vs circle', () => {
+    const world = new PhysicsWorld();
+    const a = colliderAt(world, new CircleShape(5), { x: 0, y: 0 });
+    const b = colliderAt(world, new CircleShape(5), { x: 8, y: 0 });
+    const far = colliderAt(world, new CircleShape(5), { x: 20, y: 0 });
+
+    expect(testOverlap(a, b)).toBe(true);
+    expect(testOverlap(a, far)).toBe(false);
+  });
+
+  it('circle vs polygon and polygon vs circle report the same overlap regardless of argument order', () => {
+    const world = new PhysicsWorld();
+    const box = colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
+    const circle = colliderAt(world, new CircleShape(3), { x: 0, y: 7 });
+    const farCircle = colliderAt(world, new CircleShape(3), { x: 100, y: 0 });
+
+    expect(testOverlap(circle, box)).toBe(true);
+    expect(testOverlap(box, circle)).toBe(true);
+    expect(testOverlap(box, farCircle)).toBe(false);
+  });
+
+  it('polygon vs polygon', () => {
+    const world = new PhysicsWorld();
+    const a = colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
+    const b = colliderAt(world, new BoxShape(10, 10), { x: 8, y: 0 });
+    const far = colliderAt(world, new BoxShape(10, 10), { x: 100, y: 0 });
+
+    expect(testOverlap(a, b)).toBe(true);
+    expect(testOverlap(a, far)).toBe(false);
+  });
+
+  it('circle vs polygon: face region, both vertex Voronoi regions and the centre-inside fast path', () => {
+    const world = new PhysicsWorld();
+    const box = colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
+
+    // Face region (the circle sits squarely in front of one edge).
+    expect(testOverlap(colliderAt(world, new CircleShape(3), { x: 0, y: 7 }), box)).toBe(true);
+
+    // Vertex v1 Voronoi region — nearest feature is the reference edge's start vertex.
+    expect(testOverlap(colliderAt(world, new CircleShape(3), { x: 8, y: -6 }), box)).toBe(false);
+    expect(testOverlap(colliderAt(world, new CircleShape(3.5), { x: 8, y: -6 }), box)).toBe(true);
+
+    // Vertex v2 Voronoi region — nearest feature is the reference edge's end vertex.
+    expect(testOverlap(colliderAt(world, new CircleShape(1), { x: 5.3, y: -6 }), box)).toBe(false);
+    expect(testOverlap(colliderAt(world, new CircleShape(1.5), { x: 5.3, y: -6 }), box)).toBe(true);
+
+    // Centre strictly inside the polygon: always an overlap regardless of radius.
+    expect(testOverlap(colliderAt(world, new CircleShape(1), { x: 0, y: 0 }), box)).toBe(true);
   });
 });

--- a/packages/exojs-physics/test/pair-key.test.ts
+++ b/packages/exojs-physics/test/pair-key.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { pairKey,pairKeyStride } from '../src/ContactGraph';
+import { Collider } from '../src/Collider';
+import { ContactGraph,pairKey,pairKeyStride } from '../src/ContactGraph';
+import { createTransform } from '../src/math';
+import { PhysicsBody } from '../src/PhysicsBody';
+import { CircleShape } from '../src/shapes/CircleShape';
 
 /**
  * A4: the contact pair key packs two collider ids into one integer. The old
@@ -38,5 +42,36 @@ describe('ContactGraph pairKey (A4 16-bit overflow fix)', () => {
     expect(oldKey(65_536, 5)).toBe(oldKey(0, 5));
     expect(pairKey(65_536, 5)).not.toBe(pairKey(0, 5));
     expect(pairKeyStride).toBe(2 ** 26);
+  });
+});
+
+/**
+ * `ContactGraph.update()`'s `makeSensorEvent` tie-break (which collider is the
+ * "sensor" when both overlapping colliders are sensors) leans on the broad
+ * phase's documented invariant that every `CandidatePair` has `a.id < b.id`. In
+ * every real step that invariant holds, so the ternary's "b wins" branch is
+ * dead in practice. `update()` is a public method that accepts a plain
+ * `CandidatePair[]` and does not itself re-validate the ordering, so this
+ * white-box test constructs a graph directly and feeds it a deliberately
+ * reversed pair to pin that the tie-break still resolves to the numerically
+ * lower id — the defensive branch a SweepAndPrune-fed pair never reaches.
+ */
+describe('ContactGraph.update sensor tie-break (both colliders are sensors)', () => {
+  it('resolves the sensor to the lower-id collider even when the pair is passed in the opposite order', () => {
+    const graph = new ContactGraph();
+    const higherIdSensor = new Collider({ shape: new CircleShape(10), isSensor: true });
+    const lowerIdSensor = new Collider({ shape: new CircleShape(10), isSensor: true });
+
+    higherIdSensor._attach(new PhysicsBody(), 9);
+    lowerIdSensor._attach(new PhysicsBody(), 3);
+    higherIdSensor.synchronize(createTransform(0, 0, 0));
+    lowerIdSensor.synchronize(createTransform(0, 0, 0));
+
+    // Reverse of the documented order: `a` is the higher id.
+    graph.update([{ a: higherIdSensor, b: lowerIdSensor }]);
+
+    expect(graph.sensorEnter).toHaveLength(1);
+    expect(graph.sensorEnter[0]!.sensor).toBe(lowerIdSensor);
+    expect(graph.sensorEnter[0]!.other).toBe(higherIdSensor);
   });
 });

--- a/packages/exojs-physics/test/queries.test.ts
+++ b/packages/exojs-physics/test/queries.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { Collider } from '../src/Collider';
 import type { RayHit } from '../src/index';
-import { BoxShape, CircleShape, PhysicsWorld } from '../src/index';
+import { BoxShape, CircleShape, PhysicsWorld, PolygonShape } from '../src/index';
 import { colliderAt } from './support';
 
 describe('queries', () => {
@@ -93,5 +93,144 @@ describe('queries', () => {
     expect(world.queryPoint({ x: 0, y: 0 }, { category: 0x0001, mask: 0x0001 })).toEqual([]);
     // Query whose mask includes 0x0002 finds it.
     expect(world.queryPoint({ x: 0, y: 0 }, { category: 0x0001, mask: 0x0002 })).toHaveLength(1);
+  });
+
+  it('queryPoint tests circle colliders by radial distance', () => {
+    const world = new PhysicsWorld();
+    const circle = colliderAt(world, new CircleShape(5), { x: 0, y: 0 });
+
+    expect(world.queryPoint({ x: 3, y: 0 })).toEqual([circle]);
+    expect(world.queryPoint({ x: 10, y: 0 })).toEqual([]);
+  });
+
+  it('queryPoint rejects a point inside a non-rectangular polygon AABB but outside the shape', () => {
+    const world = new PhysicsWorld();
+    const triangle = colliderAt(
+      world,
+      new PolygonShape([
+        { x: -10, y: 10 },
+        { x: 10, y: 10 },
+        { x: 0, y: -10 },
+      ]),
+      { x: 0, y: 0 },
+    );
+
+    // Inside the triangle's bounding box, but past the slanted edge (outside the shape).
+    expect(world.queryPoint({ x: 9.8, y: 9 })).toEqual([]);
+    // Inside both the AABB and the triangle itself.
+    expect(world.queryPoint({ x: 0, y: 0 })).toEqual([triangle]);
+  });
+
+  it('queryAabb skips colliders excluded by the filter', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 }, 0, 'static', { filter: { category: 0x0002 } });
+
+    expect(world.queryAabb({ minX: -10, minY: -10, maxX: 10, maxY: 10 }, { category: 0x0001, mask: 0x0001 })).toEqual([]);
+  });
+
+  it('forEachAabbHit skips colliders excluded by the filter', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 }, 0, 'static', { filter: { category: 0x0002 } });
+    const visited: Collider[] = [];
+
+    world.forEachAabbHit({ minX: -10, minY: -10, maxX: 10, maxY: 10 }, { category: 0x0001, mask: 0x0001 }, c => visited.push(c));
+    expect(visited).toEqual([]);
+  });
+
+  it('forEachAabbHit skips colliders whose AABB does not overlap (no filter involved)', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, new BoxShape(10, 10), { x: 100, y: 0 });
+    const visited: Collider[] = [];
+
+    world.forEachAabbHit({ minX: -10, minY: -10, maxX: 10, maxY: 10 }, undefined, c => visited.push(c));
+    expect(visited).toEqual([]);
+  });
+
+  it('rayCast skips colliders excluded by the filter', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, new BoxShape(10, 10), { x: 50, y: 0 }, 0, 'static', { filter: { category: 0x0002 } });
+    const far = colliderAt(world, new BoxShape(10, 10), { x: 100, y: 0 });
+
+    const hit = world.rayCast({ x: 0, y: 0 }, { x: 1, y: 0 }, { category: 0x0001, mask: 0x0001 });
+    expect(hit).not.toBeNull();
+    expect((hit as RayHit).collider).toBe(far);
+  });
+
+  it('rayCast tracks the nearest hit as closer and farther colliders are encountered', () => {
+    const world = new PhysicsWorld();
+    // Encounter order deliberately mixed: medium, then nearer (updates best), then farther (best unchanged).
+    colliderAt(world, new BoxShape(6, 6), { x: 50, y: 0 });
+    const near = colliderAt(world, new BoxShape(6, 6), { x: 20, y: 0 });
+    colliderAt(world, new BoxShape(6, 6), { x: 80, y: 0 });
+
+    const hit = world.rayCast({ x: 0, y: 0 }, { x: 1, y: 0 });
+    expect(hit).not.toBeNull();
+    expect((hit as RayHit).collider).toBe(near);
+  });
+
+  it('rayCast respects maxDistance and reports no hit past it', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, new CircleShape(5), { x: 50, y: 0 });
+
+    expect(world.rayCast({ x: 0, y: 0 }, { x: 1, y: 0 }, undefined, 20)).toBeNull();
+  });
+
+  it('rayCast misses a circle that lies behind the ray origin (pointing away)', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, new CircleShape(5), { x: -50, y: 0 });
+
+    expect(world.rayCast({ x: 0, y: 0 }, { x: 1, y: 0 })).toBeNull();
+  });
+
+  it('rayCast misses a circle the ray passes beside (negative discriminant)', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, new CircleShape(3), { x: 50, y: 10 });
+
+    expect(world.rayCast({ x: 0, y: 0 }, { x: 1, y: 0 })).toBeNull();
+  });
+
+  it('rayCast from inside a convex polygon reports no entry hit', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, new BoxShape(20, 20), { x: 0, y: 0 });
+
+    // The ray starts already inside the box, so it never crosses an entering face.
+    expect(world.rayCast({ x: 0, y: 0 }, { x: 1, y: 0 })).toBeNull();
+  });
+
+  it('rayCast against a polygon respects maxDistance', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, new BoxShape(10, 10), { x: 100, y: 0 });
+
+    expect(world.rayCast({ x: 0, y: 0 }, { x: 1, y: 0 }, undefined, 50)).toBeNull();
+  });
+
+  it('rayCastAll throws on a zero direction', () => {
+    const world = new PhysicsWorld();
+
+    expect(() => world.rayCastAll({ x: 0, y: 0 }, { x: 0, y: 0 })).toThrow(RangeError);
+  });
+
+  it('rayCastAll skips colliders excluded by the filter', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, new BoxShape(10, 10), { x: 50, y: 0 }, 0, 'static', { filter: { category: 0x0002 } });
+    const far = colliderAt(world, new BoxShape(10, 10), { x: 150, y: 0 });
+
+    const hits = world.rayCastAll({ x: 0, y: 0 }, { x: 1, y: 0 }, { category: 0x0001, mask: 0x0001 });
+    expect(hits.map(h => h.collider)).toEqual([far]);
+  });
+
+  it('overlapShape skips colliders excluded by the filter', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, new BoxShape(20, 20), { x: 0, y: 0 }, 0, 'static', { filter: { category: 0x0002 } });
+
+    expect(world.overlapShape(new CircleShape(5), { x: 8, y: 0 }, { category: 0x0001, mask: 0x0001 })).toEqual([]);
+  });
+
+  it('overlapShape supports a rotated polygon probe shape', () => {
+    const world = new PhysicsWorld();
+    const box = colliderAt(world, new BoxShape(20, 20), { x: 0, y: 0 });
+
+    expect(world.overlapShape(new BoxShape(4, 4), { x: 8, y: 0 }, undefined, Math.PI / 4)).toEqual([box]);
+    expect(world.overlapShape(new BoxShape(4, 4), { x: 100, y: 0 }, undefined, Math.PI / 4)).toEqual([]);
   });
 });

--- a/packages/exojs-physics/test/shapes.test.ts
+++ b/packages/exojs-physics/test/shapes.test.ts
@@ -88,6 +88,43 @@ describe('PolygonShape — convex validation', () => {
     expect(Object.isFrozen(p.vertices)).toBe(true);
     expect(Object.isFrozen(p.normals)).toBe(true);
   });
+
+  it('welds a coincident interior vertex (within the weld epsilon) instead of keeping it as a distinct point', () => {
+    const p = new PolygonShape([
+      { x: -5, y: -5 },
+      { x: 5, y: -5 },
+      { x: 5.00001, y: -5 }, // duplicate of the previous vertex, well within weldEpsilon
+      { x: 5, y: 5 },
+      { x: -5, y: 5 },
+    ]);
+
+    expect(p.count).toBe(4);
+    expect(p.area).toBeCloseTo(100, 3);
+  });
+
+  it('rejects vertices that all weld together into fewer than three distinct points', () => {
+    expect(
+      () =>
+        new PolygonShape([
+          { x: 0, y: 0 },
+          { x: 0.00001, y: 0 },
+          { x: 0.00002, y: 0 },
+        ]),
+    ).toThrow(RangeError);
+  });
+
+  it('drops a trailing vertex that duplicates the first (wrap-around weld)', () => {
+    const p = new PolygonShape([
+      { x: -5, y: -5 },
+      { x: 5, y: -5 },
+      { x: 5, y: 5 },
+      { x: -5, y: 5 },
+      { x: -5, y: -4.99999 }, // duplicates the first vertex, closing the loop
+    ]);
+
+    expect(p.count).toBe(4);
+    expect(p.area).toBeCloseTo(100, 3);
+  });
 });
 
 describe('BoxShape', () => {

--- a/packages/exojs-physics/test/sleeping.test.ts
+++ b/packages/exojs-physics/test/sleeping.test.ts
@@ -115,6 +115,19 @@ describe('sleeping', () => {
     }
   });
 
+  it('enableSleeping: false skips the sleep-timer pass entirely (bodies never sleep)', () => {
+    // perf.test.ts also exercises `enableSleeping: false`, but its coverage-run
+    // guard returns before ever calling `world.step` under istanbul
+    // instrumentation, so that path needs its own small, un-gated test here.
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY }, enableSleeping: false });
+    addFloor(world, 300);
+    const box = addBox(world, 0, 300 - 16 - 2);
+
+    advance(world, 3); // well past the default timeToSleep
+
+    expect(box.isSleeping).toBe(false);
+  });
+
   it('sleep transitions are deterministic across identical runs', () => {
     const run = (): string => {
       const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });

--- a/packages/exojs-physics/test/world.test.ts
+++ b/packages/exojs-physics/test/world.test.ts
@@ -1,7 +1,9 @@
 import type { SceneNode } from '@codexo/exojs';
 import { describe, expect, it } from 'vitest';
 
-import { BoxShape, CircleShape, Collider, PhysicsBody, PhysicsWorld } from '../src/index';
+import { createAabb, expandAabb } from '../src/Aabb';
+import { BoxShape, CircleShape, Collider, DistanceJoint, PhysicsBody, PhysicsWorld } from '../src/index';
+import { colliderAt } from './support';
 
 interface FakeNode {
   skewX: number;
@@ -124,12 +126,310 @@ describe('PhysicsWorld lifecycle and mass model', () => {
     expect(body.isMassReady).toBe(false);
   });
 
+  it('destroying an already-destroyed collider a second time is a safe no-op', () => {
+    const world = new PhysicsWorld();
+    const body = world.add(new PhysicsBody({ type: 'dynamic' }));
+    const collider = body.addCollider({ shape: new BoxShape(10, 10), density: 1 });
+
+    world.destroyCollider(collider);
+    // Second destroy: the collider is already spliced out of body._colliders, so
+    // PhysicsBody._removeCollider's indexOf must return -1 (already-removed guard).
+    expect(() => world.destroyCollider(collider)).not.toThrow();
+  });
+
   it('throws when used after destroy', () => {
     const world = new PhysicsWorld();
     world.destroy();
 
     expect(() => world.add(new PhysicsBody())).toThrow();
     expect(() => world.step(1 / 60)).toThrow();
+  });
+
+  it('destroy marks every contained body destroyed and is idempotent', () => {
+    const world = new PhysicsWorld();
+    const body = world.add(new PhysicsBody({ type: 'dynamic', colliders: [{ shape: new BoxShape(10, 10) }] }));
+
+    world.destroy();
+
+    expect(body.destroyed).toBe(true);
+    expect(world.bodies).toHaveLength(0);
+
+    // Calling destroy again is a no-op guard, not a second teardown.
+    expect(() => world.destroy()).not.toThrow();
+  });
+
+  it('rejects an invalid subStepCount (non-integer or below 1)', () => {
+    expect(() => new PhysicsWorld({ subStepCount: 2.5 })).toThrow(RangeError);
+    expect(() => new PhysicsWorld({ subStepCount: 0 })).toThrow(RangeError);
+    expect(() => new PhysicsWorld({ subStepCount: -1 })).toThrow(RangeError);
+  });
+
+  it('destroying a body that was never added tears it down without crashing', () => {
+    const world = new PhysicsWorld();
+    const body = new PhysicsBody({ type: 'dynamic', colliders: [{ shape: new BoxShape(10, 10) }] });
+
+    // Never passed to world.add() — destroyBody must still find and tear it down
+    // (the "created and destroyed within the same dispatch" case documented on
+    // PhysicsWorld._removeBody).
+    world.destroyBody(body);
+
+    expect(body.destroyed).toBe(true);
+    expect(() => body.addCollider({ shape: new BoxShape(5, 5) })).toThrow();
+    expect(() => body.setTransform({ x: 1, y: 1 })).toThrow();
+    // body.attached is still false (it never joined a world), so world.add lets it
+    // through the "already attached" guard and hits the destroyed guard instead.
+    expect(() => world.add(body)).toThrow();
+  });
+});
+
+describe('PhysicsWorld joints and backend accessors', () => {
+  it('exposes added/removed joints via the joints getter and steps a static-anchored joint', () => {
+    const world = new PhysicsWorld();
+    const anchor = world.add(new PhysicsBody({ type: 'static' }));
+    const bob = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 50 }, colliders: [{ shape: new CircleShape(5) }] }));
+    const joint = world.addJoint(new DistanceJoint({ bodyA: anchor, bodyB: bob, length: 50 }));
+
+    expect(world.joints).toContain(joint);
+
+    // A static anchor never joins the dynamic-island union (bodyA.type !== 'dynamic').
+    expect(() => world.step(1 / 60)).not.toThrow();
+
+    world.removeJoint(joint);
+    expect(world.joints).not.toContain(joint);
+  });
+
+  it('addJoint is idempotent when the same joint instance is added twice', () => {
+    const world = new PhysicsWorld();
+    const anchor = world.add(new PhysicsBody({ type: 'static' }));
+    const bob = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 50 }, colliders: [{ shape: new CircleShape(5) }] }));
+    const joint = new DistanceJoint({ bodyA: anchor, bodyB: bob, length: 50 });
+
+    world.addJoint(joint);
+    world.addJoint(joint); // second add is a no-op guard (already tracked)
+
+    expect(world.joints.filter(j => j === joint)).toHaveLength(1);
+  });
+
+  it('removeJoint on a joint that was never added is a safe no-op', () => {
+    const world = new PhysicsWorld();
+    const anchor = world.add(new PhysicsBody({ type: 'static' }));
+    const bob = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 50 }, colliders: [{ shape: new CircleShape(5) }] }));
+    const joint = new DistanceJoint({ bodyA: anchor, bodyB: bob, length: 50 });
+
+    expect(() => world.removeJoint(joint)).not.toThrow();
+    expect(world.joints).not.toContain(joint);
+  });
+
+  it('steps a jointed pair of dynamic bodies, coupling them into one sleep island', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    // `bodyB` is added first (the lower island index) but passed as the joint's
+    // *second* body — deliberately reversed from index order, so the island
+    // union-find takes its `rootB < rootA` branch, not just `rootA < rootB`.
+    const dynB = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 20, y: 0 }, colliders: [{ shape: new CircleShape(5), density: 1 }] }));
+    const dynA = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [{ shape: new CircleShape(5), density: 1 }] }));
+    const joint = world.addJoint(new DistanceJoint({ bodyA: dynA, bodyB: dynB, length: 20 }));
+
+    expect(() => world.step(1 / 60)).not.toThrow();
+    expect(world.joints).toContain(joint);
+
+    // A disabled joint is still tracked but skipped by the island-coupling check.
+    joint.enabled = false;
+    expect(() => world.step(1 / 60)).not.toThrow();
+  });
+
+  it('unioning an already-merged pair a second time (contact + joint on the same pair) is a no-op', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    // The two circles overlap (distance 8 < the sum of their radii, 10), so the
+    // same pair is unioned twice in one pass: once via the solid contact (which
+    // merges them first), once via the joint. The second call finds both
+    // already at the same union-find root — neither `_union` branch fires.
+    const dynB = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 8, y: 0 }, colliders: [{ shape: new CircleShape(5), density: 1 }] }));
+    const dynA = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [{ shape: new CircleShape(5), density: 1 }] }));
+    const joint = world.addJoint(new DistanceJoint({ bodyA: dynA, bodyB: dynB, length: 8 }));
+
+    expect(() => world.step(1 / 60)).not.toThrow();
+    expect(world.joints).toContain(joint);
+  });
+
+  it('exposes the detection backend and its contact graph', () => {
+    const world = new PhysicsWorld();
+
+    expect(world.backend).toBeDefined();
+    expect(world.backend.contactGraph.recordCount).toBe(0);
+  });
+
+  it('sorts persistent solid contacts by (a.id, b.id), including ties on a.id, and removeCollider drops only the matching record', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+    // The floor is added first (lowest id) and both boxes rest on it without
+    // touching each other — two solid contacts share the same `a` (the floor),
+    // so the sort comparator must fall through to comparing `b.id`.
+    colliderAt(world, new BoxShape(400, 20), { x: 0, y: 100 });
+    const boxLeft = world.add(new PhysicsBody({ type: 'dynamic', position: { x: -50, y: 100 - 10 - 5 }, colliders: [{ shape: new BoxShape(16, 16) }] }));
+    world.add(new PhysicsBody({ type: 'dynamic', position: { x: 50, y: 100 - 10 - 5 }, colliders: [{ shape: new BoxShape(16, 16) }] }));
+
+    for (let i = 0; i < 30; i++) {
+      world.step(1 / 60);
+    }
+
+    const contacts = world.backend.contactGraph.solidContacts;
+
+    expect(contacts.length).toBeGreaterThanOrEqual(2);
+
+    for (let i = 1; i < contacts.length; i++) {
+      const prev = contacts[i - 1]!;
+      const cur = contacts[i]!;
+
+      expect(prev.a.id < cur.a.id || (prev.a.id === cur.a.id && prev.b.id < cur.b.id)).toBe(true);
+    }
+
+    // Confirm a genuine tie on `a.id` occurred (otherwise the assertion above
+    // would pass trivially without ever exercising the tie-break branch).
+    expect(contacts.some((c, i) => i > 0 && contacts[i - 1]!.a.id === c.a.id)).toBe(true);
+
+    // Destroying one box's collider must drop only its own record, leaving the
+    // other box's still-touching floor contact intact (ContactGraph.removeCollider
+    // skips records that reference neither the destroyed collider's side).
+    world.destroyCollider(boxLeft.colliders[0]!);
+    expect(world.backend.contactGraph.recordCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('accepts an explicit fixedDelta and maxSubSteps, forwarding both to the time stepper', () => {
+    const world = new PhysicsWorld({ fixedDelta: 1 / 30, maxSubSteps: 2 });
+
+    expect(world.timeStepper.fixedDelta).toBeCloseTo(1 / 30, 9);
+  });
+
+  it('a frame delta smaller than fixedDelta accumulates without running any fixed step', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+    const body = world.add(new PhysicsBody({ type: 'dynamic', colliders: [{ shape: new BoxShape(10, 10), density: 1 }] }));
+
+    world.step(1 / 100_000); // far smaller than the default fixedDelta (1/60)
+
+    expect(body.y).toBe(0); // no fixed step ran yet — nothing integrated
+  });
+});
+
+describe('Aabb helpers', () => {
+  it('createAabb returns a zero-extent box at the origin', () => {
+    expect(createAabb()).toEqual({ minX: 0, minY: 0, maxX: 0, maxY: 0 });
+  });
+
+  it('expandAabb grows every side by margin, mutating and returning the same object', () => {
+    const box = { minX: 10, minY: 20, maxX: 30, maxY: 40 };
+    const result = expandAabb(box, 5);
+
+    expect(result).toBe(box);
+    expect(box).toEqual({ minX: 5, minY: 15, maxX: 35, maxY: 45 });
+  });
+
+  it('expandAabb with a negative margin shrinks the box', () => {
+    const box = { minX: 0, minY: 0, maxX: 10, maxY: 10 };
+
+    expandAabb(box, -2);
+
+    expect(box).toEqual({ minX: 2, minY: 2, maxX: 8, maxY: 8 });
+  });
+});
+
+describe('Collider validation and accessors', () => {
+  it('rejects a negative or non-finite density', () => {
+    expect(() => new Collider({ shape: new BoxShape(10, 10), density: -1 })).toThrow(RangeError);
+    expect(() => new Collider({ shape: new BoxShape(10, 10), density: Number.NaN })).toThrow(RangeError);
+  });
+
+  it('throws reading .body before the collider is attached to a body in a world', () => {
+    const collider = new Collider({ shape: new BoxShape(10, 10) });
+
+    expect(() => collider.body).toThrow();
+  });
+
+  it('exposes the world transform after synchronize', () => {
+    const world = new PhysicsWorld();
+    const body = world.add(new PhysicsBody({ type: 'static', position: { x: 5, y: 7 }, colliders: [{ shape: new BoxShape(10, 10) }] }));
+    const collider = body.colliders[0]!;
+
+    expect(collider.worldTransform.x).toBe(5);
+    expect(collider.worldTransform.y).toBe(7);
+  });
+});
+
+describe('PhysicsBody accessors, force/torque/impulse and mass edge cases', () => {
+  it('exposes position as a fresh Vector and body-local centre-of-mass accessors', () => {
+    const world = new PhysicsWorld();
+    const body = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 3, y: 4 }, colliders: [{ shape: new BoxShape(10, 10), density: 1 }] }));
+
+    expect(body.position.x).toBe(3);
+    expect(body.position.y).toBe(4);
+    // A centred, symmetric box puts the centre of mass at the body origin.
+    expect(body.centerOfMassX).toBeCloseTo(0, 6);
+    expect(body.centerOfMassY).toBeCloseTo(0, 6);
+  });
+
+  it('synchronizeColliders refreshes every collider from the current transform', () => {
+    const world = new PhysicsWorld();
+    const body = world.add(new PhysicsBody({ type: 'static', position: { x: 12, y: 34 }, colliders: [{ shape: new CircleShape(5) }] }));
+    const collider = body.colliders[0]!;
+
+    body.synchronizeColliders();
+
+    expect(collider.worldCenter.x).toBe(12);
+    expect(collider.worldCenter.y).toBe(34);
+  });
+
+  it('applyForce accumulates a world-space force integrated on the next step', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const body = world.add(new PhysicsBody({ type: 'dynamic', colliders: [{ shape: new BoxShape(10, 10), density: 1 }] }));
+
+    expect(body.applyForce(1000, 0)).toBe(body);
+
+    world.step(1 / 60);
+    expect(body.linearVelocityX).toBeGreaterThan(0);
+  });
+
+  it('applyTorque accumulates a torque integrated on the next step', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const body = world.add(new PhysicsBody({ type: 'dynamic', colliders: [{ shape: new BoxShape(10, 10), density: 1 }] }));
+
+    expect(body.applyTorque(500)).toBe(body);
+
+    world.step(1 / 60);
+    expect(body.angularVelocity).not.toBe(0);
+  });
+
+  it('applyImpulse is a no-op on a static (infinite-mass) body', () => {
+    const world = new PhysicsWorld();
+    const body = world.add(new PhysicsBody({ type: 'static', colliders: [{ shape: new BoxShape(10, 10) }] }));
+
+    expect(body.applyImpulse(1000, 1000)).toBe(body);
+    expect(body.linearVelocityX).toBe(0);
+    expect(body.linearVelocityY).toBe(0);
+  });
+
+  it('addCollider accepts a pre-built Collider instance on a not-yet-attached body', () => {
+    const body = new PhysicsBody({ type: 'dynamic' });
+    const collider = new Collider({ shape: new BoxShape(10, 10), density: 1 });
+
+    const returned = body.addCollider(collider);
+
+    expect(returned).toBe(collider);
+    expect(body.colliders).toContain(collider);
+    expect(collider.id).toBe(-1); // no owner yet — no id allocation happens
+  });
+
+  it('ignores zero-density colliders when aggregating mass but still counts a positive-density one', () => {
+    const world = new PhysicsWorld();
+    const body = world.add(
+      new PhysicsBody({
+        type: 'dynamic',
+        colliders: [
+          { shape: new BoxShape(10, 10), density: 0 },
+          { shape: new BoxShape(10, 10), density: 2 },
+        ],
+      }),
+    );
+
+    expect(body.mass).toBeCloseTo(200, 6); // only the density-2 collider contributes
+    expect(body.isMassReady).toBe(true);
   });
 });
 
@@ -153,5 +453,52 @@ describe('PhysicsWorld.attach convenience', () => {
     world.step(1 / 60);
     expect(node.x).toBe(55);
     expect(node.y).toBe(77);
+  });
+
+  it('creates a body with only the required shape option (every other field defaults)', () => {
+    const world = new PhysicsWorld();
+    const node = fakeNode();
+    const body = world.attach(node as unknown as SceneNode, { shape: new CircleShape(5) });
+
+    expect(body.type).toBe('dynamic'); // BodyOptions default
+    expect(body.gravityScale).toBe(1);
+    expect(body.fixedRotation).toBe(false);
+    expect(body.colliders[0]!.density).toBe(1); // Collider default
+    expect(body.colliders[0]!.isSensor).toBe(false);
+  });
+
+  it('creates a body with every optional field specified', () => {
+    const world = new PhysicsWorld();
+    const node = fakeNode();
+    const body = world.attach(node as unknown as SceneNode, {
+      type: 'dynamic',
+      position: { x: 1, y: 2 },
+      angle: 0.5,
+      gravityScale: 2,
+      fixedRotation: true,
+      shape: new BoxShape(10, 10),
+      offset: { x: 1, y: 1 },
+      rotation: 0.1,
+      density: 3,
+      friction: 0.4,
+      restitution: 0.6,
+      isSensor: true,
+      filter: { category: 0x0002, mask: 0x0002, group: 0 },
+    });
+
+    expect(body.type).toBe('dynamic');
+    expect(body.gravityScale).toBe(2);
+    expect(body.fixedRotation).toBe(true);
+
+    const collider = body.colliders[0]!;
+
+    expect(collider.offsetX).toBe(1);
+    expect(collider.offsetY).toBe(1);
+    expect(collider.localRotation).toBeCloseTo(0.1, 9);
+    expect(collider.density).toBe(3);
+    expect(collider.friction).toBeCloseTo(0.4, 9);
+    expect(collider.restitution).toBeCloseTo(0.6, 9);
+    expect(collider.isSensor).toBe(true);
+    expect(collider.filter.category).toBe(0x0002);
   });
 });

--- a/packages/exojs-react/test/Scenes.test.tsx
+++ b/packages/exojs-react/test/Scenes.test.tsx
@@ -128,4 +128,106 @@ describe('<Scenes> / <Scene> / useActiveScene', () => {
 
     await waitFor(() => expect(onError).toHaveBeenCalledWith(failure));
   });
+
+  it('wraps a non-Error rejection from app.scene.setScene() (scene switch) before dispatching it', async () => {
+    const app = makeApp();
+    const view = render(<Tree app={app} active="title" />);
+    await view.findByTestId('active');
+
+    const onError = vi.fn();
+    app.onError.add(onError);
+    app.scene.setScene.mockRejectedValueOnce('switch failed as a plain string');
+
+    view.rerender(<Tree app={app} active="game" />);
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(new Error('switch failed as a plain string')));
+  });
+
+  it('routes a rejected app.scene.setScene(null) (no matching <Scene>) to app.onError', async () => {
+    const app = makeApp();
+    const view = render(<Tree app={app} active="title" />);
+    await view.findByTestId('active');
+
+    const onError = vi.fn();
+    app.onError.add(onError);
+    const failure = new Error('clear failed');
+    app.scene.setScene.mockRejectedValueOnce(failure);
+
+    view.rerender(<Tree app={app} active="does-not-exist" />);
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(failure));
+  });
+
+  it('wraps a non-Error rejection from app.scene.setScene(null) (no matching <Scene>) before dispatching it', async () => {
+    const app = makeApp();
+    const view = render(<Tree app={app} active="title" />);
+    await view.findByTestId('active');
+
+    const onError = vi.fn();
+    app.onError.add(onError);
+    app.scene.setScene.mockRejectedValueOnce('clear failed as a plain string');
+
+    view.rerender(<Tree app={app} active="does-not-exist" />);
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(new Error('clear failed as a plain string')));
+  });
+
+  it('wraps a non-Error rejection from the first app.start() activation before dispatching it', async () => {
+    const app = makeApp();
+    const onError = vi.fn();
+    app.onError.add(onError);
+    app.start.mockRejectedValueOnce('start failed as a plain string');
+
+    render(<Tree app={app} active="title" />);
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(new Error('start failed as a plain string')));
+  });
+
+  it('does not install the scene when the component unmounts before app.start() resolves', async () => {
+    const app = makeApp();
+    let resolveStart!: (value: MockApplication) => void;
+    app.start.mockImplementationOnce(
+      () =>
+        new Promise<MockApplication>(resolve => {
+          resolveStart = resolve;
+        }),
+    );
+
+    const view = render(<Tree app={app} active="title" />);
+    expect(app.start).toHaveBeenCalledTimes(1);
+
+    // Unmount before the pending start() promise settles — the effect's
+    // cleanup already ran (cancelled = true) by the time it resolves below.
+    view.unmount();
+    resolveStart(app);
+
+    // Flush the microtask queue so the (now-late) `.then` in `apply()` runs;
+    // it must be a no-op rather than calling setInstance on an unmounted tree.
+    await Promise.resolve().then(() => Promise.resolve());
+    expect(view.queryByTestId('active')).toBeNull();
+  });
+
+  it('ignores non-<Scene> children when collecting the scene registry', async () => {
+    const app = makeApp();
+    const { findByTestId } = render(
+      <ExoContext.Provider value={app}>
+        <Scenes active="title">
+          <Scene name="title" component={TitleScene}>
+            <span data-testid="hud">title-hud</span>
+          </Scene>
+          {'a stray text child'}
+          <div data-testid="not-a-scene">ignored</div>
+        </Scenes>
+      </ExoContext.Provider>,
+    );
+
+    expect((await findByTestId('hud')).textContent).toBe('title-hud');
+  });
+});
+
+describe('<Scene> rendered directly', () => {
+  it('renders nothing on its own', () => {
+    const { container } = render(<Scene name="standalone" component={TitleScene} />);
+    expect(container.innerHTML).toBe('');
+  });
 });

--- a/packages/exojs-react/test/useExoApplication.test.tsx
+++ b/packages/exojs-react/test/useExoApplication.test.tsx
@@ -17,6 +17,18 @@ vi.mock('@codexo/exojs', async importActual => {
   return { ...actual, Application: MockApp };
 });
 
+/**
+ * Drives `useExoApplication` WITHOUT ever attaching the returned `canvasRef` to
+ * an element — exercises the mount effect's early-return guard (`canvasRef.current`
+ * stays null, so no Application is constructed).
+ */
+function NoCanvasHarness({ options, expose }: { options?: ExoApplicationOptions; expose: (result: UseExoApplicationResult) => void }): ReactElement {
+  const result = useExoApplication(options);
+  expose(result);
+
+  return <div data-testid="no-canvas" />;
+}
+
 interface HarnessProps {
   options?: ExoApplicationOptions;
   onReady?: (app: Application) => void;
@@ -88,6 +100,16 @@ describe('useExoApplication — construction & wiring', () => {
     expect(harness.result().canvasRef).toBe(refBefore);
     // A live prop change must NOT tear down and rebuild the Application.
     expect(MockApplication.instances).toHaveLength(1);
+  });
+});
+
+describe('useExoApplication — canvasRef never attached', () => {
+  it('does not construct an Application while canvasRef.current stays null', () => {
+    let latest: UseExoApplicationResult | undefined;
+    render(<NoCanvasHarness options={{ canvas: { width: 800, height: 600 } }} expose={r => (latest = r)} />);
+
+    expect(MockApplication.instances).toHaveLength(0);
+    expect(latest!.app).toBeNull();
   });
 });
 

--- a/packages/exojs-react/test/useScene.test.tsx
+++ b/packages/exojs-react/test/useScene.test.tsx
@@ -96,4 +96,53 @@ describe('useScene', () => {
 
     await waitFor(() => expect(onError).toHaveBeenCalledWith(failure));
   });
+
+  it('wraps a non-Error rejection from the first app.start() activation before dispatching it', async () => {
+    const app = makeApp();
+    const onError = vi.fn();
+    app.onError.add(onError);
+    app.start.mockRejectedValueOnce('start failed as a plain string');
+
+    render(provide(app, <SceneProbe sceneClass={LevelScene} />));
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(new Error('start failed as a plain string')));
+  });
+
+  it('wraps a non-Error rejection from the best-effort setScene(null) cleanup on unmount before dispatching it', async () => {
+    const app = makeApp();
+    const view = render(provide(app, <SceneProbe sceneClass={LevelScene} />));
+    await view.findByText('LevelScene');
+
+    const onError = vi.fn();
+    app.onError.add(onError);
+    app.scene.setScene.mockRejectedValueOnce('clear failed as a plain string');
+
+    view.unmount();
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(new Error('clear failed as a plain string')));
+  });
+
+  it('does not install the scene when the component unmounts before app.start() resolves', async () => {
+    const app = makeApp();
+    let resolveStart!: (value: MockApplication) => void;
+    app.start.mockImplementationOnce(
+      () =>
+        new Promise<MockApplication>(resolve => {
+          resolveStart = resolve;
+        }),
+    );
+
+    const view = render(provide(app, <SceneProbe sceneClass={LevelScene} />));
+    expect(app.start).toHaveBeenCalledTimes(1);
+
+    // Unmount before the pending start() promise settles — the effect's
+    // cleanup already ran (cancelled = true) by the time it resolves below.
+    view.unmount();
+    resolveStart(app);
+
+    // Flush the microtask queue so the (now-late) `.then` in `apply()` runs;
+    // it must be a no-op rather than calling setScene on an unmounted tree.
+    await Promise.resolve().then(() => Promise.resolve());
+    expect(view.queryByText('LevelScene')).toBeNull();
+  });
 });

--- a/packages/exojs-tiled/src/TiledMap.ts
+++ b/packages/exojs-tiled/src/TiledMap.ts
@@ -655,7 +655,10 @@ function checkGidCoverage(map: TiledMap, source: string): void {
         if (object === undefined) continue;
         const gid = object.gid;
 
-        if (gid !== undefined && map.findTilesetForGid(gid) === undefined) {
+        // gid 0 (after masking the flip bits) is the empty-cell sentinel, the
+        // same as in tile-layer data — accept it as "no tile" instead of
+        // rejecting it as uncovered.
+        if (gid !== undefined && maskTiledGid(gid) !== 0 && map.findTilesetForGid(gid) === undefined) {
           throw new TiledFormatError(source, `${layerPath}.objects[${o}].gid`, `gid ${gid} (masked: ${maskTiledGid(gid)}) is not covered by any tileset`);
         }
       }

--- a/packages/exojs-tiled/test/TiledMap.test.ts
+++ b/packages/exojs-tiled/test/TiledMap.test.ts
@@ -1,7 +1,8 @@
 import { Texture } from '@codexo/exojs';
 import { TileLayer, TileMap, TileSet } from '@codexo/exojs-tilemap';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, test } from 'vitest';
 
+import type { TiledChunkData, TiledLayerData, TiledMapData, TiledObjectData, TiledPropertyData } from '../src/data';
 import { TiledTileLayer } from '../src/TiledLayer';
 import { TiledMap } from '../src/TiledMap';
 import { TiledTileset } from '../src/TiledTileset';
@@ -447,5 +448,349 @@ describe('TiledMap.toTileMap — error cases', () => {
     const map = new TiledMap('col.tmj', data, [collectionTs]);
     expect(() => map.toTileMap()).toThrow(TiledFormatError);
     expect(() => map.toTileMap()).toThrow(/collection-of-images/);
+  });
+});
+
+// ── Object-kind conversion breadth (ellipse/polygon/polyline/dropped-tile) ──────
+
+describe('TiledMap.toTileMap — object kind conversion', () => {
+  function makeObjectKindMap(objectOverrides: Record<string, unknown>): TileMap {
+    const data = validateTiledMapData({
+      type: 'map', version: '1.10', orientation: 'orthogonal', renderorder: 'right-down',
+      width: 1, height: 1, tilewidth: 16, tileheight: 16, infinite: false,
+      layers: [{
+        id: 1, name: 'Objects', type: 'objectgroup', visible: true, x: 0, y: 0, opacity: 1,
+        objects: [{ id: 1, name: 'obj', type: '', x: 0, y: 0, width: 16, height: 16, rotation: 0, visible: true, ...objectOverrides }],
+      }],
+      tilesets: [],
+    }, 'objkind.tmj');
+    return new TiledMap('objkind.tmj', data, []).toTileMap();
+  }
+
+  it('maps an ellipse object to kind "ellipse"', () => {
+    const obj = makeObjectKindMap({ ellipse: true }).objectLayers[0]!.objects[0]!;
+    expect(obj.kind).toBe('ellipse');
+  });
+
+  it('maps a polygon object to kind "polygon" with converted points', () => {
+    const points = [{ x: 0, y: 0 }, { x: 8, y: 0 }, { x: 8, y: 8 }];
+    const obj = makeObjectKindMap({ polygon: points }).objectLayers[0]!.objects[0]!;
+    expect(obj.kind).toBe('polygon');
+    if (obj.kind === 'polygon') expect(obj.points).toEqual(points);
+  });
+
+  it('maps a polyline object to kind "polyline" with converted points', () => {
+    const points = [{ x: 0, y: 0 }, { x: 4, y: 4 }];
+    const obj = makeObjectKindMap({ polyline: points }).objectLayers[0]!.objects[0]!;
+    expect(obj.kind).toBe('polyline');
+    if (obj.kind === 'polyline') expect(obj.points).toEqual(points);
+  });
+
+  it('drops a tile object whose tileset has no atlas image (skipped at conversion)', () => {
+    const noImageTs = new TiledTileset({ name: 'no-image', tilewidth: 16, tileheight: 16, tilecount: 1, columns: 1 }, 1);
+    const data = validateTiledMapData({
+      type: 'map', version: '1.10', orientation: 'orthogonal', renderorder: 'right-down',
+      width: 1, height: 1, tilewidth: 16, tileheight: 16, infinite: false,
+      layers: [{
+        id: 1, name: 'Objects', type: 'objectgroup', visible: true, x: 0, y: 0, opacity: 1,
+        objects: [{ id: 1, name: 'obj', type: '', x: 0, y: 0, width: 16, height: 16, rotation: 0, visible: true, gid: 1 }],
+      }],
+      tilesets: [{ firstgid: 1, name: 'no-image', tilewidth: 16, tileheight: 16, tilecount: 1, columns: 1 }],
+    }, 'noimg.tmj');
+    const tm = new TiledMap('noimg.tmj', data, [noImageTs]).toTileMap();
+    expect(tm.objectLayers[0]!.objects).toHaveLength(0);
+  });
+});
+
+// ── Text-object TextStyle field breadth ─────────────────────────────────────────
+
+describe('TiledMap.toTileMap — text object style conversion', () => {
+  function makeTextObjectMap(textData: Record<string, unknown>): TileMap {
+    const data = validateTiledMapData({
+      type: 'map', version: '1.10', orientation: 'orthogonal', renderorder: 'right-down',
+      width: 1, height: 1, tilewidth: 16, tileheight: 16, infinite: false,
+      layers: [{
+        id: 1, name: 'Objects', type: 'objectgroup', visible: true, x: 0, y: 0, opacity: 1,
+        objects: [{ id: 1, name: 'label', type: '', x: 0, y: 0, width: 16, height: 16, rotation: 0, visible: true, text: textData }],
+      }],
+      tilesets: [],
+    }, 'text.tmj');
+    return new TiledMap('text.tmj', data, []).toTileMap();
+  }
+
+  it('omits optional TextStyle fields entirely when absent from the source text object', () => {
+    const obj = makeTextObjectMap({ text: 'plain' }).objectLayers[0]!.objects[0]!;
+    expect(obj.kind).toBe('text');
+    if (obj.kind === 'text') expect(obj.text).toEqual({ text: 'plain' });
+  });
+
+  it('includes fontFamily, italic, underline, strikeout, halign, and valign when present', () => {
+    const obj = makeTextObjectMap({
+      text: 'styled', fontfamily: 'Arial', italic: true, underline: true, strikeout: true, halign: 'right', valign: 'bottom',
+    }).objectLayers[0]!.objects[0]!;
+    expect(obj.kind).toBe('text');
+    if (obj.kind === 'text') {
+      expect(obj.text.fontFamily).toBe('Arial');
+      expect(obj.text.italic).toBe(true);
+      expect(obj.text.underline).toBe(true);
+      expect(obj.text.strikeout).toBe(true);
+      expect(obj.text.halign).toBe('right');
+      expect(obj.text.valign).toBe('bottom');
+    }
+  });
+});
+
+// ── Per-tile collision shape kind breadth ───────────────────────────────────────
+
+describe('TiledMap.toTileMap — per-tile collision shape kinds', () => {
+  it('converts point, ellipse, polygon, and polyline collision shapes; drops text and gid shapes', () => {
+    const ts = new TiledTileset(
+      {
+        name: 'collide', tilewidth: 16, tileheight: 16, tilecount: 1, columns: 1,
+        imagewidth: 16, imageheight: 16,
+        tiles: [{
+          id: 0,
+          objectgroup: {
+            id: 1, name: '', type: 'objectgroup', visible: true, opacity: 1, x: 0, y: 0,
+            draworder: 'topdown',
+            objects: [
+              { id: 1, name: '', type: '', x: 0, y: 0, width: 0, height: 0, rotation: 0, visible: true, text: { text: 'dropped' } },
+              { id: 2, name: '', type: '', x: 0, y: 0, width: 0, height: 0, rotation: 0, visible: true, gid: 1 },
+              { id: 3, name: '', type: '', x: 1, y: 1, width: 0, height: 0, rotation: 0, visible: true, point: true },
+              { id: 4, name: '', type: '', x: 2, y: 2, width: 4, height: 4, rotation: 0, visible: true, ellipse: true },
+              { id: 5, name: '', type: '', x: 0, y: 0, width: 0, height: 0, rotation: 0, visible: true, polygon: [{ x: 0, y: 0 }, { x: 2, y: 0 }, { x: 2, y: 2 }] },
+              { id: 6, name: '', type: '', x: 0, y: 0, width: 0, height: 0, rotation: 0, visible: true, polyline: [{ x: 0, y: 0 }, { x: 3, y: 3 }] },
+            ],
+          },
+        }],
+      },
+      1,
+      { imageUrl: 'collide.png', texture: makeTexture(16, 16) },
+    );
+    const data = validateTiledMapData({ ...RAW_MINIMAL, layers: [] }, 'collide.tmj');
+    const tm = new TiledMap('collide.tmj', data, [ts]).toTileMap();
+    const collision = tm.tilesets[0]!.getTileDefinition(0)?.collision;
+    expect(collision).toHaveLength(4);
+    expect(collision?.map(shape => shape.kind)).toEqual(['point', 'ellipse', 'polygon', 'polyline']);
+  });
+});
+
+// ── buildTileDefinitions edge cases ──────────────────────────────────────────────
+
+describe('TiledMap.toTileMap — buildTileDefinitions edge cases', () => {
+  it('skips an out-of-range tile id and a tile whose animation/collision fully filter to empty', () => {
+    const ts = new TiledTileset(
+      {
+        name: 'edge', tilewidth: 16, tileheight: 16, tilecount: 2, columns: 2,
+        imagewidth: 32, imageheight: 16,
+        tiles: [
+          { id: 5 }, // out of range for tilecount: 2
+          {
+            id: 0,
+            animation: [{ tileid: 99, duration: 100 }], // out-of-range frame, filtered to empty
+            objectgroup: {
+              id: 1, name: '', type: 'objectgroup', visible: true, opacity: 1, x: 0, y: 0,
+              draworder: 'topdown',
+              objects: [{ id: 1, name: '', type: '', x: 0, y: 0, width: 0, height: 0, rotation: 0, visible: true, text: { text: 'x' } }],
+            },
+          },
+        ],
+      },
+      1,
+      { imageUrl: 'edge.png', texture: makeTexture(32, 16) },
+    );
+    const data = validateTiledMapData({ ...RAW_MINIMAL, layers: [] }, 'edgeTiles.tmj');
+    const tm = new TiledMap('edgeTiles.tmj', data, [ts]).toTileMap();
+    const runtimeTs = tm.tilesets[0]!;
+    expect(runtimeTs.getTileDefinition(0)).toBeUndefined();
+    expect(runtimeTs.getTileDefinition(5)).toBeUndefined();
+  });
+});
+
+// ── parseTiledColor breadth (AARRGGBB, malformed length, invalid hex digits) ────
+
+describe('TiledMap.toTileMap — background colour parsing edge cases', () => {
+  it('parses an 8-digit AARRGGBB colour, dropping the leading alpha', () => {
+    const data = validateTiledMapData({ ...RAW_MINIMAL, backgroundcolor: '#ff112233' }, 'argb.tmj');
+    const tm = new TiledMap('argb.tmj', data, [ATLAS_TILESET]).toTileMap();
+    expect(tm.backgroundColor).toBe(0x112233);
+  });
+
+  it('returns null for a malformed-length colour string', () => {
+    const data = validateTiledMapData({ ...RAW_MINIMAL, backgroundcolor: '#1234' }, 'shortcolor.tmj');
+    const tm = new TiledMap('shortcolor.tmj', data, [ATLAS_TILESET]).toTileMap();
+    expect(tm.backgroundColor).toBeNull();
+  });
+
+  it('returns null for invalid hex digits', () => {
+    const data = validateTiledMapData({ ...RAW_MINIMAL, backgroundcolor: '#zzzzzz' }, 'badhex.tmj');
+    const tm = new TiledMap('badhex.tmj', data, [ATLAS_TILESET]).toTileMap();
+    expect(tm.backgroundColor).toBeNull();
+  });
+
+  it('accepts a colour string without a leading "#"', () => {
+    const data = validateTiledMapData({ ...RAW_MINIMAL, backgroundcolor: '112233' }, 'nohash.tmj');
+    const tm = new TiledMap('nohash.tmj', data, [ATLAS_TILESET]).toTileMap();
+    expect(tm.backgroundColor).toBe(0x112233);
+  });
+});
+
+// ── Property conversion edge cases ──────────────────────────────────────────────
+
+describe('TiledMap.toTileMap — property conversion edge cases', () => {
+  it('converts float, color, and file property types to their raw values', () => {
+    const data = validateTiledMapData({
+      ...RAW_MINIMAL,
+      properties: [
+        { name: 'speed', type: 'float', value: 2.5 },
+        { name: 'tint', type: 'color', value: '#ff0000ff' },
+        { name: 'sfx', type: 'file', value: 'sounds/hit.wav' },
+      ],
+    }, 'floatcolorfile.tmj');
+    const tm = new TiledMap('floatcolorfile.tmj', data, [ATLAS_TILESET]).toTileMap();
+    expect(tm.properties['speed']).toBe(2.5);
+    expect(tm.properties['tint']).toBe('#ff0000ff');
+    expect(tm.properties['sfx']).toBe('sounds/hit.wav');
+  });
+
+  it('omits a property whose converted value is undefined (defensive; requires bypassing validate.ts, whose `value` field is never undefined)', () => {
+    const data = validateTiledMapData({ ...RAW_MINIMAL, layers: [] }, 'ghost.tmj');
+    const bogusProp = { name: 'ghost', type: 'string', propertytype: undefined, value: undefined } as unknown as TiledPropertyData;
+    const dataWithGhost: TiledMapData = { ...data, properties: [bogusProp] };
+    const tm = new TiledMap('ghost.tmj', dataWithGhost, [ATLAS_TILESET]).toTileMap();
+    expect(tm.properties).toEqual({});
+  });
+
+  it('throws when converting a property with an unrecognised type (defensive; validate.ts normally restricts property.type to 8 known values)', () => {
+    const data = validateTiledMapData({
+      ...RAW_MINIMAL,
+      properties: [{ name: 'weird', type: 'string', value: 'x' }],
+    }, 'weird.tmj');
+    // Mutate the already-parsed property to simulate an invariant violation that
+    // validate.ts's own type restriction would normally prevent.
+    (data.properties![0] as { type: string }).type = 'vector3';
+    const map = new TiledMap('weird.tmj', data, [ATLAS_TILESET]);
+    expect(() => map.toTileMap()).toThrow(/unrecognised Tiled property type "vector3"/);
+  });
+});
+
+// ── Defensive coverage of otherwise-unreachable branches ────────────────────────
+//
+// The tests below intentionally bypass validate.ts's invariants (which a
+// TiledMap built via loadTiledMap() always upholds) by either constructing
+// TiledMapData by hand or tampering with an already-validated map's internal
+// state. TiledMap's own constructor does not re-run validate.ts, so these are
+// legitimate (if unusual) call shapes for a caller that skips loadTiledMap.
+
+function makeBareMapData(overrides: Partial<TiledMapData> & { layers: TiledMapData['layers'] }): TiledMapData {
+  return {
+    type: 'map',
+    version: '1.10',
+    orientation: 'orthogonal',
+    renderorder: 'right-down',
+    width: 1,
+    height: 1,
+    tilewidth: 16,
+    tileheight: 16,
+    infinite: false,
+    tilesets: [],
+    properties: [],
+    ...overrides,
+  };
+}
+
+describe('TiledMap — defensive coverage of otherwise-unreachable branches', () => {
+  it('tolerates an explicit undefined entry in the tilesets array (sort() never invokes the comparator on it)', () => {
+    const data = validateTiledMapData({ ...RAW_MINIMAL, layers: [] }, 'holetilesets.tmj');
+    const map = new TiledMap('holetilesets.tmj', data, [TILESET, undefined as unknown as TiledTileset]);
+    expect(map.tilesets).toHaveLength(2);
+    const tm = map.toTileMap();
+    // TILESET has no texture (skipped) and the hole is skipped too → no runtime tilesets.
+    expect(tm.tilesets).toHaveLength(0);
+  });
+
+  it('resolveGid returns null when no tileset covers the masked gid (requires clearing tilesets after construction, since valid construction always guarantees coverage)', () => {
+    const map = makeAtlasMap();
+    (map as unknown as { tilesets: TiledTileset[] }).tilesets = [];
+    const tm = map.toTileMap();
+    expect(tm.layers[0]!.getTileAt(0, 0)).toBeNull();
+  });
+
+  it('skips a hole in a tile layer\'s raw data array (defensive; requires a genuine sparse hole, which JSON parsing never produces)', () => {
+    const holedData: number[] = new Array(3) as number[];
+    holedData[0] = 0;
+    holedData[2] = 0;
+    const layer: TiledLayerData = {
+      type: 'tilelayer', id: 1, name: 'HoleData', visible: true, opacity: 1, x: 0, y: 0,
+      width: 3, height: 1, data: holedData,
+    };
+    const data = makeBareMapData({ width: 3, height: 1, layers: [layer] });
+    const map = new TiledMap('holedata.tmj', data, []);
+    const tm = map.toTileMap();
+    expect(tm.layers[0]!.getTileAt(1, 0)).toBeNull();
+  });
+
+  it('silently ignores a layer of an unrecognised type end-to-end (defensive; bypasses validate.ts\'s restriction of layer.type to 4 known values)', () => {
+    const bogusLayer = { type: 'unknown-layer-type', id: 1, name: 'Bogus', visible: true, opacity: 1, x: 0, y: 0 } as unknown as TiledLayerData;
+    const data = makeBareMapData({ layers: [bogusLayer] });
+    const map = new TiledMap('bogus.tmj', data, []);
+    const tm = map.toTileMap();
+    expect(tm.layers).toHaveLength(0);
+    expect(tm.objectLayers).toHaveLength(0);
+    expect(tm.imageLayers).toHaveLength(0);
+  });
+
+  it('skips tile-layer population when both data and chunks are undefined (defensive; bypasses validate.ts\'s "exactly one of data/chunks" check)', () => {
+    const layer: TiledLayerData = {
+      type: 'tilelayer', id: 1, name: 'Bare', visible: true, opacity: 1, x: 0, y: 0, width: 1, height: 1,
+    };
+    const data = makeBareMapData({ layers: [layer] });
+    const map = new TiledMap('bare.tmj', data, []);
+    const tm = map.toTileMap();
+    expect(tm.layers[0]!.getTileAt(0, 0)).toBeNull();
+  });
+
+  it('defaults an image layer texture to null when no texture was preloaded for its id', () => {
+    const layer: TiledLayerData = {
+      type: 'imagelayer', id: 1, name: 'Bg', visible: true, opacity: 1, x: 0, y: 0, image: 'bg.png',
+    };
+    const data = makeBareMapData({ layers: [layer] });
+    const tm = new TiledMap('imgnotex.tmj', data, []).toTileMap(); // no imageTextures map passed → defaults to empty
+    expect(tm.imageLayers[0]!.texture).toBeNull();
+  });
+
+  it('skips a hole in an infinite tile layer\'s chunks array during GID-coverage validation', () => {
+    const chunks: TiledChunkData[] = new Array(2) as TiledChunkData[];
+    chunks[1] = { x: 0, y: 0, width: 1, height: 1, data: [0] };
+    const layer: TiledLayerData = {
+      type: 'tilelayer', id: 1, name: 'Inf', visible: true, opacity: 1, x: 0, y: 0, width: 0, height: 0, chunks,
+    };
+    const data = makeBareMapData({ infinite: true, layers: [layer] });
+    expect(() => new TiledMap('holechunks.tmj', data, [])).not.toThrow();
+  });
+
+  it('skips a hole in an object layer\'s objects array during GID-coverage validation', () => {
+    const objects: TiledObjectData[] = new Array(2) as TiledObjectData[];
+    objects[1] = { id: 1, name: '', type: '', x: 0, y: 0, width: 0, height: 0, rotation: 0, visible: true };
+    const layer: TiledLayerData = {
+      type: 'objectgroup', id: 1, name: 'Objs', visible: true, opacity: 1, x: 0, y: 0, objects,
+    };
+    const data = makeBareMapData({ layers: [layer] });
+    expect(() => new TiledMap('holeobjects.tmj', data, [])).not.toThrow();
+  });
+
+  test('BUG: an object gid of 0 is rejected as "not covered by any tileset" instead of being treated as the empty-cell sentinel like tile-layer GIDs', () => {
+    // EXPECTED: findTilesetForGid's own doc comment states gid 0 is "the empty-cell
+    // sentinel". checkGidArray (used for tile-layer data/chunks) special-cases
+    // `gid !== 0` accordingly. checkGidCoverage's object-layer branch has no such
+    // guard, so a (Tiled never emits this) object with gid: 0 is rejected instead
+    // of being silently accepted as "no tile", unlike its tile-layer counterpart.
+    const layer: TiledLayerData = {
+      type: 'objectgroup', id: 1, name: 'Objs', visible: true, opacity: 1, x: 0, y: 0,
+      objects: [{ id: 1, name: '', type: '', x: 0, y: 0, width: 0, height: 0, rotation: 0, visible: true, gid: 0 }],
+    };
+    const data = makeBareMapData({ layers: [layer] });
+    expect(() => new TiledMap('objgid0.tmj', data, [])).toThrow(TiledFormatError);
+    expect(() => new TiledMap('objgid0.tmj', data, [])).toThrow(/gid 0.*is not covered/);
   });
 });

--- a/packages/exojs-tiled/test/TiledMap.test.ts
+++ b/packages/exojs-tiled/test/TiledMap.test.ts
@@ -779,18 +779,15 @@ describe('TiledMap — defensive coverage of otherwise-unreachable branches', ()
     expect(() => new TiledMap('holeobjects.tmj', data, [])).not.toThrow();
   });
 
-  test('BUG: an object gid of 0 is rejected as "not covered by any tileset" instead of being treated as the empty-cell sentinel like tile-layer GIDs', () => {
-    // EXPECTED: findTilesetForGid's own doc comment states gid 0 is "the empty-cell
-    // sentinel". checkGidArray (used for tile-layer data/chunks) special-cases
-    // `gid !== 0` accordingly. checkGidCoverage's object-layer branch has no such
-    // guard, so a (Tiled never emits this) object with gid: 0 is rejected instead
-    // of being silently accepted as "no tile", unlike its tile-layer counterpart.
+  test('an object gid of 0 is accepted as the empty-cell sentinel, like tile-layer GIDs', () => {
+    // findTilesetForGid documents gid 0 as "the empty-cell sentinel" and
+    // checkGidArray (tile-layer data/chunks) special-cases it; the object-layer
+    // coverage check treats it the same way.
     const layer: TiledLayerData = {
       type: 'objectgroup', id: 1, name: 'Objs', visible: true, opacity: 1, x: 0, y: 0,
       objects: [{ id: 1, name: '', type: '', x: 0, y: 0, width: 0, height: 0, rotation: 0, visible: true, gid: 0 }],
     };
     const data = makeBareMapData({ layers: [layer] });
-    expect(() => new TiledMap('objgid0.tmj', data, [])).toThrow(TiledFormatError);
-    expect(() => new TiledMap('objgid0.tmj', data, [])).toThrow(/gid 0.*is not covered/);
+    expect(() => new TiledMap('objgid0.tmj', data, [])).not.toThrow();
   });
 });

--- a/packages/exojs-tiled/test/decodeLayerData.test.ts
+++ b/packages/exojs-tiled/test/decodeLayerData.test.ts
@@ -133,4 +133,54 @@ describe('decodeTiledLayerData', () => {
     });
     await expect(decodeTiledLayerData(raw, 'test.tmj')).rejects.toThrow(TiledFormatError);
   });
+
+  it('rejects an unrecognised (non-empty) compression value', async () => {
+    const raw = makeRawMap({
+      type: 'tilelayer',
+      encoding: 'base64',
+      compression: 'rle',
+      data: bytesToBase64(gidsToBytes(GIDS)),
+    });
+    await expect(decodeTiledLayerData(raw, 'test.tmj')).rejects.toThrow(TiledFormatError);
+    await expect(decodeTiledLayerData(raw, 'test.tmj')).rejects.toThrow(/unsupported tile layer compression/);
+  });
+
+  it('skips a non-object entry in the chunks array', async () => {
+    const raw = makeRawMap({
+      type: 'tilelayer',
+      encoding: 'base64',
+      chunks: [null, { x: 0, y: 0, width: 4, height: 2, data: bytesToBase64(gidsToBytes(GIDS)) }],
+    });
+    await decodeTiledLayerData(raw, 'test.tmj');
+    const layer = (raw.layers as Record<string, unknown>[])[0];
+    const chunks = layer.chunks as unknown[];
+    expect(chunks[0]).toBeNull();
+    expect((chunks[1] as Record<string, unknown>).data).toEqual(GIDS);
+  });
+
+  it('leaves a chunk whose data is not a string untouched', async () => {
+    const raw = makeRawMap({
+      type: 'tilelayer',
+      encoding: 'base64',
+      chunks: [{ x: 0, y: 0, width: 1, height: 1 }], // no "data" field
+    });
+    await decodeTiledLayerData(raw, 'test.tmj');
+    const layer = (raw.layers as Record<string, unknown>[])[0];
+    const chunk = (layer.chunks as Record<string, unknown>[])[0];
+    expect(chunk.data).toBeUndefined();
+  });
+
+  it('skips a non-object entry in a layers array', async () => {
+    const raw = makeRawMap({ type: 'tilelayer', data: [...GIDS] });
+    (raw.layers as unknown[]).unshift('not-a-layer-object');
+    await decodeTiledLayerData(raw, 'test.tmj');
+    const layers = raw.layers as unknown[];
+    expect(layers[0]).toBe('not-a-layer-object');
+    expect((layers[1] as Record<string, unknown>).data).toEqual(GIDS);
+  });
+
+  it('returns a non-object raw document unchanged without throwing', async () => {
+    await expect(decodeTiledLayerData('not a map', 'test.tmj')).resolves.toBe('not a map');
+    await expect(decodeTiledLayerData(null, 'test.tmj')).resolves.toBeNull();
+  });
 });

--- a/packages/exojs-tiled/test/loadTiledMap.test.ts
+++ b/packages/exojs-tiled/test/loadTiledMap.test.ts
@@ -153,6 +153,31 @@ describe('loadTiledMap — collection-of-images tileset', () => {
   });
 });
 
+describe('loadTiledMap — image layer nested inside a group layer', () => {
+  const { context, loaderLoad } = makeContext({
+    'nested-image.tmj': {
+      type: 'map', version: '1.10', orientation: 'orthogonal', renderorder: 'right-down',
+      width: 1, height: 1, tilewidth: 16, tileheight: 16, infinite: false,
+      layers: [{
+        id: 1, name: 'Group', type: 'group', visible: true, x: 0, y: 0, opacity: 1,
+        layers: [{ id: 2, name: 'Bg', type: 'imagelayer', visible: true, x: 0, y: 0, opacity: 1, image: 'bg.png' }],
+      }],
+      tilesets: [],
+    },
+  });
+
+  it('loads the texture for an image layer nested inside a group layer', async () => {
+    await loadTiledMap('nested-image.tmj', context);
+    expect(loaderLoad).toHaveBeenCalledWith(Texture, 'bg.png');
+  });
+
+  it('attaches the preloaded texture to the nested image layer via toTileMap()', async () => {
+    const map = await loadTiledMap('nested-image.tmj', context);
+    const runtime = map.toTileMap();
+    expect(runtime.imageLayers[0]!.texture).toBeInstanceOf(Texture);
+  });
+});
+
 describe('loadTiledMap — error propagation', () => {
   it('propagates TiledFormatError for invalid TMJ', async () => {
     const { context } = makeContext({

--- a/packages/exojs-tiled/test/validate.test.ts
+++ b/packages/exojs-tiled/test/validate.test.ts
@@ -42,6 +42,29 @@ describe('TiledFormatError', () => {
   });
 });
 
+describe('primitive validators — error message shape for each unmet expectation', () => {
+  it('describes a null value as "null" (not "object")', () => {
+    expect(() => validateTiledMapData(null, SOURCE)).toThrow(/expected an object, got null/);
+  });
+
+  it('expectArray throws when given a non-array', () => {
+    const base = { id: 1, name: '', type: '', x: 0, y: 0, width: 16, height: 16, rotation: 0, visible: true };
+    expect(() => validateTiledObjectData({ ...base, polygon: 'not-an-array' }, SOURCE, '')).toThrow(/expected an array, got string/);
+  });
+
+  it('expectString throws when given a non-string', () => {
+    expect(() => validateTiledPropertyData({ name: 42, value: 'x' }, SOURCE, '')).toThrow(/expected a string, got number/);
+  });
+
+  it('expectInteger throws when given a non-integer number', () => {
+    expect(() => validateTiledAnimationFrameData({ tileid: 1.5, duration: 100 }, SOURCE, '')).toThrow(/expected an integer, got 1.5/);
+  });
+
+  it('expectNonNegativeInteger throws when given a negative integer', () => {
+    expect(() => validateTiledAnimationFrameData({ tileid: -1, duration: 100 }, SOURCE, '')).toThrow(/expected a non-negative integer, got -1/);
+  });
+});
+
 describe('validateTiledPropertyData', () => {
   it('parses a string property, defaulting type to "string"', () => {
     expect(validateTiledPropertyData({ name: 'label', value: 'hello' }, SOURCE, '')).toEqual({
@@ -281,6 +304,12 @@ describe('checkTiledLayerInfiniteConsistency', () => {
     const group = validateTiledLayerData(baseLayer({ type: 'group', layers: [inconsistentChild] }), SOURCE, 'layers[0]');
     expect(() => checkTiledLayerInfiniteConsistency([group], false, SOURCE, 'layers')).toThrow(/has "chunks" on a finite map/);
   });
+
+  it('skips a hole in the layers array (defensive; a genuine sparse hole, not producible by JSON.parse)', () => {
+    const layers: import('../src/data').TiledLayerData[] = new Array(2) as import('../src/data').TiledLayerData[];
+    layers[1] = tileLayer({ data: [1] });
+    expect(() => checkTiledLayerInfiniteConsistency(layers, false, SOURCE, 'layers')).not.toThrow();
+  });
 });
 
 describe('validateTiledTileData', () => {
@@ -356,6 +385,23 @@ describe('validateTiledTilesetFileData', () => {
   it('throws on a non-object root', () => {
     expect(() => validateTiledTilesetFileData([], 'tiles.tsj')).toThrow(/expected an object, got an array/);
   });
+
+  it('parses wangsets with colors and wangtiles', () => {
+    const result = validateTiledTilesetFileData({
+      name: 'terrain', tilewidth: 16, tileheight: 16, tilecount: 4, columns: 2,
+      wangsets: [{
+        name: 'ground',
+        type: 'corner',
+        tile: -1,
+        colors: [{ name: 'grass', color: '#00ff00', tile: 0, probability: 1 }],
+        wangtiles: [{ tileid: 0, wangid: [0, 1, 0, 1, 0, 1, 0, 1] }],
+      }],
+    }, 'terrain.tsj');
+    expect(result.wangsets).toHaveLength(1);
+    expect(result.wangsets?.[0]).toMatchObject({ name: 'ground', type: 'corner', tile: -1 });
+    expect(result.wangsets?.[0].colors[0]).toEqual({ name: 'grass', color: '#00ff00', tile: 0, probability: 1 });
+    expect(result.wangsets?.[0].wangtiles[0]).toEqual({ tileid: 0, wangid: [0, 1, 0, 1, 0, 1, 0, 1] });
+  });
 });
 
 describe('validateTiledMapData', () => {
@@ -412,5 +458,14 @@ describe('validateTiledMapData', () => {
 
   it('throws on a non-object root', () => {
     expect(() => validateTiledMapData('not a map', SOURCE)).toThrow(/expected an object, got string/);
+  });
+
+  it('parses a numeric compressionlevel', () => {
+    const result = validateTiledMapData({ ...validMap, compressionlevel: 6 }, SOURCE);
+    expect(result.compressionlevel).toBe(6);
+  });
+
+  it('throws when version is neither a string nor a number', () => {
+    expect(() => validateTiledMapData({ ...validMap, version: true }, SOURCE)).toThrow(/expected a string or number, got boolean/);
   });
 });

--- a/packages/exojs-tiled/test/wangSets.test.ts
+++ b/packages/exojs-tiled/test/wangSets.test.ts
@@ -92,6 +92,14 @@ describe('tiledWangSetToWangSet — corner type', () => {
     expect(result.isMember(11)).toBe(true);
     expect(result.isMember(12)).toBe(true);
   });
+
+  it('treats missing wangid indices as unset rather than throwing', () => {
+    // A wangid array shorter than 8 entries leaves the corner indices (1, 3, 5, 7)
+    // undefined; the `?? 0` fallback must treat all of them as "not this terrain".
+    const shortSet = makeWangSet('corner', [{ tileid: 30, wangid: [] }]);
+    const result = tiledWangSetToWangSet(shortSet, TILESET_INDEX)!;
+    expect(result.getTileId(0)).toBe(30);
+  });
 });
 
 describe('tiledWangSetToWangSet — edge type', () => {
@@ -130,6 +138,14 @@ describe('tiledWangSetToWangSet — edge type', () => {
     const result = tiledWangSetToWangSet(edgeSet, 0)!;
     // right(2) | left(8) = 10
     expect(result.getTileId(10)).toBe(22);
+  });
+
+  it('treats missing wangid indices as unset rather than throwing', () => {
+    // A wangid array shorter than 8 entries leaves the edge indices (0, 2, 4, 6)
+    // undefined; the `?? 0` fallback must treat all of them as "not this terrain".
+    const shortSet = makeWangSet('edge', [{ tileid: 40, wangid: [] }]);
+    const result = tiledWangSetToWangSet(shortSet, 0)!;
+    expect(result.getTileId(0)).toBe(40);
   });
 });
 

--- a/packages/exojs-tilemap/test/TileAnimator.test.ts
+++ b/packages/exojs-tilemap/test/TileAnimator.test.ts
@@ -171,6 +171,128 @@ describe('TileAnimator', () => {
     expect(tile?.transform.flipX).toBe(true);
   });
 
+  it('update() is a no-op for non-positive or non-finite deltaSeconds', () => {
+    const ts = makeTileset256();
+    ts._setDefinition(0, {
+      animation: [
+        { localTileId: 0, duration: 100 },
+        { localTileId: 1, duration: 100 },
+      ],
+    });
+
+    const layer = makeLayer(ts, 3, 3);
+    setTile(layer, ts, 0, 0, 0);
+
+    const animator = new TileAnimator(layer);
+
+    animator.update(0); // zero
+    animator.update(-1); // negative
+    animator.update(NaN); // non-finite
+    animator.update(Infinity); // non-finite
+
+    // None of these advanced the clock or wrote a frame.
+    expect(animator.elapsedMs).toBe(0);
+    expect(layer.getTileAt(0, 0)?.localTileId).toBe(0);
+  });
+
+  it('update() is a no-op when there are no animated cells to advance', () => {
+    const ts = makeTileset256();
+    const layer = makeLayer(ts, 2, 2);
+    setTile(layer, ts, 0, 0, 5); // no animation definition → not registered
+
+    const animator = new TileAnimator(layer);
+    expect(animator.animatedCellCount).toBe(0);
+
+    // update() must return early via the `this._cells.length === 0` guard clause.
+    expect(() => animator.update(0.5)).not.toThrow();
+    expect(animator.elapsedMs).toBe(0);
+  });
+
+  it('ignores an animation whose frames reference an out-of-range local tile id', () => {
+    const ts = makeTileset256();
+    // localTileId 999 exceeds the 256-tile tileset — malformed data.
+    ts._setDefinition(0, {
+      animation: [
+        { localTileId: 0, duration: 100 },
+        { localTileId: 999, duration: 100 },
+      ],
+    });
+
+    const layer = makeLayer(ts, 2, 2);
+    setTile(layer, ts, 0, 0, 0);
+
+    const animator = new TileAnimator(layer);
+    // The malformed cell must be skipped entirely during the scan.
+    expect(animator.animatedCellCount).toBe(0);
+  });
+
+  it('ignores an animation whose total duration is zero', () => {
+    const ts = makeTileset256();
+    // Both frame durations clamp to 0 (Math.max(0, duration)) → total is 0.
+    ts._setDefinition(0, {
+      animation: [
+        { localTileId: 0, duration: 0 },
+        { localTileId: 1, duration: -5 },
+      ],
+    });
+
+    const layer = makeLayer(ts, 2, 2);
+    setTile(layer, ts, 0, 0, 0);
+
+    const animator = new TileAnimator(layer);
+    expect(animator.animatedCellCount).toBe(0);
+  });
+
+  it('rescan() resets to frame 0 before re-scanning the layers', () => {
+    const ts = makeTileset256();
+    ts._setDefinition(0, {
+      animation: [
+        { localTileId: 0, duration: 100 },
+        { localTileId: 1, duration: 100 },
+      ],
+    });
+
+    const layer = makeLayer(ts, 2, 2);
+    setTile(layer, ts, 0, 0, 0);
+
+    const animator = new TileAnimator(layer);
+    animator.update(0.15); // → frame 1
+    expect(layer.getTileAt(0, 0)?.localTileId).toBe(1);
+
+    // A second animated cell appears after construction; rescan() must pick it up.
+    setTile(layer, ts, 1, 1, 0);
+    animator.rescan();
+
+    // rescan() resets first (frame 0, clock 0) then re-scans both cells.
+    expect(layer.getTileAt(0, 0)?.localTileId).toBe(0);
+    expect(animator.elapsedMs).toBe(0);
+    expect(animator.animatedCellCount).toBe(2);
+  });
+
+  it('destroy() drops the cell registry and zeroes the clock', () => {
+    const ts = makeTileset256();
+    ts._setDefinition(0, {
+      animation: [
+        { localTileId: 0, duration: 100 },
+        { localTileId: 1, duration: 100 },
+      ],
+    });
+
+    const layer = makeLayer(ts, 2, 2);
+    setTile(layer, ts, 0, 0, 0);
+
+    const animator = new TileAnimator(layer);
+    animator.update(0.05);
+    expect(animator.animatedCellCount).toBe(1);
+
+    animator.destroy();
+
+    expect(animator.animatedCellCount).toBe(0);
+    expect(animator.elapsedMs).toBe(0);
+    // The layer itself is untouched by destroy — only the registry is dropped.
+    expect(layer.destroyed).toBe(false);
+  });
+
   it('accepts multiple layers', () => {
     const ts = makeTileset256();
     ts._setDefinition(0, {

--- a/packages/exojs-tilemap/test/TileSet.test.ts
+++ b/packages/exojs-tilemap/test/TileSet.test.ts
@@ -1,0 +1,137 @@
+import { TextureRegion } from '@codexo/exojs';
+import { type Texture } from '@codexo/exojs';
+import { describe, expect, it } from 'vitest';
+
+import { TileSet } from '../src/TileSet';
+import type { TileDefinition } from '../src/types';
+
+// ── Test helpers ──────────────────────────────────────────────────────────
+
+function fakeTexture(width = 512, height = 512): Texture {
+  return {
+    width,
+    height,
+    uid: 0,
+    label: 'test',
+    destroy: () => {},
+    destroyed: false,
+  } as unknown as Texture;
+}
+
+function fakeRegion(width = 512, height = 512): TextureRegion {
+  return new TextureRegion(fakeTexture(width, height), { x: 0, y: 0, width, height });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('TileSet construction validation', () => {
+  it('rejects a missing or non-string name', () => {
+    expect(() => new TileSet({
+      name: '',
+      texture: fakeRegion(),
+      tileWidth: 32,
+      tileHeight: 32,
+      tileCount: 16,
+    })).toThrow(/name must be a non-empty string/);
+  });
+
+  it('rejects a missing texture', () => {
+    expect(() => new TileSet({
+      name: 't',
+      texture: undefined as unknown as TextureRegion,
+      tileWidth: 32,
+      tileHeight: 32,
+      tileCount: 16,
+    })).toThrow(/valid TextureRegion/);
+  });
+
+  it('rejects a grid whose computed width exceeds the atlas', () => {
+    // 40px atlas, tileWidth 32, explicit columns 2 → grid width 64 > 40.
+    expect(() => new TileSet({
+      name: 't',
+      texture: fakeRegion(40, 320),
+      tileWidth: 32,
+      tileHeight: 32,
+      tileCount: 8,
+      columns: 2,
+    })).toThrow(/grid width exceeds atlas/);
+  });
+
+  it('rejects a grid whose computed height exceeds the atlas', () => {
+    // 1 column forces every one of the 8 tiles into its own row: 8 rows * 32px = 256 > 40.
+    expect(() => new TileSet({
+      name: 't',
+      texture: fakeRegion(320, 40),
+      tileWidth: 32,
+      tileHeight: 32,
+      tileCount: 8,
+      columns: 1,
+    })).toThrow(/grid height exceeds atlas/);
+  });
+});
+
+describe('TileSet._setDefinition', () => {
+  it('rejects an out-of-range localTileId', () => {
+    const ts = new TileSet({ name: 't', texture: fakeRegion(), tileWidth: 32, tileHeight: 32, tileCount: 4 });
+    expect(() => ts._setDefinition(4, {})).toThrow(/out of range/);
+    expect(() => ts._setDefinition(-1, {})).toThrow(/out of range/);
+  });
+
+  it('copies and freezes per-tile collision shapes', () => {
+    const ts = new TileSet({ name: 't', texture: fakeRegion(), tileWidth: 32, tileHeight: 32, tileCount: 4 });
+    const collision = [{
+      kind: 'rectangle' as const,
+      id: 1, name: '', type: '', x: 0, y: 0, width: 8, height: 8, rotation: 0, visible: true, properties: {},
+    }];
+
+    ts._setDefinition(0, { collision });
+
+    const def = ts.getTileDefinition(0);
+    expect(def?.collision).toHaveLength(1);
+    expect(def?.collision).not.toBe(collision); // defensive copy
+    expect(Object.isFrozen(def?.collision)).toBe(true);
+  });
+});
+
+describe('TileSet._setDefinitions', () => {
+  it('replaces the internal definitions map from an array, copying each field', () => {
+    const ts = new TileSet({ name: 't', texture: fakeRegion(), tileWidth: 32, tileHeight: 32, tileCount: 4 });
+    const collision = [{
+      kind: 'rectangle' as const,
+      id: 1, name: '', type: '', x: 0, y: 0, width: 8, height: 8, rotation: 0, visible: true, properties: {},
+    }];
+    const definitions: TileDefinition[] = [
+      {
+        localTileId: 0,
+        properties: { solid: true },
+        animation: [{ localTileId: 0, duration: 100 }, { localTileId: 1, duration: 100 }],
+        collision,
+      },
+      { localTileId: 1 }, // no properties/animation/collision at all
+    ];
+
+    ts._setDefinitions(definitions);
+
+    const def0 = ts.getTileDefinition(0);
+    expect(def0?.properties).toEqual({ solid: true });
+    expect(def0?.animation).toHaveLength(2);
+    expect(def0?.collision).toHaveLength(1);
+    expect(def0?.collision).not.toBe(collision);
+
+    const def1 = ts.getTileDefinition(1);
+    expect(def1?.properties).toBeUndefined();
+    expect(def1?.animation).toBeUndefined();
+    expect(def1?.collision).toBeUndefined();
+  });
+
+  it('clears prior definitions before applying the new array', () => {
+    const ts = new TileSet({ name: 't', texture: fakeRegion(), tileWidth: 32, tileHeight: 32, tileCount: 4 });
+    ts._setDefinition(2, { properties: { a: 1 } });
+    expect(ts.getTileDefinition(2)).toBeDefined();
+
+    ts._setDefinitions([{ localTileId: 0 }]);
+
+    expect(ts.getTileDefinition(2)).toBeUndefined();
+    expect(ts.getTileDefinition(0)).toBeDefined();
+  });
+});

--- a/packages/exojs-tilemap/test/autoTile.test.ts
+++ b/packages/exojs-tilemap/test/autoTile.test.ts
@@ -299,6 +299,87 @@ describe('WangSet — membership', () => {
     expect(wangSet.isMember(0)).toBe(false);
     expect(wangSet.members.has(10)).toBe(true);
   });
+
+  it('accepts a plain Record blobMap (not just a Map) and exposes it via blobMap', () => {
+    const wangSet = new WangSet({
+      blobMap: { 0: 10, 255: 11 },
+      tilesetIndex: 0,
+    });
+
+    expect(wangSet.getTileId(0)).toBe(10);
+    expect(wangSet.getTileId(255)).toBe(11);
+    expect(wangSet.isMember(10)).toBe(true);
+    expect(wangSet.isMember(11)).toBe(true);
+
+    // The public getter exposes the same resolved mapping, keyed by number.
+    expect(wangSet.blobMap.get(0)).toBe(10);
+    expect(wangSet.blobMap.get(255)).toBe(11);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Test 4b: applyVariant edge cases — unmapped mask / missing tileset
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('autoTile — applyVariant defensive paths', () => {
+  it('leaves a cell untouched when its computed mask has no blobMap entry', () => {
+    const ts = makeTileset256();
+    const layer = makeLayer(ts, 3, 3);
+
+    // Fill the grid so the center cell computes a non-zero mask, but the
+    // blobMap only maps mask 0 → 0 — every other mask is unmapped.
+    for (let ty = 0; ty < 3; ty++) {
+      for (let tx = 0; tx < 3; tx++) {
+        setTile(layer, ts, tx, ty, 0);
+      }
+    }
+
+    const sparseBlobMap = new Map<number, number>([[0, 0]]);
+    const wangSet = new WangSet({ blobMap: sparseBlobMap, tilesetIndex: 0, type: 'blob' });
+    autoTile(layer, wangSet, { wrapBorder: false });
+
+    // Center (1,1) computes mask 255, which has no mapping — the cell must be
+    // left exactly as painted (localTileId 0), never rewritten.
+    expect(layer.getTileAt(1, 1)?.localTileId).toBe(0);
+  });
+
+  it('leaves a cell untouched when the wangSet.tilesetIndex has no matching tileset on the layer', () => {
+    const ts = makeTileset256();
+    const layer = makeLayer(ts, 2, 2);
+    setTile(layer, ts, 0, 0, 0);
+    setTile(layer, ts, 1, 0, 0);
+
+    // matchFn bypasses the tilesetIndex membership gate entirely, so a
+    // wangSet.tilesetIndex that doesn't correspond to any of the layer's
+    // tilesets can still reach applyVariant's tileset lookup.
+    const wangSet = new WangSet({ blobMap: identityBlobMap(), tilesetIndex: 99, type: 'blob' });
+    autoTile(layer, wangSet, { matchFn: () => true, wrapBorder: false });
+
+    // layer.tilesets[99] is undefined → applyVariant must bail out silently.
+    expect(layer.getTileAt(0, 0)?.localTileId).toBe(0);
+    expect(layer.getTileAt(1, 0)?.localTileId).toBe(0);
+  });
+
+  it('refreshCell defaults wrapBorder to true and honours a custom matchFn', () => {
+    const ts = makeTileset256();
+    const layer = makeLayer(ts, 3, 3);
+
+    for (let ty = 0; ty < 3; ty++) {
+      for (let tx = 0; tx < 3; tx++) {
+        setTile(layer, ts, tx, ty, 0);
+      }
+    }
+
+    const wangSet = new WangSet({ blobMap: identityBlobMap(), tilesetIndex: 0, type: 'blob' });
+
+    // No `wrapBorder` key at all (exercises the `?? true` default) and a
+    // matchFn that unconditionally accepts every cell.
+    expect(() => refreshCell(layer, 0, 0, wangSet, { matchFn: () => true })).not.toThrow();
+
+    // wrapBorder defaulting to true means every corner neighbor counts as
+    // in-group, so the corner cell ends up with the full mask (255).
+    expect(layer.getTileAt(0, 0)?.localTileId).toBe(255);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/packages/exojs-tilemap/test/chunkGeometry.test.ts
+++ b/packages/exojs-tilemap/test/chunkGeometry.test.ts
@@ -178,4 +178,29 @@ describe('buildChunkPages', () => {
     const pages = buildChunkPages(stubChunk(packTile(0, 20, TILE_TRANSFORM_IDENTITY)), [tileset], 32, 32);
     expect(pages).toHaveLength(0);
   });
+
+  it('returns no pages when the chunk reports itself empty (short-circuit before scanning cells)', () => {
+    const tileset = makeTileset();
+    const emptyChunk: ReadonlyTileChunk = {
+      cx: 0, cy: 0, width: 1, height: 1, revision: 1,
+      empty: true,
+      getRawAt: () => {
+        throw new Error('must not be called when chunk.empty is true');
+      },
+      cloneTiles: () => new Uint32Array([0]),
+    };
+    expect(buildChunkPages(emptyChunk, [tileset], 32, 32)).toEqual([]);
+  });
+
+  it('skips cells whose underlying texture reports a non-positive width or height', () => {
+    // The TextureRegion/TileSet must construct with valid, positive dimensions
+    // (both types enforce this) — but the underlying Texture is a live,
+    // mutable object (e.g. a not-yet-decoded image, or a lost GPU context) that
+    // can legitimately report 0 afterwards. buildChunkPages must guard against it.
+    const tileset = makeTileset('degenerate', 16, 32, 32, 512, 512);
+    (tileset.texture.texture as unknown as { width: number }).width = 0;
+
+    const pages = buildChunkPages(stubChunk(packTile(0, 0, TILE_TRANSFORM_IDENTITY)), [tileset], 32, 32);
+    expect(pages).toHaveLength(0);
+  });
 });

--- a/packages/exojs-tilemap/test/extension.test.ts
+++ b/packages/exojs-tilemap/test/extension.test.ts
@@ -1,9 +1,17 @@
 import { ExtensionRegistry } from '@codexo/exojs/extensions';
+import type { RenderBackend } from '@codexo/exojs/renderer-sdk';
+import { RenderBackendType } from '@codexo/exojs/renderer-sdk';
 import { beforeEach,describe, expect, it } from 'vitest';
 
 import { resetExtensionRegistryForTesting } from '../../../src/extensions/testing';
 import { TileChunkNode } from '../src/TileChunkNode';
 import { tilemapExtension } from '../src/tilemapExtension';
+import { WebGl2TileChunkRenderer } from '../src/webgl2/WebGl2TileChunkRenderer';
+import { WebGpuTileChunkRenderer } from '../src/webgpu/WebGpuTileChunkRenderer';
+
+function fakeBackend(backendType: RenderBackendType): RenderBackend {
+  return { backendType } as unknown as RenderBackend;
+}
 
 describe('@codexo/exojs-tilemap root', () => {
   it('tilemapExtension has correct id', () => {
@@ -27,6 +35,19 @@ describe('@codexo/exojs-tilemap root', () => {
   it('root import does NOT register in ExtensionRegistry', () => {
     const registry = ExtensionRegistry.list();
     expect(registry.some(e => e.id === '@codexo/exojs-tilemap')).toBe(false);
+  });
+
+  it('the renderer binding creates the matching backend-specific renderer', () => {
+    const create = tilemapExtension.renderers![0]!.create;
+
+    expect(create(fakeBackend(RenderBackendType.WebGl2))).toBeInstanceOf(WebGl2TileChunkRenderer);
+    expect(create(fakeBackend(RenderBackendType.WebGpu))).toBeInstanceOf(WebGpuTileChunkRenderer);
+  });
+
+  it('the renderer binding throws for an unsupported backend type', () => {
+    const create = tilemapExtension.renderers![0]!.create;
+
+    expect(() => create(fakeBackend('unsupported' as RenderBackendType))).toThrow(/Unsupported render backend/);
   });
 });
 

--- a/packages/exojs-tilemap/test/nodes.test.ts
+++ b/packages/exojs-tilemap/test/nodes.test.ts
@@ -180,6 +180,35 @@ describe('TileLayerNode', () => {
     expect(node.chunkNodes).toHaveLength(2);
   });
 
+  it('_collectContent is a no-op (skips super call) when the layer is invisible', () => {
+    const tileset = makeTileset();
+    const layer = makeLayer(tileset, { visible: false });
+    const node = new TileLayerNode(layer);
+
+    const mockBuilder = { view: { center: { x: 0, y: 0 } } };
+
+    expect(() => (node as unknown as { _collectContent(b: unknown): void })._collectContent(mockBuilder)).not.toThrow();
+  });
+
+  it('propagates a non-null tintColor onto chunk tints (RGB channels extracted from the packed color)', () => {
+    const tileset = makeTileset();
+    const layer = fillLayer(
+      new TileLayer({
+        id: 1, name: 'tinted', width: 4, height: 4, tileWidth: 32, tileHeight: 32,
+        tilesets: [tileset], tintColor: 0x336699,
+      }),
+      tileset,
+    );
+    const node = new TileLayerNode(layer);
+
+    expect(node.chunkNodes.length).toBeGreaterThan(0);
+    for (const chunk of node.chunkNodes) {
+      expect(chunk.tint.r).toBe(0x33);
+      expect(chunk.tint.g).toBe(0x66);
+      expect(chunk.tint.b).toBe(0x99);
+    }
+  });
+
   it('destroy() frees chunk nodes but not the layer', () => {
     const tileset = makeTileset();
     const layer = fillLayer(makeLayer(tileset), tileset);
@@ -240,6 +269,37 @@ describe('TileChunkNode geometry cache', () => {
     node.setPosition(123, 456);
 
     expect(node.pages).toBe(first); // geometry is transform-independent
+  });
+
+  it('exposes its chunk coordinates and empty status', () => {
+    const tileset = makeTileset();
+    // 40-wide map so chunk (1,1) is distinct from (0,0).
+    const layer = new TileLayer({ id: 1, name: 'l', width: 40, height: 40, tileWidth: 32, tileHeight: 32, tilesets: [tileset] });
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+    layer.setTileAt(33, 33, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+
+    const [first, second] = new TileLayerNode(layer).chunkNodes;
+
+    expect(first!.chunkX).toBe(0);
+    expect(first!.chunkY).toBe(0);
+    expect(first!.isEmpty).toBe(false);
+
+    expect(second!.chunkX).toBe(1);
+    expect(second!.chunkY).toBe(1);
+    expect(second!.isEmpty).toBe(false);
+  });
+
+  it('isEmpty reflects the built page geometry (recomputed lazily via pages)', () => {
+    const tileset = makeTileset();
+    const layer = makeLayer(tileset);
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+
+    const node = new TileLayerNode(layer).chunkNodes[0];
+    expect(node.isEmpty).toBe(false);
+
+    layer.clearTileAt(0, 0);
+    // The chunk still exists (materialised) but its geometry is now empty.
+    expect(node.isEmpty).toBe(true);
   });
 
   it('exposes accurate local bounds for culling (clamped edge chunk)', () => {

--- a/packages/exojs-tilemap/test/object-layer.test.ts
+++ b/packages/exojs-tilemap/test/object-layer.test.ts
@@ -82,6 +82,18 @@ describe('ObjectLayer', () => {
     expect(layer.query({ type: 'nope' })).toHaveLength(0);
   });
 
+  it('copies and freezes the layer-level properties option when provided', () => {
+    const mutable = { region: 'overworld' };
+    const layer = new ObjectLayer({ id: 1, properties: mutable });
+
+    expect(layer.properties.region).toBe('overworld');
+    expect(Object.isFrozen(layer.properties)).toBe(true);
+    expect(layer.properties).not.toBe(mutable);
+
+    mutable.region = 'changed';
+    expect(layer.properties.region).toBe('overworld'); // defensive copy
+  });
+
   it('getObjectById / getObjectByName resolve the first match or undefined', () => {
     const layer = new ObjectLayer({ id: 1, objects: [rectangle(7, 'hero', 'spawn')] });
 

--- a/packages/exojs-tilemap/test/serialization.test.ts
+++ b/packages/exojs-tilemap/test/serialization.test.ts
@@ -54,4 +54,36 @@ describe('tilemap serialization', () => {
 
     expect(() => Prefab.fromJSON({ type: 'TileMapNode', map: 'missing.tmj' }).instantiate(emptyLoader)).toThrow(/pre-loaded/);
   });
+
+  it('throws when no map field is present at all (procedural map, never given a source key)', () => {
+    const emptyLoader = { keyFor: () => null, peek: () => null } as unknown as Loader;
+
+    expect(() => Prefab.fromJSON({ type: 'TileMapNode' }).instantiate(emptyLoader)).toThrow(/pre-loaded/);
+  });
+
+  it('omits the map/pixelSnapMode keys entirely for a procedural map with default pixelSnapMode', () => {
+    const map = new TileMap({ name: 'procedural', width: 4, height: 4, tileWidth: 32, tileHeight: 32 });
+    const node = new TileMapNode(map); // pixelSnapMode stays 'none'
+    const loaderWithoutSourceKey = { keyFor: () => null, peek: () => null } as unknown as Loader;
+
+    const data = Prefab.from(node, loaderWithoutSourceKey).toJSON();
+
+    expect(data.map).toBeUndefined();
+    expect(data.pixelSnapMode).toBeUndefined();
+
+    node.destroy();
+    map.destroy();
+  });
+
+  it('read() leaves pixelSnapMode at its default when the field is absent from the data', () => {
+    const map = new TileMap({ name: 'world', width: 4, height: 4, tileWidth: 32, tileHeight: 32 });
+    const loader = fakeLoader(map, 'world.tmj');
+
+    const restored = Prefab.fromJSON({ type: 'TileMapNode', map: 'world.tmj' }).instantiate(loader) as TileMapNode;
+
+    expect(restored.pixelSnapMode).toBe('none');
+
+    restored.destroy();
+    map.destroy();
+  });
 });

--- a/packages/exojs-tilemap/test/tilemap.test.ts
+++ b/packages/exojs-tilemap/test/tilemap.test.ts
@@ -8,6 +8,7 @@ import { TileChunk } from '../src/TileChunk';
 import { TileLayer } from '../src/TileLayer';
 import { TileMap } from '../src/TileMap';
 import { TileSet } from '../src/TileSet';
+import type { ResolvedTile } from '../src/types';
 import {
   packTile,
   TILE_TRANSFORM_IDENTITY,
@@ -15,6 +16,8 @@ import {
   tileToLocalInChunk,
   tileTransformLabel,
   unpackTile,
+  validateNonNegativeInteger,
+  validatePositiveInteger,
 } from '../src/types';
 
 // ── helpers ────────────────────────────────────────────────────────────
@@ -119,6 +122,20 @@ describe('tileTransformLabel', () => {
   });
   it('diag+flipX+flipY', () => {
     expect(tileTransformLabel({ flipX: true, flipY: true, diagonal: true })).toBe('diag+flipX+flipY');
+  });
+});
+
+describe('validatePositiveInteger / validateNonNegativeInteger', () => {
+  it('validatePositiveInteger rejects a value beyond Number.MAX_SAFE_INTEGER', () => {
+    // Finite, integer, and positive — passes the first guard — but unsafe.
+    expect(() => validatePositiveInteger(Number.MAX_SAFE_INTEGER * 2, 'x')).toThrow(/exceeds safe integer range/);
+  });
+
+  it('validateNonNegativeInteger rejects negative, non-finite, and non-integer values', () => {
+    expect(() => validateNonNegativeInteger(-1, 'x')).toThrow(/non-negative integer/);
+    expect(() => validateNonNegativeInteger(NaN, 'x')).toThrow(/non-negative integer/);
+    expect(() => validateNonNegativeInteger(1.5, 'x')).toThrow(/non-negative integer/);
+    expect(() => validateNonNegativeInteger(0, 'x')).not.toThrow();
   });
 });
 
@@ -403,6 +420,33 @@ describe('TileChunk', () => {
     expect(() => new TileChunk(Number.MAX_SAFE_INTEGER + 1, 0, 2, 2)).toThrow();
   });
 
+  it('rejects non-finite or non-integer cy', () => {
+    expect(() => new TileChunk(0, NaN, 2, 2)).toThrow();
+    expect(() => new TileChunk(0, Infinity, 2, 2)).toThrow();
+    expect(() => new TileChunk(0, 1.5, 2, 2)).toThrow();
+  });
+
+  it('rejects non-safe-integer dimensions', () => {
+    // Positive but non-integer — passes the `<= 0` guard, fails isSafeInteger.
+    expect(() => new TileChunk(0, 0, 1.5, 2)).toThrow();
+    expect(() => new TileChunk(0, 0, 2, 1.5)).toThrow();
+  });
+
+  it('rejects a size exceeding the TypedArray maximum length', () => {
+    // 100000 * 50000 = 5e9, a safe integer but > 0xFFFFFFFF.
+    expect(() => new TileChunk(0, 0, 100000, 50000)).toThrow();
+  });
+
+  it('_getRawStorage exposes the live backing array (package-internal)', () => {
+    const chunk = new TileChunk(0, 0, 2, 2);
+    chunk._setRawAt(0, 0, 42);
+    const storage = chunk._getRawStorage();
+    expect(storage[0]).toBe(42);
+    // It is the SAME array (not a clone) — mutating it affects the chunk.
+    storage[1] = 7;
+    expect(chunk.getRawAt(1, 0)).toBe(7);
+  });
+
   it('getRawAt validates local coordinates', () => {
     const chunk = new TileChunk(0, 0, 8, 8);
     expect(() => chunk.getRawAt(-1, 0)).toThrow();
@@ -500,6 +544,53 @@ describe('TileLayer', () => {
       id: 0, name: 'l', width: 0, height: 64,
       tileWidth: 16, tileHeight: 16, tilesets: [ts],
     })).toThrow();
+  });
+
+  it('rejects a missing or empty name', () => {
+    expect(() => new TileLayer({
+      id: 0, name: '', width: 4, height: 4,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    })).toThrow(/name must be a non-empty string/);
+  });
+
+  it('rejects a tilesets option that is not an array', () => {
+    expect(() => new TileLayer({
+      id: 0, name: 'l', width: 4, height: 4,
+      tileWidth: 16, tileHeight: 16, tilesets: null as unknown as TileSet[],
+    })).toThrow(/tilesets must be an array/);
+  });
+
+  it('rejects opacity outside 0..1', () => {
+    expect(() => new TileLayer({
+      id: 0, name: 'l', width: 4, height: 4,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts], opacity: 1.5,
+    })).toThrow(/opacity must be 0\.\.1/);
+    expect(() => new TileLayer({
+      id: 0, name: 'l', width: 4, height: 4,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts], opacity: -0.1,
+    })).toThrow(/opacity must be 0\.\.1/);
+  });
+
+  it('rejects non-finite offsets', () => {
+    expect(() => new TileLayer({
+      id: 0, name: 'l', width: 4, height: 4,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts], offsetX: NaN,
+    })).toThrow(/offset must be finite/);
+    expect(() => new TileLayer({
+      id: 0, name: 'l', width: 4, height: 4,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts], offsetY: Infinity,
+    })).toThrow(/offset must be finite/);
+  });
+
+  it('rejects non-finite parallax factors', () => {
+    expect(() => new TileLayer({
+      id: 0, name: 'l', width: 4, height: 4,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts], parallaxX: NaN,
+    })).toThrow(/parallax must be finite/);
+    expect(() => new TileLayer({
+      id: 0, name: 'l', width: 4, height: 4,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts], parallaxY: Infinity,
+    })).toThrow(/parallax must be finite/);
   });
 
   it('inBounds check', () => {
@@ -713,6 +804,16 @@ describe('TileLayer', () => {
     expect(raw).not.toBe(0);
   });
 
+  it('setTileAt / fillRect reject an invalid tile reference', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 16, height: 16,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    expect(() => layer.setTileAt(0, 0, {} as unknown as ResolvedTile)).toThrow(/valid ResolvedTile/);
+    expect(() => layer.setTileAt(0, 0, null as unknown as ResolvedTile)).toThrow(/valid ResolvedTile/);
+    expect(() => layer.fillRect(0, 0, 2, 2, {} as unknown as ResolvedTile)).toThrow(/valid ResolvedTile/);
+  });
+
   it('fillRect fills a region', () => {
     const layer = new TileLayer({
       id: 0, name: 'l', width: 16, height: 16,
@@ -724,6 +825,84 @@ describe('TileLayer', () => {
     expect(layer.getTileAt(5, 5)).not.toBeNull();
     expect(layer.getTileAt(1, 1)).toBeNull();
     expect(layer.getTileAt(6, 2)).toBeNull();
+  });
+
+  it('fillRect skips out-of-bounds cells and is a no-op when nothing changes', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 8, height: 8,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    const ref = { tileset: ts, localTileId: 2, transform: TILE_TRANSFORM_IDENTITY };
+
+    // Rect extends past every edge — only the in-bounds cells are touched.
+    layer.fillRect(-2, -2, 4, 4, ref);
+    expect(layer.getTileAt(0, 0)).not.toBeNull();
+    expect(layer.revision).toBe(1);
+
+    // Filling the exact same region with the same tile is a full no-op:
+    // every cell write is rejected as unchanged, so the revision never bumps.
+    layer.fillRect(-2, -2, 4, 4, ref);
+    expect(layer.revision).toBe(1);
+  });
+
+  it('clearRect clears a filled region and is a no-op on untouched chunks', () => {
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 16, height: 16,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts],
+    });
+    const ref = { tileset: ts, localTileId: 2, transform: TILE_TRANSFORM_IDENTITY };
+
+    // No chunk has been created yet anywhere — clearRect must skip cleanly.
+    layer.clearRect(0, 0, 4, 4);
+    expect(layer.revision).toBe(0);
+
+    layer.fillRect(2, 2, 4, 4, ref);
+    const revAfterFill = layer.revision;
+
+    // Clear a region that partially extends out of bounds.
+    layer.clearRect(2, 2, 20, 4);
+    expect(layer.getTileAt(2, 2)).toBeNull();
+    expect(layer.getTileAt(5, 5)).toBeNull();
+    expect(layer.revision).toBeGreaterThan(revAfterFill);
+
+    const revAfterClear = layer.revision;
+    // Clearing the already-cleared region again changes nothing.
+    layer.clearRect(2, 2, 20, 4);
+    expect(layer.revision).toBe(revAfterClear);
+  });
+
+  it('getTileAt treats a cell referencing an out-of-range tileset or local tile id as empty', () => {
+    const smallTs = makeTileset('small', 4);
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 8, height: 8,
+      tileWidth: 16, tileHeight: 16, tilesets: [smallTs],
+    });
+
+    // Directly corrupt the raw storage — bypasses setTileAt's validation, which
+    // can never itself produce these out-of-range packed values.
+    const chunk = layer._ensureChunk(0, 0);
+    chunk._setRawAt(0, 0, packTile(5, 0, TILE_TRANSFORM_IDENTITY)); // tilesetIndex 5 doesn't exist
+    chunk._setRawAt(1, 0, packTile(0, 99, TILE_TRANSFORM_IDENTITY)); // localTileId 99 exceeds tileCount 4
+
+    expect(layer.getTileAt(0, 0)).toBeNull();
+    expect(layer.getTileAt(1, 0)).toBeNull();
+  });
+
+  it('tilesInRect skips cells referencing an out-of-range tileset or local tile id', () => {
+    const smallTs = makeTileset('small', 4);
+    const layer = new TileLayer({
+      id: 0, name: 'l', width: 8, height: 8,
+      tileWidth: 16, tileHeight: 16, tilesets: [smallTs],
+    });
+
+    const chunk = layer._ensureChunk(0, 0);
+    chunk._setRawAt(0, 0, packTile(5, 0, TILE_TRANSFORM_IDENTITY)); // out-of-range tileset
+    chunk._setRawAt(1, 0, packTile(0, 99, TILE_TRANSFORM_IDENTITY)); // out-of-range local id
+    chunk._setRawAt(2, 0, packTile(0, 1, TILE_TRANSFORM_IDENTITY)); // valid
+
+    const tiles = [...layer.tilesInRect(0, 0, 8, 8)];
+    expect(tiles).toHaveLength(1);
+    expect(tiles[0]!.tx).toBe(2);
   });
 
   it('tilesInRect iterates non-empty tiles', () => {
@@ -1075,6 +1254,20 @@ describe('TileMap', () => {
     expect(map.getImageLayerById(999)).toBeUndefined();
   });
 
+  it('getImageLayer finds the first image layer matching the name', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      imageLayers: [
+        new ImageLayer({ id: 1, name: 'bg', image: 'bg.png' }),
+        new ImageLayer({ id: 2, name: 'fg', image: 'fg.png' }),
+      ],
+    });
+    expect(map.getImageLayer('bg')!.id).toBe(1);
+    expect(map.getImageLayer('fg')!.id).toBe(2);
+    expect(map.getImageLayer('missing')).toBeUndefined();
+  });
+
   it('removeImageLayer removes the layer by ID', () => {
     const layer = new ImageLayer({ id: 1, name: 'removable', image: 'bg.png' });
     const map = new TileMap({
@@ -1149,6 +1342,23 @@ describe('TileMap', () => {
       tileWidth: 32, tileHeight: 32,
     });
     expect(() => map.clearTileAt(999, 0, 0)).toThrow();
+  });
+
+  it('clearTileAt convenience clears the tile on an existing layer', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      tilesets: [ts],
+      layers: [
+        new TileLayer({ id: 1, name: 'l', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] }),
+      ],
+    });
+    const ref = { tileset: ts, localTileId: 2, transform: TILE_TRANSFORM_IDENTITY };
+    map.setTileAt(1, 3, 3, ref);
+    expect(map.getTileAt(1, 3, 3)).not.toBeNull();
+
+    map.clearTileAt(1, 3, 3);
+    expect(map.getTileAt(1, 3, 3)).toBeNull();
   });
 
   it('multiple tilesets', () => {

--- a/packages/exojs-tilemap/test/view.test.ts
+++ b/packages/exojs-tilemap/test/view.test.ts
@@ -288,6 +288,13 @@ describe('TileMapView bands', () => {
     expect(() => view.band('missing')).toThrow(/"ground"/);
   });
 
+  it('band() lists "(none)" when the view has no bands defined at all', () => {
+    const { map } = makeWorldMap();
+    const view = map.createView(); // no bands option
+
+    expect(() => view.band('missing')).toThrow(/\(none\)/);
+  });
+
   it('throws at construction for an unknown layer id', () => {
     const { map } = makeWorldMap();
 
@@ -890,6 +897,94 @@ describe('TileMapBand bounds', () => {
     const rect = band.getBounds();
 
     expect([rect.x, rect.y, rect.width, rect.height]).toEqual([50, 60, 256, 256]);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// TileMapBand — internal membership operations (direct, bypassing TileMapView)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('TileMapBand internal membership operations', () => {
+  it('updateBounds collapses to a degenerate rect when every child is invisible', () => {
+    const tileset = makeTileset();
+    const node = new TileLayerNode(makeLayer(tileset));
+    const band = new TileMapBand('b', [node]);
+
+    node.visible = false;
+    band.setPosition(9, 4);
+
+    const rect = band.getBounds();
+    expect([rect.x, rect.y, rect.width, rect.height]).toEqual([9, 4, 0, 0]);
+  });
+
+  it('_adopt is a no-op when the node is already a member (no duplicate membership)', () => {
+    const tileset = makeTileset();
+    const node = new TileLayerNode(makeLayer(tileset));
+    const band = new TileMapBand('b', [node]);
+
+    expect(band.layerNodes).toHaveLength(1);
+
+    band._adopt(node); // already a member
+
+    expect(band.layerNodes).toHaveLength(1);
+    expect(band.layerNodes[0]).toBe(node);
+  });
+
+  it('_release is a no-op for a node that was never a member', () => {
+    const tileset = makeTileset();
+    const memberNode = new TileLayerNode(makeLayer(tileset, { id: 1 }));
+    const strangerNode = new TileLayerNode(makeLayer(tileset, { id: 2 }));
+    const band = new TileMapBand('b', [memberNode]);
+
+    expect(() => band._release(strangerNode)).not.toThrow();
+    expect(band.layerNodes).toEqual([memberNode]);
+  });
+
+  it('_release does not attempt to detach a member node that was already reparented elsewhere', () => {
+    const tileset = makeTileset();
+    const node = new TileLayerNode(makeLayer(tileset));
+    const band = new TileMapBand('b', [node]);
+    const otherContainer = new Container();
+
+    otherContainer.addChild(node); // reparent away from the band
+
+    band._release(node); // still band membership, but node.parent !== band
+
+    expect(band.layerNodes).toHaveLength(0);
+    expect(node.parent).toBe(otherContainer); // untouched by _release
+  });
+
+  it('_reorder falls back to index 0 for either member id missing from the document map', () => {
+    const tileset = makeTileset();
+    const nodeA = new TileLayerNode(makeLayer(tileset, { id: 1 }));
+    const nodeB = new TileLayerNode(makeLayer(tileset, { id: 2 }));
+    const band = new TileMapBand('b', [nodeA, nodeB]);
+
+    // Only nodeB's id is present in the document index map; nodeA falls back to 0
+    // (covers the fallback for the comparator's first operand, the defined
+    // value for its second).
+    expect(() => band._reorder(new Map([[2, 5]]))).not.toThrow();
+    expect(band.layerNodes).toHaveLength(2);
+
+    // Swap which id is present, so the opposite operand hits the fallback and
+    // the previously-fallback operand now resolves a defined value.
+    expect(() => band._reorder(new Map([[1, 3]]))).not.toThrow();
+    expect(band.layerNodes).toHaveLength(2);
+  });
+
+  it('_reorder skips re-adding a member node that is no longer parented to the band', () => {
+    const tileset = makeTileset();
+    const nodeA = new TileLayerNode(makeLayer(tileset, { id: 1 }));
+    const nodeB = new TileLayerNode(makeLayer(tileset, { id: 2 }));
+    const band = new TileMapBand('b', [nodeA, nodeB]);
+    const otherContainer = new Container();
+
+    otherContainer.addChild(nodeA); // reparent away, but membership is kept
+
+    expect(() => band._reorder(new Map([[1, 0], [2, 1]]))).not.toThrow();
+    expect(band.layerNodes).toEqual([nodeA, nodeB]); // membership unaffected
+    expect(nodeA.parent).toBe(otherContainer); // not re-adopted by the band
+    expect(band.children).toContain(nodeB);
   });
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -108,18 +108,19 @@ export default defineConfig({
       // itself (the exact command the CI job runs) below the floor.
       //
       // A ratchet floor, not a target: set a few points below the measured
-      // baseline (statements 84.80%, branches 77.92%, functions 88.55%, lines
-      // 85.08% as of 2026-07-04 after the fleet-3 coverage pass over
-      // core/resources, ui/debug, non-GPU rendering, and audio/input, core +
-      // all extension packages) so normal test-suite churn doesn't flake the
+      // baseline (statements 86.61%, branches 81.95%, functions 90.31%, lines
+      // 86.73% as of 2026-07-04 after the fleet-4 pass over the extension
+      // packages — physics/audio-fx/tilemap/particles/tiled/ldtk/aseprite/
+      // react; remaining gaps are almost entirely GPU renderer files covered
+      // by the browser lanes) so normal test-suite churn doesn't flake the
       // gate, while still catching a real regression. Raise the floor as
       // coverage grows — never lower it without an explicit reason recorded
       // here.
       thresholds: {
-        statements: 82,
-        branches: 75,
-        functions: 86,
-        lines: 82,
+        statements: 84,
+        branches: 79,
+        functions: 88,
+        lines: 84,
       },
     },
     projects: [


### PR DESCRIPTION
## Coverage fleet round 4 — extension packages

Three worktree-isolated agents over the package logic (GPU renderer files deliberately excluded — they belong to the browser-lane track):

- **physics**: 91.7% -> **99.8% lines**, 82.5% -> **96.6% branches** (+101 tests; PhysicsDebugDraw 20% -> 100%). The solver/narrowphase core held up — one suspected narrowphase finding was adversarially disproven via a 2M-trial randomized search.
- **audio-fx**: 90.0% -> **98.7% stmts**, 73.1% -> **98.4% branches** (+169 tests; BitCrusherEffect 0% -> 100%; new suspended-AudioContext harness reproduces the real autoplay-pending window deterministically).
- **package tails**: tiled/ldtk/react at **100%**, aseprite 99%, tilemap/particles non-GPU gaps closed (+170 tests).

Suite grows 6,472 -> 6,897 tests. Global coverage 84.8/77.9/88.6/85.1 -> **86.6/82.0/90.3/86.7**; ratchet raised 82/75/86/82 -> **84/79/88/84**. Remaining gaps are almost entirely GPU renderer files (browser-lane territory).

## Three package bugs found by the pass, fixed here

1. **`PrismaticJoint` zero-length axis** — `Math.hypot(0,0) || 1` only guarded the division; the local axis stayed (0,0) and the joint constrained nothing (the body free-fell). Now throws `RangeError` on a zero-length or non-finite axis, matching the package's config-validation convention.
2. **`WheelJoint` zero-length axis** — same root cause, same fix (no suspension, no lateral lock).
3. **`TiledMap` object gid 0** — rejected as "not covered by any tileset" although gid 0 is the documented empty-cell sentinel and tile-layer data already treats it that way; the object-layer coverage check now masks flip bits and accepts 0 as "no tile".

All fleet `BUG:` pins flipped to assert the fixed behaviour. Full suite, lint, prettier, and docs:api:check green.