### PR TITLE
fix(dx): sharpen misleading/vague error messages on 4 beginner paths

### DIFF
--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -314,6 +314,15 @@ export class Application {
     const inputOptions = appSettings.input ?? {};
     const canvas = canvasOptions.element ?? createDefaultCanvas();
 
+    // A wrong `canvas.element` (e.g. a <div> from a mistyped querySelector cast)
+    // otherwise surfaces much later as a misleading "This browser or hardware
+    // does not support WebGL." from the backend, once `canvas.getContext` turns
+    // out not to be a function. Catch the real cause here instead.
+    assert(
+      canvas instanceof HTMLCanvasElement,
+      `Application canvas.element must be an HTMLCanvasElement (got ${(canvas as object).constructor?.name ?? typeof canvas}). Pass a real <canvas> element, or omit canvas.element to let Application create one.`,
+    );
+
     const logicalWidth = canvasOptions.width ?? defaultCanvasSettings.width;
     const logicalHeight = canvasOptions.height ?? defaultCanvasSettings.height;
 
@@ -779,7 +788,19 @@ export class Application {
 
     const target = typeof mount === 'string' ? document.querySelector(mount) : mount;
 
-    target?.append(this.canvas);
+    if (target === null) {
+      // A string selector that matches nothing is a common typo — warn instead
+      // of silently leaving the canvas unattached (a beginner otherwise sees a
+      // blank page with no signal as to why).
+      logger.warn(
+        `Application canvas.mount selector "${mount as string}" did not match any element — the canvas was created but never attached to the page. Check the selector for typos, or append \`app.canvas\` to the DOM yourself.`,
+        { source: 'Application', once: `application:mount-miss:${mount as string}` },
+      );
+
+      return;
+    }
+
+    target.append(this.canvas);
   }
 
   /**

--- a/src/resources/factories/ImageFactory.ts
+++ b/src/resources/factories/ImageFactory.ts
@@ -71,7 +71,11 @@ export class ImageFactory extends AbstractAssetFactory<DecodedImage> {
         'error',
         () => {
           finalize();
-          reject(new Error('Error loading image source.'));
+          reject(
+            new Error(
+              'Failed to decode image source — the bytes may be corrupted, an unsupported format, or (if loaded with the wrong Asset.kind) not an image at all.',
+            ),
+          );
         },
         { once: true },
       );

--- a/src/resources/factories/SoundFactory.ts
+++ b/src/resources/factories/SoundFactory.ts
@@ -47,7 +47,17 @@ export class SoundFactory extends AbstractAssetFactory<Sound> {
    * constructs a {@link Sound} with the given options.
    */
   public async create(source: ArrayBuffer, options: SoundFactoryOptions = {}): Promise<Sound> {
-    const audioBuffer = await decodeAudioData(source);
+    let audioBuffer: AudioBuffer;
+
+    try {
+      audioBuffer = await decodeAudioData(source);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      throw new Error(`Failed to decode audio data: ${message} (if loaded with the wrong Asset.kind, this file may not be an audio format at all).`, {
+        cause: error,
+      });
+    }
 
     const sound = new Sound(audioBuffer, {
       ...options.playbackOptions,

--- a/src/resources/factories/SvgFactory.ts
+++ b/src/resources/factories/SvgFactory.ts
@@ -87,7 +87,7 @@ export class SvgFactory extends AbstractAssetFactory<HTMLImageElement> {
         'error',
         () => {
           finalize();
-          reject(new Error('Error loading image source.'));
+          reject(new Error('Failed to decode SVG source — the markup may be malformed, or (if loaded with the wrong Asset.kind) not SVG at all.'));
         },
         { once: true },
       );

--- a/src/resources/factories/TextureFactory.ts
+++ b/src/resources/factories/TextureFactory.ts
@@ -70,7 +70,11 @@ export class TextureFactory extends AbstractAssetFactory<Texture> {
         'error',
         () => {
           finalize();
-          reject(new Error('Error loading image source.'));
+          reject(
+            new Error(
+              'Failed to decode image source — the bytes may be corrupted, an unsupported format, or (if loaded with the wrong Asset.kind) not an image at all.',
+            ),
+          );
         },
         { once: true },
       );

--- a/test/core/application-lifecycle.test.ts
+++ b/test/core/application-lifecycle.test.ts
@@ -471,6 +471,30 @@ describe('Application lifecycle / getters / sizing', () => {
 
       expect(app.canvas.parentElement).toBeNull();
     });
+
+    test('warns once and leaves the canvas unattached when the mount selector matches no element', async () => {
+      const { Application } = await loadHarness();
+      // `loadHarness()` calls `vi.resetModules()`, so `Application` resolved its
+      // `#core/logging` singleton fresh — grab THAT instance, not the one bound
+      // by this file's static top-level import.
+      const { logger: freshLogger, LogSeverity: freshLogSeverity } = await import('#core/logging');
+      const messages: string[] = [];
+      const removeSink = freshLogger.addSink(entry => {
+        if (entry.severity >= freshLogSeverity.Warning) messages.push(entry.message);
+      });
+
+      try {
+        const app = new Application({ canvas: { mount: '#does-not-exist-anywhere' }, backend: { type: 'webgl2' } });
+
+        expect(app.canvas.parentElement).toBeNull();
+        expect(messages).toEqual([
+          'Application canvas.mount selector "#does-not-exist-anywhere" did not match any element — the canvas was created but never attached to the page. Check the selector for typos, or append `app.canvas` to the DOM yourself.',
+        ]);
+      } finally {
+        removeSink();
+        freshLogger._resetOnce();
+      }
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -948,6 +972,15 @@ describe('Application lifecycle / getters / sizing', () => {
       expect(
         () => new Application({ backend: { type: 'webgl2' }, extensions: null as unknown as ReadonlyArray<import('#extensions/Extension').Extension> }),
       ).not.toThrow();
+    });
+
+    test('throws a targeted message when canvas.element is not an HTMLCanvasElement', async () => {
+      const { Application } = await loadHarness();
+      const div = document.createElement('div');
+
+      expect(() => new Application({ canvas: { element: div as unknown as HTMLCanvasElement }, backend: { type: 'webgl2' } })).toThrow(
+        'Application canvas.element must be an HTMLCanvasElement (got HTMLDivElement). Pass a real <canvas> element, or omit canvas.element to let Application create one.',
+      );
     });
   });
 

--- a/test/resources/image-factory.test.ts
+++ b/test/resources/image-factory.test.ts
@@ -128,7 +128,9 @@ describe('ImageFactory', () => {
       const promise = factory.create(PNG_HEADER);
       lastImage().dispatchEvent(new Event('error'));
 
-      await expect(promise).rejects.toThrow('Error loading image source.');
+      await expect(promise).rejects.toThrow(
+        'Failed to decode image source — the bytes may be corrupted, an unsupported format, or (if loaded with the wrong Asset.kind) not an image at all.',
+      );
     });
 
     test('create() rejects with a clear message on "abort"', async () => {

--- a/test/resources/sound-factory.test.ts
+++ b/test/resources/sound-factory.test.ts
@@ -89,10 +89,16 @@ describe('SoundFactory', () => {
     ).rejects.toThrow();
   });
 
-  test('create() propagates decode errors', async () => {
-    decodeAudioDataMock.mockRejectedValueOnce(new Error('corrupt audio data'));
+  test('create() wraps decode errors with a kind-mismatch hint, preserving the original as .cause', async () => {
+    const decodeError = new Error('corrupt audio data');
+    decodeAudioDataMock.mockRejectedValueOnce(decodeError);
     const factory = new SoundFactory();
 
-    await expect(factory.create(new ArrayBuffer(8))).rejects.toThrow('corrupt audio data');
+    const promise = factory.create(new ArrayBuffer(8));
+
+    await expect(promise).rejects.toThrow(
+      'Failed to decode audio data: corrupt audio data (if loaded with the wrong Asset.kind, this file may not be an audio format at all).',
+    );
+    await expect(promise).rejects.toMatchObject({ cause: decodeError });
   });
 });

--- a/test/resources/svg-factory.test.ts
+++ b/test/resources/svg-factory.test.ts
@@ -76,7 +76,9 @@ describe('SvgFactory', () => {
     const promise = factory.create('<svg></svg>');
     lastImage().dispatchEvent(new Event('error'));
 
-    await expect(promise).rejects.toThrow('Error loading image source.');
+    await expect(promise).rejects.toThrow(
+      'Failed to decode SVG source — the markup may be malformed, or (if loaded with the wrong Asset.kind) not SVG at all.',
+    );
   });
 
   test('create() rejects with a clear message on "abort"', async () => {

--- a/test/resources/texture-factory.test.ts
+++ b/test/resources/texture-factory.test.ts
@@ -108,7 +108,9 @@ describe('TextureFactory', () => {
       const promise = factory.create(PNG_HEADER);
       lastImage().dispatchEvent(new Event('error'));
 
-      await expect(promise).rejects.toThrow('Error loading image source.');
+      await expect(promise).rejects.toThrow(
+        'Failed to decode image source — the bytes may be corrupted, an unsupported format, or (if loaded with the wrong Asset.kind) not an image at all.',
+      );
     });
 
     test('create() rejects with a clear message on "abort"', async () => {


### PR DESCRIPTION
## Summary

Part of the M1 error-message audit of the top-10 beginner paths (`new Application` with a bad canvas, 404 loads, using a texture before load, adding a node to two parents, playing sound before unlock, wrong asset kind, using a destroyed resource, forgetting `app.start()`, misspelled asset key, double renderer/extension registration).

Four message-only / single-guard cheap fixes, no new validation layer or structural change:

- **Application `_mountCanvas()`**: warn once (dev-mode) instead of silently leaving the canvas unattached when `canvas.mount` is a CSS selector that matches nothing.
- **Application constructor**: validate `canvas.element instanceof HTMLCanvasElement` up front. Previously a wrong element type (e.g. a `<div>`) surfaced three layers down as the actively misleading `"This browser or hardware does not support WebGL."`
- **TextureFactory / ImageFactory / SvgFactory**: the `<img>`-fallback decode-error path rejected with a bare `"Error loading image source."` — now names the likely causes (corrupt bytes, unsupported format, wrong `Asset.kind`).
- **SoundFactory**: wrap `decodeAudioData()` failures with a kind-mismatch hint, preserving the original browser error as `.cause`.

Full 10-path audit table + structural follow-up recommendations (a `Sprite` built from a not-yet-loaded texture goes permanently invisible via `NaN` scale; no `_destroyed` guard on `SceneNode`/`Container`/`Texture`; `Assets.from()` catalogs have no typo protection) are in `.workspace/reviews/2026-07-12-error-message-audit.md` (local review notes, not committed — gitignored).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm docs:api:check` in sync (no public JSDoc touched)
- [x] `pnpm format:check` clean
- [x] `eslint` clean on all changed files
- [x] Full `exojs` jsdom vitest project: 302 files, 4762 tests passed, 0 failed
- [x] 2 new tests added (`test/core/application-lifecycle.test.ts`): mount-selector-miss warning, wrong-canvas-element-type throw
- [x] 3 existing snapshot assertions updated for the new Texture/Image/Svg factory message; 1 existing SoundFactory test updated to assert the wrapped message + `.cause`
- [x] `pnpm install` + full pre-push `verify:quick` gate passed on push

https://claude.ai/code/session_01RHB7cLgoonJHLQg9ScdXby