### PR TITLE
docs(rendering): RetainedContainer guide + runnable example

### DIFF
--- a/examples/examples.json
+++ b/examples/examples.json
@@ -1221,6 +1221,20 @@
             "level": "intro"
         },
         {
+            "slug": "retained-container",
+            "path": "scene-graph/retained-container.js",
+            "language": "typescript",
+            "title": "Retained Container",
+            "description": "Hold a large static sprite field in a RetainedContainer and pan the whole group as a camera: the retained tier replays the subtree as O(batches) with one group-matrix update, while a plain Container walks every child each frame. Toggle the tier and compare the frame-time readout.",
+            "backend": "core",
+            "tags": [
+                "scene-graph",
+                "rendering",
+                "performance"
+            ],
+            "level": "advanced"
+        },
+        {
             "slug": "pivot-and-anchor",
             "path": "scene-graph/pivot-and-anchor.js",
             "language": "typescript",

--- a/examples/scene-graph/retained-container.js
+++ b/examples/scene-graph/retained-container.js
@@ -1,0 +1,157 @@
+// Auto-generated from retained-container.ts — edit the .ts source, not this file.
+import { Application, Color, Container, Rectangle, RetainedContainer, Scene, Sprite, Texture } from '@codexo/exojs';
+import { mountControlPanel, mountControls } from '@examples/runtime';
+const app = new Application({
+    canvas: {
+        width: 1280,
+        height: 720,
+        mount: document.body,
+        sizingMode: 'fit',
+    },
+    clearColor: new Color(6, 9, 18, 1),
+});
+// A decor field far larger than the viewport: thousands of sprites that are
+// authored ONCE and never mutated again — the exact shape the retained tier is
+// built for. Only the group as a whole ever moves (the "camera" pan below).
+const FIELD_COLUMNS = 96;
+const FIELD_ROWS = 60;
+const TILE_SPACING = 34;
+const FIELD_COUNT = FIELD_COLUMNS * FIELD_ROWS;
+class RetainedContainerScene extends Scene {
+    atlas;
+    // Typed as the base Container so the same field code works whether the
+    // active group is a RetainedContainer or a plain Container.
+    field;
+    retained = true;
+    elapsed = 0;
+    // Exponential moving average of the wall-clock frame time, so the readout
+    // is legible instead of flickering frame to frame.
+    smoothedFrameMs = 0;
+    hud;
+    panel;
+    init() {
+        this.atlas = createAtlasTexture();
+        this.field = this.buildField(this.retained);
+        this.hud = mountControls({
+            title: 'Retained Container',
+            controls: [
+                { keys: ['Retained tier'], action: 'the whole static field replays as O(batches) — no per-child walk' },
+                { keys: ['Plain container'], action: 'every child is walked and re-collected each frame' },
+            ],
+            hint: 'The field only ever moves as a whole. Toggle the tier and watch the frame-time readout.',
+        });
+        this.panel = mountControlPanel({ title: 'Render tier' });
+        this.panel.addToggle({
+            label: 'Retained tier',
+            value: this.retained,
+            onChange: value => {
+                this.retained = value;
+                // Rebuild the field into the other container type. Destroying the
+                // OLD group is safe: it owns no child that outlives it, so the
+                // whole subtree is torn down together (see the in-place-destroy
+                // footgun in the guide).
+                this.field.destroy();
+                this.field = this.buildField(this.retained);
+            },
+        });
+    }
+    update(delta) {
+        this.elapsed += delta.seconds;
+    }
+    draw(context) {
+        const { width, height } = this.app.canvas;
+        context.backend.clear();
+        // Pan the whole field along a slow Lissajous path, like a camera drifting
+        // over a static world. For a RetainedContainer this is ONE group-matrix
+        // update per frame — the retained fragment is untouched, so no descendant
+        // transform is recomputed and no child is re-collected. A plain Container
+        // still walks all FIELD_COUNT children every frame to place them.
+        const panX = width / 2 + Math.cos(this.elapsed * 0.35) * 140;
+        const panY = height / 2 + Math.sin(this.elapsed * 0.5) * 90;
+        this.field.setPosition(panX, panY);
+        context.render(this.field);
+        // frameTimeMs is wall-clock and both tiers draw the SAME pixels with the
+        // same draw calls, so the gap you see is the CPU collect/walk cost the
+        // retained tier removes. The gap widens with field size and on slower
+        // machines; on a fast desktop with a few thousand sprites it can be small.
+        this.smoothedFrameMs += (context.stats.frameTimeMs - this.smoothedFrameMs) * 0.1;
+        const tier = this.retained ? 'RetainedContainer' : 'plain Container';
+        this.hud.setStatus(`${tier} · ${FIELD_COUNT} static sprites · submitted: ${context.stats.submittedNodes} · ` +
+            `drawCalls: ${context.stats.drawCalls} · frame: ${this.smoothedFrameMs.toFixed(2)} ms`);
+    }
+    /**
+     * Build the decor field into a fresh container of the requested tier.
+     * Both branches produce an identical scene; only the container type differs,
+     * which is the whole point of the comparison.
+     */
+    buildField(retained) {
+        // The ONLY line that opts into the retained tier. There is no runtime
+        // toggle on the instance itself — the tier is chosen at construction.
+        const group = retained ? new RetainedContainer() : new Container();
+        const frames = [new Rectangle(0, 0, 64, 64), new Rectangle(64, 0, 64, 64), new Rectangle(0, 64, 64, 64), new Rectangle(64, 64, 64, 64)];
+        const palette = [Color.white, Color.skyBlue, Color.gold, Color.mediumSpringGreen, Color.hotPink, Color.mediumPurple];
+        let index = 0;
+        for (let row = 0; row < FIELD_ROWS; row++) {
+            for (let column = 0; column < FIELD_COLUMNS; column++) {
+                const sprite = new Sprite(this.atlas);
+                // Deterministic layout, centered on the group origin so panning the
+                // group reveals the field drifting as one rigid sheet.
+                sprite.setTextureFrame(frames[index % frames.length]);
+                sprite.setAnchor(0.5);
+                sprite.setPosition((column - (FIELD_COLUMNS - 1) / 2) * TILE_SPACING, (row - (FIELD_ROWS - 1) / 2) * TILE_SPACING);
+                sprite.setScale(0.42);
+                sprite.setTint(palette[index % palette.length]);
+                // Authored once, never mutated again: no per-frame setter runs on a
+                // child, so the retained fragment stays clean and is spliced whole.
+                group.addChild(sprite);
+                index++;
+            }
+        }
+        return group;
+    }
+    destroy() {
+        this.hud?.dispose();
+        this.panel?.dispose();
+        this.field?.destroy();
+        this.atlas?.destroy();
+    }
+}
+app.start(new RetainedContainerScene());
+/** Draw a small 2x2 sprite atlas procedurally so the example needs no asset load. */
+function createAtlasTexture() {
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d');
+    canvas.width = 128;
+    canvas.height = 128;
+    drawAtlasCell(context, 0, 0, '#0f172a', '#ffd166', 'circle');
+    drawAtlasCell(context, 64, 0, '#10243d', '#7dd3fc', 'diamond');
+    drawAtlasCell(context, 0, 64, '#112b21', '#4ade80', 'square');
+    drawAtlasCell(context, 64, 64, '#23163c', '#ff6b6b', 'triangle');
+    return new Texture(canvas);
+}
+function drawAtlasCell(context, x, y, background, accent, shape) {
+    context.fillStyle = background;
+    context.fillRect(x, y, 64, 64);
+    context.fillStyle = accent;
+    context.beginPath();
+    if (shape === 'circle') {
+        context.arc(x + 32, y + 32, 18, 0, Math.PI * 2);
+    }
+    else if (shape === 'diamond') {
+        context.moveTo(x + 32, y + 12);
+        context.lineTo(x + 52, y + 32);
+        context.lineTo(x + 32, y + 52);
+        context.lineTo(x + 12, y + 32);
+        context.closePath();
+    }
+    else if (shape === 'square') {
+        context.rect(x + 16, y + 16, 32, 32);
+    }
+    else {
+        context.moveTo(x + 32, y + 12);
+        context.lineTo(x + 52, y + 52);
+        context.lineTo(x + 12, y + 52);
+        context.closePath();
+    }
+    context.fill();
+}

--- a/examples/scene-graph/retained-container.ts
+++ b/examples/scene-graph/retained-container.ts
@@ -1,0 +1,186 @@
+import { Application, Color, Container, Rectangle, RetainedContainer, Scene, Sprite, Texture } from '@codexo/exojs';
+import { mountControlPanel, mountControls } from '@examples/runtime';
+
+const app = new Application({
+    canvas: {
+        width: 1280,
+        height: 720,
+        mount: document.body,
+        sizingMode: 'fit',
+    },
+    clearColor: new Color(6, 9, 18, 1),
+});
+
+// A decor field far larger than the viewport: thousands of sprites that are
+// authored ONCE and never mutated again — the exact shape the retained tier is
+// built for. Only the group as a whole ever moves (the "camera" pan below).
+const FIELD_COLUMNS = 96;
+const FIELD_ROWS = 60;
+const TILE_SPACING = 34;
+const FIELD_COUNT = FIELD_COLUMNS * FIELD_ROWS;
+
+class RetainedContainerScene extends Scene {
+    private atlas!: Texture;
+    // Typed as the base Container so the same field code works whether the
+    // active group is a RetainedContainer or a plain Container.
+    private field!: Container;
+    private retained = true;
+    private elapsed = 0;
+    // Exponential moving average of the wall-clock frame time, so the readout
+    // is legible instead of flickering frame to frame.
+    private smoothedFrameMs = 0;
+
+    private hud!: ReturnType<typeof mountControls>;
+    private panel!: ReturnType<typeof mountControlPanel>;
+
+    override init(): void {
+        this.atlas = createAtlasTexture();
+        this.field = this.buildField(this.retained);
+
+        this.hud = mountControls({
+            title: 'Retained Container',
+            controls: [
+                { keys: ['Retained tier'], action: 'the whole static field replays as O(batches) — no per-child walk' },
+                { keys: ['Plain container'], action: 'every child is walked and re-collected each frame' },
+            ],
+            hint: 'The field only ever moves as a whole. Toggle the tier and watch the frame-time readout.',
+        });
+
+        this.panel = mountControlPanel({ title: 'Render tier' });
+        this.panel.addToggle({
+            label: 'Retained tier',
+            value: this.retained,
+            onChange: value => {
+                this.retained = value;
+                // Rebuild the field into the other container type. Destroying the
+                // OLD group is safe: it owns no child that outlives it, so the
+                // whole subtree is torn down together (see the in-place-destroy
+                // footgun in the guide).
+                this.field.destroy();
+                this.field = this.buildField(this.retained);
+            },
+        });
+    }
+
+    override update(delta): void {
+        this.elapsed += delta.seconds;
+    }
+
+    override draw(context): void {
+        const { width, height } = this.app.canvas;
+
+        context.backend.clear();
+
+        // Pan the whole field along a slow Lissajous path, like a camera drifting
+        // over a static world. For a RetainedContainer this is ONE group-matrix
+        // update per frame — the retained fragment is untouched, so no descendant
+        // transform is recomputed and no child is re-collected. A plain Container
+        // still walks all FIELD_COUNT children every frame to place them.
+        const panX = width / 2 + Math.cos(this.elapsed * 0.35) * 140;
+        const panY = height / 2 + Math.sin(this.elapsed * 0.5) * 90;
+
+        this.field.setPosition(panX, panY);
+        context.render(this.field);
+
+        // frameTimeMs is wall-clock and both tiers draw the SAME pixels with the
+        // same draw calls, so the gap you see is the CPU collect/walk cost the
+        // retained tier removes. The gap widens with field size and on slower
+        // machines; on a fast desktop with a few thousand sprites it can be small.
+        this.smoothedFrameMs += (context.stats.frameTimeMs - this.smoothedFrameMs) * 0.1;
+
+        const tier = this.retained ? 'RetainedContainer' : 'plain Container';
+        this.hud.setStatus(
+            `${tier} · ${FIELD_COUNT} static sprites · submitted: ${context.stats.submittedNodes} · ` +
+                `drawCalls: ${context.stats.drawCalls} · frame: ${this.smoothedFrameMs.toFixed(2)} ms`,
+        );
+    }
+
+    /**
+     * Build the decor field into a fresh container of the requested tier.
+     * Both branches produce an identical scene; only the container type differs,
+     * which is the whole point of the comparison.
+     */
+    private buildField(retained: boolean): Container {
+        // The ONLY line that opts into the retained tier. There is no runtime
+        // toggle on the instance itself — the tier is chosen at construction.
+        const group = retained ? new RetainedContainer() : new Container();
+
+        const frames = [new Rectangle(0, 0, 64, 64), new Rectangle(64, 0, 64, 64), new Rectangle(0, 64, 64, 64), new Rectangle(64, 64, 64, 64)];
+        const palette = [Color.white, Color.skyBlue, Color.gold, Color.mediumSpringGreen, Color.hotPink, Color.mediumPurple];
+
+        let index = 0;
+
+        for (let row = 0; row < FIELD_ROWS; row++) {
+            for (let column = 0; column < FIELD_COLUMNS; column++) {
+                const sprite = new Sprite(this.atlas);
+
+                // Deterministic layout, centered on the group origin so panning the
+                // group reveals the field drifting as one rigid sheet.
+                sprite.setTextureFrame(frames[index % frames.length]);
+                sprite.setAnchor(0.5);
+                sprite.setPosition((column - (FIELD_COLUMNS - 1) / 2) * TILE_SPACING, (row - (FIELD_ROWS - 1) / 2) * TILE_SPACING);
+                sprite.setScale(0.42);
+                sprite.setTint(palette[index % palette.length]);
+
+                // Authored once, never mutated again: no per-frame setter runs on a
+                // child, so the retained fragment stays clean and is spliced whole.
+                group.addChild(sprite);
+                index++;
+            }
+        }
+
+        return group;
+    }
+
+    override destroy(): void {
+        this.hud?.dispose();
+        this.panel?.dispose();
+        this.field?.destroy();
+        this.atlas?.destroy();
+    }
+}
+
+app.start(new RetainedContainerScene());
+
+/** Draw a small 2x2 sprite atlas procedurally so the example needs no asset load. */
+function createAtlasTexture(): Texture {
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d')!;
+
+    canvas.width = 128;
+    canvas.height = 128;
+
+    drawAtlasCell(context, 0, 0, '#0f172a', '#ffd166', 'circle');
+    drawAtlasCell(context, 64, 0, '#10243d', '#7dd3fc', 'diamond');
+    drawAtlasCell(context, 0, 64, '#112b21', '#4ade80', 'square');
+    drawAtlasCell(context, 64, 64, '#23163c', '#ff6b6b', 'triangle');
+
+    return new Texture(canvas);
+}
+
+function drawAtlasCell(context: CanvasRenderingContext2D, x: number, y: number, background: string, accent: string, shape: string): void {
+    context.fillStyle = background;
+    context.fillRect(x, y, 64, 64);
+
+    context.fillStyle = accent;
+    context.beginPath();
+
+    if (shape === 'circle') {
+        context.arc(x + 32, y + 32, 18, 0, Math.PI * 2);
+    } else if (shape === 'diamond') {
+        context.moveTo(x + 32, y + 12);
+        context.lineTo(x + 52, y + 32);
+        context.lineTo(x + 32, y + 52);
+        context.lineTo(x + 12, y + 32);
+        context.closePath();
+    } else if (shape === 'square') {
+        context.rect(x + 16, y + 16, 32, 32);
+    } else {
+        context.moveTo(x + 32, y + 12);
+        context.lineTo(x + 52, y + 52);
+        context.lineTo(x + 12, y + 52);
+        context.closePath();
+    }
+
+    context.fill();
+}

--- a/site/src/content/api/retained-container.json
+++ b/site/src/content/api/retained-container.json
@@ -559,7 +559,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Release the retained GPU instruction set and fragment cache, then destroy this container and its subtree. Beware the in-place-destroy footgun: SceneNode.destroy does not detach a node from its parent, and the retained fragment keeps the whole previously-collected command range — including a child's resources — until a structural change drops it. Destroying a child directly leaves the fragment replaying freed resources, because nothing invalidated it. Call Container.removeChild first (removal bumps the structure revision and drops the fragment), or destroy the whole group at once."
         },
         {
           "name": "focus",

--- a/site/src/content/guide/rendering/retained-containers.mdx
+++ b/site/src/content/guide/rendering/retained-containers.mdx
@@ -1,0 +1,132 @@
+---
+title: 'Retained containers'
+description: 'Declare a large, mostly-static subtree as a RetainedContainer so it replays as O(batches) and moves as a single GPU-matrix update — and learn the group-local space, invalidation, and lifecycle rules the tier trades for that speed.'
+---
+
+import ExamplePreview from '../../../components/ExamplePreview.astro';
+import Callout from '../../../components/Callout.astro';
+
+# Retained containers
+
+The scene graph earns its keep on content that changes: every frame the engine walks the tree, resolves transforms, culls, and rebuilds the render plan. For a subtree that is _mostly static and/or moves as a whole_ — a decorated tilemap, a parallax backdrop, a built-once UI panel with hundreds of icons — that per-frame walk is pure overhead. You already know the subtree looks the same as last frame; the engine re-derives it anyway.
+
+[`RetainedContainer`](/ExoJS/en/api/retained-container/) is a [`Container`](/ExoJS/en/api/container/) that lets you _declare_ that fact. While its subtree is unchanged, the whole previously-collected command range is spliced straight into the render plan — no walk, no per-child culling, no material keys — and moving the container (or the camera over it) changes exactly one per-group GPU matrix instead of touching every descendant.
+
+It is the third rendering tier, sitting between the two you already have:
+
+- **Plain scene graph** — the default. Flexible, re-walked every frame. Right for anything that changes.
+- **`RetainedContainer`** — a static subtree that replays whole and moves as a unit.
+- **[Immediate mode](/ExoJS/en/guide/rendering/immediate-mode/)** — no nodes at all; you draw geometry yourself each frame. Right for throwaway, procedural, or self-simulated content.
+
+## When to reach for it
+
+A subtree is a good `RetainedContainer` when all of these hold:
+
+- **It is large.** A handful of nodes is not worth the machinery — the per-frame walk was already cheap. The win scales with child count.
+- **It is static, or nearly so.** Children are authored once and then left alone. The group as a whole may still move, rotate, or scale freely — that is the point.
+- **It moves as a unit, if it moves.** Panning a camera over a static world, scrolling a background, sliding a whole panel on-screen. One matrix update covers the entire subtree.
+
+Reach for immediate mode instead when the content is procedural or changes completely every frame; reach for a plain container when children animate independently. `RetainedContainer` is specifically the "thousands of things that sit still while the camera glides over them" case.
+
+<Callout type="hint" title="It is opt-in, and only at construction">
+There is no runtime toggle and no configuration. You choose the tier by constructing a `RetainedContainer` instead of a `Container`; everything else is the normal node API. If the subtree turns out to be a poor fit, swapping back is a one-word edit.
+</Callout>
+
+## Declaring one
+
+```ts
+import { RetainedContainer } from '@codexo/exojs';
+
+// Opt in at construction. From here it is an ordinary Container.
+const decor = new RetainedContainer();
+```
+
+Fill it once with static children, add it to your scene, and move only the group:
+
+```js
+init() {
+    this.decor = new RetainedContainer();
+
+    for (const tile of this.level.decorTiles) {
+        const sprite = new Sprite(this.atlas);
+        sprite.setPosition(tile.x, tile.y);
+        this.decor.addChild(sprite);
+    }
+}
+
+draw(context) {
+    context.backend.clear();
+
+    // Panning the camera over the world is ONE group-matrix update — no
+    // descendant transform is recomputed, no child is re-collected.
+    this.decor.setPosition(-this.cameraX, -this.cameraY);
+    context.render(this.decor);
+}
+```
+
+## Transform semantics: group-local space
+
+The speed comes from a deliberate trade: descendants of an engaged group resolve their transforms in **group-local space**, and the group matrix is applied once, on the GPU, at playback. That is invisible to rendering — the pixels are identical to a plain container — but it changes what spatial queries return _inside_ the group.
+
+- [`getBounds()`](/ExoJS/en/api/scene-node/) and hit-testing on a child report **group-local** coordinates, not world coordinates.
+- Per-child view culling is disabled inside the group; the group is culled as a whole.
+- `pixelSnapMode` snapping operates on group-local coordinates.
+
+For a true world-space position or orientation of a node inside the group — picking, spatial audio, physics, any math against nodes outside the group — use [`getWorldTransform()`](/ExoJS/en/api/scene-node/), which composes through the group boundary and returns the real world matrix:
+
+```js
+update() {
+    // getBounds() here is group-local. For a real world position, compose
+    // through the boundary:
+    const worldMatrix = this.enemyInsideGroup.getWorldTransform();
+    this.audio.setPosition(worldMatrix.tx, worldMatrix.ty);
+}
+```
+
+<Callout type="warning" title="getBounds() inside a group is group-local">
+This is the one behavioural surprise of the tier. If you read a child's `getBounds()` and expect world coordinates, you will be off by the group's transform. `getWorldTransform()` is the escape hatch, and it is exact — it accounts for group engage/disengage flips too.
+</Callout>
+
+The engine has no inherited alpha, so a group-wide fade is not a property you set on the container. Tint each drawable, or cache the whole group as a bitmap and fade that.
+
+## Invalidation: any mutation drops the fragment
+
+The retained fragment is kept in lockstep with the subtree by the same revision contract every node already uses. **Any mutation inside the subtree drops the fragment for one frame** — that frame re-walks and re-collects normally, then the fragment is recaptured. Adding or removing a child, changing a sprite's texture, moving a descendant: each one invalidates automatically. You never manage the cache by hand.
+
+If you mutate through a custom `Drawable` backed by externally mutable data (the pattern the tilemap package uses), call [`invalidateContent()`](/ExoJS/en/api/scene-node/) after the mutation so the skip does not serve a stale frame.
+
+<Callout type="pitfall" title="A group that changes every frame is pure overhead">
+The tier pays off only while the subtree holds still. If a child mutates on every frame, the fragment is dropped on every frame — you pay the full walk _plus_ the retention bookkeeping, and a reference build measured the retained path ~1.5× slower than immediate mode on fully-dynamic content. In a development build the engine watches for this and warns once if a group invalidates on effectively every frame. If you see that warning, split the moving children out into a sibling plain container and keep only the static remainder retained.
+</Callout>
+
+## Lifecycle and the in-place-destroy footgun
+
+Adding and removing children works exactly as on a plain container, and both correctly invalidate the fragment. Destroying is where the retained tier has a sharp edge.
+
+Because the fragment holds the whole previously-collected command range, it keeps references to the resources of every child — and [`destroy()`](/ExoJS/en/api/scene-node/) does **not** detach a node from its parent. So calling `child.destroy()` on a child that is still in the group leaves the child in the child list, does not bump the structure revision, and the fragment keeps replaying the freed resources until some _other_ change happens to invalidate it.
+
+<Callout type="pitfall" title="Remove before you destroy a child">
+`retained.removeChild(child)` first, then `child.destroy()`. Removal bumps the structure revision, which drops the fragment, so the next frame re-collects without the departed child. Destroying a child in place skips that step. Destroying the whole `RetainedContainer` is always safe — it tears down its subtree and releases the retained GPU bundle together.
+</Callout>
+
+## Effects on children: supported, with one depth rule
+
+Nodes with filters, a mask, a clip, or `cacheAsBitmap` are supported as **direct** children of a `RetainedContainer`. They stay in world space and re-collect every frame, layered correctly with the retained remainder.
+
+Nesting such an effect-bearing node _deeper_ than one level below the group boundary disengages the whole group: it falls back to rendering as an exact plain `Container` — correct pixels, no retention — and warns once in a development build. Keep effect-heavy nodes at the top level of the group, or move them out of it.
+
+## Performance, honestly
+
+The retained tier removes **CPU** work: the per-frame subtree walk, per-child transform resolution, per-child culling, and render-plan rebuilding. It does not change the number of draw calls — batching is identical to a plain container — so a GPU-bound scene will not get faster, and a small subtree will not show a measurable difference because its walk was already cheap.
+
+Where it wins is a large, static subtree that the camera pans across: the walk that a plain container repeats every frame collapses to an O(batches) replay plus one matrix update. The gap grows with child count and is widest on lower-end machines and mobile. Measure it in your scene rather than assuming — the [Performance](/ExoJS/en/guide/debugging/performance/) chapter and the debug overlay's frame-time and submitted-node counters are the right instruments.
+
+## Worked example
+
+The example holds a field of several thousand static sprites and pans it as a camera along a slow path. Toggle between the retained tier and a plain container holding the identical field, and watch the smoothed frame-time readout: same pixels, same draw calls, different CPU cost per frame.
+
+<ExamplePreview chapter="scene-graph" slug="retained-container" />
+
+## Where to go next
+
+`RetainedContainer` and [immediate mode](/ExoJS/en/guide/rendering/immediate-mode/) are the two escape hatches from the per-frame scene-graph walk — retention for static node trees, immediate mode for procedural geometry with no nodes at all. To find out whether the walk is actually your bottleneck before reaching for either, start with the [Performance](/ExoJS/en/guide/debugging/performance/) chapter.

--- a/site/src/lib/guide-structure.ts
+++ b/site/src/lib/guide-structure.ts
@@ -388,6 +388,18 @@ const RAW_PARTS: ReadonlyArray<RawPart> = [
                 examples: ['geometry-graphics/immediate-mode-rendering'],
                 apiLinks: ['rendering-context', 'render-batch', 'geometry', 'matrix', 'color'],
             },
+            {
+                slug: 'retained-containers',
+                level: 'advanced',
+                learningGoals: [
+                    'declare a large, mostly-static subtree as a RetainedContainer',
+                    'pan the whole group as one GPU-matrix update instead of touching every child',
+                    'recognise the group-local space, lifecycle, and invalidation rules the tier trades for that speed',
+                ],
+                prerequisites: ['runtime/scene-graph'],
+                examples: ['scene-graph/retained-container'],
+                apiLinks: ['retained-container', 'container', 'scene-node'],
+            },
         ],
     },
     {

--- a/src/rendering/RetainedContainer.ts
+++ b/src/rendering/RetainedContainer.ts
@@ -251,6 +251,18 @@ export class RetainedContainer extends Container {
     }
   }
 
