### PR TITLE
feat(bench): CPU-only physics benchmark domain (native exojs-physics arm)

### DIFF
--- a/packages/exojs-bench/package.json
+++ b/packages/exojs-bench/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "scripts": {
     "bench:setup": "pnpm install --dir competitors --ignore-workspace && node competitors/link.mjs",
-    "bench": "tsx src/run.ts",
-    "perf:baseline": "tsx src/run.ts",
+    "bench": "node --conditions=@codexo/source --import ../../scripts/glsl-register.mjs --import tsx/esm src/run.ts",
+    "perf:baseline": "node --conditions=@codexo/source --import ../../scripts/glsl-register.mjs --import tsx/esm src/run.ts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "vitest run --root ../.. --project=exojs-bench"
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@codexo/exojs": "workspace:*",
     "@codexo/exojs-config": "workspace:*",
+    "@codexo/exojs-physics": "workspace:*",
     "@types/node": "^25.6.0",
     "@webgpu/types": "^0.1.69",
     "playwright": "^1.50.0",

--- a/packages/exojs-bench/src/physics/PhysicsAdapter.ts
+++ b/packages/exojs-bench/src/physics/PhysicsAdapter.ts
@@ -1,0 +1,104 @@
+import type { BaseCellResult } from '../shared/result';
+
+/**
+ * Identifier for one of the fixed set of physics scene archetypes.
+ *
+ * Kept deliberately small (review-note "don't overdo the physics implementation"):
+ * a settling box stack, a field of bouncing dynamic bodies, and a mixed
+ * static-geometry + dynamic-bodies scene. These cover the three cost regimes an
+ * ExoJS user cares about when deciding stay-native vs. attach an adapter —
+ * resting-contact solving, wide broad-phase + many active contacts, and a mix.
+ */
+export type PhysicsArchetypeId = 'box-stack' | 'many-dynamic' | 'mixed-static-dynamic';
+
+/** Structural definition of a physics archetype, independent of any physics engine arm. */
+export interface PhysicsArchetypeSpec {
+  /** Archetype identifier. */
+  readonly id: PhysicsArchetypeId;
+  /** Dynamic-body counts swept for this archetype, smallest to largest. */
+  readonly bodyCounts: readonly number[];
+  /** World gravity in px/s² (+Y down). */
+  readonly gravity: { readonly x: number; readonly y: number };
+  /**
+   * Fraction of dynamic bodies (in 0..1) given a deterministic initial impulse
+   * at setup, selected through the shared {@link '../shared/mutation'} RNG so
+   * every arm perturbs the identical body set for a fixed seed. `0` for the
+   * archetypes that settle purely under gravity.
+   */
+  readonly perturbFraction: number;
+}
+
+/** One physics matrix cell: an (engine, config, archetype, body count) combination to measure. */
+export interface PhysicsCellSpec {
+  /** Physics engine arm label, e.g. `'exojs-physics'`. */
+  readonly engine: string;
+  /** Arm configuration label, e.g. `'native'`. */
+  readonly config: string;
+  /** Archetype identifier for this cell. */
+  readonly archetype: PhysicsArchetypeId;
+  /** Number of dynamic bodies for this cell. */
+  readonly bodyCount: number;
+  /** Discarded warmup `step`s run before timing starts (lets a stack settle into steady state). */
+  readonly warmupSteps: number;
+  /** Number of timed `step`s measured for this cell. */
+  readonly timedSteps: number;
+}
+
+/** Structural counters gathered for a single physics cell — the CPU-domain analogue of draw calls. */
+export interface PhysicsStructuralCounters {
+  /** Live body count in the world (static + dynamic). */
+  readonly bodyCount: number;
+  /** Touching solid contacts resolved on the last step (broad×narrow-phase load proxy). */
+  readonly contactCount: number;
+}
+
+/**
+ * Measured outcome for a single physics cell. Extends the domain-agnostic
+ * {@link BaseCellResult} (spec/status/note) with the physics-specific per-`step`
+ * CPU time (median/p95) and structural counters.
+ */
+export interface PhysicsCellResult extends BaseCellResult<PhysicsCellSpec> {
+  /** Median per-`step` CPU time in milliseconds. */
+  readonly stepMsMedian: number;
+  /** 95th-percentile per-`step` CPU time in milliseconds. */
+  readonly stepMsP95: number;
+  /** Structural counters sampled after the timed window. */
+  readonly structural: PhysicsStructuralCounters;
+}
+
+/**
+ * Neutral contract a physics engine arm implements so the harness can drive it
+ * identically across arms — the CPU-domain counterpart of the rendering
+ * {@link '../rendering/EngineAdapter'.EngineAdapter}.
+ *
+ * The native `@codexo/exojs-physics` arm is the only implementation today; the
+ * planned matter.js + rapier adapter arms (a separate follow-on) implement this
+ * same interface so a stay-native vs. attach-an-adapter comparison drops in
+ * without the driver or archetypes changing.
+ */
+export interface PhysicsAdapter {
+  /** Physics engine arm label, e.g. `'exojs-physics'`. */
+  readonly engine: string;
+  /** Arm configuration label, e.g. `'native'`. */
+  readonly config: string;
+  /**
+   * Build the world and its bodies for the given archetype/body count from the
+   * shared deterministic RNG seed, so every arm simulates the identical scene.
+   */
+  setup(spec: PhysicsArchetypeSpec, bodyCount: number, seed: number): void;
+  /** Advance the world by one fixed step of `dt` seconds. */
+  step(dt: number): void;
+  /** Sample the structural counters (called after the timed window). */
+  sampleStructural(): PhysicsStructuralCounters;
+  /** Release the world and its bodies. */
+  teardown(): void;
+  /**
+   * Order-sensitive signature of the perturbed-body index set the most recent
+   * {@link setup} selected (see `shared/mutation.ts::mutationSignature`). The
+   * driver compares it against the canonical selection for the cell and fails
+   * loudly on divergence, so a future cross-arm comparison rests on an assertion
+   * rather than a prose contract. Optional: an arm that omits it is skipped with
+   * a warning, leaving its determinism unverified rather than blocking the run.
+   */
+  mutationSignature?(): string;
+}

--- a/packages/exojs-bench/src/physics/adapters/exojs-physics.ts
+++ b/packages/exojs-bench/src/physics/adapters/exojs-physics.ts
@@ -1,0 +1,209 @@
+import { BoxShape, CircleShape, PhysicsBody, PhysicsWorld } from '@codexo/exojs-physics';
+
+import { mutationSignature, selectMutationIndices } from '../../shared/mutation';
+import { createRng } from '../../shared/rng';
+import type { PhysicsAdapter, PhysicsArchetypeSpec, PhysicsStructuralCounters } from '../PhysicsAdapter';
+
+/** Side length of a dynamic box / diameter reference for a dynamic circle, px. */
+const BODY_SIZE = 16;
+/** Peak per-axis initial speed applied to a perturbed body, px/s. */
+const PERTURB_SPEED = 400;
+
+/**
+ * Native `@codexo/exojs-physics` arm of the physics benchmark.
+ *
+ * Drives the real public API discovered from the package source: construct a
+ * {@link PhysicsWorld} with gravity, add {@link PhysicsBody} instances carrying a
+ * single collider (`BoxShape`/`CircleShape`) via `world.add`, and advance with
+ * `world.step(dt)`. Structural counters read straight off the world
+ * (`world.bodies.length`) and its detection backend
+ * (`world.backend.contactGraph.solidContacts.length`).
+ *
+ * All scene randomness comes from the shared deterministic RNG so a scene is
+ * byte-reproducible for a fixed seed, and the perturbed-body set is chosen
+ * through the shared `selectMutationIndices` so a future matter/rapier arm
+ * perturbs the identical bodies (asserted via {@link mutationSignature}).
+ */
+export const createExoJsPhysicsAdapter = (): PhysicsAdapter => {
+  let world: PhysicsWorld | null = null;
+  let perturbedSignature = mutationSignature([]);
+
+  /** Build a static box collider body at a world position. */
+  const staticBox = (x: number, y: number, width: number, height: number): PhysicsBody =>
+    new PhysicsBody({ type: 'static', position: { x, y }, colliders: [{ shape: new BoxShape(width, height), friction: 0.5 }] });
+
+  /**
+   * `box-stack`: `columns` independent stacks of boxes settling on a wide static
+   * floor. Resting-contact solving with warm-start + sleeping is the dominant
+   * cost once settled.
+   */
+  const buildBoxStack = (w: PhysicsWorld, bodyCount: number, rng: () => number): void => {
+    const rows = 8;
+    const columns = Math.max(1, Math.ceil(bodyCount / rows));
+    const spacing = BODY_SIZE + 6;
+    const floorTop = 1_200;
+    const width = columns * spacing + 200;
+
+    w.add(staticBox(width / 2, floorTop + 20, width, 40));
+
+    let placed = 0;
+
+    for (let c = 0; c < columns && placed < bodyCount; c++) {
+      const x = 100 + c * spacing;
+
+      for (let r = 0; r < rows && placed < bodyCount; r++) {
+        // Sub-pixel deterministic jitter so the lattice is not perfectly
+        // degenerate (identical columns would under-exercise the broad phase).
+        const jitter = (rng() - 0.5) * 0.5;
+
+        w.add(
+          new PhysicsBody({
+            type: 'dynamic',
+            position: { x: x + jitter, y: floorTop - BODY_SIZE / 2 - 1 - r * BODY_SIZE },
+            colliders: [{ shape: new BoxShape(BODY_SIZE, BODY_SIZE), density: 1, friction: 0.5 }],
+          }),
+        );
+
+        placed++;
+      }
+    }
+  };
+
+  /**
+   * `many-dynamic`: a grid of small dynamic circles inside a bounded box (four
+   * static walls), every body given a deterministic initial impulse. Wide
+   * broad-phase load with many simultaneously-active bouncing contacts.
+   */
+  const buildManyDynamic = (w: PhysicsWorld, bodyCount: number, rng: () => number, perturbed: readonly number[]): void => {
+    const radius = BODY_SIZE / 2;
+    const cell = BODY_SIZE + 8;
+    const columns = Math.ceil(Math.sqrt(bodyCount));
+    const side = columns * cell + 80;
+    const wall = 40;
+
+    // Four static walls forming the bounded box.
+    w.add(staticBox(side / 2, side + wall / 2, side + wall * 2, wall)); // floor
+    w.add(staticBox(side / 2, -wall / 2, side + wall * 2, wall)); // ceiling
+    w.add(staticBox(-wall / 2, side / 2, wall, side)); // left
+    w.add(staticBox(side + wall / 2, side / 2, wall, side)); // right
+
+    const perturbedSet = new Set(perturbed);
+
+    for (let i = 0; i < bodyCount; i++) {
+      const col = i % columns;
+      const row = Math.floor(i / columns);
+      const body = w.add(
+        new PhysicsBody({
+          type: 'dynamic',
+          position: { x: 40 + col * cell + radius, y: 40 + row * cell + radius },
+          colliders: [{ shape: new CircleShape(radius), density: 1, friction: 0, restitution: 0.4 }],
+        }),
+      );
+
+      if (perturbedSet.has(i)) {
+        body.linearVelocityX = (rng() - 0.5) * 2 * PERTURB_SPEED;
+        body.linearVelocityY = (rng() - 0.5) * 2 * PERTURB_SPEED;
+      }
+    }
+  };
+
+  /**
+   * `mixed-static-dynamic`: a static floor plus a lattice of static box
+   * obstacles, with dynamic boxes raining onto them from above. The common game
+   * mix of an immovable level and many active bodies.
+   */
+  const buildMixed = (w: PhysicsWorld, bodyCount: number, rng: () => number): void => {
+    const spacing = BODY_SIZE + 10;
+    const columns = Math.max(1, Math.ceil(Math.sqrt(bodyCount)));
+    const fieldWidth = columns * spacing + 200;
+    const floorTop = 1_400;
+
+    w.add(staticBox(fieldWidth / 2, floorTop + 20, fieldWidth, 40));
+
+    // A few rows of static peg obstacles the dynamic bodies collide with on the
+    // way down (staggered so bodies do not fall through clean gaps).
+    const pegRows = 4;
+
+    for (let pr = 0; pr < pegRows; pr++) {
+      const y = 500 + pr * 200;
+      const offset = pr % 2 === 0 ? 0 : spacing;
+
+      for (let x = 120 + offset; x < fieldWidth - 120; x += spacing * 2) {
+        w.add(staticBox(x, y, BODY_SIZE * 2, BODY_SIZE / 2));
+      }
+    }
+
+    for (let i = 0; i < bodyCount; i++) {
+      const col = i % columns;
+      const row = Math.floor(i / columns);
+      const jitter = (rng() - 0.5) * 2;
+
+      w.add(
+        new PhysicsBody({
+          type: 'dynamic',
+          position: { x: 120 + col * spacing + jitter, y: 100 - row * spacing },
+          colliders: [{ shape: new BoxShape(BODY_SIZE, BODY_SIZE), density: 1, friction: 0.3, restitution: 0.1 }],
+        }),
+      );
+    }
+  };
+
+  return {
+    engine: 'exojs-physics',
+    config: 'native',
+
+    setup(spec: PhysicsArchetypeSpec, bodyCount: number, seed: number): void {
+      const w = new PhysicsWorld({ gravity: spec.gravity });
+      // Shared-RNG perturbed-body selection: the cross-arm determinism receipt.
+      const perturbed = selectMutationIndices(bodyCount, spec.perturbFraction, seed);
+
+      perturbedSignature = mutationSignature(perturbed);
+
+      // Independent placement/velocity stream (same seed, separate instance):
+      // deterministic across arms, distinct from the selection stream.
+      const rng = createRng(seed ^ 0x5f35_6495);
+
+      switch (spec.id) {
+        case 'box-stack':
+          buildBoxStack(w, bodyCount, rng);
+          break;
+        case 'many-dynamic':
+          buildManyDynamic(w, bodyCount, rng, perturbed);
+          break;
+        case 'mixed-static-dynamic':
+          buildMixed(w, bodyCount, rng);
+          break;
+      }
+
+      world = w;
+    },
+
+    step(dt: number): void {
+      if (world === null) {
+        throw new Error('exojs-physics adapter: step() called before setup().');
+      }
+
+      world.step(dt);
+    },
+
+    sampleStructural(): PhysicsStructuralCounters {
+      if (world === null) {
+        throw new Error('exojs-physics adapter: sampleStructural() called before setup().');
+      }
+
+      return {
+        bodyCount: world.bodies.length,
+        contactCount: world.backend.contactGraph.solidContacts.length,
+      };
+    },
+
+    teardown(): void {
+      world?.destroy();
+      world = null;
+    },
+
+    mutationSignature(): string {
+      return perturbedSignature;
+    },
+  };
+};

--- a/packages/exojs-bench/src/physics/archetypes.ts
+++ b/packages/exojs-bench/src/physics/archetypes.ts
@@ -1,0 +1,89 @@
+import type { PhysicsAdapter, PhysicsArchetypeSpec, PhysicsCellSpec } from './PhysicsAdapter';
+
+/**
+ * Fixed physics timestep, seconds. `PhysicsWorld` defaults to `1/60` and owns a
+ * fixed-step accumulator, so passing exactly `1/60` to `step` advances precisely
+ * one fixed sub-step per call — the timed unit is one deterministic physics step.
+ */
+export const STEP_DELTA = 1 / 60;
+
+/**
+ * Dynamic-body counts swept per archetype. Capped in the low thousands on
+ * purpose: `@codexo/exojs-physics`'s broad phase is a stateless O(n log n)
+ * sort-and-sweep (no spatial hash), so tens of thousands of simultaneously-live
+ * colliders leave the node-scaling regime this benchmark measures. Three
+ * geometric steps are enough to fit a slope and spot a knee without an
+ * exhaustive matrix.
+ */
+const BODY_COUNTS = [200, 1_000, 4_000] as const;
+
+/**
+ * The physics archetypes. Kept to three representative scenes (review-note
+ * "don't overdo it"):
+ * - `box-stack` — settling columns of boxes on a static floor: resting-contact
+ *   solving + warm-start + sleeping, the tall-stack stability path.
+ * - `many-dynamic` — a field of small dynamic bodies bouncing in a bounded box,
+ *   every body perturbed with an initial impulse: wide broad-phase + many
+ *   simultaneously-active contacts, nothing resting.
+ * - `mixed-static-dynamic` — static obstacle geometry with dynamic bodies raining
+ *   onto it: the common game mix of immovable level + active bodies.
+ */
+export const PHYSICS_ARCHETYPES: readonly PhysicsArchetypeSpec[] = [
+  { id: 'box-stack', bodyCounts: BODY_COUNTS, gravity: { x: 0, y: 1_000 }, perturbFraction: 0 },
+  { id: 'many-dynamic', bodyCounts: BODY_COUNTS, gravity: { x: 0, y: 300 }, perturbFraction: 1 },
+  { id: 'mixed-static-dynamic', bodyCounts: BODY_COUNTS, gravity: { x: 0, y: 1_000 }, perturbFraction: 0 },
+];
+
+/**
+ * Timed-step count shrinks as body count grows so a cell's wall-clock stays
+ * bounded. Recorded per cell in the report: a median over 120 steps must not be
+ * presented as equal in confidence to one over 480.
+ */
+export const timedStepsFor = (bodyCount: number): number => {
+  if (bodyCount >= 4_000) return 120;
+  if (bodyCount >= 1_000) return 240;
+
+  return 480;
+};
+
+/**
+ * Warmup-step count for a given body count — discarded steps that let a stack
+ * settle into steady state (warm-started persistent contacts, sleeping islands)
+ * before timing, so the measured median reflects the steady-state solver cost
+ * rather than the transient settling spike. A settling stack needs a few seconds
+ * of simulated time; 240 steps at `1/60` is 4 s.
+ */
+export const warmupStepsFor = (bodyCount: number): number => {
+  if (bodyCount >= 4_000) return 180;
+
+  return 240;
+};
+
+/**
+ * Deterministic per-cell RNG seed. Fixed base folded with the archetype ordinal
+ * and body count so every arm builds byte-identical scenes for a cell, and two
+ * different cells never share a seed.
+ */
+export const seedFor = (archetypeOrdinal: number, bodyCount: number): number => 0x9e37_79b1 ^ (archetypeOrdinal * 0x0100_0193) ^ bodyCount;
+
+/** Cross-product of arms × archetypes × body counts. */
+export const buildPhysicsMatrix = (adapters: readonly PhysicsAdapter[]): PhysicsCellSpec[] => {
+  const cells: PhysicsCellSpec[] = [];
+
+  for (const adapter of adapters) {
+    for (const archetype of PHYSICS_ARCHETYPES) {
+      for (const bodyCount of archetype.bodyCounts) {
+        cells.push({
+          engine: adapter.engine,
+          config: adapter.config,
+          archetype: archetype.id,
+          bodyCount,
+          warmupSteps: warmupStepsFor(bodyCount),
+          timedSteps: timedStepsFor(bodyCount),
+        });
+      }
+    }
+  }
+
+  return cells;
+};

--- a/packages/exojs-bench/src/physics/driver.ts
+++ b/packages/exojs-bench/src/physics/driver.ts
@@ -1,0 +1,192 @@
+import { mutationSignature, selectMutationIndices } from '../shared/mutation';
+import type { BaseProvenance, HostInfo, LibraryProvenance } from '../shared/provenance';
+import { readHostInfo, readLibraryProvenance } from '../shared/provenance';
+import { createCpuTimer, median, percentile, shouldAbort } from '../shared/timing';
+import { createExoJsPhysicsAdapter } from './adapters/exojs-physics';
+import { buildPhysicsMatrix, PHYSICS_ARCHETYPES, seedFor,STEP_DELTA } from './archetypes';
+import type { PhysicsAdapter, PhysicsCellResult, PhysicsCellSpec } from './PhysicsAdapter';
+
+/** npm package name of the native physics arm, resolved for version provenance. */
+const NATIVE_PHYSICS_PACKAGE = '@codexo/exojs-physics';
+
+/**
+ * Catastrophic-regression step budget (ms). The physics domain is CPU-bound and
+ * fast; a cell whose last-window median blows past this is a runaway (a
+ * pathological body count or an accidental O(n²) regression), so it aborts to
+ * `exceeded` rather than hanging the run. Deliberately loose — it is a hang
+ * guard, not a performance gate.
+ */
+const STEP_BUDGET_MS = 250;
+/** Sliding window (steps) `shouldAbort` medians over, so one GC spike cannot trip the abort. */
+const ABORT_WINDOW = 30;
+
+/**
+ * Provenance stamped onto every physics run. Extends the shared
+ * {@link BaseProvenance} (timestamp + engine version) with the CPU-domain host
+ * (Node runtime + CPU) and the fixed timestep the step-time medians are measured
+ * against. There is no GPU adapter or software-rasterizer bit here — physics is
+ * pure CPU, so the honesty concern is instead the host CPU/Node identity.
+ */
+export interface PhysicsProvenance extends BaseProvenance {
+  /** Node runtime + CPU host the step-time numbers were measured on. */
+  readonly host: HostInfo;
+  /** Fixed physics timestep (seconds) each timed `step` advanced. */
+  readonly fixedDelta: number;
+  /** Disclosed caveats about how these numbers were produced. */
+  readonly caveats: readonly string[];
+}
+
+/** Full outcome of a physics matrix run: provenance, arm-version provenance, and every cell result. */
+export interface PhysicsMatrixOutcome {
+  /** The single provenance stamp for the run (one Node process, one host). */
+  readonly provenance: PhysicsProvenance;
+  /** Version + resolution provenance for each physics engine arm. */
+  readonly libraries: readonly LibraryProvenance[];
+  /** One result per matrix cell, in completion order. */
+  readonly results: readonly PhysicsCellResult[];
+}
+
+/** Callback invoked the instant a cell finishes measuring, for incremental checkpointing. */
+export type PhysicsCellResultSink = (result: PhysicsCellResult) => void;
+
+/** Keeps only the cells whose defined `filter` fields all match. */
+const applyFilter = (cells: readonly PhysicsCellSpec[], filter: Partial<PhysicsCellSpec>): PhysicsCellSpec[] => {
+  const entries = Object.entries(filter).filter(([, value]) => value !== undefined);
+
+  return cells.filter(cell => entries.every(([key, value]) => cell[key as keyof PhysicsCellSpec] === value));
+};
+
+/** The archetype spec and its ordinal (for the deterministic seed) for a cell. */
+const archetypeFor = (id: PhysicsCellSpec['archetype']): { spec: (typeof PHYSICS_ARCHETYPES)[number]; ordinal: number } => {
+  const ordinal = PHYSICS_ARCHETYPES.findIndex(archetype => archetype.id === id);
+
+  if (ordinal === -1) {
+    throw new Error(`Unknown physics archetype '${id}'.`);
+  }
+
+  return { spec: PHYSICS_ARCHETYPES[ordinal]!, ordinal };
+};
+
+/**
+ * Measure one cell: build the scene, assert its cross-arm determinism, warm it
+ * to steady state, then time `timedSteps` `step`s and reduce to median/p95.
+ * Aborts to `exceeded` on a sustained runaway (see {@link STEP_BUDGET_MS}).
+ */
+const runCell = (adapter: PhysicsAdapter, spec: PhysicsCellSpec): PhysicsCellResult => {
+  const { spec: archetype, ordinal } = archetypeFor(spec.archetype);
+  const seed = seedFor(ordinal, spec.bodyCount);
+
+  adapter.setup(archetype, spec.bodyCount, seed);
+
+  // Cross-arm determinism guard (review B3/B5): the perturbed-body set the arm
+  // selected must match the canonical shared selection for this cell. With one
+  // arm today this is a self-check; it is what a future matter/rapier arm is
+  // asserted against so a divergent RNG path fails loudly instead of silently
+  // simulating a different scene. An arm that omits the signature is skipped.
+  const armSignature = adapter.mutationSignature?.();
+
+  if (armSignature !== undefined) {
+    const canonical = mutationSignature(selectMutationIndices(spec.bodyCount, archetype.perturbFraction, seed));
+
+    if (armSignature !== canonical) {
+      adapter.teardown();
+      throw new Error(`Determinism divergence for ${spec.engine}/${spec.archetype}/${spec.bodyCount}: arm=${armSignature} canonical=${canonical}.`);
+    }
+  }
+
+  for (let i = 0; i < spec.warmupSteps; i++) {
+    adapter.step(STEP_DELTA);
+  }
+
+  const timer = createCpuTimer();
+  let exceeded = false;
+
+  for (let i = 0; i < spec.timedSteps; i++) {
+    timer.begin();
+    adapter.step(STEP_DELTA);
+    timer.end();
+
+    if (shouldAbort(timer.samples, STEP_BUDGET_MS, ABORT_WINDOW)) {
+      exceeded = true;
+      break;
+    }
+  }
+
+  const structural = adapter.sampleStructural();
+
+  adapter.teardown();
+
+  const samples = timer.samples;
+  const stepMsMedian = median(samples);
+  const stepMsP95 = percentile(samples, 95);
+
+  return {
+    spec,
+    stepMsMedian,
+    stepMsP95,
+    structural,
+    status: exceeded ? 'exceeded' : 'ok',
+    ...(exceeded && { note: `aborted: last-${ABORT_WINDOW}-step median exceeded ${STEP_BUDGET_MS}ms/step` }),
+  };
+};
+
+/**
+ * Run the whole physics matrix end-to-end in this Node process.
+ *
+ * Unlike the rendering domain there is no browser and no GPU: physics is pure
+ * CPU work, so the harness is a straight loop calling `world.step`. Every cell
+ * runs in the SAME process back-to-back (same-run discipline: JIT warmth and
+ * allocator state are shared and comparable), and `onCellResult` fires after
+ * each cell so the caller can checkpoint it immediately.
+ */
+export const runPhysicsMatrix = (options: {
+  adapters?: readonly PhysicsAdapter[];
+  filter?: Partial<PhysicsCellSpec>;
+  /** Forces every selected cell's timed-step count to this value (smoke/spot-check knob; never a reportable run). */
+  timedStepsOverride?: number;
+  onCellResult?: PhysicsCellResultSink;
+} = {}): PhysicsMatrixOutcome => {
+  const adapters = options.adapters ?? [createExoJsPhysicsAdapter()];
+  const libraries = readLibraryProvenance([NATIVE_PHYSICS_PACKAGE]);
+  const engineVersion = libraries[0]?.version ?? 'unknown';
+
+  const allCells = buildPhysicsMatrix(adapters);
+  const filtered = options.filter ? applyFilter(allCells, options.filter) : allCells;
+  const cells =
+    options.timedStepsOverride === undefined ? filtered : filtered.map(cell => ({ ...cell, timedSteps: options.timedStepsOverride! }));
+
+  if (cells.length === 0) {
+    throw new Error('The physics matrix is empty: no arm/archetype/body-count matched the requested filter.');
+  }
+
+  const adaptersByEngine = new Map(adapters.map(adapter => [`${adapter.engine}/${adapter.config}`, adapter]));
+  const onCellResult: PhysicsCellResultSink = options.onCellResult ?? ((): void => undefined);
+  const results: PhysicsCellResult[] = [];
+
+  for (const cell of cells) {
+    const adapter = adaptersByEngine.get(`${cell.engine}/${cell.config}`);
+
+    if (adapter === undefined) {
+      throw new Error(`No physics adapter registered for ${cell.engine}/${cell.config}.`);
+    }
+
+    const result = runCell(adapter, cell);
+
+    results.push(result);
+    onCellResult(result);
+  }
+
+  const provenance: PhysicsProvenance = {
+    timestamp: new Date().toISOString(),
+    engineVersion,
+    host: readHostInfo(),
+    fixedDelta: STEP_DELTA,
+    caveats: [
+      'Step time is CPU wall-clock per world.step() over the timed window (median/p95), measured in one Node process (same-run discipline).',
+      'Single native arm (exojs-physics); matter.js / rapier adapter arms are a separate follow-on and are NOT included here.',
+      'Scenes are warmed to steady state before timing; the per-cell warmupSteps/timedSteps counts are recorded for honesty.',
+    ],
+  };
+
+  return { provenance, libraries, results };
+};

--- a/packages/exojs-bench/src/physics/index.ts
+++ b/packages/exojs-bench/src/physics/index.ts
@@ -1,0 +1,27 @@
+// Physics benchmark domain — the SECOND domain of `@codexo/exojs-bench`.
+//
+// Unlike the rendering domain (webgl2/webgpu, driven through a headless-browser
+// Vite/Playwright harness), physics is pure CPU work: `@codexo/exojs-physics`
+// runs in plain Node, so this domain is a straight loop calling `world.step`
+// with no browser and no GPU. Everything physics-specific — the archetypes, the
+// native exojs-physics arm, the step-time driver and report — lives under this
+// folder; the domain-agnostic pieces (timing, RNG, mutation-determinism, the
+// incremental checkpoint writer, provenance/report skeletons, CLI arg parsing)
+// live under `../shared` and are shared with the rendering domain.
+//
+// The matter.js + rapier adapter arms are a SEPARATE follow-on: add them under
+// `adapters/`, implement the `PhysicsAdapter` interface, and pass them into
+// `runPhysicsMatrix({ adapters })`.
+
+export { createExoJsPhysicsAdapter } from './adapters/exojs-physics';
+export { buildPhysicsMatrix, PHYSICS_ARCHETYPES, STEP_DELTA } from './archetypes';
+export { type PhysicsMatrixOutcome, type PhysicsProvenance, runPhysicsMatrix } from './driver';
+export type {
+  PhysicsAdapter,
+  PhysicsArchetypeId,
+  PhysicsArchetypeSpec,
+  PhysicsCellResult,
+  PhysicsCellSpec,
+  PhysicsStructuralCounters,
+} from './PhysicsAdapter';
+export { type PhysicsReportData, writePhysicsReport } from './report';

--- a/packages/exojs-bench/src/physics/report.ts
+++ b/packages/exojs-bench/src/physics/report.ts
@@ -1,0 +1,124 @@
+import type { LibraryProvenance } from '../shared/provenance';
+import { csvField, formatCount as count, formatMs as ms, writeReportArtifacts } from '../shared/report';
+import type { PhysicsProvenance } from './driver';
+import type { PhysicsCellResult } from './PhysicsAdapter';
+
+/** Everything one physics run produces: the provenance stamp, arm versions, and per-cell results. */
+export interface PhysicsReportData {
+  /** The run's provenance stamp (host, engine version, timestep, caveats). */
+  readonly provenance: PhysicsProvenance;
+  /** Version + resolution provenance for each physics engine arm. */
+  readonly libraries: readonly LibraryProvenance[];
+  /** One result per matrix cell. */
+  readonly results: readonly PhysicsCellResult[];
+}
+
+/** Ordered columns shared by the CSV and the Markdown table. */
+const COLUMNS = [
+  'engine',
+  'config',
+  'archetype',
+  'bodyCount',
+  'warmupSteps',
+  'timedSteps',
+  'stepMsMedian',
+  'stepMsP95',
+  'bodies',
+  'contacts',
+  'status',
+  'note',
+] as const;
+
+const toRow = (result: PhysicsCellResult): string[] => {
+  const { spec, structural } = result;
+
+  return [
+    spec.engine,
+    spec.config,
+    spec.archetype,
+    String(spec.bodyCount),
+    String(spec.warmupSteps),
+    String(spec.timedSteps),
+    ms(result.stepMsMedian),
+    ms(result.stepMsP95),
+    count(structural.bodyCount),
+    count(structural.contactCount),
+    result.status,
+    result.note ?? '',
+  ];
+};
+
+const toCsv = (data: PhysicsReportData): string =>
+  [COLUMNS.join(','), ...data.results.map(result => toRow(result).map(csvField).join(','))].join('\n');
+
+/**
+ * Human-readable Markdown: the arm versions and the host/provenance block first
+ * (a step-time number is only comparable if the CPU + Node + exojs-physics
+ * version that produced it are on the record), the disclosed caveats, then one
+ * table with the structural counters (bodies, contacts) sitting BESIDE the
+ * timings — a fast step that came from fewer contacts must be visible in the
+ * same row.
+ */
+const toMarkdown = (data: PhysicsReportData): string => {
+  const { provenance } = data;
+  const lines: string[] = [];
+
+  lines.push('# Physics Benchmark Results', '');
+
+  lines.push('## Arms', '');
+
+  if (data.libraries.length === 0) {
+    lines.push('- (none)', '');
+  } else {
+    for (const library of data.libraries) {
+      const resolved = library.resolvedFrom.length > 0 ? library.resolvedFrom : 'not resolved';
+
+      lines.push(`- \`${library.name}\` @ **${library.version}** (resolved from: ${resolved})`);
+    }
+
+    lines.push('');
+  }
+
+  lines.push('## Provenance', '');
+  lines.push(`- Engine version (exojs-physics): ${provenance.engineVersion}`);
+  lines.push(`- Node: ${provenance.host.node}`);
+  lines.push(`- CPU: ${provenance.host.cpu} (${String(provenance.host.cpuCount)} logical)`);
+  lines.push(`- OS: ${provenance.host.os} (${provenance.host.arch})`);
+  lines.push(`- Fixed timestep: ${String(provenance.fixedDelta)} s`);
+  lines.push(`- Timestamp: ${provenance.timestamp}`);
+  lines.push('');
+
+  lines.push('## Caveats', '');
+
+  for (const caveat of provenance.caveats) {
+    lines.push(`- ${caveat}`);
+  }
+
+  lines.push('');
+
+  lines.push('## Results', '');
+  lines.push(`| ${COLUMNS.join(' | ')} |`);
+  lines.push(`| ${COLUMNS.map(() => '---').join(' | ')} |`);
+
+  for (const result of data.results) {
+    lines.push(`| ${toRow(result).map(field => field.replaceAll('|', '\\|')).join(' | ')} |`);
+  }
+
+  lines.push('');
+
+  return lines.join('\n');
+};
+
+/**
+ * Writes the three physics report artifacts into `outDir`:
+ * - `results.json` — full fidelity (provenance + every result field).
+ * - `results.csv` — one row per cell, machine-parseable.
+ * - `results.md` — provenance/caveats block plus a human-readable table.
+ */
+export const writePhysicsReport = (data: PhysicsReportData, outDir: string): void => {
+  writeReportArtifacts(outDir, {
+    json: `${JSON.stringify(data, null, 2)}\n`,
+    csv: `${toCsv(data)}\n`,
+    md: toMarkdown(data),
+  });
+};

--- a/packages/exojs-bench/src/rendering/EngineAdapter.ts
+++ b/packages/exojs-bench/src/rendering/EngineAdapter.ts
@@ -1,3 +1,5 @@
+import type { BaseCellResult } from '../shared/result';
+
 /** Rendering backend under test. */
 export type Backend = 'webgl2' | 'webgpu';
 
@@ -68,10 +70,12 @@ export interface StructuralCounters {
   bufferUploads: number;
 }
 
-/** Measured outcome for a single matrix cell. */
-export interface CellResult {
-  /** The cell this result belongs to. */
-  readonly spec: CellSpec;
+/**
+ * Measured outcome for a single matrix cell. Extends the domain-agnostic
+ * {@link BaseCellResult} (spec/status/note) with the rendering-specific timing
+ * fields (per-frame CPU + full-frame GPU medians/p95) and structural counters.
+ */
+export interface CellResult extends BaseCellResult<CellSpec> {
   /** Median per-frame CPU time in milliseconds. */
   readonly cpuMsMedian: number;
   /** 95th-percentile per-frame CPU time in milliseconds. */
@@ -82,10 +86,6 @@ export interface CellResult {
   readonly frameMsP95: number | null;
   /** Structural draw-call counters gathered while measuring this cell. */
   readonly structural: StructuralCounters;
-  /** Whether the cell completed normally, exceeded a budget, or could not be measured. */
-  readonly status: 'ok' | 'exceeded' | 'unavailable';
-  /** Optional free-text note explaining a non-`'ok'` status. */
-  readonly note?: string;
 }
 
 /** Neutral contract an engine arm implements so the harness can drive it identically across arms. */

--- a/packages/exojs-bench/src/rendering/driver.ts
+++ b/packages/exojs-bench/src/rendering/driver.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -6,17 +6,24 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { srcConditions } from '@codexo/exojs-config/vitest';
 import { chromium } from 'playwright';
 
+import type { BaseProvenance, LibraryProvenance } from '../shared/provenance';
+import { readLibraryProvenance } from '../shared/provenance';
 import { buildMatrix } from './archetypes';
 import type { Backend, CellResult, CellSpec, EngineAdapter } from './EngineAdapter';
+
+// Re-exported so `rendering/index.ts` and the CLI keep importing `LibraryProvenance`
+// from the rendering barrel unchanged while the definition lives in `shared/`.
+export type { LibraryProvenance } from '../shared/provenance';
 
 /**
  * Provenance stamped onto every baseline run. Without it a wall-clock number is
  * meaningless: the same matrix on a real GPU and on a software rasterizer
- * produce numbers that look comparable but are not. `software` is the honesty
- * bit — when true, {@link '../report'.writeReport} marks every timing column
- * untrusted.
+ * produce numbers that look comparable but are not. Extends the shared
+ * {@link BaseProvenance} (timestamp + engine version) with the rendering-
+ * specific GPU fields. `software` is the honesty bit — when true,
+ * {@link '../report'.writeReport} marks every timing column untrusted.
  */
-export interface Provenance {
+export interface Provenance extends BaseProvenance {
   /** GPU/adapter identity string (`WEBGL_debug_renderer_info` unmasked renderer). */
   readonly adapter: string;
   /** Rendering backend this provenance describes. */
@@ -25,10 +32,6 @@ export interface Provenance {
   readonly flags: readonly string[];
   /** Whether Chromium ran headless. */
   readonly headless: boolean;
-  /** ExoJS package version under test. */
-  readonly engineVersion: string;
-  /** ISO-8601 timestamp of the run. */
-  readonly timestamp: string;
   /** True when the adapter is a software rasterizer — timings are then untrusted. */
   readonly software: boolean;
 }
@@ -73,70 +76,8 @@ const readEngineVersion = (): string => {
   return manifest.version ?? '0.0.0';
 };
 
-/**
- * Provenance for one committed competitor library arm: the exact installed
- * version and where it was resolved from. Stamped into every report header so a
- * "ExoJS vs Pixi" statement is auditable — a reader can see precisely which
- * Pixi build produced the numbers and reproduce it.
- */
-export interface LibraryProvenance {
-  /** npm package name, e.g. `pixi.js`. */
-  readonly name: string;
-  /** Exact installed version (from the resolved package manifest). */
-  readonly version: string;
-  /** Absolute path the manifest was resolved from — the reproducibility receipt. */
-  readonly resolvedFrom: string;
-}
-
-/**
- * Read the installed version of each committed competitor library arm.
- *
- * The versions are pinned to an EXACT version in `@codexo/exojs-bench`'s
- * devDependencies (no `^`/`~`), so the number read here is the number that was
- * benchmarked. Resolution walks up from the package's main entry to its
- * `package.json` (some packages do not expose `./package.json` in `exports`, so
- * a direct `require.resolve('pixi.js/package.json')` can fail). A library that
- * cannot be resolved is recorded as `not-installed` rather than throwing — an
- * exojs-only run must not need the competitor deps present.
- */
-const readLibraryProvenance = (): LibraryProvenance[] => {
-  const nodeRequire = createRequire(import.meta.url);
-  const libraries = ['pixi.js'];
-  const provenance: LibraryProvenance[] = [];
-
-  for (const name of libraries) {
-    try {
-      let manifestPath: string;
-
-      try {
-        manifestPath = nodeRequire.resolve(`${name}/package.json`);
-      } catch {
-        // Package hides ./package.json behind exports: walk up from the entry.
-        let dir = dirname(nodeRequire.resolve(name));
-
-        while (!existsSync(resolve(dir, 'package.json'))) {
-          const parent = dirname(dir);
-
-          if (parent === dir) {
-            throw new Error(`could not locate package.json for '${name}'`);
-          }
-
-          dir = parent;
-        }
-
-        manifestPath = resolve(dir, 'package.json');
-      }
-
-      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { version?: string };
-
-      provenance.push({ name, version: manifest.version ?? 'unknown', resolvedFrom: manifestPath });
-    } catch {
-      provenance.push({ name, version: 'not-installed', resolvedFrom: '' });
-    }
-  }
-
-  return provenance;
-};
+/** Competitor library arms whose installed version + resolution are stamped into every report header. */
+const LIBRARY_ARMS = ['pixi.js'] as const;
 
 /**
  * Adapter capability descriptors known to the driver. Only `engine`, `config`
@@ -589,7 +530,7 @@ export const runMatrix = async (options: {
   onCellResult?: CellResultSink;
 }): Promise<MatrixOutcome> => {
   const engineVersion = readEngineVersion();
-  const libraries = readLibraryProvenance();
+  const libraries = readLibraryProvenance(LIBRARY_ARMS);
   const allCells = buildMatrix(ADAPTER_CAPABILITIES, options.backends);
   const filtered = options.filter ? applyFilter(allCells, options.filter) : allCells;
   const cells = options.timedFramesOverride === undefined ? filtered : filtered.map(cell => ({ ...cell, timedFrames: options.timedFramesOverride! }));

--- a/packages/exojs-bench/src/rendering/report.ts
+++ b/packages/exojs-bench/src/rendering/report.ts
@@ -1,7 +1,6 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
-
-import type { LibraryProvenance, Provenance } from './driver';
+import type { LibraryProvenance } from '../shared/provenance';
+import { csvField, formatCount as count, formatMs as ms, writeReportArtifacts } from '../shared/report';
+import type { Provenance } from './driver';
 import type { CellResult } from './EngineAdapter';
 
 /** Node count at or above which a full-frame time is beyond any interactive budget. */
@@ -19,12 +18,6 @@ export interface ReportData {
   /** One result per matrix cell. */
   readonly results: readonly CellResult[];
 }
-
-/** Formats a millisecond figure to three decimals, or `n/a` when unavailable. */
-const ms = (value: number | null): string => (value === null ? 'n/a' : value.toFixed(3));
-
-/** Formats a structural counter: integers stay integers, uneven per-frame totals keep two decimals. */
-const count = (value: number): string => (Number.isInteger(value) ? String(value) : value.toFixed(2));
 
 /** True when any provenance stamp reports a software rasterizer. */
 const isSoftware = (data: ReportData): boolean => data.provenance.some(entry => entry.software);
@@ -56,9 +49,6 @@ const CSV_HEADER = [
   'status',
   'note',
 ] as const;
-
-/** Escapes a CSV field, quoting when it holds a comma, quote or newline. */
-const csvField = (value: string): string => (/[",\n]/.test(value) ? `"${value.replaceAll('"', '""')}"` : value);
 
 const toCsvRow = (result: CellResult): string => {
   const { spec, structural } = result;
@@ -217,8 +207,9 @@ const toMarkdown = (data: ReportData): string => {
  * - `results.md` — provenance block plus a human-readable table.
  */
 export const writeReport = (data: ReportData, outDir: string): void => {
-  mkdirSync(outDir, { recursive: true });
-  writeFileSync(join(outDir, 'results.json'), `${JSON.stringify(data, null, 2)}\n`);
-  writeFileSync(join(outDir, 'results.csv'), `${toCsv(data)}\n`);
-  writeFileSync(join(outDir, 'results.md'), toMarkdown(data));
+  writeReportArtifacts(outDir, {
+    json: `${JSON.stringify(data, null, 2)}\n`,
+    csv: `${toCsv(data)}\n`,
+    md: toMarkdown(data),
+  });
 };

--- a/packages/exojs-bench/src/run.ts
+++ b/packages/exojs-bench/src/run.ts
@@ -1,16 +1,23 @@
 import { resolve } from 'node:path';
 
+// `./physics` is imported for TYPES only here (erased at runtime); its module
+// graph — the `@codexo/exojs-physics` source arm — is loaded lazily via a
+// dynamic `import()` inside `runPhysicsDomain`, so a rendering run never pays for it.
+import type { PhysicsCellResult, PhysicsCellSpec } from './physics';
 import type { ArchetypeId, Backend, CellResult, CellSpec } from './rendering';
 import { runMatrix, writeReport } from './rendering';
 import { parseArgs } from './shared/args';
 import { createCheckpointWriter } from './shared/checkpoint';
 
-/** Domains this CLI can drive. Rendering is the first; `physics` etc. can be added as sibling barrels. */
-const DOMAINS = ['rendering'] as const;
+/** Domains this CLI can drive. Each has its own archetypes + arms; the shared layer (timing, provenance, checkpoint, report skeleton) is reused across both. */
+const DOMAINS = ['rendering', 'physics'] as const;
 type Domain = (typeof DOMAINS)[number];
 
-/** Default output directory for the generated report artifacts (gitignored). */
+/** Default output directory for the rendering report artifacts (gitignored). */
 const DEFAULT_OUT_DIR = '.workspace/output/baseline/';
+
+/** Default output directory for the physics report artifacts (gitignored). */
+const DEFAULT_PHYSICS_OUT_DIR = '.workspace/output/physics/';
 
 /** Backends run when `--backend` is not given. `buildMatrix` gates each to the adapters that support it. */
 const DEFAULT_BACKENDS: readonly Backend[] = ['webgl2', 'webgpu'];
@@ -136,6 +143,102 @@ const runRenderingDomain = async (args: Map<string, string>): Promise<void> => {
   console.log(`\nReport written to ${outDir} (results.json, results.csv, results.md)`);
 };
 
+/**
+ * Run the physics benchmark domain end-to-end and write its report artifacts.
+ *
+ * Physics is CPU-only: no browser, no GPU. The whole matrix runs in THIS Node
+ * process as a straight loop over `world.step`, so the domain module is imported
+ * dynamically (only when selected) — a rendering run never loads the physics
+ * arm's `@codexo/exojs-physics` source graph, and vice versa.
+ *
+ * Flags mirror the rendering domain: `--archetype` and `--bodies` filter the
+ * matrix (the `--bodies` node-sweep analogue), `--frames` overrides the timed-
+ * step count for a fast spot-check (never a reportable run).
+ */
+const runPhysicsDomain = async (args: Map<string, string>): Promise<void> => {
+  const { runPhysicsMatrix, writePhysicsReport } = await import('./physics');
+
+  const archetypeArg = args.get('archetype');
+  const bodiesArg = args.get('bodies');
+  const framesArg = args.get('frames');
+  const outDir = resolve(args.get('out') ?? DEFAULT_PHYSICS_OUT_DIR);
+
+  const filter: { -readonly [K in keyof PhysicsCellSpec]?: PhysicsCellSpec[K] } = {};
+
+  if (archetypeArg !== undefined) {
+    filter.archetype = archetypeArg as PhysicsCellSpec['archetype'];
+  }
+
+  if (bodiesArg !== undefined) {
+    const bodyCount = Number.parseInt(bodiesArg, 10);
+
+    if (Number.isNaN(bodyCount)) {
+      throw new Error(`--bodies must be an integer (got '${bodiesArg}').`);
+    }
+
+    filter.bodyCount = bodyCount;
+  }
+
+  // `--frames`: override every selected cell's timed-step count (like the
+  // rendering domain's flag). A convenience knob for fast iteration only — it
+  // flattens the per-body-count step budgets the report's `timedSteps` column
+  // exists to make honest, so any run using it is a non-reportable SUBSET RUN.
+  let timedStepsOverride: number | undefined;
+
+  if (framesArg !== undefined) {
+    const frames = Number.parseInt(framesArg, 10);
+
+    if (Number.isNaN(frames) || frames < 1) {
+      throw new Error(`--frames must be a positive integer (got '${framesArg}').`);
+    }
+
+    timedStepsOverride = frames;
+  }
+
+  const isSubset = archetypeArg !== undefined || bodiesArg !== undefined || timedStepsOverride !== undefined;
+
+  if (isSubset) {
+    console.warn('SUBSET RUN — not a reportable comparison (see the same-run rule).');
+  }
+
+  console.log(
+    `Running physics benchmark: ${archetypeArg ? `archetype=${archetypeArg}` : 'all archetypes'}${bodiesArg ? `, bodies=${bodiesArg}` : ''}${timedStepsOverride !== undefined ? `, frames=${timedStepsOverride} (OVERRIDE — thin sampling, not reportable)` : ''}`,
+  );
+
+  // Incremental, crash-safe checkpoint: each cell is persisted the instant it
+  // lands, reusing the same shared writer the rendering domain uses.
+  const checkpoint = createCheckpointWriter<PhysicsCellResult>(outDir);
+
+  const data = runPhysicsMatrix({
+    ...(isSubset && { filter }),
+    ...(timedStepsOverride !== undefined && { timedStepsOverride }),
+    onCellResult: result => checkpoint.append(result),
+  });
+
+  console.log(`\nPer-cell checkpoints written incrementally to ${checkpoint.jsonlPath}`);
+
+  console.log('\n=== Arms ===');
+
+  for (const library of data.libraries) {
+    console.log(`  ${library.name} @ ${library.version}${library.resolvedFrom.length > 0 ? ` (from ${library.resolvedFrom})` : ''}`);
+  }
+
+  console.log('\n=== Provenance ===');
+  console.log(`  node=${data.provenance.host.node} cpu="${data.provenance.host.cpu}" (${String(data.provenance.host.cpuCount)} logical) os=${data.provenance.host.os} engine=${data.provenance.engineVersion} fixedDelta=${String(data.provenance.fixedDelta)}`);
+
+  writePhysicsReport(data, outDir);
+
+  console.log('\n=== Per-step time (median) + structural ===');
+
+  for (const result of data.results) {
+    console.log(
+      `  ${result.spec.engine.padEnd(14)} ${result.spec.config.padEnd(7)} ${result.spec.archetype.padEnd(20)} n=${String(result.spec.bodyCount).padStart(6)} bodies=${String(result.structural.bodyCount).padStart(6)} contacts=${String(result.structural.contactCount).padStart(6)} stepMsMedian=${result.stepMsMedian.toFixed(4)} stepMsP95=${result.stepMsP95.toFixed(4)} status=${result.status}`,
+    );
+  }
+
+  console.log(`\nReport written to ${outDir} (results.json, results.csv, results.md)`);
+};
+
 const main = async (): Promise<void> => {
   const args = parseArgs(process.argv.slice(2));
   const domain = resolveDomain(args.get('domain'));
@@ -143,6 +246,9 @@ const main = async (): Promise<void> => {
   switch (domain) {
     case 'rendering':
       await runRenderingDomain(args);
+      break;
+    case 'physics':
+      await runPhysicsDomain(args);
       break;
   }
 };

--- a/packages/exojs-bench/src/shared/provenance.ts
+++ b/packages/exojs-bench/src/shared/provenance.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { arch as osArch, cpus, platform as osPlatform, release as osRelease } from 'node:os';
+import { dirname, resolve } from 'node:path';
+
+/**
+ * Domain-agnostic provenance primitives (review #325: the provenance header was
+ * rendering-coupled and living under `rendering/`).
+ *
+ * A wall-clock number is meaningless without the context that produced it, and
+ * that context splits into a genuinely shared part — WHEN the run happened and
+ * WHICH version of the primary package under test produced it — and a
+ * domain-specific part. Rendering adds the GPU adapter string, launch flags and
+ * the software-rasterizer honesty bit; physics adds the Node runtime and CPU
+ * host. Those domain parts stay in each domain's driver, extending
+ * {@link BaseProvenance}.
+ */
+
+/** The provenance fields every domain records, regardless of what it measured. */
+export interface BaseProvenance {
+  /** ISO-8601 timestamp of the run. */
+  readonly timestamp: string;
+  /** Version of the primary package under test (ExoJS core for rendering, `@codexo/exojs-physics` for physics). */
+  readonly engineVersion: string;
+}
+
+/**
+ * Provenance for one committed library arm: the exact installed version and
+ * where it was resolved from. Stamped into every report header so a comparison
+ * ("ExoJS vs Pixi", "stay-native vs adapter") is auditable — a reader can see
+ * precisely which build produced the numbers and reproduce it.
+ */
+export interface LibraryProvenance {
+  /** npm package name, e.g. `pixi.js` or `@codexo/exojs-physics`. */
+  readonly name: string;
+  /** Exact installed version (from the resolved package manifest). */
+  readonly version: string;
+  /** Absolute path the manifest was resolved from — the reproducibility receipt. */
+  readonly resolvedFrom: string;
+}
+
+/**
+ * Read the installed version + resolution path of each named package arm.
+ *
+ * Resolution walks up from the package's main entry to its `package.json` (some
+ * packages do not expose `./package.json` in `exports`, so a direct
+ * `require.resolve('<name>/package.json')` can fail). A package that cannot be
+ * resolved is recorded as `not-installed` rather than throwing — a run that does
+ * not need every arm present must not be blocked by a missing one.
+ *
+ * Lifted out of the rendering driver (where it was hardcoded to `['pixi.js']`)
+ * so the physics domain can read `@codexo/exojs-physics`'s version the same way.
+ */
+export const readLibraryProvenance = (names: readonly string[]): LibraryProvenance[] => {
+  const nodeRequire = createRequire(import.meta.url);
+  const provenance: LibraryProvenance[] = [];
+
+  for (const name of names) {
+    try {
+      let manifestPath: string;
+
+      try {
+        manifestPath = nodeRequire.resolve(`${name}/package.json`);
+      } catch {
+        // Package hides ./package.json behind exports: walk up from the entry.
+        let dir = dirname(nodeRequire.resolve(name));
+
+        while (!existsSync(resolve(dir, 'package.json'))) {
+          const parent = dirname(dir);
+
+          if (parent === dir) {
+            throw new Error(`could not locate package.json for '${name}'`);
+          }
+
+          dir = parent;
+        }
+
+        manifestPath = resolve(dir, 'package.json');
+      }
+
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { version?: string };
+
+      provenance.push({ name, version: manifest.version ?? 'unknown', resolvedFrom: manifestPath });
+    } catch {
+      provenance.push({ name, version: 'not-installed', resolvedFrom: '' });
+    }
+  }
+
+  return provenance;
+};
+
+/**
+ * Host + runtime provenance for a CPU-bound (Node) benchmark domain. A physics
+ * step-time number is only comparable across runs if the CPU and Node version
+ * that produced it are on the record — the CPU-domain analogue of rendering's
+ * GPU adapter string.
+ */
+export interface HostInfo {
+  /** `process.version`, e.g. `v24.14.1`. */
+  readonly node: string;
+  /** First logical CPU's model string (all cores are assumed identical). */
+  readonly cpu: string;
+  /** Number of logical CPUs reported by the OS. */
+  readonly cpuCount: number;
+  /** `os.platform()` + `os.release()`, e.g. `win32 10.0.26100`. */
+  readonly os: string;
+  /** `os.arch()`, e.g. `x64`. */
+  readonly arch: string;
+}
+
+/** Snapshot the Node runtime + CPU host for a CPU-bound domain's provenance header. */
+export const readHostInfo = (): HostInfo => {
+  const logicalCpus = cpus();
+
+  return {
+    node: process.version,
+    cpu: logicalCpus[0]?.model.trim() ?? 'unknown',
+    cpuCount: logicalCpus.length,
+    os: `${osPlatform()} ${osRelease()}`,
+    arch: osArch(),
+  };
+};

--- a/packages/exojs-bench/src/shared/report.ts
+++ b/packages/exojs-bench/src/shared/report.ts
@@ -1,0 +1,45 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Domain-agnostic report-writing primitives (review #325: the report skeleton
+ * was rendering-coupled and living under `rendering/`).
+ *
+ * Both domains emit the same three artifacts — a full-fidelity `results.json`, a
+ * machine-parseable `results.csv`, and a human-readable `results.md` — and share
+ * the same value-formatting and CSV-escaping rules. What differs is the COLUMN
+ * SET (draw calls / GPU frame time for rendering, body/contact counts / step
+ * time for physics); each domain builds its own rows and table, then hands the
+ * three rendered strings here to be written together.
+ */
+
+/** Formats a millisecond figure to three decimals, or `n/a` when unavailable. */
+export const formatMs = (value: number | null): string => (value === null ? 'n/a' : value.toFixed(3));
+
+/** Formats a structural counter: integers stay integers, uneven per-step/frame totals keep two decimals. */
+export const formatCount = (value: number): string => (Number.isInteger(value) ? String(value) : value.toFixed(2));
+
+/** Escapes a CSV field, quoting when it holds a comma, quote or newline. */
+export const csvField = (value: string): string => (/[",\n]/.test(value) ? `"${value.replaceAll('"', '""')}"` : value);
+
+/** The three rendered report artifacts, already formatted by the domain. */
+export interface ReportArtifacts {
+  /** Full-fidelity JSON (provenance + every result field). */
+  readonly json: string;
+  /** One row per cell, machine-parseable. */
+  readonly csv: string;
+  /** Provenance block plus a human-readable table. */
+  readonly md: string;
+}
+
+/**
+ * Write the three report artifacts into `outDir` as `results.{json,csv,md}`,
+ * creating the directory if needed. The domain renders the strings; this writes
+ * them with one consistent naming/layout contract.
+ */
+export const writeReportArtifacts = (outDir: string, artifacts: ReportArtifacts): void => {
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(join(outDir, 'results.json'), artifacts.json);
+  writeFileSync(join(outDir, 'results.csv'), artifacts.csv);
+  writeFileSync(join(outDir, 'results.md'), artifacts.md);
+};

--- a/packages/exojs-bench/src/shared/result.ts
+++ b/packages/exojs-bench/src/shared/result.ts
@@ -1,0 +1,29 @@
+/**
+ * Domain-agnostic cell-result core (review #325: `CellResult` was
+ * rendering-coupled and living under `rendering/`).
+ *
+ * Every benchmark domain measures a matrix of cells and reports, per cell,
+ * whether it completed and an optional explanation — regardless of what the
+ * cell actually measured (per-frame GPU time for rendering, per-`step` CPU time
+ * for physics). Those three fields are the genuinely shared shape; each domain
+ * extends {@link BaseCellResult} with its own spec type, timing fields and
+ * structural counters (draw calls for rendering, body/contact counts for
+ * physics), which stay in the domain folder.
+ */
+
+/** Whether a cell completed normally, exceeded a budget, or could not be measured. */
+export type CellStatus = 'ok' | 'exceeded' | 'unavailable';
+
+/**
+ * Shared base every domain's per-cell result extends. Generic over the domain's
+ * own cell-spec type so the spec stays strongly typed while the status/note
+ * contract is written once.
+ */
+export interface BaseCellResult<TSpec> {
+  /** The cell this result belongs to. */
+  readonly spec: TSpec;
+  /** Whether the cell completed normally, exceeded a budget, or could not be measured. */
+  readonly status: CellStatus;
+  /** Optional free-text note explaining a non-`'ok'` status (or a disclosed caveat). */
+  readonly note?: string;
+}

--- a/packages/exojs-bench/tsconfig.json
+++ b/packages/exojs-bench/tsconfig.json
@@ -1,13 +1,18 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "_comment": "The engine is benchmarked through its internal `#*` subpath imports. Node forbids an `imports` target escaping this package with `../`, and the harness's `#*` imports only run in the browser page (resolved by the driver's Vite alias, see rendering/driver.ts) — never in the Node CLI. The `paths` map below reproduces the root package.json's `#* -> ./src/*` wildcard so the type-checker resolves engine source from `<repo>/src`.",
+  "_comment": "The rendering domain benchmarks the engine through its internal `#*` subpath imports (resolved in the browser page by the driver's Vite alias, never in the Node CLI); the `#* -> ../../src/*` path reproduces the root package.json wildcard for the type-checker. The physics domain instead imports the `@codexo/exojs-physics` package (which itself imports the `@codexo/exojs` barrel), and neither exposes a `@codexo/source` export condition, so those specifiers are mapped to source here — mirroring the runtime aliasing in scripts/glsl-loader.mjs and vitest.config.ts's aliasConfig.",
   "extends": "@codexo/exojs-config/typescript/test.json",
   "compilerOptions": {
     "noEmit": true,
     "customConditions": ["@codexo/source"],
     "types": ["vitest/globals", "node", "@webgpu/types"],
     "paths": {
-      "#*": ["../../src/*"]
+      "#*": ["../../src/*"],
+      "@codexo/exojs-physics": ["../exojs-physics/src/index.ts"],
+      "@codexo/exojs": ["../../src/index.ts"],
+      "@codexo/exojs/extensions": ["../../src/extensions/index.ts"],
+      "@codexo/exojs/renderer-sdk": ["../../src/renderer-sdk.ts"],
+      "@codexo/exojs/debug": ["../../src/debug/index.ts"]
     }
   },
   "include": ["src/**/*", "test/**/*", "../../src/typings.d.ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       '@codexo/exojs-config':
         specifier: workspace:*
         version: link:../exojs-config
+      '@codexo/exojs-physics':
+        specifier: workspace:*
+        version: link:../exojs-physics
       '@types/node':
         specifier: ^25.6.0
         version: 25.9.4


### PR DESCRIPTION
Adds a second benchmark domain to `@codexo/exojs-bench`: **physics**, measuring `@codexo/exojs-physics` step time. Foundation + the native arm only — matter.js/rapier adapter arms are a separate follow-on.

## 1. Shared generalization (review #325)
The #325 review noted `Backend`, `Provenance`, `CellResult` were still rendering-coupled under `rendering/`. Lifted the genuinely domain-agnostic parts into `src/shared/` so both domains reuse them:

- **`shared/result.ts`** — `CellStatus` + `BaseCellResult<TSpec>` (spec/status/note).
- **`shared/provenance.ts`** — `BaseProvenance` (timestamp/engineVersion), `LibraryProvenance` + a generic `readLibraryProvenance(names)` (was hardcoded to `['pixi.js']`), and `readHostInfo()` for CPU-bound domains.
- **`shared/report.ts`** — `csvField`/`formatMs`/`formatCount` + `writeReportArtifacts()`.

Rendering now extends these (`CellResult extends BaseCellResult<CellSpec>`, `Provenance extends BaseProvenance`, report imports the shared helpers). **Rendering-specific bits stay in `rendering/`**: GPU `Backend`, draw-call/texture-bind structural counters, the software-rasterizer honesty bit. No rendering behaviour change.

## 2. Physics domain (`src/physics/`)
CPU-only: no browser, no GPU. Runs as a straight loop over `world.step()` in Node/tsx, source-accurate via the repo's existing `scripts/glsl-register.mjs` loader + `--conditions=@codexo/source`.

- **`PhysicsAdapter`** — neutral per-arm contract: `setup`/`step`/`sampleStructural`/`teardown` + optional `mutationSignature`. The planned matter/rapier arms implement this.
- **`adapters/exojs-physics.ts`** — native arm driving `PhysicsWorld` / `PhysicsBody` / `Box|CircleShape` / `world.step`; scenes built from the shared deterministic RNG.
- **`archetypes.ts`** — 3 lean archetypes: `box-stack` (settling columns), `many-dynamic` (bouncing field in a bounded box, all perturbed), `mixed-static-dynamic` (static obstacles + raining bodies). `--bodies` node-sweep; per-body-count warmup/timed-step budgets.
- **`driver.ts`** — Node matrix runner: step-time median/p95 via shared timing, cross-arm determinism assert via shared mutation, host + `exojs-physics` version provenance, runaway-step abort guard, incremental per-cell checkpoint.
- **`report.ts`** — `results.{json,csv,md}` via the shared report skeleton (provenance + disclosed caveats + structural-beside-timing table).

## 3. Wiring
`--domain=physics` added to `run.ts` (lazy-imported, so a rendering run never loads the physics arm's source graph). The `bench` script now uses the source-accurate node invocation for both domains. `--domain rendering` (default) unchanged.

## Verification
- Physics proof run (`--domain physics --archetype box-stack --bodies 200 --frames 60`): produces step-time samples + structural counters; all three archetypes simulate cleanly with distinct profiles; determinism assertion passes.
- `--domain rendering` still works end-to-end (tiny subset run: all 3 arms measured on real GPU) and the full bench test suite passes (46/46).
- `pnpm --filter @codexo/exojs-bench typecheck` + lint clean; `pnpm run verify:quick` exit 0 (no `--no-verify`).
- No measured numbers committed (report artifacts are gitignored under `.workspace/`).

## Follow-on (matter/rapier)
Add arms under `src/physics/adapters/`, implement `PhysicsAdapter`, and pass them into `runPhysicsMatrix({ adapters })`. The cross-arm determinism assert already routes every arm through the shared `selectMutationIndices`/`mutationSignature`. Competitor deps are out of scope here (isolation config gates the heavy deps first, per the design note).

Structural change (shared-type lift) — **not** enabling automerge; leaving for coordinator review.