### PR TITLE
perf(rendering): pack sprite tint into shared transform slot, drop per-instance a_color (B-11)

### DIFF
--- a/src/rendering/sprite/spriteMaterialSources.ts
+++ b/src/rendering/sprite/spriteMaterialSources.ts
@@ -12,8 +12,8 @@
  * projection binding exactly as the default sprite path does, so a custom
  * material keeps the single `drawArraysInstanced` / `drawIndexed` batch.
  *
- * Both paths (locations 0, 3, 4, 5, 6) fetch each instance's world transform
- * from the shared transform storage keyed by `a_nodeIndex` / `nodeIndex`: the
+ * Both paths (locations 0, 3, 5, 6) fetch each instance's world transform and
+ * tint from the shared transform storage keyed by `a_nodeIndex` / `nodeIndex`: the
  * WebGL2 path samples the `u_transforms` texture, the WGSL path reads the
  * `transforms` storage buffer (group(0) binding(1)).
  *
@@ -25,7 +25,8 @@
 
 /**
  * GLSL ES 3.00 vertex shader for the custom sprite-material path. Identical
- * corner expansion and attribute contract to the default sprite vertex shader.
+ * corner expansion and attribute contract to the default sprite vertex shader
+ * (tint read from the shared transform slot's texel 2, no per-instance color).
  * @internal
  */
 export const spriteVertexGlsl = `#version 300 es
@@ -37,7 +38,6 @@ precision highp int;
 // quad this invocation is computing.
 layout(location = 0) in vec4 a_localBounds;     // left, top, right, bottom (local space)
 layout(location = 3) in vec4 a_uvBounds;        // uMin, vMin, uMax, vMax (normalised, already flipY-swapped)
-layout(location = 4) in vec4 a_color;           // RGBA tint
 layout(location = 5) in uint a_textureSlot;
 layout(location = 6) in uint a_nodeIndex;       // row into the shared transform buffer
 
@@ -58,11 +58,13 @@ void main(void) {
     float localX = (cornerX == 0) ? a_localBounds.x : a_localBounds.z;
     float localY = (cornerY == 0) ? a_localBounds.y : a_localBounds.w;
 
-    // Fetch the per-instance world transform from the shared buffer (row =
-    // a_nodeIndex): texel 0 = (a, b, c, d), texel 1 = (tx, ty, 0, 0).
+    // Fetch the per-instance world transform and tint from the shared buffer
+    // (row = a_nodeIndex): texel 0 = (a, b, c, d), texel 1 = (tx, ty, 0, 0),
+    // texel 2 = tint (rgb 0..1, a).
     int row = int(a_nodeIndex);
     vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
     vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+    vec4 m2 = texelFetch(u_transforms, ivec2(2, row), 0);
 
     float worldX = (m0.x * localX) + (m0.y * localY) + m1.x;
     float worldY = (m0.z * localX) + (m0.w * localY) + m1.y;
@@ -73,7 +75,7 @@ void main(void) {
     float v = (cornerY == 0) ? a_uvBounds.y : a_uvBounds.w;
     v_texcoord = vec2(u, v);
 
-    v_color = vec4(a_color.rgb * a_color.a, a_color.a);
+    v_color = vec4(m2.rgb * m2.a, m2.a);
     v_textureSlot = a_textureSlot;
 }
 `;
