### PR TITLE
feat(rendering): v0.16 Track B Slice 2 — RetainedContainer + GPU container transform

### DIFF
--- a/site/src/content/api/abstract-text.json
+++ b/site/src/content/api/abstract-text.json
@@ -1753,64 +1753,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -1965,27 +1907,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2068,6 +1989,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cullable",
@@ -2306,6 +2285,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "rotation",

--- a/site/src/content/api/animated-sprite.json
+++ b/site/src/content/api/animated-sprite.json
@@ -2333,64 +2333,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -2545,27 +2487,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2648,6 +2569,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cullable",
@@ -3007,6 +2986,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "repeat",

--- a/site/src/content/api/bitmap-text.json
+++ b/site/src/content/api/bitmap-text.json
@@ -1845,64 +1845,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -2057,27 +1999,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2160,6 +2081,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cullable",
@@ -2515,6 +2494,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "rotation",

--- a/site/src/content/api/button.json
+++ b/site/src/content/api/button.json
@@ -2415,64 +2415,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -2627,27 +2569,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2755,6 +2676,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "colors",
@@ -3175,6 +3154,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "right",

--- a/site/src/content/api/container.json
+++ b/site/src/content/api/container.json
@@ -2078,64 +2078,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -2290,27 +2232,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2418,6 +2339,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cullable",
@@ -2677,6 +2656,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "right",

--- a/site/src/content/api/drawable.json
+++ b/site/src/content/api/drawable.json
@@ -1659,64 +1659,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -1871,27 +1813,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -1974,6 +1895,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cullable",
@@ -2212,6 +2191,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "rotation",

--- a/site/src/content/api/graphics.json
+++ b/site/src/content/api/graphics.json
@@ -3589,64 +3589,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -3801,27 +3743,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -3929,6 +3850,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cullable",
@@ -4301,6 +4280,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "right",

--- a/site/src/content/api/htmltext.json
+++ b/site/src/content/api/htmltext.json
@@ -2322,64 +2322,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -2534,27 +2476,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2662,6 +2583,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "css",
@@ -2963,6 +2942,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "ready",

--- a/site/src/content/api/label.json
+++ b/site/src/content/api/label.json
@@ -2436,64 +2436,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -2648,27 +2590,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2776,6 +2697,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cullable",
@@ -3056,6 +3035,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "right",

--- a/site/src/content/api/mesh.json
+++ b/site/src/content/api/mesh.json
@@ -1709,64 +1709,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -1921,27 +1863,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2024,6 +1945,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "colors",
@@ -2423,6 +2402,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "rotation",

--- a/site/src/content/api/nine-slice-sprite.json
+++ b/site/src/content/api/nine-slice-sprite.json
@@ -1954,64 +1954,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -2166,27 +2108,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2302,6 +2223,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cullable",
@@ -2594,6 +2573,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "region",

