### PR TITLE
fix(resources): weakly-held deferred handles + co-handle heal tracking (A4/A5)

### DIFF
--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -31,6 +31,7 @@ import { FactoryRegistry } from './FactoryRegistry';
 import { LoadingQueue } from './LoadingQueue';
 import type { SeamlessAdapter } from './seamless';
 import { BinaryAsset, CsvAsset, FontAsset, type ImageAsset, Json, SubtitleAsset, type SvgAsset, TextAsset, WasmAsset, XmlAsset } from './tokens';
+import { WeakHandleSet } from './WeakHandleSet';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -288,15 +289,37 @@ export class Loader {
 
   // ── Seamless deferred handles (asset-system v2) ───────────────────────────
   // Adapter per seamless type; handles pending or failed, keyed by _key(type, source).
-  // Each entry tracks the SET of distinct handles in flight for the key (§7
+  // Each entry tracks the SET of distinct live handles for the key (§7
   // multi-handle fill): two catalog leaves for one source share a single
   // source-keyed decode yet are each filled in place. The first handle inserted
   // is the representative — the object that becomes the canonical `_resources`
-  // entry on store, mirroring the old single-handle contract. Successful fills
-  // remove the entry (the representative moves to _resources); failed entries
-  // stay so a later get() retries and heals the SAME handles in place.
+  // entry on store, mirroring the old single-handle contract.
+  //
+  // The entry PERSISTS across the store→evict→heal cycle (it is not dropped once
+  // the payload converges into `_resources`): the stored resource is registered
+  // here too, so a co-handle adopted from an already-stored donor joins the same
+  // set (audit A5) and a refcount-0 eviction re-arms EVERY live consumer, not
+  // just the representative. Handles are held WEAKLY ({@link WeakHandleSet}) so a
+  // fully-released source does not pin its evicted 0×0 `Texture`/`Sound` for the
+  // loader's lifetime (audit A4); `_deferredFinalization` prunes the emptied
+  // entry once the GC reclaims the last handle.
   private readonly _seamlessAdapters = new Map<AssetConstructor, SeamlessAdapter<unknown>>();
-  private readonly _deferred = new Map<string, { readonly handles: Set<object>; readonly options: unknown }>();
+  private readonly _deferred = new Map<string, { readonly handles: WeakHandleSet; readonly options: unknown }>();
+
+  // Prunes a deferred entry once the GC reclaims a handle registered under its
+  // key. When the last live handle for a key is gone the entry (and any evicted
+  // marker) is dropped, so `_deferred` cannot grow unbounded with dead handles
+  // at streaming scale (audit A4). The held value is the resource key. Spurious
+  // callbacks (a handle re-registered across evict cycles fires more than once)
+  // are safe — prune + delete-if-empty is idempotent.
+  private readonly _deferredFinalization = new FinalizationRegistry<string>((key: string): void => {
+    const entry = this._deferred.get(key);
+
+    if (entry !== undefined && !entry.handles.prune()) {
+      this._deferred.delete(key);
+      this._evicted.delete(key);
+    }
+  });
 
   // Value-asset refs (asset-system v2 §4.6): the ref is the stable identity —
   // entries persist for the loader's lifetime (fill keeps them, fail keeps
@@ -1426,8 +1449,7 @@ export class Loader {
     const stored = this._resources.get(ctor)?.get(meta.src);
 
     if (deferredEntry === undefined && stored === undefined) {
-      this._deferred.set(key, { handles: new Set([handle]), options: meta.opts });
-      this._handleKeys.set(handle, key);
+      this._createDeferredEntry(key, handle, meta.opts);
       this._claim(key, ctor, meta.src, claimer);
 
       if (background) {
@@ -1447,22 +1469,25 @@ export class Loader {
       // caller already holds this leaf) and register it so `release(handle)`
       // can resolve its key.
       //
-      // §7 remainder: this co-handle fills once from the stored payload but is
-      // NOT entered into the (already-cleared) deferred set, so a LATER
-      // evict+heal of this key will not touch it (it keeps the stale payload).
-      // Weak-retention over the full lifetime is the §7 follow-up; out of scope.
+      // Enter the co-handle into the key's (persistent) deferred set so a LATER
+      // evict+heal of this key re-arms and re-fills it too (audit A5). The stored
+      // donor was itself registered here at store time, so the entry already
+      // exists (its representative stays canonical); the co-handle only ever
+      // joins, never displaces it.
       const adapter = this._seamlessAdapters.get(ctor);
 
       adapter?.fill(handle, stored);
-      this._handleKeys.set(handle, key);
+
+      const entry = deferredEntry ?? this._createDeferredEntry(key, stored as object, meta.opts);
+
+      this._addDeferredHandle(key, entry, handle);
     } else if (deferredEntry !== undefined && stored === undefined && !deferredEntry.handles.has(handle)) {
       // A distinct handle is in flight for this key and nothing is stored yet:
       // join the key's handle set so `_storeResource` fills THIS handle too
       // (§7 multi-handle fill — this is the former silent hang). A conflicting
       // FETCH option (source-keyed decode can't differ) warns; differing
       // per-handle sampler options are fine (each handle carries its own).
-      deferredEntry.handles.add(handle);
-      this._handleKeys.set(handle, key);
+      this._addDeferredHandle(key, deferredEntry, handle);
       this._warnOnFetchOptionConflict(ctor, meta.src, key, deferredEntry.options, meta.opts);
     }
     // else: the SAME handle re-adopted, or already filled — a no-op.
@@ -1490,7 +1515,7 @@ export class Loader {
       // FETCH option warns — per-handle sampler/pre-size differences are fine.
       this._warnOnFetchOptionConflict(type, source, key, entry.options, options);
 
-      const representative = this._representative(entry.handles);
+      const representative = entry.handles.first();
 
       if (representative !== undefined) {
         if (adapter.stateOf(representative) === 'failed') {
@@ -1513,8 +1538,7 @@ export class Loader {
     // renders with the requested sampler options instead of the default.
     const handle = adapter.createPlaceholder(options);
 
-    this._deferred.set(key, { handles: new Set([handle as object]), options });
-    this._handleKeys.set(handle as object, key);
+    this._createDeferredEntry(key, handle as object, options);
     this._startSeamlessFetch(type, source, options);
 
     return handle;
@@ -1673,33 +1697,53 @@ export class Loader {
   }
 
   /**
-   * Free a key's payload while keeping its handle identity: find the handle
-   * (post-fill in `_resources`, or in-flight in `_deferred`), adapter-evict it
-   * (drops payload + re-arms to 'loading'), remove the stored resource, and
-   * re-register the handle in `_deferred` so the next claim heals in place.
-   * Also drops a not-yet-started background-queue entry. Seamless payloads only
-   * this slice — value-ref eviction is an accepted gap (§6 follow-up).
+   * Free a key's payload while keeping its handle identity: adapter-evict EVERY
+   * live consumer handle for the key (drops payload + re-arms each to 'loading'),
+   * remove the stored resource, and leave the handles registered in `_deferred`
+   * so the next claim heals them all in place. Also drops a not-yet-started
+   * background-queue entry. Seamless payloads only this slice — value-ref
+   * eviction is an accepted gap (§6 follow-up).
+   *
+   * Only a payload that has already converged into `_resources` is dropped here.
+   * A fetch still in flight (nothing stored yet) is left to the running fetch,
+   * which fills then frees on arrival (§4.7) — evicting mid-flight would race it.
    * @internal
    */
   private _evictKey(key: string, type: AssetConstructor, source: string): void {
     const adapter = this._seamlessAdapters.get(type);
-    // A still-deferred handle means the fetch is in flight and has not filled
-    // yet: leave it to the running fetch (which completes and fills the — now
-    // unclaimed — handle; §4.7 minimal). Only a payload that already converged
-    // into `_resources` is dropped in place here.
-    const deferred = this._deferred.get(key);
-    const handle = this._representative(deferred?.handles) ?? this._resources.get(type)?.get(source);
+    const stored = this._resources.get(type)?.get(source);
 
-    if (adapter !== undefined && deferred === undefined && handle !== undefined) {
-      adapter.evict(handle);
+    if (adapter !== undefined && stored !== undefined) {
+      const entry = this._deferred.get(key);
+      // Re-arm every live consumer handle in place: the representative AND any
+      // co-handle adopted from the stored donor (audit A5), so a later claim
+      // heals them all — not just the canonical one. The stored donor is itself
+      // a member (registered at store time); guard the fallback for the (defensive)
+      // case where no entry exists.
+      let evictedStored = false;
+
+      if (entry !== undefined) {
+        for (const handle of entry.handles) {
+          adapter.evict(handle);
+
+          if (handle === stored) {
+            evictedStored = true;
+          }
+        }
+      }
+
+      if (!evictedStored) {
+        adapter.evict(stored);
+      }
+
       this._resources.get(type)?.delete(source);
-      // The original options were consumed when the payload converged into
-      // `_resources` (the pre-fill `_deferred` entry is gone); the re-fetch
-      // re-derives them from the manifest entry, if any. Only the canonical
-      // representative is re-armed here — co-handles filled alongside it keep
-      // their payload (the §7 remainder gap).
-      this._deferred.set(key, { handles: new Set([handle as object]), options: undefined });
-      this._handleKeys.set(handle as object, key);
+
+      // Keep the handles registered (weakly) so the next claim heals them in
+      // place; the entry persists from store time, carrying the original options.
+      if (entry === undefined) {
+        this._createDeferredEntry(key, stored as object);
+      }
+
       this._evicted.add(key);
       // A load that just settled may leave a resolved-but-not-yet-cleaned
       // in-flight entry (its `.finally` cleanup is a pending microtask). Drop it
@@ -2233,9 +2277,39 @@ export class Loader {
     );
   }
 
-  /** The representative (first-inserted) member of a handle/ref set, or `undefined` if empty. @internal */
+  /** The representative (first-inserted) member of a ref set, or `undefined` if empty. @internal */
   private _representative<T>(members: ReadonlySet<T> | undefined): T | undefined {
     return members === undefined ? undefined : members.values().next().value;
+  }
+
+  /**
+   * Register a fresh deferred entry for `key` holding `handle` weakly, wire the
+   * reverse `handle → key` lookup, and arm GC pruning. Returns the entry so the
+   * caller can add further co-handles.
+   */
+  private _createDeferredEntry(key: string, handle: object, options?: unknown): { readonly handles: WeakHandleSet; readonly options: unknown } {
+    const entry = { handles: new WeakHandleSet(handle), options };
+
+    this._deferred.set(key, entry);
+    this._handleKeys.set(handle, key);
+    this._deferredFinalization.register(handle, key);
+
+    return entry;
+  }
+
+  /**
+   * Add `handle` to an existing deferred entry's weak handle set (idempotent for
+   * an already-tracked handle), wire the reverse lookup, and arm GC pruning.
+   */
+  private _addDeferredHandle(key: string, entry: { readonly handles: WeakHandleSet }, handle: object): void {
+    this._handleKeys.set(handle, key);
+
+    if (entry.handles.has(handle)) {
+      return;
+    }
+
+    entry.handles.add(handle);
+    this._deferredFinalization.register(handle, key);
   }
 
   /**
@@ -2441,8 +2515,9 @@ export class Loader {
         adapter.fill(handle, resource);
       }
 
-      this._deferred.delete(key);
-
+      // The entry is NOT dropped here: it persists as the key's live-handle
+      // registry so a co-handle adopt (audit A5) joins it and a refcount-0
+      // eviction re-arms every consumer. The representative stays canonical.
       if (representative !== undefined && representative !== resource) {
         resource = representative;
         filledDeferredHandle = true;
@@ -2473,6 +2548,15 @@ export class Loader {
     // Record the canonical reverse key (first alias wins) for object resources.
     if (typeof resource === 'object' && resource !== null && !this._resourceKeys.has(resource)) {
       this._resourceKeys.set(resource, { type, source: alias });
+    }
+
+    // Register the stored seamless resource as its key's representative so a
+    // later eviction re-arms it and a co-handle adopt (audit A5) joins the same
+    // set. A resource that already came from a deferred handle is a member
+    // already; a plain `load()` donor (no prior get()) is added here. Held
+    // weakly, so a fully-released source does not pin its evicted payload (A4).
+    if (typeof resource === 'object' && resource !== null && this._seamlessAdapters.has(type) && this._deferred.get(key) === undefined) {
+      this._createDeferredEntry(key, resource);
     }
 
     this.onLoaded.dispatch(type, alias, resource);

--- a/src/resources/WeakHandleSet.ts
+++ b/src/resources/WeakHandleSet.ts
@@ -1,0 +1,97 @@
+/**
+ * An insertion-ordered set of asset handles held **weakly** (via {@link WeakRef}).
+ *
+ * The {@link Loader} tracks the live consumer handles for one asset key — the
+ * representative plus every co-handle adopted for the same source — so that a
+ * refcount-0 eviction can re-arm them all and a later claim heals them in place
+ * (asset-system v2 §7). Holding them strongly would keep evicted `Texture` /
+ * `Sound` objects alive for the loader's lifetime, so a streaming open world
+ * that claims/releases thousands of sources would grow the deferred bookkeeping
+ * unbounded (audit A4). Storing them weakly lets the GC reclaim a handle once
+ * the game drops its last reference; a companion `FinalizationRegistry` in the
+ * loader then prunes the emptied entry.
+ *
+ * Iteration and {@link first} transparently skip handles the GC has already
+ * reclaimed; {@link prune} compacts the dead slots out.
+ * @internal
+ */
+export class WeakHandleSet {
+  private readonly _refs: Array<WeakRef<object>> = [];
+
+  public constructor(handle?: object) {
+    if (handle !== undefined) {
+      this._refs.push(new WeakRef(handle));
+    }
+  }
+
+  /** Add `handle` if it is not already a live member (dedup by identity). */
+  public add(handle: object): void {
+    if (this.has(handle)) {
+      return;
+    }
+
+    this._refs.push(new WeakRef(handle));
+  }
+
+  /** True if `handle` is currently a live member. */
+  public has(handle: object): boolean {
+    for (const ref of this._refs) {
+      if (ref.deref() === handle) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /** The first still-live handle in insertion order, or `undefined` if none remain. */
+  public first(): object | undefined {
+    for (const ref of this._refs) {
+      const handle = ref.deref();
+
+      if (handle !== undefined) {
+        return handle;
+      }
+    }
+
+    return undefined;
+  }
+
+  /** Iterate the still-live handles in insertion order (dead slots are skipped). */
+  public *[Symbol.iterator](): IterableIterator<object> {
+    for (const ref of this._refs) {
+      const handle = ref.deref();
+
+      if (handle !== undefined) {
+        yield handle;
+      }
+    }
+  }
+
+  /**
+   * Drop the slots whose handle the GC has reclaimed. Returns `true` if at least
+   * one live handle remains, `false` if the set is now empty.
+   */
+  public prune(): boolean {
+    let write = 0;
+    let alive = false;
+
+    for (let read = 0; read < this._refs.length; read++) {
+      const ref = this._refs[read];
+
+      if (ref?.deref() !== undefined) {
+        this._refs[write++] = ref;
+        alive = true;
+      }
+    }
+
+    this._refs.length = write;
+
+    return alive;
+  }
+
+  /** True when no live handle remains. */
+  public get isEmpty(): boolean {
+    return this.first() === undefined;
+  }
+}

--- a/test/resources/loader-deferred-handles.test.ts
+++ b/test/resources/loader-deferred-handles.test.ts
@@ -1,0 +1,184 @@
+import { materializeAssetBindings } from '#extensions/materialize';
+import { Texture } from '#rendering/texture/Texture';
+import { createLeaf } from '#resources/assetKindRegistry';
+import { coreAssetBindings } from '#resources/coreAssetBindings';
+import { Loader } from '#resources/Loader';
+import { WeakHandleSet } from '#resources/WeakHandleSet';
+
+/** Loader with all core asset bindings (mirrors createCoreLoader in the sibling suites). */
+function createCoreLoader(): Loader {
+  const loader = new Loader();
+  materializeAssetBindings(loader, coreAssetBindings);
+  return loader;
+}
+
+const originalFetch = global.fetch;
+
+const mockFetchImage = (): void => {
+  global.fetch = vi.fn(
+    async (): Promise<Response> =>
+      ({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        arrayBuffer: async () => new ArrayBuffer(8),
+      }) as unknown as Response,
+  );
+};
+
+/** Typed introspection over the private deferred registry. */
+function deferredHandles(loader: Loader, key: string): WeakHandleSet | undefined {
+  return (loader as unknown as { _deferred: Map<string, { handles: WeakHandleSet }> })._deferred.get(key)?.handles;
+}
+function deferredHas(loader: Loader, key: string): boolean {
+  return (loader as unknown as { _deferred: Map<string, unknown> })._deferred.has(key);
+}
+function evictedHas(loader: Loader, key: string): boolean {
+  return (loader as unknown as { _evicted: Set<string> })._evicted.has(key);
+}
+function keyOf(loader: Loader, source: string): string {
+  return (loader as unknown as { _key(t: unknown, s: string): string })._key(Texture, source);
+}
+
+/** Real major GC + macrotask hops so reclaimed WeakRefs settle. Needs `--expose-gc`. */
+const gc = (globalThis as { gc?: () => void }).gc;
+async function forceGc(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    gc?.();
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+}
+
+describe('deferred handle bookkeeping (audit A4 / A5)', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async () => ({ width: 4, height: 4 })),
+    );
+    mockFetchImage();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    global.fetch = originalFetch;
+  });
+
+  // ── A4: evicted handles are held WEAKLY, not pinned for the loader's lifetime ──
+
+  test('A4: an evicted handle is re-registered WEAKLY (WeakHandleSet), not in a strong Set', async () => {
+    const loader = createCoreLoader();
+    const key = keyOf(loader, 'x.png');
+
+    const handle = loader.get('x.png');
+    await handle.loaded;
+    expect(handle.source).not.toBeNull();
+
+    loader.release(handle); // refcount 0 → evict in place, re-arm for heal
+
+    const handles = deferredHandles(loader, key);
+    // The finding: before the fix the evicted handle sat in a strong Set for the
+    // loader's lifetime. It must now live in a WeakHandleSet so the GC can
+    // reclaim it once the game drops its last reference.
+    expect(handles).toBeInstanceOf(WeakHandleSet);
+    expect(handles?.has(handle)).toBe(true); // still healable while referenced
+    expect(handle.source).toBeNull(); // payload actually dropped
+  });
+
+  test('A4: identity still heals in place after eviction (weak retention keeps the live handle)', async () => {
+    const loader = createCoreLoader();
+
+    const handle = loader.get('x.png');
+    await handle.loaded;
+    loader.release(handle);
+    expect(handle.source).toBeNull();
+
+    const again = loader.get('x.png');
+    expect(again).toBe(handle); // SAME object — identity preserved across the heal
+    await handle.loaded;
+    expect(handle.source).not.toBeNull();
+  });
+
+  // GC-dependent proof that the A4 leak is actually closed: once the game drops
+  // its last reference to an evicted handle, the deferred entry (and its evicted
+  // marker) is reclaimed rather than accumulating forever. Runs only under
+  // `--expose-gc`; the structural test above is the deterministic CI guard.
+  test.runIf(typeof gc === 'function')('A4: a fully-released evicted handle is pruned from _deferred by the GC', async () => {
+    const loader = createCoreLoader();
+    const key = keyOf(loader, 'orphan.png');
+
+    let handle: Texture | null = loader.get('orphan.png');
+    await handle.loaded;
+
+    loader.release(handle); // evict → re-registered weakly, no live claim
+    expect(deferredHas(loader, key)).toBe(true);
+    expect(evictedHas(loader, key)).toBe(true);
+
+    // Drop the game's last reference so the evicted handle becomes GC-eligible.
+    // eslint-disable-next-line no-useless-assignment -- intentional: releases the GC root under test
+    handle = null;
+
+    await forceGc();
+
+    // FinalizationRegistry pruned the emptied entry — no unbounded growth.
+    expect(deferredHas(loader, key)).toBe(false);
+    expect(evictedHas(loader, key)).toBe(false);
+  });
+
+  // ── A5: a co-handle adopted from a stored donor joins the deferred set ──
+
+  test('A5: a co-handle adopted from a stored donor appears in the deferred set', async () => {
+    const loader = createCoreLoader();
+    const key = keyOf(loader, 'x.png');
+
+    // Donor stored first (loaded elsewhere before the co-handle is adopted).
+    const donor = loader.get('x.png');
+    await donor.loaded;
+    expect(donor.source).not.toBeNull();
+
+    // A distinct leaf for the SAME source (what Assets.from() hands back).
+    const coHandle = createLeaf('texture', 'x.png') as Texture;
+    expect(coHandle).not.toBe(donor);
+
+    loader._adopt(coHandle, Symbol('adopter'));
+
+    // Filled in place from the stored donor…
+    expect(coHandle.loadState).toBe('ready');
+    expect(coHandle.source).not.toBeNull();
+    // …AND entered into the key's deferred set (the finding: previously it was
+    // filled once but never tracked, so a later evict+heal skipped it).
+    expect(deferredHandles(loader, key)?.has(coHandle)).toBe(true);
+    expect(deferredHandles(loader, key)?.has(donor)).toBe(true);
+  });
+
+  test('A5: a co-handle is evicted AND healed alongside the donor across an eviction cycle', async () => {
+    const loader = createCoreLoader();
+    const key = keyOf(loader, 'x.png');
+    const adopter = Symbol('adopter');
+
+    const donor = loader.get('x.png'); // claims under the app-lifetime root scope
+    await donor.loaded;
+
+    const coHandle = createLeaf('texture', 'x.png') as Texture;
+    loader._adopt(coHandle, adopter); // claims under `adopter`
+    expect(coHandle.source).not.toBeNull();
+
+    // Drop BOTH claim scopes → refcount 0 → evict.
+    loader.release(donor); // releases the root-scope claim
+    loader._release(key, adopter); // releases the adopter-scope claim → eviction
+
+    // The finding: previously only the donor was re-armed; the co-handle kept its
+    // stale payload. Both must now drop in place.
+    expect(donor.source).toBeNull();
+    expect(coHandle.source).toBeNull();
+    expect(coHandle.loadState).toBe('loading');
+
+    // Re-claim → one re-fetch heals EVERY live consumer in place.
+    const again = loader.get('x.png');
+    expect(again).toBe(donor);
+    await donor.loaded;
+
+    expect(donor.source).not.toBeNull();
+    expect(coHandle.source).not.toBeNull();
+    expect(coHandle.loadState).toBe('ready');
+  });
+});

--- a/test/resources/weak-handle-set.test.ts
+++ b/test/resources/weak-handle-set.test.ts
@@ -1,0 +1,92 @@
+import { WeakHandleSet } from '#resources/WeakHandleSet';
+
+/** Real major GC + a macrotask hop so reclaimed WeakRefs settle. Needs `--expose-gc`. */
+const gc = (globalThis as { gc?: () => void }).gc;
+async function forceGc(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    gc?.();
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+}
+
+describe('WeakHandleSet', () => {
+  test('is empty on construction with no seed handle', () => {
+    const set = new WeakHandleSet();
+
+    expect(set.isEmpty).toBe(true);
+    expect(set.first()).toBeUndefined();
+    expect([...set]).toEqual([]);
+  });
+
+  test('seeds with a handle and reports it as the first live member', () => {
+    const a = { id: 'a' };
+    const set = new WeakHandleSet(a);
+
+    expect(set.isEmpty).toBe(false);
+    expect(set.has(a)).toBe(true);
+    expect(set.first()).toBe(a);
+    expect([...set]).toEqual([a]);
+  });
+
+  test('preserves insertion order across add()', () => {
+    const a = { id: 'a' };
+    const b = { id: 'b' };
+    const c = { id: 'c' };
+    const set = new WeakHandleSet(a);
+
+    set.add(b);
+    set.add(c);
+
+    expect([...set]).toEqual([a, b, c]);
+    expect(set.first()).toBe(a); // representative is stable (first inserted)
+  });
+
+  test('add() dedups by identity (no duplicate members)', () => {
+    const a = { id: 'a' };
+    const set = new WeakHandleSet(a);
+
+    set.add(a);
+    set.add(a);
+
+    expect([...set]).toEqual([a]);
+  });
+
+  test('has() is false for a never-added handle', () => {
+    const set = new WeakHandleSet({ id: 'a' });
+
+    expect(set.has({ id: 'b' })).toBe(false);
+  });
+
+  test('prune() keeps all still-live slots and reports remaining life', () => {
+    const a = { id: 'a' };
+    const b = { id: 'b' };
+    const set = new WeakHandleSet(a);
+    set.add(b);
+
+    expect(set.prune()).toBe(true);
+    expect([...set]).toEqual([a, b]);
+  });
+
+  // GC-dependent: proves the whole point of the class — a dropped handle is
+  // reclaimable and prune() compacts it out. Runs only under `--expose-gc`
+  // (`NODE_OPTIONS=--expose-gc`); the deterministic tests above are the CI guard.
+  test.runIf(typeof gc === 'function')('prune() drops the slot of a GC-reclaimed handle', async () => {
+    const survivor = { id: 'survivor' };
+    const set = new WeakHandleSet(survivor);
+    set.add({ id: 'ephemeral' }); // no strong reference kept — GC-eligible
+
+    await forceGc();
+
+    expect(set.prune()).toBe(true); // survivor remains
+    expect([...set]).toEqual([survivor]);
+  });
+
+  test.runIf(typeof gc === 'function')('becomes empty once the last handle is reclaimed', async () => {
+    const set = new WeakHandleSet({ id: 'only' }); // no strong reference kept
+
+    await forceGc();
+
+    expect(set.prune()).toBe(false);
+    expect(set.isEmpty).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two asset-system findings from the 2026-07-11 expert review (#276), both in the seamless deferred-handle registry (`Loader._deferred`):

- **A4 (P2 — memory reclamation):** a refcount-0 eviction re-registered the handle in `_deferred` with a strong `Set`, so the evicted `Texture`/`Sound` JS object never GC'd even after the game dropped every reference. GPU memory *was* freed (`setSource(null)`), but a streaming open world that claims/releases thousands of unique sources grew `_deferred` unbounded with dead 0×0 placeholders — a JS-heap leak.
- **A5 (P3 — correctness):** a co-handle filled from an already-stored donor (an `Assets.from()` leaf adopted after the source loaded elsewhere) was filled once but never entered into the deferred set, so a later evict+heal re-armed only the representative and the co-handle kept a stale payload.

## Root cause

`_deferred` conflated two jobs — in-flight tracking (dropped on store) and evicted-handle identity retention (kept forever, strongly) — and only ever tracked the representative handle per key.

## Approach

Make `_deferred` a **persistent, weak per-key registry of every live consumer handle**.

- New `WeakHandleSet` (`src/resources/WeakHandleSet.ts`) holds handles via `WeakRef`, skipping GC-reclaimed slots on iterate/`first`. A `FinalizationRegistry` on the loader prunes an emptied entry (and its `_evicted` marker) once the GC reclaims the last handle — closing the A4 leak while keeping in-place healing for any still-referenced handle.
- The entry now persists across store→evict→heal: the stored resource is registered as its representative, a co-handle adopt joins the same set (A5), and `_evictKey` re-arms **every** live consumer, not just the canonical one.
- The in-flight/stored discriminator in `_evictKey` switches from "no deferred entry" to "nothing stored yet" (equivalent under the old delete-on-store, correct under the new persistent entry).

No public API change (all edits are `@internal`/private; `docs:api:check` clean). Pre-1.0 clean change, no shims.

## Test evidence

- `test/resources/loader-deferred-handles.test.ts` reproduces both findings — the 4 finding-specific tests **fail on the pre-fix loader** (verified by reverting `Loader.ts`), pass after:
  - A4: evicted handle is re-registered in a `WeakHandleSet` (not a strong `Set`); still heals in place while referenced; and (under `--expose-gc`) a fully-released evicted handle is GC-pruned from `_deferred`/`_evicted`.
  - A5: a co-handle adopted from a stored donor appears in the deferred set, and is evicted **and** healed alongside the donor across an eviction cycle.
- `test/resources/weak-handle-set.test.ts` covers the new structure (add/has/first/iterate/prune/isEmpty).
- GC-reclaim assertions run under `NODE_OPTIONS=--expose-gc` (verified passing + stable ×3); the structural/behavioral assertions are the deterministic CI guard.
- Full `exojs` jsdom project green: **4739 passed**, 12 skipped. Typecheck, lint, `verify:quick` all clean.

Fixes #276

https://claude.ai/code/session_01RHB7cLgoonJHLQg9ScdXby
