### PR TITLE
perf(webgpu): prewarm + flush-path caching for instanced/text renderers (fixes #277)

### DIFF
--- a/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
@@ -6,7 +6,8 @@ import type { NineSliceQuad } from '#rendering/sprite/nineSlice';
 import type { NineSliceSprite } from '#rendering/sprite/NineSliceSprite';
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
 import { Texture } from '#rendering/texture/Texture';
-import { type BlendModes } from '#rendering/types';
+import { BlendModes } from '#rendering/types';
+import type { View } from '#rendering/View';
 
 import { AbstractWebGpuRenderer } from './AbstractWebGpuRenderer';
 import type { WebGpuBackend } from './WebGpuBackend';
@@ -93,7 +94,14 @@ const quadIndices = new Uint16Array([0, 1, 2, 0, 2, 3]);
 /** Instanced renderer for {@link NineSliceSprite} using WebGPU. */
 export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSliceSprite> {
   private readonly _projectionData = new Float32Array(projectionByteLength / Float32Array.BYTES_PER_ELEMENT);
+  // Projection-uniform skip state: a matching (view identity, view.updateId,
+  // group-transform id) triple means the shared UBO already holds this flush's
+  // projection, so the 128-byte write is skipped — static frames issue zero
+  // projection uploads. Mirrors the sprite renderer's redundant-write skip.
+  private _writtenView: View | null = null;
+  private _writtenViewUpdateId = -1;
   private _writtenGroupTransformId = -1;
+  private _hasWrittenProjection = false;
 
   private _device: GPUDevice | null = null;
   private _shaderModule: GPUShaderModule | null = null;
@@ -112,6 +120,14 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
   private _instanceFloat32 = new Float32Array(this._instanceData);
   private _instanceUint32 = new Uint32Array(this._instanceData);
   private readonly _pipelines = new Map<string, GPURenderPipeline>();
+  // Single-texture group(1) bind groups cached per texture (WeakMap so a
+  // short-lived texture does not pin its GPU bind group). The entry stores the
+  // resolved view AND sampler it was built from: the view detects a
+  // backend-recreated GPU texture (resize / content rebuild), the sampler
+  // detects a sampler-only refresh (setScaleMode / setWrapMode bumps
+  // texture.version, recreating the sampler while the view identity stays put).
+  // Dropped wholesale on disconnect / device loss.
+  private _textureBindGroups = new WeakMap<Texture | RenderTexture, { group: GPUBindGroup; view: GPUTextureView; sampler: GPUSampler }>();
 
   private _quadIndex = 0;
   private _maxNodeIndex = 0;
@@ -169,6 +185,13 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     this._indexBuffer = null;
     this._transformBindGroup = null;
     this._transformStorageBuffer = null;
+    // Bind groups and the projection UBO belong to the (possibly lost) device;
+    // drop the caches so reconnect rebuilds them against the fresh device.
+    this._textureBindGroups = new WeakMap<Texture | RenderTexture, { group: GPUBindGroup; view: GPUTextureView; sampler: GPUSampler }>();
+    this._writtenView = null;
+    this._writtenViewUpdateId = -1;
+    this._writtenGroupTransformId = -1;
+    this._hasWrittenProjection = false;
     this._uniformBuffer = null;
     this._pipelineLayout = null;
     this._textureBindGroupLayout = null;
@@ -296,13 +319,27 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     }
 
     // ProjectionUniforms layout: mat4x4 projection + mat4x4 group, packed via
-    // the shared canonical (non-transposed) column order.
-    packAffineMat4(backend.view.getTransform(), this._projectionData, 0);
-    packAffineMat4(backend.renderGroupTransform ?? Matrix.identity, this._projectionData, 16);
+    // the shared canonical (non-transposed) column order. The write is skipped
+    // when the UBO already holds this exact (view, updateId, group-id) state —
+    // static frames then issue zero projection uploads.
+    const view = backend.view;
 
-    this._writtenGroupTransformId = backend.renderGroupTransformId;
+    if (
+      !this._hasWrittenProjection ||
+      this._writtenView !== view ||
+      this._writtenViewUpdateId !== view.updateId ||
+      this._writtenGroupTransformId !== backend.renderGroupTransformId
+    ) {
+      packAffineMat4(view.getTransform(), this._projectionData, 0);
+      packAffineMat4(backend.renderGroupTransform ?? Matrix.identity, this._projectionData, 16);
 
-    device.queue.writeBuffer(uniformBuffer, 0, this._projectionData.buffer, this._projectionData.byteOffset, this._projectionData.byteLength);
+      this._writtenView = view;
+      this._writtenViewUpdateId = view.updateId;
+      this._writtenGroupTransformId = backend.renderGroupTransformId;
+      this._hasWrittenProjection = true;
+
+      device.queue.writeBuffer(uniformBuffer, 0, this._projectionData.buffer, this._projectionData.byteOffset, this._projectionData.byteLength);
+    }
 
     const scissor = backend.getScissorRect();
     const maskClipsAll = scissor !== null && (scissor.width <= 0 || scissor.height <= 0);
@@ -356,7 +393,7 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
 
       const storage = backend.getTransformStorageBuffer(needCount);
       const transformBindGroup = this._getOrCreateTransformBindGroup(device, uniformBuffer, storage.buffer);
-      const textureBindGroup = this._createTextureBindGroup(device, backend, this._currentTexture!);
+      const textureBindGroup = this._getOrCreateTextureBindGroup(device, backend, this._currentTexture!);
 
       const stencil = backend._passCoordinator.stencilActive;
       const pipeline = this._getPipeline(this._currentBlendMode!, backend.renderTargetFormat, stencil);
@@ -404,17 +441,85 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     return this._transformBindGroup;
   }
 