--- a/site/src/content/api/panel.json
+++ b/site/src/content/api/panel.json
@@ -2415,64 +2415,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -2625,27 +2567,6 @@
           "params": [],
           "returnType": null,
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
-        },
-        {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "tabIndex",
@@ -2818,6 +2739,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "color",
@@ -3140,6 +3119,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "right",

--- a/site/src/content/api/particle-system.json
+++ b/site/src/content/api/particle-system.json
@@ -2432,64 +2432,6 @@
           "description": "Maximum particle count this system will store. Fixed at construction."
         },
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -2770,27 +2712,6 @@
           "description": ""
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "rotations",
           "signature": "rotations: Float32Array",
           "signatureTokens": [
@@ -3041,6 +2962,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cullable",
@@ -3416,6 +3395,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "rotation",

--- a/site/src/content/api/progress-bar.json
+++ b/site/src/content/api/progress-bar.json
@@ -2415,64 +2415,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -2627,27 +2569,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2755,6 +2676,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cornerRadius",
@@ -3077,6 +3056,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "right",

--- a/site/src/content/api/render-node.json
+++ b/site/src/content/api/render-node.json
@@ -1566,64 +1566,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -1778,27 +1720,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -1860,6 +1781,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cullable",
@@ -2077,6 +2056,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "rotation",

--- a/site/src/content/api/repeating-sprite.json
+++ b/site/src/content/api/repeating-sprite.json
@@ -1849,64 +1849,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -2061,27 +2003,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2164,6 +2085,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cullable",
@@ -2549,6 +2528,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "region",

--- a/site/src/content/api/retained-container.json
+++ b/site/src/content/api/retained-container.json
@@ -1,0 +1,3501 @@
+{
+  "title": "RetainedContainer",
+  "description": "A Container that declares its subtree \"mostly static and/or moves as a whole\" (Track B Wave 4). While the subtree is unchanged, its whole previously-collected command range is spliced into the render plan — no walk, no per-child culling, no material keys — and moving the container (or the camera) changes only one per-group GPU matrix instead of touching every descendant. Opt-in at construction; there is no runtime toggle (S2-D1). The existing revision contract (RenderNode.invalidateContent and the automatic bumps on built-in mutation paths) is the entire authoring surface: any mutation inside the subtree drops the retained fragment for one frame. Trade-offs of the group-local space convention (spec §5/§6): descendants resolve group-relative transforms, so hit-testing/`getBounds()` inside the group are group-local; per-child view culling is disabled inside the group (the group is culled as a whole); `pixelSnapMode` snapping operates on group-local coordinates; particle-extension drawables bake their own transforms and are not group-transform-aware. Group-wide fades are done per-drawable tint (the engine has no inherited alpha) or via RenderNode.cacheAsBitmap. Nodes with filters/mask/clip/ cacheAsBitmap are supported as DIRECT children (they stay world-space and re-collect every frame); nesting them deeper DISENGAGES the group — it then renders as an exact plain Container (correct output, no retention) and warns once in dev builds.",
+  "symbol": "RetainedContainer",
+  "kind": "class",
+  "subsystem": "rendering",
+  "importPath": "@codexo/exojs",
+  "tier": "stable",
+  "memberCount": 94,
+  "counts": {
+    "constructors": 1,
+    "methods": 44,
+    "properties": 36,
+    "events": 13
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "A Container that declares its subtree \"mostly static and/or moves as a whole\" (Track B Wave 4). While the subtree is unchanged, its whole previously-collected command range is spliced into the render plan — no walk, no per-child culling, no material keys — and moving the container (or the camera) changes only one per-group GPU matrix instead of touching every descendant.",
+        "Opt-in at construction; there is no runtime toggle (S2-D1). The existing revision contract (RenderNode.invalidateContent and the automatic bumps on built-in mutation paths) is the entire authoring surface: any mutation inside the subtree drops the retained fragment for one frame.",
+        "Trade-offs of the group-local space convention (spec §5/§6): descendants resolve group-relative transforms, so hit-testing/`getBounds()` inside the group are group-local; per-child view culling is disabled inside the group (the group is culled as a whole); `pixelSnapMode` snapping operates on group-local coordinates; particle-extension drawables bake their own transforms and are not group-transform-aware. Group-wide fades are done per-drawable tint (the engine has no inherited alpha) or via RenderNode.cacheAsBitmap. Nodes with filters/mask/clip/ cacheAsBitmap are supported as DIRECT children (they stay world-space and re-collect every frame); nesting them deeper DISENGAGES the group — it then renders as an exact plain Container (correct output, no retention) and warns once in dev builds."
+      ],
+      "importLine": "import { RetainedContainer } from '@codexo/exojs'",
+      "sourceLink": null
+    },
+    {
+      "id": "constructors",
+      "title": "Constructors",
+      "members": [
+        {
+          "name": "new",
+          "signature": "new(): RetainedContainer",
+          "signatureTokens": [
+            {
+              "text": "new",
+              "kind": "keyword"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "RetainedContainer",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": "RetainedContainer",
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "methods",
+      "title": "Methods",
+      "members": [
+        {
+          "name": "_invalidateBoundsCascade",
+          "signature": "_invalidateBoundsCascade(): void",
+          "signatureTokens": [
+            {
+              "text": "_invalidateBoundsCascade",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "void",
+          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
+        },
+        {
+          "name": "_invalidateSubtreeTransform",
+          "signature": "_invalidateSubtreeTransform(): void",
+          "signatureTokens": [
+            {
+              "text": "_invalidateSubtreeTransform",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "void",
+          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
+        },
+        {
+          "name": "_markOwnTransformDirty",
+          "signature": "_markOwnTransformDirty(): void",
+          "signatureTokens": [
+            {
+              "text": "_markOwnTransformDirty",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "void",
+          "description": "Own-transform mutations move the whole group: bump the group-matrix version and refresh ancestor bounds flags (the group's world AABB moved), but do NOT content-dirty the fragment — that decoupling is the entire point of the retained tier (spec §4.3)."
+        },
+        {
+          "name": "_updateOrigin",
+          "signature": "_updateOrigin(): void",
+          "signatureTokens": [
+            {
+              "text": "_updateOrigin",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "void",
+          "description": "Re-derive origin from the fractional anchor and the CURRENT local bounds. Uses local (untransformed) bounds on purpose: the transform multiplies the origin by scale itself, so deriving from world bounds would double-apply scale whenever the anchor is set after scaling. Subclasses whose local bounds change after construction (e.g. a sprite switching to a texture sub-frame) must call this to keep an anchored node anchored."
+        },
+        {
+          "name": "addChild",
+          "signature": "addChild(children: RenderNode[]): this",
+          "signatureTokens": [
+            {
+              "text": "addChild",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "children",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "RenderNode",
+              "kind": "type"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "children",
+              "type": "RenderNode[]",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": "Append one or more children to the end of the child list. Each child is detached from its previous parent (if any) before being added."
+        },
+        {
+          "name": "addChildAt",
+          "signature": "addChildAt(child: RenderNode, index: number): this",
+          "signatureTokens": [
+            {
+              "text": "addChildAt",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "child",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "RenderNode",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "index",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "child",
+              "type": "RenderNode",
+              "optional": false
+            },
+            {
+              "name": "index",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds. Self-as-child is a no-op."
+        },
+        {
+          "name": "addFilter",
+          "signature": "addFilter(filter: Filter): this",
+          "signatureTokens": [
+            {
+              "text": "addFilter",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "filter",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Filter",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "filter",
+              "type": "Filter",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": ""
+        },
+        {
+          "name": "blur",
+          "signature": "blur(): this",
+          "signatureTokens": [
+            {
+              "text": "blur",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "this",
+          "description": "Release keyboard focus from this node if it currently holds it."
+        },
+        {
+          "name": "clearFilters",
+          "signature": "clearFilters(): this",
+          "signatureTokens": [
+            {
+              "text": "clearFilters",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "this",
+          "description": ""
+        },
+        {
+          "name": "collidesWith",
+          "signature": "collidesWith(target: Collidable): CollisionResponse | null",
+          "signatureTokens": [
+            {
+              "text": "collidesWith",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "target",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Collidable",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "CollisionResponse",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "target",
+              "type": "Collidable",
+              "optional": false
+            }
+          ],
+          "returnType": "CollisionResponse | null",
+          "description": "Compute a full CollisionResponse between this shape and target. Returns null in two cases: - the shapes do not overlap, **or** - the specific shape-pair combination does not support response generation (e.g. Line against any shape, Ellipse against Ellipse or Polygon). Use intersectsWith for a universal boolean overlap check that works across all supported shape pairs."
+        },
+        {
+          "name": "contains",
+          "signature": "contains(x: number, y: number): boolean",
+          "signatureTokens": [
+            {
+              "text": "contains",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "x",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "y",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "x",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "y",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "description": "Hit-test the world-space point (x, y) against this node. For world-axis-aligned nodes (own and inherited rotation a multiple of 90° and no skew) the AABB equals the oriented box, so the cheap getBounds test is exact. For rotated or skewed nodes the point is mapped back into local space with the inverse of the global transform and tested against the untransformed getLocalBounds — i.e. a true oriented-box test. This is the exact inverse of the forward map that getBounds and the renderer use to place the node's corners, so picking matches the rendered quad instead of over-reporting hits in the empty AABB corners of a rotated node."
+        },
+        {
+          "name": "destroy",
+          "signature": "destroy(): void",
+          "signatureTokens": [
+            {
+              "text": "destroy",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "void",
+          "description": ""
+        },
+        {
+          "name": "focus",
+          "signature": "focus(): this",
+          "signatureTokens": [
+            {
+              "text": "focus",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "this",
+          "description": "Request keyboard focus for this node through its owning focus service."
+        },
+        {
+          "name": "getBounds",
+          "signature": "getBounds(): Rectangle",
+          "signatureTokens": [
+            {
+              "text": "getBounds",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": "Rectangle",
+          "description": ""
+        },
+        {
+          "name": "getChildAt",
+          "signature": "getChildAt(index: number): RenderNode",
+          "signatureTokens": [
+            {
+              "text": "getChildAt",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "index",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "RenderNode",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "index",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "RenderNode",
+          "description": ""
+        },
+        {
+          "name": "getChildIndex",
+          "signature": "getChildIndex(child: RenderNode): number",
+          "signatureTokens": [
+            {
+              "text": "getChildIndex",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "child",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "RenderNode",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "child",
+              "type": "RenderNode",
+              "optional": false
+            }
+          ],
+          "returnType": "number",
+          "description": ""
+        },
+        {
+          "name": "getGlobalTransform",
+          "signature": "getGlobalTransform(): Matrix",
+          "signatureTokens": [
+            {
+              "text": "getGlobalTransform",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Matrix",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": "Matrix",
+          "description": ""
+        },
+        {
+          "name": "getLocalBounds",
+          "signature": "getLocalBounds(): Rectangle",
+          "signatureTokens": [
+            {
+              "text": "getLocalBounds",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": "Rectangle",
+          "description": ""
+        },
+        {
+          "name": "getNormals",
+          "signature": "getNormals(): Vector[]",
+          "signatureTokens": [
+            {
+              "text": "getNormals",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Vector",
+              "kind": "type"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": "Vector[]",
+          "description": "Return the outward-facing edge normals used by the SAT solver. The array should be cached and reused across calls."
+        },
+        {
+          "name": "getTransform",
+          "signature": "getTransform(): Matrix",
+          "signatureTokens": [
+            {
+              "text": "getTransform",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Matrix",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": "Matrix",
+          "description": ""
+        },
+        {
+          "name": "intersectsWith",
+          "signature": "intersectsWith(target: Collidable): boolean",
+          "signatureTokens": [
+            {
+              "text": "intersectsWith",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "target",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Collidable",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "target",
+              "type": "Collidable",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "description": "Test whether this shape overlaps target using a fast boolean algorithm (no penetration depth or normal computed). Prefer this over collidesWith when only the yes/no result is needed."
+        },
+        {
+          "name": "invalidateCache",
+          "signature": "invalidateCache(): this",
+          "signatureTokens": [
+            {
+              "text": "invalidateCache",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "this",
+          "description": ""
+        },
+        {
+          "name": "invalidateContent",
+          "signature": "invalidateContent(): this",
+          "signatureTokens": [
+            {
+              "text": "invalidateContent",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "this",
+          "description": "Mark this node's visual content dirty without going through a standard setter — e.g. a custom Drawable subclass backed by externally mutable data (the pattern TileChunkNode in @codexo/exojs-tilemap already uses via its own _chunk.revision compare). Call this after mutating such state so the Track-B retained-plan skip does not serve a stale frame for this node."
+        },
+        {
+          "name": "inView",
+          "signature": "inView(view: View): boolean",
+          "signatureTokens": [
+            {
+              "text": "inView",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "view",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "View",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "view",
+              "type": "View",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "description": ""
+        },
+        {
+          "name": "move",
+          "signature": "move(x: number, y: number): this",
+          "signatureTokens": [
+            {
+              "text": "move",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "x",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "y",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "x",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "y",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": ""
+        },
+        {
+          "name": "project",
+          "signature": "project(axis: Vector, result: Interval): Interval",
+          "signatureTokens": [
+            {
+              "text": "project",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "axis",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Vector",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "result",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Interval",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Interval",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "axis",
+              "type": "Vector",
+              "optional": false
+            },
+            {
+              "name": "result",
+              "type": "Interval",
+              "optional": false
+            }
+          ],
+          "returnType": "Interval",
+          "description": "Project this shape onto axis and write the scalar min/max into interval. Used internally by the SAT solver."
+        },
+        {
+          "name": "removeChild",
+          "signature": "removeChild(child: RenderNode): this",
+          "signatureTokens": [
+            {
+              "text": "removeChild",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "child",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "RenderNode",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "child",
+              "type": "RenderNode",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": "Remove child from this container. No-op if not present."
+        },
+        {
+          "name": "removeChildAt",
+          "signature": "removeChildAt(index: number): this",
+          "signatureTokens": [
+            {
+              "text": "removeChildAt",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "index",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "index",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": ""
+        },
+        {
+          "name": "removeChildren",
+          "signature": "removeChildren(begin: number, end: number): this",
+          "signatureTokens": [
+            {
+              "text": "removeChildren",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "begin",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "end",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "begin",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "end",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": "Remove children in the half-open range [begin, end). Defaults to the entire child list. Throws if the range is invalid."
+        },
+        {
+          "name": "removeFilter",
+          "signature": "removeFilter(filter: Filter): this",
+          "signatureTokens": [
+            {
+              "text": "removeFilter",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "filter",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Filter",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "filter",
+              "type": "Filter",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": ""
+        },
+        {
+          "name": "render",
+          "signature": "render(backend: RenderBackend): this",
+          "signatureTokens": [
+            {
+              "text": "render",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "backend",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "RenderBackend",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "backend",
+              "type": "RenderBackend",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": "Raw rendering entry point. Direct backend access — bypasses the RenderPlan pipeline machinery. Prefer the high-level RenderingContext.render path via the owning RenderingContext wherever possible."
+        },
+        {
+          "name": "rotate",
+          "signature": "rotate(degrees: number): this",
+          "signatureTokens": [
+            {
+              "text": "rotate",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "degrees",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "degrees",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": ""
+        },
+        {
+          "name": "setAnchor",
+          "signature": "setAnchor(x: number, y: number): this",
+          "signatureTokens": [
+            {
+              "text": "setAnchor",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "x",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "y",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "x",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "y",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": ""
+        },
+        {
+          "name": "setChildIndex",
+          "signature": "setChildIndex(child: RenderNode, index: number): this",
+          "signatureTokens": [
+            {
+              "text": "setChildIndex",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "child",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "RenderNode",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "index",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "child",
+              "type": "RenderNode",
+              "optional": false
+            },
+            {
+              "name": "index",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": ""
+        },
+        {
+          "name": "setOrigin",
+          "signature": "setOrigin(x: number, y: number): this",
+          "signatureTokens": [
+            {
+              "text": "setOrigin",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "x",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "y",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "x",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "y",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": ""
+        },
+        {
+          "name": "setPosition",
+          "signature": "setPosition(x: number, y: number): this",
+          "signatureTokens": [
+            {
+              "text": "setPosition",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "x",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "y",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "x",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "y",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": ""
+        },
+        {
+          "name": "setRotation",
+          "signature": "setRotation(degrees: number): this",
+          "signatureTokens": [
+            {
+              "text": "setRotation",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "degrees",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "degrees",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": ""
+        },
+        {
+          "name": "setScale",
+          "signature": "setScale(x: number, y: number): this",
+          "signatureTokens": [
+            {
+              "text": "setScale",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "x",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "y",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "x",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "y",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": ""
+        },
+        {
+          "name": "setSkew",
+          "signature": "setSkew(x: number, y: number): this",
+          "signatureTokens": [
+            {
+              "text": "setSkew",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "x",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "y",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "x",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "y",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": ""
+        },
+        {
+          "name": "swapChildren",
+          "signature": "swapChildren(firstChild: RenderNode, secondChild: RenderNode): this",
+          "signatureTokens": [
+            {
+              "text": "swapChildren",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "firstChild",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "RenderNode",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "secondChild",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "RenderNode",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "firstChild",
+              "type": "RenderNode",
+              "optional": false
+            },
+            {
+              "name": "secondChild",
+              "type": "RenderNode",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": ""
+        },
+        {
+          "name": "updateBounds",
+          "signature": "updateBounds(): this",
+          "signatureTokens": [
+            {
+              "text": "updateBounds",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "this",
+          "description": "World AABB of the group: children aggregate in group-local space, so every child rect is lifted by the group's own world matrix (spec §6 — group-local aggregate × group matrix). Barrier-bearing direct children escape the group convention (plan D-P4) and are already world-space."
+        },
+        {
+          "name": "updateParentTransform",
+          "signature": "updateParentTransform(): this",
+          "signatureTokens": [
+            {
+              "text": "updateParentTransform",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "this",
+          "description": ""
+        },
+        {
+          "name": "updateTransform",
+          "signature": "updateTransform(): this",
+          "signatureTokens": [
+            {
+              "text": "updateTransform",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "this",
+          "description": ""
+        },
+        {
+          "name": "setInternalSpriteFactory",
+          "signature": "setInternalSpriteFactory(factory: () => RenderNodeSpriteLike | null): void",
+          "signatureTokens": [
+            {
+              "text": "setInternalSpriteFactory",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "factory",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ") => ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "RenderNodeSpriteLike",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "factory",
+              "type": "() => RenderNodeSpriteLike | null",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "collisionType",
+          "signature": "collisionType: CollisionType",
+          "signatureTokens": [
+            {
+              "text": "collisionType",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "CollisionType",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "cursor",
+          "signature": "cursor: string | null",
+          "signatureTokens": [
+            {
+              "text": "cursor",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "draggable",
+          "signature": "draggable: boolean",
+          "signatureTokens": [
+            {
+              "text": "draggable",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true and interactive is also true, this node will be automatically repositioned to follow the pointer during a drag gesture. The framework captures the pointer offset at drag-start so the node doesn't snap to the cursor position. Both interactive and draggable must be set for dragging to work — a draggable but non-interactive node will never receive pointerdown and therefore cannot start a drag."
+        },
+        {
+          "name": "flags",
+          "signature": "flags: Flags<SceneNodeTransformFlags>",
+          "signatureTokens": [
+            {
+              "text": "flags",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Flags",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "SceneNodeTransformFlags",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "focusable",
+          "signature": "focusable: boolean",
+          "signatureTokens": [
+            {
+              "text": "focusable",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, this node can receive keyboard focus — via focus, Tab traversal, or app.focus.focus(node) — and is delivered key events through onKeyDown / onKeyUp while focused."
+        },
+        {
+          "name": "name",
+          "signature": "name: string | null",
+          "signatureTokens": [
+            {
+              "text": "name",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
+        },
+        {
+          "name": "tabIndex",
+          "signature": "tabIndex: number",
+          "signatureTokens": [
+            {
+              "text": "tabIndex",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Tab-traversal order among focusable nodes in the same focus scope. Lower values are visited first; equal values keep document (tree) order."
+        },
+        {
+          "name": "anchor",
+          "signature": "anchor: ObservableVector",
+          "signatureTokens": [
+            {
+              "text": "anchor",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ObservableVector",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Normalized anchor in 0..1 along each axis that derives origin from the current bounds size. (0, 0) = top-left, (0.5, 0.5) = center, (1, 1) = bottom-right. Updates origin whenever the anchor or the local bounds change."
+        },
+        {
+          "name": "bottom",
+          "signature": "bottom: number",
+          "signatureTokens": [
+            {
+              "text": "bottom",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "cacheAsBitmap",
+          "signature": "cacheAsBitmap: boolean",
+          "signatureTokens": [
+            {
+              "text": "cacheAsBitmap",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "children",
+          "signature": "children: RenderNode[]",
+          "signatureTokens": [
+            {
+              "text": "children",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "RenderNode",
+              "kind": "type"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
+        },
+        {
+          "name": "cullable",
+          "signature": "cullable: boolean",
+          "signatureTokens": [
+            {
+              "text": "cullable",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When false, this node is never culled by the viewport check and is always considered in-view. Defaults to true."
+        },
+        {
+          "name": "cullArea",
+          "signature": "cullArea: Rectangle | null",
+          "signatureTokens": [
+            {
+              "text": "cullArea",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "filters",
+          "signature": "filters: readonly Filter[]",
+          "signatureTokens": [
+            {
+              "text": "filters",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Filter",
+              "kind": "type"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "height",
+          "signature": "height: number",
+          "signatureTokens": [
+            {
+              "text": "height",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "interactive",
+          "signature": "interactive: boolean",
+          "signatureTokens": [
+            {
+              "text": "interactive",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "isAlignedBox",
+          "signature": "isAlignedBox: boolean",
+          "signatureTokens": [
+            {
+              "text": "isAlignedBox",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "left",
+          "signature": "left: number",
+          "signatureTokens": [
+            {
+              "text": "left",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "mask",
+          "signature": "mask: MaskSource",
+          "signatureTokens": [
+            {
+              "text": "mask",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "MaskSource",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "The mask source that controls visibility of this node's render output. See MaskSource for accepted source types and their semantics. Setting to null removes any active mask. Setting a RenderNode that is this is rejected (a node cannot mask itself); other cycles (mask of mask of self) are not detected."
+        },
+        {
+          "name": "origin",
+          "signature": "origin: ObservableVector",
+          "signatureTokens": [
+            {
+              "text": "origin",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ObservableVector",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "parent",
+          "signature": "parent: Container | null",
+          "signatureTokens": [
+            {
+              "text": "parent",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Container",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "position",
+          "signature": "position: ObservableVector",
+          "signatureTokens": [
+            {
+              "text": "position",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ObservableVector",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
+        },
+        {
+          "name": "right",
+          "signature": "right: number",
+          "signatureTokens": [
+            {
+              "text": "right",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "rotation",
+          "signature": "rotation: number",
+          "signatureTokens": [
+            {
+              "text": "rotation",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Rotation angle in degrees. Wraps via trimRotation on assignment."
+        },
+        {
+          "name": "scale",
+          "signature": "scale: ObservableVector",
+          "signatureTokens": [
+            {
+              "text": "scale",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ObservableVector",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "skewX",
+          "signature": "skewX: number",
+          "signatureTokens": [
+            {
+              "text": "skewX",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Horizontal skew angle in degrees. Shears the node along the X axis (positive values lean the top edge right). Combines correctly with rotation and scale."
+        },
+        {
+          "name": "skewY",
+          "signature": "skewY: number",
+          "signatureTokens": [
+            {
+              "text": "skewY",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Vertical skew angle in degrees. Shears the node along the Y axis (positive values lean the left edge downward). Combines correctly with rotation and scale."
+        },
+        {
+          "name": "top",
+          "signature": "top: number",
+          "signatureTokens": [
+            {
+              "text": "top",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "visible",
+          "signature": "visible: boolean",
+          "signatureTokens": [
+            {
+              "text": "visible",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "width",
+          "signature": "width: number",
+          "signatureTokens": [
+            {
+              "text": "width",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "x",
+          "signature": "x: number",
+          "signatureTokens": [
+            {
+              "text": "x",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "y",
+          "signature": "y: number",
+          "signatureTokens": [
+            {
+              "text": "y",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "zIndex",
+          "signature": "zIndex: number",
+          "signatureTokens": [
+            {
+              "text": "zIndex",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "events",
+      "title": "Events",
+      "members": [
+        {
+          "name": "onBlur",
+          "signature": "onBlur: Signal<[RenderNode]>",
+          "signatureTokens": [
+            {
+              "text": "onBlur",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Signal",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "RenderNode",
+              "kind": "type"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Fired when this node loses keyboard focus."
+        },
+        {
+          "name": "onDrag",
+          "signature": "onDrag: Signal<[InteractionEvent]>",
+          "signatureTokens": [
+            {
+              "text": "onDrag",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Signal",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "InteractionEvent",
+              "kind": "type"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Fired on every pointer-move while this node is being dragged. Does not bubble."
+        },
+        {
+          "name": "onDragEnd",
+          "signature": "onDragEnd: Signal<[InteractionEvent]>",
+          "signatureTokens": [
+            {
+              "text": "onDragEnd",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Signal",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "InteractionEvent",
+              "kind": "type"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Fired when the drag gesture ends (pointer-up or cancel). Does not bubble."
+        },
+        {
+          "name": "onDragStart",
+          "signature": "onDragStart: Signal<[InteractionEvent]>",
+          "signatureTokens": [
+            {
+              "text": "onDragStart",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Signal",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "InteractionEvent",
+              "kind": "type"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Fired once when a drag gesture begins on this node. Does not bubble."
+        },
+        {
+          "name": "onFocus",
+          "signature": "onFocus: Signal<[RenderNode]>",
+          "signatureTokens": [
+            {
+              "text": "onFocus",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Signal",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "RenderNode",
+              "kind": "type"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Fired when this node gains keyboard focus."
+        },
+        {
+          "name": "onKeyDown",
+          "signature": "onKeyDown: Signal<[KeyEvent]>",
+          "signatureTokens": [
+            {
+              "text": "onKeyDown",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Signal",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "KeyEvent",
+              "kind": "type"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Fired for each key pressed while this node holds focus."
+        },
+        {
+          "name": "onKeyUp",
+          "signature": "onKeyUp: Signal<[KeyEvent]>",
+          "signatureTokens": [
+            {
+              "text": "onKeyUp",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Signal",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "KeyEvent",
+              "kind": "type"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Fired for each key released while this node holds focus."
+        },
+        {
+          "name": "onPointerDown",
+          "signature": "onPointerDown: Signal<[InteractionEvent]>",
+          "signatureTokens": [
+            {
+              "text": "onPointerDown",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Signal",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "InteractionEvent",
+              "kind": "type"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "onPointerMove",
+          "signature": "onPointerMove: Signal<[InteractionEvent]>",
+          "signatureTokens": [
+            {
+              "text": "onPointerMove",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Signal",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "InteractionEvent",
+              "kind": "type"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "onPointerOut",
+          "signature": "onPointerOut: Signal<[InteractionEvent]>",
+          "signatureTokens": [
+            {
+              "text": "onPointerOut",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Signal",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "InteractionEvent",
+              "kind": "type"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "onPointerOver",
+          "signature": "onPointerOver: Signal<[InteractionEvent]>",
+          "signatureTokens": [
+            {
+              "text": "onPointerOver",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Signal",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "InteractionEvent",
+              "kind": "type"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "onPointerTap",
+          "signature": "onPointerTap: Signal<[InteractionEvent]>",
+          "signatureTokens": [
+            {
+              "text": "onPointerTap",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Signal",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "InteractionEvent",
+              "kind": "type"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "onPointerUp",
+          "signature": "onPointerUp: Signal<[InteractionEvent]>",
+          "signatureTokens": [
+            {
+              "text": "onPointerUp",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Signal",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "InteractionEvent",
+              "kind": "type"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/rendering/RetainedContainer.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/RetainedContainer.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/rendering/RetainedContainer.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/RetainedContainer.ts"
+}

--- a/site/src/content/api/scroll-container.json
+++ b/site/src/content/api/scroll-container.json
@@ -2553,64 +2553,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -2786,27 +2728,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2914,6 +2835,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cullable",
@@ -3194,6 +3173,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "right",

--- a/site/src/content/api/sprite.json
+++ b/site/src/content/api/sprite.json
@@ -1825,64 +1825,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -2037,27 +1979,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2140,6 +2061,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cullable",
@@ -2428,6 +2407,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "rotation",

--- a/site/src/content/api/stack.json
+++ b/site/src/content/api/stack.json
@@ -2491,64 +2491,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -2703,27 +2645,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2831,6 +2752,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cullable",
@@ -3153,6 +3132,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "right",

--- a/site/src/content/api/text.json
+++ b/site/src/content/api/text.json
@@ -1779,64 +1779,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -1991,27 +1933,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2144,6 +2065,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "colorGlyphs",
@@ -2457,6 +2436,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "rotation",

--- a/site/src/content/api/tile-layer-node.json
+++ b/site/src/content/api/tile-layer-node.json
@@ -2150,64 +2150,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -2362,27 +2304,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2490,6 +2411,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cullable",
@@ -2791,6 +2770,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "right",

--- a/site/src/content/api/tile-map-band.json
+++ b/site/src/content/api/tile-map-band.json
@@ -2098,64 +2098,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -2302,27 +2244,6 @@
           "description": "The band name (unique within its owning TileMapView). Narrows the inherited SceneNode.name from string | null to a required string; assigned once at construction."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2430,6 +2351,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cullable",
@@ -2743,6 +2722,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "right",

--- a/site/src/content/api/tile-map-node.json
+++ b/site/src/content/api/tile-map-node.json
@@ -2205,64 +2205,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -2417,27 +2359,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2545,6 +2466,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cullable",
@@ -2879,6 +2858,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "right",

--- a/site/src/content/api/uiroot.json
+++ b/site/src/content/api/uiroot.json
@@ -2077,64 +2077,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -2289,27 +2231,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2417,6 +2338,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cullable",
@@ -2676,6 +2655,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "right",

--- a/site/src/content/api/video.json
+++ b/site/src/content/api/video.json
@@ -2457,64 +2457,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -2669,27 +2611,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2830,6 +2751,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cullable",
@@ -3265,6 +3244,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "progress",

--- a/site/src/content/api/widget.json
+++ b/site/src/content/api/widget.json
@@ -2398,64 +2398,6 @@
       "title": "Properties",
       "members": [
         {
-          "name": "clip",
-          "signature": "clip: boolean",
-          "signatureTokens": [
-            {
-              "text": "clip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
-        },
-        {
-          "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
-          "signatureTokens": [
-            {
-              "text": "clipShape",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
-        },
-        {
           "name": "collisionType",
           "signature": "collisionType: CollisionType",
           "signatureTokens": [
@@ -2610,27 +2552,6 @@
           "description": "Optional human-readable identity for this node. Defaults to null. Purely a label the engine never interprets: useful for debugging, find-by-name lookups, prefab references, and as a stable key when merging serialized state back onto an existing tree. Not required to be unique."
         },
         {
-          "name": "preserveDrawOrder",
-          "signature": "preserveDrawOrder: boolean",
-          "signatureTokens": [
-            {
-              "text": "preserveDrawOrder",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
-        },
-        {
           "name": "tabIndex",
           "signature": "tabIndex: number",
           "signatureTokens": [
@@ -2738,6 +2659,64 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "clip",
+          "signature": "clip: boolean",
+          "signatureTokens": [
+            {
+              "text": "clip",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, descendants are geometrically clipped to clipShape. Unlike mask (which is alpha/visibility masking), clip is a hard geometric boundary: - clipShape === null — clip to this node's world-space bounds (getBounds), using the GPU scissor fast path. - clipShape is a Rectangle — clip to that world-space rectangle via scissor. - clipShape is a Geometry — clip to the geometry's silhouette via the stencil buffer (WebGL2). Only fragments inside the shape survive. Clipping wraps the node's final (filtered/masked) output and acts as a render barrier: draw commands are never reordered or batched across the clip boundary."
+        },
+        {
+          "name": "clipShape",
+          "signature": "clipShape: Rectangle | Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "clipShape",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Clip region used when clip is true. A Rectangle (or null for the node's bounds) maps to the scissor fast path; a Geometry maps to the stencil path. Has no effect while clip is false."
         },
         {
           "name": "cullable",
@@ -3018,6 +2997,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "preserveDrawOrder",
+          "signature": "preserveDrawOrder: boolean",
+          "signatureTokens": [
+            {
+              "text": "preserveDrawOrder",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, material-aware overlap reordering is disabled for this node's draw-order scope. Draw commands are submitted in exact document order (after scope-local z-sorting), preserving the painter's guarantee irrespective of material compatibility or AABB safety analysis. Adjacency coalescing of consecutive same-material draws still applies; it does not change visual output order."
         },
         {
           "name": "right",

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -432,10 +432,36 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
     return this;
   }
 
+  /**
+   * `true` on transform-group boundary nodes ({@link RetainedContainer}):
+   * descendants combine against identity instead of this node's world matrix,
+   * so their global transforms are group-relative (Track B Slice 2, §5).
+   * A getter, not a field: the boundary is LIVE state — RetainedContainer
+   * disengages it when a deep barrier forces the plain-Container fallback
+   * (plan D-P4), and descendants pick the flip up lazily through the
+   * parent-version compare below.
+   * @internal
+   */
+  public get _isTransformGroupBoundary(): boolean {
+    return false;
+  }
+
+  /**
+   * Whether this node opts back OUT of a parent transform-group boundary and
+   * resolves world-space transforms. Overridden by RenderNode for
+   * barrier-effect nodes (filters/mask/clip/cacheAsBitmap), whose effect
+   * machinery composites in world space (plan decision D-P4).
+   * @internal
+   */
+  protected _escapesTransformGroup(): boolean {
+    return false;
+  }
+
   public getGlobalTransform(): Matrix {
     const parent = this._parentNode;
-    const parentTransform = parent !== null ? parent.getGlobalTransform() : null;
-    const parentVersion = parent !== null ? parent._globalTransformVersion : 0;
+    const boundary = parent !== null && parent._isTransformGroupBoundary && !this._escapesTransformGroup();
+    const parentTransform = parent !== null && !boundary ? parent.getGlobalTransform() : null;
+    const parentVersion = parent !== null && !boundary ? parent._globalTransformVersion : 0;
     const stale = this.flags.has(SceneNodeTransformFlags.GlobalTransform) || this._combinedParentVersion !== parentVersion;
 
     if (stale) {
@@ -652,7 +678,16 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
     // separately bumping the node revision. Over-invalidation is correctness-safe
     // (just less skipping); under-invalidation is the bug this closes.
     this._markContentDirty();
+    this._invalidateBoundsFlags();
+  }
 
+  /**
+   * Flag-only bounds invalidation: own BoundsRect + ancestor walk, WITHOUT a
+   * revision stamp. Used by transform-group boundaries whose own moves must
+   * refresh ancestor world bounds but must NOT invalidate retained fragments.
+   * @internal
+   */
+  protected _invalidateBoundsFlags(): void {
     // Mark own bounds + notify interaction for THIS node unconditionally —
     // the manager filters to tracked interactive nodes so this call is O(1)
     // for the common case (non-interactive node — fast Set.has miss).
@@ -709,39 +744,46 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
     }
   }
 
+  /**
+   * Tail of every own-transform mutation path (position/rotation/scale/origin/
+   * skew). Default: cascade bounds and stamp content-dirty — exactly the
+   * pre-Slice-2 behavior. {@link RetainedContainer} overrides this to bump its
+   * group-matrix version instead of invalidating its retained fragment (§4.3).
+   * @internal
+   */
+  protected _markOwnTransformDirty(): void {
+    this._invalidateBoundsCascade();
+    this._markContentDirty();
+  }
+
   private _setPositionDirty(): void {
     this.flags.push(SceneNodeTransformFlags.Translation);
     this._invalidateSubtreeTransform();
-    this._invalidateBoundsCascade();
-    this._markContentDirty();
+    this._markOwnTransformDirty();
   }
 
   private _setRotationDirty(): void {
     this.flags.push(SceneNodeTransformFlags.Rotation);
     this._invalidateSubtreeTransform();
-    this._invalidateBoundsCascade();
-    this._markContentDirty();
+    this._markOwnTransformDirty();
   }
 
   private _setScalingDirty(): void {
     this.flags.push(SceneNodeTransformFlags.Scaling);
     this._invalidateSubtreeTransform();
-    this._invalidateBoundsCascade();
-    this._markContentDirty();
+    this._markOwnTransformDirty();
   }
 
   private _setOriginDirty(): void {
     this.flags.push(SceneNodeTransformFlags.Origin);
     this._invalidateSubtreeTransform();
-    this._invalidateBoundsCascade();
-    this._markContentDirty();
+    this._markOwnTransformDirty();
   }
 
   private _setSkewDirty(): void {
     this.flags.push(SceneNodeTransformFlags.Skew);
     this._invalidateSubtreeTransform();
-    this._invalidateBoundsCascade();
-    this._markContentDirty();
+    this._markOwnTransformDirty();
   }
 
   /**

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -243,7 +243,10 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
   }
 
   public set cullable(cullable: boolean) {
-    this._cullable = cullable;
+    if (this._cullable !== cullable) {
+      this._cullable = cullable;
+      this._markStructureDirty();
+    }
   }
 
   /**
@@ -256,7 +259,10 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
   }
 
   public set cullArea(rect: Rectangle | null) {
-    this._cullArea = rect;
+    if (this._cullArea !== rect) {
+      this._cullArea = rect;
+      this._markStructureDirty();
+    }
   }
 
   /**

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -26,7 +26,7 @@ import { RenderNode } from './RenderNode';
  * @stable
  */
 export class Container extends RenderNode {
-  private readonly _children: RenderNode[] = [];
+  protected readonly _children: RenderNode[] = [];
   private _retainedPlan: RetainedPlanCache | null = null;
 
   public get children(): RenderNode[] {

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -27,7 +27,7 @@ import { RenderNode } from './RenderNode';
  */
 export class Container extends RenderNode {
   private readonly _children: RenderNode[] = [];
-  private readonly _retainedPlan: RetainedPlanCache = new RetainedPlanCache();
+  private _retainedPlan: RetainedPlanCache | null = null;
 
   public get children(): RenderNode[] {
     return this._children;
@@ -255,7 +255,7 @@ export class Container extends RenderNode {
 
     const viewUpdateId = builder.view.updateId;
 
-    if (this._retainedPlan.isClean(this._contentRevision, this._structureRevision, viewUpdateId, builder.backend)) {
+    if (this._retainedPlan !== null && this._retainedPlan.isClean(this._contentRevision, this._structureRevision, viewUpdateId, builder.backend)) {
       this._replayRetainedChildren(builder);
 
       return;
@@ -274,7 +274,8 @@ export class Container extends RenderNode {
    * its own independent skip decision.
    */
   private _replayRetainedChildren(builder: RenderPlanBuilder): void {
-    const slots = this._retainedPlan.slots;
+    // Non-null: only called from the isClean-guarded fast path above.
+    const slots = this._retainedPlan!.slots;
     let slotIndex = 0;
 
     for (let index = 0; index < this._children.length; index++) {
@@ -297,23 +298,39 @@ export class Container extends RenderNode {
    * set of retained slots for next frame's fast path.
    */
   private _collectAndCaptureChildren(builder: RenderPlanBuilder, viewUpdateId: number): void {
-    const capturedSlots: RetainedDrawSlot[] = [];
+    let sawSlotCandidate = false;
+    let capturedSlots: RetainedDrawSlot[] | null = null;
 
     for (let index = 0; index < this._children.length; index++) {
+      // In-bounds: index < length.
+      const child = this._children[index]!;
+
+      // Only a plain, non-barrier drawable can ever produce a retained slot
+      // (exactly one Draw entry for itself). Every other child skips the
+      // peek/capture bookkeeping entirely -- the S2-D4 zero-slot fix: 99.7% of
+      // containers in the Slice-1 measurement had no direct drawable children
+      // and paid pure overhead here.
+      if (!child._isDrawableForRenderPlan() || child._renderPlanHasBarrierEffects()) {
+        child._collect(builder, index);
+
+        continue;
+      }
+
+      sawSlotCandidate = true;
+
       const beforeCount = builder._peekCurrentScopeEntries().length;
 
-      // In-bounds: index < length.
-      this._children[index]!._collect(builder, index);
+      child._collect(builder, index);
 
       const entries = builder._peekCurrentScopeEntries();
 
       if (entries.length === beforeCount + 1) {
         const entry = entries[entries.length - 1]!;
 
-        if (entry.kind === RenderEntryKind.Draw && entry.command.drawable === this._children[index]) {
+        if (entry.kind === RenderEntryKind.Draw && entry.command.drawable === child) {
           const command = entry.command;
 
-          capturedSlots.push({
+          (capturedSlots ??= []).push({
             childIndex: index,
             drawable: command.drawable,
             seq: command.seq,
@@ -328,7 +345,18 @@ export class Container extends RenderNode {
       }
     }
 
-    this._retainedPlan.capture(this._contentRevision, this._structureRevision, viewUpdateId, builder.backend, capturedSlots);
+    // Allocate/refresh the cache only when there is (or once was) anything to
+    // retain: a slot candidate this frame, or an already-live cache that must
+    // be re-keyed so it cannot go stale-clean.
+    if (sawSlotCandidate || this._retainedPlan !== null) {
+      (this._retainedPlan ??= new RetainedPlanCache()).capture(
+        this._contentRevision,
+        this._structureRevision,
+        viewUpdateId,
+        builder.backend,
+        capturedSlots ?? [],
+      );
+    }
   }
 
   public override contains(x: number, y: number): boolean {
@@ -358,7 +386,7 @@ export class Container extends RenderNode {
 
   public override destroy(): void {
     this.removeChildren();
-    this._retainedPlan.invalidate();
+    this._retainedPlan?.invalidate();
 
     super.destroy();
   }

--- a/src/rendering/RenderNode.ts
+++ b/src/rendering/RenderNode.ts
@@ -378,7 +378,7 @@ export abstract class RenderNode extends SceneNode {
       return;
     }
 
-    if (!this.inView(builder.view)) {
+    if (!builder._isViewCullSuppressed && !this.inView(builder.view)) {
       builder.backend.stats.culledNodes++;
 
       return;
@@ -389,6 +389,18 @@ export abstract class RenderNode extends SceneNode {
 
   /** @internal */
   public _collectForRenderPlan(builder: RenderPlanBuilder): void {
+    if (this._isTransformGroupBoundary) {
+      builder._pushViewCullSuppression();
+
+      try {
+        this._collectContent(builder);
+      } finally {
+        builder._popViewCullSuppression();
+      }
+
+      return;
+    }
+
     this._collectContent(builder);
   }
 

--- a/src/rendering/RenderNode.ts
+++ b/src/rendering/RenderNode.ts
@@ -473,6 +473,10 @@ export abstract class RenderNode extends SceneNode {
     return this._filters.length > 0 || this._mask !== null || this._cacheAsBitmap || this.clip || isAdvancedBlendMode(this._renderPlanGetBlendMode());
   }
 
+  protected override _escapesTransformGroup(): boolean {
+    return this._renderPlanHasBarrierEffects();
+  }
+
   /** @internal */
   public _renderPlanGetMaskSource(): MaskSource {
     return this._mask;

--- a/src/rendering/RenderNode.ts
+++ b/src/rendering/RenderNode.ts
@@ -107,6 +107,8 @@ export abstract class RenderNode extends SceneNode {
    */
   public draggable = false;
 
+  private _preserveDrawOrder = false;
+
   /**
    * When `true`, material-aware overlap reordering is disabled for this
    * node's draw-order scope. Draw commands are submitted in exact document
@@ -118,7 +120,19 @@ export abstract class RenderNode extends SceneNode {
    *
    * @default false
    */
-  public preserveDrawOrder = false;
+  public get preserveDrawOrder(): boolean {
+    return this._preserveDrawOrder;
+  }
+
+  public set preserveDrawOrder(preserveDrawOrder: boolean) {
+    if (this._preserveDrawOrder !== preserveDrawOrder) {
+      this._preserveDrawOrder = preserveDrawOrder;
+      this.invalidateCache();
+      this._markStructureDirty();
+    }
+  }
+
+  private _clip = false;
 
   /**
    * When `true`, descendants are geometrically clipped to {@link clipShape}.
@@ -138,7 +152,19 @@ export abstract class RenderNode extends SceneNode {
    *
    * @default false
    */
-  public clip = false;
+  public get clip(): boolean {
+    return this._clip;
+  }
+
+  public set clip(clip: boolean) {
+    if (this._clip !== clip) {
+      this._clip = clip;
+      this.invalidateCache();
+      this._markStructureDirty();
+    }
+  }
+
+  private _clipShape: Rectangle | Geometry | null = null;
 
   /**
    * Clip region used when {@link clip} is `true`. A `Rectangle` (or `null` for
@@ -147,7 +173,17 @@ export abstract class RenderNode extends SceneNode {
    *
    * @default null
    */
-  public clipShape: Rectangle | Geometry | null = null;
+  public get clipShape(): Rectangle | Geometry | null {
+    return this._clipShape;
+  }
+
+  public set clipShape(clipShape: Rectangle | Geometry | null) {
+    if (this._clipShape !== clipShape) {
+      this._clipShape = clipShape;
+      this.invalidateCache();
+      this._markStructureDirty();
+    }
+  }
 
   // Interaction signals are lazily materialized: a non-interactive node (the
   // common case) allocates none. The dispatch path uses _peekInteractionSignal,

--- a/src/rendering/RetainedContainer.ts
+++ b/src/rendering/RetainedContainer.ts
@@ -1,0 +1,222 @@
+import { logger } from '#core/logging';
+import { nextNodeRevision } from '#core/NodeRevision';
+import type { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
+import { RetainedGroupFragment } from '#rendering/plan/RetainedGroupFragment';
+
+import { Container } from './Container';
+
+/**
+ * A {@link Container} that declares its subtree "mostly static and/or moves
+ * as a whole" (Track B Wave 4). While the subtree is unchanged, its whole
+ * previously-collected command range is spliced into the render plan — no
+ * walk, no per-child culling, no material keys — and moving the container
+ * (or the camera) changes only one per-group GPU matrix instead of touching
+ * every descendant.
+ *
+ * Opt-in at construction; there is no runtime toggle (S2-D1). The existing
+ * revision contract ({@link RenderNode.invalidateContent} and the automatic
+ * bumps on built-in mutation paths) is the entire authoring surface: any
+ * mutation inside the subtree drops the retained fragment for one frame.
+ *
+ * Trade-offs of the group-local space convention (spec §5/§6): descendants
+ * resolve group-relative transforms, so hit-testing/`getBounds()` inside the
+ * group are group-local; per-child view culling is disabled inside the group
+ * (the group is culled as a whole); `pixelSnapMode` snapping operates on
+ * group-local coordinates; particle-extension drawables bake their own
+ * transforms and are not group-transform-aware. Group-wide fades are done
+ * per-drawable tint (the engine has no inherited alpha) or via
+ * {@link RenderNode.cacheAsBitmap}. Nodes with filters/mask/clip/
+ * cacheAsBitmap are supported as DIRECT children (they stay world-space and
+ * re-collect every frame); nesting them deeper DISENGAGES the group — it
+ * then renders as an exact plain {@link Container} (correct output, no
+ * retention) and warns once in dev builds.
+ *
+ * @example
+ * ```ts
+ * const world = new RetainedContainer(); // large static tilemap decor
+ * world.addChild(...thousandsOfSprites);
+ * scene.root.addChild(world);
+ * world.setPosition(-cameraX, -cameraY); // one matrix update per frame
+ * ```
+ */
+export class RetainedContainer extends Container {
+  private readonly _fragment = new RetainedGroupFragment();
+  private _groupVersion = 0;
+  private _boundaryDisengaged = false;
+
+  /**
+   * The group convention is LIVE state (plan D-P4, Option A): `true` while
+   * engaged; flips to `false` when a barrier-effect node sits deeper than
+   * one level inside the subtree, falling back to exact plain-Container
+   * behavior instead of rendering wrong effect placement. Descendants pick
+   * a flip up lazily through the getGlobalTransform parent-version seam.
+   * @internal
+   */
+  public override get _isTransformGroupBoundary(): boolean {
+    return !this._boundaryDisengaged;
+  }
+
+  /**
+   * Monotonic stamp of the container's own transform mutations (spec §4.3).
+   * The retained fragment does not key on it — the group matrix is read live
+   * at playback — but diagnostics and tests observe decoupling through it.
+   * @internal
+   */
+  public get _groupMatrixVersion(): number {
+    return this._groupVersion;
+  }
+
+  /**
+   * Own-transform mutations move the whole group: bump the group-matrix
+   * version and refresh ancestor bounds flags (the group's world AABB
+   * moved), but do NOT content-dirty the fragment — that decoupling is the
+   * entire point of the retained tier (spec §4.3).
+   */
+  protected override _markOwnTransformDirty(): void {
+    this._groupVersion = nextNodeRevision();
+    this._invalidateBoundsFlags();
+  }
+
+  /**
+   * World AABB of the group: children aggregate in group-local space, so
+   * every child rect is lifted by the group's own world matrix (spec §6 —
+   * group-local aggregate × group matrix). Barrier-bearing direct children
+   * escape the group convention (plan D-P4) and are already world-space.
+   */
+  public override updateBounds(): this {
+    if (this._boundaryDisengaged) {
+      // Deep-barrier fallback: children are world-space, aggregate plainly.
+      return super.updateBounds();
+    }
+
+    const world = this.getGlobalTransform();
+
+    this._bounds.reset().addRect(this.getLocalBounds(), world);
+
+    for (const child of this._children) {
+      if (!child.visible) {
+        continue;
+      }
+
+      if (child._renderPlanHasBarrierEffects()) {
+        this._bounds.addRect(child.getBounds());
+      } else {
+        this._bounds.addRect(child.getBounds(), world);
+      }
+    }
+
+    return this;
+  }
+
+  /** @internal */
+  protected override _collectContent(builder: RenderPlanBuilder): void {
+    if (this._boundaryDisengaged) {
+      // Deep-barrier fallback (plan D-P4): exact plain-Container behavior,
+      // including the Slice-1 per-child cache.
+      super._collectContent(builder);
+
+      return;
+    }
+
+    // Task 8 replaces the engaged path with the fragment splice; until then
+    // the group collects fully every frame (correct, just not yet retained).
+    for (let index = 0; index < this._children.length; index++) {
+      // In-bounds: index < length.
+      this._children[index]!._collect(builder, index);
+    }
+  }
+
+  public override destroy(): void {
+    this._fragment.invalidate();
+
+    super.destroy();
+  }
+
+  private _deepBarrierCheckContent = -1;
+  private _deepBarrierCheckStructure = -1;
+  private _deepBarrierWarned = false;
+
+  /** @internal */
+  public override _collect(builder: RenderPlanBuilder, seq?: number): void {
+    // Re-evaluate the deep-barrier fallback BEFORE culling/bounds run, so an
+    // engagement flip never mixes spaces within one frame (plan D-P4).
+    // Skipped entirely while the subtree revisions are unchanged.
+    this._refreshBoundaryEngagement();
+    super._collect(builder, seq);
+  }
+
+  /**
+   * Deep-barrier fallback decision (plan D-P4, Option A). Re-scans the
+   * subtree only when its content/structure revisions changed since the last
+   * check — every effect toggle and attach/detach bumps them (task 1), so the
+   * runtime-toggle path invalidates for free, and the scan cost lands only on
+   * frames that already pay an O(subtree) re-collect.
+   */
+  private _refreshBoundaryEngagement(): void {
+    if (this._deepBarrierCheckContent === this._contentRevision && this._deepBarrierCheckStructure === this._structureRevision) {
+      return;
+    }
+
+    this._deepBarrierCheckContent = this._contentRevision;
+    this._deepBarrierCheckStructure = this._structureRevision;
+
+    const disengage = this._subtreeHasDeepBarrier();
+
+    if (disengage === this._boundaryDisengaged) {
+      return;
+    }
+
+    this._boundaryDisengaged = disengage;
+    // Spaces flip: descendants recombine lazily through the live boundary
+    // getter; the fragment (captured in the other space) and the aggregate
+    // bounds must drop immediately.
+    this._fragment.invalidate();
+    this._invalidateBoundsFlags();
+
+    if (__DEV__ && disengage && !this._deepBarrierWarned) {
+      this._deepBarrierWarned = true;
+      logger.warn(
+        `RetainedContainer${this.name ? ` '${this.name}'` : ''} contains a node with filters/mask/clip/cacheAsBitmap ` +
+          'nested deeper than one level below the group boundary. Retention and the group transform are disabled — ' +
+          'it renders as a plain Container — until the effect-bearing node is moved up to a direct child of the ' +
+          'group or out of it.',
+        { source: 'rendering' },
+      );
+    }
+  }
+
+  /**
+   * `true` when any barrier-effect node sits deeper than one level below this
+   * boundary. Direct barrier children escape to world space (supported), and
+   * their subtrees are world-space wholesale, so the scan skips them.
+   */
+  private _subtreeHasDeepBarrier(): boolean {
+    for (const child of this._children) {
+      if (child._renderPlanHasBarrierEffects()) {
+        continue;
+      }
+
+      if (child instanceof Container && this._scanForBarriers(child)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private _scanForBarriers(container: Container): boolean {
+    // Uses the public `children` getter: protected `_children` of OTHER
+    // Container instances is not accessible from a subclass in TypeScript.
+    for (const child of container.children) {
+      if (child._renderPlanHasBarrierEffects()) {
+        return true;
+      }
+
+      if (child instanceof Container && this._scanForBarriers(child)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/src/rendering/RetainedContainer.ts
+++ b/src/rendering/RetainedContainer.ts
@@ -5,6 +5,11 @@ import { RetainedGroupFragment } from '#rendering/plan/RetainedGroupFragment';
 
 import { Container } from './Container';
 
+/** Observation window for the S2-D1 retention diagnostic, in fragment builds (~frames). */
+const retainedDiagnosticWindow = 120;
+/** Invalidated builds within one window that trigger the warning (90% — "effectively every frame"). */
+const retainedDiagnosticThreshold = 108;
+
 /**
  * A {@link Container} that declares its subtree "mostly static and/or moves
  * as a whole" (Track B Wave 4). While the subtree is unchanged, its whole
@@ -43,6 +48,9 @@ export class RetainedContainer extends Container {
   private readonly _fragment = new RetainedGroupFragment();
   private _groupVersion = 0;
   private _boundaryDisengaged = false;
+  private _devFragmentBuilds = 0;
+  private _devFragmentInvalidations = 0;
+  private _devRetentionWarned = false;
 
   /**
    * The group convention is LIVE state (plan D-P4, Option A): `true` while
@@ -129,7 +137,10 @@ export class RetainedContainer extends Container {
       // container's own transform (a move only changes the group matrix).
       builder._replayRetainedFragment(this._fragment.entries);
 
-      // Task 10 hooks the dev diagnostic here: this._trackRetention(false);
+      if (__DEV__) {
+        this._trackRetention(false);
+      }
+
       return;
     }
 
@@ -138,8 +149,10 @@ export class RetainedContainer extends Container {
       this._children[index]!._collect(builder, index);
     }
 
-    // Task 10 hooks the dev diagnostic here, BEFORE capture:
-    // this._trackRetention(this._fragment.hasCapture);
+    if (__DEV__) {
+      this._trackRetention(this._fragment.hasCapture);
+    }
+
     this._fragment.capture(this._contentRevision, this._structureRevision, builder.backend, builder._snapshotScopeEntries(builder._peekCurrentScopeEntries()));
   }
 
@@ -147,6 +160,43 @@ export class RetainedContainer extends Container {
     this._fragment.invalidate();
 
     super.destroy();
+  }
+
+  /**
+   * S2-D1 dev diagnostic: count fragment builds vs invalidations over a
+   * sliding window and warn ONCE when this container invalidates on
+   * effectively every frame — the retention is pure overhead there (the
+   * reference's retained arm measured 1.5x slower than immediate mode on
+   * fully-dynamic content). Dev builds only; stripped from production via
+   * the __DEV__ guard at the call sites.
+   */
+  private _trackRetention(invalidated: boolean): void {
+    if (this._devRetentionWarned) {
+      return;
+    }
+
+    this._devFragmentBuilds++;
+
+    if (invalidated) {
+      this._devFragmentInvalidations++;
+    }
+
+    if (this._devFragmentBuilds < retainedDiagnosticWindow) {
+      return;
+    }
+
+    if (this._devFragmentInvalidations >= retainedDiagnosticThreshold) {
+      this._devRetentionWarned = true;
+      logger.warn(
+        `RetainedContainer${this.name ? ` '${this.name}'` : ''} invalidated its retained fragment on ` +
+          `${this._devFragmentInvalidations} of the last ${this._devFragmentBuilds} frames — the retention is pure ` +
+          `overhead here. Remove the RetainedContainer boundary or split the dynamic children out of the group.`,
+        { source: 'rendering' },
+      );
+    }
+
+    this._devFragmentBuilds = 0;
+    this._devFragmentInvalidations = 0;
   }
 
   private _deepBarrierCheckContent = -1;

--- a/src/rendering/RetainedContainer.ts
+++ b/src/rendering/RetainedContainer.ts
@@ -164,7 +164,7 @@ export class RetainedContainer extends Container {
 
   /**
    * S2-D1 dev diagnostic: count fragment builds vs invalidations over a
-   * sliding window and warn ONCE when this container invalidates on
+   * tumbling window and warn ONCE when this container invalidates on
    * effectively every frame — the retention is pure overhead there (the
    * reference's retained arm measured 1.5x slower than immediate mode on
    * fully-dynamic content). Dev builds only; stripped from production via

--- a/src/rendering/RetainedContainer.ts
+++ b/src/rendering/RetainedContainer.ts
@@ -110,20 +110,37 @@ export class RetainedContainer extends Container {
 
   /** @internal */
   protected override _collectContent(builder: RenderPlanBuilder): void {
+    if (this._children.length === 0) {
+      return;
+    }
+
     if (this._boundaryDisengaged) {
       // Deep-barrier fallback (plan D-P4): exact plain-Container behavior,
-      // including the Slice-1 per-child cache.
+      // including the Slice-1 per-child cache. Never captures a fragment.
       super._collectContent(builder);
 
       return;
     }
 
-    // Task 8 replaces the engaged path with the fragment splice; until then
-    // the group collects fully every frame (correct, just not yet retained).
+    if (this._fragment.isClean(this._contentRevision, this._structureRevision, builder.backend)) {
+      // The whole-range splice (spec §4.2): no walk, no cull, no material
+      // keys. The key deliberately omits View.updateId (group-level culling
+      // makes the fragment view-independent — the camera-pan win) and the
+      // container's own transform (a move only changes the group matrix).
+      builder._replayRetainedFragment(this._fragment.entries);
+
+      // Task 10 hooks the dev diagnostic here: this._trackRetention(false);
+      return;
+    }
+
     for (let index = 0; index < this._children.length; index++) {
       // In-bounds: index < length.
       this._children[index]!._collect(builder, index);
     }
+
+    // Task 10 hooks the dev diagnostic here, BEFORE capture:
+    // this._trackRetention(this._fragment.hasCapture);
+    this._fragment.capture(this._contentRevision, this._structureRevision, builder.backend, builder._snapshotScopeEntries(builder._peekCurrentScopeEntries()));
   }
 
   public override destroy(): void {

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -18,7 +18,8 @@ import {
   type GroupScopeEntry,
   type ScopeEntry,
 } from './RenderScope';
-import type { RetainedDrawSlot } from './RetainedPlanCache';
+import type { RetainedFragmentEntry, RetainedFragmentGroup } from './RetainedGroupFragment';
+import type { RetainedDrawData } from './RetainedPlanCache';
 
 interface MutableGroupScope extends GroupScope {
   _nextSeq: number;
@@ -84,6 +85,10 @@ export class RenderPlanBuilder {
 
   private _nodeIndex = 0;
 
+  // Track B Slice 2: count of transform-group boundaries currently being
+  // collected below. See `_isViewCullSuppressed`.
+  private _viewCullSuppression = 0;
+
   public build(root: RenderNode, backend: RenderBackend): RenderPlan {
     this.backend = backend;
     this._view = null;
@@ -94,6 +99,7 @@ export class RenderPlanBuilder {
     this._barrierEntryPoolCursor = 0;
     this._scopeStack.length = 0;
     this._hasPending = false;
+    this._viewCullSuppression = 0;
     // Base this plan's node indices after whatever earlier render() calls already
     // wrote into the frame-scoped transform buffer, so every draw across all
     // render() calls in the frame references a distinct slot and can batch.
@@ -213,6 +219,8 @@ export class RenderPlanBuilder {
 
     const groupScope = this._acquireGroupScope(this._resolvePreserveDrawOrder(node));
 
+    groupScope.transformNode = node._isTransformGroupBoundary ? node : null;
+
     this._pushGroupEntry(reservedSeq, reservedZ, groupScope);
 
     this._scopeStack.push(groupScope);
@@ -270,14 +278,36 @@ export class RenderPlanBuilder {
   }
 
   /**
-   * @internal — replay a single previously-captured {@link RetainedDrawSlot}
+   * @internal — true while collecting below a transform-group boundary.
+   * Inside a group, child bounds are group-local, so testing them against the
+   * world-space view rect would be meaningless; the group is culled as a
+   * whole by RetainedContainer._collect instead (spec §6).
+   */
+  public get _isViewCullSuppressed(): boolean {
+    return this._viewCullSuppression > 0;
+  }
+
+  /** @internal — enter a transform-group subtree (see {@link _isViewCullSuppressed}). */
+  public _pushViewCullSuppression(): void {
+    this._viewCullSuppression++;
+  }
+
+  /** @internal — leave a transform-group subtree. */
+  public _popViewCullSuppression(): void {
+    this._viewCullSuppression--;
+  }
+
+  /**
+   * @internal — replay a single previously-captured {@link RetainedDrawData}
    * into the current scope: reuses its cached material key and screen-space
    * bounds verbatim, only assigning a fresh frame-local `nodeIndex`. Used by
-   * {@link RetainedPlanCache} for the Wave 3 static-subtree skip; callers must
-   * have already verified the owning container's subtree is unchanged
-   * (content + structure revision, view, and backend all match the capture).
+   * {@link RetainedPlanCache} for the Wave 3 static-subtree skip and by
+   * {@link _replayRetainedFragment} for the Slice 2 whole-fragment splice;
+   * callers must have already verified the owning container's subtree is
+   * unchanged (content + structure revision, and backend all match the
+   * capture — plus view for the Slice-1 per-child cache).
    */
-  public _replayRetainedDraw(slot: RetainedDrawSlot): void {
+  public _replayRetainedDraw(slot: RetainedDrawData): void {
     // Mirror the scope bookkeeping that `_reserveEntryPlacement` maintains on the
     // normal emit path, but HONOR the slot's verbatim seq/zIndex instead of
     // assigning a fresh seq. Skipping this leaves the active scope's placement
@@ -316,6 +346,101 @@ export class RenderPlanBuilder {
     this._pushDrawEntry(slot.seq, slot.zIndex, command);
   }
 
+  /**
+   * @internal — deep-copy the given scope entries into an owned, pool-free
+   * fragment tree (Track B Slice 2, plan decision D-P3). Draws copy their
+   * placement/material/bounds verbatim; nested groups recurse; barrier nodes
+   * are recorded as re-dispatch references only (spec §8). Called by
+   * {@link RetainedContainer} right after a full collect of its scope.
+   */
+  public _snapshotScopeEntries(entries: readonly ScopeEntry[]): RetainedFragmentEntry[] {
+    const captured: RetainedFragmentEntry[] = [];
+
+    for (const entry of entries) {
+      if (entry.kind === RenderEntryKind.Draw) {
+        const command = entry.command;
+
+        captured.push({
+          kind: RenderEntryKind.Draw,
+          drawable: command.drawable,
+          seq: command.seq,
+          zIndex: command.zIndex,
+          material: { ...command.material },
+          minX: command.minX,
+          minY: command.minY,
+          maxX: command.maxX,
+          maxY: command.maxY,
+        });
+      } else if (entry.kind === RenderEntryKind.Group) {
+        captured.push({
+          kind: RenderEntryKind.Group,
+          seq: entry.seq,
+          zIndex: entry.zIndex,
+          preserveDrawOrder: entry.scope.preserveDrawOrder,
+          transformNode: entry.scope.transformNode,
+          entries: this._snapshotScopeEntries(entry.scope.entries),
+        });
+      } else {
+        captured.push({
+          kind: RenderEntryKind.Barrier,
+          seq: entry.seq,
+          node: entry.scope.node,
+        });
+      }
+    }
+
+    return captured;
+  }
+
+  /**
+   * @internal — replay a captured fragment into the current scope: the
+   * whole-range splice (spec §4.2). No scene-graph walk, no cull, no bounds,
+   * no material keys — draws re-acquire pooled commands with fresh
+   * frame-local nodeIndex values (multi-render() bases stay coherent), nested
+   * groups re-acquire pooled scopes, and barrier nodes re-dispatch through a
+   * normal `_collect` (spec §8).
+   */
+  public _replayRetainedFragment(entries: readonly RetainedFragmentEntry[]): void {
+    for (const entry of entries) {
+      if (entry.kind === RenderEntryKind.Draw) {
+        this._replayRetainedDraw(entry);
+      } else if (entry.kind === RenderEntryKind.Group) {
+        this._replayRetainedGroup(entry);
+      } else {
+        entry.node._collect(this, entry.seq);
+      }
+    }
+  }
+
+  private _replayRetainedGroup(fragment: RetainedFragmentGroup): void {
+    // Mirror _replayRetainedDraw's scope bookkeeping for the group entry's
+    // verbatim seq/zIndex (see the invariants documented there).
+    const scope = this._currentScope();
+
+    if (fragment.seq >= scope._nextSeq) {
+      scope._nextSeq = fragment.seq + 1;
+    }
+
+    if (scope.firstZ === null) {
+      scope.firstZ = fragment.zIndex;
+    } else if (!scope.hasMixedZ && scope.firstZ !== fragment.zIndex) {
+      scope.hasMixedZ = true;
+    }
+
+    const groupScope = this._acquireGroupScope(fragment.preserveDrawOrder);
+
+    groupScope.transformNode = fragment.transformNode;
+
+    this._pushGroupEntry(fragment.seq, fragment.zIndex, groupScope);
+    this._scopeStack.push(groupScope);
+
+    try {
+      this._replayRetainedFragment(fragment.entries);
+    } finally {
+      this._scopeStack.pop();
+    }
+  }
+
   private _resetRuntimeState(): void {
     this._scopeStack.length = 0;
     this._hasPending = false;
@@ -326,6 +451,7 @@ export class RenderPlanBuilder {
     this._barrierEntryPoolCursor = 0;
     this._view = null;
     this._nodeIndex = 0;
+    this._viewCullSuppression = 0;
   }
 
   private _acquireGroupScope(preserveDrawOrder: boolean): MutableGroupScope {
@@ -334,6 +460,7 @@ export class RenderPlanBuilder {
       entries: [],
       hasMixedZ: false,
       preserveDrawOrder: false,
+      transformNode: null,
       _nextSeq: 0,
       firstZ: null,
     };
@@ -344,6 +471,7 @@ export class RenderPlanBuilder {
     scope.entries.length = 0;
     scope.hasMixedZ = false;
     scope.preserveDrawOrder = preserveDrawOrder;
+    scope.transformNode = null;
     scope._nextSeq = 0;
     scope.firstZ = null;
 

--- a/src/rendering/plan/RenderPlanPlayer.ts
+++ b/src/rendering/plan/RenderPlanPlayer.ts
@@ -1,3 +1,4 @@
+import { Matrix } from '#math/Matrix';
 import type { RenderBackend } from '#rendering/RenderBackend';
 
 import { RenderEntryKind } from './RenderCommand';
@@ -21,6 +22,8 @@ interface RenderGroupPlaybackContext {
 interface RenderPlanPlaybackContext {
   passInstructionIndex: number;
   passGroupIndex: number;
+  activeGroupTransform: Matrix | null;
+  groupTransformDepth: number;
 }
 
 /**
@@ -39,6 +42,7 @@ interface RenderPlanPlaybackHooks {
   _prepareDrawCommand?(instruction: RenderInstruction): void;
   _endRenderGroup?(entries: readonly ScopeEntry[], startIndex: number, count: number): void;
   _endDrawPlan?(): void;
+  _setRenderGroupTransform?(transform: Matrix | null): void;
 }
 
 /**
@@ -75,6 +79,9 @@ const groupRunLength = (entries: readonly ScopeEntry[], startIndex: number): num
 
 /** @internal */
 export class RenderPlanPlayer {
+  /** Per-depth scratch matrices for composed group transforms (reused across frames). */
+  private static readonly _groupTransformScratch: Matrix[] = [];
+
   public static play(plan: RenderPlan, backend: RenderBackend): void {
     const hooks = backend as RenderBackend & RenderPlanPlaybackHooks;
 
@@ -205,11 +212,56 @@ export class RenderPlanPlayer {
           currentInstructionIndex = 0;
         }
       } else if (entry.kind === RenderEntryKind.Group) {
-        this._playGroup(entry.scope, backend, hooks, context);
+        const transformNode = entry.scope.transformNode;
+
+        if (transformNode !== null && hooks._setRenderGroupTransform !== undefined) {
+          const outer = context.activeGroupTransform;
+          const scratch = (RenderPlanPlayer._groupTransformScratch[context.groupTransformDepth] ??= new Matrix());
+
+          // The boundary node's global transform is relative to the nearest
+          // ENCLOSING group (identity-parent convention, spec §5), so nested
+          // retained groups compose onto the outer group's world matrix.
+          scratch.copy(transformNode.getGlobalTransform());
+
+          if (outer !== null) {
+            scratch.combine(outer);
+          }
+
+          context.groupTransformDepth++;
+          context.activeGroupTransform = scratch;
+          hooks._setRenderGroupTransform(scratch);
+
+          try {
+            this._playGroup(entry.scope, backend, hooks, context);
+          } finally {
+            context.groupTransformDepth--;
+            context.activeGroupTransform = outer;
+            hooks._setRenderGroupTransform(outer);
+          }
+        } else {
+          this._playGroup(entry.scope, backend, hooks, context);
+        }
       } else {
-        RenderEffectExecutor.play(entry.scope, backend, childScope => {
-          this._playScope(childScope, backend, hooks, context);
-        });
+        // Barrier subtrees collect in world space (a barrier-bearing child
+        // escapes the group-relative convention, plan D-P4), so their playback
+        // must not apply the group uniform.
+        const suspended = context.activeGroupTransform;
+
+        if (suspended !== null) {
+          context.activeGroupTransform = null;
+          hooks._setRenderGroupTransform?.(null);
+        }
+
+        try {
+          RenderEffectExecutor.play(entry.scope, backend, childScope => {
+            this._playScope(childScope, backend, hooks, context);
+          });
+        } finally {
+          if (suspended !== null) {
+            context.activeGroupTransform = suspended;
+            hooks._setRenderGroupTransform?.(suspended);
+          }
+        }
       }
     }
   }
@@ -218,6 +270,8 @@ export class RenderPlanPlayer {
     return {
       passInstructionIndex: 0,
       passGroupIndex: 0,
+      activeGroupTransform: null,
+      groupTransformDepth: 0,
     };
   }
 

--- a/src/rendering/plan/RenderScope.ts
+++ b/src/rendering/plan/RenderScope.ts
@@ -75,6 +75,13 @@ export interface GroupScope {
   entries: ScopeEntry[];
   hasMixedZ: boolean;
   preserveDrawOrder: boolean;
+  /**
+   * The transform-group boundary node whose world matrix scopes this group's
+   * draws (Track B Slice 2), or `null` for a plain scope. Read live by the
+   * plan player at playback time — never captured — so a group move between
+   * collect and play (or across multi-render() bases) is always honored.
+   */
+  transformNode: RenderNode | null;
 }
 
 /** @internal */

--- a/src/rendering/plan/RetainedGroupFragment.ts
+++ b/src/rendering/plan/RetainedGroupFragment.ts
@@ -1,0 +1,77 @@
+import type { RenderBackend } from '#rendering/RenderBackend';
+import type { RenderNode } from '#rendering/RenderNode';
+
+import type { RenderEntryKind } from './RenderCommand';
+import type { RetainedDrawData } from './RetainedPlanCache';
+
+/** A captured draw: replayed verbatim with a fresh frame-local nodeIndex. @internal */
+export interface RetainedFragmentDraw extends RetainedDrawData {
+  readonly kind: RenderEntryKind.Draw;
+}
+
+/** A captured nested group scope (a plain or retained Container below the group). @internal */
+export interface RetainedFragmentGroup {
+  readonly kind: RenderEntryKind.Group;
+  readonly seq: number;
+  readonly zIndex: number;
+  readonly preserveDrawOrder: boolean;
+  readonly transformNode: RenderNode | null;
+  readonly entries: readonly RetainedFragmentEntry[];
+}
+
+/**
+ * A barrier-effect node inside the fragment. NOT captured — re-dispatched
+ * through a normal `_collect` on every replay (spec §8: semantics-neutral by
+ * construction; the node reference stays valid because any change below it
+ * content-dirties the owning RetainedContainer and drops the fragment).
+ * @internal
+ */
+export interface RetainedFragmentBarrier {
+  readonly kind: RenderEntryKind.Barrier;
+  readonly seq: number;
+  readonly node: RenderNode;
+}
+
+/** @internal */
+export type RetainedFragmentEntry = RetainedFragmentDraw | RetainedFragmentGroup | RetainedFragmentBarrier;
+
+/**
+ * Whole-command-range fragment cache for one {@link RetainedContainer}
+ * (Track B Slice 2, spec §4.2). Keyed on the subtree's aggregate
+ * content/structure revision and the backend identity — deliberately NOT on
+ * `View.updateId` (group-level culling makes the fragment view-independent;
+ * this is the camera-pan win) and NOT on the container's own transform
+ * (a group move only changes the group matrix, §4.3).
+ */
+export class RetainedGroupFragment {
+  private _entries: readonly RetainedFragmentEntry[] = [];
+  private _contentRevision = -1;
+  private _structureRevision = -1;
+  private _backend: RenderBackend | null = null;
+  private _hasCapture = false;
+
+  public get hasCapture(): boolean {
+    return this._hasCapture;
+  }
+
+  public get entries(): readonly RetainedFragmentEntry[] {
+    return this._entries;
+  }
+
+  public isClean(contentRevision: number, structureRevision: number, backend: RenderBackend): boolean {
+    return this._hasCapture && this._contentRevision === contentRevision && this._structureRevision === structureRevision && this._backend === backend;
+  }
+
+  public capture(contentRevision: number, structureRevision: number, backend: RenderBackend, entries: readonly RetainedFragmentEntry[]): void {
+    this._entries = entries;
+    this._contentRevision = contentRevision;
+    this._structureRevision = structureRevision;
+    this._backend = backend;
+    this._hasCapture = true;
+  }
+
+  public invalidate(): void {
+    this._hasCapture = false;
+    this._entries = [];
+  }
+}

--- a/src/rendering/plan/RetainedPlanCache.ts
+++ b/src/rendering/plan/RetainedPlanCache.ts
@@ -4,15 +4,14 @@ import type { RenderBackend } from '#rendering/RenderBackend';
 import type { MaterialKey } from './RenderCommand';
 
 /**
+ * The replayable payload of one previously-collected draw: everything
+ * `RenderPlanBuilder.emitDraw` computed for it (material key, bounds in the
+ * capture's space convention, seq/zIndex placement). Base shape shared by the
+ * Slice-1 per-child {@link RetainedDrawSlot} and the Slice-2 whole-fragment
+ * {@link RetainedFragmentDraw}.
  * @internal
- *
- * A previously-collected, still-valid draw command snapshot for one direct
- * `Drawable` child of a `Container` — everything `RenderPlanBuilder.emitDraw`
- * would have computed for it (material key, screen-space bounds), captured so
- * it can be replayed without redoing cull/bounds/material-key work.
  */
-export interface RetainedDrawSlot {
-  readonly childIndex: number;
+export interface RetainedDrawData {
   readonly drawable: Drawable;
   readonly seq: number;
   readonly zIndex: number;
@@ -21,6 +20,18 @@ export interface RetainedDrawSlot {
   readonly minY: number;
   readonly maxX: number;
   readonly maxY: number;
+}
+
+/**
+ * @internal
+ *
+ * A previously-collected, still-valid draw command snapshot for one direct
+ * `Drawable` child of a `Container` — everything `RenderPlanBuilder.emitDraw`
+ * would have computed for it, captured so it can be replayed without redoing
+ * cull/bounds/material-key work.
+ */
+export interface RetainedDrawSlot extends RetainedDrawData {
+  readonly childIndex: number;
 }
 
 /**

--- a/src/rendering/plan/RetainedPlanCache.ts
+++ b/src/rendering/plan/RetainedPlanCache.ts
@@ -36,8 +36,10 @@ export interface RetainedDrawSlot extends RetainedDrawData {
 
 /**
  * Per-`Container` fragment cache for the Wave 3 static-subtree-skip (Track B,
- * Slice 1 — design spec §5.2/§5.4). One instance is owned by each `Container`
- * (`Container._retainedPlan`). Caches the direct-`Drawable`-child draw slots
+ * Slice 1 — design spec §5.2/§5.4). Lazily allocated by `Container` the first
+ * time a direct drawable child produces a capturable slot; containers without
+ * such children never own one (`Container._retainedPlan`). Caches the
+ * direct-`Drawable`-child draw slots
  * produced by the last full (non-skipped) collect of that container's own
  * scope, keyed on the container's aggregate content/structure revision
  * (`SceneNode._contentRevision`/`_structureRevision`), the active view's

--- a/src/rendering/public.ts
+++ b/src/rendering/public.ts
@@ -29,6 +29,7 @@ export { RenderPipeline } from './RenderPipeline';
 export type { RenderStats } from './RenderStats';
 export { createRenderStats, resetRenderStats } from './RenderStats';
 export { RenderTarget } from './RenderTarget';
+export { RetainedContainer } from './RetainedContainer';
 export { BlendModes, BufferTypes, BufferUsage, isAdvancedBlendMode, RenderingPrimitives, ScaleModes, ShaderPrimitives, WrapModes } from './types';
 export type { ViewFollowOptions, ViewFollowTarget, ViewOptions, ViewShakeOptions } from './View';
 export { View, ViewFlags } from './View';

--- a/src/rendering/sprite/spriteMaterialSources.ts
+++ b/src/rendering/sprite/spriteMaterialSources.ts
@@ -91,6 +91,7 @@ void main(void) {
 export const spriteVertexWgsl = `
 struct ProjectionUniforms {
     matrix: mat4x4<f32>,
+    group: mat4x4<f32>,
 };
 
 struct TransformSlot {
@@ -136,7 +137,7 @@ fn vertexMain(input: VertexInput, @builtin(vertex_index) vid: u32) -> VertexOutp
     let worldX = slot.m0.x * localX + slot.m0.y * localY + slot.m1.x;
     let worldY = slot.m0.z * localX + slot.m0.w * localY + slot.m1.y;
 
-    output.position = projection.matrix * vec4<f32>(worldX, worldY, 0.0, 1.0);
+    output.position = projection.matrix * projection.group * vec4<f32>(worldX, worldY, 0.0, 1.0);
 
     let u = select(input.uvBounds.x, input.uvBounds.z, cornerX == 1u);
     let v = select(input.uvBounds.y, input.uvBounds.w, cornerY == 1u);

--- a/src/rendering/sprite/spriteMaterialSources.ts
+++ b/src/rendering/sprite/spriteMaterialSources.ts
@@ -42,6 +42,7 @@ layout(location = 5) in uint a_textureSlot;
 layout(location = 6) in uint a_nodeIndex;       // row into the shared transform buffer
 
 uniform mat3 u_projection;
+uniform mat3 u_group;
 uniform sampler2D u_transforms;                 // shared per-frame transform buffer (3 texels/row)
 
 out vec2 v_texcoord;
@@ -66,7 +67,7 @@ void main(void) {
     float worldX = (m0.x * localX) + (m0.y * localY) + m1.x;
     float worldY = (m0.z * localX) + (m0.w * localY) + m1.y;
 
-    gl_Position = vec4((u_projection * vec3(worldX, worldY, 1.0)).xy, 0.0, 1.0);
+    gl_Position = vec4((u_projection * u_group * vec3(worldX, worldY, 1.0)).xy, 0.0, 1.0);
 
     float u = (cornerX == 0) ? a_uvBounds.x : a_uvBounds.z;
     float v = (cornerY == 0) ? a_uvBounds.y : a_uvBounds.w;

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -170,6 +170,8 @@ export class WebGl2Backend implements RenderBackend {
   private _renderTarget: RenderTarget;
   private readonly _snapTransform: Matrix = new Matrix();
   private _renderer: Renderer | null = null;
+  private _renderGroupTransform: Matrix | null = null;
+  private _renderGroupTransformId = 0;
   private _shader: Shader | null = null;
   private _blendMode: BlendModes | null = null;
   private _texture: Texture | RenderTexture | null = null;
@@ -971,6 +973,38 @@ export class WebGl2Backend implements RenderBackend {
     this._flushActiveRenderer();
 
     return this;
+  }
+
+  /**
+   * Active per-group transform for the draws submitted until the next call
+   * (Track B Slice 2, S2-D2). `null` means identity (no retained group).
+   * Renderers fold it into their vertex stage as `u_group`.
+   * @internal
+   */
+  public get renderGroupTransform(): Matrix | null {
+    return this._renderGroupTransform;
+  }
+
+  /**
+   * Monotonic stamp bumped on every {@link _setRenderGroupTransform} call.
+   * Renderers compare it to skip redundant `u_group` re-staging within an
+   * unchanged group scope.
+   * @internal
+   */
+  public get renderGroupTransformId(): number {
+    return this._renderGroupTransformId;
+  }
+
+  /**
+   * Playback hook (RenderPlanPlayer): enter/leave a retained transform group.
+   * A group is a flush boundary by design (S2-D2) — the pending batch must
+   * drain under the OLD group matrix before the new one takes effect.
+   * @internal
+   */
+  public _setRenderGroupTransform(transform: Matrix | null): void {
+    this._flushActiveRenderer();
+    this._renderGroupTransform = transform;
+    this._renderGroupTransformId++;
   }
 
   public destroy(): void {

--- a/src/rendering/webgl2/WebGl2MeshRenderer.ts
+++ b/src/rendering/webgl2/WebGl2MeshRenderer.ts
@@ -1,3 +1,4 @@
+import { Matrix } from '#math/Matrix';
 import type { Geometry } from '#rendering/geometry/Geometry';
 import type { Material, UniformValue } from '#rendering/material/Material';
 import type { Mesh } from '#rendering/mesh/Mesh';
@@ -27,6 +28,7 @@ const initialNodeIndexCapacity = 64;
 const defaultVertexColor = 0xffffffff; // white, full alpha
 const maxCustomTextureSlots = 8;
 const transformTextureUnit = 8;
+const identityGroupMat3 = new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
 
 interface MeshRendererConnection {
   readonly gl: WebGL2RenderingContext;
@@ -73,6 +75,7 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> {
     { length: Math.max(transformTextureUnit + 1, maxCustomTextureSlots + 1) },
     (_, i) => new Int32Array([i]),
   );
+  private readonly _groupComposeScratch = new Matrix();
 
   private _vertexCapacity = initialVertexCapacity;
   private _indexCapacity = initialIndexCapacity;
@@ -424,8 +427,18 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> {
       shader.getUniform('u_projection').setValue(backend.view.getTransform().toArray(false));
     }
 
+    if (shader.uniforms.has('u_group')) {
+      const groupTransform = backend.renderGroupTransform;
+
+      shader.getUniform('u_group').setValue(groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3);
+    }
+
     if (shader.uniforms.has('u_translation')) {
-      shader.getUniform('u_translation').setValue(mesh.getGlobalTransform().toArray(false));
+      const groupTransform = backend.renderGroupTransform;
+      const translation =
+        groupTransform !== null ? this._groupComposeScratch.copy(mesh.getGlobalTransform()).combine(groupTransform) : mesh.getGlobalTransform();
+
+      shader.getUniform('u_translation').setValue(translation.toArray(false));
     }
 
     if (shader.uniforms.has('u_tint')) {
@@ -465,6 +478,12 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> {
   ): void {
     if (shader.uniforms.has('u_projection')) {
       shader.getUniform('u_projection').setValue(backend.view.getTransform().toArray(false));
+    }
+
+    if (shader.uniforms.has('u_group')) {
+      const groupTransform = backend.renderGroupTransform;
+
+      shader.getUniform('u_group').setValue(groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3);
     }
 
     if (shader.uniforms.has('u_transforms')) {

--- a/src/rendering/webgl2/WebGl2MeshRenderer.ts
+++ b/src/rendering/webgl2/WebGl2MeshRenderer.ts
@@ -434,6 +434,10 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> {
     }
 
     if (shader.uniforms.has('u_translation')) {
+      // Invariant: a custom mesh vertex shader must not declare BOTH `u_group`
+      // and consume `u_translation` — that would apply the group transform
+      // twice (once staged as `u_group`, once folded in here). This CPU-side
+      // compose is the fallback for shaders WITHOUT `u_group`.
       const groupTransform = backend.renderGroupTransform;
       const translation =
         groupTransform !== null ? this._groupComposeScratch.copy(mesh.getGlobalTransform()).combine(groupTransform) : mesh.getGlobalTransform();

--- a/src/rendering/webgl2/WebGl2NineSliceSpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2NineSliceSpriteRenderer.ts
@@ -24,6 +24,7 @@ layout(location = 2) in vec4 a_color;        // RGBA tint
 layout(location = 3) in uint a_nodeIndex;    // row into the shared transform buffer
 
 uniform mat3 u_projection;
+uniform mat3 u_group;
 uniform sampler2D u_transforms;              // shared per-frame transform buffer (3 texels/row)
 
 out vec2 v_texcoord;
@@ -45,7 +46,7 @@ void main(void) {
     float worldX = (m0.x * localX) + (m0.y * localY) + m1.x;
     float worldY = (m0.z * localX) + (m0.w * localY) + m1.y;
 
-    gl_Position = vec4((u_projection * vec3(worldX, worldY, 1.0)).xy, 0.0, 1.0);
+    gl_Position = vec4((u_projection * u_group * vec3(worldX, worldY, 1.0)).xy, 0.0, 1.0);
 
     float u = (cornerX == 0) ? a_uvBounds.x : a_uvBounds.z;
     float v = (cornerY == 0) ? a_uvBounds.y : a_uvBounds.w;
@@ -72,6 +73,7 @@ void main(void) {
 const instanceStrideBytes = 32;
 const wordsPerInstance = instanceStrideBytes / Uint32Array.BYTES_PER_ELEMENT;
 const transformTextureUnit = 1;
+const identityGroupMat3 = new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
 
 interface NineSliceRendererConnection {
   readonly gl: WebGL2RenderingContext;
@@ -95,6 +97,7 @@ export class WebGl2NineSliceSpriteRenderer extends AbstractWebGl2Renderer<NineSl
   private _currentTexture: Texture | RenderTexture | null = null;
   private _currentView: View | null = null;
   private _currentViewId = -1;
+  private _currentGroupTransformId = -1;
 
   private _instanceBuffer: WebGl2RenderBuffer | null = null;
   private _vao: WebGl2VertexArrayObject | null = null;
@@ -236,6 +239,14 @@ export class WebGl2NineSliceSpriteRenderer extends AbstractWebGl2Renderer<NineSl
       this._shader.getUniform('u_projection').setValue(view.getTransform().toArray(false));
     }
 
+    if (this._shader.uniforms.has('u_group') && this._currentGroupTransformId !== backend.renderGroupTransformId) {
+      this._currentGroupTransformId = backend.renderGroupTransformId;
+
+      const groupTransform = backend.renderGroupTransform;
+
+      this._shader.getUniform('u_group').setValue(groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3);
+    }
+
     if (this._currentTexture !== null) {
       this._shader.getUniform('u_texture').setValue(new Int32Array([0]));
     }
@@ -284,6 +295,7 @@ export class WebGl2NineSliceSpriteRenderer extends AbstractWebGl2Renderer<NineSl
     this._currentTexture = null;
     this._currentView = null;
     this._currentViewId = -1;
+    this._currentGroupTransformId = -1;
     this._quadIndex = 0;
     this._maxNodeIndex = 0;
   }

--- a/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
@@ -27,6 +27,7 @@ layout(location = 2) in vec4 a_color;        // RGBA tint (normalised)
 layout(location = 3) in uint a_nodeIndex;    // transform row
 
 uniform mat3 u_projection;
+uniform mat3 u_group;
 uniform sampler2D u_transforms;
 
 out vec2 v_texcoord;
@@ -49,7 +50,7 @@ void main(void) {
 
     float wx = m0.x * lx + m0.y * ly + m1.x;
     float wy = m0.z * lx + m0.w * ly + m1.y;
-    gl_Position = vec4((u_projection * vec3(wx, wy, 1.0)).xy, 0.0, 1.0);
+    gl_Position = vec4((u_projection * u_group * vec3(wx, wy, 1.0)).xy, 0.0, 1.0);
 
     float u = (destW > 0.0)
         ? ((lx - a_quadBounds.x) / destW) * a_uvParams.x + a_uvParams.z
@@ -76,6 +77,7 @@ layout(location = 2) in vec4 a_color;        // RGBA tint
 layout(location = 3) in uint a_nodeIndex;    // transform row
 
 uniform mat3 u_projection;
+uniform mat3 u_group;
 uniform sampler2D u_transforms;
 
 out vec2 v_texcoord;
@@ -95,7 +97,7 @@ void main(void) {
 
     float wx = m0.x * lx + m0.y * ly + m1.x;
     float wy = m0.z * lx + m0.w * ly + m1.y;
-    gl_Position = vec4((u_projection * vec3(wx, wy, 1.0)).xy, 0.0, 1.0);
+    gl_Position = vec4((u_projection * u_group * vec3(wx, wy, 1.0)).xy, 0.0, 1.0);
 
     float u = (cx == 0) ? a_uvBounds.x : a_uvBounds.z;
     float v = (cy == 0) ? a_uvBounds.y : a_uvBounds.w;
@@ -129,6 +131,7 @@ const geoStrideBytes = 32; // 8 × uint32 (matches NineSlice layout)
 const geoWordsPerInstance = geoStrideBytes / Uint32Array.BYTES_PER_ELEMENT;
 
 const transformTextureUnit = 1;
+const identityGroupMat3 = new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
 
 // ---------------------------------------------------------------------------
 // Sampler cache helper
@@ -190,6 +193,7 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
   private readonly _snapBounds = new Rectangle();
   private _currentView: unknown = null;
   private _currentViewId = -1;
+  private _currentGroupTransformId = -1;
 
   public constructor(batchSize: number) {
     super();
@@ -393,6 +397,21 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
       this._geoPathShader.getUniform('u_projection').setValue(proj);
     }
 
+    if (this._currentGroupTransformId !== backend.renderGroupTransformId) {
+      this._currentGroupTransformId = backend.renderGroupTransformId;
+
+      const groupTransform = backend.renderGroupTransform;
+      const groupArray = groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3;
+
+      if (this._shaderPathShader.uniforms.has('u_group')) {
+        this._shaderPathShader.getUniform('u_group').setValue(groupArray);
+      }
+
+      if (this._geoPathShader.uniforms.has('u_group')) {
+        this._geoPathShader.getUniform('u_group').setValue(groupArray);
+      }
+    }
+
     if (this._shaderQuadCount > 0) {
       this._flushShaderBatch(backend);
     }
@@ -553,6 +572,7 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
     this._connection = null;
     this._currentView = null;
     this._currentViewId = -1;
+    this._currentGroupTransformId = -1;
     this._resetBatchState();
   }
 

--- a/src/rendering/webgl2/WebGl2SpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2SpriteRenderer.ts
@@ -55,6 +55,7 @@ import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './
  * breaks on material instance, base texture, blend mode, or buffer capacity.
  */
 
+const identityGroupMat3 = new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
 const maxBatchTextures = 8;
 // Sprite base textures occupy units 0..7; the shared transform buffer texture
 // binds on unit 8, matching the mesh renderer's convention.
@@ -101,6 +102,7 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> {
   private _currentBlendMode: BlendModes | null = null;
   private _currentView: View | null = null;
   private _currentViewId = -1;
+  private _currentGroupTransformId = -1;
 
   private _instanceBuffer: WebGl2RenderBuffer | null = null;
   private _vao: WebGl2VertexArrayObject | null = null;
@@ -184,11 +186,25 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> {
         this._currentViewId = view.updateId;
         this._shader.getUniform('u_projection').setValue(view.getTransform().toArray(false));
       }
+
+      if (this._shader.uniforms.has('u_group') && this._currentGroupTransformId !== backend.renderGroupTransformId) {
+        this._currentGroupTransformId = backend.renderGroupTransformId;
+
+        const groupTransform = backend.renderGroupTransform;
+
+        this._shader.getUniform('u_group').setValue(groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3);
+      }
     } else {
       // Custom path: projection is set per flush (cheap, and the cached
       // default-shader view state does not carry over to a custom program).
       if (shader.uniforms.has('u_projection')) {
         shader.getUniform('u_projection').setValue(backend.view.getTransform().toArray(false));
+      }
+
+      if (shader.uniforms.has('u_group')) {
+        const groupTransform = backend.renderGroupTransform;
+
+        shader.getUniform('u_group').setValue(groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3);
       }
 
       // The single base texture binds to unit 0 as `u_texture`.
@@ -270,6 +286,7 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> {
     this._currentBlendMode = null;
     this._currentView = null;
     this._currentViewId = -1;
+    this._currentGroupTransformId = -1;
     this._instanceCount = 0;
     this._maxNodeIndex = 0;
   }

--- a/src/rendering/webgl2/WebGl2TextRenderer.ts
+++ b/src/rendering/webgl2/WebGl2TextRenderer.ts
@@ -39,6 +39,8 @@ import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './
 const nodeTexels = 10;
 const nodeFloats = nodeTexels * 4; // 40 floats per node
 
+const identityGroupMat3 = new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
+
 // Per-vertex layout (28 bytes):
 //   a_position : vec2  f32  (offset  0,  8 bytes)  ← WORLD space (CPU-transformed)
 //   a_texcoord : vec2  f32  (offset  8,  8 bytes)
@@ -481,6 +483,11 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
 
       if (shader.uniforms.has('u_projection')) {
         shader.getUniform('u_projection').setValue(view.getTransform().toArray(false));
+      }
+      if (shader.uniforms.has('u_group')) {
+        const groupTransform = backend.renderGroupTransform;
+
+        shader.getUniform('u_group').setValue(groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3);
       }
       if (shader.uniforms.has('u_texture')) {
         shader.getUniform('u_texture').setValue(this._textureUnitScratch);

--- a/src/rendering/webgl2/glsl/mesh.vert
+++ b/src/rendering/webgl2/glsl/mesh.vert
@@ -7,6 +7,7 @@ layout(location = 2) in vec4 a_color;
 layout(location = 6) in uint a_nodeIndex;
 
 uniform mat3 u_projection;
+uniform mat3 u_group;
 uniform sampler2D u_transforms;
 
 out vec2 v_texcoord;
@@ -23,7 +24,7 @@ void main(void) {
         m1.x, m1.y, 1.0
     );
 
-    gl_Position = vec4((u_projection * transform * vec3(a_position, 1.0)).xy, 0.0, 1.0);
+    gl_Position = vec4((u_projection * u_group * transform * vec3(a_position, 1.0)).xy, 0.0, 1.0);
     v_texcoord = a_texcoord;
     v_color = a_color;
     v_tint = texelFetch(u_transforms, ivec2(2, row), 0);

--- a/src/rendering/webgl2/glsl/nine-slice-sprite.vert
+++ b/src/rendering/webgl2/glsl/nine-slice-sprite.vert
@@ -10,6 +10,7 @@ layout(location = 2) in vec4 a_color;        // RGBA tint
 layout(location = 3) in uint a_nodeIndex;    // row into the shared transform buffer
 
 uniform mat3 u_projection;
+uniform mat3 u_group;
 uniform sampler2D u_transforms;              // shared per-frame transform buffer (3 texels/row)
 
 out vec2 v_texcoord;
@@ -31,7 +32,7 @@ void main(void) {
     float worldX = (m0.x * localX) + (m0.y * localY) + m1.x;
     float worldY = (m0.z * localX) + (m0.w * localY) + m1.y;
 
-    gl_Position = vec4((u_projection * vec3(worldX, worldY, 1.0)).xy, 0.0, 1.0);
+    gl_Position = vec4((u_projection * u_group * vec3(worldX, worldY, 1.0)).xy, 0.0, 1.0);
 
     float u = (cornerX == 0) ? a_uvBounds.x : a_uvBounds.z;
     float v = (cornerY == 0) ? a_uvBounds.y : a_uvBounds.w;

--- a/src/rendering/webgl2/glsl/sprite.vert
+++ b/src/rendering/webgl2/glsl/sprite.vert
@@ -12,6 +12,7 @@ layout(location = 5) in uint a_textureSlot;
 layout(location = 6) in uint a_nodeIndex;       // row into the shared transform buffer
 
 uniform mat3 u_projection;
+uniform mat3 u_group;
 uniform sampler2D u_transforms;                 // shared per-frame transform buffer (3 texels/row)
 
 out vec2 v_texcoord;
@@ -40,7 +41,7 @@ void main(void) {
     float worldX = (m0.x * localX) + (m0.y * localY) + m1.x;
     float worldY = (m0.z * localX) + (m0.w * localY) + m1.y;
 
-    gl_Position = vec4((u_projection * vec3(worldX, worldY, 1.0)).xy, 0.0, 1.0);
+    gl_Position = vec4((u_projection * u_group * vec3(worldX, worldY, 1.0)).xy, 0.0, 1.0);
 
     // UV: pick from the bounds rectangle. The CPU pre-swaps Y bounds when
     // the texture is flipY, so the shader doesn't have to know.

--- a/src/rendering/webgl2/glsl/text.vert
+++ b/src/rendering/webgl2/glsl/text.vert
@@ -14,13 +14,14 @@ layout(location = 2) in float a_nodeIndex;  // row into the per-node data textur
 layout(location = 3) in vec2  a_gradUV;     // normalised gradient UV (CPU-computed)
 
 uniform mat3 u_projection;
+uniform mat3 u_group;
 
 flat out int  v_nodeIndex;
      out vec2 v_texcoord;
      out vec2 v_gradUV;
 
 void main(void) {
-    gl_Position = vec4((u_projection * vec3(a_position, 1.0)).xy, 0.0, 1.0);
+    gl_Position = vec4((u_projection * u_group * vec3(a_position, 1.0)).xy, 0.0, 1.0);
     v_texcoord  = a_texcoord;
     v_nodeIndex = int(a_nodeIndex);
     v_gradUV    = a_gradUV;

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -161,6 +161,8 @@ export class WebGpuBackend implements RenderBackend {
   private _renderTarget: RenderTarget;
   private readonly _snapTransform: Matrix = new Matrix();
   private _renderer: Renderer | null = null;
+  private _renderGroupTransform: Matrix | null = null;
+  private _renderGroupTransformId = 0;
   private _texture: Texture | RenderTexture | null = null;
   private _clearRequested = false;
   private _hasPresentedFrame = false;
@@ -980,6 +982,38 @@ export class WebGpuBackend implements RenderBackend {
     // flushes into the same open pass (via WebGpuInstanceArena) and no longer end
     // it themselves, collapsing thousands of per-draw submits into one per frame.
     this._passCoordinatorInstance?.endPass();
+  }
+
+  /**
+   * Active per-group transform for the draws submitted until the next call
+   * (Track B Slice 2, S2-D2). `null` means identity (no retained group).
+   * Renderers fold it into their vertex stage as the projection UBO's `group`.
+   * @internal
+   */
+  public get renderGroupTransform(): Matrix | null {
+    return this._renderGroupTransform;
+  }
+
+  /**
+   * Monotonic stamp bumped on every {@link _setRenderGroupTransform} call.
+   * Renderers compare it to skip redundant group re-staging within an
+   * unchanged group scope.
+   * @internal
+   */
+  public get renderGroupTransformId(): number {
+    return this._renderGroupTransformId;
+  }
+
+  /**
+   * Playback hook (RenderPlanPlayer): enter/leave a retained transform group.
+   * A group is a flush boundary by design (S2-D2) — the pending batch must
+   * drain under the OLD group matrix before the new one takes effect.
+   * @internal
+   */
+  public _setRenderGroupTransform(transform: Matrix | null): void {
+    this._flushActiveRenderer();
+    this._renderGroupTransform = transform;
+    this._renderGroupTransformId++;
   }
 
   /**

--- a/src/rendering/webgpu/WebGpuMeshRenderer.ts
+++ b/src/rendering/webgpu/WebGpuMeshRenderer.ts
@@ -84,6 +84,7 @@ struct TransformSlot {
 
 struct TransformUniforms {
     projection: mat3x3<f32>,
+    group: mat3x3<f32>,
     flags: vec4<f32>,
 };
 
@@ -103,7 +104,7 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
     );
 
     var output: VertexOutput;
-    output.position = vec4<f32>((uniforms.projection * world).xy, 0.0, 1.0);
+    output.position = vec4<f32>((uniforms.projection * uniforms.group * world).xy, 0.0, 1.0);
     output.texcoord = input.texcoord;
     output.color = input.color;
     output.tint = slot.m2;
@@ -128,7 +129,7 @@ fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
 const vertexStrideBytes = 20;
 const wordsPerVertex = vertexStrideBytes / 4;
 const tintByteLength = 32; // vec4 tint + vec4 flags (only flags.x used)
-const transformUniformByteLength = 64; // mat3x3<f32> (48B) + vec4<f32> flags (16B)
+const transformUniformByteLength = 112; // mat3x3<f32> projection (48B) + mat3x3<f32> group (48B) + vec4<f32> flags (16B)
 
 // Custom-shader uniform layout:
 //   mat3x3<f32> projection   — 48 bytes (3 vec3 columns padded to vec4 in WGSL)
@@ -890,9 +891,16 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
     const vertexCount = mesh.vertexCount;
 
     if (bake) {
-      // Bake (view * globalTransform) into vertex positions on the CPU,
+      // Bake (view * group * globalTransform) into vertex positions on the CPU,
       // matching the primitive renderer's no-uniforms approach.
-      const matrix = this._combinedTransform.copy(mesh.getGlobalTransform()).combine(backend.view.getTransform());
+      const groupTransform = backend.renderGroupTransform;
+      const matrix = this._combinedTransform.copy(mesh.getGlobalTransform());
+
+      if (groupTransform !== null) {
+        matrix.combine(groupTransform);
+      }
+
+      matrix.combine(backend.view.getTransform());
 
       const a = matrix.a;
       const b = matrix.b;
@@ -1145,6 +1153,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
   private _writeInstancedUniformSlot(slot: number, backend: WebGpuBackend, premultiplySample: boolean): void {
     const data = this._instancedUniformScratch;
     const projection = backend.view.getTransform();
+    const groupTransform = backend.renderGroupTransform;
 
     data.fill(0);
     data[0] = projection.a;
@@ -1154,7 +1163,22 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
     data[8] = projection.x;
     data[9] = projection.y;
     data[10] = 1;
-    data[12] = premultiplySample ? 1 : 0;
+
+    if (groupTransform !== null) {
+      data[12] = groupTransform.a;
+      data[13] = groupTransform.b;
+      data[16] = groupTransform.c;
+      data[17] = groupTransform.d;
+      data[20] = groupTransform.x;
+      data[21] = groupTransform.y;
+      data[22] = 1;
+    } else {
+      data[12] = 1;
+      data[17] = 1;
+      data[22] = 1;
+    }
+
+    data[24] = premultiplySample ? 1 : 0;
 
     this._device!.queue.writeBuffer(this._instancedUniformBuffer!, slot * this._uniformAlignment, data.buffer, data.byteOffset, transformUniformByteLength);
   }
@@ -1598,7 +1622,8 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
     const data = new Float32Array(slotFloats);
 
     const proj = backend.view.getTransform();
-    const trans = mesh.getGlobalTransform();
+    const groupTransform = backend.renderGroupTransform;
+    const trans = groupTransform !== null ? this._combinedTransform.copy(mesh.getGlobalTransform()).combine(groupTransform) : mesh.getGlobalTransform();
 
     // mat3 (column-major): [a, c, tx | b, d, ty | 0, 0, 1] in 2D.
     // WGSL mat3x3 has each column padded to vec4. Store as:

--- a/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
@@ -16,6 +16,7 @@ import { stencilContentDepthStencilState } from './WebGpuStencilState';
 export const nineSliceShaderSource = `
 struct ProjectionUniforms {
     matrix: mat4x4<f32>,
+    group: mat4x4<f32>,
 };
 
 struct TransformSlot {
@@ -62,7 +63,7 @@ fn vertexMain(input: VertexInput, @builtin(vertex_index) vid: u32) -> VertexOutp
     let worldX = slot.m0.x * localX + slot.m0.y * localY + slot.m1.x;
     let worldY = slot.m0.z * localX + slot.m0.w * localY + slot.m1.y;
 
-    output.position = projection.matrix * vec4<f32>(worldX, worldY, 0.0, 1.0);
+    output.position = projection.matrix * projection.group * vec4<f32>(worldX, worldY, 0.0, 1.0);
 
     let u = select(input.uvBounds.x, input.uvBounds.z, cornerX == 1u);
     let v = select(input.uvBounds.y, input.uvBounds.w, cornerY == 1u);
@@ -82,7 +83,8 @@ fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
 
 const instanceStrideBytes = 32;
 const wordsPerInstance = instanceStrideBytes / Uint32Array.BYTES_PER_ELEMENT; // = 8
-const projectionByteLength = 64;
+const projectionByteLength = 128;
+const identityGroupMat4 = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
 const initialBatchCapacity = 32;
 const indicesPerInstance = 6;
 const quadIndices = new Uint16Array([0, 1, 2, 0, 2, 3]);
@@ -90,6 +92,7 @@ const quadIndices = new Uint16Array([0, 1, 2, 0, 2, 3]);
 /** Instanced renderer for {@link NineSliceSprite} using WebGPU. */
 export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSliceSprite> {
   private readonly _projectionData = new Float32Array(projectionByteLength / Float32Array.BYTES_PER_ELEMENT);
+  private _writtenGroupTransformId = -1;
 
   private _device: GPUDevice | null = null;
   private _shaderModule: GPUShaderModule | null = null;
@@ -285,7 +288,7 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
       activePass !== null &&
       this._instanceArena.cursor > 0 &&
       this._instanceArena.tracksPass(activePass) &&
-      activePass.viewUpdateId !== backend.view.updateId
+      (activePass.viewUpdateId !== backend.view.updateId || this._writtenGroupTransformId !== backend.renderGroupTransformId)
     ) {
       backend._passCoordinator.endPass();
       this._instanceArena.resetPass();
@@ -294,6 +297,37 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     const viewMatrix = backend.view.getTransform();
 
     this._projectionData.set([viewMatrix.a, viewMatrix.c, 0, 0, viewMatrix.b, viewMatrix.d, 0, 0, 0, 0, 1, 0, viewMatrix.x, viewMatrix.y, 0, viewMatrix.z]);
+
+    const groupTransform = backend.renderGroupTransform;
+
+    if (groupTransform !== null) {
+      this._projectionData.set(
+        [
+          groupTransform.a,
+          groupTransform.c,
+          0,
+          0,
+          groupTransform.b,
+          groupTransform.d,
+          0,
+          0,
+          0,
+          0,
+          1,
+          0,
+          groupTransform.x,
+          groupTransform.y,
+          0,
+          groupTransform.z,
+        ],
+        16,
+      );
+    } else {
+      this._projectionData.set(identityGroupMat4, 16);
+    }
+
+    this._writtenGroupTransformId = backend.renderGroupTransformId;
+
     device.queue.writeBuffer(uniformBuffer, 0, this._projectionData.buffer, this._projectionData.byteOffset, this._projectionData.byteLength);
 
     const scissor = backend.getScissorRect();

--- a/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
@@ -23,6 +23,7 @@ import { stencilContentDepthStencilState } from './WebGpuStencilState';
 export const commonWgsl = `
 struct ProjectionUniforms {
     matrix: mat4x4<f32>,
+    group: mat4x4<f32>,
 };
 struct TransformSlot {
     m0: vec4<f32>,
@@ -69,7 +70,7 @@ fn shaderVert(input: ShaderVIn, @builtin(vertex_index) vid: u32) -> VOut {
     let slot = transforms[input.nodeIndex];
     let wx = slot.m0.x * lx + slot.m0.y * ly + slot.m1.x;
     let wy = slot.m0.z * lx + slot.m0.w * ly + slot.m1.y;
-    out.pos = projection.matrix * vec4<f32>(wx, wy, 0.0, 1.0);
+    out.pos = projection.matrix * projection.group * vec4<f32>(wx, wy, 0.0, 1.0);
 
     let u = select(input.uvParams.z, ((lx - input.quadBounds.x) / destW) * input.uvParams.x + input.uvParams.z, destW > 0.0);
     let v = select(input.uvParams.w, ((ly - input.quadBounds.y) / destH) * input.uvParams.y + input.uvParams.w, destH > 0.0);
@@ -108,7 +109,7 @@ fn geoVert(input: GeoVIn, @builtin(vertex_index) vid: u32) -> VOut {
     let slot = transforms[input.nodeIndex];
     let wx = slot.m0.x * lx + slot.m0.y * ly + slot.m1.x;
     let wy = slot.m0.z * lx + slot.m0.w * ly + slot.m1.y;
-    out.pos = projection.matrix * vec4<f32>(wx, wy, 0.0, 1.0);
+    out.pos = projection.matrix * projection.group * vec4<f32>(wx, wy, 0.0, 1.0);
 
     let u = select(input.uvBounds.x, input.uvBounds.z, cx == 1u);
     let v = select(input.uvBounds.y, input.uvBounds.w, cy == 1u);
@@ -129,7 +130,8 @@ fn geoFrag(input: VOut) -> @location(0) vec4<f32> {
 
 const shaderStrideBytes = 40; // float32x4 bounds + float32x4 uvParams + unorm8x4 + uint32
 const geoStrideBytes = 32; // float32x4 bounds + unorm16x4 + unorm8x4 + uint32 (NineSlice layout)
-const projectionByteLength = 64;
+const projectionByteLength = 128;
+const identityGroupMat4 = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
 const initialBatchCapacity = 32;
 const indicesPerInstance = 6;
 const quadIndices = new Uint16Array([0, 1, 2, 0, 2, 3]);
@@ -147,6 +149,7 @@ function repeatModeToAddressMode(mode: RepeatMode): GPUAddressMode {
 /** Instanced renderer for {@link RepeatingSprite} using WebGPU. */
 export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<RepeatingSprite> {
   private readonly _projData = new Float32Array(projectionByteLength / Float32Array.BYTES_PER_ELEMENT);
+  private _writtenGroupTransformId = -1;
 
   // Shared GPU objects
   private _device: GPUDevice | null = null;
@@ -429,7 +432,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
       activePass !== null &&
       this._instanceArena.cursor > 0 &&
       this._instanceArena.tracksPass(activePass) &&
-      activePass.viewUpdateId !== backend.view.updateId
+      (activePass.viewUpdateId !== backend.view.updateId || this._writtenGroupTransformId !== backend.renderGroupTransformId)
     ) {
       backend._passCoordinator.endPass();
       this._instanceArena.resetPass();
@@ -437,6 +440,37 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
 
     const vm = backend.view.getTransform();
     this._projData.set([vm.a, vm.c, 0, 0, vm.b, vm.d, 0, 0, 0, 0, 1, 0, vm.x, vm.y, 0, vm.z]);
+
+    const groupTransform = backend.renderGroupTransform;
+
+    if (groupTransform !== null) {
+      this._projData.set(
+        [
+          groupTransform.a,
+          groupTransform.c,
+          0,
+          0,
+          groupTransform.b,
+          groupTransform.d,
+          0,
+          0,
+          0,
+          0,
+          1,
+          0,
+          groupTransform.x,
+          groupTransform.y,
+          0,
+          groupTransform.z,
+        ],
+        16,
+      );
+    } else {
+      this._projData.set(identityGroupMat4, 16);
+    }
+
+    this._writtenGroupTransformId = backend.renderGroupTransformId;
+
     device.queue.writeBuffer(uniform, 0, this._projData.buffer, this._projData.byteOffset, this._projData.byteLength);
 
     const scissor = backend.getScissorRect();

--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -19,6 +19,7 @@ import { stencilContentDepthStencilState } from './WebGpuStencilState';
 export const spriteShaderSource = `
 struct ProjectionUniforms {
     matrix: mat4x4<f32>,
+    group: mat4x4<f32>,
 };
 
 struct TransformSlot {
@@ -106,7 +107,7 @@ fn vertexMain(input: VertexInput, @builtin(vertex_index) vid: u32) -> VertexOutp
     let worldX = slot.m0.x * localX + slot.m0.y * localY + slot.m1.x;
     let worldY = slot.m0.z * localX + slot.m0.w * localY + slot.m1.y;
 
-    output.position = projection.matrix * vec4<f32>(worldX, worldY, 0.0, 1.0);
+    output.position = projection.matrix * projection.group * vec4<f32>(worldX, worldY, 0.0, 1.0);
 
     let u = select(input.uvBounds.x, input.uvBounds.z, cornerX == 1u);
     let v = select(input.uvBounds.y, input.uvBounds.w, cornerY == 1u);
@@ -167,7 +168,8 @@ fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
 
 const instanceStrideBytes = 36;
 const wordsPerInstance = instanceStrideBytes / Uint32Array.BYTES_PER_ELEMENT;
-const projectionByteLength = 64;
+const projectionByteLength = 128;
+const identityGroupMat4 = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
 const initialBatchCapacity = 32;
 const maxBatchTextures = 8;
 const maxCustomTextureSlots = 7; // user texture uniforms; group(2) binding 1..N
@@ -194,6 +196,7 @@ interface CustomSpriteResources {
 
 export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
   private readonly _projectionData = new Float32Array(projectionByteLength / Float32Array.BYTES_PER_ELEMENT);
+  private _writtenGroupTransformId = -1;
 
   private _device: GPUDevice | null = null;
   private _shaderModule: GPUShaderModule | null = null;
@@ -492,6 +495,36 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
 
     this._projectionData.set([viewMatrix.a, viewMatrix.c, 0, 0, viewMatrix.b, viewMatrix.d, 0, 0, 0, 0, 1, 0, viewMatrix.x, viewMatrix.y, 0, viewMatrix.z]);
 
+    const groupTransform = backend.renderGroupTransform;
+
+    if (groupTransform !== null) {
+      this._projectionData.set(
+        [
+          groupTransform.a,
+          groupTransform.c,
+          0,
+          0,
+          groupTransform.b,
+          groupTransform.d,
+          0,
+          0,
+          0,
+          0,
+          1,
+          0,
+          groupTransform.x,
+          groupTransform.y,
+          0,
+          groupTransform.z,
+        ],
+        16,
+      );
+    } else {
+      this._projectionData.set(identityGroupMat4, 16);
+    }
+
+    this._writtenGroupTransformId = backend.renderGroupTransformId;
+
     device.queue.writeBuffer(uniformBuffer, 0, this._projectionData.buffer, this._projectionData.byteOffset, this._projectionData.byteLength);
 
     const scissor = backend.getScissorRect();
@@ -617,7 +650,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
       activePass !== null &&
       this._instanceArena.cursor > 0 &&
       this._instanceArena.tracksPass(activePass) &&
-      activePass.viewUpdateId !== backend.view.updateId
+      (activePass.viewUpdateId !== backend.view.updateId || this._writtenGroupTransformId !== backend.renderGroupTransformId)
     ) {
       backend._passCoordinator.endPass();
       this._instanceArena.resetPass();

--- a/src/rendering/webgpu/WebGpuTextRenderer.ts
+++ b/src/rendering/webgpu/WebGpuTextRenderer.ts
@@ -37,8 +37,9 @@ const initialVertexCapacity = 256;
 const initialIndexCapacity = 384;
 const initialNodeCapacity = 32;
 
-// FrameUniforms: 3 × vec4<f32> = 48 bytes (projection mat3x3 column-major)
-const projectionBytes = 48;
+// FrameUniforms: 6 × vec4<f32> = 96 bytes (projection + group mat3x3, column-major)
+const projectionBytes = 96;
+const identityGroupMat3 = new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
 
 type ShaderType = 'sdf' | 'msdf' | 'color';
 
@@ -63,6 +64,9 @@ struct FrameUniforms {
     projCol0 : vec4<f32>,
     projCol1 : vec4<f32>,
     projCol2 : vec4<f32>,
+    groupCol0 : vec4<f32>,
+    groupCol1 : vec4<f32>,
+    groupCol2 : vec4<f32>,
 };
 
 @group(0) @binding(0) var<uniform>       frame : FrameUniforms;
@@ -104,7 +108,12 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
         vec3<f32>(t0.w, t1.w, 1.0),
     );
 
-    let worldPos = proj * xf * vec3<f32>(input.position, 1.0);
+    let grp = mat3x3<f32>(
+        frame.groupCol0.xyz,
+        frame.groupCol1.xyz,
+        frame.groupCol2.xyz,
+    );
+    let worldPos = proj * grp * xf * vec3<f32>(input.position, 1.0);
 
     let bSize  = t9.zw;
     var gradUV = vec2<f32>(0.0);
@@ -340,6 +349,23 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     this._projData[9] = m[7]!;
     this._projData[10] = m[8]!;
     this._projData[11] = 0;
+
+    const groupTransform = backend.renderGroupTransform;
+    const g = groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3;
+
+    this._projData[12] = g[0]!;
+    this._projData[13] = g[1]!;
+    this._projData[14] = g[2]!;
+    this._projData[15] = 0;
+    this._projData[16] = g[3]!;
+    this._projData[17] = g[4]!;
+    this._projData[18] = g[5]!;
+    this._projData[19] = 0;
+    this._projData[20] = g[6]!;
+    this._projData[21] = g[7]!;
+    this._projData[22] = g[8]!;
+    this._projData[23] = 0;
+
     device.queue.writeBuffer(this._projBuffer!, 0, this._projData.buffer, 0, projectionBytes);
 
     // Upload per-node style data (may reallocate the storage buffer)

--- a/test/core/__snapshots__/root-index-snapshot.test.ts.snap
+++ b/test/core/__snapshots__/root-index-snapshot.test.ts.snap
@@ -134,6 +134,7 @@ exports[`root index export surface snapshot > sorted runtime export names match 
   "RenderingContext",
   "RenderingPrimitives",
   "RepeatingSprite",
+  "RetainedContainer",
   "SERIALIZATION_VERSION",
   "Sampler",
   "ScaleModes",

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -289,6 +289,7 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "RepeatingSprite: class",
   "RepeatingSpriteOptions: interface",
   "ResolvedGamepadDefinition: interface",
+  "RetainedContainer: class",
   "SERIALIZATION_VERSION: variable",
   "Sampler: class",
   "SamplerOptions: interface",

--- a/test/core/scene-node-revision-invariants.test.ts
+++ b/test/core/scene-node-revision-invariants.test.ts
@@ -1,0 +1,202 @@
+import { Color } from '#core/Color';
+import { Rectangle } from '#math/Rectangle';
+import { Container } from '#rendering/Container';
+import { Drawable } from '#rendering/Drawable';
+import { Filter } from '#rendering/filters/Filter';
+import type { RenderNode } from '#rendering/RenderNode';
+import { BlendModes } from '#rendering/types';
+
+// Mirror the existing NoopFilter in test/rendering/render-plan.test.ts exactly
+// (check its constructor/apply signature there before finalizing this class).
+class NoopFilter extends Filter {
+  public override apply(): void {
+    // no-op
+  }
+}
+
+type DirtyKind = 'content' | 'structure';
+
+interface MutatorCase {
+  readonly name: string;
+  readonly expects: DirtyKind;
+  readonly create: () => RenderNode;
+  readonly mutate: (node: RenderNode) => void;
+}
+
+const drawableCase = (name: string, expects: DirtyKind, mutate: (node: Drawable) => void, create: () => Drawable = () => new Drawable()): MutatorCase => ({
+  name,
+  expects,
+  create,
+  mutate: node => mutate(node as Drawable),
+});
+
+const containerCase = (name: string, expects: DirtyKind, mutate: (node: Container) => void, create: () => Container = () => new Container()): MutatorCase => ({
+  name,
+  expects,
+  create,
+  mutate: node => mutate(node as Container),
+});
+
+// Bare Drawable()/Container() instances have zero-size local bounds, so
+// mutators whose effect is derived from local bounds (setAnchor, width,
+// height) would be no-ops against the default fixture. Give those cases a
+// node with non-empty local bounds so the mutation actually changes a value.
+const withLocalBounds = <T extends Drawable | Container>(node: T): T => {
+  node.getLocalBounds().set(0, 0, 16, 16);
+
+  return node;
+};
+
+const containerWithSizedChild = (): Container => {
+  const container = new Container();
+
+  container.addChild(withLocalBounds(new Drawable()));
+
+  return container;
+};
+
+// THE TABLE. One row per public member that changes visual output. Adding a
+// mutator to SceneNode/RenderNode/Drawable/Container without a row here is a
+// review error; a row whose bump assertion fails is an engine bug.
+const cases: readonly MutatorCase[] = [
+  // SceneNode transform family — content-dirty.
+  drawableCase('setPosition', 'content', n => n.setPosition(10, 20)),
+  // A same-value assignment (cloning the current, default (0,0) position) is
+  // correctly a no-op under the equality-guarded vector setter, so the clone
+  // is mutated to a different value first to exercise a real change.
+  drawableCase('position setter', 'content', n => {
+    const next = n.position.clone();
+
+    next.set(next.x + 10, next.y + 20);
+    n.position = next;
+  }),
+  drawableCase('x setter', 'content', n => (n.x = 5)),
+  drawableCase('y setter', 'content', n => (n.y = 5)),
+  drawableCase('setRotation', 'content', n => n.setRotation(45)),
+  drawableCase('rotation setter', 'content', n => (n.rotation = 45)),
+  drawableCase('setScale', 'content', n => n.setScale(2, 2)),
+  drawableCase('setOrigin', 'content', n => n.setOrigin(4, 4)),
+  // setAnchor derives origin from local bounds (origin = boundsSize *
+  // anchor), so it is a no-op against the default zero-size Drawable bounds.
+  drawableCase(
+    'setAnchor',
+    'content',
+    n => n.setAnchor(0.5, 0.5),
+    () => withLocalBounds(new Drawable()),
+  ),
+  drawableCase('setSkew', 'content', n => n.setSkew(10, 0)),
+  drawableCase('skewX setter', 'content', n => (n.skewX = 10)),
+  drawableCase('skewY setter', 'content', n => (n.skewY = 10)),
+  drawableCase('move', 'content', n => n.move(1, 1)),
+  drawableCase('rotate', 'content', n => n.rotate(5)),
+  drawableCase('zIndex setter', 'content', n => (n.zIndex = 3)),
+  // SceneNode cull family — structure-dirty (same class as `visible`: changes
+  // WHICH draws a collect emits). These are two of the five audit gaps.
+  drawableCase('cullable setter', 'structure', n => (n.cullable = false)),
+  drawableCase('cullArea setter', 'structure', n => (n.cullArea = new Rectangle(0, 0, 8, 8))),
+  // SceneNode visibility — structure-dirty (D6, already wired in Slice 1).
+  drawableCase('visible setter', 'structure', n => (n.visible = false)),
+  // RenderNode effect/plan-shape family. First three are audit gaps.
+  drawableCase('preserveDrawOrder setter', 'structure', n => (n.preserveDrawOrder = true)),
+  drawableCase('clip setter', 'structure', n => (n.clip = true)),
+  drawableCase('clipShape setter', 'structure', n => (n.clipShape = new Rectangle(0, 0, 8, 8))),
+  drawableCase('filters setter', 'content', n => (n.filters = [new NoopFilter()])),
+  drawableCase('addFilter', 'content', n => n.addFilter(new NoopFilter())),
+  drawableCase('mask setter', 'content', n => (n.mask = new Rectangle(0, 0, 8, 8))),
+  drawableCase('cacheAsBitmap setter', 'content', n => (n.cacheAsBitmap = true)),
+  drawableCase('invalidateCache', 'content', n => n.invalidateCache()),
+  drawableCase('invalidateContent', 'content', n => n.invalidateContent()),
+  // Drawable visual-source family — content-dirty.
+  drawableCase('setTint', 'content', n => n.setTint(new Color(10, 20, 30))),
+  drawableCase('setBlendMode', 'content', n => n.setBlendMode(BlendModes.Add)),
+  drawableCase('pixelSnapMode setter', 'content', n => (n.pixelSnapMode = 'geometry')),
+  // Container structural mutators — structure-dirty (wired in Slice 1).
+  containerCase('addChild', 'structure', n => n.addChild(new Drawable())),
+  // addChild is itself a structure-dirty mutator (tested above), so the
+  // sized child needed to make the width/height division non-trivial must be
+  // added during `create` — before the "before" revisions are captured —
+  // not inside `mutate`, or the structure-dirty assertion below would be
+  // polluted by the addChild call rather than reflecting the width/height
+  // setter alone.
+  containerCase('width setter', 'content', n => (n.width = 128), containerWithSizedChild),
+  containerCase('height setter', 'content', n => (n.height = 128), containerWithSizedChild),
+];
+
+describe('revision invariants: every public visual mutator bumps the right revision', () => {
+  for (const mutatorCase of cases) {
+    test(`${mutatorCase.name} is ${mutatorCase.expects}-dirty and propagates to the parent`, () => {
+      const parent = new Container();
+      const node = mutatorCase.create();
+
+      parent.addChild(node);
+
+      const nodeContentBefore = node._contentRevision;
+      const nodeStructureBefore = node._structureRevision;
+      const parentContentBefore = parent._contentRevision;
+      const parentStructureBefore = parent._structureRevision;
+
+      mutatorCase.mutate(node);
+
+      // Structure implies content (NodeRevision.touchStructure), so content
+      // must advance for BOTH kinds.
+      expect(node._contentRevision).toBeGreaterThan(nodeContentBefore);
+      expect(parent._contentRevision).toBeGreaterThan(parentContentBefore);
+
+      if (mutatorCase.expects === 'structure') {
+        expect(node._structureRevision).toBeGreaterThan(nodeStructureBefore);
+        expect(parent._structureRevision).toBeGreaterThan(parentStructureBefore);
+      } else {
+        expect(node._structureRevision).toBe(nodeStructureBefore);
+        expect(parent._structureRevision).toBe(parentStructureBefore);
+      }
+
+      parent.destroy();
+    });
+
+    test(`${mutatorCase.name} does not touch an unrelated sibling subtree`, () => {
+      const root = new Container();
+      const parent = new Container();
+      const sibling = new Container();
+      const node = mutatorCase.create();
+
+      root.addChild(parent);
+      root.addChild(sibling);
+      parent.addChild(node);
+
+      const siblingContentBefore = sibling._contentRevision;
+
+      mutatorCase.mutate(node);
+
+      expect(sibling._contentRevision).toBe(siblingContentBefore);
+
+      root.destroy();
+    });
+  }
+
+  test('same-value writes to the five gap members are no-ops (no spurious bump)', () => {
+    const node = new Drawable();
+
+    node.cullable = false;
+    node.clip = true;
+    node.preserveDrawOrder = true;
+
+    const before = node._structureRevision;
+
+    node.cullable = false;
+    node.clip = true;
+    node.preserveDrawOrder = true;
+
+    // Read-then-write (rather than the literal `node.cullArea = node.cullArea`)
+    // to dodge eslint's no-self-assign rule while keeping the same runtime
+    // effect: writing the current value back must stay a no-op.
+    const cullArea = node.cullArea;
+    const clipShape = node.clipShape;
+
+    node.cullArea = cullArea;
+    node.clipShape = clipShape;
+
+    expect(node._structureRevision).toBe(before);
+
+    node.destroy();
+  });
+});

--- a/test/core/scene-node-transform-group.test.ts
+++ b/test/core/scene-node-transform-group.test.ts
@@ -1,0 +1,133 @@
+import { Rectangle } from '#math/Rectangle';
+import { Container } from '#rendering/Container';
+import { Drawable } from '#rendering/Drawable';
+
+/** Test double for the task-7 RetainedContainer: only the boundary flag. */
+class BoundaryContainer extends Container {
+  public override get _isTransformGroupBoundary(): boolean {
+    return true;
+  }
+}
+
+describe('transform-group boundary: descendants resolve group-relative transforms', () => {
+  test('a child below a boundary ignores the boundary ancestor chain (identity parent)', () => {
+    const world = new Container();
+    const group = new BoundaryContainer();
+    const child = new Drawable();
+
+    world.setPosition(100, 100);
+    group.setPosition(40, 0);
+    child.setPosition(5, 5);
+
+    world.addChild(group);
+    group.addChild(child);
+
+    // Group-relative: only the child's own local transform.
+    expect(child.getGlobalTransform().x).toBe(5);
+    expect(child.getGlobalTransform().y).toBe(5);
+    // The boundary node itself still resolves its REAL world transform.
+    expect(group.getGlobalTransform().x).toBe(140);
+    expect(group.getGlobalTransform().y).toBe(100);
+
+    world.destroy();
+  });
+
+  test('moving the boundary node does not change (or even recompute) a child global transform', () => {
+    const group = new BoundaryContainer();
+    const child = new Drawable();
+
+    group.addChild(child);
+    child.setPosition(5, 5);
+    child.getGlobalTransform(); // settle
+
+    const before = child.getGlobalTransform().x;
+
+    group.setPosition(500, 500);
+
+    expect(child.getGlobalTransform().x).toBe(before);
+
+    group.destroy();
+  });
+
+  test('a nested plain container below the boundary stays group-relative too', () => {
+    const group = new BoundaryContainer();
+    const mid = new Container();
+    const leaf = new Drawable();
+
+    group.setPosition(300, 0);
+    mid.setPosition(10, 0);
+    leaf.setPosition(1, 0);
+
+    group.addChild(mid);
+    mid.addChild(leaf);
+
+    expect(leaf.getGlobalTransform().x).toBe(11);
+
+    group.destroy();
+  });
+
+  test('a barrier-bearing direct child ESCAPES the boundary and stays world-space (D-P4)', () => {
+    const group = new BoundaryContainer();
+    const clipped = new Drawable();
+
+    group.setPosition(40, 0);
+    clipped.setPosition(5, 0);
+    clipped.clip = true;
+    clipped.clipShape = new Rectangle(0, 0, 8, 8);
+
+    group.addChild(clipped);
+
+    // World-space: group translation + own translation.
+    expect(clipped.getGlobalTransform().x).toBe(45);
+
+    // And it follows a group move lazily, like any world-space child.
+    group.setPosition(100, 0);
+
+    expect(clipped.getGlobalTransform().x).toBe(105);
+
+    group.destroy();
+  });
+});
+
+describe('own-transform dirty seam (_markOwnTransformDirty)', () => {
+  class GroupLikeContainer extends Container {
+    public ownTransformMarks = 0;
+
+    protected override _markOwnTransformDirty(): void {
+      // Group semantics preview (task 7): version-bump instead of
+      // content-dirtying, but ancestors still get stale-bounds flags.
+      this.ownTransformMarks++;
+      this._invalidateBoundsFlags();
+    }
+  }
+
+  test('a subclass can reroute own-transform mutations away from the content revision', () => {
+    const node = new GroupLikeContainer();
+    const contentBefore = node._contentRevision;
+
+    node.setPosition(10, 10);
+    node.setRotation(45);
+    node.setScale(2);
+
+    expect(node.ownTransformMarks).toBe(3);
+    expect(node._contentRevision).toBe(contentBefore);
+
+    node.destroy();
+  });
+
+  test("the default seam keeps today's behavior: setPosition is content-dirty and bounds-cascading", () => {
+    const parent = new Container();
+    const node = new Drawable();
+
+    parent.addChild(node);
+    parent.getBounds(); // settle bounds flags
+
+    const before = node._contentRevision;
+
+    node.setPosition(10, 10);
+
+    expect(node._contentRevision).toBeGreaterThan(before);
+
+    parent.destroy();
+  });
+});

--- a/test/perf/baseline/adapters/exojs.ts
+++ b/test/perf/baseline/adapters/exojs.ts
@@ -3,6 +3,7 @@ import { Color } from '#core/Color';
 import { Scene } from '#core/Scene';
 import { Container } from '#rendering/Container';
 import { RenderBackendType } from '#rendering/RenderBackendType';
+import { RetainedContainer } from '#rendering/RetainedContainer';
 import { Sprite } from '#rendering/sprite/Sprite';
 import { Texture } from '#rendering/texture/Texture';
 import type { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
@@ -69,7 +70,10 @@ const createDistinctTexture = (index: number, total: number): Texture => {
  * sequence (`resetStats(); clear(); rendering.render(root); flush()`) is
  * identical on both, so only {@link init} branches on the backend type.
  */
-export const createExoJsAdapter = (backendFilter?: readonly Backend[]): EngineAdapter => {
+/** Which ExoJS arm this adapter represents: today's default path, or the Slice-2 RetainedContainer spine. */
+export type ExoJsAdapterConfig = 'current' | 'retained';
+
+export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: ExoJsAdapterConfig = 'current'): EngineAdapter => {
   const supported: readonly Backend[] = backendFilter ?? ['webgl2', 'webgpu'];
 
   let app: Application | null = null;
@@ -79,7 +83,7 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[]): EngineAd
 
   return {
     engine: 'exojs',
-    config: 'current',
+    config,
 
     supports(backend: Backend): boolean {
       return supported.includes(backend);
@@ -121,15 +125,21 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[]): EngineAd
 
       // Nested-container spine whose depth equals `nestingDepth`; leaves are
       // distributed evenly across it (round-robin), so a deeper archetype pays
-      // for deeper transform propagation.
-      const sceneRoot = new Container();
+      // for deeper transform propagation. When `config === 'retained'` every
+      // spine container is a `RetainedContainer` (Track B Slice 2): on
+      // static-heavy the whole spine retains (spec §10(a)); on dynamic-heavy
+      // the wobbling leaves invalidate their spine groups every frame (the
+      // honest §10(c) measurement of the opt-in's cost when content churns).
+      const createSpineContainer = (): Container => (config === 'retained' ? new RetainedContainer() : new Container());
+
+      const sceneRoot = createSpineContainer();
 
       sceneRoot.cullable = spec.cullingEnabled;
 
       const spine: Container[] = [sceneRoot];
 
       for (let depth = 1; depth < spec.nestingDepth; depth++) {
-        const container = new Container();
+        const container = createSpineContainer();
 
         container.cullable = spec.cullingEnabled;
         spine[depth - 1]!.addChild(container);

--- a/test/perf/baseline/archetypes.test.ts
+++ b/test/perf/baseline/archetypes.test.ts
@@ -1,3 +1,4 @@
+import { createExoJsAdapter } from './adapters/exojs';
 import { ARCHETYPES, buildMatrix, createRng, timedFramesFor } from './archetypes';
 import type { Backend, EngineAdapter } from './EngineAdapter';
 
@@ -80,5 +81,18 @@ describe('buildMatrix', () => {
     const big = cells.find(c => c.nodeCount === 100_000)!;
 
     expect(big.timedFrames).toBe(timedFramesFor(100_000));
+  });
+});
+
+describe('exojs adapter config axis', () => {
+  test('the retained config produces an adapter labeled engine=exojs config=retained', () => {
+    const adapter = createExoJsAdapter(undefined, 'retained');
+
+    expect(adapter.engine).toBe('exojs');
+    expect(adapter.config).toBe('retained');
+  });
+
+  test('the default stays current', () => {
+    expect(createExoJsAdapter().config).toBe('current');
   });
 });

--- a/test/perf/baseline/driver.ts
+++ b/test/perf/baseline/driver.ts
@@ -89,7 +89,10 @@ const capabilityDescriptor = (engine: string, config: string, backends: readonly
   teardown: driverSideOnly,
 });
 
-const ADAPTER_CAPABILITIES: readonly EngineAdapter[] = [capabilityDescriptor('exojs', 'current', ['webgl2', 'webgpu'])];
+const ADAPTER_CAPABILITIES: readonly EngineAdapter[] = [
+  capabilityDescriptor('exojs', 'current', ['webgl2', 'webgpu']),
+  capabilityDescriptor('exojs', 'retained', ['webgl2', 'webgpu']),
+];
 
 /**
  * Load Vite through the copy vitest already depends on. Vite is not a direct

--- a/test/perf/baseline/page/harness.ts
+++ b/test/perf/baseline/page/harness.ts
@@ -376,8 +376,10 @@ const runBaselineMatrix = async (cells: CellSpec[]): Promise<CellResult[]> => {
 
   const adapters = new Map<string, EngineAdapter>();
   const exojs = createExoJsAdapter();
+  const exojsRetained = createExoJsAdapter(undefined, 'retained');
 
   adapters.set(adapterKey(exojs.engine, exojs.config), exojs);
+  adapters.set(adapterKey(exojsRetained.engine, exojsRetained.config), exojsRetained);
 
   const referenceAdapters = await loadReferenceAdapters();
 

--- a/test/rendering/browser/webgl2-group-uniform.test.ts
+++ b/test/rendering/browser/webgl2-group-uniform.test.ts
@@ -1,0 +1,268 @@
+/**
+ * WebGL2 group-uniform browser test — v0.16 Track B Slice 2 proof entry.
+ *
+ * Verifies that a backend-level group transform (`u_group`) offsets sprite
+ * output, and that clearing it restores identity. Establishes the pixel
+ * proof for the additive `u_group` plumbing before any caller
+ * (RetainedPlanCache / RenderPlanPlayer) constructs a group.
+ *
+ * Run via:  pnpm test:browser:webgl
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Matrix } from '#math/Matrix';
+import { Container } from '#rendering/Container';
+import type { RenderNode } from '#rendering/RenderNode';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+
+// ---------------------------------------------------------------------------
+// Shader mocks
+//
+// The vitest shaderPlugin replaces every .vert/.frag import with
+// `export default ""`. `WebGl2Backend#initialize` connects the renderer
+// registry eagerly (compiling every registered renderer's program, not just
+// the ones a given test renders), so the Sprite + Mesh + Text shaders that
+// `wireCoreRenderers()` registers all need valid GLSL sources even though
+// this file only ever renders a Sprite.
+// ---------------------------------------------------------------------------
+
+const shaderSources = vi.hoisted(() => ({
+  spriteVert: `#version 300 es
+precision mediump float;
+in vec4 a_localBounds;
+in vec4 a_uvBounds;
+in vec4 a_color;
+in uint a_textureSlot;
+in uint a_nodeIndex;
+uniform mat3 u_projection;
+uniform mat3 u_group;
+uniform sampler2D u_transforms;
+out vec2 v_uv;
+out vec4 v_color;
+flat out uint v_textureSlot;
+void main() {
+  vec2 local;
+  if (gl_VertexID == 0) local = vec2(a_localBounds.x, a_localBounds.y);
+  else if (gl_VertexID == 1) local = vec2(a_localBounds.z, a_localBounds.y);
+  else if (gl_VertexID == 2) local = vec2(a_localBounds.x, a_localBounds.w);
+  else local = vec2(a_localBounds.z, a_localBounds.w);
+  vec2 uv;
+  if (gl_VertexID == 0) uv = vec2(a_uvBounds.x, a_uvBounds.y);
+  else if (gl_VertexID == 1) uv = vec2(a_uvBounds.z, a_uvBounds.y);
+  else if (gl_VertexID == 2) uv = vec2(a_uvBounds.x, a_uvBounds.w);
+  else uv = vec2(a_uvBounds.z, a_uvBounds.w);
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
+  vec3 clip = u_projection * u_group * vec3(world, 1.0);
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = uv; v_color = a_color; v_textureSlot = a_textureSlot;
+}`,
+
+  spriteFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv;
+in vec4 v_color;
+flat in uint v_textureSlot;
+uniform sampler2D u_texture0;
+uniform sampler2D u_texture1;
+uniform sampler2D u_texture2;
+uniform sampler2D u_texture3;
+uniform sampler2D u_texture4;
+uniform sampler2D u_texture5;
+uniform sampler2D u_texture6;
+uniform sampler2D u_texture7;
+out vec4 outColor;
+vec4 sampleTexture(uint slot, vec2 uv) {
+  if (slot == uint(0)) return texture(u_texture0, uv);
+  if (slot == uint(1)) return texture(u_texture1, uv);
+  if (slot == uint(2)) return texture(u_texture2, uv);
+  if (slot == uint(3)) return texture(u_texture3, uv);
+  if (slot == uint(4)) return texture(u_texture4, uv);
+  if (slot == uint(5)) return texture(u_texture5, uv);
+  if (slot == uint(6)) return texture(u_texture6, uv);
+  return texture(u_texture7, uv);
+}
+void main() { outColor = sampleTexture(v_textureSlot, v_uv) * v_color; }`,
+
+  meshVert: `#version 300 es
+precision mediump float;
+in vec2 a_position;
+in vec2 a_texcoord;
+in vec4 a_color;
+in uint a_nodeIndex;
+uniform mat3 u_projection;
+uniform sampler2D u_transforms;
+out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
+void main() {
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  mat3 t = mat3(m0.x,m0.z,0.0, m0.y,m0.w,0.0, m1.x,m1.y,1.0);
+  vec3 world = t * vec3(a_position, 1.0);
+  vec3 clip = u_projection * world;
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = a_texcoord; v_color = a_color;
+  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+}`,
+
+  meshFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv; in vec4 v_color; in vec4 v_tint;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() { outColor = texture(u_texture, v_uv) * v_color * v_tint; }`,
+
+  textVert: `#version 300 es
+precision mediump float;
+in vec2 a_position; in vec2 a_texcoord; in float a_nodeIndex;
+uniform mat3 u_projection;
+out vec2 v_uv;
+void main() {
+  float ni = a_nodeIndex;
+  vec3 clip = u_projection * vec3(a_position + vec2(ni * 0.0), 1.0);
+  gl_Position = vec4(clip.xy, 0.0, 1.0); v_uv = a_texcoord;
+}`,
+
+  textFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() { outColor = texture(u_texture, v_uv); }`,
+}));
+
+vi.mock('#rendering/webgl2/glsl/sprite.vert', () => ({ default: shaderSources.spriteVert }));
+vi.mock('#rendering/webgl2/glsl/sprite.frag', () => ({ default: shaderSources.spriteFrag }));
+vi.mock('#rendering/webgl2/glsl/mesh.vert', () => ({ default: shaderSources.meshVert }));
+vi.mock('#rendering/webgl2/glsl/mesh.frag', () => ({ default: shaderSources.meshFrag }));
+vi.mock('#rendering/webgl2/glsl/text.vert', () => ({ default: shaderSources.textVert }));
+vi.mock('#rendering/webgl2/glsl/text-color.frag', () => ({ default: shaderSources.textFrag }));
+vi.mock('#rendering/webgl2/glsl/text-msdf.frag', () => ({ default: shaderSources.textFrag }));
+vi.mock('#rendering/webgl2/glsl/text-sdf.frag', () => ({ default: shaderSources.textFrag }));
+
+// ---------------------------------------------------------------------------
+// Infrastructure helpers
+// ---------------------------------------------------------------------------
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const createBackend = async (): Promise<WebGl2Backend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const app: Application = {
+    canvas,
+    options: {
+      clearColor: Color.black,
+      canvas: { width: canvasSize, height: canvasSize },
+      rendering: {
+        debug: false,
+        webglAttributes: {
+          alpha: false,
+          antialias: false,
+          premultipliedAlpha: false,
+          preserveDrawingBuffer: true,
+          stencil: false,
+          depth: false,
+        },
+        spriteRendererBatchSize: 1024,
+        particleRendererBatchSize: 1024,
+      },
+    },
+  } as unknown as Application;
+
+  const backend = new WebGl2Backend(app);
+
+  await backend.initialize();
+  wireCoreRenderers(backend, app.options.rendering);
+
+  return backend;
+};
+
+const render = (backend: WebGl2Backend, node: RenderNode): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+  node.render(backend);
+  backend.flush();
+};
+
+const readPixel = (backend: WebGl2Backend, x: number, y: number): RgbaTuple => {
+  const buf = new Uint8Array(4);
+  const gl = backend.context;
+
+  gl.readPixels(Math.floor(x), backend.renderTarget.height - Math.floor(y) - 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+
+  return [buf[0], buf[1], buf[2], buf[3]];
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 8): void => {
+  for (let i = 0; i < 4; i++) {
+    expect(Math.abs(actual[i] - expected[i])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+const createSolidTexture = (color: string, width = 16, height = 16): Texture => {
+  const src = document.createElement('canvas');
+
+  src.width = width;
+  src.height = height;
+
+  const ctx = src.getContext('2d')!;
+
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, width, height);
+
+  return new Texture(src);
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WebGL2 group uniform (u_group)', () => {
+  test('a backend-level group transform offsets sprite output; clearing it restores identity', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ff0000', 16, 16);
+    const root = new Container();
+    const sprite = new Sprite(texture);
+    const groupTransform = new Matrix();
+
+    try {
+      sprite.setPosition(0, 0);
+      root.addChild(sprite);
+
+      // translate(24, 24) as an ExoJS Matrix: x/y carry the translation.
+      groupTransform.x = 24;
+      groupTransform.y = 24;
+
+      backend._setRenderGroupTransform(groupTransform);
+      render(backend, root);
+
+      // Sprite local 0..16 shifted by the group to 24..40.
+      expectPixelNear(readPixel(backend, 32, 32), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(backend, 8, 8), [0, 0, 0, 255]);
+
+      backend._setRenderGroupTransform(null);
+      render(backend, root);
+
+      // Identity again: sprite back at 0..16.
+      expectPixelNear(readPixel(backend, 8, 8), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(backend, 32, 32), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgl2-retained-container.test.ts
+++ b/test/rendering/browser/webgl2-retained-container.test.ts
@@ -1,0 +1,486 @@
+/**
+ * WebGL2 renderer-matrix browser tests — RetainedContainer pixel cells
+ * (Track B Slice 2, spec §8/§10(d) correctness gate).
+ *
+ * Seven cells asserting real rendered output for the retained-group feature
+ * shipped across tasks 3-8: camera motion over a retained fragment, a group
+ * move via the group matrix, a child mutation inside the group, a tint/alpha
+ * change inside the group, bitmap text lifted by the group uniform, an
+ * effect-bearing direct child (cacheAsBitmap) that escapes the group
+ * convention, and a depth-2 effect node that disengages the boundary
+ * (plan D-P4 Option A) while keeping pixel-correct plain-Container output.
+ *
+ * Run via:  pnpm test:browser:webgl
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import type { RenderNode } from '#rendering/RenderNode';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { BitmapText, type BmFontData } from '#rendering/text/BitmapText';
+import { BmFont } from '#rendering/text/BmFont';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+
+// ---------------------------------------------------------------------------
+// Shader mocks
+//
+// The vitest shaderPlugin replaces every .vert/.frag import with
+// `export default ""`. `WebGl2Backend#initialize` connects the renderer
+// registry eagerly (compiling every registered renderer's program, not just
+// the ones a given test renders), so the Sprite + Mesh + Text shaders that
+// `wireCoreRenderers()` registers all need valid GLSL sources even though
+// this file only ever renders Sprite/BitmapText nodes.
+//
+// spriteVert and the extended textVert both declare/multiply `u_group`
+// (copied from webgl2-group-uniform.test.ts, task 3's proof entry) so the
+// group uniform lifts both sprite and bitmap-text vertices the same way the
+// production shaders do (spec §7 text exception).
+// ---------------------------------------------------------------------------
+
+const shaderSources = vi.hoisted(() => ({
+  spriteVert: `#version 300 es
+precision mediump float;
+in vec4 a_localBounds;
+in vec4 a_uvBounds;
+in vec4 a_color;
+in uint a_textureSlot;
+in uint a_nodeIndex;
+uniform mat3 u_projection;
+uniform mat3 u_group;
+uniform sampler2D u_transforms;
+out vec2 v_uv;
+out vec4 v_color;
+flat out uint v_textureSlot;
+void main() {
+  vec2 local;
+  if (gl_VertexID == 0) local = vec2(a_localBounds.x, a_localBounds.y);
+  else if (gl_VertexID == 1) local = vec2(a_localBounds.z, a_localBounds.y);
+  else if (gl_VertexID == 2) local = vec2(a_localBounds.x, a_localBounds.w);
+  else local = vec2(a_localBounds.z, a_localBounds.w);
+  vec2 uv;
+  if (gl_VertexID == 0) uv = vec2(a_uvBounds.x, a_uvBounds.y);
+  else if (gl_VertexID == 1) uv = vec2(a_uvBounds.z, a_uvBounds.y);
+  else if (gl_VertexID == 2) uv = vec2(a_uvBounds.x, a_uvBounds.w);
+  else uv = vec2(a_uvBounds.z, a_uvBounds.w);
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
+  vec3 clip = u_projection * u_group * vec3(world, 1.0);
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = uv; v_color = a_color; v_textureSlot = a_textureSlot;
+}`,
+
+  spriteFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv;
+in vec4 v_color;
+flat in uint v_textureSlot;
+uniform sampler2D u_texture0;
+uniform sampler2D u_texture1;
+uniform sampler2D u_texture2;
+uniform sampler2D u_texture3;
+uniform sampler2D u_texture4;
+uniform sampler2D u_texture5;
+uniform sampler2D u_texture6;
+uniform sampler2D u_texture7;
+out vec4 outColor;
+vec4 sampleTexture(uint slot, vec2 uv) {
+  if (slot == uint(0)) return texture(u_texture0, uv);
+  if (slot == uint(1)) return texture(u_texture1, uv);
+  if (slot == uint(2)) return texture(u_texture2, uv);
+  if (slot == uint(3)) return texture(u_texture3, uv);
+  if (slot == uint(4)) return texture(u_texture4, uv);
+  if (slot == uint(5)) return texture(u_texture5, uv);
+  if (slot == uint(6)) return texture(u_texture6, uv);
+  return texture(u_texture7, uv);
+}
+void main() { outColor = sampleTexture(v_textureSlot, v_uv) * v_color; }`,
+
+  meshVert: `#version 300 es
+precision mediump float;
+in vec2 a_position;
+in vec2 a_texcoord;
+in vec4 a_color;
+in uint a_nodeIndex;
+uniform mat3 u_projection;
+uniform sampler2D u_transforms;
+out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
+void main() {
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  mat3 t = mat3(m0.x,m0.z,0.0, m0.y,m0.w,0.0, m1.x,m1.y,1.0);
+  vec3 world = t * vec3(a_position, 1.0);
+  vec3 clip = u_projection * world;
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = a_texcoord; v_color = a_color;
+  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+}`,
+
+  meshFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv; in vec4 v_color; in vec4 v_tint;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() { outColor = texture(u_texture, v_uv) * v_color * v_tint; }`,
+
+  // Explicit layout locations are load-bearing: WebGl2TextRenderer links this
+  // vertex source into THREE separate programs (sdf/msdf/color shaders), but
+  // wires its single shared VAO's attribute pointers from only one of them
+  // (the sdf shader). Without matching explicit locations, a GLSL linker is
+  // free to assign a_position/a_texcoord/a_nodeIndex to different locations
+  // per program even from identical source, desyncing the VAO from whichever
+  // program is actually active when a "color" (BitmapText) batch draws.
+  textVert: `#version 300 es
+precision mediump float;
+layout(location = 0) in vec2 a_position;
+layout(location = 1) in vec2 a_texcoord;
+layout(location = 2) in float a_nodeIndex;
+uniform mat3 u_projection;
+uniform mat3 u_group;
+out vec2 v_uv;
+void main() {
+  float ni = a_nodeIndex;
+  vec3 clip = u_projection * u_group * vec3(a_position + vec2(ni * 0.0), 1.0);
+  gl_Position = vec4(clip.xy, 0.0, 1.0); v_uv = a_texcoord;
+}`,
+
+  textFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() { outColor = texture(u_texture, v_uv); }`,
+}));
+
+vi.mock('#rendering/webgl2/glsl/sprite.vert', () => ({ default: shaderSources.spriteVert }));
+vi.mock('#rendering/webgl2/glsl/sprite.frag', () => ({ default: shaderSources.spriteFrag }));
+vi.mock('#rendering/webgl2/glsl/mesh.vert', () => ({ default: shaderSources.meshVert }));
+vi.mock('#rendering/webgl2/glsl/mesh.frag', () => ({ default: shaderSources.meshFrag }));
+vi.mock('#rendering/webgl2/glsl/text.vert', () => ({ default: shaderSources.textVert }));
+vi.mock('#rendering/webgl2/glsl/text-color.frag', () => ({ default: shaderSources.textFrag }));
+vi.mock('#rendering/webgl2/glsl/text-msdf.frag', () => ({ default: shaderSources.textFrag }));
+vi.mock('#rendering/webgl2/glsl/text-sdf.frag', () => ({ default: shaderSources.textFrag }));
+
+// ---------------------------------------------------------------------------
+// Infrastructure helpers
+// ---------------------------------------------------------------------------
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const createBackend = async (): Promise<WebGl2Backend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const app: Application = {
+    canvas,
+    options: {
+      clearColor: Color.black,
+      canvas: { width: canvasSize, height: canvasSize },
+      rendering: {
+        debug: false,
+        webglAttributes: {
+          alpha: false,
+          antialias: false,
+          premultipliedAlpha: false,
+          preserveDrawingBuffer: true,
+          stencil: false,
+          depth: false,
+        },
+        spriteRendererBatchSize: 1024,
+        particleRendererBatchSize: 1024,
+      },
+    },
+  } as unknown as Application;
+
+  const backend = new WebGl2Backend(app);
+
+  await backend.initialize();
+  wireCoreRenderers(backend, app.options.rendering);
+
+  return backend;
+};
+
+const render = (backend: WebGl2Backend, node: RenderNode): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+  node.render(backend);
+  backend.flush();
+};
+
+const readPixel = (backend: WebGl2Backend, x: number, y: number): RgbaTuple => {
+  const buf = new Uint8Array(4);
+  const gl = backend.context;
+
+  gl.readPixels(Math.floor(x), backend.renderTarget.height - Math.floor(y) - 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+
+  return [buf[0], buf[1], buf[2], buf[3]];
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 8): void => {
+  for (let i = 0; i < 4; i++) {
+    expect(Math.abs(actual[i] - expected[i])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+const createSolidTexture = (color: string, width = 16, height = 16): Texture => {
+  const src = document.createElement('canvas');
+
+  src.width = width;
+  src.height = height;
+
+  const ctx = src.getContext('2d')!;
+
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, width, height);
+
+  return new Texture(src);
+};
+
+// A BitmapText whose single glyph 'A' fills the whole `size`×`size` atlas page,
+// placed at the line origin so its quad covers (0,0)–(size,size) before any
+// node transform. The atlas page is a solid-colour texture, so the
+// colour-atlas shader (msdf = false) emits that colour directly — deterministic
+// pixels with no runtime font rasterisation or atlas-upload timing. Copied
+// verbatim from webgl2-bitmap-text.test.ts's font fixture.
+const createSolidBitmapText = (color: string, size: number): { text: BitmapText; texture: Texture } => {
+  const texture = createSolidTexture(color, size, size);
+  const fontData: BmFontData = {
+    pages: ['atlas_0.png'],
+    chars: new Map([[65, { x: 0, y: 0, width: size, height: size, xOffset: 0, yOffset: 0, xAdvance: size, page: 0 }]]),
+    kernings: new Map(),
+    // base === lineHeight ⇒ yBearing 0 ⇒ the glyph top sits at the line origin.
+    lineHeight: size,
+    base: size,
+  };
+
+  return { text: new BitmapText('A', new BmFont(fontData, [texture])), texture };
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WebGL2 renderer matrix: RetainedContainer cells', () => {
+  test('cell 1 — retained group under camera motion: fragment splices, pixels track the view', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ff0000', 16, 16);
+    const root = new Container();
+    const group = new RetainedContainer();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.setPosition(8, 8);
+      group.addChild(sprite);
+      root.addChild(group);
+
+      render(backend, root); // frame 1: full collect + capture
+      expectPixelNear(readPixel(backend, 16, 16), [255, 0, 0, 255]);
+
+      // Pan the camera 16px right: the sprite must appear 16px further left.
+      // The default view of a 64x64 canvas is centered at (32, 32).
+      backend.view.setCenter(backend.view.center.x + 16, backend.view.center.y);
+      render(backend, root); // frame 2: spliced (no re-collect) — must still track the view
+
+      expectPixelNear(readPixel(backend, 0, 16), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(backend, 24, 16), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 2 — group move: one matrix update relocates the whole group', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#00ff00', 16, 16);
+    const root = new Container();
+    const group = new RetainedContainer();
+    const sprite = new Sprite(texture);
+
+    try {
+      group.addChild(sprite);
+      root.addChild(group);
+
+      render(backend, root);
+      expectPixelNear(readPixel(backend, 8, 8), [0, 255, 0, 255]);
+
+      group.setPosition(32, 32);
+      render(backend, root);
+
+      expectPixelNear(readPixel(backend, 40, 40), [0, 255, 0, 255]);
+      expectPixelNear(readPixel(backend, 8, 8), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 3 — child mutation inside the group is visible on the next frame', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ff0000', 16, 16);
+    const root = new Container();
+    const group = new RetainedContainer();
+    const sprite = new Sprite(texture);
+
+    try {
+      group.addChild(sprite);
+      root.addChild(group);
+
+      render(backend, root);
+      expectPixelNear(readPixel(backend, 8, 8), [255, 0, 0, 255]);
+
+      sprite.setPosition(24, 24);
+      render(backend, root);
+
+      expectPixelNear(readPixel(backend, 32, 32), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(backend, 8, 8), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 4 — tint/alpha change on a drawable inside the group is never served stale', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ffffff', 16, 16);
+    const root = new Container();
+    const group = new RetainedContainer();
+    const sprite = new Sprite(texture);
+
+    try {
+      group.addChild(sprite);
+      root.addChild(group);
+
+      render(backend, root);
+      expectPixelNear(readPixel(backend, 8, 8), [255, 255, 255, 255]);
+
+      sprite.tint = new Color(0, 255, 0);
+      render(backend, root);
+
+      expectPixelNear(readPixel(backend, 8, 8), [0, 255, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 5 — bitmap text inside a moved group renders at the group position', async () => {
+    const backend = await createBackend();
+    const { text, texture } = createSolidBitmapText('#ff0000', 32);
+    const root = new Container();
+    const group = new RetainedContainer();
+
+    try {
+      text.setPosition(8, 8); // covers (8,8)-(40,40) — same fixture/probes as webgl2-bitmap-text.test.ts
+      group.addChild(text);
+      root.addChild(group);
+
+      render(backend, root); // frame 1: full collect + capture
+      expectPixelNear(readPixel(backend, 16, 16), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(backend, 38, 38), [255, 0, 0, 255]);
+
+      // Move the group by (16, 0): text bakes group-relative vertices, so the
+      // u_group uniform must lift them (spec §7 text exception) — the glyph
+      // now covers (24,8)-(56,40).
+      group.setPosition(16, 0);
+      render(backend, root); // frame 2: spliced — the group matrix alone must relocate it
+
+      expectPixelNear(readPixel(backend, 32, 16), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(backend, 54, 38), [255, 0, 0, 255]);
+      // The original (un-shifted) position is now background.
+      expectPixelNear(readPixel(backend, 16, 16), [0, 0, 0, 255]);
+    } finally {
+      text.destroy();
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 6 — effect-bearing DIRECT child (cacheAsBitmap barrier) inside a moved group stays world-correct', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ff0000', 16, 16);
+    const root = new Container();
+    const group = new RetainedContainer();
+    const cached = new Sprite(texture);
+
+    try {
+      // Barrier child escapes the group convention: world-space, and
+      // cacheAsBitmap is visually neutral, so "semantics-neutral by
+      // construction" is directly pixel-assertable: identical placement to
+      // a plain sprite at the group position.
+      cached.cacheAsBitmap = true;
+      group.addChild(cached);
+      root.addChild(group);
+
+      group.setPosition(16, 16);
+      render(backend, root);
+
+      expectPixelNear(readPixel(backend, 24, 24), [255, 0, 0, 255]); // sprite 16..32
+      expectPixelNear(readPixel(backend, 8, 8), [0, 0, 0, 255]);
+      expectPixelNear(readPixel(backend, 40, 40), [0, 0, 0, 255]);
+
+      render(backend, root); // spliced frame: barrier re-dispatches, same output
+      expectPixelNear(readPixel(backend, 24, 24), [255, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 7 — effect-bearing node nested TWO levels deep: the boundary disengages and output stays correct', async () => {
+    const backend = await createBackend();
+    const red = createSolidTexture('#ff0000', 16, 16);
+    const green = createSolidTexture('#00ff00', 16, 16);
+    const root = new Container();
+    const group = new RetainedContainer();
+    const mid = new Container();
+    const deepCached = new Sprite(red);
+    const plainLeaf = new Sprite(green);
+
+    try {
+      deepCached.cacheAsBitmap = true; // barrier at depth 2 -> D-P4 Option A fallback
+      mid.setPosition(8, 8);
+      mid.addChild(deepCached);
+      group.addChild(mid);
+      group.addChild(plainLeaf);
+      group.setPosition(16, 16);
+      root.addChild(group);
+
+      render(backend, root);
+
+      // CORRECT output, not a warning: the deep effect lands at its true
+      // world position (16+8 -> 24..40) and the plain sibling at the group
+      // position (16..32) — the disengaged group renders exactly like a
+      // plain Container (group uniform identity, world-space transforms).
+      expectPixelNear(readPixel(backend, 36, 36), [255, 0, 0, 255]); // deep cached sprite only
+      expectPixelNear(readPixel(backend, 18, 18), [0, 255, 0, 255]); // plain leaf only
+      expectPixelNear(readPixel(backend, 8, 8), [0, 0, 0, 255]);
+      expectPixelNear(readPixel(backend, 46, 46), [0, 0, 0, 255]);
+
+      render(backend, root); // second frame: identical (no retention, no drift)
+      expectPixelNear(readPixel(backend, 36, 36), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(backend, 18, 18), [0, 255, 0, 255]);
+    } finally {
+      root.destroy();
+      red.destroy();
+      green.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgpu-group-uniform.test.ts
+++ b/test/rendering/browser/webgpu-group-uniform.test.ts
@@ -1,0 +1,184 @@
+/**
+ * WebGPU group matrix — projection UBO extension browser test (Track B Slice 2,
+ * S2-D2, plan D-P1).
+ *
+ * The group matrix joins the existing group(0) projection uniform data instead
+ * of a dynamic-offset binding: `WebGpuBackend._setRenderGroupTransform` sets a
+ * backend-level transform that all vertex stages compose as
+ * `projection * group * (existing math)`. This is purely additive — identity
+ * until a caller sets a group — so a single scenario (offset, then clear back
+ * to identity) is sufficient to prove the wiring end to end through the real
+ * sprite pipeline.
+ *
+ * WebGPU shaders are real inline WGSL — no mocks. A struct/size mismatch
+ * between the TS-side buffer layout and the WGSL struct surfaces as a GPU
+ * validation error inside `renderScene`'s pushErrorScope.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Matrix } from '#math/Matrix';
+import { Container } from '#rendering/Container';
+import type { RenderNode } from '#rendering/RenderNode';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+import { getBackendDevice } from './webgpu-test-helpers';
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: {
+      canvas: { width: canvasSize, height: canvasSize },
+      clearColor: Color.black,
+    },
+  }) as unknown as Application;
+
+const createSolidTexture = (color: string, size: number): Texture => {
+  const source = document.createElement('canvas');
+
+  source.width = size;
+  source.height = size;
+
+  const context = source.getContext('2d');
+
+  if (!context) {
+    throw new Error('2D context is required to create test textures.');
+  }
+
+  context.fillStyle = color;
+  context.fillRect(0, 0, size, size);
+
+  return new Texture(source);
+};
+
+const setupBackend = async (): Promise<WebGpuBackend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  await backend.initialize();
+  wireCoreRenderers(backend);
+
+  return backend;
+};
+
+// Read the presented WebGPU canvas back through a 2D canvas. drawImage accepts a
+// WebGPU-configured canvas as an image source, giving CPU-side pixel access
+// without touching the backend's managed GPU textures.
+const readCanvas = (backend: WebGpuBackend): ((x: number, y: number) => RgbaTuple) => {
+  const source = backend.context.canvas as HTMLCanvasElement;
+  const readback = document.createElement('canvas');
+
+  readback.width = canvasSize;
+  readback.height = canvasSize;
+
+  const ctx = readback.getContext('2d');
+
+  if (!ctx) {
+    throw new Error('2D context is required for canvas readback.');
+  }
+
+  ctx.drawImage(source, 0, 0);
+
+  return (x: number, y: number): RgbaTuple => {
+    const { data } = ctx.getImageData(Math.floor(x), Math.floor(y), 1, 1);
+
+    return [data[0], data[1], data[2], data[3]];
+  };
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 12): void => {
+  for (let index = 0; index < 4; index++) {
+    expect(Math.abs(actual[index] - expected[index])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+// On the software (swiftshader) adapter used in CI the WebGPU device can be
+// dropped mid-test ("Instance dropped in popErrorScope"). Treat that as a
+// device-lost skip rather than a failure.
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+// Render a scene through the real plan path inside a validation error scope.
+// Returns false when the device dropped mid-test (the caller should bail).
+const renderScene = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
+  const device = getBackendDevice(backend);
+
+  device.pushErrorScope('validation');
+
+  let validationError: GPUError | null;
+
+  try {
+    backend.resetStats();
+    backend.clear(Color.black);
+    root.render(backend);
+    backend.flush();
+    validationError = await device.popErrorScope();
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+
+  expect(validationError).toBeNull();
+
+  return true;
+};
+
+describe('WebGPU group matrix (projection UBO extension)', () => {
+  test('a backend-level group transform offsets sprite output; clearing it restores identity', async ctx => {
+    const backend = await setupBackend();
+    const texture = createSolidTexture('#ff0000', 16);
+    const root = new Container();
+    const sprite = new Sprite(texture);
+    const groupTransform = new Matrix();
+
+    try {
+      sprite.setPosition(0, 0);
+      root.addChild(sprite);
+
+      groupTransform.x = 24;
+      groupTransform.y = 24;
+
+      backend._setRenderGroupTransform(groupTransform);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      let readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(32, 32), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(8, 8), [0, 0, 0, 255]);
+
+      backend._setRenderGroupTransform(null);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      readPixel = readCanvas(backend);
+      expectPixelNear(readPixel(8, 8), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(32, 32), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgpu-retained-container.test.ts
+++ b/test/rendering/browser/webgpu-retained-container.test.ts
@@ -1,0 +1,453 @@
+/**
+ * WebGPU renderer-matrix browser tests — RetainedContainer pixel cells
+ * (Track B Slice 2, spec §8/§10(d) correctness gate).
+ *
+ * Mirrors webgl2-retained-container.test.ts 1:1 on the WebGPU harness: real
+ * inline WGSL (no mocks), `renderScene`'s validation-scope helper, and a
+ * device-loss skip via `ctx.skip` exactly as the other opt-in WebGPU browser
+ * specs do. Seven cells asserting real rendered output for the retained-group
+ * feature shipped across tasks 3-8: camera motion over a retained fragment, a
+ * group move via the group matrix, a child mutation inside the group, a
+ * tint/alpha change inside the group, bitmap text lifted by the group
+ * uniform, an effect-bearing direct child (cacheAsBitmap) that escapes the
+ * group convention, and a depth-2 effect node that disengages the boundary
+ * (plan D-P4 Option A) while keeping pixel-correct plain-Container output.
+ *
+ * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
+ * against Mesa lavapipe); `renderScene` only skips when the software adapter
+ * drops the device mid-test.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import type { RenderNode } from '#rendering/RenderNode';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { BitmapText, type BmFontData } from '#rendering/text/BitmapText';
+import { BmFont } from '#rendering/text/BmFont';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+import { getBackendDevice } from './webgpu-test-helpers';
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: {
+      canvas: { width: canvasSize, height: canvasSize },
+      clearColor: Color.black,
+    },
+  }) as unknown as Application;
+
+const createSolidTexture = (color: string, size: number): Texture => {
+  const source = document.createElement('canvas');
+
+  source.width = size;
+  source.height = size;
+
+  const context = source.getContext('2d');
+
+  if (!context) {
+    throw new Error('2D context is required to create test textures.');
+  }
+
+  context.fillStyle = color;
+  context.fillRect(0, 0, size, size);
+
+  return new Texture(source);
+};
+
+// A BitmapText whose single glyph 'A' fills the whole `size`×`size` atlas page,
+// placed at the line origin so its quad covers (0,0)–(size,size) before any
+// node transform. The atlas page is a solid-colour texture, so the
+// colour-atlas shader (msdf = false) emits that colour directly — deterministic
+// pixels with no runtime font rasterisation or atlas-upload timing. Copied
+// verbatim from webgpu-stencil-clip.test.ts's font fixture.
+const createSolidBitmapText = (color: string, size: number): { text: BitmapText; texture: Texture } => {
+  const texture = createSolidTexture(color, size);
+  const fontData: BmFontData = {
+    pages: ['atlas_0.png'],
+    chars: new Map([[65, { x: 0, y: 0, width: size, height: size, xOffset: 0, yOffset: 0, xAdvance: size, page: 0 }]]),
+    kernings: new Map(),
+    // base === lineHeight ⇒ yBearing 0 ⇒ the glyph top sits at the line origin.
+    lineHeight: size,
+    base: size,
+  };
+
+  return { text: new BitmapText('A', new BmFont(fontData, [texture])), texture };
+};
+
+const setupBackend = async (): Promise<WebGpuBackend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  await backend.initialize();
+  wireCoreRenderers(backend);
+
+  return backend;
+};
+
+// Read the presented WebGPU canvas back through a 2D canvas. drawImage accepts a
+// WebGPU-configured canvas as an image source, giving CPU-side pixel access
+// without touching the backend's managed GPU textures.
+const readCanvas = (backend: WebGpuBackend): ((x: number, y: number) => RgbaTuple) => {
+  const source = backend.context.canvas as HTMLCanvasElement;
+  const readback = document.createElement('canvas');
+
+  readback.width = canvasSize;
+  readback.height = canvasSize;
+
+  const ctx = readback.getContext('2d');
+
+  if (!ctx) {
+    throw new Error('2D context is required for canvas readback.');
+  }
+
+  ctx.drawImage(source, 0, 0);
+
+  return (x: number, y: number): RgbaTuple => {
+    const { data } = ctx.getImageData(Math.floor(x), Math.floor(y), 1, 1);
+
+    return [data[0], data[1], data[2], data[3]];
+  };
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 12): void => {
+  for (let index = 0; index < 4; index++) {
+    expect(Math.abs(actual[index] - expected[index])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+// On the software (swiftshader) adapter used in CI the WebGPU device can be
+// dropped mid-test ("Instance dropped in popErrorScope"). Treat that as a
+// device-lost skip rather than a failure.
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+// Render a scene through the real plan path inside a validation error scope.
+// Returns false when the device dropped mid-test (the caller should bail).
+// Every render call gets its own fresh scope — never more than one flush per
+// pushErrorScope.
+const renderScene = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
+  const device = getBackendDevice(backend);
+
+  device.pushErrorScope('validation');
+
+  let validationError: GPUError | null;
+
+  try {
+    backend.resetStats();
+    backend.clear(Color.black);
+    root.render(backend);
+    backend.flush();
+    validationError = await device.popErrorScope();
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+
+  expect(validationError).toBeNull();
+
+  return true;
+};
+
+describe('WebGPU renderer matrix: RetainedContainer cells', () => {
+  test('cell 1 — retained group under camera motion: fragment splices, pixels track the view', async ctx => {
+    const backend = await setupBackend();
+    const texture = createSolidTexture('#ff0000', 16);
+    const root = new Container();
+    const group = new RetainedContainer();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.setPosition(8, 8);
+      group.addChild(sprite);
+      root.addChild(group);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      let readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(16, 16), [255, 0, 0, 255]);
+
+      // Pan the camera 16px right: the sprite must appear 16px further left.
+      // The default view of a 64x64 canvas is centered at (32, 32).
+      backend.view.setCenter(backend.view.center.x + 16, backend.view.center.y);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(0, 16), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(24, 16), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 2 — group move: one matrix update relocates the whole group', async ctx => {
+    const backend = await setupBackend();
+    const texture = createSolidTexture('#00ff00', 16);
+    const root = new Container();
+    const group = new RetainedContainer();
+    const sprite = new Sprite(texture);
+
+    try {
+      group.addChild(sprite);
+      root.addChild(group);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      let readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(8, 8), [0, 255, 0, 255]);
+
+      group.setPosition(32, 32);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(40, 40), [0, 255, 0, 255]);
+      expectPixelNear(readPixel(8, 8), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 3 — child mutation inside the group is visible on the next frame', async ctx => {
+    const backend = await setupBackend();
+    const texture = createSolidTexture('#ff0000', 16);
+    const root = new Container();
+    const group = new RetainedContainer();
+    const sprite = new Sprite(texture);
+
+    try {
+      group.addChild(sprite);
+      root.addChild(group);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      let readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(8, 8), [255, 0, 0, 255]);
+
+      sprite.setPosition(24, 24);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(32, 32), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(8, 8), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 4 — tint/alpha change on a drawable inside the group is never served stale', async ctx => {
+    const backend = await setupBackend();
+    const texture = createSolidTexture('#ffffff', 16);
+    const root = new Container();
+    const group = new RetainedContainer();
+    const sprite = new Sprite(texture);
+
+    try {
+      group.addChild(sprite);
+      root.addChild(group);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      let readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(8, 8), [255, 255, 255, 255]);
+
+      sprite.tint = new Color(0, 255, 0);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(8, 8), [0, 255, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 5 — bitmap text inside a moved group renders at the group position', async ctx => {
+    const backend = await setupBackend();
+    const { text, texture } = createSolidBitmapText('#ff0000', 32);
+    const root = new Container();
+    const group = new RetainedContainer();
+
+    try {
+      text.setPosition(8, 8); // covers (8,8)-(40,40) — same fixture as webgpu-stencil-clip.test.ts
+      group.addChild(text);
+      root.addChild(group);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      let readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(16, 16), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(38, 38), [255, 0, 0, 255]);
+
+      // Move the group by (16, 0): text bakes group-relative vertices, so the
+      // u_group uniform must lift them (spec §7 text exception) — the glyph
+      // now covers (24,8)-(56,40).
+      group.setPosition(16, 0);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(32, 16), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(54, 38), [255, 0, 0, 255]);
+      // The original (un-shifted) position is now background.
+      expectPixelNear(readPixel(16, 16), [0, 0, 0, 255]);
+    } finally {
+      text.destroy();
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 6 — effect-bearing DIRECT child (cacheAsBitmap barrier) inside a moved group stays world-correct', async ctx => {
+    const backend = await setupBackend();
+    const texture = createSolidTexture('#ff0000', 16);
+    const root = new Container();
+    const group = new RetainedContainer();
+    const cached = new Sprite(texture);
+
+    try {
+      // Barrier child escapes the group convention: world-space, and
+      // cacheAsBitmap is visually neutral, so "semantics-neutral by
+      // construction" is directly pixel-assertable: identical placement to
+      // a plain sprite at the group position.
+      cached.cacheAsBitmap = true;
+      group.addChild(cached);
+      root.addChild(group);
+
+      group.setPosition(16, 16);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      let readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(24, 24), [255, 0, 0, 255]); // sprite 16..32
+      expectPixelNear(readPixel(8, 8), [0, 0, 0, 255]);
+      expectPixelNear(readPixel(40, 40), [0, 0, 0, 255]);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        // spliced frame: barrier re-dispatches, same output
+        return;
+      }
+
+      readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(24, 24), [255, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 7 — effect-bearing node nested TWO levels deep: the boundary disengages and output stays correct', async ctx => {
+    const backend = await setupBackend();
+    const red = createSolidTexture('#ff0000', 16);
+    const green = createSolidTexture('#00ff00', 16);
+    const root = new Container();
+    const group = new RetainedContainer();
+    const mid = new Container();
+    const deepCached = new Sprite(red);
+    const plainLeaf = new Sprite(green);
+
+    try {
+      deepCached.cacheAsBitmap = true; // barrier at depth 2 -> D-P4 Option A fallback
+      mid.setPosition(8, 8);
+      mid.addChild(deepCached);
+      group.addChild(mid);
+      group.addChild(plainLeaf);
+      group.setPosition(16, 16);
+      root.addChild(group);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      let readPixel = readCanvas(backend);
+
+      // CORRECT output, not a warning: the deep effect lands at its true
+      // world position (16+8 -> 24..40) and the plain sibling at the group
+      // position (16..32) — the disengaged group renders exactly like a
+      // plain Container (group uniform identity, world-space transforms).
+      expectPixelNear(readPixel(36, 36), [255, 0, 0, 255]); // deep cached sprite only
+      expectPixelNear(readPixel(18, 18), [0, 255, 0, 255]); // plain leaf only
+      expectPixelNear(readPixel(8, 8), [0, 0, 0, 255]);
+      expectPixelNear(readPixel(46, 46), [0, 0, 0, 255]);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        // second frame: identical (no retention, no drift)
+        return;
+      }
+
+      readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(36, 36), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(18, 18), [0, 255, 0, 255]);
+    } finally {
+      root.destroy();
+      red.destroy();
+      green.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/retained-container.test.ts
+++ b/test/rendering/retained-container.test.ts
@@ -1,11 +1,13 @@
 import { logger } from '#core/logging';
+import type { Matrix } from '#math/Matrix';
 import { Rectangle } from '#math/Rectangle';
 import { Container } from '#rendering/Container';
 import { Drawable } from '#rendering/Drawable';
 import { type DrawCommand, RenderEntryKind } from '#rendering/plan/RenderCommand';
 import { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
 import { RenderPlanOptimizer } from '#rendering/plan/RenderPlanOptimizer';
-import type { GroupScope } from '#rendering/plan/RenderScope';
+import { RenderPlanPlayer } from '#rendering/plan/RenderPlanPlayer';
+import type { GroupScope, GroupScopeEntry } from '#rendering/plan/RenderScope';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import { RenderBackendType } from '#rendering/RenderBackendType';
 import { createRenderStats } from '#rendering/RenderStats';
@@ -95,6 +97,38 @@ const gatherScopeDraws = (scope: GroupScope, out: DrawCommand[]): void => {
       gatherScopeDraws(entry.scope.childPlan, out);
     }
   }
+};
+
+// `build()` always wraps its `root` argument in one Group entry of its own
+// (see `RenderPlanBuilder.build`: `root._collect(this)` runs through the same
+// `emitNode` path as any other node), so a node's OWN Group entry is never a
+// direct child of `plan.passes[0].root.entries` unless that node was itself
+// passed as `build()`'s root — it is nested one or more Group/Barrier scopes
+// deep. Search the whole scope tree for the entry whose `transformNode` is
+// the exact node under test (stronger than an unqualified "first Group entry"
+// find, and correct regardless of nesting depth).
+const findGroupEntryFor = (scope: GroupScope, node: Container): GroupScopeEntry | undefined => {
+  for (const entry of scope.entries) {
+    if (entry.kind === RenderEntryKind.Group) {
+      if (entry.scope.transformNode === node) {
+        return entry;
+      }
+
+      const nested = findGroupEntryFor(entry.scope, node);
+
+      if (nested !== undefined) {
+        return nested;
+      }
+    } else if (entry.kind === RenderEntryKind.Barrier && entry.scope.childPlan !== null) {
+      const nested = findGroupEntryFor(entry.scope.childPlan, node);
+
+      if (nested !== undefined) {
+        return nested;
+      }
+    }
+  }
+
+  return undefined;
 };
 
 const collectDraws = (root: Container, backend: RenderBackend): DrawCommand[] => {
@@ -460,6 +494,345 @@ describe('RetainedContainer: deep-barrier fallback (plan D-P4, spec 8)', () => {
     expect(String(disengageWarnings[0]![0])).toContain('decor');
 
     warnSpy.mockRestore();
+    root.destroy();
+    backend.destroy();
+  });
+});
+
+describe('RetainedContainer: whole-range fragment splice (spec 4.2)', () => {
+  test('a clean second frame replays without getBounds()/material-key work for any descendant', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const group = new RetainedContainer();
+    const mid = new Container();
+    const leafA = new LeafDrawable('a');
+    const leafB = new LeafDrawable('b');
+
+    mid.addChild(leafA);
+    group.addChild(mid);
+    group.addChild(leafB);
+    root.addChild(group);
+
+    collectDraws(root, backend); // frame 1: full collect + capture
+
+    const boundsSpyA = vi.spyOn(leafA, 'getBounds');
+    const boundsSpyB = vi.spyOn(leafB, 'getBounds');
+    const materialSpyA = vi.spyOn(leafA, '_getOrComputeMaterialKey');
+    const materialSpyB = vi.spyOn(leafB, '_getOrComputeMaterialKey');
+    const collectSpy = vi.spyOn(mid, '_collect');
+
+    const frame2 = snapshot(collectDraws(root, backend)); // frame 2: splice
+
+    expect(boundsSpyA).not.toHaveBeenCalled();
+    expect(boundsSpyB).not.toHaveBeenCalled();
+    expect(materialSpyA).not.toHaveBeenCalled();
+    expect(materialSpyB).not.toHaveBeenCalled();
+    expect(collectSpy).not.toHaveBeenCalled(); // no scene-graph walk at all
+
+    expect(frame2.map(d => d.id)).toEqual(['a', 'b']);
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('output equivalence: spliced frame equals the full-collect frame byte for byte', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const group = new RetainedContainer();
+    const mid = new Container();
+
+    mid.addChild(new LeafDrawable('a'));
+    mid.addChild(new LeafDrawable('b'));
+    group.addChild(mid);
+    group.addChild(new LeafDrawable('c'));
+    root.addChild(group);
+
+    const frame1 = snapshot(collectDraws(root, backend));
+    const frame2 = snapshot(collectDraws(root, backend));
+
+    expect(frame2).toEqual(frame1);
+
+    root.destroy();
+    backend.destroy();
+  });
+});
+
+describe('RetainedContainer: invalidation gates and view independence', () => {
+  test('camera pan does NOT drop the fragment (no viewUpdateId in the key)', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const group = new RetainedContainer();
+    const leaf = new LeafDrawable('a');
+
+    group.addChild(leaf);
+    root.addChild(group);
+
+    collectDraws(root, backend);
+
+    // A real pan (bumps View.updateId) small enough that the group's 0..16
+    // world AABB still overlaps the 800x600 view centered here — a large pan
+    // would legitimately whole-group-cull it (spec 6), which is a different
+    // code path than the one this test pins.
+    backend.view.setCenter(50, 50);
+
+    const materialSpy = vi.spyOn(leaf, '_getOrComputeMaterialKey');
+    const draws = collectDraws(root, backend);
+
+    expect(materialSpy).not.toHaveBeenCalled(); // spliced despite the pan
+    expect(draws).toHaveLength(1);
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('moving the GROUP does not drop the fragment; the plan still carries the group node live', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const group = new RetainedContainer();
+    const leaf = new LeafDrawable('a');
+
+    group.addChild(leaf);
+    root.addChild(group);
+
+    collectDraws(root, backend);
+    group.setPosition(50, 50);
+
+    const materialSpy = vi.spyOn(leaf, '_getOrComputeMaterialKey');
+    const builder = RenderPlanBuilder.acquire();
+    const plan = builder.build(root, backend);
+
+    expect(materialSpy).not.toHaveBeenCalled(); // fragment survived the move
+
+    const groupEntry = findGroupEntryFor(plan.passes[0]!.root, group);
+
+    expect(groupEntry).toBeDefined();
+
+    if (groupEntry !== undefined) {
+      expect(groupEntry.scope.transformNode).toBe(group);
+      // Live read at play time resolves the NEW matrix.
+      expect(groupEntry.scope.transformNode!.getGlobalTransform().x).toBe(50);
+    }
+
+    RenderPlanBuilder.release(builder);
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('a child mutation inside the group forces one full re-collect, then retains again', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const group = new RetainedContainer();
+    const leaf = new LeafDrawable('a');
+
+    group.addChild(leaf);
+    root.addChild(group);
+
+    collectDraws(root, backend);
+    leaf.setPosition(7, 7);
+
+    const draws = collectDraws(root, backend);
+
+    expect(draws[0]!.minX).toBe(7); // fresh bounds, not the stale capture
+
+    const materialSpy = vi.spyOn(leaf, '_getOrComputeMaterialKey');
+
+    collectDraws(root, backend);
+
+    expect(materialSpy).not.toHaveBeenCalled(); // re-retained
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('adding/removing a child (structure) forces a re-collect', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const group = new RetainedContainer();
+
+    group.addChild(new LeafDrawable('a'));
+    root.addChild(group);
+    collectDraws(root, backend);
+
+    group.addChild(new LeafDrawable('b'));
+
+    expect(collectDraws(root, backend).map(d => (d.drawable as LeafDrawable).id)).toEqual(['a', 'b']);
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('a barrier-bearing direct child re-dispatches through _collect on every spliced frame', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const group = new RetainedContainer();
+    const clipped = new LeafDrawable('clipped');
+
+    clipped.clip = true;
+    clipped.clipShape = new Rectangle(0, 0, 8, 8);
+    group.addChild(clipped);
+    group.addChild(new LeafDrawable('plain'));
+    root.addChild(group);
+
+    collectDraws(root, backend); // capture (fragment holds a barrier record + one draw)
+
+    const collectSpy = vi.spyOn(clipped, '_collect');
+
+    collectDraws(root, backend); // spliced frame
+
+    expect(collectSpy).toHaveBeenCalledTimes(1); // re-dispatched, not captured
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('a nested RetainedContainer is captured inside the outer fragment with its own transformNode', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const outer = new RetainedContainer();
+    const inner = new RetainedContainer();
+
+    inner.addChild(new LeafDrawable('a'));
+    outer.addChild(inner);
+    root.addChild(outer);
+
+    collectDraws(root, backend); // capture
+
+    const builder = RenderPlanBuilder.acquire();
+    const plan = builder.build(root, backend); // spliced
+    const outerEntry = findGroupEntryFor(plan.passes[0]!.root, outer);
+
+    expect(outerEntry).toBeDefined();
+
+    if (outerEntry !== undefined) {
+      expect(outerEntry.scope.transformNode).toBe(outer);
+
+      const innerEntry = findGroupEntryFor(outerEntry.scope, inner);
+
+      expect(innerEntry).toBeDefined();
+
+      if (innerEntry !== undefined) {
+        expect(innerEntry.scope.transformNode).toBe(inner); // survives snapshot -> replay
+      }
+    }
+
+    RenderPlanBuilder.release(builder);
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('a deep barrier disables retention entirely; removing it re-engages and splices again', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const group = new RetainedContainer();
+    const mid = new Container();
+    const deep = new LeafDrawable('deep');
+
+    deep.cacheAsBitmap = true; // barrier at depth 2 -> boundary disengages
+    mid.addChild(deep);
+    group.addChild(mid);
+    root.addChild(group);
+
+    collectDraws(root, backend);
+    expect(group._isTransformGroupBoundary).toBe(false);
+
+    // Disengaged: plain-Container collect every frame, no fragment splice.
+    const collectSpy = vi.spyOn(mid, '_collect');
+
+    collectDraws(root, backend);
+    expect(collectSpy).toHaveBeenCalledTimes(1);
+
+    // Remove the deep barrier: re-engage, capture, then splice.
+    deep.cacheAsBitmap = false;
+    collectDraws(root, backend); // full collect + capture
+    expect(group._isTransformGroupBoundary).toBe(true);
+
+    collectSpy.mockClear();
+    collectDraws(root, backend); // spliced
+
+    expect(collectSpy).not.toHaveBeenCalled();
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('optimizer audit: the group scope is its own segment — no reorder across the boundary despite mixed spaces', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const group = new RetainedContainer();
+    const before = new LeafDrawable('world-before');
+    const inside = new LeafDrawable('group-local');
+    const after = new LeafDrawable('world-after');
+
+    // World draws overlap the group draw NUMERICALLY (group-local 0..16 vs
+    // world 0..16) but live in different spaces; the segment boundary must
+    // prevent any cross-space comparison/merge (spec §6, recon §12 audit).
+    group.addChild(inside);
+    root.addChild(before);
+    root.addChild(group);
+    root.addChild(after);
+
+    const order = collectDraws(root, backend).map(d => (d.drawable as LeafDrawable).id);
+
+    expect(order).toEqual(['world-before', 'group-local', 'world-after']);
+
+    // Second (spliced) frame preserves the same segmented order.
+    const order2 = collectDraws(root, backend).map(d => (d.drawable as LeafDrawable).id);
+
+    expect(order2).toEqual(order);
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('deferred verification point: a moved, spliced RetainedContainer plays back through RenderPlanPlayer with the group matrix composed onto its children', () => {
+    // Pins the player compose order end-to-end (RenderPlanPlayer._playGroup,
+    // not just the builder's plan shape): a moved RetainedContainer whose
+    // fragment is SPLICED (not re-collected) must still drive
+    // `_setRenderGroupTransform` with the live group world matrix at play
+    // time, and the drawable underneath must be issued while that transform
+    // is active -- exactly the group x relative-world composition spec 4.3/5
+    // promises. Uses a mock/spy backend rather than a real GPU backend.
+    const backend = createTestBackend();
+    const root = new Container();
+    const group = new RetainedContainer();
+    const leaf = new LeafDrawable('a');
+
+    group.addChild(leaf);
+    root.addChild(group);
+
+    // Frame 1: full collect + capture.
+    const builder1 = RenderPlanBuilder.acquire();
+
+    builder1.build(root, backend);
+    RenderPlanBuilder.release(builder1);
+
+    group.setPosition(50, 50);
+
+    // Frame 2: the fragment survives the group move (pinned above) -- splice.
+    const builder2 = RenderPlanBuilder.acquire();
+    const plan = builder2.build(root, backend);
+
+    RenderPlanBuilder.release(builder2);
+
+    let activeTransform: Matrix | null = null;
+    const drawsSeenUnderTransform: Array<{ id: string; x: number | null }> = [];
+
+    const playbackBackend: RenderBackend = {
+      ...backend,
+      _setRenderGroupTransform(transform: Matrix | null) {
+        activeTransform = transform;
+      },
+      draw(drawable: Drawable) {
+        drawsSeenUnderTransform.push({ id: (drawable as LeafDrawable).id, x: activeTransform?.x ?? null });
+
+        return this;
+      },
+    } as unknown as RenderBackend;
+
+    RenderPlanPlayer.play(plan, playbackBackend);
+
+    expect(drawsSeenUnderTransform).toEqual([{ id: 'a', x: 50 }]);
+
     root.destroy();
     backend.destroy();
   });

--- a/test/rendering/retained-container.test.ts
+++ b/test/rendering/retained-container.test.ts
@@ -1,0 +1,466 @@
+import { logger } from '#core/logging';
+import { Rectangle } from '#math/Rectangle';
+import { Container } from '#rendering/Container';
+import { Drawable } from '#rendering/Drawable';
+import { type DrawCommand, RenderEntryKind } from '#rendering/plan/RenderCommand';
+import { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
+import { RenderPlanOptimizer } from '#rendering/plan/RenderPlanOptimizer';
+import type { GroupScope } from '#rendering/plan/RenderScope';
+import type { RenderBackend } from '#rendering/RenderBackend';
+import { RenderBackendType } from '#rendering/RenderBackendType';
+import { createRenderStats } from '#rendering/RenderStats';
+import { RenderTarget } from '#rendering/RenderTarget';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+
+class LeafDrawable extends Drawable {
+  public constructor(public readonly id: string) {
+    super();
+    this.getLocalBounds().set(0, 0, 16, 16);
+  }
+}
+
+// File-local fake backend (repo convention keeps test harnesses file-local
+// rather than importing them across test files).
+const createTestBackend = (): RenderBackend => {
+  const renderTarget = new RenderTarget(800, 600, true);
+
+  return {
+    backendType: RenderBackendType.WebGl2,
+    stats: createRenderStats(),
+    renderTarget,
+    get view() {
+      return renderTarget.view;
+    },
+    async initialize() {
+      return this;
+    },
+    resetStats() {
+      return this;
+    },
+    clear() {
+      return this;
+    },
+    resize() {
+      return this;
+    },
+    setView(v) {
+      renderTarget.setView(v);
+      return this;
+    },
+    setRenderTarget() {
+      return this;
+    },
+    pushScissorRect() {
+      return this;
+    },
+    popScissorRect() {
+      return this;
+    },
+    composeWithAlphaMask() {
+      return this;
+    },
+    acquireRenderTexture() {
+      throw new Error('not used in this test');
+    },
+    releaseRenderTexture() {
+      return this;
+    },
+    draw() {
+      return this;
+    },
+    execute() {
+      return this;
+    },
+    flush() {
+      return this;
+    },
+    destroy() {
+      renderTarget.destroy();
+    },
+  } as unknown as RenderBackend;
+};
+
+// `build()` wraps a Container root in its own Group scope (see
+// retained-plan-cache.test.ts), so the draws for a scene never live at
+// `pass.root.entries` — they are nested one or more Group/Barrier scopes deep.
+// Walk the scope tree in entry order to recover the true post-optimize paint
+// order.
+const gatherScopeDraws = (scope: GroupScope, out: DrawCommand[]): void => {
+  for (const entry of scope.entries) {
+    if (entry.kind === RenderEntryKind.Draw) {
+      out.push(entry.command);
+    } else if (entry.kind === RenderEntryKind.Group) {
+      gatherScopeDraws(entry.scope, out);
+    } else if (entry.kind === RenderEntryKind.Barrier && entry.scope.childPlan !== null) {
+      gatherScopeDraws(entry.scope.childPlan, out);
+    }
+  }
+};
+
+const collectDraws = (root: Container, backend: RenderBackend): DrawCommand[] => {
+  const builder = RenderPlanBuilder.acquire();
+  const plan = builder.build(root, backend);
+
+  RenderPlanOptimizer.optimize(plan);
+
+  const draws: DrawCommand[] = [];
+  for (const pass of plan.passes) {
+    gatherScopeDraws(pass.root, draws);
+  }
+
+  RenderPlanBuilder.release(builder);
+
+  return draws;
+};
+
+const snapshot = (draws: readonly DrawCommand[]) =>
+  draws.map(d => ({
+    id: (d.drawable as LeafDrawable).id,
+    seq: d.seq,
+    zIndex: d.zIndex,
+    material: { ...d.material },
+    minX: d.minX,
+    minY: d.minY,
+    maxX: d.maxX,
+    maxY: d.maxY,
+  }));
+
+describe('RetainedContainer: revision decoupling (spec 4.3)', () => {
+  test('moving the container bumps the group-matrix version, NOT its content revision', () => {
+    const group = new RetainedContainer();
+
+    group.addChild(new Drawable());
+
+    const contentBefore = group._contentRevision;
+    const versionBefore = group._groupMatrixVersion;
+
+    group.setPosition(100, 50);
+    group.setRotation(15);
+    group.setScale(2);
+
+    expect(group._groupMatrixVersion).toBeGreaterThan(versionBefore);
+    expect(group._contentRevision).toBe(contentBefore);
+
+    group.destroy();
+  });
+
+  test('moving the container does not content-dirty its ancestors either', () => {
+    const root = new Container();
+    const group = new RetainedContainer();
+
+    root.addChild(group);
+
+    const rootBefore = root._contentRevision;
+
+    group.setPosition(10, 10);
+
+    expect(root._contentRevision).toBe(rootBefore);
+
+    root.destroy();
+  });
+
+  test('mutations INSIDE the subtree still content-dirty the container (existing D7 propagation)', () => {
+    const group = new RetainedContainer();
+    const leaf = new Drawable();
+
+    group.addChild(leaf);
+
+    const before = group._contentRevision;
+
+    leaf.setPosition(3, 3);
+
+    expect(group._contentRevision).toBeGreaterThan(before);
+
+    group.destroy();
+  });
+
+  test('structural mutations on the container itself still structure-dirty it', () => {
+    const group = new RetainedContainer();
+    const before = group._structureRevision;
+
+    group.addChild(new Drawable());
+
+    expect(group._structureRevision).toBeGreaterThan(before);
+
+    group.destroy();
+  });
+});
+
+describe('RetainedContainer: group bounds and group-level culling (spec 6)', () => {
+  test('getBounds() lifts group-local child bounds into world space', () => {
+    const group = new RetainedContainer();
+    const leaf = new LeafDrawable('a'); // local bounds 0..16
+
+    group.addChild(leaf);
+    group.setPosition(100, 200);
+
+    const bounds = group.getBounds();
+
+    expect(bounds.left).toBe(100);
+    expect(bounds.top).toBe(200);
+    expect(bounds.right).toBe(116);
+    expect(bounds.bottom).toBe(216);
+
+    group.destroy();
+  });
+
+  test('a group fully outside the view is culled as a whole; panning the view brings it back', () => {
+    const backend = createTestBackend(); // 800x600 view
+    const root = new Container();
+    const group = new RetainedContainer();
+
+    group.addChild(new LeafDrawable('a'));
+    group.setPosition(2000, 2000);
+    root.addChild(group);
+
+    expect(collectDraws(root, backend)).toHaveLength(0);
+
+    backend.view.setCenter(2000, 2000);
+
+    expect(collectDraws(root, backend)).toHaveLength(1);
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('output equivalence at identity: a RetainedContainer collects the same draw data as a plain Container', () => {
+    const backend = createTestBackend();
+
+    const buildScene = (group: Container): Container => {
+      const root = new Container();
+      const mid = new Container();
+
+      mid.addChild(new LeafDrawable('a'));
+      mid.addChild(new LeafDrawable('b'));
+      group.addChild(mid);
+      group.addChild(new LeafDrawable('c'));
+      root.addChild(group);
+
+      return root;
+    };
+
+    const plainRoot = buildScene(new Container());
+    const retainedRoot = buildScene(new RetainedContainer());
+
+    // At identity the group-local space IS world space, so the collected
+    // draw data must be byte-identical (the documented space convention
+    // makes them differ only under a non-identity group transform).
+    expect(snapshot(collectDraws(retainedRoot, backend))).toEqual(snapshot(collectDraws(plainRoot, backend)));
+
+    plainRoot.destroy();
+    retainedRoot.destroy();
+    backend.destroy();
+  });
+
+  test('under a group translation, captured bounds stay group-local (the space convention)', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const group = new RetainedContainer();
+    const leaf = new LeafDrawable('a');
+
+    leaf.setPosition(5, 5);
+    group.setPosition(100, 100);
+    group.addChild(leaf);
+    root.addChild(group);
+
+    const draws = collectDraws(root, backend);
+
+    expect(draws).toHaveLength(1);
+    // Group-local: the leaf's own 5..21, NOT 105..121.
+    expect(draws[0]!.minX).toBe(5);
+    expect(draws[0]!.minY).toBe(5);
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('per-child view culling is suppressed inside an engaged group; the identical plain Container scene DOES cull that child', () => {
+    const backend = createTestBackend(); // 800x600 view
+
+    const buildScene = (group: Container): { root: Container; far: LeafDrawable } => {
+      const root = new Container();
+      const near = new LeafDrawable('near'); // group-local origin -> on-screen
+      const far = new LeafDrawable('far');
+
+      far.setPosition(-5000, 0); // far outside the view rect in EITHER space
+      group.setPosition(100, 100); // group's world AABB still intersects the view via `near`
+      group.addChild(near);
+      group.addChild(far);
+      root.addChild(group);
+
+      return { root, far };
+    };
+
+    // Plain Container: normal per-child culling drops the far child.
+    const plain = buildScene(new Container());
+    const plainDraws = collectDraws(plain.root, backend);
+
+    expect(plainDraws.some(d => d.drawable === plain.far)).toBe(false);
+
+    // Engaged RetainedContainer: the group is culled as a whole (its AABB is
+    // in view), and per-child culling inside the boundary is suppressed, so
+    // the far child's draw command must be collected. Its group-local bounds
+    // are meaningless against the world-space view rect (spec 6) -- culling
+    // it per-child here would be wrong, not just slow.
+    const retained = buildScene(new RetainedContainer());
+    const retainedDraws = collectDraws(retained.root, backend);
+
+    expect(retainedDraws.some(d => d.drawable === retained.far)).toBe(true);
+
+    plain.root.destroy();
+    retained.root.destroy();
+    backend.destroy();
+  });
+});
+
+describe('RetainedContainer: deep-barrier fallback (plan D-P4, spec 8)', () => {
+  test('a barrier nested deeper than one level disengages the boundary: descendants go world-space', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const group = new RetainedContainer();
+    const mid = new Container();
+    const deepClipped = new LeafDrawable('deep');
+    const plainLeaf = new LeafDrawable('plain');
+
+    deepClipped.clip = true;
+    deepClipped.clipShape = new Rectangle(0, 0, 8, 8);
+    mid.setPosition(10, 0);
+    mid.addChild(deepClipped);
+    group.setPosition(40, 0);
+    group.addChild(mid);
+    group.addChild(plainLeaf);
+    root.addChild(group);
+
+    // Engagement is (re-)evaluated at the top of the group's _collect.
+    collectDraws(root, backend);
+
+    expect(group._isTransformGroupBoundary).toBe(false);
+    expect(mid.getGlobalTransform().x).toBe(50); // world (40 + 10), not group-relative 10
+    expect(plainLeaf.getGlobalTransform().x).toBe(40); // world, not group-relative 0
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('the disengaged plan is unmarked and byte-identical to a plain Container scene', () => {
+    const backend = createTestBackend();
+
+    const buildScene = (groupNode: Container): Container => {
+      const sceneRoot = new Container();
+      const midNode = new Container();
+      const deep = new LeafDrawable('deep');
+
+      deep.clip = true;
+      deep.clipShape = new Rectangle(0, 0, 8, 8);
+      midNode.setPosition(10, 0);
+      midNode.addChild(deep);
+      groupNode.setPosition(40, 0);
+      groupNode.addChild(midNode);
+      groupNode.addChild(new LeafDrawable('plain'));
+      sceneRoot.addChild(groupNode);
+
+      return sceneRoot;
+    };
+
+    const plainRoot = buildScene(new Container());
+    const retainedRoot = buildScene(new RetainedContainer());
+
+    expect(snapshot(collectDraws(retainedRoot, backend))).toEqual(snapshot(collectDraws(plainRoot, backend)));
+
+    // And the scope carries NO transformNode (group uniform stays identity).
+    const builder = RenderPlanBuilder.acquire();
+    const plan = builder.build(retainedRoot, backend);
+    const groupEntry = plan.passes[0]!.root.entries.find(entry => entry.kind === RenderEntryKind.Group);
+
+    expect(groupEntry).toBeDefined();
+
+    if (groupEntry?.kind === RenderEntryKind.Group) {
+      expect(groupEntry.scope.transformNode).toBeNull();
+    }
+
+    RenderPlanBuilder.release(builder);
+    plainRoot.destroy();
+    retainedRoot.destroy();
+    backend.destroy();
+  });
+
+  test('runtime toggle: removing the deep barrier re-engages the boundary on the next collect', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const group = new RetainedContainer();
+    const mid = new Container();
+    const deepClipped = new LeafDrawable('deep');
+
+    deepClipped.clip = true;
+    deepClipped.clipShape = new Rectangle(0, 0, 8, 8);
+    mid.addChild(deepClipped);
+    group.addChild(mid);
+    group.setPosition(40, 0);
+    root.addChild(group);
+
+    collectDraws(root, backend);
+    expect(group._isTransformGroupBoundary).toBe(false);
+
+    deepClipped.clip = false; // structure-dirty (task 1) -> re-scan on next collect
+
+    collectDraws(root, backend);
+    expect(group._isTransformGroupBoundary).toBe(true);
+    expect(mid.getGlobalTransform().x).toBe(0); // group-relative again (lazy recombine)
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('a barrier DIRECT child does not disengage; a barrier direct child of a NESTED group disengages the outer group only', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const outer = new RetainedContainer();
+    const inner = new RetainedContainer();
+    const directBarrier = new LeafDrawable('direct');
+
+    directBarrier.clip = true;
+    directBarrier.clipShape = new Rectangle(0, 0, 8, 8);
+    inner.addChild(directBarrier);
+    outer.addChild(inner);
+    root.addChild(outer);
+
+    collectDraws(root, backend);
+
+    // Depth 1 for inner (supported escape) but depth 2 for outer: only the
+    // outer boundary disengages, so inner.getGlobalTransform is true world
+    // and the escaped barrier composes correctly.
+    expect(inner._isTransformGroupBoundary).toBe(true);
+    expect(outer._isTransformGroupBoundary).toBe(false);
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('disengaging warns once in dev builds, naming the container', () => {
+    const backend = createTestBackend();
+    const warnSpy = vi.spyOn(logger, 'warn');
+    const root = new Container();
+    const group = new RetainedContainer();
+    const mid = new Container();
+    const deepClipped = new LeafDrawable('deep');
+
+    group.name = 'decor';
+    deepClipped.clip = true;
+    deepClipped.clipShape = new Rectangle(0, 0, 8, 8);
+    mid.addChild(deepClipped);
+    group.addChild(mid);
+    root.addChild(group);
+
+    collectDraws(root, backend);
+    collectDraws(root, backend);
+
+    const disengageWarnings = warnSpy.mock.calls.filter(call => String(call[0]).includes('renders as a plain Container'));
+
+    expect(disengageWarnings).toHaveLength(1);
+    expect(String(disengageWarnings[0]![0])).toContain('decor');
+
+    warnSpy.mockRestore();
+    root.destroy();
+    backend.destroy();
+  });
+});

--- a/test/rendering/retained-container.test.ts
+++ b/test/rendering/retained-container.test.ts
@@ -899,3 +899,66 @@ describe('RetainedContainer: alpha/tint staleness guard (spec 8, plan D-P2)', ()
     backend.destroy();
   });
 });
+
+describe('RetainedContainer: dev diagnostic for pathological invalidation (S2-D1)', () => {
+  test('warns once when the fragment invalidates on effectively every frame of the observation window', () => {
+    const backend = createTestBackend();
+    const warnSpy = vi.spyOn(logger, 'warn');
+    const root = new Container();
+    const group = new RetainedContainer();
+    const leaf = new LeafDrawable('a');
+
+    group.name = 'hud';
+    group.addChild(leaf);
+    root.addChild(group);
+
+    // 121 collects, each preceded by a child mutation -> every build after
+    // the first is an invalidation of an existing capture.
+    for (let frame = 0; frame <= 120; frame++) {
+      leaf.setPosition(frame, 0);
+      collectDraws(root, backend);
+    }
+
+    const retainedWarnings = warnSpy.mock.calls.filter(call => String(call[0]).includes('RetainedContainer'));
+
+    expect(retainedWarnings).toHaveLength(1);
+    expect(String(retainedWarnings[0]![0])).toContain('hud');
+
+    // Keep mutating far past the window: still exactly one warning.
+    for (let frame = 0; frame < 130; frame++) {
+      leaf.setPosition(frame, 1);
+      collectDraws(root, backend);
+    }
+
+    expect(warnSpy.mock.calls.filter(call => String(call[0]).includes('RetainedContainer'))).toHaveLength(1);
+
+    warnSpy.mockRestore();
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('a mostly-static group (occasional invalidation) never warns', () => {
+    const backend = createTestBackend();
+    const warnSpy = vi.spyOn(logger, 'warn');
+    const root = new Container();
+    const group = new RetainedContainer();
+    const leaf = new LeafDrawable('a');
+
+    group.addChild(leaf);
+    root.addChild(group);
+
+    for (let frame = 0; frame < 300; frame++) {
+      if (frame % 10 === 0) {
+        leaf.setPosition(frame, 0); // 10% invalidation rate
+      }
+
+      collectDraws(root, backend);
+    }
+
+    expect(warnSpy.mock.calls.filter(call => String(call[0]).includes('RetainedContainer'))).toHaveLength(0);
+
+    warnSpy.mockRestore();
+    root.destroy();
+    backend.destroy();
+  });
+});

--- a/test/rendering/retained-container.test.ts
+++ b/test/rendering/retained-container.test.ts
@@ -1,3 +1,4 @@
+import { Color } from '#core/Color';
 import { logger } from '#core/logging';
 import type { Matrix } from '#math/Matrix';
 import { Rectangle } from '#math/Rectangle';
@@ -832,6 +833,67 @@ describe('RetainedContainer: invalidation gates and view independence', () => {
     RenderPlanPlayer.play(plan, playbackBackend);
 
     expect(drawsSeenUnderTransform).toEqual([{ id: 'a', x: 50 }]);
+
+    root.destroy();
+    backend.destroy();
+  });
+});
+
+describe('RetainedContainer: alpha/tint staleness guard (spec 8, plan D-P2)', () => {
+  test('the engine has no container-level alpha/tint surface that could bypass invalidation', () => {
+    const group = new RetainedContainer();
+
+    // Pin the D-P2 ground truth: if someone later ADDS Container.alpha or
+    // Container.tint, this test fails and forces them to decide the guard
+    // shape (fold into per-group uniform data vs invalidate) explicitly.
+    expect('alpha' in group).toBe(false);
+    expect('tint' in group).toBe(false);
+
+    group.destroy();
+  });
+
+  test('a tint (incl. alpha channel) change on a drawable inside the group drops the fragment', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const group = new RetainedContainer();
+    const leaf = new LeafDrawable('a');
+
+    group.addChild(leaf);
+    root.addChild(group);
+
+    collectDraws(root, backend); // capture
+
+    leaf.setTint(new Color(255, 0, 0, 0.5));
+
+    const materialSpy = vi.spyOn(leaf, '_getOrComputeMaterialKey');
+
+    collectDraws(root, backend);
+
+    // A real re-collect happened (Pixi #10757 class: tint/alpha must never
+    // be served from a stale retained frame).
+    expect(materialSpy).toHaveBeenCalled();
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test("toggling the group's own visibility is honored immediately (structure-dirty + collect gate)", () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const group = new RetainedContainer();
+
+    group.addChild(new LeafDrawable('a'));
+    root.addChild(group);
+
+    expect(collectDraws(root, backend)).toHaveLength(1);
+
+    group.visible = false;
+
+    expect(collectDraws(root, backend)).toHaveLength(0);
+
+    group.visible = true;
+
+    expect(collectDraws(root, backend)).toHaveLength(1);
 
     root.destroy();
     backend.destroy();

--- a/test/rendering/retained-group-fragment.test.ts
+++ b/test/rendering/retained-group-fragment.test.ts
@@ -1,0 +1,322 @@
+import { Container } from '#rendering/Container';
+import { Drawable } from '#rendering/Drawable';
+import { type DrawCommand, type MaterialKey, RenderEntryKind } from '#rendering/plan/RenderCommand';
+import { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
+import { RenderPlanOptimizer } from '#rendering/plan/RenderPlanOptimizer';
+import type { GroupScope } from '#rendering/plan/RenderScope';
+import { type RetainedFragmentEntry, RetainedGroupFragment } from '#rendering/plan/RetainedGroupFragment';
+import type { RenderBackend } from '#rendering/RenderBackend';
+import { RenderBackendType } from '#rendering/RenderBackendType';
+import { createRenderStats } from '#rendering/RenderStats';
+import { RenderTarget } from '#rendering/RenderTarget';
+
+const material: MaterialKey = { rendererId: 1, blendMode: 0, textureId: -1, shaderId: -1, pipelineKey: 1, bindKey: 1 };
+const fakeBackendA = {} as RenderBackend;
+const fakeBackendB = {} as RenderBackend;
+
+const makeDrawEntry = (drawable: Drawable): RetainedFragmentEntry => ({
+  kind: RenderEntryKind.Draw,
+  drawable,
+  seq: 0,
+  zIndex: 0,
+  material,
+  minX: 0,
+  minY: 0,
+  maxX: 16,
+  maxY: 16,
+});
+
+describe('RetainedGroupFragment', () => {
+  test('isClean is false before any capture; hasCapture reflects lifecycle', () => {
+    const fragment = new RetainedGroupFragment();
+
+    expect(fragment.hasCapture).toBe(false);
+    expect(fragment.isClean(1, 1, fakeBackendA)).toBe(false);
+    expect(fragment.entries).toEqual([]);
+  });
+
+  test('isClean requires content, structure and backend to match — and nothing else (no view key)', () => {
+    const fragment = new RetainedGroupFragment();
+    const drawable = new Drawable();
+    const entries = [makeDrawEntry(drawable)];
+
+    fragment.capture(5, 3, fakeBackendA, entries);
+
+    expect(fragment.hasCapture).toBe(true);
+    expect(fragment.isClean(5, 3, fakeBackendA)).toBe(true);
+    expect(fragment.entries).toBe(entries);
+
+    expect(fragment.isClean(6, 3, fakeBackendA)).toBe(false); // content changed
+    expect(fragment.isClean(5, 4, fakeBackendA)).toBe(false); // structure changed
+    expect(fragment.isClean(5, 3, fakeBackendB)).toBe(false); // backend swapped
+
+    drawable.destroy();
+  });
+
+  test('invalidate() clears the capture', () => {
+    const fragment = new RetainedGroupFragment();
+    const drawable = new Drawable();
+
+    fragment.capture(1, 1, fakeBackendA, [makeDrawEntry(drawable)]);
+    fragment.invalidate();
+
+    expect(fragment.hasCapture).toBe(false);
+    expect(fragment.isClean(1, 1, fakeBackendA)).toBe(false);
+    expect(fragment.entries).toEqual([]);
+
+    drawable.destroy();
+  });
+});
+
+// File-local fake backend (repo convention keeps test harnesses file-local
+// rather than importing them across test files) — duplicated verbatim from
+// test/rendering/retained-subtree-skip.test.ts.
+const createTestBackend = (): RenderBackend => {
+  const renderTarget = new RenderTarget(800, 600, true);
+
+  return {
+    backendType: RenderBackendType.WebGl2,
+    stats: createRenderStats(),
+    renderTarget,
+    get view() {
+      return renderTarget.view;
+    },
+    async initialize() {
+      return this;
+    },
+    resetStats() {
+      return this;
+    },
+    clear() {
+      return this;
+    },
+    resize() {
+      return this;
+    },
+    setView(v) {
+      renderTarget.setView(v);
+      return this;
+    },
+    setRenderTarget() {
+      return this;
+    },
+    pushScissorRect() {
+      return this;
+    },
+    popScissorRect() {
+      return this;
+    },
+    composeWithAlphaMask() {
+      return this;
+    },
+    acquireRenderTexture() {
+      throw new Error('not used in this test');
+    },
+    releaseRenderTexture() {
+      return this;
+    },
+    draw() {
+      return this;
+    },
+    execute() {
+      return this;
+    },
+    flush() {
+      return this;
+    },
+    destroy() {
+      renderTarget.destroy();
+    },
+  } as unknown as RenderBackend;
+};
+
+// `build()` wraps a Container root in its own Group scope, so the draws for a
+// scene never live at `pass.root.entries` — they are nested one or more
+// Group/Barrier scopes deep. Walk the scope tree in entry order to recover the
+// true post-optimize paint order.
+const gatherScopeDraws = (scope: GroupScope, out: DrawCommand[]): void => {
+  for (const entry of scope.entries) {
+    if (entry.kind === RenderEntryKind.Draw) {
+      out.push(entry.command);
+    } else if (entry.kind === RenderEntryKind.Group) {
+      gatherScopeDraws(entry.scope, out);
+    } else if (entry.kind === RenderEntryKind.Barrier && entry.scope.childPlan !== null) {
+      gatherScopeDraws(entry.scope.childPlan, out);
+    }
+  }
+};
+
+// Every collected Container (not just the pass root) wraps its own direct
+// children in a fresh GroupScope (RenderPlanBuilder.emitNode's group branch),
+// so a boundary nested under a plain ancestor lives one scope deeper than a
+// shallow `entries.find` on the outer scope would reach (same "nested one or
+// more Group scopes deep" convention `gatherScopeDraws` above documents).
+// Locate the scope that directly owns the draw entry for `drawableId`.
+const findScopeOwningDraw = (scope: GroupScope, drawableId: string): GroupScope | null => {
+  for (const entry of scope.entries) {
+    if (entry.kind === RenderEntryKind.Draw && (entry.command.drawable as LeafDrawable).id === drawableId) {
+      return scope;
+    }
+
+    if (entry.kind === RenderEntryKind.Group) {
+      const found = findScopeOwningDraw(entry.scope, drawableId);
+
+      if (found !== null) {
+        return found;
+      }
+    }
+  }
+
+  return null;
+};
+
+const collectDraws = (root: Container, backend: RenderBackend): DrawCommand[] => {
+  const builder = RenderPlanBuilder.acquire();
+  const plan = builder.build(root, backend);
+
+  RenderPlanOptimizer.optimize(plan);
+
+  const draws: DrawCommand[] = [];
+  for (const pass of plan.passes) {
+    gatherScopeDraws(pass.root, draws);
+  }
+
+  RenderPlanBuilder.release(builder);
+
+  return draws;
+};
+
+const snapshot = (draws: readonly DrawCommand[]) =>
+  draws.map(d => ({
+    id: (d.drawable as LeafDrawable).id,
+    seq: d.seq,
+    zIndex: d.zIndex,
+    material: { ...d.material },
+    minX: d.minX,
+    minY: d.minY,
+    maxX: d.maxX,
+    maxY: d.maxY,
+  }));
+
+class BoundaryContainer extends Container {
+  public override get _isTransformGroupBoundary(): boolean {
+    return true;
+  }
+}
+
+class LeafDrawable extends Drawable {
+  public constructor(public readonly id: string) {
+    super();
+    this.getLocalBounds().set(0, 0, 16, 16);
+  }
+}
+
+class SnapshotProbeContainer extends BoundaryContainer {
+  public lastSnapshot: RetainedFragmentEntry[] | null = null;
+
+  protected override _collectContent(builder: RenderPlanBuilder): void {
+    super._collectContent(builder);
+    this.lastSnapshot = builder._snapshotScopeEntries(builder._peekCurrentScopeEntries());
+  }
+}
+
+class ReplayFragmentContainer extends BoundaryContainer {
+  public constructor(private readonly _entries: readonly RetainedFragmentEntry[]) {
+    super();
+  }
+
+  protected override _collectContent(builder: RenderPlanBuilder): void {
+    builder._replayRetainedFragment(this._entries);
+  }
+}
+
+describe('builder: transformNode marking, cull suppression, snapshot/replay round-trip', () => {
+  test('emitNode marks a boundary container scope with transformNode', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const group = new BoundaryContainer();
+
+    group.addChild(new LeafDrawable('a'));
+    root.addChild(group);
+
+    const builder = RenderPlanBuilder.acquire();
+    const plan = builder.build(root, backend);
+    // `group`'s own scope (holding its direct child, the 'a' draw) is nested
+    // below root's own wrapping scope — see findScopeOwningDraw.
+    const groupScope = findScopeOwningDraw(plan.passes[0]!.root, 'a');
+
+    expect(groupScope).not.toBeNull();
+    expect(groupScope!.transformNode).toBe(group);
+
+    // A PLAIN container scope stays unmarked.
+    const plainRoot = new Container();
+    const plain = new Container();
+
+    plain.addChild(new LeafDrawable('b'));
+    plainRoot.addChild(plain);
+
+    const plainPlan = builder.build(plainRoot, backend);
+    const plainScope = findScopeOwningDraw(plainPlan.passes[0]!.root, 'b');
+
+    expect(plainScope).not.toBeNull();
+    expect(plainScope!.transformNode).toBeNull();
+
+    RenderPlanBuilder.release(builder);
+    root.destroy();
+    plainRoot.destroy();
+    backend.destroy();
+  });
+
+  test('inside a boundary container, per-child view culling is suppressed', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const group = new BoundaryContainer();
+    const farLeaf = new LeafDrawable('far');
+
+    // Group-relative position far outside the 800x600 view: without
+    // suppression this child would be culled against a space it is not in.
+    farLeaf.setPosition(5000, 5000);
+    group.addChild(farLeaf);
+    root.addChild(group);
+
+    const draws = collectDraws(root, backend);
+
+    expect(draws.map(d => (d.drawable as LeafDrawable).id)).toEqual(['far']);
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('snapshot -> replay reproduces the identical draw data with fresh nodeIndex', () => {
+    const backend = createTestBackend();
+    const probeRoot = new Container();
+    const probe = new SnapshotProbeContainer();
+    const mid = new Container();
+
+    mid.addChild(new LeafDrawable('a'));
+    mid.addChild(new LeafDrawable('b'));
+    probe.addChild(mid);
+    probe.addChild(new LeafDrawable('c'));
+    probeRoot.addChild(probe);
+
+    const originalDraws = snapshot(collectDraws(probeRoot, backend));
+
+    expect(probe.lastSnapshot).not.toBeNull();
+
+    const replayRoot = new Container();
+    const replay = new ReplayFragmentContainer(probe.lastSnapshot!);
+
+    replayRoot.addChild(replay);
+
+    const replayedRaw = collectDraws(replayRoot, backend);
+    const replayed = snapshot(replayedRaw);
+
+    expect(replayed).toEqual(originalDraws);
+    // Fresh frame-local node indices, not stale captured ones.
+    expect(replayedRaw.map(d => d.nodeIndex)).toEqual(replayedRaw.map((_, i) => i));
+
+    probeRoot.destroy();
+    replayRoot.destroy();
+    backend.destroy();
+  });
+});

--- a/test/rendering/retained-subtree-skip.test.ts
+++ b/test/rendering/retained-subtree-skip.test.ts
@@ -5,6 +5,7 @@ import { type DrawCommand, RenderEntryKind } from '#rendering/plan/RenderCommand
 import { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
 import { RenderPlanOptimizer } from '#rendering/plan/RenderPlanOptimizer';
 import type { GroupScope } from '#rendering/plan/RenderScope';
+import { RetainedPlanCache } from '#rendering/plan/RetainedPlanCache';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import { RenderBackendType } from '#rendering/RenderBackendType';
 import { createRenderStats } from '#rendering/RenderStats';
@@ -389,6 +390,66 @@ describe('static-subtree skip: invalidation gates', () => {
 
     expect(materialSpy).toHaveBeenCalled();
 
+    root.destroy();
+    backend.destroy();
+  });
+});
+
+describe('zero-slot containers pay no retained-cache overhead (S2-D4)', () => {
+  test('a container tree without any direct drawable children never calls capture()', () => {
+    const backend = createTestBackend();
+    const captureSpy = vi.spyOn(RetainedPlanCache.prototype, 'capture');
+    const root = new Container();
+    const branchA = new Container();
+    const branchB = new Container();
+
+    root.addChild(branchA);
+    root.addChild(branchB);
+
+    collectDraws(root, backend);
+    collectDraws(root, backend);
+
+    expect(captureSpy).not.toHaveBeenCalled();
+
+    captureSpy.mockRestore();
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('a container WITH a drawable child still captures and still takes the fast path', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const leaf = new LeafDrawable('a');
+
+    root.addChild(leaf);
+    collectDraws(root, backend);
+
+    const materialSpy = vi.spyOn(leaf, '_getOrComputeMaterialKey');
+
+    collectDraws(root, backend);
+
+    expect(materialSpy).not.toHaveBeenCalled();
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('mixed tree: only the drawable-bearing container captures', () => {
+    const backend = createTestBackend();
+    const captureSpy = vi.spyOn(RetainedPlanCache.prototype, 'capture');
+    const root = new Container();
+    const drawableless = new Container();
+    const drawableBearing = new Container();
+
+    drawableBearing.addChild(new LeafDrawable('a'));
+    drawableless.addChild(drawableBearing);
+    root.addChild(drawableless);
+
+    collectDraws(root, backend);
+
+    expect(captureSpy).toHaveBeenCalledTimes(1);
+
+    captureSpy.mockRestore();
     root.destroy();
     backend.destroy();
   });


### PR DESCRIPTION
## Summary

Wave 4 of Track B: the container-level retained tier. `RetainedContainer extends Container` is an explicit, construction-time opt-in boundary whose unchanged subtree splices its previously built command range into the render plan (no walk, no cull, no material keys), and whose descendants hold group-relative transforms — a moved container or camera updates a single per-group GPU matrix (`u_group` mat3 on WebGL2, extended group(0) projection UBO on WebGPU) instead of re-uploading per-node transforms.

Also ships the two approved scope add-ons: a systematic revision-invariant guard (mutator table; closed five dirty-tracking gaps: `cullable`, `cullArea`, `preserveDrawOrder`, `clip`, `clipShape`) and lazy `RetainedPlanCache` allocation (removes pure overhead for the 99.7% of containers that never capture slots), plus the S2-D1 dev diagnostic (once-per-container warning when a fragment invalidates on effectively every frame).

Design + plan: `.workspace/specs/v0.16-render-track-b/02-design-slice-2.md` / `03-plan-slice-2.md` (local).

## Correctness

- Deep-barrier semantics (D-P4): direct barrier children escape to world space (player suspends the group uniform around their scopes); a barrier nested deeper than one level disengages the whole boundary — exact plain-Container behavior, correct output, once-per-container dev warning. No wrong-pixels-with-warning paths.
- Output equivalence: spliced vs full-collect plans are byte-identical (drawable identity, seq, zIndex, material key, bounds) modulo fresh node indices — unit-pinned, including nested groups and runtime barrier toggles.
- 7 new pixel cells on BOTH backends (camera pan, group move, child mutation, tint, bitmap text, cacheAsBitmap barrier, depth-2 disengage) — all green on real hardware; full suites: unit 7218 passed, browser WebGL2 195, WebGPU 135.
- Plain `Container` semantics are untouched (Slice-1 behavior preserved; acceptance criterion (b) confirmed no regression on any archetype).

## Acceptance results (honest)

Measured same-session on real hardware (RTX 5070 Ti, software=false), `pnpm perf:baseline`:

- (b) `current` config: **no regression** on any archetype (deltas within the run-to-run noise band established by a same-session repeat run). PASS
- (d) both browser pixel suites green. PASS
- (c) dynamic-heavy retained: 1.2-1.85x slower than current — within the reference renderer's own ~1.5x retained-vs-immediate band; opt-in docs + the S2-D1 diagnostic address misuse. PASS with caveat: four 100k retained cells hit the 200 ms frame-budget abort at least once (tail latency, suspected unpooled fragment snapshot allocation on every-frame invalidation).
- (a) static-heavy @100k retained: **FAIL** — does not flatten into the reference's O(changed-nodes) class (WebGL2 53.80 ms retained vs 51.35 ms current; still linear at ~0.54 us/node). Validated as architectural, not a bench artifact: the splice is provably active (constant small draw counts, mutationFraction 0); what remains linear is playback (per-sprite draw submission, transform writes, optimizer pass). The reference caches the batched instruction set, not the command list. The follow-up slice targets exactly that layer (retained per-group instruction set, O(batches) playback); this PR is the correctness-clean foundation it builds on. Camera-pan and group-move wins (fragment survives both) do land as designed.

## Follow-ups (filed in the local Track-B workspace notes)

1. O(batches) retained instruction set (the missed acceptance target) + fragment record pooling + cached group aggregate bounds.
2. `getWorldTransform()` accessor + dev-guard for interaction/audio consumers under a boundary (group-local space is documented but silent); RetainedContainer stays un-promoted in guides until then.
3. Pre-existing WebGPU instanced-mesh affine transposition (rotated divergence; predates this branch) + shared affine-packing helper + rotated-parity pixel cells.
4. Amend parent-spec D7 (through-boundary revision propagation is required by the owned-snapshot design; the container-own-move decoupling D7 actually wanted is implemented and test-pinned).