### PR TITLE
dx(examples): make the example catalog strict-mode clean

### DIFF
--- a/examples/application-scenes/camera-and-view.js
+++ b/examples/application-scenes/camera-and-view.js
@@ -20,7 +20,10 @@ class CameraViewScene extends Scene {
     moveY = 0;
     zoom = 0;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.camera = new View(0, 0, width, height);
         this.world = new Graphics();
         this.world.lineWidth = 2;

--- a/examples/application-scenes/camera-and-view.ts
+++ b/examples/application-scenes/camera-and-view.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Graphics, Keyboard, Scene, Text, View } from '@codexo/exojs';
+import { Application, Color, Graphics, Keyboard, type RenderingContext, Scene, Text, type Time, View } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -22,7 +22,9 @@ class CameraViewScene extends Scene {
     private zoom = 0;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.camera = new View(0, 0, width, height);
 
@@ -79,12 +81,12 @@ class CameraViewScene extends Scene {
         });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.camera.move(this.moveX * 420 * delta.seconds, this.moveY * 420 * delta.seconds);
         this.camera.setZoom(Math.max(0.25, this.camera.zoomLevel + this.zoom * 0.75 * delta.seconds));
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.clear(Color.black);
         context.render(this.world, { view: this.camera });
         context.render(this.overlay, { view: context.screenView });

