### PR TITLE
fix(examples): make tilemap examples pass strict typecheck:examples

### DIFF
--- a/examples/tilemap/ldtk-world-import.ts
+++ b/examples/tilemap/ldtk-world-import.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Color, Container, Graphics, Scene, Text } from '@codexo/exojs';
+import { Application, Asset, Color, Container, Graphics, type RenderingContext, Scene, Text } from '@codexo/exojs';
 import { getLdtkIntGridValueAt, LdtkMap, ldtkExtension } from '@codexo/exojs-ldtk';
 import { TileMapNode } from '@codexo/exojs-tilemap';
 import { mountControlPanel, mountControls } from '@examples/runtime';
@@ -151,7 +151,7 @@ class LdtkWorldImportScene extends Scene {
         return labels;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.content);
     }

--- a/examples/tilemap/tile-chunks-and-bands.js
+++ b/examples/tilemap/tile-chunks-and-bands.js
@@ -88,7 +88,7 @@ class TileChunksAndBandsScene extends Scene {
         // tiles visually cover the explorer whenever they overlap.
         this.worldRoot.addChild(this.mapView.band('ground'), actorLayer, this.mapView.band('canopy'));
         // ── Camera: follows the explorer, clamped to the map bounds ───────
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
         this.camera = new View(this.explorer.x, this.explorer.y, width, height);
         this.camera.follow(this.explorer, { lerp: 0.12 });
         this.camera.setBounds(new Rectangle(0, 0, MAP_WIDTH, MAP_HEIGHT));

--- a/examples/tilemap/tile-chunks-and-bands.ts
+++ b/examples/tilemap/tile-chunks-and-bands.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Color, Container, Keyboard, type PixelSnapMode, Rectangle, Scene, Sprite, Spritesheet, type SpritesheetData, TextureRegion, View } from '@codexo/exojs';
+import { Application, Asset, Color, Container, Keyboard, type PixelSnapMode, Rectangle, type RenderingContext, Scene, Sprite, Spritesheet, type SpritesheetData, TextureRegion, type Time, View } from '@codexo/exojs';
 import { TILE_TRANSFORM_IDENTITY, TileLayer, TileMap, tilemapExtension, TileSet, type TileMapView } from '@codexo/exojs-tilemap';
 import { mountControlPanel, mountControls } from '@examples/runtime';
 
@@ -105,7 +105,7 @@ class TileChunksAndBandsScene extends Scene {
         this.worldRoot.addChild(this.mapView.band('ground'), actorLayer, this.mapView.band('canopy'));
 
         // ── Camera: follows the explorer, clamped to the map bounds ───────
-        const { width, height } = this.app.canvas;
+        const { width, height } = app.canvas;
 
         this.camera = new View(this.explorer.x, this.explorer.y, width, height);
         this.camera.follow(this.explorer, { lerp: 0.12 });
@@ -168,7 +168,7 @@ class TileChunksAndBandsScene extends Scene {
         });
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         if (this.moveX !== 0 || this.moveY !== 0) {
             const length = Math.hypot(this.moveX, this.moveY) || 1;
 
@@ -178,7 +178,7 @@ class TileChunksAndBandsScene extends Scene {
         }
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.worldRoot, { view: this.camera });
     }

--- a/examples/tilemap/tiled-map-import.ts
+++ b/examples/tilemap/tiled-map-import.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Color, Graphics, Scene } from '@codexo/exojs';
+import { Application, Asset, Color, Graphics, type RenderingContext, Scene } from '@codexo/exojs';
 import { tiledExtension, TileMapNode } from '@codexo/exojs-tiled';
 import { ObjectKind, type ObjectQuery, type TileMapObject } from '@codexo/exojs-tilemap';
 import { mountControlPanel, mountControls } from '@examples/runtime';
@@ -123,7 +123,7 @@ class TiledMapImportScene extends Scene {
         this.hud.setStatus(`${FILTERS[this.filterIndex]!.label}: ${matches.length} match(es) — ${names}`);
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         context.backend.clear();
         context.render(this.mapNode);
         context.render(this.overlay);


### PR DESCRIPTION
## Summary
- #307 added three tilemap examples with un-annotated `draw()`/`update()` overrides, which fail under the strict `typecheck:examples` tsconfig introduced by #298 (implicit-any parameters).
- The required GitHub CI does not run `typecheck:examples`, so #307 merged anyway, but the local `.husky/pre-push` hook runs `verify:quick` (which does include it) — blocking every push after rebasing onto main.
- Annotates `context`/`delta` parameters with the same `RenderingContext`/`Time` types every other example uses, and switches `tile-chunks-and-bands.ts` to read canvas size off the module-scope `app` (`Application`) instead of `this.app` (`Scene['app']`, which is `Application | null`), matching the convention used by every other example that reads `app.canvas`.
- Regenerated the committed `.js` siblings via `examples:sync`; only `tile-chunks-and-bands.js` changes, since the other two edits are type-only and erase during transpilation.

## Test plan
- [x] `pnpm typecheck:examples` — 0 errors (was 5 errors in 3 files)
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm verify:quick` — full local gate green (same checks as `.husky/pre-push`)
- [x] `pnpm --filter @codexo/exojs-examples examples:sync` re-run, diff limited to the 4 touched files