### PR TITLE
fix(scene): collision-free no-parent transform-version sentinel (T3) + reparent/subclass coverage

### DIFF
--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -74,6 +74,20 @@ const orientedCorners = [new Vector(), new Vector(), new Vector(), new Vector()]
 let dirtyWalkEpoch = 1;
 
 /**
+ * Sentinel `parentVersion` used by {@link SceneNode.getGlobalTransform} when
+ * NOTHING above this node contributes to its world matrix — the node is a
+ * root, or its parent is an engaged transform-group boundary the node does not
+ * escape (T3, expert review 2026-07-11). It is deliberately outside the range
+ * of every real `_globalTransformVersion` (which starts at 1 and only
+ * increments), so a boundary flip that later reads a real, still-unresolved
+ * parent version can never false-match a child that previously cached this
+ * sentinel — independent of the order in which the parent transform and the
+ * parent version are read. Do NOT change this to a value a real version can
+ * take (e.g. 0 once versions also started at 0), or the collision returns.
+ */
+const NO_PARENT_VERSION = 0;
+
+/**
  * Transform-bearing leaf in the scene-graph hierarchy. Carries position,
  * rotation, scale, skew, origin, and a 2-component {@link Vector} `anchor`
  * used to derive `origin` from the local bounds. Implements {@link Collidable}
@@ -159,8 +173,14 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
    * derived caches that also depend on the world transform (e.g. Sprite's quad
    * vertices/normals) can invalidate against it the same way {@link getBounds}
    * does via {@link _boundsBuiltAtVersion}.
+   *
+   * Starts at 1, never 0: {@link NO_PARENT_VERSION} reserves 0 as the
+   * no-parent-contribution sentinel, so a real version can never collide with
+   * it (T3). The initial value is otherwise irrelevant — the first
+   * {@link getGlobalTransform} recompute increments it, and every consumer
+   * compares against a `-1` "unset" of its own.
    */
-  protected _globalTransformVersion = 0;
+  protected _globalTransformVersion = 1;
   private _combinedParentVersion = -1;
   private _boundsBuiltAtVersion = -1;
   private _localBounds = new Rectangle();
@@ -511,7 +531,7 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
     const parent = this._parentNode;
     const boundary = parent !== null && parent._isTransformGroupBoundary && !this._escapesTransformGroup();
     const parentTransform = parent !== null && !boundary ? parent.getGlobalTransform() : null;
