### PR TITLE
chore(bench): pin phaser/excalibur/matter/rapier competitor deps

### DIFF
--- a/packages/exojs-bench/competitors/package.json
+++ b/packages/exojs-bench/competitors/package.json
@@ -2,8 +2,13 @@
   "name": "exojs-bench-competitors",
   "version": "0.0.0",
   "private": true,
-  "description": "Pinned exact-version competitor libraries for @codexo/exojs-bench (Pixi, and future Phaser/Excalibur/matter/rapier arms). Deliberately NOT a pnpm-workspace.yaml member: a plain root `pnpm install` never resolves or downloads anything here, so a normal contributor pays zero weight for competitor libraries. Only `pnpm --filter @codexo/exojs-bench bench:setup` installs this folder (via `pnpm install --ignore-workspace`, so a supply-chain review of a version bump should also sanity-check its release age by hand -- `--ignore-workspace` means the root pnpm-workspace.yaml's minimumReleaseAge gate does not apply here) and links the results into ../node_modules so the adapters' plain `import 'pixi.js'` (etc.) resolve unmodified.",
+  "description": "Pinned exact-version competitor libraries for @codexo/exojs-bench (Pixi, Phaser, Excalibur, matter-js, rapier2d-compat arms). Deliberately NOT a pnpm-workspace.yaml member: a plain root `pnpm install` never resolves or downloads anything here, so a normal contributor pays zero weight for competitor libraries. Only `pnpm --filter @codexo/exojs-bench bench:setup` installs this folder (via `pnpm install --ignore-workspace`, so a supply-chain review of a version bump should also sanity-check its release age by hand -- `--ignore-workspace` means the root pnpm-workspace.yaml's minimumReleaseAge gate does not apply here) and links the results into ../node_modules so the adapters' plain `import 'pixi.js'` (etc.) resolve unmodified.",
   "dependencies": {
-    "pixi.js": "8.19.0"
+    "pixi.js": "8.19.0",
+    "phaser": "3.90.0",
+    "excalibur": "0.32.0",
+    "matter-js": "0.20.0",
+    "@types/matter-js": "0.20.2",
+    "@dimforge/rapier2d-compat": "0.19.3"
   }
 }

--- a/packages/exojs-bench/competitors/pnpm-lock.yaml
+++ b/packages/exojs-bench/competitors/pnpm-lock.yaml
@@ -8,17 +8,38 @@ importers:
 
   .:
     dependencies:
+      '@dimforge/rapier2d-compat':
+        specifier: 0.19.3
+        version: 0.19.3
+      '@types/matter-js':
+        specifier: 0.20.2
+        version: 0.20.2
+      excalibur:
+        specifier: 0.32.0
+        version: 0.32.0
+      matter-js:
+        specifier: 0.20.0
+        version: 0.20.0
+      phaser:
+        specifier: 3.90.0
+        version: 3.90.0
       pixi.js:
         specifier: 8.19.0
         version: 8.19.0
 
 packages:
 
+  '@dimforge/rapier2d-compat@0.19.3':
+    resolution: {integrity: sha512-5HZUgiSpu9Uba3He+4SCPVte3h2vgxcodkxWThRjd3X/zgq/Z4OyRUKpNEOsOR6AC+OfulPkkZ5asZGzRMpcwA==}
+
   '@pixi/colord@2.9.6':
     resolution: {integrity: sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==}
 
   '@types/earcut@3.0.0':
     resolution: {integrity: sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==}
+
+  '@types/matter-js@0.20.2':
+    resolution: {integrity: sha512-3PPKy3QxvZ89h9+wdBV2488I1JLVs7DEpIkPvgO8JC1mUdiVSO37ZIvVctOTD7hIq8OAL2gJ3ugGSuUip6DhCw==}
 
   '@webgpu/types@0.1.71':
     resolution: {integrity: sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==}
@@ -33,6 +54,9 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  excalibur@0.32.0:
+    resolution: {integrity: sha512-anCvsZK2Dh3BTlw/ERHr3fvfqF2vdJHw88soCs3r6EIwxbhibNRILMZw3Ae6GMTY8FkzRfkGLyk7DlEZVesUaw==}
+
   gifuct-js@2.1.2:
     resolution: {integrity: sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==}
 