+  /**
+   * Release the retained GPU instruction set and fragment cache, then destroy
+   * this container and its subtree.
+   *
+   * Beware the in-place-destroy footgun: {@link SceneNode.destroy} does not
+   * detach a node from its parent, and the retained fragment keeps the whole
+   * previously-collected command range — including a child's resources — until
+   * a structural change drops it. Destroying a child directly leaves the
+   * fragment replaying freed resources, because nothing invalidated it. Call
+   * {@link Container.removeChild} first (removal bumps the structure revision
+   * and drops the fragment), or destroy the whole group at once.
+   */
   public override destroy(): void {
     // dispose(): invalidates AND releases the retained GPU bundle (Slice 3, S3-D3).
     this._fragment.dispose();


### PR DESCRIPTION
## What

Adds developer documentation for the retained render tier (`RetainedContainer`, PRs #271/#279), which shipped with zero user-facing docs.

### Guide
New chapter **Rendering → Retained containers** (`rendering/retained-containers`), registered in `guide-structure.ts`:
- What the retained tier is and where it sits between the plain scene graph and immediate mode.
- When to use it (large, static, moves-as-a-whole) vs. when not to.
- Transform semantics: group-local space, and `getWorldTransform()` for real world-space queries.
- One-frame invalidation on any subtree mutation, plus the dev "invalidates every frame" diagnostic.
- Lifecycle and the **in-place-destroy footgun** (`destroy()` does not detach; remove the child first so the fragment drops).
- The deep-barrier fallback for filters/mask/clip/cacheAsBitmap.
- An honest performance section: the win is CPU-only (no draw-call change) and scales with static child count.

### Example
`scene-graph/retained-container` — a several-thousand-sprite static field panned as a camera, with a toggle between the retained tier and a plain `Container` and a smoothed frame-time readout. Procedural atlas texture, no asset load. Generated `.js` committed via `examples:sync`.

### JSDoc
Documented `RetainedContainer.destroy()` (lead sentence + the remove-before-destroy footgun) and regenerated the committed API page.

## Gates run
- `pnpm typecheck:examples` — pass
- `pnpm typecheck:guides` — pass
- `pnpm docs:api:check` — in sync
- eslint + prettier on touched files — clean
- guide/catalog reconciliation + prose-link vitest suites — 60 tests pass
- `test:examples:smoke --only retained-container` — passed in headless Chromium (canvas rendered, no runtime error)
- `pnpm site:build` — succeeds (MDX compiles, page emitted)

## API audit findings
No blocking issues in `RetainedContainer` itself. One pre-existing note surfaced in the generated API page (inherited, not touched here): several inherited members carry mismatched descriptions from the base class — e.g. `blur()` is documented as "Release keyboard focus…". These are base-class JSDoc issues outside this change's scope.

https://claude.ai/code/session_01RHB7cLgoonJHLQg9ScdXby