### PR TITLE
fix(bench): make render-arm culling symmetric for fair cross-arm comparison

### DIFF
--- a/packages/exojs-bench/src/rendering/EngineAdapter.ts
+++ b/packages/exojs-bench/src/rendering/EngineAdapter.ts
@@ -16,7 +16,22 @@ export interface ArchetypeSpec {
   readonly textureCount: number;
   /** Fraction of nodes mutated per frame, in 0..1. */
   readonly mutationFraction: number;
-  /** Whether frustum/off-screen culling is enabled for this archetype. */
+  /**
+   * Whether frustum/off-screen culling is enabled for this archetype (drives
+   * `.cullable` on every spine container and leaf sprite in both adapters).
+   * Currently `false` for every archetype in `archetypes.ts` (review C4
+   * fairness fix): every archetype keeps its sprites on-screen, so a cull
+   * check can only ever be a no-op there, and the two engines do NOT pay the
+   * same cost for an identically-set flag. ExoJS's `cullable` drives a real
+   * per-node bounds+intersection check in the render walk
+   * (`SceneNode.inView`); Pixi's `cullable` is inert unless the app registers
+   * `CullerPlugin` (or `Culler.shared.cull(...)` is called explicitly), which
+   * `adapters/pixi.ts` does not do. Leaving this `true` therefore adds
+   * cull-walk overhead to the ExoJS arm with no matching cost on the Pixi arm.
+   * If a future archetype needs genuine off-screen content, either give Pixi
+   * an equivalent `CullerPlugin` registration before flipping this back to
+   * `true`, or disclose the asymmetry explicitly in the report.
+   */
   readonly cullingEnabled: boolean;
 }
 

--- a/packages/exojs-bench/src/rendering/adapters/README.md
+++ b/packages/exojs-bench/src/rendering/adapters/README.md
@@ -78,7 +78,13 @@ comparison is meaningless. `exojs.ts` follows these rules and any new adapter
 
 1. **Same node set.** Build exactly `nodeCount` leaves for the archetype, laid
    out and nested as `spec` describes (`nestingDepth`, `textureCount`,
-   `cullingEnabled`, the `overdraw` stacking).
+   `cullingEnabled`, the `overdraw` stacking). `cullingEnabled` is currently
+   `false` on every archetype (review C4): ExoJS's `.cullable` drives a real
+   per-node bounds check in the render walk, but Pixi's `.cullable` is inert
+   unless the app registers `CullerPlugin` — an identically-set flag does NOT
+   cost the same on both arms. A new adapter that wants culling on must give
+   Pixi (or whichever arm is inert) an equivalent culling mechanism first, or
+   the comparison is asymmetric again.
 2. **Same mutation selection.** Use `selectMutationIndices(nodeCount,
    spec.mutationFraction, seed)` (from `../../shared/mutation.ts`) — the shared,
    canonical selection — to pick the leaves you mutate, and expose the result

--- a/packages/exojs-bench/src/rendering/adapters/exojs.ts
+++ b/packages/exojs-bench/src/rendering/adapters/exojs.ts
@@ -136,6 +136,11 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
 
       const sceneRoot = createSpineContainer();
 
+      // `spec.cullingEnabled` is `false` for every archetype (see
+      // `archetypes.ts` and `EngineAdapter.ts::cullingEnabled` for the review
+      // C4 fairness rationale): the exojs render walk pays a real per-node
+      // cost for this flag that the Pixi arm's identically-set flag does not,
+      // so it stays off here to keep the arms cull-symmetric.
       sceneRoot.cullable = spec.cullingEnabled;
 
       const spine: Container[] = [sceneRoot];