--- a/examples/application-scenes/camera-basic.js
+++ b/examples/application-scenes/camera-basic.js
@@ -18,7 +18,10 @@ class CameraBasicScene extends Scene {
     uiBar;
     zoom = 1;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.bunny = new Sprite(this.loader.get('image/ship-a.png'));
         this.bunny.setAnchor(0.5).setPosition(width / 2, height / 2);
         this.grid = new Graphics();
@@ -33,19 +36,25 @@ class CameraBasicScene extends Scene {
         this.uiBar = new Graphics();
         this.uiBar.fillColor = new Color(0, 0, 0, 0.6);
         this.uiBar.drawRectangle(0, 0, width, 40);
-        this.app.input.onPointerMove.add(p => {
-            this.app.rendering.view.setCenter(p.x, p.y);
+        app.input.onPointerMove.add(p => {
+            app.rendering.view.setCenter(p.x, p.y);
         });
-        this.app.input.onMouseWheel.add(delta => {
+        app.input.onMouseWheel.add(delta => {
             this.zoom = Math.max(0.2, Math.min(4, this.zoom - delta.y * 0.001));
-            this.app.rendering.view.setZoom(this.zoom);
+            app.rendering.view.setZoom(this.zoom);
         });
     }
     update(delta) {
-        this.app.rendering.view.rotation += delta.seconds * 15;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        app.rendering.view.rotation += delta.seconds * 15;
     }
     draw(context) {
-        const { width } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width } = app.canvas;
         context.backend.clear();
         context.render(this.grid);
         context.render(this.bunny);

--- a/examples/application-scenes/camera-basic.ts
+++ b/examples/application-scenes/camera-basic.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Graphics, Scene, Sprite } from '@codexo/exojs';
+import { Application, Color, Graphics, type RenderingContext, Scene, Sprite, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -20,7 +20,9 @@ class CameraBasicScene extends Scene {
     private zoom = 1;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.bunny = new Sprite(this.loader.get('image/ship-a.png'));
         this.bunny.setAnchor(0.5).setPosition(width / 2, height / 2);
@@ -41,22 +43,26 @@ class CameraBasicScene extends Scene {
         this.uiBar.fillColor = new Color(0, 0, 0, 0.6);
         this.uiBar.drawRectangle(0, 0, width, 40);
 
-        this.app.input.onPointerMove.add(p => {
-            this.app.rendering.view.setCenter(p.x, p.y);
+        app.input.onPointerMove.add(p => {
+            app.rendering.view.setCenter(p.x, p.y);
         });
 
-        this.app.input.onMouseWheel.add(delta => {
+        app.input.onMouseWheel.add(delta => {
             this.zoom = Math.max(0.2, Math.min(4, this.zoom - delta.y * 0.001));
-            this.app.rendering.view.setZoom(this.zoom);
+            app.rendering.view.setZoom(this.zoom);
         });
     }
 
-    override update(delta): void {
-        this.app.rendering.view.rotation += delta.seconds * 15;
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        app.rendering.view.rotation += delta.seconds * 15;
     }
 
-    override draw(context): void {
-        const { width } = this.app.canvas;
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width } = app.canvas;
 
         context.backend.clear();
         context.render(this.grid);

--- a/examples/application-scenes/hud-overlay-scene.js
+++ b/examples/application-scenes/hud-overlay-scene.js
@@ -35,7 +35,10 @@ class GameScene extends Scene {
         this.health.value = (Math.sin(this.time) + 1) / 2;
     }
     draw(context) {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         context.backend.clear(new Color(20, 32, 58));
         this.ring.clear();
         this.ring.lineWidth = 20;

--- a/examples/application-scenes/hud-overlay-scene.ts
+++ b/examples/application-scenes/hud-overlay-scene.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Graphics, Label, ProgressBar, Scene } from '@codexo/exojs';
+import { Application, Color, Graphics, Label, ProgressBar, type RenderingContext, Scene, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -34,14 +34,16 @@ class GameScene extends Scene {
         this.ui.addChild(this.health);
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.angle += delta.seconds * 90;
         this.time += delta.seconds;
         this.health.value = (Math.sin(this.time) + 1) / 2;
     }
 
-    override draw(context): void {
-        const { width, height } = this.app.canvas;
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         context.backend.clear(new Color(20, 32, 58));
         this.ring.clear();

--- a/examples/application-scenes/multi-view-split-screen.js
+++ b/examples/application-scenes/multi-view-split-screen.js
@@ -30,7 +30,10 @@ class SplitScreenScene extends Scene {
         down: 0,
     };
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.texture = this.loader.get('image/ship-a.png');
         this.leftView = new View(0, 0, width / 2, height).setViewport(0, 0, 0.5, 1);
         this.rightView = new View(0, 0, width / 2, height).setViewport(0.5, 0, 0.5, 1);

--- a/examples/application-scenes/multi-view-split-screen.ts
+++ b/examples/application-scenes/multi-view-split-screen.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Graphics, Keyboard, Scene, Sprite, Texture, View } from '@codexo/exojs';
+import { Application, Color, Graphics, Keyboard, type RenderingContext, Scene, Sprite, Texture, type Time, View } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -32,7 +32,9 @@ class SplitScreenScene extends Scene {
     };
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.texture = this.loader.get('image/ship-a.png');
 
@@ -102,7 +104,7 @@ class SplitScreenScene extends Scene {
         });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         const speed = 300 * delta.seconds;
 
         this.leftPlayer.move((this.move.d - this.move.a) * speed, (this.move.s - this.move.w) * speed);
@@ -111,7 +113,7 @@ class SplitScreenScene extends Scene {
         this.rightView.setCenter(this.rightPlayer.position.x, this.rightPlayer.position.y);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.clear(Color.black);
         context.render(this.leftPlayer, { view: this.leftView });
         context.render(this.rightPlayer, { view: this.leftView });

--- a/examples/application-scenes/multiple-scenes.js
+++ b/examples/application-scenes/multiple-scenes.js
@@ -16,36 +16,45 @@ class MenuScene extends Scene {
     label;
     onTap;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.label = new Text('MENU\nClick to Start', { align: 'center', fillColor: Color.white, fontSize: 34, fontWeight: 'bold' });
         this.label.setAnchor(0.5);
         this.label.setPosition(width / 2, height / 2);
         this.inputs.onTrigger(Keyboard.Space, () => {
-            void this.app.scene.setScene(gameScene);
+            void app.scene.setScene(gameScene);
         });
         this.onTap = () => {
-            void this.app.scene.setScene(gameScene);
+            void app.scene.setScene(gameScene);
         };
-        this.app.input.onPointerTap.add(this.onTap);
+        app.input.onPointerTap.add(this.onTap);
     }
     draw(context) {
         context.backend.clear(new Color(18, 38, 72, 1));
         context.render(this.label);
     }
     destroy() {
-        this.app.input.onPointerTap.remove(this.onTap);
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        app.input.onPointerTap.remove(this.onTap);
         super.destroy();
     }
 }
 class GameScene extends Scene {
     label;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.label = new Text('GAME\nEsc to Menu', { align: 'center', fillColor: Color.white, fontSize: 34, fontWeight: 'bold' });
         this.label.setAnchor(0.5);
         this.label.setPosition(width / 2, height / 2);
         this.inputs.onTrigger(Keyboard.Escape, () => {
-            void this.app.scene.setScene(menuScene);
+            void app.scene.setScene(menuScene);
         });
     }
     draw(context) {

--- a/examples/application-scenes/multiple-scenes.ts
+++ b/examples/application-scenes/multiple-scenes.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Keyboard, Scene, Text } from '@codexo/exojs';
+import { Application, Color, Keyboard, type RenderingContext, Scene, Text } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -18,29 +18,33 @@ class MenuScene extends Scene {
     private onTap!: () => void;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.label = new Text('MENU\nClick to Start', { align: 'center', fillColor: Color.white, fontSize: 34, fontWeight: 'bold' });
         this.label.setAnchor(0.5);
         this.label.setPosition(width / 2, height / 2);
 
         this.inputs.onTrigger(Keyboard.Space, () => {
-            void this.app.scene.setScene(gameScene);
+            void app.scene.setScene(gameScene);
         });
 
         this.onTap = () => {
-            void this.app.scene.setScene(gameScene);
+            void app.scene.setScene(gameScene);
         };
-        this.app.input.onPointerTap.add(this.onTap);
+        app.input.onPointerTap.add(this.onTap);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear(new Color(18, 38, 72, 1));
         context.render(this.label);
     }
 
     override destroy(): void {
-        this.app.input.onPointerTap.remove(this.onTap);
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        app.input.onPointerTap.remove(this.onTap);
         super.destroy();
     }
 }
@@ -49,18 +53,20 @@ class GameScene extends Scene {
     private label!: Text;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.label = new Text('GAME\nEsc to Menu', { align: 'center', fillColor: Color.white, fontSize: 34, fontWeight: 'bold' });
         this.label.setAnchor(0.5);
         this.label.setPosition(width / 2, height / 2);
 
         this.inputs.onTrigger(Keyboard.Escape, () => {
-            void this.app.scene.setScene(menuScene);
+            void app.scene.setScene(menuScene);
         });
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear(new Color(24, 72, 42, 1));
         context.render(this.label);
     }

--- a/examples/application-scenes/pause-and-resume.js
+++ b/examples/application-scenes/pause-and-resume.js
@@ -16,7 +16,10 @@ class PauseResumeScene extends Scene {
     sprite;
     label;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.sprite = new Sprite(this.loader.get('image/ship-a.png'));
         this.sprite.setAnchor(0.5);
         this.sprite.setPosition(width / 2, height / 2);
@@ -29,7 +32,7 @@ class PauseResumeScene extends Scene {
             this.label.text = this.paused ? 'Paused (draw running)' : 'Running';
         });
         // Same toggle on click/tap so the pause works without a keyboard.
-        this.app.input.onPointerTap.add(() => {
+        app.input.onPointerTap.add(() => {
             // scene.paused skips update() + systems each frame; drawing continues.
             this.paused = !this.paused;
             this.label.text = this.paused ? 'Paused (draw running)' : 'Running';

--- a/examples/application-scenes/pause-and-resume.ts
+++ b/examples/application-scenes/pause-and-resume.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Keyboard, Scene, Sprite, Text } from '@codexo/exojs';
+import { Application, Color, Keyboard, type RenderingContext, Scene, Sprite, Text, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -18,7 +18,9 @@ class PauseResumeScene extends Scene {
     private label!: Text;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.sprite = new Sprite(this.loader.get('image/ship-a.png'));
         this.sprite.setAnchor(0.5);
@@ -35,19 +37,19 @@ class PauseResumeScene extends Scene {
         });
 
         // Same toggle on click/tap so the pause works without a keyboard.
-        this.app.input.onPointerTap.add(() => {
+        app.input.onPointerTap.add(() => {
             // scene.paused skips update() + systems each frame; drawing continues.
             this.paused = !this.paused;
             this.label.text = this.paused ? 'Paused (draw running)' : 'Running';
         });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         // Not called while paused — the SceneManager skips a paused scene's update().
         this.sprite.rotate(delta.seconds * 180);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
         context.render(this.label);

--- a/examples/application-scenes/picture-in-picture.js
+++ b/examples/application-scenes/picture-in-picture.js
@@ -19,7 +19,10 @@ class PictureInPictureScene extends Scene {
     velocity = 220;
     frame;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.sprite = new Sprite(this.loader.get('image/ship-a.png'));
         this.mainView = new View(0, 0, width, height);
         this.pipView = new View(0, 0, width * 0.3, height * 0.3).setViewport(0.68, 0.04, 0.28, 0.28);

--- a/examples/application-scenes/picture-in-picture.ts
+++ b/examples/application-scenes/picture-in-picture.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Graphics, Scene, Sprite, View } from '@codexo/exojs';
+import { Application, Color, Graphics, type RenderingContext, Scene, Sprite, type Time, View } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -21,7 +21,9 @@ class PictureInPictureScene extends Scene {
     private frame!: Graphics;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.sprite = new Sprite(this.loader.get('image/ship-a.png'));
 
@@ -40,7 +42,7 @@ class PictureInPictureScene extends Scene {
         this.frame.drawRectangle(width * 0.68, height * 0.04, width * 0.28, height * 0.28);
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.sprite.move(this.velocity * delta.seconds, 0);
 
         if (this.sprite.position.x > 320 || this.sprite.position.x < -320) {
@@ -50,7 +52,7 @@ class PictureInPictureScene extends Scene {
         this.pipView.follow(this.sprite, { lerp: 1 });
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.clear(Color.black);
         context.render(this.sprite, { view: this.mainView });
         context.render(this.sprite, { view: this.pipView });

--- a/examples/application-scenes/scene-lifecycle.js
+++ b/examples/application-scenes/scene-lifecycle.js
@@ -32,7 +32,10 @@ class LifecycleScene extends Scene {
     timer;
     text;
     async init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // This scene is procedural — nothing to fetch — but a real scene would
         // resolve its assets here before touching the scene graph, e.g.:
         //   const texture = this.loader.get('ship.png');

--- a/examples/application-scenes/scene-lifecycle.ts
+++ b/examples/application-scenes/scene-lifecycle.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Color, Scene, Text, Time, Timer } from '@codexo/exojs';
+import { Application, Asset, Color, type RenderingContext, Scene, Text, Time, Timer } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -34,7 +34,9 @@ class LifecycleScene extends Scene {
     private text!: Text;
 
     override async init(): Promise<void> {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // This scene is procedural — nothing to fetch — but a real scene would
         // resolve its assets here before touching the scene graph, e.g.:
@@ -65,7 +67,7 @@ class LifecycleScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         this.drawCount++;
         context.backend.clear();
         this.text.text = [...this.events.slice(-8), `draw ${this.drawCount}`].join('\n');

--- a/examples/application-scenes/world-vs-screen-coords.js
+++ b/examples/application-scenes/world-vs-screen-coords.js
@@ -19,8 +19,11 @@ class WorldScreenScene extends Scene {
     text;
     pointer = { x: 0, y: 0 };
     init() {
-        const width = this.app.width;
-        const height = this.app.height;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const width = app.width;
+        const height = app.height;
         this.view = new View(260, 160, width, height);
         this.grid = new Graphics();
         this.markers = new Graphics();
@@ -33,10 +36,10 @@ class WorldScreenScene extends Scene {
         for (let y = -200; y <= 1000; y += 100) {
             this.grid.drawLine(-200, y, 1200, y);
         }
-        this.app.input.onPointerMove.add(pointer => {
+        app.input.onPointerMove.add(pointer => {
             this.pointer = { x: pointer.x, y: pointer.y };
         });
-        this.app.input.onPointerTap.add(pointer => {
+        app.input.onPointerTap.add(pointer => {
             const world = this.toWorld(pointer.x, pointer.y);
             this.markers.fillColor = new Color(255, 220, 80);
             this.markers.drawCircle(world.x, world.y, 8);

--- a/examples/application-scenes/world-vs-screen-coords.ts
+++ b/examples/application-scenes/world-vs-screen-coords.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Graphics, Scene, Text, View } from '@codexo/exojs';
+import { Application, Color, Graphics, type RenderingContext, Scene, Text, View } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -21,8 +21,10 @@ class WorldScreenScene extends Scene {
     private pointer = { x: 0, y: 0 };
 
     override init(): void {
-        const width = this.app.width;
-        const height = this.app.height;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const width = app.width;
+        const height = app.height;
 
         this.view = new View(260, 160, width, height);
         this.grid = new Graphics();
@@ -40,18 +42,18 @@ class WorldScreenScene extends Scene {
             this.grid.drawLine(-200, y, 1200, y);
         }
 
-        this.app.input.onPointerMove.add(pointer => {
+        app.input.onPointerMove.add(pointer => {
             this.pointer = { x: pointer.x, y: pointer.y };
         });
 
-        this.app.input.onPointerTap.add(pointer => {
+        app.input.onPointerTap.add(pointer => {
             const world = this.toWorld(pointer.x, pointer.y);
             this.markers.fillColor = new Color(255, 220, 80);
             this.markers.drawCircle(world.x, world.y, 8);
         });
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         const world = this.toWorld(this.pointer.x, this.pointer.y);
 
         this.text.text = `screen: ${this.pointer.x | 0}, ${this.pointer.y | 0}\nworld: ${world.x | 0}, ${world.y | 0}`;
@@ -65,7 +67,7 @@ class WorldScreenScene extends Scene {
         context.render(this.text);
     }
 
-    private toWorld(screenX, screenY): { x: number; y: number } {
+    private toWorld(screenX: number, screenY: number): { x: number; y: number } {
         // Pointer coordinates are already in design space, so screenToWorld only
         // has to undo this view's camera transform (pan/zoom) to reach world space.
         return this.view.screenToWorld(screenX, screenY);

--- a/examples/audio-basics/audio-buses.js
+++ b/examples/audio-basics/audio-buses.js
@@ -33,7 +33,10 @@ class AudioBusesScene extends Scene {
     sfxButton = { x: 0, y: 0, w: 0, h: 0 };
     hud;
     async init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // Centre the bus mixer horizontally and spread the bars across the wide
         // 16:9 canvas.
         this.trackW = width * 0.5;
@@ -65,25 +68,25 @@ class AudioBusesScene extends Scene {
             status: 'Click or press any key to start the music…',
             hint: 'Master scales every bus; Music and SFX scale only their own. Bars show live volume, labels show it in dB.',
         });
-        this.app.input.onPointerDown.add(p => {
+        app.input.onPointerDown.add(p => {
             this.drag = this.rowFromY(p.y);
             this.updateSlider(p.x);
         });
-        this.app.input.onPointerMove.add(p => {
+        app.input.onPointerMove.add(p => {
             this.updateSlider(p.x);
         });
-        this.app.input.onPointerUp.add(() => {
+        app.input.onPointerUp.add(() => {
             this.drag = -1;
         });
-        this.app.input.onPointerTap.add(p => {
+        app.input.onPointerTap.add(p => {
             if (this.insideSfxButton(p.x, p.y)) {
-                this.app.audio.play(this.sfx);
+                app.audio.play(this.sfx);
                 this.hud.setStatus('SFX fired on the SFX bus — try lowering Master or SFX, then fire again.');
             }
         });
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically.
-        this.app.audio.play(this.music, { loop: true, volume: 0.6 });
+        app.audio.play(this.music, { loop: true, volume: 0.6 });
         this.hud.setStatus('Music playing on the Music bus. Drag a bar to mix.');
     }
     rowFromY(y) {
@@ -103,6 +106,9 @@ class AudioBusesScene extends Scene {
         rows[this.drag].bus().volume = t;
     }
     draw(context) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         this.graphics.clear();
         rows.forEach((row, index) => {
@@ -123,7 +129,7 @@ class AudioBusesScene extends Scene {
         for (const label of this.labels)
             context.render(label);
         context.render(this.sfxLabel);
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/audio-basics/audio-buses.ts
+++ b/examples/audio-basics/audio-buses.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Assets, AudioStream, Color, Graphics, Scene, Sound, Text } from '@codexo/exojs';
+import { Application, Asset, Assets, AudioStream, Color, Graphics, type RenderingContext, Scene, Sound, Text } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -36,7 +36,9 @@ class AudioBusesScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override async init(): Promise<void> {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // Centre the bus mixer horizontally and spread the bars across the wide
         // 16:9 canvas.
@@ -74,26 +76,26 @@ class AudioBusesScene extends Scene {
             hint: 'Master scales every bus; Music and SFX scale only their own. Bars show live volume, labels show it in dB.',
         });
 
-        this.app.input.onPointerDown.add(p => {
+        app.input.onPointerDown.add(p => {
             this.drag = this.rowFromY(p.y);
             this.updateSlider(p.x);
         });
-        this.app.input.onPointerMove.add(p => {
+        app.input.onPointerMove.add(p => {
             this.updateSlider(p.x);
         });
-        this.app.input.onPointerUp.add(() => {
+        app.input.onPointerUp.add(() => {
             this.drag = -1;
         });
-        this.app.input.onPointerTap.add(p => {
+        app.input.onPointerTap.add(p => {
             if (this.insideSfxButton(p.x, p.y)) {
-                this.app.audio.play(this.sfx);
+                app.audio.play(this.sfx);
                 this.hud.setStatus('SFX fired on the SFX bus — try lowering Master or SFX, then fire again.');
             }
         });
 
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically.
-        this.app.audio.play(this.music, { loop: true, volume: 0.6 });
+        app.audio.play(this.music, { loop: true, volume: 0.6 });
         this.hud.setStatus('Music playing on the Music bus. Drag a bar to mix.');
     }
 
@@ -114,7 +116,9 @@ class AudioBusesScene extends Scene {
         rows[this.drag].bus().volume = t;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         this.graphics.clear();
 
@@ -139,7 +143,7 @@ class AudioBusesScene extends Scene {
         for (const label of this.labels) context.render(label);
         context.render(this.sfxLabel);
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/audio-basics/crossfade-tracks.js
+++ b/examples/audio-basics/crossfade-tracks.js
@@ -35,7 +35,10 @@ class CrossfadeTracksScene extends Scene {
     meterBaseY = 0;
     hud;
     async init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // Spread the two meters across the wide canvas: each sits a third of the
         // way in from its side, centred on the meter width.
         this.meterAX = width * 0.33 - METER_W / 2;
@@ -67,7 +70,7 @@ class CrossfadeTracksScene extends Scene {
             status: 'Click or press any key to start…',
             hint: 'The brighter meter with the bar above it is the active track; both loop continuously while their volumes ramp.',
         });
-        this.app.input.onPointerTap.add(() => {
+        app.input.onPointerTap.add(() => {
             // stopAfter: false keeps both loops alive so we can crossfade back.
             if (this.toB) {
                 void crossFade(this.trackAVoice, this.trackBVoice, 2000, { toVolume: PEAK, stopAfter: false });
@@ -82,8 +85,8 @@ class CrossfadeTracksScene extends Scene {
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically — start both loops (B silent) so
         // crossFade only has to ramp gains rather than start playback mid-fade.
-        this.trackAVoice = this.app.audio.play(this.trackA, { loop: true, volume: PEAK });
-        this.trackBVoice = this.app.audio.play(this.trackB, { loop: true, volume: 0 });
+        this.trackAVoice = app.audio.play(this.trackA, { loop: true, volume: PEAK });
+        this.trackBVoice = app.audio.play(this.trackB, { loop: true, volume: 0 });
         this.hud.setStatus('Track A active — click to crossfade.');
     }
     drawMeter(x, level, active, color) {
@@ -106,6 +109,9 @@ class CrossfadeTracksScene extends Scene {
         }
     }
     draw(context) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         this.graphics.clear();
         // voice.volume returns the fade TARGET immediately, so ease the
@@ -124,7 +130,7 @@ class CrossfadeTracksScene extends Scene {
         context.render(this.labelA);
         context.render(this.labelB);
         context.render(this.nowPlaying);
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/audio-basics/crossfade-tracks.ts
+++ b/examples/audio-basics/crossfade-tracks.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Assets, AudioStream, Color, crossFade, Graphics, Scene, Text, type Voice } from '@codexo/exojs';
+import { Application, Asset, Assets, AudioStream, Color, crossFade, Graphics, type RenderingContext, Scene, Text, type Voice } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -39,7 +39,9 @@ class CrossfadeTracksScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override async init(): Promise<void> {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // Spread the two meters across the wide canvas: each sits a third of the
         // way in from its side, centred on the meter width.
@@ -77,7 +79,7 @@ class CrossfadeTracksScene extends Scene {
             hint: 'The brighter meter with the bar above it is the active track; both loop continuously while their volumes ramp.',
         });
 
-        this.app.input.onPointerTap.add(() => {
+        app.input.onPointerTap.add(() => {
             // stopAfter: false keeps both loops alive so we can crossfade back.
             if (this.toB) {
                 void crossFade(this.trackAVoice, this.trackBVoice, 2000, { toVolume: PEAK, stopAfter: false });
@@ -92,8 +94,8 @@ class CrossfadeTracksScene extends Scene {
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically — start both loops (B silent) so
         // crossFade only has to ramp gains rather than start playback mid-fade.
-        this.trackAVoice = this.app.audio.play(this.trackA, { loop: true, volume: PEAK });
-        this.trackBVoice = this.app.audio.play(this.trackB, { loop: true, volume: 0 });
+        this.trackAVoice = app.audio.play(this.trackA, { loop: true, volume: PEAK });
+        this.trackBVoice = app.audio.play(this.trackB, { loop: true, volume: 0 });
         this.hud.setStatus('Track A active — click to crossfade.');
     }
 
@@ -120,7 +122,9 @@ class CrossfadeTracksScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         this.graphics.clear();
 
@@ -145,7 +149,7 @@ class CrossfadeTracksScene extends Scene {
         context.render(this.labelB);
         context.render(this.nowPlaying);
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/audio-basics/music-loop.js
+++ b/examples/audio-basics/music-loop.js
@@ -21,7 +21,10 @@ class MusicLoopScene extends Scene {
     hud;
     panel;
     async init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // Wide progress bar centred horizontally on the 16:9 canvas.
         this.bar = { x: width * 0.15, y: height * 0.5, w: width * 0.7, h: 28 };
         // A single streaming track — the browser's media pipeline loops it
@@ -32,7 +35,7 @@ class MusicLoopScene extends Scene {
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically — play() returns the Voice now,
         // and all live control (volume, rate, loop, seek) lives on it.
-        this.musicVoice = this.app.audio.play(this.music, { loop: true, volume: 0.7, playbackRate: 1 });
+        this.musicVoice = app.audio.play(this.music, { loop: true, volume: 0.7, playbackRate: 1 });
         this.graphics = new Graphics();
         this.status = new Text('', { fillColor: Color.white, fontSize: 18 }).setPosition(this.bar.x, this.bar.y - 36);
         // Shown while the browser still blocks audio (`app.audio.locked`); the
@@ -87,6 +90,9 @@ class MusicLoopScene extends Scene {
         this.hud.setStatus('Playing — use the panel to mix.');
     }
     draw(context) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         this.graphics.clear();
         const duration = this.musicVoice.duration;
@@ -107,7 +113,7 @@ class MusicLoopScene extends Scene {
         this.status.text = `${state}   ${position}   ${Math.round(this.musicVoice.playbackRate * 100)}% speed   Loop ${this.musicVoice.loop ? 'on' : 'off'}`;
         context.render(this.graphics);
         context.render(this.status);
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/audio-basics/music-loop.ts
+++ b/examples/audio-basics/music-loop.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Assets, AudioStream, Color, Graphics, type Loopable, type Pausable, type RatePitched, Scene, type Seekable, Text, type Voice } from '@codexo/exojs';
+import { Application, Asset, Assets, AudioStream, Color, Graphics, type Loopable, type Pausable, type RatePitched, type RenderingContext, Scene, type Seekable, Text, type Voice } from '@codexo/exojs';
 import { mountControlPanel, mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -23,7 +23,9 @@ class MusicLoopScene extends Scene {
     private panel!: ReturnType<typeof mountControlPanel>;
 
     override async init(): Promise<void> {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // Wide progress bar centred horizontally on the 16:9 canvas.
         this.bar = { x: width * 0.15, y: height * 0.5, w: width * 0.7, h: 28 };
@@ -37,7 +39,7 @@ class MusicLoopScene extends Scene {
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically — play() returns the Voice now,
         // and all live control (volume, rate, loop, seek) lives on it.
-        this.musicVoice = this.app.audio.play(this.music, { loop: true, volume: 0.7, playbackRate: 1 }) as Voice & Seekable & Pausable & Loopable & RatePitched;
+        this.musicVoice = app.audio.play(this.music, { loop: true, volume: 0.7, playbackRate: 1 }) as Voice & Seekable & Pausable & Loopable & RatePitched;
 
         this.graphics = new Graphics();
         this.status = new Text('', { fillColor: Color.white, fontSize: 18 }).setPosition(this.bar.x, this.bar.y - 36);
@@ -97,7 +99,9 @@ class MusicLoopScene extends Scene {
         this.hud.setStatus('Playing — use the panel to mix.');
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         this.graphics.clear();
 
@@ -124,7 +128,7 @@ class MusicLoopScene extends Scene {
         context.render(this.graphics);
         context.render(this.status);
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/audio-basics/play-sound.js
+++ b/examples/audio-basics/play-sound.js
@@ -16,9 +16,12 @@ class PlaySoundScene extends Scene {
     text;
     index = 0;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // Keep example SFX comfortable — full volume is jarring in the docs.
-        this.app.audio.sound.volume = 0.5;
+        app.audio.sound.volume = 0.5;
         // Path-only get() infers Sound from the .ogg extension — sidesteps a
         // compile-time overload ambiguity between Sound and the Json token form
         // when passing the Sound token explicitly.
@@ -26,11 +29,11 @@ class PlaySoundScene extends Scene {
         this.text = new Text('Click anywhere to play SFX', { fillColor: Color.white, fontSize: 24, align: 'center' })
             .setAnchor(0.5, 0.5)
             .setPosition(width / 2, height / 2);
-        this.app.input.onPointerTap.add(() => {
+        app.input.onPointerTap.add(() => {
             // Cycle through the pool so each tap plays a different sound.
             const sound = this.sounds[this.index];
             this.index = (this.index + 1) % this.sounds.length;
-            this.app.audio.play(sound);
+            app.audio.play(sound);
             this.text.text = `Playing: ${SOUND_KEYS[(this.index + this.sounds.length - 1) % this.sounds.length]}`;
         });
     }

--- a/examples/audio-basics/play-sound.ts
+++ b/examples/audio-basics/play-sound.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene, Sound, Text } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, Sound, Text } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -19,10 +19,12 @@ class PlaySoundScene extends Scene {
     private index = 0;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // Keep example SFX comfortable — full volume is jarring in the docs.
-        this.app.audio.sound.volume = 0.5;
+        app.audio.sound.volume = 0.5;
 
         // Path-only get() infers Sound from the .ogg extension — sidesteps a
         // compile-time overload ambiguity between Sound and the Json token form
@@ -31,16 +33,16 @@ class PlaySoundScene extends Scene {
         this.text = new Text('Click anywhere to play SFX', { fillColor: Color.white, fontSize: 24, align: 'center' })
             .setAnchor(0.5, 0.5)
             .setPosition(width / 2, height / 2);
-        this.app.input.onPointerTap.add(() => {
+        app.input.onPointerTap.add(() => {
             // Cycle through the pool so each tap plays a different sound.
             const sound = this.sounds[this.index];
             this.index = (this.index + 1) % this.sounds.length;
-            this.app.audio.play(sound);
+            app.audio.play(sound);
             this.text.text = `Playing: ${SOUND_KEYS[(this.index + this.sounds.length - 1) % this.sounds.length]}`;
         });
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.text);
     }

--- a/examples/audio-basics/random-pitch-pool.js
+++ b/examples/audio-basics/random-pitch-pool.js
@@ -28,7 +28,10 @@ class RandomPitchPoolScene extends Scene {
     trackHalf = 0;
     hud;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.centerX = width / 2;
         this.trackY = height * 0.55;
         this.trackHalf = width * 0.38;
@@ -67,20 +70,26 @@ class RandomPitchPoolScene extends Scene {
         });
     }
     update(delta) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.flash = Math.max(0, this.flash - delta.seconds * 4);
         // Core defers playback until the AudioContext unlocks on the first
         // gesture; skip firing while audio is still locked.
-        if (!this.active || this.app.audio.locked)
+        if (!this.active || app.audio.locked)
             return;
         this.timer += delta.seconds;
         while (this.timer > FIRE_INTERVAL) {
             this.timer -= FIRE_INTERVAL;
             this.lastCents = Math.random() * (DETUNE_RANGE * 2) - DETUNE_RANGE;
             this.flash = 1;
-            this.app.audio.play(this.sound, { playbackRate: Math.pow(2, this.lastCents / 1200) });
+            app.audio.play(this.sound, { playbackRate: Math.pow(2, this.lastCents / 1200) });
         }
     }
     draw(context) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         this.graphics.clear();
         // Centre baseline.
@@ -97,7 +106,7 @@ class RandomPitchPoolScene extends Scene {
         context.render(this.graphics);
         context.render(this.label);
         context.render(this.readout);
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/audio-basics/random-pitch-pool.ts
+++ b/examples/audio-basics/random-pitch-pool.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Graphics, Keyboard, Scene, Sound, Text } from '@codexo/exojs';
+import { Application, Color, Graphics, Keyboard, type RenderingContext, Scene, Sound, Text, type Time } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -31,7 +31,9 @@ class RandomPitchPoolScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.centerX = width / 2;
         this.trackY = height * 0.55;
@@ -76,23 +78,27 @@ class RandomPitchPoolScene extends Scene {
         });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.flash = Math.max(0, this.flash - delta.seconds * 4);
 
         // Core defers playback until the AudioContext unlocks on the first
         // gesture; skip firing while audio is still locked.
-        if (!this.active || this.app.audio.locked) return;
+        if (!this.active || app.audio.locked) return;
 
         this.timer += delta.seconds;
         while (this.timer > FIRE_INTERVAL) {
             this.timer -= FIRE_INTERVAL;
             this.lastCents = Math.random() * (DETUNE_RANGE * 2) - DETUNE_RANGE;
             this.flash = 1;
-            this.app.audio.play(this.sound, { playbackRate: Math.pow(2, this.lastCents / 1200) });
+            app.audio.play(this.sound, { playbackRate: Math.pow(2, this.lastCents / 1200) });
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         this.graphics.clear();
 
@@ -114,7 +120,7 @@ class RandomPitchPoolScene extends Scene {
         context.render(this.label);
         context.render(this.readout);
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/audio-basics/sound-pool.js
+++ b/examples/audio-basics/sound-pool.js
@@ -28,7 +28,10 @@ class SoundPoolScene extends Scene {
     evictions = 0;
     hud;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // impactHeavy is long enough (~0.5 s) that rapid fire actually overlaps -
         // a short click ends before the next shot and the pool never fills.
         // Path-only get() infers Sound from the .ogg extension — sidesteps a
@@ -66,6 +69,9 @@ class SoundPoolScene extends Scene {
         });
     }
     spawnVoice() {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         // Retire any voices that have finished naturally.
         this.voices = this.voices.filter(end => end > this.clock);
         // At capacity the engine evicts the oldest source; mirror that here.
@@ -75,15 +81,18 @@ class SoundPoolScene extends Scene {
         }
         this.voices.push(this.clock + this.sound.duration);
         // Small random pitch per shot keeps the barrage from sounding robotic.
-        this.app.audio.play(this.sound, { playbackRate: 0.85 + Math.random() * 0.3, volume: 0.5 });
+        app.audio.play(this.sound, { playbackRate: 0.85 + Math.random() * 0.3, volume: 0.5 });
     }
     update(delta) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.clock += delta.seconds;
         // Drop voices that have ended this frame so the meter reads truthfully.
         this.voices = this.voices.filter(end => end > this.clock);
         // Core defers playback until the AudioContext unlocks on the first
         // gesture; skip firing while audio is still locked.
-        if (!this.firing || this.app.audio.locked)
+        if (!this.firing || app.audio.locked)
             return;
         this.timer += delta.seconds;
         while (this.timer >= FIRE_INTERVAL) {
@@ -92,6 +101,9 @@ class SoundPoolScene extends Scene {
         }
     }
     draw(context) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         this.graphics.clear();
         const active = this.voices.length;
@@ -100,8 +112,8 @@ class SoundPoolScene extends Scene {
         const cell = 70;
         const gap = 12;
         const totalW = cols * cell + (cols - 1) * gap;
-        const startX = (this.app.width - totalW) / 2;
-        const startY = this.app.height * 0.42;
+        const startX = (app.width - totalW) / 2;
+        const startY = app.height * 0.42;
         for (let i = 0; i < POOL_SIZE; i++) {
             const col = i % cols;
             const rowI = Math.floor(i / cols);
@@ -119,7 +131,7 @@ class SoundPoolScene extends Scene {
         context.render(this.graphics);
         context.render(this.label);
         context.render(this.readout);
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/audio-basics/sound-pool.ts
+++ b/examples/audio-basics/sound-pool.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Graphics, Keyboard, Scene, Sound, Text } from '@codexo/exojs';
+import { Application, Color, Graphics, Keyboard, type RenderingContext, Scene, Sound, Text, type Time } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -31,7 +31,9 @@ class SoundPoolScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // impactHeavy is long enough (~0.5 s) that rapid fire actually overlaps -
         // a short click ends before the next shot and the pool never fills.
@@ -75,6 +77,8 @@ class SoundPoolScene extends Scene {
     }
 
     private spawnVoice(): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         // Retire any voices that have finished naturally.
         this.voices = this.voices.filter(end => end > this.clock);
 
@@ -86,17 +90,19 @@ class SoundPoolScene extends Scene {
 
         this.voices.push(this.clock + this.sound.duration);
         // Small random pitch per shot keeps the barrage from sounding robotic.
-        this.app.audio.play(this.sound, { playbackRate: 0.85 + Math.random() * 0.3, volume: 0.5 });
+        app.audio.play(this.sound, { playbackRate: 0.85 + Math.random() * 0.3, volume: 0.5 });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.clock += delta.seconds;
         // Drop voices that have ended this frame so the meter reads truthfully.
         this.voices = this.voices.filter(end => end > this.clock);
 
         // Core defers playback until the AudioContext unlocks on the first
         // gesture; skip firing while audio is still locked.
-        if (!this.firing || this.app.audio.locked) return;
+        if (!this.firing || app.audio.locked) return;
 
         this.timer += delta.seconds;
         while (this.timer >= FIRE_INTERVAL) {
@@ -105,7 +111,9 @@ class SoundPoolScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         this.graphics.clear();
 
@@ -116,8 +124,8 @@ class SoundPoolScene extends Scene {
         const cell = 70;
         const gap = 12;
         const totalW = cols * cell + (cols - 1) * gap;
-        const startX = (this.app.width - totalW) / 2;
-        const startY = this.app.height * 0.42;
+        const startX = (app.width - totalW) / 2;
+        const startY = app.height * 0.42;
 
         for (let i = 0; i < POOL_SIZE; i++) {
             const col = i % cols;
@@ -139,7 +147,7 @@ class SoundPoolScene extends Scene {
         context.render(this.label);
         context.render(this.readout);
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/audio-fx/compressor.js
+++ b/examples/audio-fx/compressor.js
@@ -36,7 +36,10 @@ class CompressorScene extends Scene {
     meterY = 0;
     hud;
     async init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // Wide horizontal bars centred on the 16:9 canvas; labels sit to the left.
         this.barW = width * 0.45;
         this.barX = width * 0.32;
@@ -63,19 +66,19 @@ class CompressorScene extends Scene {
             status: 'Click or press any key to start…',
             hint: 'The red bar shows live gain reduction — louder peaks pull it further right.',
         });
-        this.app.input.onPointerDown.add(p => {
+        app.input.onPointerDown.add(p => {
             this.drag = this.sliderAt(p.y);
             this.apply(p.x);
         });
-        this.app.input.onPointerMove.add(p => {
+        app.input.onPointerMove.add(p => {
             this.apply(p.x);
         });
-        this.app.input.onPointerUp.add(() => {
+        app.input.onPointerUp.add(() => {
             this.drag = -1;
         });
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically.
-        this.app.audio.play(this.music, { loop: true, volume: 0.8 });
+        app.audio.play(this.music, { loop: true, volume: 0.8 });
         this.hud.setStatus('Compressing music bus…');
     }
     sliderAt(y) {
@@ -95,6 +98,9 @@ class CompressorScene extends Scene {
         return this.filter[def.key];
     }
     draw(context) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         this.gfx.clear();
         for (let i = 0; i < sliders.length; i++) {
@@ -119,7 +125,7 @@ class CompressorScene extends Scene {
         this.meterLabel.text = `gain reduction: ${reduction.toFixed(1)} dB`;
         context.render(this.meterLabel);
         context.render(this.gfx);
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/audio-fx/compressor.ts
+++ b/examples/audio-fx/compressor.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Assets, AudioStream, Color, Graphics, Scene, Text } from '@codexo/exojs';
+import { Application, Asset, Assets, AudioStream, Color, Graphics, type RenderingContext, Scene, Text } from '@codexo/exojs';
 import { CompressorEffect } from '@codexo/exojs-audio-fx';
 import { mountControls } from '@examples/runtime';
 
@@ -47,7 +47,9 @@ class CompressorScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override async init(): Promise<void> {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // Wide horizontal bars centred on the 16:9 canvas; labels sit to the left.
         this.barW = width * 0.45;
@@ -80,20 +82,20 @@ class CompressorScene extends Scene {
             hint: 'The red bar shows live gain reduction — louder peaks pull it further right.',
         });
 
-        this.app.input.onPointerDown.add(p => {
+        app.input.onPointerDown.add(p => {
             this.drag = this.sliderAt(p.y);
             this.apply(p.x);
         });
-        this.app.input.onPointerMove.add(p => {
+        app.input.onPointerMove.add(p => {
             this.apply(p.x);
         });
-        this.app.input.onPointerUp.add(() => {
+        app.input.onPointerUp.add(() => {
             this.drag = -1;
         });
 
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically.
-        this.app.audio.play(this.music, { loop: true, volume: 0.8 });
+        app.audio.play(this.music, { loop: true, volume: 0.8 });
         this.hud.setStatus('Compressing music bus…');
     }
 
@@ -113,7 +115,9 @@ class CompressorScene extends Scene {
         return this.filter[def.key];
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         this.gfx.clear();
         for (let i = 0; i < sliders.length; i++) {
@@ -141,7 +145,7 @@ class CompressorScene extends Scene {
 
         context.render(this.gfx);
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/audio-fx/ducking.js
+++ b/examples/audio-fx/ducking.js
@@ -32,7 +32,10 @@ class DuckingScene extends Scene {
     voiceBarY = 0;
     hud;
     async init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // Wide meters centred on the 16:9 canvas.
         this.barX = width * 0.1;
         this.barW = width * 0.8;
@@ -73,17 +76,17 @@ class DuckingScene extends Scene {
             status: 'Click or press any key to start…',
             hint: 'When the voice plays, the music meter ducks down while the voice meter spikes.',
         });
-        this.app.input.onPointerTap.add(() => {
+        app.input.onPointerTap.add(() => {
             // The pointer gesture also unlocks the AudioContext; firing while
             // still locked would be silent, so wait until audio is ready.
-            if (this.app.audio.locked)
+            if (app.audio.locked)
                 return;
-            this.app.audio.play(this.voice, { bus: this.voiceBus });
+            app.audio.play(this.voice, { bus: this.voiceBus });
             this.hud.setStatus('Voice playing — music ducked');
         });
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically.
-        this.app.audio.play(this.music, { loop: true, volume: 0.7 });
+        app.audio.play(this.music, { loop: true, volume: 0.7 });
         this.hud.setStatus('Music playing — click to duck it');
     }
     bar(label, name, y, level, color) {
@@ -94,6 +97,9 @@ class DuckingScene extends Scene {
         label.text = `${name}: ${(level * 100).toFixed(0)}%`;
     }
     draw(context) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         // RMS reads 0 in silence, so the meters are honest (flat until audio plays).
         const music = this.musicLevel.getRms();
         const voice = this.voiceLevel.getRms();
@@ -107,7 +113,7 @@ class DuckingScene extends Scene {
         context.render(this.gfx);
         context.render(this.musicLabel);
         context.render(this.voiceLabel);
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/audio-fx/ducking.ts
+++ b/examples/audio-fx/ducking.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Assets, AudioBus, AudioStream, Color, Graphics, Scene, Sound, Text } from '@codexo/exojs';
+import { Application, Asset, Assets, AudioBus, AudioStream, Color, Graphics, type RenderingContext, Scene, Sound, Text } from '@codexo/exojs';
 import { AudioAnalyser, DuckingEffect } from '@codexo/exojs-audio-fx';
 import { mountControls } from '@examples/runtime';
 
@@ -34,7 +34,9 @@ class DuckingScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override async init(): Promise<void> {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // Wide meters centred on the 16:9 canvas.
         this.barX = width * 0.1;
@@ -84,17 +86,17 @@ class DuckingScene extends Scene {
             hint: 'When the voice plays, the music meter ducks down while the voice meter spikes.',
         });
 
-        this.app.input.onPointerTap.add(() => {
+        app.input.onPointerTap.add(() => {
             // The pointer gesture also unlocks the AudioContext; firing while
             // still locked would be silent, so wait until audio is ready.
-            if (this.app.audio.locked) return;
-            this.app.audio.play(this.voice, { bus: this.voiceBus });
+            if (app.audio.locked) return;
+            app.audio.play(this.voice, { bus: this.voiceBus });
             this.hud.setStatus('Voice playing — music ducked');
         });
 
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically.
-        this.app.audio.play(this.music, { loop: true, volume: 0.7 });
+        app.audio.play(this.music, { loop: true, volume: 0.7 });
         this.hud.setStatus('Music playing — click to duck it');
     }
 
@@ -106,7 +108,9 @@ class DuckingScene extends Scene {
         label.text = `${name}: ${(level * 100).toFixed(0)}%`;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         // RMS reads 0 in silence, so the meters are honest (flat until audio plays).
         const music = this.musicLevel.getRms();
         const voice = this.voiceLevel.getRms();
@@ -122,7 +126,7 @@ class DuckingScene extends Scene {
         context.render(this.musicLabel);
         context.render(this.voiceLabel);
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/audio-fx/reverb-and-delay.js
+++ b/examples/audio-fx/reverb-and-delay.js
@@ -28,7 +28,10 @@ class ReverbAndDelayScene extends Scene {
     hud;
     panel;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // A large click pad centred on the canvas.
         this.pad = { x: width / 2 - 240, y: height * 0.36, w: 480, h: 160 };
         // Path-only get() infers Sound from the .ogg extension — sidesteps a
@@ -108,12 +111,12 @@ class ReverbAndDelayScene extends Scene {
                 this.delay.feedback = v;
             },
         });
-        this.app.input.onPointerTap.add(() => {
+        app.input.onPointerTap.add(() => {
             // The pointer gesture also unlocks the AudioContext; firing while
             // still locked would be silent, so wait until audio is ready.
-            if (this.app.audio.locked)
+            if (app.audio.locked)
                 return;
-            this.app.audio.play(this.sound);
+            app.audio.play(this.sound);
             this.flash = 1;
             this.triggers += 1;
             this.hud.setStatus(`Impacts triggered: ${this.triggers}`);
@@ -124,16 +127,19 @@ class ReverbAndDelayScene extends Scene {
         this.flash = Math.max(0, this.flash - delta.seconds * 2.2);
     }
     draw(context) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         this.gfx.clear();
         // A big click pad that flashes on each trigger so the play action reads.
         const lit = Math.floor(60 + this.flash * 180);
         this.gfx.fillColor = new Color(lit, lit, Math.floor(60 + this.flash * 120));
         this.gfx.drawRectangle(this.pad.x, this.pad.y, this.pad.w, this.pad.h);
-        this.prompt.text = this.app.audio.locked ? 'Click or press a key to enable audio' : 'Click to play impact';
+        this.prompt.text = app.audio.locked ? 'Click or press a key to enable audio' : 'Click to play impact';
         context.render(this.gfx);
         context.render(this.prompt);
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/audio-fx/reverb-and-delay.ts
+++ b/examples/audio-fx/reverb-and-delay.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Graphics, Scene, Sound, Text } from '@codexo/exojs';
+import { Application, Color, Graphics, type RenderingContext, Scene, Sound, Text, type Time } from '@codexo/exojs';
 import { DelayEffect, ReverbEffect } from '@codexo/exojs-audio-fx';
 import { mountControlPanel, mountControls } from '@examples/runtime';
 
@@ -30,7 +30,9 @@ class ReverbAndDelayScene extends Scene {
     private panel!: ReturnType<typeof mountControlPanel>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // A large click pad centred on the canvas.
         this.pad = { x: width / 2 - 240, y: height * 0.36, w: 480, h: 160 };
@@ -118,11 +120,11 @@ class ReverbAndDelayScene extends Scene {
             },
         });
 
-        this.app.input.onPointerTap.add(() => {
+        app.input.onPointerTap.add(() => {
             // The pointer gesture also unlocks the AudioContext; firing while
             // still locked would be silent, so wait until audio is ready.
-            if (this.app.audio.locked) return;
-            this.app.audio.play(this.sound);
+            if (app.audio.locked) return;
+            app.audio.play(this.sound);
             this.flash = 1;
             this.triggers += 1;
             this.hud.setStatus(`Impacts triggered: ${this.triggers}`);
@@ -131,11 +133,13 @@ class ReverbAndDelayScene extends Scene {
         this.hud.setStatus('Click anywhere to trigger the impact');
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.flash = Math.max(0, this.flash - delta.seconds * 2.2);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         this.gfx.clear();
 
@@ -144,11 +148,11 @@ class ReverbAndDelayScene extends Scene {
         this.gfx.fillColor = new Color(lit, lit, Math.floor(60 + this.flash * 120));
         this.gfx.drawRectangle(this.pad.x, this.pad.y, this.pad.w, this.pad.h);
 
-        this.prompt.text = this.app.audio.locked ? 'Click or press a key to enable audio' : 'Click to play impact';
+        this.prompt.text = app.audio.locked ? 'Click or press a key to enable audio' : 'Click to play impact';
         context.render(this.gfx);
         context.render(this.prompt);
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/audio-fx/vocoder.js
+++ b/examples/audio-fx/vocoder.js
@@ -27,7 +27,10 @@ class VocoderScene extends Scene {
     tapPrompt;
     hud;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // The spoken voice is the modulator: route every phrase onto its own bus
         // so the vocoder can read its spectral envelope.
         this.modulatorBus = new AudioBus('modulator', { parent: app.audio.master });
@@ -61,30 +64,36 @@ class VocoderScene extends Scene {
             onChange: index => (this.phraseIndex = index),
         });
         panel.addButton({ label: 'Speak', onClick: () => this.speak() });
-        this.app.input.onPointerTap.add(() => this.speak());
+        app.input.onPointerTap.add(() => this.speak());
         // The carrier is a sustained saw tone shaped by the voice envelope.
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts the carrier automatically.
-        this.app.audio.play(new AudioGenerator({ frequency: 110, type: 'sawtooth' }), { volume: 0.45 });
+        app.audio.play(new AudioGenerator({ frequency: 110, type: 'sawtooth' }), { volume: 0.45 });
         this.hud.setStatus('Ready — pick a phrase and speak.');
     }
     speak() {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         // The pointer gesture also unlocks the AudioContext; speaking while
         // still locked would be silent, so wait until audio is ready.
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             return;
         }
         const phrase = PHRASES[this.phraseIndex];
         const sound = this.phrases.get(phrase.key);
         if (sound)
-            this.app.audio.play(sound, { bus: this.modulatorBus });
+            app.audio.play(sound, { bus: this.modulatorBus });
         this.hud.setStatus(`Speaking: "${phrase.label}"`);
         this.phraseLabel.text = `"${phrase.label}"`;
     }
     draw(context) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         context.render(this.phraseLabel);
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/audio-fx/vocoder.ts
+++ b/examples/audio-fx/vocoder.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, AudioBus, AudioGenerator, Color, Scene, Sound, Text } from '@codexo/exojs';
+import { Application, Asset, AudioBus, AudioGenerator, Color, type RenderingContext, Scene, Sound, Text } from '@codexo/exojs';
 import { VocoderEffect } from '@codexo/exojs-audio-fx';
 import { mountControlPanel, mountControls } from '@examples/runtime';
 
@@ -30,7 +30,9 @@ class VocoderScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // The spoken voice is the modulator: route every phrase onto its own bus
         // so the vocoder can read its spectral envelope.
@@ -72,35 +74,39 @@ class VocoderScene extends Scene {
         });
         panel.addButton({ label: 'Speak', onClick: () => this.speak() });
 
-        this.app.input.onPointerTap.add(() => this.speak());
+        app.input.onPointerTap.add(() => this.speak());
 
         // The carrier is a sustained saw tone shaped by the voice envelope.
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts the carrier automatically.
-        this.app.audio.play(new AudioGenerator({ frequency: 110, type: 'sawtooth' }), { volume: 0.45 });
+        app.audio.play(new AudioGenerator({ frequency: 110, type: 'sawtooth' }), { volume: 0.45 });
         this.hud.setStatus('Ready — pick a phrase and speak.');
     }
 
     private speak(): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         // The pointer gesture also unlocks the AudioContext; speaking while
         // still locked would be silent, so wait until audio is ready.
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             return;
         }
 
         const phrase = PHRASES[this.phraseIndex];
 
         const sound = this.phrases.get(phrase.key);
-        if (sound) this.app.audio.play(sound, { bus: this.modulatorBus });
+        if (sound) app.audio.play(sound, { bus: this.modulatorBus });
         this.hud.setStatus(`Speaking: "${phrase.label}"`);
         this.phraseLabel.text = `"${phrase.label}"`;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         context.render(this.phraseLabel);
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/beat-detection/beat-sync-pulse.js
+++ b/examples/beat-detection/beat-sync-pulse.js
@@ -28,7 +28,10 @@ class BeatSyncPulseScene extends Scene {
     hud;
     tapPrompt;
     async init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // AudioStream has no seamless adapter — await it explicitly.
         const { track } = await this.loader.load(Assets.from({ track: Asset.kind('music', 'audio/demo-loop-main.ogg') }));
         this.music = track;
@@ -64,7 +67,7 @@ class BeatSyncPulseScene extends Scene {
             },
         });
         this.detector = new BeatDetector();
-        this.detector.source = this.app.audio.music;
+        this.detector.source = app.audio.music;
         this.detector.onBeat.add(() => {
             this.pulse = this.intensity;
             this.burst.reset();
@@ -73,7 +76,7 @@ class BeatSyncPulseScene extends Scene {
         });
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically.
-        this.app.audio.play(this.music, { loop: true, volume: 0.8 });
+        app.audio.play(this.music, { loop: true, volume: 0.8 });
     }
     update(delta) {
         this.pulse = Math.max(0, this.pulse - delta.seconds * 1.2);
@@ -81,10 +84,13 @@ class BeatSyncPulseScene extends Scene {
         this.particles.update(delta);
     }
     draw(context) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         context.render(this.particles);
         context.render(this.sprite);
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/beat-detection/beat-sync-pulse.ts
+++ b/examples/beat-detection/beat-sync-pulse.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Assets, AudioStream, Color, Scene, Sprite, Text, Vector } from '@codexo/exojs';
+import { Application, Asset, Assets, AudioStream, Color, type RenderingContext, Scene, Sprite, Text, type Time, Vector } from '@codexo/exojs';
 import { BeatDetector } from '@codexo/exojs-audio-fx';
 import {
     AlphaFadeOverLifetime,
@@ -37,7 +37,9 @@ class BeatSyncPulseScene extends Scene {
     private tapPrompt!: Text;
 
     override async init(): Promise<void> {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // AudioStream has no seamless adapter — await it explicitly.
         const { track } = await this.loader.load(Assets.from({ track: Asset.kind('music', 'audio/demo-loop-main.ogg') }));
@@ -79,7 +81,7 @@ class BeatSyncPulseScene extends Scene {
         });
 
         this.detector = new BeatDetector();
-        this.detector.source = this.app.audio.music;
+        this.detector.source = app.audio.music;
         this.detector.onBeat.add(() => {
             this.pulse = this.intensity;
             this.burst.reset();
@@ -89,21 +91,23 @@ class BeatSyncPulseScene extends Scene {
 
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically.
-        this.app.audio.play(this.music, { loop: true, volume: 0.8 });
+        app.audio.play(this.music, { loop: true, volume: 0.8 });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.pulse = Math.max(0, this.pulse - delta.seconds * 1.2);
         this.sprite.setScale(1 + this.pulse);
         this.particles.update(delta);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         context.render(this.particles);
         context.render(this.sprite);
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/beat-detection/frequency-bands.js
+++ b/examples/beat-detection/frequency-bands.js
@@ -42,11 +42,14 @@ class FrequencyBandsScene extends Scene {
     hud;
     tapPrompt;
     async init() {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         // AudioStream has no seamless adapter — await it explicitly.
         const { track } = await this.loader.load(Assets.from({ track: Asset.kind('music', 'audio/demo-loop-main.ogg') }));
         this.music = track;
         this.analyser = new AudioAnalyser({ fftSize: 2048, smoothingTimeConstant: 0.75 });
-        this.analyser.source = this.app.audio.music;
+        this.analyser.source = app.audio.music;
         // Log-spaced bin boundaries across the spectrum. Index 0 (DC) is skipped
         // so the lowest band starts at the first meaningful bin.
         const binCount = this.analyser.frequencyBinCount;
@@ -57,7 +60,7 @@ class FrequencyBandsScene extends Scene {
             this.bandEdges.push(Math.round(minBin * Math.pow(maxBin / minBin, t)));
         }
         this.bars = new Graphics();
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
         const gap = 16;
         const slotWidth = (width - gap) / BAND_COUNT;
         const barWidth = slotWidth - gap;
@@ -79,7 +82,7 @@ class FrequencyBandsScene extends Scene {
             .setPosition(width / 2, height - 48);
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically.
-        this.app.audio.play(this.music, { loop: true, volume: 0.8 });
+        app.audio.play(this.music, { loop: true, volume: 0.8 });
     }
     update() {
         const spectrum = this.analyser.getSpectrum();
@@ -95,8 +98,11 @@ class FrequencyBandsScene extends Scene {
         }
     }
     draw(context) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
         const gap = 16;
         const slotWidth = (width - gap) / BAND_COUNT;
         const barWidth = slotWidth - gap;
@@ -115,7 +121,7 @@ class FrequencyBandsScene extends Scene {
         for (const label of this.labels) {
             context.render(label);
         }
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/beat-detection/frequency-bands.ts
+++ b/examples/beat-detection/frequency-bands.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Assets, AudioStream, Color, Graphics, Scene, Text } from '@codexo/exojs';
+import { Application, Asset, Assets, AudioStream, Color, Graphics, type RenderingContext, Scene, Text } from '@codexo/exojs';
 import { AudioAnalyser } from '@codexo/exojs-audio-fx';
 import { mountControls } from '@examples/runtime';
 
@@ -46,12 +46,14 @@ class FrequencyBandsScene extends Scene {
     private tapPrompt!: Text;
 
     override async init(): Promise<void> {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         // AudioStream has no seamless adapter — await it explicitly.
         const { track } = await this.loader.load(Assets.from({ track: Asset.kind('music', 'audio/demo-loop-main.ogg') }));
         this.music = track;
 
         this.analyser = new AudioAnalyser({ fftSize: 2048, smoothingTimeConstant: 0.75 });
-        this.analyser.source = this.app.audio.music;
+        this.analyser.source = app.audio.music;
 
         // Log-spaced bin boundaries across the spectrum. Index 0 (DC) is skipped
         // so the lowest band starts at the first meaningful bin.
@@ -65,7 +67,7 @@ class FrequencyBandsScene extends Scene {
 
         this.bars = new Graphics();
 
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
         const gap = 16;
         const slotWidth = (width - gap) / BAND_COUNT;
         const barWidth = slotWidth - gap;
@@ -90,7 +92,7 @@ class FrequencyBandsScene extends Scene {
 
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically.
-        this.app.audio.play(this.music, { loop: true, volume: 0.8 });
+        app.audio.play(this.music, { loop: true, volume: 0.8 });
     }
 
     override update(): void {
@@ -110,10 +112,12 @@ class FrequencyBandsScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
 
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
         const gap = 16;
         const slotWidth = (width - gap) / BAND_COUNT;
         const barWidth = slotWidth - gap;
@@ -139,7 +143,7 @@ class FrequencyBandsScene extends Scene {
             context.render(label);
         }
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/beat-detection/tempo-tracking.js
+++ b/examples/beat-detection/tempo-tracking.js
@@ -28,13 +28,16 @@ class TempoTrackingScene extends Scene {
     hud;
     tapPrompt;
     async init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const marginX = width * 0.08;
         // AudioStream has no seamless adapter — await it explicitly.
         const { track } = await this.loader.load(Assets.from({ track: Asset.kind('music', 'audio/demo-loop-main.ogg') }));
         this.music = track;
         this.detector = new BeatDetector();
-        this.detector.source = this.app.audio.music;
+        this.detector.source = app.audio.music;
         this.readout = new Text('BPM —', { fillColor: Color.white, fontSize: 40 });
         this.readout.setPosition(marginX, height * 0.18);
         this.confidenceLabel = new Text('Confidence', { fillColor: new Color(150, 220, 175), fontSize: 20 });
@@ -54,7 +57,7 @@ class TempoTrackingScene extends Scene {
             .setPosition(width / 2, height - 48);
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically.
-        this.app.audio.play(this.music, { loop: true, volume: 0.8 });
+        app.audio.play(this.music, { loop: true, volume: 0.8 });
     }
     update(delta) {
         // Raw onset strength straight from the detector (positive spectral flux).
@@ -64,13 +67,16 @@ class TempoTrackingScene extends Scene {
         this.onsetPeak = Math.max(this.onset, this.onsetPeak * (1 - delta.seconds * 0.4));
     }
     draw(context) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const bpm = this.detector.tempo;
         const confidence = this.detector.confidence;
         const onsetNorm = Math.min(1, this.onset / this.onsetPeak);
         this.readout.text = bpm > 0 ? `BPM ${bpm.toFixed(1)}` : 'BPM —  (listening…)';
         this.confidenceLabel.text = `Confidence  ${confidence.toFixed(2)}`;
         this.onsetLabel.text = `Onset energy  ${this.onset.toFixed(2)}`;
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
         const marginX = width * 0.08;
         const meterWidth = width - marginX * 2;
         const meterHeight = 30;
@@ -92,7 +98,7 @@ class TempoTrackingScene extends Scene {
         context.render(this.readout);
         context.render(this.confidenceLabel);
         context.render(this.onsetLabel);
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/beat-detection/tempo-tracking.ts
+++ b/examples/beat-detection/tempo-tracking.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Assets, AudioStream, Color, Graphics, Scene, Text } from '@codexo/exojs';
+import { Application, Asset, Assets, AudioStream, Color, Graphics, type RenderingContext, Scene, Text, type Time } from '@codexo/exojs';
 import { BeatDetector } from '@codexo/exojs-audio-fx';
 import { mountControls } from '@examples/runtime';
 
@@ -30,7 +30,9 @@ class TempoTrackingScene extends Scene {
     private tapPrompt!: Text;
 
     override async init(): Promise<void> {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const marginX = width * 0.08;
 
         // AudioStream has no seamless adapter — await it explicitly.
@@ -38,7 +40,7 @@ class TempoTrackingScene extends Scene {
         this.music = track;
 
         this.detector = new BeatDetector();
-        this.detector.source = this.app.audio.music;
+        this.detector.source = app.audio.music;
 
         this.readout = new Text('BPM —', { fillColor: Color.white, fontSize: 40 });
         this.readout.setPosition(marginX, height * 0.18);
@@ -65,10 +67,10 @@ class TempoTrackingScene extends Scene {
 
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically.
-        this.app.audio.play(this.music, { loop: true, volume: 0.8 });
+        app.audio.play(this.music, { loop: true, volume: 0.8 });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         // Raw onset strength straight from the detector (positive spectral flux).
         this.onset = this.detector.onsetStrength;
 
@@ -77,7 +79,9 @@ class TempoTrackingScene extends Scene {
         this.onsetPeak = Math.max(this.onset, this.onsetPeak * (1 - delta.seconds * 0.4));
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const bpm = this.detector.tempo;
         const confidence = this.detector.confidence;
         const onsetNorm = Math.min(1, this.onset / this.onsetPeak);
@@ -86,7 +90,7 @@ class TempoTrackingScene extends Scene {
         this.confidenceLabel.text = `Confidence  ${confidence.toFixed(2)}`;
         this.onsetLabel.text = `Onset energy  ${this.onset.toFixed(2)}`;
 
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
         const marginX = width * 0.08;
         const meterWidth = width - marginX * 2;
         const meterHeight = 30;
@@ -114,7 +118,7 @@ class TempoTrackingScene extends Scene {
         context.render(this.confidenceLabel);
         context.render(this.onsetLabel);
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/custom-renderers/custom-render-pass.js
+++ b/examples/custom-renderers/custom-render-pass.js
@@ -19,7 +19,10 @@ class CustomRenderPassScene extends Scene {
     pipeline;
     angle = 0;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.back = new Sprite(this.loader.get('image/ship-a.png'))
             .setAnchor(0.5)
             .setPosition(width / 2 - 200, height / 2)
@@ -36,7 +39,7 @@ class CustomRenderPassScene extends Scene {
         this.pipeline = new RenderPipeline()
             .addPass(new RenderNodePass(this.back, { clear: Color.black }))
             .addPass(new CallbackRenderPass((context) => {
-            const { width: w, height: h } = this.app.canvas;
+            const { width: w, height: h } = app.canvas;
             this.between.clear();
             this.between.lineWidth = 10;
             this.between.lineColor = new Color(130, 240, 170);

--- a/examples/custom-renderers/custom-render-pass.ts
+++ b/examples/custom-renderers/custom-render-pass.ts
@@ -1,4 +1,4 @@
-import { Application, CallbackRenderPass, Color, Graphics, RenderNodePass, RenderPipeline, Scene, Sprite } from '@codexo/exojs';
+import { Application, CallbackRenderPass, Color, Graphics, type RenderingContext, RenderNodePass, RenderPipeline, Scene, Sprite, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -21,7 +21,9 @@ class CustomRenderPassScene extends Scene {
     private angle = 0;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.back = new Sprite(this.loader.get('image/ship-a.png'))
             .setAnchor(0.5)
@@ -41,7 +43,7 @@ class CustomRenderPassScene extends Scene {
             .addPass(new RenderNodePass(this.back, { clear: Color.black }))
             .addPass(
                 new CallbackRenderPass((context) => {
-                    const { width: w, height: h } = this.app.canvas;
+                    const { width: w, height: h } = app.canvas;
                     this.between.clear();
                     this.between.lineWidth = 10;
                     this.between.lineColor = new Color(130, 240, 170);
@@ -52,11 +54,11 @@ class CustomRenderPassScene extends Scene {
             .addPass(new RenderNodePass(this.front));
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.angle += delta.seconds * 2.2;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         this.pipeline.execute(context);
     }
 }

--- a/examples/custom-renderers/custom-triangle-renderer.js
+++ b/examples/custom-renderers/custom-triangle-renderer.js
@@ -133,7 +133,10 @@ const app = new Application({
 class CustomTriangleRendererScene extends Scene {
     triangleRenderer;
     init() {
-        this.triangleRenderer = new CustomTriangleRenderer(this.app.backend);
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        this.triangleRenderer = new CustomTriangleRenderer(app.backend);
     }
     draw() {
         this.triangleRenderer.draw();

--- a/examples/custom-renderers/custom-triangle-renderer.ts
+++ b/examples/custom-renderers/custom-triangle-renderer.ts
@@ -150,7 +150,9 @@ class CustomTriangleRendererScene extends Scene {
     private triangleRenderer!: CustomTriangleRenderer;
 
     override init(): void {
-        this.triangleRenderer = new CustomTriangleRenderer(this.app.backend);
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        this.triangleRenderer = new CustomTriangleRenderer(app.backend);
     }
 
     override draw(): void {

--- a/examples/debug-layer/asset-browser.js
+++ b/examples/debug-layer/asset-browser.js
@@ -143,11 +143,14 @@ class AssetBrowserScene extends Scene {
     loadedCats = new Set();
     loadingCats = new Set();
     async init() {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.assetLoader = this.loader;
         await this.ensureCategory(this.cat);
-        this.app.input.onPointerTap.add(p => this.onTap(p.x, p.y));
-        this.app.input.onPointerMove.add(p => this.onMove(p.x, p.y));
-        this.app.input.onMouseWheel.add(v => this.onWheel(v.y));
+        app.input.onPointerTap.add(p => this.onTap(p.x, p.y));
+        app.input.onPointerMove.add(p => this.onMove(p.x, p.y));
+        app.input.onMouseWheel.add(v => this.onWheel(v.y));
         this.selectFirstInCategory();
     }
     /** Load a category's assets (and build its preview objects) exactly once. */
@@ -390,6 +393,9 @@ class AssetBrowserScene extends Scene {
         return null;
     }
     toggleAudio() {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         if (!this.key)
             return;
         const map = this.currentPlayingMap();
@@ -408,7 +414,7 @@ class AssetBrowserScene extends Scene {
         else {
             // New asset: stop the previous preview and start this one.
             this.previewVoice?.stop();
-            this.previewVoice = this.app.audio.play(stream);
+            this.previewVoice = app.audio.play(stream);
             this.previewKey = this.key;
         }
     }
@@ -960,7 +966,7 @@ class AssetBrowserScene extends Scene {
         const sprite = this.tilesetSprites.get(this.key ?? '');
         if (!sprite)
             return;
-        const entry = assets.demo.tilesets[this.key ?? ''];
+        const entry = assets.demo.tilesets[(this.key ?? '')];
         const { cx, cy, maxW, maxH } = this.previewCenter();
         this.fitSprite(sprite, maxW, maxH - 30, cx, cy - 15);
         context.render(sprite);
@@ -983,7 +989,7 @@ class AssetBrowserScene extends Scene {
             `License: ${data.license ?? 'CC0'}`,
             `Packs: ${packs.length}`,
             '',
-            ...packs.slice(0, 14).map((p) => `  ${p.slug}  (${Object.values(p.fileCountByExtension ?? {}).reduce((a, b) => a + b, 0)} files)`),
+            ...packs.slice(0, 14).map(p => `  ${p.slug}  (${Object.values(p.fileCountByExtension ?? {}).reduce((a, b) => a + b, 0)} files)`),
         ];
         this.txtMeta.text = lines.join('\n');
         this.txtMeta.setPosition(PREVIEW_X + 30, PREVIEW_Y + 60);

--- a/examples/debug-layer/asset-browser.ts
+++ b/examples/debug-layer/asset-browser.ts
@@ -1,7 +1,7 @@
 import { Asset } from '@codexo/exojs';
 import {
-    Application, AudioStream, Color, FontAsset, Graphics, Json, type Pausable, Scene,
-    type Seekable, type SpritesheetData, Sprite, Spritesheet, SvgAsset, Text, Texture, type Voice,
+    Application, AudioStream, Color, FontAsset, Graphics, Json, type Pausable, type RenderingContext, Scene,
+    type Seekable, type SpritesheetData, Sprite, Spritesheet, SvgAsset, Text, Texture, type Time, type Voice,
 } from '@codexo/exojs';
 
 // Dynamic category accessor: maps a category key to the correct sub-object
@@ -10,6 +10,21 @@ import {
 function getCategoryData(catKey: string): Record<string, unknown> {
     if (catKey === 'technical') return assets.technical as unknown as Record<string, unknown>;
     return (assets.demo as unknown as Record<string, Record<string, unknown>>)[catKey] ?? {};
+}
+
+// Union of the tileset catalog entry shapes — every entry declares
+// tileWidth/tileHeight even though only some also carry `data`.
+type TilesetEntry = (typeof assets.demo.tilesets)[keyof typeof assets.demo.tilesets];
+
+// Shape of the vendor pack manifest JSON files loaded per `vendor/*.json` key.
+interface VendorPack {
+    slug: string;
+    fileCountByExtension?: Record<string, number>;
+}
+
+interface VendorManifest {
+    license?: string;
+    packs?: VendorPack[];
 }
 
 const W = 1280;
@@ -122,7 +137,7 @@ class AssetBrowserScene extends Scene {
     cursorSprites  = new Map<string, Sprite>();
     tilesetSprites = new Map<string, Sprite>();
     soundSpriteData = new Map<string, any>();
-    vendorData     = new Map<string, any>();
+    vendorData     = new Map<string, VendorManifest>();
 
     animG: Graphics | null = null;
     audioG: Graphics | null = null;
@@ -173,12 +188,14 @@ class AssetBrowserScene extends Scene {
     loadingCats = new Set<string>();
 
     override async init(): Promise<void> {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.assetLoader = this.loader;
         await this.ensureCategory(this.cat);
 
-        this.app.input.onPointerTap.add(p => this.onTap(p.x, p.y));
-        this.app.input.onPointerMove.add(p => this.onMove(p.x, p.y));
-        this.app.input.onMouseWheel.add(v => this.onWheel(v.y));
+        app.input.onPointerTap.add(p => this.onTap(p.x, p.y));
+        app.input.onPointerMove.add(p => this.onMove(p.x, p.y));
+        app.input.onMouseWheel.add(v => this.onWheel(v.y));
 
         this.selectFirstInCategory();
     }
@@ -363,7 +380,7 @@ class AssetBrowserScene extends Scene {
             case 'vendor': {
                 await Promise.all(
                     Object.entries(assets.demo.vendor ?? {}).map(async ([k, url]) => {
-                        this.vendorData.set(k, await loader.load(Asset.kind('json', url as string)));
+                        this.vendorData.set(k, await loader.load(Asset.kind<VendorManifest>('json', url as string)));
                     }),
                 );
                 break;
@@ -377,7 +394,7 @@ class AssetBrowserScene extends Scene {
     private techFlatKeys(): string[] {
 
         const out: string[] = [];
-        for (const subcat of ['alpha', 'filtering', 'color']) {
+        for (const subcat of ['alpha', 'filtering', 'color'] as const) {
             const items = assets.technical[subcat];
             if (!items) continue;
             out.push(subcat);
@@ -450,6 +467,8 @@ class AssetBrowserScene extends Scene {
     }
 
     private toggleAudio(): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         if (!this.key) return;
         const map = this.currentPlayingMap();
         if (!map) return;
@@ -463,7 +482,7 @@ class AssetBrowserScene extends Scene {
         } else {
             // New asset: stop the previous preview and start this one.
             this.previewVoice?.stop();
-            this.previewVoice = this.app.audio.play(stream) as Voice & Pausable & Seekable;
+            this.previewVoice = app.audio.play(stream) as Voice & Pausable & Seekable;
             this.previewKey = this.key;
         }
     }
@@ -575,7 +594,7 @@ class AssetBrowserScene extends Scene {
         this.scrollOff = Math.max(0, Math.min(maxScroll, this.scrollOff + delta));
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         if (!this.animPlaying) return;
         if (this.cat !== 'sprites' && this.cat !== 'spritesheets' && this.cat !== 'inputPrompts') return;
         const frames = this.currentFrameKeys();
@@ -587,7 +606,7 @@ class AssetBrowserScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear(C.bg);
         this.drawPreviewBg(context);
         this.drawPreviewContent(context);
@@ -595,7 +614,7 @@ class AssetBrowserScene extends Scene {
         this.drawToolbar(context);
     }
 
-    private drawNoAssets(context): void {
+    private drawNoAssets(context: RenderingContext): void {
         const g = this.gPreview;
         g.clear();
         g.fillColor = C.panel;
@@ -604,7 +623,7 @@ class AssetBrowserScene extends Scene {
         context.render(this.txtNoAssets);
     }
 
-    private drawToolbar(context): void {
+    private drawToolbar(context: RenderingContext): void {
         const g = this.gToolbar;
         g.clear();
 
@@ -667,7 +686,7 @@ class AssetBrowserScene extends Scene {
         }
     }
 
-    private drawSidebar(context): void {
+    private drawSidebar(context: RenderingContext): void {
         const g = this.gSidebar;
         g.clear();
 
@@ -727,7 +746,7 @@ class AssetBrowserScene extends Scene {
         }
     }
 
-    private drawPreviewBg(context): void {
+    private drawPreviewBg(context: RenderingContext): void {
         const { r, g, b } = BG_OPTIONS[this.bgIdx];
         const bg = this.gPreview;
         bg.clear();
@@ -736,7 +755,7 @@ class AssetBrowserScene extends Scene {
         context.render(bg);
     }
 
-    private drawPreviewContent(context): void {
+    private drawPreviewContent(context: RenderingContext): void {
         if (!this.key) {
             this.txtNoSel.setPosition(PREVIEW_X + (PREVIEW_W / 2) - 130, H / 2 - 10);
             context.render(this.txtNoSel);
@@ -775,7 +794,7 @@ class AssetBrowserScene extends Scene {
         this.drawInfoBar(context);
     }
 
-    private drawInfoBar(context): void {
+    private drawInfoBar(context: RenderingContext): void {
         const g = this.gInfoBar;
         g.clear();
         g.fillColor = C.infoBar;
@@ -834,7 +853,7 @@ class AssetBrowserScene extends Scene {
         sprite.setPosition(cx, cy);
     }
 
-    private drawTexPreview(context): void {
+    private drawTexPreview(context: RenderingContext): void {
         const sprite = this.texSprites.get(this.key ?? '');
         if (!sprite) return;
         const { cx, cy, maxW, maxH } = this.previewCenter();
@@ -842,7 +861,7 @@ class AssetBrowserScene extends Scene {
         context.render(sprite);
     }
 
-    private drawSprPreview(context): void {
+    private drawSprPreview(context: RenderingContext): void {
         const ss = this.sprSheets.get(this.key ?? '');
         if (!ss) return;
         const frames = [...ss.sprites.keys()];
@@ -855,7 +874,7 @@ class AssetBrowserScene extends Scene {
         this.drawAnimControls(context, frames.length);
     }
 
-    private drawSshPreview(context): void {
+    private drawSshPreview(context: RenderingContext): void {
         const ss = this.sshSheets.get(this.key ?? '');
         if (!ss) return;
         const frames = [...ss.sprites.keys()];
@@ -868,7 +887,7 @@ class AssetBrowserScene extends Scene {
         this.drawAnimControls(context, frames.length);
     }
 
-    private drawInpPreview(context): void {
+    private drawInpPreview(context: RenderingContext): void {
         const ss = this.inpSheets.get(this.key ?? '');
         if (ss) {
             const frames = [...ss.sprites.keys()];
@@ -884,7 +903,7 @@ class AssetBrowserScene extends Scene {
         }
     }
 
-    private drawSvgPreview(context): void {
+    private drawSvgPreview(context: RenderingContext): void {
         const sprite = this.svgSprites.get(this.key ?? '');
         if (!sprite) return;
         const { cx, cy, maxW, maxH } = this.previewCenter();
@@ -892,7 +911,7 @@ class AssetBrowserScene extends Scene {
         context.render(sprite);
     }
 
-    private drawAudioPreview(context, musicMap: Map<string, AudioStream>): void {
+    private drawAudioPreview(context: RenderingContext, musicMap: Map<string, AudioStream>): void {
         if (!this.audioG) this.audioG = new Graphics();
         const music = musicMap.get(this.key ?? '');
         const isPlaying = music ? this.previewIsPlaying() : false;
@@ -916,7 +935,7 @@ class AssetBrowserScene extends Scene {
         context.render(this.txtMeta);
     }
 
-    private drawSoundSpritePreview(context): void {
+    private drawSoundSpritePreview(context: RenderingContext): void {
         if (!this.audioG) this.audioG = new Graphics();
         const music   = this.soundSpriteAudio.get(this.key ?? '');
         const data    = this.soundSpriteData.get(this.key ?? '');
@@ -949,7 +968,7 @@ class AssetBrowserScene extends Scene {
         }
     }
 
-    private drawFontPreview(context): void {
+    private drawFontPreview(context: RenderingContext): void {
         const family = this.fontFamilies.get(this.key ?? '');
         if (!family) {
             this.txtMeta.text = `Font: ${this.key}\n${this.assetPath()}`;
@@ -976,14 +995,14 @@ class AssetBrowserScene extends Scene {
         context.render(t2);
     }
 
-    private drawVideoPreview(context): void {
+    private drawVideoPreview(context: RenderingContext): void {
         this.txtMeta.text =
             `VIDEO\n\nKey: assets.video.${this.key}\nURL: ${this.assetPath()}\n\nOpen the URL in your browser to preview.`;
         this.txtMeta.setPosition(PREVIEW_X + 40, PREVIEW_Y + 80);
         context.render(this.txtMeta);
     }
 
-    private drawTechPreview(context): void {
+    private drawTechPreview(context: RenderingContext): void {
         if (!this.key?.includes('.')) return;
         const sprite = this.techSprites.get(this.key);
         if (!sprite) return;
@@ -1000,7 +1019,7 @@ class AssetBrowserScene extends Scene {
         }
     }
 
-    private drawBgPreview(context): void {
+    private drawBgPreview(context: RenderingContext): void {
         const sprite = this.bgSprites.get(this.key ?? '');
         if (!sprite) return;
         const { cx, cy, maxW, maxH } = this.previewCenter();
@@ -1008,7 +1027,7 @@ class AssetBrowserScene extends Scene {
         context.render(sprite);
     }
 
-    private drawCursorPreview(context): void {
+    private drawCursorPreview(context: RenderingContext): void {
         const sprite = this.cursorSprites.get(this.key ?? '');
         if (!sprite) return;
         const { cx, cy, maxW, maxH } = this.previewCenter();
@@ -1016,10 +1035,10 @@ class AssetBrowserScene extends Scene {
         context.render(sprite);
     }
 
-    private drawTilesetPreview(context): void {
+    private drawTilesetPreview(context: RenderingContext): void {
         const sprite = this.tilesetSprites.get(this.key ?? '');
         if (!sprite) return;
-        const entry: any = assets.demo.tilesets[this.key ?? '' as keyof typeof assets.demo.tilesets] as any;
+        const entry: TilesetEntry | undefined = assets.demo.tilesets[(this.key ?? '') as keyof typeof assets.demo.tilesets];
         const { cx, cy, maxW, maxH } = this.previewCenter();
         this.fitSprite(sprite, maxW, maxH - 30, cx, cy - 15);
         context.render(sprite);
@@ -1031,7 +1050,7 @@ class AssetBrowserScene extends Scene {
         }
     }
 
-    private drawVendorPreview(context): void {
+    private drawVendorPreview(context: RenderingContext): void {
         const data = this.vendorData.get(this.key ?? '');
         if (!data) {
             this.txtMeta.text = `Loading: ${this.assetPath()}`;
@@ -1039,19 +1058,19 @@ class AssetBrowserScene extends Scene {
             context.render(this.txtMeta);
             return;
         }
-        const packs: any[] = data.packs ?? [];
+        const packs = data.packs ?? [];
         const lines = [
             `License: ${data.license ?? 'CC0'}`,
             `Packs: ${packs.length}`,
             '',
-            ...packs.slice(0, 14).map((p: any) => `  ${p.slug}  (${Object.values(p.fileCountByExtension ?? {}).reduce((a: number, b: number) => a + b, 0)} files)`),
+            ...packs.slice(0, 14).map(p => `  ${p.slug}  (${Object.values(p.fileCountByExtension ?? {}).reduce((a, b) => a + b, 0)} files)`),
         ];
         this.txtMeta.text = lines.join('\n');
         this.txtMeta.setPosition(PREVIEW_X + 30, PREVIEW_Y + 60);
         context.render(this.txtMeta);
     }
 
-    private drawAnimControls(context, frameCount: number): void {
+    private drawAnimControls(context: RenderingContext, frameCount: number): void {
         if (!this.animG) this.animG = new Graphics();
         const g  = this.animG;
         const bx = PREVIEW_X + 16;

--- a/examples/debug-layer/bounding-boxes.js
+++ b/examples/debug-layer/bounding-boxes.js
@@ -19,7 +19,10 @@ class BoundingBoxesScene extends Scene {
     sprites;
     time = 0;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const count = 7;
         const margin = width * 0.12;
         const step = (width - 2 * margin) / (count - 1);
@@ -34,7 +37,10 @@ class BoundingBoxesScene extends Scene {
         });
     }
     update(delta) {
-        const { height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { height } = app.canvas;
         this.time += delta.seconds;
         for (const { sprite, speed } of this.sprites) {
             sprite.setRotation(this.time * 35 * speed);

--- a/examples/debug-layer/bounding-boxes.ts
+++ b/examples/debug-layer/bounding-boxes.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene, Sprite } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, Sprite, type Time } from '@codexo/exojs';
 import { DebugOverlay } from '@codexo/exojs/debug';
 
 const app = new Application({
@@ -22,7 +22,9 @@ class BoundingBoxesScene extends Scene {
     private time = 0;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const count = 7;
         const margin = width * 0.12;
         const step = (width - 2 * margin) / (count - 1);
@@ -38,8 +40,10 @@ class BoundingBoxesScene extends Scene {
         });
     }
 
-    override update(delta): void {
-        const { height } = this.app.canvas;
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { height } = app.canvas;
 
         this.time += delta.seconds;
         for (const { sprite, speed } of this.sprites) {
@@ -48,7 +52,7 @@ class BoundingBoxesScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.root);
     }

--- a/examples/debug-layer/performance-overlay.js
+++ b/examples/debug-layer/performance-overlay.js
@@ -19,7 +19,10 @@ class PerformanceOverlayScene extends Scene {
     sprites;
     layer;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // All sprites share one texture, so adding them to a single container and
         // rendering it once lets the renderer batch them into a single draw call.
         // Rendering each sprite with its own `context.render(sprite)` call would
@@ -40,7 +43,10 @@ class PerformanceOverlayScene extends Scene {
         });
     }
     update(delta) {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         for (const item of this.sprites) {
             item.sprite.move(item.vx * delta.seconds, item.vy * delta.seconds);
             if (item.sprite.position.x < 0 || item.sprite.position.x > width)

--- a/examples/debug-layer/performance-overlay.ts
+++ b/examples/debug-layer/performance-overlay.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Container, Keyboard, Scene, Sprite } from '@codexo/exojs';
+import { Application, Color, Container, Keyboard, type RenderingContext, Scene, Sprite, type Time } from '@codexo/exojs';
 import { DebugOverlay } from '@codexo/exojs/debug';
 
 const app = new Application({
@@ -22,7 +22,9 @@ class PerformanceOverlayScene extends Scene {
     private layer!: Container;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // All sprites share one texture, so adding them to a single container and
         // rendering it once lets the renderer batch them into a single draw call.
@@ -44,8 +46,10 @@ class PerformanceOverlayScene extends Scene {
         });
     }
 
-    override update(delta): void {
-        const { width, height } = this.app.canvas;
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         for (const item of this.sprites) {
             item.sprite.move(item.vx * delta.seconds, item.vy * delta.seconds);
@@ -54,7 +58,7 @@ class PerformanceOverlayScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.layer);
     }

--- a/examples/debug-layer/pointer-and-hittest.js
+++ b/examples/debug-layer/pointer-and-hittest.js
@@ -19,7 +19,10 @@ debug.layers.pointerStack.visible = true;
 class PointerAndHittestScene extends Scene {
     sprites;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.sprites = [];
         for (let i = 0; i < 5; i++) {
             const sprite = new Sprite(this.loader.get('image/ship-a.png'))

--- a/examples/debug-layer/pointer-and-hittest.ts
+++ b/examples/debug-layer/pointer-and-hittest.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene, Sprite } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, Sprite } from '@codexo/exojs';
 import { DebugOverlay } from '@codexo/exojs/debug';
 
 const app = new Application({
@@ -22,7 +22,9 @@ class PointerAndHittestScene extends Scene {
     private sprites!: Sprite[];
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.sprites = [];
         for (let i = 0; i < 5; i++) {
@@ -43,7 +45,7 @@ class PointerAndHittestScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.root);
     }

--- a/examples/debug-layer/signal-bus-inspector.ts
+++ b/examples/debug-layer/signal-bus-inspector.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene, Signal, Text, Time, Timer } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, Signal, Text, Time, Timer } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -49,7 +49,7 @@ class SignalBusInspectorScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         this.text.text =
             `Manual Signal Inspector\n\nspawn listeners: ${this.signals.spawn.count}\n` +
                 `damage listeners: ${this.signals.damage.count}\n` +

--- a/examples/filters/blur-filter.js
+++ b/examples/filters/blur-filter.js
@@ -21,7 +21,10 @@ class BlurFilterScene extends Scene {
     panel;
     slider;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.blur = new BlurFilter({ radius: 4, quality: 2 });
         this.sprite = new Sprite(this.loader.get(PIXEL_GRID)).setAnchor(0.5).setScale(4.5).setPosition(width / 2, height / 2);
         this.sprite.filters = [this.blur];

--- a/examples/filters/blur-filter.ts
+++ b/examples/filters/blur-filter.ts
@@ -1,4 +1,4 @@
-import { Application, BlurFilter, Color, Scene, Sprite } from '@codexo/exojs';
+import { Application, BlurFilter, Color, type RenderingContext, Scene, Sprite } from '@codexo/exojs';
 import { mountControlPanel, mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -25,7 +25,9 @@ class BlurFilterScene extends Scene {
     private slider!: ReturnType<ReturnType<typeof mountControlPanel>['addSlider']>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.blur = new BlurFilter({ radius: 4, quality: 2 });
         this.sprite = new Sprite(this.loader.get(PIXEL_GRID)).setAnchor(0.5).setScale(4.5).setPosition(width / 2, height / 2);
@@ -76,7 +78,7 @@ class BlurFilterScene extends Scene {
         this.hud.setStatus(this.statusText());
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
     }

--- a/examples/filters/chromatic-aberration.js
+++ b/examples/filters/chromatic-aberration.js
@@ -38,7 +38,10 @@ class ChromaticAberrationScene extends Scene {
     hud;
     panel;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.filter =
             app.backend.backendType === RenderBackendType.WebGpu
                 ? new WebGpuShaderFilter({ fragmentSource: wgsl, uniforms: { uOffset: 0 } })

--- a/examples/filters/chromatic-aberration.ts
+++ b/examples/filters/chromatic-aberration.ts
@@ -1,4 +1,4 @@
-import { Application, Color, RenderBackendType, Scene, Sprite, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
+import { Application, Color, RenderBackendType, type RenderingContext, Scene, Sprite, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
 import { mountControlPanel, mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -43,7 +43,9 @@ class ChromaticAberrationScene extends Scene {
     private panel!: ReturnType<typeof mountControlPanel>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.filter =
             app.backend.backendType === RenderBackendType.WebGpu
@@ -88,7 +90,7 @@ class ChromaticAberrationScene extends Scene {
         return this.intensity === 0 ? 'Intensity: 0% (no split — original)' : `Intensity: ${pct}%  (uOffset ${offset})`;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
     }

--- a/examples/filters/color-filter.js
+++ b/examples/filters/color-filter.js
@@ -50,7 +50,10 @@ class ColorFilterScene extends Scene {
     hud;
     cycle;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.sprite = new Sprite(this.loader.get(HUE_RAMP)).setAnchor(0.5).setScale(4).setPosition(width / 2, height / 2);
         // The built-in ColorFilter multiplies by a solid colour (warm tint here).
         this.tint = new ColorFilter(new Color(255, 160, 120));

--- a/examples/filters/color-filter.ts
+++ b/examples/filters/color-filter.ts
@@ -1,4 +1,4 @@
-import { Application, Color, ColorFilter, RenderBackendType, Scene, Sprite, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
+import { Application, Color, ColorFilter, RenderBackendType, type RenderingContext, Scene, Sprite, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
 import { mountControlPanel, mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -59,7 +59,9 @@ class ColorFilterScene extends Scene {
     private cycle!: ReturnType<ReturnType<typeof mountControlPanel>['addCycle']>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.sprite = new Sprite(this.loader.get(HUE_RAMP)).setAnchor(0.5).setScale(4).setPosition(width / 2, height / 2);
 
@@ -105,7 +107,7 @@ class ColorFilterScene extends Scene {
         return `Preset: ${PRESETS[this.index]}  (${this.index + 1}/${PRESETS.length})`;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
     }

--- a/examples/filters/crt-scanlines.js
+++ b/examples/filters/crt-scanlines.js
@@ -24,7 +24,10 @@ class CrtScanlinesScene extends Scene {
     hud;
     panel;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.filter =
             app.backend.backendType === RenderBackendType.WebGpu
                 ? new WebGpuShaderFilter({ fragmentSource: wgsl })

--- a/examples/filters/crt-scanlines.ts
+++ b/examples/filters/crt-scanlines.ts
@@ -1,4 +1,4 @@
-import { Application, Color, RenderBackendType, Scene, Sprite, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
+import { Application, Color, RenderBackendType, type RenderingContext, Scene, Sprite, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
 import { mountControlPanel, mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -28,7 +28,9 @@ class CrtScanlinesScene extends Scene {
     private panel!: ReturnType<typeof mountControlPanel>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.filter =
             app.backend.backendType === RenderBackendType.WebGpu
@@ -60,7 +62,7 @@ class CrtScanlinesScene extends Scene {
         return this.enabled ? 'CRT: ON (scanlines + barrel + vignette)' : 'CRT: OFF (original sprite)';
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
     }

--- a/examples/filters/custom-fragment-shader.js
+++ b/examples/filters/custom-fragment-shader.js
@@ -34,7 +34,10 @@ class CustomFragmentShaderScene extends Scene {
     sprite;
     hud;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.filter =
             app.backend.backendType === RenderBackendType.WebGpu
                 ? new WebGpuShaderFilter({ fragmentSource: wgsl, uniforms: { uTime: 0 } })

--- a/examples/filters/custom-fragment-shader.ts
+++ b/examples/filters/custom-fragment-shader.ts
@@ -1,4 +1,4 @@
-import { Application, Color, RenderBackendType, Scene, Sprite, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
+import { Application, Color, RenderBackendType, type RenderingContext, Scene, Sprite, type Time, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -38,7 +38,9 @@ class CustomFragmentShaderScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.filter =
             app.backend.backendType === RenderBackendType.WebGpu
@@ -54,12 +56,12 @@ class CustomFragmentShaderScene extends Scene {
         });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.time += delta.seconds;
         this.filter.uniforms.uTime = this.time;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
     }

--- a/examples/filters/filter-stack.js
+++ b/examples/filters/filter-stack.js
@@ -25,7 +25,10 @@ class FilterStackScene extends Scene {
     hud;
     panel;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.sprite = new Sprite(this.loader.get(PRIMARY_RAMP)).setAnchor(0.5).setScale(4).setPosition(width / 2, height / 2);
         this.blur = new BlurFilter({ radius: 4, quality: 2 });
         this.tint = new ColorFilter(new Color(140, 210, 255));

--- a/examples/filters/filter-stack.ts
+++ b/examples/filters/filter-stack.ts
@@ -1,4 +1,4 @@
-import { Application, BlurFilter, Color, ColorFilter, RenderBackendType, Scene, Sprite, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
+import { Application, BlurFilter, Color, ColorFilter, RenderBackendType, type RenderingContext, Scene, Sprite, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
 import { mountControlPanel, mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -29,7 +29,9 @@ class FilterStackScene extends Scene {
     private panel!: ReturnType<typeof mountControlPanel>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.sprite = new Sprite(this.loader.get(PRIMARY_RAMP)).setAnchor(0.5).setScale(4).setPosition(width / 2, height / 2);
         this.blur = new BlurFilter({ radius: 4, quality: 2 });
@@ -91,7 +93,7 @@ class FilterStackScene extends Scene {
         return labels.length > 0 ? `Active: ${labels.join(' → ')}` : 'Active: none (original sprite)';
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
     }

--- a/examples/filters/metaballs.js
+++ b/examples/filters/metaballs.js
@@ -49,7 +49,10 @@ class MetaballsScene extends Scene {
         });
     }
     update(delta) {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         for (const point of this.points) {
             point.a += delta.seconds * (0.4 + point.r / 600);
         }

--- a/examples/filters/metaballs.ts
+++ b/examples/filters/metaballs.ts
@@ -1,4 +1,4 @@
-import { Application, BlurFilter, Color, Graphics, RenderBackendType, Scene, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
+import { Application, BlurFilter, Color, Graphics, RenderBackendType, type RenderingContext, Scene, type Time, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
 import { mountControlPanel, mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -55,8 +55,10 @@ class MetaballsScene extends Scene {
         });
     }
 
-    override update(delta): void {
-        const { width, height } = this.app.canvas;
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         for (const point of this.points) {
             point.a += delta.seconds * (0.4 + point.r / 600);
@@ -71,7 +73,7 @@ class MetaballsScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.balls);
     }

--- a/examples/filters/noise-vignette.js
+++ b/examples/filters/noise-vignette.js
@@ -37,7 +37,10 @@ class NoiseVignetteScene extends Scene {
     hud;
     panel;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.filter =
             app.backend.backendType === RenderBackendType.WebGpu
                 ? new WebGpuShaderFilter({ fragmentSource: wgsl, uniforms: { uTime: 0, uIntensity: this.intensity } })

--- a/examples/filters/noise-vignette.ts
+++ b/examples/filters/noise-vignette.ts
@@ -1,4 +1,4 @@
-import { Application, Color, RenderBackendType, Scene, Sprite, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
+import { Application, Color, RenderBackendType, type RenderingContext, Scene, Sprite, type Time, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
 import { mountControlPanel, mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -41,7 +41,9 @@ class NoiseVignetteScene extends Scene {
     private panel!: ReturnType<typeof mountControlPanel>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.filter =
             app.backend.backendType === RenderBackendType.WebGpu
@@ -82,12 +84,12 @@ class NoiseVignetteScene extends Scene {
         return this.intensity === 0 ? 'Intensity: 0% (clean frame)' : `Intensity: ${Math.round(this.intensity * 100)}%`;
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.time += delta.seconds;
         this.filter.uniforms.uTime = this.time;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
     }

--- a/examples/filters/palette-cycling.js
+++ b/examples/filters/palette-cycling.js
@@ -39,7 +39,10 @@ class PaletteCyclingScene extends Scene {
     offset = 0;
     hud;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.palette = LutFilter.fromImage(buildPaletteCanvas(0));
         this.filter = new LutFilter({ mode: '1d' }).setLut(this.palette);
         this.sprite = new Sprite(this.loader.get(PRIMARY_RAMP)).setAnchor(0.5).setScale(4);

--- a/examples/filters/palette-cycling.ts
+++ b/examples/filters/palette-cycling.ts
@@ -1,4 +1,4 @@
-import { Application, Color, LutFilter, Scene, Sprite, Texture } from '@codexo/exojs';
+import { Application, Color, LutFilter, type RenderingContext, Scene, Sprite, Texture, type Time } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -44,7 +44,9 @@ class PaletteCyclingScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.palette = LutFilter.fromImage(buildPaletteCanvas(0));
         this.filter = new LutFilter({ mode: '1d' }).setLut(this.palette);
@@ -60,12 +62,12 @@ class PaletteCyclingScene extends Scene {
         });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.offset = (this.offset + delta.seconds * 80) % PALETTE_SIZE;
         this.palette.source = buildPaletteCanvas(Math.floor(this.offset));
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
     }

--- a/examples/geometry-graphics/gradient.js
+++ b/examples/geometry-graphics/gradient.js
@@ -16,8 +16,11 @@ class GradientScene extends Scene {
     orbGradient;
     orb;
     init() {
-        const centerX = this.app.width / 2;
-        const centerY = this.app.height / 2;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const centerX = app.width / 2;
+        const centerY = app.height / 2;
         this.backgroundGradient = new LinearGradient([
             { offset: 0, color: new Color(255, 90, 40, 1) },
             { offset: 0.45, color: new Color(255, 210, 70, 1) },
@@ -34,9 +37,12 @@ class GradientScene extends Scene {
         this.orb.setOrigin(0.5).setPosition(centerX, centerY);
     }
     update(delta) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.background.rotate(delta.seconds * 8);
         this.orb.rotate(-delta.seconds * 30);
-        this.orb.setScale(1 + Math.sin(this.app.activeTime.seconds * 2) * 0.07);
+        this.orb.setScale(1 + Math.sin(app.activeTime.seconds * 2) * 0.07);
     }
     draw(context) {
         context.backend.clear();

--- a/examples/geometry-graphics/gradient.ts
+++ b/examples/geometry-graphics/gradient.ts
@@ -1,4 +1,4 @@
-import { Application, Color, LinearGradient, RadialGradient, Scene, Sprite } from '@codexo/exojs';
+import { Application, Color, LinearGradient, RadialGradient, type RenderingContext, Scene, Sprite, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -18,8 +18,10 @@ class GradientScene extends Scene {
     private orb!: Sprite;
 
     override init(): void {
-        const centerX = this.app.width / 2;
-        const centerY = this.app.height / 2;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const centerX = app.width / 2;
+        const centerY = app.height / 2;
 
         this.backgroundGradient = new LinearGradient(
             [
@@ -46,13 +48,15 @@ class GradientScene extends Scene {
         this.orb.setOrigin(0.5).setPosition(centerX, centerY);
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.background.rotate(delta.seconds * 8);
         this.orb.rotate(-delta.seconds * 30);
-        this.orb.setScale(1 + Math.sin(this.app.activeTime.seconds * 2) * 0.07);
+        this.orb.setScale(1 + Math.sin(app.activeTime.seconds * 2) * 0.07);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.background);
         context.render(this.orb);

--- a/examples/geometry-graphics/graphics-gradient.js
+++ b/examples/geometry-graphics/graphics-gradient.js
@@ -16,7 +16,10 @@ class GraphicsGradientScene extends Scene {
     ring;
     badge;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.sceneRoot = new Container();
         this.sceneRoot.setPosition(width / 2, height / 2);
         this.panel = new Graphics();
@@ -49,9 +52,12 @@ class GraphicsGradientScene extends Scene {
         this.sceneRoot.addChild(this.panel, this.orb, this.ring, this.badge);
     }
     update(delta) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.sceneRoot.rotate(delta.seconds * 8);
         this.badge.rotate(delta.seconds * 60);
-        this.orb.setScale(1 + Math.sin(this.app.activeTime.seconds * 2) * 0.06);
+        this.orb.setScale(1 + Math.sin(app.activeTime.seconds * 2) * 0.06);
     }
     draw(context) {
         context.backend.clear();

--- a/examples/geometry-graphics/graphics-gradient.ts
+++ b/examples/geometry-graphics/graphics-gradient.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Container, Graphics, LinearGradient, RadialGradient, Scene } from '@codexo/exojs';
+import { Application, Color, Container, Graphics, LinearGradient, RadialGradient, type RenderingContext, Scene, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -18,7 +18,9 @@ class GraphicsGradientScene extends Scene {
     private badge!: Graphics;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.sceneRoot = new Container();
         this.sceneRoot.setPosition(width / 2, height / 2);
@@ -69,13 +71,15 @@ class GraphicsGradientScene extends Scene {
         this.sceneRoot.addChild(this.panel, this.orb, this.ring, this.badge);
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.sceneRoot.rotate(delta.seconds * 8);
         this.badge.rotate(delta.seconds * 60);
-        this.orb.setScale(1 + Math.sin(this.app.activeTime.seconds * 2) * 0.06);
+        this.orb.setScale(1 + Math.sin(app.activeTime.seconds * 2) * 0.06);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sceneRoot);
     }

--- a/examples/geometry-graphics/graphics-primitives.js
+++ b/examples/geometry-graphics/graphics-primitives.js
@@ -17,7 +17,10 @@ class GraphicsPrimitivesScene extends Scene {
     diamond;
     star;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.sceneRoot = new Container();
         this.sceneRoot.setPosition(width / 2, height / 2);
         this.panel = new Graphics();
@@ -35,9 +38,12 @@ class GraphicsPrimitivesScene extends Scene {
         this.sceneRoot.addChild(this.panel, this.circle, this.diamond, this.star);
     }
     update(delta) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.sceneRoot.rotate(delta.seconds * 9);
         this.star.rotate(delta.seconds * 60);
-        this.circle.y = Math.sin(this.app.activeTime.seconds * 2) * 18;
+        this.circle.y = Math.sin(app.activeTime.seconds * 2) * 18;
     }
     draw(context) {
         context.backend.clear();

--- a/examples/geometry-graphics/graphics-primitives.ts
+++ b/examples/geometry-graphics/graphics-primitives.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Container, Graphics, Scene } from '@codexo/exojs';
+import { Application, Color, Container, Graphics, type RenderingContext, Scene, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -19,7 +19,9 @@ class GraphicsPrimitivesScene extends Scene {
     private star!: Graphics;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.sceneRoot = new Container();
         this.sceneRoot.setPosition(width / 2, height / 2);
@@ -43,13 +45,15 @@ class GraphicsPrimitivesScene extends Scene {
         this.sceneRoot.addChild(this.panel, this.circle, this.diamond, this.star);
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.sceneRoot.rotate(delta.seconds * 9);
         this.star.rotate(delta.seconds * 60);
-        this.circle.y = Math.sin(this.app.activeTime.seconds * 2) * 18;
+        this.circle.y = Math.sin(app.activeTime.seconds * 2) * 18;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sceneRoot);
     }

--- a/examples/geometry-graphics/immediate-mode-rendering.js
+++ b/examples/geometry-graphics/immediate-mode-rendering.js
@@ -78,7 +78,10 @@ class ImmediateModeScene extends Scene {
     hud;
     panel;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const centerX = width / 2;
         const centerY = height / 2;
         // --- Procedural gears: each drawn with its own drawGeometry call. ---
@@ -135,7 +138,10 @@ class ImmediateModeScene extends Scene {
         this.elapsed += delta.seconds;
     }
     draw(context) {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const centerX = width / 2;
         const centerY = height / 2;
         const time = this.elapsed;

--- a/examples/geometry-graphics/immediate-mode-rendering.ts
+++ b/examples/geometry-graphics/immediate-mode-rendering.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Geometry, Matrix, RenderBatch, Scene } from '@codexo/exojs';
+import { Application, Color, Geometry, Matrix, RenderBatch, type RenderingContext, Scene, type Time } from '@codexo/exojs';
 import { mountControlPanel, mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -107,7 +107,9 @@ class ImmediateModeScene extends Scene {
     private panel!: ReturnType<typeof mountControlPanel>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const centerX = width / 2;
         const centerY = height / 2;
 
@@ -170,12 +172,14 @@ class ImmediateModeScene extends Scene {
         });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.elapsed += delta.seconds;
     }
 
-    override draw(context): void {
-        const { width, height } = this.app.canvas;
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const centerX = width / 2;
         const centerY = height / 2;
         const time = this.elapsed;

--- a/examples/geometry-graphics/infinite-grid.js
+++ b/examples/geometry-graphics/infinite-grid.js
@@ -59,7 +59,10 @@ class InfiniteGridScene extends Scene {
     sprite;
     filter;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.view = new View(0, 0, width, height);
         this.sprite = new Sprite(this.loader.get('image/uv-grid-256.png'));
         this.sprite.width = width;

--- a/examples/geometry-graphics/infinite-grid.ts
+++ b/examples/geometry-graphics/infinite-grid.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Keyboard, RenderBackendType, Scene, Sprite, View, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
+import { Application, Color, Keyboard, RenderBackendType, type RenderingContext, Scene, Sprite, type Time, View, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -63,7 +63,9 @@ class InfiniteGridScene extends Scene {
     private filter!: WebGl2ShaderFilter | WebGpuShaderFilter;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.view = new View(0, 0, width, height);
         this.sprite = new Sprite(this.loader.get('image/uv-grid-256.png'));
@@ -88,14 +90,14 @@ class InfiniteGridScene extends Scene {
         this.inputs.onStop(Keyboard.E, () => { if (this.move.zoom > 0) this.move.zoom = 0; });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.view.move(this.move.x * 340 * delta.seconds, this.move.y * 340 * delta.seconds);
         this.view.setZoom(Math.max(0.2, this.view.zoomLevel + this.move.zoom * delta.seconds));
         this.filter.uniforms.uCenter = [this.view.center.x, this.view.center.y];
         this.filter.uniforms.uViewSize = [this.view.width, this.view.height];
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
     }

--- a/examples/geometry-graphics/mesh-deformed-grid.js
+++ b/examples/geometry-graphics/mesh-deformed-grid.js
@@ -52,7 +52,10 @@ class MeshDeformedGridScene extends Scene {
     mesh;
     time = 0;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const grid = buildGrid();
         this.restVertices = grid.vertices.slice();
         this.mesh = new Mesh({

--- a/examples/geometry-graphics/mesh-deformed-grid.ts
+++ b/examples/geometry-graphics/mesh-deformed-grid.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Mesh, Scene } from '@codexo/exojs';
+import { Application, Color, Mesh, type RenderingContext, Scene, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -60,7 +60,9 @@ class MeshDeformedGridScene extends Scene {
     private time = 0;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const grid = buildGrid();
 
         this.restVertices = grid.vertices.slice();
@@ -73,7 +75,7 @@ class MeshDeformedGridScene extends Scene {
         this.mesh.setPosition((width / 2) | 0, (height / 2) | 0);
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.time += delta.seconds;
         const verts = this.mesh.vertices;
         const rest = this.restVertices;
@@ -89,7 +91,7 @@ class MeshDeformedGridScene extends Scene {
         this.mesh.recomputeLocalBounds();
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.mesh);
     }

--- a/examples/geometry-graphics/mesh-textured-quad.js
+++ b/examples/geometry-graphics/mesh-textured-quad.js
@@ -14,7 +14,10 @@ const HALF = 300;
 class MeshTexturedQuadScene extends Scene {
     quad;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.quad = new Mesh({
             vertices: new Float32Array([
                 -HALF,

--- a/examples/geometry-graphics/mesh-textured-quad.ts
+++ b/examples/geometry-graphics/mesh-textured-quad.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Mesh, Scene } from '@codexo/exojs';
+import { Application, Color, Mesh, type RenderingContext, Scene, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -17,7 +17,9 @@ class MeshTexturedQuadScene extends Scene {
     private quad!: Mesh;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.quad = new Mesh({
             vertices: new Float32Array([
@@ -38,11 +40,11 @@ class MeshTexturedQuadScene extends Scene {
         this.quad.setPosition((width / 2) | 0, (height / 2) | 0);
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.quad.rotate(delta.seconds * 30);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.quad);
     }

--- a/examples/geometry-graphics/mesh-triangle.js
+++ b/examples/geometry-graphics/mesh-triangle.js
@@ -12,7 +12,10 @@ const app = new Application({
 class MeshTriangleScene extends Scene {
     triangle;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.triangle = new Mesh({
             vertices: new Float32Array([0, -100, 100, 100, -100, 100]),
             colors: new Uint32Array([

--- a/examples/geometry-graphics/mesh-triangle.ts
+++ b/examples/geometry-graphics/mesh-triangle.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Mesh, Scene } from '@codexo/exojs';
+import { Application, Color, Mesh, type RenderingContext, Scene, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -14,7 +14,9 @@ class MeshTriangleScene extends Scene {
     private triangle!: Mesh;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.triangle = new Mesh({
             vertices: new Float32Array([0, -100, 100, 100, -100, 100]),
@@ -28,11 +30,11 @@ class MeshTriangleScene extends Scene {
         this.triangle.setPosition((width / 2) | 0, (height / 2) | 0);
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.triangle.rotate(delta.seconds * 60);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.triangle);
     }

--- a/examples/getting-started/game-loop.js
+++ b/examples/getting-started/game-loop.js
@@ -15,7 +15,10 @@ const app = new Application({
 class GameLoopScene extends Scene {
     sprite;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.sprite = new Sprite(this.loader.get('image/ship-a.png'));
         this.sprite.setAnchor(0.5);
         this.sprite.setPosition(width / 2, height / 2);

--- a/examples/getting-started/game-loop.ts
+++ b/examples/getting-started/game-loop.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene, Sprite } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, Sprite, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -17,18 +17,20 @@ class GameLoopScene extends Scene {
     private sprite!: Sprite;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.sprite = new Sprite(this.loader.get('image/ship-a.png'));
         this.sprite.setAnchor(0.5);
         this.sprite.setPosition(width / 2, height / 2);
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.sprite.rotate(delta.seconds * 120);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
     }

--- a/examples/getting-started/hello-world.js
+++ b/examples/getting-started/hello-world.js
@@ -16,7 +16,10 @@ const app = new Application({
 class HelloWorldScene extends Scene {
     sprite;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.sprite = new Sprite(this.loader.get('image/ship-a.png'));
         this.sprite.setAnchor(0.5);
         this.sprite.setPosition(width / 2, height / 2);

--- a/examples/getting-started/hello-world.ts
+++ b/examples/getting-started/hello-world.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene, Sprite } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, Sprite } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -18,14 +18,16 @@ class HelloWorldScene extends Scene {
     private sprite!: Sprite;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.sprite = new Sprite(this.loader.get('image/ship-a.png'));
         this.sprite.setAnchor(0.5);
         this.sprite.setPosition(width / 2, height / 2);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
     }

--- a/examples/getting-started/resize-and-dpr.js
+++ b/examples/getting-started/resize-and-dpr.js
@@ -45,7 +45,10 @@ class ResizeScene extends Scene {
     }
     // #region guide:layout
     layout() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const dpr = Math.max(1, window.devicePixelRatio || 1);
         this.sprite.setPosition(width / 2, height / 2);
         this.info.setPosition(width / 2, 12);

--- a/examples/getting-started/resize-and-dpr.ts
+++ b/examples/getting-started/resize-and-dpr.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene, Sprite, Text } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, Sprite, Text } from '@codexo/exojs';
 
 // #region guide:app-setup
 const app = new Application({
@@ -47,7 +47,7 @@ class ResizeScene extends Scene {
         this.layout();
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
         context.render(this.info);
@@ -55,7 +55,9 @@ class ResizeScene extends Scene {
 
     // #region guide:layout
     private layout(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const dpr = Math.max(1, window.devicePixelRatio || 1);
 
         this.sprite.setPosition(width / 2, height / 2);

--- a/examples/input/action-mapping.js
+++ b/examples/input/action-mapping.js
@@ -27,9 +27,12 @@ class ActionMappingScene extends Scene {
     actions = { moveX: 0, moveY: 0, jump: false };
     hud;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.sprite = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5).setPosition(width / 2, height / 2);
-        const pad0 = this.app.input.getGamepad(0);
+        const pad0 = app.input.getGamepad(0);
         // --- Move action: keyboard WASD/arrows feed key axes ---
         this.inputs.onActive([Keyboard.A, Keyboard.Left], () => (this.keys.left = 1));
         this.inputs.onStop([Keyboard.A, Keyboard.Left], () => (this.keys.left = 0));

--- a/examples/input/action-mapping.ts
+++ b/examples/input/action-mapping.ts
@@ -1,4 +1,4 @@
-import { Application, Color, GamepadAxis, GamepadButton, Keyboard, Scene, Sprite } from '@codexo/exojs';
+import { Application, Color, GamepadAxis, GamepadButton, Keyboard, type RenderingContext, Scene, Sprite, type Time } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -29,11 +29,13 @@ class ActionMappingScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.sprite = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5).setPosition(width / 2, height / 2);
 
-        const pad0 = this.app.input.getGamepad(0);
+        const pad0 = app.input.getGamepad(0);
 
         // --- Move action: keyboard WASD/arrows feed key axes ---
         this.inputs.onActive([Keyboard.A, Keyboard.Left], () => (this.keys.left = 1));
@@ -72,7 +74,7 @@ class ActionMappingScene extends Scene {
         this.lastDevice = device;
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         const keyX = this.keys.right - this.keys.left;
         const keyY = this.keys.down - this.keys.up;
 
@@ -93,7 +95,7 @@ class ActionMappingScene extends Scene {
         this.hud.setHint(`Driven by: ${this.lastDevice}`);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
     }

--- a/examples/input/gamepad.js
+++ b/examples/input/gamepad.js
@@ -23,16 +23,20 @@ class GamepadScene extends Scene {
     status;
     container;
     async init() {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const buttonsData = (await this.loader.load(Asset.kind('json', 'json/buttons.json')));
         this.buttons = new Spritesheet(this.loader.get('image/buttons.png'), buttonsData);
-        this.status = this.createStatus();
-        this.container = this.createGamepad();
+        const { width, height } = app.canvas;
+        this.status = this.createStatus(width, height);
+        this.container = this.createGamepad(width, height);
         for (const sprite of this.mappingButtons.values()) {
             sprite.setTint(this.buttonColor);
         }
-        this.app.input.onGamepadConnected.add(pad => this.handleGamepadConnected(pad));
-        this.app.input.onGamepadDisconnected.add(pad => this.handleGamepadDisconnected(pad));
-        for (const pad of this.app.input.gamepads) {
+        app.input.onGamepadConnected.add(pad => this.handleGamepadConnected(pad));
+        app.input.onGamepadDisconnected.add(pad => this.handleGamepadDisconnected(pad));
+        for (const pad of app.input.gamepads) {
             if (pad.connected) {
                 this.setActivePad(pad);
                 break;
@@ -53,7 +57,10 @@ class GamepadScene extends Scene {
         if (this.activePad !== pad) {
             return;
         }
-        const next = this.app.input.gamepads.find((other) => other !== pad && other.connected) || null;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const next = app.input.gamepads.find(other => other !== pad && other.connected) || null;
         this.setActivePad(next);
     }
     setActivePad(pad) {
@@ -91,25 +98,23 @@ class GamepadScene extends Scene {
             reset();
         }
     }
-    createStatus() {
-        const { width, height } = this.app.canvas;
+    createStatus(width, height) {
         const status = this.buttons.getFrameSprite('status');
         status.setAnchor(0.5);
         status.setPosition(width / 2, height / 5);
         status.setTint(this.buttonColor);
         return status;
     }
-    createGamepad() {
+    createGamepad(width, height) {
         const container = new Container();
-        container.addChild(this.createDPadField());
-        container.addChild(this.createFaceButtons());
-        container.addChild(this.createShoulderButtons());
-        container.addChild(this.createMenuButtons());
-        container.addChild(this.createJoysticks());
+        container.addChild(this.createDPadField(width, height));
+        container.addChild(this.createFaceButtons(width, height));
+        container.addChild(this.createShoulderButtons(width, height));
+        container.addChild(this.createMenuButtons(width, height));
+        container.addChild(this.createJoysticks(width, height));
         return container;
     }
-    createDPadField() {
-        const { width, height } = this.app.canvas;
+    createDPadField(width, height) {
         const mappedButtons = this.mappingButtons;
         const container = new Container();
         const dPad = this.buttons.getFrameSprite('dpad');
@@ -136,8 +141,7 @@ class GamepadScene extends Scene {
         container.setPosition(width / 5, height / 2);
         return container;
     }
-    createFaceButtons() {
-        const { width, height } = this.app.canvas;
+    createFaceButtons(width, height) {
         const mappedButtons = this.mappingButtons;
         const container = new Container();
         const buttonTop = this.buttons.getFrameSprite('FaceTop');
@@ -164,8 +168,7 @@ class GamepadScene extends Scene {
         container.setPosition(width * 0.8, height / 2);
         return container;
     }
-    createShoulderButtons() {
-        const { width, height } = this.app.canvas;
+    createShoulderButtons(width, height) {
         const mappedButtons = this.mappingButtons;
         const container = new Container();
         const leftButton = this.buttons.getFrameSprite('ShoulderLeftBottom');
@@ -189,8 +192,7 @@ class GamepadScene extends Scene {
         container.setPosition(width / 2, height / 5);
         return container;
     }
-    createMenuButtons() {
-        const { width, height } = this.app.canvas;
+    createMenuButtons(width, height) {
         const mappedButtons = this.mappingButtons;
         const container = new Container();
         const selectButton = this.buttons.getFrameSprite('Select');
@@ -205,8 +207,7 @@ class GamepadScene extends Scene {
         container.setPosition(width / 2, height / 2);
         return container;
     }
-    createJoysticks() {
-        const { width, height } = this.app.canvas;
+    createJoysticks(width, height) {
         const mappedButtons = this.mappingButtons;
         const mappingFunctions = this.mappingFunctions;
         const container = new Container();

--- a/examples/input/gamepad.ts
+++ b/examples/input/gamepad.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Color, Container, GamepadAxis, GamepadButton, lerp, Scene, Sprite, Spritesheet, type SpritesheetData, Vector } from '@codexo/exojs';
+import { Application, Asset, Color, Container, type Gamepad, GamepadAxis, GamepadButton, type InputChannel, lerp, type RenderingContext, Scene, Sprite, Spritesheet, type SpritesheetData, Vector } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -14,31 +14,34 @@ const app = new Application({
 });
 
 class GamepadScene extends Scene {
-    private activePad: any = null;
+    private activePad: Gamepad | null = null;
     private buttons!: Spritesheet;
     private buttonColor = new Color(255, 255, 255, 0.25);
-    private mappingButtons = new Map<any, any>();
-    private mappingFunctions = new Map<any, any>();
+    private mappingButtons = new Map<InputChannel, Sprite>();
+    private mappingFunctions = new Map<InputChannel, (value: number) => void>();
     private resetFunctions: Array<() => void> = [];
     private padBindings: Array<{ unbind(): void }> = [];
     private status!: Sprite;
     private container!: Container;
 
     override async init(): Promise<void> {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const buttonsData = (await this.loader.load(Asset.kind('json', 'json/buttons.json'))) as SpritesheetData;
 
         this.buttons = new Spritesheet(this.loader.get('image/buttons.png'), buttonsData);
-        this.status = this.createStatus();
-        this.container = this.createGamepad();
+        const { width, height } = app.canvas;
+        this.status = this.createStatus(width, height);
+        this.container = this.createGamepad(width, height);
 
         for (const sprite of this.mappingButtons.values()) {
             sprite.setTint(this.buttonColor);
         }
 
-        this.app.input.onGamepadConnected.add(pad => this.handleGamepadConnected(pad));
-        this.app.input.onGamepadDisconnected.add(pad => this.handleGamepadDisconnected(pad));
+        app.input.onGamepadConnected.add(pad => this.handleGamepadConnected(pad));
+        app.input.onGamepadDisconnected.add(pad => this.handleGamepadDisconnected(pad));
 
-        for (const pad of this.app.input.gamepads) {
+        for (const pad of app.input.gamepads) {
             if (pad.connected) {
                 this.setActivePad(pad);
                 break;
@@ -46,28 +49,30 @@ class GamepadScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.status);
         context.render(this.container);
     }
 
-    private handleGamepadConnected(pad): void {
+    private handleGamepadConnected(pad: Gamepad): void {
         if (!this.activePad) {
             this.setActivePad(pad);
         }
     }
 
-    private handleGamepadDisconnected(pad): void {
+    private handleGamepadDisconnected(pad: Gamepad): void {
         if (this.activePad !== pad) {
             return;
         }
 
-        const next = this.app.input.gamepads.find((other: any) => other !== pad && other.connected) || null;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const next = app.input.gamepads.find(other => other !== pad && other.connected) || null;
         this.setActivePad(next);
     }
 
-    private setActivePad(pad): void {
+    private setActivePad(pad: Gamepad | null): void {
         for (const binding of this.padBindings) {
             binding.unbind();
         }
@@ -116,8 +121,7 @@ class GamepadScene extends Scene {
         }
     }
 
-    private createStatus(): Sprite {
-        const { width, height } = this.app.canvas;
+    private createStatus(width: number, height: number): Sprite {
         const status = this.buttons.getFrameSprite('status');
 
         status.setAnchor(0.5);
@@ -127,20 +131,19 @@ class GamepadScene extends Scene {
         return status;
     }
 
-    private createGamepad(): Container {
+    private createGamepad(width: number, height: number): Container {
         const container = new Container();
 
-        container.addChild(this.createDPadField());
-        container.addChild(this.createFaceButtons());
-        container.addChild(this.createShoulderButtons());
-        container.addChild(this.createMenuButtons());
-        container.addChild(this.createJoysticks());
+        container.addChild(this.createDPadField(width, height));
+        container.addChild(this.createFaceButtons(width, height));
+        container.addChild(this.createShoulderButtons(width, height));
+        container.addChild(this.createMenuButtons(width, height));
+        container.addChild(this.createJoysticks(width, height));
 
         return container;
     }
 
-    private createDPadField(): Container {
-        const { width, height } = this.app.canvas;
+    private createDPadField(width: number, height: number): Container {
         const mappedButtons = this.mappingButtons;
         const container = new Container();
         const dPad = this.buttons.getFrameSprite('dpad');
@@ -174,8 +177,7 @@ class GamepadScene extends Scene {
         return container;
     }
 
-    private createFaceButtons(): Container {
-        const { width, height } = this.app.canvas;
+    private createFaceButtons(width: number, height: number): Container {
         const mappedButtons = this.mappingButtons;
         const container = new Container();
         const buttonTop = this.buttons.getFrameSprite('FaceTop');
@@ -211,8 +213,7 @@ class GamepadScene extends Scene {
         return container;
     }
 
-    private createShoulderButtons(): Container {
-        const { width, height } = this.app.canvas;
+    private createShoulderButtons(width: number, height: number): Container {
         const mappedButtons = this.mappingButtons;
         const container = new Container();
         const leftButton = this.buttons.getFrameSprite('ShoulderLeftBottom');
@@ -244,8 +245,7 @@ class GamepadScene extends Scene {
         return container;
     }
 
-    private createMenuButtons(): Container {
-        const { width, height } = this.app.canvas;
+    private createMenuButtons(width: number, height: number): Container {
         const mappedButtons = this.mappingButtons;
         const container = new Container();
         const selectButton = this.buttons.getFrameSprite('Select');
@@ -266,8 +266,7 @@ class GamepadScene extends Scene {
         return container;
     }
 
-    private createJoysticks(): Container {
-        const { width, height } = this.app.canvas;
+    private createJoysticks(width: number, height: number): Container {
         const mappedButtons = this.mappingButtons;
         const mappingFunctions = this.mappingFunctions;
         const container = new Container();

--- a/examples/input/key-rebinding.js
+++ b/examples/input/key-rebinding.js
@@ -56,7 +56,10 @@ class KeyRebindingScene extends Scene {
     jumpBinding;
     hud;
     init() {
-        const { height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { height } = app.canvas;
         this.groundY = height - 240;
         this.heroY = this.groundY;
         this.graphics = new Graphics();
@@ -67,7 +70,7 @@ class KeyRebindingScene extends Scene {
             this.rebindRequested = true;
             this.refreshHud();
         });
-        this.app.input.onKeyDown.add(channel => {
+        app.input.onKeyDown.add(channel => {
             if (!this.rebindRequested) {
                 return;
             }
@@ -115,7 +118,10 @@ class KeyRebindingScene extends Scene {
         }
     }
     draw(context) {
-        const { width } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width } = app.canvas;
         context.backend.clear();
         this.graphics.clear();
         // Static ground line, just below where the hero square rests.

--- a/examples/input/key-rebinding.ts
+++ b/examples/input/key-rebinding.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Graphics, Keyboard, Scene } from '@codexo/exojs';
+import { Application, Color, Graphics, Keyboard, type RenderingContext, Scene, type Time } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -68,7 +68,9 @@ class KeyRebindingScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const { height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { height } = app.canvas;
 
         this.groundY = height - 240;
         this.heroY = this.groundY;
@@ -82,7 +84,7 @@ class KeyRebindingScene extends Scene {
             this.refreshHud();
         });
 
-        this.app.input.onKeyDown.add(channel => {
+        app.input.onKeyDown.add(channel => {
             if (!this.rebindRequested) {
                 return;
             }
@@ -127,7 +129,7 @@ class KeyRebindingScene extends Scene {
         this.hud.setHint(this.rebindRequested ? 'Press any key to assign jump…' : 'Binding restored from localStorage on reload.');
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         // Simple gravity so the rebound jump is visible.
         this.jumpVelocity = Math.min(900, this.jumpVelocity + 1800 * delta.seconds);
         this.heroY += this.jumpVelocity * delta.seconds;
@@ -138,8 +140,10 @@ class KeyRebindingScene extends Scene {
         }
     }
 
-    override draw(context): void {
-        const { width } = this.app.canvas;
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width } = app.canvas;
 
         context.backend.clear();
         this.graphics.clear();

--- a/examples/input/keyboard.js
+++ b/examples/input/keyboard.js
@@ -34,7 +34,10 @@ class KeyboardScene extends Scene {
     right;
     hud;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.square = new Graphics();
         this.position = { x: width / 2, y: height / 2 };
         // Per-frame polling source: one binding per direction, each listening to
@@ -61,7 +64,10 @@ class KeyboardScene extends Scene {
         });
     }
     update(delta) {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const speed = 280 * delta.seconds;
         const moveX = (this.right.active ? 1 : 0) - (this.left.active ? 1 : 0);
         const moveY = (this.down.active ? 1 : 0) - (this.up.active ? 1 : 0);

--- a/examples/input/keyboard.ts
+++ b/examples/input/keyboard.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Graphics, Keyboard, Scene } from '@codexo/exojs';
+import { Application, Color, Graphics, Keyboard, type RenderingContext, Scene, type Time } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -36,7 +36,9 @@ class KeyboardScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.square = new Graphics();
         this.position = { x: width / 2, y: height / 2 };
@@ -67,8 +69,10 @@ class KeyboardScene extends Scene {
         });
     }
 
-    override update(delta): void {
-        const { width, height } = this.app.canvas;
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const speed = 280 * delta.seconds;
         const moveX = (this.right.active ? 1 : 0) - (this.left.active ? 1 : 0);
         const moveY = (this.down.active ? 1 : 0) - (this.up.active ? 1 : 0);
@@ -81,7 +85,7 @@ class KeyboardScene extends Scene {
         this.hud.setStatus(`Held: ${held.length ? held.join(' + ') : 'none'}`);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         this.square.clear();
         this.square.fillColor = new Color(120, 200, 255);

--- a/examples/input/mouse-and-pointer.js
+++ b/examples/input/mouse-and-pointer.js
@@ -30,25 +30,28 @@ class MouseAndPointerScene extends Scene {
     clicks = 0;
     hud;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.pointer = { x: width / 2, y: height / 2 };
         this.previous = { x: width / 2, y: height / 2 };
         this.ship = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5).setPosition(width / 2, height / 2);
         this.ship.interactive = true;
         this.ship.draggable = true;
         this.crosshair = new Graphics();
-        this.app.input.onPointerMove.add(pointer => {
+        app.input.onPointerMove.add(pointer => {
             this.pointer.x = pointer.x;
             this.pointer.y = pointer.y;
             this.buttons = pointer.buttons;
         });
-        this.app.input.onPointerDown.add(pointer => {
+        app.input.onPointerDown.add(pointer => {
             this.buttons = pointer.buttons;
         });
-        this.app.input.onPointerUp.add(pointer => {
+        app.input.onPointerUp.add(pointer => {
             this.buttons = pointer.buttons;
         });
-        this.app.input.onPointerTap.add(() => {
+        app.input.onPointerTap.add(() => {
             this.clicks++;
         });
         this.hud = mountControls({

--- a/examples/input/mouse-and-pointer.ts
+++ b/examples/input/mouse-and-pointer.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Graphics, Scene, Sprite } from '@codexo/exojs';
+import { Application, Color, Graphics, type RenderingContext, Scene, Sprite } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -32,7 +32,9 @@ class MouseAndPointerScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.pointer = { x: width / 2, y: height / 2 };
         this.previous = { x: width / 2, y: height / 2 };
@@ -42,18 +44,18 @@ class MouseAndPointerScene extends Scene {
         this.ship.draggable = true;
         this.crosshair = new Graphics();
 
-        this.app.input.onPointerMove.add(pointer => {
+        app.input.onPointerMove.add(pointer => {
             this.pointer.x = pointer.x;
             this.pointer.y = pointer.y;
             this.buttons = pointer.buttons;
         });
-        this.app.input.onPointerDown.add(pointer => {
+        app.input.onPointerDown.add(pointer => {
             this.buttons = pointer.buttons;
         });
-        this.app.input.onPointerUp.add(pointer => {
+        app.input.onPointerUp.add(pointer => {
             this.buttons = pointer.buttons;
         });
-        this.app.input.onPointerTap.add(() => {
+        app.input.onPointerTap.add(() => {
             this.clicks++;
         });
 
@@ -86,7 +88,7 @@ class MouseAndPointerScene extends Scene {
         );
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.ship);
 

--- a/examples/input/multi-gamepad.js
+++ b/examples/input/multi-gamepad.js
@@ -24,8 +24,11 @@ class MultiGamepadScene extends Scene {
     connectPrompt;
     hud;
     init() {
-        const { width, height } = this.app.canvas;
-        this.players = this.app.input.gamepads.map((pad, index) => {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
+        this.players = app.input.gamepads.map((pad, index) => {
             const sprite = new Sprite(this.loader.get('image/ship-a.png'))
                 .setAnchor(0.5)
                 .setScale(0.6)
@@ -40,9 +43,9 @@ class MultiGamepadScene extends Scene {
         });
         // Track controller presence with the engine's connect/disconnect signals
         // and prompt with an on-screen Text while none is attached.
-        this.hasPad = this.app.input.gamepads.some(pad => pad.connected);
-        this.app.input.onGamepadConnected.add(() => (this.hasPad = true));
-        this.app.input.onGamepadDisconnected.add(() => (this.hasPad = this.app.input.gamepads.some(pad => pad.connected)));
+        this.hasPad = app.input.gamepads.some(pad => pad.connected);
+        app.input.onGamepadConnected.add(() => (this.hasPad = true));
+        app.input.onGamepadDisconnected.add(() => (this.hasPad = app.input.gamepads.some(pad => pad.connected)));
         this.connectPrompt = new Text('Connect one or more controllers to play', { fillColor: Color.white, fontSize: 24, align: 'center' })
             .setAnchor(0.5, 0.5)
             .setPosition(width / 2, height / 2);
@@ -53,8 +56,8 @@ class MultiGamepadScene extends Scene {
             hint: 'Up to four pads, one coloured ship each.',
         });
         this.refreshHud();
-        this.app.input.onGamepadConnected.add(() => this.refreshHud());
-        this.app.input.onGamepadDisconnected.add(() => this.refreshHud());
+        app.input.onGamepadConnected.add(() => this.refreshHud());
+        app.input.onGamepadDisconnected.add(() => this.refreshHud());
     }
     refreshHud() {
         const lines = this.players.map((player, index) => {

--- a/examples/input/multi-gamepad.ts
+++ b/examples/input/multi-gamepad.ts
@@ -1,4 +1,4 @@
-import { Application, Color, GamepadAxis, Scene, Sprite, Text } from '@codexo/exojs';
+import { Application, Color, GamepadAxis, type RenderingContext, Scene, Sprite, Text, type Time } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -33,9 +33,11 @@ class MultiGamepadScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
-        this.players = this.app.input.gamepads.map((pad, index) => {
+        this.players = app.input.gamepads.map((pad, index) => {
             const sprite = new Sprite(this.loader.get('image/ship-a.png'))
                 .setAnchor(0.5)
                 .setScale(0.6)
@@ -53,9 +55,9 @@ class MultiGamepadScene extends Scene {
 
         // Track controller presence with the engine's connect/disconnect signals
         // and prompt with an on-screen Text while none is attached.
-        this.hasPad = this.app.input.gamepads.some(pad => pad.connected);
-        this.app.input.onGamepadConnected.add(() => (this.hasPad = true));
-        this.app.input.onGamepadDisconnected.add(() => (this.hasPad = this.app.input.gamepads.some(pad => pad.connected)));
+        this.hasPad = app.input.gamepads.some(pad => pad.connected);
+        app.input.onGamepadConnected.add(() => (this.hasPad = true));
+        app.input.onGamepadDisconnected.add(() => (this.hasPad = app.input.gamepads.some(pad => pad.connected)));
         this.connectPrompt = new Text('Connect one or more controllers to play', { fillColor: Color.white, fontSize: 24, align: 'center' })
             .setAnchor(0.5, 0.5)
             .setPosition(width / 2, height / 2);
@@ -68,8 +70,8 @@ class MultiGamepadScene extends Scene {
         });
 
         this.refreshHud();
-        this.app.input.onGamepadConnected.add(() => this.refreshHud());
-        this.app.input.onGamepadDisconnected.add(() => this.refreshHud());
+        app.input.onGamepadConnected.add(() => this.refreshHud());
+        app.input.onGamepadDisconnected.add(() => this.refreshHud());
     }
 
     private refreshHud(): void {
@@ -82,7 +84,7 @@ class MultiGamepadScene extends Scene {
         this.hud.setStatus(lines.join(' · '));
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         for (const player of this.players) {
             if (!player.pad.connected) {
                 continue;
@@ -92,7 +94,7 @@ class MultiGamepadScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
 
         for (const player of this.players) {

--- a/examples/input/multitouch.js
+++ b/examples/input/multitouch.js
@@ -33,30 +33,33 @@ class MultitouchScene extends Scene {
     pointers = new Map();
     hud;
     init() {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.graphics = new Graphics();
         // Reusable label pool — one Text per possible touch, repositioned each frame.
         for (let i = 0; i < MAX_TOUCHES; i++) {
             this.labels.push(new Text('', { fillColor: Color.white, fontSize: 16 }).setAnchor(0.5));
         }
-        this.app.input.onPointerDown.add(pointer => {
+        app.input.onPointerDown.add(pointer => {
             if (this.pointers.size >= MAX_TOUCHES || this.pointers.has(pointer.id)) {
                 return;
             }
             this.pointers.set(pointer.id, { id: pointer.id, x: pointer.x, y: pointer.y });
             this.refreshHud();
         });
-        this.app.input.onPointerMove.add(pointer => {
+        app.input.onPointerMove.add(pointer => {
             const touch = this.pointers.get(pointer.id);
             if (touch) {
                 touch.x = pointer.x;
                 touch.y = pointer.y;
             }
         });
-        this.app.input.onPointerUp.add(pointer => {
+        app.input.onPointerUp.add(pointer => {
             this.pointers.delete(pointer.id);
             this.refreshHud();
         });
-        this.app.input.onPointerCancel.add(pointer => {
+        app.input.onPointerCancel.add(pointer => {
             this.pointers.delete(pointer.id);
             this.refreshHud();
         });

--- a/examples/input/multitouch.ts
+++ b/examples/input/multitouch.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Graphics, Scene, Text } from '@codexo/exojs';
+import { Application, Color, Graphics, type RenderingContext, Scene, Text } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -43,6 +43,8 @@ class MultitouchScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.graphics = new Graphics();
 
         // Reusable label pool — one Text per possible touch, repositioned each frame.
@@ -50,7 +52,7 @@ class MultitouchScene extends Scene {
             this.labels.push(new Text('', { fillColor: Color.white, fontSize: 16 }).setAnchor(0.5));
         }
 
-        this.app.input.onPointerDown.add(pointer => {
+        app.input.onPointerDown.add(pointer => {
             if (this.pointers.size >= MAX_TOUCHES || this.pointers.has(pointer.id)) {
                 return;
             }
@@ -58,7 +60,7 @@ class MultitouchScene extends Scene {
             this.pointers.set(pointer.id, { id: pointer.id, x: pointer.x, y: pointer.y });
             this.refreshHud();
         });
-        this.app.input.onPointerMove.add(pointer => {
+        app.input.onPointerMove.add(pointer => {
             const touch = this.pointers.get(pointer.id);
 
             if (touch) {
@@ -66,11 +68,11 @@ class MultitouchScene extends Scene {
                 touch.y = pointer.y;
             }
         });
-        this.app.input.onPointerUp.add(pointer => {
+        app.input.onPointerUp.add(pointer => {
             this.pointers.delete(pointer.id);
             this.refreshHud();
         });
-        this.app.input.onPointerCancel.add(pointer => {
+        app.input.onPointerCancel.add(pointer => {
             this.pointers.delete(pointer.id);
             this.refreshHud();
         });
@@ -87,7 +89,7 @@ class MultitouchScene extends Scene {
         this.hud.setStatus(`Active touches: ${this.pointers.size} / ${MAX_TOUCHES}`);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         this.graphics.clear();
 

--- a/examples/input/pointer-to-world.js
+++ b/examples/input/pointer-to-world.js
@@ -30,8 +30,11 @@ class PointerToWorldScene extends Scene {
     userZoom = 1;
     hud;
     init() {
-        const width = this.app.width;
-        const height = this.app.height;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const width = app.width;
+        const height = app.height;
         this.view = new View(width / 2, height / 2, width, height);
         this.grid = new Graphics();
         this.markers = new Graphics();
@@ -46,16 +49,16 @@ class PointerToWorldScene extends Scene {
         for (let y = -480; y <= height + 480; y += 80) {
             this.grid.drawLine(-640, y, width + 640, y);
         }
-        this.app.input.onPointerMove.add(pointer => {
+        app.input.onPointerMove.add(pointer => {
             this.cursor.x = pointer.x;
             this.cursor.y = pointer.y;
         });
-        this.app.input.onPointerTap.add(pointer => {
+        app.input.onPointerTap.add(pointer => {
             const world = this.view.screenToWorld(pointer.x, pointer.y);
             this.markerWorld.push({ x: world.x, y: world.y });
         });
         // Scroll to nudge a user-controlled zoom that the automatic breath multiplies.
-        this.app.input.onMouseWheel.add(offset => {
+        app.input.onMouseWheel.add(offset => {
             this.userZoom = Math.max(0.4, Math.min(3, this.userZoom + (offset.y < 0 ? 0.1 : -0.1)));
         });
         this.hud = mountControls({
@@ -70,8 +73,11 @@ class PointerToWorldScene extends Scene {
         });
     }
     update(delta) {
-        const width = this.app.width;
-        const height = this.app.height;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const width = app.width;
+        const height = app.height;
         this.elapsed += delta.seconds;
         // Slow figure-eight pan plus a gentle zoom breath.
         const centerX = width / 2 + Math.sin(this.elapsed * 0.5) * 220;

--- a/examples/input/pointer-to-world.ts
+++ b/examples/input/pointer-to-world.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Graphics, Scene, View } from '@codexo/exojs';
+import { Application, Color, Graphics, type RenderingContext, Scene, type Time, View } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -32,8 +32,10 @@ class PointerToWorldScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const width = this.app.width;
-        const height = this.app.height;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const width = app.width;
+        const height = app.height;
 
         this.view = new View(width / 2, height / 2, width, height);
         this.grid = new Graphics();
@@ -53,19 +55,19 @@ class PointerToWorldScene extends Scene {
             this.grid.drawLine(-640, y, width + 640, y);
         }
 
-        this.app.input.onPointerMove.add(pointer => {
+        app.input.onPointerMove.add(pointer => {
             this.cursor.x = pointer.x;
             this.cursor.y = pointer.y;
         });
 
-        this.app.input.onPointerTap.add(pointer => {
+        app.input.onPointerTap.add(pointer => {
             const world = this.view.screenToWorld(pointer.x, pointer.y);
 
             this.markerWorld.push({ x: world.x, y: world.y });
         });
 
         // Scroll to nudge a user-controlled zoom that the automatic breath multiplies.
-        this.app.input.onMouseWheel.add(offset => {
+        app.input.onMouseWheel.add(offset => {
             this.userZoom = Math.max(0.4, Math.min(3, this.userZoom + (offset.y < 0 ? 0.1 : -0.1)));
         });
 
@@ -81,9 +83,11 @@ class PointerToWorldScene extends Scene {
         });
     }
 
-    override update(delta): void {
-        const width = this.app.width;
-        const height = this.app.height;
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const width = app.width;
+        const height = app.height;
 
         this.elapsed += delta.seconds;
 
@@ -102,7 +106,7 @@ class PointerToWorldScene extends Scene {
         this.hud.setStatus(`Screen ${Math.round(this.cursor.x)}, ${Math.round(this.cursor.y)} → World ${this.world.x.toFixed(0)}, ${this.world.y.toFixed(0)} · zoom ${this.view.zoomLevel.toFixed(2)}`);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.backend.setView(this.view);
 

--- a/examples/particles/bonfire.js
+++ b/examples/particles/bonfire.js
@@ -15,7 +15,10 @@ class BonfireScene extends Scene {
     fireSystem;
     smokeSystem;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.fireSystem = new ParticleSystem(this.loader.get(assets.demo.textures.particleFlame));
         this.fireSystem.setPosition(width * 0.5, height * 0.75);
         this.fireSystem.setBlendMode(BlendModes.Additive);

--- a/examples/particles/bonfire.ts
+++ b/examples/particles/bonfire.ts
@@ -1,4 +1,4 @@
-import { Application, BlendModes, Color, Scene } from '@codexo/exojs';
+import { Application, BlendModes, Color, type RenderingContext, Scene, type Time } from '@codexo/exojs';
 import {
     ColorGradient,
     ColorOverLifetime,
@@ -27,7 +27,9 @@ class BonfireScene extends Scene {
     private smokeSystem!: ParticleSystem;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.fireSystem = new ParticleSystem(this.loader.get(assets.demo.textures.particleFlame));
         this.fireSystem.setPosition(width * 0.5, height * 0.75);
@@ -74,12 +76,12 @@ class BonfireScene extends Scene {
         );
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.fireSystem.update(delta);
         this.smokeSystem.update(delta);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.smokeSystem);
         context.render(this.fireSystem);

--- a/examples/particles/cursor-attractor-particles.js
+++ b/examples/particles/cursor-attractor-particles.js
@@ -22,7 +22,10 @@ class CursorAttractorParticlesScene extends Scene {
     mode = 'attract';
     hud;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.system = new ParticleSystem(this.loader.get(assets.demo.textures.particleLight), { capacity: 32000 });
         this.system.setPosition(width / 2, height / 2);
         this.system.addSpawnModule(new RateSpawn({
@@ -41,7 +44,7 @@ class CursorAttractorParticlesScene extends Scene {
         this.system.addUpdateModule(this.attractor);
         this.system.addUpdateModule(this.repeller);
         this.system.addUpdateModule(new AlphaFadeOverLifetime());
-        this.app.input.onPointerMove.add(pointer => {
+        app.input.onPointerMove.add(pointer => {
             const localX = pointer.x - this.system.position.x;
             const localY = pointer.y - this.system.position.y;
             this.attractor.x = localX;
@@ -65,7 +68,7 @@ class CursorAttractorParticlesScene extends Scene {
         });
         // A pointer button also flips the mode, so the demo is usable without
         // the slider panel; keep the toggle UI in sync when that happens.
-        this.app.input.onPointerDown.add(() => {
+        app.input.onPointerDown.add(() => {
             const next = this.mode === 'attract' ? 'repel' : 'attract';
             this.setMode(next);
             toggle.set(next === 'repel');

--- a/examples/particles/cursor-attractor-particles.ts
+++ b/examples/particles/cursor-attractor-particles.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene, Vector } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, type Time, Vector } from '@codexo/exojs';
 import {
     AlphaFadeOverLifetime,
     AttractToPoint,
@@ -34,7 +34,9 @@ class CursorAttractorParticlesScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.system = new ParticleSystem(this.loader.get(assets.demo.textures.particleLight), { capacity: 32000 });
         this.system.setPosition(width / 2, height / 2);
@@ -60,7 +62,7 @@ class CursorAttractorParticlesScene extends Scene {
         this.system.addUpdateModule(this.repeller);
         this.system.addUpdateModule(new AlphaFadeOverLifetime());
 
-        this.app.input.onPointerMove.add(pointer => {
+        app.input.onPointerMove.add(pointer => {
             const localX = pointer.x - this.system.position.x;
             const localY = pointer.y - this.system.position.y;
 
@@ -88,7 +90,7 @@ class CursorAttractorParticlesScene extends Scene {
 
         // A pointer button also flips the mode, so the demo is usable without
         // the slider panel; keep the toggle UI in sync when that happens.
-        this.app.input.onPointerDown.add(() => {
+        app.input.onPointerDown.add(() => {
             const next = this.mode === 'attract' ? 'repel' : 'attract';
 
             this.setMode(next);
@@ -112,11 +114,11 @@ class CursorAttractorParticlesScene extends Scene {
         }
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.system.update(delta);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.system);
     }

--- a/examples/particles/custom-wgsl-module.js
+++ b/examples/particles/custom-wgsl-module.js
@@ -53,7 +53,10 @@ class CustomWgslModuleScene extends Scene {
     hud;
     reportedMode = false;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.system = new ParticleSystem(this.loader.get(assets.demo.textures.particleLight), { capacity: 26000 });
         this.system.setPosition(width / 2, height - 60);
         this.system.addSpawnModule(new RateSpawn({

--- a/examples/particles/custom-wgsl-module.ts
+++ b/examples/particles/custom-wgsl-module.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene, Vector } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, type Time, Vector } from '@codexo/exojs';
 import {
     Constant,
     particlesExtension,
@@ -38,7 +38,7 @@ class SwayModule extends UpdateModule {
         this.frequency = frequency;
     }
 
-    apply(system, dt): void {
+    override apply(system: ParticleSystem, dt: number): void {
         for (let i = 0; i < system.liveCount; i++) {
             system.velX[i] += Math.sin(system.elapsed[i] * this.frequency) * this.amplitude * dt;
         }
@@ -67,7 +67,9 @@ class CustomWgslModuleScene extends Scene {
     private reportedMode = false;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.system = new ParticleSystem(this.loader.get(assets.demo.textures.particleLight), { capacity: 26000 });
         this.system.setPosition(width / 2, height - 60);
@@ -91,7 +93,7 @@ class CustomWgslModuleScene extends Scene {
         });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.system.update(delta);
 
         // gpuMode is only meaningful after the first update() compiled the
@@ -102,7 +104,7 @@ class CustomWgslModuleScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.system);
     }

--- a/examples/particles/emitter-basics.js
+++ b/examples/particles/emitter-basics.js
@@ -16,7 +16,10 @@ class EmitterBasicsScene extends Scene {
     system;
     hud;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.system = new ParticleSystem(this.loader.get(assets.demo.textures.particleLight), { capacity: 4000 });
         this.system.setPosition(width / 2, height - 80);
         // Rate, lifetime, and a cone-shaped velocity spread: a fountain that

--- a/examples/particles/emitter-basics.ts
+++ b/examples/particles/emitter-basics.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, type Time } from '@codexo/exojs';
 import {
     ApplyForce,
     ColorGradient,
@@ -30,7 +30,9 @@ class EmitterBasicsScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.system = new ParticleSystem(this.loader.get(assets.demo.textures.particleLight), { capacity: 4000 });
         this.system.setPosition(width / 2, height - 80);
@@ -82,11 +84,11 @@ class EmitterBasicsScene extends Scene {
         });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.system.update(delta);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.system);
     }

--- a/examples/particles/fireworks.js
+++ b/examples/particles/fireworks.js
@@ -44,7 +44,10 @@ class FireworksScene extends Scene {
     launchCount = 0;
     hud;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.canvasSize = new Size(width, height);
         this.rocketTexture = this.loader.get(assets.demo.textures.particleStar);
         // Single explosion system shared by every detonation. We reposition and
@@ -67,7 +70,7 @@ class FireworksScene extends Scene {
             { t: 1, v: 0 },
         ])));
         // Click anywhere to launch a rocket from the bottom at that x.
-        this.app.input.onPointerDown.add(pointer => this.launchRocket(pointer.x));
+        app.input.onPointerDown.add(pointer => this.launchRocket(pointer.x));
         // Ambient fallback: keep the sky alive even without clicks.
         this.autoLaunchTimer = new Timer(autoLaunchInterval, true);
         this.hud = mountControls({

--- a/examples/particles/fireworks.ts
+++ b/examples/particles/fireworks.ts
@@ -1,4 +1,4 @@
-import { Application, BlendModes, Color, Random, Scene, Size, Sprite, Texture, Time, Timer, Vector } from '@codexo/exojs';
+import { Application, BlendModes, Color, Random, type RenderingContext, Scene, Size, Sprite, Texture, Time, Timer, Vector } from '@codexo/exojs';
 import {
     AlphaFadeOverLifetime,
     ApplyForce,
@@ -65,7 +65,9 @@ class FireworksScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.canvasSize = new Size(width, height);
         this.rocketTexture = this.loader.get(assets.demo.textures.particleStar);
@@ -97,7 +99,7 @@ class FireworksScene extends Scene {
         );
 
         // Click anywhere to launch a rocket from the bottom at that x.
-        this.app.input.onPointerDown.add(pointer => this.launchRocket(pointer.x));
+        app.input.onPointerDown.add(pointer => this.launchRocket(pointer.x));
 
         // Ambient fallback: keep the sky alive even without clicks.
         this.autoLaunchTimer = new Timer(autoLaunchInterval, true);
@@ -141,7 +143,7 @@ class FireworksScene extends Scene {
         this.hud.setStatus(`Launched: ${this.launchCount} · in flight: ${this.rockets.length}`);
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         const dt = delta.seconds;
 
         if (this.autoLaunchTimer.expired) {
@@ -169,7 +171,7 @@ class FireworksScene extends Scene {
         this.explosions.update(delta);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.explosions);
 

--- a/examples/particles/gpu-particles.js
+++ b/examples/particles/gpu-particles.js
@@ -26,7 +26,10 @@ class GpuParticlesScene extends Scene {
     system;
     hud;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.system = new ParticleSystem(this.loader.get('image/particle-light.png'), { capacity: CAPACITY });
         this.system.setPosition(width / 2, height - 80);
         this.system.addSpawnModule(new RateSpawn({

--- a/examples/particles/gpu-particles.ts
+++ b/examples/particles/gpu-particles.ts
@@ -1,4 +1,4 @@
-import { Application, Color, RenderBackendType, Scene, Vector } from '@codexo/exojs';
+import { Application, Color, RenderBackendType, type RenderingContext, Scene, type Time, Vector } from '@codexo/exojs';
 import {
     AlphaFadeOverLifetime,
     ApplyForce,
@@ -38,7 +38,9 @@ class GpuParticlesScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.system = new ParticleSystem(this.loader.get('image/particle-light.png'), { capacity: CAPACITY });
         this.system.setPosition(width / 2, height - 80);
@@ -61,7 +63,7 @@ class GpuParticlesScene extends Scene {
         });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.system.update(delta);
 
         const backend = this.system.gpuMode ? 'WebGPU (GPU compute)' : 'WebGL2 (CPU fallback)';
@@ -69,7 +71,7 @@ class GpuParticlesScene extends Scene {
         this.hud.setStatus(`${this.system.aliveCount.toLocaleString()} live / ${CAPACITY.toLocaleString()} cap · ${backend}`);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.system);
     }

--- a/examples/performance/backend-comparison.js
+++ b/examples/performance/backend-comparison.js
@@ -19,7 +19,10 @@ let backendType = 'webgpu';
 class DemoScene extends Scene {
     sprites;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.sprites = Array.from({ length: 2200 }, () => {
             const sprite = new Sprite(this.loader.get('image/ship-a.png'));
             sprite.setAnchor(0.5);
@@ -37,7 +40,10 @@ class DemoScene extends Scene {
         });
     }
     update(delta) {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         for (const item of this.sprites) {
             item.sprite.move(item.vx * delta.seconds, item.vy * delta.seconds);
             if (item.sprite.position.x < 0 || item.sprite.position.x > width)

--- a/examples/performance/backend-comparison.ts
+++ b/examples/performance/backend-comparison.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Keyboard, Scene, Sprite } from '@codexo/exojs';
+import { Application, Color, Keyboard, type RenderingContext, Scene, Sprite, type Time } from '@codexo/exojs';
 import { DebugOverlay } from '@codexo/exojs/debug';
 
 const options = {
@@ -22,7 +22,9 @@ class DemoScene extends Scene {
     private sprites!: { sprite: Sprite; vx: number; vy: number }[];
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.sprites = Array.from({ length: 2200 }, () => {
             const sprite = new Sprite(this.loader.get('image/ship-a.png'));
@@ -41,8 +43,10 @@ class DemoScene extends Scene {
         });
     }
 
-    override update(delta): void {
-        const { width, height } = this.app.canvas;
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         for (const item of this.sprites) {
             item.sprite.move(item.vx * delta.seconds, item.vy * delta.seconds);
             if (item.sprite.position.x < 0 || item.sprite.position.x > width) item.vx *= -1;
@@ -50,7 +54,7 @@ class DemoScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         for (const { sprite } of this.sprites) context.render(sprite);
     }

--- a/examples/performance/multi-texture-stress.js
+++ b/examples/performance/multi-texture-stress.js
@@ -17,7 +17,10 @@ class MultiTextureStressScene extends Scene {
     spriteLayer;
     textureInfos;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.sprites = [];
         this.spriteLayer = new Container();
         this.spriteLayer.setPosition(width / 2, height / 2);
@@ -54,7 +57,10 @@ class MultiTextureStressScene extends Scene {
         }
     }
     update(delta) {
-        const time = this.app.activeTime.seconds;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const time = app.activeTime.seconds;
         this.spriteLayer.rotation = Math.sin(time * 0.45) * 5;
         for (const entry of this.sprites) {
             const localPhase = time + entry.phase;

--- a/examples/performance/multi-texture-stress.ts
+++ b/examples/performance/multi-texture-stress.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Container, Rectangle, Scene, Sprite, Texture } from '@codexo/exojs';
+import { Application, Color, Container, Rectangle, type RenderingContext, Scene, Sprite, Texture, type Time } from '@codexo/exojs';
 
 const GRID_COLUMNS = 50;
 const GRID_ROWS = 22;
@@ -25,7 +25,9 @@ class MultiTextureStressScene extends Scene {
     private textureInfos!: TextureInfo[];
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.sprites = [];
         this.spriteLayer = new Container();
@@ -68,8 +70,10 @@ class MultiTextureStressScene extends Scene {
         }
     }
 
-    override update(delta): void {
-        const time = this.app.activeTime.seconds;
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const time = app.activeTime.seconds;
 
         this.spriteLayer.rotation = Math.sin(time * 0.45) * 5;
 
@@ -84,7 +88,7 @@ class MultiTextureStressScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.spriteLayer);
     }

--- a/examples/performance/particle-stress.js
+++ b/examples/performance/particle-stress.js
@@ -32,7 +32,10 @@ class ParticleStressScene extends Scene {
     sharedTexture;
     particleSystems;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.sharedTexture = createParticleTexture();
         this.particleSystems = [];
         this.particleSystems.push(this.buildSystem({
@@ -111,7 +114,10 @@ class ParticleStressScene extends Scene {
         return { instance: system, baseX: config.x, baseY: config.y };
     }
     update(delta) {
-        const time = this.app.activeTime.seconds;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const time = app.activeTime.seconds;
         for (let i = 0; i < this.particleSystems.length; i++) {
             const entry = this.particleSystems[i];
             const wave = time + i * 1.2;

--- a/examples/performance/particle-stress.ts
+++ b/examples/performance/particle-stress.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene, Texture } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, Texture, type Time } from '@codexo/exojs';
 import {
     AlphaFadeOverLifetime,
     ApplyForce,
@@ -34,7 +34,7 @@ class TintCycle extends UpdateModule {
         this.palette = palette;
     }
 
-    apply(system): void {
+    override apply(system: ParticleSystem): void {
         const { color, liveCount, elapsed } = system;
         for (let i = 0; i < liveCount; i++) {
             if (elapsed[i] === 0) {
@@ -49,7 +49,9 @@ class ParticleStressScene extends Scene {
     private particleSystems!: { instance: ParticleSystem; baseX: number; baseY: number }[];
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.sharedTexture = createParticleTexture();
         this.particleSystems = [];
@@ -152,8 +154,10 @@ class ParticleStressScene extends Scene {
         return { instance: system, baseX: config.x, baseY: config.y };
     }
 
-    override update(delta): void {
-        const time = this.app.activeTime.seconds;
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const time = app.activeTime.seconds;
 
         for (let i = 0; i < this.particleSystems.length; i++) {
             const entry = this.particleSystems[i];
@@ -165,7 +169,7 @@ class ParticleStressScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
 
         for (const entry of this.particleSystems) {

--- a/examples/performance/sprite-stress.js
+++ b/examples/performance/sprite-stress.js
@@ -16,7 +16,10 @@ class SpriteStressScene extends Scene {
     sprites;
     spriteLayer;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const atlasTexture = createAtlasTexture();
         this.sprites = [];
         this.spriteLayer = new Container();
@@ -53,7 +56,10 @@ class SpriteStressScene extends Scene {
         }
     }
     update(delta) {
-        const time = this.app.activeTime.seconds;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const time = app.activeTime.seconds;
         this.spriteLayer.rotate(delta.seconds * 2.5);
         for (const entry of this.sprites) {
             const localPhase = time + entry.phase;

--- a/examples/performance/sprite-stress.ts
+++ b/examples/performance/sprite-stress.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Container, Rectangle, Scene, Sprite, Texture } from '@codexo/exojs';
+import { Application, Color, Container, Rectangle, type RenderingContext, Scene, Sprite, Texture, type Time } from '@codexo/exojs';
 
 const GRID_COLUMNS = 56;
 const GRID_ROWS = 30;
@@ -18,7 +18,9 @@ class SpriteStressScene extends Scene {
     private spriteLayer!: Container;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const atlasTexture = createAtlasTexture();
 
         this.sprites = [];
@@ -62,8 +64,10 @@ class SpriteStressScene extends Scene {
         }
     }
 
-    override update(delta): void {
-        const time = this.app.activeTime.seconds;
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const time = app.activeTime.seconds;
 
         this.spriteLayer.rotate(delta.seconds * 2.5);
 
@@ -78,7 +82,7 @@ class SpriteStressScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.spriteLayer);
     }

--- a/examples/physics/sprite-follows-body.js
+++ b/examples/physics/sprite-follows-body.js
@@ -24,7 +24,10 @@ class SpriteFollowsBodyScene extends Scene {
     settled = 0;
     hud;
     async init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // Gravity in px/s², +Y down — matches the engine's screen space.
         this.world = new PhysicsWorld({ gravity: { x: 0, y: 1400 } });
         const characters = new Spritesheet(this.loader.get(assets.demo.spritesheets.platformerCharacters.image), (await this.loader.load(Asset.kind('json', assets.demo.spritesheets.platformerCharacters.data))));
@@ -65,9 +68,12 @@ class SpriteFollowsBodyScene extends Scene {
         });
     }
     update(delta) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         // Advance the simulation; bound sprites are synced inside step().
         this.world.step(delta.seconds);
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
         const body = this.actorBody;
         const restingSpeed = Math.hypot(body.linearVelocityX, body.linearVelocityY);
         if (body.y > this.floorY - 60 && restingSpeed < 6) {

--- a/examples/physics/sprite-follows-body.ts
+++ b/examples/physics/sprite-follows-body.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Color, Scene, Sprite, Spritesheet, type SpritesheetData, Vector } from '@codexo/exojs';
+import { Application, Asset, Color, type RenderingContext, Scene, Sprite, Spritesheet, type SpritesheetData, type Time, Vector } from '@codexo/exojs';
 import { BoxShape, type PhysicsBody, PhysicsWorld } from '@codexo/exojs-physics';
 import { mountControls } from '@examples/runtime';
 
@@ -27,7 +27,9 @@ class SpriteFollowsBodyScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override async init(): Promise<void> {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // Gravity in px/s², +Y down — matches the engine's screen space.
         this.world = new PhysicsWorld({ gravity: { x: 0, y: 1400 } });
@@ -80,11 +82,13 @@ class SpriteFollowsBodyScene extends Scene {
         });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         // Advance the simulation; bound sprites are synced inside step().
         this.world.step(delta.seconds);
 
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
         const body = this.actorBody;
         const restingSpeed = Math.hypot(body.linearVelocityX, body.linearVelocityY);
 
@@ -107,7 +111,7 @@ class SpriteFollowsBodyScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.floor);
         context.render(this.actor);

--- a/examples/physics/tiled-map-physics-actor.js
+++ b/examples/physics/tiled-map-physics-actor.js
@@ -41,6 +41,9 @@ class TiledMapPhysicsActorScene extends Scene {
     debug;
     hud;
     async init() {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.world = new PhysicsWorld({ gravity: { x: 0, y: 1500 } });
         // ── Tileset + a single ground tile layer ──────────────────────────
         // The map-pack tilesheet is a uniform 64×64 grid (17 columns), so it
@@ -120,11 +123,14 @@ class TiledMapPhysicsActorScene extends Scene {
         this.actorBody.applyImpulse(2600, 0);
         // Physics debug overlay: outlines every collider so the bridge output
         // is visible on top of the rendered tiles.
-        this.debug = new PhysicsDebugDraw(this.app, this.world, { drawShapes: true, drawCenters: true });
+        this.debug = new PhysicsDebugDraw(app, this.world, { drawShapes: true, drawCenters: true });
     }
     update(delta) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.world.step(delta.seconds);
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
         const body = this.actorBody;
         // Loop the demo: nudge the actor again once it settles, and rescue it if
         // it ever escapes the bounds.

--- a/examples/physics/tiled-map-physics-actor.ts
+++ b/examples/physics/tiled-map-physics-actor.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Color, Scene, Sprite, Spritesheet, type SpritesheetData, TextureRegion, Vector } from '@codexo/exojs';
+import { Application, Asset, Color, type RenderingContext, Scene, Sprite, Spritesheet, type SpritesheetData, TextureRegion, type Time, Vector } from '@codexo/exojs';
 import { BoxShape, type PhysicsBody, PhysicsWorld } from '@codexo/exojs-physics';
 import { PhysicsDebugDraw } from '@codexo/exojs-physics/debug';
 import { ObjectKind, ObjectLayer, type RectangleObject, TILE_TRANSFORM_IDENTITY, TileLayer, TileMap, tilemapExtension, TileMapNode, TileSet } from '@codexo/exojs-tilemap';
@@ -45,6 +45,8 @@ class TiledMapPhysicsActorScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override async init(): Promise<void> {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.world = new PhysicsWorld({ gravity: { x: 0, y: 1500 } });
 
         // ── Tileset + a single ground tile layer ──────────────────────────
@@ -138,13 +140,15 @@ class TiledMapPhysicsActorScene extends Scene {
 
         // Physics debug overlay: outlines every collider so the bridge output
         // is visible on top of the rendered tiles.
-        this.debug = new PhysicsDebugDraw(this.app, this.world, { drawShapes: true, drawCenters: true });
+        this.debug = new PhysicsDebugDraw(app, this.world, { drawShapes: true, drawCenters: true });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.world.step(delta.seconds);
 
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
         const body = this.actorBody;
 
         // Loop the demo: nudge the actor again once it settles, and rescue it if
@@ -160,7 +164,7 @@ class TiledMapPhysicsActorScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.mapNode);
         context.render(this.actor);

--- a/examples/render-targets/bloom-lite.js
+++ b/examples/render-targets/bloom-lite.js
@@ -23,7 +23,10 @@ class BloomLiteScene extends Scene {
     pipeline;
     time = 0;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.baseRt = new RenderTexture(width, height);
         this.glowRt = new RenderTexture(width, height);
         this.blurredRt = new RenderTexture(width, height);
@@ -47,7 +50,10 @@ class BloomLiteScene extends Scene {
             .addPass(new RenderNodePass(this.glowSprite));
     }
     update(delta) {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.time += delta.seconds;
         this.bunny.setPosition(width / 2 + Math.cos(this.time * 1.7) * (width * 0.32), height / 2 + Math.sin(this.time * 1.2) * (height * 0.32));
     }

--- a/examples/render-targets/bloom-lite.ts
+++ b/examples/render-targets/bloom-lite.ts
@@ -1,4 +1,4 @@
-import { Application, BlendModes, BlurFilter, CallbackRenderPass, Color, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite } from '@codexo/exojs';
+import { Application, BlendModes, BlurFilter, CallbackRenderPass, Color, type RenderingContext, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -25,7 +25,9 @@ class BloomLiteScene extends Scene {
     private time = 0;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.baseRt = new RenderTexture(width, height);
         this.glowRt = new RenderTexture(width, height);
@@ -61,13 +63,15 @@ class BloomLiteScene extends Scene {
             .addPass(new RenderNodePass(this.glowSprite));
     }
 
-    override update(delta): void {
-        const { width, height } = this.app.canvas;
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.time += delta.seconds;
         this.bunny.setPosition(width / 2 + Math.cos(this.time * 1.7) * (width * 0.32), height / 2 + Math.sin(this.time * 1.2) * (height * 0.32));
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         this.pipeline.execute(context);
     }
 

--- a/examples/render-targets/mini-map.js
+++ b/examples/render-targets/mini-map.js
@@ -24,7 +24,10 @@ class MiniMapScene extends Scene {
     pipeline;
     time = 0;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const miniX = width - 220 - 20;
         const miniY = 20;
         // Grid + player live in one container so the same subtree can be drawn at
@@ -57,7 +60,10 @@ class MiniMapScene extends Scene {
             .addPass(new RenderNodePass(this.overlay));
     }
     update(delta) {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const marginX = 80;
         const marginY = 60;
         this.time += delta.seconds;

--- a/examples/render-targets/mini-map.ts
+++ b/examples/render-targets/mini-map.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Container, Graphics, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite, View } from '@codexo/exojs';
+import { Application, Color, Container, Graphics, type RenderingContext, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite, type Time, View } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -26,7 +26,9 @@ class MiniMapScene extends Scene {
     private time = 0;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const miniX = width - 220 - 20;
         const miniY = 20;
 
@@ -64,8 +66,10 @@ class MiniMapScene extends Scene {
             .addPass(new RenderNodePass(this.overlay));
     }
 
-    override update(delta): void {
-        const { width, height } = this.app.canvas;
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const marginX = 80;
         const marginY = 60;
 
@@ -88,7 +92,7 @@ class MiniMapScene extends Scene {
         this.player.drawCircle(px, py, 18);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         this.pipeline.execute(context);
     }
 

--- a/examples/render-targets/post-processing-chain.js
+++ b/examples/render-targets/post-processing-chain.js
@@ -23,7 +23,10 @@ class PostProcessingChainScene extends Scene {
     pipeline;
     time = 0;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.scene = new Graphics();
         this.a = new RenderTexture(width, height);
         this.b = new RenderTexture(width, height);
@@ -39,7 +42,10 @@ class PostProcessingChainScene extends Scene {
             .addPass(new RenderNodePass(this.final, { clear: Color.black }));
     }
     update(delta) {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.time += delta.seconds;
         this.scene.clear();
         this.scene.fillColor = new Color(80, 130, 255);

--- a/examples/render-targets/post-processing-chain.ts
+++ b/examples/render-targets/post-processing-chain.ts
@@ -1,4 +1,4 @@
-import { Application, BlurFilter, CallbackRenderPass, Color, ColorFilter, Graphics, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite } from '@codexo/exojs';
+import { Application, BlurFilter, CallbackRenderPass, Color, ColorFilter, Graphics, type RenderingContext, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -25,7 +25,9 @@ class PostProcessingChainScene extends Scene {
     private time = 0;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.scene = new Graphics();
         this.a = new RenderTexture(width, height);
@@ -43,8 +45,10 @@ class PostProcessingChainScene extends Scene {
             .addPass(new RenderNodePass(this.final, { clear: Color.black }));
     }
 
-    override update(delta): void {
-        const { width, height } = this.app.canvas;
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.time += delta.seconds;
         this.scene.clear();
         this.scene.fillColor = new Color(80, 130, 255);
@@ -53,7 +57,7 @@ class PostProcessingChainScene extends Scene {
         this.scene.drawCircle(width / 2 + Math.cos(this.time * 1.2 + 1) * (width * 0.3), height / 2 + Math.sin(this.time * 1.3 + 0.7) * (height * 0.34), 54);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         this.pipeline.execute(context);
     }
 

--- a/examples/render-targets/render-pipeline.js
+++ b/examples/render-targets/render-pipeline.js
@@ -29,8 +29,11 @@ class RenderPipelineScene extends Scene {
     detachResize = null;
     time = 0;
     init() {
-        const screenView = this.app.rendering.screenView;
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const screenView = app.rendering.screenView;
+        const { width, height } = app.canvas;
         this.sceneRt = new RenderTexture(width, height);
         this.blurredRt = new RenderTexture(width, height);
         this.composite = new Sprite(this.blurredRt);
@@ -61,11 +64,14 @@ class RenderPipelineScene extends Scene {
             this.blurredRt.setSize(width, height);
             this.frame.resize(width, height);
         };
-        this.app.onResize.add(handleResize);
-        this.detachResize = () => this.app.onResize.remove(handleResize);
+        app.onResize.add(handleResize);
+        this.detachResize = () => app.onResize.remove(handleResize);
     }
     update(delta) {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.time += delta.seconds;
         // `enabled` lives on the pass — flip it and the composer skips the step next frame.
         this.blurPass.enabled = Math.floor(this.time / 2.5) % 2 === 0;

--- a/examples/render-targets/render-pipeline.ts
+++ b/examples/render-targets/render-pipeline.ts
@@ -1,4 +1,4 @@
-import { Application, BlurFilter, CallbackRenderPass, Color, Container, Graphics, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite } from '@codexo/exojs';
+import { Application, BlurFilter, CallbackRenderPass, Color, Container, Graphics, type RenderingContext, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -31,8 +31,10 @@ class RenderPipelineScene extends Scene {
     private time = 0;
 
     override init(): void {
-        const screenView = this.app!.rendering.screenView;
-        const { width, height } = this.app!.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const screenView = app.rendering.screenView;
+        const { width, height } = app.canvas;
 
         this.sceneRt = new RenderTexture(width, height);
         this.blurredRt = new RenderTexture(width, height);
@@ -65,17 +67,19 @@ class RenderPipelineScene extends Scene {
 
         // Keep the caller-owned off-screen targets matched to the canvas, then cascade resize into the
         // pipeline (effect passes would rebuild their scratch here).
-        const handleResize = (width, height): void => {
+        const handleResize = (width: number, height: number): void => {
             this.sceneRt.setSize(width, height);
             this.blurredRt.setSize(width, height);
             this.frame.resize(width, height);
         };
-        this.app!.onResize.add(handleResize);
-        this.detachResize = () => this.app!.onResize.remove(handleResize);
+        app.onResize.add(handleResize);
+        this.detachResize = () => app.onResize.remove(handleResize);
     }
 
-    override update(delta): void {
-        const { width, height } = this.app!.canvas;
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.time += delta.seconds;
 
         // `enabled` lives on the pass — flip it and the composer skips the step next frame.
@@ -90,7 +94,7 @@ class RenderPipelineScene extends Scene {
         this.hudBar.drawRectangle(20, 20, 200, 16);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         this.frame.execute(context);
     }
 

--- a/examples/render-targets/render-to-texture.js
+++ b/examples/render-targets/render-to-texture.js
@@ -17,9 +17,12 @@ class RenderToTextureScene extends Scene {
     renderTexture;
     renderSprite;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.container = this.createBunnyContainer(this.loader.get('image/ship-a.png'));
-        this.renderTexture = this.createRenderTexture(this.container);
+        this.renderTexture = this.createRenderTexture(app.backend, this.container);
         this.renderSprite = new Sprite(this.renderTexture);
         this.renderSprite.setPosition(width, height);
         this.renderSprite.setAnchor(1, 1);
@@ -35,8 +38,7 @@ class RenderToTextureScene extends Scene {
         }
         return container;
     }
-    createRenderTexture(container) {
-        const backend = this.app.backend;
+    createRenderTexture(backend, container) {
         const renderTexture = new RenderTexture(Math.ceil(container.width), Math.ceil(container.height));
         backend.setRenderTarget(renderTexture);
         backend.clear();

--- a/examples/render-targets/render-to-texture.ts
+++ b/examples/render-targets/render-to-texture.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Container, RenderTexture, Scene, Sprite, Texture } from '@codexo/exojs';
+import { Application, Color, Container, type RenderingContext, RenderTexture, Scene, Sprite, Texture } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -19,11 +19,13 @@ class RenderToTextureScene extends Scene {
     private renderSprite!: Sprite;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.container = this.createBunnyContainer(this.loader.get('image/ship-a.png'));
 
-        this.renderTexture = this.createRenderTexture(this.container);
+        this.renderTexture = this.createRenderTexture(app.backend, this.container);
 
         this.renderSprite = new Sprite(this.renderTexture);
         this.renderSprite.setPosition(width, height);
@@ -46,8 +48,7 @@ class RenderToTextureScene extends Scene {
         return container;
     }
 
-    private createRenderTexture(container: Container): RenderTexture {
-        const backend = this.app.backend;
+    private createRenderTexture(backend: Application['backend'], container: Container): RenderTexture {
         const renderTexture = new RenderTexture(Math.ceil(container.width), Math.ceil(container.height));
 
         backend.setRenderTarget(renderTexture);
@@ -60,7 +61,7 @@ class RenderToTextureScene extends Scene {
         return renderTexture;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.container);
         context.render(this.renderSprite);

--- a/examples/render-targets/trail-feedback.js
+++ b/examples/render-targets/trail-feedback.js
@@ -25,7 +25,10 @@ class TrailFeedbackScene extends Scene {
     forward = true;
     time = 0;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.rtA = new RenderTexture(width, height);
         this.rtB = new RenderTexture(width, height);
         this.bunny = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5);
@@ -52,7 +55,10 @@ class TrailFeedbackScene extends Scene {
             .addPass(new RenderNodePass(showA, { clear: Color.black }));
     }
     update(delta) {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.time += delta.seconds;
         this.bunny.setPosition(width / 2 + Math.cos(this.time * 2.0) * (width * 0.36), height / 2 + Math.sin(this.time * 2.7) * (height * 0.34));
     }

--- a/examples/render-targets/trail-feedback.ts
+++ b/examples/render-targets/trail-feedback.ts
@@ -1,4 +1,4 @@
-import { Application, CallbackRenderPass, Color, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite } from '@codexo/exojs';
+import { Application, CallbackRenderPass, Color, type RenderingContext, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -27,7 +27,9 @@ class TrailFeedbackScene extends Scene {
     private time = 0;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.rtA = new RenderTexture(width, height);
         this.rtB = new RenderTexture(width, height);
@@ -68,13 +70,15 @@ class TrailFeedbackScene extends Scene {
             .addPass(new RenderNodePass(showA, { clear: Color.black }));
     }
 
-    override update(delta): void {
-        const { width, height } = this.app.canvas;
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.time += delta.seconds;
         this.bunny.setPosition(width / 2 + Math.cos(this.time * 2.0) * (width * 0.36), height / 2 + Math.sin(this.time * 2.7) * (height * 0.34));
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         (this.forward ? this.pipeAtoB : this.pipeBtoA).execute(context);
         this.forward = !this.forward;
     }

--- a/examples/render-targets/water-mirror.js
+++ b/examples/render-targets/water-mirror.js
@@ -32,7 +32,10 @@ class WaterMirrorScene extends Scene {
     pipeline;
     time = 0;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const half = height / 2;
         this.rt = new RenderTexture(width, half);
         this.source = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5).setPosition(width / 2, half / 2).setScale(2.6);
@@ -54,7 +57,10 @@ class WaterMirrorScene extends Scene {
             .addPass(new RenderNodePass(this.mirror));
     }
     update(delta) {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const quarter = height / 4;
         this.time += delta.seconds;
         this.source.setPosition(width / 2 + Math.cos(this.time * 1.7) * (width * 0.3), quarter + Math.sin(this.time * 1.3) * (quarter * 0.55));

--- a/examples/render-targets/water-mirror.ts
+++ b/examples/render-targets/water-mirror.ts
@@ -1,4 +1,4 @@
-import { Application, CallbackRenderPass, Color, RenderBackendType, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
+import { Application, CallbackRenderPass, Color, RenderBackendType, type RenderingContext, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite, type Time, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -35,7 +35,9 @@ class WaterMirrorScene extends Scene {
     private time = 0;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const half = height / 2;
 
         this.rt = new RenderTexture(width, half);
@@ -64,15 +66,17 @@ class WaterMirrorScene extends Scene {
             .addPass(new RenderNodePass(this.mirror));
     }
 
-    override update(delta): void {
-        const { width, height } = this.app.canvas;
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const quarter = height / 4;
         this.time += delta.seconds;
         this.source.setPosition(width / 2 + Math.cos(this.time * 1.7) * (width * 0.3), quarter + Math.sin(this.time * 1.3) * (quarter * 0.55));
         this.filter.uniforms.uTime = this.time;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         this.pipeline.execute(context);
     }
 

--- a/examples/scene-graph/containers.js
+++ b/examples/scene-graph/containers.js
@@ -16,7 +16,10 @@ class ContainersScene extends Scene {
     rainbow;
     bunnies;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const { bunny, rainbow } = this.loader.get(Assets.from({ bunny: Asset.kind('texture', 'image/ship-a.png'), rainbow: Asset.kind('texture', 'image/hue-ramp.png') }));
         this.rainbow = new Sprite(rainbow);
         this.bunnies = new Container();

--- a/examples/scene-graph/containers.ts
+++ b/examples/scene-graph/containers.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Assets, Color, Container, Scene, Sprite } from '@codexo/exojs';
+import { Application, Asset, Assets, Color, Container, type RenderingContext, Scene, Sprite, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -18,7 +18,9 @@ class ContainersScene extends Scene {
     private bunnies!: Container;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const { bunny, rainbow } = this.loader.get(Assets.from({ bunny: Asset.kind('texture', 'image/ship-a.png'), rainbow: Asset.kind('texture', 'image/hue-ramp.png') }));
 
         this.rainbow = new Sprite(rainbow);
@@ -37,7 +39,7 @@ class ContainersScene extends Scene {
         this.bunnies.setAnchor(0.5);
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         const bounds = this.bunnies.getBounds();
 
         this.rainbow.x = bounds.x;
@@ -48,7 +50,7 @@ class ContainersScene extends Scene {
         this.bunnies.rotate(delta.seconds * 36);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.rainbow);
         context.render(this.bunnies);

--- a/examples/scene-graph/local-vs-global-transform.js
+++ b/examples/scene-graph/local-vs-global-transform.js
@@ -19,7 +19,10 @@ class LocalVsGlobalTransformScene extends Scene {
     localLabel;
     globalLabel;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const texture = this.loader.get('image/ship-a.png');
         this.parent = new Container().setPosition(width / 4, height / 2);
         this.localSprite = new Sprite(texture)

--- a/examples/scene-graph/local-vs-global-transform.ts
+++ b/examples/scene-graph/local-vs-global-transform.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Container, Scene, Sprite, Text } from '@codexo/exojs';
+import { Application, Color, Container, type RenderingContext, Scene, Sprite, Text, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -21,7 +21,9 @@ class LocalVsGlobalTransformScene extends Scene {
     private globalLabel!: Text;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const texture = this.loader.get('image/ship-a.png');
 
         this.parent = new Container().setPosition(width / 4, height / 2);
@@ -43,11 +45,11 @@ class LocalVsGlobalTransformScene extends Scene {
         this.globalLabel.setPosition((width * 3) / 4 - 50, height / 2 - 220);
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.parent.rotate(delta.seconds * 60);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.parent);
         context.render(this.globalSprite);

--- a/examples/scene-graph/masks.js
+++ b/examples/scene-graph/masks.js
@@ -16,7 +16,10 @@ class MasksScene extends Scene {
     gfxSprite;
     time = 0;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const tex = this.loader.get(ALPHA_RINGS);
         this.rectSprite = new Sprite(tex);
         this.rectSprite.setScale(1);
@@ -34,7 +37,10 @@ class MasksScene extends Scene {
         this.gfxSprite.mask = circle;
     }
     update(delta) {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.time += delta.seconds;
         const r = 80;
         this.rectMask.x = (width / 4 + Math.cos(this.time * 1.4) * r - 55) | 0;

--- a/examples/scene-graph/masks.ts
+++ b/examples/scene-graph/masks.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Graphics, Rectangle, Scene, Sprite } from '@codexo/exojs';
+import { Application, Color, Graphics, Rectangle, type RenderingContext, Scene, Sprite, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -19,7 +19,9 @@ class MasksScene extends Scene {
     private time = 0;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const tex = this.loader.get(ALPHA_RINGS);
 
         this.rectSprite = new Sprite(tex);
@@ -40,8 +42,10 @@ class MasksScene extends Scene {
         this.gfxSprite.mask = circle;
     }
 
-    override update(delta): void {
-        const { width, height } = this.app.canvas;
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.time += delta.seconds;
 
         const r = 80;
@@ -49,7 +53,7 @@ class MasksScene extends Scene {
         this.rectMask.y = (height / 2 + Math.sin(this.time * 1.4) * r - 55) | 0;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.rectSprite);
         context.render(this.gfxSprite);

--- a/examples/scene-graph/nested-transforms.js
+++ b/examples/scene-graph/nested-transforms.js
@@ -19,7 +19,10 @@ class NestedTransformsScene extends Scene {
     moonOrbit;
     moon;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.sun = new Graphics();
         this.sun.fillColor = new Color(255, 220, 90);
         this.sun.drawCircle(0, 0, 30);

--- a/examples/scene-graph/nested-transforms.ts
+++ b/examples/scene-graph/nested-transforms.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Container, Graphics, Scene } from '@codexo/exojs';
+import { Application, Color, Container, Graphics, type RenderingContext, Scene, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -21,7 +21,9 @@ class NestedTransformsScene extends Scene {
     private moon!: Graphics;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.sun = new Graphics();
         this.sun.fillColor = new Color(255, 220, 90);
@@ -45,13 +47,13 @@ class NestedTransformsScene extends Scene {
         this.moonOrbit.addChild(this.moon);
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.planetOrbit.rotate(delta.seconds * 30);
         this.planet.rotate(delta.seconds * 120);
         this.moonOrbit.rotate(delta.seconds * 180);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.planetOrbit);
     }

--- a/examples/scene-graph/parallax-starfield.js
+++ b/examples/scene-graph/parallax-starfield.js
@@ -19,7 +19,10 @@ class ParallaxStarfieldScene extends Scene {
     layers;
     pointer = { x: 0, y: 0 };
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const margin = 80;
         this.pointer = { x: width / 2, y: height / 2 };
         this.layers = counts.map((count, index) => {
@@ -33,12 +36,15 @@ class ParallaxStarfieldScene extends Scene {
             }
             return g;
         });
-        this.app.input.onPointerMove.add(pointer => {
+        app.input.onPointerMove.add(pointer => {
             this.pointer = { x: pointer.x, y: pointer.y };
         });
     }
     draw(context) {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         context.backend.clear();
         for (let i = 0; i < this.layers.length; i++) {
             const layer = this.layers[i];

--- a/examples/scene-graph/parallax-starfield.ts
+++ b/examples/scene-graph/parallax-starfield.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Graphics, Scene } from '@codexo/exojs';
+import { Application, Color, Graphics, type RenderingContext, Scene } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -22,7 +22,9 @@ class ParallaxStarfieldScene extends Scene {
     private pointer = { x: 0, y: 0 };
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const margin = 80;
 
         this.pointer = { x: width / 2, y: height / 2 };
@@ -39,13 +41,15 @@ class ParallaxStarfieldScene extends Scene {
             return g;
         });
 
-        this.app.input.onPointerMove.add(pointer => {
+        app.input.onPointerMove.add(pointer => {
             this.pointer = { x: pointer.x, y: pointer.y };
         });
     }
 
-    override draw(context): void {
-        const { width, height } = this.app.canvas;
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         context.backend.clear();
         for (let i = 0; i < this.layers.length; i++) {
             const layer = this.layers[i];

--- a/examples/scene-graph/pivot-and-anchor.js
+++ b/examples/scene-graph/pivot-and-anchor.js
@@ -24,7 +24,10 @@ class PivotAndAnchorScene extends Scene {
     mode = 0;
     timer = 0;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.sprite = new Sprite(this.loader.get('image/ship-a.png')).setPosition(width / 2, height / 2);
         this.pivotMarker = new Graphics();
         this.label = new Text('', { fillColor: Color.white, fontSize: 18 });

--- a/examples/scene-graph/pivot-and-anchor.ts
+++ b/examples/scene-graph/pivot-and-anchor.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Graphics, Scene, Sprite, Text } from '@codexo/exojs';
+import { Application, Color, Graphics, type RenderingContext, Scene, Sprite, Text, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -27,7 +27,9 @@ class PivotAndAnchorScene extends Scene {
     private timer = 0;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.sprite = new Sprite(this.loader.get('image/ship-a.png')).setPosition(width / 2, height / 2);
         this.pivotMarker = new Graphics();
@@ -43,7 +45,7 @@ class PivotAndAnchorScene extends Scene {
         this.label.text = `mode: ${mode.name}`;
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.timer += delta.seconds;
         this.sprite.rotate(delta.seconds * 90);
         if (this.timer > 1.8) {
@@ -53,7 +55,7 @@ class PivotAndAnchorScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         const m = this.sprite.getGlobalTransform();
         context.backend.clear();
         context.render(this.sprite);

--- a/examples/scene-graph/retained-container.js
+++ b/examples/scene-graph/retained-container.js
@@ -59,7 +59,10 @@ class RetainedContainerScene extends Scene {
         this.elapsed += delta.seconds;
     }
     draw(context) {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         context.backend.clear();
         // Pan the whole field along a slow Lissajous path, like a camera drifting
         // over a static world. For a RetainedContainer this is ONE group-matrix

--- a/examples/scene-graph/retained-container.ts
+++ b/examples/scene-graph/retained-container.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Container, Rectangle, RetainedContainer, Scene, Sprite, Texture } from '@codexo/exojs';
+import { Application, Color, Container, Rectangle, type RenderingContext, RetainedContainer, Scene, Sprite, Texture, type Time } from '@codexo/exojs';
 import { mountControlPanel, mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -62,12 +62,14 @@ class RetainedContainerScene extends Scene {
         });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.elapsed += delta.seconds;
     }
 
-    override draw(context): void {
-        const { width, height } = this.app.canvas;
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         context.backend.clear();
 

--- a/examples/scene-graph/z-ordering.js
+++ b/examples/scene-graph/z-ordering.js
@@ -17,7 +17,10 @@ class ZOrderingScene extends Scene {
     label;
     sprites;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const texture = this.loader.get('image/ship-a.png');
         this.group = new Container();
         this.label = new Text('Press 1, 2, 3 — front: 3 (blue)', { fillColor: Color.white, fontSize: 18 });

--- a/examples/scene-graph/z-ordering.ts
+++ b/examples/scene-graph/z-ordering.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Container, Keyboard, Scene, Sprite, Text } from '@codexo/exojs';
+import { Application, Color, Container, Keyboard, type RenderingContext, Scene, Sprite, Text } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -19,7 +19,9 @@ class ZOrderingScene extends Scene {
     private sprites!: Sprite[];
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const texture = this.loader.get('image/ship-a.png');
 
         this.group = new Container();
@@ -52,7 +54,7 @@ class ZOrderingScene extends Scene {
         this.label.text = `Press 1, 2, 3 — front: ${names[index]}`;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.group);
         context.render(this.label);

--- a/examples/showcase/audio-reactive-particles.js
+++ b/examples/showcase/audio-reactive-particles.js
@@ -26,13 +26,16 @@ class AudioReactiveParticlesScene extends Scene {
     hud;
     tapPrompt;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.music = this.loader.get(Asset.kind('music', assets.demo.audio.musicLoop));
         // Two parallel taps of the same track: the analyser gives per-band
         // energy (drives emission), the detector gives beats (recolours).
-        this.analyser = new AudioAnalyser({ fftSize: 1024, source: this.app.audio.music });
+        this.analyser = new AudioAnalyser({ fftSize: 1024, source: app.audio.music });
         this.detector = new BeatDetector();
-        this.detector.source = this.app.audio.music;
+        this.detector.source = app.audio.music;
         this.ps = new ParticleSystem(this.loader.get(assets.demo.textures.particleLight), { capacity: 6000 });
         this.ps.setPosition(width / 2, height / 2);
         // The rate (density) and the cone speed range (spread) are mutated every
@@ -68,7 +71,7 @@ class AudioReactiveParticlesScene extends Scene {
             .setPosition(width / 2, height - 64);
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically — play() returns the Voice now.
-        this.musicVoice = this.app.audio.play(this.music, { loop: true, volume: 0.8 });
+        this.musicVoice = app.audio.play(this.music, { loop: true, volume: 0.8 });
     }
     update(delta) {
         // Low band (bass) drives how MANY particles spawn this second.
@@ -86,9 +89,12 @@ class AudioReactiveParticlesScene extends Scene {
         this.ps.update(delta);
     }
     draw(context) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         context.render(this.ps);
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/showcase/audio-reactive-particles.ts
+++ b/examples/showcase/audio-reactive-particles.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, AudioStream, Color, Scene, Text, Vector, type Voice } from '@codexo/exojs';
+import { Application, Asset, AudioStream, Color, type RenderingContext, Scene, Text, type Time, Vector, type Voice } from '@codexo/exojs';
 import { AudioAnalyser, BeatDetector } from '@codexo/exojs-audio-fx';
 import {
     AlphaFadeOverLifetime,
@@ -36,15 +36,17 @@ class AudioReactiveParticlesScene extends Scene {
     private tapPrompt!: Text;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.music = this.loader.get(Asset.kind('music', assets.demo.audio.musicLoop));
 
         // Two parallel taps of the same track: the analyser gives per-band
         // energy (drives emission), the detector gives beats (recolours).
-        this.analyser = new AudioAnalyser({ fftSize: 1024, source: this.app.audio.music });
+        this.analyser = new AudioAnalyser({ fftSize: 1024, source: app.audio.music });
         this.detector = new BeatDetector();
-        this.detector.source = this.app.audio.music;
+        this.detector.source = app.audio.music;
 
         this.ps = new ParticleSystem(this.loader.get(assets.demo.textures.particleLight), { capacity: 6000 });
         this.ps.setPosition(width / 2, height / 2);
@@ -86,10 +88,10 @@ class AudioReactiveParticlesScene extends Scene {
 
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically — play() returns the Voice now.
-        this.musicVoice = this.app.audio.play(this.music, { loop: true, volume: 0.8 });
+        this.musicVoice = app.audio.play(this.music, { loop: true, volume: 0.8 });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         // Low band (bass) drives how MANY particles spawn this second.
         const low = this.analyser.getBandEnergy(20, 180);
         // High band (treble) drives how WIDE the velocity cone fans out.
@@ -109,11 +111,13 @@ class AudioReactiveParticlesScene extends Scene {
         this.ps.update(delta);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         context.render(this.ps);
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/showcase/audio-visualisation.js
+++ b/examples/showcase/audio-visualisation.js
@@ -25,14 +25,17 @@ class AudioVisualisationScene extends Scene {
     hud;
     tapPrompt;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.music = this.loader.get(Asset.kind('music', assets.demo.audio.musicLoop));
         // One analyser tap for spectrum/waveform, one beat detector for the
         // beat-pulse ring. Both read the music bus the stream plays through,
         // without altering playback.
-        this.analyser = new AudioAnalyser({ source: this.app.audio.music });
+        this.analyser = new AudioAnalyser({ source: app.audio.music });
         this.detector = new BeatDetector();
-        this.detector.source = this.app.audio.music;
+        this.detector.source = app.audio.music;
         this.canvas = document.createElement('canvas');
         this.canvas.style.position = 'absolute';
         this.canvas.style.top = '12.5%';
@@ -61,10 +64,10 @@ class AudioVisualisationScene extends Scene {
         this.tapPrompt = new Text('Click or press any key to start the music', { fillColor: Color.white, fontSize: 22, align: 'center' })
             .setAnchor(0.5, 0.5)
             .setPosition(width / 2, height - 64);
-        this.app.input.onPointerDown.add(() => {
+        app.input.onPointerDown.add(() => {
             // The first gesture only unlocks audio (core auto-starts the queued
             // track); subsequent clicks toggle play / pause.
-            if (this.app.audio.locked) {
+            if (app.audio.locked) {
                 return;
             }
             if (this.musicVoice.paused) {
@@ -77,9 +80,12 @@ class AudioVisualisationScene extends Scene {
         });
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically — play() returns the Voice now.
-        this.musicVoice = this.app.audio.play(this.music, { loop: true, volume: 0.8 });
+        this.musicVoice = app.audio.play(this.music, { loop: true, volume: 0.8 });
     }
     draw(context) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const canvas = this.canvas;
         const freqData = this.analyser.getSpectrum();
         const timeDomain = this.analyser.getWaveform();
@@ -122,7 +128,7 @@ class AudioVisualisationScene extends Scene {
         this.screen.updateTexture();
         context.backend.clear();
         context.render(this.screen);
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/showcase/audio-visualisation.ts
+++ b/examples/showcase/audio-visualisation.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, AudioStream, Color, type Pausable, Scene, type Seekable, Sprite, Text, Texture, type Voice } from '@codexo/exojs';
+import { Application, Asset, AudioStream, Color, type Pausable, type RenderingContext, Scene, type Seekable, Sprite, Text, Texture, type Voice } from '@codexo/exojs';
 import { AudioAnalyser, BeatDetector } from '@codexo/exojs-audio-fx';
 import { mountControls } from '@examples/runtime';
 
@@ -27,16 +27,18 @@ class AudioVisualisationScene extends Scene {
     private tapPrompt!: Text;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.music = this.loader.get(Asset.kind('music', assets.demo.audio.musicLoop));
 
         // One analyser tap for spectrum/waveform, one beat detector for the
         // beat-pulse ring. Both read the music bus the stream plays through,
         // without altering playback.
-        this.analyser = new AudioAnalyser({ source: this.app.audio.music });
+        this.analyser = new AudioAnalyser({ source: app.audio.music });
         this.detector = new BeatDetector();
-        this.detector.source = this.app.audio.music;
+        this.detector.source = app.audio.music;
 
         this.canvas = document.createElement('canvas');
         this.canvas.style.position = 'absolute';
@@ -72,10 +74,10 @@ class AudioVisualisationScene extends Scene {
             .setAnchor(0.5, 0.5)
             .setPosition(width / 2, height - 64);
 
-        this.app.input.onPointerDown.add(() => {
+        app.input.onPointerDown.add(() => {
             // The first gesture only unlocks audio (core auto-starts the queued
             // track); subsequent clicks toggle play / pause.
-            if (this.app.audio.locked) {
+            if (app.audio.locked) {
                 return;
             }
 
@@ -89,10 +91,12 @@ class AudioVisualisationScene extends Scene {
 
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically — play() returns the Voice now.
-        this.musicVoice = this.app.audio.play(this.music, { loop: true, volume: 0.8 }) as Voice & Pausable & Seekable;
+        this.musicVoice = app.audio.play(this.music, { loop: true, volume: 0.8 }) as Voice & Pausable & Seekable;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const canvas = this.canvas;
         const freqData = this.analyser.getSpectrum();
         const timeDomain = this.analyser.getWaveform();
@@ -147,7 +151,7 @@ class AudioVisualisationScene extends Scene {
         context.backend.clear();
         context.render(this.screen);
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/showcase/boss-intro-cinematic.js
+++ b/examples/showcase/boss-intro-cinematic.js
@@ -26,7 +26,10 @@ class BossIntroCinematicScene extends Scene {
     width = 0;
     height = 0;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.width = width;
         this.height = height;
         // Start the camera left of the boss so the push-in sweeps across to it.
@@ -58,13 +61,16 @@ class BossIntroCinematicScene extends Scene {
             .setPosition(width / 2, height - 64);
         // Core defers playback until the AudioContext unlocks on the first
         // gesture; start the cinematic in lockstep with the sting on unlock.
-        this.musicVoice = this.app.audio.play(this.music, { loop: true, volume: 0.2 });
-        this.app.audio.onUnlock.add(() => this.playSequence());
+        this.musicVoice = app.audio.play(this.music, { loop: true, volume: 0.2 });
+        app.audio.onUnlock.add(() => this.playSequence());
         this.inputs.onTrigger(Keyboard.R, () => this.replay());
-        this.app.input.onPointerDown.add(() => this.replay());
+        app.input.onPointerDown.add(() => this.replay());
     }
     replay() {
-        if (this.app.audio.locked) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        if (app.audio.locked) {
             return;
         }
         // Restart the sting from the top so the reveal beat lines up again.
@@ -77,9 +83,12 @@ class BossIntroCinematicScene extends Scene {
         this.hud.setStatus('Replaying…');
     }
     playSequence() {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = this;
         // Wipe any in-flight tweens and reset the visible state to frame zero.
-        this.app.tweens.clear();
+        app.tweens.clear();
         this.view.reset(width * 0.42, height / 2, width, height);
         this.view.stopShake();
         this.barSize.v = 0;
@@ -87,13 +96,13 @@ class BossIntroCinematicScene extends Scene {
         this.title.text = '';
         this.boss.setScale(0.4);
         // Letterbox bars slam in.
-        this.app.tweens.create(this.barSize).to({ v: 84 }, 0.6).start();
+        app.tweens.create(this.barSize).to({ v: 84 }, 0.6).start();
         // Slow camera push-in toward the boss.
-        this.app.tweens.create(this.view.center).to({ x: width * 0.55, y: height / 2 }, 2.0).start();
+        app.tweens.create(this.view.center).to({ x: width * 0.55, y: height / 2 }, 2.0).start();
         // The boss looms larger as the camera arrives.
-        this.app.tweens.create(this.boss.scale).to({ x: 2.1, y: 2.1 }, 1.8).delay(1.1).start();
+        app.tweens.create(this.boss.scale).to({ x: 2.1, y: 2.1 }, 1.8).delay(1.1).start();
         // Typewriter title reveal — its onStart IS the reveal beat: punch a shake.
-        this.app.tweens
+        app.tweens
             .create(this.titleState)
             .to({ count: titleText.length }, 1.0)
             .delay(1.6)
@@ -105,13 +114,16 @@ class BossIntroCinematicScene extends Scene {
         })
             .start();
         // Music swells up under the reveal.
-        this.app.tweens.create(this.musicVoice).to({ volume: 0.85 }, 2.0).start();
+        app.tweens.create(this.musicVoice).to({ volume: 0.85 }, 2.0).start();
     }
     update(delta) {
         // Advance the camera shake (and follow/bounds) animation each frame.
         this.view.update(delta.milliseconds);
     }
     draw(context) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = this;
         context.backend.clear(new Color(16, 16, 24));
         this.bg.clear();
@@ -128,7 +140,7 @@ class BossIntroCinematicScene extends Scene {
         this.bars.drawRectangle(0, 0, width, this.barSize.v);
         this.bars.drawRectangle(0, height - this.barSize.v, width, this.barSize.v);
         context.render(this.bars);
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/showcase/boss-intro-cinematic.ts
+++ b/examples/showcase/boss-intro-cinematic.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, AudioStream, Color, Graphics, Keyboard, type Pausable, Scene, type Seekable, Sprite, Text, View, type Voice } from '@codexo/exojs';
+import { Application, Asset, AudioStream, Color, Graphics, Keyboard, type Pausable, type RenderingContext, Scene, type Seekable, Sprite, Text, type Time, View, type Voice } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -29,7 +29,9 @@ class BossIntroCinematicScene extends Scene {
     private height = 0;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.width = width;
         this.height = height;
 
@@ -65,15 +67,17 @@ class BossIntroCinematicScene extends Scene {
 
         // Core defers playback until the AudioContext unlocks on the first
         // gesture; start the cinematic in lockstep with the sting on unlock.
-        this.musicVoice = this.app.audio.play(this.music, { loop: true, volume: 0.2 }) as Voice & Seekable & Pausable;
-        this.app.audio.onUnlock.add(() => this.playSequence());
+        this.musicVoice = app.audio.play(this.music, { loop: true, volume: 0.2 }) as Voice & Seekable & Pausable;
+        app.audio.onUnlock.add(() => this.playSequence());
 
         this.inputs.onTrigger(Keyboard.R, () => this.replay());
-        this.app.input.onPointerDown.add(() => this.replay());
+        app.input.onPointerDown.add(() => this.replay());
     }
 
     private replay(): void {
-        if (this.app.audio.locked) {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        if (app.audio.locked) {
             return;
         }
 
@@ -88,10 +92,12 @@ class BossIntroCinematicScene extends Scene {
     }
 
     private playSequence(): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = this;
 
         // Wipe any in-flight tweens and reset the visible state to frame zero.
-        this.app.tweens.clear();
+        app.tweens.clear();
         this.view.reset(width * 0.42, height / 2, width, height);
         this.view.stopShake();
         this.barSize.v = 0;
@@ -100,13 +106,13 @@ class BossIntroCinematicScene extends Scene {
         this.boss.setScale(0.4);
 
         // Letterbox bars slam in.
-        this.app.tweens.create(this.barSize).to({ v: 84 }, 0.6).start();
+        app.tweens.create(this.barSize).to({ v: 84 }, 0.6).start();
         // Slow camera push-in toward the boss.
-        this.app.tweens.create(this.view.center).to({ x: width * 0.55, y: height / 2 }, 2.0).start();
+        app.tweens.create(this.view.center).to({ x: width * 0.55, y: height / 2 }, 2.0).start();
         // The boss looms larger as the camera arrives.
-        this.app.tweens.create(this.boss.scale).to({ x: 2.1, y: 2.1 }, 1.8).delay(1.1).start();
+        app.tweens.create(this.boss.scale).to({ x: 2.1, y: 2.1 }, 1.8).delay(1.1).start();
         // Typewriter title reveal — its onStart IS the reveal beat: punch a shake.
-        this.app.tweens
+        app.tweens
             .create(this.titleState)
             .to({ count: titleText.length }, 1.0)
             .delay(1.6)
@@ -118,15 +124,17 @@ class BossIntroCinematicScene extends Scene {
             })
             .start();
         // Music swells up under the reveal.
-        this.app.tweens.create(this.musicVoice).to({ volume: 0.85 }, 2.0).start();
+        app.tweens.create(this.musicVoice).to({ volume: 0.85 }, 2.0).start();
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         // Advance the camera shake (and follow/bounds) animation each frame.
         this.view.update(delta.milliseconds);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = this;
 
         context.backend.clear(new Color(16, 16, 24));
@@ -145,7 +153,7 @@ class BossIntroCinematicScene extends Scene {
         this.bars.drawRectangle(0, height - this.barSize.v, width, this.barSize.v);
         context.render(this.bars);
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/showcase/color-grading.js
+++ b/examples/showcase/color-grading.js
@@ -77,7 +77,10 @@ class ColorGradingScene extends Scene {
     hud;
     cycle;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.luts = LOOKS.map(look => LutFilter.fromImage(buildLut3D(look.transform)));
         this.filter = new LutFilter({ mode: '3d', size: LUT_SIZE }).setLut(this.luts[0]);
         this.sprite = new Sprite(this.loader.get(PRIMARY_RAMP)).setAnchor(0.5).setScale(3.5);

--- a/examples/showcase/color-grading.ts
+++ b/examples/showcase/color-grading.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Keyboard, LutFilter, Scene, Sprite, Texture } from '@codexo/exojs';
+import { Application, Color, Keyboard, LutFilter, type RenderingContext, Scene, Sprite, Texture } from '@codexo/exojs';
 import { mountControlPanel, mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -85,7 +85,9 @@ class ColorGradingScene extends Scene {
     private cycle!: { set(value: number): void };
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.luts = LOOKS.map(look => LutFilter.fromImage(buildLut3D(look.transform)));
         this.filter = new LutFilter({ mode: '3d', size: LUT_SIZE }).setLut(this.luts[0]);
@@ -126,7 +128,7 @@ class ColorGradingScene extends Scene {
         this.hud.setStatus(`${LOOKS[this.index].name}  (${this.index + 1}/${LOOKS.length})`);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
     }

--- a/examples/showcase/damage-flash.js
+++ b/examples/showcase/damage-flash.js
@@ -21,7 +21,10 @@ class DamageFlashScene extends Scene {
     hud;
     hits = 0;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.hit = new Signal();
         this.ship = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5).setScale(2.2).setPosition(width / 2, height / 2);
         this.filterColor = new Color(255, 255, 255, 1);
@@ -36,9 +39,9 @@ class DamageFlashScene extends Scene {
             this.hits++;
             this.hud.setStatus(`Hits: ${this.hits}`);
             this.filterColor.set(255, 120, 120, 1);
-            this.app.tweens.create(this.filterColor).to({ r: 255, g: 255, b: 255 }, 0.2).start();
+            app.tweens.create(this.filterColor).to({ r: 255, g: 255, b: 255 }, 0.2).start();
         });
-        this.app.input.onPointerTap.add(() => {
+        app.input.onPointerTap.add(() => {
             this.hit.dispatch();
         });
     }

--- a/examples/showcase/damage-flash.ts
+++ b/examples/showcase/damage-flash.ts
@@ -1,4 +1,4 @@
-import { Application, Color, ColorFilter, Scene, Signal, Sprite } from '@codexo/exojs';
+import { Application, Color, ColorFilter, type RenderingContext, Scene, Signal, Sprite } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -23,7 +23,9 @@ class DamageFlashScene extends Scene {
     private hits = 0;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.hit = new Signal();
         this.ship = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5).setScale(2.2).setPosition(width / 2, height / 2);
@@ -41,14 +43,14 @@ class DamageFlashScene extends Scene {
             this.hits++;
             this.hud.setStatus(`Hits: ${this.hits}`);
             this.filterColor.set(255, 120, 120, 1);
-            this.app.tweens.create(this.filterColor).to({ r: 255, g: 255, b: 255 }, 0.2).start();
+            app.tweens.create(this.filterColor).to({ r: 255, g: 255, b: 255 }, 0.2).start();
         });
-        this.app.input.onPointerTap.add(() => {
+        app.input.onPointerTap.add(() => {
             this.hit.dispatch();
         });
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.ship);
     }

--- a/examples/showcase/dialog-system.js
+++ b/examples/showcase/dialog-system.js
@@ -30,7 +30,10 @@ class DialogSystemScene extends Scene {
     done = false;
     awaitingChoice = false;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // Portrait sits on the left; the dialog column runs to its right and
         // fills the wider 16:9 frame as a classic VN bottom-third box.
         this.portrait = new Sprite(this.loader.get(assets.demo.textures.shipA)).setAnchor(0.5).setScale(2.4).setPosition(width * 0.16, height * 0.62);
@@ -56,7 +59,7 @@ class DialogSystemScene extends Scene {
             this.panel.addButton({ label: choice, onClick: () => this.choose(choice) });
         }
         this.setChoicesVisible(false);
-        this.app.input.onPointerTap.add(() => this.advance());
+        app.input.onPointerTap.add(() => this.advance());
     }
     advance() {
         if (this.awaitingChoice) {
@@ -84,7 +87,10 @@ class DialogSystemScene extends Scene {
         this.namePlate.text = lines[this.lineIndex].speaker;
     }
     choose(choice) {
-        this.app.audio.play(this.beep, { playbackRate: 1.2, volume: 0.3 });
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        app.audio.play(this.beep, { playbackRate: 1.2, volume: 0.3 });
         this.choicePrompt.text = `You chose: ${choice}`;
         this.hud.setStatus(`Reply: ${choice}`);
         this.awaitingChoice = false;
@@ -98,12 +104,15 @@ class DialogSystemScene extends Scene {
         this.choicePrompt.visible = !visible && this.choicePrompt.text.length > 0;
     }
     update(delta) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         if (!this.done && !this.awaitingChoice) {
             this.timer += delta.seconds;
             while (this.timer > 0.035 && this.chars < lines[this.lineIndex].text.length) {
                 this.timer -= 0.035;
                 this.chars++;
-                this.app.audio.play(this.beep, { playbackRate: 1.9, volume: 0.14 });
+                app.audio.play(this.beep, { playbackRate: 1.9, volume: 0.14 });
             }
             this.done = this.chars >= lines[this.lineIndex].text.length;
         }

--- a/examples/showcase/dialog-system.ts
+++ b/examples/showcase/dialog-system.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene, Sound, Sprite, Text } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, Sound, Sprite, Text, type Time } from '@codexo/exojs';
 import { mountControlPanel, mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -39,7 +39,9 @@ class DialogSystemScene extends Scene {
     private awaitingChoice = false;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // Portrait sits on the left; the dialog column runs to its right and
         // fills the wider 16:9 frame as a classic VN bottom-third box.
@@ -74,7 +76,7 @@ class DialogSystemScene extends Scene {
         }
         this.setChoicesVisible(false);
 
-        this.app.input.onPointerTap.add(() => this.advance());
+        app.input.onPointerTap.add(() => this.advance());
     }
 
     private advance(): void {
@@ -108,7 +110,9 @@ class DialogSystemScene extends Scene {
     }
 
     private choose(choice: string): void {
-        this.app.audio.play(this.beep, { playbackRate: 1.2, volume: 0.3 });
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        app.audio.play(this.beep, { playbackRate: 1.2, volume: 0.3 });
         this.choicePrompt.text = `You chose: ${choice}`;
         this.hud.setStatus(`Reply: ${choice}`);
         this.awaitingChoice = false;
@@ -123,20 +127,22 @@ class DialogSystemScene extends Scene {
         this.choicePrompt.visible = !visible && this.choicePrompt.text.length > 0;
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         if (!this.done && !this.awaitingChoice) {
             this.timer += delta.seconds;
             while (this.timer > 0.035 && this.chars < lines[this.lineIndex].text.length) {
                 this.timer -= 0.035;
                 this.chars++;
-                this.app.audio.play(this.beep, { playbackRate: 1.9, volume: 0.14 });
+                app.audio.play(this.beep, { playbackRate: 1.9, volume: 0.14 });
             }
             this.done = this.chars >= lines[this.lineIndex].text.length;
         }
         this.box.text = lines[this.lineIndex].text.slice(0, this.chars);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear(new Color(20, 24, 34));
         context.render(this.portrait);
         context.render(this.namePlate);

--- a/examples/showcase/gamepad-spaceship.js
+++ b/examples/showcase/gamepad-spaceship.js
@@ -29,9 +29,12 @@ class GamepadSpaceshipScene extends Scene {
     connectPrompt;
     hud;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.ship = new Sprite(this.loader.get(assets.demo.textures.shipA)).setAnchor(0.5).setScale(0.5).setPosition(width / 2, height / 2);
-        this.engine = this.app.audio.play(new AudioGenerator({ type: 'sawtooth', frequency: 90 }), { volume: 0 });
+        this.engine = app.audio.play(new AudioGenerator({ type: 'sawtooth', frequency: 90 }), { volume: 0 });
         this.fx = new Graphics();
         this.particles = new ParticleSystem(this.loader.get(assets.demo.textures.particleSpark), { capacity: 4000 });
         this.burst = new BurstSpawn({
@@ -44,9 +47,9 @@ class GamepadSpaceshipScene extends Scene {
         this.particles.addSpawnModule(this.burst);
         this.particles.addUpdateModule(new AlphaFadeOverLifetime());
         for (let i = 0; i < 4; i++) {
-            this.asteroids.push(this.spawnAsteroid());
+            this.asteroids.push(this.spawnAsteroid(width, height));
         }
-        this.pad = this.app.input.getGamepad(0);
+        this.pad = app.input.getGamepad(0);
         this.pad.onActive(GamepadAxis.LeftStickX, (v) => (this.thrust.x = v));
         this.pad.onStop(GamepadAxis.LeftStickX, () => (this.thrust.x = 0));
         this.pad.onActive(GamepadAxis.LeftStickY, (v) => (this.thrust.y = v));
@@ -54,9 +57,9 @@ class GamepadSpaceshipScene extends Scene {
         this.pad.onStart(GamepadButton.RightTrigger, () => this.fire());
         // Track controller presence with the engine's connect/disconnect signals
         // and prompt with an on-screen Text while none is attached.
-        this.hasPad = this.app.input.gamepads.some(pad => pad.connected);
-        this.app.input.onGamepadConnected.add(() => (this.hasPad = true));
-        this.app.input.onGamepadDisconnected.add(() => (this.hasPad = this.app.input.gamepads.some(pad => pad.connected)));
+        this.hasPad = app.input.gamepads.some(pad => pad.connected);
+        app.input.onGamepadConnected.add(() => (this.hasPad = true));
+        app.input.onGamepadDisconnected.add(() => (this.hasPad = app.input.gamepads.some(pad => pad.connected)));
         this.connectPrompt = new Text('Connect a controller to fly', { fillColor: Color.white, fontSize: 24, align: 'center' })
             .setAnchor(0.5, 0.5)
             .setPosition(width / 2, height / 2);
@@ -69,8 +72,7 @@ class GamepadSpaceshipScene extends Scene {
             status: 'Score: 0',
         });
     }
-    spawnAsteroid() {
-        const { width, height } = this.app.canvas;
+    spawnAsteroid(width, height) {
         const fromLeft = Math.random() < 0.5;
         return {
             x: fromLeft ? -20 : width + 20,
@@ -102,7 +104,10 @@ class GamepadSpaceshipScene extends Scene {
         }
     }
     update(delta) {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const mag = Math.min(1, Math.hypot(this.thrust.x, this.thrust.y));
         if (mag > 0.05) {
             this.facing = Math.atan2(this.thrust.y, this.thrust.x);
@@ -136,7 +141,7 @@ class GamepadSpaceshipScene extends Scene {
                 const asteroid = this.asteroids[a];
                 if (Math.hypot(bullet.x - asteroid.x, bullet.y - asteroid.y) < asteroid.radius) {
                     this.impact(asteroid.x, asteroid.y);
-                    this.asteroids[a] = this.spawnAsteroid();
+                    this.asteroids[a] = this.spawnAsteroid(width, height);
                     this.bullets.splice(i, 1);
                     break;
                 }

--- a/examples/showcase/gamepad-spaceship.ts
+++ b/examples/showcase/gamepad-spaceship.ts
@@ -1,4 +1,4 @@
-import { Application, AudioGenerator, Color, GamepadAxis, GamepadButton, Graphics, Scene, Sprite, Text, Vector, type Voice } from '@codexo/exojs';
+import { Application, AudioGenerator, Color, type Gamepad, GamepadAxis, GamepadButton, Graphics, type RenderingContext, Scene, Sprite, Text, type Time, Vector, type Voice } from '@codexo/exojs';
 import {
     AlphaFadeOverLifetime,
     BurstSpawn,
@@ -47,17 +47,19 @@ class GamepadSpaceshipScene extends Scene {
     private fx!: Graphics;
     private particles!: ParticleSystem;
     private burst!: BurstSpawn;
-    private pad: any = null;
+    private pad: Gamepad | null = null;
     private score = 0;
     private hasPad = false;
     private connectPrompt!: Text;
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.ship = new Sprite(this.loader.get(assets.demo.textures.shipA)).setAnchor(0.5).setScale(0.5).setPosition(width / 2, height / 2);
-        this.engine = this.app.audio.play(new AudioGenerator({ type: 'sawtooth', frequency: 90 }), { volume: 0 });
+        this.engine = app.audio.play(new AudioGenerator({ type: 'sawtooth', frequency: 90 }), { volume: 0 });
 
         this.fx = new Graphics();
 
@@ -73,10 +75,10 @@ class GamepadSpaceshipScene extends Scene {
         this.particles.addUpdateModule(new AlphaFadeOverLifetime());
 
         for (let i = 0; i < 4; i++) {
-            this.asteroids.push(this.spawnAsteroid());
+            this.asteroids.push(this.spawnAsteroid(width, height));
         }
 
-        this.pad = this.app.input.getGamepad(0);
+        this.pad = app.input.getGamepad(0);
         this.pad.onActive(GamepadAxis.LeftStickX, (v: number) => (this.thrust.x = v));
         this.pad.onStop(GamepadAxis.LeftStickX, () => (this.thrust.x = 0));
         this.pad.onActive(GamepadAxis.LeftStickY, (v: number) => (this.thrust.y = v));
@@ -85,9 +87,9 @@ class GamepadSpaceshipScene extends Scene {
 
         // Track controller presence with the engine's connect/disconnect signals
         // and prompt with an on-screen Text while none is attached.
-        this.hasPad = this.app.input.gamepads.some(pad => pad.connected);
-        this.app.input.onGamepadConnected.add(() => (this.hasPad = true));
-        this.app.input.onGamepadDisconnected.add(() => (this.hasPad = this.app.input.gamepads.some(pad => pad.connected)));
+        this.hasPad = app.input.gamepads.some(pad => pad.connected);
+        app.input.onGamepadConnected.add(() => (this.hasPad = true));
+        app.input.onGamepadDisconnected.add(() => (this.hasPad = app.input.gamepads.some(pad => pad.connected)));
         this.connectPrompt = new Text('Connect a controller to fly', { fillColor: Color.white, fontSize: 24, align: 'center' })
             .setAnchor(0.5, 0.5)
             .setPosition(width / 2, height / 2);
@@ -102,8 +104,7 @@ class GamepadSpaceshipScene extends Scene {
         });
     }
 
-    private spawnAsteroid(): Asteroid {
-        const { width, height } = this.app.canvas;
+    private spawnAsteroid(width: number, height: number): Asteroid {
         const fromLeft = Math.random() < 0.5;
 
         return {
@@ -140,8 +141,10 @@ class GamepadSpaceshipScene extends Scene {
         }
     }
 
-    override update(delta): void {
-        const { width, height } = this.app.canvas;
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         const mag = Math.min(1, Math.hypot(this.thrust.x, this.thrust.y));
 
@@ -183,7 +186,7 @@ class GamepadSpaceshipScene extends Scene {
 
                 if (Math.hypot(bullet.x - asteroid.x, bullet.y - asteroid.y) < asteroid.radius) {
                     this.impact(asteroid.x, asteroid.y);
-                    this.asteroids[a] = this.spawnAsteroid();
+                    this.asteroids[a] = this.spawnAsteroid(width, height);
                     this.bullets.splice(i, 1);
                     break;
                 }
@@ -201,7 +204,7 @@ class GamepadSpaceshipScene extends Scene {
         else if (point.y > height + 24) point.y = -24;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
 
         this.fx.clear();

--- a/examples/showcase/loading-progress-with-shader.js
+++ b/examples/showcase/loading-progress-with-shader.js
@@ -32,7 +32,10 @@ class LoadingProgressWithShaderScene extends Scene {
     ring;
     filter;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.progress = { v: 0 };
         this.label = new Text('0%', { fillColor: Color.white, fontSize: 42, align: 'center' });
         this.label.setAnchor(0.5, 0.5).setPosition(width / 2, height / 2);
@@ -42,7 +45,7 @@ class LoadingProgressWithShaderScene extends Scene {
                 ? new WebGpuShaderFilter({ fragmentSource: wgsl, uniforms: { uProgress: 0 } })
                 : new WebGl2ShaderFilter({ fragmentSource: glsl, uniforms: { uProgress: 0 } });
         this.ring.filters = [this.filter];
-        this.app.tweens.create(this.progress).to({ v: 1 }, 2.4).start();
+        app.tweens.create(this.progress).to({ v: 1 }, 2.4).start();
     }
     update() {
         this.filter.uniforms.uProgress = this.progress.v;

--- a/examples/showcase/loading-progress-with-shader.ts
+++ b/examples/showcase/loading-progress-with-shader.ts
@@ -1,4 +1,4 @@
-import { Application, Color, RenderBackendType, Scene, Sprite, Text, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
+import { Application, Color, RenderBackendType, type RenderingContext, Scene, Sprite, Text, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -35,7 +35,9 @@ class LoadingProgressWithShaderScene extends Scene {
     private filter!: WebGl2ShaderFilter | WebGpuShaderFilter;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.progress = { v: 0 };
         this.label = new Text('0%', { fillColor: Color.white, fontSize: 42, align: 'center' });
@@ -46,7 +48,7 @@ class LoadingProgressWithShaderScene extends Scene {
                 ? new WebGpuShaderFilter({ fragmentSource: wgsl, uniforms: { uProgress: 0 } })
                 : new WebGl2ShaderFilter({ fragmentSource: glsl, uniforms: { uProgress: 0 } });
         this.ring.filters = [this.filter];
-        this.app.tweens.create(this.progress).to({ v: 1 }, 2.4).start();
+        app.tweens.create(this.progress).to({ v: 1 }, 2.4).start();
     }
 
     override update(): void {
@@ -54,7 +56,7 @@ class LoadingProgressWithShaderScene extends Scene {
         this.label.text = `${(this.progress.v * 100) | 0}%`;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear(new Color(14, 18, 28));
         context.render(this.ring);
         context.render(this.label);

--- a/examples/showcase/low-band-camera-shake.js
+++ b/examples/showcase/low-band-camera-shake.js
@@ -20,9 +20,12 @@ class LowBandCameraShakeScene extends Scene {
     hud;
     tapPrompt;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.music = this.loader.get(Asset.kind('music', assets.demo.audio.musicLoop));
-        this.analyser = new AudioAnalyser({ fftSize: 1024, source: this.app.audio.music });
+        this.analyser = new AudioAnalyser({ fftSize: 1024, source: app.audio.music });
         this.view = new View(width / 2, height / 2, width, height);
         this.sprite = new Sprite(this.loader.get(assets.demo.textures.shipA)).setAnchor(0.5).setScale(3).setPosition(width / 2, height / 2);
         this.hud = mountControls({
@@ -38,7 +41,7 @@ class LowBandCameraShakeScene extends Scene {
             .setPosition(width / 2, height - 64);
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically — play() returns the Voice now.
-        this.musicVoice = this.app.audio.play(this.music, { loop: true, volume: 0.8 });
+        this.musicVoice = app.audio.play(this.music, { loop: true, volume: 0.8 });
     }
     update(delta) {
         const low = this.analyser.getBandEnergy(20, 180);
@@ -53,11 +56,14 @@ class LowBandCameraShakeScene extends Scene {
         }
     }
     draw(context) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear(new Color(22, 24, 34));
         context.backend.setView(this.view);
         context.render(this.sprite);
         context.backend.setView(null);
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/showcase/low-band-camera-shake.ts
+++ b/examples/showcase/low-band-camera-shake.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, AudioStream, Color, Scene, Sprite, Text, View, type Voice } from '@codexo/exojs';
+import { Application, Asset, AudioStream, Color, type RenderingContext, Scene, Sprite, Text, type Time, View, type Voice } from '@codexo/exojs';
 import { AudioAnalyser } from '@codexo/exojs-audio-fx';
 import { mountControls } from '@examples/runtime';
 
@@ -22,10 +22,12 @@ class LowBandCameraShakeScene extends Scene {
     private tapPrompt!: Text;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.music = this.loader.get(Asset.kind('music', assets.demo.audio.musicLoop));
-        this.analyser = new AudioAnalyser({ fftSize: 1024, source: this.app.audio.music });
+        this.analyser = new AudioAnalyser({ fftSize: 1024, source: app.audio.music });
         this.view = new View(width / 2, height / 2, width, height);
         this.sprite = new Sprite(this.loader.get(assets.demo.textures.shipA)).setAnchor(0.5).setScale(3).setPosition(width / 2, height / 2);
 
@@ -44,10 +46,10 @@ class LowBandCameraShakeScene extends Scene {
 
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically — play() returns the Voice now.
-        this.musicVoice = this.app.audio.play(this.music, { loop: true, volume: 0.8 });
+        this.musicVoice = app.audio.play(this.music, { loop: true, volume: 0.8 });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         const low = this.analyser.getBandEnergy(20, 180);
 
         // No constant floor: amplitude is purely low-band energy, so a quiet
@@ -63,13 +65,15 @@ class LowBandCameraShakeScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear(new Color(22, 24, 34));
         context.backend.setView(this.view);
         context.render(this.sprite);
         context.backend.setView(null);
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/showcase/minimap-with-mask.js
+++ b/examples/showcase/minimap-with-mask.js
@@ -22,7 +22,10 @@ class MinimapWithMaskScene extends Scene {
     pipeline;
     time = 0;
     init() {
-        const { width } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width } = app.canvas;
         // Park the round minimap in the top-right corner of the 16:9 canvas.
         const miniSize = 260;
         const miniX = width - miniSize - 20;
@@ -58,7 +61,10 @@ class MinimapWithMaskScene extends Scene {
         this.time += delta.seconds;
     }
     drawWorld(backend) {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const marginX = 80;
         const marginY = 60;
         const right = width - marginX;

--- a/examples/showcase/minimap-with-mask.ts
+++ b/examples/showcase/minimap-with-mask.ts
@@ -1,4 +1,4 @@
-import { Application, CallbackRenderPass, Color, Graphics, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite } from '@codexo/exojs';
+import { Application, CallbackRenderPass, Color, Graphics, type RenderingContext, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -24,7 +24,9 @@ class MinimapWithMaskScene extends Scene {
     private time = 0;
 
     override init(): void {
-        const { width } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width } = app.canvas;
 
         // Park the round minimap in the top-right corner of the 16:9 canvas.
         const miniSize = 260;
@@ -67,12 +69,14 @@ class MinimapWithMaskScene extends Scene {
             .addPass(new RenderNodePass(this.frame));
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.time += delta.seconds;
     }
 
-    private drawWorld(backend): void {
-        const { width, height } = this.app.canvas;
+    private drawWorld(backend: RenderingContext['backend']): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const marginX = 80;
         const marginY = 60;
         const right = width - marginX;
@@ -94,7 +98,7 @@ class MinimapWithMaskScene extends Scene {
         this.player.render(backend);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         this.pipeline.execute(context);
     }
 

--- a/examples/showcase/mouse-parallax.js
+++ b/examples/showcase/mouse-parallax.js
@@ -20,8 +20,11 @@ class MouseParallaxScene extends Scene {
     pointer = { x: 0, y: 0 };
     hud;
     init() {
-        const width = this.app.width;
-        const height = this.app.height;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const width = app.width;
+        const height = app.height;
         this.pointer = { x: width / 2, y: height / 2 };
         // Spread the circle field across the full 16:9 canvas: 16 columns wide so
         // the layers fill the extra horizontal space instead of bunching on the left.
@@ -42,13 +45,16 @@ class MouseParallaxScene extends Scene {
             controls: [{ keys: 'Mouse', action: 'shift the layers' }],
             hint: 'Move the mouse — far layers drift slowly, near layers race ahead.',
         });
-        this.app.input.onPointerMove.add(p => {
+        app.input.onPointerMove.add(p => {
             this.pointer = { x: p.x, y: p.y };
         });
     }
     draw(context) {
-        const width = this.app.width;
-        const height = this.app.height;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const width = app.width;
+        const height = app.height;
         context.backend.clear(new Color(18, 22, 34));
         for (let i = 0; i < this.layers.length; i++) {
             const layer = this.layers[i];

--- a/examples/showcase/mouse-parallax.ts
+++ b/examples/showcase/mouse-parallax.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Container, Graphics, Scene } from '@codexo/exojs';
+import { Application, Color, Container, Graphics, type RenderingContext, Scene } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -23,8 +23,10 @@ class MouseParallaxScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const width = this.app.width;
-        const height = this.app.height;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const width = app.width;
+        const height = app.height;
         this.pointer = { x: width / 2, y: height / 2 };
 
         // Spread the circle field across the full 16:9 canvas: 16 columns wide so
@@ -49,14 +51,16 @@ class MouseParallaxScene extends Scene {
             hint: 'Move the mouse — far layers drift slowly, near layers race ahead.',
         });
 
-        this.app.input.onPointerMove.add(p => {
+        app.input.onPointerMove.add(p => {
             this.pointer = { x: p.x, y: p.y };
         });
     }
 
-    override draw(context): void {
-        const width = this.app.width;
-        const height = this.app.height;
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const width = app.width;
+        const height = app.height;
 
         context.backend.clear(new Color(18, 22, 34));
         for (let i = 0; i < this.layers.length; i++) {

--- a/examples/showcase/orb-dodge.js
+++ b/examples/showcase/orb-dodge.js
@@ -110,6 +110,9 @@ class PlayScene extends Scene {
         this.orbs.push({ gfx, vx: ((tx - ox) / dist) * speed, vy: ((ty - oy) / dist) * speed, danger });
     }
     update(delta) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.elapsed += delta.seconds;
         this.spawnTimer += delta.seconds;
         if (this.spawnTimer >= SPAWN_INTERVAL) {
@@ -161,7 +164,7 @@ class PlayScene extends Scene {
         this.orbs = gameEnded ? [] : survived;
         if (gameEnded) {
             gameOver.setResult(this.score, this.elapsed);
-            void this.app.scene.setScene(gameOver);
+            void app.scene.setScene(gameOver);
             return;
         }
         this.timeText.text = `${this.elapsed.toFixed(1)} s`;
@@ -192,6 +195,9 @@ class GameOverScene extends Scene {
         this.finalTime = time;
     }
     init() {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.title = new Text('GAME OVER', {
             align: 'center',
             fillColor: new Color(255, 80, 80),
@@ -215,7 +221,7 @@ class GameOverScene extends Scene {
         this.hint.setAnchor(0.5);
         this.hint.setPosition(CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2 + 70);
         const restart = () => {
-            void this.app.scene.setScene(play);
+            void app.scene.setScene(play);
         };
         this.inputs.onTrigger(Keyboard.Space, restart);
         this.inputs.onTrigger(Keyboard.R, restart);

--- a/examples/showcase/orb-dodge.ts
+++ b/examples/showcase/orb-dodge.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Container, Graphics, Keyboard, Scene, Text } from '@codexo/exojs';
+import { Application, Color, Container, Graphics, Keyboard, type RenderingContext, Scene, Text, type Time } from '@codexo/exojs';
 
 const CANVAS_WIDTH = 1280;
 const CANVAS_HEIGHT = 720;
@@ -111,7 +111,9 @@ class PlayScene extends Scene {
         this.orbs.push({ gfx, vx: ((tx - ox) / dist) * speed, vy: ((ty - oy) / dist) * speed, danger });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.elapsed += delta.seconds;
         this.spawnTimer += delta.seconds;
 
@@ -174,14 +176,14 @@ class PlayScene extends Scene {
 
         if (gameEnded) {
             gameOver.setResult(this.score, this.elapsed);
-            void this.app.scene.setScene(gameOver);
+            void app.scene.setScene(gameOver);
             return;
         }
 
         this.timeText.text = `${this.elapsed.toFixed(1)} s`;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.world);
         context.render(this.scoreText);
@@ -211,6 +213,8 @@ class GameOverScene extends Scene {
     }
 
     override init(): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.title = new Text('GAME OVER', {
             align: 'center',
             fillColor: new Color(255, 80, 80),
@@ -237,13 +241,13 @@ class GameOverScene extends Scene {
         this.hint.setPosition(CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2 + 70);
 
         const restart = (): void => {
-            void this.app.scene.setScene(play);
+            void app.scene.setScene(play);
         };
         this.inputs.onTrigger(Keyboard.Space, restart);
         this.inputs.onTrigger(Keyboard.R, restart);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.title);
         context.render(this.stats);

--- a/examples/showcase/pause-blur.js
+++ b/examples/showcase/pause-blur.js
@@ -29,7 +29,10 @@ class GameScene extends Scene {
     pauseLabel;
     hud;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.sprite = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5).setScale(2).setPosition(width / 2, height / 2);
         this.addChild(this.sprite);
         // Pause overlay on the UI layer, hidden until paused.
@@ -48,7 +51,7 @@ class GameScene extends Scene {
         });
         this.inputs.onTrigger(Keyboard.Escape, () => this.togglePause());
         // Same toggle on click/tap so the pause works without a keyboard.
-        this.app.input.onPointerTap.add(() => this.togglePause());
+        app.input.onPointerTap.add(() => this.togglePause());
     }
     update(delta) {
         // Not called while paused — the SceneManager skips update() + systems.

--- a/examples/showcase/pause-blur.ts
+++ b/examples/showcase/pause-blur.ts
@@ -1,4 +1,4 @@
-import { Application, BlurFilter, Color, Keyboard, Label, Panel, Scene, Sprite } from '@codexo/exojs';
+import { Application, BlurFilter, Color, Keyboard, Label, Panel, type RenderingContext, Scene, Sprite, type Time } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -32,7 +32,9 @@ class GameScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.sprite = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5).setScale(2).setPosition(width / 2, height / 2);
         this.addChild(this.sprite);
@@ -56,16 +58,16 @@ class GameScene extends Scene {
 
         this.inputs.onTrigger(Keyboard.Escape, () => this.togglePause());
         // Same toggle on click/tap so the pause works without a keyboard.
-        this.app.input.onPointerTap.add(() => this.togglePause());
+        app.input.onPointerTap.add(() => this.togglePause());
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         // Not called while paused — the SceneManager skips update() + systems.
         this.time += delta.seconds;
         this.sprite.setRotation(this.time * 80);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear(new Color(20, 24, 34));
         context.render(this.root);
     }

--- a/examples/showcase/rectangles-collision.js
+++ b/examples/showcase/rectangles-collision.js
@@ -21,7 +21,10 @@ class RectanglesCollisionScene extends Scene {
     overlap;
     hud;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const texture = this.loader.get('image/hue-ramp.png');
         // Two axis-aligned rectangles (no rotation) so collision is a true AABB
         // test. Explicit width/height drive the sprite scale; anchor 0.5 keeps the

--- a/examples/showcase/rectangles-collision.ts
+++ b/examples/showcase/rectangles-collision.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Graphics, Scene, Sprite, Texture } from '@codexo/exojs';
+import { Application, Color, Graphics, type RenderingContext, Scene, Sprite, Texture } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -24,7 +24,9 @@ class RectanglesCollisionScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const texture = this.loader.get('image/hue-ramp.png');
 
         // Two axis-aligned rectangles (no rotation) so collision is a true AABB
@@ -87,7 +89,7 @@ class RectanglesCollisionScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear(new Color(18, 22, 30));
         context.render(this.boxA);
         context.render(this.boxB);

--- a/examples/showcase/screen-shake-on-explosion.js
+++ b/examples/showcase/screen-shake-on-explosion.js
@@ -20,7 +20,10 @@ class ScreenShakeOnExplosionScene extends Scene {
     burstPos;
     burst;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.view = new View(width / 2, height / 2, width, height);
         this.ps = new ParticleSystem(this.loader.get('image/particle-light.png'), { capacity: 5000 });
         this.ps.setPosition(width / 2, height / 2);
@@ -34,7 +37,7 @@ class ScreenShakeOnExplosionScene extends Scene {
         });
         this.ps.addSpawnModule(this.burst);
         this.ps.addUpdateModule(new AlphaFadeOverLifetime());
-        this.app.input.onPointerTap.add(p => {
+        app.input.onPointerTap.add(p => {
             this.burstPos.set(p.x - this.ps.position.x, p.y - this.ps.position.y);
             this.burst.reset();
             this.view.shake(22, 280, { frequency: 26, decay: true });

--- a/examples/showcase/screen-shake-on-explosion.ts
+++ b/examples/showcase/screen-shake-on-explosion.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene, Vector, View } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, type Time, Vector, View } from '@codexo/exojs';
 import {
     AlphaFadeOverLifetime,
     BurstSpawn,
@@ -29,7 +29,9 @@ class ScreenShakeOnExplosionScene extends Scene {
     private burst!: BurstSpawn;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.view = new View(width / 2, height / 2, width, height);
         this.ps = new ParticleSystem(this.loader.get('image/particle-light.png'), { capacity: 5000 });
@@ -44,18 +46,18 @@ class ScreenShakeOnExplosionScene extends Scene {
         });
         this.ps.addSpawnModule(this.burst);
         this.ps.addUpdateModule(new AlphaFadeOverLifetime());
-        this.app.input.onPointerTap.add(p => {
+        app.input.onPointerTap.add(p => {
             this.burstPos.set(p.x - this.ps.position.x, p.y - this.ps.position.y);
             this.burst.reset();
             this.view.shake(22, 280, { frequency: 26, decay: true });
         });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.ps.update(delta);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.backend.setView(this.view);
         context.render(this.ps);

--- a/examples/showcase/typewriter-text.js
+++ b/examples/showcase/typewriter-text.js
@@ -20,7 +20,10 @@ class TypewriterTextScene extends Scene {
     last = 0;
     tapPrompt;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.sound = this.loader.get('audio/ui-click.ogg');
         this.text = new Text('', { fillColor: Color.white, fontSize: 40, lineHeight: 56, maxWidth: 900 });
         this.text.setAnchor(0, 0.5).setPosition(width * 0.12, height / 2);
@@ -30,22 +33,25 @@ class TypewriterTextScene extends Scene {
         this.tapPrompt = new Text('Click or press any key to enable the typing sound', { fillColor: Color.white, fontSize: 22, align: 'center' })
             .setAnchor(0.5, 0.5)
             .setPosition(width / 2, height - 64);
-        this.app.tweens
+        app.tweens
             .create(this.state)
             .to({ count: message.length }, 2.4)
             .onUpdate(() => {
             const n = this.state.count | 0;
             if (n > this.last)
-                this.app.audio.play(this.sound, { playbackRate: 1.6 });
+                app.audio.play(this.sound, { playbackRate: 1.6 });
             this.last = n;
             this.text.text = message.slice(0, n);
         })
             .start();
     }
     draw(context) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         context.render(this.text);
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/showcase/typewriter-text.ts
+++ b/examples/showcase/typewriter-text.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene, Sound, Text } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, Sound, Text } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -23,7 +23,9 @@ class TypewriterTextScene extends Scene {
     private tapPrompt!: Text;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.sound = this.loader.get('audio/ui-click.ogg');
         this.text = new Text('', { fillColor: Color.white, fontSize: 40, lineHeight: 56, maxWidth: 900 });
@@ -35,23 +37,25 @@ class TypewriterTextScene extends Scene {
         this.tapPrompt = new Text('Click or press any key to enable the typing sound', { fillColor: Color.white, fontSize: 22, align: 'center' })
             .setAnchor(0.5, 0.5)
             .setPosition(width / 2, height - 64);
-        this.app.tweens
+        app.tweens
             .create(this.state)
             .to({ count: message.length }, 2.4)
             .onUpdate(() => {
                 const n = this.state.count | 0;
-                if (n > this.last) this.app.audio.play(this.sound, { playbackRate: 1.6 });
+                if (n > this.last) app.audio.play(this.sound, { playbackRate: 1.6 });
                 this.last = n;
                 this.text.text = message.slice(0, n);
             })
             .start();
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         context.render(this.text);
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/showcase/vinyl-record.js
+++ b/examples/showcase/vinyl-record.js
@@ -22,9 +22,12 @@ class VinylRecordScene extends Scene {
     hud;
     tapPrompt;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.music = this.loader.get(Asset.kind('music', assets.demo.audio.musicLoop));
-        this.analyser = new AudioAnalyser({ fftSize: 1024, source: this.app.audio.music });
+        this.analyser = new AudioAnalyser({ fftSize: 1024, source: app.audio.music });
         this.disc = new Graphics();
         this.bars = new Graphics();
         this.hud = mountControls({
@@ -40,7 +43,7 @@ class VinylRecordScene extends Scene {
             .setPosition(width / 2, height - 64);
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically — play() returns the Voice now.
-        this.musicVoice = this.app.audio.play(this.music, { loop: true, volume: 0.8 });
+        this.musicVoice = app.audio.play(this.music, { loop: true, volume: 0.8 });
     }
     update(delta) {
         // Spin speed is driven by live audio energy, not a constant fallback BPM.
@@ -55,7 +58,10 @@ class VinylRecordScene extends Scene {
         }
     }
     draw(context) {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const cx = width / 2;
         const cy = height / 2;
         const spectrum = this.analyser.getSpectrum();
@@ -89,7 +95,7 @@ class VinylRecordScene extends Scene {
             this.bars.drawLine(x0, y0, x1, y1);
         }
         context.render(this.bars);
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/showcase/vinyl-record.ts
+++ b/examples/showcase/vinyl-record.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, AudioStream, Color, Graphics, Scene, Text, type Voice } from '@codexo/exojs';
+import { Application, Asset, AudioStream, Color, Graphics, type RenderingContext, Scene, Text, type Time, type Voice } from '@codexo/exojs';
 import { AudioAnalyser } from '@codexo/exojs-audio-fx';
 import { mountControls } from '@examples/runtime';
 
@@ -24,10 +24,12 @@ class VinylRecordScene extends Scene {
     private tapPrompt!: Text;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.music = this.loader.get(Asset.kind('music', assets.demo.audio.musicLoop));
-        this.analyser = new AudioAnalyser({ fftSize: 1024, source: this.app.audio.music });
+        this.analyser = new AudioAnalyser({ fftSize: 1024, source: app.audio.music });
         this.disc = new Graphics();
         this.bars = new Graphics();
 
@@ -46,10 +48,10 @@ class VinylRecordScene extends Scene {
 
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically — play() returns the Voice now.
-        this.musicVoice = this.app.audio.play(this.music, { loop: true, volume: 0.8 });
+        this.musicVoice = app.audio.play(this.music, { loop: true, volume: 0.8 });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         // Spin speed is driven by live audio energy, not a constant fallback BPM.
         // Silence → energy 0 → the platter holds perfectly still.
         const energy = this.analyser.getRms();
@@ -64,8 +66,10 @@ class VinylRecordScene extends Scene {
         }
     }
 
-    override draw(context): void {
-        const { width, height } = this.app.canvas;
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const cx = width / 2;
         const cy = height / 2;
         const spectrum = this.analyser.getSpectrum();
@@ -101,7 +105,7 @@ class VinylRecordScene extends Scene {
         }
         context.render(this.bars);
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/spatial-audio/falloff-curves.js
+++ b/examples/spatial-audio/falloff-curves.js
@@ -45,7 +45,10 @@ class FalloffCurvesScene extends Scene {
     plot = { x: 0, y: 0, w: 0, h: 0 };
     hud;
     async init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // Sources spread across the lower half; the listener starts centred.
         const sourceY = height * 0.72;
         this.sources = MODELS.map(({ model, color, tx }) => ({ model, color, x: width * tx, y: sourceY }));
@@ -83,17 +86,20 @@ class FalloffCurvesScene extends Scene {
             status: 'Click or press any key to start…',
             hint: 'Each source uses a different distance model — move the listener to compare attenuation.',
         });
-        this.app.input.onPointerMove.add(pointer => {
+        app.input.onPointerMove.add(pointer => {
             this.listener.x = pointer.x;
             this.listener.y = pointer.y;
         });
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically — just call play().
         for (const sound of this.sounds)
-            this.app.audio.play(sound, { loop: true, volume: 0.5 });
+            app.audio.play(sound, { loop: true, volume: 0.5 });
         this.hud.setStatus('Move the pointer to relocate the listener');
     }
     draw(context) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         this.graphics.clear();
         // Falloff-curve plots in the upper canvas area.
@@ -127,7 +133,7 @@ class FalloffCurvesScene extends Scene {
         context.render(this.graphics);
         for (const label of this.labels)
             context.render(label);
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/spatial-audio/falloff-curves.ts
+++ b/examples/spatial-audio/falloff-curves.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Color, Graphics, Scene, Sound, Text } from '@codexo/exojs';
+import { Application, Asset, Color, Graphics, type RenderingContext, Scene, Sound, Text } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -61,7 +61,9 @@ class FalloffCurvesScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override async init(): Promise<void> {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // Sources spread across the lower half; the listener starts centred.
         const sourceY = height * 0.72;
@@ -106,18 +108,20 @@ class FalloffCurvesScene extends Scene {
             hint: 'Each source uses a different distance model — move the listener to compare attenuation.',
         });
 
-        this.app.input.onPointerMove.add(pointer => {
+        app.input.onPointerMove.add(pointer => {
             this.listener.x = pointer.x;
             this.listener.y = pointer.y;
         });
 
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically — just call play().
-        for (const sound of this.sounds) this.app.audio.play(sound, { loop: true, volume: 0.5 });
+        for (const sound of this.sounds) app.audio.play(sound, { loop: true, volume: 0.5 });
         this.hud.setStatus('Move the pointer to relocate the listener');
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         context.backend.clear();
         this.graphics.clear();
 
@@ -157,7 +161,7 @@ class FalloffCurvesScene extends Scene {
         context.render(this.graphics);
         for (const label of this.labels) context.render(label);
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/spatial-audio/listener-and-source.js
+++ b/examples/spatial-audio/listener-and-source.js
@@ -37,7 +37,10 @@ class ListenerAndSourceScene extends Scene {
     tapPrompt;
     hud;
     async init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // A continuous music loop, not a one-shot: spatialization is only
         // audible while there is sustained signal to pan/attenuate. The derived
         // Sound below reads .audioBuffer synchronously, so await load() instead
@@ -66,7 +69,7 @@ class ListenerAndSourceScene extends Scene {
             status: 'Click or press any key to start…',
             hint: 'The green dot is the listener. Drag the red source — volume falls off with distance.',
         });
-        this.app.input.onPointerDown.add(pointer => {
+        app.input.onPointerDown.add(pointer => {
             const source = this.sound.position;
             if (!source)
                 return;
@@ -76,7 +79,7 @@ class ListenerAndSourceScene extends Scene {
             if (dx * dx + dy * dy < SOURCE_RADIUS * SOURCE_RADIUS * 4)
                 this.dragging = true;
         });
-        this.app.input.onPointerMove.add(pointer => {
+        app.input.onPointerMove.add(pointer => {
             if (!this.dragging)
                 return;
             // sound.position only seeds NEW voices - a live voice moves via
@@ -84,16 +87,19 @@ class ListenerAndSourceScene extends Scene {
             this.sound.position = { x: pointer.x, y: pointer.y };
             this.voice.position = { x: pointer.x, y: pointer.y };
         });
-        this.app.input.onPointerUp.add(() => {
+        app.input.onPointerUp.add(() => {
             this.dragging = false;
         });
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically — just call play().
         // play() returns the narrow Voice interface; Sound voices are spatializable.
-        this.voice = this.app.audio.play(this.sound, { loop: true, volume: 1 });
+        this.voice = app.audio.play(this.sound, { loop: true, volume: 1 });
         this.hud.setStatus('Drag the red source to move it');
     }
     draw(context) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const source = this.sound.position ?? { x: 0, y: 0 };
         const dx = source.x - this.listener.x;
         const dy = source.y - this.listener.y;
@@ -119,7 +125,7 @@ class ListenerAndSourceScene extends Scene {
         this.graphics.drawCircle(source.x, source.y, SOURCE_RADIUS);
         context.render(this.graphics);
         context.render(this.label);
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/spatial-audio/listener-and-source.ts
+++ b/examples/spatial-audio/listener-and-source.ts
@@ -1,5 +1,5 @@
 import { Application, Asset, Color, Graphics, Scene, Sound, Text } from '@codexo/exojs';
-import type { Spatializable, Voice } from '@codexo/exojs';
+import type { RenderingContext, Spatializable, Voice } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -41,7 +41,9 @@ class ListenerAndSourceScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override async init(): Promise<void> {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // A continuous music loop, not a one-shot: spatialization is only
         // audible while there is sustained signal to pan/attenuate. The derived
@@ -75,7 +77,7 @@ class ListenerAndSourceScene extends Scene {
             hint: 'The green dot is the listener. Drag the red source — volume falls off with distance.',
         });
 
-        this.app.input.onPointerDown.add(pointer => {
+        app.input.onPointerDown.add(pointer => {
             const source = this.sound.position;
             if (!source) return;
             const dx = pointer.x - source.x;
@@ -83,25 +85,27 @@ class ListenerAndSourceScene extends Scene {
             // Generous grab radius so the source is easy to pick up.
             if (dx * dx + dy * dy < SOURCE_RADIUS * SOURCE_RADIUS * 4) this.dragging = true;
         });
-        this.app.input.onPointerMove.add(pointer => {
+        app.input.onPointerMove.add(pointer => {
             if (!this.dragging) return;
             // sound.position only seeds NEW voices - a live voice moves via
             // voice.position, so update both (descriptor + running loop).
             this.sound.position = { x: pointer.x, y: pointer.y };
             this.voice.position = { x: pointer.x, y: pointer.y };
         });
-        this.app.input.onPointerUp.add(() => {
+        app.input.onPointerUp.add(() => {
             this.dragging = false;
         });
 
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically — just call play().
         // play() returns the narrow Voice interface; Sound voices are spatializable.
-        this.voice = this.app.audio.play(this.sound, { loop: true, volume: 1 }) as Voice & Spatializable;
+        this.voice = app.audio.play(this.sound, { loop: true, volume: 1 }) as Voice & Spatializable;
         this.hud.setStatus('Drag the red source to move it');
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const source = this.sound.position ?? { x: 0, y: 0 };
         const dx = source.x - this.listener.x;
         const dy = source.y - this.listener.y;
@@ -133,7 +137,7 @@ class ListenerAndSourceScene extends Scene {
         context.render(this.graphics);
         context.render(this.label);
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/spatial-audio/moving-source.js
+++ b/examples/spatial-audio/moving-source.js
@@ -35,7 +35,10 @@ class MovingSourceScene extends Scene {
     tapPrompt;
     hud;
     async init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // A continuous music loop, not a one-shot: spatialization is only
         // audible while there is sustained signal to pan/attenuate. The derived
         // Sound below reads .audioBuffer synchronously, so await load() instead
@@ -67,7 +70,7 @@ class MovingSourceScene extends Scene {
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically — just call play().
         // play() returns the narrow Voice interface; Sound voices are spatializable.
-        this.voice = this.app.audio.play(this.sound, { loop: true, volume: 1 });
+        this.voice = app.audio.play(this.sound, { loop: true, volume: 1 });
         this.hud.setStatus('Source orbiting the listener');
     }
     update(delta) {
@@ -82,6 +85,9 @@ class MovingSourceScene extends Scene {
         this.voice.position = position;
     }
     draw(context) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const source = this.sound.position ?? { x: 0, y: 0 };
         const dx = source.x - this.listener.x;
         const dy = source.y - this.listener.y;
@@ -106,7 +112,7 @@ class MovingSourceScene extends Scene {
         this.graphics.drawCircle(source.x, source.y, 16);
         context.render(this.graphics);
         context.render(this.label);
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/spatial-audio/moving-source.ts
+++ b/examples/spatial-audio/moving-source.ts
@@ -1,5 +1,5 @@
 import { Application, Asset, Color, Graphics, Scene, Sound, Text } from '@codexo/exojs';
-import type { Spatializable, Voice } from '@codexo/exojs';
+import type { RenderingContext, Spatializable, Time, Voice } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -39,7 +39,9 @@ class MovingSourceScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override async init(): Promise<void> {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // A continuous music loop, not a one-shot: spatialization is only
         // audible while there is sustained signal to pan/attenuate. The derived
@@ -76,11 +78,11 @@ class MovingSourceScene extends Scene {
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically — just call play().
         // play() returns the narrow Voice interface; Sound voices are spatializable.
-        this.voice = this.app.audio.play(this.sound, { loop: true, volume: 1 }) as Voice & Spatializable;
+        this.voice = app.audio.play(this.sound, { loop: true, volume: 1 }) as Voice & Spatializable;
         this.hud.setStatus('Source orbiting the listener');
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.angle += delta.seconds * 1.1;
         const position = {
             x: this.listener.x + Math.cos(this.angle) * ORBIT_X,
@@ -92,7 +94,9 @@ class MovingSourceScene extends Scene {
         this.voice.position = position;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const source = this.sound.position ?? { x: 0, y: 0 };
         const dx = source.x - this.listener.x;
         const dy = source.y - this.listener.y;
@@ -123,7 +127,7 @@ class MovingSourceScene extends Scene {
         context.render(this.graphics);
         context.render(this.label);
 
-        if (this.app.audio.locked) {
+        if (app.audio.locked) {
             context.render(this.tapPrompt);
         }
     }

--- a/examples/sprites-textures/blendmodes.js
+++ b/examples/sprites-textures/blendmodes.js
@@ -51,7 +51,10 @@ class BlendmodesScene extends Scene {
     // return value is intentionally unused. The subsequent 2-argument `get()`
     // calls for the same sources are unaffected and stay seamless.
     async init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const samplerOptions = { scaleMode: ScaleModes.Nearest };
         await this.loader.load(Asset.kind('texture', ALPHA_RINGS, { samplerOptions }));
         await this.loader.load(Asset.kind('texture', assets.demo.textures.shipA, { samplerOptions }));
@@ -82,7 +85,7 @@ class BlendmodesScene extends Scene {
             index: 0,
             onChange: index => this.setIndex(index),
         });
-        this.app.input.onPointerDown.add(() => this.setIndex((this.index + 1) % BLEND_MODES.length));
+        app.input.onPointerDown.add(() => this.setIndex((this.index + 1) % BLEND_MODES.length));
         // Apply the initial mode (Normal) without skipping it.
         this.applyBlendMode();
     }
@@ -98,7 +101,10 @@ class BlendmodesScene extends Scene {
         this.hud.setStatus(`${name}  (${this.index + 1}/${BLEND_MODES.length})`);
     }
     update(delta) {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const offset = (Math.cos(this.ticker * 1.4) * 0.5 + 0.5) * (width * 0.22);
         this.left.setPosition(width / 2 - offset, height / 2);
         this.right.setPosition(width / 2 + offset, height / 2);

--- a/examples/sprites-textures/blendmodes.ts
+++ b/examples/sprites-textures/blendmodes.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, BlendModes, Color, ScaleModes, Scene, Sprite } from '@codexo/exojs';
+import { Application, Asset, BlendModes, Color, type RenderingContext, ScaleModes, Scene, Sprite, type Time } from '@codexo/exojs';
 import { mountControlPanel, mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -55,7 +55,9 @@ class BlendmodesScene extends Scene {
     // return value is intentionally unused. The subsequent 2-argument `get()`
     // calls for the same sources are unaffected and stay seamless.
     override async init(): Promise<void> {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         const samplerOptions = { scaleMode: ScaleModes.Nearest };
         await this.loader.load(Asset.kind('texture', ALPHA_RINGS, { samplerOptions }));
@@ -93,7 +95,7 @@ class BlendmodesScene extends Scene {
             onChange: index => this.setIndex(index),
         });
 
-        this.app.input.onPointerDown.add(() => this.setIndex((this.index + 1) % BLEND_MODES.length));
+        app.input.onPointerDown.add(() => this.setIndex((this.index + 1) % BLEND_MODES.length));
 
         // Apply the initial mode (Normal) without skipping it.
         this.applyBlendMode();
@@ -113,8 +115,10 @@ class BlendmodesScene extends Scene {
         this.hud.setStatus(`${name}  (${this.index + 1}/${BLEND_MODES.length})`);
     }
 
-    override update(delta): void {
-        const { width, height } = this.app.canvas;
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const offset = (Math.cos(this.ticker * 1.4) * 0.5 + 0.5) * (width * 0.22);
 
         this.left.setPosition(width / 2 - offset, height / 2);
@@ -123,7 +127,7 @@ class BlendmodesScene extends Scene {
         this.ticker += delta.seconds;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.background);
         context.render(this.left);

--- a/examples/sprites-textures/sprite-basics.js
+++ b/examples/sprites-textures/sprite-basics.js
@@ -20,7 +20,10 @@ class SpriteBasicsScene extends Scene {
     elapsed = 0;
     hud;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.ship = new Sprite(this.loader.get('image/ship-a.png'));
         this.ship.setPosition((width / 2) | 0, (height / 2) | 0);
         this.ship.setAnchor(0.5);
@@ -33,8 +36,11 @@ class SpriteBasicsScene extends Scene {
         });
     }
     update(delta) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.elapsed += delta.seconds;
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
         // Position: a gentle figure-eight drift around the canvas centre.
         const driftX = Math.sin(this.elapsed * 0.8) * 90;
         const driftY = Math.sin(this.elapsed * 1.6) * 50;

--- a/examples/sprites-textures/sprite-basics.ts
+++ b/examples/sprites-textures/sprite-basics.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene, Sprite } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, Sprite, type Time } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -22,7 +22,9 @@ class SpriteBasicsScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.ship = new Sprite(this.loader.get('image/ship-a.png'));
         this.ship.setPosition((width / 2) | 0, (height / 2) | 0);
@@ -37,10 +39,12 @@ class SpriteBasicsScene extends Scene {
         });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.elapsed += delta.seconds;
 
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
 
         // Position: a gentle figure-eight drift around the canvas centre.
         const driftX = Math.sin(this.elapsed * 0.8) * 90;
@@ -61,7 +65,7 @@ class SpriteBasicsScene extends Scene {
         this.hud.setStatus(`alpha ${alpha.toFixed(2)}`);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.ship);
     }

--- a/examples/sprites-textures/spritesheet-frames.js
+++ b/examples/sprites-textures/spritesheet-frames.js
@@ -23,7 +23,10 @@ class SpritesheetFramesScene extends Scene {
     playing = true;
     hud;
     async init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const texture = this.loader.get('image/platformer-characters.png');
         const data = (await this.loader.load(Asset.kind('json', 'json/platformer-characters.json')));
         this.spritesheet = new Spritesheet(texture, data);

--- a/examples/sprites-textures/spritesheet-frames.ts
+++ b/examples/sprites-textures/spritesheet-frames.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Color, Scene, Spritesheet, type SpritesheetData } from '@codexo/exojs';
+import { Application, Asset, Color, type RenderingContext, Scene, Spritesheet, type SpritesheetData, type Time } from '@codexo/exojs';
 import { mountControlPanel, mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -26,7 +26,9 @@ class SpritesheetFramesScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override async init(): Promise<void> {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const texture = this.loader.get('image/platformer-characters.png');
         const data = (await this.loader.load(Asset.kind('json', 'json/platformer-characters.json'))) as SpritesheetData;
 
@@ -72,7 +74,7 @@ class SpritesheetFramesScene extends Scene {
         this.hud.setStatus(`Frame: ${frames[this.frameIndex]}  (${this.frameIndex + 1}/${frames.length})`);
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         if (!this.playing) {
             return;
         }
@@ -88,7 +90,7 @@ class SpritesheetFramesScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.spritesheet.getFrameSprite(this.walkFrames()[this.frameIndex]));
     }

--- a/examples/sprites-textures/svg-drawable.js
+++ b/examples/sprites-textures/svg-drawable.js
@@ -16,7 +16,10 @@ class SvgDrawableScene extends Scene {
     texture;
     sprite;
     async init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // SvgAsset has no seamless adapter (unlike Texture/Sound), so it is
         // awaited via `load()` rather than fetched synchronously via `get()`.
         // The exo.js wordmark SVG carries only a viewBox (no width/height), so

--- a/examples/sprites-textures/svg-drawable.ts
+++ b/examples/sprites-textures/svg-drawable.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Color, Scene, Sprite, SvgAsset, Texture } from '@codexo/exojs';
+import { Application, Asset, Color, type RenderingContext, Scene, Sprite, SvgAsset, Texture } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -18,7 +18,9 @@ class SvgDrawableScene extends Scene {
     private sprite!: Sprite;
 
     override async init(): Promise<void> {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // SvgAsset has no seamless adapter (unlike Texture/Sound), so it is
         // awaited via `load()` rather than fetched synchronously via `get()`.
@@ -40,7 +42,7 @@ class SvgDrawableScene extends Scene {
         this.sprite.setPosition((width / 2) | 0, (height / 2) | 0);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
     }

--- a/examples/sprites-textures/texture-loader.js
+++ b/examples/sprites-textures/texture-loader.js
@@ -22,7 +22,10 @@ class TextureLoaderScene extends Scene {
     barWidth = 0;
     progress = { loaded: 0, total: 3 };
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // Seamless get() returns placeholder handles immediately; each pops in
         // (loadState → 'ready') as its fetch completes, polled in update().
         this.textures = [this.loader.get('image/ship-a.png'), this.loader.get('image/hue-ramp.png'), this.loader.get('image/uv-grid-256.png')];

--- a/examples/sprites-textures/texture-loader.ts
+++ b/examples/sprites-textures/texture-loader.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Graphics, Scene, Sprite, Text, Texture } from '@codexo/exojs';
+import { Application, Color, Graphics, type RenderingContext, Scene, Sprite, Text, Texture } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -24,7 +24,9 @@ class TextureLoaderScene extends Scene {
     private progress = { loaded: 0, total: 3 };
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // Seamless get() returns placeholder handles immediately; each pops in
         // (loadState → 'ready') as its fetch completes, polled in update().
@@ -53,7 +55,7 @@ class TextureLoaderScene extends Scene {
         this.progress.loaded = this.textures.filter(texture => texture.loadState === 'ready').length;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         const { loaded, total } = this.progress;
         this.bar.clear();

--- a/examples/sprites-textures/video-drawable.js
+++ b/examples/sprites-textures/video-drawable.js
@@ -28,7 +28,10 @@ class VideoDrawableScene extends Scene {
     loadedVideos = new Set();
     switching = false;
     async init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // Video has no seamless adapter (unlike Texture/Sound), so it is
         // awaited via `load()` rather than fetched synchronously via `get()`.
         const loaded = await this.loader.load(Assets.from({ [VIDEOS[0].name]: Asset.kind('video', VIDEOS[0].url) }));
@@ -51,11 +54,11 @@ class VideoDrawableScene extends Scene {
             status: `Playing — ${VIDEOS[0].label}`,
             hint: 'The video streams as a live GPU texture with a sprite composited over it.',
         });
-        this.app.input.onPointerTap.add(() => {
+        app.input.onPointerTap.add(() => {
             this.video.toggle();
             this.hud.setStatus(this.video.playing ? `Playing — ${VIDEOS[this.videoIdx].label}` : 'Paused');
         });
-        this.app.input.onKeyDown.add(channel => {
+        app.input.onKeyDown.add(channel => {
             const idx = [Keyboard.One, Keyboard.Two, Keyboard.Three, Keyboard.Four].indexOf(channel);
             if (idx !== -1)
                 void this.switchVideo(idx);
@@ -64,7 +67,10 @@ class VideoDrawableScene extends Scene {
     }
     /** Sizing + playback options shared by every video the example swaps in. */
     configureVideo() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.video.width = width;
         this.video.height = height;
         // Muted playback autoplays reliably under browser autoplay policy without
@@ -95,8 +101,11 @@ class VideoDrawableScene extends Scene {
         }
     }
     update(delta) {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.elapsed += delta.seconds;
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
         // Drift the composited sprite across the video so the overlay is obvious.
         this.overlay.setPosition(width / 2 + Math.sin(this.elapsed) * (width * 0.3), height / 2 + Math.cos(this.elapsed * 0.7) * (height * 0.25));
         this.overlay.rotate(delta.seconds * 60);

--- a/examples/sprites-textures/video-drawable.ts
+++ b/examples/sprites-textures/video-drawable.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Assets, Color, Keyboard, Scene, Sprite, Texture, Video } from '@codexo/exojs';
+import { Application, Asset, Assets, Color, Keyboard, type RenderingContext, Scene, Sprite, Texture, type Time, Video } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 // Every video in the asset catalog, switchable at runtime with the number
@@ -31,7 +31,9 @@ class VideoDrawableScene extends Scene {
     private switching = false;
 
     override async init(): Promise<void> {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // Video has no seamless adapter (unlike Texture/Sound), so it is
         // awaited via `load()` rather than fetched synchronously via `get()`.
@@ -59,12 +61,12 @@ class VideoDrawableScene extends Scene {
             hint: 'The video streams as a live GPU texture with a sprite composited over it.',
         });
 
-        this.app.input.onPointerTap.add(() => {
+        app.input.onPointerTap.add(() => {
             this.video.toggle();
             this.hud.setStatus(this.video.playing ? `Playing — ${VIDEOS[this.videoIdx].label}` : 'Paused');
         });
 
-        this.app.input.onKeyDown.add(channel => {
+        app.input.onKeyDown.add(channel => {
             const idx = [Keyboard.One, Keyboard.Two, Keyboard.Three, Keyboard.Four].indexOf(channel);
             if (idx !== -1) void this.switchVideo(idx);
         });
@@ -74,7 +76,9 @@ class VideoDrawableScene extends Scene {
 
     /** Sizing + playback options shared by every video the example swaps in. */
     private configureVideo(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.video.width = width;
         this.video.height = height;
         // Muted playback autoplays reliably under browser autoplay policy without
@@ -103,17 +107,19 @@ class VideoDrawableScene extends Scene {
         }
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.elapsed += delta.seconds;
 
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
 
         // Drift the composited sprite across the video so the overlay is obvious.
         this.overlay.setPosition(width / 2 + Math.sin(this.elapsed) * (width * 0.3), height / 2 + Math.cos(this.elapsed * 0.7) * (height * 0.25));
         this.overlay.rotate(delta.seconds * 60);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.video);
         context.render(this.overlay);

--- a/examples/text-fonts/basic-text.js
+++ b/examples/text-fonts/basic-text.js
@@ -16,8 +16,11 @@ class BasicTextScene extends Scene {
     time;
     text;
     async init() {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         await this.loader.load(Asset.kind('font', 'font/Kenney Future.ttf', { family: 'Kenney Future' }));
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
         this.time = new Time();
         this.text = new Text('Hello World!', {
             align: 'left',

--- a/examples/text-fonts/basic-text.ts
+++ b/examples/text-fonts/basic-text.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Color, Scene, Text, Time } from '@codexo/exojs';
+import { Application, Asset, Color, type RenderingContext, Scene, Text, Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -18,9 +18,11 @@ class BasicTextScene extends Scene {
     private text!: Text;
 
     override async init(): Promise<void> {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         await this.loader.load(Asset.kind('font', 'font/Kenney Future.ttf', { family: 'Kenney Future' }));
 
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
 
         this.time = new Time();
 
@@ -37,12 +39,12 @@ class BasicTextScene extends Scene {
         this.text.setAnchor(0.5, 0.5);
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.text.text = `Hello World! ${this.time.addTime(delta).seconds | 0}`;
         this.text.rotate(delta.seconds * 36);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.text);
     }

--- a/examples/text-fonts/bitmap-text-basic.js
+++ b/examples/text-fonts/bitmap-text-basic.js
@@ -17,9 +17,12 @@ class BitmapTextBasicScene extends Scene {
     counter;
     frame = 0;
     async init() {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.font = await this.loader.load(Asset.kind('bmFont', assets.demo.fonts.kenneyBlocksFnt));
         const font = this.font;
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
         const marginX = width * 0.08;
         this.title = new BitmapText('BITMAP TEXT', font, { scale: 1.5 });
         this.title.tint = new Color(255, 220, 80);

--- a/examples/text-fonts/bitmap-text-basic.ts
+++ b/examples/text-fonts/bitmap-text-basic.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, BitmapText, BmFont, Color, Scene } from '@codexo/exojs';
+import { Application, Asset, BitmapText, BmFont, Color, type RenderingContext, Scene } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -19,10 +19,12 @@ class BitmapTextBasicScene extends Scene {
     private frame = 0;
 
     override async init(): Promise<void> {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.font = await this.loader.load(Asset.kind('bmFont', assets.demo.fonts.kenneyBlocksFnt));
 
         const font = this.font;
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
         const marginX = width * 0.08;
 
         this.title = new BitmapText('BITMAP TEXT', font, { scale: 1.5 });
@@ -48,7 +50,7 @@ class BitmapTextBasicScene extends Scene {
         this.counter.text = `Frame: ${++this.frame}`;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.title);
         context.render(this.info);

--- a/examples/text-fonts/multiline-and-wrap.js
+++ b/examples/text-fonts/multiline-and-wrap.js
@@ -20,7 +20,10 @@ class MultilineAndWrapScene extends Scene {
     titleC;
     textC;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // Three wrap modes side by side across the 16:9 canvas: one column each.
         const colWidth = width / 3;
         const titleY = height * 0.16;

--- a/examples/text-fonts/multiline-and-wrap.ts
+++ b/examples/text-fonts/multiline-and-wrap.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene, Text } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, Text } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -24,7 +24,9 @@ class MultilineAndWrapScene extends Scene {
     private textC!: Text;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         // Three wrap modes side by side across the 16:9 canvas: one column each.
         const colWidth = width / 3;
@@ -51,7 +53,7 @@ class MultilineAndWrapScene extends Scene {
         this.textC.setPosition(colX(2), bodyY);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.titleA);
         context.render(this.titleB);

--- a/examples/text-fonts/stroke-and-shadow.js
+++ b/examples/text-fonts/stroke-and-shadow.js
@@ -15,7 +15,10 @@ const app = new Application({
 class StrokeAndShadowScene extends Scene {
     title;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.title = new Text('EXOJS', {
             fillColor: new Color(230, 240, 255),
             fontSize: 120,

--- a/examples/text-fonts/stroke-and-shadow.ts
+++ b/examples/text-fonts/stroke-and-shadow.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene, Text } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, Text } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -17,7 +17,9 @@ class StrokeAndShadowScene extends Scene {
     private title!: Text;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.title = new Text('EXOJS', {
             fillColor: new Color(230, 240, 255),
@@ -34,7 +36,7 @@ class StrokeAndShadowScene extends Scene {
         this.title.setPosition(width / 2, height / 2);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear(new Color(24, 28, 42));
         context.render(this.title);
     }

--- a/examples/text-fonts/text-glitch.js
+++ b/examples/text-fonts/text-glitch.js
@@ -42,7 +42,10 @@ class TextGlitchScene extends Scene {
     text;
     filter;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.text = new Text('SIGNAL LOST', { fillColor: Color.white, fontSize: 100, align: 'center' });
         this.text.setAnchor(0.5, 0.5);
         this.text.setPosition(width / 2, height / 2);

--- a/examples/text-fonts/text-glitch.ts
+++ b/examples/text-fonts/text-glitch.ts
@@ -1,4 +1,4 @@
-import { Application, Color, RenderBackendType, Scene, Text, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
+import { Application, Color, RenderBackendType, type RenderingContext, Scene, Text, WebGl2ShaderFilter, WebGpuShaderFilter } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -46,7 +46,9 @@ class TextGlitchScene extends Scene {
     private filter!: WebGl2ShaderFilter | WebGpuShaderFilter;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.text = new Text('SIGNAL LOST', { fillColor: Color.white, fontSize: 100, align: 'center' });
         this.text.setAnchor(0.5, 0.5);
@@ -62,7 +64,7 @@ class TextGlitchScene extends Scene {
         this.filter.uniforms.uShift = (Math.random() - 0.5) * 0.01;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.text);
     }

--- a/examples/text-fonts/web-fonts.js
+++ b/examples/text-fonts/web-fonts.js
@@ -16,8 +16,11 @@ class WebFontsScene extends Scene {
     default;
     loaded;
     async init() {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         await this.loader.load(Asset.kind('font', 'font/Kenney Future.ttf', { family: 'Kenney Future' }));
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
         this.default = new Text('Default Font', { fillColor: Color.white, fontSize: 52, align: 'center' });
         this.default.setAnchor(0.5, 0.5);
         this.default.setPosition(width / 2, height / 2 - 60);

--- a/examples/text-fonts/web-fonts.ts
+++ b/examples/text-fonts/web-fonts.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Color, Scene, Text } from '@codexo/exojs';
+import { Application, Asset, Color, type RenderingContext, Scene, Text } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -18,9 +18,11 @@ class WebFontsScene extends Scene {
     private loaded!: Text;
 
     override async init(): Promise<void> {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         await this.loader.load(Asset.kind('font', 'font/Kenney Future.ttf', { family: 'Kenney Future' }));
 
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
 
         this.default = new Text('Default Font', { fillColor: Color.white, fontSize: 52, align: 'center' });
         this.default.setAnchor(0.5, 0.5);
@@ -30,7 +32,7 @@ class WebFontsScene extends Scene {
         this.loaded.setPosition(width / 2, height / 2 + 60);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.default);
         context.render(this.loaded);

--- a/examples/tweens-animation/easing-curves.js
+++ b/examples/tweens-animation/easing-curves.js
@@ -60,7 +60,10 @@ class EasingCurvesScene extends Scene {
     cellWidth = 0;
     cellHeight = 0;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.cellWidth = width / COLS;
         this.cellHeight = (height - HEADER) / ROWS;
         this.labels = EASINGS.map(([name], index) => {

--- a/examples/tweens-animation/easing-curves.ts
+++ b/examples/tweens-animation/easing-curves.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Ease, Graphics, Scene, Text } from '@codexo/exojs';
+import { Application, Color, Ease, Graphics, type RenderingContext, Scene, Text, type Time } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -64,7 +64,9 @@ class EasingCurvesScene extends Scene {
     private cellHeight = 0;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.cellWidth = width / COLS;
         this.cellHeight = (height - HEADER) / ROWS;
@@ -97,7 +99,7 @@ class EasingCurvesScene extends Scene {
         return plotTop + plotHeight * (1 - Math.max(0, Math.min(1, norm)));
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.t += this.direction * delta.seconds * 0.6;
 
         if (this.t >= 1) {
@@ -109,7 +111,7 @@ class EasingCurvesScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
 
         const g = this.graphics;

--- a/examples/tweens-animation/frame-animation.js
+++ b/examples/tweens-animation/frame-animation.js
@@ -19,7 +19,10 @@ class FrameAnimationScene extends Scene {
     frameCount = 0;
     hud;
     async init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const texture = this.loader.get('image/platformer-characters.png');
         const data = (await this.loader.load(Asset.kind('json', 'json/platformer-characters.json')));
         const sheet = new Spritesheet(texture, data);

--- a/examples/tweens-animation/frame-animation.ts
+++ b/examples/tweens-animation/frame-animation.ts
@@ -1,4 +1,4 @@
-import { AnimatedSprite, Application, Asset, Color, Scene, Spritesheet, type SpritesheetData } from '@codexo/exojs';
+import { AnimatedSprite, Application, Asset, Color, type RenderingContext, Scene, Spritesheet, type SpritesheetData, type Time } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -22,7 +22,9 @@ class FrameAnimationScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
 
     override async init(): Promise<void> {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const texture = this.loader.get('image/platformer-characters.png');
         const data = (await this.loader.load(Asset.kind('json', 'json/platformer-characters.json'))) as SpritesheetData;
         const sheet = new Spritesheet(texture, data);
@@ -46,11 +48,11 @@ class FrameAnimationScene extends Scene {
         this.sprite.play('walk');
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.sprite.update(delta);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
     }

--- a/examples/tweens-animation/interrupt-and-replace.js
+++ b/examples/tweens-animation/interrupt-and-replace.js
@@ -16,13 +16,16 @@ class InterruptAndReplaceScene extends Scene {
     sprite;
     moveTween = null;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.sprite = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5).setPosition(width / 2, height / 2);
-        this.app.input.onPointerTap.add(pointer => {
+        app.input.onPointerTap.add(pointer => {
             if (this.moveTween !== null) {
                 this.moveTween.stop();
             }
-            this.moveTween = this.app.tweens.create(this.sprite.position).to({ x: pointer.x, y: pointer.y }, 0.35).start();
+            this.moveTween = app.tweens.create(this.sprite.position).to({ x: pointer.x, y: pointer.y }, 0.35).start();
         });
     }
     draw(context) {

--- a/examples/tweens-animation/interrupt-and-replace.ts
+++ b/examples/tweens-animation/interrupt-and-replace.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene, Sprite, Tween } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, Sprite, Tween } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -18,18 +18,20 @@ class InterruptAndReplaceScene extends Scene {
     private moveTween: Tween | null = null;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.sprite = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5).setPosition(width / 2, height / 2);
-        this.app.input.onPointerTap.add(pointer => {
+        app.input.onPointerTap.add(pointer => {
             if (this.moveTween !== null) {
                 this.moveTween.stop();
             }
-            this.moveTween = this.app.tweens.create(this.sprite.position).to({ x: pointer.x, y: pointer.y }, 0.35).start();
+            this.moveTween = app.tweens.create(this.sprite.position).to({ x: pointer.x, y: pointer.y }, 0.35).start();
         });
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
     }

--- a/examples/tweens-animation/tween-basics.js
+++ b/examples/tweens-animation/tween-basics.js
@@ -18,14 +18,17 @@ class TweenBasicsScene extends Scene {
     forward;
     backward;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const left = width * 0.1;
         const right = width * 0.9;
         this.sprite = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5).setPosition(left, height / 2);
         this.text = new Text('Tween running', { fillColor: Color.white, fontSize: 18 });
         this.text.setPosition(20, 20);
-        this.forward = this.app.tweens.create(this.sprite.position).to({ x: right }, 1.2);
-        this.backward = this.app.tweens.create(this.sprite.position).to({ x: left }, 1.2);
+        this.forward = app.tweens.create(this.sprite.position).to({ x: right }, 1.2);
+        this.backward = app.tweens.create(this.sprite.position).to({ x: left }, 1.2);
         this.forward
             .onComplete(() => {
             this.text.text = 'Completed -> reverse';

--- a/examples/tweens-animation/tween-basics.ts
+++ b/examples/tweens-animation/tween-basics.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene, Sprite, Text, Tween } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, Sprite, Text, Tween } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -20,15 +20,17 @@ class TweenBasicsScene extends Scene {
     private backward!: Tween;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         const left = width * 0.1;
         const right = width * 0.9;
 
         this.sprite = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5).setPosition(left, height / 2);
         this.text = new Text('Tween running', { fillColor: Color.white, fontSize: 18 });
         this.text.setPosition(20, 20);
-        this.forward = this.app.tweens.create(this.sprite.position).to({ x: right }, 1.2);
-        this.backward = this.app.tweens.create(this.sprite.position).to({ x: left }, 1.2);
+        this.forward = app.tweens.create(this.sprite.position).to({ x: right }, 1.2);
+        this.backward = app.tweens.create(this.sprite.position).to({ x: left }, 1.2);
         this.forward
             .onComplete(() => {
                 this.text.text = 'Completed -> reverse';
@@ -41,7 +43,7 @@ class TweenBasicsScene extends Scene {
         });
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
         context.render(this.text);

--- a/examples/tweens-animation/tween-chains.js
+++ b/examples/tweens-animation/tween-chains.js
@@ -15,32 +15,35 @@ const app = new Application({
 class TweenChainsScene extends Scene {
     sprite;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // A rectangle centred in the frame, spread across the wider 16:9 space.
         const left = width / 2 - width * 0.28;
         const right = width / 2 + width * 0.28;
         const top = height / 2 - height * 0.28;
         const bottom = height / 2 + height * 0.28;
         this.sprite = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5).setPosition(left, top);
-        const a = this.app.tweens
+        const a = app.tweens
             .create(this.sprite.position)
             .to({ x: right, y: top }, 0.6)
             .onComplete(() => {
             this.sprite.setRotation(90);
         });
-        const b = this.app.tweens
+        const b = app.tweens
             .create(this.sprite.position)
             .to({ x: right, y: bottom }, 0.6)
             .onComplete(() => {
             this.sprite.setRotation(180);
         });
-        const c = this.app.tweens
+        const c = app.tweens
             .create(this.sprite.position)
             .to({ x: left, y: bottom }, 0.6)
             .onComplete(() => {
             this.sprite.setRotation(270);
         });
-        const d = this.app.tweens
+        const d = app.tweens
             .create(this.sprite.position)
             .to({ x: left, y: top }, 0.6)
             .onComplete(() => {

--- a/examples/tweens-animation/tween-chains.ts
+++ b/examples/tweens-animation/tween-chains.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene, Sprite } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, Sprite } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -17,7 +17,9 @@ class TweenChainsScene extends Scene {
     private sprite!: Sprite;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         // A rectangle centred in the frame, spread across the wider 16:9 space.
         const left = width / 2 - width * 0.28;
         const right = width / 2 + width * 0.28;
@@ -26,25 +28,25 @@ class TweenChainsScene extends Scene {
 
         this.sprite = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5).setPosition(left, top);
 
-        const a = this.app.tweens
+        const a = app.tweens
             .create(this.sprite.position)
             .to({ x: right, y: top }, 0.6)
             .onComplete(() => {
                 this.sprite.setRotation(90);
             });
-        const b = this.app.tweens
+        const b = app.tweens
             .create(this.sprite.position)
             .to({ x: right, y: bottom }, 0.6)
             .onComplete(() => {
                 this.sprite.setRotation(180);
             });
-        const c = this.app.tweens
+        const c = app.tweens
             .create(this.sprite.position)
             .to({ x: left, y: bottom }, 0.6)
             .onComplete(() => {
                 this.sprite.setRotation(270);
             });
-        const d = this.app.tweens
+        const d = app.tweens
             .create(this.sprite.position)
             .to({ x: left, y: top }, 0.6)
             .onComplete(() => {
@@ -58,7 +60,7 @@ class TweenChainsScene extends Scene {
         a.start();
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
     }

--- a/examples/tweens-animation/tween-from-array.js
+++ b/examples/tweens-animation/tween-from-array.js
@@ -28,16 +28,22 @@ class TweenFromArrayScene extends Scene {
     sprite;
     waypoints = [];
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.waypoints = waypointFractions.map(({ fx, fy }) => ({ x: fx * width, y: fy * height }));
         this.sprite = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5).setPosition(this.waypoints[0].x, this.waypoints[0].y);
         this.buildPath();
     }
     buildPath() {
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         let first = null;
         let prev = null;
         for (let i = 1; i < this.waypoints.length; i++) {
-            const next = this.app.tweens.create(this.sprite.position).to(this.waypoints[i], 0.35).easing(Ease.sineInOut);
+            const next = app.tweens.create(this.sprite.position).to(this.waypoints[i], 0.35).easing(Ease.sineInOut);
             if (first === null)
                 first = next;
             if (prev !== null)

--- a/examples/tweens-animation/tween-from-array.ts
+++ b/examples/tweens-animation/tween-from-array.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Ease, Scene, Sprite, Tween } from '@codexo/exojs';
+import { Application, Color, Ease, type RenderingContext, Scene, Sprite, Tween } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -31,7 +31,9 @@ class TweenFromArrayScene extends Scene {
     private waypoints: Array<{ x: number; y: number }> = [];
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.waypoints = waypointFractions.map(({ fx, fy }) => ({ x: fx * width, y: fy * height }));
         this.sprite = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5).setPosition(this.waypoints[0].x, this.waypoints[0].y);
@@ -39,10 +41,12 @@ class TweenFromArrayScene extends Scene {
     }
 
     private buildPath(): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         let first: Tween | null = null;
         let prev: Tween | null = null;
         for (let i = 1; i < this.waypoints.length; i++) {
-            const next = this.app.tweens.create(this.sprite.position).to(this.waypoints[i], 0.35).easing(Ease.sineInOut);
+            const next = app.tweens.create(this.sprite.position).to(this.waypoints[i], 0.35).easing(Ease.sineInOut);
             if (first === null) first = next;
             if (prev !== null) prev.chain(next);
             prev = next;
@@ -54,7 +58,7 @@ class TweenFromArrayScene extends Scene {
         first!.start();
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
     }

--- a/examples/tweens-animation/tween-with-yoyo.js
+++ b/examples/tweens-animation/tween-with-yoyo.js
@@ -15,10 +15,13 @@ const app = new Application({
 class TweenWithYoyoScene extends Scene {
     sprite;
     init() {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null)
+            throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
         this.sprite = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5).setPosition(width / 2, height / 2);
-        this.app.tweens.create(this.sprite.scale).to({ x: 1.5, y: 1.5 }, 0.8).yoyo(true).repeat(-1).start();
-        this.app.tweens.create(this.sprite).to({ rotation: 20 }, 0.8).yoyo(true).repeat(-1).start();
+        app.tweens.create(this.sprite.scale).to({ x: 1.5, y: 1.5 }, 0.8).yoyo(true).repeat(-1).start();
+        app.tweens.create(this.sprite).to({ rotation: 20 }, 0.8).yoyo(true).repeat(-1).start();
     }
     draw(context) {
         context.backend.clear();

--- a/examples/tweens-animation/tween-with-yoyo.ts
+++ b/examples/tweens-animation/tween-with-yoyo.ts
@@ -1,4 +1,4 @@
-import { Application, Color, Scene, Sprite } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, Sprite } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -17,14 +17,16 @@ class TweenWithYoyoScene extends Scene {
     private sprite!: Sprite;
 
     override init(): void {
-        const { width, height } = this.app.canvas;
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        const { width, height } = app.canvas;
 
         this.sprite = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5).setPosition(width / 2, height / 2);
-        this.app.tweens.create(this.sprite.scale).to({ x: 1.5, y: 1.5 }, 0.8).yoyo(true).repeat(-1).start();
-        this.app.tweens.create(this.sprite).to({ rotation: 20 }, 0.8).yoyo(true).repeat(-1).start();
+        app.tweens.create(this.sprite.scale).to({ x: 1.5, y: 1.5 }, 0.8).yoyo(true).repeat(-1).start();
+        app.tweens.create(this.sprite).to({ rotation: 20 }, 0.8).yoyo(true).repeat(-1).start();
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.sprite);
     }

--- a/examples/ui/hud-and-widgets.ts
+++ b/examples/ui/hud-and-widgets.ts
@@ -1,4 +1,4 @@
-import { Application, Button, Color, Label, Panel, ProgressBar, Scene, Stack } from '@codexo/exojs';
+import { Application, Button, Color, Label, Panel, ProgressBar, type RenderingContext, Scene, Stack, type Time } from '@codexo/exojs';
 
 const app = new Application({
     canvas: {
@@ -65,12 +65,12 @@ class HudScene extends Scene {
         this.ui.addChild(panel);
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.angle += delta.seconds * 60;
         this.spinner.setRotation(this.angle);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         // scene.root is explicit; scene.ui is auto-rendered above it.
         context.render(this.root);
     }

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -9,9 +9,15 @@
   // editor-visible "`fill` does not exist in TextStyleOptions" diagnostics also
   // fail `pnpm typecheck:examples`.
   //
-  // `strict` is intentionally off so idiomatic example patterns (untyped
-  // `draw(context)` params, etc.) don't add noise — TypeScript's object-literal
-  // excess-property check, which flags the stale style keys, runs regardless.
+  // `strict` is ON. Example code is a copy-paste surface for `create-exo-app`
+  // scaffolds, which are strict by default — code that only compiles under
+  // `strict: false` here would fail to compile the moment a user pastes it in.
+  // All lifecycle overrides (`update(delta: Time)`, `draw(context:
+  // RenderingContext)`, etc.) are explicitly typed, and every `this.app` read
+  // is narrowed via a local `const app = this.app; if (app === null) throw ...`
+  // guard at the top of the owning method (mirrors the `Scene.inputs` /
+  // `Scene.tweens` / `Scene.loader` getters, which throw the same way when
+  // accessed before the scene is attached).
   //
   // Scope: the full example catalog. Every `.js` under `examples/` is
   // type-checked against the engine source types, so stale TextStyle keys are
@@ -38,7 +44,7 @@
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,
-    "strict": false,
+    "strict": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary

`pnpm typecheck:examples` previously ran with `strict: false`, so example code that users copy-paste into a strict TypeScript scaffold (the `create-exo-app` templates are strict by default) could fail to compile for them. This PR flips `strict: true` in `tsconfig.examples.json` and fixes every resulting error properly — no `any` / non-null-assertion carpet-bombing (the two pre-existing `this.app!` assertions in `render-pipeline.ts` were even removed).

## Error inventory at the strict flip (before any fixes)

**573 errors across 124 example files:**

| Code | Count | Meaning |
|---|---|---|
| TS2531 | 334 | `Object is possibly 'null'` — all `this.app` (Scene.app is `Application \| null`) |
| TS7006 | 235 | implicit-`any` parameter — 146x `context`, 76x `delta`, 13 misc |
| TS7053 | 2 | string-index into typed asset catalog |
| TS2769 | 1 | `reduce` overload on `unknown[]` |
| TS2345 | 1 | `Application \| null` passed where `Application` expected |

**After: 0 errors.** `pnpm typecheck:examples` is green with `strict: true`.

## Fix patterns

- **`this.app` (334x):** capture `const app = this.app;` + throw-guard at the top of the owning method — TS narrowing survives into arrow closures (signal handlers), unlike guarding `this.app` directly. The throw message mirrors the existing `Scene.inputs`/`Scene.tweens`/`Scene.loader` getters.
- **Lifecycle overrides (221x):** explicit `override update(delta: Time)` / `override draw(context: RenderingContext)` with type-only imports (TS does not infer override parameter types from the base class).
- **Targeted fixes:** typed `Map<InputChannel, Sprite>` / `Gamepad` in `input/gamepad.ts` and `showcase/gamepad-spaceship.ts`; `as const` catalog iteration + a typed `VendorManifest` via `Asset.kind<T>('json', ...)` in `debug-layer/asset-browser.ts`; typed `UpdateModule.apply(system: ParticleSystem, dt: number)` overrides in the particles examples; canvas dimensions threaded as parameters instead of re-reading `this.app.canvas` inside non-void helper methods.
- `.js` mirrors regenerated via `examples:sync`; tsconfig comment updated to document the strict rationale.

## API DX findings (signals worth an engine-side look, not papered over here)

1. **`Scene.app: Application | null` is the dominant strict-mode papercut** — 334 of 573 errors (58%). Every scene that touches `this.app` in `init()`/`update()`/`draw()` needs a guard, even though the framework guarantees attachment before those hooks run. An `appOrThrow`-style getter (like `inputs`/`tweens`/`loader` already have), or typing `app` non-null with a documented throw, would eliminate the single biggest strict-mode friction for users. Filed as the key takeaway.
2. **Base-class lifecycle params don't propagate** — `override update(delta)` is implicit-`any` under strict (TS design limitation). 221 signatures needed explicit types; scaffold templates and docs should always show the typed form.
3. **Playground/Monaco drift (checked, deliberately not changed):** Monaco in `site/src/components/EditorCode.tsx` sets `strict: false` + `noImplicitAny: false` and loads the permissive `editor-support.d.ts` shim (which typecheck:examples deliberately excludes). The two configs were already divergent before this PR; aligning Monaco to strict is a separate playground-UX decision (it would surface red squiggles for JS playground snippets) and is left as a follow-up.

## Gates

- `pnpm typecheck:examples` (now strict): **green** (573 -> 0)
- `pnpm examples:sync`: run, `.js` mirrors committed
- `pnpm lint`: **0 errors** (26 pre-existing warnings, untouched files)
- `pnpm format:check`: **clean**
- `pnpm test:examples:smoke`: **104 passed / 20 failed — failure set byte-for-byte identical to origin/main baseline** (verified by stashing the diff and re-running: same 20 pre-existing failures, all music/video asset-kind registry gaps and headless-WebGPU texture issues, unrelated to this change). Zero regressions.

No engine code changes, no version bumps.

https://claude.ai/code/session_01RHB7cLgoonJHLQg9ScdXby