### PR TITLE
fix(rendering): evict destroyed drawables from RetainedContainer replay (P3f)

### DIFF
--- a/site/src/content/api/abstract-text.json
+++ b/site/src/content/api/abstract-text.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 87,
+  "memberCount": 88,
   "counts": {
     "constructors": 1,
     "methods": 39,
-    "properties": 34,
+    "properties": 35,
     "events": 13
   },
   "sections": [
@@ -2126,6 +2126,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "filters",

--- a/site/src/content/api/animated-sprite.json
+++ b/site/src/content/api/animated-sprite.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 107,
+  "memberCount": 108,
   "counts": {
     "constructors": 1,
     "methods": 48,
-    "properties": 43,
+    "properties": 44,
     "events": 15
   },
   "sections": [
@@ -2756,6 +2756,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "filters",

--- a/site/src/content/api/bitmap-text.json
+++ b/site/src/content/api/bitmap-text.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 95,
+  "memberCount": 96,
   "counts": {
     "constructors": 1,
     "methods": 40,
-    "properties": 41,
+    "properties": 42,
     "events": 13
   },
   "sections": [
@@ -2218,6 +2218,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "filters",

--- a/site/src/content/api/button.json
+++ b/site/src/content/api/button.json
@@ -6,11 +6,11 @@
   "subsystem": "ui",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 108,
+  "memberCount": 109,
   "counts": {
     "constructors": 1,
     "methods": 49,
-    "properties": 44,
+    "properties": 45,
     "events": 14
   },
   "sections": [
@@ -2911,6 +2911,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "enabled",

--- a/site/src/content/api/container.json
+++ b/site/src/content/api/container.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 94,
+  "memberCount": 95,
   "counts": {
     "constructors": 1,
     "methods": 44,
-    "properties": 36,
+    "properties": 37,
     "events": 13
   },
   "sections": [
@@ -2476,6 +2476,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "filters",

--- a/site/src/content/api/drawable.json
+++ b/site/src/content/api/drawable.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 83,
+  "memberCount": 84,
   "counts": {
     "constructors": 1,
     "methods": 37,
-    "properties": 32,
+    "properties": 33,
     "events": 13
   },
   "sections": [
@@ -2032,6 +2032,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "filters",

--- a/site/src/content/api/graphics.json
+++ b/site/src/content/api/graphics.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 115,
+  "memberCount": 116,
   "counts": {
     "constructors": 1,
     "methods": 59,
-    "properties": 42,
+    "properties": 43,
     "events": 13
   },
   "sections": [
@@ -4008,6 +4008,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "fillColor",

--- a/site/src/content/api/htmltext.json
+++ b/site/src/content/api/htmltext.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 101,
+  "memberCount": 102,
   "counts": {
     "constructors": 1,
     "methods": 47,
-    "properties": 40,
+    "properties": 41,
     "events": 13
   },
   "sections": [
@@ -2741,6 +2741,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "filters",

--- a/site/src/content/api/label.json
+++ b/site/src/content/api/label.json
@@ -6,11 +6,11 @@
   "subsystem": "ui",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 104,
+  "memberCount": 105,
   "counts": {
     "constructors": 1,
     "methods": 49,
-    "properties": 41,
+    "properties": 42,
     "events": 13
   },
   "sections": [
@@ -2834,6 +2834,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "enabled",

--- a/site/src/content/api/mesh.json
+++ b/site/src/content/api/mesh.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 93,
+  "memberCount": 94,
   "counts": {
     "constructors": 1,
     "methods": 38,
-    "properties": 41,
+    "properties": 42,
     "events": 13
   },
   "sections": [
@@ -2123,6 +2123,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "filters",

--- a/site/src/content/api/nine-slice-sprite.json
+++ b/site/src/content/api/nine-slice-sprite.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 94,
+  "memberCount": 95,
   "counts": {
     "constructors": 1,
     "methods": 41,
-    "properties": 39,
+    "properties": 40,
     "events": 13
   },
   "sections": [
@@ -2360,6 +2360,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "filters",

--- a/site/src/content/api/panel.json
+++ b/site/src/content/api/panel.json
@@ -6,11 +6,11 @@
   "subsystem": "ui",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 107,
+  "memberCount": 108,
   "counts": {
     "constructors": 1,
     "methods": 49,
-    "properties": 44,
+    "properties": 45,
     "events": 13
   },
   "sections": [
@@ -2918,6 +2918,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "enabled",

--- a/site/src/content/api/particle-system.json
+++ b/site/src/content/api/particle-system.json
@@ -6,11 +6,11 @@
   "subsystem": "particles",
   "importPath": "@codexo/exojs-particles",
   "tier": "stable",
-  "memberCount": 125,
+  "memberCount": 126,
   "counts": {
     "constructors": 4,
     "methods": 49,
-    "properties": 59,
+    "properties": 60,
     "events": 13
   },
   "sections": [
@@ -3132,6 +3132,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "filters",

--- a/site/src/content/api/progress-bar.json
+++ b/site/src/content/api/progress-bar.json
@@ -6,11 +6,11 @@
   "subsystem": "ui",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 106,
+  "memberCount": 107,
   "counts": {
     "constructors": 1,
     "methods": 49,
-    "properties": 43,
+    "properties": 44,
     "events": 13
   },
   "sections": [
@@ -2834,6 +2834,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "enabled",

--- a/site/src/content/api/render-node.json
+++ b/site/src/content/api/render-node.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 78,
+  "memberCount": 79,
   "counts": {
     "constructors": 1,
     "methods": 35,
-    "properties": 29,
+    "properties": 30,
     "events": 13
   },
   "sections": [
@@ -1918,6 +1918,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "filters",

--- a/site/src/content/api/repeating-sprite.json
+++ b/site/src/content/api/repeating-sprite.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 96,
+  "memberCount": 97,
   "counts": {
     "constructors": 1,
     "methods": 39,
-    "properties": 43,
+    "properties": 44,
     "events": 13
   },
   "sections": [
@@ -2222,6 +2222,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "filters",

--- a/site/src/content/api/retained-container.json
+++ b/site/src/content/api/retained-container.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "advanced",
-  "memberCount": 95,
+  "memberCount": 96,
   "counts": {
     "constructors": 1,
     "methods": 45,
-    "properties": 36,
+    "properties": 37,
     "events": 13
   },
   "sections": [
@@ -2505,6 +2505,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "filters",

--- a/site/src/content/api/scene-node.json
+++ b/site/src/content/api/scene-node.json
@@ -6,11 +6,11 @@
   "subsystem": "core",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 45,
+  "memberCount": 46,
   "counts": {
     "constructors": 1,
     "methods": 26,
-    "properties": 18,
+    "properties": 19,
     "events": 0
   },
   "sections": [
@@ -1400,6 +1400,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "isAlignedBox",

--- a/site/src/content/api/scroll-container.json
+++ b/site/src/content/api/scroll-container.json
@@ -6,11 +6,11 @@
   "subsystem": "ui",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 107,
+  "memberCount": 108,
   "counts": {
     "constructors": 1,
     "methods": 51,
-    "properties": 42,
+    "properties": 43,
     "events": 13
   },
   "sections": [
@@ -2972,6 +2972,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "enabled",

--- a/site/src/content/api/sprite.json
+++ b/site/src/content/api/sprite.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 92,
+  "memberCount": 93,
   "counts": {
     "constructors": 1,
     "methods": 39,
-    "properties": 39,
+    "properties": 40,
     "events": 13
   },
   "sections": [
@@ -2198,6 +2198,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "filters",

--- a/site/src/content/api/stack.json
+++ b/site/src/content/api/stack.json
@@ -6,11 +6,11 @@
   "subsystem": "ui",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 107,
+  "memberCount": 108,
   "counts": {
     "constructors": 1,
     "methods": 51,
-    "properties": 42,
+    "properties": 43,
     "events": 13
   },
   "sections": [
@@ -2889,6 +2889,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "direction",

--- a/site/src/content/api/text.json
+++ b/site/src/content/api/text.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 94,
+  "memberCount": 95,
   "counts": {
     "constructors": 1,
     "methods": 39,
-    "properties": 41,
+    "properties": 42,
     "events": 13
   },
   "sections": [
@@ -2223,6 +2223,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "filters",

--- a/site/src/content/api/tile-layer-node.json
+++ b/site/src/content/api/tile-layer-node.json
@@ -6,11 +6,11 @@
   "subsystem": "tilemap",
   "importPath": "@codexo/exojs-tilemap",
   "tier": "advanced",
-  "memberCount": 97,
+  "memberCount": 98,
   "counts": {
     "constructors": 1,
     "methods": 45,
-    "properties": 38,
+    "properties": 39,
     "events": 13
   },
   "sections": [
@@ -2548,6 +2548,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "filters",

--- a/site/src/content/api/tile-map-band.json
+++ b/site/src/content/api/tile-map-band.json
@@ -6,11 +6,11 @@
   "subsystem": "tilemap",
   "importPath": "@codexo/exojs-tilemap",
   "tier": "advanced",
-  "memberCount": 96,
+  "memberCount": 97,
   "counts": {
     "constructors": 0,
     "methods": 45,
-    "properties": 38,
+    "properties": 39,
     "events": 13
   },
   "sections": [
@@ -2488,6 +2488,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "filters",

--- a/site/src/content/api/tile-map-node.json
+++ b/site/src/content/api/tile-map-node.json
@@ -6,11 +6,11 @@
   "subsystem": "tilemap",
   "importPath": "@codexo/exojs-tilemap",
   "tier": "advanced",
-  "memberCount": 99,
+  "memberCount": 100,
   "counts": {
     "constructors": 1,
     "methods": 46,
-    "properties": 39,
+    "properties": 40,
     "events": 13
   },
   "sections": [
@@ -2603,6 +2603,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "filters",

--- a/site/src/content/api/uiroot.json
+++ b/site/src/content/api/uiroot.json
@@ -6,11 +6,11 @@
   "subsystem": "ui",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 97,
+  "memberCount": 98,
   "counts": {
     "constructors": 1,
     "methods": 44,
-    "properties": 38,
+    "properties": 39,
     "events": 14
   },
   "sections": [
@@ -2475,6 +2475,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "filters",

--- a/site/src/content/api/video.json
+++ b/site/src/content/api/video.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 117,
+  "memberCount": 118,
   "counts": {
     "constructors": 1,
     "methods": 50,
-    "properties": 51,
+    "properties": 52,
     "events": 15
   },
   "sections": [
@@ -2909,6 +2909,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "duration",

--- a/site/src/content/api/widget.json
+++ b/site/src/content/api/widget.json
@@ -6,11 +6,11 @@
   "subsystem": "ui",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 102,
+  "memberCount": 103,
   "counts": {
     "constructors": 1,
     "methods": 49,
-    "properties": 39,
+    "properties": 40,
     "events": 13
   },
   "sections": [
@@ -2796,6 +2796,27 @@
           "params": [],
           "returnType": null,
           "description": "Custom rectangle used for viewport cull intersection test. When set, replaces the default node bounds in cull checks. Set to null to restore default bounds-based culling."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
         },
         {
           "name": "enabled",

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -189,6 +189,7 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
   private _zIndex = 0;
   private _cullable = true;
   private _cullArea: Rectangle | null = null;
+  private _isDestroyed = false;
   /** Lazily-built oriented bounding box (the local bounds under the global transform) for rotated-node SAT. */
   private _orientedBounds: Polygon | null = null;
 
@@ -270,6 +271,17 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
 
   public set parent(parent: Container | null) {
     this._parentNode = parent;
+  }
+
+  /**
+   * `true` once {@link destroy} has run on this node. A destroyed node has
+   * released its pooled resources (transform/bounds), renders nothing, and
+   * must not be reused or re-attached. The render plan skips a destroyed node
+   * and — for a {@link RetainedContainer} — evicts it from any cached fragment
+   * so a child destroyed without `removeChild` cannot be replayed stale.
+   */
+  public get destroyed(): boolean {
+    return this._isDestroyed;
   }
 
   public get visible(): boolean {
@@ -780,6 +792,7 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
   }
 
   public destroy(): void {
+    this._isDestroyed = true;
     this._transform.destroy();
     this._position.destroy();
     this._scale.destroy();

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -269,9 +269,19 @@ export class Container extends RenderNode {
     const viewUpdateId = builder.view.updateId;
 
     if (this._retainedPlan !== null && this._retainedPlan.isClean(this._contentRevision, this._structureRevision, viewUpdateId, builder.backend)) {
-      this._replayRetainedChildren(builder);
+      if (__DEV__ && this._retainedPlan._devHasDestroyedDrawable()) {
+        // P3f: a direct drawable child was destroy()ed but left attached, so
+        // no revision bumped and the slot cache still looks clean. Drop the
+        // stale capture (releasing the strong refs) and fall through to a full
+        // collect, which skips the destroyed child (RenderNode._collect dev
+        // guard) and recaptures without it. Silent here — the loud diagnostic
+        // is owned by the nearest RetainedContainer (P3f).
+        this._retainedPlan.invalidate();
+      } else {
+        this._replayRetainedChildren(builder);
 
-      return;
+        return;
+      }
     }
 
     this._collectAndCaptureChildren(builder, viewUpdateId);

--- a/src/rendering/RenderNode.ts
+++ b/src/rendering/RenderNode.ts
@@ -374,6 +374,15 @@ export abstract class RenderNode extends SceneNode {
 
   /** @internal */
   public _collect(builder: RenderPlanBuilder, seq?: number): void {
+    if (__DEV__ && this.destroyed) {
+      // A node destroy()ed but left attached to the tree (the documented
+      // footgun) has released its pooled transform/bounds; collecting it would
+      // read freed state and re-pin it. Skip it — the diagnostic is emitted
+      // once by the nearest RetainedContainer (P3f); the plain path degrades
+      // silently to "renders nothing", which is the correct result.
+      return;
+    }
+
     if (!this.visible) {
       return;
     }

--- a/src/rendering/RetainedContainer.ts
+++ b/src/rendering/RetainedContainer.ts
@@ -63,6 +63,7 @@ export class RetainedContainer extends Container {
   private _devFragmentBuilds = 0;
   private _devFragmentInvalidations = 0;
   private _devRetentionWarned = false;
+  private _devDestroyedWarned = false;
 
   /**
    * The boundary is ALWAYS engaged (F13/R3 superseded the whole-group
@@ -186,7 +187,18 @@ export class RetainedContainer extends Container {
       return;
     }
 
-    if (this._fragment.isClean(this._contentRevision, this._structureRevision, builder.backend)) {
+    const fragmentClean = this._fragment.isClean(this._contentRevision, this._structureRevision, builder.backend);
+
+    if (fragmentClean && __DEV__ && this._fragment._devHasDestroyedDrawable()) {
+      // P3f: a descendant was destroy()ed but left attached, so no revision
+      // bumped and the capture still looks clean. Replaying it would splice a
+      // dead drawable for a whole frame and pin it against GC. Drop the capture
+      // (releasing the strong refs), warn once, and fall through to a full
+      // collect — which skips the destroyed child (RenderNode._collect dev
+      // guard) and recaptures a clean fragment.
+      this._fragment.invalidate();
+      this._warnReplayedDestroyed();
+    } else if (fragmentClean) {
       // Fast tier (Slice 3, S3-D2): a valid recorded instruction set splices
       // as an EMPTY scope — the player replays O(batches), the optimizer sees
       // nothing. Falls through the ladder: instruction replay -> entry replay
@@ -307,6 +319,27 @@ export class RetainedContainer extends Container {
 
   private _escapeCheckContent = -1;
   private _escapeCheckStructure = -1;
+
+  /**
+   * P3f dev diagnostic: warn ONCE when the retained fragment was found holding
+   * a child that was `destroy()`ed without `removeChild()` (so it stayed
+   * attached and the capture still looked clean). Dev builds only; the call
+   * site is `__DEV__`-guarded and stripped from production.
+   */
+  private _warnReplayedDestroyed(): void {
+    if (this._devDestroyedWarned) {
+      return;
+    }
+
+    this._devDestroyedWarned = true;
+    logger.warn(
+      `RetainedContainer${this.name ? ` '${this.name}'` : ''} held a child that was destroy()ed without ` +
+        'removeChild() — it stayed attached to the subtree, so no revision change dropped the retained fragment. ' +
+        'The stale capture has been evicted and the destroyed child skipped; detach children (removeChild) before ' +
+        'or instead of destroying them.',
+      { source: 'rendering' },
+    );
+  }
   private _deepBarrierWarned = false;
   /**
    * Direct children whose subtrees contain a deep barrier (F13/R3): they

--- a/src/rendering/plan/RetainedGroupFragment.ts
+++ b/src/rendering/plan/RetainedGroupFragment.ts
@@ -248,6 +248,7 @@ export class RetainedGroupFragment {
   }
 
   public invalidate(): void {
+    this._releaseDrawableRefs();
     this._hasCapture = false;
     this._entries.length = 0;
     this._replayedSinceCapture = false;
@@ -255,6 +256,37 @@ export class RetainedGroupFragment {
     this._wastedCaptures = 0;
     this._recordableFor = null;
     this._instructions?.invalidate();
+  }
+
+  /**
+   * @internal — dev-only P3f probe: `true` when any captured draw still
+   * references a destroyed {@link Drawable} (a child destroy()ed without
+   * `removeChild`, so no revision bump dropped the capture). Scans only the
+   * live prefix of the grow-only draw pool — the same O(draws) the replay
+   * already walks — so it adds no allocation and is stripped from production
+   * via the `__DEV__` guard at the call site.
+   */
+  public _devHasDestroyedDrawable(): boolean {
+    for (let index = 0; index < this._drawCursor; index++) {
+      // `?.`: released pool records (post-invalidate) hold no drawable.
+      if (this._drawPool[index]!.drawable?.destroyed) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Drop the grow-only draw pool's strong references to their drawables so an
+   * evicted/destroyed drawable can be garbage-collected (P3f). The pooled
+   * record objects survive and their `drawable` is rewritten in place on the
+   * next capture, so pool reuse is unaffected.
+   */
+  private _releaseDrawableRefs(): void {
+    for (let index = 0; index < this._drawCursor; index++) {
+      this._drawPool[index]!.drawable = undefined as unknown as Drawable;
+    }
   }
 
   /**

--- a/src/rendering/plan/RetainedPlanCache.ts
+++ b/src/rendering/plan/RetainedPlanCache.ts
@@ -142,9 +142,41 @@ export class RetainedPlanCache {
   }
 
   public invalidate(): void {
+    this._releaseDrawableRefs();
     this._hasCapture = false;
     this._slots.length = 0;
     this._poolCursor = 0;
+  }
+
+  /**
+   * @internal — dev-only P3f probe: `true` when any captured slot still
+   * references a destroyed {@link Drawable} (a direct drawable child
+   * destroy()ed without `removeChild`, so no revision bump dropped the
+   * capture). Scans only the active slot list — the same O(slots) the replay
+   * already walks — and is stripped from production via the `__DEV__` guard at
+   * the call site.
+   */
+  public _devHasDestroyedDrawable(): boolean {
+    for (let index = 0; index < this._slots.length; index++) {
+      // `?.`: released pool records (post-invalidate) hold no drawable.
+      if (this._slots[index]!.drawable?.destroyed) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Drop the grow-only slot pool's strong references to their drawables so an
+   * evicted/destroyed drawable can be garbage-collected (P3f). The pooled slot
+   * objects survive and their `drawable` is rewritten in place on the next
+   * capture, so pool reuse is unaffected.
+   */
+  private _releaseDrawableRefs(): void {
+    for (let index = 0; index < this._poolCursor; index++) {
+      this._slotPool[index]!.drawable = undefined as unknown as Drawable;
+    }
   }
 
   private _acquireSlot(): MutableRetainedDrawSlot {

--- a/test/rendering/retained-container.test.ts
+++ b/test/rendering/retained-container.test.ts
@@ -1490,3 +1490,73 @@ describe('RetainedContainer: deep-barrier escape scoped to the offending sub-bra
     backend.destroy();
   });
 });
+
+describe('RetainedContainer: destroyed-child eviction (P3f)', () => {
+  test('a child destroy()ed without removeChild is evicted from the replay next frame and warns once', () => {
+    const backend = createTestBackend();
+    const warnSpy = vi.spyOn(logger, 'warn');
+    const root = new Container();
+    const group = new RetainedContainer();
+    const leafA = new LeafDrawable('a');
+    const leafB = new LeafDrawable('b');
+
+    group.name = 'decor';
+    group.addChild(leafA);
+    group.addChild(leafB);
+    root.addChild(group);
+
+    // Frame 1: full collect + capture (both children present).
+    expect(collectDraws(root, backend).map(d => (d.drawable as LeafDrawable).id)).toEqual(['a', 'b']);
+
+    // The footgun: destroy WITHOUT removeChild — the child stays attached, so
+    // no revision bump and the fragment is still "clean".
+    leafA.destroy();
+
+    // Frame 2: the retained fragment must NOT replay the destroyed drawable.
+    const frame2 = collectDraws(root, backend).map(d => (d.drawable as LeafDrawable).id);
+    expect(frame2).toEqual(['b']);
+    expect(frame2).not.toContain('a');
+
+    // Frame 3: still evicted, and no per-frame warning storm.
+    const frame3 = collectDraws(root, backend).map(d => (d.drawable as LeafDrawable).id);
+    expect(frame3).toEqual(['b']);
+
+    const destroyedWarnings = warnSpy.mock.calls.filter(call => String(call[0]).includes('destroy'));
+
+    expect(destroyedWarnings).toHaveLength(1);
+    expect(String(destroyedWarnings[0]![0])).toContain('decor');
+
+    warnSpy.mockRestore();
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('a destroyed drawable nested in a plain sub-container is also evicted', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const group = new RetainedContainer();
+    const mid = new Container();
+    const leafA = new LeafDrawable('a');
+    const leafB = new LeafDrawable('b');
+
+    mid.addChild(leafA);
+    group.addChild(mid);
+    group.addChild(leafB);
+    root.addChild(group);
+
+    expect(
+      collectDraws(root, backend)
+        .map(d => (d.drawable as LeafDrawable).id)
+        .sort(),
+    ).toEqual(['a', 'b']);
+
+    leafA.destroy();
+
+    const frame2 = collectDraws(root, backend).map(d => (d.drawable as LeafDrawable).id);
+
+    expect(frame2).toEqual(['b']);
+
+    root.destroy();
+    backend.destroy();
+  });
+});

--- a/test/rendering/retained-group-fragment.test.ts
+++ b/test/rendering/retained-group-fragment.test.ts
@@ -85,6 +85,34 @@ describe('RetainedGroupFragment', () => {
 
     drawable.destroy();
   });
+
+  test('_devHasDestroyedDrawable reports a destroyed captured drawable (P3f)', () => {
+    const fragment = new RetainedGroupFragment();
+    const drawable = new Drawable();
+
+    fragment.capture(1, 1, fakeBackendA, [makeScopeDrawEntry(drawable)]);
+
+    expect(fragment._devHasDestroyedDrawable()).toBe(false);
+
+    drawable.destroy();
+
+    expect(fragment._devHasDestroyedDrawable()).toBe(true);
+  });
+
+  test('invalidate() releases the pooled strong reference to drawables so they can GC (P3f)', () => {
+    const fragment = new RetainedGroupFragment();
+    const drawable = new Drawable();
+
+    fragment.capture(1, 1, fakeBackendA, [makeScopeDrawEntry(drawable)]);
+    drawable.destroy();
+
+    // Before the fix the grow-only draw pool still pins the destroyed drawable
+    // even after the entries array is emptied.
+    fragment.invalidate();
+
+    expect(fragment._devHasDestroyedDrawable()).toBe(false);
+    expect(fragment.entries).toEqual([]);
+  });
 });
 
 // File-local fake backend (repo convention keeps test harnesses file-local


### PR DESCRIPTION
## Expert-review finding P3f (Robustness, P2)

> The retained fragment holds **strong `drawable` refs** across frames and replays them verbatim; a child `destroy()`ed without `removeChild` replays a dead drawable.
> — `01-rendering-core.md` findings table

### Root cause

A `RetainedContainer` keys its whole-range fragment splice on the subtree's content/structure revision. Calling `child.destroy()` **without** a preceding `removeChild()` (a documented footgun) leaves the child attached, so **no revision bumps** and the fragment stays "clean". The splice then replays the destroyed drawable verbatim for a full frame — rendering stale GPU state — and the fragment's grow-only draw pool keeps a **strong reference** to the destroyed object, pinning it against GC. The plain `Container` Slice-1 slot cache shares the hazard.

### Approach (dev-guarded — zero production hot-path cost)

- **`SceneNode.destroyed`** — a lifecycle flag set in `destroy()`.
- **`RenderNode._collect`** skips a destroyed-but-attached node in dev builds (renders nothing — the correct result — instead of reading freed pooled transform/bounds and re-pinning it).
- **`RetainedContainer._collectContent`** scans the clean fragment for a destroyed drawable before replay — the same `O(draws)` the splice already walks, **no extra pass**. On a hit it warns **once**, evicts the capture, and falls through to a full collect that recaptures without the dead child.
- **`RetainedGroupFragment` / `RetainedPlanCache`** `invalidate()` now release the pooled draw records' strong drawable references so an evicted/destroyed drawable can be garbage-collected. `_devHasDestroyedDrawable()` is the shared dev probe.
- The plain `Container` slot cache gets the same **silent** eviction, so a destroyed drawable nested in a plain sub-container of a group is also dropped.

Every check is stripped from production via `__DEV__`, so the static replay path keeps its zero per-frame cost. This makes the engine behavior match/exceed the destroy-without-remove footgun documented in the retained-container guide.

### Tests (TDD)

- `retained-container.test.ts`: destroyed direct child evicted from replay + one-shot warning naming the container; destroyed drawable nested in a plain sub-container also evicted.
- `retained-group-fragment.test.ts`: `_devHasDestroyedDrawable` probe; `invalidate()` releases the pooled strong reference (GC).

### Verification

- `pnpm typecheck` (core + packages) — clean
- Node: full `exojs` project suite (4738 passed, 12 skipped)
- Browser retained-container suites: WebGL2 (7/7) and WebGPU (7/7)
- `pnpm lint:strict` (0 errors), `pnpm format:check`, `pnpm docs:api:check` — clean
- API docs regenerated for the new `SceneNode.destroyed` symbol

https://claude.ai/code/session_01RHB7cLgoonJHLQg9ScdXby