--- a/packages/exojs-bench/src/rendering/adapters/pixi.ts
+++ b/packages/exojs-bench/src/rendering/adapters/pixi.ts
@@ -151,6 +151,13 @@ export const createPixiAdapter = (): EngineAdapter => {
       // propagation identically for a fair per-node cost.
       const sceneRoot = new Container();
 
+      // `spec.cullingEnabled` is `false` for every archetype (review C4
+      // fairness fix, see `archetypes.ts`): setting `.cullable` here is a
+      // no-op anyway because this arm never registers `CullerPlugin` (nor
+      // calls `Culler.shared.cull(...)`) — the flag is inert data on Pixi
+      // unless one of those is wired up. Kept in sync with the ExoJS arm's
+      // flag purely so both scenes stay a byte-for-byte transcription of
+      // each other, not because it does anything on this side.
       sceneRoot.cullable = spec.cullingEnabled;
 
       const spine: Container[] = [sceneRoot];

--- a/packages/exojs-bench/src/rendering/archetypes.ts
+++ b/packages/exojs-bench/src/rendering/archetypes.ts
@@ -15,10 +15,26 @@ const GPU_BOUND_COUNTS = [1_000, 5_000, 25_000] as const;
  * at 25k: a 100k measurement there would be dominated by overdraw and state
  * changes and would say nothing about node scaling.
  */
+// Fairness (review C4): `cullingEnabled` is `false` on every archetype below.
+// Every archetype keeps its sprites fully on-screen (`GRID_MARGIN` in the
+// adapters), so a viewport cull check never actually removes a node here —
+// it can only ever be a no-op. Left on, it was pure asymmetric overhead: the
+// exojs adapter's `cullable` flag drives a REAL per-node bounds+intersection
+// check in the render walk (`SceneNode.inView`, called from every
+// `RenderNode.build`), while Pixi's `cullable` flag is inert data unless the
+// app registers `CullerPlugin` (or something calls `Culler.shared.cull(...)`
+// explicitly) — neither adapter does, so the Pixi arm paid nothing for the
+// identically-set flag. That inflated ExoJS's per-node cost in every
+// cross-arm comparison for a check that never changed the visible set.
+// Disabling it on both arms makes them do the same visible-set work; see
+// `EngineAdapter.ts`'s `cullingEnabled` doc and the report's Methodology
+// section for the full disclosure. Re-enabling it for a future archetype that
+// genuinely has off-screen content requires giving Pixi an equivalent
+// `CullerPlugin` registration first, or the asymmetry returns.
 export const ARCHETYPES: readonly ArchetypeSpec[] = [
-  { id: 'static-heavy', nodeCounts: SCALING_COUNTS, nestingDepth: 4, textureCount: 1, mutationFraction: 0, cullingEnabled: true },
-  { id: 'dynamic-heavy', nodeCounts: SCALING_COUNTS, nestingDepth: 4, textureCount: 1, mutationFraction: 0.075, cullingEnabled: true },
-  { id: 'deep-hierarchy', nodeCounts: SCALING_COUNTS, nestingDepth: 16, textureCount: 1, mutationFraction: 0.01, cullingEnabled: true },
+  { id: 'static-heavy', nodeCounts: SCALING_COUNTS, nestingDepth: 4, textureCount: 1, mutationFraction: 0, cullingEnabled: false },
+  { id: 'dynamic-heavy', nodeCounts: SCALING_COUNTS, nestingDepth: 4, textureCount: 1, mutationFraction: 0.075, cullingEnabled: false },
+  { id: 'deep-hierarchy', nodeCounts: SCALING_COUNTS, nestingDepth: 16, textureCount: 1, mutationFraction: 0.01, cullingEnabled: false },
   // Sprites are stretched to the full viewport by the exojs adapter (see the
   // `overdraw` branch in `adapters/exojs.ts::buildScene`) so stacking
   // nodeCount of them is genuine fill-bound overdraw, not 8x8px noise (review
@@ -32,7 +48,7 @@ export const ARCHETYPES: readonly ArchetypeSpec[] = [
   // 16-texture ceiling, or the archetype stops breaking batches entirely.
   // NOTE: this changes the benchmark definition — results measured before
   // 2026-07-11 (textureCount 16) are not comparable on this archetype.
-  { id: 'batch-breaking', nodeCounts: GPU_BOUND_COUNTS, nestingDepth: 2, textureCount: 24, mutationFraction: 0, cullingEnabled: true },
+  { id: 'batch-breaking', nodeCounts: GPU_BOUND_COUNTS, nestingDepth: 2, textureCount: 24, mutationFraction: 0, cullingEnabled: false },
 ];
 
 /**

--- a/packages/exojs-bench/src/rendering/report.ts
+++ b/packages/exojs-bench/src/rendering/report.ts
@@ -140,6 +140,22 @@ const toMarkdown = (data: ReportData): string => {
     lines.push('');
   }
 
+  // Methodology disclosure (review C4): the benchmark used to leave
+  // per-archetype culling on while every archetype kept its sprites
+  // on-screen, so the cull check never removed a node — pure asymmetric
+  // overhead, since ExoJS's `cullable` drives a real per-node bounds check in
+  // the render walk while Pixi's `cullable` is inert unless `CullerPlugin` is
+  // registered (it is not, in `adapters/pixi.ts`). Culling is now disabled on
+  // every archetype (`cullingEnabled: false` in `archetypes.ts`) so both arms
+  // do identical visible-set work; this line makes that explicit in every
+  // generated report rather than leaving it to source-comment archaeology.
+  lines.push(
+    '## Methodology',
+    '',
+    '- **Culling:** disabled on every archetype (`cullingEnabled: false`). Every archetype keeps its sprites fully on-screen, so a cull check never removes a node — it can only add overhead. ExoJS\'s `cullable` flag drives a real per-node bounds/intersection check in the render walk; Pixi\'s `cullable` flag is inert unless the app registers `CullerPlugin`, which this harness does not do. Leaving culling on would therefore have charged the ExoJS arm cull-walk cost the Pixi arm never pays for the same setting — disabling it keeps the two arms cull-symmetric.',
+    '',
+  );
+
   lines.push('## Results', '');
 
   // Annotate the timing column headers when timings are untrusted; structural

--- a/packages/exojs-bench/test/smoke.test.ts
+++ b/packages/exojs-bench/test/smoke.test.ts
@@ -74,9 +74,10 @@ describe('baseline harness smoke', () => {
     expect(result.structural.drawCalls).toBeGreaterThan(0);
 
     // Deterministic structural gate: this fixed 1k static-heavy scene issues
-    // exactly ONE draw call per frame (one texture, one batch, culling on but
-    // everything on-screen). Structural counters are noise-free, so a change in
-    // this number for the fixed scene is a real regression, not timing drift.
+    // exactly ONE draw call per frame (one texture, one batch; culling is
+    // disabled cross-arm per review C4, see `archetypes.ts`). Structural
+    // counters are noise-free, so a change in this number for the fixed scene
+    // is a real regression, not timing drift.
     expect(result.structural.drawCalls).toBe(1);
 
     // A real per-frame CPU time was measured. No timing THRESHOLD is asserted.


### PR DESCRIPTION
## Summary
- The `@codexo/exojs-bench` rendering harness set `cullingEnabled: true` on nearly every archetype. Both adapters set the corresponding `.cullable` flag, but the two engines do not pay the same cost for it: ExoJS's render walk performs a real per-node bounds+intersection check (`SceneNode.inView`, called from `RenderNode.build`), while Pixi's `.cullable` flag is inert unless the app registers `CullerPlugin` (or calls `Culler.shared.cull(...)` explicitly) — `adapters/pixi.ts` does neither. Since every archetype keeps its sprites fully on-screen (`GRID_MARGIN`), the cull check never actually removed a node on either arm, so it was pure asymmetric overhead the ExoJS arm alone paid, inflating its per-node cost in every cross-arm comparison (review finding C4).
- Fix (approach a, per the task brief): set `cullingEnabled: false` on every archetype in `archetypes.ts`, so both arms do identical visible-set work.
- Disclosed the decision everywhere a reader would look: `EngineAdapter.ts`'s `cullingEnabled` JSDoc, the `archetypes.ts` header comment, both adapters' `cullable` assignment comments, the adapters `README.md` fairness rules, the `smoke.test.ts` comment, and a new `## Methodology` section emitted in every generated report (`report.ts`).
- No measured numbers are part of this change (ground-truth guard).

## Test plan
- [x] `pnpm --filter @codexo/exojs-bench typecheck` — clean
- [x] `pnpm --filter @codexo/exojs-bench lint` — clean
- [x] Foreground subset run on real GPU (RTX 5070 Ti, headless Chromium, WebGL2): `static-heavy`/1k nodes/3 frames across `exojs` (current + retained) and `pixi` — all cells `status: ok`, generated `results.md` shows the new Methodology section
- [x] `pnpm run verify:quick` — passes (0 errors; only pre-existing unrelated warnings)