### PR TITLE
fix(build): stop emitting stray .d.ts trees from single-file bundle configs

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -121,6 +121,14 @@ function basePlugins(options: {
   ];
 }
 
+// The root tsconfig inherits `declaration: true` (library profile). Only the
+// `modules` build is meant to emit declarations (into dist/esm); every other
+// config must switch them off, or @rollup/plugin-typescript emits the whole
+// .d.ts tree as bundle assets — polluting dist/ with a duplicate declaration
+// tree and inflating the Codecov bundle-analysis numbers (incompressible
+// assets are counted at raw size in the gzip column).
+const noDeclarations = { declaration: false, declarationMap: false } as const;
+
 const bundled: RollupOptions = {
   input: 'src/index.ts',
   output: {
@@ -132,7 +140,7 @@ const bundled: RollupOptions = {
     ...basePlugins({
       exportConditions: sourceConditions,
       transform: typescript({
-        compilerOptions: { incremental: false },
+        compilerOptions: { incremental: false, ...noDeclarations },
         outputToFilesystem: false,
       }),
       minify: 'production',
@@ -153,7 +161,7 @@ const iife: RollupOptions = {
   plugins: basePlugins({
     exportConditions: sourceConditions,
     transform: typescript({
-      compilerOptions: { incremental: false },
+      compilerOptions: { incremental: false, ...noDeclarations },
       outputToFilesystem: false,
     }),
   }),
@@ -172,7 +180,7 @@ const iifeMin: RollupOptions = {
     ...basePlugins({
       exportConditions: sourceConditions,
       transform: typescript({
-        compilerOptions: { incremental: false },
+        compilerOptions: { incremental: false, ...noDeclarations },
         outputToFilesystem: false,
       }),
       minify: 'always',
@@ -197,7 +205,7 @@ const debugBundled: RollupOptions = {
   plugins: basePlugins({
     exportConditions: sourceConditions,
     transform: typescript({
-      compilerOptions: { incremental: false },
+      compilerOptions: { incremental: false, ...noDeclarations },
       outputToFilesystem: false,
     }),
     minify: 'production',


### PR DESCRIPTION
## Problem

Codecov's Bundles tab reported nonsense for the single-file bundles: `exo-iife-min` showed **1.58MB total / 1.06MB gzip** while the real file is **695kB / 174kB** — the gzip figure was larger than the correctly-reported unminified full bundle (438kB).

## Root cause

The root tsconfig inherits `declaration: true` from the shared library profile. The four single-file rollup configs (`exo-esm`, `iife`, `iife-min`, `debug`) never overrode it, so `@rollup/plugin-typescript` emitted the entire declaration tree as bundle assets in **each** of those builds:

- a duplicate 316-file `.d.ts` tree written into `dist/` (never published — `files` whitelists only `dist/esm/` + the bundles — but wasted build work),
- ~888kB of `.d.ts` assets counted into the Codecov bundle stats. The Codecov plugin only gzips `css|html|json|js|svg|txt|xml|xhtml`, so incompressible assets land in the gzip column at **raw size**: 174,070 (js gzip) + 887,897 (d.ts raw) = 1,061,967 = the reported 1.06MB, byte-exact (per-asset breakdown pulled via the Codecov GraphQL API).

`exo-full-iife` looked correct because it uses the esbuild transform (no typescript plugin, no declarations). `exo-esm` was equally affected (reported 1.58MB/1.06MB, real 688kB/172kB).

## Fix

Only the `modules` build is meant to emit declarations (into `dist/esm`); every other config now sets `declaration: false, declarationMap: false` explicitly.

## Verification

- stray `.d.ts` outside `dist/esm`: 316 → 0; `dist/esm` keeps its 316
- `pnpm size` green (real numbers: esm 172.32kB, iife-min 175.24kB gzip)
- `pnpm verify:exports` green (10 targets)
- production-stripping test 15/15 green
- Codecov bundle report will show true sizes from the next main upload