### PR TITLE
fix(webgl2): evict and rebuild GL handles on real context restore (B-09, #275)

### DIFF
--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -173,9 +173,13 @@ const renderTargetTextureSyncUnit = 17;
  * {@link WebGl2ParticleRenderer}) registered in the {@link RendererRegistry}.
  *
  * Emits {@link WebGl2Backend.onContextLost} / {@link WebGl2Backend.onContextRestored}
- * Signals when the browser loses or regains the GL context. The browser
- * recreates the context automatically; renderers reconnect their
- * GPU-side state as needed on the next draw.
+ * Signals when the browser loses or regains the GL context. On loss the
+ * `webglcontextlost` default is cancelled (`preventDefault`) so the browser
+ * schedules a `webglcontextrestored` event; on restore every device-bound GL
+ * object (texture / framebuffer / renderbuffer handles, renderer buffers, VAOs
+ * and shader programs, the shared transform texture, compositors and retained
+ * bundles) is evicted and rebuilt against the fresh context — mirroring the
+ * WebGPU backend's `_teardownDeviceState`. See {@link _reinitializeDeviceState}.
  */
 export class WebGl2Backend implements RenderBackend {
   public readonly backendType = RenderBackendType.WebGl2;
@@ -185,7 +189,7 @@ export class WebGl2Backend implements RenderBackend {
 
   private readonly _context: WebGL2RenderingContext;
   private readonly _rootRenderTarget: RenderTarget;
-  private readonly _onContextLostHandler: () => void;
+  private readonly _onContextLostHandler: (event: Event) => void;
   private readonly _onContextRestoredHandler: () => void;
   private readonly _textureStates: Map<Texture | RenderTexture, ManagedTextureState> = new Map<Texture | RenderTexture, ManagedTextureState>();
   private readonly _renderTargetStates: Map<RenderTarget, ManagedRenderTargetState> = new Map<RenderTarget, ManagedRenderTargetState>();
@@ -207,6 +211,13 @@ export class WebGl2Backend implements RenderBackend {
 
   private _canvas: HTMLCanvasElement;
   private _contextLost: boolean;
+  private _destroyed = false;
+  private _pendingRestore: ReturnType<typeof setTimeout> | null = null;
+  // Cached BEFORE any context loss: `restoreContext()` only restores the
+  // context when invoked on the same extension instance `loseContext()` was
+  // triggered on. A fresh `getExtension()` after the loss returns a different
+  // object that cannot drive the restore (verified against headless Chromium).
+  private readonly _loseContextExtension: WEBGL_lose_context | null;
   /** Whether `EXT_color_buffer_float` is available (float RenderTexture targets are renderable). */
   private _floatRenderable = false;
   private _renderTarget: RenderTarget;
@@ -259,6 +270,12 @@ export class WebGl2Backend implements RenderBackend {
     // Enable + cache float color-buffer renderability. getExtension() is the
     // enable call; without it, RGBA16F/RGBA32F are not color-renderable in WebGL2.
     this._floatRenderable = this._context.getExtension('EXT_color_buffer_float') !== null;
+
+    // Grab the lose-context extension up front so a later restore can act on the
+    // live instance (see the field comment). `null` on backends that don't
+    // expose it — the recovery path then simply relies on the browser's own
+    // automatic restoration.
+    this._loseContextExtension = this._context.getExtension('WEBGL_lose_context');
 
     if (this._contextLost) {
       this._restoreContext();
@@ -1357,6 +1374,13 @@ export class WebGl2Backend implements RenderBackend {
   }
 
   public destroy(): void {
+    this._destroyed = true;
+
+    if (this._pendingRestore !== null) {
+      clearTimeout(this._pendingRestore);
+      this._pendingRestore = null;
+    }
+
     this._removeEvents();
     this.onContextLost.destroy();
     this.onContextRestored.destroy();
@@ -1437,7 +1461,26 @@ export class WebGl2Backend implements RenderBackend {
   }
 
   private _restoreContext(): void {
-    this._context.getExtension('WEBGL_lose_context')?.restoreContext();
+    // Schedule the extension-driven restore on a fresh task. A synchronous
+    // `restoreContext()` call from inside the `webglcontextlost` handler is
+    // silently ignored by Chromium — the browser only honours it once the lost
+    // event has finished processing. Deferring is also correct for a real GPU
+    // loss: `restoreContext()` only affects extension-triggered losses, so it
+    // is a harmless no-op there (the browser auto-restores because we called
+    // `preventDefault`). Guarded against a destroy() that lands first.
+    if (this._pendingRestore !== null) {
+      return;
+    }
+
+    this._pendingRestore = setTimeout(() => {
+      this._pendingRestore = null;
+
+      if (this._destroyed || !this._contextLost) {
+        return;
+      }
+
+      this._loseContextExtension?.restoreContext();
+    }, 0);
   }
 
   private _setupContext(): void {
@@ -1464,7 +1507,15 @@ export class WebGl2Backend implements RenderBackend {
     this._canvas.removeEventListener('webglcontextrestored', this._onContextRestoredHandler, false);
   }
 
-  private _onContextLost(): void {
+  private _onContextLost(event: Event): void {
+    // WebGL only fires `webglcontextrestored` if the `webglcontextlost`
+    // default action is cancelled — without this the context stays dead
+    // forever after a real GPU reset (mobile tab-switch, driver TDR) and the
+    // canvas goes permanently blank. This is separate from the synthetic
+    // `WEBGL_lose_context.restoreContext()` call below, which only drives the
+    // extension-based lose/restore cycle used in tests.
+    event.preventDefault();
+
     this._contextLost = true;
     this.onContextLost.dispatch();
     this._restoreContext();
@@ -1473,15 +1524,110 @@ export class WebGl2Backend implements RenderBackend {
   private _onContextRestored(): void {
     this._contextLost = false;
 
+    // Every GL object created against the lost context is dead. Evict and
+    // rebuild all device-bound state before drawing resumes; otherwise the
+    // caches keep dangling handles and the next frame is a blank canvas or an
+    // INVALID_OPERATION storm.
+    this._reinitializeDeviceState();
+
+    this.onContextRestored.dispatch();
+  }
+
+  /**
+   * Drop every device-bound GL object cached against the lost context and
+   * rebuild the pieces needed to draw against the fresh one. User-facing
+   * handles ({@link Texture}, {@link RenderTexture}, {@link RenderTarget})
+   * keep their identity — their GPU-side state is recreated lazily on next
+   * use. Mirrors the WebGPU backend's `_teardownDeviceState` (B-09).
+   */
+  private _reinitializeDeviceState(): void {
+    const gl = this._context;
+
+    // Re-enable the float color-buffer extension: extension enablement does
+    // not survive a context loss, so RGBA16F/RGBA32F render targets would stop
+    // being color-renderable until this is re-fetched on the fresh context.
+    this._floatRenderable = gl.getExtension('EXT_color_buffer_float') !== null;
+
+    // Evict all managed texture / render-target state (deletes the now-dead
+    // handles — harmless on the fresh context — frees the resource accountant,
+    // and detaches destroy listeners). The maps are repopulated lazily with
+    // fresh handles on next access. Clears `_stencilStates` too (each entry is
+    // dropped when its render target is evicted).
+    this._destroyManagedResources();
+
+    // The shared transform texture's handle died with the context. Drop the
+    // wrapper (its GL handle was just evicted above) and reset the upload
+    // bookkeeping so a fresh DataTexture + full re-upload happens on next bind.
+    this._transformTexture = null;
+    this._transformTextureCount = -1;
+    this._transformTextureHash = 0;
+
+    // Disconnect renderers so they release their (dead) buffers / VAOs / shader
+    // programs, then reconnect to rebuild them against the fresh context. This
+    // also resets each batched renderer's `appliedVersion` VAO cache.
+    this.rendererRegistry.disconnect();
+
+    // Compositors and the stencil clipper connect lazily on first use; drop
+    // their dead GPU state and clear the connected flags so the next use
+    // reconnects against the fresh context.
+    if (this._maskCompositorConnected) {
+      this._maskCompositor.disconnect();
+      this._maskCompositorConnected = false;
+    }
+
+    if (this._backdropBlendCompositorConnected) {
+      this._backdropBlendCompositor.disconnect();
+      this._backdropBlendCompositorConnected = false;
+    }
+
+    if (this._stencilClipperConnected) {
+      this._stencilClipper.disconnect();
+      this._stencilClipperConnected = false;
+    }
+
+    this._stencilStates.clear();
+
     // Every retained group bundle's GL objects died with the lost context:
     // drop them and bump the generations so all recorded instruction sets
     // fail collect-time validation and re-record against the restored
-    // context (S3-D3, stale-instruction pitfall #9).
+    // context (S3-D3, stale-instruction pitfall #9). Any capture in flight is
+    // abandoned — its instructions keep the sentinel generation.
     for (const bundle of this._retainedBundles) {
       bundle._invalidateDeviceResources();
     }
 
-    this.onContextRestored.dispatch();
+    this._retainedCaptures.length = 0;
+
+    // Reset the cached GL bind state — every handle these tracked is dead, so
+    // the next bind must run unconditionally rather than short-circuiting on a
+    // stale identity match.
+    this._boundFramebuffer = null;
+    this._texture = null;
+    this._textureUnit = 0;
+    this._vao = null;
+    this._shader = null;
+    this._blendMode = null;
+    this._renderer = null;
+    this._renderTarget = this._rootRenderTarget;
+    this._activeDrawCommand = null;
+
+    this.rendererRegistry.connect(this);
+
+    // Re-apply the GL global state the constructor establishes (blend enable,
+    // clear color, disabled depth / stencil / cull) and re-bind the root
+    // target + default blend mode so the next frame draws correctly.
+    this._setupContext();
+    this._bindRenderTarget(this._renderTarget);
+    this.setBlendMode(BlendModes.Normal);
+
+    // Deleting GL objects that belonged to the lost context raises a benign
+    // INVALID_OPERATION on some drivers (the handles no longer belong to the
+    // live context). Drain the error queue so the rebuilt context starts clean
+    // and the application's own `getError()` checks aren't tripped by teardown
+    // artifacts. Bounded so a genuinely wedged context can't spin here.
+    for (let drained = 0; drained < 64 && gl.getError() !== gl.NO_ERROR; drained++) {
+      // Intentionally empty: each getError() call pops one queued error.
+    }
   }
 
   private _createFramebuffer(): WebGLFramebuffer {

--- a/test/perf/rendering/context-restore-webgl2.test.ts
+++ b/test/perf/rendering/context-restore-webgl2.test.ts
@@ -1,0 +1,180 @@
+/**
+ * WebGl2Backend — context-loss / restore handle-invalidation bookkeeping (B-09).
+ *
+ * These run in Node against the recording fake WebGL2 context (see
+ * `harness.ts`), driving the REAL backend + renderers. They assert the
+ * device-state teardown/rebuild bookkeeping that a real `webglcontextrestored`
+ * triggers — the part the previous implementation skipped, leaving dangling GL
+ * handles after a genuine GPU reset.
+ *
+ * The browser lane (`test/rendering/browser/webgl2-context-restore.test.ts`)
+ * proves the same recovery end-to-end with real pixels via WEBGL_lose_context;
+ * this lane pins the CPU-side cache invalidation deterministically.
+ */
+import type { RenderTexture } from '#rendering/texture/RenderTexture';
+import type { Texture } from '#rendering/texture/Texture';
+
+import { buildSpriteScene, makeTexture } from './fixtures';
+import { createWebGl2Harness, measureFrame, type WebGl2Harness } from './harness';
+
+interface ManagedTextureState {
+  readonly handle: object;
+}
+
+// Private surface we assert against — the caches a real restore must evict and
+// rebuild. Reached via a typed cast rather than `any` so the shape stays honest.
+interface BackendInternals {
+  _contextLost: boolean;
+  readonly _textureStates: Map<Texture | RenderTexture, ManagedTextureState>;
+  readonly _renderTargetStates: Map<object, object>;
+  _onContextLost(event: Event): void;
+  _onContextRestored(): void;
+}
+
+const internals = (harness: WebGl2Harness): BackendInternals => harness.backend as unknown as BackendInternals;
+
+describe('WebGl2Backend: real context-restore handle invalidation (B-09)', () => {
+  test('webglcontextlost cancels the default so the browser can restore', () => {
+    const harness = createWebGl2Harness();
+
+    try {
+      const preventDefault = vi.fn();
+
+      internals(harness)._onContextLost({ preventDefault } as unknown as Event);
+
+      // Without preventDefault() the browser never fires webglcontextrestored
+      // and the canvas stays permanently blank after a real GPU reset.
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+      expect(internals(harness)._contextLost).toBe(true);
+    } finally {
+      harness.destroy();
+    }
+  });
+
+  test('restore evicts every cached texture / render-target handle', () => {
+    const harness = createWebGl2Harness();
+
+    try {
+      const texture = makeTexture(64);
+      const { root } = buildSpriteScene({ count: 4, textures: [texture] });
+
+      measureFrame(harness, root);
+
+      const back = internals(harness);
+      const rootTarget = harness.backend.renderTarget as unknown as object;
+      const rootStateBefore = back._renderTargetStates.get(rootTarget);
+
+      // A rendered frame populated the texture cache (content texture +
+      // shared transform DataTexture) and the root render-target state.
+      expect(back._textureStates.size).toBeGreaterThan(0);
+      expect(rootStateBefore).toBeDefined();
+
+      back._onContextRestored();
+
+      // Every content texture handle is dropped; the texture cache repopulates
+      // lazily on the next draw against the fresh context.
+      expect(back._contextLost).toBe(false);
+      expect(back._textureStates.size).toBe(0);
+
+      // The render-target cache was evicted too — the root target is then
+      // immediately re-bound so the next frame can draw, but with a BRAND-NEW
+      // state object (fresh framebuffer binding), never the dead one.
+      const rootStateAfter = back._renderTargetStates.get(rootTarget);
+
+      expect(rootStateAfter).toBeDefined();
+      expect(rootStateAfter).not.toBe(rootStateBefore);
+
+      root.destroy();
+    } finally {
+      harness.destroy();
+    }
+  });
+
+  test('the same Texture gets a fresh GL handle after restore (no stale handle reuse)', () => {
+    const harness = createWebGl2Harness();
+
+    try {
+      const texture = makeTexture(64);
+      const { root } = buildSpriteScene({ count: 1, textures: [texture] });
+      const back = internals(harness);
+
+      measureFrame(harness, root);
+      const handleBefore = back._textureStates.get(texture)?.handle;
+
+      expect(handleBefore).toBeDefined();
+
+      back._onContextRestored();
+      measureFrame(harness, root);
+      const handleAfter = back._textureStates.get(texture)?.handle;
+
+      expect(handleAfter).toBeDefined();
+      // A distinct fake handle object proves the dead one was not reused.
+      expect(handleAfter).not.toBe(handleBefore);
+
+      root.destroy();
+    } finally {
+      harness.destroy();
+    }
+  });
+
+  test('rendering resumes after restore — draw calls are issued against the rebuilt device', () => {
+    const harness = createWebGl2Harness();
+
+    try {
+      const texture = makeTexture(64);
+      const { root } = buildSpriteScene({ count: 8, textures: [texture] });
+      const back = internals(harness);
+
+      const before = measureFrame(harness, root);
+
+      expect(before.drawCalls).toBeGreaterThan(0);
+
+      // Simulate a full real lose → restore cycle.
+      back._onContextLost({ preventDefault: vi.fn() } as unknown as Event);
+      back._onContextRestored();
+
+      // The renderers reconnected (fresh buffers / VAOs / shader programs), so
+      // the very next frame draws exactly as before — not a blank canvas.
+      const after = measureFrame(harness, root);
+
+      expect(after.drawCalls).toBe(before.drawCalls);
+      expect(after.batches).toBe(before.batches);
+
+      root.destroy();
+    } finally {
+      harness.destroy();
+    }
+  });
+
+  test('GPU memory accounting is released on restore and re-accrued on next draw', () => {
+    const harness = createWebGl2Harness();
+
+    try {
+      const texture = makeTexture(64);
+      const { root } = buildSpriteScene({ count: 4, textures: [texture] });
+      const back = internals(harness);
+      const stats = harness.backend.stats;
+
+      measureFrame(harness, root);
+      const bytesLive = stats.gpuMemoryBytes;
+
+      expect(bytesLive).toBeGreaterThan(0);
+
+      back._onContextRestored();
+
+      // Eviction freed the dead resources' accounted bytes; the renderers'
+      // reconnect immediately re-books their buffer allocations, so the total
+      // is non-negative and the caches are consistent (no double-count).
+      expect(stats.gpuMemoryBytes).toBeGreaterThanOrEqual(0);
+      expect(stats.gpuMemoryBytes).toBeLessThanOrEqual(bytesLive);
+
+      // Next frame re-accrues the content-texture / transform-texture storage.
+      measureFrame(harness, root);
+      expect(stats.gpuMemoryBytes).toBeGreaterThan(0);
+
+      root.destroy();
+    } finally {
+      harness.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgl2-context-restore.test.ts
+++ b/test/rendering/browser/webgl2-context-restore.test.ts
@@ -1,0 +1,318 @@
+/**
+ * WebGL2 real context lose/restore browser test (B-09).
+ *
+ * Drives a genuine GL context-loss cycle through the `WEBGL_lose_context`
+ * extension — `loseContext()` fires `webglcontextlost`, `restoreContext()`
+ * fires `webglcontextrestored` — and asserts that rendering RESUMES with valid
+ * resources afterwards by reading back pixels. This is the end-to-end proof for
+ * the finding: synthetic signal-only tests passed while a real reset left the
+ * backend drawing with dangling GL handles. After the fix, the backend evicts
+ * and rebuilds all device-bound state on restore, so the same scene renders
+ * identical pixels before and after the loss.
+ *
+ * Run via:  pnpm test:browser:webgl
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import type { RenderNode } from '#rendering/RenderNode';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+
+// ---------------------------------------------------------------------------
+// Shader mocks (see webgl2-sprite-solid-color.test.ts — the registry compiles
+// every core renderer's program on connect, so all core shaders need real GLSL).
+// ---------------------------------------------------------------------------
+
+const shaderSources = vi.hoisted(() => ({
+  spriteVert: `#version 300 es
+precision mediump float;
+in vec4 a_localBounds;
+in vec4 a_uvBounds;
+in vec4 a_color;
+in uint a_textureSlot;
+in uint a_nodeIndex;
+uniform mat3 u_projection;
+uniform sampler2D u_transforms;
+out vec2 v_uv;
+out vec4 v_color;
+flat out uint v_textureSlot;
+void main() {
+  vec2 local;
+  if (gl_VertexID == 0) local = vec2(a_localBounds.x, a_localBounds.y);
+  else if (gl_VertexID == 1) local = vec2(a_localBounds.z, a_localBounds.y);
+  else if (gl_VertexID == 2) local = vec2(a_localBounds.x, a_localBounds.w);
+  else local = vec2(a_localBounds.z, a_localBounds.w);
+  vec2 uv;
+  if (gl_VertexID == 0) uv = vec2(a_uvBounds.x, a_uvBounds.y);
+  else if (gl_VertexID == 1) uv = vec2(a_uvBounds.z, a_uvBounds.y);
+  else if (gl_VertexID == 2) uv = vec2(a_uvBounds.x, a_uvBounds.w);
+  else uv = vec2(a_uvBounds.z, a_uvBounds.w);
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
+  vec3 clip = u_projection * vec3(world, 1.0);
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = uv; v_color = a_color; v_textureSlot = a_textureSlot;
+}`,
+
+  meshVert: `#version 300 es
+precision mediump float;
+in vec2 a_position;
+in vec2 a_texcoord;
+in vec4 a_color;
+in uint a_nodeIndex;
+uniform mat3 u_projection;
+uniform sampler2D u_transforms;
+out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
+void main() {
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  mat3 t = mat3(m0.x,m0.z,0.0, m0.y,m0.w,0.0, m1.x,m1.y,1.0);
+  vec3 world = t * vec3(a_position, 1.0);
+  vec3 clip = u_projection * world;
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = a_texcoord; v_color = a_color;
+  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+}`,
+
+  meshFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv; in vec4 v_color; in vec4 v_tint;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() { outColor = texture(u_texture, v_uv) * v_color * v_tint; }`,
+
+  textVert: `#version 300 es
+precision mediump float;
+in vec2 a_position; in vec2 a_texcoord; in float a_nodeIndex;
+uniform mat3 u_projection;
+out vec2 v_uv;
+void main() {
+  float ni = a_nodeIndex;
+  vec3 clip = u_projection * vec3(a_position + vec2(ni * 0.0), 1.0);
+  gl_Position = vec4(clip.xy, 0.0, 1.0); v_uv = a_texcoord;
+}`,
+
+  textFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() { outColor = texture(u_texture, v_uv); }`,
+}));
+
+vi.mock('#rendering/webgl2/glsl/sprite.vert', () => ({ default: shaderSources.spriteVert }));
+vi.mock('#rendering/webgl2/glsl/sprite.frag', async () => ({ default: (await import('./_spriteFragMock')).createSpriteFragMockSource('v_uv') }));
+vi.mock('#rendering/webgl2/glsl/mesh.vert', () => ({ default: shaderSources.meshVert }));
+vi.mock('#rendering/webgl2/glsl/mesh.frag', () => ({ default: shaderSources.meshFrag }));
+vi.mock('#rendering/webgl2/glsl/text.vert', () => ({ default: shaderSources.textVert }));
+vi.mock('#rendering/webgl2/glsl/text-color.frag', () => ({ default: shaderSources.textFrag }));
+vi.mock('#rendering/webgl2/glsl/text-msdf.frag', () => ({ default: shaderSources.textFrag }));
+vi.mock('#rendering/webgl2/glsl/text-sdf.frag', () => ({ default: shaderSources.textFrag }));
+
+// ---------------------------------------------------------------------------
+// Infrastructure helpers
+// ---------------------------------------------------------------------------
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const createBackend = async (): Promise<WebGl2Backend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+  // The canvas must be attached for the browser to deliver webglcontextlost /
+  // webglcontextrestored events reliably across engines.
+  document.body.appendChild(canvas);
+
+  const app: Application = {
+    canvas,
+    options: {
+      clearColor: Color.black,
+      canvas: { width: canvasSize, height: canvasSize },
+      rendering: {
+        debug: false,
+        webglAttributes: {
+          alpha: false,
+          antialias: false,
+          premultipliedAlpha: false,
+          preserveDrawingBuffer: true,
+          stencil: false,
+          depth: false,
+        },
+        spriteRendererBatchSize: 1024,
+        particleRendererBatchSize: 1024,
+      },
+    },
+  } as unknown as Application;
+
+  const backend = new WebGl2Backend(app);
+
+  await backend.initialize();
+  wireCoreRenderers(backend, app.options.rendering);
+
+  return backend;
+};
+
+const render = (backend: WebGl2Backend, node: RenderNode): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+  node.render(backend);
+  backend.flush();
+};
+
+const readPixel = (backend: WebGl2Backend, x: number, y: number): RgbaTuple => {
+  const buf = new Uint8Array(4);
+  const gl = backend.context;
+
+  gl.readPixels(Math.floor(x), backend.renderTarget.height - Math.floor(y) - 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+
+  return [buf[0], buf[1], buf[2], buf[3]];
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 8): void => {
+  for (let i = 0; i < 4; i++) {
+    expect(Math.abs(actual[i] - expected[i])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+const createSolidTexture = (color: string, width = 16, height = 16): Texture => {
+  const src = document.createElement('canvas');
+
+  src.width = width;
+  src.height = height;
+
+  const ctx = src.getContext('2d')!;
+
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, width, height);
+
+  return new Texture(src);
+};
+
+/**
+ * Force a real GL context loss and wait for the backend's `onContextRestored`
+ * to fire. `WEBGL_lose_context.loseContext()` dispatches `webglcontextlost`
+ * (which the backend cancels with preventDefault); the backend then calls
+ * `restoreContext()`, which dispatches `webglcontextrestored` on a later task —
+ * so we await the backend signal rather than assuming synchronous delivery.
+ */
+const loseAndRestoreContext = async (backend: WebGl2Backend): Promise<void> => {
+  const gl = backend.context;
+  const canvas = gl.canvas as HTMLCanvasElement;
+  const lose = gl.getExtension('WEBGL_lose_context');
+
+  expect(lose, 'WEBGL_lose_context must be available to drive this test').not.toBeNull();
+
+  const seen: string[] = [];
+
+  canvas.addEventListener('webglcontextlost', () => seen.push('lost'), { once: true });
+  canvas.addEventListener('webglcontextrestored', () => seen.push('restored'), { once: true });
+
+  const restored = new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error(`webglcontextrestored not delivered within 5s (raw events: ${seen.join(',') || 'none'}, isLost: ${gl.isContextLost()})`)),
+      5000,
+    );
+
+    backend.onContextRestored.add(() => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
+
+  lose!.loseContext();
+
+  await restored;
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WebGL2 real context lose/restore (B-09)', () => {
+  test('a sprite renders identically after a real lose/restore cycle', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ff0000', 16, 16);
+    const root = new Container();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.setPosition(8, 8);
+      root.addChild(sprite);
+
+      // Baseline: red inside the sprite, black (clear color) outside.
+      render(backend, root);
+      expectPixelNear(readPixel(backend, 16, 16), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(backend, 40, 40), [0, 0, 0, 255]);
+
+      // Genuine GPU reset: every GL handle created before this point is dead.
+      await loseAndRestoreContext(backend);
+
+      expect(backend.context.isContextLost()).toBe(false);
+
+      // The same scene must render the same pixels — proving the backend
+      // rebuilt its textures / buffers / VAOs / shader programs against the
+      // fresh context instead of drawing with dangling handles.
+      render(backend, root);
+      expectPixelNear(readPixel(backend, 16, 16), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(backend, 40, 40), [0, 0, 0, 255]);
+
+      // No lingering GL error storm from stale handles.
+      expect(backend.context.getError()).toBe(backend.context.NO_ERROR);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('survives two consecutive lose/restore cycles and a tint change', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ffffff', 16, 16);
+    const root = new Container();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.setPosition(8, 8);
+      sprite.tint = new Color(0, 255, 0);
+      root.addChild(sprite);
+
+      render(backend, root);
+      expectPixelNear(readPixel(backend, 16, 16), [0, 255, 0, 255]);
+
+      await loseAndRestoreContext(backend);
+      await loseAndRestoreContext(backend);
+
+      // A fresh texture created AFTER the losses must also upload + sample
+      // correctly on the rebuilt context.
+      const blueTexture = createSolidTexture('#0000ff', 16, 16);
+      const blueSprite = new Sprite(blueTexture);
+
+      blueSprite.setPosition(32, 32);
+      root.addChild(blueSprite);
+      sprite.tint = Color.white;
+
+      render(backend, root);
+
+      expectPixelNear(readPixel(backend, 16, 16), [255, 255, 255, 255]);
+      expectPixelNear(readPixel(backend, 40, 40), [0, 0, 255, 255]);
+      expect(backend.context.getError()).toBe(backend.context.NO_ERROR);
+
+      blueTexture.destroy();
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #275 (audit finding **B-09**, P2). On a genuine WebGL2 context loss (mobile tab-switch, driver TDR) the backend only flipped a flag and called `restoreContext()`; the cached GL handles were never invalidated. After a real restore every handle is dead, so the next frame drew with dangling handles → **blank canvas or an `INVALID_OPERATION` storm**. The pre-existing synthetic signal-only tests passed because they never exercised the rebuild path.

## Root cause (two independent bugs)

1. **The context could never be restored.** The `webglcontextlost` handler never called `event.preventDefault()`, so per the WebGL spec the browser never scheduled a `webglcontextrestored` event — a real loss was permanent. It also called `restoreContext()` *synchronously inside the lost handler* (Chromium silently ignores that) and via a *fresh* `getExtension()` result. Empirically verified against headless Chromium + Firefox: `restoreContext()` only drives a restore when invoked on the **live extension instance obtained before the loss**, on a later task.
2. **Restore evicted almost nothing.** `_onContextRestored` invalidated only the retained instruction-set bundles; `_textureStates`, `_renderTargetStates`, the shared transform texture, renderer buffers/VAOs/shader programs, and the compositors all kept dead handles.

## Approach

Mirrors the WebGPU backend's `_teardownDeviceState` (the audit rated that path production-grade and recommended the WebGL2 side copy it):

- `_onContextLost` now cancels the default action so the browser can restore, and schedules the extension-driven restore on a fresh task using the `WEBGL_lose_context` instance **cached in the constructor** (pre-loss).
- `_onContextRestored` delegates to a new `_reinitializeDeviceState()` that:
  - re-enables `EXT_color_buffer_float` (extension enablement does not survive a loss),
  - evicts every managed texture / render-target handle (frees the resource accountant, detaches destroy listeners),
  - drops the shared transform texture + upload bookkeeping,
  - disconnects **and reconnects** all renderers (rebuilds buffers / VAOs / shader programs, resets the VAO `appliedVersion` cache),
  - disconnects the mask / backdrop-blend compositors and stencil clipper (lazy reconnect on next use),
  - invalidates the retained bundles and drops in-flight captures,
  - resets the cached GL bind state, re-applies the GL global state, re-binds the root target + default blend mode,
  - drains benign teardown `INVALID_OPERATION`s so the app's own `getError()` starts clean.
- `destroy()` cancels any pending restore and a `_destroyed` guard stops a late timer callback.

Pre-1.0 clean break — no shims.

## Test evidence

- **Browser lane** (`test/rendering/browser/webgl2-context-restore.test.ts`): drives a **real** `WEBGL_lose_context` lose/restore cycle and asserts the scene renders **identical pixels** afterwards, including a two-cycle case and a texture created *after* the losses. Passes on **Chromium and Firefox**.
- **Node lane** (`test/perf/rendering/context-restore-webgl2.test.ts`, 5 tests): pins the invalidation bookkeeping against the recording fake context — `preventDefault` on loss, full cache eviction, **fresh GL handle identity** after restore for the same `Texture`, draw-call resumption, and GPU-memory accounting release/re-accrual.

Full verification run locally: `pnpm typecheck`, `eslint`, `prettier --check`, `pnpm docs:api:check`, full WebGL2 Chromium browser suite (**213 passed**), Firefox context-restore, `rendering-perf` Node lane (**66 passed**), and the existing jsdom `webgl2-backend` suite (**9 passed**).

Note: the retained instruction-set bundles (Slice 3) already hooked their own generation-bump into the restore path; that behavior is preserved and folded into the new teardown.

https://claude.ai/code/session_01RHB7cLgoonJHLQg9ScdXby