-  private _createTextureBindGroup(device: GPUDevice, backend: WebGpuBackend, texture: Texture | RenderTexture): GPUBindGroup {
-    const binding = backend.getTextureBinding(texture);
+  /**
+   * Build (or reuse) the group(1) texture bind group for `texture`. The binding
+   * is resolved BEFORE the cache lookup on purpose: resolving is what syncs a
+   * dirty/mutated texture's content to the GPU, so it must run every flush even
+   * when the bind group itself is served from cache. The cached entry is reused
+   * while both the resolved view AND sampler identities are unchanged, and
+   * rebuilt in place otherwise (resize → new view, setScaleMode/setWrapMode →
+   * new sampler).
+   */
+  private _getOrCreateTextureBindGroup(device: GPUDevice, backend: WebGpuBackend, texture: Texture | RenderTexture): GPUBindGroup {
+    const { view, sampler } = backend.getTextureBinding(texture);
+    const cached = this._textureBindGroups.get(texture);
 
-    return device.createBindGroup({
+    if (cached?.view === view && cached.sampler === sampler) {
+      return cached.group;
+    }
+
+    const group = device.createBindGroup({
       label: 'nine-slice:texture-bind-group',
       layout: this._textureBindGroupLayout!,
       entries: [
-        { binding: 0, resource: binding.view },
-        { binding: 1, resource: binding.sampler },
+        { binding: 0, resource: view },
+        { binding: 1, resource: sampler },
       ],
     });
+
+    this._textureBindGroups.set(texture, { group, view, sampler });
+
+    return group;
+  }
+
+  /**
+   * Pre-create render pipelines for every blend-mode × target-format pair this
+   * renderer can produce, asynchronously and in parallel. Called from the
+   * backend init path so first-frame draws do not block on synchronous WGSL
+   * compilation. Only the no-clip (`:n`) variants are prewarmed; stencil
+   * pipelines compile lazily on the first clipped draw (mirrors the sprite,
+   * mesh and text renderers).
+   */
+  public async prewarmPipelines(formats: readonly GPUTextureFormat[]): Promise<void> {
+    const device = this._device;
+
+    if (!device || !this._shaderModule || !this._pipelineLayout) {
+      return;
+    }
+
+    if (typeof device.createRenderPipelineAsync !== 'function') {
+      return;
+    }
+
+    const blendModes: readonly BlendModes[] = [
+      BlendModes.Normal,
+      BlendModes.Additive,
+      BlendModes.Subtract,
+      BlendModes.Multiply,
+      BlendModes.Screen,
+      BlendModes.Darken,
+      BlendModes.Lighten,
+    ];
+
+    const promises: Array<Promise<void>> = [];
+
+    for (const blendMode of blendModes) {
+      for (const format of formats) {
+        const key = `${blendMode}:${format}:n`;
+
+        if (this._pipelines.has(key)) {
+          continue;
+        }
+
+        promises.push(
+          device.createRenderPipelineAsync(this._buildPipelineDescriptor(blendMode, format)).then(pipeline => {
+            this._pipelines.set(key, pipeline);
+          }),
+        );
+      }
+    }
+
+    await Promise.all(promises);
   }
 
   private _getPipeline(blendMode: BlendModes, format: GPUTextureFormat, stencil: boolean): GPURenderPipeline {
@@ -426,6 +531,18 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     }
 
     if (!this._device || !this._shaderModule || !this._pipelineLayout) {
+      throw new Error('WebGpuNineSliceSpriteRenderer: renderer must be connected first.');
+    }
+
+    const pipeline = this._device.createRenderPipeline(this._buildPipelineDescriptor(blendMode, format, stencil));
+
+    this._pipelines.set(key, pipeline);
+
+    return pipeline;
+  }
+
+  private _buildPipelineDescriptor(blendMode: BlendModes, format: GPUTextureFormat, stencil = false): GPURenderPipelineDescriptor {
+    if (!this._shaderModule || !this._pipelineLayout) {
       throw new Error('WebGpuNineSliceSpriteRenderer: renderer must be connected first.');
     }
 
@@ -468,11 +585,7 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
       descriptor.depthStencil = stencilContentDepthStencilState();
     }
 
-    const pipeline = this._device.createRenderPipeline(descriptor);
-
-    this._pipelines.set(key, pipeline);
-
-    return pipeline;
+    return descriptor;
   }
 
   // Grow the CPU staging array for the batch currently being packed. The GPU

--- a/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
@@ -8,7 +8,8 @@ import { computeShaderTiling, type RepeatingSpriteQuad } from '#rendering/sprite
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { RepeatMode } from '#rendering/texture/repeat';
 import { Texture } from '#rendering/texture/Texture';
-import { type BlendModes } from '#rendering/types';
+import { BlendModes } from '#rendering/types';
+import type { View } from '#rendering/View';
 
 import { AbstractWebGpuRenderer } from './AbstractWebGpuRenderer';
 import type { WebGpuBackend } from './WebGpuBackend';
@@ -150,12 +151,20 @@ function repeatModeToAddressMode(mode: RepeatMode): GPUAddressMode {
 /** Instanced renderer for {@link RepeatingSprite} using WebGPU. */
 export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<RepeatingSprite> {
   private readonly _projData = new Float32Array(projectionByteLength / Float32Array.BYTES_PER_ELEMENT);
+  // Projection-uniform skip state: a matching (view identity, view.updateId,
+  // group-transform id) triple means the shared UBO already holds this flush's
+  // projection, so the 128-byte write is skipped — static frames issue zero
+  // projection uploads. Mirrors the sprite renderer's redundant-write skip.
+  private _writtenView: View | null = null;
+  private _writtenViewUpdateId = -1;
   private _writtenGroupTransformId = -1;
+  private _hasWrittenProjection = false;
 
   // Shared GPU objects
   private _device: GPUDevice | null = null;
   private _uniformBindGroupLayout: GPUBindGroupLayout | null = null;
   private _textureBindGroupLayout: GPUBindGroupLayout | null = null;
+  private _pipelineLayout: GPUPipelineLayout | null = null;
   private _shaderModule: GPUShaderModule | null = null;
   private _uniformBuffer: GPUBuffer | null = null;
   private _indexBuffer: GPUBuffer | null = null;
@@ -163,6 +172,13 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
   private _transformStorageBuf: GPUBuffer | null = null;
   private readonly _pipelines = new Map<string, GPURenderPipeline>();
   private readonly _samplers = new Map<string, GPUSampler>();
+  // Single-texture group(1) bind groups cached per texture (WeakMap so a
+  // short-lived texture does not pin its GPU bind group). The entry stores the
+  // resolved view AND sampler it was built from: the view detects a
+  // backend-recreated GPU texture (resize / content rebuild), the sampler
+  // detects a sampler-only refresh (setScaleMode / setWrapMode, or the two
+  // paths' distinct samplers). Dropped wholesale on disconnect / device loss.
+  private _textureBindGroups = new WeakMap<Texture | RenderTexture, { group: GPUBindGroup; view: GPUTextureView; sampler: GPUSampler }>();
 
   // Frame-scoped append arena shared by both paths: a single flush only ever
   // draws one path (render() flushes on a path change), so consecutive batch
@@ -222,6 +238,14 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
       ],
     });
 
