### PR TITLE
chore(release): align main to 0.15.2, port the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to ExoJS are documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.2] - 2026-07-04
+
+Bugfix release. Ten defects found by the coverage-fleet passes on the v0.16
+line, back-ported: seven in the engine, three in the extension packages.
+
+### Fixed
+
+- **`Application` dropped the `seed` option.** The constructor's options
+  literal omitted the field, so deterministic seeding of the per-Application
+  RNG was a documented no-op.
+- **`Application` dropped `fixedTimeStep`.** Same root cause: the options
+  literal omitted the field, so the fixed-step loop always ran at the 60 Hz
+  default regardless of configuration.
+- **`Loader.backgroundLoad()` re-entrancy.** Calling it again while a
+  background load was in flight double-queued not-yet-started entries,
+  letting `onProgress` report `loaded > total`.
+- **`Loader.registerManifest()` option comparison.** Re-registering a manifest
+  with deeply-equal options of a shared class prototype was rejected,
+  contradicting the documented contract. The structural compare now covers
+  same-prototype instances and compares `Date`s by timestamp; exotic
+  containers stay reference-compared.
+- **`Tween` repeat overshoot dropped.** `update()` clamped elapsed time before
+  computing cycle overflow, so overshoot past a cycle boundary was silently
+  discarded instead of carrying into the next cycle.
+- **`AudioManager.onUnlock` never fired for late-constructed managers.** When
+  the shared `AudioContext` was already running at construction time, the
+  manager's own buses consumed the one-shot ready signal first; the unlock
+  signal is now dispatched on a microtask in that case.
+- **Gamepad ghost slot on double disconnect.** With the compact slot strategy,
+  two disconnects in a single poll used a stale snapshot and left a ghost
+  `connected` pad; the sweep now resolves browser indices against the live map.
+- **`PrismaticJoint` accepted a zero-length axis.** `Math.hypot(0, 0) || 1`
+  only guarded the division; the local axis stayed `(0, 0)` and the joint
+  constrained nothing (the body free-fell). A zero-length or non-finite axis
+  now throws a `RangeError`, matching the package's config-validation
+  convention.
+- **`WheelJoint` accepted a zero-length axis.** Same root cause and fix as
+  `PrismaticJoint` (no suspension, no lateral lock).
+- **`TiledMap` rejected objects with gid 0.** Gid 0 is the documented
+  empty-cell sentinel and tile-layer data already treats it that way, but the
+  object-layer coverage check reported it as "not covered by any tileset". The
+  check now masks the flip bits and accepts 0 as "no tile".
+
 ## [0.15.1] - 2026-07-04
 
 Bugfix release. Twelve engine defects back-ported from the v0.16 line —

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@codexo/exojs",
   "description": "A TypeScript-first browser 2D runtime for games and interactive apps.",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "type": "module",
   "packageManager": "pnpm@11.4.0",
   "files": [

--- a/packages/exojs-aseprite/package.json
+++ b/packages/exojs-aseprite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexo/exojs-aseprite",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Aseprite sprite sheet asset extension for ExoJS.",
   "repository": {
     "type": "git",

--- a/packages/exojs-audio-fx/package.json
+++ b/packages/exojs-audio-fx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexo/exojs-audio-fx",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Audio effects, DSP, beat detection and analysis for ExoJS.",
   "repository": {
     "type": "git",

--- a/packages/exojs-ldtk/package.json
+++ b/packages/exojs-ldtk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexo/exojs-ldtk",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "LDtk level format asset extension for ExoJS.",
   "repository": {
     "type": "git",

--- a/packages/exojs-particles/package.json
+++ b/packages/exojs-particles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexo/exojs-particles",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Particle system extension for ExoJS.",
   "repository": {
     "type": "git",

--- a/packages/exojs-physics/package.json
+++ b/packages/exojs-physics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexo/exojs-physics",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Native 2D collision, query and sensor runtime for ExoJS.",
   "repository": {
     "type": "git",

--- a/packages/exojs-react/package.json
+++ b/packages/exojs-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexo/exojs-react",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "React integration for ExoJS.",
   "repository": {
     "type": "git",

--- a/packages/exojs-tiled/package.json
+++ b/packages/exojs-tiled/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexo/exojs-tiled",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Tiled map format asset extension for ExoJS.",
   "repository": {
     "type": "git",

--- a/packages/exojs-tilemap/package.json
+++ b/packages/exojs-tilemap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexo/exojs-tilemap",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Generic, format-independent tilemap runtime for ExoJS.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The 0.15.2 hotfix was cut from `release/0.15.x` (back-ported coverage-fleet fixes from #256/#258 — seven engine bugs, three package bugs).

Mirrors #252/#253 in a single PR so the version-coherence checks never see the changelog and the lockstep versions out of sync:

- port the `[0.15.2]` changelog section to main
- bump all nine lockstep `package.json` files 0.15.1 -> 0.15.2

`verify:lockstep` and the release coherence suite (71 tests) pass locally.