-    const parentVersion = parent !== null && !boundary ? parent._globalTransformVersion : 0;
+    const parentVersion = parent !== null && !boundary ? parent._globalTransformVersion : NO_PARENT_VERSION;
     const stale = this.flags.has(SceneNodeTransformFlags.GlobalTransform) || this._combinedParentVersion !== parentVersion;
 
     if (stale) {

--- a/test/core/scene-node-parent-version-sentinel.test.ts
+++ b/test/core/scene-node-parent-version-sentinel.test.ts
@@ -1,0 +1,95 @@
+import { Container } from '#rendering/Container';
+import { Drawable } from '#rendering/Drawable';
+
+/**
+ * Test double for a transform-group boundary whose engagement flips at
+ * runtime — mirrors RetainedContainer's live `_isTransformGroupBoundary`
+ * getter without a render backend.
+ */
+class ToggleBoundary extends Container {
+  public engaged = true;
+
+  public override get _isTransformGroupBoundary(): boolean {
+    return this.engaged;
+  }
+}
+
+/** Exposes the protected transform-version counter for the sentinel invariant. */
+class VersionProbe extends Drawable {
+  public get transformVersion(): number {
+    return this._globalTransformVersion;
+  }
+}
+
+/**
+ * Regression coverage for finding T3 (expert review 2026-07-11,
+ * 01-rendering-core.md): `getGlobalTransform()` encodes "no parent contributes
+ * to my world matrix" as `parentVersion = 0`. Before the fix the per-node
+ * `_globalTransformVersion` counter ALSO started at 0, so the sentinel
+ * collided with the natural initial version of a never-resolved parent. The
+ * collision was masked only because `parent.getGlobalTransform()` is evaluated
+ * BEFORE `parentVersion` is read (forcing the parent to >= 1) — a statement
+ * ordering a future refactor could silently break, re-introducing a stale
+ * transform on a boundary flip.
+ *
+ * The fix makes the sentinel structurally distinct: real versions start at 1
+ * and only increment, so 0 is unreachable as a legitimate version and the
+ * boundary-flip compare is collision-free regardless of read order.
+ */
+describe('SceneNode getGlobalTransform: no-parent sentinel cannot collide with a real version (T3)', () => {
+  test('a never-resolved node reports a transform version distinct from the no-parent sentinel (0)', () => {
+    const node = new VersionProbe();
+
+    // getGlobalTransform() uses 0 to mean "no parent contribution". A real
+    // _globalTransformVersion must therefore never be 0, or a boundary flip
+    // that reads a still-unresolved parent's version could false-clean-skip
+    // the child's first world-space resolve.
+    expect(node.transformVersion).not.toBe(0);
+
+    node.destroy();
+  });
+
+  test('the version stays clear of the sentinel across resolves and mutations', () => {
+    const parent = new Container();
+    const node = new VersionProbe();
+
+    parent.addChild(node);
+
+    expect(node.transformVersion).not.toBe(0);
+
+    node.getGlobalTransform();
+    expect(node.transformVersion).not.toBe(0);
+
+    node.setPosition(10, 20);
+    node.getGlobalTransform();
+    expect(node.transformVersion).not.toBe(0);
+
+    parent.destroy();
+  });
+
+  test('disengaging a boundary forces a child that stored the sentinel to recompute against the parent', () => {
+    const world = new Container();
+    const group = new ToggleBoundary();
+    const child = new VersionProbe();
+
+    world.setPosition(100, 0);
+    group.setPosition(40, 0);
+    child.setPosition(5, 0);
+
+    world.addChild(group);
+    group.addChild(child);
+
+    // Engaged: child is group-local, so it stores the no-parent sentinel as
+    // its combined-parent version.
+    expect(child.getGlobalTransform().x).toBe(5);
+
+    // Flip the boundary off: the child must now compose the parent chain. This
+    // exercises the exact seam T3 guards — a false-clean skip here would leave
+    // the child rendering in the stale group-local space.
+    group.engaged = false;
+
+    expect(child.getGlobalTransform().x).toBe(145);
+
+    world.destroy();
+  });
+});

--- a/test/core/scene-node-revision-invariants.test.ts
+++ b/test/core/scene-node-revision-invariants.test.ts
@@ -3,8 +3,16 @@ import { Rectangle } from '#math/Rectangle';
 import { Container } from '#rendering/Container';
 import { Drawable } from '#rendering/Drawable';
 import { Filter } from '#rendering/filters/Filter';
+import { Mesh } from '#rendering/mesh/Mesh';
 import type { RenderNode } from '#rendering/RenderNode';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { NineSliceSprite } from '#rendering/sprite/NineSliceSprite';
+import { Sprite } from '#rendering/sprite/Sprite';
+import type { Texture } from '#rendering/texture/Texture';
 import { BlendModes } from '#rendering/types';
+
+// Minimal fake texture (no GPU): enough for the visual-source mutators below.
+const makeTexture = (w = 64, h = 64): Texture => ({ width: w, height: h, flipY: false, updateSource: () => undefined }) as unknown as Texture;
 
 // Mirror the existing NoopFilter in test/rendering/render-plan.test.ts exactly
 // (check its constructor/apply signature there before finalizing this class).
@@ -56,8 +64,10 @@ const containerWithSizedChild = (): Container => {
 };
 
 // THE TABLE. One row per public member that changes visual output. Adding a
-// mutator to SceneNode/RenderNode/Drawable/Container without a row here is a
-// review error; a row whose bump assertion fails is an engine bug.
+// mutator to SceneNode/RenderNode/Drawable/Container — OR to a Drawable
+// SUBCLASS (Sprite/NineSliceSprite/Mesh/Text/…, see `subclassCases` below) —
+// without a row here is a review error; a row whose bump assertion fails is an
+// engine bug.
 const cases: readonly MutatorCase[] = [
   // SceneNode transform family — content-dirty.
   drawableCase('setPosition', 'content', n => n.setPosition(10, 20)),
@@ -122,8 +132,64 @@ const cases: readonly MutatorCase[] = [
   containerCase('height setter', 'content', n => (n.height = 128), containerWithSizedChild),
 ];
 
+// SUBCLASS mutator table (C1, expert review 2026-07-11). The base table above
+// only guards SceneNode/RenderNode/Drawable/Container; a Drawable subclass that
+// mutates a transform-relevant / visual-source field (texture, frame, geometry,
+// nine-slice metrics) routes through `invalidateCache`/`_markContentDirty` just
+// like a base mutator and must obey the SAME revision contract. Every row here
+// is content-dirty: these change WHAT is drawn, not WHICH draws are emitted.
+// RetainedContainer's deliberately-divergent transform mutator is asserted
+// separately below (it is the one subclass that reroutes away from content).
+const subclassCases: readonly MutatorCase[] = [
+  // Sprite visual-source family.
+  drawableCase(
+    'Sprite.setTexture',
+    'content',
+    n => (n as unknown as Sprite).setTexture(makeTexture(32, 16)),
+    () => new Sprite(null),
+  ),
+  drawableCase(
+    'Sprite.texture setter',
+    'content',
+    n => ((n as unknown as Sprite).texture = makeTexture(32, 16)),
+    () => new Sprite(null),
+  ),
+  drawableCase(
+    'Sprite.setTextureFrame',
+    'content',
+    n => (n as unknown as Sprite).setTextureFrame(new Rectangle(0, 0, 10, 10)),
+    () => new Sprite(makeTexture(64, 32)),
+  ),
+  // Mesh visual-source: swapping the texture.
+  drawableCase(
+    'Mesh.texture setter',
+    'content',
+    n => ((n as unknown as Mesh).texture = makeTexture(16, 16)),
+    () => new Mesh({ vertices: new Float32Array([0, 0, 16, 0, 8, 16]) }),
+  ),
+  // NineSliceSprite metric mutators — all re-tessellate the quad geometry.
+  drawableCase(
+    'NineSliceSprite.setSize',
+    'content',
+    n => (n as unknown as NineSliceSprite).setSize(50, 40),
+    () => new NineSliceSprite(makeTexture(64, 64), { slices: 10 }),
+  ),
+  drawableCase(
+    'NineSliceSprite.setBorder',
+    'content',
+    n => (n as unknown as NineSliceSprite).setBorder(12),
+    () => new NineSliceSprite(makeTexture(64, 64), { slices: 10 }),
+  ),
+  drawableCase(
+    'NineSliceSprite.setSlices',
+    'content',
+    n => (n as unknown as NineSliceSprite).setSlices(8),
+    () => new NineSliceSprite(makeTexture(64, 64), { slices: 10 }),
+  ),
+];
+
 describe('revision invariants: every public visual mutator bumps the right revision', () => {
-  for (const mutatorCase of cases) {
+  for (const mutatorCase of [...cases, ...subclassCases]) {
     test(`${mutatorCase.name} is ${mutatorCase.expects}-dirty and propagates to the parent`, () => {
       const parent = new Container();
       const node = mutatorCase.create();
@@ -198,5 +264,68 @@ describe('revision invariants: every public visual mutator bumps the right revis
     expect(node._structureRevision).toBe(before);
 
     node.destroy();
+  });
+});
+
+// C1: RetainedContainer is the one Drawable subclass whose transform-relevant
+// mutator deliberately DIVERGES from the base contract — an own-transform move
+// reroutes to the group-matrix version instead of content-dirtying the
+// retained fragment (spec §4.3). The base table cannot express this (it asserts
+// content propagation on every transform mutator), so the divergence is pinned
+// here explicitly. This is the reason the base-table rule must carry the "OR a
+// subclass" clause: a subclass author extending RetainedContainer, or adding a
+// new boundary subclass, must consciously choose one contract or the other.
+describe('revision invariants: RetainedContainer reroutes its OWN transform mutators (subclass exception)', () => {
+  test('own-transform mutators bump the group-matrix version, NOT content or structure', () => {
+    const group = new RetainedContainer();
+
+    group.addChild(new Drawable());
+
+    const contentBefore = group._contentRevision;
+    const structureBefore = group._structureRevision;
+    const versionBefore = group._groupMatrixVersion;
+
+    group.setPosition(10, 20);
+    group.setRotation(45);
+    group.setScale(2);
+    group.setSkew(5, 0);
+    group.setOrigin(1, 1);
+
+    expect(group._groupMatrixVersion).toBeGreaterThan(versionBefore);
+    expect(group._contentRevision).toBe(contentBefore);
+    expect(group._structureRevision).toBe(structureBefore);
+
+    group.destroy();
+  });
+
+  test("a mutation INSIDE the subtree still content-dirties the group (decoupling is scoped to the group's own transform)", () => {
+    const group = new RetainedContainer();
+    const leaf = new Drawable();
+
+    group.addChild(leaf);
+
+    const before = group._contentRevision;
+
+    leaf.setPosition(3, 3);
+
+    expect(group._contentRevision).toBeGreaterThan(before);
+
+    group.destroy();
+  });
+
+  test('a moving RetainedContainer does not content-dirty its ancestors', () => {
+    const root = new Container();
+    const group = new RetainedContainer();
+
+    root.addChild(group);
+    group.addChild(new Drawable());
+
+    const rootContentBefore = root._contentRevision;
+
+    group.setPosition(500, 500);
+
+    expect(root._contentRevision).toBe(rootContentBefore);
+
+    root.destroy();
   });
 });

--- a/test/rendering/retained-container-reparent.test.ts
+++ b/test/rendering/retained-container-reparent.test.ts
@@ -1,0 +1,468 @@
+import { Rectangle } from '#math/Rectangle';
+import { Container } from '#rendering/Container';
+import { Drawable } from '#rendering/Drawable';
+import { type DrawCommand, RenderEntryKind } from '#rendering/plan/RenderCommand';
+import { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
+import { RenderPlanOptimizer } from '#rendering/plan/RenderPlanOptimizer';
+import type { GroupScope } from '#rendering/plan/RenderScope';
+import type { RetainedGroupFragment } from '#rendering/plan/RetainedGroupFragment';
+import type { RenderBackend } from '#rendering/RenderBackend';
+import { RenderBackendType } from '#rendering/RenderBackendType';
+import { createRenderStats } from '#rendering/RenderStats';
+import { RenderTarget } from '#rendering/RenderTarget';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+
+// Coverage for the "reparent across boundaries" hole called out in the expert
+// review (2026-07-11, 01-rendering-core.md §4): the transform space-flip was
+// only exercised via the barrier toggle, never via addChild/removeChild. These
+// tests move nodes IN, OUT, and BETWEEN RetainedContainer boundaries and assert
+// transforms, versions, and retained-state invalidation — including the F13/R3
+// escaped-branch lifecycle (a deep-barrier branch reparented out/in/between).
+
+class LeafDrawable extends Drawable {
+  public constructor(public readonly id: string) {
+    super();
+    this.getLocalBounds().set(0, 0, 16, 16);
+  }
+}
+
+interface FragmentCarrier {
+  _fragment: RetainedGroupFragment;
+}
+
+const fragmentOf = (group: RetainedContainer): RetainedGroupFragment => (group as unknown as FragmentCarrier)._fragment;
+
+// File-local fake backend (repo convention keeps harnesses file-local).
+const createTestBackend = (): RenderBackend => {
+  const renderTarget = new RenderTarget(800, 600, true);
+
+  return {
+    backendType: RenderBackendType.WebGl2,
+    stats: createRenderStats(),
+    renderTarget,
+    get view() {
+      return renderTarget.view;
+    },
+    async initialize() {
+      return this;
+    },
+    resetStats() {
+      return this;
+    },
+    clear() {
+      return this;
+    },
+    resize() {
+      return this;
+    },
+    setView(v) {
+      renderTarget.setView(v);
+      return this;
+    },
+    setRenderTarget() {
+      return this;
+    },
+    pushScissorRect() {
+      return this;
+    },
+    popScissorRect() {
+      return this;
+    },
+    composeWithAlphaMask() {
+      return this;
+    },
+    acquireRenderTexture() {
+      throw new Error('not used in this test');
+    },
+    releaseRenderTexture() {
+      return this;
+    },
+    draw() {
+      return this;
+    },
+    execute() {
+      return this;
+    },
+    flush() {
+      return this;
+    },
+    destroy() {
+      renderTarget.destroy();
+    },
+  } as unknown as RenderBackend;
+};
+
+const gatherScopeDraws = (scope: GroupScope, out: DrawCommand[]): void => {
+  for (const entry of scope.entries) {
+    if (entry.kind === RenderEntryKind.Draw) {
+      out.push(entry.command);
+    } else if (entry.kind === RenderEntryKind.Group) {
+      gatherScopeDraws(entry.scope, out);
+    } else if (entry.kind === RenderEntryKind.Barrier && entry.scope.childPlan !== null) {
+      gatherScopeDraws(entry.scope.childPlan, out);
+    }
+  }
+};
+
+const collectDraws = (root: Container, backend: RenderBackend): DrawCommand[] => {
+  const builder = RenderPlanBuilder.acquire();
+  const plan = builder.build(root, backend);
+
+  RenderPlanOptimizer.optimize(plan);
+
+  const draws: DrawCommand[] = [];
+  for (const pass of plan.passes) {
+    gatherScopeDraws(pass.root, draws);
+  }
+
+  RenderPlanBuilder.release(builder);
+
+  return draws;
+};
+
+const idsOf = (draws: readonly DrawCommand[]): string[] => draws.map(d => (d.drawable as LeafDrawable).id);
+
+describe('RetainedContainer reparenting: transform space flips across the boundary', () => {
+  test('reparenting a node OUT of a group flips it from group-local to world space', () => {
+    const world = new Container();
+    const group = new RetainedContainer();
+    const outside = new Container();
+    const child = new Drawable();
+
+    group.setPosition(40, 0);
+    outside.setPosition(1000, 0);
+    child.setPosition(5, 0);
+
+    world.addChild(group);
+    world.addChild(outside);
+    group.addChild(child);
+
+    // Inside the group: group-local rendering space, composed world space.
+    expect(child.getGlobalTransform().x).toBe(5);
+    expect(child.getWorldTransform().x).toBe(45);
+
+    outside.addChild(child); // reparent OUT (addChild detaches from `group` first)
+
+    expect(child.parent).toBe(outside);
+    // No boundary above now: global === world, composed through `outside`.
+    expect(child.getGlobalTransform().x).toBe(1005);
+    expect(child.getWorldTransform().x).toBe(1005);
+    expect(child.getWorldTransform()).toBe(child.getGlobalTransform());
+
+    world.destroy();
+  });
+
+  test('reparenting a node INTO a group flips it from world space to group-local', () => {
+    const world = new Container();
+    const group = new RetainedContainer();
+    const outside = new Container();
+    const child = new Drawable();
+
+    group.setPosition(40, 0);
+    outside.setPosition(100, 0);
+    child.setPosition(5, 0);
+
+    world.addChild(group);
+    world.addChild(outside);
+    outside.addChild(child);
+
+    // Outside: plain world composition.
+    expect(child.getGlobalTransform().x).toBe(105);
+    expect(child.getWorldTransform().x).toBe(105);
+
+    group.addChild(child); // reparent IN
+
+    expect(child.parent).toBe(group);
+    // Now group-local for rendering, composed through the boundary for world.
+    expect(child.getGlobalTransform().x).toBe(5);
+    expect(child.getWorldTransform().x).toBe(45);
+
+    world.destroy();
+  });
+
+  test('reparenting BETWEEN two groups rebases to the new group boundary', () => {
+    const world = new Container();
+    const groupA = new RetainedContainer();
+    const groupB = new RetainedContainer();
+    const child = new Drawable();
+
+    groupA.setPosition(40, 0);
+    groupB.setPosition(200, 0);
+    child.setPosition(5, 0);
+
+    world.addChild(groupA);
+    world.addChild(groupB);
+    groupA.addChild(child);
+
+    expect(child.getGlobalTransform().x).toBe(5);
+    expect(child.getWorldTransform().x).toBe(45);
+
+    groupB.addChild(child); // group A -> group B
+
+    expect(child.parent).toBe(groupB);
+    // Group-local is unchanged (5), but world rebases onto group B.
+    expect(child.getGlobalTransform().x).toBe(5);
+    expect(child.getWorldTransform().x).toBe(205);
+
+    world.destroy();
+  });
+
+  test('reparenting bumps the structure revision on both old and new parent, leaving the group matrix version alone', () => {
+    const world = new Container();
+    const group = new RetainedContainer();
+    const outside = new Container();
+    const child = new Drawable();
+
+    world.addChild(group);
+    world.addChild(outside);
+    group.addChild(child);
+
+    const groupStructureBefore = group._structureRevision;
+    const outsideStructureBefore = outside._structureRevision;
+    const groupMatrixBefore = group._groupMatrixVersion;
+
+    outside.addChild(child); // reparent out
+
+    // Removal structure-dirties the old parent; addition structure-dirties the new one.
+    expect(group._structureRevision).toBeGreaterThan(groupStructureBefore);
+    expect(outside._structureRevision).toBeGreaterThan(outsideStructureBefore);
+    // Reparenting is a structural change, NOT an own-transform move of the group.
+    expect(group._groupMatrixVersion).toBe(groupMatrixBefore);
+
+    world.destroy();
+  });
+});
+
+describe('RetainedContainer reparenting: retained fragment invalidation', () => {
+  test('reparenting a child OUT invalidates the group fragment and drops the child from the group plan', () => {
+    const backend = createTestBackend();
+    const world = new Container();
+    const group = new RetainedContainer();
+    const outside = new Container();
+    const leafA = new LeafDrawable('a');
+    const leafB = new LeafDrawable('b');
+
+    group.addChild(leafA);
+    group.addChild(leafB);
+    world.addChild(group);
+    world.addChild(outside);
+
+    collectDraws(world, backend); // frame 1: capture
+    const frame2 = idsOf(collectDraws(world, backend)); // frame 2: clean splice
+
+    expect(frame2).toEqual(['a', 'b']);
+    expect(fragmentOf(group).isClean(group._contentRevision, group._structureRevision, backend)).toBe(true);
+
+    outside.addChild(leafB); // reparent OUT
+
+    // The structural change dropped the fragment's clean state immediately.
+    expect(fragmentOf(group).isClean(group._contentRevision, group._structureRevision, backend)).toBe(false);
+
+    const frame3 = idsOf(collectDraws(world, backend));
+
+    // 'b' still renders (now under `outside`), but no longer inside the group's plan.
+    expect(frame3).toContain('a');
+    expect(frame3).toContain('b');
+    // Fragment re-captured after the re-collect, and now holds only 'a'.
+    expect(fragmentOf(group).isClean(group._contentRevision, group._structureRevision, backend)).toBe(true);
+
+    world.destroy();
+    backend.destroy();
+  });
+
+  test('reparenting a child INTO a group captures it into the group fragment', () => {
+    const backend = createTestBackend();
+    const world = new Container();
+    const group = new RetainedContainer();
+    const outside = new Container();
+    const leafA = new LeafDrawable('a');
+    const leafB = new LeafDrawable('b');
+
+    group.addChild(leafA);
+    outside.addChild(leafB);
+    world.addChild(group);
+    world.addChild(outside);
+
+    collectDraws(world, backend);
+    collectDraws(world, backend); // settle the fragment
+
+    group.addChild(leafB); // reparent IN
+
+    expect(fragmentOf(group).isClean(group._contentRevision, group._structureRevision, backend)).toBe(false);
+
+    const frame = idsOf(collectDraws(world, backend));
+
+    expect(frame).toContain('a');
+    expect(frame).toContain('b');
+    expect(fragmentOf(group).isClean(group._contentRevision, group._structureRevision, backend)).toBe(true);
+
+    world.destroy();
+    backend.destroy();
+  });
+});
+
+describe('RetainedContainer reparenting: escaped deep-barrier branch (F13/R3)', () => {
+  const makeDeepBarrierBranch = (): { branch: Container; deep: LeafDrawable } => {
+    const branch = new Container();
+    const deep = new LeafDrawable('deep');
+
+    // Barrier one level BELOW the direct child => the whole branch escapes.
+    deep.clip = true;
+    deep.clipShape = new Rectangle(0, 0, 8, 8);
+    branch.addChild(deep);
+
+    return { branch, deep };
+  };
+
+  test('an escaped branch reports as escaped while inside the group, world-space for its subtree', () => {
+    const group = new RetainedContainer();
+    const { branch, deep } = makeDeepBarrierBranch();
+
+    group.setPosition(40, 0);
+    branch.setPosition(10, 0);
+
+    group.addChild(branch);
+
+    expect(group._childEscapesTransformGroup(branch)).toBe(true);
+    // Escaped branch resolves world-space (group translation folded in).
+    expect(branch.getGlobalTransform().x).toBe(50);
+    expect(deep.getWorldTransform()).toBe(deep.getGlobalTransform());
+
+    group.destroy();
+  });
+
+  test('reparenting an escaped branch OUT drops its group membership and rebases it under the new parent', () => {
+    const world = new Container();
+    const group = new RetainedContainer();
+    const outside = new Container();
+    const { branch, deep } = makeDeepBarrierBranch();
+
+    group.setPosition(40, 0);
+    outside.setPosition(1000, 0);
+    branch.setPosition(10, 0);
+    deep.setPosition(1, 0);
+
+    world.addChild(group);
+    world.addChild(outside);
+    group.addChild(branch);
+
+    // Establish escape membership.
+    expect(group._childEscapesTransformGroup(branch)).toBe(true);
+    expect(deep.getGlobalTransform().x).toBe(51); // 40 + 10 + 1 (world-space escape)
+
+    outside.addChild(branch); // reparent the escaped branch OUT
+
+    // Group no longer tracks it; the branch is a plain child of `outside`.
+    expect(group._childEscapesTransformGroup(branch)).toBe(false);
+    expect(branch.parent).toBe(outside);
+    expect(deep.getGlobalTransform().x).toBe(1011); // 1000 + 10 + 1
+    expect(deep.getWorldTransform()).toBe(deep.getGlobalTransform());
+
+    world.destroy();
+  });
+
+  test('reparenting a deep-barrier branch INTO a group makes it an escaped branch of the new group', () => {
+    const world = new Container();
+    const group = new RetainedContainer();
+    const outside = new Container();
+    const { branch, deep } = makeDeepBarrierBranch();
+
+    group.setPosition(40, 0);
+    outside.setPosition(1000, 0);
+    branch.setPosition(10, 0);
+    deep.setPosition(1, 0);
+
+    world.addChild(group);
+    world.addChild(outside);
+    outside.addChild(branch);
+
+    // Outside a boundary it is not "escaped" (no boundary to escape); plain world.
+    expect(deep.getGlobalTransform().x).toBe(1011);
+
+    group.addChild(branch); // reparent IN
+
+    expect(group._childEscapesTransformGroup(branch)).toBe(true);
+    // Still world-space (it escapes), but now folded through the group's translation.
+    expect(deep.getGlobalTransform().x).toBe(51);
+    expect(deep.getWorldTransform()).toBe(deep.getGlobalTransform());
+
+    world.destroy();
+  });
+
+  test('reparenting an escaped branch BETWEEN groups moves the membership', () => {
+    const world = new Container();
+    const groupA = new RetainedContainer();
+    const groupB = new RetainedContainer();
+    const { branch, deep } = makeDeepBarrierBranch();
+
+    groupA.setPosition(40, 0);
+    groupB.setPosition(200, 0);
+    branch.setPosition(10, 0);
+    deep.setPosition(1, 0);
+
+    world.addChild(groupA);
+    world.addChild(groupB);
+    groupA.addChild(branch);
+
+    expect(groupA._childEscapesTransformGroup(branch)).toBe(true);
+    expect(deep.getGlobalTransform().x).toBe(51); // via group A
+
+    groupB.addChild(branch); // A -> B
+
+    expect(groupA._childEscapesTransformGroup(branch)).toBe(false);
+    expect(groupB._childEscapesTransformGroup(branch)).toBe(true);
+    expect(deep.getGlobalTransform().x).toBe(211); // 200 + 10 + 1 via group B
+
+    world.destroy();
+  });
+
+  test('reparenting a deep-barrier branch IN invalidates the group fragment at the flip; it re-engages once the branch leaves', () => {
+    const backend = createTestBackend();
+    const world = new Container();
+    const group = new RetainedContainer();
+    const outside = new Container();
+    const staticLeaf = new LeafDrawable('static');
+    const { branch } = makeDeepBarrierBranch();
+
+    group.addChild(staticLeaf);
+    outside.addChild(branch);
+    world.addChild(group);
+    world.addChild(outside);
+
+    collectDraws(world, backend);
+    collectDraws(world, backend);
+    // Steady state: a plain group with a static child holds a clean fragment.
+    expect(fragmentOf(group).isClean(group._contentRevision, group._structureRevision, backend)).toBe(true);
+
+    group.addChild(branch); // reparent the escaped branch IN
+
+    // The structural change dropped the fragment's clean state immediately.
+    expect(fragmentOf(group).isClean(group._contentRevision, group._structureRevision, backend)).toBe(false);
+
+    const framesEscaped = idsOf(collectDraws(world, backend));
+
+    expect(group._childEscapesTransformGroup(branch)).toBe(true);
+    // Output stays correct across the flip: the static child and the escaped
+    // deep-barrier leaf both render.
+    expect(framesEscaped).toContain('static');
+    expect(framesEscaped).toContain('deep');
+
+    outside.addChild(branch); // reparent it back OUT: group fully re-engages
+
+    expect(group._childEscapesTransformGroup(branch)).toBe(false);
+
+    collectDraws(world, backend);
+    collectDraws(world, backend);
+
+    // With no escaped branch left, the group returns to a clean retained fragment.
+    expect(fragmentOf(group).isClean(group._contentRevision, group._structureRevision, backend)).toBe(true);
+    // Nothing was lost across the reparent: the static child stays in the group,
+    // the deep-barrier leaf now renders under `outside`.
+    const finalFrame = idsOf(collectDraws(world, backend));
+    expect(finalFrame).toContain('static');
+    expect(finalFrame).toContain('deep');
+
+    world.destroy();
+    backend.destroy();
+  });
+});


### PR DESCRIPTION
Addresses three related findings from the expert review (2026-07-11, `01-rendering-core.md`), one PR.

## 1. T3 — `parentVersion = 0` sentinel collision (the fix)

`SceneNode.getGlobalTransform()` encodes "nothing above me contributes to my world matrix" (root, or an engaged transform-group boundary the node doesn't escape) as `parentVersion = 0`. But the per-node `_globalTransformVersion` counter **also started at 0**, so the sentinel collided with a never-resolved parent's natural initial version. It was correct today only because `parent.getGlobalTransform()` is evaluated *before* `parentVersion` is read (forcing the parent to ≥1) — load-bearing statement ordering a future refactor could silently break, re-introducing a stale-space render on a boundary flip.

**Fix:** make the sentinel structurally distinct rather than order-dependent. Real versions now start at **1** and only increment, so `0` (`NO_PARENT_VERSION`, now a named constant) is unreachable as a legitimate version and the boundary-flip compare is collision-free regardless of read order. No consumer compares the version against `0` (all use `-1` "unset" sentinels of their own), so the shift is behaviorally inert on today's paths.

Note: this was a **latent fragility** (P3), not a live black-box bug — the eval-order rescue means no reparent/flip through the public API reproduces a skipped resolve on current code. The TDD "failing first" test therefore pins the *invariant* the fix establishes (a real version is never the no-parent sentinel), which fails on the old `= 0` init and passes on `= 1`.

## 2. Reparent-across-boundary coverage (review §4 hole)

New `test/rendering/retained-container-reparent.test.ts`: moving nodes **in / out / between** `RetainedContainer` boundaries, asserting transforms (`getGlobalTransform` group-local vs `getWorldTransform` world), revisions (structure bumped on both parents; group-matrix version untouched), and retained-fragment invalidation (`isClean` drops at the structural change, re-captures on the next collect). Includes the #289 F13/R3 escaped deep-barrier branch reparented out / in / between groups, asserting escape membership (`_childEscapesTransformGroup`) and fragment lifecycle track the reparent.

## 3. C1 — subclass mutators in the invariant table

Extended `test/core/scene-node-revision-invariants.test.ts` with a subclass-mutator table (`Sprite.setTexture` / `texture` / `setTextureFrame`, `Mesh.texture`, `NineSliceSprite.setSize` / `setBorder` / `setSlices` — all content-dirty) run through the same bump/propagate/no-sibling assertions, and a block pinning `RetainedContainer`'s deliberately-divergent own-transform contract (group-matrix version, not content/structure). The "adding a mutator without a row is a review error" guarantee now covers subclasses too.

## Verification

- Full Node suite: **7489 passed / 16 skipped / 0 failed** (`pnpm test`).
- Browser retained-container + rotated-retained-group suites, **both backends**: WebGL2 12/12, WebGPU 12/12.
- `pnpm typecheck` clean; `docs:api:generate` in sync; changed files Prettier + ESLint clean. (`lint:strict` shows 2 pre-existing warnings in `src/rendering/Container.ts`, untouched by this PR.)

This is in the scene/transform risk area — **no automerge**; an adversarial review gates the merge.

https://claude.ai/code/session_01RHB7cLgoonJHLQg9ScdXby