@@ -81,7 +83,7 @@ void main(void) {
 /**
  * WGSL vertex stage + shared bindings for the custom sprite-material path.
  * Prepend to a material's fragment WGSL: it declares the per-instance
- * `VertexInput` (locations 0, 3, 4, 5, 6), the `VertexOutput` a custom
+ * `VertexInput` (locations 0, 3, 5, 6), the `VertexOutput` a custom
  * `@fragment` consumes, the group(0) projection uniform + shared transform
  * storage buffer, the group(1) base texture and sampler (`u_texture` /
  * `u_sampler`), and the `vertexMain` entry point. The fragment author adds their
@@ -109,7 +111,6 @@ struct TransformSlot {
 struct VertexInput {
     @location(0) localBounds: vec4<f32>,
     @location(3) uvBounds: vec4<f32>,
-    @location(4) color: vec4<f32>,
     @location(5) textureSlot: u32,
     @location(6) nodeIndex: u32,
 };
@@ -130,9 +131,9 @@ fn vertexMain(input: VertexInput, @builtin(vertex_index) vid: u32) -> VertexOutp
     let localX = select(input.localBounds.x, input.localBounds.z, cornerX == 1u);
     let localY = select(input.localBounds.y, input.localBounds.w, cornerY == 1u);
 
-    // Fetch this instance's world transform from the shared storage buffer,
-    // keyed by nodeIndex: m0 = (a, b, c, d), m1 = (tx, ty, 0, 0). (m2 carries the
-    // node tint, unused here — the sprite keeps its own per-instance color.)
+    // Fetch this instance's world transform and tint from the shared storage
+    // buffer, keyed by nodeIndex: m0 = (a, b, c, d), m1 = (tx, ty, 0, 0),
+    // m2 = tint (rgb 0..1, a).
     let slot = transforms[input.nodeIndex];
     let worldX = slot.m0.x * localX + slot.m0.y * localY + slot.m1.x;
     let worldY = slot.m0.z * localX + slot.m0.w * localY + slot.m1.y;
@@ -143,7 +144,7 @@ fn vertexMain(input: VertexInput, @builtin(vertex_index) vid: u32) -> VertexOutp
     let v = select(input.uvBounds.y, input.uvBounds.w, cornerY == 1u);
     output.texcoord = vec2<f32>(u, v);
 
-    output.color = vec4<f32>(input.color.rgb * input.color.a, input.color.a);
+    output.color = vec4<f32>(slot.m2.rgb * slot.m2.a, slot.m2.a);
 
     return output;
 }

--- a/src/rendering/webgl2/WebGl2SpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2SpriteRenderer.ts
@@ -26,23 +26,22 @@ import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './
  * the quad each invocation is computing. All per-sprite data lives in a
  * single per-instance buffer (divisor = 1).
  *
- * Per-instance layout (36 bytes per sprite, 5 attributes):
+ * Per-instance layout (32 bytes per sprite, 4 attributes):
  * ```
  *   localBounds    f32x4       (offset  0, 16 bytes)  — left, top, right, bottom
  *   uvBounds       u16x4 norm  (offset 16,  8 bytes)  — uMin, vMin, uMax, vMax
- *   color          u8x4  norm  (offset 24,  4 bytes)  — RGBA tint
- *   textureSlot    u32         (offset 28,  4 bytes)  — multi-texture slot
- *   nodeIndex      u32         (offset 32,  4 bytes)  — row into the shared TransformBuffer
+ *   textureSlot    u32         (offset 24,  4 bytes)  — multi-texture slot
+ *   nodeIndex      u32         (offset 28,  4 bytes)  — row into the shared TransformBuffer
  * ```
  *
- * The per-instance world transform no longer lives in this buffer: it is
- * fetched in the vertex shader from the shared {@link TransformBuffer}
+ * Neither the per-instance world transform nor the tint live in this buffer:
+ * both are fetched in the vertex shader from the shared {@link TransformBuffer}
  * texture (`u_transforms`) keyed by `a_nodeIndex`, exactly like the mesh
- * renderer. The render-group upload boundary (PR #44) already packs every
- * draw command's transform into that buffer at its stable `nodeIndex`, so the
- * sprite just reads it back instead of re-packing 24 bytes of affine rows per
- * instance. vs. the previous per-vertex layout (80 bytes per quad), the
- * vertex shader still expands one instance into four corners on the GPU.
+ * renderer (transform = texels 0/1, tint = texel 2). The render-group upload
+ * boundary already packs every draw command's transform AND tint into that
+ * buffer at its stable `nodeIndex`, so the sprite reads both back instead of
+ * duplicating a per-instance color stream. The vertex shader still expands one
+ * instance into four corners on the GPU.
  *
  * # Default vs custom-material path
  *
@@ -70,7 +69,7 @@ const transformTextureUnit = 16;
 // Deliberately decoupled from maxBatchTextures — bumping the default-path
 // batch capacity must not silently widen what materials may request.
 const maxCustomTextureSlots = 8;
-const instanceStrideBytes = 36;
+const instanceStrideBytes = 32;
 const wordsPerInstance = instanceStrideBytes / Uint32Array.BYTES_PER_ELEMENT;
 
 interface SpriteRendererConnection {
@@ -302,7 +301,7 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
   }
 
   // ── Retained-batch record/replay (Track B Slice 3, Tasks 6/7) ────────────
-  // The bundle stores raw instance bytes; this renderer owns the 36-byte
+  // The bundle stores raw instance bytes; this renderer owns the 32-byte
   // layout, so the layout-aware finalize steps (node-index scan/rebase, VAO
   // attribute wiring) and the replay dispatch live here.
 
@@ -313,7 +312,8 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
 
     for (let i = 0; i < payload.instanceCount; i++) {
       // In-bounds: the payload's word range was appended to the bundle store.
-      const node = words[start + i * wordsPerInstance + 8]!;
+      // nodeIndex is the last word of the 32-byte (8-word) instance layout.
+      const node = words[start + i * wordsPerInstance + 7]!;
 
       if (node < range.min) {
         range.min = node;
@@ -331,7 +331,7 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
     const start = payload.byteOffset / Uint32Array.BYTES_PER_ELEMENT;
 
     for (let i = 0; i < payload.instanceCount; i++) {
-      const index = start + i * wordsPerInstance + 8;
+      const index = start + i * wordsPerInstance + 7;
 
       // In-bounds: see the scan above.
       words[index] = (words[index]! - base) >>> 0;
@@ -359,9 +359,8 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
     vao
       .addAttribute(buffer, this._shader.getAttribute('a_localBounds'), gl.FLOAT, false, instanceStrideBytes, base + 0, false, 1)
       .addAttribute(buffer, this._shader.getAttribute('a_uvBounds'), gl.UNSIGNED_SHORT, true, instanceStrideBytes, base + 16, false, 1)
-      .addAttribute(buffer, this._shader.getAttribute('a_color'), gl.UNSIGNED_BYTE, true, instanceStrideBytes, base + 24, false, 1)
-      .addAttribute(buffer, this._shader.getAttribute('a_textureSlot'), gl.UNSIGNED_INT, false, instanceStrideBytes, base + 28, true, 1)
-      .addAttribute(buffer, this._shader.getAttribute('a_nodeIndex'), gl.UNSIGNED_INT, false, instanceStrideBytes, base + 32, true, 1);
+      .addAttribute(buffer, this._shader.getAttribute('a_textureSlot'), gl.UNSIGNED_INT, false, instanceStrideBytes, base + 24, true, 1)
+      .addAttribute(buffer, this._shader.getAttribute('a_nodeIndex'), gl.UNSIGNED_INT, false, instanceStrideBytes, base + 28, true, 1);
   }
 
   /**
@@ -437,9 +436,8 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
     this._vao = new WebGl2VertexArrayObject(RenderingPrimitives.TriangleStrip)
       .addAttribute(this._instanceBuffer, this._shader.getAttribute('a_localBounds'), gl.FLOAT, false, instanceStrideBytes, 0, false, 1)
       .addAttribute(this._instanceBuffer, this._shader.getAttribute('a_uvBounds'), gl.UNSIGNED_SHORT, true, instanceStrideBytes, 16, false, 1)
-      .addAttribute(this._instanceBuffer, this._shader.getAttribute('a_color'), gl.UNSIGNED_BYTE, true, instanceStrideBytes, 24, false, 1)
-      .addAttribute(this._instanceBuffer, this._shader.getAttribute('a_textureSlot'), gl.UNSIGNED_INT, false, instanceStrideBytes, 28, true, 1)
-      .addAttribute(this._instanceBuffer, this._shader.getAttribute('a_nodeIndex'), gl.UNSIGNED_INT, false, instanceStrideBytes, 32, true, 1)
+      .addAttribute(this._instanceBuffer, this._shader.getAttribute('a_textureSlot'), gl.UNSIGNED_INT, false, instanceStrideBytes, 24, true, 1)
+      .addAttribute(this._instanceBuffer, this._shader.getAttribute('a_nodeIndex'), gl.UNSIGNED_INT, false, instanceStrideBytes, 28, true, 1)
       .connect(this._createVaoRuntime(this._connection));
 
     // Pin the per-slot sampler uniforms to texture units 0..N-1. Strict on
@@ -575,16 +573,15 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
     u32[offset + 4] = uMin | (vMin << 16);
     u32[offset + 5] = uMax | (vMax << 16);
 
-    // color (u8x4 packed) at word 6
-    u32[offset + 6] = sprite.tint.toRgba();
+    // textureSlot (u32) at word 6. The tint is NOT packed here: the vertex
+    // shader reads it from the shared transform slot's texel 2 (same value the
+    // transform-buffer upload boundary wrote from this sprite's tint).
+    u32[offset + 6] = slot;
 
-    // textureSlot (u32) at word 7
-    u32[offset + 7] = slot;
-
-    // nodeIndex (u32) at word 8 — row into the shared transform buffer.
+    // nodeIndex (u32) at word 7 — row into the shared transform buffer.
     const node = nodeIndex >>> 0;
 
-    u32[offset + 8] = node;
+    u32[offset + 7] = node;
 
     if (node > this._maxNodeIndex) {
       this._maxNodeIndex = node;

--- a/src/rendering/webgl2/glsl/sprite.vert
+++ b/src/rendering/webgl2/glsl/sprite.vert
@@ -7,7 +7,6 @@ precision highp int;
 // quad this invocation is computing.
 layout(location = 0) in vec4 a_localBounds;     // left, top, right, bottom (local space)
 layout(location = 3) in vec4 a_uvBounds;        // uMin, vMin, uMax, vMax (normalised, already flipY-swapped)
-layout(location = 4) in vec4 a_color;           // RGBA tint
 layout(location = 5) in uint a_textureSlot;
 layout(location = 6) in uint a_nodeIndex;       // row into the shared transform buffer
 
@@ -29,13 +28,16 @@ void main(void) {
     float localX = (cornerX == 0) ? a_localBounds.x : a_localBounds.z;
     float localY = (cornerY == 0) ? a_localBounds.y : a_localBounds.w;
 
-    // Fetch the world transform for this instance from the shared buffer,
-    // keyed by a_nodeIndex. Row layout: texel 0 = (a, b, c, d),
-    // texel 1 = (tx, ty, 0, 0). (texel 2 carries tint, unused here — the
-    // sprite keeps its own per-instance a_color.)
+    // Fetch the world transform and tint for this instance from the shared
+    // buffer, keyed by a_nodeIndex. Row layout: texel 0 = (a, b, c, d),
+    // texel 1 = (tx, ty, 0, 0), texel 2 = tint (rgb in 0..1, a). The node tint
+    // is the sprite's own tint (written at the transform-buffer upload
+    // boundary), so reading it here unifies with the mesh path and removes the
+    // redundant per-instance a_color stream.
     int row = int(a_nodeIndex);
     vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0); // a, b, c, d
     vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0); // tx, ty, 0, 0
+    vec4 m2 = texelFetch(u_transforms, ivec2(2, row), 0); // tint (rgb 0..1, a)
 
     // world = M * (localX, localY, 1)
     float worldX = (m0.x * localX) + (m0.y * localY) + m1.x;
@@ -49,6 +51,6 @@ void main(void) {
     float v = (cornerY == 0) ? a_uvBounds.y : a_uvBounds.w;
     v_texcoord = vec2(u, v);
 
-    v_color = vec4(a_color.rgb * a_color.a, a_color.a);
+    v_color = vec4(m2.rgb * m2.a, m2.a);
     v_textureSlot = a_textureSlot;
 }

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -1276,13 +1276,13 @@ export class WebGpuBackend implements RenderBackend {
 
     bytes.set(new Uint8Array(instanceData, 0, byteLength));
 
-    // Scan the frame-global node indices (word 8 of each 9-word instance) so
+    // Scan the frame-global node indices (word 7 of each 8-word instance) so
     // capture end can rebase them group-local and copy the row range once.
     const words = new Uint32Array(bytes.buffer);
     let minNodeIndex = 0xffffffff;
     let maxNodeIndex = 0;
 
-    for (let i = 8; i < words.length; i += 9) {
+    for (let i = 7; i < words.length; i += 8) {
       // In-bounds: i < words.length via the loop guard.
       const nodeIndex = words[i]!;
 
@@ -1393,12 +1393,12 @@ export class WebGpuBackend implements RenderBackend {
     bundle.ensureCapacity(device, frame.totalBytes, transformBytes);
 
     for (const batch of staged) {
-      // Rebase word 8 (nodeIndex) of every 9-word instance to group-local
+      // Rebase word 7 (nodeIndex) of every 8-word instance to group-local
       // indices — the cached bytes become immune to frame-local index shifts
       // (S3-D4) and address the group-owned row copy below.
       const words = new Uint32Array(batch.bytes.buffer, batch.bytes.byteOffset, batch.bytes.byteLength / Uint32Array.BYTES_PER_ELEMENT);
 
-      for (let i = 8; i < words.length; i += 9) {
+      for (let i = 7; i < words.length; i += 8) {
         // In-bounds: i < words.length via the loop guard.
         words[i] = words[i]! - base;
       }

--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -143,15 +143,14 @@ ${textureBindings}
 
 ${samplerBindings}
 
-// Per-instance vertex layout (36 bytes per sprite). The four corners
+// Per-instance vertex layout (32 bytes per sprite). The four corners
 // of the quad are derived from @builtin(vertex_index) 0..3 inside the
-// vertex shader — there is no per-vertex stream. The world transform is
-// fetched from the shared transform storage buffer keyed by nodeIndex
+// vertex shader — there is no per-vertex stream. The world transform AND the
+// tint are fetched from the shared transform storage buffer keyed by nodeIndex
 // instead of being packed inline.
 struct VertexInput {
     @location(0) localBounds: vec4<f32>,        // left, top, right, bottom (local space)
     @location(3) uvBounds: vec4<f32>,           // uMin, vMin, uMax, vMax (CPU pre-swaps for flipY)
-    @location(4) color: vec4<f32>,              // RGBA tint
     @location(5) packedSlotFlags: u32,          // bits 0..7 = slot, bit 8 = premultiply
     @location(6) nodeIndex: u32,                // row into the shared transform storage buffer
 };
@@ -176,9 +175,11 @@ fn vertexMain(input: VertexInput, @builtin(vertex_index) vid: u32) -> VertexOutp
     let localX = select(input.localBounds.x, input.localBounds.z, cornerX == 1u);
     let localY = select(input.localBounds.y, input.localBounds.w, cornerY == 1u);
 
-    // Fetch this instance's world transform from the shared storage buffer,
-    // keyed by nodeIndex: m0 = (a, b, c, d), m1 = (tx, ty, 0, 0). (m2 carries the
-    // node tint, unused here — the sprite keeps its own per-instance color.)
+    // Fetch this instance's world transform and tint from the shared storage
+    // buffer, keyed by nodeIndex: m0 = (a, b, c, d), m1 = (tx, ty, 0, 0),
+    // m2 = tint (rgb 0..1, a). The node tint is this sprite's own tint, so
+    // reading it here unifies with the mesh path and drops the per-instance
+    // color stream.
     let slot = transforms[input.nodeIndex];
     let worldX = slot.m0.x * localX + slot.m0.y * localY + slot.m1.x;
     let worldY = slot.m0.z * localX + slot.m0.w * localY + slot.m1.y;
@@ -189,7 +190,7 @@ fn vertexMain(input: VertexInput, @builtin(vertex_index) vid: u32) -> VertexOutp
     let v = select(input.uvBounds.y, input.uvBounds.w, cornerY == 1u);
     output.texcoord = vec2<f32>(u, v);
 
-    output.color = vec4(input.color.rgb * input.color.a, input.color.a);
+    output.color = vec4(slot.m2.rgb * slot.m2.a, slot.m2.a);
     output.textureSlot = input.packedSlotFlags & 0xFFu;
     output.premultiplySample = (input.packedSlotFlags >> 8u) & 1u;
 
@@ -220,7 +221,7 @@ fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
 `;
 };
 
-const instanceStrideBytes = 36;
+const instanceStrideBytes = 32;
 const wordsPerInstance = instanceStrideBytes / Uint32Array.BYTES_PER_ELEMENT;
 const projectionByteLength = 128;
 const initialBatchCapacity = 32;
@@ -1071,16 +1072,15 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     u32[offset + 4] = uMin | (vMin << 16);
     u32[offset + 5] = uMax | (vMax << 16);
 
-    // color (u8x4 packed) at word 6 (offset 24)
-    u32[offset + 6] = sprite.tint.toRgba();
+    // packedSlotFlags (u32) at word 6 (offset 24). The tint is NOT packed here:
+    // the vertex shader reads it from the shared transform slot's texel 2 (m2),
+    // the same value the transform-storage upload wrote from this sprite's tint.
+    u32[offset + 6] = packedSlotFlags;
 
-    // packedSlotFlags (u32) at word 7 (offset 28)
-    u32[offset + 7] = packedSlotFlags;
-
-    // nodeIndex (u32) at word 8 (offset 32) — row into the shared transform buffer.
+    // nodeIndex (u32) at word 7 (offset 28) — row into the shared transform buffer.
     const node = nodeIndex >>> 0;
 
-    u32[offset + 8] = node;
+    u32[offset + 7] = node;
 
     if (node > this._maxNodeIndex) {
       this._maxNodeIndex = node;
@@ -1294,18 +1294,13 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
                 format: 'unorm16x4',
               },
               {
-                shaderLocation: 4,
-                offset: 24,
-                format: 'unorm8x4',
-              },
-              {
                 shaderLocation: 5,
-                offset: 28,
+                offset: 24,
                 format: 'uint32',
               },
               {
                 shaderLocation: 6,
-                offset: 32,
+                offset: 28,
                 format: 'uint32',
               },
             ],
@@ -1444,9 +1439,8 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
             attributes: [
               { shaderLocation: 0, offset: 0, format: 'float32x4' },
               { shaderLocation: 3, offset: 16, format: 'unorm16x4' },
-              { shaderLocation: 4, offset: 24, format: 'unorm8x4' },
-              { shaderLocation: 5, offset: 28, format: 'uint32' },
-              { shaderLocation: 6, offset: 32, format: 'uint32' },
+              { shaderLocation: 5, offset: 24, format: 'uint32' },
+              { shaderLocation: 6, offset: 28, format: 'uint32' },
             ],
           },
         ],

--- a/test/perf/rendering/retained-instruction-webgl2.test.ts
+++ b/test/perf/rendering/retained-instruction-webgl2.test.ts
@@ -122,7 +122,7 @@ describe('WebGL2 retained instruction set: record + splice ladder (Tasks 6/7)', 
       expect(f4.batches).toBe(2);
       expect(f4.instances).toBe(4);
       expect(f4.visibleNodes).toBe(4); // stats parity: replay bumps submittedNodes from the descriptor
-      expect(f4.uploadedBufferBytes).toBe(36); // ONLY the live outside sprite
+      expect(f4.uploadedBufferBytes).toBe(32); // ONLY the live outside sprite
       expect(f4.transformUploads).toBe(0);
       expect(f4.bufferUploads).toBe(1);
 
@@ -140,11 +140,11 @@ describe('WebGL2 retained instruction set: record + splice ladder (Tasks 6/7)', 
       const bundle = bundleOf(group);
       const words = bundle.instanceWords;
 
-      // 3 instances of 9 words each; word 8 is the node index. The outside
+      // 3 instances of 8 words each; word 7 is the node index. The outside
       // sprite occupied shared row 0, so the group's rows started at 1+ —
       // after the rebase they MUST read 0..2.
-      expect(bundle.usedWords).toBe(3 * 9);
-      expect([words[0 * 9 + 8], words[1 * 9 + 8], words[2 * 9 + 8]]).toEqual([0, 1, 2]);
+      expect(bundle.usedWords).toBe(3 * 8);
+      expect([words[0 * 8 + 7], words[1 * 8 + 7], words[2 * 8 + 7]]).toEqual([0, 1, 2]);
 
       // The group-owned transform store holds the GROUP-RELATIVE transforms
       // (getGlobalTransform stops at the boundary): translation = the child's
@@ -186,7 +186,7 @@ describe('WebGL2 retained instruction set: record + splice ladder (Tasks 6/7)', 
       expect(beginSpy).not.toHaveBeenCalled();
       expect(replaySpy).toHaveBeenCalledTimes(2);
       expect(moved.instances).toBe(4);
-      expect(moved.uploadedBufferBytes).toBe(36); // still only the live outside sprite
+      expect(moved.uploadedBufferBytes).toBe(32); // still only the live outside sprite
 
       root.destroy();
     });

--- a/test/perf/rendering/structural-sprite.test.ts
+++ b/test/perf/rendering/structural-sprite.test.ts
@@ -27,7 +27,7 @@ const withHarness = (fn: (harness: WebGl2Harness) => void): void => {
 };
 
 describe('structural — Sprite', () => {
-  it('1000 sprites / 1 texture → one draw, 1000 instances, 36 bytes each', () => {
+  it('1000 sprites / 1 texture → one draw, 1000 instances, 32 bytes each', () => {
     withHarness(harness => {
       const { root } = buildSpriteScene({ count: 1000, textures: makeTextures(1) });
       const m = measureSteadyFrame(harness, root, 2);
@@ -36,7 +36,7 @@ describe('structural — Sprite', () => {
       expect(m.batches).toBe(1);
       expect(m.instances).toBe(1000);
       expect(m.visibleNodes).toBe(1000);
-      expect(m.uploadedBufferBytes).toBe(1000 * 36);
+      expect(m.uploadedBufferBytes).toBe(1000 * 32);
 
       root.destroy();
     });

--- a/test/rendering/browser/webgl2-animated-sprite.test.ts
+++ b/test/rendering/browser/webgl2-animated-sprite.test.ts
@@ -64,7 +64,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = a_color; v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es

--- a/test/rendering/browser/webgl2-bitmap-text.test.ts
+++ b/test/rendering/browser/webgl2-bitmap-text.test.ts
@@ -90,7 +90,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = a_color; v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es

--- a/test/rendering/browser/webgl2-context-restore.test.ts
+++ b/test/rendering/browser/webgl2-context-restore.test.ts
@@ -58,7 +58,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = a_color; v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es

--- a/test/rendering/browser/webgl2-custom-mesh-material.test.ts
+++ b/test/rendering/browser/webgl2-custom-mesh-material.test.ts
@@ -56,7 +56,7 @@ void main() {
 
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = a_color;
+  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
 

--- a/test/rendering/browser/webgl2-custom-sprite-material.test.ts
+++ b/test/rendering/browser/webgl2-custom-sprite-material.test.ts
@@ -14,8 +14,9 @@ import { wireCoreRenderers } from './_coreRenderers';
 // The browser project rewrites `.vert`/`.frag` imports to empty strings, so the
 // default engine shaders the backend compiles on connect must be mocked with
 // valid sources. The sprite vertex mock keeps the REAL pinned attribute
-// locations (0..5) so the renderer's shared VAO matches the custom material's
-// `spriteVertexGlsl` (which is also location-pinned). The custom path compiles
+// locations (0, 3, 5, 6; tint read from transform texel 2) so the renderer's
+// shared VAO matches the custom material's `spriteVertexGlsl` (which is also
+// location-pinned). The custom path compiles
 // the real `spriteVertexGlsl` constant — that module is not a `.vert` import and
 // is therefore NOT mocked.
 const shaderSources = vi.hoisted(() => ({
@@ -24,7 +25,6 @@ precision highp float;
 precision highp int;
 layout(location = 0) in vec4 a_localBounds;
 layout(location = 3) in vec4 a_uvBounds;
-layout(location = 4) in vec4 a_color;
 layout(location = 5) in uint a_textureSlot;
 layout(location = 6) in uint a_nodeIndex;
 uniform mat3 u_projection;
@@ -41,13 +41,14 @@ void main() {
   int row = int(a_nodeIndex);
   vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
   vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  vec4 m2 = texelFetch(u_transforms, ivec2(2, row), 0);
   float worldX = (m0.x * localX) + (m0.y * localY) + m1.x;
   float worldY = (m0.z * localX) + (m0.w * localY) + m1.y;
   gl_Position = vec4((u_projection * vec3(worldX, worldY, 1.0)).xy, 0.0, 1.0);
   float u = (cornerX == 0) ? a_uvBounds.x : a_uvBounds.z;
   float v = (cornerY == 0) ? a_uvBounds.y : a_uvBounds.w;
   v_texcoord = vec2(u, v);
-  v_color = vec4(a_color.rgb * a_color.a, a_color.a);
+  v_color = vec4(m2.rgb * m2.a, m2.a);
   v_textureSlot = a_textureSlot;
 }`,
 

--- a/test/rendering/browser/webgl2-dpr-resolution.test.ts
+++ b/test/rendering/browser/webgl2-dpr-resolution.test.ts
@@ -52,7 +52,7 @@ void main() {
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = a_color;
+  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
   meshVertexSource: `#version 300 es

--- a/test/rendering/browser/webgl2-draw-geometry.test.ts
+++ b/test/rendering/browser/webgl2-draw-geometry.test.ts
@@ -60,7 +60,7 @@ void main() {
 
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = a_color;
+  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
 

--- a/test/rendering/browser/webgl2-graphics-gradient.test.ts
+++ b/test/rendering/browser/webgl2-graphics-gradient.test.ts
@@ -49,7 +49,7 @@ void main() {
 
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = a_color;
+  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
 

--- a/test/rendering/browser/webgl2-graphics-solid-fill.test.ts
+++ b/test/rendering/browser/webgl2-graphics-solid-fill.test.ts
@@ -60,7 +60,7 @@ void main() {
 
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = a_color;
+  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
 

--- a/test/rendering/browser/webgl2-group-uniform.test.ts
+++ b/test/rendering/browser/webgl2-group-uniform.test.ts
@@ -62,7 +62,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * u_group * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = a_color; v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es

--- a/test/rendering/browser/webgl2-mesh-tint.test.ts
+++ b/test/rendering/browser/webgl2-mesh-tint.test.ts
@@ -67,7 +67,7 @@ void main() {
 
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = a_color;
+  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
 

--- a/test/rendering/browser/webgl2-nine-slice.test.ts
+++ b/test/rendering/browser/webgl2-nine-slice.test.ts
@@ -66,7 +66,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = a_color; v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es

--- a/test/rendering/browser/webgl2-particles.test.ts
+++ b/test/rendering/browser/webgl2-particles.test.ts
@@ -71,7 +71,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = a_color; v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es

--- a/test/rendering/browser/webgl2-pixel-snap.test.ts
+++ b/test/rendering/browser/webgl2-pixel-snap.test.ts
@@ -58,7 +58,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = a_color; v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
   meshVert: `#version 300 es
 precision mediump float;

--- a/test/rendering/browser/webgl2-render-error-surface.test.ts
+++ b/test/rendering/browser/webgl2-render-error-surface.test.ts
@@ -54,7 +54,7 @@ void main() {
 
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = a_color;
+  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
 

--- a/test/rendering/browser/webgl2-render-pipeline.test.ts
+++ b/test/rendering/browser/webgl2-render-pipeline.test.ts
@@ -46,7 +46,7 @@ void main() {
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = a_color;
+  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
   meshVertexSource: `#version 300 es

--- a/test/rendering/browser/webgl2-render-plan.test.ts
+++ b/test/rendering/browser/webgl2-render-plan.test.ts
@@ -47,7 +47,7 @@ void main() {
 
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = a_color;
+  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
 

--- a/test/rendering/browser/webgl2-render-to-texture.test.ts
+++ b/test/rendering/browser/webgl2-render-to-texture.test.ts
@@ -47,7 +47,7 @@ void main() {
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = a_color;
+  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
   meshVertexSource: `#version 300 es

--- a/test/rendering/browser/webgl2-renderer-perf.test.ts
+++ b/test/rendering/browser/webgl2-renderer-perf.test.ts
@@ -33,7 +33,6 @@ precision highp float;
 precision highp int;
 layout(location = 0) in vec4 a_localBounds;
 layout(location = 3) in vec4 a_uvBounds;
-layout(location = 4) in vec4 a_color;
 layout(location = 5) in uint a_textureSlot;
 layout(location = 6) in uint a_nodeIndex;
 uniform mat3 u_projection;
@@ -50,13 +49,14 @@ void main() {
   int row = int(a_nodeIndex);
   vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
   vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  vec4 m2 = texelFetch(u_transforms, ivec2(2, row), 0);
   float worldX = (m0.x * localX) + (m0.y * localY) + m1.x;
   float worldY = (m0.z * localX) + (m0.w * localY) + m1.y;
   gl_Position = vec4((u_projection * vec3(worldX, worldY, 1.0)).xy, 0.0, 1.0);
   float u = (cornerX == 0) ? a_uvBounds.x : a_uvBounds.z;
   float v = (cornerY == 0) ? a_uvBounds.y : a_uvBounds.w;
   v_texcoord = vec2(u, v);
-  v_color = vec4(a_color.rgb * a_color.a, a_color.a);
+  v_color = vec4(m2.rgb * m2.a, m2.a);
   v_textureSlot = a_textureSlot;
 }`,
 

--- a/test/rendering/browser/webgl2-repeating-sprite.test.ts
+++ b/test/rendering/browser/webgl2-repeating-sprite.test.ts
@@ -65,7 +65,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = a_color; v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es

--- a/test/rendering/browser/webgl2-retained-container.test.ts
+++ b/test/rendering/browser/webgl2-retained-container.test.ts
@@ -73,7 +73,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * u_group * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = a_color; v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es

--- a/test/rendering/browser/webgl2-retained-instruction-replay.test.ts
+++ b/test/rendering/browser/webgl2-retained-instruction-replay.test.ts
@@ -72,7 +72,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * u_group * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = a_color; v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es

--- a/test/rendering/browser/webgl2-rotated-mesh.test.ts
+++ b/test/rendering/browser/webgl2-rotated-mesh.test.ts
@@ -65,7 +65,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * u_group * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = a_color; v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   // Real production mesh.vert (canonical TransformSlot column order).

--- a/test/rendering/browser/webgl2-rotated-retained-group.test.ts
+++ b/test/rendering/browser/webgl2-rotated-retained-group.test.ts
@@ -73,7 +73,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * u_group * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = a_color; v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   // Real production mesh.vert (canonical TransformSlot column order + u_group).

--- a/test/rendering/browser/webgl2-split-viewport.test.ts
+++ b/test/rendering/browser/webgl2-split-viewport.test.ts
@@ -41,7 +41,7 @@ void main() {
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = a_color;
+  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
   meshVertexSource: `#version 300 es

--- a/test/rendering/browser/webgl2-sprite-real-shader-tint.test.ts
+++ b/test/rendering/browser/webgl2-sprite-real-shader-tint.test.ts
@@ -1,0 +1,267 @@
+/**
+ * WebGL2 Sprite browser test — real `sprite.vert` texel-2 tint pixel proof
+ * (closes #321).
+ *
+ * B-11 moved sprite tint out of a per-instance `a_color` attribute and into
+ * the shared transform texture's texel 2 (`ivec2(2, nodeIndex)`, channels
+ * r/g/b/a, premultiplied in the vertex shader as
+ * `vec4(m2.rgb * m2.a, m2.a)`). Every OTHER `browser-webgl-chromium` pixel
+ * spec stubs `.vert`/`.frag` to `""` and substitutes hand-written mock GLSL
+ * (see `webgl2-sprite-solid-color.test.ts`), and the one spec that DOES load
+ * the real file (`webgl2-shader-compile.test.ts`) only compiles/links it —
+ * it never renders a pixel. So a wrong texel index or a swizzled channel in
+ * the shipped `sprite.vert` would ship completely undetected.
+ *
+ * This spec closes that gap: it substitutes the REAL `sprite.vert`/
+ * `sprite.frag` source (loaded through a `?raw` import — the same
+ * stub-bypass technique `webgl2-shader-compile.test.ts` uses) in place of the
+ * hand-written sprite mocks, then drives the actual `WebGl2SpriteRenderer`
+ * through a real `Sprite`/`Container` scene and reads back rendered pixels.
+ * Mesh/Text stay mocked (same reason as the solid-color spec: `initialize()`
+ * eagerly compiles every registered renderer's program).
+ *
+ * Run via:  pnpm test:browser:webgl
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import type { RenderNode } from '#rendering/RenderNode';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+
+// ---------------------------------------------------------------------------
+// Shader wiring
+//
+// Sprite: substitute the REAL shipped GLSL, loaded via a `?raw` import so the
+// `shaderStubPlugin` (which only stubs ids ending in `.vert`/`.frag`, not
+// `.vert?raw`/`.frag?raw`) never touches it. This is the exact bypass
+// `webgl2-shader-compile.test.ts` relies on, applied here through `vi.mock` so
+// the REAL text stands in for the renderer's normal (stubbed-to-"") import.
+//
+// Mesh/Text: hand-written mocks copied from `webgl2-sprite-solid-color.test.ts`
+// — `WebGl2Backend#initialize` connects the whole renderer registry eagerly
+// (compiling Sprite + Mesh + Text together), so those two still need *valid*
+// GLSL even though this file only ever renders a Sprite.
+// ---------------------------------------------------------------------------
+
+vi.mock('#rendering/webgl2/glsl/sprite.vert', async () => {
+  const real = await import('../../../src/rendering/webgl2/glsl/sprite.vert?raw');
+
+  return { default: real.default };
+});
+
+vi.mock('#rendering/webgl2/glsl/sprite.frag', async () => {
+  const real = await import('../../../src/rendering/webgl2/glsl/sprite.frag?raw');
+
+  return { default: real.default };
+});
+
+const nonSpriteShaderSources = vi.hoisted(() => ({
+  meshVert: `#version 300 es
+precision mediump float;
+in vec2 a_position;
+in vec2 a_texcoord;
+in vec4 a_color;
+in uint a_nodeIndex;
+uniform mat3 u_projection;
+uniform sampler2D u_transforms;
+out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
+void main() {
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  mat3 t = mat3(m0.x,m0.z,0.0, m0.y,m0.w,0.0, m1.x,m1.y,1.0);
+  vec3 world = t * vec3(a_position, 1.0);
+  vec3 clip = u_projection * world;
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = a_texcoord; v_color = a_color;
+  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+}`,
+
+  meshFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv; in vec4 v_color; in vec4 v_tint;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() { outColor = texture(u_texture, v_uv) * v_color * v_tint; }`,
+
+  textVert: `#version 300 es
+precision mediump float;
+in vec2 a_position; in vec2 a_texcoord; in float a_nodeIndex;
+uniform mat3 u_projection;
+out vec2 v_uv;
+void main() {
+  float ni = a_nodeIndex;
+  vec3 clip = u_projection * vec3(a_position + vec2(ni * 0.0), 1.0);
+  gl_Position = vec4(clip.xy, 0.0, 1.0); v_uv = a_texcoord;
+}`,
+
+  textFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() { outColor = texture(u_texture, v_uv); }`,
+}));
+
+vi.mock('#rendering/webgl2/glsl/mesh.vert', () => ({ default: nonSpriteShaderSources.meshVert }));
+vi.mock('#rendering/webgl2/glsl/mesh.frag', () => ({ default: nonSpriteShaderSources.meshFrag }));
+vi.mock('#rendering/webgl2/glsl/text.vert', () => ({ default: nonSpriteShaderSources.textVert }));
+vi.mock('#rendering/webgl2/glsl/text-color.frag', () => ({ default: nonSpriteShaderSources.textFrag }));
+vi.mock('#rendering/webgl2/glsl/text-msdf.frag', () => ({ default: nonSpriteShaderSources.textFrag }));
+vi.mock('#rendering/webgl2/glsl/text-sdf.frag', () => ({ default: nonSpriteShaderSources.textFrag }));
+
+// ---------------------------------------------------------------------------
+// Infrastructure helpers (mirrors webgl2-sprite-solid-color.test.ts)
+// ---------------------------------------------------------------------------
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const createBackend = async (): Promise<WebGl2Backend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const app: Application = {
+    canvas,
+    options: {
+      clearColor: Color.black,
+      canvas: { width: canvasSize, height: canvasSize },
+      rendering: {
+        debug: false,
+        webglAttributes: {
+          alpha: false,
+          antialias: false,
+          premultipliedAlpha: false,
+          preserveDrawingBuffer: true,
+          stencil: false,
+          depth: false,
+        },
+        spriteRendererBatchSize: 1024,
+        particleRendererBatchSize: 1024,
+      },
+    },
+  } as unknown as Application;
+
+  const backend = new WebGl2Backend(app);
+
+  await backend.initialize();
+  wireCoreRenderers(backend, app.options.rendering);
+
+  return backend;
+};
+
+const render = (backend: WebGl2Backend, node: RenderNode): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+  node.render(backend);
+  backend.flush();
+};
+
+const readPixel = (backend: WebGl2Backend, x: number, y: number): RgbaTuple => {
+  const buf = new Uint8Array(4);
+  const gl = backend.context;
+
+  gl.readPixels(Math.floor(x), backend.renderTarget.height - Math.floor(y) - 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+
+  return [buf[0], buf[1], buf[2], buf[3]];
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 8): void => {
+  for (let i = 0; i < 4; i++) {
+    expect(Math.abs(actual[i] - expected[i])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+const createSolidTexture = (color: string, width = 16, height = 16): Texture => {
+  const src = document.createElement('canvas');
+
+  src.width = width;
+  src.height = height;
+
+  const ctx = src.getContext('2d')!;
+
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, width, height);
+
+  return new Texture(src);
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WebGL2 Sprite — real sprite.vert texel-2 tint (#321)', () => {
+  test('the real shader source made it past the stub (not an empty string)', async () => {
+    const real = await import('../../../src/rendering/webgl2/glsl/sprite.vert?raw');
+
+    expect(real.default.length).toBeGreaterThan(0);
+    expect(real.default).toContain('ivec2(2, row)');
+  });
+
+  test('full-opaque tint renders the exact tint colour (texel-2 index + rgb swizzle)', async () => {
+    const backend = await createBackend();
+    // Opaque white texture: sampleColor is (1,1,1,1), so the rendered pixel is
+    // driven entirely by the tint the shader reads from transform texel 2.
+    const texture = createSolidTexture('#ffffff', 16, 16);
+    const root = new Container();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.setPosition(8, 8);
+      sprite.tint = new Color(20, 180, 90); // alpha defaults to 1 (fully opaque)
+      root.addChild(sprite);
+
+      render(backend, root);
+
+      // With alpha == 1 the Normal blend (ONE, ONE_MINUS_SRC_ALPHA) reduces to
+      // a plain overwrite, so the readback must equal the tint exactly (within
+      // 8-bit quantisation tolerance). A wrong texel index (e.g. reading the
+      // transform texel instead of the tint texel) or a permuted rgb swizzle
+      // would both produce a visibly different colour here.
+      expectPixelNear(readPixel(backend, 16, 16), [20, 180, 90, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('partial-alpha tint proves the float premultiply (m2.rgb * m2.a) path', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ffffff', 16, 16);
+    const root = new Container();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.setPosition(8, 8);
+      sprite.tint = new Color(255, 0, 0, 0.5); // 50% alpha red
+      root.addChild(sprite);
+
+      render(backend, root);
+
+      // Correct path: the vertex shader premultiplies (m2.rgb * m2.a, m2.a) =
+      // (0.5, 0, 0, 0.5). Normal blend (ONE, ONE_MINUS_SRC_ALPHA) against the
+      // black clear colour then yields src + dst*(1 - srcA) = (0.5,0,0) + 0 =
+      // (0.5, 0, 0) -> ~(128, 0, 0).
+      //
+      // This specifically catches two classes of shader regression that the
+      // full-opaque case above cannot, because alpha == 1 makes them a no-op:
+      //  - dropping the `* m2.a` multiply (would read back ~(255, 0, 0) instead)
+      //  - a channel swizzle on the tint texel (would shift the 128 into the
+      //    wrong channel, e.g. `m2.gbr` moves it to blue)
+      expectPixelNear(readPixel(backend, 16, 16), [128, 0, 0, 255], 10);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgl2-sprite-solid-color.test.ts
+++ b/test/rendering/browser/webgl2-sprite-solid-color.test.ts
@@ -61,7 +61,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = a_color; v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es

--- a/test/rendering/browser/webgl2-stencil-clip.test.ts
+++ b/test/rendering/browser/webgl2-stencil-clip.test.ts
@@ -46,7 +46,7 @@ void main() {
 
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = a_color;
+  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
 

--- a/test/rendering/browser/webgl2-text-layout.test.ts
+++ b/test/rendering/browser/webgl2-text-layout.test.ts
@@ -57,7 +57,7 @@ void main() {
 
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = a_color;
+  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
 

--- a/test/rendering/browser/webgl2-video.test.ts
+++ b/test/rendering/browser/webgl2-video.test.ts
@@ -78,7 +78,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = a_color; v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es

--- a/test/rendering/browser/webgpu-custom-sprite-material.test.ts
+++ b/test/rendering/browser/webgpu-custom-sprite-material.test.ts
@@ -7,7 +7,7 @@
  * {@link WebGpuSpriteRenderer} and asserts the custom path (group 0 projection +
  * shared transform storage, group 1 base texture, group 2 user UBO) issues an
  * instanced draw without raising a GPU validation error, while keeping the
- * 36-byte instance buffer (transform fetched from storage by nodeIndex).
+ * 32-byte instance buffer (transform and tint fetched from storage by nodeIndex).
  *
  * Run via:  pnpm test:browser:webgpu
  */

--- a/test/rendering/webgl2-retained-group-resources.test.ts
+++ b/test/rendering/webgl2-retained-group-resources.test.ts
@@ -113,25 +113,25 @@ describe('WebGl2RetainedGroupResources: device resources (Task 6)', () => {
     const bundle = new WebGl2RetainedGroupResources();
 
     bundle._beginCapture();
-    bundle._appendInstanceWords(new Uint32Array(18).fill(3)); // two 9-word instances
+    bundle._appendInstanceWords(new Uint32Array(16).fill(3)); // two 8-word instances
     bundle._connectDevice(gl, accountant);
     bundle._uploadInstances();
 
     expect(bundle.instanceBuffer).not.toBeNull();
     expect(recorder.bufferReallocations).toBe(1);
-    expect(recorder.bufferUploadBytes).toBe(18 * 4);
-    expect(stats.gpuMemoryBytes).toBe(18 * 4);
+    expect(recorder.bufferUploadBytes).toBe(16 * 4);
+    expect(stats.gpuMemoryBytes).toBe(16 * 4);
 
     // Recapture with fewer words: in-place update, storage stays booked at the high-water mark.
     const buffer = bundle.instanceBuffer;
 
     bundle._beginCapture();
-    bundle._appendInstanceWords(new Uint32Array(9).fill(4));
+    bundle._appendInstanceWords(new Uint32Array(8).fill(4));
     bundle._uploadInstances();
 
     expect(bundle.instanceBuffer).toBe(buffer);
     expect(recorder.bufferSubUpdates).toBe(1);
-    expect(stats.gpuMemoryBytes).toBe(18 * 4);
+    expect(stats.gpuMemoryBytes).toBe(16 * 4);
 
     bundle.destroy();
 

--- a/test/rendering/webgpu-retained-record-replay.test.ts
+++ b/test/rendering/webgpu-retained-record-replay.test.ts
@@ -390,12 +390,13 @@ describe('WebGPU retained record/replay: fallback ladder + B-06 submit collapse'
 
       expect(instanceWrites).toHaveLength(1);
 
-      // Two 36-byte instances; word 8 of each is the (rebased) node index.
+      // Two 32-byte instances (8 words each); the last word of each is the
+      // (rebased) node index — tint is read from the shared transform slot.
       const words = new Uint32Array(instanceWrites[0]!.bytes.buffer, instanceWrites[0]!.bytes.byteOffset, instanceWrites[0]!.bytes.byteLength / 4);
 
-      expect(words).toHaveLength(18);
-      expect(words[8]).toBe(0);
-      expect(words[17]).toBe(1);
+      expect(words).toHaveLength(16);
+      expect(words[7]).toBe(0);
+      expect(words[15]).toBe(1);
 
       // The group-owned transform copy covers exactly the group's 2 rows.
       const transformWrites = environment.writes().filter(write => write.label === retainedTransformLabel);


### PR DESCRIPTION
## B-11 — transform-slot packing (both backends)

Sprites read only texels 0/1 of the shared 12-float per-node transform slot and carried a redundant per-instance `a_color` vertex stream, so texel 2 (per-node tint, already used by mesh) was dead-read. This drops the sprite `a_color` attribute and reads tint from the shared slot's texel 2 (`m2`), unifying the sprite path with mesh.

- Instance stride 36→32 bytes, 5→4 attributes (localBounds/uvBounds/textureSlot/nodeIndex).
- Retained-batch nodeIndex offset updated on both backends (word 8→7; WebGPU record/rebase loops `i=8;+=9`→`i=7;+=8`).
- `TransformBuffer.ts` untouched → delta-upload / dirty-range / static-frame-zero-upload preserved by construction.
- Instance-buffer shrink observed: 1000 sprites now upload 1000×32 (was ×36).

**Option (a) (sprite-specific 8-float slot) was rejected:** the transform buffer is a single flat array keyed by a global nodeIndex with fixed 12-float stride shared by sprite/mesh/nine-slice/repeating; per-type stride is invasive/fragile in mixed scenes for a P3.

## Verification (author)
node 4846 passed · rendering-perf 66 · browser-webgl2 215 · browser-webgpu 156 (real WGSL) · tsc 0 · eslint 0 errors.

## Adversarial review (cross-model): APPROVE WITH FOLLOW-UPS
Offset math (both backends), alpha-precision change, premultiply/swizzle/channel-order (shared `TransformBuffer.write`), nine-slice/repeating isolation, and leftover-attribute checks all PASS on independent re-derivation.

**Follow-up (non-blocking, pre-existing gap):** no test executes/pixel-checks the *real* WebGL2 `sprite.vert` body — browser pixel tests stub `.vert` to `""` and hand-mock GLSL; the compile test only asserts COMPILE/LINK. A wrong texel index/swizzle would compile+link fine. Shader math was verified statically instead. See follow-up issue to close the gap.

Risky gate: NOT auto-merged pending human decision.