### PR TITLE
perf(webgpu): reuse custom-material user-uniform buffers and bind groups (B-10)

### DIFF
--- a/src/rendering/webgpu/WebGpuMeshRenderer.ts
+++ b/src/rendering/webgpu/WebGpuMeshRenderer.ts
@@ -3,7 +3,7 @@
 import { Matrix } from '#math/Matrix';
 import { packAffineMat3Std140 } from '#rendering/affinePacking';
 import type { Geometry } from '#rendering/geometry/Geometry';
-import type { Material, UniformValue } from '#rendering/material/Material';
+import type { Material } from '#rendering/material/Material';
 import type { Mesh } from '#rendering/mesh/Mesh';
 import type { DrawCommand } from '#rendering/plan/RenderCommand';
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
@@ -15,6 +15,16 @@ import { AbstractWebGpuRenderer } from './AbstractWebGpuRenderer';
 import type { WebGpuBackend } from './WebGpuBackend';
 import { getWebGpuBlendState } from './WebGpuBlendState';
 import { stencilContentDepthStencilState } from './WebGpuStencilState';
+import {
+  collectScalarUniforms,
+  collectTextureBindings,
+  createUserUniformState,
+  packUserUniforms,
+  resetUserUniformState,
+  resolveUserUniformBindGroup,
+  userUniformBufferBytes,
+  type UserUniformState,
+} from './webgpuUserUniforms';
 
 /** WGSL source for the default (non-instanced) mesh pipeline. @internal */
 export const meshShaderSource = `
@@ -214,9 +224,11 @@ interface CustomShaderResources {
   meshUniformBuffer: GPUBuffer | null;
   meshUniformBufferCapacity: number;
   meshUniformBindGroup: GPUBindGroup | null;
-  // User-uniform UBO (re-uploaded per frame).
+  // User-uniform UBO: buffer reused across frames; the persistent scratch +
+  // cached user bind group re-upload/rebuild only on an actual change (B-10).
   userUniformBuffer: GPUBuffer | null;
   userUniformBufferCapacity: number;
+  userUniform: UserUniformState;
   // Mesh texture bind group cache keyed by texture identity, paired with the
   // texture view it was built from so a mutable texture (DataTexture content
   // update / resize) invalidates it. WeakMap avoids retaining short-lived
@@ -554,8 +566,8 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
         (resources.totalIndices * Uint16Array.BYTES_PER_ELEMENT + 3) & ~3,
       );
 
-      // Build/refresh user uniform UBO from the material (re-built every frame
-      // so mutations to material.uniforms.X are picked up).
+      // Refresh the user uniform UBO from the material — uploaded only when the
+      // uniform values actually changed since the last frame (B-10).
       this._uploadUserUniforms(material, resources);
     }
 
@@ -688,7 +700,8 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
           lastFormat = renderTargetFormat;
           lastTexture = null;
           // User bind group is shader-scoped; rebind once per shader switch.
-          pass.setBindGroup(2, this._buildUserBindGroup(backend, dc.customShader, resources));
+          // Reused across frames unless the UBO or a bound texture view changed.
+          pass.setBindGroup(2, this._getUserBindGroup(backend, dc.customShader, resources));
         }
 
         const cursor = customDrawCursors.get(dc.customShader) ?? 0;
@@ -1502,6 +1515,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
       meshUniformBindGroup: null,
       userUniformBuffer: null,
       userUniformBufferCapacity: 0,
+      userUniform: createUserUniformState(),
       meshTextureBindGroups: new WeakMap(),
       sampler,
       drawCount: 0,
@@ -1755,10 +1769,11 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
     const device = this._device!;
     const scalarValues = collectScalarUniforms(material);
 
-    // Always create a UBO (even if empty) since binding 0 of the user layout
-    // is fixed. Min size 16 bytes to satisfy WebGPU's minimum buffer size.
-    const slotCount = Math.max(scalarValues.length, 1);
-    const bufferBytes = slotCount * 16;
+    // Always keep a UBO (even if empty) since binding 0 of the user layout is
+    // fixed. Min size 16 bytes to satisfy WebGPU's minimum buffer size. The
+    // buffer is reused across frames — only (re)created on capacity growth.
+    const bufferBytes = userUniformBufferBytes(scalarValues.length);
+    let forceWrite = false;
 
     if (resources.userUniformBuffer === null || resources.userUniformBufferCapacity < bufferBytes) {
       resources.userUniformBuffer?.destroy();
@@ -1768,56 +1783,31 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
         size: bufferBytes,
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
       });
+      // A fresh buffer holds undefined contents and voids any bind group that
+      // referenced the old identity.
+      forceWrite = true;
+      resources.userUniform.bindGroup = null;
+      resources.userUniform.bindGroupBuffer = null;
     }
 
-    const data = new Float32Array(bufferBytes / 4);
+    // Pack into the reused scratch and upload only when the values changed.
+    if (packUserUniforms(scalarValues, resources.userUniform, forceWrite)) {
+      const data = resources.userUniform.data;
 
-    let slot = 0;
-    for (const value of scalarValues) {
-      const baseFloatIndex = slot * 4;
-
-      if (typeof value === 'number') {
-        data[baseFloatIndex] = value;
-      } else if (value instanceof Float32Array) {
-        data.set(value, baseFloatIndex);
-      } else if (value instanceof Int32Array) {
-        for (let i = 0; i < value.length; i++) {
-          data[baseFloatIndex + i] = value[i]!;
-        }
-      } else {
-        const arr = value as readonly number[];
-        for (let i = 0; i < arr.length; i++) {
-          data[baseFloatIndex + i] = arr[i]!;
-        }
-      }
-
-      slot++;
+      device.queue.writeBuffer(resources.userUniformBuffer, 0, data.buffer, data.byteOffset, bufferBytes);
     }
-
-    device.queue.writeBuffer(resources.userUniformBuffer, 0, data);
   }
 
-  private _buildUserBindGroup(backend: WebGpuBackend, material: Material, resources: CustomShaderResources): GPUBindGroup {
-    const device = this._device!;
-    const entries: GPUBindGroupEntry[] = [];
-
-    entries.push({ binding: 0, resource: { buffer: resources.userUniformBuffer! } });
-
-    let bindingIndex = 1;
-
-    for (const texture of collectTextureBindings(material)) {
-      const binding = backend.getTextureBinding(texture);
-      entries.push({ binding: bindingIndex, resource: binding.view });
-      bindingIndex++;
-      entries.push({ binding: bindingIndex, resource: binding.sampler });
-      bindingIndex++;
-    }
-
-    return device.createBindGroup({
-      label: 'mesh:material-user-bind-group',
-      layout: resources.userLayout,
-      entries,
-    });
+  private _getUserBindGroup(backend: WebGpuBackend, material: Material, resources: CustomShaderResources): GPUBindGroup {
+    return resolveUserUniformBindGroup(
+      this._device!,
+      backend,
+      material,
+      resources.userLayout,
+      'mesh:material-user-bind-group',
+      resources.userUniformBuffer!,
+      resources.userUniform,
+    );
   }
 
   private _releaseCustomShaderResources(resources: CustomShaderResources): void {
@@ -1836,52 +1826,6 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
     resources.indexBufferCapacity = 0;
     resources.meshUniformBufferCapacity = 0;
     resources.userUniformBufferCapacity = 0;
+    resetUserUniformState(resources.userUniform);
   }
-}
-
-function isTextureUniform(value: UniformValue): value is Texture | RenderTexture {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'width' in value &&
-    'height' in value &&
-    !(value instanceof Float32Array) &&
-    !(value instanceof Int32Array) &&
-    !Array.isArray(value)
-  );
-}
-
-/** Scalar/vector/matrix uniforms (texture values excluded) in declaration order. */
-function collectScalarUniforms(material: Material): Array<Exclude<UniformValue, Texture | RenderTexture>> {
-  const result: Array<Exclude<UniformValue, Texture | RenderTexture>> = [];
-
-  for (const value of Object.values(material.uniforms)) {
-    if (!isTextureUniform(value)) {
-      result.push(value);
-    }
-  }
-
-  return result;
-}
-
-/**
- * Texture bindings claimed by the material, in a stable order: texture-valued
- * entries of `uniforms` first (declaration order), then the dedicated
- * `textures` map (declaration order). The WGSL source must declare its
- * `@group(2)` texture/sampler pairs in this same order.
- */
-function collectTextureBindings(material: Material): Array<Texture | RenderTexture> {
-  const result: Array<Texture | RenderTexture> = [];
-
-  for (const value of Object.values(material.uniforms)) {
-    if (isTextureUniform(value)) {
-      result.push(value);
-    }
-  }
-
-  for (const texture of Object.values(material.textures)) {
-    result.push(texture);
-  }
-
-  return result;
 }

--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -3,7 +3,6 @@
 import { Matrix } from '#math/Matrix';
 import { Rectangle } from '#math/Rectangle';
 import { packAffineMat4 } from '#rendering/affinePacking';
-import type { UniformValue } from '#rendering/material/Material';
 import type { SpriteMaterial } from '#rendering/material/SpriteMaterial';
 import type { Sprite } from '#rendering/sprite/Sprite';
 import { spriteVertexWgsl } from '#rendering/sprite/spriteMaterialSources';
@@ -19,6 +18,16 @@ import { WebGpuInstanceArena } from './WebGpuInstanceArena';
 import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
 import { retainedGroupUniformBytes, type WebGpuRetainedBatchPayload } from './WebGpuRetainedGroupResources';
 import { stencilContentDepthStencilState } from './WebGpuStencilState';
+import {
+  collectScalarUniforms,
+  collectTextureBindings,
+  createUserUniformState,
+  packUserUniforms,
+  resetUserUniformState,
+  resolveUserUniformBindGroup,
+  userUniformBufferBytes,
+  type UserUniformState,
+} from './webgpuUserUniforms';
 
 /**
  * Multi-texture batch slot tiers the sprite pipeline can be generated for.
@@ -259,6 +268,10 @@ interface CustomSpriteResources {
   pipelines: Map<string, GPURenderPipeline>;
   userUniformBuffer: GPUBuffer | null;
   userUniformBufferCapacity: number;
+  // Persistent UBO scratch + cached user bind group, reused across frames and
+  // re-uploaded/rebuilt only when the material's uniform values or bound
+  // texture views actually change (B-10).
+  userUniform: UserUniformState;
   baseTextureBindGroups: WeakMap<Texture | RenderTexture, { group: GPUBindGroup; view: GPUTextureView }>;
 }
 
@@ -1339,7 +1352,8 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     const resources = this._getOrCreateCustomResources(material, device);
     const baseTexture = this._currentBaseTexture ?? Texture.empty;
 
-    // Re-built every frame so mutations to material.uniforms.X are picked up.
+    // Uploaded only when the material's uniform values changed since the last
+    // frame (B-10); a static material issues zero writes here.
     this._uploadUserUniforms(material, resources, device);
 
     const pipeline = this._getOrCreateCustomPipeline(resources, this._currentBlendMode!, backend.renderTargetFormat, stencil, device);
@@ -1347,7 +1361,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, transformBindGroup);
     pass.setBindGroup(1, this._getCustomBaseTextureBindGroup(resources, backend, baseTexture, device));
-    pass.setBindGroup(2, this._buildUserBindGroup(material, resources, backend, device));
+    pass.setBindGroup(2, this._getUserBindGroup(material, resources, backend, device));
     pass.setVertexBuffer(0, instanceBuffer, instanceByteOffset);
     pass.setIndexBuffer(this._indexBuffer!, 'uint16');
     pass.drawIndexed(indicesPerSprite, this._instanceCount, 0, 0, 0);
@@ -1385,6 +1399,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
       pipelines: new Map(),
       userUniformBuffer: null,
       userUniformBufferCapacity: 0,
+      userUniform: createUserUniformState(),
       baseTextureBindGroups: new WeakMap(),
     };
 
@@ -1525,10 +1540,12 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
   private _uploadUserUniforms(material: SpriteMaterial, resources: CustomSpriteResources, device: GPUDevice): void {
     const scalarValues = collectScalarUniforms(material);
 
-    // Always create a UBO (even if empty) since binding 0 of the user layout is
-    // fixed. Min size 16 bytes to satisfy WebGPU's minimum buffer size.
-    const slotCount = Math.max(scalarValues.length, 1);
-    const bufferBytes = slotCount * 16;
+    // Always keep a UBO (even if empty) since binding 0 of the user layout is
+    // fixed. Min size 16 bytes to satisfy WebGPU's minimum buffer size. The
+    // buffer is reused across frames — only (re)created when the slot count
+    // outgrows its capacity.
+    const bufferBytes = userUniformBufferBytes(scalarValues.length);
+    let forceWrite = false;
 
     if (resources.userUniformBuffer === null || resources.userUniformBufferCapacity < bufferBytes) {
       resources.userUniformBuffer?.destroy();
@@ -1538,53 +1555,31 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
         size: bufferBytes,
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
       });
+      // A fresh buffer holds undefined contents and voids any bind group that
+      // referenced the old identity.
+      forceWrite = true;
+      resources.userUniform.bindGroup = null;
+      resources.userUniform.bindGroupBuffer = null;
     }
 
-    const data = new Float32Array(bufferBytes / 4);
+    // Pack into the reused scratch and upload only when the values changed.
+    if (packUserUniforms(scalarValues, resources.userUniform, forceWrite)) {
+      const data = resources.userUniform.data;
 
-    let slot = 0;
-
-    for (const value of scalarValues) {
-      const baseFloatIndex = slot * 4;
-
-      if (typeof value === 'number') {
-        data[baseFloatIndex] = value;
-      } else if (value instanceof Float32Array) {
-        data.set(value, baseFloatIndex);
-      } else if (value instanceof Int32Array) {
-        for (let i = 0; i < value.length; i++) {
-          data[baseFloatIndex + i] = value[i]!;
-        }
-      } else {
-        const arr = value as readonly number[];
-
-        for (let i = 0; i < arr.length; i++) {
-          data[baseFloatIndex + i] = arr[i]!;
-        }
-      }
-
-      slot++;
+      device.queue.writeBuffer(resources.userUniformBuffer, 0, data.buffer, data.byteOffset, bufferBytes);
     }
-
-    device.queue.writeBuffer(resources.userUniformBuffer, 0, data);
   }
 
-  private _buildUserBindGroup(material: SpriteMaterial, resources: CustomSpriteResources, backend: WebGpuBackend, device: GPUDevice): GPUBindGroup {
-    const entries: GPUBindGroupEntry[] = [];
-
-    entries.push({ binding: 0, resource: { buffer: resources.userUniformBuffer! } });
-
-    let bindingIndex = 1;
-
-    for (const texture of collectTextureBindings(material)) {
-      const binding = backend.getTextureBinding(texture);
-      entries.push({ binding: bindingIndex, resource: binding.view });
-      bindingIndex++;
-      entries.push({ binding: bindingIndex, resource: binding.sampler });
-      bindingIndex++;
-    }
-
-    return device.createBindGroup({ label: 'sprite:material-user-bind-group', layout: resources.userLayout, entries });
+  private _getUserBindGroup(material: SpriteMaterial, resources: CustomSpriteResources, backend: WebGpuBackend, device: GPUDevice): GPUBindGroup {
+    return resolveUserUniformBindGroup(
+      device,
+      backend,
+      material,
+      resources.userLayout,
+      'sprite:material-user-bind-group',
+      resources.userUniformBuffer!,
+      resources.userUniform,
+    );
   }
 
   private _releaseCustomResources(resources: CustomSpriteResources): void {
@@ -1592,53 +1587,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     resources.pipelines.clear();
     resources.userUniformBuffer = null;
     resources.userUniformBufferCapacity = 0;
+    resetUserUniformState(resources.userUniform);
     resources.baseTextureBindGroups = new WeakMap();
   }
-}
-
-function isTextureUniform(value: UniformValue): value is Texture | RenderTexture {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'width' in value &&
-    'height' in value &&
-    !(value instanceof Float32Array) &&
-    !(value instanceof Int32Array) &&
-    !Array.isArray(value)
-  );
-}
-
-/** Scalar/vector/matrix uniforms (texture values excluded) in declaration order. */
-function collectScalarUniforms(material: SpriteMaterial): Array<Exclude<UniformValue, Texture | RenderTexture>> {
-  const result: Array<Exclude<UniformValue, Texture | RenderTexture>> = [];
-
-  for (const value of Object.values(material.uniforms)) {
-    if (!isTextureUniform(value)) {
-      result.push(value);
-    }
-  }
-
-  return result;
-}
-
-/**
- * Texture bindings claimed by the material, in a stable order: texture-valued
- * entries of `uniforms` first (declaration order), then the dedicated
- * `textures` map. The WGSL source must declare its `@group(2)` texture/sampler
- * pairs in this same order.
- */
-function collectTextureBindings(material: SpriteMaterial): Array<Texture | RenderTexture> {
-  const result: Array<Texture | RenderTexture> = [];
-
-  for (const value of Object.values(material.uniforms)) {
-    if (isTextureUniform(value)) {
-      result.push(value);
-    }
-  }
-
-  for (const texture of Object.values(material.textures)) {
-    result.push(texture);
-  }
-
-  return result;
 }

--- a/src/rendering/webgpu/webgpuUserUniforms.ts
+++ b/src/rendering/webgpu/webgpuUserUniforms.ts
@@ -1,0 +1,276 @@
+/// <reference types="@webgpu/types" />
+
+import type { Material, UniformValue } from '#rendering/material/Material';
+import type { RenderTexture } from '#rendering/texture/RenderTexture';
+import type { Texture } from '#rendering/texture/Texture';
+
+import type { WebGpuBackend } from './WebGpuBackend';
+
+/**
+ * Shared user-uniform handling for the WebGPU custom-material paths
+ * (WebGpuSpriteRenderer / WebGpuMeshRenderer group(2)).
+ *
+ * The two renderers pack an identical `@group(2)` layout — one UBO at binding 0
+ * followed by texture/sampler pairs — so the packing, change-detection, and
+ * bind-group caching live here to keep them byte-for-byte consistent (B-10).
+ *
+ * The core contract fixed by B-10: the per-material UBO scratch and its GPU
+ * bind group are reused across frames and re-uploaded/rebuilt only when the
+ * material's uniform VALUES (or bound texture views) actually change — a static
+ * custom-material scene then issues zero uniform writes and zero bind-group
+ * creations per frame instead of one of each per flush.
+ * @internal
+ */
+
+/** Whether a uniform value is a bound texture rather than a scalar/vector. */
+export function isTextureUniform(value: UniformValue): value is Texture | RenderTexture {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'width' in value &&
+    'height' in value &&
+    !(value instanceof Float32Array) &&
+    !(value instanceof Int32Array) &&
+    !Array.isArray(value)
+  );
+}
+
+/** Scalar/vector/matrix uniforms (texture values excluded) in declaration order. */
+export function collectScalarUniforms(material: Material): Array<Exclude<UniformValue, Texture | RenderTexture>> {
+  const result: Array<Exclude<UniformValue, Texture | RenderTexture>> = [];
+
+  for (const value of Object.values(material.uniforms)) {
+    if (!isTextureUniform(value)) {
+      result.push(value);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Texture bindings claimed by the material, in a stable order: texture-valued
+ * entries of `uniforms` first (declaration order), then the dedicated
+ * `textures` map (declaration order). The WGSL source must declare its
+ * `@group(2)` texture/sampler pairs in this same order.
+ */
+export function collectTextureBindings(material: Material): Array<Texture | RenderTexture> {
+  const result: Array<Texture | RenderTexture> = [];
+
+  for (const value of Object.values(material.uniforms)) {
+    if (isTextureUniform(value)) {
+      result.push(value);
+    }
+  }
+
+  for (const texture of Object.values(material.textures)) {
+    result.push(texture);
+  }
+
+  return result;
+}
+
+/**
+ * Persistent, per-material cache for a custom material's `@group(2)` resources.
+ * Reused across frames; recreated wholesale when its owning material resource
+ * bundle is (re)built on reconnect so a lost device never keeps stale handles.
+ */
+export interface UserUniformState {
+  /** CPU mirror of the UBO's last-uploaded contents; reused across frames. */
+  data: Float32Array;
+  /** Float count populated on the last upload; `-1` before the first upload. */
+  floatCount: number;
+  /** Cached user bind group, or `null` before the first build / after an invalidation. */
+  bindGroup: GPUBindGroup | null;
+  /** UBO identity the cached bind group binds — a new buffer invalidates it. */
+  bindGroupBuffer: GPUBuffer | null;
+  /** Texture views the cached bind group binds — a refreshed view invalidates it. */
+  bindGroupViews: GPUTextureView[];
+  /** Samplers the cached bind group binds — a refreshed sampler invalidates it. */
+  bindGroupSamplers: GPUSampler[];
+}
+
+/** Fresh, empty {@link UserUniformState} for a newly created material resource bundle. */
+export function createUserUniformState(): UserUniformState {
+  return {
+    data: new Float32Array(0),
+    floatCount: -1,
+    bindGroup: null,
+    bindGroupBuffer: null,
+    bindGroupViews: [],
+    bindGroupSamplers: [],
+  };
+}
+
+/** Drop every cached handle so a device-loss teardown never keeps stale GPU objects. */
+export function resetUserUniformState(state: UserUniformState): void {
+  state.data = new Float32Array(0);
+  state.floatCount = -1;
+  state.bindGroup = null;
+  state.bindGroupBuffer = null;
+  state.bindGroupViews = [];
+  state.bindGroupSamplers = [];
+}
+
+/**
+ * Bytes required to hold `scalarCount` material uniforms — each occupies one
+ * `≤vec4` 16-byte slot, with a minimum of one slot to satisfy WebGPU's minimum
+ * uniform-buffer size.
+ */
+export function userUniformBufferBytes(scalarCount: number): number {
+  return Math.max(scalarCount, 1) * 16;
+}
+
+/**
+ * Pack `scalarValues` into `state.data` (reused across frames) and report
+ * whether the packed bytes differ from the previous upload. Every slot writes
+ * its four components — trailing components of a scalar/vec2/vec3 are zeroed —
+ * so a uniform changing arity in place is handled correctly.
+ *
+ * `forceWrite` (the destination GPU buffer was just recreated and holds
+ * undefined contents) always reports changed. On `true`, the caller uploads
+ * `state.data` over `[0, {@link userUniformBufferBytes}(scalarValues.length))`.
+ */
+export function packUserUniforms(
+  scalarValues: ReadonlyArray<Exclude<UniformValue, Texture | RenderTexture>>,
+  state: UserUniformState,
+  forceWrite: boolean,
+): boolean {
+  const slotCount = Math.max(scalarValues.length, 1);
+  const floatCount = slotCount * 4;
+
+  // A shape change (slot count differs) always re-uploads: the previous mirror
+  // no longer describes the same layout.
+  let changed = forceWrite || state.floatCount !== floatCount;
+
+  // Grow the scratch only when it cannot hold this frame's slots; a fresh array
+  // starts zeroed and has no prior snapshot to diff against, so force the write.
+  if (state.data.length < floatCount) {
+    state.data = new Float32Array(floatCount);
+    changed = true;
+  }
+
+  const data = state.data;
+  let slot = 0;
+
+  for (const value of scalarValues) {
+    const base = slot * 4;
+    let c0: number;
+    let c1: number;
+    let c2: number;
+    let c3: number;
+
+    if (typeof value === 'number') {
+      c0 = value;
+      c1 = 0;
+      c2 = 0;
+      c3 = 0;
+    } else {
+      // Float32Array | Int32Array | readonly number[] — all index-addressable;
+      // the UBO slot holds at most a vec4, so only the first four are consumed.
+      const arr = value as ArrayLike<number>;
+      const length = arr.length;
+
+      c0 = length > 0 ? arr[0]! : 0;
+      c1 = length > 1 ? arr[1]! : 0;
+      c2 = length > 2 ? arr[2]! : 0;
+      c3 = length > 3 ? arr[3]! : 0;
+    }
+
+    if (data[base] !== c0) {
+      data[base] = c0;
+      changed = true;
+    }
+    if (data[base + 1] !== c1) {
+      data[base + 1] = c1;
+      changed = true;
+    }
+    if (data[base + 2] !== c2) {
+      data[base + 2] = c2;
+      changed = true;
+    }
+    if (data[base + 3] !== c3) {
+      data[base + 3] = c3;
+      changed = true;
+    }
+
+    slot++;
+  }
+
+  state.floatCount = floatCount;
+
+  return changed;
+}
+
+/**
+ * Build (or reuse) the custom material's `@group(2)` bind group: the user UBO
+ * at binding 0 followed by texture/sampler pairs. Texture bindings are always
+ * re-resolved (which syncs a mutated texture's content before sampling), and
+ * the cached group is reused while the UBO identity and every resolved
+ * view/sampler are unchanged — a static material then creates zero bind groups
+ * per frame while a texture swap/resize rebuilds exactly once.
+ */
+export function resolveUserUniformBindGroup(
+  device: GPUDevice,
+  backend: WebGpuBackend,
+  material: Material,
+  layout: GPUBindGroupLayout,
+  label: string,
+  uniformBuffer: GPUBuffer,
+  state: UserUniformState,
+): GPUBindGroup {
+  const textures = collectTextureBindings(material);
+  const views: GPUTextureView[] = [];
+  const samplers: GPUSampler[] = [];
+
+  // Resolve every binding first — this uploads a dirty texture's content to the
+  // GPU before it is sampled, so it must run every frame even on a cache hit.
+  for (const texture of textures) {
+    const binding = backend.getTextureBinding(texture);
+
+    views.push(binding.view);
+    samplers.push(binding.sampler);
+  }
+
+  if (
+    state.bindGroup !== null &&
+    state.bindGroupBuffer === uniformBuffer &&
+    sameReferences(state.bindGroupViews, views) &&
+    sameReferences(state.bindGroupSamplers, samplers)
+  ) {
+    return state.bindGroup;
+  }
+
+  const entries: GPUBindGroupEntry[] = [{ binding: 0, resource: { buffer: uniformBuffer } }];
+  let bindingIndex = 1;
+
+  for (let i = 0; i < textures.length; i++) {
+    entries.push({ binding: bindingIndex, resource: views[i]! });
+    bindingIndex++;
+    entries.push({ binding: bindingIndex, resource: samplers[i]! });
+    bindingIndex++;
+  }
+
+  const group = device.createBindGroup({ label, layout, entries });
+
+  state.bindGroup = group;
+  state.bindGroupBuffer = uniformBuffer;
+  state.bindGroupViews = views;
+  state.bindGroupSamplers = samplers;
+
+  return group;
+}
+
+function sameReferences(a: readonly unknown[], b: readonly unknown[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/test/rendering/webgpu-custom-material-uniform-caching.test.ts
+++ b/test/rendering/webgpu-custom-material-uniform-caching.test.ts
@@ -1,0 +1,297 @@
+/**
+ * WebGPU custom-material user-uniform flush hot-path caching (expert review B-10).
+ *
+ * The custom SpriteMaterial / MeshMaterial paths used to allocate a fresh
+ * `Float32Array` and issue an unconditional `writeBuffer` for the group(2) user
+ * UBO on EVERY flush, and rebuild the user bind group every flush — per-frame GC
+ * pressure and buffer churn for any scene using custom materials. These tests
+ * drive the REAL WebGpuBackend + renderers against a mock device (see
+ * webgpuMockEnvironment) and require, after warmup:
+ *
+ * - a static frame re-uploads ZERO user uniforms and creates ZERO new user
+ *   uniform buffers / bind groups while still drawing,
+ * - mutating a uniform value re-uploads exactly once, with NO new buffer and NO
+ *   new bind group (the persistent buffer is updated in place),
+ * - a renderer disconnect (device-loss teardown) drops the caches so the next
+ *   frame rebuilds cleanly, then returns to zero-churn steady state.
+ */
+
+import { Color } from '#core/Color';
+import { MeshMaterial } from '#rendering/material/MeshMaterial';
+import { ShaderSource } from '#rendering/material/ShaderSource';
+import { SpriteMaterial } from '#rendering/material/SpriteMaterial';
+import { Mesh } from '#rendering/mesh/Mesh';
+import type { RenderNode } from '#rendering/RenderNode';
+import { Sprite } from '#rendering/sprite/Sprite';
+import type { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { countLabel, createCanvasTexture, createMockBackend, createMockWebGpuEnvironment } from './webgpuMockEnvironment';
+
+const renderFrame = (backend: WebGpuBackend, nodes: readonly RenderNode[]): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+
+  for (const node of nodes) {
+    node.render(backend);
+  }
+
+  backend.flush();
+};
+
+// Fragment-only WGSL: the engine prepends the canonical sprite vertex module.
+const spriteFragmentWgsl = `
+struct UserUniforms { color: vec4<f32> };
+@group(2) @binding(0) var<uniform> u_user: UserUniforms;
+
+@fragment
+fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+  let base = textureSample(u_texture, u_sampler, input.texcoord);
+  return vec4<f32>(base.rgb * u_user.color.rgb, 1.0);
+}
+`.trim();
+
+const meshWgsl = `
+struct MeshUniforms {
+  projection: mat3x3<f32>,
+  translation: mat3x3<f32>,
+  tint: vec4<f32>,
+};
+@group(0) @binding(0) var<uniform> u_mesh: MeshUniforms;
+
+@group(1) @binding(0) var u_texture: texture_2d<f32>;
+@group(1) @binding(1) var u_sampler: sampler;
+
+struct UserUniforms { color: vec4<f32> };
+@group(2) @binding(0) var<uniform> u_user: UserUniforms;
+
+struct VertexInput {
+  @location(0) position: vec2<f32>,
+  @location(1) texcoord: vec2<f32>,
+  @location(2) color: vec4<f32>,
+};
+
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) texcoord: vec2<f32>,
+};
+
+@vertex
+fn vertexMain(input: VertexInput) -> VertexOutput {
+  var out: VertexOutput;
+  let world = u_mesh.translation * vec3<f32>(input.position, 1.0);
+  let clip = u_mesh.projection * world;
+  out.position = vec4<f32>(clip.xy, 0.0, 1.0);
+  out.texcoord = input.texcoord;
+  return out;
+}
+
+@fragment
+fn fragmentMain(in: VertexOutput) -> @location(0) vec4<f32> {
+  let sampled = textureSample(u_texture, u_sampler, in.texcoord);
+  return vec4<f32>(sampled.rgb * u_user.color.rgb, 1.0);
+}
+`.trim();
+
+describe('WebGPU custom SpriteMaterial user-uniform flush caching', () => {
+  const uniformLabel = 'sprite:material-user-uniform-buffer';
+  const bindGroupLabel = 'sprite:material-user-bind-group';
+
+  const makeSprite = (): { sprite: Sprite; material: SpriteMaterial } => {
+    const material = new SpriteMaterial({
+      shader: new ShaderSource({ wgsl: spriteFragmentWgsl }),
+      uniforms: { u_userColor: [1, 0, 0.5, 1] },
+    });
+    const sprite = new Sprite(createCanvasTexture());
+
+    sprite.material = material;
+
+    return { sprite, material };
+  };
+
+  test('a static frame after warmup re-uploads no user uniforms and creates no new user buffers or bind groups', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createMockBackend(environment);
+      const { sprite } = makeSprite();
+
+      renderFrame(backend, [sprite]);
+
+      // Warmup uploaded the user UBO once and created it once.
+      expect(countLabel(environment.writeBufferLabels(), uniformLabel)).toBe(1);
+      expect(countLabel(environment.createBufferLabels(), uniformLabel)).toBe(1);
+      expect(countLabel(environment.bindGroupLabels(), bindGroupLabel)).toBe(1);
+
+      const writeMark = environment.writeBufferLabels().length;
+      const createMark = environment.createBufferLabels().length;
+      const bindMark = environment.bindGroupLabels().length;
+      const drawMark = environment.drawIndexedCount();
+
+      renderFrame(backend, [sprite]);
+
+      expect(environment.drawIndexedCount()).toBe(drawMark + 1);
+      expect(countLabel(environment.writeBufferLabels(), uniformLabel, writeMark)).toBe(0);
+      expect(countLabel(environment.createBufferLabels(), uniformLabel, createMark)).toBe(0);
+      expect(countLabel(environment.bindGroupLabels(), bindGroupLabel, bindMark)).toBe(0);
+
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('mutating a uniform value re-uploads exactly once with no new buffer and no new bind group', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createMockBackend(environment);
+      const { sprite, material } = makeSprite();
+
+      renderFrame(backend, [sprite]);
+      renderFrame(backend, [sprite]); // steady state established
+
+      const writeMark = environment.writeBufferLabels().length;
+      const createMark = environment.createBufferLabels().length;
+      const bindMark = environment.bindGroupLabels().length;
+
+      material.uniforms.u_userColor = [0, 1, 0.25, 1];
+      renderFrame(backend, [sprite]);
+
+      expect(countLabel(environment.writeBufferLabels(), uniformLabel, writeMark)).toBe(1);
+      expect(countLabel(environment.createBufferLabels(), uniformLabel, createMark)).toBe(0);
+      expect(countLabel(environment.bindGroupLabels(), bindGroupLabel, bindMark)).toBe(0);
+
+      // Unchanged again → back to zero uploads.
+      const writeAfterChange = environment.writeBufferLabels().length;
+
+      renderFrame(backend, [sprite]);
+
+      expect(countLabel(environment.writeBufferLabels(), uniformLabel, writeAfterChange)).toBe(0);
+
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('a renderer disconnect drops the caches so the next frame rebuilds, then returns to zero churn', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createMockBackend(environment);
+      const { sprite } = makeSprite();
+
+      renderFrame(backend, [sprite]);
+      renderFrame(backend, [sprite]);
+
+      // Simulate a device-loss teardown + recovery: disconnect and reconnect
+      // every renderer (mirrors WebGpuBackend's reconnect path).
+      backend.rendererRegistry.disconnect();
+      backend.rendererRegistry.connect(backend);
+
+      const writeMark = environment.writeBufferLabels().length;
+      const createMark = environment.createBufferLabels().length;
+      const bindMark = environment.bindGroupLabels().length;
+
+      renderFrame(backend, [sprite]);
+
+      // Clean rebuild: a fresh user UBO created + uploaded, fresh bind group.
+      expect(countLabel(environment.createBufferLabels(), uniformLabel, createMark)).toBe(1);
+      expect(countLabel(environment.writeBufferLabels(), uniformLabel, writeMark)).toBe(1);
+      expect(countLabel(environment.bindGroupLabels(), bindGroupLabel, bindMark)).toBe(1);
+
+      // Steady state restored after the rebuild.
+      const writeAfterRebuild = environment.writeBufferLabels().length;
+      const bindAfterRebuild = environment.bindGroupLabels().length;
+
+      renderFrame(backend, [sprite]);
+
+      expect(countLabel(environment.writeBufferLabels(), uniformLabel, writeAfterRebuild)).toBe(0);
+      expect(countLabel(environment.bindGroupLabels(), bindGroupLabel, bindAfterRebuild)).toBe(0);
+
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+});
+
+describe('WebGPU custom MeshMaterial user-uniform flush caching', () => {
+  const uniformLabel = 'mesh:material-user-uniform-buffer';
+  const bindGroupLabel = 'mesh:material-user-bind-group';
+
+  const makeMesh = (): { mesh: Mesh; material: MeshMaterial } => {
+    const material = new MeshMaterial({
+      shader: new ShaderSource({ wgsl: meshWgsl }),
+      uniforms: { u_userColor: [1, 0, 0.5, 1] },
+    });
+    const mesh = new Mesh({
+      vertices: new Float32Array([0, 0, 16, 0, 16, 16, 0, 0, 16, 16, 0, 16]),
+      uvs: new Float32Array([0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1]),
+      texture: createCanvasTexture(),
+      material,
+    });
+
+    mesh.setPosition(24, 24);
+
+    return { mesh, material };
+  };
+
+  test('a static frame after warmup re-uploads no user uniforms and creates no new user buffers or bind groups', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createMockBackend(environment);
+      const { mesh } = makeMesh();
+
+      renderFrame(backend, [mesh]);
+
+      expect(countLabel(environment.writeBufferLabels(), uniformLabel)).toBe(1);
+      expect(countLabel(environment.createBufferLabels(), uniformLabel)).toBe(1);
+      expect(countLabel(environment.bindGroupLabels(), bindGroupLabel)).toBe(1);
+
+      const writeMark = environment.writeBufferLabels().length;
+      const createMark = environment.createBufferLabels().length;
+      const bindMark = environment.bindGroupLabels().length;
+      const drawMark = environment.drawIndexedCount();
+
+      renderFrame(backend, [mesh]);
+
+      expect(environment.drawIndexedCount()).toBe(drawMark + 1);
+      expect(countLabel(environment.writeBufferLabels(), uniformLabel, writeMark)).toBe(0);
+      expect(countLabel(environment.createBufferLabels(), uniformLabel, createMark)).toBe(0);
+      expect(countLabel(environment.bindGroupLabels(), bindGroupLabel, bindMark)).toBe(0);
+
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('mutating a uniform value re-uploads exactly once with no new buffer and no new bind group', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createMockBackend(environment);
+      const { mesh, material } = makeMesh();
+
+      renderFrame(backend, [mesh]);
+      renderFrame(backend, [mesh]);
+
+      const writeMark = environment.writeBufferLabels().length;
+      const createMark = environment.createBufferLabels().length;
+      const bindMark = environment.bindGroupLabels().length;
+
+      material.uniforms.u_userColor = [0, 1, 0.25, 1];
+      renderFrame(backend, [mesh]);
+
+      expect(countLabel(environment.writeBufferLabels(), uniformLabel, writeMark)).toBe(1);
+      expect(countLabel(environment.createBufferLabels(), uniformLabel, createMark)).toBe(0);
+      expect(countLabel(environment.bindGroupLabels(), bindGroupLabel, bindMark)).toBe(0);
+
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+});

--- a/test/rendering/webgpuMockEnvironment.ts
+++ b/test/rendering/webgpuMockEnvironment.ts
@@ -28,6 +28,8 @@ export interface MockWebGpuEnvironment {
   bindGroupLabels(): readonly string[];
   /** Labels of every queue.writeBuffer target, in call order. */
   writeBufferLabels(): readonly string[];
+  /** Labels of every device.createBuffer call, in call order. */
+  createBufferLabels(): readonly string[];
   /** Number of render pipelines synchronously created (async prewarm excluded). */
   syncPipelineCount(): number;
   drawIndexedCount(): number;
@@ -50,6 +52,7 @@ export const createMockWebGpuEnvironment = (): MockWebGpuEnvironment => {
   let syncPipelineCount = 0;
   const bindGroupLabels: string[] = [];
   const writeBufferLabels: string[] = [];
+  const createBufferLabels: string[] = [];
 
   const pass = {
     setPipeline: (): void => {},
@@ -94,11 +97,14 @@ export const createMockWebGpuEnvironment = (): MockWebGpuEnvironment => {
     },
     createRenderPipelineAsync: async (): Promise<GPURenderPipeline> => ({}) as GPURenderPipeline,
     createCommandEncoder: () => encoder as unknown as GPUCommandEncoder,
-    createBuffer: (descriptor: GPUBufferDescriptor): GPUBuffer =>
-      ({
+    createBuffer: (descriptor: GPUBufferDescriptor): GPUBuffer => {
+      createBufferLabels.push(descriptor.label ?? '');
+
+      return {
         label: descriptor.label ?? '',
         destroy: (): void => {},
-      }) as unknown as GPUBuffer,
+      } as unknown as GPUBuffer;
+    },
     createTexture: (): GPUTexture => {
       // A stable view per GPU texture, matching the backend's cached-view
       // contract (a fresh view identity means "texture was recreated").
@@ -146,6 +152,7 @@ export const createMockWebGpuEnvironment = (): MockWebGpuEnvironment => {
     bindGroupCount: () => bindGroupCount,
     bindGroupLabels: () => bindGroupLabels,
     writeBufferLabels: () => writeBufferLabels,
+    createBufferLabels: () => createBufferLabels,
     syncPipelineCount: () => syncPipelineCount,
     drawIndexedCount: () => drawIndexedCount,
     restore: (): void => {


### PR DESCRIPTION
## Summary

Fixes expert-review finding **B-10**: the WebGPU custom-material paths re-created their group(2) user-uniform data every frame.

`WebGpuSpriteRenderer._uploadUserUniforms` / `WebGpuMeshRenderer._uploadUserUniforms` allocated a fresh `Float32Array` and issued an **unconditional** `queue.writeBuffer` for the user UBO on **every flush**, and `_buildUserBindGroup` created a **fresh `GPUBindGroup` every flush** — per-frame GC pressure and GPU-object churn for any scene using custom materials.

## Approach

New shared module `src/rendering/webgpu/webgpuUserUniforms.ts` (both renderers pack an identical group(2) layout, so the logic is factored to stay byte-for-byte consistent):

- **`packUserUniforms`** reuses a persistent per-material `Float32Array` scratch and reports whether the packed bytes changed since the last upload; the caller uploads only on a real change. Every slot writes all four components (trailing components of a scalar/vec2/vec3 zeroed), so an in-place arity change is still exact.
- **`resolveUserUniformBindGroup`** caches the user bind group and reuses it while the UBO identity and every resolved texture view/sampler are unchanged — still re-resolving bindings each frame so a mutated texture uploads its content before sampling (mirrors the existing base-texture cache contract).
- The persistent GPU UBO is reused across frames (was already only grown on demand); a capacity-growth recreation forces the next upload and invalidates the cached bind group.

All caches live in the per-material resource bundle and are dropped on renderer disconnect (device loss) via `resetUserUniformState`, so a reconnect rebuilds cleanly. Consistent with #281 (custom path uses its own fixed layout), #290 (bind-group caches drop on disconnect), and #286 (shader modules stay routed through the checked `_createShaderModule`).

**Result:** a static custom-material scene issues zero user-uniform writes and zero bind-group creations per frame instead of one of each per flush.

## Tests (TDD)

`test/rendering/webgpu-custom-material-uniform-caching.test.ts` drives the real `WebGpuBackend` + renderers against the mock device (harness from #290, extended with a `createBuffer` label counter). For **both** the sprite and mesh custom paths:

- static second frame → **0** user-uniform writes, **0** new user buffers, **0** new bind groups (still draws);
- changed uniform value → **exactly one** write, **no** new buffer, **no** new bind group;
- renderer disconnect (device-loss teardown) → clean rebuild, then back to zero-churn steady state.

Verified these 5 tests fail against the pre-fix renderers and pass after.

## Verification

- `pnpm test` (exojs): 4813 passed, 15 skipped
- `pnpm test:browser:webgpu`: 156 passed (real adapter — custom-material draws raise no validation error)
- `pnpm test:browser:webgl`: 215 passed
- `pnpm typecheck`, `eslint`, `docs:api:check`: clean

https://claude.ai/code/session_01RHB7cLgoonJHLQg9ScdXby