### PR TITLE
feat(rendering): lift WebGPU sprite batcher texture ceiling to 16/32 slots (fixes #274)

### DIFF
--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -45,7 +45,7 @@ import {
   WebGpuRetainedCaptureFrame,
   WebGpuRetainedGroupBundle,
 } from './WebGpuRetainedGroupResources';
-import type { WebGpuSpriteRenderer } from './WebGpuSpriteRenderer';
+import { baseSpriteBatchTextureSlots, maxSpriteBatchTextureSlots, type WebGpuSpriteRenderer } from './WebGpuSpriteRenderer';
 import { WebGpuTransformStorage } from './WebGpuTransformStorage';
 
 interface ManagedWebGpuTextureState {
@@ -1491,7 +1491,35 @@ export class WebGpuBackend implements RenderBackend {
       // that way (float RenderTextures default to nearest, so this is a bonus).
       const floatFeatures = (['float32-filterable', 'float32-blendable'] as const).filter(feature => adapter.features?.has(feature) ?? false);
 
-      device = await adapter.requestDevice(floatFeatures.length > 0 ? { requiredFeatures: floatFeatures } : undefined);
+      // The sprite batcher sizes its multi-texture bind-group layout from the
+      // GRANTED device limits (resolveSpriteBatchTextureSlots): request up to
+      // the 32-slot ceiling when the adapter offers more than the spec base of
+      // 16 texture/sampler bindings per stage. Requesting min(adapterLimit,
+      // ceiling) is always satisfiable, so this can never fail the request.
+      const requiredLimits: Record<string, number> = {};
+      const adapterLimits = (adapter as { limits?: GPUSupportedLimits }).limits;
+
+      if (adapterLimits !== undefined) {
+        for (const limit of ['maxSampledTexturesPerShaderStage', 'maxSamplersPerShaderStage'] as const) {
+          const available = adapterLimits[limit];
+
+          if (typeof available === 'number' && available > baseSpriteBatchTextureSlots) {
+            requiredLimits[limit] = Math.min(maxSpriteBatchTextureSlots, available);
+          }
+        }
+      }
+
+      const descriptor: GPUDeviceDescriptor = {};
+
+      if (floatFeatures.length > 0) {
+        descriptor.requiredFeatures = floatFeatures;
+      }
+
+      if (Object.keys(requiredLimits).length > 0) {
+        descriptor.requiredLimits = requiredLimits;
+      }
+
+      device = await adapter.requestDevice(Object.keys(descriptor).length > 0 ? descriptor : undefined);
     } catch (error) {
       throw this._createInitializationError('Failed to request a WebGPU device.', error);
     }

--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -20,8 +20,101 @@ import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
 import { retainedGroupUniformBytes, type WebGpuRetainedBatchPayload } from './WebGpuRetainedGroupResources';
 import { stencilContentDepthStencilState } from './WebGpuStencilState';
 
-/** WGSL source for the default sprite pipeline. @internal */
-export const spriteShaderSource = `
+/**
+ * Multi-texture batch slot tiers the sprite pipeline can be generated for.
+ * Quantizing to fixed tiers means only these WGSL variants can ever ship —
+ * all of them covered by the shader-compile browser test.
+ * @internal
+ */
+export const spriteBatchTextureSlotTiers = [8, 16, 32] as const;
+
+/**
+ * Legacy slot count, used only when a device exposes no limits object
+ * (non-conformant mocks — every real WebGPU device reports limits).
+ * @internal
+ */
+export const fallbackSpriteBatchTextureSlots = 8;
+
+/**
+ * Slot tier guaranteed by WebGPU's base limits: both
+ * `maxSampledTexturesPerShaderStage` and `maxSamplersPerShaderStage` default
+ * to 16, so 16 texture+sampler pairs are bindable on every conformant device
+ * (parity with the WebGL2 batcher's 16 slots).
+ * @internal
+ */
+export const baseSpriteBatchTextureSlots = 16;
+
+/**
+ * Hard ceiling for the multi-texture batch layout. WebGpuBackend requests
+ * this much of `maxSampledTexturesPerShaderStage` / `maxSamplersPerShaderStage`
+ * at device creation when the adapter offers more than the base 16.
+ * Diminishing returns cap the tier here: beyond 32 the per-fragment slot
+ * switch and bind-group churn outgrow the flush savings.
+ * @internal
+ */
+export const maxSpriteBatchTextureSlots = 32;
+
+/**
+ * Number of multi-texture batch slots the sprite pipeline uses on `device`,
+ * derived from the GRANTED device limits and quantized to the
+ * {@link spriteBatchTextureSlotTiers} (8 / 16 / 32).
+ *
+ * WGSL `binding_array` is not core WebGPU (and has no standard feature flag
+ * to detect), so the batch ceiling is capability-gated on device limits
+ * instead: the WGSL source and the group(1) bind-group layout are generated
+ * for `min(maxSampledTexturesPerShaderStage, maxSamplersPerShaderStage)`
+ * quantized down to a tier. Every conformant device reaches at least the
+ * 16-slot tier (spec base limits); adapters granting 32+ reach the 32-slot
+ * tier. A device without a limits object falls back to the legacy 8-slot
+ * layout.
+ * @internal
+ */
+export const resolveSpriteBatchTextureSlots = (device: GPUDevice): number => {
+  // Defensive optional access: mocked devices in unit tests (and hypothetical
+  // non-conformant implementations) may not expose a limits object at all.
+  const limits = (device as { limits?: GPUSupportedLimits }).limits;
+
+  if (limits === undefined) {
+    return fallbackSpriteBatchTextureSlots;
+  }
+
+  const available = Math.min(limits.maxSampledTexturesPerShaderStage ?? 0, limits.maxSamplersPerShaderStage ?? 0);
+
+  if (available >= maxSpriteBatchTextureSlots) {
+    return maxSpriteBatchTextureSlots;
+  }
+
+  if (available >= baseSpriteBatchTextureSlots) {
+    return baseSpriteBatchTextureSlots;
+  }
+
+  return fallbackSpriteBatchTextureSlots;
+};
+
+/**
+ * WGSL source for the default sprite pipeline, generated for `textureSlots`
+ * multi-texture batch slots: group(1) binds `textureSlots` texture views at
+ * bindings [0, N) and their samplers at [N, 2N), and `sampleTexture`
+ * dispatches over the same slot range.
+ * @internal
+ */
+export const buildSpriteShaderSource = (textureSlots: number): string => {
+  const textureBindings = Array.from(
+    { length: textureSlots },
+    (_, slot) => `@group(1) @binding(${slot})\nvar spriteTexture${slot}: texture_2d<f32>;`,
+  ).join('\n');
+  const samplerBindings = Array.from(
+    { length: textureSlots },
+    (_, slot) => `@group(1) @binding(${textureSlots + slot})\nvar spriteSampler${slot}: sampler;`,
+  ).join('\n');
+  // The last slot is the switch default so every u32 value maps to a texture.
+  const sampleCases = Array.from({ length: textureSlots }, (_, slot) =>
+    slot < textureSlots - 1
+      ? `        case ${slot}u: {\n            return textureSampleGrad(spriteTexture${slot}, spriteSampler${slot}, uv, ddx, ddy);\n        }`
+      : `        default: {\n            return textureSampleGrad(spriteTexture${slot}, spriteSampler${slot}, uv, ddx, ddy);\n        }`,
+  ).join('\n');
+
+  return `
 struct ProjectionUniforms {
     matrix: mat4x4<f32>,
     group: mat4x4<f32>,
@@ -38,39 +131,9 @@ var<uniform> projection: ProjectionUniforms;
 @group(0) @binding(1)
 var<storage, read> transforms: array<TransformSlot>;
 
-@group(1) @binding(0)
-var spriteTexture0: texture_2d<f32>;
-@group(1) @binding(1)
-var spriteTexture1: texture_2d<f32>;
-@group(1) @binding(2)
-var spriteTexture2: texture_2d<f32>;
-@group(1) @binding(3)
-var spriteTexture3: texture_2d<f32>;
-@group(1) @binding(4)
-var spriteTexture4: texture_2d<f32>;
-@group(1) @binding(5)
-var spriteTexture5: texture_2d<f32>;
-@group(1) @binding(6)
-var spriteTexture6: texture_2d<f32>;
-@group(1) @binding(7)
-var spriteTexture7: texture_2d<f32>;
+${textureBindings}
 
-@group(1) @binding(8)
-var spriteSampler0: sampler;
-@group(1) @binding(9)
-var spriteSampler1: sampler;
-@group(1) @binding(10)
-var spriteSampler2: sampler;
-@group(1) @binding(11)
-var spriteSampler3: sampler;
-@group(1) @binding(12)
-var spriteSampler4: sampler;
-@group(1) @binding(13)
-var spriteSampler5: sampler;
-@group(1) @binding(14)
-var spriteSampler6: sampler;
-@group(1) @binding(15)
-var spriteSampler7: sampler;
+${samplerBindings}
 
 // Per-instance vertex layout (36 bytes per sprite). The four corners
 // of the quad are derived from @builtin(vertex_index) 0..3 inside the
@@ -127,30 +190,7 @@ fn vertexMain(input: VertexInput, @builtin(vertex_index) vid: u32) -> VertexOutp
 
 fn sampleTexture(slot: u32, uv: vec2<f32>, ddx: vec2<f32>, ddy: vec2<f32>) -> vec4<f32> {
     switch slot {
-        case 0u: {
-            return textureSampleGrad(spriteTexture0, spriteSampler0, uv, ddx, ddy);
-        }
-        case 1u: {
-            return textureSampleGrad(spriteTexture1, spriteSampler1, uv, ddx, ddy);
-        }
-        case 2u: {
-            return textureSampleGrad(spriteTexture2, spriteSampler2, uv, ddx, ddy);
-        }
-        case 3u: {
-            return textureSampleGrad(spriteTexture3, spriteSampler3, uv, ddx, ddy);
-        }
-        case 4u: {
-            return textureSampleGrad(spriteTexture4, spriteSampler4, uv, ddx, ddy);
-        }
-        case 5u: {
-            return textureSampleGrad(spriteTexture5, spriteSampler5, uv, ddx, ddy);
-        }
-        case 6u: {
-            return textureSampleGrad(spriteTexture6, spriteSampler6, uv, ddx, ddy);
-        }
-        default: {
-            return textureSampleGrad(spriteTexture7, spriteSampler7, uv, ddx, ddy);
-        }
+${sampleCases}
     }
 }
 
@@ -170,12 +210,15 @@ fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
     return resolvedSample * input.color;
 }
 `;
+};
 
 const instanceStrideBytes = 36;
 const wordsPerInstance = instanceStrideBytes / Uint32Array.BYTES_PER_ELEMENT;
 const projectionByteLength = 128;
 const initialBatchCapacity = 32;
-const maxBatchTextures = 8;
+// Deliberately decoupled from the multi-texture batch slot count — bumping the
+// default-path batch tiers must not silently widen the custom-material
+// contract (mirrors the WebGL2 renderer's maxCustomTextureSlots convention).
 const maxCustomTextureSlots = 7; // user texture uniforms; group(2) binding 1..N
 const indicesPerSprite = 6;
 // Static index buffer: two triangles forming a quad, vertex IDs 0..3 in
@@ -184,7 +227,7 @@ const quadIndices = new Uint16Array([0, 1, 2, 0, 2, 3]);
 
 /**
  * Cached group(1) bind group for one ordered set of batch textures.
- * `textures`, `views` and `samplers` are the fully-resolved 8-slot arrays
+ * `textures`, `views` and `samplers` are the fully-resolved slot-count arrays
  * (fillers included): the views detect a backend-recreated GPU texture
  * (resize / content-driven rebuild), the samplers detect a sampler-only
  * refresh — `_syncTexture` recreates the sampler on EVERY texture.version
@@ -262,7 +305,11 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
   private _instanceUint32 = new Uint32Array(this._instanceData);
   private readonly _pipelines: Map<string, GPURenderPipeline> = new Map<string, GPURenderPipeline>();
 
-  private readonly _activeTextures: Array<Texture | RenderTexture | null> = new Array(maxBatchTextures).fill(null);
+  // Multi-texture batch slot count for the connected device (resolved from
+  // its granted limits at connect; see resolveSpriteBatchTextureSlots). Fixed
+  // per connection: every cache keyed on it is dropped on disconnect.
+  private _maxBatchTextures = fallbackSpriteBatchTextureSlots;
+  private _activeTextures: Array<Texture | RenderTexture | null> = new Array(fallbackSpriteBatchTextureSlots).fill(null);
   // group(1) bind groups cached per ordered texture set, anchored on the
   // resolved slot-0 texture (WeakMap so short-lived textures do not pin their
   // GPU bind groups across long sessions). Rebuilt when the backend hands out
@@ -293,7 +340,12 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     }
 
     this._device = backend.device;
-    this._shaderModule = this._device.createShaderModule({ label: 'sprite:shader', code: spriteShaderSource });
+    // The slot count is a property of the granted device limits, so it is
+    // resolved once per connection — before the shader module and the
+    // group(1) layout are built from it.
+    this._maxBatchTextures = resolveSpriteBatchTextureSlots(this._device);
+    this._activeTextures = new Array<Texture | RenderTexture | null>(this._maxBatchTextures).fill(null);
+    this._shaderModule = this._device.createShaderModule({ label: 'sprite:shader', code: buildSpriteShaderSource(this._maxBatchTextures) });
 
     this._uniformBindGroupLayout = this._device.createBindGroupLayout({
       label: 'sprite:bind-group-layout:uniform',
@@ -317,15 +369,15 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     this._textureBindGroupLayout = this._device.createBindGroupLayout({
       label: 'sprite:bind-group-layout:texture',
       entries: [
-        ...Array.from({ length: maxBatchTextures }, (_, index) => ({
+        ...Array.from({ length: this._maxBatchTextures }, (_, index) => ({
           binding: index,
           visibility: GPUShaderStage.FRAGMENT,
           texture: {
             sampleType: 'float' as const,
           },
         })),
-        ...Array.from({ length: maxBatchTextures }, (_, index) => ({
-          binding: maxBatchTextures + index,
+        ...Array.from({ length: this._maxBatchTextures }, (_, index) => ({
+          binding: this._maxBatchTextures + index,
           visibility: GPUShaderStage.FRAGMENT,
           sampler: {
             type: 'filtering' as const,
@@ -406,6 +458,8 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     this._currentMaterial = null;
     this._currentBaseTexture = null;
     this._resetSlots();
+    this._maxBatchTextures = fallbackSpriteBatchTextureSlots;
+    this._activeTextures = new Array<Texture | RenderTexture | null>(fallbackSpriteBatchTextureSlots).fill(null);
   }
 
   public render(sprite: Sprite): void {
@@ -464,14 +518,14 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     return sprite.getRenderBounds(backend.view, snap.width, snap.height, this._snapBounds);
   }
 
-  /** Default multi-texture path: rotate the base texture through 8 slots. */
+  /** Default multi-texture path: rotate the base texture through the device's batch slots. */
   private _renderDefault(sprite: Sprite, texture: Texture | RenderTexture, backend: WebGpuBackend, nodeIndex: number): void {
     const blendMode = sprite.blendMode;
 
     // Flush triggers: blend-mode change, texture-slot exhaustion, or a custom
     // batch still in flight that must drain first.
     const blendModeChanged = this._currentBlendMode !== null && blendMode !== this._currentBlendMode;
-    const slotExhausted = !this._textureSlots.has(texture) && this._slotCount >= maxBatchTextures;
+    const slotExhausted = !this._textureSlots.has(texture) && this._slotCount >= this._maxBatchTextures;
     const materialSwitch = this._currentMaterial !== null && this._instanceCount > 0;
 
     if (blendModeChanged || slotExhausted || materialSwitch) {
@@ -1081,12 +1135,13 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     // Bindings are resolved BEFORE the cache lookup on purpose: resolving is
     // what syncs a dirty/mutated texture's content to the GPU, so it must run
     // every flush even when the bind group itself is served from cache.
+    const slotCapacity = this._maxBatchTextures;
     const fallbackTexture = textures[0] ?? Texture.empty;
     const fallbackBinding = backend.getTextureBinding(fallbackTexture);
-    const resolvedTextures = new Array<Texture | RenderTexture>(maxBatchTextures);
-    const resolvedBindings = new Array<ReturnType<WebGpuBackend['getTextureBinding']>>(maxBatchTextures);
+    const resolvedTextures = new Array<Texture | RenderTexture>(slotCapacity);
+    const resolvedBindings = new Array<ReturnType<WebGpuBackend['getTextureBinding']>>(slotCapacity);
 
-    for (let i = 0; i < maxBatchTextures; i++) {
+    for (let i = 0; i < slotCapacity; i++) {
       const texture = textures[i] ?? fallbackTexture;
 
       resolvedTextures[i] = texture;
@@ -1107,7 +1162,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     for (const entry of entries) {
       let texturesMatch = true;
 
-      for (let i = 0; i < maxBatchTextures; i++) {
+      for (let i = 0; i < slotCapacity; i++) {
         if (entry.textures[i] !== resolvedTextures[i]) {
           texturesMatch = false;
           break;
@@ -1120,8 +1175,8 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
 
       let bindingsMatch = true;
 
-      for (let i = 0; i < maxBatchTextures; i++) {
-        // In-bounds: all arrays are fixed at maxBatchTextures entries. The
+      for (let i = 0; i < slotCapacity; i++) {
+        // In-bounds: all arrays are fixed at the connection's slot count. The
         // sampler check is load-bearing: a texture.version bump (setScaleMode/
         // setWrapMode) refreshes the sampler while the view identity stays put.
         if (entry.views[i] !== resolvedBindings[i]!.view || entry.samplers[i] !== resolvedBindings[i]!.sampler) {
@@ -1156,19 +1211,20 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
   }
 
   private _buildTextureBindGroup(device: GPUDevice, resolvedBindings: ReadonlyArray<ReturnType<WebGpuBackend['getTextureBinding']>>): GPUBindGroup {
+    const slotCapacity = this._maxBatchTextures;
     const entries: GPUBindGroupEntry[] = [];
 
-    // resolvedBindings always holds maxBatchTextures fully-resolved bindings.
-    for (let i = 0; i < maxBatchTextures; i++) {
+    // resolvedBindings always holds one fully-resolved binding per batch slot.
+    for (let i = 0; i < slotCapacity; i++) {
       entries.push({
         binding: i,
         resource: resolvedBindings[i]!.view,
       });
     }
 
-    for (let i = 0; i < maxBatchTextures; i++) {
+    for (let i = 0; i < slotCapacity; i++) {
       entries.push({
-        binding: maxBatchTextures + i,
+        binding: slotCapacity + i,
         resource: resolvedBindings[i]!.sampler,
       });
     }

--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -99,10 +99,9 @@ export const resolveSpriteBatchTextureSlots = (device: GPUDevice): number => {
  * @internal
  */
 export const buildSpriteShaderSource = (textureSlots: number): string => {
-  const textureBindings = Array.from(
-    { length: textureSlots },
-    (_, slot) => `@group(1) @binding(${slot})\nvar spriteTexture${slot}: texture_2d<f32>;`,
-  ).join('\n');
+  const textureBindings = Array.from({ length: textureSlots }, (_, slot) => `@group(1) @binding(${slot})\nvar spriteTexture${slot}: texture_2d<f32>;`).join(
+    '\n',
+  );
   const samplerBindings = Array.from(
     { length: textureSlots },
     (_, slot) => `@group(1) @binding(${textureSlots + slot})\nvar spriteSampler${slot}: sampler;`,

--- a/test/rendering/browser/webgpu-retained-instruction-replay.test.ts
+++ b/test/rendering/browser/webgpu-retained-instruction-replay.test.ts
@@ -173,24 +173,33 @@ interface FragmentCarrier {
 
 const fragmentOf = (group: RetainedContainer): RetainedGroupFragment => (group as unknown as FragmentCarrier)._fragment;
 
-// 9 distinct fully-saturated colours: enough to overflow the 8-slot batcher so
-// one retained group records TWO batches (multi-batch replay coverage).
-const palette9 = ['#ff0000', '#00ff00', '#0000ff', '#ffff00', '#ff00ff', '#00ffff', '#ff8000', '#8000ff', '#00ff80'];
+// Distinct colours built from four channel levels (black skipped): enough of
+// them to overflow the batcher's MAXIMUM texture-slot tier (32, see
+// resolveSpriteBatchTextureSlots) so one retained group records TWO batches
+// (multi-batch replay coverage) whatever slot count the device was granted.
+const channelLevels = ['00', '55', 'aa', 'ff'] as const;
+const paletteColor = (index: number): string => {
+  const combo = index + 1; // +1 skips black (the clear colour)
+
+  return `#${channelLevels[combo % 4]!}${channelLevels[Math.floor(combo / 4) % 4]!}${channelLevels[Math.floor(combo / 16) % 4]!}`;
+};
+const palette36 = Array.from({ length: 36 }, (_, i) => paletteColor(i));
 
 describe('WebGPU renderer matrix: retained instruction replay cells', () => {
   test('cell 1 — multi-batch replay is pixel-identical to the record frame (fast/slow equivalence)', async ctx => {
     const backend = await setupBackend();
-    const textures = palette9.map(color => createSolidTexture(color, 8));
+    const textures = palette36.map(color => createSolidTexture(color, 8));
     const root = new Container();
     const group = new RetainedContainer();
 
     try {
-      // A 3x3 grid of 8px sprites over 9 distinct textures: sprites 0-7 land
-      // in the first recorded batch, sprite 8 in the second.
+      // A 6x6 grid of 8px sprites over 36 distinct textures: more than the
+      // granted texture-slot tier, so the first `slots` sprites land in the
+      // first recorded batch and the rest in the second.
       for (let i = 0; i < textures.length; i++) {
         const sprite = new Sprite(textures[i]!);
 
-        sprite.setPosition((i % 3) * 8, Math.floor(i / 3) * 8);
+        sprite.setPosition((i % 6) * 8, Math.floor(i / 6) * 8);
         group.addChild(sprite);
       }
 
@@ -208,11 +217,15 @@ describe('WebGPU renderer matrix: retained instruction replay cells', () => {
 
       expect(fragmentOf(group).instructions?.hasRecording).toBe(true);
 
+      // Cell i centre = ((i % 6) * 8 + 4, floor(i / 6) * 8 + 4). Cells 0-15
+      // sit in the first recorded batch on every tier; cells 33 and 35 sit in
+      // the second batch on every tier (the tier ceiling is 32).
       const probes: ReadonlyArray<readonly [number, number, string]> = [
-        [4, 4, palette9[0]!], // batch 1
-        [20, 4, palette9[2]!], // batch 1
-        [12, 12, palette9[4]!], // batch 1
-        [20, 20, palette9[8]!], // batch 2
+        [4, 4, palette36[0]!], // batch 1
+        [20, 4, palette36[2]!], // batch 1
+        [12, 12, palette36[7]!], // batch 1
+        [28, 44, palette36[33]!], // batch 2
+        [44, 44, palette36[35]!], // batch 2
       ];
       let readPixel = readCanvas(backend);
       const slowPixels = probes.map(([x, y]) => readPixel(x, y));

--- a/test/rendering/browser/webgpu-shader-compile.test.ts
+++ b/test/rendering/browser/webgpu-shader-compile.test.ts
@@ -42,7 +42,7 @@ import { compositorShaderSource as maskCompositorWgsl } from '#rendering/webgpu/
 import { instancedMeshShaderSource, meshShaderSource } from '#rendering/webgpu/WebGpuMeshRenderer';
 import { nineSliceShaderSource } from '#rendering/webgpu/WebGpuNineSliceSpriteRenderer';
 import { commonWgsl, geoPathEntries, shaderPathEntries } from '#rendering/webgpu/WebGpuRepeatingSpriteRenderer';
-import { spriteShaderSource } from '#rendering/webgpu/WebGpuSpriteRenderer';
+import { buildSpriteShaderSource, spriteBatchTextureSlotTiers } from '#rendering/webgpu/WebGpuSpriteRenderer';
 import { stencilWriteShaderSource } from '#rendering/webgpu/WebGpuStencilClipper';
 import { textShaderSource } from '#rendering/webgpu/WebGpuTextRenderer';
 
@@ -61,7 +61,9 @@ const shaders: readonly ShaderEntry[] = [
   // Combined exactly as `onConnect` feeds `createShaderModule`: shared struct/
   // binding declarations + both entry-point sets in one module.
   { name: 'WebGpuRepeatingSpriteRenderer (combined)', source: commonWgsl + shaderPathEntries + geoPathEntries },
-  { name: 'WebGpuSpriteRenderer', source: spriteShaderSource },
+  // The sprite shader is generated per slot tier from the device limits
+  // (issue #274); every tier that can ever ship is compiled here.
+  ...spriteBatchTextureSlotTiers.map(tier => ({ name: `WebGpuSpriteRenderer (${tier} texture slots)`, source: buildSpriteShaderSource(tier) })),
   { name: 'WebGpuStencilClipper', source: stencilWriteShaderSource },
   { name: 'WebGpuTextRenderer', source: textShaderSource },
   { name: 'spriteMaterialSources spriteVertexWgsl (custom-material vertex prelude)', source: spriteVertexWgsl },

--- a/test/rendering/browser/webgpu-single-submit.test.ts
+++ b/test/rendering/browser/webgpu-single-submit.test.ts
@@ -6,9 +6,9 @@
  * `.workspace/specs/04-webgpu-overhead-investigation.md`). The WebGPU backend
  * used to open a fresh command encoder + render pass and call
  * `device.queue.submit()` on EVERY batch flush — i.e. once per draw call. In the
- * `batch-breaking` archetype (many interleaved textures overflowing the 8-slot
- * batcher) that is one GPU submit per ~8 sprites, and Dawn/D3D12's per-submit
- * cost degrades super-linearly, so the frame time explodes.
+ * `batch-breaking` archetype (many interleaved textures overflowing the
+ * batcher's texture slots) that is one GPU submit per batch, and Dawn/D3D12's
+ * per-submit cost degrades super-linearly, so the frame time explodes.
  *
  * These tests spy on `device.queue.submit` for a single rendered frame:
  *   1. A single-target sprite scene that forces MANY batch flushes must still
@@ -183,26 +183,20 @@ const countSubmits = (backend: WebGpuBackend, body: () => void): number => {
   return count;
 };
 
-// 16 distinct fully-saturated colours; consecutive entries never share a hue so
-// a batcher with 8 texture slots breaks into >= 2 draw calls.
-const palette16 = [
-  '#ff0000',
-  '#00ff00',
-  '#0000ff',
-  '#ffff00',
-  '#ff00ff',
-  '#00ffff',
-  '#ff8000',
-  '#8000ff',
-  '#00ff80',
-  '#80ff00',
-  '#0080ff',
-  '#ff0080',
-  '#808080',
-  '#c04040',
-  '#40c040',
-  '#4040c0',
-];
+// Distinct colours built from four channel levels (black skipped), so any two
+// distinct palette entries differ by at least 0x55 in some channel — far above
+// the probe tolerance. The palette is sized to exceed the sprite batcher's
+// MAXIMUM texture-slot tier (32, see resolveSpriteBatchTextureSlots), so a
+// scene using the full palette always breaks into >= 2 draw calls regardless
+// of the slot count the device was granted (16 base / 32 ceiling).
+const channelLevels = ['00', '55', 'aa', 'ff'] as const;
+const paletteColor = (index: number): string => {
+  // +1 skips black (the clear colour).
+  const combo = index + 1;
+
+  return `#${channelLevels[combo % 4]!}${channelLevels[Math.floor(combo / 4) % 4]!}${channelLevels[Math.floor(combo / 16) % 4]!}`;
+};
+const palette36 = Array.from({ length: 36 }, (_, i) => paletteColor(i));
 
 // Parse a `#rrggbb` string to an opaque RGBA tuple (canvas alphaMode 'opaque').
 const hexToRgba = (hex: string): RgbaTuple => [parseInt(hex.slice(1, 3), 16), parseInt(hex.slice(3, 5), 16), parseInt(hex.slice(5, 7), 16), 255];
@@ -225,11 +219,13 @@ const buildGridScene = (textures: readonly Texture[], columns: number, cell: num
   return root;
 };
 
-// A scene that forces a batch break: `textures[0]` at the top-left corner (0,0)
-// and the rest laid out in a row at y=24. With >= 9 distinct textures the 8-slot
-// batcher flushes the first 8 sprites (including textures[0]) into an open pass,
-// which is exactly the "earlier draws recorded into a still-open pass" precondition
-// the deferral defects hinge on. The (0,0) sprite centre (4,4) is the probe point.
+// A scene that forces a batch break: `corner` at the top-left (0,0) and the
+// rest laid out on an in-canvas grid from y=16 down (off-screen sprites would
+// be culled and never claim a texture slot). With more distinct textures than
+// the batcher's maximum slot tier (32), the batcher flushes a first batch —
+// including the corner sprite — into an open pass, which is exactly the
+// "earlier draws recorded into a still-open pass" precondition the deferral
+// defects hinge on. The (0,0) sprite centre (4,4) is the probe point.
 const buildBreakScene = (textures: readonly Texture[], corner: Texture): Container => {
   const root = new Container();
   const cornerSprite = new Sprite(corner);
@@ -242,9 +238,9 @@ const buildBreakScene = (textures: readonly Texture[], corner: Texture): Contain
   for (let i = 0; i < textures.length; i++) {
     const sprite = new Sprite(textures[i]!);
 
-    sprite.setPosition(i * 7, 24);
-    sprite.width = 8;
-    sprite.height = 8;
+    sprite.setPosition((i % 8) * 7, 16 + Math.floor(i / 8) * 7);
+    sprite.width = 6;
+    sprite.height = 6;
     root.addChild(sprite);
   }
 
@@ -261,10 +257,11 @@ const renderRoot = (backend: WebGpuBackend, root: RenderNode): void => {
 describe('WebGPU single-submit frame', () => {
   test('a multi-batch single-target sprite scene submits the frame exactly once, with correct per-batch pixels', async ctx => {
     const backend = await setupBackend();
-    // 16 distinct textures over a 4x4 grid of 16px cells: sprites 0-7 land in the
-    // first batch, 8-15 in the second (the 8-slot batcher breaks past texture 8).
-    const textures = palette16.map(color => createSolidTexture(color, 16));
-    const root = buildGridScene(textures, 4, 16);
+    // 36 distinct textures over a 6x6 grid of 10px cells: more unique textures
+    // than the batcher's maximum slot tier (32), so the scene splits into at
+    // least two batches whatever slot count the device was granted.
+    const textures = palette36.map(color => createSolidTexture(color, 16));
+    const root = buildGridScene(textures, 6, 10);
 
     try {
       // Warm up: compile pipelines, upload textures, and let the instance arena
@@ -289,19 +286,23 @@ describe('WebGPU single-submit frame', () => {
 
       expect(submits).toBe(1);
 
-      // Pixel probes at cell centres across BOTH batches. A broken arena where
+      // Pixel probes at cell centres across the batches. A broken arena where
       // every batch reads the last batch's bytes would still submit once, but
       // these cells would paint the wrong colour/position — so the probes are
-      // what actually guard the merge. Cell i centre = (col*16+8, row*16+8).
+      // what actually guard the merge. Cell i centre = (col*10+5, row*10+5).
       const readPixel = readCanvas(backend);
+      const probeCell = (index: number): void => {
+        expectPixelNear(readPixel((index % 6) * 10 + 5, Math.floor(index / 6) * 10 + 5), hexToRgba(palette36[index]!));
+      };
 
-      // Batch 1 (sprites 0-7):
-      expectPixelNear(readPixel(8, 8), hexToRgba(palette16[0]!)); // cell 0
-      expectPixelNear(readPixel(56, 8), hexToRgba(palette16[3]!)); // cell 3
-      // Batch 2 (sprites 8-15):
-      expectPixelNear(readPixel(8, 40), hexToRgba(palette16[8]!)); // cell 8
-      expectPixelNear(readPixel(40, 40), hexToRgba(palette16[10]!)); // cell 10
-      expectPixelNear(readPixel(56, 56), hexToRgba(palette16[15]!)); // cell 15
+      // First batch (early slots), a slot past the legacy 8-slot ceiling, one
+      // deep into the granted tier, and the tail cells of the LAST batch:
+      probeCell(0);
+      probeCell(3);
+      probeCell(10);
+      probeCell(20);
+      probeCell(33);
+      probeCell(35);
     } finally {
       root.destroy();
       textures.forEach(texture => texture.destroy());
@@ -413,8 +414,8 @@ describe('WebGPU single-submit frame', () => {
   // boundary. The fix ends the open pass before the growth.
   test('two render() calls in one frame — first batch-breaks, second grows transform storage — keep both plans, no validation error', async ctx => {
     const backend = await setupBackend();
-    const breakTextures = palette16.slice(1, 9).map(color => createSolidTexture(color, 8));
-    const cornerTexture = createSolidTexture(palette16[0]!, 8);
+    const breakTextures = palette36.slice(1).map(color => createSolidTexture(color, 8));
+    const cornerTexture = createSolidTexture(palette36[0]!, 8);
     const fillTexture = createSolidTexture('#00ff80', 16);
     const planOne = buildBreakScene(breakTextures, cornerTexture);
 
@@ -440,7 +441,7 @@ describe('WebGPU single-submit frame', () => {
 
       backend.resetStats();
       backend.clear(Color.black);
-      planOne.render(backend); // 9 distinct textures → batch break → pass open
+      planOne.render(backend); // 36 distinct textures (> max slot tier) → batch break → pass open
       planTwo.render(backend); // reserve() grows the storage while that pass is open
       backend.flush();
       planTwo.destroy();
@@ -465,7 +466,7 @@ describe('WebGPU single-submit frame', () => {
       const readPixel = readCanvas(backend);
 
       // First plan's corner sprite survived (its batch was not dropped):
-      expectPixelNear(readPixel(4, 4), hexToRgba(palette16[0]!));
+      expectPixelNear(readPixel(4, 4), hexToRgba(palette36[0]!));
       // Second plan's fill is present:
       expectPixelNear(readPixel(40, 40), hexToRgba('#00ff80'));
     } finally {
@@ -483,8 +484,8 @@ describe('WebGPU single-submit frame', () => {
   // open pass so the clear applies at the point it was requested.
   test('a mid-frame clear() applies where requested: it wipes prior content and keeps later content', async ctx => {
     const backend = await setupBackend();
-    const breakTextures = palette16.slice(1, 9).map(color => createSolidTexture(color, 8));
-    const cornerTexture = createSolidTexture(palette16[0]!, 8);
+    const breakTextures = palette36.slice(1).map(color => createSolidTexture(color, 8));
+    const cornerTexture = createSolidTexture(palette36[0]!, 8);
     const greenTexture = createSolidTexture('#00ff00', 16);
     const planOne = buildBreakScene(breakTextures, cornerTexture);
     const laterRoot = new Container();
@@ -538,7 +539,7 @@ describe('WebGPU single-submit frame', () => {
   // content and only the later draw sees the new content.
   test('a texture updated between two same-frame renders: the earlier draw keeps the OLD content', async ctx => {
     const backend = await setupBackend();
-    const breakTextures = palette16.slice(1, 9).map(color => createSolidTexture(color, 8));
+    const breakTextures = palette36.slice(1).map(color => createSolidTexture(color, 8));
     const mutable = createMutableTexture('#ff0000', 8);
     const planOne = buildBreakScene(breakTextures, mutable.texture);
     const laterRoot = new Container();

--- a/test/rendering/browser/webgpu-texture-batching.test.ts
+++ b/test/rendering/browser/webgpu-texture-batching.test.ts
@@ -1,0 +1,227 @@
+/**
+ * WebGPU sprite batcher texture-slot capacity — real-device acceptance test
+ * (issue #274, F9b follow-up).
+ *
+ * The WebGPU sprite renderer used to hard-code 8 texture slots per batch;
+ * the WGSL source and group(1) bind-group layout are now generated for a
+ * slot count resolved from the granted device limits (16 base tier / 32
+ * ceiling, see resolveSpriteBatchTextureSlots). These tests verify on the
+ * REAL device that:
+ *
+ *  1. the device reaches at least the 16-slot tier (spec base limits),
+ *  2. exactly `slots` distinct-texture sprites draw in ONE draw call — with
+ *     pixel probes on slots >= 8 proving the generated shader's upper slots
+ *     sample the right texture (not just that the draw count dropped),
+ *  3. the (slots + 1)-th distinct texture still splits the batch.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+import { baseSpriteBatchTextureSlots, maxSpriteBatchTextureSlots, resolveSpriteBatchTextureSlots } from '#rendering/webgpu/WebGpuSpriteRenderer';
+
+import { wireCoreRenderers } from './_coreRenderers';
+import { getBackendDevice } from './webgpu-test-helpers';
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+const gridColumns = 6;
+const gridCell = 10;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: {
+      canvas: { width: canvasSize, height: canvasSize },
+      clearColor: Color.black,
+    },
+  }) as unknown as Application;
+
+const setupBackend = async (): Promise<WebGpuBackend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  await backend.initialize();
+  wireCoreRenderers(backend);
+
+  return backend;
+};
+
+// Distinct colours built from four channel levels (black skipped): any two
+// distinct entries differ by at least 0x55 in some channel, far above the
+// probe tolerance. Covers up to maxSpriteBatchTextureSlots + 1 = 33 entries.
+const channelLevels = ['00', '55', 'aa', 'ff'] as const;
+const paletteColor = (index: number): string => {
+  const combo = index + 1; // +1 skips black (the clear colour)
+
+  return `#${channelLevels[combo % 4]!}${channelLevels[Math.floor(combo / 4) % 4]!}${channelLevels[Math.floor(combo / 16) % 4]!}`;
+};
+
+const hexToRgba = (hex: string): RgbaTuple => [parseInt(hex.slice(1, 3), 16), parseInt(hex.slice(3, 5), 16), parseInt(hex.slice(5, 7), 16), 255];
+
+const createSolidTexture = (color: string, size = 8): Texture => {
+  const source = document.createElement('canvas');
+
+  source.width = size;
+  source.height = size;
+
+  const ctx = source.getContext('2d')!;
+
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, size, size);
+
+  return new Texture(source);
+};
+
+// A non-overlapping grid of solid sprites, one distinct texture per cell.
+const buildGridScene = (textures: readonly Texture[]): Container => {
+  const root = new Container();
+
+  for (let i = 0; i < textures.length; i++) {
+    const sprite = new Sprite(textures[i]!);
+
+    sprite.setPosition((i % gridColumns) * gridCell, Math.floor(i / gridColumns) * gridCell);
+    sprite.width = gridCell;
+    sprite.height = gridCell;
+    root.addChild(sprite);
+  }
+
+  return root;
+};
+
+const renderRoot = (backend: WebGpuBackend, root: Container): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+  root.render(backend);
+  backend.flush();
+};
+
+const readCanvas = (backend: WebGpuBackend): ((x: number, y: number) => RgbaTuple) => {
+  const source = backend.context.canvas as HTMLCanvasElement;
+  const readback = document.createElement('canvas');
+
+  readback.width = canvasSize;
+  readback.height = canvasSize;
+
+  const ctx = readback.getContext('2d')!;
+
+  ctx.drawImage(source, 0, 0);
+
+  return (x: number, y: number): RgbaTuple => {
+    const { data } = ctx.getImageData(Math.floor(x), Math.floor(y), 1, 1);
+
+    return [data[0], data[1], data[2], data[3]];
+  };
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 16): void => {
+  for (let i = 0; i < 4; i++) {
+    expect(Math.abs(actual[i] - expected[i])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+/** Render `body`, skipping the test on a software-adapter device loss. */
+const renderChecked = (ctx: { skip: (reason: string) => void }, body: () => void): boolean => {
+  try {
+    body();
+
+    return true;
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+};
+
+describe('WebGPU sprite batcher texture-slot capacity (real device)', () => {
+  test('the granted device limits reach at least the 16-slot tier', async () => {
+    const backend = await setupBackend();
+
+    try {
+      const slots = resolveSpriteBatchTextureSlots(getBackendDevice(backend));
+
+      // Spec base limits guarantee 16 sampled textures + 16 samplers per
+      // stage; the backend requests up to the 32 ceiling.
+      expect(slots).toBeGreaterThanOrEqual(baseSpriteBatchTextureSlots);
+      expect(slots).toBeLessThanOrEqual(maxSpriteBatchTextureSlots);
+    } finally {
+      backend.destroy();
+    }
+  });
+
+  test('exactly `slots` distinct textures draw in ONE draw call with correct pixels; the (slots+1)-th splits', async ctx => {
+    const backend = await setupBackend();
+    const slots = resolveSpriteBatchTextureSlots(getBackendDevice(backend));
+    const colors = Array.from({ length: slots + 1 }, (_, i) => paletteColor(i));
+    const textures = colors.map(color => createSolidTexture(color));
+    const fullBatch = buildGridScene(textures.slice(0, slots));
+    const overflow = buildGridScene(textures);
+
+    try {
+      // Warm up both scenes: pipelines, texture uploads, arena growth.
+      for (let frame = 0; frame < 2; frame++) {
+        if (!renderChecked(ctx, () => renderRoot(backend, fullBatch))) {
+          return;
+        }
+
+        if (!renderChecked(ctx, () => renderRoot(backend, overflow))) {
+          return;
+        }
+      }
+
+      // `slots` distinct textures: ONE batch, ONE draw call.
+      if (!renderChecked(ctx, () => renderRoot(backend, fullBatch))) {
+        return;
+      }
+
+      expect(backend.stats.drawCalls).toBe(1);
+
+      // Pixel probes prove the upper slots sample the RIGHT texture: cell 8
+      // is the first slot past the legacy 8-slot layout, cell slots-1 is the
+      // last slot of the generated layout.
+      const readFull = readCanvas(backend);
+      const probe = (read: (x: number, y: number) => RgbaTuple, index: number): void => {
+        expectPixelNear(read((index % gridColumns) * gridCell + gridCell / 2, Math.floor(index / gridColumns) * gridCell + gridCell / 2), hexToRgba(colors[index]!));
+      };
+
+      probe(readFull, 0);
+      probe(readFull, 7);
+      probe(readFull, 8);
+      probe(readFull, slots - 1);
+
+      // One more distinct texture: the batch splits into exactly two draws.
+      if (!renderChecked(ctx, () => renderRoot(backend, overflow))) {
+        return;
+      }
+
+      expect(backend.stats.drawCalls).toBe(2);
+
+      const readOverflow = readCanvas(backend);
+
+      probe(readOverflow, 0);
+      probe(readOverflow, slots - 1);
+      probe(readOverflow, slots); // first sprite of the second batch
+    } finally {
+      fullBatch.destroy();
+      overflow.destroy();
+      textures.forEach(texture => texture.destroy());
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgpu-texture-batching.test.ts
+++ b/test/rendering/browser/webgpu-texture-batching.test.ts
@@ -197,7 +197,10 @@ describe('WebGPU sprite batcher texture-slot capacity (real device)', () => {
       // last slot of the generated layout.
       const readFull = readCanvas(backend);
       const probe = (read: (x: number, y: number) => RgbaTuple, index: number): void => {
-        expectPixelNear(read((index % gridColumns) * gridCell + gridCell / 2, Math.floor(index / gridColumns) * gridCell + gridCell / 2), hexToRgba(colors[index]!));
+        expectPixelNear(
+          read((index % gridColumns) * gridCell + gridCell / 2, Math.floor(index / gridColumns) * gridCell + gridCell / 2),
+          hexToRgba(colors[index]!),
+        );
       };
 
       probe(readFull, 0);

--- a/test/rendering/webgpu-affine-packing-parity.test.ts
+++ b/test/rendering/webgpu-affine-packing-parity.test.ts
@@ -24,7 +24,7 @@ import { TransformBuffer } from '#rendering/TransformBuffer';
 import { instancedMeshShaderSource, WebGpuMeshRenderer } from '#rendering/webgpu/WebGpuMeshRenderer';
 import { nineSliceShaderSource } from '#rendering/webgpu/WebGpuNineSliceSpriteRenderer';
 import { geoPathEntries, shaderPathEntries } from '#rendering/webgpu/WebGpuRepeatingSpriteRenderer';
-import { spriteShaderSource } from '#rendering/webgpu/WebGpuSpriteRenderer';
+import { baseSpriteBatchTextureSlots, buildSpriteShaderSource } from '#rendering/webgpu/WebGpuSpriteRenderer';
 import { textShaderSource } from '#rendering/webgpu/WebGpuTextRenderer';
 
 // ── Fixtures: asymmetric (rotation + skew) affine matrices ───────────────────
@@ -136,7 +136,9 @@ describe('WGSL slot math parity across instanced renderers', () => {
     new RegExp(String.raw`slot\.m0\.z\s*\*\s*${lx}\s*\+\s*slot\.m0\.w\s*\*\s*${ly}\s*\+\s*slot\.m1\.y`);
 
   const cases: ReadonlyArray<{ name: string; source: string; lx: string; ly: string }> = [
-    { name: 'sprite', source: spriteShaderSource, lx: 'localX', ly: 'localY' },
+    // The vertex stage (where the TransformSlot math lives) is identical
+    // across the generated slot tiers; the base tier stands in for all.
+    { name: 'sprite', source: buildSpriteShaderSource(baseSpriteBatchTextureSlots), lx: 'localX', ly: 'localY' },
     { name: 'nine-slice', source: nineSliceShaderSource, lx: 'localX', ly: 'localY' },
     { name: 'repeating-sprite (shader path)', source: shaderPathEntries, lx: 'lx', ly: 'ly' },
     { name: 'repeating-sprite (geometry path)', source: geoPathEntries, lx: 'lx', ly: 'ly' },

--- a/test/rendering/webgpu-sprite-texture-slots.test.ts
+++ b/test/rendering/webgpu-sprite-texture-slots.test.ts
@@ -1,0 +1,382 @@
+/**
+ * WebGPU sprite batcher texture-slot capacity (issue #274, F9b follow-up).
+ *
+ * The WebGPU sprite renderer used to hard-code an 8-texture bind-group layout,
+ * so scenes with more than 8 unique textures split into one flush per 8
+ * sprites — while the WebGL2 batcher had already been lifted to 16 slots (F9).
+ *
+ * WGSL `binding_array` is not core WebGPU, so the lift is capability-gated on
+ * DEVICE LIMITS instead: the WGSL source and bind-group layout are generated
+ * for a slot count derived from `min(maxSampledTexturesPerShaderStage,
+ * maxSamplersPerShaderStage)`, quantized to the 8 / 16 / 32 tiers (the spec's
+ * base limits guarantee 16; the backend requests up to 32 at device creation
+ * when the adapter offers more). A device that exposes no limits object
+ * (non-conformant mocks) falls back to the legacy 8-slot path.
+ *
+ * These tests drive the REAL WebGpuBackend + sprite renderer against a mock
+ * device with controlled limits and count `drawIndexed` calls per frame.
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { materializeRendererBindings } from '#extensions/materialize';
+import { buildCoreRendererBindings } from '#rendering/coreRendererBindings';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+import { resolveSpriteBatchTextureSlots } from '#rendering/webgpu/WebGpuSpriteRenderer';
+
+interface MockLimits {
+  readonly maxSampledTexturesPerShaderStage: number;
+  readonly maxSamplersPerShaderStage: number;
+}
+
+interface MockWebGpuEnvironment {
+  readonly canvas: HTMLCanvasElement;
+  drawIndexedCount(): number;
+  /** Descriptors passed to adapter.requestDevice, in call order. */
+  requestDeviceDescriptors(): ReadonlyArray<GPUDeviceDescriptor | undefined>;
+  /** Texture-typed entry count of every created bind group layout, by label. */
+  textureLayoutEntryCounts(): ReadonlyMap<string, number>;
+  restore(): void;
+}
+
+const globalStubs: ReadonlyArray<readonly [string, unknown]> = [
+  ['GPUBufferUsage', { COPY_DST: 1, INDEX: 2, UNIFORM: 4, VERTEX: 8, STORAGE: 16, COPY_SRC: 32 }],
+  ['GPUShaderStage', { VERTEX: 1, FRAGMENT: 2 }],
+  ['GPUColorWrite', { ALL: 0xf }],
+  ['GPUTextureUsage', { COPY_DST: 1, TEXTURE_BINDING: 2, RENDER_ATTACHMENT: 4, COPY_SRC: 8 }],
+];
+
+interface MockEnvironmentOptions {
+  /** Limits the mock ADAPTER advertises (drives requiredLimits negotiation). */
+  readonly adapterLimits?: MockLimits;
+  /** Limits the mock DEVICE reports as granted. Omit for a limit-less device. */
+  readonly deviceLimits?: MockLimits;
+}
+
+const createMockWebGpuEnvironment = (options: MockEnvironmentOptions = {}): MockWebGpuEnvironment => {
+  const previousGpu = Object.getOwnPropertyDescriptor(navigator, 'gpu');
+  const previousGlobals = globalStubs.map(([name]) => [name, Object.getOwnPropertyDescriptor(globalThis, name)] as const);
+
+  let drawIndexedCount = 0;
+  const requestDeviceDescriptors: Array<GPUDeviceDescriptor | undefined> = [];
+  const textureLayoutEntryCounts = new Map<string, number>();
+
+  const pass = {
+    setPipeline: (): void => {},
+    setBindGroup: (): void => {},
+    setVertexBuffer: (): void => {},
+    setIndexBuffer: (): void => {},
+    setScissorRect: (): void => {},
+    pushDebugGroup: (): void => {},
+    popDebugGroup: (): void => {},
+    draw: (): void => {},
+    drawIndexed: (): void => {
+      drawIndexedCount++;
+    },
+    end: (): void => {},
+  };
+  const encoder = {
+    beginRenderPass: () => pass,
+    finish: () => ({ label: 'command-buffer' }) as unknown as GPUCommandBuffer,
+  };
+  const queue = {
+    writeBuffer: (): void => {},
+    submit: (): void => {},
+    copyExternalImageToTexture: (): void => {},
+    writeTexture: (): void => {},
+  };
+  const device = {
+    createShaderModule: () => ({}) as GPUShaderModule,
+    createBindGroupLayout: (descriptor: GPUBindGroupLayoutDescriptor): GPUBindGroupLayout => {
+      let textureEntries = 0;
+
+      for (const entry of descriptor.entries) {
+        if ((entry as GPUBindGroupLayoutEntry).texture !== undefined) {
+          textureEntries++;
+        }
+      }
+
+      textureLayoutEntryCounts.set(descriptor.label ?? '', textureEntries);
+
+      return {} as GPUBindGroupLayout;
+    },
+    createPipelineLayout: () => ({}) as GPUPipelineLayout,
+    createBindGroup: () => ({}) as GPUBindGroup,
+    createRenderPipeline: () => ({}) as GPURenderPipeline,
+    createCommandEncoder: () => encoder as unknown as GPUCommandEncoder,
+    createBuffer: (descriptor: GPUBufferDescriptor): GPUBuffer =>
+      ({
+        label: descriptor.label ?? '',
+        destroy: (): void => {},
+      }) as unknown as GPUBuffer,
+    createTexture: (): GPUTexture => {
+      const view = {} as GPUTextureView;
+
+      return {
+        destroy: (): void => {},
+        createView: () => view,
+      } as unknown as GPUTexture;
+    },
+    createSampler: () => ({}) as GPUSampler,
+    lost: new Promise<GPUDeviceLostInfo>(() => {}),
+    queue,
+    ...(options.deviceLimits !== undefined ? { limits: options.deviceLimits } : {}),
+  } as unknown as GPUDevice;
+  const context = {
+    configure: (): void => {},
+    unconfigure: (): void => {},
+    getCurrentTexture: () =>
+      ({
+        createView: () => ({}) as GPUTextureView,
+      }) as unknown as GPUTexture,
+  } as unknown as GPUCanvasContext;
+  const gpu = {
+    requestAdapter: async () =>
+      ({
+        ...(options.adapterLimits !== undefined ? { limits: options.adapterLimits } : {}),
+        requestDevice: async (descriptor?: GPUDeviceDescriptor) => {
+          requestDeviceDescriptors.push(descriptor);
+
+          return device;
+        },
+      }) as unknown as GPUAdapter,
+    getPreferredCanvasFormat: () => 'bgra8unorm' as GPUTextureFormat,
+  } as unknown as GPU;
+  const canvas = document.createElement('canvas');
+
+  Object.defineProperty(navigator, 'gpu', { configurable: true, value: gpu });
+
+  for (const [name, value] of globalStubs) {
+    Object.defineProperty(globalThis, name, { configurable: true, value });
+  }
+
+  Object.defineProperty(canvas, 'getContext', {
+    configurable: true,
+    value: (contextType: string) => (contextType === 'webgpu' ? context : null),
+  });
+
+  return {
+    canvas,
+    drawIndexedCount: () => drawIndexedCount,
+    requestDeviceDescriptors: () => requestDeviceDescriptors,
+    textureLayoutEntryCounts: () => textureLayoutEntryCounts,
+    restore: (): void => {
+      if (previousGpu) {
+        Object.defineProperty(navigator, 'gpu', previousGpu);
+      } else {
+        Object.defineProperty(navigator, 'gpu', { configurable: true, value: undefined });
+      }
+
+      for (const [name, descriptor] of previousGlobals) {
+        if (descriptor) {
+          Object.defineProperty(globalThis, name, descriptor);
+        } else {
+          Object.defineProperty(globalThis, name, { configurable: true, value: undefined });
+        }
+      }
+    },
+  };
+};
+
+const createBackend = async (environment: MockWebGpuEnvironment): Promise<WebGpuBackend> => {
+  const app = {
+    canvas: environment.canvas,
+    options: {
+      canvas: { width: 128, height: 128 },
+      clearColor: Color.black,
+    },
+  } as unknown as Application;
+  const backend = new WebGpuBackend(app);
+
+  materializeRendererBindings(backend, buildCoreRendererBindings({}));
+  await backend.initialize();
+
+  return backend;
+};
+
+const createCanvasTexture = (size = 16): Texture => {
+  const sourceCanvas = document.createElement('canvas');
+
+  sourceCanvas.width = size;
+  sourceCanvas.height = size;
+
+  const texture = new Texture(sourceCanvas);
+
+  texture.generateMipMap = false;
+  texture.updateSource();
+
+  return texture;
+};
+
+/** One sprite per distinct texture, laid out on a grid inside the 128px view. */
+const createDistinctTextureSprites = (count: number): { sprites: Sprite[]; textures: Texture[] } => {
+  const textures = Array.from({ length: count }, () => createCanvasTexture());
+  const sprites = textures.map((texture, i) => {
+    const sprite = new Sprite(texture);
+
+    sprite.setPosition((i % 16) * 8, Math.floor(i / 16) * 8);
+    sprite.width = 8;
+    sprite.height = 8;
+
+    return sprite;
+  });
+
+  return { sprites, textures };
+};
+
+const renderFrame = (backend: WebGpuBackend, sprites: readonly Sprite[]): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+
+  for (const sprite of sprites) {
+    sprite.render(backend);
+  }
+
+  backend.flush();
+};
+
+/** drawIndexed calls issued by exactly one steady-state frame. */
+const measureFrameDraws = (environment: MockWebGpuEnvironment, backend: WebGpuBackend, sprites: readonly Sprite[]): number => {
+  renderFrame(backend, sprites); // warmup: uploads, pipelines, arena growth
+  const before = environment.drawIndexedCount();
+
+  renderFrame(backend, sprites);
+
+  return environment.drawIndexedCount() - before;
+};
+
+describe('resolveSpriteBatchTextureSlots', () => {
+  const makeDevice = (limits?: MockLimits): GPUDevice => ({ ...(limits !== undefined ? { limits } : {}) }) as unknown as GPUDevice;
+
+  test('quantizes the granted limits to the 8 / 16 / 32 tiers', () => {
+    expect(resolveSpriteBatchTextureSlots(makeDevice({ maxSampledTexturesPerShaderStage: 16, maxSamplersPerShaderStage: 16 }))).toBe(16);
+    expect(resolveSpriteBatchTextureSlots(makeDevice({ maxSampledTexturesPerShaderStage: 32, maxSamplersPerShaderStage: 32 }))).toBe(32);
+    expect(resolveSpriteBatchTextureSlots(makeDevice({ maxSampledTexturesPerShaderStage: 1048576, maxSamplersPerShaderStage: 1048576 }))).toBe(32);
+    // The tightest of the two limits drives the tier.
+    expect(resolveSpriteBatchTextureSlots(makeDevice({ maxSampledTexturesPerShaderStage: 1048576, maxSamplersPerShaderStage: 16 }))).toBe(16);
+    expect(resolveSpriteBatchTextureSlots(makeDevice({ maxSampledTexturesPerShaderStage: 24, maxSamplersPerShaderStage: 24 }))).toBe(16);
+    // Below-spec limits collapse to the legacy 8-slot floor.
+    expect(resolveSpriteBatchTextureSlots(makeDevice({ maxSampledTexturesPerShaderStage: 8, maxSamplersPerShaderStage: 8 }))).toBe(8);
+  });
+
+  test('a device without a limits object falls back to the legacy 8-slot path', () => {
+    expect(resolveSpriteBatchTextureSlots(makeDevice())).toBe(8);
+  });
+});
+
+describe('WebGPU sprite batcher texture-slot capacity', () => {
+  test('16 distinct textures batch into ONE draw on a base-limits (16/16) device; the 17th splits', async () => {
+    const limits: MockLimits = { maxSampledTexturesPerShaderStage: 16, maxSamplersPerShaderStage: 16 };
+    const environment = createMockWebGpuEnvironment({ adapterLimits: limits, deviceLimits: limits });
+
+    try {
+      const backend = await createBackend(environment);
+      const sixteen = createDistinctTextureSprites(16);
+      const seventeen = createDistinctTextureSprites(17);
+
+      expect(measureFrameDraws(environment, backend, sixteen.sprites)).toBe(1);
+      expect(measureFrameDraws(environment, backend, seventeen.sprites)).toBe(2);
+
+      // The generated bind-group layout carries exactly 16 texture entries.
+      expect(environment.textureLayoutEntryCounts().get('sprite:bind-group-layout:texture')).toBe(16);
+
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('32 distinct textures batch into ONE draw when the device grants 32 slots; the 33rd splits', async () => {
+    const adapterLimits: MockLimits = { maxSampledTexturesPerShaderStage: 1048576, maxSamplersPerShaderStage: 1048576 };
+    const deviceLimits: MockLimits = { maxSampledTexturesPerShaderStage: 32, maxSamplersPerShaderStage: 32 };
+    const environment = createMockWebGpuEnvironment({ adapterLimits, deviceLimits });
+
+    try {
+      const backend = await createBackend(environment);
+      const thirtyTwo = createDistinctTextureSprites(32);
+      const thirtyThree = createDistinctTextureSprites(33);
+
+      expect(measureFrameDraws(environment, backend, thirtyTwo.sprites)).toBe(1);
+      expect(measureFrameDraws(environment, backend, thirtyThree.sprites)).toBe(2);
+
+      expect(environment.textureLayoutEntryCounts().get('sprite:bind-group-layout:texture')).toBe(32);
+
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('a limit-less mock device keeps the legacy 8-slot batching (9 textures split into 2 draws)', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createBackend(environment);
+      const eight = createDistinctTextureSprites(8);
+      const nine = createDistinctTextureSprites(9);
+
+      expect(measureFrameDraws(environment, backend, eight.sprites)).toBe(1);
+      expect(measureFrameDraws(environment, backend, nine.sprites)).toBe(2);
+
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('requestDevice asks for at most 32 sampled textures / samplers when the adapter offers more', async () => {
+    const adapterLimits: MockLimits = { maxSampledTexturesPerShaderStage: 1048576, maxSamplersPerShaderStage: 4096 };
+    const deviceLimits: MockLimits = { maxSampledTexturesPerShaderStage: 32, maxSamplersPerShaderStage: 32 };
+    const environment = createMockWebGpuEnvironment({ adapterLimits, deviceLimits });
+
+    try {
+      const backend = await createBackend(environment);
+      const descriptors = environment.requestDeviceDescriptors();
+
+      expect(descriptors).toHaveLength(1);
+      expect(descriptors[0]?.requiredLimits).toEqual({
+        maxSampledTexturesPerShaderStage: 32,
+        maxSamplersPerShaderStage: 32,
+      });
+
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('requestDevice requests no extra limits when the adapter only offers the spec base (16/16)', async () => {
+    const limits: MockLimits = { maxSampledTexturesPerShaderStage: 16, maxSamplersPerShaderStage: 16 };
+    const environment = createMockWebGpuEnvironment({ adapterLimits: limits, deviceLimits: limits });
+
+    try {
+      const backend = await createBackend(environment);
+      const descriptors = environment.requestDeviceDescriptors();
+
+      expect(descriptors).toHaveLength(1);
+      expect(descriptors[0]?.requiredLimits).toBeUndefined();
+
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('an adapter without a limits object is not asked for requiredLimits', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createBackend(environment);
+      const descriptors = environment.requestDeviceDescriptors();
+
+      expect(descriptors).toHaveLength(1);
+      expect(descriptors[0]?.requiredLimits).toBeUndefined();
+
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #274 (review finding F9b follow-up).

## Root cause

The WebGPU sprite renderer hard-coded its multi-texture batch at **8 texture slots**: a fixed 8-pair (`texture_2d` + `sampler`) `@group(1)` bind-group layout, a hand-written 8-case WGSL `sampleTexture` switch, and `maxBatchTextures = 8` in the flush trigger. Scenes with more than 8 unique textures split into one flush per 8 sprites, while the WebGL2 batcher had already been lifted to 16 slots in #272 (F9).

## Design decision

The issue suggested `binding_array<texture_2d<f32>>`. Assessment: **WGSL `binding_array` is not core WebGPU** — it exists only as a non-standard Chromium experimental extension with no `GPUFeatureName` to capability-gate on, so it cannot ship in a production engine today. Rejected.

Instead, the ceiling is capability-gated on **device limits**, which is fully standard:

- The WGSL source (`buildSpriteShaderSource(slots)`) and the `@group(1)` bind-group layout are **generated per device connection** for a slot count resolved from `min(limits.maxSampledTexturesPerShaderStage, limits.maxSamplersPerShaderStage)` (`resolveSpriteBatchTextureSlots`).
- The count is **quantized to fixed 8 / 16 / 32 tiers**, so only three shader variants can ever ship — every one of them is compiled against a real device in the WGSL compile browser test.
- **16 is the guaranteed floor on every conformant device**: WebGPU's base limits default both `maxSampledTexturesPerShaderStage` and `maxSamplersPerShaderStage` to 16. This restores parity with WebGL2's 16 slots with no negotiation at all.
- `WebGpuBackend` now passes `requiredLimits` at `requestDevice` asking for up to the **32-slot ceiling** when the adapter offers more than the base 16 (requesting `min(adapterLimit, 32)` is always satisfiable, so device creation can never fail from this). The renderer reads the **granted** device limits, never the adapter's.
- A device exposing no `limits` object (non-conformant mocks) falls back to the **legacy 8-slot path** — the existing mock-device unit suites run byte-identical to before.
- The tier is fixed per connection; all caches keyed on it (texture-set bind groups, pipelines, shader module) are already dropped on disconnect/device-loss, so no invalidation semantics change.
- Ceiling rationale: beyond 32 the per-fragment slot switch and bind-group width outgrow the flush savings (WebGL2 also stops at 16 with `MAX_TEXTURE_IMAGE_UNITS >= 16`).

Per the issue's second point: the custom-material texture cap (`maxCustomTextureSlots = 7`) stays **deliberately decoupled** from the batch slot count, now documented with the same wording convention as the WebGL2 renderer.

## Test evidence

TDD: the new node suite was written first and failed against the 8-slot implementation (5 failing / 3 passing), then went green after the change.

New tests:

- `test/rendering/webgpu-sprite-texture-slots.test.ts` (node, mock device with controlled limits): tier quantization (16/16→16, 32+→32, 24→16, 8→8, no-limits→8), 16 distinct textures → 1 `drawIndexed` + 17th splits, 32 → 1 + 33rd splits on a 32-slot device, legacy 8-slot fallback, bind-group-layout width matches the tier, `requiredLimits` capped at 32 and omitted when the adapter offers only the base/no limits.
- `test/rendering/browser/webgpu-texture-batching.test.ts` (real device): granted tier is >= 16; exactly `slots` distinct textures render in ONE draw call with pixel probes on slots 8+ and `slots-1` proving the generated upper slots sample the right texture; the `(slots+1)`-th texture splits into exactly 2 draws with correct pixels in both batches.

Updated tests (scenes that relied on 9/16 textures overflowing the 8-slot batcher now use 33+ textures — beyond the 32 ceiling — so they keep forcing batch breaks on any granted tier):

- `webgpu-single-submit.test.ts` (grid + the three deferral-defect break scenes, laid out in-canvas so no sprite is culled away from claiming a slot)
- `webgpu-retained-instruction-replay.test.ts` (multi-batch retained replay coverage)
- `webgpu-shader-compile.test.ts` now compiles all three generated tiers (8/16/32)
- `webgpu-affine-packing-parity.test.ts` consumes the generated source (vertex stage is tier-independent)

Verification runs (all green):

- `pnpm test` — 407 files, 7371 passed / 13 skipped
- `pnpm test:browser:webgpu` — 35 files, 152 passed (incl. all three WGSL tier compiles and the new real-device acceptance test)
- `pnpm test:browser:webgl` — 36 files, 211 passed
- `pnpm typecheck`, `eslint --max-warnings=0` on touched files, `pnpm docs:api:check` (in sync — all new exports are `@internal`), pre-push `verify:quick`

Do not enable automerge — this PR is gated on an adversarial review.

https://claude.ai/code/session_01RHB7cLgoonJHLQg9ScdXby