+    // Both entry points (shader / geometry) share the same group layout, so a
+    // single pipeline layout is built once at connect and reused for every
+    // pipeline variant (and by prewarm) instead of per pipeline compile.
+    this._pipelineLayout = device.createPipelineLayout({
+      label: 'repeating-sprite:pipeline-layout',
+      bindGroupLayouts: [this._uniformBindGroupLayout, this._textureBindGroupLayout],
+    });
+
     this._uniformBuffer = device.createBuffer({
       label: 'repeating-sprite:uniform-buffer',
       size: projectionByteLength,
@@ -242,11 +266,19 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     this._uniformBuffer?.destroy();
     this._pipelines.clear();
     this._samplers.clear();
+    // Bind groups and the projection UBO belong to the (possibly lost) device;
+    // drop the caches so reconnect rebuilds them against the fresh device.
+    this._textureBindGroups = new WeakMap<Texture | RenderTexture, { group: GPUBindGroup; view: GPUTextureView; sampler: GPUSampler }>();
+    this._writtenView = null;
+    this._writtenViewUpdateId = -1;
+    this._writtenGroupTransformId = -1;
+    this._hasWrittenProjection = false;
 
     this._indexBuffer = null;
     this._uniformBuffer = null;
     this._transformBindGroup = null;
     this._transformStorageBuf = null;
+    this._pipelineLayout = null;
     this._textureBindGroupLayout = null;
     this._uniformBindGroupLayout = null;
     this._shaderModule = null;
@@ -440,13 +472,27 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     }
 
     // ProjectionUniforms layout: mat4x4 projection + mat4x4 group, packed via
-    // the shared canonical (non-transposed) column order.
-    packAffineMat4(backend.view.getTransform(), this._projData, 0);
-    packAffineMat4(backend.renderGroupTransform ?? Matrix.identity, this._projData, 16);
+    // the shared canonical (non-transposed) column order. The write is skipped
+    // when the UBO already holds this exact (view, updateId, group-id) state —
+    // static frames then issue zero projection uploads.
+    const view = backend.view;
 
-    this._writtenGroupTransformId = backend.renderGroupTransformId;
+    if (
+      !this._hasWrittenProjection ||
+      this._writtenView !== view ||
+      this._writtenViewUpdateId !== view.updateId ||
+      this._writtenGroupTransformId !== backend.renderGroupTransformId
+    ) {
+      packAffineMat4(view.getTransform(), this._projData, 0);
+      packAffineMat4(backend.renderGroupTransform ?? Matrix.identity, this._projData, 16);
 
-    device.queue.writeBuffer(uniform, 0, this._projData.buffer, this._projData.byteOffset, this._projData.byteLength);
+      this._writtenView = view;
+      this._writtenViewUpdateId = view.updateId;
+      this._writtenGroupTransformId = backend.renderGroupTransformId;
+      this._hasWrittenProjection = true;
+
+      device.queue.writeBuffer(uniform, 0, this._projData.buffer, this._projData.byteOffset, this._projData.byteLength);
+    }
 
     const scissor = backend.getScissorRect();
     const maskClipsAll = scissor !== null && (scissor.width <= 0 || scissor.height <= 0);
@@ -537,15 +583,10 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     const modeX = this._currentModeX ?? 'repeat';
     const modeY = this._currentModeY ?? 'repeat';
     const sampler = this._getOrCreateSampler(device, modeX, modeY);
+    // The shader path pairs the resolved texture view with a wrap-mode sampler
+    // (not the backend's default), so the cache is keyed on both identities.
     const texView = backend.getTextureBinding(this._currentTexture).view;
-    const textureBindGroup = device.createBindGroup({
-      label: 'repeating-sprite:texture-bind-group:shader',
-      layout: this._textureBindGroupLayout!,
-      entries: [
-        { binding: 0, resource: texView },
-        { binding: 1, resource: sampler },
-      ],
-    });
+    const textureBindGroup = this._getOrCreateTextureBindGroup(device, this._currentTexture, texView, sampler, 'repeating-sprite:texture-bind-group:shader');
 
     const pipeline = this._getPipeline('shader', this._currentBlendMode, backend.renderTargetFormat, stencil);
 
@@ -577,14 +618,13 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
 
     // Geometry path: use backend's default (clamp) sampler.
     const binding = backend.getTextureBinding(this._currentTexture);
-    const textureBindGroup = device.createBindGroup({
-      label: 'repeating-sprite:texture-bind-group:geo',
-      layout: this._textureBindGroupLayout!,
-      entries: [
-        { binding: 0, resource: binding.view },
-        { binding: 1, resource: binding.sampler },
-      ],
-    });
+    const textureBindGroup = this._getOrCreateTextureBindGroup(
+      device,
+      this._currentTexture,
+      binding.view,
+      binding.sampler,
+      'repeating-sprite:texture-bind-group:geo',
+    );
 
     const pipeline = this._getPipeline('geo', this._currentBlendMode, backend.renderTargetFormat, stencil);
 
@@ -639,19 +679,58 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     return this._transformBindGroup;
   }
 
+  /**
+   * Build (or reuse) the group(1) texture bind group pairing `view` with
+   * `sampler`. Cached per texture; the caller resolves the binding (syncing
+   * dirty content) before this runs. The entry is reused while both the view
+   * AND sampler identities match, and rebuilt in place otherwise (resize → new
+   * view; setScaleMode/setWrapMode or a path switch → new sampler).
+   */
+  private _getOrCreateTextureBindGroup(
+    device: GPUDevice,
+    texture: Texture | RenderTexture,
+    view: GPUTextureView,
+    sampler: GPUSampler,
+    label: string,
+  ): GPUBindGroup {
+    const cached = this._textureBindGroups.get(texture);
+
+    if (cached?.view === view && cached.sampler === sampler) {
+      return cached.group;
+    }
+
+    const group = device.createBindGroup({
+      label,
+      layout: this._textureBindGroupLayout!,
+      entries: [
+        { binding: 0, resource: view },
+        { binding: 1, resource: sampler },
+      ],
+    });
+
+    this._textureBindGroups.set(texture, { group, view, sampler });
+
+    return group;
+  }
+
   private _getPipeline(kind: 'shader' | 'geo', blend: BlendModes, format: GPUTextureFormat, stencil: boolean): GPURenderPipeline {
     const key = `${kind}:${blend}:${format}:${stencil ? 's' : 'n'}`;
     const existing = this._pipelines.get(key);
     if (existing) return existing;
 
-    if (!this._device || !this._shaderModule || !this._uniformBindGroupLayout || !this._textureBindGroupLayout) {
+    if (!this._device || !this._shaderModule || !this._pipelineLayout) {
       throw new Error('WebGpuRepeatingSpriteRenderer: not connected.');
     }
 
-    const layout = this._device.createPipelineLayout({
-      label: 'repeating-sprite:pipeline-layout',
-      bindGroupLayouts: [this._uniformBindGroupLayout, this._textureBindGroupLayout],
-    });
+    const pipeline = this._device.createRenderPipeline(this._buildPipelineDescriptor(kind, blend, format, stencil));
+    this._pipelines.set(key, pipeline);
+    return pipeline;
+  }
+
+  private _buildPipelineDescriptor(kind: 'shader' | 'geo', blend: BlendModes, format: GPUTextureFormat, stencil = false): GPURenderPipelineDescriptor {
+    if (!this._shaderModule || !this._pipelineLayout) {
+      throw new Error('WebGpuRepeatingSpriteRenderer: not connected.');
+    }
 
     const isShader = kind === 'shader';
     const strideBytes = isShader ? shaderStrideBytes : geoStrideBytes;
@@ -684,7 +763,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
 
     const desc: GPURenderPipelineDescriptor = {
       label: 'repeating-sprite:render-pipeline',
-      layout,
+      layout: this._pipelineLayout,
       vertex: {
         module: this._shaderModule,
         entryPoint: isShader ? 'shaderVert' : 'geoVert',
@@ -702,9 +781,60 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
       desc.depthStencil = stencilContentDepthStencilState();
     }
 
-    const pipeline = this._device.createRenderPipeline(desc);
-    this._pipelines.set(key, pipeline);
-    return pipeline;
+    return desc;
+  }
+
+  /**
+   * Pre-create render pipelines for every entry point (shader / geometry) ×
+   * blend-mode × target-format combination this renderer can produce,
+   * asynchronously and in parallel. Called from the backend init path so
+   * first-frame draws do not block on synchronous WGSL compilation. Only the
+   * no-clip (`:n`) variants are prewarmed; stencil pipelines compile lazily on
+   * the first clipped draw (mirrors the sprite, mesh and text renderers).
+   */
+  public async prewarmPipelines(formats: readonly GPUTextureFormat[]): Promise<void> {
+    const device = this._device;
+
+    if (!device || !this._shaderModule || !this._pipelineLayout) {
+      return;
+    }
+
+    if (typeof device.createRenderPipelineAsync !== 'function') {
+      return;
+    }
+
+    const kinds: ReadonlyArray<'shader' | 'geo'> = ['shader', 'geo'];
+    const blendModes: readonly BlendModes[] = [
+      BlendModes.Normal,
+      BlendModes.Additive,
+      BlendModes.Subtract,
+      BlendModes.Multiply,
+      BlendModes.Screen,
+      BlendModes.Darken,
+      BlendModes.Lighten,
+    ];
+
+    const promises: Array<Promise<void>> = [];
+
+    for (const kind of kinds) {
+      for (const blendMode of blendModes) {
+        for (const format of formats) {
+          const key = `${kind}:${blendMode}:${format}:n`;
+
+          if (this._pipelines.has(key)) {
+            continue;
+          }
+
+          promises.push(
+            device.createRenderPipelineAsync(this._buildPipelineDescriptor(kind, blendMode, format)).then(pipeline => {
+              this._pipelines.set(key, pipeline);
+            }),
+          );
+        }
+      }
+    }
+
+    await Promise.all(promises);
   }
 
   // Grow the CPU staging arrays for the batch being packed. The GPU instance

--- a/src/rendering/webgpu/WebGpuTextRenderer.ts
+++ b/src/rendering/webgpu/WebGpuTextRenderer.ts
@@ -7,6 +7,7 @@ import type { TextPageQuads } from '#rendering/text/Text';
 import { Text } from '#rendering/text/Text';
 import type { Texture } from '#rendering/texture/Texture';
 import { BlendModes } from '#rendering/types';
+import type { View } from '#rendering/View';
 
 import { AbstractWebGpuRenderer } from './AbstractWebGpuRenderer';
 import type { WebGpuBackend } from './WebGpuBackend';
@@ -283,6 +284,16 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
   private _frameBindGroup: GPUBindGroup | null = null;
   private _frameBindGroupDirty = true;
 
+  // FrameUniforms (projection + group) skip state: a matching (view identity,
+  // view.updateId, group-transform id) triple means the proj UBO already holds
+  // this flush's transform, so the 96-byte write is skipped. Per-node style
+  // data (the storage buffer) is uploaded unconditionally — it genuinely
+  // changes per frame; only the shared projection is elided here.
+  private _writtenView: View | null = null;
+  private _writtenViewUpdateId = -1;
+  private _writtenGroupTransformId = -1;
+  private _hasWrittenProjection = false;
+
   // CPU-side working arrays
   private _vertexCapacity = initialVertexCapacity;
   private _indexCapacity = initialIndexCapacity;
@@ -336,11 +347,27 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     });
 
     // Upload FrameUniforms: projection + group as vec4-padded mat3x3 columns,
