### PR TITLE
feat(rendering): float RenderTexture color formats (both backends) — forward-port of v0.15.3

### DIFF
--- a/site/src/content/api/capture-options.json
+++ b/site/src/content/api/capture-options.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 3,
+  "memberCount": 4,
   "counts": {
     "constructors": 0,
     "methods": 0,
-    "properties": 3,
+    "properties": 4,
     "events": 0
   },
   "sections": [
@@ -52,6 +52,31 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "format",
+          "signature": "format?: ColorTextureFormat",
+          "signatureTokens": [
+            {
+              "text": "format",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ColorTextureFormat",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Color attachment format for the allocated target. Defaults to 'rgba8'. Float formats require EXT_color_buffer_float — check RenderingContext.supportsColorFormat first."
         },
         {
           "name": "height",

--- a/site/src/content/api/render-texture.json
+++ b/site/src/content/api/render-texture.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 33,
+  "memberCount": 34,
   "counts": {
     "constructors": 1,
     "methods": 16,
-    "properties": 16,
+    "properties": 17,
     "events": 0
   },
   "sections": [
@@ -32,7 +32,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(width: number, height: number, options?: Partial<SamplerOptions>): RenderTexture",
+          "signature": "new(width: number, height: number, options?: RenderTextureOptions): RenderTexture",
           "signatureTokens": [
             {
               "text": "new",
@@ -87,20 +87,8 @@
               "kind": "punctuation"
             },
             {
-              "text": "Partial",
+              "text": "RenderTextureOptions",
               "kind": "type"
-            },
-            {
-              "text": "<",
-              "kind": "punctuation"
-            },
-            {
-              "text": "SamplerOptions",
-              "kind": "type"
-            },
-            {
-              "text": ">",
-              "kind": "punctuation"
             },
             {
               "text": ")",
@@ -128,7 +116,7 @@
             },
             {
               "name": "options",
-              "type": "Partial<SamplerOptions>",
+              "type": "RenderTextureOptions",
               "optional": true
             }
           ],
@@ -1023,6 +1011,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "format",
+          "signature": "format: ColorTextureFormat",
+          "signatureTokens": [
+            {
+              "text": "format",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ColorTextureFormat",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Color attachment format, fixed at construction. Defaults to 'rgba8'."
         },
         {
           "name": "generateMipMap",

--- a/site/src/content/api/rendering-context.json
+++ b/site/src/content/api/rendering-context.json
@@ -6,10 +6,10 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 15,
+  "memberCount": 16,
   "counts": {
     "constructors": 1,
-    "methods": 10,
+    "methods": 11,
     "properties": 4,
     "events": 0
   },
@@ -151,7 +151,7 @@
             }
           ],
           "returnType": "RenderTexture",
-          "description": "Renders node into an off-screen RenderTexture and returns it. The View is centered at (width / 2, height / 2) so that the origin of the node's local space sits at the center of the render texture. Saves and restores the active render target and view so the caller's rendering state is undisturbed."
+          "description": ""
         },
         {
           "name": "clear",
@@ -560,6 +560,53 @@
           ],
           "returnType": "void",
           "description": "Resize the camera and screen view to match new canvas dimensions. Preserves the camera's center and zoom; only the visible area size changes."
+        },
+        {
+          "name": "supportsColorFormat",
+          "signature": "supportsColorFormat(format: ColorTextureFormat): boolean",
+          "signatureTokens": [
+            {
+              "text": "supportsColorFormat",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "format",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ColorTextureFormat",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "format",
+              "type": "ColorTextureFormat",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "description": "Whether a RenderTexture of the given color format can be rendered into on the active backend. 'rgba8' is always supported; the float formats ('rgba16f' / 'rgba32f') require hardware/extension support (WebGL2 EXT_color_buffer_float). Check this before allocating a float target and fall back to 'rgba8' yourself if unsupported — the engine throws rather than silently producing a broken target."
         },
         {
           "name": "trackView",

--- a/src/rendering/RenderBackend.ts
+++ b/src/rendering/RenderBackend.ts
@@ -5,6 +5,7 @@ import type { Geometry } from '#rendering/geometry/Geometry';
 import type { Mesh } from '#rendering/mesh/Mesh';
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { Texture } from '#rendering/texture/Texture';
+import type { ColorTextureFormat } from '#rendering/types';
 
 import type { BackendRenderPass } from './BackendRenderPass';
 import type { Drawable } from './Drawable';
@@ -78,6 +79,13 @@ export interface RenderBackend {
    * level (or disabling the stencil test at the outermost level).
    */
   popStencilClip(): this;
+
+  /**
+   * Whether a {@link RenderTexture} of the given color format can be rendered
+   * into on this backend/context. `'rgba8'` is always supported; float formats
+   * depend on hardware/extension support. Check before allocating a float target.
+   */
+  supportsColorFormat(format: ColorTextureFormat): boolean;
 
   acquireRenderTexture(width: number, height: number): RenderTexture;
   releaseRenderTexture(texture: RenderTexture): this;

--- a/src/rendering/RenderingContext.ts
+++ b/src/rendering/RenderingContext.ts
@@ -9,6 +9,7 @@ import type { RenderPassCoordinatorHost } from '#rendering/pass/RenderPassCoordi
 import { StencilAttachmentMode } from '#rendering/pass/RenderPassDescriptor';
 import { playRenderTree } from '#rendering/plan/playRenderTree';
 import { RenderTexture } from '#rendering/texture/RenderTexture';
+import type { ColorTextureFormat } from '#rendering/types';
 
 import type { DrawContext, RenderToOptions } from './DrawContext';
 import { type RenderBackend } from './RenderBackend';
@@ -22,6 +23,12 @@ export interface CaptureOptions {
   width: number;
   height: number;
   clearColor?: Color;
+  /**
+   * Color attachment format for the allocated target. Defaults to `'rgba8'`.
+   * Float formats require `EXT_color_buffer_float` — check
+   * {@link RenderingContext.supportsColorFormat} first.
+   */
+  format?: ColorTextureFormat;
 }
 
 export interface RenderOptions {
@@ -221,8 +228,20 @@ export class RenderingContext implements System, DrawContext {
    * Saves and restores the active render target and view so the caller's
    * rendering state is undisturbed.
    */
+  /**
+   * Whether a {@link RenderTexture} of the given color format can be rendered
+   * into on the active backend. `'rgba8'` is always supported; the float formats
+   * (`'rgba16f'` / `'rgba32f'`) require hardware/extension support (WebGL2
+   * `EXT_color_buffer_float`). Check this before allocating a float target and
+   * fall back to `'rgba8'` yourself if unsupported — the engine throws rather
+   * than silently producing a broken target.
+   */
+  public supportsColorFormat(format: ColorTextureFormat): boolean {
+    return this._backend.supportsColorFormat(format);
+  }
+
   public capture(node: RenderNode, options: CaptureOptions): RenderTexture {
-    const target = new RenderTexture(options.width, options.height);
+    const target = new RenderTexture(options.width, options.height, options.format !== undefined ? { format: options.format } : undefined);
     const view = new View(options.width / 2, options.height / 2, options.width, options.height);
     const coordinator = (this._backend as RenderBackend & Partial<RenderPassCoordinatorHost>)._passCoordinator;
 

--- a/src/rendering/texture/RenderTexture.ts
+++ b/src/rendering/texture/RenderTexture.ts
@@ -1,9 +1,21 @@
 import { assert } from '#core/dev';
 import { isPowerOfTwo } from '#math/utils';
 import { RenderTarget } from '#rendering/RenderTarget';
-import { ScaleModes, WrapModes } from '#rendering/types';
+import { type ColorTextureFormat, ScaleModes, WrapModes } from '#rendering/types';
 
 import type { SamplerOptions } from './Sampler';
+
+/** Construction options for {@link RenderTexture}. */
+export interface RenderTextureOptions extends Partial<SamplerOptions> {
+  /**
+   * Color attachment format. Defaults to `'rgba8'` (unchanged 8-bit behaviour).
+   * The float formats (`'rgba16f'` / `'rgba32f'`) allocate a floating-point
+   * offscreen target for rendering values outside `[0, 1]` — they require
+   * `EXT_color_buffer_float` at render time (throws otherwise) and default to
+   * `nearest` sampling. The format is immutable for the texture's lifetime.
+   */
+  format?: ColorTextureFormat;
+}
 
 /**
  * An off-screen render target that can also be sampled as a texture.
@@ -27,21 +39,31 @@ export class RenderTexture extends RenderTarget {
 
   private _source: DataView | null = null;
   private _textureVersion = 0;
+  private readonly _format: ColorTextureFormat;
   private _scaleMode: ScaleModes;
   private _wrapMode: WrapModes;
   private _premultiplyAlpha: boolean;
   private _generateMipMap: boolean;
   private _flipY: boolean;
 
-  public constructor(width: number, height: number, options?: Partial<SamplerOptions>) {
+  public constructor(width: number, height: number, options?: RenderTextureOptions) {
     assert(width > 0 && height > 0, `RenderTexture dimensions must be positive (got ${width}×${height})`);
     super(width, height, false);
 
+    const format = options?.format ?? 'rgba8';
+
+    // Float targets are point-sampled by default: linear filtering of a float
+    // texture requires OES_texture_float_linear, which is not guaranteed. An
+    // explicit `scaleMode` in `options` still overrides this.
+    const defaults: SamplerOptions =
+      format === 'rgba8' ? RenderTexture.defaultSamplerOptions : { ...RenderTexture.defaultSamplerOptions, scaleMode: ScaleModes.Nearest };
+
     const { scaleMode, wrapMode, premultiplyAlpha, generateMipMap, flipY } = {
-      ...RenderTexture.defaultSamplerOptions,
+      ...defaults,
       ...options,
     };
 
+    this._format = format;
     this._scaleMode = scaleMode;
     this._wrapMode = wrapMode;
     this._premultiplyAlpha = premultiplyAlpha;
@@ -56,6 +78,11 @@ export class RenderTexture extends RenderTarget {
 
   public set source(source: DataView | null) {
     this.setSource(source);
+  }
+
+  /** Color attachment format, fixed at construction. Defaults to `'rgba8'`. */
+  public get format(): ColorTextureFormat {
+    return this._format;
   }
 
   public get scaleMode(): ScaleModes {

--- a/src/rendering/types.ts
+++ b/src/rendering/types.ts
@@ -73,6 +73,21 @@ export enum WrapModes {
 }
 
 /**
+ * Color attachment format for an offscreen {@link RenderTexture}.
+ *
+ * - `'rgba8'` — 8-bit fixed-point RGBA (the default; universally supported).
+ * - `'rgba16f'` — half-float RGBA. Stores values outside `[0, 1]` at reduced
+ *   precision; usually enough for feedback/state buffers.
+ * - `'rgba32f'` — full-float RGBA. Highest precision, 16 bytes per pixel.
+ *
+ * The float formats require `EXT_color_buffer_float` to be *rendered into*
+ * (WebGL2). Allocating one on a context without the extension throws at
+ * render-target preparation. Float render targets default to `nearest`
+ * sampling; linear filtering additionally requires `OES_texture_float_linear`.
+ */
+export type ColorTextureFormat = 'rgba8' | 'rgba16f' | 'rgba32f';
+
+/**
  * GPU primitive topology used when issuing draw calls.
  * Values are WebGL2 GLenum constants (e.g. `gl.TRIANGLES`).
  */

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -24,7 +24,7 @@ import { DataTexture, type DataTextureFormat } from '#rendering/texture/DataText
 import { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { Texture } from '#rendering/texture/Texture';
 import { TransformBuffer } from '#rendering/TransformBuffer';
-import { BlendModes } from '#rendering/types';
+import { BlendModes, type ColorTextureFormat } from '#rendering/types';
 import type { View } from '#rendering/View';
 
 import { WebGl2BackdropBlendCompositor } from './WebGl2BackdropBlendCompositor';
@@ -165,6 +165,8 @@ export class WebGl2Backend implements RenderBackend {
 
   private _canvas: HTMLCanvasElement;
   private _contextLost: boolean;
+  /** Whether `EXT_color_buffer_float` is available (float RenderTexture targets are renderable). */
+  private _floatRenderable = false;
   private _renderTarget: RenderTarget;
   private readonly _snapTransform: Matrix = new Matrix();
   private _renderer: Renderer | null = null;
@@ -204,6 +206,10 @@ export class WebGl2Backend implements RenderBackend {
 
     this._context = __DEV__ && debug ? makeWebGl2DebugContext(gl) : gl;
     this._contextLost = this._context.isContextLost();
+
+    // Enable + cache float color-buffer renderability. getExtension() is the
+    // enable call; without it, RGBA16F/RGBA32F are not color-renderable in WebGL2.
+    this._floatRenderable = this._context.getExtension('EXT_color_buffer_float') !== null;
 
     if (this._contextLost) {
       this._restoreContext();
@@ -714,6 +720,16 @@ export class WebGl2Backend implements RenderBackend {
    */
   public _rebindActiveTarget(): void {
     this._bindRenderTarget(this._renderTarget);
+  }
+
+  /**
+   * Whether a {@link RenderTexture} of this color format can be rendered into
+   * on this context. `'rgba8'` is always supported; the float formats require
+   * the `EXT_color_buffer_float` WebGL2 extension. Callers should check this
+   * before allocating a float target and fall back to `'rgba8'` themselves.
+   */
+  public supportsColorFormat(format: ColorTextureFormat): boolean {
+    return format === 'rgba8' || this._floatRenderable;
   }
 
   public acquireRenderTexture(width: number, height: number): RenderTexture {
@@ -1301,6 +1317,12 @@ export class WebGl2Backend implements RenderBackend {
   }
 
   private _prepareRenderTarget(target: RenderTarget): ManagedRenderTargetState {
+    if (target instanceof RenderTexture && target.format !== 'rgba8' && !this._floatRenderable) {
+      throw new Error(
+        `RenderTexture: format '${target.format}' requires the WebGL2 extension 'EXT_color_buffer_float', which this context does not support. Check backend.supportsColorFormat() and fall back to 'rgba8'.`,
+      );
+    }
+
     const state = this._getRenderTargetState(target);
 
     if (target instanceof RenderTexture && state.framebuffer) {
@@ -1475,13 +1497,15 @@ export class WebGl2Backend implements RenderBackend {
 
         gl.pixelStorei(gl.UNPACK_ALIGNMENT, 4);
       } else if (texture instanceof RenderTexture) {
+        const info = webgl2DataTextureFormat(texture.format);
+
         if (state.version === -1 || state.width !== texture.width || state.height !== texture.height || texture.source === null) {
-          gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, texture.width, texture.height, 0, gl.RGBA, gl.UNSIGNED_BYTE, texture.source);
-          this._bookTextureStorage(state, texture, RGBA8_BYTES_PER_PIXEL);
-          this._accountant.recordTextureUpload(texture.width * texture.height * RGBA8_BYTES_PER_PIXEL);
+          gl.texImage2D(gl.TEXTURE_2D, 0, info.internalFormat, texture.width, texture.height, 0, info.format, info.type, texture.source);
+          this._bookTextureStorage(state, texture, info.bytesPerPixel);
+          this._accountant.recordTextureUpload(texture.width * texture.height * info.bytesPerPixel);
         } else {
-          gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, texture.width, texture.height, gl.RGBA, gl.UNSIGNED_BYTE, texture.source);
-          this._accountant.recordTextureUpload(texture.width * texture.height * RGBA8_BYTES_PER_PIXEL);
+          gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, texture.width, texture.height, info.format, info.type, texture.source);
+          this._accountant.recordTextureUpload(texture.width * texture.height * info.bytesPerPixel);
         }
       } else if (texture.source) {
         if (state.version === -1 || state.width !== texture.width || state.height !== texture.height) {
@@ -1572,25 +1596,27 @@ export class WebGl2Backend implements RenderBackend {
 const RGBA8_BYTES_PER_PIXEL = 4;
 
 interface WebGl2DataTextureFormatInfo {
-  readonly internalFormat: number; // gl.R8 / gl.R32F / gl.RGBA8 / gl.RGBA32F
+  readonly internalFormat: number; // gl.R8 / gl.R32F / gl.RGBA8 / gl.RGBA16F / gl.RGBA32F
   readonly format: number; // gl.RED / gl.RGBA
-  readonly type: number; // gl.UNSIGNED_BYTE / gl.FLOAT
+  readonly type: number; // gl.UNSIGNED_BYTE / gl.HALF_FLOAT / gl.FLOAT
   readonly channels: number;
+  readonly bytesPerPixel: number;
 }
 
-// WebGL2RenderingContext is not defined in jsdom; resolve constants from
-// the live gl context instead of the global class so test environments
-// without WebGL2 still load this module.
-function webgl2DataTextureFormat(format: DataTextureFormat): WebGl2DataTextureFormatInfo {
+// Handles both DataTexture (single- and four-channel) and RenderTexture
+// (four-channel color attachment) formats — the four-channel entries overlap.
+function webgl2DataTextureFormat(format: DataTextureFormat | ColorTextureFormat): WebGl2DataTextureFormatInfo {
   const gl = WebGL2RenderingContext;
   switch (format) {
     case 'r8':
-      return { internalFormat: gl.R8, format: gl.RED, type: gl.UNSIGNED_BYTE, channels: 1 };
+      return { internalFormat: gl.R8, format: gl.RED, type: gl.UNSIGNED_BYTE, channels: 1, bytesPerPixel: 1 };
     case 'r32f':
-      return { internalFormat: gl.R32F, format: gl.RED, type: gl.FLOAT, channels: 1 };
+      return { internalFormat: gl.R32F, format: gl.RED, type: gl.FLOAT, channels: 1, bytesPerPixel: 4 };
     case 'rgba8':
-      return { internalFormat: gl.RGBA8, format: gl.RGBA, type: gl.UNSIGNED_BYTE, channels: 4 };
+      return { internalFormat: gl.RGBA8, format: gl.RGBA, type: gl.UNSIGNED_BYTE, channels: 4, bytesPerPixel: 4 };
+    case 'rgba16f':
+      return { internalFormat: gl.RGBA16F, format: gl.RGBA, type: gl.HALF_FLOAT, channels: 4, bytesPerPixel: 8 };
     case 'rgba32f':
-      return { internalFormat: gl.RGBA32F, format: gl.RGBA, type: gl.FLOAT, channels: 4 };
+      return { internalFormat: gl.RGBA32F, format: gl.RGBA, type: gl.FLOAT, channels: 4, bytesPerPixel: 16 };
   }
 }

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -24,7 +24,7 @@ import { RenderTarget } from '#rendering/RenderTarget';
 import { DataTexture, type DataTextureFormat } from '#rendering/texture/DataTexture';
 import { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { Texture } from '#rendering/texture/Texture';
-import type { BlendModes } from '#rendering/types';
+import type { BlendModes, ColorTextureFormat } from '#rendering/types';
 import { ScaleModes, WrapModes } from '#rendering/types';
 import type { View } from '#rendering/View';
 
@@ -224,7 +224,18 @@ export class WebGpuBackend implements RenderBackend {
   }
 
   public get renderTargetFormat(): GPUTextureFormat {
-    return this._renderTarget === this._rootRenderTarget ? this.format : managedTextureFormat;
+    if (this._renderTarget === this._rootRenderTarget) {
+      return this.format;
+    }
+
+    // Offscreen targets carry their own color format (rgba8unorm by default, or a
+    // float format for a float RenderTexture). Renderers key their pipelines on
+    // this, so it must match the bound attachment or WebGPU rejects the draw.
+    if (this._renderTarget instanceof RenderTexture) {
+      return this._getGpuTextureFormat(this._renderTarget);
+    }
+
+    return managedTextureFormat;
   }
 
   public get clearRequested(): boolean {
@@ -639,6 +650,14 @@ export class WebGpuBackend implements RenderBackend {
     };
   }
 
+  public supportsColorFormat(_format: ColorTextureFormat): boolean {
+    // rgba8, rgba16float and rgba32float are all core color-renderable in WebGPU.
+    // (Linear filtering / blending of float32 targets needs the optional
+    // float32-filterable / float32-blendable features, requested at init when
+    // available; float RenderTextures default to nearest, unblended feedback.)
+    return true;
+  }
+
   public acquireRenderTexture(width: number, height: number): RenderTexture {
     for (let index = 0; index < this._temporaryRenderTextures.length; index++) {
       // index is bounded by the array length via the for-loop guard.
@@ -977,7 +996,13 @@ export class WebGpuBackend implements RenderBackend {
     let device: GPUDevice | null;
 
     try {
-      device = await adapter.requestDevice();
+      // rgba16float and rgba32float are both core color-renderable in WebGPU (no
+      // feature needed). Opt into the optional float features the adapter offers
+      // so float32 targets can additionally be linear-sampled / blended when used
+      // that way (float RenderTextures default to nearest, so this is a bonus).
+      const floatFeatures = (['float32-filterable', 'float32-blendable'] as const).filter(feature => adapter.features?.has(feature) ?? false);
+
+      device = await adapter.requestDevice(floatFeatures.length > 0 ? { requiredFeatures: floatFeatures } : undefined);
     } catch (error) {
       throw this._createInitializationError('Failed to request a WebGPU device.', error);
     }
@@ -1473,6 +1498,9 @@ export class WebGpuBackend implements RenderBackend {
       const format: DataTextureFormat = texture.format;
       return webgpuDataTextureFormat(format).gpuFormat;
     }
+    if (texture instanceof RenderTexture) {
+      return webgpuColorTextureFormat(texture.format);
+    }
     return managedTextureFormat;
   }
 
@@ -1681,6 +1709,18 @@ interface WebGpuDataTextureFormatInfo {
   readonly gpuFormat: GPUTextureFormat;
   readonly bytesPerPixel: number;
   readonly channels: number;
+}
+
+/** Map a {@link RenderTexture} color format to its WebGPU render-target format. */
+function webgpuColorTextureFormat(format: ColorTextureFormat): GPUTextureFormat {
+  switch (format) {
+    case 'rgba8':
+      return 'rgba8unorm';
+    case 'rgba16f':
+      return 'rgba16float';
+    case 'rgba32f':
+      return 'rgba32float';
+  }
 }
 
 function webgpuDataTextureFormat(format: DataTextureFormat): WebGpuDataTextureFormatInfo {

--- a/test/rendering/browser/webgl2-render-to-texture.test.ts
+++ b/test/rendering/browser/webgl2-render-to-texture.test.ts
@@ -743,4 +743,72 @@ describe('RenderTo WebGL2 browser', () => {
       backend.destroy();
     }
   });
+
+  test('float RenderTexture round-trips values outside [0,1] (or throws clearly without EXT_color_buffer_float)', async () => {
+    const backend = await createBackend();
+
+    try {
+      expect(backend.supportsColorFormat('rgba8')).toBe(true);
+
+      const floatSupported = backend.supportsColorFormat('rgba32f');
+      const size = 16;
+      const target = new RenderTexture(size, size, { format: 'rgba32f' });
+
+      if (!floatSupported) {
+        // Acceptance #5: without the extension, preparing a float target throws
+        // a clear error rather than yielding an incomplete framebuffer.
+        expect(() => backend.setRenderTarget(target)).toThrow(/EXT_color_buffer_float/);
+        target.destroy();
+        return;
+      }
+
+      // Acceptance #1 + #2: a render-complete float FBO stores values outside
+      // [0, 1] and reads them back within full-float precision.
+      backend.setRenderTarget(target);
+      backend.setView(target.view);
+
+      const gl = backend.context;
+
+      gl.disable(gl.BLEND);
+
+      const vs = gl.createShader(gl.VERTEX_SHADER)!;
+      gl.shaderSource(
+        vs,
+        '#version 300 es\nvoid main() {\n  float x=float((gl_VertexID&1)<<2)-1.0;\n  float y=float((gl_VertexID&2)<<1)-1.0;\n  gl_Position=vec4(x,y,0.0,1.0);\n}',
+      );
+      gl.compileShader(vs);
+
+      const fs = gl.createShader(gl.FRAGMENT_SHADER)!;
+      gl.shaderSource(fs, '#version 300 es\nprecision highp float;\nout vec4 c;\nvoid main(){c=vec4(2.5,-1.0,0.5,3.0);}');
+      gl.compileShader(fs);
+
+      const prog = gl.createProgram()!;
+      gl.attachShader(prog, vs);
+      gl.attachShader(prog, fs);
+      gl.linkProgram(prog);
+      expect(gl.getProgramParameter(prog, gl.LINK_STATUS)).toBe(true);
+      gl.useProgram(prog);
+      gl.viewport(0, 0, size, size);
+      gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+
+      gl.deleteShader(vs);
+      gl.deleteShader(fs);
+      gl.deleteProgram(prog);
+
+      expect(gl.checkFramebufferStatus(gl.FRAMEBUFFER)).toBe(gl.FRAMEBUFFER_COMPLETE);
+
+      const out = new Float32Array(4);
+      gl.readPixels(size / 2, size / 2, 1, 1, gl.RGBA, gl.FLOAT, out);
+
+      expect(out[0]).toBeCloseTo(2.5, 3);
+      expect(out[1]).toBeCloseTo(-1.0, 3);
+      expect(out[2]).toBeCloseTo(0.5, 3);
+      expect(out[3]).toBeCloseTo(3.0, 3);
+
+      backend.setRenderTarget(backend.renderTarget);
+      target.destroy();
+    } finally {
+      backend.destroy();
+    }
+  });
 });

--- a/test/rendering/browser/webgpu-render-to-texture.test.ts
+++ b/test/rendering/browser/webgpu-render-to-texture.test.ts
@@ -9,6 +9,8 @@
 
 import type { Application } from '#core/Application';
 import { Color } from '#core/Color';
+import { Graphics } from '#rendering/primitives/Graphics';
+import { RenderingContext } from '#rendering/RenderingContext';
 import { RenderTexture } from '#rendering/texture/RenderTexture';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
@@ -74,5 +76,47 @@ describe('RenderTo WebGPU browser', () => {
 
     target.destroy();
     backend.destroy();
+  });
+
+  test('float RenderTexture targets are valid render targets on WebGPU (no validation error)', async ctx => {
+    const backend = await setupBackend(ctx);
+    const context = new RenderingContext(backend);
+    const device = backend.device;
+
+    try {
+      // rgba16float and rgba32float are core color-renderable in WebGPU.
+      expect(backend.supportsColorFormat('rgba8')).toBe(true);
+      expect(backend.supportsColorFormat('rgba16f')).toBe(true);
+      expect(backend.supportsColorFormat('rgba32f')).toBe(true);
+
+      // rgba32f: clearing into the float target proves the attachment is valid.
+      device.pushErrorScope('validation');
+      const full = new RenderTexture(32, 32, { format: 'rgba32f' });
+      backend.setRenderTarget(full);
+      backend.clear(new Color(255, 0, 0));
+      backend.setRenderTarget(backend.renderTarget);
+      backend.flush();
+      const clearError = await device.popErrorScope();
+      // Surface the WebGPU message on failure instead of an opaque `GPUValidationError {}`.
+      expect(clearError && `rgba32f clear: ${clearError.message}`).toBeNull();
+
+      // rgba16f: a full engine draw exercises the real render pipeline built for a
+      // float target format — the pipeline's color format must match the pass's.
+      device.pushErrorScope('validation');
+      const half = new RenderTexture(32, 32, { format: 'rgba16f' });
+      const green = new Graphics();
+      green.fillColor = new Color(0, 255, 0);
+      green.drawRectangle(0, 0, 32, 32);
+      context.renderTo(green, { target: half, view: half.view, clear: Color.transparentBlack });
+      backend.flush();
+      const drawError = await device.popErrorScope();
+      expect(drawError && `rgba16f draw: ${drawError.message}`).toBeNull();
+
+      green.destroy();
+      half.destroy();
+      full.destroy();
+    } finally {
+      backend.destroy();
+    }
   });
 });

--- a/test/rendering/texture/render-texture-format.test.ts
+++ b/test/rendering/texture/render-texture-format.test.ts
@@ -1,0 +1,36 @@
+import { RenderTexture } from '#rendering/texture/RenderTexture';
+import { ScaleModes } from '#rendering/types';
+
+describe('RenderTexture color format', () => {
+  test('defaults to rgba8 (unchanged 8-bit behaviour)', () => {
+    expect(new RenderTexture(8, 8).format).toBe('rgba8');
+    expect(new RenderTexture(8, 8, {}).format).toBe('rgba8');
+    expect(new RenderTexture(8, 8, { format: 'rgba8' }).format).toBe('rgba8');
+  });
+
+  test('carries the requested float format', () => {
+    expect(new RenderTexture(8, 8, { format: 'rgba16f' }).format).toBe('rgba16f');
+    expect(new RenderTexture(8, 8, { format: 'rgba32f' }).format).toBe('rgba32f');
+  });
+
+  test('rgba8 keeps the default linear scale mode', () => {
+    expect(new RenderTexture(8, 8).scaleMode).toBe(ScaleModes.Linear);
+    expect(new RenderTexture(8, 8, { format: 'rgba8' }).scaleMode).toBe(ScaleModes.Linear);
+  });
+
+  test('float formats default to nearest sampling (linear needs OES_texture_float_linear)', () => {
+    expect(new RenderTexture(8, 8, { format: 'rgba16f' }).scaleMode).toBe(ScaleModes.Nearest);
+    expect(new RenderTexture(8, 8, { format: 'rgba32f' }).scaleMode).toBe(ScaleModes.Nearest);
+  });
+
+  test('an explicit scaleMode overrides the float nearest default', () => {
+    expect(new RenderTexture(8, 8, { format: 'rgba32f', scaleMode: ScaleModes.Linear }).scaleMode).toBe(ScaleModes.Linear);
+  });
+
+  test('other sampler options still apply on a float target', () => {
+    const rt = new RenderTexture(8, 8, { format: 'rgba16f', generateMipMap: true, flipY: false });
+    expect(rt.format).toBe('rgba16f');
+    expect(rt.generateMipMap).toBe(true);
+    expect(rt.flipY).toBe(false);
+  });
+});


### PR DESCRIPTION
## Forward-port: float RenderTexture color formats (both backends) → 0.16

Ports the v0.15.3 feature (release PR #265, off `release/0.15.x`) onto `main`
(the 0.16 dev line). Same change, docs regenerated as JSON for the 0.16 pipeline.

Adds floating-point offscreen render targets, unblocking multi-pass feedback
effects (velocity/flow fields, HDR accumulators, high-precision trails) that
quantize away on 8-bit intermediates.

- `RenderTexture { format }` option — `'rgba16f'` / `'rgba32f'` alongside the
  default `'rgba8'` (fully backward compatible) + a `format` getter; float
  targets default to `nearest`.
- **Both backends:** WebGL2 (`EXT_color_buffer_float`) and WebGPU (core-renderable
  `rgba16float`/`rgba32float`); fixes a WebGPU `renderTargetFormat` mismatch that
  reported `rgba8unorm` for every offscreen target.
- Capability query `RenderingContext/RenderBackend.supportsColorFormat(format)`;
  `CaptureOptions.format` threads through `capture`. WebGL2 throws clearly on an
  unsupported float format (no silent broken framebuffer).

### Verification
Same as #265: unit; WebGL2 browser float round-trip (real readback); WebGPU
browser float render (validation-error-scoped); node rendering + both browser
lanes; typecheck / lint / format / docs:api all green. `rgba8` unchanged.
