### PR TITLE
perf(bench): fix WebGPU frameMsMedian vsync cadence, probe undercount, assert cross-arm determinism (B1/B3/B4)

### DIFF
--- a/test/perf/baseline/EngineAdapter.ts
+++ b/test/perf/baseline/EngineAdapter.ts
@@ -85,6 +85,16 @@ export interface EngineAdapter {
   /** Release resources held by the current scene and engine instance. */
   teardown(): void;
   /**
+   * Order-sensitive signature of the mutation-index set the most recent
+   * {@link buildScene} selected (see `mutation.ts::mutationSignature`). The
+   * harness compares it against the canonical selection for the cell and fails
+   * loudly on any divergence, so the cross-arm comparison rests on an assertion
+   * rather than a manual contract (review B3). Optional: an arm that omits it is
+   * skipped with a warning, leaving its determinism unverified rather than
+   * blocking the run.
+   */
+  mutationSignature?(): string;
+  /**
    * The live WebGPU device when this adapter was initialised on the `'webgpu'`
    * backend, so the harness can attach a structural probe to it — unlike a
    * WebGL2 context (recoverable from the canvas via `getContext('webgl2')`),

--- a/test/perf/baseline/adapters/README.md
+++ b/test/perf/baseline/adapters/README.md
@@ -62,6 +62,12 @@ Every arm implements (full JSDoc in `../EngineAdapter.ts`):
 - `gpuDevice?(): GPUDevice | null` — optional; return the live `GPUDevice` when
   initialised on `'webgpu'` so the harness can attach its structural probe (a
   WebGL2 context is instead recovered from the canvas). Return `null` otherwise.
+- `mutationSignature?(): string` — optional but **strongly recommended**; return
+  `mutationSignature(selectedIndices)` (from `../mutation.ts`) for the set your
+  most recent `buildScene` selected. The harness asserts it against the canonical
+  selection and **fails the run loudly** if it diverges, so the cross-arm
+  comparison rests on a check rather than this prose (review B3). An arm that
+  omits it runs, but prints a warning that its determinism is unverified.
 
 ### Two configs (the tier-gap axis)
 
@@ -88,14 +94,16 @@ any reference adapter **must** follow them identically:
 1. **Same node set.** Build exactly `nodeCount` leaves for the archetype, laid
    out and nested as `spec` describes (`nestingDepth`, `textureCount`,
    `cullingEnabled`, the `overdraw` stacking).
-2. **Same mutation selection.** Seed a fresh RNG with
-   `createRng(seed)` (from `../archetypes`) and draw **exactly one** `rng()`
-   value **per leaf, in ascending leaf index order**, selecting the leaf for
-   mutation when `rng() < spec.mutationFraction`. Draw the value for _every_
-   leaf even when `mutationFraction` is `0`-effectively-skipped — the point is
-   that both arms, seeded the same way and drawing in the same order, select the
-   byte-for-byte identical set of node indices. Do not batch, reorder, or draw
-   more than one value per leaf.
+2. **Same mutation selection.** Use `selectMutationIndices(nodeCount,
+spec.mutationFraction, seed)` (from `../mutation.ts`) — the shared, canonical
+   selection — to pick the leaves you mutate, and expose the result through
+   `mutationSignature()` (see the contract list above). The helper seeds a fresh
+   `createRng(seed)` and draws **exactly one** `rng()` value **per leaf, in
+   ascending index order**, selecting the leaf when `rng() < mutationFraction`
+   (drawing for _every_ leaf even when the fraction is `0`). Both arms, sharing
+   this one code path, therefore select the byte-for-byte identical index set,
+   and the harness verifies it. Do not re-implement the draw loop, batch,
+   reorder, or draw more than one value per leaf.
 3. **Same per-frame work.** `mutate(frame)` must disturb only that selected set,
    with a displacement small enough to never cross the viewport edge (so culling
    never changes the visible set mid-run).

--- a/test/perf/baseline/adapters/exojs.ts
+++ b/test/perf/baseline/adapters/exojs.ts
@@ -8,8 +8,8 @@ import { Sprite } from '#rendering/sprite/Sprite';
 import { Texture } from '#rendering/texture/Texture';
 import type { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
-import { createRng } from '../archetypes';
 import type { ArchetypeSpec, Backend, EngineAdapter } from '../EngineAdapter';
+import { mutationSignature, selectMutationIndices } from '../mutation';
 
 /** Fixed design-space viewport the harness canvas renders (see `page/index.html`). */
 const VIEWPORT_WIDTH = 1280;
@@ -80,6 +80,8 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
   let root: Container | null = null;
   let textures: Texture[] = [];
   let mutableLeaves: MutableLeaf[] = [];
+  /** Leaf indices the most recent buildScene selected for mutation — the source of {@link EngineAdapter.mutationSignature}. */
+  let mutableIndices: number[] = [];
 
   return {
     engine: 'exojs',
@@ -152,7 +154,13 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
       const cellHeight = (VIEWPORT_HEIGHT - 2 * GRID_MARGIN) / rows;
       const overdraw = spec.id === 'overdraw';
 
-      const rng = createRng(seed);
+      // Canonical, shared mutation selection: draw one RNG value per leaf in
+      // index order and select when below `mutationFraction`. Using the shared
+      // `selectMutationIndices` (rather than re-inlining the draw here) is what
+      // makes the cross-arm fairness contract a single asserted code path (B3);
+      // `mutationSignature()` below reports the exact set the harness verifies.
+      const selectedIndices = selectMutationIndices(nodeCount, spec.mutationFraction, seed);
+      const selectedSet = new Set(selectedIndices);
       const leaves: MutableLeaf[] = [];
 
       for (let i = 0; i < nodeCount; i++) {
@@ -179,17 +187,18 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
         sprite.setPosition(x, y);
         spine[i % spine.length]!.addChild(sprite);
 
-        // Draw one RNG value per leaf, in index order, unconditionally — even
-        // when `mutationFraction` is 0 — so any adapter seeded the same way
-        // draws from the identical stream position and selects the exact same
-        // mutation set (see the adapters README's cross-arm fairness contract).
-        if (rng() < spec.mutationFraction) {
+        if (selectedSet.has(i)) {
           leaves.push({ sprite, baseX: x, baseY: y });
         }
       }
 
       root = sceneRoot;
       mutableLeaves = leaves;
+      mutableIndices = selectedIndices;
+    },
+
+    mutationSignature(): string {
+      return mutationSignature(mutableIndices);
     },
 
     mutate(frame: number): void {
@@ -245,6 +254,7 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
 
       textures = [];
       mutableLeaves = [];
+      mutableIndices = [];
 
       if (app !== null) {
         app.destroy();

--- a/test/perf/baseline/mutation.test.ts
+++ b/test/perf/baseline/mutation.test.ts
@@ -1,0 +1,73 @@
+import { mutationSignature, selectMutationIndices } from './mutation';
+
+/** Seed the harness pins for every cell (see `page/harness.ts`). */
+const SEED = 0xc0ffee;
+
+describe('selectMutationIndices', () => {
+  test('is deterministic: identical inputs yield identical selections', () => {
+    const a = selectMutationIndices(1_000, 0.075, SEED);
+    const b = selectMutationIndices(1_000, 0.075, SEED);
+
+    expect(a).toEqual(b);
+  });
+
+  test('draws one value per leaf in ascending index order (fraction 1 selects all, 0 selects none)', () => {
+    expect(selectMutationIndices(5, 1, SEED)).toEqual([0, 1, 2, 3, 4]);
+    expect(selectMutationIndices(1_000, 0, SEED)).toEqual([]);
+  });
+
+  test('returns indices in strictly ascending order within the node range', () => {
+    const indices = selectMutationIndices(2_000, 0.1, SEED);
+
+    for (let i = 1; i < indices.length; i++) {
+      expect(indices[i]!).toBeGreaterThan(indices[i - 1]!);
+    }
+
+    expect(indices[0]!).toBeGreaterThanOrEqual(0);
+    expect(indices[indices.length - 1]!).toBeLessThan(2_000);
+  });
+
+  test('a different seed selects a different set (RNG actually drives selection)', () => {
+    const a = selectMutationIndices(1_000, 0.075, SEED);
+    const b = selectMutationIndices(1_000, 0.075, SEED + 1);
+
+    expect(a).not.toEqual(b);
+  });
+
+  // Regression lock: the exact canonical selection for the real dynamic-heavy 1k
+  // cell (mutationFraction 0.075). A change here means the shared RNG stream or
+  // the selection algorithm moved — which would silently invalidate every
+  // cross-session comparison — so it must be a deliberate, reviewed change.
+  test('locks the canonical dynamic-heavy 1k selection', () => {
+    const indices = selectMutationIndices(1_000, 0.075, SEED);
+
+    expect(indices.length).toBe(66);
+    expect(indices.slice(0, 10)).toEqual([0, 11, 25, 37, 58, 75, 92, 105, 107, 110]);
+  });
+});
+
+describe('mutationSignature', () => {
+  test('is deterministic and order-sensitive', () => {
+    expect(mutationSignature([0, 1, 2])).toBe(mutationSignature([0, 1, 2]));
+    expect(mutationSignature([0, 1])).not.toBe(mutationSignature([1, 0]));
+  });
+
+  test('folds length so an empty selection never collides with a single-element one', () => {
+    expect(mutationSignature([])).not.toBe(mutationSignature([0]));
+  });
+
+  test('distinguishes selections that differ by a single index', () => {
+    expect(mutationSignature([0, 1, 2])).not.toBe(mutationSignature([0, 1, 3]));
+  });
+
+  test('is 8 lowercase hex digits', () => {
+    expect(mutationSignature([1, 2, 3])).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  // Regression lock for the canonical dynamic-heavy 1k signature: this is the
+  // exact value the harness asserts each engine arm against (review B3). If it
+  // changes, the cross-arm determinism guard's baseline moved.
+  test('locks the canonical dynamic-heavy 1k signature', () => {
+    expect(mutationSignature(selectMutationIndices(1_000, 0.075, SEED))).toBe('fa80f958');
+  });
+});

--- a/test/perf/baseline/mutation.ts
+++ b/test/perf/baseline/mutation.ts
@@ -1,0 +1,65 @@
+import { createRng } from './archetypes';
+
+/**
+ * Canonical per-frame mutation SELECTION for a scene cell: the ordered list of
+ * leaf indices in `[0, nodeCount)` whose sprites wobble every frame.
+ *
+ * Draws exactly one `rng()` value per leaf, in ascending index order, and selects
+ * the leaf when the draw is below `mutationFraction`. The value is drawn for every
+ * leaf even when `mutationFraction` is `0` (nothing selected), so any adapter
+ * seeded identically consumes the identical stream position and reaches the same
+ * selection — the cross-arm fairness contract (see `adapters/README.md`).
+ *
+ * Factoring the selection here, rather than re-inlining the RNG loop in every
+ * engine adapter, turns that contract from prose into a single shared code path
+ * and gives the harness a canonical set to assert each arm against (review B3).
+ */
+export const selectMutationIndices = (nodeCount: number, mutationFraction: number, seed: number): number[] => {
+  const rng = createRng(seed);
+  const selected: number[] = [];
+
+  for (let index = 0; index < nodeCount; index++) {
+    if (rng() < mutationFraction) {
+      selected.push(index);
+    }
+  }
+
+  return selected;
+};
+
+/**
+ * Order-sensitive FNV-1a signature of a mutation-index list as an 8-hex-digit
+ * string. Two arms that selected the identical indices in the identical order
+ * produce the identical signature; any divergence — a different count, different
+ * indices, or a different order — changes it. The list length is folded in first
+ * so an empty selection never collides with a single-element one.
+ *
+ * This is the cross-arm determinism guard (review B3): the harness compares each
+ * arm's reported signature against the canonical {@link selectMutationIndices}
+ * signature for the same `(archetype, nodeCount, seed)` and fails loudly on a
+ * mismatch, catching a reference adapter that draws its RNG differently.
+ */
+export const mutationSignature = (indices: readonly number[]): string => {
+  // FNV-1a 32-bit: offset basis 0x811c9dc5, prime 0x01000193, via Math.imul.
+  let hash = 0x811c9dc5;
+
+  const mix = (byte: number): void => {
+    hash ^= byte & 0xff;
+    hash = Math.imul(hash, 0x01000193);
+  };
+
+  const mixUint32 = (value: number): void => {
+    mix(value & 0xff);
+    mix((value >>> 8) & 0xff);
+    mix((value >>> 16) & 0xff);
+    mix((value >>> 24) & 0xff);
+  };
+
+  mixUint32(indices.length);
+
+  for (const index of indices) {
+    mixUint32(index >>> 0);
+  }
+
+  return (hash >>> 0).toString(16).padStart(8, '0');
+};

--- a/test/perf/baseline/page/harness.ts
+++ b/test/perf/baseline/page/harness.ts
@@ -3,6 +3,7 @@ import { ARCHETYPES } from '../archetypes';
 import type { CellResult, CellSpec, EngineAdapter, StructuralCounters } from '../EngineAdapter';
 import { attachWebGl2Probe, attachWebGpuProbe, type StructuralProbe } from '../metrics/structural';
 import { createCpuTimer, median, percentile } from '../metrics/timing';
+import { mutationSignature, selectMutationIndices } from '../mutation';
 
 /** Fixed RNG seed shared by every cell so both benchmark arms select the same mutation set. */
 const SEED = 0xc0ffee;
@@ -37,30 +38,40 @@ const perFrameStructural = (totals: StructuralCounters, frames: number): { struc
 const NO_GPU_TIMER_NOTE = 'frame time from rAF delta; no GPU timer';
 
 /**
+ * Note recorded on a WebGPU cell whose frame time comes from the queue's
+ * submit-to-done wall clock rather than the rAF present cadence. This value is
+ * de-vsynced GPU work, not a hardware timestamp — see {@link createWebGpuGpuTimer}.
+ */
+const WEBGPU_SUBMIT_TIMER_NOTE = 'frame time from queue.onSubmittedWorkDone (submit→done wall-clock; de-vsynced GPU work, not a hardware timestamp)';
+
+/**
  * Per-frame GPU-time source. `available` is false for the inert fallback used
  * when no GPU timer exists; callers then fall back to the rAF-delta wall clock.
  */
 interface GpuFrameTimer {
   /** Whether a real GPU timer is wired (vs. the inert fallback). */
   readonly available: boolean;
+  /** Caveat to attach to the cell when THIS timer's samples are the reported frame time, or null when the source needs none. */
+  readonly note: string | null;
   /** Open a GPU-time query bracketing the current frame's GPU commands. */
   beginFrame(): void;
   /** Close the current frame's GPU-time query. */
   endFrame(): void;
-  /** Drain resolved queries and return every elapsed-time sample (ms) gathered. */
-  collect(): number[];
+  /** Drain/await pending samples and return every elapsed-time sample (ms) gathered. */
+  collect(): Promise<number[]>;
 }
 
 /** GPU timer used when no timer extension/feature is available: contributes nothing, never fabricates a number. */
 const noopGpuTimer: GpuFrameTimer = {
   available: false,
+  note: null,
   beginFrame(): void {
     /* no GPU timer wired */
   },
   endFrame(): void {
     /* no GPU timer wired */
   },
-  collect(): number[] {
+  async collect(): Promise<number[]> {
     return [];
   },
 };
@@ -128,6 +139,8 @@ const createWebGl2GpuTimer = (gl: WebGL2RenderingContext): GpuFrameTimer => {
 
   return {
     available: true,
+    // A real hardware GPU-time query: canonical GPU frame time, no caveat needed.
+    note: null,
     beginFrame(): void {
       if (failed) {
         return;
@@ -161,7 +174,7 @@ const createWebGl2GpuTimer = (gl: WebGL2RenderingContext): GpuFrameTimer => {
         failed = true;
       }
     },
-    collect(): number[] {
+    async collect(): Promise<number[]> {
       // Results are near-certainly resolved once every timed frame has run;
       // spin-drain with a hard cap so a stuck query can never hang the harness.
       for (let spins = 0; pending.length > 0 && spins < 10_000; spins++) {
@@ -174,12 +187,71 @@ const createWebGl2GpuTimer = (gl: WebGL2RenderingContext): GpuFrameTimer => {
 };
 
 /**
- * Attach the structural probe (and, on WebGL2, a GPU timer) for a cell. The
- * WebGL2 context is recoverable from the canvas — `getContext('webgl2')` returns
- * the same object the engine created — but the WebGPU device is not, so it comes
- * from the adapter. WebGPU has no externally-wireable GPU timer: `timestamp-query`
- * needs `timestampWrites` injected into the backend's own render-pass
- * descriptors, out of the harness's reach, so its frame time is the rAF delta.
+ * WebGPU per-frame GPU timer that de-vsyncs the frame-time measurement.
+ *
+ * WebGPU exposes no externally-wireable hardware timestamp: `timestamp-query`
+ * would need `timestampWrites` injected into the backend's own render-pass
+ * descriptors, out of the harness's reach. The historical fallback — the delta
+ * between consecutive `requestAnimationFrame` callbacks — measures the DISPLAY
+ * PRESENT cadence, not GPU work: with a canvas swapchain the browser paces rAF to
+ * the refresh interval, so every small cell pins to the vsync quantum (e.g. 6.9ms
+ * at 144Hz) regardless of how little the GPU actually did. That column is
+ * therefore vsync cadence dressed up as GPU time (review B1).
+ *
+ * Instead, each frame this timer records the wall-clock interval from just AFTER
+ * the frame's command buffer was submitted (endFrame runs right after
+ * `renderFrame`, which calls `queue.submit` synchronously) until the device
+ * queue signals that submitted work is complete, via `queue.onSubmittedWorkDone`.
+ * That promise resolves on QUEUE COMPLETION, independent of the swapchain present
+ * that gates rAF, so the sample reflects the frame's actual GPU execution time
+ * rather than the vsync interval. Because the harness paces frames from rAF, the
+ * GPU has drained the previous frame before the next submit, so each frame's
+ * submit→done delta is that frame's own work (not a cumulative queue backlog).
+ *
+ * Caveats, documented honestly on the cell via {@link WEBGPU_SUBMIT_TIMER_NOTE}:
+ * this is a CPU-observed wall clock, not a hardware timestamp — it carries the
+ * fixed latency of the completion callback and is subject to the same
+ * `performance.now()` resolution clamp as the CPU timer (100µs until the page is
+ * served cross-origin-isolated). It is nonetheless a true measure of per-frame
+ * work rather than presentation cadence.
+ */
+const createWebGpuGpuTimer = (device: GPUDevice): GpuFrameTimer => {
+  const pending: Array<Promise<void>> = [];
+  const samplesMs: number[] = [];
+
+  return {
+    available: true,
+    note: WEBGPU_SUBMIT_TIMER_NOTE,
+    beginFrame(): void {
+      // The measurement bracket opens at endFrame (post-submit); nothing to do
+      // here. Kept for interface symmetry with the WebGL2 query timer.
+    },
+    endFrame(): void {
+      // renderFrame has already recorded AND submitted this frame's work.
+      const submittedAt = performance.now();
+
+      pending.push(
+        device.queue.onSubmittedWorkDone().then(() => {
+          samplesMs.push(performance.now() - submittedAt);
+        }),
+      );
+    },
+    async collect(): Promise<number[]> {
+      await Promise.all(pending);
+
+      return samplesMs;
+    },
+  };
+};
+
+/**
+ * Attach the structural probe and a per-frame GPU timer for a cell. The WebGL2
+ * context is recoverable from the canvas — `getContext('webgl2')` returns the
+ * same object the engine created — but the WebGPU device is not, so it comes from
+ * the adapter. WebGL2 uses a hardware `EXT_disjoint_timer_query_webgl2` timer when
+ * present; WebGPU has no externally-wireable hardware timestamp, so it uses the
+ * submit-to-done wall clock (see {@link createWebGpuGpuTimer}) — a de-vsynced
+ * measure of GPU work that replaces the old vsync-bound rAF delta (review B1).
  */
 const attachProbes = (adapter: EngineAdapter, spec: CellSpec, canvas: HTMLCanvasElement): { probe: StructuralProbe; gpuTimer: GpuFrameTimer } => {
   if (spec.backend === 'webgpu') {
@@ -189,7 +261,7 @@ const attachProbes = (adapter: EngineAdapter, spec: CellSpec, canvas: HTMLCanvas
       throw new Error('The webgpu backend did not expose a GPUDevice for probe attachment.');
     }
 
-    return { probe: attachWebGpuProbe(device), gpuTimer: noopGpuTimer };
+    return { probe: attachWebGpuProbe(device), gpuTimer: createWebGpuGpuTimer(device) };
   }
 
   const gl = canvas.getContext('webgl2');
@@ -207,12 +279,13 @@ const attachProbes = (adapter: EngineAdapter, spec: CellSpec, canvas: HTMLCanvas
  * then run the cell's timed frames FROM `requestAnimationFrame` while sampling
  * per-frame CPU time, full-frame wall-clock and draw-call structure.
  *
- * Frame wall-clock is the delta between consecutive rAF callbacks. Where a GPU
- * timer resolved real samples they take precedence; otherwise the rAF delta is
- * reported with {@link NO_GPU_TIMER_NOTE} — a GPU number is never fabricated.
- * The CPU timer still brackets exactly `mutate` + `renderFrame` (the primary
- * metric); the GPU-query bracket sits outside it so the restructuring does not
- * change what CPU time measures.
+ * Frame time prefers a real GPU timer: the WebGL2 hardware query, or the WebGPU
+ * submit-to-done wall clock (de-vsynced GPU work; review B1). Only when no GPU
+ * timer resolved samples does it fall back to the rAF delta, reported with
+ * {@link NO_GPU_TIMER_NOTE} — a GPU number is never fabricated. The CPU timer
+ * still brackets exactly `mutate` + `renderFrame` (the primary metric); the GPU
+ * bracket sits outside it so the restructuring does not change what CPU time
+ * measures.
  */
 export const runCell = async (adapter: EngineAdapter, spec: CellSpec, canvas: HTMLCanvasElement): Promise<CellResult> => {
   const archetype = ARCHETYPES.find(candidate => candidate.id === spec.archetype);
@@ -228,6 +301,27 @@ export const runCell = async (adapter: EngineAdapter, spec: CellSpec, canvas: HT
 
   try {
     adapter.buildScene(archetype, spec.nodeCount, SEED);
+
+    // B3 — cross-arm mutation determinism. The comparison across arms is valid
+    // only if every arm wobbles the IDENTICAL leaf set for a given (archetype,
+    // nodeCount, seed). Rather than compare arms pairwise (fragile), assert each
+    // arm against the CANONICAL selection derived from the neutral archetype spec
+    // — which transitively guarantees all arms agree. An arm that draws its RNG
+    // differently (the exact failure the fairness contract warns about) fails
+    // loudly HERE instead of silently producing an incomparable result. Arms that
+    // do not report a signature (optional method) are skipped with a warning.
+    const expectedSignature = mutationSignature(selectMutationIndices(spec.nodeCount, archetype.mutationFraction, SEED));
+    const actualSignature = adapter.mutationSignature?.();
+
+    if (actualSignature === undefined) {
+      console.warn(
+        `[baseline] arm engine='${spec.engine}' config='${spec.config}' reports no mutation signature; cross-arm determinism is UNVERIFIED for this arm (see EngineAdapter.mutationSignature).`,
+      );
+    } else if (actualSignature !== expectedSignature) {
+      throw new Error(
+        `Cross-arm mutation determinism violated: engine='${spec.engine}' config='${spec.config}' selected a different wobble set than the canonical seed=0x${SEED.toString(16)} selection for archetype='${spec.archetype}' n=${spec.nodeCount} (expected ${expectedSignature}, got ${actualSignature}). Arms are not comparable.`,
+      );
+    }
 
     for (let frame = 0; frame < WARMUP_FRAMES; frame++) {
       adapter.mutate(frame);
@@ -289,9 +383,26 @@ export const runCell = async (adapter: EngineAdapter, spec: CellSpec, canvas: HT
     });
 
     const measuredFrames = timer.samples.length;
+
+    // B4 — structural-probe self-check. The probe monkeypatches the live graphics
+    // context AFTER engine init (the device/context does not exist earlier), so an
+    // engine that cached its draw/bind method references at init would bypass the
+    // wrappers and silently report zero — an undercount masquerading as truth.
+    // Every archetype places drawable, on-screen sprites, so a non-empty cell MUST
+    // issue at least one draw; a zero here means the probe was bypassed, not that
+    // the scene drew nothing. Fail loudly rather than report the undercount.
+    // (Pre-wrapping the WebGL2 context BEFORE init was rejected: creating the
+    // context early would freeze the attributes the engine sets on its first
+    // getContext — e.g. antialias — changing what is measured.)
+    if (spec.nodeCount > 0 && probe.counters.drawCalls === 0) {
+      throw new Error(
+        `Structural probe recorded 0 draw calls for a non-empty ${spec.backend} scene (engine='${spec.engine}' config='${spec.config}' archetype='${spec.archetype}' n=${spec.nodeCount}); the probe wrappers were bypassed — counts are untrustworthy.`,
+      );
+    }
+
     const { structural, note: unevenNote } = perFrameStructural(probe.counters, measuredFrames);
 
-    const gpuSamplesMs = gpuTimer.collect();
+    const gpuSamplesMs = await gpuTimer.collect();
     const gpuUsable = gpuTimer.available && gpuSamplesMs.length > 0;
     const frameSamplesMs = gpuUsable ? gpuSamplesMs : rafDeltasMs;
     const frameMsMedian = frameSamplesMs.length > 0 ? median(frameSamplesMs) : null;
@@ -299,7 +410,7 @@ export const runCell = async (adapter: EngineAdapter, spec: CellSpec, canvas: HT
 
     const notes = [
       exceeded ? `a timed frame exceeded ${FRAME_BUDGET_MS}ms; cell aborted after ${measuredFrames} frame(s)` : unevenNote,
-      gpuUsable ? null : NO_GPU_TIMER_NOTE,
+      gpuUsable ? gpuTimer.note : NO_GPU_TIMER_NOTE,
     ].filter((value): value is string => value !== null);
     const note = notes.length > 0 ? notes.join('; ') : null;
 


### PR DESCRIPTION
Addresses three findings from the 2026-07-11 benchmark-methodology review (`05-benchmarks-methodology.md`).

## B1 — WebGPU `frameMsMedian` was vsync cadence, not GPU work
The WebGPU arm had no GPU timer, so `frameMsMedian` fell back to the delta between `requestAnimationFrame` callbacks — which the browser paces to the display refresh, so every small cell pinned to the vsync quantum (measured **6.900 ms constant** = 144 Hz) regardless of actual work.

Fix: a WebGPU `GpuFrameTimer` that measures the wall-clock interval from just after `queue.submit` until `queue.onSubmittedWorkDone()` resolves. That promise fires on **queue completion**, independent of the swapchain present that gates rAF, so the sample reflects real per-frame GPU work. It is a CPU-observed wall clock (carries completion-callback latency, `performance.now` resolution), not a hardware timestamp — documented in code and surfaced on each cell via a `note`.

Illustrative before/after (RTX 5070 Ti, headless, machine **not** idle — NOT committed as thresholds):
- before: `frameMsMedian` = 6.900 / 6.900 (current / retained) — flat vsync
- after: `frameMsMedian` ≈ 3.2 / 4.1 — below the vsync quantum, differs per arm, sub-ms precision

## B3 — cross-arm mutation determinism now asserted, not prose
The "byte-identical mutation selection across arms" contract was documented but unverified. Extracted the selection into a shared `selectMutationIndices()` + order-sensitive `mutationSignature()` (`mutation.ts`); the ExoJS adapter now selects via that shared path and reports its signature through the new optional `EngineAdapter.mutationSignature()`. `runCell` computes the canonical signature from the neutral archetype spec and **throws loudly** if an arm diverges (verified: a tampered signature aborts the run with a clear message). Arms that omit the method warn rather than block.

## B4 — structural-probe undercount self-check
The probe monkeypatches the live context after engine init; an engine caching draw/bind refs at init would bypass it and silently report zero. Added a self-check in `runCell`: a non-empty cell that records 0 draw calls now **fails loudly** as a bypassed probe rather than reporting the undercount as truth. (Pre-wrapping the context before init was rejected — it would freeze context attributes the engine sets on first `getContext`.)

## Tests / verification
- New `mutation.test.ts` (10 tests): selection determinism, one-draw-per-leaf ordering, RNG sensitivity, signature order-sensitivity + length-folding, and regression locks for the canonical dynamic-heavy 1k selection/signature.
- Verified end-to-end on real GPU (WebGL2 hardware-timer path + WebGPU submit-timer path both run `ok`, draws intact).
- typecheck, eslint, prettier clean on all touched files.

Rebased onto #322 (COOP/COEP high-res timers), which merged while this was in flight — clean, no conflict; the two changes compose (high-res timer sharpens the B1 measurement).