### PR TITLE
fix(audio): defer AudioContext creation, stop pre-unlock listener leak, smooth spatial params (AU2/AU3/AU4)

### DIFF
--- a/packages/exojs-audio-fx/test/effects/auto-wah-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/auto-wah-effect.test.ts
@@ -100,7 +100,12 @@ describe('AutoWahEffect', () => {
   // ---------------------------------------------------------------------------
 
   describe('inputNode and outputNode', () => {
+    // Calling getAudioContext() here ensures isAudioContextReady() returns true
+    // for all tests in this describe block and below, so the constructor calls
+    // _setupNodes() immediately rather than deferring via onAudioContextReady.
+
     it('are defined after construction', () => {
+      getAudioContext();
       const effect = new AutoWahEffect();
       expect(effect.inputNode).toBeDefined();
       expect(effect.outputNode).toBeDefined();
@@ -108,6 +113,7 @@ describe('AutoWahEffect', () => {
     });
 
     it('are different instances', () => {
+      getAudioContext();
       const effect = new AutoWahEffect();
       expect(effect.inputNode).not.toBe(effect.outputNode);
       effect.destroy();
@@ -118,6 +124,28 @@ describe('AutoWahEffect', () => {
       effect.destroy();
       expect(() => effect.inputNode).toThrow('AutoWahEffect not yet initialized.');
       expect(() => effect.outputNode).toThrow('AutoWahEffect not yet initialized.');
+    });
+  });
+
+  describe('construction before the audio context is ready', () => {
+    it('registers a deferred onAudioContextReady setup and _onAudioContextReady wires the nodes', async () => {
+      // A fresh module registry via vi.resetModules() guarantees the internal
+      // audio-context singleton starts in its virgin (not-ready) state, so
+      // construction defers node setup instead of creating it synchronously.
+      vi.resetModules();
+      const { AutoWahEffect: FreshAutoWahEffect } = await import('../../src/effects/AutoWahEffect');
+      const effect = new FreshAutoWahEffect();
+      expect(() => effect.inputNode).toThrow('AutoWahEffect not yet initialized.');
+
+      // Simulate the AudioContext becoming ready by invoking the deferred
+      // hook directly with a fresh mock AudioContext.
+      const ctx = new AudioContext();
+      (effect as unknown as { _onAudioContextReady: (ctx: AudioContext) => void })._onAudioContextReady(ctx);
+
+      expect(effect.inputNode).toBeDefined();
+      expect(effect.outputNode).toBeDefined();
+      expect(effect.inputNode).not.toBe(effect.outputNode);
+      effect.destroy();
     });
   });
 

--- a/packages/exojs-audio-fx/test/effects/chorus-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/chorus-effect.test.ts
@@ -82,7 +82,12 @@ describe('ChorusEffect', () => {
   });
 
   describe('inputNode and outputNode', () => {
+    // Calling getAudioContext() here ensures isAudioContextReady() returns true
+    // for all tests in this describe block and below, so the constructor calls
+    // _setupNodes() immediately rather than deferring via onAudioContextReady.
+
     it('inputNode and outputNode are defined after construction', () => {
+      getAudioContext();
       const filter = new ChorusEffect();
       expect(filter.inputNode).toBeDefined();
       expect(filter.outputNode).toBeDefined();
@@ -90,7 +95,30 @@ describe('ChorusEffect', () => {
     });
 
     it('inputNode and outputNode are different instances', () => {
+      getAudioContext();
       const filter = new ChorusEffect();
+      expect(filter.inputNode).not.toBe(filter.outputNode);
+      filter.destroy();
+    });
+  });
+
+  describe('construction before the audio context is ready', () => {
+    it('registers a deferred onAudioContextReady setup and _onAudioContextReady wires the nodes', async () => {
+      // A fresh module registry via vi.resetModules() guarantees the internal
+      // audio-context singleton starts in its virgin (not-ready) state, so
+      // construction defers node setup instead of creating it synchronously.
+      vi.resetModules();
+      const { ChorusEffect: FreshChorusEffect } = await import('../../src/effects/ChorusEffect');
+      const filter = new FreshChorusEffect();
+      expect(() => filter.inputNode).toThrow('ChorusEffect not yet initialized.');
+
+      // Simulate the AudioContext becoming ready by invoking the deferred
+      // hook directly with a fresh mock AudioContext.
+      const ctx = new AudioContext();
+      (filter as unknown as { _onAudioContextReady: (ctx: AudioContext) => void })._onAudioContextReady(ctx);
+
+      expect(filter.inputNode).toBeDefined();
+      expect(filter.outputNode).toBeDefined();
       expect(filter.inputNode).not.toBe(filter.outputNode);
       filter.destroy();
     });

--- a/packages/exojs-audio-fx/test/effects/compressor-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/compressor-effect.test.ts
@@ -100,18 +100,26 @@ describe('CompressorEffect', () => {
 
   describe('construction before the audio context is ready', () => {
     it('registers a deferred onAudioContextReady setup and _onAudioContextReady wires the node', async () => {
-      // The shared mock AudioContext is always 'running', so
-      // onAudioContextReady.add() synchronously creates the context and
-      // dispatches ready inside the constructor call itself — the deferred
-      // callback (and the constructor's else-branch registration) both
-      // execute before `new` returns. Using a fresh module registry via
-      // vi.resetModules() guarantees the internal audio-context singleton
-      // starts in its virgin (not-ready) state for this one test, regardless
-      // of what earlier tests in this file already did with getAudioContext().
+      // Using a fresh module registry via vi.resetModules() guarantees the
+      // internal audio-context singleton starts in its virgin (not-ready)
+      // state for this one test, regardless of what earlier tests in this
+      // file already did with getAudioContext(). With no AudioContext created
+      // yet, construction cannot set up the node synchronously — it registers
+      // `_onAudioContextReady` on the `onAudioContextReady` signal instead.
       vi.resetModules();
       const { CompressorEffect: FreshCompressorEffect } = await import('../../src/effects/CompressorEffect');
       const effect = new FreshCompressorEffect();
+      expect(() => effect.inputNode).toThrow('CompressorEffect not yet initialized.');
+
+      // Simulate the AudioContext becoming ready (e.g. after the first user
+      // gesture) by invoking the deferred hook directly with a fresh mock
+      // AudioContext — this is exactly what onAudioContextReady.dispatch()
+      // would call in production.
+      const ctx = new AudioContext();
+      (effect as unknown as { _onAudioContextReady: (ctx: AudioContext) => void })._onAudioContextReady(ctx);
+
       expect(effect.inputNode).toBeDefined();
+      expect(effect.inputNode).toBe(effect.outputNode);
       effect.destroy();
     });
   });

--- a/packages/exojs-audio-fx/test/effects/equalizer-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/equalizer-effect.test.ts
@@ -21,10 +21,22 @@ const makeBiquadFilterNode = (ctx: AudioContext, filterType: BiquadFilterType) =
 describe('EqualizerEffect', () => {
   describe('deferred setup before AudioContext exists', () => {
     it('registers a deferred onAudioContextReady setup when constructed before any AudioContext exists', async () => {
+      // A fresh module registry via vi.resetModules() guarantees the internal
+      // audio-context singleton starts in its virgin (not-ready) state, so
+      // construction defers node setup instead of creating it synchronously.
       vi.resetModules();
       const { EqualizerEffect: FreshEqualizerEffect } = await import('../../src/effects/EqualizerEffect');
       const effect = new FreshEqualizerEffect();
+      expect(() => effect.inputNode).toThrow('EqualizerEffect not yet initialized.');
+
+      // Simulate the AudioContext becoming ready by invoking the deferred
+      // hook directly with a fresh mock AudioContext.
+      const ctx = new AudioContext();
+      (effect as unknown as { _onAudioContextReady: (ctx: AudioContext) => void })._onAudioContextReady(ctx);
+
       expect(effect.inputNode).toBeDefined();
+      expect(effect.outputNode).toBeDefined();
+      expect(effect.inputNode).not.toBe(effect.outputNode);
       effect.destroy();
     });
   });

--- a/packages/exojs-audio-fx/test/effects/flanger-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/flanger-effect.test.ts
@@ -97,7 +97,12 @@ describe('FlangerEffect', () => {
   // -------------------------------------------------------------------------
 
   describe('inputNode and outputNode', () => {
+    // Calling getAudioContext() here ensures isAudioContextReady() returns true
+    // for all tests in this describe block and below, so the constructor calls
+    // _setupNodes() immediately rather than deferring via onAudioContextReady.
+
     it('inputNode and outputNode are defined after construction', () => {
+      getAudioContext();
       const effect = new FlangerEffect();
       expect(effect.inputNode).toBeDefined();
       expect(effect.outputNode).toBeDefined();
@@ -105,6 +110,7 @@ describe('FlangerEffect', () => {
     });
 
     it('inputNode and outputNode are different instances', () => {
+      getAudioContext();
       const effect = new FlangerEffect();
       expect(effect.inputNode).not.toBe(effect.outputNode);
       effect.destroy();
@@ -120,6 +126,28 @@ describe('FlangerEffect', () => {
       const effect = new FlangerEffect();
       effect.destroy();
       expect(() => effect.outputNode).toThrow('FlangerEffect not yet initialized.');
+    });
+  });
+
+  describe('construction before the audio context is ready', () => {
+    it('registers a deferred onAudioContextReady setup and _onAudioContextReady wires the nodes', async () => {
+      // A fresh module registry via vi.resetModules() guarantees the internal
+      // audio-context singleton starts in its virgin (not-ready) state, so
+      // construction defers node setup instead of creating it synchronously.
+      vi.resetModules();
+      const { FlangerEffect: FreshFlangerEffect } = await import('../../src/effects/FlangerEffect');
+      const effect = new FreshFlangerEffect();
+      expect(() => effect.inputNode).toThrow('FlangerEffect not yet initialized.');
+
+      // Simulate the AudioContext becoming ready by invoking the deferred
+      // hook directly with a fresh mock AudioContext.
+      const ctx = new AudioContext();
+      (effect as unknown as { _onAudioContextReady: (ctx: AudioContext) => void })._onAudioContextReady(ctx);
+
+      expect(effect.inputNode).toBeDefined();
+      expect(effect.outputNode).toBeDefined();
+      expect(effect.inputNode).not.toBe(effect.outputNode);
+      effect.destroy();
     });
   });
 

--- a/packages/exojs-audio-fx/test/effects/phaser-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/phaser-effect.test.ts
@@ -243,7 +243,12 @@ describe('PhaserEffect', () => {
   // -------------------------------------------------------------------------
 
   describe('inputNode and outputNode', () => {
+    // Calling getAudioContext() here ensures isAudioContextReady() returns true
+    // for all tests in this describe block and below, so the constructor calls
+    // _setupNodes() immediately rather than deferring via onAudioContextReady.
+
     it('inputNode and outputNode are defined after construction', () => {
+      getAudioContext();
       const effect = new PhaserEffect();
       expect(effect.inputNode).toBeDefined();
       expect(effect.outputNode).toBeDefined();
@@ -251,6 +256,7 @@ describe('PhaserEffect', () => {
     });
 
     it('inputNode and outputNode are different instances', () => {
+      getAudioContext();
       const effect = new PhaserEffect();
       expect(effect.inputNode).not.toBe(effect.outputNode);
       effect.destroy();
@@ -266,6 +272,28 @@ describe('PhaserEffect', () => {
       const effect = new PhaserEffect();
       effect.destroy();
       expect(() => effect.outputNode).toThrow('PhaserEffect not yet initialized.');
+    });
+  });
+
+  describe('construction before the audio context is ready', () => {
+    it('registers a deferred onAudioContextReady setup and _onAudioContextReady wires the nodes', async () => {
+      // A fresh module registry via vi.resetModules() guarantees the internal
+      // audio-context singleton starts in its virgin (not-ready) state, so
+      // construction defers node setup instead of creating it synchronously.
+      vi.resetModules();
+      const { PhaserEffect: FreshPhaserEffect } = await import('../../src/effects/PhaserEffect');
+      const effect = new FreshPhaserEffect();
+      expect(() => effect.inputNode).toThrow('PhaserEffect not yet initialized.');
+
+      // Simulate the AudioContext becoming ready by invoking the deferred
+      // hook directly with a fresh mock AudioContext.
+      const ctx = new AudioContext();
+      (effect as unknown as { _onAudioContextReady: (ctx: AudioContext) => void })._onAudioContextReady(ctx);
+
+      expect(effect.inputNode).toBeDefined();
+      expect(effect.outputNode).toBeDefined();
+      expect(effect.inputNode).not.toBe(effect.outputNode);
+      effect.destroy();
     });
   });
 

--- a/packages/exojs-audio-fx/test/effects/ring-modulator-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/ring-modulator-effect.test.ts
@@ -106,7 +106,12 @@ describe('RingModulatorEffect', () => {
   // -------------------------------------------------------------------------
 
   describe('inputNode and outputNode', () => {
+    // Calling getAudioContext() here ensures isAudioContextReady() returns true
+    // for all tests in this describe block and below, so the constructor calls
+    // _setupNodes() immediately rather than deferring via onAudioContextReady.
+
     it('are defined after construction', () => {
+      getAudioContext();
       const effect = new RingModulatorEffect();
       expect(effect.inputNode).toBeDefined();
       expect(effect.outputNode).toBeDefined();
@@ -114,6 +119,7 @@ describe('RingModulatorEffect', () => {
     });
 
     it('are different instances', () => {
+      getAudioContext();
       const effect = new RingModulatorEffect();
       expect(effect.inputNode).not.toBe(effect.outputNode);
       effect.destroy();
@@ -124,6 +130,28 @@ describe('RingModulatorEffect', () => {
       effect.destroy();
       expect(() => effect.inputNode).toThrow('RingModulatorEffect not yet initialized.');
       expect(() => effect.outputNode).toThrow('RingModulatorEffect not yet initialized.');
+    });
+  });
+
+  describe('construction before the audio context is ready', () => {
+    it('registers a deferred onAudioContextReady setup and _onAudioContextReady wires the nodes', async () => {
+      // A fresh module registry via vi.resetModules() guarantees the internal
+      // audio-context singleton starts in its virgin (not-ready) state, so
+      // construction defers node setup instead of creating it synchronously.
+      vi.resetModules();
+      const { RingModulatorEffect: FreshRingModulatorEffect } = await import('../../src/effects/RingModulatorEffect');
+      const effect = new FreshRingModulatorEffect();
+      expect(() => effect.inputNode).toThrow('RingModulatorEffect not yet initialized.');
+
+      // Simulate the AudioContext becoming ready by invoking the deferred
+      // hook directly with a fresh mock AudioContext.
+      const ctx = new AudioContext();
+      (effect as unknown as { _onAudioContextReady: (ctx: AudioContext) => void })._onAudioContextReady(ctx);
+
+      expect(effect.inputNode).toBeDefined();
+      expect(effect.outputNode).toBeDefined();
+      expect(effect.inputNode).not.toBe(effect.outputNode);
+      effect.destroy();
     });
   });
 

--- a/packages/exojs-audio-fx/test/effects/tremolo-effect.test.ts
+++ b/packages/exojs-audio-fx/test/effects/tremolo-effect.test.ts
@@ -135,7 +135,12 @@ describe('TremoloEffect', () => {
   // -------------------------------------------------------------------------
 
   describe('inputNode and outputNode', () => {
+    // Calling getAudioContext() here ensures isAudioContextReady() returns true
+    // for all tests in this describe block and below, so the constructor calls
+    // _setupNodes() immediately rather than deferring via onAudioContextReady.
+
     it('inputNode and outputNode are defined after construction', () => {
+      getAudioContext();
       const effect = new TremoloEffect();
       expect(effect.inputNode).toBeDefined();
       expect(effect.outputNode).toBeDefined();
@@ -143,6 +148,7 @@ describe('TremoloEffect', () => {
     });
 
     it('inputNode and outputNode are different instances', () => {
+      getAudioContext();
       const effect = new TremoloEffect();
       expect(effect.inputNode).not.toBe(effect.outputNode);
       effect.destroy();
@@ -158,6 +164,28 @@ describe('TremoloEffect', () => {
       const effect = new TremoloEffect();
       effect.destroy();
       expect(() => effect.outputNode).toThrow('TremoloEffect not yet initialized.');
+    });
+  });
+
+  describe('construction before the audio context is ready', () => {
+    it('registers a deferred onAudioContextReady setup and _onAudioContextReady wires the nodes', async () => {
+      // A fresh module registry via vi.resetModules() guarantees the internal
+      // audio-context singleton starts in its virgin (not-ready) state, so
+      // construction defers node setup instead of creating it synchronously.
+      vi.resetModules();
+      const { TremoloEffect: FreshTremoloEffect } = await import('../../src/effects/TremoloEffect');
+      const effect = new FreshTremoloEffect();
+      expect(() => effect.inputNode).toThrow('TremoloEffect not yet initialized.');
+
+      // Simulate the AudioContext becoming ready by invoking the deferred
+      // hook directly with a fresh mock AudioContext.
+      const ctx = new AudioContext();
+      (effect as unknown as { _onAudioContextReady: (ctx: AudioContext) => void })._onAudioContextReady(ctx);
+
+      expect(effect.inputNode).toBeDefined();
+      expect(effect.outputNode).toBeDefined();
+      expect(effect.inputNode).not.toBe(effect.outputNode);
+      effect.destroy();
     });
   });
 

--- a/site/src/content/api/audio-bus.json
+++ b/site/src/content/api/audio-bus.json
@@ -395,7 +395,7 @@
         },
         {
           "name": "onceSetup",
-          "signature": "onceSetup(callback: () => void): void",
+          "signature": "onceSetup(callback: () => void): () => void",
           "signatureTokens": [
             {
               "text": "onceSetup",
@@ -434,6 +434,14 @@
               "kind": "punctuation"
             },
             {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ") => ",
+              "kind": "punctuation"
+            },
+            {
               "text": "void",
               "kind": "keyword"
             }
@@ -445,8 +453,8 @@
               "optional": false
             }
           ],
-          "returnType": "void",
-          "description": "Subscribe to the moment this bus's audio nodes are ready. Internal use."
+          "returnType": "() => void",
+          "description": "Run callback the moment this bus's audio nodes are ready: immediately if it is already set up, otherwise queued on the bus and flushed when the context unlocks. Returns an unsubscribe function that removes the still-pending callback (a no-op once it has fired). Internal use. The queue lives on the bus rather than the global unlock signal, so many voices deferring a reconnect before the first user gesture do not pile listeners onto that singleton, and anything torn down pre-unlock drops its own pending callback (AU3)."
         },
         {
           "name": "removeEffect",

--- a/site/src/content/api/audio-listener.json
+++ b/site/src/content/api/audio-listener.json
@@ -31,7 +31,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(): AudioListener",
+          "signature": "new(settings: SpatialSmoothingSettings): AudioListener",
           "signatureTokens": [
             {
               "text": "new",
@@ -40,6 +40,18 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "settings",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "SpatialSmoothingSettings",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -54,7 +66,13 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "settings",
+              "type": "SpatialSmoothingSettings",
+              "optional": false
+            }
+          ],
           "returnType": "AudioListener",
           "description": ""
         }

--- a/site/src/content/api/audio-manager.json
+++ b/site/src/content/api/audio-manager.json
@@ -6,11 +6,11 @@
   "subsystem": "audio",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 18,
+  "memberCount": 19,
   "counts": {
     "constructors": 1,
     "methods": 10,
-    "properties": 6,
+    "properties": 7,
     "events": 1
   },
   "sections": [
@@ -636,6 +636,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "spatial",
+          "signature": "spatial: SpatialSmoothingSettings",
+          "signatureTokens": [
+            {
+              "text": "spatial",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "SpatialSmoothingSettings",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Tunable smoothing applied to per-frame panner/listener position updates, shared by the AudioListener and every spatial voice. Adjust smoothing (the setTargetAtTime time constant) or teleportThreshold (the snap-instead-of-ramp jump distance) to trade responsiveness against zipper-noise suppression (AU4). Reachable as app.audio.spatial."
         },
         {
           "name": "locked",

--- a/site/src/content/api/functions.json
+++ b/site/src/content/api/functions.json
@@ -325,7 +325,7 @@
             }
           ],
           "returnType": "Promise<AudioBuffer>",
-          "description": "Decode raw audio bytes into an AudioBuffer using the shared OfflineAudioContext. The context's sample rate is derived from the live AudioContext, ensuring decoded buffers are compatible with playback nodes. Note: on some older mobile WebKit versions decodeAudioData requires a running (live) context — decoding may fail with a browser-level error rather than an ExoJS-shaped error in those environments."
+          "description": "Decode raw audio bytes into an AudioBuffer using the shared OfflineAudioContext. The context's sample rate matches the live AudioContext when one exists, else defaults to 44.1 kHz — decoding never forces a live context into existence. Note: on some older mobile WebKit versions decodeAudioData requires a running (live) context — decoding may fail with a browser-level error rather than an ExoJS-shaped error in those environments."
         },
         {
           "name": "defineAsset",
@@ -470,7 +470,7 @@
           ],
           "params": [],
           "returnType": "OfflineAudioContext",
-          "description": "Return the shared singleton OfflineAudioContext used for audio decoding. Its sample rate matches the live AudioContext. Creates the live context as a side effect if it does not exist yet."
+          "description": "Return the shared singleton OfflineAudioContext used for audio decoding. Its sample rate matches the live AudioContext when one already exists, otherwise a 44.1 kHz default is used. Never creates a live AudioContext — decoding before the first user gesture must not spawn a suspended context (AU2); buffers resample transparently on playback if the rates differ."
         },
         {
           "name": "inRange",

--- a/site/src/content/api/spatial-smoothing-settings.json
+++ b/site/src/content/api/spatial-smoothing-settings.json
@@ -1,0 +1,92 @@
+{
+  "title": "SpatialSmoothingSettings",
+  "description": "Tunable smoothing settings shared by the listener and all spatial voices. Owned by AudioManager and reachable as `app.audio.spatial`.",
+  "symbol": "SpatialSmoothingSettings",
+  "kind": "interface",
+  "subsystem": "audio",
+  "importPath": "@codexo/exojs",
+  "tier": "stable",
+  "memberCount": 2,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 2,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Tunable smoothing settings shared by the listener and all spatial voices. Owned by AudioManager and reachable as `app.audio.spatial`."
+      ],
+      "importLine": "import { SpatialSmoothingSettings } from '@codexo/exojs'",
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "smoothing",
+          "signature": "smoothing: number",
+          "signatureTokens": [
+            {
+              "text": "smoothing",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Time constant (seconds) passed to setTargetAtTime when ramping a moving position toward its target. 0 (or negative) disables ramping — positions snap each frame. Default DEFAULT_SPATIAL_SMOOTHING (20 ms)."
+        },
+        {
+          "name": "teleportThreshold",
+          "signature": "teleportThreshold: number",
+          "signatureTokens": [
+            {
+              "text": "teleportThreshold",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Position jump (world units) treated as a teleport: the param snaps with setValueAtTime instead of ramping. Default DEFAULT_TELEPORT_THRESHOLD."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/audio/spatial-smoothing.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/audio/spatial-smoothing.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/audio/spatial-smoothing.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/audio/spatial-smoothing.ts"
+}

--- a/src/audio/AudioBus.ts
+++ b/src/audio/AudioBus.ts
@@ -48,6 +48,15 @@ export class AudioBus {
   private readonly _effects: AudioEffect[] = [];
   private _setup: AudioBusSetup | null = null;
   private _scheduledStopId: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * Callbacks queued via {@link AudioBus.onceSetup} while the context is still
+   * locked, flushed once this bus's nodes exist. Kept on the bus (not the global
+   * unlock signal) so pre-gesture deferrals don't accumulate there and are
+   * dropped on {@link AudioBus.destroy} (AU3).
+   */
+  private _pendingSetup: Array<() => void> | null = null;
+  /** Unsubscribe for this bus's deferred connect to a not-yet-ready parent. */
+  private _parentSetupDispose: (() => void) | null = null;
   private readonly _onAudioContextReady = (ctx: AudioContext): void => {
     onAudioContextReady.remove(this._onAudioContextReady);
     this._setupAudio(ctx);
@@ -184,6 +193,11 @@ export class AudioBus {
 
   public destroy(): void {
     onAudioContextReady.remove(this._onAudioContextReady);
+    this._parentSetupDispose?.();
+    this._parentSetupDispose = null;
+    // Drop any setup callbacks still queued on this bus so they neither fire nor
+    // linger after teardown (AU3).
+    this._pendingSetup = null;
     this._clearScheduledStop();
     for (const effect of this._effects) {
       effect.destroy();
@@ -219,6 +233,7 @@ export class AudioBus {
     this._setup = { audioContext, inputNode, outputNode, panNode };
     this._rebuildEffectChain();
     this._connectUpstream();
+    this._flushPendingSetup();
   }
 
   private _connectUpstream(): void {
@@ -228,8 +243,10 @@ export class AudioBus {
       if (parentInput) {
         this._setup.outputNode.connect(parentInput);
       } else {
-        // Parent not yet ready — subscribe to parent's setup
-        this._parent.onceSetup(() => {
+        // Parent not yet ready — subscribe to parent's setup, keeping the
+        // disposer so a teardown before the parent unlocks unsubscribes (AU3).
+        this._parentSetupDispose = this._parent.onceSetup(() => {
+          this._parentSetupDispose = null;
           if (this._setup && this._parent) {
             const node = this._parent._getInputNode();
             if (node) this._setup.outputNode.connect(node);
@@ -241,15 +258,41 @@ export class AudioBus {
     }
   }
 
-  /** Subscribe to the moment this bus's audio nodes are ready. Internal use. */
-  public onceSetup(callback: () => void): void {
+  /** Run every callback queued via {@link AudioBus.onceSetup} now that the nodes exist. */
+  private _flushPendingSetup(): void {
+    const pending = this._pendingSetup;
+    if (pending === null) return;
+    this._pendingSetup = null;
+    for (const callback of pending) {
+      callback();
+    }
+  }
+
+  /**
+   * Run `callback` the moment this bus's audio nodes are ready: immediately if it
+   * is already set up, otherwise queued on the bus and flushed when the context
+   * unlocks. Returns an unsubscribe function that removes the still-pending
+   * callback (a no-op once it has fired). Internal use.
+   *
+   * The queue lives on the bus rather than the global unlock signal, so many
+   * voices deferring a reconnect before the first user gesture do not pile
+   * listeners onto that singleton, and anything torn down pre-unlock drops its
+   * own pending callback (AU3).
+   */
+  public onceSetup(callback: () => void): () => void {
     if (this._setup) {
       callback();
-    } else {
-      onAudioContextReady.once(() => {
-        if (this._setup) callback();
-      });
+      return (): void => undefined;
     }
+
+    const pending = (this._pendingSetup ??= []);
+    pending.push(callback);
+
+    return (): void => {
+      if (this._pendingSetup === null) return;
+      const index = this._pendingSetup.indexOf(callback);
+      if (index !== -1) this._pendingSetup.splice(index, 1);
+    };
   }
 
   private _rebuildEffectChain(): void {

--- a/src/audio/AudioListener.ts
+++ b/src/audio/AudioListener.ts
@@ -3,6 +3,7 @@ import { Vector } from '#math/Vector';
 import type { View } from '#rendering/View';
 
 import { getAudioContext, isAudioContextReady, onAudioContextReady } from './audio-context';
+import { createSpatialSmoothingSettings, SmoothedAudioParam, type SpatialSmoothingSettings } from './spatial-smoothing';
 
 /**
  * Anything {@link AudioListener.target} can be set to. The listener reads
@@ -37,12 +38,22 @@ export class AudioListener {
 
   private _audioListener: WebAudioListener | null = null;
   private _ctx: AudioContext | null = null;
+  private readonly _settings: SpatialSmoothingSettings;
+  private readonly _smoothX = new SmoothedAudioParam();
+  private readonly _smoothY = new SmoothedAudioParam();
+  private readonly _smoothZ = new SmoothedAudioParam();
   private readonly _onAudioContextReady = (ctx: AudioContext): void => {
     onAudioContextReady.remove(this._onAudioContextReady);
     this._setup(ctx);
   };
 
-  public constructor() {
+  /**
+   * @param settings - Shared position-smoothing settings (normally
+   *   `app.audio.spatial`, supplied by {@link AudioManager}). Defaults to a
+   *   fresh settings object with the standard 20 ms time constant when omitted.
+   */
+  public constructor(settings: SpatialSmoothingSettings = createSpatialSmoothingSettings()) {
+    this._settings = settings;
     if (isAudioContextReady()) {
       this._setup(getAudioContext());
     } else {
@@ -64,10 +75,13 @@ export class AudioListener {
         setPosition: (x: number, y: number, z: number) => void;
       }>;
       if (listener.positionX && listener.positionY && listener.positionZ) {
-        listener.positionX.setValueAtTime(this.position.x, t);
-        listener.positionY.setValueAtTime(this.position.y, t);
-        listener.positionZ.setValueAtTime(0, t);
+        // Route through the smoothing layer (setTargetAtTime + epsilon-skip +
+        // teleport-snap) so listener motion never zippers the whole mix (AU4).
+        this._smoothX.write(listener.positionX, this.position.x, t, this._settings);
+        this._smoothY.write(listener.positionY, this.position.y, t, this._settings);
+        this._smoothZ.write(listener.positionZ, 0, t, this._settings);
       } else if (listener.setPosition) {
+        // Legacy AudioParam-less API: snap only (no smoothing available).
         listener.setPosition(this.position.x, this.position.y, 0);
       }
     }

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -9,6 +9,7 @@ import { AudioListener } from './AudioListener';
 import type { SpatialVoice } from './BaseVoice';
 import { InputVoice } from './InputVoice';
 import type { Playable, PlayOptions, Voice } from './Playable';
+import { createSpatialSmoothingSettings, type SpatialSmoothingSettings } from './spatial-smoothing';
 
 /**
  * Per-{@link Application} owner of the audio mix: three pre-configured
@@ -30,6 +31,14 @@ export class AudioManager implements System {
   public readonly sound: AudioBus;
   public readonly listener: AudioListener;
   /**
+   * Tunable smoothing applied to per-frame panner/listener position updates,
+   * shared by the {@link AudioListener} and every spatial voice. Adjust
+   * `smoothing` (the `setTargetAtTime` time constant) or `teleportThreshold`
+   * (the snap-instead-of-ramp jump distance) to trade responsiveness against
+   * zipper-noise suppression (AU4). Reachable as `app.audio.spatial`.
+   */
+  public readonly spatial: SpatialSmoothingSettings = createSpatialSmoothingSettings();
+  /**
    * Fires once when the AudioContext transitions to "running" — i.e. the first
    * user gesture unlocks audio under the browser's autoplay policy. Check
    * {@link AudioManager.locked} for the current state; sounds played while
@@ -45,7 +54,7 @@ export class AudioManager implements System {
     this.master = new AudioBus('master', { parent: null });
     this.music = new AudioBus('music', { parent: this.master });
     this.sound = new AudioBus('sound', { parent: this.master });
-    this.listener = new AudioListener();
+    this.listener = new AudioListener(this.spatial);
 
     // Built-ins are also lookup-able via getBus.
     this._registered.set('master', this.master);

--- a/src/audio/BaseVoice.ts
+++ b/src/audio/BaseVoice.ts
@@ -7,6 +7,7 @@ import type { AudioBus } from './AudioBus';
 import type { AudioEffect } from './AudioEffect';
 import type { AudioManager } from './AudioManager';
 import type { Spatializable, Voice } from './Playable';
+import { SmoothedAudioParam } from './spatial-smoothing';
 
 /** Distance-attenuation configuration for a spatial voice. */
 export interface VoiceSpatialConfig {
@@ -79,6 +80,11 @@ export abstract class BaseVoice implements Voice, Spatializable, SpatialVoice {
   private _position: Vector | null = null;
   private _followNode: SceneNode | null = null;
   private _spatialRegistered = false;
+  private readonly _smoothX = new SmoothedAudioParam();
+  private readonly _smoothY = new SmoothedAudioParam();
+  private readonly _smoothZ = new SmoothedAudioParam();
+  /** Unsubscribe for a deferred bus-reconnect queued while the bus was locked (AU3). */
+  private _pendingBusSetup: (() => void) | null = null;
 
   /** Per-voice effect chain, inserted between the output gain and the bus. */
   private readonly _effects: AudioEffect[] = [];
@@ -270,10 +276,14 @@ export abstract class BaseVoice implements Voice, Spatializable, SpatialVoice {
     }>;
     const t = this._audioContext.currentTime;
     if (panner.positionX) {
-      panner.positionX.setValueAtTime(x, t);
-      panner.positionY!.setValueAtTime(y, t);
-      panner.positionZ!.setValueAtTime(0, t);
+      // Route through the smoothing layer (setTargetAtTime + epsilon-skip +
+      // teleport-snap) to eliminate per-frame zipper noise on moving sources (AU4).
+      const settings = this._manager.spatial;
+      this._smoothX.write(panner.positionX, x, t, settings);
+      this._smoothY.write(panner.positionY!, y, t, settings);
+      this._smoothZ.write(panner.positionZ!, 0, t, settings);
     } else if (panner.setPosition) {
+      // Legacy AudioParam-less API: snap only (no smoothing available).
       panner.setPosition(x, y, 0);
     }
   }
@@ -301,9 +311,14 @@ export abstract class BaseVoice implements Voice, Spatializable, SpatialVoice {
     }
 
     // Bus not set up yet (AudioContext still locked) — route to the destination
-    // for now and reconnect to the bus once it comes online.
+    // for now and reconnect to the bus once it comes online. Keep the disposer
+    // and drop any previous pending reconnect so a voice deferring repeatedly
+    // (or ending) before the first gesture never leaves stale callbacks queued
+    // on the bus (AU3).
     tail.connect(this._audioContext.destination);
-    this._bus.onceSetup((): void => {
+    this._pendingBusSetup?.();
+    this._pendingBusSetup = this._bus.onceSetup((): void => {
+      this._pendingBusSetup = null;
       if (this._ended) return;
       const node = this._bus._getInputNode();
       if (node !== null) {
@@ -365,6 +380,11 @@ export abstract class BaseVoice implements Voice, Spatializable, SpatialVoice {
     if (this._ended) return;
     this._ended = true;
     this._clearStopTimer();
+
+    // Drop a still-pending deferred bus reconnect so it doesn't linger on the
+    // bus (or fire) after this voice ends pre-unlock (AU3).
+    this._pendingBusSetup?.();
+    this._pendingBusSetup = null;
 
     this._teardownSource();
     this._panner?.disconnect();

--- a/src/audio/audio-context.ts
+++ b/src/audio/audio-context.ts
@@ -6,6 +6,15 @@ interface AudioContextEventTarget {
 
 const interactionEvents = ['mousedown', 'touchstart', 'touchend', 'keydown'] as const;
 
+/**
+ * Sample rate used for the decoding {@link OfflineAudioContext} when no live
+ * {@link AudioContext} exists yet. 44.1 kHz is universally supported; decoded
+ * buffers at this rate are transparently resampled by any playback context that
+ * later runs at a different rate, so this never forces a live context into
+ * existence merely to decode audio before the first user gesture (AU2).
+ */
+const DEFAULT_SAMPLE_RATE = 44100;
+
 let internalAudioContext: AudioContext | null = null;
 let internalOfflineAudioContext: OfflineAudioContext | null = null;
 let interactionListenersAdded = false;
@@ -36,9 +45,14 @@ const getOrCreateOfflineAudioContext = (): OfflineAudioContext => {
   }
 
   if (internalOfflineAudioContext === null) {
-    const audioContext = getOrCreateAudioContext();
+    // Derive the sample rate from an already-live context when one exists, but
+    // never CREATE one just to read `sampleRate` — decoding audio at load time
+    // (before any user gesture) must not spawn a suspended live AudioContext
+    // (AU2). Buffers decoded at DEFAULT_SAMPLE_RATE resample transparently on
+    // playback if the live context later runs at a different rate.
+    const sampleRate = internalAudioContext?.sampleRate ?? DEFAULT_SAMPLE_RATE;
 
-    internalOfflineAudioContext = new OfflineAudioContext(1, 2, audioContext.sampleRate);
+    internalOfflineAudioContext = new OfflineAudioContext(1, 2, sampleRate);
   }
 
   return internalOfflineAudioContext;
@@ -84,16 +98,26 @@ const addInteractionListeners = (): void => {
   interactionListenersAdded = true;
 };
 
-const ensureAudioContextReadyMonitoring = (): void => {
-  const audioContext = getOrCreateAudioContext();
+const ensureStateChangeListener = (audioContext: AudioContext): void => {
   const audioContextEventTarget = audioContext as unknown as AudioContextEventTarget;
 
   if (!stateChangeListenerAdded && typeof audioContextEventTarget.addEventListener === 'function') {
     audioContextEventTarget.addEventListener('statechange', onAudioContextStateChange);
     stateChangeListenerAdded = true;
   }
+};
 
-  dispatchReadyIfRunning();
+const ensureAudioContextReadyMonitoring = (): void => {
+  // Do NOT create a live AudioContext here — merely observing readiness must not
+  // spawn a suspended context before the first user gesture (AU2). If a context
+  // already exists (created explicitly via getAudioContext, or on the first
+  // gesture) wire up its statechange listener and check whether it is running.
+  const audioContext = getExistingAudioContext();
+
+  if (audioContext !== null) {
+    ensureStateChangeListener(audioContext);
+    dispatchReadyIfRunning();
+  }
 
   if (!readyDispatched) {
     addInteractionListeners();
@@ -101,7 +125,10 @@ const ensureAudioContextReadyMonitoring = (): void => {
 };
 
 const onUserInteraction = (): void => {
+  // The first gesture is where the live context is finally created and resumed —
+  // the browser's autoplay policy requires resume() to run inside a user gesture.
   const audioContext = getOrCreateAudioContext();
+  ensureStateChangeListener(audioContext);
 
   if (audioContext.state === 'running') {
     dispatchReadyIfRunning();
@@ -182,15 +209,18 @@ export const isAudioContextReady = (): boolean => {
 
 /**
  * Return the shared singleton `OfflineAudioContext` used for audio decoding.
- * Its sample rate matches the live `AudioContext`. Creates the live context
- * as a side effect if it does not exist yet.
+ * Its sample rate matches the live `AudioContext` when one already exists,
+ * otherwise a 44.1 kHz default is used. Never creates a live `AudioContext` —
+ * decoding before the first user gesture must not spawn a suspended context
+ * (AU2); buffers resample transparently on playback if the rates differ.
  */
 export const getOfflineAudioContext = (): OfflineAudioContext => getOrCreateOfflineAudioContext();
 
 /**
  * Decode raw audio bytes into an `AudioBuffer` using the shared
- * `OfflineAudioContext`. The context's sample rate is derived from the live
- * `AudioContext`, ensuring decoded buffers are compatible with playback nodes.
+ * `OfflineAudioContext`. The context's sample rate matches the live
+ * `AudioContext` when one exists, else defaults to 44.1 kHz — decoding never
+ * forces a live context into existence.
  *
  * Note: on some older mobile WebKit versions `decodeAudioData` requires a
  * running (live) context — decoding may fail with a browser-level error rather

--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -19,5 +19,6 @@ export { HighpassFilter, LowpassFilter } from './filters';
 export type { Loopable, Pausable, Playable, PlayOptions, RatePitched, Seekable, Spatializable, Voice } from './Playable';
 export type { AudioSpriteClip, DistanceModel, SoundOptions, SoundPlayOptions } from './Sound';
 export { Sound, SoundPoolStrategy } from './Sound';
+export type { SpatialSmoothingSettings } from './spatial-smoothing';
 export { WorkletEffect } from './WorkletEffect';
 export { registerAudioWorkletProcessor } from '#audio/worklet/registerWorklet';

--- a/src/audio/spatial-smoothing.ts
+++ b/src/audio/spatial-smoothing.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared position-smoothing layer for spatial audio. Both the
+ * {@link AudioListener} and every spatial {@link BaseVoice} write their
+ * per-frame `positionX/Y/Z` (and, in future, orientation) `AudioParam`s through
+ * this layer instead of calling `setValueAtTime` directly every frame.
+ *
+ * Writing a raw stepwise value each frame produces audible zipper noise on fast
+ * movement (expert-review finding AU4). Instead each param is:
+ * - **skipped** when the new value is within {@link POSITION_EPSILON} of the last
+ *   written value (a stationary emitter costs zero param scheduling after its
+ *   first frame), and
+ * - **snapped** with `setValueAtTime` on the first write and on a teleport (a
+ *   jump larger than {@link SpatialSmoothingSettings.teleportThreshold}), so a
+ *   warp does not audibly glide across the stereo field, or
+ * - **ramped** with `setTargetAtTime` toward the target using the configured
+ *   time constant, which is robust to a variable frame rate and converges within
+ *   ~3τ.
+ *
+ * This is the tactical smoothing layer for today's panner/listener surface; the
+ * forthcoming 3D-spatializer design (`S2-audio-spatializer`) extends the same
+ * settings object with distance/panning defaults.
+ */
+
+/** Time constant (seconds) for `setTargetAtTime`. 20 ms — see module docs. */
+export const DEFAULT_SPATIAL_SMOOTHING = 0.02;
+
+/** Position jump (world units) treated as a teleport → snap instead of ramp. */
+export const DEFAULT_TELEPORT_THRESHOLD = 400;
+
+/**
+ * Position deltas below this (world units) are treated as stationary and skipped
+ * entirely, so a static emitter/listener stops scheduling params after its first
+ * frame.
+ */
+export const POSITION_EPSILON = 0.01;
+
+/**
+ * Tunable smoothing settings shared by the listener and all spatial voices. Owned
+ * by {@link AudioManager} and reachable as `app.audio.spatial`.
+ */
+export interface SpatialSmoothingSettings {
+  /**
+   * Time constant (seconds) passed to `setTargetAtTime` when ramping a moving
+   * position toward its target. `0` (or negative) disables ramping — positions
+   * snap each frame. Default {@link DEFAULT_SPATIAL_SMOOTHING} (20 ms).
+   */
+  smoothing: number;
+  /**
+   * Position jump (world units) treated as a teleport: the param snaps with
+   * `setValueAtTime` instead of ramping. Default
+   * {@link DEFAULT_TELEPORT_THRESHOLD}.
+   */
+  teleportThreshold: number;
+}
+
+/** Construct the default spatial smoothing settings. */
+export const createSpatialSmoothingSettings = (): SpatialSmoothingSettings => ({
+  smoothing: DEFAULT_SPATIAL_SMOOTHING,
+  teleportThreshold: DEFAULT_TELEPORT_THRESHOLD,
+});
+
+/**
+ * Tracks the last value written to a single `AudioParam` so per-frame updates can
+ * be epsilon-skipped, snapped, or ramped (see module docs). One instance per
+ * scalar param (x / y / z). Allocation-free on the hot path.
+ */
+export class SmoothedAudioParam {
+  private _last = 0;
+  private _hasWritten = false;
+
+  /**
+   * Write `value` to `param` at time `now`, applying epsilon-skip / teleport-snap
+   * / ramp according to `settings`.
+   */
+  public write(param: AudioParam, value: number, now: number, settings: SpatialSmoothingSettings): void {
+    if (this._hasWritten && Math.abs(value - this._last) < POSITION_EPSILON) {
+      return;
+    }
+
+    if (!this._hasWritten || settings.smoothing <= 0 || Math.abs(value - this._last) > settings.teleportThreshold) {
+      param.cancelScheduledValues(now);
+      param.setValueAtTime(value, now);
+    } else {
+      param.setTargetAtTime(value, now, settings.smoothing);
+    }
+
+    this._last = value;
+    this._hasWritten = true;
+  }
+
+  /** Forget the last written value so the next write snaps (used on teardown / reuse). */
+  public reset(): void {
+    this._hasWritten = false;
+    this._last = 0;
+  }
+}

--- a/test/audio/audio-bus.test.ts
+++ b/test/audio/audio-bus.test.ts
@@ -570,7 +570,7 @@ describe('AudioBus', () => {
     bus.destroy();
   });
 
-  test('onceSetup() defers the callback via onAudioContextReady.once() when not yet set up, and skips it if still not set up when that fires', async () => {
+  test('onceSetup() queues the callback on the bus (NOT the global unlock signal) while locked — no per-callback accumulation (AU3)', async () => {
     vi.resetModules();
     const fakeSignal = new Signal<[AudioContext]>();
 
@@ -582,21 +582,51 @@ describe('AudioBus', () => {
 
     const { AudioBus: DeferredAudioBus } = await import('#audio/AudioBus');
     const bus = new DeferredAudioBus('deferred-once-setup');
+
+    // The bus's own setup handler is the ONLY listener on the global signal.
+    // onceSetup must not add another per registered callback — deferrals are
+    // queued on the bus itself, so a chatty pre-unlock game does not pile
+    // closures onto the singleton (AU3).
+    const countAfterConstruct = fakeSignal.count;
+    bus.onceSetup(vi.fn());
+    bus.onceSetup(vi.fn());
+    bus.onceSetup(vi.fn());
+    expect(fakeSignal.count).toBe(countAfterConstruct);
+
+    vi.doUnmock('#audio/audio-context');
+    vi.resetModules();
+  });
+
+  test('onceSetup() drops a still-pending callback on destroy() so it never fires (AU3 leak fix)', async () => {
+    vi.resetModules();
+    const fakeSignal = new Signal<[AudioContext]>();
+
+    const makeFakeGain = () => ({ connect: vi.fn(), disconnect: vi.fn(), gain: { setTargetAtTime: vi.fn() } });
+    const fakeCtx = {
+      currentTime: 0,
+      destination: {},
+      createGain: makeFakeGain,
+      createStereoPanner: () => ({ connect: vi.fn(), disconnect: vi.fn(), pan: { setTargetAtTime: vi.fn() } }),
+    } as unknown as AudioContext;
+
+    vi.doMock('#audio/audio-context', () => ({
+      getAudioContext: () => fakeCtx,
+      isAudioContextReady: () => false,
+      onAudioContextReady: fakeSignal,
+    }));
+
+    const { AudioBus: DeferredAudioBus } = await import('#audio/AudioBus');
+    const bus = new DeferredAudioBus('deferred-destroyed');
     const callback = vi.fn();
 
-    // Remove the bus's own pending `_onAudioContextReady` subscription so it
-    // never sets up (simulates a bus whose own setup is stuck / far off) —
-    // isolating onceSetup()'s independent deferred-check behavior below.
-    const ownHandler = (bus as unknown as { _onAudioContextReady: (ctx: AudioContext) => void })._onAudioContextReady;
-    fakeSignal.remove(ownHandler);
-
-    const countBeforeOnceSetup = fakeSignal.count;
     bus.onceSetup(callback);
-    expect(fakeSignal.count).toBe(countBeforeOnceSetup + 1);
+    // Destroying before the context unlocks drops the queued callback...
+    bus.destroy();
 
-    // The global "ready" event fires, but this bus is STILL not set up — the
-    // once-handler's internal `if (this._setup)` guard must skip the callback.
-    fakeSignal.dispatch({} as AudioContext);
+    // ...so when the bus would have set up, nothing fires.
+    const ready = (bus as unknown as { _onAudioContextReady: (ctx: AudioContext) => void })._onAudioContextReady;
+    ready(fakeCtx);
+    fakeSignal.dispatch(fakeCtx);
 
     expect(callback).not.toHaveBeenCalled();
 
@@ -604,9 +634,48 @@ describe('AudioBus', () => {
     vi.resetModules();
   });
 
+  test('onceSetup() flushes queued callbacks once the bus sets up (AU3)', async () => {
+    vi.resetModules();
+    const fakeSignal = new Signal<[AudioContext]>();
+
+    const makeFakeGain = () => ({ connect: vi.fn(), disconnect: vi.fn(), gain: { setTargetAtTime: vi.fn() } });
+    const fakeCtx = {
+      currentTime: 0,
+      destination: {},
+      createGain: makeFakeGain,
+      createStereoPanner: () => ({ connect: vi.fn(), disconnect: vi.fn(), pan: { setTargetAtTime: vi.fn() } }),
+    } as unknown as AudioContext;
+
+    vi.doMock('#audio/audio-context', () => ({
+      getAudioContext: () => fakeCtx,
+      isAudioContextReady: () => false,
+      onAudioContextReady: fakeSignal,
+    }));
+
+    const { AudioBus: DeferredAudioBus } = await import('#audio/AudioBus');
+    const bus = new DeferredAudioBus('deferred-flush');
+    const callback = vi.fn();
+
+    bus.onceSetup(callback);
+    expect(callback).not.toHaveBeenCalled();
+
+    // The bus sets up when the context unlocks — its queued callbacks flush then.
+    const ready = (bus as unknown as { _onAudioContextReady: (ctx: AudioContext) => void })._onAudioContextReady;
+    ready(fakeCtx);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // The unsubscribe handle is inert once the callback has fired.
+    const dispose = bus.onceSetup(vi.fn()); // already set up → fires immediately, returns a no-op disposer
+    expect(() => dispose()).not.toThrow();
+
+    vi.doUnmock('#audio/audio-context');
+    vi.resetModules();
+  });
+
   // ---- _connectUpstream(): parent not yet set up -> subscribe, then connect once it is ----
 
-  test('a child bus whose parent is not yet set up subscribes via onceSetup and connects once the parent becomes ready', async () => {
+  test('a child bus whose parent is not yet set up subscribes via onceSetup and connects when the parent sets up (flush)', async () => {
     vi.resetModules();
     const fakeSignal = new Signal<[AudioContext]>();
 
@@ -642,21 +711,17 @@ describe('AudioBus', () => {
     childReady(fakeCtx);
     expect(child._getInputNode()).not.toBeNull();
     expect(parent._getInputNode()).toBeNull();
-    // The child's output has not been connected upstream yet.
+    // The child's output has not been connected upstream yet — it queued a
+    // reconnect on the parent via parent.onceSetup(...).
     const childOutput = child._getOutputNode() as unknown as { connect: MockInstance };
     expect(childOutput.connect).not.toHaveBeenCalled();
 
-    // Now the parent becomes ready — its own setup runs, and (deferred from
-    // above) the pending onceSetup subscription registered on the shared
-    // signal is still pending.
+    // Now the parent becomes ready — its own setup runs and flushes the queued
+    // onceSetup callback, which connects the child's output into the parent's
+    // freshly-created input node (AU3: the flush happens on the bus's own setup,
+    // not on a separate global dispatch).
     parentReady(fakeCtx);
     expect(parent._getInputNode()).not.toBeNull();
-
-    // Firing the shared signal again runs the once-handler registered by
-    // onceSetup, which — now that the parent is set up — connects the child's
-    // output into the parent's input node.
-    fakeSignal.dispatch(fakeCtx);
-
     expect(childOutput.connect).toHaveBeenCalledWith(parent._getInputNode());
 
     vi.doUnmock('#audio/audio-context');

--- a/test/audio/audio-context.test.ts
+++ b/test/audio/audio-context.test.ts
@@ -63,7 +63,7 @@ describe('audio/audio-context — getOfflineAudioContext()', () => {
     vi.resetModules();
   });
 
-  it('returns a lazily-created singleton, reused across repeated calls (public wrapper)', async () => {
+  it('returns a lazily-created singleton, reused across repeated calls, WITHOUT spawning a live context (AU2)', async () => {
     let audioContextCreations = 0;
     let offlineCreations = 0;
 
@@ -98,8 +98,12 @@ describe('audio/audio-context — getOfflineAudioContext()', () => {
     const second = getOfflineAudioContext();
 
     expect(second).toBe(first);
-    expect(audioContextCreations).toBe(1); // the live context is created once as a side effect
+    // Decoding must NOT force a live AudioContext into existence — it falls back
+    // to the default 44.1 kHz sample rate before any gesture (AU2).
+    expect(audioContextCreations).toBe(0);
     expect(offlineCreations).toBe(1);
+    // The default sample rate is used when no live context exists yet.
+    expect((first as unknown as { sampleRate: number }).sampleRate).toBe(44100);
   });
 });
 

--- a/test/audio/audio-listener.test.ts
+++ b/test/audio/audio-listener.test.ts
@@ -158,6 +158,37 @@ describe('AudioListener', () => {
     listener.destroy();
   });
 
+  // AU4: listener position writes go through the smoothing layer — first write
+  // snaps, an ordinary move ramps (setTargetAtTime, no zipper), and a stationary
+  // listener is not re-written each frame (epsilon-skip).
+  test('_tick() snaps the first position, ramps a move, and skips a stationary listener (AU4)', () => {
+    const listener = new AudioListener();
+    const l = getListenerMock() as unknown as {
+      positionX: { setValueAtTime: MockInstance; setTargetAtTime: MockInstance; cancelScheduledValues: MockInstance };
+    };
+
+    // First tick: snap into place with setValueAtTime, never a ramp.
+    listener.target = { x: 100, y: 0 };
+    listener._tick();
+    expect(l.positionX.setValueAtTime).toHaveBeenCalledWith(100, expect.any(Number));
+    expect(l.positionX.setTargetAtTime).not.toHaveBeenCalled();
+
+    // Move a little: ramp toward the target with setTargetAtTime.
+    l.positionX.setValueAtTime.mockClear();
+    listener.target = { x: 130, y: 0 };
+    listener._tick();
+    expect(l.positionX.setTargetAtTime).toHaveBeenCalledWith(130, expect.any(Number), expect.any(Number));
+    expect(l.positionX.setValueAtTime).not.toHaveBeenCalled();
+
+    // Stationary: no further scheduling.
+    l.positionX.setTargetAtTime.mockClear();
+    listener._tick();
+    expect(l.positionX.setTargetAtTime).not.toHaveBeenCalled();
+    expect(l.positionX.setValueAtTime).not.toHaveBeenCalled();
+
+    listener.destroy();
+  });
+
   // 7. Setup writes orientation (forward = -Z, up = +Y)
   test('construction sets up 2D orientation: forward (0,0,-1) and up (0,1,0)', () => {
     // The _setup method is called synchronously when AudioContext is running.

--- a/test/audio/audio-manager-update.test.ts
+++ b/test/audio/audio-manager-update.test.ts
@@ -25,9 +25,9 @@ const setupPannerSpy = () => {
         maxDistance: 10000,
         refDistance: 1,
         rolloffFactor: 1,
-        positionX: { setValueAtTime: vi.fn() },
-        positionY: { setValueAtTime: vi.fn() },
-        positionZ: { setValueAtTime: vi.fn() },
+        positionX: { setValueAtTime: vi.fn(), setTargetAtTime: vi.fn(), cancelScheduledValues: vi.fn() },
+        positionY: { setValueAtTime: vi.fn(), setTargetAtTime: vi.fn(), cancelScheduledValues: vi.fn() },
+        positionZ: { setValueAtTime: vi.fn(), setTargetAtTime: vi.fn(), cancelScheduledValues: vi.fn() },
       }) as unknown as PannerNode,
   );
   return { restore: () => spy.mockRestore() };

--- a/test/audio/audio-manager.test.ts
+++ b/test/audio/audio-manager.test.ts
@@ -1,4 +1,5 @@
-﻿import { AudioBus } from '#audio/AudioBus';
+﻿import { getAudioContext } from '#audio/audio-context';
+import { AudioBus } from '#audio/AudioBus';
 import { AudioManager } from '#audio/AudioManager';
 import { Signal } from '#core/Signal';
 
@@ -244,11 +245,13 @@ describe('AudioManager', () => {
   });
 
   test('onUnlock fires (once, async) for an AudioManager built while the shared AudioContext is already running', async () => {
-    // Our global test AudioContext mock starts 'running' immediately, so this
-    // mirrors "an AudioManager constructed after the context has already
-    // unlocked" — e.g. a second Application in the same process. The one-shot
-    // module-global ready signal has already fired by then, so the manager
-    // dispatches its own unlock on a microtask instead.
+    // Our global test AudioContext mock starts 'running' immediately. Creating
+    // the shared context explicitly first (as an earlier gesture / explicit
+    // getAudioContext would) mirrors "an AudioManager constructed after the
+    // context has already unlocked" — e.g. a second Application in the same
+    // process. The one-shot module-global ready signal has already fired by
+    // then, so the manager dispatches its own unlock on a microtask instead.
+    getAudioContext();
     const mixer = new AudioManager();
     expect(mixer.locked).toBe(false);
 

--- a/test/audio/base-voice.test.ts
+++ b/test/audio/base-voice.test.ts
@@ -105,9 +105,9 @@ interface MockPanner {
   maxDistance: number;
   refDistance: number;
   rolloffFactor: number;
-  positionX: { setValueAtTime: MockInstance };
-  positionY: { setValueAtTime: MockInstance };
-  positionZ: { setValueAtTime: MockInstance };
+  positionX: { setValueAtTime: MockInstance; setTargetAtTime: MockInstance; cancelScheduledValues: MockInstance };
+  positionY: { setValueAtTime: MockInstance; setTargetAtTime: MockInstance; cancelScheduledValues: MockInstance };
+  positionZ: { setValueAtTime: MockInstance; setTargetAtTime: MockInstance; cancelScheduledValues: MockInstance };
 }
 
 const setupPannerSpy = (): { panners: MockPanner[]; restore: () => void } => {
@@ -122,9 +122,9 @@ const setupPannerSpy = (): { panners: MockPanner[]; restore: () => void } => {
       maxDistance: 10000,
       refDistance: 1,
       rolloffFactor: 1,
-      positionX: { setValueAtTime: vi.fn() },
-      positionY: { setValueAtTime: vi.fn() },
-      positionZ: { setValueAtTime: vi.fn() },
+      positionX: { setValueAtTime: vi.fn(), setTargetAtTime: vi.fn(), cancelScheduledValues: vi.fn() },
+      positionY: { setValueAtTime: vi.fn(), setTargetAtTime: vi.fn(), cancelScheduledValues: vi.fn() },
+      positionZ: { setValueAtTime: vi.fn(), setTargetAtTime: vi.fn(), cancelScheduledValues: vi.fn() },
     };
     panners.push(panner);
     return panner as unknown as PannerNode;
@@ -555,6 +555,39 @@ describe('BaseVoice — deferred bus connect while the bus is not yet set up', (
 
     output.restore();
     factory.restore();
+    sound.destroy();
+  });
+
+  // AU3: many short voices played before the first user gesture must not pile
+  // deferred-reconnect closures onto the global unlock signal, and a voice that
+  // ends before unlock must drop its pending reconnect from the bus.
+  test('pre-unlock voices queue their deferred reconnect on the bus (not the global signal), and drop it on stop() (AU3)', () => {
+    const factory = setupSourceSpy();
+    const manager = new AudioManager();
+    const ctx = getAudioContext();
+
+    const originalState = ctx.state;
+    ctx.state = 'suspended';
+    const bus = new AudioBus('deferred-accumulation', { parent: null });
+
+    const pendingCount = (): number => (bus as unknown as { _pendingSetup: unknown[] | null })._pendingSetup?.length ?? 0;
+    const signalCountBefore = onAudioContextReady.count;
+
+    const sound = new Sound(createAudioBufferStub());
+    const voices = [manager.play(sound, { bus }), manager.play(sound, { bus }), manager.play(sound, { bus })];
+
+    // Each voice queued exactly one reconnect on the BUS; the global unlock
+    // signal did not grow per voice (only the bus's own subscription lives there).
+    expect(pendingCount()).toBe(3);
+    expect(onAudioContextReady.count).toBe(signalCountBefore);
+
+    // Ending the voices before unlock unsubscribes their queued reconnects.
+    for (const voice of voices) voice.stop();
+    expect(pendingCount()).toBe(0);
+
+    ctx.state = originalState;
+    factory.restore();
+    bus.destroy();
     sound.destroy();
   });
 });

--- a/test/audio/sound-spatial.test.ts
+++ b/test/audio/sound-spatial.test.ts
@@ -23,9 +23,9 @@ interface MockPannerNode {
   maxDistance: number;
   refDistance: number;
   rolloffFactor: number;
-  positionX: { setValueAtTime: MockInstance };
-  positionY: { setValueAtTime: MockInstance };
-  positionZ: { setValueAtTime: MockInstance };
+  positionX: { setValueAtTime: MockInstance; setTargetAtTime: MockInstance; cancelScheduledValues: MockInstance };
+  positionY: { setValueAtTime: MockInstance; setTargetAtTime: MockInstance; cancelScheduledValues: MockInstance };
+  positionZ: { setValueAtTime: MockInstance; setTargetAtTime: MockInstance; cancelScheduledValues: MockInstance };
 }
 
 const setupPannerSpy = (): {
@@ -44,9 +44,9 @@ const setupPannerSpy = (): {
       maxDistance: 10000,
       refDistance: 1,
       rolloffFactor: 1,
-      positionX: { setValueAtTime: vi.fn() },
-      positionY: { setValueAtTime: vi.fn() },
-      positionZ: { setValueAtTime: vi.fn() },
+      positionX: { setValueAtTime: vi.fn(), setTargetAtTime: vi.fn(), cancelScheduledValues: vi.fn() },
+      positionY: { setValueAtTime: vi.fn(), setTargetAtTime: vi.fn(), cancelScheduledValues: vi.fn() },
+      positionZ: { setValueAtTime: vi.fn(), setTargetAtTime: vi.fn(), cancelScheduledValues: vi.fn() },
     };
     panners.push(panner);
     return panner as unknown as PannerNode;
@@ -129,21 +129,28 @@ describe('Sound — spatial (PannerNode)', () => {
     sound.destroy();
   });
 
-  // 4. update() calls _tickSpatial with position coordinates
-  test('update() writes sound.position x/y to PannerNode', () => {
+  // 4. Position is written to the panner: the first write snaps it into place,
+  // and a stationary source is not re-written every frame (epsilon-skip, AU4).
+  test('update() writes sound.position x/y to PannerNode, then skips a stationary source', () => {
     const spy = setupPannerSpy();
     const mixer = new AudioManager();
     const sound = new Sound(createAudioBufferStub());
     sound.position = { x: 55, y: 66 };
     mixer.play(sound);
     const panner = spy.panners[0];
-    panner.positionX.setValueAtTime.mockClear();
-    panner.positionY.setValueAtTime.mockClear();
-    panner.positionZ.setValueAtTime.mockClear();
-    mixer.update();
+
+    // The first spatial write (at play time) snaps the position into place.
     expect(panner.positionX.setValueAtTime).toHaveBeenCalledWith(55, expect.any(Number));
     expect(panner.positionY.setValueAtTime).toHaveBeenCalledWith(66, expect.any(Number));
     expect(panner.positionZ.setValueAtTime).toHaveBeenCalledWith(0, expect.any(Number));
+
+    // Stationary → no further param scheduling on the next frame.
+    panner.positionX.setValueAtTime.mockClear();
+    panner.positionX.setTargetAtTime.mockClear();
+    mixer.update();
+    expect(panner.positionX.setValueAtTime).not.toHaveBeenCalled();
+    expect(panner.positionX.setTargetAtTime).not.toHaveBeenCalled();
+
     spy.restore();
     sound.destroy();
   });
@@ -301,15 +308,16 @@ describe('Sound — spatial (PannerNode)', () => {
     expect(panner.positionX.setValueAtTime).toHaveBeenCalledWith(305, expect.any(Number));
     expect(panner.positionY.setValueAtTime).toHaveBeenCalledWith(406, expect.any(Number));
 
-    // A group move (camera pan) is picked up on the next spatial tick.
+    // A group move (camera pan) is picked up on the next spatial tick — a
+    // moderate move ramps smoothly (setTargetAtTime) rather than snapping (AU4).
     group.setPosition(-100, 0);
-    panner.positionX.setValueAtTime.mockClear();
-    panner.positionY.setValueAtTime.mockClear();
+    panner.positionX.setTargetAtTime.mockClear();
+    panner.positionY.setTargetAtTime.mockClear();
 
     voice._tickSpatial();
 
-    expect(panner.positionX.setValueAtTime).toHaveBeenCalledWith(-95, expect.any(Number));
-    expect(panner.positionY.setValueAtTime).toHaveBeenCalledWith(6, expect.any(Number));
+    expect(panner.positionX.setTargetAtTime).toHaveBeenCalledWith(-95, expect.any(Number), expect.any(Number));
+    expect(panner.positionY.setTargetAtTime).toHaveBeenCalledWith(6, expect.any(Number), expect.any(Number));
 
     spy.restore();
     group.destroy();

--- a/test/audio/sound-voice.test.ts
+++ b/test/audio/sound-voice.test.ts
@@ -62,10 +62,22 @@ interface MockPanner {
   maxDistance: number;
   refDistance: number;
   rolloffFactor: number;
-  positionX: { setValueAtTime: MockInstance };
-  positionY: { setValueAtTime: MockInstance };
-  positionZ: { setValueAtTime: MockInstance };
+  positionX: SpatialParamMock;
+  positionY: SpatialParamMock;
+  positionZ: SpatialParamMock;
 }
+
+interface SpatialParamMock {
+  setValueAtTime: MockInstance;
+  setTargetAtTime: MockInstance;
+  cancelScheduledValues: MockInstance;
+}
+
+const makeSpatialParamMock = (): SpatialParamMock => ({
+  setValueAtTime: vi.fn(),
+  setTargetAtTime: vi.fn(),
+  cancelScheduledValues: vi.fn(),
+});
 
 const setupPannerSpy = (): { panners: MockPanner[]; restore: () => void } => {
   const ctx = getAudioContext() as AudioContext & { createPanner: () => PannerNode };
@@ -79,9 +91,9 @@ const setupPannerSpy = (): { panners: MockPanner[]; restore: () => void } => {
       maxDistance: 10000,
       refDistance: 1,
       rolloffFactor: 1,
-      positionX: { setValueAtTime: vi.fn() },
-      positionY: { setValueAtTime: vi.fn() },
-      positionZ: { setValueAtTime: vi.fn() },
+      positionX: makeSpatialParamMock(),
+      positionY: makeSpatialParamMock(),
+      positionZ: makeSpatialParamMock(),
     };
     panners.push(panner);
     return panner as unknown as PannerNode;

--- a/test/audio/spatial-smoothing.test.ts
+++ b/test/audio/spatial-smoothing.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for the shared spatial position-smoothing layer
+ * (`src/audio/spatial-smoothing.ts`) that fixes AU4 zipper noise: epsilon-skip
+ * for stationary emitters, teleport-snap on large jumps, and `setTargetAtTime`
+ * ramping for ordinary movement.
+ */
+
+import {
+  createSpatialSmoothingSettings,
+  DEFAULT_SPATIAL_SMOOTHING,
+  DEFAULT_TELEPORT_THRESHOLD,
+  POSITION_EPSILON,
+  SmoothedAudioParam,
+  type SpatialSmoothingSettings,
+} from '#audio/spatial-smoothing';
+
+interface MockParam {
+  setValueAtTime: MockInstance;
+  setTargetAtTime: MockInstance;
+  cancelScheduledValues: MockInstance;
+}
+
+const makeParam = (): MockParam => ({
+  setValueAtTime: vi.fn(),
+  setTargetAtTime: vi.fn(),
+  cancelScheduledValues: vi.fn(),
+});
+
+describe('spatial-smoothing — defaults', () => {
+  test('createSpatialSmoothingSettings() returns the documented defaults', () => {
+    const settings = createSpatialSmoothingSettings();
+    expect(settings.smoothing).toBe(DEFAULT_SPATIAL_SMOOTHING);
+    expect(settings.teleportThreshold).toBe(DEFAULT_TELEPORT_THRESHOLD);
+    expect(DEFAULT_SPATIAL_SMOOTHING).toBe(0.02);
+    expect(DEFAULT_TELEPORT_THRESHOLD).toBe(400);
+  });
+});
+
+describe('SmoothedAudioParam', () => {
+  let settings: SpatialSmoothingSettings;
+
+  beforeEach(() => {
+    settings = createSpatialSmoothingSettings();
+  });
+
+  test('first write snaps with setValueAtTime (never a ramp)', () => {
+    const p = makeParam();
+    const s = new SmoothedAudioParam();
+
+    s.write(p as unknown as AudioParam, 100, 0, settings);
+
+    expect(p.setValueAtTime).toHaveBeenCalledWith(100, 0);
+    expect(p.cancelScheduledValues).toHaveBeenCalledWith(0);
+    expect(p.setTargetAtTime).not.toHaveBeenCalled();
+  });
+
+  test('a small subsequent move ramps with setTargetAtTime (no zipper)', () => {
+    const p = makeParam();
+    const s = new SmoothedAudioParam();
+
+    s.write(p as unknown as AudioParam, 100, 0, settings);
+    p.setValueAtTime.mockClear();
+    p.setTargetAtTime.mockClear();
+
+    s.write(p as unknown as AudioParam, 150, 0.016, settings);
+
+    expect(p.setTargetAtTime).toHaveBeenCalledWith(150, 0.016, DEFAULT_SPATIAL_SMOOTHING);
+    expect(p.setValueAtTime).not.toHaveBeenCalled();
+  });
+
+  test('a stationary value (within epsilon) is skipped entirely', () => {
+    const p = makeParam();
+    const s = new SmoothedAudioParam();
+
+    s.write(p as unknown as AudioParam, 100, 0, settings);
+    p.setValueAtTime.mockClear();
+    p.setTargetAtTime.mockClear();
+    p.cancelScheduledValues.mockClear();
+
+    // Move by less than POSITION_EPSILON — treated as stationary.
+    s.write(p as unknown as AudioParam, 100 + POSITION_EPSILON / 2, 0.016, settings);
+
+    expect(p.setValueAtTime).not.toHaveBeenCalled();
+    expect(p.setTargetAtTime).not.toHaveBeenCalled();
+    expect(p.cancelScheduledValues).not.toHaveBeenCalled();
+  });
+
+  test('a jump larger than teleportThreshold snaps instead of ramping', () => {
+    const p = makeParam();
+    const s = new SmoothedAudioParam();
+
+    s.write(p as unknown as AudioParam, 0, 0, settings);
+    p.setValueAtTime.mockClear();
+    p.setTargetAtTime.mockClear();
+
+    s.write(p as unknown as AudioParam, DEFAULT_TELEPORT_THRESHOLD + 1, 0.016, settings);
+
+    expect(p.setValueAtTime).toHaveBeenCalledWith(DEFAULT_TELEPORT_THRESHOLD + 1, 0.016);
+    expect(p.setTargetAtTime).not.toHaveBeenCalled();
+  });
+
+  test('smoothing <= 0 disables ramping — every write snaps', () => {
+    const p = makeParam();
+    const s = new SmoothedAudioParam();
+    settings.smoothing = 0;
+
+    s.write(p as unknown as AudioParam, 10, 0, settings);
+    s.write(p as unknown as AudioParam, 20, 0.016, settings);
+
+    expect(p.setValueAtTime).toHaveBeenCalledTimes(2);
+    expect(p.setTargetAtTime).not.toHaveBeenCalled();
+  });
+
+  test('reset() makes the next write snap again', () => {
+    const p = makeParam();
+    const s = new SmoothedAudioParam();
+
+    s.write(p as unknown as AudioParam, 100, 0, settings);
+    s.reset();
+    p.setValueAtTime.mockClear();
+    p.setTargetAtTime.mockClear();
+
+    s.write(p as unknown as AudioParam, 110, 0.016, settings);
+
+    expect(p.setValueAtTime).toHaveBeenCalledWith(110, 0.016);
+    expect(p.setTargetAtTime).not.toHaveBeenCalled();
+  });
+});

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -328,6 +328,7 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "SoundOptions: interface",
   "SoundPlayOptions: interface",
   "SoundPoolStrategy: enum",
+  "SpatialSmoothingSettings: interface",
   "Spatializable: interface",
   "Sprite: class",
   "SpriteFlags: enum",

--- a/test/rendering/video.test.ts
+++ b/test/rendering/video.test.ts
@@ -1,3 +1,4 @@
+import { getAudioContext } from '#audio/audio-context';
 import { AudioBus } from '#audio/AudioBus';
 import type { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
 import { Video } from '#rendering/video/Video';
@@ -110,6 +111,14 @@ const createBuilder = (): { view: View; backend: { stats: { culledNodes: number 
 });
 
 describe('Video', () => {
+  // Video defers its audio-node setup until the AudioContext exists. Since AU2,
+  // merely constructing audio components no longer eagerly spawns a live context
+  // (that waits for the first user gesture), so create it explicitly here — the
+  // global mock starts 'running', standing in for an already-unlocked context.
+  beforeAll(() => {
+    getAudioContext();
+  });
+
   test('updates texture frame when metadata arrives even before render()', () => {
     const mockVideo = createMockVideoElement();
     const video = new Video(mockVideo.element);

--- a/test/utils/audio-context.test.ts
+++ b/test/utils/audio-context.test.ts
@@ -67,7 +67,7 @@ describe('utils/audio-context', () => {
     expect(addEventListenerSpy).not.toHaveBeenCalled();
   });
 
-  it('creates the audio context lazily when a ready subscriber is added', async () => {
+  it('does NOT create the audio context when a ready subscriber is added — only registers interaction listeners, deferring creation to the first user gesture (AU2)', async () => {
     let audioContextCreations = 0;
 
     class TestAudioContext {
@@ -105,8 +105,14 @@ describe('utils/audio-context', () => {
 
     onAudioContextReady.once(() => undefined);
 
-    expect(audioContextCreations).toBe(1);
+    // A suspended live AudioContext must not be spawned before a user gesture —
+    // subscribing only wires up the interaction listeners (AU2).
+    expect(audioContextCreations).toBe(0);
     expect(addEventListenerSpy).toHaveBeenCalled();
+
+    // The first gesture is what finally creates and resumes the live context.
+    document.dispatchEvent(new MouseEvent('mousedown'));
+    expect(audioContextCreations).toBe(1);
   });
 
   it('registers keydown alongside pointer events as an unlock gesture', async () => {


### PR DESCRIPTION
Fixes three related audio findings from the 2026-07-11 expert review (03-assets-audio-physics): AU2, AU3, AU4.

## AU2 — live AudioContext created before the first user gesture

**Root cause:** two paths in `src/audio/audio-context.ts` forced a live `AudioContext` into existence pre-gesture: `getOrCreateOfflineAudioContext()` created one merely to read `sampleRate` for the decoding `OfflineAudioContext`, and `ensureAudioContextReadyMonitoring()` created one just to observe readiness (it runs whenever anything subscribes to `onAudioContextReady`, i.e. on every `AudioBus`/`AudioListener` construction). Both spawn a suspended context under the browser autoplay policy (console notices, suspended-context surprises).

**Fix:**
- The decoding `OfflineAudioContext` derives its sample rate from an already-live context when one exists, otherwise falls back to 44.1 kHz (`DEFAULT_SAMPLE_RATE`); decoded buffers resample transparently at playback if rates differ. Decoding never creates a live context.
- Readiness monitoring only registers the interaction listeners while no context exists; the live context is created inside the first user gesture (`onUserInteraction`) — exactly where `resume()` is allowed — or by an explicit `getAudioContext()` call. The statechange listener is attached whenever/wherever the context first appears.

## AU3 — pre-unlock listener accumulation

**Root cause:** `AudioBus.onceSetup()` registered a fresh closure on the global `onAudioContextReady` signal for every call, and `BaseVoice._connectTail()` calls it for every voice played while the bus is locked. Nothing ever unsubscribed, so a chatty pre-gesture game piled unbounded closures onto the singleton signal, including closures for voices/buses already destroyed.

**Fix (clean break, `onceSetup` signature change):**
- Deferred callbacks are queued **on the bus** (`_pendingSetup`) and flushed by the bus's own `_setupAudio()` — zero per-callback listeners on the global signal (only the bus's single constructor subscription remains there).
- `onceSetup()` now returns an unsubscribe function. `BaseVoice` keeps the disposer and drops its pending reconnect in `_finish()` (voice ends pre-unlock) and when re-deferring; `AudioBus.destroy()` drops its whole pending queue and disposes its deferred parent-connect subscription.

## AU4 — unsmoothed panner/listener parameter writes (zipper noise)

**Root cause:** `BaseVoice._tickSpatial()` and `AudioListener._tick()` wrote `positionX/Y/Z` with `setValueAtTime` every frame — stepwise param changes audibly zipper on fast movement.

**Fix (in line with the S2 spatializer design spec §5, so it will not be superseded):** new shared smoothing layer `src/audio/spatial-smoothing.ts`:
- `setTargetAtTime` ramping with τ = 20 ms default (robust to variable frame rate, converges within ~3τ);
- **epsilon-skip** (0.01 wu): a stationary emitter/listener costs zero AudioParam scheduling after its first frame (also a perf win — previously 3 unconditional writes/frame/voice);
- **teleport snap** (> 400 wu jump, or first write): `cancelScheduledValues` + `setValueAtTime` so warps don't glide across the stereo field;
- tunable via new `app.audio.spatial` (`SpatialSmoothingSettings { smoothing, teleportThreshold }`), shared by the listener and all spatial voices; `smoothing = 0` restores snap behavior. Legacy `setPosition()` fallback path stays snap-only.

Scope is deliberately limited to today's panner/listener surface — the full spatializer (listener depth, coupled distance defaults, emitters) remains the S2 design pass; its Slice 1 extends this same settings object and helper.

## Tests (TDD, Node lane with mocked AudioContext)

- **New** `test/audio/spatial-smoothing.test.ts` (7 tests): snap-on-first-write, ramp-on-move, epsilon-skip, teleport-snap, smoothing=0 disable, reset.
- **AU2:** `test/utils/audio-context.test.ts` — subscribing to `onAudioContextReady` creates **no** context (was: asserted 1); context is created by the first gesture. `test/audio/audio-context.test.ts` — `getOfflineAudioContext()` spawns no live context and uses the 44.1 kHz default.
- **AU3:** `test/audio/base-voice.test.ts` — 3 pre-unlock voices ⇒ global signal count unchanged, bus queue = 3, and `stop()` drains the queue to 0. `test/audio/audio-bus.test.ts` — no per-callback signal accumulation; destroy-before-unlock drops queued callbacks; flush-on-setup.
- **AU4:** `test/audio/audio-listener.test.ts` + `test/audio/sound-spatial.test.ts` — first write snaps, moves ramp via `setTargetAtTime`, stationary frames schedule nothing.
- Full `exojs` project: **297 files, 4737 passed / 12 skipped**; audio subset ran 3× green (flake check). `tsc --noEmit`, ESLint (0 errors), Prettier, and `docs:api:check` all pass (pre-push `verify:quick` gate ran clean). API docs regenerated; root-index export inventory snapshot updated (+`SpatialSmoothingSettings`).

https://claude.ai/code/session_01RHB7cLgoonJHLQg9ScdXby
