### PR TITLE
feat(resources): seamless Sound + refcount/claims + this.loader — Asset System v2 slice 3

### DIFF
--- a/site/src/content/api/extension-type-map.json
+++ b/site/src/content/api/extension-type-map.json
@@ -6,11 +6,11 @@
   "subsystem": "resources",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 11,
+  "memberCount": 16,
   "counts": {
     "constructors": 0,
     "methods": 0,
-    "properties": 11,
+    "properties": 16,
     "events": 0
   },
   "sections": [
@@ -29,6 +29,27 @@
       "id": "properties",
       "title": "Properties",
       "members": [
+        {
+          "name": "aac",
+          "signature": "aac: Sound",
+          "signatureTokens": [
+            {
+              "text": "aac",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Sound",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
         {
           "name": "avif",
           "signature": "avif: Texture",
@@ -135,6 +156,69 @@
           "description": ""
         },
         {
+          "name": "m4a",
+          "signature": "m4a: Sound",
+          "signatureTokens": [
+            {
+              "text": "m4a",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Sound",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "mp3",
+          "signature": "mp3: Sound",
+          "signatureTokens": [
+            {
+              "text": "mp3",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Sound",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "ogg",
+          "signature": "ogg: Sound",
+          "signatureTokens": [
+            {
+              "text": "ogg",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Sound",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
           "name": "otf",
           "signature": "otf: FontFace",
           "signatureTokens": [
@@ -190,6 +274,27 @@
             },
             {
               "text": "FontFace",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "wav",
+          "signature": "wav: Sound",
+          "signatureTokens": [
+            {
+              "text": "wav",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Sound",
               "kind": "type"
             }
           ],

--- a/site/src/content/api/loader.json
+++ b/site/src/content/api/loader.json
@@ -740,7 +740,7 @@
         },
         {
           "name": "get",
-          "signature": "get(path: LoadByPath<S> extends Texture ? S : never, options?: TextureFactoryOptions & PreSizeOptions): Texture",
+          "signature": "get(path: LoadByPath<S> extends Sound | Texture ? S : never, options?: unknown): LoadByPath<S>",
           "signatureTokens": [
             {
               "text": "get",
@@ -787,6 +787,14 @@
               "kind": "punctuation"
             },
             {
+              "text": "Sound",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
               "text": "Texture",
               "kind": "type"
             },
@@ -823,16 +831,8 @@
               "kind": "punctuation"
             },
             {
-              "text": "TextureFactoryOptions",
-              "kind": "type"
-            },
-            {
-              "text": " & ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "PreSizeOptions",
-              "kind": "type"
+              "text": "unknown",
+              "kind": "keyword"
             },
             {
               "text": ")",
@@ -843,23 +843,35 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "LoadByPath",
               "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "S",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
             }
           ],
           "params": [
             {
               "name": "path",
-              "type": "LoadByPath<S> extends Texture ? S : never",
+              "type": "LoadByPath<S> extends Sound | Texture ? S : never",
               "optional": false
             },
             {
               "name": "options",
-              "type": "TextureFactoryOptions & PreSizeOptions",
+              "type": "unknown",
               "optional": true
             }
           ],
-          "returnType": "Texture",
+          "returnType": "LoadByPath<S>",
           "description": "Seamless access by path alone — the asset type is inferred from the file extension (basename-only, longest-suffix-first; see ExtensionTypeMap). Accepts only paths whose inferred type has a seamless adapter (compile-time gate); dynamic strings resolving to an unregistered extension or a non-seamless type throw with guidance."
         },
         {

--- a/site/src/content/api/loader.json
+++ b/site/src/content/api/loader.json
@@ -6,10 +6,10 @@
   "subsystem": "resources",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 60,
+  "memberCount": 62,
   "counts": {
     "constructors": 1,
-    "methods": 49,
+    "methods": 51,
     "properties": 2,
     "events": 8
   },
@@ -4328,6 +4328,121 @@
           ],
           "returnType": "this",
           "description": "Registers the seamless-handle adapter for type, enabling the deferred get(type, source) form for it. One adapter per type."
+        },
+        {
+          "name": "release",
+          "signature": "release(handle: object): void",
+          "signatureTokens": [
+            {
+              "text": "release",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "handle",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "object",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "handle",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Releases the app-lifetime claim on an asset. When the released claim is the last one on that key, the payload is evicted immediately: a seamless handle's payload is dropped in place (identity preserved, loadState → 'loading') so a later get heals every dangling consumer, and a not-yet-started background entry is dropped from the queue. Accepts either the deferred handle / value-ref returned by get, or the (type, source) pair. Releasing an unclaimed or unknown asset is a no-op."
+        },
+        {
+          "name": "release",
+          "signature": "release(type: AssetConstructor, source: string): void",
+          "signatureTokens": [
+            {
+              "text": "release",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "type",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "AssetConstructor",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "source",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "type",
+              "type": "AssetConstructor",
+              "optional": false
+            },
+            {
+              "name": "source",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Releases the app-lifetime claim on an asset. When the released claim is the last one on that key, the payload is evicted immediately: a seamless handle's payload is dropped in place (identity preserved, loadState → 'loading') so a later get heals every dangling consumer, and a not-yet-started background entry is dropped from the queue. Accepts either the deferred handle / value-ref returned by get, or the (type, source) pair. Releasing an unclaimed or unknown asset is a no-op."
         },
         {
           "name": "setConcurrency",

--- a/site/src/content/api/scene.json
+++ b/site/src/content/api/scene.json
@@ -6,11 +6,11 @@
   "subsystem": "core",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 22,
+  "memberCount": 23,
   "counts": {
     "constructors": 1,
     "methods": 12,
-    "properties": 7,
+    "properties": 8,
     "events": 2
   },
   "sections": [
@@ -737,6 +737,27 @@
           "params": [],
           "returnType": null,
           "description": "Scene-bound input registry. Bindings created via this.inputs.onTrigger(...) etc. are automatically unbound when the scene is destroyed — no manual cleanup required. Throws if accessed before the scene is attached to an Application."
+        },
+        {
+          "name": "loader",
+          "signature": "loader: SceneLoader",
+          "signatureTokens": [
+            {
+              "text": "loader",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "SceneLoader",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Scene-scoped claim view over the application Loader. Assets claimed via this.loader.get/load(...) are held under this scene's own claim scope and released automatically when the scene is destroyed — scene-private assets are evicted on unload with zero manual bookkeeping. App-lifetime assets stay on app.loader. Throws if accessed before the scene is attached to an Application."
         },
         {
           "name": "root",

--- a/site/src/content/api/seamless-adapter.json
+++ b/site/src/content/api/seamless-adapter.json
@@ -6,10 +6,10 @@
   "subsystem": "resources",
   "importPath": "@codexo/exojs",
   "tier": "advanced",
-  "memberCount": 5,
+  "memberCount": 6,
   "counts": {
     "constructors": 0,
-    "methods": 5,
+    "methods": 6,
     "properties": 0,
     "events": 0
   },
@@ -126,6 +126,53 @@
           ],
           "returnType": "T",
           "description": "Create a fresh deferred handle, already in the 'loading' state."
+        },
+        {
+          "name": "evict",
+          "signature": "evict(handle: T): void",
+          "signatureTokens": [
+            {
+              "text": "evict",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "handle",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "handle",
+              "type": "T",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Drop the payload back to a placeholder in place (refcount-0 eviction); identity is kept so a later fill heals every consumer."
         },
         {
           "name": "fail",

--- a/site/src/content/api/sound.json
+++ b/site/src/content/api/sound.json
@@ -6,11 +6,11 @@
   "subsystem": "audio",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 25,
+  "memberCount": 27,
   "counts": {
     "constructors": 1,
     "methods": 9,
-    "properties": 15,
+    "properties": 17,
     "events": 0
   },
   "sections": [
@@ -33,7 +33,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(audioBuffer: AudioBuffer, options: SoundOptions): Sound",
+          "signature": "new(audioBuffer: AudioBuffer | null, options: SoundOptions): Sound",
           "signatureTokens": [
             {
               "text": "new",
@@ -54,6 +54,14 @@
             {
               "text": "AudioBuffer",
               "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
             },
             {
               "text": ", ",
@@ -87,7 +95,7 @@
           "params": [
             {
               "name": "audioBuffer",
-              "type": "AudioBuffer",
+              "type": "AudioBuffer | null",
               "optional": false
             },
             {
@@ -685,7 +693,7 @@
         },
         {
           "name": "audioBuffer",
-          "signature": "audioBuffer: AudioBuffer",
+          "signature": "audioBuffer: AudioBuffer | null",
           "signatureTokens": [
             {
               "text": "audioBuffer",
@@ -698,11 +706,19 @@
             {
               "text": "AudioBuffer",
               "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
             }
           ],
           "params": [],
           "returnType": null,
-          "description": "The underlying decoded audio data. Useful for sharing a single decoded buffer across multiple Sound instances."
+          "description": "The underlying decoded audio data, or null for a deferred handle whose payload hasn't finished loading yet. Useful for sharing a single decoded buffer across multiple Sound instances."
         },
         {
           "name": "distanceModel",
@@ -745,6 +761,60 @@
           "params": [],
           "returnType": null,
           "description": "Playable duration in seconds — the full buffer, or the clip span for a Sound.clip."
+        },
+        {
+          "name": "loaded",
+          "signature": "loaded: Promise<this>",
+          "signatureTokens": [
+            {
+              "text": "loaded",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Promise",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Promise that settles with this sound once its payload has loaded — resolved immediately for 'ready' sounds, rejected with the load error for 'failed' ones. Re-materialized when a failed load is retried, so read it fresh from this getter rather than caching it across load cycles."
+        },
+        {
+          "name": "loadState",
+          "signature": "loadState: LoadStateValue",
+          "signatureTokens": [
+            {
+              "text": "loadState",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "LoadStateValue",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Load lifecycle of this sound. Directly constructed sounds are 'ready'; deferred handles returned by the Loader's seamless pipeline start 'loading' and become 'ready' once the payload fills in, or 'failed' when the load errors."
         },
         {
           "name": "maxDistance",

--- a/site/src/content/api/sound.json
+++ b/site/src/content/api/sound.json
@@ -814,7 +814,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Load lifecycle of this sound. Directly constructed sounds are 'ready'; deferred handles returned by the Loader's seamless pipeline start 'loading' and become 'ready' once the payload fills in, or 'failed' when the load errors."
+          "description": "Load lifecycle of this sound. Directly constructed sounds are 'ready'; deferred handles returned by loader.get(Sound, …) start 'loading' and become 'ready' once the payload fills in, or 'failed' when the load errors."
         },
         {
           "name": "maxDistance",

--- a/src/audio/Sound.ts
+++ b/src/audio/Sound.ts
@@ -1,3 +1,4 @@
+import { LoadState, type LoadStateValue } from '#core/LoadState';
 import { clamp } from '#math/utils';
 import { Vector } from '#math/Vector';
 
@@ -119,7 +120,9 @@ interface PooledVoice {
  * lazily) — `Sound` is best for short, frequently-triggered clips.
  */
 export class Sound implements Playable {
-  private readonly _audioBuffer: AudioBuffer;
+  private _audioBuffer: AudioBuffer | null;
+  /** @internal — load lifecycle, driven by the Loader's seamless pipeline. */
+  public readonly _loadState = new LoadState<Sound>();
   private readonly _sprites = new Map<string, NormalizedAudioSpriteClip>();
 
   // Playable buffer window (seconds). Full buffer by default; narrowed by clip().
@@ -150,14 +153,38 @@ export class Sound implements Playable {
   // Active voice pool — tracks concurrent voices for eviction logic.
   private readonly _activeVoices: PooledVoice[] = [];
 
-  /** The underlying decoded audio data. Useful for sharing a single decoded buffer across multiple `Sound` instances. */
-  public get audioBuffer(): AudioBuffer {
+  /**
+   * The underlying decoded audio data, or `null` for a deferred handle whose
+   * payload hasn't finished loading yet. Useful for sharing a single decoded
+   * buffer across multiple `Sound` instances.
+   */
+  public get audioBuffer(): AudioBuffer | null {
     return this._audioBuffer;
   }
 
   /** Playable duration in seconds — the full buffer, or the clip span for a {@link Sound.clip}. */
   public get duration(): number {
     return this._clipEnd - this._clipStart;
+  }
+
+  /**
+   * Load lifecycle of this sound. Directly constructed sounds are `'ready'`;
+   * deferred handles returned by the Loader's seamless pipeline start
+   * `'loading'` and become `'ready'` once the payload fills in, or `'failed'`
+   * when the load errors.
+   */
+  public get loadState(): LoadStateValue {
+    return this._loadState.value;
+  }
+
+  /**
+   * Promise that settles with this sound once its payload has loaded —
+   * resolved immediately for `'ready'` sounds, rejected with the load error
+   * for `'failed'` ones. Re-materialized when a failed load is retried, so
+   * read it fresh from this getter rather than caching it across load cycles.
+   */
+  public get loaded(): Promise<this> {
+    return this._loadState.loaded(this) as Promise<this>;
   }
 
   public get poolSize(): number {
@@ -267,9 +294,9 @@ export class Sound implements Playable {
     this._rolloffFactor = Math.max(0, value);
   }
 
-  public constructor(audioBuffer: AudioBuffer, options: SoundOptions = {}) {
+  public constructor(audioBuffer: AudioBuffer | null = null, options: SoundOptions = {}) {
     this._audioBuffer = audioBuffer;
-    this._clipEnd = audioBuffer.duration;
+    this._clipEnd = audioBuffer?.duration ?? 0;
 
     const { poolSize, poolStrategy, priority, sprites, volume, loop, playbackRate, muted, distanceModel, refDistance, maxDistance, rolloffFactor } = options;
 
@@ -370,6 +397,10 @@ export class Sound implements Playable {
    * own independent voice pool.
    */
   public clip(offset: number, duration: number): Sound {
+    if (this._audioBuffer === null) {
+      throw new Error('Sound.clip() is unavailable: the sound is not loaded yet.');
+    }
+
     const start = clamp(offset, 0, this._audioBuffer.duration);
     const end = clamp(start + duration, start, this._audioBuffer.duration);
 
@@ -390,6 +421,28 @@ export class Sound implements Playable {
     clip._clipEnd = end;
 
     return clip;
+  }
+
+  /**
+   * Transplant a decoded buffer into this handle in place (seamless fill).
+   * Resets the clip window to the full buffer.
+   * @internal
+   */
+  public _setBuffer(buffer: AudioBuffer): void {
+    this._audioBuffer = buffer;
+    this._clipStart = 0;
+    this._clipEnd = buffer.duration;
+  }
+
+  /**
+   * Drop the decoded payload back to the placeholder state (refcount-0 eviction).
+   * Identity is preserved; a later load heals in place.
+   * @internal
+   */
+  public _evictBuffer(): void {
+    this._audioBuffer = null;
+    this._clipStart = 0;
+    this._clipEnd = 0;
   }
 
   /**
@@ -449,6 +502,10 @@ export class Sound implements Playable {
    * descriptor's position, and tracks the voice for eviction.
    */
   private _buildVoice(manager: AudioManager, options: PlayOptions, offset: number, window: SoundVoiceWindow): Voice {
+    if (this._audioBuffer === null) {
+      throw new Error('Sound playback is unavailable: the sound is not loaded yet.');
+    }
+
     const loop = options.loop ?? this.loop;
     const playbackRate = clamp(options.playbackRate ?? this.playbackRate, 0.1, 20);
     const detune = options.detune ?? 0;

--- a/src/audio/Sound.ts
+++ b/src/audio/Sound.ts
@@ -1,8 +1,10 @@
 import { LoadState, type LoadStateValue } from '#core/LoadState';
+import { logger } from '#core/logging';
 import { clamp } from '#math/utils';
 import { Vector } from '#math/Vector';
 
 import { getAudioContext, isAudioContextReady } from './audio-context';
+import type { AudioBus } from './AudioBus';
 import type { AudioManager } from './AudioManager';
 import { NoopVoice } from './NoopVoice';
 import type { Playable, PlayOptions, Voice } from './Playable';
@@ -454,10 +456,17 @@ export class Sound implements Playable {
    * strategy picks a victim to stop before the new voice starts.
    */
   public _createVoice(manager: AudioManager, options: PlayOptions): Voice {
+    const bus = options.bus ?? manager.sound;
+    const notLoaded = this._notLoadedVoice(bus);
+
+    if (notLoaded !== null) {
+      return notLoaded;
+    }
+
     const offset = this._clipStart + Math.max(0, options.time ?? 0);
 
     if (offset >= this._clipEnd) {
-      return new NoopVoice(options.bus ?? manager.sound);
+      return new NoopVoice(bus);
     }
 
     return this._buildVoice(manager, options, offset, {
@@ -479,6 +488,13 @@ export class Sound implements Playable {
       throw new Error(`Sound sprite "${name}" is not defined.`);
     }
 
+    const bus = options.bus ?? manager.sound;
+    const notLoaded = this._notLoadedVoice(bus);
+
+    if (notLoaded !== null) {
+      return notLoaded;
+    }
+
     const clipOffset = Math.max(0, options.time ?? 0);
     const offset = clip.start + clipOffset;
 
@@ -497,16 +513,42 @@ export class Sound implements Playable {
   }
 
   /**
+   * If the sound is not playable-loaded, return a {@link NoopVoice} with a
+   * differentiated warning; otherwise return `null` so the caller builds a
+   * real voice. Both the main path ({@link Sound._createVoice}) and the sprite
+   * path ({@link Sound._createSpriteVoice}) route through this before reaching
+   * {@link Sound._buildVoice} — after eviction the sprite path can otherwise
+   * hand `_buildVoice` a `null` buffer (a sprite defined while loaded, then
+   * evicted and replayed before the reload settles).
+   */
+  private _notLoadedVoice(bus: AudioBus): Voice | null {
+    if (this._loadState.value === 'failed') {
+      logger.warn('Sound.play() called on a sound that failed to load; playing silence.', { source: 'Sound' });
+      return new NoopVoice(bus);
+    }
+
+    if (this._audioBuffer === null || this._loadState.value === 'loading') {
+      logger.warn('Sound.play() called on a sound that is not yet loaded; playing silence. Await sound.loaded or use loader.load().', { source: 'Sound' });
+      return new NoopVoice(bus);
+    }
+
+    return null;
+  }
+
+  /**
    * Shared voice construction for full-buffer and sprite playback. Enforces the
    * pool limit, builds the {@link SoundVoice}, seeds spatialization from the
    * descriptor's position, and tracks the voice for eviction.
    */
   private _buildVoice(manager: AudioManager, options: PlayOptions, offset: number, window: SoundVoiceWindow): Voice {
-    // @internal invariant: the buffer is non-null here. Callers (`_createVoice`/
-    // `_createSpriteVoice`) are responsible for routing not-loaded/failed sounds
-    // away from `_buildVoice`; Task 2 completes that routing for both the main
-    // and the sprite path.
-    const buffer = this._audioBuffer!;
+    // @internal invariant: the buffer is non-null here. Both `_createVoice` and
+    // `_createSpriteVoice` route through `_notLoadedVoice` before reaching this
+    // method, so a null buffer can no longer arrive through any real caller.
+    const buffer = this._audioBuffer;
+
+    if (buffer === null) {
+      throw new Error('Sound._buildVoice() invariant violated: called with a null buffer.');
+    }
 
     const loop = options.loop ?? this.loop;
     const playbackRate = clamp(options.playbackRate ?? this.playbackRate, 0.1, 20);

--- a/src/audio/Sound.ts
+++ b/src/audio/Sound.ts
@@ -169,9 +169,9 @@ export class Sound implements Playable {
 
   /**
    * Load lifecycle of this sound. Directly constructed sounds are `'ready'`;
-   * deferred handles returned by the Loader's seamless pipeline start
-   * `'loading'` and become `'ready'` once the payload fills in, or `'failed'`
-   * when the load errors.
+   * deferred handles returned by `loader.get(Sound, …)` start `'loading'` and
+   * become `'ready'` once the payload fills in, or `'failed'` when the load
+   * errors.
    */
   public get loadState(): LoadStateValue {
     return this._loadState.value;
@@ -502,9 +502,11 @@ export class Sound implements Playable {
    * descriptor's position, and tracks the voice for eviction.
    */
   private _buildVoice(manager: AudioManager, options: PlayOptions, offset: number, window: SoundVoiceWindow): Voice {
-    if (this._audioBuffer === null) {
-      throw new Error('Sound playback is unavailable: the sound is not loaded yet.');
-    }
+    // @internal invariant: the buffer is non-null here. Callers (`_createVoice`/
+    // `_createSpriteVoice`) are responsible for routing not-loaded/failed sounds
+    // away from `_buildVoice`; Task 2 completes that routing for both the main
+    // and the sprite path.
+    const buffer = this._audioBuffer!;
 
     const loop = options.loop ?? this.loop;
     const playbackRate = clamp(options.playbackRate ?? this.playbackRate, 0.1, 20);
@@ -539,7 +541,7 @@ export class Sound implements Playable {
         maxDistance: this._maxDistance,
         rolloffFactor: this._rolloffFactor,
       },
-      buffer: this._audioBuffer,
+      buffer,
       loop,
       playbackRate,
       detune,

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -1,9 +1,19 @@
 import type { Tween } from '#animation/Tween';
+import type { Sound } from '#audio/Sound';
 import type { InputBinding, InputBindingOptions, InputChannel } from '#input/InputBinding';
 import { Container } from '#rendering/Container';
 import type { RenderingContext } from '#rendering/RenderingContext';
 import type { RenderNode } from '#rendering/RenderNode';
-import type { Loader } from '#resources/Loader';
+import type { Texture } from '#rendering/texture/Texture';
+import type { Asset } from '#resources/Asset';
+import type { AssetInput } from '#resources/AssetDefinitions';
+import type { AssetRef } from '#resources/AssetRef';
+import type { Assets } from '#resources/Assets';
+import type { TextureFactoryOptions } from '#resources/factories/TextureFactory';
+import type { BatchValue, ConstrainedLoadable, InferLoadedMap, Loadable, LoadByPath, Loader, LoadReturn, PathExtension } from '#resources/Loader';
+import type { LoadingQueue } from '#resources/LoadingQueue';
+import type { PreSizeOptions } from '#resources/seamless';
+import type { BinaryAsset, CsvAsset, Json, SubtitleAsset, TextAsset, WasmAsset, XmlAsset } from '#resources/tokens';
 import { UIRoot } from '#ui/UIRoot';
 
 import type { Application } from './Application';
@@ -88,6 +98,67 @@ class SceneTweens implements Destroyable {
 }
 
 /**
+ * Scene-scoped claim view over the application {@link Loader}. Assets claimed
+ * through `scene.loader.get/load(…)` are held under this scene's claim scope
+ * and released automatically when the scene is destroyed (refcount −1), so
+ * scene-private assets are evicted on unload without manual bookkeeping.
+ * App-lifetime assets stay on `app.loader`.
+ */
+class SceneLoader implements Destroyable {
+  private readonly _scope = Symbol('scene-loader');
+
+  public constructor(private readonly _scene: Scene) {}
+
+  private get _loader(): Loader {
+    return this._scene.app!.loader;
+  }
+
+  public get(type: typeof Texture, source: string, options?: TextureFactoryOptions & PreSizeOptions): Texture;
+  public get(type: typeof Texture, sources: readonly string[], options?: TextureFactoryOptions & PreSizeOptions): Texture[];
+  public get<K extends string>(type: typeof Texture, items: Readonly<Record<K, string>>, options?: TextureFactoryOptions & PreSizeOptions): Record<K, Texture>;
+  public get<S extends string>(path: LoadByPath<S> extends Texture | Sound ? S : never, options?: unknown): LoadByPath<S>;
+  public get<T = unknown>(type: typeof Json, source: string, options?: unknown): AssetRef<T>;
+  public get(type: typeof TextAsset, source: string, options?: unknown): AssetRef<string>;
+  public get(type: typeof CsvAsset, source: string, options?: unknown): AssetRef<string[][]>;
+  public get(type: typeof XmlAsset, source: string, options?: unknown): AssetRef<Document>;
+  public get(type: typeof SubtitleAsset, source: string, options?: unknown): AssetRef<VTTCue[]>;
+  public get(type: typeof BinaryAsset, source: string, options?: unknown): AssetRef<ArrayBuffer>;
+  public get(type: typeof WasmAsset, source: string, options?: unknown): AssetRef<WebAssembly.Module>;
+  public get<T extends Loadable>(type: T, alias: string): LoadReturn<T>;
+  public get(typeOrPath: Loadable | string, source?: unknown, options?: unknown): unknown {
+    return this._loader._getClaimed(this._scope, typeOrPath, source, options);
+  }
+
+  public load<T = unknown>(type: typeof Json, path: string, options?: unknown): LoadingQueue<T>;
+  public load<T = unknown>(type: typeof Json, paths: readonly string[], options?: unknown): LoadingQueue<T[]>;
+  public load<T = unknown, K extends string = string>(type: typeof Json, items: Readonly<Record<K, string>>, options?: unknown): LoadingQueue<Record<K, T>>;
+  public load<T>(asset: Asset<T>): LoadingQueue<T>;
+  public load<M extends Record<string, AssetInput>>(assets: Assets<M>): LoadingQueue<InferLoadedMap<M>>;
+  // eslint-disable-next-line @typescript-eslint/unified-signatures -- mirrors Loader.load verbatim (rule disabled there too)
+  public load<M extends Record<string, AssetInput>>(config: M): LoadingQueue<InferLoadedMap<M>>;
+  public load<R, S extends string>(path: [PathExtension<S>] extends [never] ? never : S): LoadingQueue<R>;
+  public load<S extends string>(path: [PathExtension<S>] extends [never] ? never : S): LoadingQueue<LoadByPath<S>>;
+  public load<T extends Loadable, S extends string>(type: ConstrainedLoadable<T, S>, path: S, options?: unknown): LoadingQueue<LoadReturn<T>>;
+  public load<T extends Loadable>(type: T, paths: readonly string[], options?: unknown): LoadingQueue<Array<LoadReturn<T>>>;
+  public load<T extends Loadable, K extends string>(type: T, items: Readonly<Record<K, BatchValue>>, options?: unknown): LoadingQueue<Record<K, LoadReturn<T>>>;
+  public load(arg0: unknown, arg1?: unknown, arg2?: unknown): LoadingQueue<unknown> {
+    return this._loader._loadClaimed(this._scope, arg0, arg1, arg2);
+  }
+
+  public backgroundLoad(): void;
+  public backgroundLoad(type: Loadable, source: string, options?: unknown): void;
+  // eslint-disable-next-line @typescript-eslint/unified-signatures -- mirrors Loader.backgroundLoad verbatim (rule disabled there too)
+  public backgroundLoad(type: Loadable, sources: readonly string[], options?: unknown): void;
+  public backgroundLoad(type?: Loadable, source?: string | readonly string[], options?: unknown): void {
+    this._loader._backgroundClaimed(this._scope, type, source, options);
+  }
+
+  public destroy(): void {
+    this._loader._releaseScope(this._scope);
+  }
+}
+
+/**
  * A scene's lifecycle host. Subclass to define scene behavior:
  *
  *   class GameScene extends Scene {
@@ -124,6 +195,7 @@ export class Scene {
 
   private _inputs: SceneInputs | null = null;
   private _tweens: SceneTweens | null = null;
+  private _loader: SceneLoader | null = null;
   private _systems: SystemRegistry | null = null;
   private readonly _disposal = new DisposalScope();
 
@@ -188,6 +260,27 @@ export class Scene {
     }
 
     return this._tweens;
+  }
+
+  /**
+   * Scene-scoped claim view over the application {@link Loader}. Assets
+   * claimed via `this.loader.get/load(...)` are held under this scene's own
+   * claim scope and released automatically when the scene is destroyed —
+   * scene-private assets are evicted on unload with zero manual bookkeeping.
+   * App-lifetime assets stay on `app.loader`.
+   *
+   * Throws if accessed before the scene is attached to an {@link Application}.
+   */
+  public get loader(): SceneLoader {
+    if (this._loader === null) {
+      if (this._app === null) {
+        throw new Error('Scene.loader is unavailable before the scene is attached to an Application.');
+      }
+
+      this._loader = this._disposal.track(new SceneLoader(this));
+    }
+
+    return this._loader;
   }
 
   /**
@@ -385,6 +478,7 @@ export class Scene {
     this._disposal.destroy();
     this._inputs = null;
     this._tweens = null;
+    this._loader = null;
     this._systems = null;
     this.onLoad.destroy();
     this.onUnload.destroy();

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -1734,6 +1734,26 @@ export class Loader {
   }
 
   /**
+   * Release every claim held under a claim scope (a scene unloading its
+   * scene-private assets). Collect the held keys first, then release — `_release`
+   * mutates `_claims`, so we must not delete during iteration.
+   * @internal
+   */
+  public _releaseScope(claimer: symbol): void {
+    const held: string[] = [];
+
+    for (const [key, entry] of this._claims) {
+      if (entry.scopes.has(claimer)) {
+        held.push(key);
+      }
+    }
+
+    for (const key of held) {
+      this._release(key, claimer);
+    }
+  }
+
+  /**
    * Free a key's payload while keeping its handle identity: find the handle
    * (post-fill in `_resources`, or in-flight in `_deferred`), adapter-evict it
    * (drops payload + re-arms to 'loading'), remove the stored resource, and

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -1084,6 +1084,13 @@ export class Loader {
    * The same source always yields the same instance — also across
    * {@link load} — and options are first-wins: conflicting options on a
    * later call are ignored with a one-time dev warning.
+   *
+   * @remarks For a seamless type, `get(Type, source)` on an unloaded source
+   * returns a `'loading'` placeholder and fetches URL `<source>` — it no longer
+   * throws "missing resource". A bare alias that isn't a real path (a typo, or a
+   * not-yet-preloaded alias) therefore fetches that string and can 404 quietly
+   * instead of throwing; preloaded aliases still return the stored payload. This
+   * is intended seamless-by-default behaviour — the note is for debuggability.
    */
   public get(type: typeof Texture, source: string, options?: TextureFactoryOptions & PreSizeOptions): Texture;
   public get(type: typeof Texture, sources: readonly string[], options?: TextureFactoryOptions & PreSizeOptions): Texture[];
@@ -1215,6 +1222,12 @@ export class Loader {
    * Accepts either the deferred handle / value-ref returned by {@link get}, or
    * the `(type, source)` pair. Releasing an unclaimed or unknown asset is a
    * no-op.
+   *
+   * @remarks The `release(handle)` form resolves the key via an internal handle
+   * → key map that is populated ONLY for seamless handles and value-refs. A
+   * non-seamless legacy asset (e.g. `get(SomeNonSeamlessType, alias)`) has no
+   * such entry, so `release(handle)` silently can't find its key and won't drop
+   * the claim — use the `release(type, source)` form for those.
    */
   public release(handle: object): void;
   public release(type: AssetConstructor, source: string): void;

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -1,3 +1,4 @@
+import type { Sound } from '#audio/Sound';
 import { logger } from '#core/logging';
 import { Signal } from '#core/Signal';
 import type { AssetHandler, AssetLoadRequest } from '#extensions/Extension';
@@ -96,6 +97,11 @@ export interface ExtensionTypeMap {
   webp: Texture;
   avif: Texture;
   gif: Texture;
+  ogg: Sound;
+  mp3: Sound;
+  wav: Sound;
+  m4a: Sound;
+  aac: Sound;
 }
 
 /** Last path segment of `S` (everything after the final `/`). */
@@ -1049,7 +1055,7 @@ export class Loader {
    * gate); dynamic strings resolving to an unregistered extension or a
    * non-seamless type throw with guidance.
    */
-  public get<S extends string>(path: LoadByPath<S> extends Texture ? S : never, options?: TextureFactoryOptions & PreSizeOptions): Texture;
+  public get<S extends string>(path: LoadByPath<S> extends Texture | Sound ? S : never, options?: unknown): LoadByPath<S>;
 
   /**
    * Seamless access to a value asset: returns a stable {@link AssetRef}

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -1762,8 +1762,10 @@ export class Loader {
       this._evicted.add(key);
       // A load that just settled may leave a resolved-but-not-yet-cleaned
       // in-flight entry (its `.finally` cleanup is a pending microtask). Drop it
-      // so the reclaim's re-fetch starts fresh instead of deduping onto the
-      // stale promise, which would never re-fill the re-armed handle.
+      // so the reclaim's re-fetch starts fresh instead of deduping onto that
+      // stale resolved promise, which would never re-fill the re-armed handle.
+      // The reclaim's fresh entry is protected from this stale `.finally` by the
+      // self-entry identity guard in `_trackInFlight`.
       this._inFlight.delete(key);
     }
 
@@ -2263,7 +2265,14 @@ export class Loader {
   private _trackInFlight(type: AssetConstructor, alias: string, promise: Promise<unknown>): Promise<unknown> {
     const key = this._key(type, alias);
     const trackedPromise = promise.finally(() => {
-      this._inFlight.delete(key);
+      // Clear only our OWN entry: a superseding load (e.g. a reclaim re-fetch
+      // after an eviction dropped and re-added this key) may already own the
+      // slot. Deleting it unconditionally would un-dedup a concurrent load and
+      // let a second fetch overwrite the healed handle with its raw donor.
+      if (this._inFlight.get(key) === trackedPromise) {
+        this._inFlight.delete(key);
+      }
+
       this._preventStoreKeys.delete(key);
     });
 

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -2470,6 +2470,7 @@ export class Loader {
     // every consumer — get() before or after load(), and load()'s own promise —
     // sees exactly ONE instance per source.
     const deferredEntry = this._deferred.get(key);
+    let filledDeferredHandle = false;
 
     if (deferredEntry !== undefined && deferredEntry.handle !== resource) {
       const adapter = this._seamlessAdapters.get(type);
@@ -2489,6 +2490,7 @@ export class Loader {
 
       this._deferred.delete(key);
       resource = deferredEntry.handle;
+      filledDeferredHandle = true;
     }
 
     // Value-asset refs fill from whatever producer stores the value; the raw
@@ -2509,6 +2511,18 @@ export class Loader {
     }
 
     this.onLoaded.dispatch(type, alias, resource);
+
+    // §4.7 free-on-arrival: a deferred handle whose every claimer released
+    // during the in-flight fetch has now converged into `_resources` at
+    // refcount 0. `.loaded` was already settled by the fill above, so an
+    // awaiter holding that promise still resolves (the asset WAS complete);
+    // evicting here drops the payload in place (re-arming `.loaded` to
+    // 'loading') so it does not linger unclaimed. Gated on an actual deferred
+    // fill: a never-claimed bundle/container store (no `_deferred` entry) must
+    // persist, not be freed on arrival.
+    if (filledDeferredHandle && !this._claims.has(key)) {
+      this._evictKey(key, type, alias);
+    }
 
     return resource;
   }

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -344,6 +344,16 @@ export class Loader {
   private readonly _refs = new Map<string, { readonly ref: AssetRef<unknown>; readonly options: unknown }>();
   private readonly _valueTokens: ReadonlySet<Loadable> = new Set<Loadable>([Json, TextAsset, CsvAsset, XmlAsset, SubtitleAsset, BinaryAsset, WasmAsset]);
 
+  // ── Refcount / claims (asset-system v2 §4.7) ──────────────────────────────
+  /** App-lifetime claim scope for direct `app.loader.get/load(…)` calls. @internal */
+  private readonly _rootClaimer = Symbol('app-loader');
+  /** Resource key → claim scopes + the type/source needed to evict/re-fetch; refcount = scopes.size. @internal */
+  private readonly _claims = new Map<string, { scopes: Set<symbol>; type: AssetConstructor; source: string }>();
+  /** Keys evicted at refcount 0 (handle re-registered in `_deferred`); the next claim re-fetches into it. @internal */
+  private readonly _evicted = new Set<string>();
+  /** Deferred handle / value-ref → its resource key, for `release(handle)`. @internal */
+  private readonly _handleKeys = new WeakMap<object, string>();
+
   private _basePath: string;
   private _fetchOptions: RequestInit;
   private _concurrency: number;
@@ -765,12 +775,24 @@ export class Loader {
   // -----------------------------------------------------------------------
 
   public load(arg0: unknown, arg1?: unknown, arg2?: unknown): LoadingQueue<unknown> {
+    return this._loadClaimed(this._rootClaimer, arg0, arg1, arg2);
+  }
+
+  /**
+   * Claimed variant of {@link load}: identical logic, but every resolved key is
+   * claimed under `claimer` (refcount). The public {@link load} delegates here
+   * under the app-lifetime {@link _rootClaimer}; the scene-scoped loader proxy
+   * passes its own scope. Claiming under `_rootClaimer` (which only `release()`
+   * frees) is observationally a no-op for existing callers.
+   * @internal
+   */
+  public _loadClaimed(claimer: symbol, arg0: unknown, arg1?: unknown, arg2?: unknown): LoadingQueue<unknown> {
     // 1. Single Asset<T>
     if (arg0 instanceof AssetImpl) {
       const asset = arg0 as Asset<unknown>;
       const alias = asset._config.source;
 
-      return this._createLoadingQueue([{ alias, asset }], results => results.get(alias));
+      return this._createLoadingQueue(claimer, [{ alias, asset }], results => results.get(alias));
     }
 
     // 2. Assets<M> container
@@ -781,7 +803,7 @@ export class Loader {
         asset: a,
       }));
 
-      return this._createLoadingQueue(items, results => {
+      return this._createLoadingQueue(claimer, items, results => {
         const out: Record<string, unknown> = {};
 
         for (const { alias } of items) {
@@ -804,6 +826,7 @@ export class Loader {
       // FontAsset requires a family option — infer it from the filename when not provided
       const options: unknown = ctor === FontAsset ? { family: (path.split('/').pop()?.split(/[?#]/)[0] ?? '').replace(/\.[^.]+$/, '') } : undefined;
 
+      this._claim(this._key(ctor, path), ctor, path, claimer);
       this._onFgBatchStart(path, path);
       let notifyFn: ((success: boolean) => void) | null = null;
       const promise = this._loadSingle(ctor, path, options).then(
@@ -830,6 +853,7 @@ export class Loader {
       const options = arg2;
 
       if (typeof source === 'string') {
+        this._claim(this._key(ctor, source), ctor, source, claimer);
         this._onFgBatchStart(source, source);
         let notifyFn: ((success: boolean) => void) | null = null;
         const promise = this._loadSingle(ctor, source, options).then(
@@ -856,6 +880,7 @@ export class Loader {
         let notifyFn: ((success: boolean) => void) | null = null;
         const results: unknown[] = new Array(paths.length);
         const promises = paths.map((path, i) => {
+          this._claim(this._key(ctor, path), ctor, path, claimer);
           this._onFgBatchStart(path, path);
           return this._loadSingle(ctor, path, options).then(
             v => {
@@ -890,6 +915,7 @@ export class Loader {
             ? options
             : { ...pathOrConfig, ...(typeof options === 'object' && options !== null ? (options as Record<string, unknown>) : {}) };
 
+        this._claim(this._key(ctor, alias), ctor, alias, claimer);
         this._onFgBatchStart(alias, path);
 
         return this._loadSingle(ctor, alias, itemOptions, path).then(
@@ -921,7 +947,7 @@ export class Loader {
       asset: value instanceof AssetImpl ? value : new (Asset as new (c: AssetInput) => Asset<unknown>)(value),
     }));
 
-    return this._createLoadingQueue(items, results => {
+    return this._createLoadingQueue(claimer, items, results => {
       const out: Record<string, unknown> = {};
 
       for (const { alias } of items) {
@@ -948,6 +974,18 @@ export class Loader {
   public backgroundLoad(type: Loadable, source: string, options?: unknown): void;
   public backgroundLoad(type: Loadable, sources: readonly string[], options?: unknown): void;
   public backgroundLoad(type?: Loadable, source?: string | readonly string[], options?: unknown): void {
+    this._backgroundClaimed(this._rootClaimer, type, source, options);
+  }
+
+  /**
+   * Claimed variant of {@link backgroundLoad}: identical queueing, but every
+   * declared source is claimed under `claimer` (refcount) so a scene-scoped
+   * pre-warm releases correctly and a not-yet-started entry is dropped from the
+   * queue at refcount 0. The public {@link backgroundLoad} delegates here under
+   * the app-lifetime {@link _rootClaimer}.
+   * @internal
+   */
+  public _backgroundClaimed(claimer: symbol, type?: Loadable, source?: string | readonly string[], options?: unknown): void {
     // Start a fresh progress batch only when idle; a re-entrant call while the
     // queue is draining extends the running batch instead (mirrors the
     // accounting in _loadSingleBackground).
@@ -961,6 +999,7 @@ export class Loader {
       const sources: readonly string[] = typeof source === 'string' ? [source] : source;
 
       for (const src of sources) {
+        this._claim(this._key(ctor, src), ctor, src, claimer);
         this._addManifestEntry(ctor, src, src, options);
 
         if (this._hasResource(ctor, src)) continue;
@@ -978,6 +1017,8 @@ export class Loader {
 
     for (const [manifestType, entries] of this._manifest) {
       for (const [alias, entry] of entries) {
+        this._claim(this._key(manifestType, alias), manifestType, alias, claimer);
+
         if (this._hasResource(manifestType, alias)) continue;
 
         const key = this._key(manifestType, alias);
@@ -1079,6 +1120,19 @@ export class Loader {
    */
   public get<T extends Loadable>(type: T, alias: string): LoadReturn<T>;
   public get(typeOrPath: Loadable | string, source?: unknown, options?: unknown): unknown {
+    return this._getClaimed(this._rootClaimer, typeOrPath, source, options);
+  }
+
+  /**
+   * Claimed variant of {@link get}: identical resolution, but each resolved key
+   * is claimed under `claimer` (refcount). The public {@link get} delegates here
+   * under the app-lifetime {@link _rootClaimer}; the scene-scoped loader proxy
+   * passes its own scope. `_claim` runs AFTER `_getSeamless`/`_getRef` so an
+   * evicted key's re-fetch is driven from here (the re-armed handle reads
+   * `'loading'`, which `_getSeamless` alone would not re-fetch).
+   * @internal
+   */
+  public _getClaimed(claimer: symbol, typeOrPath: Loadable | string, source?: unknown, options?: unknown): unknown {
     if (typeof typeOrPath === 'string') {
       const path = typeOrPath;
       const ctor = this._resolveExtensionType(path);
@@ -1093,7 +1147,10 @@ export class Loader {
         throw new Error(`Loader: type ${this._describeType(ctor)} inferred from "${path}" has no seamless adapter — use load() instead.`);
       }
 
-      return this._getSeamless(ctor, pathAdapter, path, source);
+      const handle = this._getSeamless(ctor, pathAdapter, path, source);
+      this._claim(this._key(ctor, path), ctor, path, claimer);
+
+      return handle;
     }
 
     const ctor = typeOrPath;
@@ -1101,13 +1158,21 @@ export class Loader {
 
     if (adapter !== undefined) {
       if (typeof source === 'string') {
-        return this._getSeamless(ctor, adapter, source, options);
+        const handle = this._getSeamless(ctor, adapter, source, options);
+        this._claim(this._key(ctor, source), ctor, source, claimer);
+
+        return handle;
       }
 
       if (Array.isArray(source)) {
         const paths: readonly string[] = source;
 
-        return paths.map(path => this._getSeamless(ctor, adapter, path, options));
+        return paths.map(path => {
+          const handle = this._getSeamless(ctor, adapter, path, options);
+          this._claim(this._key(ctor, path), ctor, path, claimer);
+
+          return handle;
+        });
       }
 
       const out: Record<string, unknown> = {};
@@ -1115,13 +1180,17 @@ export class Loader {
 
       for (const [key, path] of Object.entries(items)) {
         out[key] = this._getSeamless(ctor, adapter, path, options);
+        this._claim(this._key(ctor, path), ctor, path, claimer);
       }
 
       return out;
     }
 
     if (this._valueTokens.has(ctor) && typeof source === 'string') {
-      return this._getRef(ctor, source, options);
+      const ref = this._getRef(ctor, source, options);
+      this._claim(this._key(ctor, source), ctor, source, claimer);
+
+      return ref;
     }
 
     const alias = source as string;
@@ -1131,7 +1200,30 @@ export class Loader {
       throw new Error(`Missing resource "${alias}" for type ${ctor.name}.`);
     }
 
+    this._claim(this._key(ctor, alias), ctor, alias, claimer);
+
     return typeMap.get(alias);
+  }
+
+  /**
+   * Releases the app-lifetime claim on an asset. When the released claim is the
+   * last one on that key, the payload is evicted immediately: a seamless
+   * handle's payload is dropped in place (identity preserved, `loadState` →
+   * `'loading'`) so a later {@link get} heals every dangling consumer, and a
+   * not-yet-started background entry is dropped from the queue.
+   *
+   * Accepts either the deferred handle / value-ref returned by {@link get}, or
+   * the `(type, source)` pair. Releasing an unclaimed or unknown asset is a
+   * no-op.
+   */
+  public release(handle: object): void;
+  public release(type: AssetConstructor, source: string): void;
+  public release(handleOrType: object | AssetConstructor, source?: string): void {
+    const key = typeof source === 'string' ? this._key(handleOrType as AssetConstructor, source) : this._handleKeys.get(handleOrType);
+
+    if (key !== undefined) {
+      this._release(key, this._rootClaimer);
+    }
   }
 
   /**
@@ -1531,6 +1623,7 @@ export class Loader {
     const handle = adapter.createPlaceholder(options);
 
     this._deferred.set(key, { handle, options });
+    this._handleKeys.set(handle as object, key);
     this._startSeamlessFetch(type, source, options);
 
     return handle;
@@ -1571,6 +1664,7 @@ export class Loader {
     const ref = new AssetRef<unknown>();
 
     this._refs.set(key, { ref, options });
+    this._handleKeys.set(ref, key);
 
     const stored = this._resources.get(type)?.get(source);
 
@@ -1591,6 +1685,95 @@ export class Loader {
     void this._loadSingle(type, source, options).catch(() => {
       /* Failure handled centrally in _onTrackedFailure. */
     });
+  }
+
+  /**
+   * Register a claim on a resource key under a claim scope (idempotent per
+   * scope). On an evicted key, kick a re-fetch into the existing, already
+   * re-armed handle so every dangling consumer heals in place.
+   * @internal
+   */
+  public _claim(key: string, type: AssetConstructor, source: string, claimer: symbol): void {
+    let entry = this._claims.get(key);
+
+    if (entry === undefined) {
+      entry = { scopes: new Set<symbol>(), type, source };
+      this._claims.set(key, entry);
+    }
+
+    entry.scopes.add(claimer);
+
+    if (this._evicted.has(key)) {
+      this._evicted.delete(key);
+
+      // The handle was re-armed to 'loading' during eviction; just re-drive the fetch.
+      if (this._seamlessAdapters.has(type)) {
+        this._startSeamlessFetch(type, source, this._deferred.get(key)?.options);
+      }
+    }
+  }
+
+  /**
+   * Drop a claim scope from a key; when the last scope releases, evict the
+   * payload immediately (refcount 0).
+   * @internal
+   */
+  public _release(key: string, claimer: symbol): void {
+    const entry = this._claims.get(key);
+
+    if (entry === undefined) {
+      return;
+    }
+
+    entry.scopes.delete(claimer);
+
+    if (entry.scopes.size === 0) {
+      this._claims.delete(key);
+      this._evictKey(key, entry.type, entry.source);
+    }
+  }
+
+  /**
+   * Free a key's payload while keeping its handle identity: find the handle
+   * (post-fill in `_resources`, or in-flight in `_deferred`), adapter-evict it
+   * (drops payload + re-arms to 'loading'), remove the stored resource, and
+   * re-register the handle in `_deferred` so the next claim heals in place.
+   * Also drops a not-yet-started background-queue entry. Seamless payloads only
+   * this slice — value-ref eviction is an accepted gap (§6 follow-up).
+   * @internal
+   */
+  private _evictKey(key: string, type: AssetConstructor, source: string): void {
+    const adapter = this._seamlessAdapters.get(type);
+    // A still-deferred handle means the fetch is in flight and has not filled
+    // yet: leave it to the running fetch (which completes and fills the — now
+    // unclaimed — handle; §4.7 minimal). Only a payload that already converged
+    // into `_resources` is dropped in place here.
+    const deferred = this._deferred.get(key);
+    const handle = deferred?.handle ?? this._resources.get(type)?.get(source);
+
+    if (adapter !== undefined && deferred === undefined && handle !== undefined) {
+      adapter.evict(handle);
+      this._resources.get(type)?.delete(source);
+      // The original options were consumed when the payload converged into
+      // `_resources` (the pre-fill `_deferred` entry is gone); the re-fetch
+      // re-derives them from the manifest entry, if any.
+      this._deferred.set(key, { handle, options: undefined });
+      this._handleKeys.set(handle as object, key);
+      this._evicted.add(key);
+      // A load that just settled may leave a resolved-but-not-yet-cleaned
+      // in-flight entry (its `.finally` cleanup is a pending microtask). Drop it
+      // so the reclaim's re-fetch starts fresh instead of deduping onto the
+      // stale promise, which would never re-fill the re-armed handle.
+      this._inFlight.delete(key);
+    }
+
+    // Drop a not-yet-started background entry (only possible while still queued;
+    // once _startBackgroundEntry ran it is in _inFlight and cannot be cancelled).
+    const queued = this._backgroundQueue.findIndex(entry => this._key(entry.type, entry.alias) === key);
+
+    if (queued !== -1) {
+      this._backgroundQueue.splice(queued, 1);
+    }
   }
 
   private async _loadSingle(type: AssetConstructor, alias: string, options?: unknown, explicitPath?: string): Promise<unknown> {
@@ -1656,7 +1839,11 @@ export class Loader {
     return this._waitForBackgroundEntry(type, alias);
   }
 
-  private _createLoadingQueue<T>(items: Array<{ alias: string; asset: Asset<unknown> }>, buildResult: (results: Map<string, unknown>) => T): LoadingQueue<T> {
+  private _createLoadingQueue<T>(
+    claimer: symbol,
+    items: Array<{ alias: string; asset: Asset<unknown> }>,
+    buildResult: (results: Map<string, unknown>) => T,
+  ): LoadingQueue<T> {
     const results = new Map<string, unknown>();
     let notifyFn: ((success: boolean) => void) | null = null;
 
@@ -1677,6 +1864,8 @@ export class Loader {
           },
         );
       }
+
+      this._claim(this._key(ctor, alias), ctor, alias, claimer);
 
       return this._loadSingleAsset(ctor, alias, asset).then(
         resource => {

--- a/src/resources/coreAssetBindings.ts
+++ b/src/resources/coreAssetBindings.ts
@@ -20,7 +20,7 @@ import { XmlFactory } from '#resources/factories/XmlFactory';
 
 import type { AssetConstructor } from './FactoryRegistry';
 import type { AssetLoaderContext, Loader } from './Loader';
-import { type SeamlessAdapter, textureSeamlessAdapter } from './seamless';
+import { type SeamlessAdapter, soundSeamlessAdapter, textureSeamlessAdapter } from './seamless';
 import { BinaryAsset, CsvAsset, FontAsset, ImageAsset, Json, SubtitleAsset, SvgAsset, TextAsset, WasmAsset, XmlAsset } from './tokens';
 
 // ---------------------------------------------------------------------------
@@ -111,7 +111,7 @@ const textureBinding = binding(
 
 const soundBinding = binding(
   Sound,
-  { typeNames: ['sound'] },
+  { typeNames: ['sound'], extensions: ['ogg', 'mp3', 'wav', 'm4a', 'aac'], seamless: soundSeamlessAdapter },
   binaryFactoryHandler(() => new SoundFactory()),
 );
 

--- a/src/resources/seamless.ts
+++ b/src/resources/seamless.ts
@@ -1,3 +1,4 @@
+import { Sound } from '#audio/Sound';
 import type { LoadStateValue } from '#core/LoadState';
 import { logger } from '#core/logging';
 import { Texture } from '#rendering/texture/Texture';
@@ -29,6 +30,8 @@ export interface SeamlessAdapter<T> {
   fill(handle: T, donor: T): void;
   /** Show the error payload on the handle and settle `'failed'`. */
   fail(handle: T, error: Error): void;
+  /** Drop the payload back to a placeholder in place (refcount-0 eviction); identity is kept so a later fill heals every consumer. */
+  evict(handle: T): void;
   /** Current load state of the handle. */
   stateOf(handle: T): LoadStateValue;
 }
@@ -87,7 +90,54 @@ export const textureSeamlessAdapter: SeamlessAdapter<Texture> = {
     handle._loadState.fail(error);
   },
 
+  evict(handle: Texture): void {
+    presizes.delete(handle);
+    handle.setSource(null); // frees the GPU upload via the version bump in updateSource()
+    handle._loadState.begin();
+  },
+
   stateOf(handle: Texture): LoadStateValue {
+    return handle.loadState;
+  },
+};
+
+/**
+ * Seamless adapter for {@link Sound}: placeholder is a bufferless Sound;
+ * fill transplants the decoded {@link AudioBuffer} in place via `_setBuffer`;
+ * fail leaves the handle bufferless (play() renders silence + warns);
+ * evict drops the buffer back to placeholder for a later heal.
+ * @internal
+ */
+export const soundSeamlessAdapter: SeamlessAdapter<Sound> = {
+  createPlaceholder(): Sound {
+    const handle = new Sound(null);
+    handle._loadState.begin();
+    return handle;
+  },
+
+  begin(handle: Sound): void {
+    handle._loadState.begin();
+  },
+
+  fill(handle: Sound, donor: Sound): void {
+    if (donor.audioBuffer === null) {
+      throw new Error('soundSeamlessAdapter.fill: donor has no decoded buffer.');
+    }
+    handle._setBuffer(donor.audioBuffer);
+    handle._loadState.settle(handle);
+  },
+
+  fail(handle: Sound, error: Error): void {
+    handle._evictBuffer();
+    handle._loadState.fail(error);
+  },
+
+  evict(handle: Sound): void {
+    handle._evictBuffer();
+    handle._loadState.begin();
+  },
+
+  stateOf(handle: Sound): LoadStateValue {
     return handle.loadState;
   },
 };

--- a/test/audio/sound-seamless.test.ts
+++ b/test/audio/sound-seamless.test.ts
@@ -1,0 +1,45 @@
+import { Sound } from '#audio/Sound';
+import { LoadState } from '#core/LoadState';
+
+function bufferStub(duration = 2): AudioBuffer {
+  return { duration } as AudioBuffer;
+}
+
+describe('Sound seamless surface', () => {
+  test('a directly constructed Sound is ready with its buffer', () => {
+    const sound = new Sound(bufferStub(3));
+    expect(sound.loadState).toBe('ready');
+    expect(sound.audioBuffer?.duration).toBe(3);
+    expect(sound.duration).toBe(3);
+  });
+
+  test('a null-placeholder Sound has no buffer and zero duration', () => {
+    const sound = new Sound(null);
+    expect(sound.audioBuffer).toBeNull();
+    expect(sound.duration).toBe(0);
+  });
+
+  test('_setBuffer transplants the payload in place and resets the clip window', () => {
+    const sound = new Sound(null);
+    sound._setBuffer(bufferStub(5));
+    expect(sound.audioBuffer?.duration).toBe(5);
+    expect(sound.duration).toBe(5);
+  });
+
+  test('_evictBuffer drops the payload back to placeholder', () => {
+    const sound = new Sound(bufferStub(4));
+    sound._evictBuffer();
+    expect(sound.audioBuffer).toBeNull();
+    expect(sound.duration).toBe(0);
+  });
+
+  test('clip() throws on an unloaded Sound', () => {
+    const sound = new Sound(null);
+    expect(() => sound.clip(0, 1)).toThrow(/not.*loaded/i);
+  });
+
+  test('has a reusable LoadState', () => {
+    const sound = new Sound(null);
+    expect(sound._loadState).toBeInstanceOf(LoadState);
+  });
+});

--- a/test/audio/sound-seamless.test.ts
+++ b/test/audio/sound-seamless.test.ts
@@ -1,5 +1,8 @@
+import { AudioManager } from '#audio/AudioManager';
+import { NoopVoice } from '#audio/NoopVoice';
 import { Sound } from '#audio/Sound';
 import { LoadState } from '#core/LoadState';
+import { logger, LogSeverity } from '#core/logging';
 
 function bufferStub(duration = 2): AudioBuffer {
   return { duration } as AudioBuffer;
@@ -41,5 +44,57 @@ describe('Sound seamless surface', () => {
   test('has a reusable LoadState', () => {
     const sound = new Sound(null);
     expect(sound._loadState).toBeInstanceOf(LoadState);
+  });
+});
+
+describe('Sound.play before load', () => {
+  afterEach(() => logger._resetOnce());
+
+  test('playing a loading sound returns NoopVoice and warns "not yet loaded"', () => {
+    const warnings: string[] = [];
+    const removeSink = logger.addSink(e => {
+      if (e.severity === LogSeverity.Warning) warnings.push(e.message);
+    });
+    try {
+      const manager = new AudioManager();
+      const sound = new Sound(null);
+      sound._loadState.begin(); // -> 'loading'
+      const voice = sound._createVoice(manager, {});
+      expect(voice).toBeInstanceOf(NoopVoice);
+      expect(warnings.some(m => /not yet loaded/i.test(m))).toBe(true);
+    } finally {
+      removeSink();
+    }
+  });
+
+  test('playing a failed sound returns NoopVoice, warns "failed", and does not re-fetch', () => {
+    const warnings: string[] = [];
+    const removeSink = logger.addSink(e => {
+      if (e.severity === LogSeverity.Warning) warnings.push(e.message);
+    });
+    try {
+      const manager = new AudioManager();
+      const sound = new Sound(null);
+      sound._loadState.fail(new Error('boom'));
+      const voice = sound._createVoice(manager, {});
+      expect(voice).toBeInstanceOf(NoopVoice);
+      expect(warnings.some(m => /failed to load/i.test(m))).toBe(true);
+    } finally {
+      removeSink();
+    }
+  });
+
+  test('a sprite replayed after eviction returns NoopVoice, not a throw', () => {
+    const manager = new AudioManager();
+    const sound = new Sound(bufferStub(4));
+    sound.defineSprite('hit', { start: 0, end: 1 }); // defined while loaded
+    sound._evictBuffer();
+    sound._loadState.begin(); // evicted -> loading
+
+    let voice: unknown;
+    expect(() => {
+      voice = sound._createSpriteVoice(manager, 'hit', {});
+    }).not.toThrow();
+    expect(voice).toBeInstanceOf(NoopVoice);
   });
 });

--- a/test/core/scene-loader.test.ts
+++ b/test/core/scene-loader.test.ts
@@ -1,0 +1,78 @@
+import { Sound } from '#audio/Sound';
+import type { Application } from '#core/Application';
+import { Scene } from '#core/Scene';
+import { materializeAssetBindings } from '#extensions/materialize';
+import { coreAssetBindings } from '#resources/coreAssetBindings';
+import { Loader } from '#resources/Loader';
+
+// SoundFactory.create() decodes bytes via the shared OfflineAudioContext
+// (`decodeAudioData` from '#audio/audio-context'). jsdom has no real audio
+// decoder, so the module is mocked wholesale — mirrors test/resources/loader-claims.test.ts.
+// `vi.mock` factories are hoisted above imports, so the mock function must be
+// created via `vi.hoisted()` to be referenced safely inside the factory below.
+const { decodeAudioDataMock } = vi.hoisted(() => ({
+  decodeAudioDataMock: vi.fn(async (): Promise<AudioBuffer> => ({ duration: 2 }) as AudioBuffer),
+}));
+
+vi.mock('#audio/audio-context', () => ({
+  decodeAudioData: decodeAudioDataMock,
+}));
+
+const originalFetch = global.fetch;
+
+function mockFetchAudio(): void {
+  global.fetch = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    arrayBuffer: async () => new ArrayBuffer(8),
+  })) as unknown as typeof fetch;
+}
+
+/** Minimal Application harness exposing a real Loader (mirrors test/ui/scene-ui.test.ts's fake-app pattern). */
+function makeAppWithAudio(): { app: Application; fetchMock: typeof fetch } {
+  mockFetchAudio();
+  const loader = new Loader();
+  materializeAssetBindings(loader, coreAssetBindings);
+  const app = { loader } as unknown as Application;
+
+  return { app, fetchMock: global.fetch };
+}
+
+describe('Scene.loader', () => {
+  afterEach(() => {
+    decodeAudioDataMock.mockClear();
+    global.fetch = originalFetch;
+  });
+
+  test('throws before the scene is attached', () => {
+    const scene = new Scene();
+    expect(() => scene.loader).toThrow(/attached/i);
+  });
+
+  test('get() through this.loader claims under the scene scope', async () => {
+    const { app } = makeAppWithAudio();
+    const scene = new Scene();
+    scene.app = app;
+
+    const handle = scene.loader.get(Sound, 'boom.ogg');
+    await handle.loaded;
+    expect(handle.audioBuffer).not.toBeNull();
+
+    // app-level release must NOT free it — the scene holds the claim.
+    app.loader.release(handle);
+    expect(handle.audioBuffer).not.toBeNull();
+  });
+
+  test('destroying the scene releases its claims (refcount 0 → evict)', async () => {
+    const { app } = makeAppWithAudio();
+    const scene = new Scene();
+    scene.app = app;
+    const handle = scene.loader.get(Sound, 'boom.ogg');
+    await handle.loaded;
+
+    scene.destroy(); // _disposal.destroy() → SceneLoader.destroy() → release all
+    expect(handle.audioBuffer).toBeNull();
+    expect(handle.loadState).toBe('loading');
+  });
+});

--- a/test/resources/loader-claims.test.ts
+++ b/test/resources/loader-claims.test.ts
@@ -66,3 +66,70 @@ describe('seamless Sound', () => {
     expectTypeOf(loader.get('music/track.mp3')).toEqualTypeOf<Sound>();
   });
 });
+
+describe('refcount / claims', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'AudioContext',
+      vi.fn(() => ({ decodeAudioData: async () => ({ duration: 2 }) as AudioBuffer })),
+    );
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async () => ({ width: 16, height: 16 })),
+    );
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    global.fetch = originalFetch;
+  });
+
+  test('app.loader.get claims under app lifetime; release() at refcount 0 evicts the payload', async () => {
+    mockFetchAudio();
+    const loader = createCoreLoader();
+    const handle = loader.get(Sound, 'boom.ogg');
+    await handle.loaded;
+    expect(handle.audioBuffer).not.toBeNull();
+
+    loader.release(handle); // refcount 0 → evict
+    expect(handle.audioBuffer).toBeNull();
+    expect(handle.loadState).toBe('loading');
+  });
+
+  test('claiming again re-fetches into the SAME handle (in-place heal)', async () => {
+    mockFetchAudio();
+    const loader = createCoreLoader();
+    const handle = loader.get(Sound, 'boom.ogg');
+    await handle.loaded;
+    loader.release(handle);
+    expect(handle.audioBuffer).toBeNull();
+
+    const again = loader.get(Sound, 'boom.ogg');
+    expect(again).toBe(handle); // identity preserved
+    await handle.loaded;
+    expect(handle.audioBuffer).not.toBeNull();
+  });
+
+  test('a not-yet-started background entry is dropped from the queue at refcount 0', async () => {
+    mockFetchAudio();
+    const loader = createCoreLoader();
+    loader.backgroundLoad(Sound, ['a.ogg', 'b.ogg', 'c.ogg']); // some remain queued behind the concurrency cap
+    // release one that is still queued
+    loader.release(Sound, 'c.ogg');
+    expect(loader['_isQueuedInBackground'](Sound, 'c.ogg')).toBe(false);
+  });
+
+  test('two distinct claim scopes keep the payload until both release', async () => {
+    mockFetchAudio();
+    const loader = createCoreLoader();
+    const scopeA = Symbol('A');
+    const scopeB = Symbol('B');
+    const handle = loader._getClaimed(scopeA, Sound, 'boom.ogg') as Sound;
+    loader._getClaimed(scopeB, Sound, 'boom.ogg');
+    await handle.loaded;
+
+    loader._release(loader['_key'](Sound, 'boom.ogg'), scopeA);
+    expect(handle.audioBuffer).not.toBeNull(); // B still holds it
+    loader._release(loader['_key'](Sound, 'boom.ogg'), scopeB);
+    expect(handle.audioBuffer).toBeNull(); // both gone → evicted
+  });
+});

--- a/test/resources/loader-claims.test.ts
+++ b/test/resources/loader-claims.test.ts
@@ -1,0 +1,68 @@
+import { expectTypeOf } from 'vitest';
+
+import { Sound } from '#audio/Sound';
+import { materializeAssetBindings } from '#extensions/materialize';
+import { coreAssetBindings } from '#resources/coreAssetBindings';
+import { Loader } from '#resources/Loader';
+
+/** Loader with all core asset bindings (mirrors createCoreLoader in loader-seamless.test.ts). */
+function createCoreLoader(): Loader {
+  const loader = new Loader();
+  materializeAssetBindings(loader, coreAssetBindings);
+  return loader;
+}
+
+// SoundFactory.create() decodes bytes via the shared OfflineAudioContext
+// (`decodeAudioData` from '#audio/audio-context'). jsdom has no real audio
+// decoder, so the module is mocked wholesale — mirroring the `{ duration }`
+// AudioBuffer stub used by test/resources/sound-factory.test.ts. `vi.mock`
+// factories are hoisted above imports, so the mock function must be created
+// via `vi.hoisted()` to be referenced safely inside the factory below.
+const { decodeAudioDataMock } = vi.hoisted(() => ({
+  decodeAudioDataMock: vi.fn(async (): Promise<AudioBuffer> => ({ duration: 2 }) as AudioBuffer),
+}));
+
+vi.mock('#audio/audio-context', () => ({
+  decodeAudioData: decodeAudioDataMock,
+}));
+
+const originalFetch = global.fetch;
+
+function mockFetchAudio(): void {
+  global.fetch = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    arrayBuffer: async () => new ArrayBuffer(8),
+  })) as unknown as typeof fetch;
+}
+
+describe('seamless Sound', () => {
+  afterEach(() => {
+    decodeAudioDataMock.mockClear();
+    global.fetch = originalFetch;
+  });
+
+  test('get(Sound, src) hands out a deferred, healing Sound', async () => {
+    mockFetchAudio();
+    const loader = createCoreLoader();
+
+    const handle = loader.get(Sound, 'boom.ogg');
+
+    expect(handle).toBeInstanceOf(Sound);
+    expect(handle.loadState).toBe('loading');
+    expect(loader.get(Sound, 'boom.ogg')).toBe(handle); // deduped identity
+
+    await handle.loaded;
+
+    expect(handle.loadState).toBe('ready');
+    expect(handle.duration).toBe(2);
+  });
+
+  test("get('boom.ogg') infers Sound via extension", () => {
+    const loader = createCoreLoader();
+
+    expectTypeOf(loader.get('boom.ogg')).toEqualTypeOf<Sound>();
+    expectTypeOf(loader.get('music/track.mp3')).toEqualTypeOf<Sound>();
+  });
+});

--- a/test/resources/loader-claims.test.ts
+++ b/test/resources/loader-claims.test.ts
@@ -2,6 +2,7 @@ import { expectTypeOf } from 'vitest';
 
 import { Sound } from '#audio/Sound';
 import { materializeAssetBindings } from '#extensions/materialize';
+import { Texture } from '#rendering/texture/Texture';
 import { coreAssetBindings } from '#resources/coreAssetBindings';
 import { Loader, type LoaderOptions } from '#resources/Loader';
 
@@ -137,7 +138,7 @@ describe('refcount / claims', () => {
     expect(handle.audioBuffer).toBeNull(); // both gone → evicted
   });
 
-  test('release while the fetch is still in flight fills the (unclaimed) handle in place', async () => {
+  test('release while the fetch is still in flight frees the handle on arrival (§4.7)', async () => {
     mockFetchAudio();
     const loader = createCoreLoader();
     const key = loader['_key'](Sound, 'boom.ogg');
@@ -147,14 +148,23 @@ describe('refcount / claims', () => {
     expect(loader['_deferred'].has(key)).toBe(true);
     expect(handle.loadState).toBe('loading');
 
+    // Capture .loaded BEFORE the fill so the awaiter holds the promise that the
+    // fill settles (a later read re-materializes a fresh 'loading' promise).
+    const captured = handle.loaded;
+
     // Release before load settles: hits _evictKey's leave-it branch (deferred
     // !== undefined) — it must NOT re-arm or drop the in-flight fetch.
     loader.release(handle);
 
-    await handle.loaded; // the running fetch completes and fills the handle
-    expect(handle.audioBuffer).not.toBeNull();
-    // Identity held: the stored resource is the same handle instance.
-    expect(loader['_resources'].get(Sound as never)?.get('boom.ogg')).toBe(handle);
+    // §4.7 free-on-arrival: the running fetch completes and settles the captured
+    // .loaded (the asset WAS fully there), but because refcount is 0 the payload
+    // is freed immediately on arrival.
+    await captured;
+    expect(handle.audioBuffer).toBeNull();
+    expect(handle.loadState).toBe('loading');
+    // Identity held: the handle is re-registered as a deferred, evicted placeholder.
+    expect(loader['_resources'].get(Sound as never)?.has('boom.ogg')).toBe(false);
+    expect(loader['_deferred'].has(key)).toBe(true);
   });
 
   test('a concurrent load in the reclaim window does not overwrite the healed handle (identity race)', async () => {
@@ -187,5 +197,46 @@ describe('refcount / claims', () => {
     // Identity preserved: still the handle, not a raw donor Sound.
     expect(loader['_resources'].get(Sound as never)?.get('boom.ogg')).toBe(handle);
     expect(handle.audioBuffer).not.toBeNull();
+  });
+
+  test('in-flight arrival at refcount 0 frees immediately but .loaded still resolves (§4.7)', async () => {
+    mockFetchAudio();
+    const loader = createCoreLoader();
+
+    const handle = loader.get(Sound, 'boom.ogg');
+    // Capture the pending .loaded before releasing: this is the promise the fill
+    // settles, so the awaiter observes the completed asset even after eviction.
+    const captured = handle.loaded;
+
+    loader.release(handle); // refcount 0 while the fetch is still in flight
+
+    // The captured promise resolves (the asset WAS fully fetched)…
+    await expect(captured).resolves.toBe(handle);
+    // …but the payload was freed on arrival because nothing claims it.
+    expect(handle.audioBuffer).toBeNull();
+    expect(handle.loadState).toBe('loading');
+  });
+
+  test('release of an unheld key is a no-op (no throw)', () => {
+    const loader = createCoreLoader();
+    expect(() => loader.release(Sound, 'never.ogg')).not.toThrow();
+  });
+
+  test('Texture eviction frees the source and heals on re-get', async () => {
+    mockFetchAudio(); // arrayBuffer response feeds the stubbed createImageBitmap
+    const loader = createCoreLoader();
+
+    const handle = loader.get(Texture, 'x.png');
+    await handle.loaded;
+    expect(handle.source).not.toBeNull();
+
+    loader.release(handle); // refcount 0 → evict in place
+    expect(handle.source).toBeNull();
+    expect(handle.loadState).toBe('loading');
+
+    const again = loader.get(Texture, 'x.png');
+    expect(again).toBe(handle); // identity preserved across the heal
+    await handle.loaded;
+    expect(handle.source).not.toBeNull();
   });
 });

--- a/test/resources/loader-claims.test.ts
+++ b/test/resources/loader-claims.test.ts
@@ -3,11 +3,11 @@ import { expectTypeOf } from 'vitest';
 import { Sound } from '#audio/Sound';
 import { materializeAssetBindings } from '#extensions/materialize';
 import { coreAssetBindings } from '#resources/coreAssetBindings';
-import { Loader } from '#resources/Loader';
+import { Loader, type LoaderOptions } from '#resources/Loader';
 
 /** Loader with all core asset bindings (mirrors createCoreLoader in loader-seamless.test.ts). */
-function createCoreLoader(): Loader {
-  const loader = new Loader();
+function createCoreLoader(options?: LoaderOptions): Loader {
+  const loader = new Loader(options);
   materializeAssetBindings(loader, coreAssetBindings);
   return loader;
 }
@@ -109,13 +109,17 @@ describe('refcount / claims', () => {
     expect(handle.audioBuffer).not.toBeNull();
   });
 
-  test('a not-yet-started background entry is dropped from the queue at refcount 0', async () => {
+  test('a not-yet-started background entry is dropped from the queue at refcount 0', () => {
     mockFetchAudio();
-    const loader = createCoreLoader();
-    loader.backgroundLoad(Sound, ['a.ogg', 'b.ogg', 'c.ogg']); // some remain queued behind the concurrency cap
-    // release one that is still queued
+    // Concurrency 1: only 'a.ogg' goes in flight; 'b'/'c' stay queued so the
+    // eviction queue-drop splice is actually exercised (at the default cap of 6
+    // all three drain synchronously and the queue is already empty).
+    const loader = createCoreLoader({ concurrency: 1 });
+    loader.backgroundLoad(Sound, ['a.ogg', 'b.ogg', 'c.ogg']);
+
+    expect(loader['_isQueuedInBackground'](Sound, 'c.ogg')).toBe(true); // still queued behind the cap
     loader.release(Sound, 'c.ogg');
-    expect(loader['_isQueuedInBackground'](Sound, 'c.ogg')).toBe(false);
+    expect(loader['_isQueuedInBackground'](Sound, 'c.ogg')).toBe(false); // dropped at refcount 0
   });
 
   test('two distinct claim scopes keep the payload until both release', async () => {
@@ -131,5 +135,57 @@ describe('refcount / claims', () => {
     expect(handle.audioBuffer).not.toBeNull(); // B still holds it
     loader._release(loader['_key'](Sound, 'boom.ogg'), scopeB);
     expect(handle.audioBuffer).toBeNull(); // both gone → evicted
+  });
+
+  test('release while the fetch is still in flight fills the (unclaimed) handle in place', async () => {
+    mockFetchAudio();
+    const loader = createCoreLoader();
+    const key = loader['_key'](Sound, 'boom.ogg');
+
+    const handle = loader.get(Sound, 'boom.ogg');
+    // Fetch is in flight: the handle is still deferred, not yet in _resources.
+    expect(loader['_deferred'].has(key)).toBe(true);
+    expect(handle.loadState).toBe('loading');
+
+    // Release before load settles: hits _evictKey's leave-it branch (deferred
+    // !== undefined) — it must NOT re-arm or drop the in-flight fetch.
+    loader.release(handle);
+
+    await handle.loaded; // the running fetch completes and fills the handle
+    expect(handle.audioBuffer).not.toBeNull();
+    // Identity held: the stored resource is the same handle instance.
+    expect(loader['_resources'].get(Sound as never)?.get('boom.ogg')).toBe(handle);
+  });
+
+  test('a concurrent load in the reclaim window does not overwrite the healed handle (identity race)', async () => {
+    mockFetchAudio();
+    const loader = createCoreLoader();
+    const key = loader['_key'](Sound, 'boom.ogg');
+
+    const handle = loader.get(Sound, 'boom.ogg');
+    await handle.loaded;
+    expect(loader['_resources'].get(Sound as never)?.get('boom.ogg')).toBe(handle);
+
+    // Evict: drops the stale in-flight entry (whose .finally is still pending).
+    loader.release(handle);
+    expect(handle.audioBuffer).toBeNull();
+
+    // Reclaim kicks a fresh re-fetch into the same handle and registers a new
+    // in-flight entry. A microtask hop lets the stale first-load `.finally`
+    // fire: without the self-entry guard in _trackInFlight it deletes the
+    // reclaim's live entry, so the concurrent load() below is no longer deduped
+    // and re-enters _loadSingle → a second _dispatchFetch whose raw donor
+    // overwrites the handle in _resources.
+    const again = loader.get(Sound, 'boom.ogg');
+    expect(again).toBe(handle);
+    await Promise.resolve();
+    const concurrent = loader.load(Sound, 'boom.ogg');
+
+    await handle.loaded;
+    await concurrent;
+
+    // Identity preserved: still the handle, not a raw donor Sound.
+    expect(loader['_resources'].get(Sound as never)?.get('boom.ogg')).toBe(handle);
+    expect(handle.audioBuffer).not.toBeNull();
   });
 });

--- a/test/resources/seamless-adapter.test.ts
+++ b/test/resources/seamless-adapter.test.ts
@@ -152,15 +152,37 @@ describe('soundSeamlessAdapter', () => {
     expect(handle.audioBuffer).toBeNull();
     expect(handle.loadState).toBe('loading');
   });
+
+  test('fill throws when the donor carries no decoded buffer', () => {
+    const handle = soundSeamlessAdapter.createPlaceholder();
+    expect(() => soundSeamlessAdapter.fill(handle, new Sound(null))).toThrow('no decoded buffer');
+  });
 });
 
 describe('textureSeamlessAdapter.evict', () => {
-  test('drops the source and re-arms', () => {
+  test('drops the real source and re-arms for a heal', () => {
     const handle = textureSeamlessAdapter.createPlaceholder();
-    // simulate a fill via a donor
-    const donor = textureSeamlessAdapter.createPlaceholder();
-    // (donor needs a real source in a full test; here assert the re-arm contract)
+    const canvas = document.createElement('canvas');
+
+    canvas.width = 16;
+    canvas.height = 16;
+
+    const donor = new Texture(canvas);
+
+    textureSeamlessAdapter.fill(handle, donor);
+
+    // Precondition: a real payload is present after the fill.
+    expect(handle.loadState).toBe('ready');
+    expect(handle.source).toBe(canvas);
+    expect(handle.width).toBe(16);
+    expect(handle.height).toBe(16);
+
     textureSeamlessAdapter.evict(handle);
+
+    // The drop must actually free the source and reset the size — these fail on a no-op evict.
+    expect(handle.source).toBeNull();
+    expect(handle.width).toBe(0);
+    expect(handle.height).toBe(0);
     expect(handle.loadState).toBe('loading');
   });
 });

--- a/test/resources/seamless-adapter.test.ts
+++ b/test/resources/seamless-adapter.test.ts
@@ -1,6 +1,11 @@
+import { Sound } from '#audio/Sound';
 import { logger, LogSeverity } from '#core/logging';
 import { Texture } from '#rendering/texture/Texture';
-import { textureSeamlessAdapter } from '#resources/seamless';
+import { soundSeamlessAdapter, textureSeamlessAdapter } from '#resources/seamless';
+
+function bufferStub(duration = 2): AudioBuffer {
+  return { duration } as AudioBuffer;
+}
 
 describe('textureSeamlessAdapter', () => {
   test("createPlaceholder returns an empty 'loading' texture", () => {
@@ -113,5 +118,49 @@ describe('textureSeamlessAdapter', () => {
     } finally {
       removeSink();
     }
+  });
+});
+
+describe('soundSeamlessAdapter', () => {
+  test('createPlaceholder yields a loading Sound with no buffer', () => {
+    const handle = soundSeamlessAdapter.createPlaceholder();
+    expect(handle).toBeInstanceOf(Sound);
+    expect(handle.loadState).toBe('loading');
+    expect(handle.audioBuffer).toBeNull();
+  });
+
+  test('fill transplants the donor buffer in place and settles ready', async () => {
+    const handle = soundSeamlessAdapter.createPlaceholder();
+    const donor = new Sound(bufferStub(3));
+    soundSeamlessAdapter.fill(handle, donor);
+    expect(handle.loadState).toBe('ready');
+    expect(handle.duration).toBe(3);
+    await expect(handle.loaded).resolves.toBe(handle);
+  });
+
+  test('fail settles failed and .loaded rejects', async () => {
+    const handle = soundSeamlessAdapter.createPlaceholder();
+    soundSeamlessAdapter.fail(handle, new Error('nope'));
+    expect(handle.loadState).toBe('failed');
+    await expect(handle.loaded).rejects.toThrow('nope');
+  });
+
+  test('evict drops the payload and re-arms for a heal', () => {
+    const handle = soundSeamlessAdapter.createPlaceholder();
+    soundSeamlessAdapter.fill(handle, new Sound(bufferStub(3)));
+    soundSeamlessAdapter.evict(handle);
+    expect(handle.audioBuffer).toBeNull();
+    expect(handle.loadState).toBe('loading');
+  });
+});
+
+describe('textureSeamlessAdapter.evict', () => {
+  test('drops the source and re-arms', () => {
+    const handle = textureSeamlessAdapter.createPlaceholder();
+    // simulate a fill via a donor
+    const donor = textureSeamlessAdapter.createPlaceholder();
+    // (donor needs a real source in a full test; here assert the re-arm contract)
+    textureSeamlessAdapter.evict(handle);
+    expect(handle.loadState).toBe('loading');
   });
 });


### PR DESCRIPTION
## Asset System v2 — Slice 3 (seamless Sound + refcount/claims + `this.loader`)

Completes **Schicht 1** of the seamless asset system (spec §4.2/§4.3/§4.7). Continues #261 (slice 0+1) and #263 (slice 2). Built subagent-driven, TDD, per-task reviewed; whole-branch review verdict **Ready to merge**.

### What's delivered
- **Sound is now seamless.** Mutable/nullable buffer + `_setBuffer`/`_evictBuffer`, `LoadState<Sound>` + `.loaded`, `null` placeholder, `clip()` throws until loaded. `loader.get(Sound, 'boom.ogg')` hands out a deferred handle that "pops in" when decoded; `ogg/mp3/wav/m4a/aac` extension inference (`get('boom.ogg')` → `Sound`).
- **`play()` before load renders silence** (`NoopVoice`) with a differentiated warning ("not yet loaded" vs "failed to load") on **both** the main and sprite voice paths.
- **`soundSeamlessAdapter`** + a new `evict()` method on the `SeamlessAdapter` interface (+ `textureSeamlessAdapter.evict`).
- **Refcount / claims subsystem** on the Loader: assets are claimed per scope (a `symbol`); the base loader claims under an app-lifetime root scope. When the last scope releases a key, its payload is evicted (CPU + GPU freed) **while the handle identity is kept** — dangling references show the placeholder again and **heal in place** on the next claim. Queue-drop of not-yet-started background entries at refcount 0. Public `loader.release(handle)` / `release(type, source)`.
- **Scene-scoped `this.loader`** — a claim view over the app loader; assets claimed via `scene.loader.get/load(…)` auto-release when the scene is destroyed (no manual asset cleanup). App-lifetime assets stay on `app.loader`.
- **§4.7 free-on-arrival** — an in-flight fetch whose last claim was released mid-flight completes (`.loaded` still resolves — the asset *was* there) but frees its payload immediately, so "background-load then abandon" doesn't leak. Gated so legitimate bundle/container stores are never touched.

### Breaking changes (pre-1.0, clean)
- `Sound.audioBuffer` getter widens to `AudioBuffer | null` (placeholder handles have no buffer yet).
- `Sound.play()` on an unloaded/failed sound returns a `NoopVoice` (was: constructed with a decoded buffer only).
- `get(Type, source)` on a now-seamless type (Sound, like Texture) returns a `'loading'` placeholder + fetches instead of throwing "missing resource" (documented — a bare-alias typo can 404 quietly).

### Explicitly out of scope
- **`Scene.load()` removal (§4.4) is deferred.** Whether `load()` is truly vestigial is decided at the **§5.4 checkpoint** with real ported code (2–3 example scenes on `get()`/`this.loader`), not up front.
- Value-ref (`AssetRef`) eviction — accepted gap (§6 follow-up); refs are claim-tracked but their (cheap) value isn't freed.
- The §4.2 locked-context NoopVoice branch — deliberately not built (Sound schedules fine on a suspended `AudioContext`).
- Graph / `Assets.from` (Slice 4), bundles/manifest/alias removal (Slice 5), real fetch-abort/`cancel()` (§4.7 follow-up).

### Follow-ups (logged, non-blocking)
- Handle bookkeeping grows monotonically with unique-source count over an app's lifetime (payloads are reclaimed; identity-stable handles are retained) — wants a heal-window / weak-retention policy.
- `SceneLoader` copies Loader's `get`/`load`/`backgroundLoad` overloads with no compiler tie — drift risk when Loader's signatures change (top post-merge follow-up).
- `release(handle)` is a no-op for non-seamless legacy assets (use `release(type, source)`) — documented.
- Background-load-then-abandon without a prior `get()` still stores at refcount 0 (indistinguishable from a legitimate bundle store; needs a "was-ever-claimed" signal).

### Verification
- Full suite **6989 passed / 1 skipped**; `typecheck` + `typecheck:examples` + `typecheck:guides` + `lint` + `docs:api:check` + `format:check` all green.
- Whole-branch review traced six claim/evict/heal interleavings coherent; claimer threading complete across all get/load/backgroundLoad forms; ordinary + bundle paths provably unaffected.