@@ -42,8 +66,14 @@ packages:
   js-binary-schema-parser@2.0.3:
     resolution: {integrity: sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==}
 
+  matter-js@0.20.0:
+    resolution: {integrity: sha512-iC9fYR7zVT3HppNnsFsp9XOoQdQN2tUyfaKg4CHLH8bN+j6GT4Gw7IH2rP0tflAebrHFw730RR3DkVSZRX8hwA==}
+
   parse-svg-path@0.2.0:
     resolution: {integrity: sha512-Tf7FFIrguPKQwzD4pWnYkR2VOv3raoHeKED80Bm+BYHI3KxC8KsgsGC5+fSMzAGDA6UEk4bHvmi+RsjmL3khpg==}
+
+  phaser@3.90.0:
+    resolution: {integrity: sha512-/cziz/5ZIn02uDkC9RzN8VF9x3Gs3XdFFf9nkiMEQT3p7hQlWuyjy4QWosU802qqno2YSLn2BfqwOKLv/sSVfQ==}
 
   pixi.js@8.19.0:
     resolution: {integrity: sha512-pq1O6emA/GFjjeF+8d3Pb5t7knD8FsnfWGqQcRjYjsqFZ7QdzG1XgjLDUu0DFJRbafjV5+g8iNLFBx0b9649lg==}
@@ -54,9 +84,13 @@ packages:
 
 snapshots:
 
+  '@dimforge/rapier2d-compat@0.19.3': {}
+
   '@pixi/colord@2.9.6': {}
 
   '@types/earcut@3.0.0': {}
+
+  '@types/matter-js@0.20.2': {}
 
   '@webgpu/types@0.1.71': {}
 
@@ -66,6 +100,8 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  excalibur@0.32.0: {}
+
   gifuct-js@2.1.2:
     dependencies:
       js-binary-schema-parser: 2.0.3
@@ -74,7 +110,13 @@ snapshots:
 
   js-binary-schema-parser@2.0.3: {}
 
+  matter-js@0.20.0: {}
+
   parse-svg-path@0.2.0: {}
+
+  phaser@3.90.0:
+    dependencies:
+      eventemitter3: 5.0.4
 
   pixi.js@8.19.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Adds phaser 3.90.0 (latest stable 3.x, deliberately not 4.x), excalibur 0.32.0, matter-js 0.20.0 + @types/matter-js 0.20.2, and @dimforge/rapier2d-compat 0.19.3 to `packages/exojs-bench/competitors/package.json` as exact-pinned dependencies, keeping the existing `pixi.js` pin.
- Regenerates `competitors/pnpm-lock.yaml` via a real `pnpm install --dir competitors --ignore-workspace`.
- The `-compat` rapier build is used deliberately: it inlines the wasm as base64 with an async `init()`, so it works under `--ignore-workspace` in a Node/tsx harness with no bundler/wasm-asset step.
- No adapters are added here -- this is only the dependency + lockfile prerequisite so the rendering (Phaser/Excalibur) and physics (matter-js/rapier2d) adapter follow-ups can proceed in parallel without touching the same lockfile.

## Test plan
- [x] `pnpm install --dir packages/exojs-bench/competitors --ignore-workspace` succeeds and produces a clean lockfile diff (only the 5 new packages, no unrelated churn)
- [x] `node competitors/link.mjs` (i.e. `bench:setup`) links all 6 competitor packages into `exojs-bench/node_modules`
- [x] `matter-js` resolves via dynamic import (`m.default.version === '0.20.0'`)
- [x] `@dimforge/rapier2d-compat` resolves and `await init(); new World({x:0,y:-9.81})` works (see PR description / follow-up notes for the exact incantation)
- [x] phaser/excalibur confirmed to require a real browser `window`/DOM at module load (no Node-resolvable entry point exists in either package's `exports` map) -- expected for the adapter to run under Playwright, not plain Node
- [x] `pnpm run verify:quick` passes (competitors/ is outside the pnpm workspace, so it is unaffected)