-    // packed via the shared canonical (non-transposed) column order.
-    packAffineMat3Std140(backend.view.getTransform(), this._projData, 0);
-    packAffineMat3Std140(backend.renderGroupTransform ?? Matrix.identity, this._projData, 12);
+    // packed via the shared canonical (non-transposed) column order. The write
+    // is skipped when the UBO already holds this exact (view, updateId,
+    // group-id) state — static text then issues zero projection uploads.
+    const view = backend.view;
 
-    device.queue.writeBuffer(this._projBuffer!, 0, this._projData.buffer, 0, projectionBytes);
+    if (
+      !this._hasWrittenProjection ||
+      this._writtenView !== view ||
+      this._writtenViewUpdateId !== view.updateId ||
+      this._writtenGroupTransformId !== backend.renderGroupTransformId
+    ) {
+      packAffineMat3Std140(view.getTransform(), this._projData, 0);
+      packAffineMat3Std140(backend.renderGroupTransform ?? Matrix.identity, this._projData, 12);
+
+      this._writtenView = view;
+      this._writtenViewUpdateId = view.updateId;
+      this._writtenGroupTransformId = backend.renderGroupTransformId;
+      this._hasWrittenProjection = true;
+
+      device.queue.writeBuffer(this._projBuffer!, 0, this._projData.buffer, 0, projectionBytes);
+    }
 
     // Upload per-node style data (may reallocate the storage buffer)
     this._uploadNodeBuffer(device);
@@ -584,6 +611,10 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
 
     this._frameBindGroup = null;
     this._frameBindGroupDirty = true;
+    this._writtenView = null;
+    this._writtenViewUpdateId = -1;
+    this._writtenGroupTransformId = -1;
+    this._hasWrittenProjection = false;
 
     this._pipelines.clear();
     this._texBindGroups = new WeakMap<Texture, { group: GPUBindGroup; view: GPUTextureView }>();

