### PR TITLE
fix(packages): bring tiled/ldtk into package-policy compliance, wire check into CI

### DIFF
--- a/.github/workflows/_ci-checks.yml
+++ b/.github/workflows/_ci-checks.yml
@@ -111,6 +111,41 @@ jobs:
       - name: Typecheck extension packages
         run: pnpm --filter "@codexo/exojs-particles" --filter "@codexo/exojs-tilemap" --filter "@codexo/exojs-tiled" --filter "@codexo/exojs-physics" --filter "@codexo/exojs-audio-fx" --filter "@codexo/exojs-aseprite" --filter "@codexo/exojs-ldtk" --filter "@codexo/exojs-react" typecheck
 
+  # Validates the published-manifest shape (exports map, files allowlist,
+  # peer/dev-dependency split, no `workspace:` leaks, ...) of every official
+  # runtime package via `@codexo/exojs-config/package-policy`. Pure Node, no
+  # third-party deps and no build required, so it stays ungated (like
+  # typecheck/lint) instead of waiting on the `build` job's dist artifact.
+  package-policy:
+    name: Package Policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: ${{ inputs.pnpm-version }}
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+          check-latest: true
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Verify package policy
+        run: pnpm verify:package-policy
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -716,7 +751,20 @@ jobs:
   required-ci:
     name: Required CI
     if: ${{ always() }}
-    needs: [changes, typecheck, lint, unit-tests, browser-tests, browser-tests-webgpu-chromium, browser-tests-audio, build, package-verify, site-build]
+    needs:
+      [
+        changes,
+        typecheck,
+        lint,
+        package-policy,
+        unit-tests,
+        browser-tests,
+        browser-tests-webgpu-chromium,
+        browser-tests-audio,
+        build,
+        package-verify,
+        site-build,
+      ]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -728,6 +776,7 @@ jobs:
           CHANGES_RESULT: ${{ needs.changes.result }}
           TYPECHECK_RESULT: ${{ needs.typecheck.result }}
           LINT_RESULT: ${{ needs.lint.result }}
+          PACKAGE_POLICY_RESULT: ${{ needs['package-policy'].result }}
           UNIT_TESTS_RESULT: ${{ needs['unit-tests'].result }}
           BROWSER_TESTS_RESULT: ${{ needs['browser-tests'].result }}
           BROWSER_WEBGPU_RESULT: ${{ needs['browser-tests-webgpu-chromium'].result }}
@@ -740,6 +789,7 @@ jobs:
           echo "changes: $CHANGES_RESULT"
           echo "typecheck: $TYPECHECK_RESULT"
           echo "lint: $LINT_RESULT"
+          echo "package-policy: $PACKAGE_POLICY_RESULT"
           echo "unit-tests: $UNIT_TESTS_RESULT"
           echo "browser-tests: $BROWSER_TESTS_RESULT"
           echo "browser-tests-webgpu-chromium: $BROWSER_WEBGPU_RESULT"
@@ -765,6 +815,7 @@ jobs:
           for entry in \
             "typecheck=$TYPECHECK_RESULT" \
             "lint=$LINT_RESULT" \
+            "package-policy=$PACKAGE_POLICY_RESULT" \
             "unit-tests=$UNIT_TESTS_RESULT" \
             "browser-tests=$BROWSER_TESTS_RESULT" \
             "browser-tests-webgpu-chromium=$BROWSER_WEBGPU_RESULT" \

--- a/packages/exojs-ldtk/package.json
+++ b/packages/exojs-ldtk/package.json
@@ -40,14 +40,13 @@
     "test": "vitest run --root ../.. --project=exojs-ldtk"
   },
   "peerDependencies": {
-    "@codexo/exojs": "0.15.x"
-  },
-  "dependencies": {
-    "@codexo/exojs-tilemap": "workspace:*"
+    "@codexo/exojs": "0.15.x",
+    "@codexo/exojs-tilemap": "0.15.x"
   },
   "devDependencies": {
     "@codexo/exojs": "workspace:*",
-    "@codexo/exojs-config": "workspace:*"
+    "@codexo/exojs-config": "workspace:*",
+    "@codexo/exojs-tilemap": "workspace:*"
   },
   "license": "MIT",
   "publishConfig": {

--- a/packages/exojs-tiled/package.json
+++ b/packages/exojs-tiled/package.json
@@ -40,14 +40,13 @@
     "test": "vitest run --root ../.. --project=exojs-tiled"
   },
   "peerDependencies": {
-    "@codexo/exojs": "0.15.x"
-  },
-  "dependencies": {
-    "@codexo/exojs-tilemap": "workspace:*"
+    "@codexo/exojs": "0.15.x",
+    "@codexo/exojs-tilemap": "0.15.x"
   },
   "devDependencies": {
     "@codexo/exojs": "workspace:*",
-    "@codexo/exojs-config": "workspace:*"
+    "@codexo/exojs-config": "workspace:*",
+    "@codexo/exojs-tilemap": "workspace:*"
   },
   "license": "MIT",
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,10 +184,6 @@ importers:
         version: 3.0.0
 
   packages/exojs-ldtk:
-    dependencies:
-      '@codexo/exojs-tilemap':
-        specifier: workspace:*
-        version: link:../exojs-tilemap
     devDependencies:
       '@codexo/exojs':
         specifier: workspace:*
@@ -195,6 +191,9 @@ importers:
       '@codexo/exojs-config':
         specifier: workspace:*
         version: link:../exojs-config
+      '@codexo/exojs-tilemap':
+        specifier: workspace:*
+        version: link:../exojs-tilemap
 
   packages/exojs-particles:
     devDependencies:
@@ -240,10 +239,6 @@ importers:
         version: 18.3.31
 
   packages/exojs-tiled:
-    dependencies:
-      '@codexo/exojs-tilemap':
-        specifier: workspace:*
-        version: link:../exojs-tilemap
     devDependencies:
       '@codexo/exojs':
         specifier: workspace:*
@@ -251,6 +246,9 @@ importers:
       '@codexo/exojs-config':
         specifier: workspace:*
         version: link:../exojs-config
+      '@codexo/exojs-tilemap':
+        specifier: workspace:*
+        version: link:../exojs-tilemap
 
   packages/exojs-tilemap:
     devDependencies:

--- a/test/release/release-coherence.test.ts
+++ b/test/release/release-coherence.test.ts
@@ -11,6 +11,7 @@ interface Manifest {
   version?: string;
   peerDependencies?: Record<string, string>;
   dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
 }
 
 const readManifest = (path: string): Manifest => JSON.parse(readFileSync(path, 'utf8')) as Manifest;
@@ -57,8 +58,16 @@ describe('release coherence', () => {
     });
   }
 
-  it('@codexo/exojs-tiled depends on @codexo/exojs-tilemap', () => {
-    const tiled = readManifest(resolve(packagesDir, 'exojs-tiled', 'package.json'));
-    expect(tiled.dependencies?.['@codexo/exojs-tilemap']).toBeDefined();
-  });
+  // exojs-tiled and exojs-ldtk both render tiles via exojs-tilemap's runtime
+  // classes, but consumers only get one copy of those classes if the host app
+  // supplies exojs-tilemap itself — hence a peerDependency (not a runtime
+  // `dependencies` entry) backed by a workspace:* devDependency for local dev/test.
+  for (const consumer of ['exojs-tiled', 'exojs-ldtk']) {
+    it(`@codexo/${consumer} declares @codexo/exojs-tilemap as a peerDependency`, () => {
+      const manifest = readManifest(resolve(packagesDir, consumer, 'package.json'));
+      expect(manifest.peerDependencies?.['@codexo/exojs-tilemap']).toBeDefined();
+      expect(manifest.devDependencies?.['@codexo/exojs-tilemap']).toBe('workspace:*');
+      expect(manifest.dependencies?.['@codexo/exojs-tilemap']).toBeUndefined();
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- `exojs-tiled` and `exojs-ldtk` declared `@codexo/exojs-tilemap` as a production `dependencies` entry with a `workspace:*` specifier. `verify:package-policy` flags this as `no workspace: in deps` and `no production deps` (extension packages must not ship production deps in a published tarball). Both packages genuinely import tilemap classes/values at runtime (not just types), so the fix moves it to `peerDependencies` (`0.15.x`, mirroring the existing `@codexo/exojs` peer) plus a `devDependencies` `workspace:*` entry — the exact pattern already used for the `@codexo/exojs` peer in every extension.
- Adds a new ungated `Package Policy` job to `.github/workflows/_ci-checks.yml` that runs `pnpm verify:package-policy` right after install. It's pure Node with no third-party deps and needs no build, so — like `typecheck`/`lint` — it runs unconditionally on every PR instead of waiting on the `build` job's dist artifact or being path-gated (this trivially covers "any `packages/**` change must trigger it").
- Wires the new job into the `required-ci` aggregate (`needs`, result env var, log line, and the required-results loop) so a policy violation blocks merges going forward.

## Test plan
- [x] `pnpm verify:package-policy` — all 10 packages pass (was 2 failing: tiled, ldtk)
- [x] `pnpm --filter @codexo/exojs-tiled typecheck` / `pnpm --filter @codexo/exojs-ldtk typecheck` — clean
- [x] `pnpm --filter @codexo/exojs-tiled test` — 351 passed / `pnpm --filter @codexo/exojs-ldtk test` — 138 passed
- [x] `pnpm --filter "@codexo/exojs-particles" --filter "@codexo/exojs-tilemap" --filter "@codexo/exojs-tiled" ... build` (the exact CI build command) — all packages build cleanly in the correct dependency order (tilemap before tiled/ldtk)
- [x] Validated `_ci-checks.yml` (and `ci.yml`/`release.yml`) YAML parses correctly (no `actionlint`/docker available locally)
- [x] Pre-push hook `verify:quick` (typecheck + typecheck:guides/examples/type-tests/packages + lint:all + format:check + docs:api:check) passed in full

Claude-Session: https://claude.ai/code/session_01RHB7cLgoonJHLQg9ScdXby