--- a/test/rendering/browser/webgpu-prewarm-bindgroup-cache.test.ts
+++ b/test/rendering/browser/webgpu-prewarm-bindgroup-cache.test.ts
@@ -1,0 +1,263 @@
+/// <reference types="@webgpu/types" />
+
+/**
+ * WebGPU prewarm + flush-path caching for the instanced/text renderers — real
+ * device (issue #277, finding F5b). Companion to the structural Node tests in
+ * test/rendering/webgpu-instanced-flush-caching.test.ts and the prewarm
+ * cache-key tests in test/rendering/webgpu-pipeline-prewarm.test.ts, this suite
+ * exercises the actual WebGPU device to prove the caches behave on a conformant
+ * implementation, not just against a mock:
+ *
+ * - after backend init, the nine-slice and repeating-sprite renderers have a
+ *   non-empty pipeline cache (prewarm compiled the no-clip variants), and
+ * - a second, byte-identical static frame creates ZERO new GPU bind groups for
+ *   the nine-slice / repeating texture group(1) and issues ZERO projection
+ *   (FrameUniforms) writes for text — while still drawing and passing WebGPU
+ *   validation.
+ *
+ * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
+ * against Mesa lavapipe); each test only skips when the software adapter drops
+ * the device mid-test. Run via: pnpm test:browser:webgpu
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import type { RenderNode } from '#rendering/RenderNode';
+import { NineSliceSprite } from '#rendering/sprite/NineSliceSprite';
+import { RepeatingSprite } from '#rendering/sprite/RepeatingSprite';
+import { resetDefaultGlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
+import { Text } from '#rendering/text/Text';
+import { Texture } from '#rendering/texture/Texture';
+import { ScaleModes } from '#rendering/types';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+import { getBackendDevice } from './webgpu-test-helpers';
+
+const canvasSize = 64;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: {
+      canvas: { width: canvasSize, height: canvasSize },
+      clearColor: Color.black,
+    },
+  }) as unknown as Application;
+
+const setupBackend = async (): Promise<WebGpuBackend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  // Register the core renderers BEFORE initialize (as Application.createBackend
+  // does in production) so the init-path pipeline prewarm actually covers them —
+  // wiring after initialize would run prewarm against an empty registry.
+  wireCoreRenderers(backend);
+  await backend.initialize();
+
+  return backend;
+};
+
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+/** Render one node through the real flush path inside a validation error scope. */
+const renderNode = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, node: RenderNode): Promise<boolean> => {
+  const device = getBackendDevice(backend);
+
+  device.pushErrorScope('validation');
+
+  let validationError: GPUError | null;
+
+  try {
+    backend.resetStats();
+    backend.clear(Color.black);
+    node.render(backend);
+    backend.flush();
+    validationError = await device.popErrorScope();
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+
+  expect(validationError?.message ?? null).toBeNull();
+
+  return true;
+};
+
+/** A small solid-colour texture with nearest sampling and no mipmaps. */
+const createSolidTexture = (size = 16): Texture => {
+  const src = document.createElement('canvas');
+
+  src.width = size;
+  src.height = size;
+
+  const context = src.getContext('2d')!;
+
+  context.fillStyle = 'rgb(120, 180, 240)';
+  context.fillRect(0, 0, size, size);
+
+  return new Texture(src, { scaleMode: ScaleModes.Nearest });
+};
+
+/**
+ * Count `device.createBindGroup` calls whose label starts with `prefix` while
+ * running `run`, restoring the original method afterwards.
+ */
+const countBindGroups = async (device: GPUDevice, prefix: string, run: () => Promise<void>): Promise<number> => {
+  const original = device.createBindGroup.bind(device);
+  let count = 0;
+
+  device.createBindGroup = ((descriptor: GPUBindGroupDescriptor): GPUBindGroup => {
+    if ((descriptor.label ?? '').startsWith(prefix)) {
+      count++;
+    }
+
+    return original(descriptor);
+  }) as GPUDevice['createBindGroup'];
+
+  try {
+    await run();
+  } finally {
+    device.createBindGroup = original;
+  }
+
+  return count;
+};
+
+const pipelineCacheSize = (backend: WebGpuBackend, node: RenderNode): number => {
+  const renderer = backend.rendererRegistry.resolve(node) as unknown as { _pipelines: Map<string, unknown> };
+
+  return renderer._pipelines.size;
+};
+
+describe('WebGPU prewarm + flush-path caching (nine-slice / repeating / text)', () => {
+  beforeEach(() => resetDefaultGlyphAtlasPool());
+  afterEach(() => resetDefaultGlyphAtlasPool());
+
+  test('nine-slice: prewarm fills the pipeline cache and a static re-flush builds no new texture bind group', async ctx => {
+    const backend = await setupBackend();
+    const texture = createSolidTexture();
+    const sprite = new NineSliceSprite(texture, { slices: 4, border: 8, width: 40, height: 40 });
+
+    try {
+      sprite.setPosition(8, 8);
+
+      // Prewarm ran during initialize(): the no-clip pipeline variants exist.
+      expect(pipelineCacheSize(backend, sprite)).toBeGreaterThan(0);
+
+      if (!(await renderNode(ctx, backend, sprite))) {
+        return;
+      }
+
+      const device = getBackendDevice(backend);
+      let drew = false;
+
+      const created = await countBindGroups(device, 'nine-slice:texture-bind-group', async () => {
+        drew = await renderNode(ctx, backend, sprite);
+      });
+
+      if (!drew) {
+        return;
+      }
+
+      expect(backend.stats.drawCalls).toBeGreaterThan(0);
+      expect(created).toBe(0);
+    } finally {
+      sprite.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('repeating-sprite: prewarm fills the pipeline cache and a static re-flush builds no new texture bind group', async ctx => {
+    const backend = await setupBackend();
+    const texture = createSolidTexture();
+    // A bare Texture source resolves to the shader (GPU-sampler-wrap) strategy.
+    const sprite = new RepeatingSprite(texture, { width: 40, height: 40 });
+
+    try {
+      sprite.setPosition(8, 8);
+
+      expect(pipelineCacheSize(backend, sprite)).toBeGreaterThan(0);
+
+      if (!(await renderNode(ctx, backend, sprite))) {
+        return;
+      }
+
+      const device = getBackendDevice(backend);
+      let drew = false;
+
+      const created = await countBindGroups(device, 'repeating-sprite:texture-bind-group', async () => {
+        drew = await renderNode(ctx, backend, sprite);
+      });
+
+      if (!drew) {
+        return;
+      }
+
+      expect(backend.stats.drawCalls).toBeGreaterThan(0);
+      expect(created).toBe(0);
+    } finally {
+      sprite.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('text: a static re-flush issues no FrameUniforms (projection) write', async ctx => {
+    const backend = await setupBackend();
+    const text = new Text('HELLO', { fillColor: Color.white, fontSize: 24 });
+
+    try {
+      text.setPosition(4, 20);
+
+      if (!(await renderNode(ctx, backend, text))) {
+        return;
+      }
+
+      const device = getBackendDevice(backend);
+      const renderer = backend.rendererRegistry.resolve(text) as unknown as { _projBuffer: GPUBuffer | null };
+      const projBuffer = renderer._projBuffer;
+
+      expect(projBuffer).not.toBeNull();
+
+      const originalWriteBuffer = device.queue.writeBuffer.bind(device.queue);
+      let projWrites = 0;
+
+      device.queue.writeBuffer = ((buffer: GPUBuffer, ...rest: unknown[]): void => {
+        if (buffer === projBuffer) {
+          projWrites++;
+        }
+
+        return (originalWriteBuffer as (...args: unknown[]) => void)(buffer, ...rest);
+      }) as GPUQueue['writeBuffer'];
+
+      let drew = false;
+
+      try {
+        drew = await renderNode(ctx, backend, text);
+      } finally {
+        device.queue.writeBuffer = originalWriteBuffer;
+      }
+
+      if (!drew) {
+        return;
+      }
+
+      expect(backend.stats.drawCalls).toBeGreaterThan(0);
+      expect(projWrites).toBe(0);
+    } finally {
+      text.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/webgpu-instanced-flush-caching.test.ts
+++ b/test/rendering/webgpu-instanced-flush-caching.test.ts
@@ -1,0 +1,261 @@
+/**
+ * WebGPU nine-slice / repeating-sprite flush hot-path caching (issue #277, F5b).
+ *
+ * Both instanced renderers used to create a fresh single-texture bind group and
+ * rewrite the 128-byte projection/group uniform on EVERY batch flush — per-frame
+ * GPU object churn that scales with flush count even for completely static
+ * scenes. These tests drive the REAL WebGpuBackend + renderers against a mock
+ * device (see webgpuMockEnvironment) and require, after warmup:
+ *
+ * - a static frame creates ZERO new bind groups and issues ZERO projection
+ *   writes while still drawing,
+ * - a view mutation re-writes the projection exactly once, then skips again,
+ * - a texture resize (fresh view identity) rebuilds the cached bind group once.
+ */
+
+import { Color } from '#core/Color';
+import type { RenderNode } from '#rendering/RenderNode';
+import { NineSliceSprite } from '#rendering/sprite/NineSliceSprite';
+import { RepeatingSprite } from '#rendering/sprite/RepeatingSprite';
+import { Texture } from '#rendering/texture/Texture';
+import { TextureRegion } from '#rendering/texture/TextureRegion';
+import type { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { countLabel, createCanvasTexture, createMockBackend, createMockWebGpuEnvironment } from './webgpuMockEnvironment';
+
+const renderFrame = (backend: WebGpuBackend, nodes: readonly RenderNode[]): void => {
+  // resetStats is the frame boundary: it resets the frame-scoped transform
+  // buffer (same driving pattern as the browser suite).
+  backend.resetStats();
+  backend.clear(Color.black);
+
+  for (const node of nodes) {
+    node.render(backend);
+  }
+
+  backend.flush();
+};
+
+describe('WebGPU NineSliceSprite flush hot-path caching', () => {
+  const uniformLabel = 'nine-slice:uniform-buffer';
+  const textureBindGroupLabel = 'nine-slice:texture-bind-group';
+
+  const makeSprite = (texture: Texture): NineSliceSprite => new NineSliceSprite(texture, { slices: 4, border: 4, width: 48, height: 48 });
+
+  test('a static frame after warmup creates no new bind groups and skips the projection write', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createMockBackend(environment);
+      const texture = createCanvasTexture();
+      const sprite = makeSprite(texture);
+
+      renderFrame(backend, [sprite]);
+
+      expect(environment.bindGroupCount()).toBeGreaterThan(0);
+      expect(countLabel(environment.writeBufferLabels(), uniformLabel)).toBe(1);
+
+      const bindGroupsAfterWarmup = environment.bindGroupCount();
+      const writesAfterWarmup = environment.writeBufferLabels().length;
+      const drawsAfterWarmup = environment.drawIndexedCount();
+
+      renderFrame(backend, [sprite]);
+
+      expect(environment.drawIndexedCount()).toBe(drawsAfterWarmup + 1);
+      expect(environment.bindGroupLabels().slice(bindGroupsAfterWarmup)).toEqual([]);
+      expect(countLabel(environment.writeBufferLabels(), uniformLabel, writesAfterWarmup)).toBe(0);
+
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('a view mutation re-writes the projection uniform exactly once, then skips again', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createMockBackend(environment);
+      const texture = createCanvasTexture();
+      const sprite = makeSprite(texture);
+
+      renderFrame(backend, [sprite]);
+      renderFrame(backend, [sprite]);
+
+      const writesBeforePan = environment.writeBufferLabels().length;
+
+      backend.view.setCenter(backend.view.center.x + 16, backend.view.center.y);
+      renderFrame(backend, [sprite]);
+
+      expect(countLabel(environment.writeBufferLabels(), uniformLabel, writesBeforePan)).toBe(1);
+
+      const writesAfterPan = environment.writeBufferLabels().length;
+
+      renderFrame(backend, [sprite]);
+
+      expect(countLabel(environment.writeBufferLabels(), uniformLabel, writesAfterPan)).toBe(0);
+
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('a texture resize (fresh view identity) rebuilds the cached texture bind group once', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createMockBackend(environment);
+      const source = document.createElement('canvas');
+
+      source.width = 16;
+      source.height = 16;
+
+      const texture = new Texture(source);
+
+      texture.generateMipMap = false;
+      texture.updateSource();
+
+      const sprite = makeSprite(texture);
+
+      renderFrame(backend, [sprite]);
+      renderFrame(backend, [sprite]); // warm: cache hit established
+
+      const mark = environment.bindGroupLabels().length;
+
+      source.width = 32;
+      source.height = 32;
+      texture.updateSource();
+      renderFrame(backend, [sprite]);
+
+      expect(countLabel(environment.bindGroupLabels(), textureBindGroupLabel, mark)).toBe(1);
+
+      const afterRebuild = environment.bindGroupLabels().length;
+
+      renderFrame(backend, [sprite]);
+
+      expect(countLabel(environment.bindGroupLabels(), textureBindGroupLabel, afterRebuild)).toBe(0);
+
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+});
+
+describe('WebGPU RepeatingSprite flush hot-path caching', () => {
+  const uniformLabel = 'repeating-sprite:uniform-buffer';
+
+  // A bare Texture source resolves to the shader (GPU-sampler-wrap) strategy;
+  // a TextureRegion source resolves to the geometry (CPU repeat-quads) strategy.
+  const makeShaderSprite = (texture: Texture): RepeatingSprite => new RepeatingSprite(texture, { width: 48, height: 48 });
+  const makeGeoSprite = (texture: Texture): RepeatingSprite =>
+    new RepeatingSprite(new TextureRegion(texture, { x: 0, y: 0, width: texture.width, height: texture.height }), { width: 48, height: 48 });
+
+  for (const [name, make, textureBindGroupLabel] of [
+    ['shader', makeShaderSprite, 'repeating-sprite:texture-bind-group:shader'],
+    ['geometry', makeGeoSprite, 'repeating-sprite:texture-bind-group:geo'],
+  ] as const) {
+    describe(`${name} strategy`, () => {
+      test('a static frame after warmup creates no new bind groups and skips the projection write', async () => {
+        const environment = createMockWebGpuEnvironment();
+
+        try {
+          const backend = await createMockBackend(environment);
+          const texture = createCanvasTexture();
+          const sprite = make(texture);
+
+          renderFrame(backend, [sprite]);
+
+          expect(environment.bindGroupCount()).toBeGreaterThan(0);
+          expect(countLabel(environment.writeBufferLabels(), uniformLabel)).toBe(1);
+
+          const bindGroupsAfterWarmup = environment.bindGroupCount();
+          const writesAfterWarmup = environment.writeBufferLabels().length;
+          const drawsAfterWarmup = environment.drawIndexedCount();
+
+          renderFrame(backend, [sprite]);
+
+          expect(environment.drawIndexedCount()).toBe(drawsAfterWarmup + 1);
+          expect(environment.bindGroupLabels().slice(bindGroupsAfterWarmup)).toEqual([]);
+          expect(countLabel(environment.writeBufferLabels(), uniformLabel, writesAfterWarmup)).toBe(0);
+
+          backend.destroy();
+        } finally {
+          environment.restore();
+        }
+      });
+
+      test('a view mutation re-writes the projection uniform exactly once, then skips again', async () => {
+        const environment = createMockWebGpuEnvironment();
+
+        try {
+          const backend = await createMockBackend(environment);
+          const texture = createCanvasTexture();
+          const sprite = make(texture);
+
+          renderFrame(backend, [sprite]);
+          renderFrame(backend, [sprite]);
+
+          const writesBeforePan = environment.writeBufferLabels().length;
+
+          backend.view.setCenter(backend.view.center.x + 16, backend.view.center.y);
+          renderFrame(backend, [sprite]);
+
+          expect(countLabel(environment.writeBufferLabels(), uniformLabel, writesBeforePan)).toBe(1);
+
+          const writesAfterPan = environment.writeBufferLabels().length;
+
+          renderFrame(backend, [sprite]);
+
+          expect(countLabel(environment.writeBufferLabels(), uniformLabel, writesAfterPan)).toBe(0);
+
+          backend.destroy();
+        } finally {
+          environment.restore();
+        }
+      });
+
+      test('a texture resize (fresh view identity) rebuilds the cached texture bind group once', async () => {
+        const environment = createMockWebGpuEnvironment();
+
+        try {
+          const backend = await createMockBackend(environment);
+          const source = document.createElement('canvas');
+
+          source.width = 16;
+          source.height = 16;
+
+          const texture = new Texture(source);
+
+          texture.generateMipMap = false;
+          texture.updateSource();
+
+          const sprite = make(texture);
+
+          renderFrame(backend, [sprite]);
+          renderFrame(backend, [sprite]); // warm: cache hit established
+
+          const mark = environment.bindGroupLabels().length;
+
+          source.width = 32;
+          source.height = 32;
+          texture.updateSource();
+          renderFrame(backend, [sprite]);
+
+          expect(countLabel(environment.bindGroupLabels(), textureBindGroupLabel, mark)).toBe(1);
+
+          const afterRebuild = environment.bindGroupLabels().length;
+
+          renderFrame(backend, [sprite]);
+
+          expect(countLabel(environment.bindGroupLabels(), textureBindGroupLabel, afterRebuild)).toBe(0);
+
+          backend.destroy();
+        } finally {
+          environment.restore();
+        }
+      });
+    });
+  }
+});

--- a/test/rendering/webgpu-pipeline-prewarm.test.ts
+++ b/test/rendering/webgpu-pipeline-prewarm.test.ts
@@ -18,6 +18,8 @@
 
 import { BlendModes } from '#rendering/types';
 import { WebGpuMeshRenderer } from '#rendering/webgpu/WebGpuMeshRenderer';
+import { WebGpuNineSliceSpriteRenderer } from '#rendering/webgpu/WebGpuNineSliceSpriteRenderer';
+import { WebGpuRepeatingSpriteRenderer } from '#rendering/webgpu/WebGpuRepeatingSpriteRenderer';
 import { WebGpuSpriteRenderer } from '#rendering/webgpu/WebGpuSpriteRenderer';
 import { WebGpuTextRenderer } from '#rendering/webgpu/WebGpuTextRenderer';
 
@@ -179,6 +181,112 @@ describe('WebGpuMeshRenderer pipeline prewarm', () => {
     expect(instancedPipelines.size).toBe(prewarmedBlendModes.length * formats.length);
 
     for (const key of [...pipelines.keys(), ...instancedPipelines.keys()]) {
+      expect(key).toMatch(lookupKeyPattern);
+    }
+  });
+});
+
+describe('WebGpuNineSliceSpriteRenderer pipeline prewarm', () => {
+  const setup = (): { renderer: WebGpuNineSliceSpriteRenderer; stub: StubDevice; pipelines: Map<string, GPURenderPipeline> } => {
+    const renderer = new WebGpuNineSliceSpriteRenderer();
+    const stub = createStubDevice();
+    const internals = renderer as unknown as {
+      _device: unknown;
+      _shaderModule: unknown;
+      _pipelineLayout: unknown;
+      _backend: unknown;
+      _pipelines: Map<string, GPURenderPipeline>;
+    };
+
+    internals._device = stub.device;
+    internals._shaderModule = {};
+    internals._pipelineLayout = {};
+    internals._backend = {};
+
+    return { renderer, stub, pipelines: internals._pipelines };
+  };
+
+  test('prewarmed pipelines are found by the hot-path lookup (no synchronous compiles)', async () => {
+    const { renderer, stub } = setup();
+
+    await renderer.prewarmPipelines(formats);
+
+    const lookup = renderer as unknown as { _getPipeline(blendMode: BlendModes, format: GPUTextureFormat, stencil: boolean): GPURenderPipeline };
+
+    for (const blendMode of prewarmedBlendModes) {
+      for (const format of formats) {
+        lookup._getPipeline(blendMode, format, false);
+      }
+    }
+
+    expect(stub.syncCreates()).toBe(0);
+  });
+
+  test('the pipeline cache holds no unreachable (suffix-less) keys after prewarm', async () => {
+    const { renderer, pipelines } = setup();
+
+    await renderer.prewarmPipelines(formats);
+
+    expect(pipelines.size).toBe(prewarmedBlendModes.length * formats.length);
+
+    for (const key of pipelines.keys()) {
+      expect(key).toMatch(lookupKeyPattern);
+    }
+  });
+});
+
+describe('WebGpuRepeatingSpriteRenderer pipeline prewarm', () => {
+  const kinds = ['shader', 'geo'] as const;
+
+  const setup = (): { renderer: WebGpuRepeatingSpriteRenderer; stub: StubDevice; pipelines: Map<string, GPURenderPipeline> } => {
+    const renderer = new WebGpuRepeatingSpriteRenderer();
+    const stub = createStubDevice();
+    const internals = renderer as unknown as {
+      _device: unknown;
+      _shaderModule: unknown;
+      _uniformBindGroupLayout: unknown;
+      _textureBindGroupLayout: unknown;
+      _pipelineLayout: unknown;
+      _pipelines: Map<string, GPURenderPipeline>;
+    };
+
+    internals._device = stub.device;
+    internals._shaderModule = {};
+    internals._uniformBindGroupLayout = {};
+    internals._textureBindGroupLayout = {};
+    internals._pipelineLayout = {};
+
+    return { renderer, stub, pipelines: internals._pipelines };
+  };
+
+  test('prewarmed shader + geometry pipelines are found by the hot-path lookup', async () => {
+    const { renderer, stub } = setup();
+
+    await renderer.prewarmPipelines(formats);
+
+    const lookup = renderer as unknown as {
+      _getPipeline(kind: 'shader' | 'geo', blend: BlendModes, format: GPUTextureFormat, stencil: boolean): GPURenderPipeline;
+    };
+
+    for (const kind of kinds) {
+      for (const blendMode of prewarmedBlendModes) {
+        for (const format of formats) {
+          lookup._getPipeline(kind, blendMode, format, false);
+        }
+      }
+    }
+
+    expect(stub.syncCreates()).toBe(0);
+  });
+
+  test('the pipeline cache holds no unreachable keys after prewarm', async () => {
+    const { renderer, pipelines } = setup();
+
+    await renderer.prewarmPipelines(formats);
+
+    expect(pipelines.size).toBe(kinds.length * prewarmedBlendModes.length * formats.length);
+
+    for (const key of pipelines.keys()) {
       expect(key).toMatch(lookupKeyPattern);
     }
   });

--- a/test/rendering/webgpuMockEnvironment.ts
+++ b/test/rendering/webgpuMockEnvironment.ts
@@ -1,0 +1,210 @@
+/**
+ * Shared mock WebGPU environment for renderer flush hot-path caching tests.
+ *
+ * Drives the REAL WebGpuBackend + core renderers against a mock device that
+ * counts createBindGroup calls and records writeBuffer / drawIndexed targets by
+ * label, so structural tests can assert per-flush GPU-object churn (bind
+ * groups, projection-uniform writes) without a real adapter. A stable
+ * per-GPU-texture view models the backend's cached-view contract (a fresh view
+ * identity means "texture was recreated").
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { materializeRendererBindings } from '#extensions/materialize';
+import { buildCoreRendererBindings } from '#rendering/coreRendererBindings';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+interface LabeledBuffer {
+  readonly label: string;
+  destroy(): void;
+}
+
+export interface MockWebGpuEnvironment {
+  readonly canvas: HTMLCanvasElement;
+  bindGroupCount(): number;
+  /** Labels of every created bind group, in call order. */
+  bindGroupLabels(): readonly string[];
+  /** Labels of every queue.writeBuffer target, in call order. */
+  writeBufferLabels(): readonly string[];
+  /** Number of render pipelines synchronously created (async prewarm excluded). */
+  syncPipelineCount(): number;
+  drawIndexedCount(): number;
+  restore(): void;
+}
+
+const globalStubs: ReadonlyArray<readonly [string, unknown]> = [
+  ['GPUBufferUsage', { COPY_DST: 1, INDEX: 2, UNIFORM: 4, VERTEX: 8, STORAGE: 16, COPY_SRC: 32 }],
+  ['GPUShaderStage', { VERTEX: 1, FRAGMENT: 2 }],
+  ['GPUColorWrite', { ALL: 0xf }],
+  ['GPUTextureUsage', { COPY_DST: 1, TEXTURE_BINDING: 2, RENDER_ATTACHMENT: 4, COPY_SRC: 8 }],
+];
+
+export const createMockWebGpuEnvironment = (): MockWebGpuEnvironment => {
+  const previousGpu = Object.getOwnPropertyDescriptor(navigator, 'gpu');
+  const previousGlobals = globalStubs.map(([name]) => [name, Object.getOwnPropertyDescriptor(globalThis, name)] as const);
+
+  let bindGroupCount = 0;
+  let drawIndexedCount = 0;
+  let syncPipelineCount = 0;
+  const bindGroupLabels: string[] = [];
+  const writeBufferLabels: string[] = [];
+
+  const pass = {
+    setPipeline: (): void => {},
+    setBindGroup: (): void => {},
+    setVertexBuffer: (): void => {},
+    setIndexBuffer: (): void => {},
+    setScissorRect: (): void => {},
+    pushDebugGroup: (): void => {},
+    popDebugGroup: (): void => {},
+    draw: (): void => {},
+    drawIndexed: (): void => {
+      drawIndexedCount++;
+    },
+    end: (): void => {},
+  };
+  const encoder = {
+    beginRenderPass: () => pass,
+    finish: () => ({ label: 'command-buffer' }) as unknown as GPUCommandBuffer,
+  };
+  const queue = {
+    writeBuffer: (buffer: LabeledBuffer): void => {
+      writeBufferLabels.push(buffer.label);
+    },
+    submit: (): void => {},
+    copyExternalImageToTexture: (): void => {},
+    writeTexture: (): void => {},
+  };
+  const device = {
+    createShaderModule: () => ({}) as GPUShaderModule,
+    createBindGroupLayout: () => ({}) as GPUBindGroupLayout,
+    createPipelineLayout: () => ({}) as GPUPipelineLayout,
+    createBindGroup: (descriptor: GPUBindGroupDescriptor): GPUBindGroup => {
+      bindGroupCount++;
+      bindGroupLabels.push(descriptor.label ?? '');
+
+      return {} as GPUBindGroup;
+    },
+    createRenderPipeline: (): GPURenderPipeline => {
+      syncPipelineCount++;
+
+      return {} as GPURenderPipeline;
+    },
+    createRenderPipelineAsync: async (): Promise<GPURenderPipeline> => ({}) as GPURenderPipeline,
+    createCommandEncoder: () => encoder as unknown as GPUCommandEncoder,
+    createBuffer: (descriptor: GPUBufferDescriptor): GPUBuffer =>
+      ({
+        label: descriptor.label ?? '',
+        destroy: (): void => {},
+      }) as unknown as GPUBuffer,
+    createTexture: (): GPUTexture => {
+      // A stable view per GPU texture, matching the backend's cached-view
+      // contract (a fresh view identity means "texture was recreated").
+      const view = {} as GPUTextureView;
+
+      return {
+        destroy: (): void => {},
+        createView: () => view,
+      } as unknown as GPUTexture;
+    },
+    createSampler: () => ({}) as GPUSampler,
+    lost: new Promise<GPUDeviceLostInfo>(() => {}),
+    queue,
+  } as unknown as GPUDevice;
+  const context = {
+    configure: (): void => {},
+    unconfigure: (): void => {},
+    getCurrentTexture: () =>
+      ({
+        createView: () => ({}) as GPUTextureView,
+      }) as unknown as GPUTexture,
+  } as unknown as GPUCanvasContext;
+  const gpu = {
+    requestAdapter: async () =>
+      ({
+        requestDevice: async () => device,
+      }) as unknown as GPUAdapter,
+    getPreferredCanvasFormat: () => 'bgra8unorm' as GPUTextureFormat,
+  } as unknown as GPU;
+  const canvas = document.createElement('canvas');
+
+  Object.defineProperty(navigator, 'gpu', { configurable: true, value: gpu });
+
+  for (const [name, value] of globalStubs) {
+    Object.defineProperty(globalThis, name, { configurable: true, value });
+  }
+
+  Object.defineProperty(canvas, 'getContext', {
+    configurable: true,
+    value: (contextType: string) => (contextType === 'webgpu' ? context : null),
+  });
+
+  return {
+    canvas,
+    bindGroupCount: () => bindGroupCount,
+    bindGroupLabels: () => bindGroupLabels,
+    writeBufferLabels: () => writeBufferLabels,
+    syncPipelineCount: () => syncPipelineCount,
+    drawIndexedCount: () => drawIndexedCount,
+    restore: (): void => {
+      if (previousGpu) {
+        Object.defineProperty(navigator, 'gpu', previousGpu);
+      } else {
+        Object.defineProperty(navigator, 'gpu', { configurable: true, value: undefined });
+      }
+
+      for (const [name, descriptor] of previousGlobals) {
+        if (descriptor) {
+          Object.defineProperty(globalThis, name, descriptor);
+        } else {
+          Object.defineProperty(globalThis, name, { configurable: true, value: undefined });
+        }
+      }
+    },
+  };
+};
+
+export const createMockBackend = async (environment: MockWebGpuEnvironment): Promise<WebGpuBackend> => {
+  const app = {
+    canvas: environment.canvas,
+    options: {
+      canvas: { width: 128, height: 128 },
+      clearColor: Color.black,
+    },
+  } as unknown as Application;
+  const backend = new WebGpuBackend(app);
+
+  materializeRendererBindings(backend, buildCoreRendererBindings({}));
+  await backend.initialize();
+
+  return backend;
+};
+
+export const createCanvasTexture = (size = 16): Texture => {
+  const sourceCanvas = document.createElement('canvas');
+
+  sourceCanvas.width = size;
+  sourceCanvas.height = size;
+
+  const texture = new Texture(sourceCanvas);
+
+  // Keep the frame to pure content passes (mipmap generation opens its own).
+  texture.generateMipMap = false;
+  texture.updateSource();
+
+  return texture;
+};
+
+export const countLabel = (labels: readonly string[], label: string, from = 0): number => {
+  let count = 0;
+
+  for (let index = from; index < labels.length; index++) {
+    if (labels[index] === label) {
+      count++;
+    }
+  }
+
+  return count;
+};


### PR DESCRIPTION
## Root cause

PR #272 gave the WebGPU **sprite** renderer a pipeline prewarm + texture bind-group cache + redundant-projection-write skip (findings F5a/F5b). The audit (issue #277) found its sibling renderers never got the same treatment:

- **Repeating-sprite and nine-slice have no `prewarmPipelines`.** The backend prewarm loop duck-types the method, so they were silently skipped — the first draw of each pipeline still blocked on synchronous WGSL compilation (first-frame hitch).
- **Repeating-sprite and nine-slice rebuilt a single-texture `group(1)` bind group and rewrote the 128-byte projection UBO on every batch flush; text rewrote its 96-byte FrameUniforms every flush.** Per-frame GPU-object churn that scales with flush count even for completely static scenes.

## Approach (mirrors the sprite renderer)

- **Prewarm** on `WebGpuNineSliceSpriteRenderer` (blend × format) and `WebGpuRepeatingSpriteRenderer` (kind × blend × format), storing under the exact key the hot-path lookup queries (`:n` suffix), no-clip variants only. Repeating now builds **one shared pipeline layout at connect** instead of a fresh one per pipeline compile.
- **Per-texture `group(1)` bind-group cache** (WeakMap) on both instanced renderers, keyed on the resolved **view AND sampler** so a resize (new view) or a `setScaleMode`/`setWrapMode` sampler refresh rebuilds in place. The binding is resolved (syncing dirty content) **before** the cache lookup, so cache hits never skip a texture upload.
- **Redundant projection / FrameUniforms write skip** on all three renderers: the 128/96-byte upload is elided while `(view identity, view.updateId, group-transform id)` are unchanged. Per-node text style data still uploads unconditionally (it genuinely changes per frame).

Consistent with PR #281's per-connection design: these renderers use a fixed single-texture layout (no tier), and **all new caches drop on disconnect** (device-loss safe), matching the sprite renderer's cache lifecycle.

## Test evidence

TDD — tests written first and confirmed red (13 failing) before the fix, green after.

- `test/rendering/webgpu-instanced-flush-caching.test.ts` — real `WebGpuBackend` + mock device: a static re-flush creates **0** bind groups and **0** projection writes while still drawing, a view pan rewrites the projection **exactly once** then skips again, and a texture resize rebuilds the cached bind group **once** (nine-slice + both repeating strategies).
- `test/rendering/webgpu-pipeline-prewarm.test.ts` — extended with nine-slice + repeating: every prewarmed pipeline is found by the hot-path lookup (**0** synchronous compiles) and no unreachable keys remain.
- `test/rendering/browser/webgpu-prewarm-bindgroup-cache.test.ts` — **real-device** (lavapipe/Chromium): prewarm fills the pipeline cache, and a static re-flush builds no new texture bind group (nine-slice/repeating) and issues no FrameUniforms write (text), all under a WebGPU validation error scope.
- Extracted the proven mock harness into `test/rendering/webgpuMockEnvironment.ts`.

Verification run locally: `vitest --project=exojs` (4747 passed), full `browser-webgpu` (155 passed) and `browser-webgl-chromium` (211 passed) lanes, `tsc --noEmit`, eslint, prettier, and `docs:api:check` all green.

https://claude.ai/code/session_01RHB7cLgoonJHLQg9ScdXby