### PR TITLE
feat(bench): add matter.js and rapier physics arms

### DIFF
--- a/packages/exojs-bench/src/physics/adapters/matter-js.ts
+++ b/packages/exojs-bench/src/physics/adapters/matter-js.ts
@@ -1,0 +1,159 @@
+import type Matter from 'matter-js';
+
+import { STEP_DELTA } from '../archetypes';
+import type { PhysicsAdapter, PhysicsArchetypeSpec, PhysicsStructuralCounters } from '../PhysicsAdapter';
+import { describePhysicsScene } from './scene';
+
+/**
+ * matter.js (`matter-js`) arm of the physics benchmark — the "attach a
+ * general-purpose 2D physics library" comparison against staying on native
+ * `@codexo/exojs-physics`.
+ *
+ * FAIRNESS (see the module header of `scene.ts` and the driver's disclosed
+ * caveats): the scene is built from the shared {@link describePhysicsScene}
+ * descriptor, so matter simulates the byte-identical body configuration (counts,
+ * positions, shapes, sizes, static/dynamic split, perturbed-body set) the native
+ * exojs arm and the rapier arm do, and the perturbed selection is asserted
+ * cross-arm through {@link PhysicsAdapter.mutationSignature}.
+ *
+ * UNIT MAPPING (the crux of a fair matter comparison — matter's units are NOT
+ * SI):
+ * - Gravity. matter integrates gravity as `accel = gravity.value * gravity.scale`
+ *   per second², with the default `scale` of `0.001`. The archetype gravity is in
+ *   px/s², so `gravity.value = px/s² ÷ 1000` reproduces the same acceleration
+ *   field the exojs arm integrates (empirically verified: default `y=1` ⇒
+ *   ≈1000 px/s²).
+ * - Timestep. `Engine.update` takes MILLISECONDS, so each `step(dt)` calls it with
+ *   `dt * 1000` — the same fixed `1/60 s` sub-step as the native arm.
+ * - Velocity. matter's body velocity is px-per-STEP, not px/s, so a perturbation
+ *   of `v` px/s is applied as `v * dt` via `Body.setVelocity`.
+ *
+ * DISCLOSED NON-EQUIVALENCE (each engine measured at its own sensible default —
+ * these are the legitimate engine differences the benchmark exists to surface):
+ * - Solver iterations: matter's constraint solver defaults (position 6 / velocity
+ *   4 / constraint 2) differ from exojs's TGS-Soft 4-substep and rapier's 4
+ *   solver iterations.
+ * - Sleeping: matter does NOT deactivate resting bodies by default
+ *   (`enableSleeping=false`), whereas exojs and rapier do — so a settled matter
+ *   stack keeps paying full solve cost. Kept at matter's default and disclosed.
+ * - `frictionAir` is set to `0` (matter's default `0.01` applies a per-step linear
+ *   drag that neither exojs nor rapier apply by default) so all three arms
+ *   integrate the SAME pure-gravity force field — matching the SCENE, while the
+ *   solver differences above are left to be measured.
+ * - Contact count is matter's active colliding-pair count (`engine.pairs
+ *   .collisionActive`), a pair-level proxy comparable to — but not semantically
+ *   identical to — exojs's solid-contact count.
+ *
+ * `matter-js` is a CommonJS default export loaded lazily via dynamic `import()`,
+ * so a checkout that never ran `bench:setup` (the competitor library is not
+ * linked) degrades to a skipped arm instead of crashing the run.
+ */
+
+/** matter's gravity `scale`; kept at its default. */
+const GRAVITY_SCALE = 0.001;
+/**
+ * matter integrates a downward acceleration of `value * scale * 1e6` px/s²
+ * (empirically: default `value = 1`, `scale = 0.001` ⇒ ≈1000 px/s²). Inverting
+ * that places the archetype's px/s² field: `value = px/s² * (1 / (scale·1e6))`.
+ * With the default scale this is `px/s² * 0.001` (so 1000 px/s² ⇒ `value = 1`).
+ */
+const PX_PER_S2_TO_MATTER = 1 / (GRAVITY_SCALE * 1_000_000);
+
+/**
+ * Resolve the matter.js arm, or `null` if the library is not linked into the
+ * bench (graceful degradation for a checkout that skipped `bench:setup`).
+ */
+export const createMatterJsAdapter = async (): Promise<PhysicsAdapter | null> => {
+  let M: typeof Matter;
+
+  try {
+    const mod = (await import('matter-js')) as unknown as { default: typeof Matter };
+
+    M = mod.default;
+  } catch {
+    console.warn("[physics] matter.js arm unavailable — 'matter-js' is not linked (run bench:setup). Skipping the matter arm.");
+
+    return null;
+  }
+
+  let engine: Matter.Engine | null = null;
+  let perturbedSignature = '';
+
+  return {
+    engine: 'matter-js',
+    config: 'default',
+
+    setup(spec: PhysicsArchetypeSpec, bodyCount: number, seed: number): void {
+      const scene = describePhysicsScene(spec, bodyCount, seed);
+
+      perturbedSignature = scene.perturbedSignature;
+
+      const created = M.Engine.create();
+
+      // Reproduce the archetype's px/s² gravity field in matter's unit model.
+      created.gravity = { x: spec.gravity.x * PX_PER_S2_TO_MATTER, y: spec.gravity.y * PX_PER_S2_TO_MATTER, scale: GRAVITY_SCALE };
+
+      const bodies: Matter.Body[] = [];
+
+      for (const desc of scene.bodies) {
+        const options: Matter.IChamferableBodyDefinition = {
+          isStatic: desc.type === 'static',
+          friction: desc.friction,
+          restitution: desc.restitution,
+          density: desc.density,
+          // Zero matter's default per-step air drag so the force field is pure
+          // gravity, matching exojs/rapier (see the disclosed non-equivalence above).
+          frictionAir: 0,
+        };
+
+        const body =
+          desc.shape.kind === 'box'
+            ? M.Bodies.rectangle(desc.x, desc.y, desc.shape.width, desc.shape.height, options)
+            : M.Bodies.circle(desc.x, desc.y, desc.shape.radius, options);
+
+        if (desc.perturb) {
+          // matter velocity is px-per-step; convert the px/s impulse with the fixed step.
+          M.Body.setVelocity(body, { x: desc.perturb.vx * STEP_DELTA, y: desc.perturb.vy * STEP_DELTA });
+        }
+
+        bodies.push(body);
+      }
+
+      M.Composite.add(created.world, bodies);
+      engine = created;
+    },
+
+    step(dt: number): void {
+      if (engine === null) {
+        throw new Error('matter-js adapter: step() called before setup().');
+      }
+
+      // Engine.update takes milliseconds; a fixed dt keeps matter's Verlet integration deterministic.
+      M.Engine.update(engine, dt * 1_000);
+    },
+
+    sampleStructural(): PhysicsStructuralCounters {
+      if (engine === null) {
+        throw new Error('matter-js adapter: sampleStructural() called before setup().');
+      }
+
+      return {
+        bodyCount: M.Composite.allBodies(engine.world).length,
+        // Active colliding pairs on the last step — matter's pair-level contact proxy.
+        contactCount: engine.pairs.collisionActive.length,
+      };
+    },
+
+    teardown(): void {
+      if (engine !== null) {
+        M.World.clear(engine.world, false);
+        M.Engine.clear(engine);
+        engine = null;
+      }
+    },
+
+    mutationSignature(): string {
+      return perturbedSignature;
+    },
+  };
+};

--- a/packages/exojs-bench/src/physics/adapters/rapier.ts
+++ b/packages/exojs-bench/src/physics/adapters/rapier.ts
@@ -1,0 +1,175 @@
+import type * as RAPIER from '@dimforge/rapier2d-compat';
+
+import type { PhysicsAdapter, PhysicsArchetypeSpec, PhysicsStructuralCounters } from '../PhysicsAdapter';
+import { describePhysicsScene } from './scene';
+
+/**
+ * rapier (`@dimforge/rapier2d-compat`) arm of the physics benchmark — the
+ * "attach a Rust/WASM physics engine" comparison against staying on native
+ * `@codexo/exojs-physics`.
+ *
+ * FAIRNESS (see `scene.ts` and the driver's disclosed caveats): the scene is
+ * built from the shared {@link describePhysicsScene} descriptor, so rapier
+ * simulates the byte-identical body configuration (counts, positions, shapes,
+ * sizes, static/dynamic split, perturbed-body set) the exojs and matter arms do,
+ * and the perturbed selection is asserted cross-arm through
+ * {@link PhysicsAdapter.mutationSignature}.
+ *
+ * UNIT MAPPING (rapier is SI-consistent, so the mapping is trivial compared to
+ * matter): gravity is an acceleration vector in world-units/s², the timestep is
+ * in seconds, and linear velocity is world-units/s. Feeding the px-scale
+ * archetype values directly makes 1 world-unit = 1 px, so gravity (px/s²),
+ * `world.timestep = 1/60 s`, and the px/s perturbation impulses all carry over
+ * unchanged. rapier's convention is unit-agnostic on the Y axis, so this arm
+ * keeps exojs's +Y-DOWN frame (positive gravity Y = down): identical numeric
+ * positions to the other two arms.
+ *
+ * DISCLOSED NON-EQUIVALENCE (each engine measured at its own sensible default):
+ * - Solver iterations: rapier's TGS-Soft defaults (4 solver iterations, 1
+ *   internal PGS iteration) differ from exojs's 4-substep TGS-Soft and matter's
+ *   6/4/2 constraint iterations.
+ * - Sleeping: rapier auto-deactivates resting bodies by default (like exojs;
+ *   unlike matter's default).
+ * - Length unit: rapier's internal tolerances (allowed penetration, prediction
+ *   distance) are tuned for ~1-unit-sized objects; this arm feeds it a px-scale
+ *   world at the default `lengthUnit = 1` (i.e. 16 px boxes, ~1000 px/s²
+ *   gravity), which is exactly what a user attaching rapier with pixel
+ *   coordinates gets. Kept at the default and disclosed rather than silently
+ *   retuned.
+ * - Contact count is the number of collider pairs whose narrow-phase manifold has
+ *   at least one solid contact point (`numContacts() > 0`), deduped — a
+ *   touching-pair count directly comparable to exojs's solid-contact count. It is
+ *   gathered once after the timed window, so its O(pairs) cost never taints a
+ *   step timing.
+ *
+ * The library bundles its WASM and requires an async `RAPIER.init()` before any
+ * world is built; both the dynamic `import()` and `init()` happen once in
+ * {@link createRapierAdapter}. A checkout that never ran `bench:setup` (the
+ * library is not linked) degrades to a skipped arm instead of crashing.
+ */
+export const createRapierAdapter = async (): Promise<PhysicsAdapter | null> => {
+  let R: typeof RAPIER;
+
+  try {
+    R = (await import('@dimforge/rapier2d-compat')) as typeof RAPIER;
+    // One-time WASM initialisation, before any world is constructed. The bundled
+    // glue prints a harmless upstream deprecation notice here — it is not an error.
+    await R.init();
+  } catch {
+    console.warn(
+      "[physics] rapier arm unavailable — '@dimforge/rapier2d-compat' is not linked or failed to init (run bench:setup). Skipping the rapier arm.",
+    );
+
+    return null;
+  }
+
+  let world: RAPIER.World | null = null;
+  let perturbedSignature = '';
+
+  /** Count collider pairs with at least one solid contact point, deduped by ordered handle pair. */
+  const countTouchingContacts = (w: RAPIER.World): number => {
+    const seen = new Set<string>();
+    let touching = 0;
+
+    w.forEachCollider(collider1 => {
+      w.contactPairsWith(collider1, collider2 => {
+        const a = collider1.handle;
+        const b = collider2.handle;
+        const key = a < b ? `${a}:${b}` : `${b}:${a}`;
+
+        if (seen.has(key)) {
+          return;
+        }
+
+        seen.add(key);
+
+        let hasContact = false;
+
+        w.contactPair(collider1, collider2, manifold => {
+          if (manifold.numContacts() > 0) {
+            hasContact = true;
+          }
+        });
+
+        if (hasContact) {
+          touching++;
+        }
+      });
+    });
+
+    return touching;
+  };
+
+  return {
+    engine: 'rapier',
+    config: 'default',
+
+    setup(spec: PhysicsArchetypeSpec, bodyCount: number, seed: number): void {
+      const scene = describePhysicsScene(spec, bodyCount, seed);
+
+      perturbedSignature = scene.perturbedSignature;
+
+      // +Y down, px world units: identical numeric frame to the exojs/matter arms.
+      const created = new R.World({ x: spec.gravity.x, y: spec.gravity.y });
+
+      created.timestep = 1 / 60;
+
+      for (const desc of scene.bodies) {
+        const bodyDesc = desc.type === 'static' ? R.RigidBodyDesc.fixed() : R.RigidBodyDesc.dynamic();
+
+        bodyDesc.setTranslation(desc.x, desc.y);
+
+        const body = created.createRigidBody(bodyDesc);
+
+        const colliderDesc = (
+          desc.shape.kind === 'box' ? R.ColliderDesc.cuboid(desc.shape.width / 2, desc.shape.height / 2) : R.ColliderDesc.ball(desc.shape.radius)
+        )
+          .setDensity(desc.density)
+          .setFriction(desc.friction)
+          .setRestitution(desc.restitution);
+
+        created.createCollider(colliderDesc, body);
+
+        if (desc.perturb) {
+          // rapier linear velocity is world-units/s — the px/s impulse carries over unchanged.
+          body.setLinvel({ x: desc.perturb.vx, y: desc.perturb.vy }, true);
+        }
+      }
+
+      world = created;
+    },
+
+    step(dt: number): void {
+      if (world === null) {
+        throw new Error('rapier adapter: step() called before setup().');
+      }
+
+      // rapier steps its own fixed internal `world.timestep`; keep it pinned to the shared dt.
+      world.timestep = dt;
+      world.step();
+    },
+
+    sampleStructural(): PhysicsStructuralCounters {
+      if (world === null) {
+        throw new Error('rapier adapter: sampleStructural() called before setup().');
+      }
+
+      return {
+        bodyCount: world.bodies.len(),
+        contactCount: countTouchingContacts(world),
+      };
+    },
+
+    teardown(): void {
+      if (world !== null) {
+        // Release the WASM-backed world (rapier holds native memory outside the JS heap).
+        world.free();
+        world = null;
+      }
+    },
+
+    mutationSignature(): string {
+      return perturbedSignature;
+    },
+  };
+};

--- a/packages/exojs-bench/src/physics/adapters/scene.ts
+++ b/packages/exojs-bench/src/physics/adapters/scene.ts
@@ -1,0 +1,236 @@
+import { mutationSignature, selectMutationIndices } from '../../shared/mutation';
+import { createRng } from '../../shared/rng';
+import type { PhysicsArchetypeSpec } from '../PhysicsAdapter';
+
+/**
+ * Engine-neutral description of a physics scene — the fairness backbone the
+ * matter.js and rapier arms build from.
+ *
+ * The native `adapters/exojs-physics.ts` arm builds its scene inline against the
+ * `@codexo/exojs-physics` API. The competitor arms cannot share that code (they
+ * speak matter/rapier body APIs), so the risk is two hand-written transcriptions
+ * quietly drifting into different scenes. This module removes that risk for the
+ * competitor arms: it produces one neutral list of {@link BodyDesc}s, drawn from
+ * the SAME shared deterministic RNG in the SAME order as the exojs arm, so
+ * matter and rapier simulate a byte-identical body configuration to each other,
+ * and — because the draw order is a faithful transcription of exojs-physics.ts —
+ * to the native arm as well.
+ *
+ * The perturbed-body selection is routed through the shared
+ * {@link selectMutationIndices} exactly as the native arm does, and its
+ * {@link mutationSignature} is returned so each arm can hand it to the harness's
+ * cross-arm determinism assertion (which fails loudly on any divergence).
+ *
+ * Coordinate convention matches exojs: +Y points DOWN, and a body's position is
+ * the CENTRE of its box/circle. Both competitor arms adopt this same convention
+ * so the numeric positions are identical across all three arms.
+ */
+
+/** Side length of a dynamic box / diameter reference for a dynamic circle, px. Mirrors `exojs-physics.ts`. */
+export const BODY_SIZE = 16;
+/** Peak per-axis initial speed applied to a perturbed body, px/s. Mirrors `exojs-physics.ts`. */
+export const PERTURB_SPEED = 400;
+
+/** A box (full width/height) or circle collider shape, engine-neutral. */
+export type ShapeDesc =
+  | { readonly kind: 'box'; readonly width: number; readonly height: number }
+  | { readonly kind: 'circle'; readonly radius: number };
+
+/** One body in the neutral scene: its role, centre position, shape and material. */
+export interface BodyDesc {
+  /** Simulation role. */
+  readonly type: 'static' | 'dynamic';
+  /** World-space centre X (px). */
+  readonly x: number;
+  /** World-space centre Y (px, +Y down). */
+  readonly y: number;
+  /** Collider shape. */
+  readonly shape: ShapeDesc;
+  /** Mass density (px-area units); mirrors the exojs collider `density`. Ignored for static bodies. */
+  readonly density: number;
+  /** Coulomb friction coefficient; mirrors the exojs collider `friction`. */
+  readonly friction: number;
+  /** Restitution (bounciness); mirrors the exojs collider `restitution`. */
+  readonly restitution: number;
+  /** Initial linear velocity (px/s) for a perturbed dynamic body; absent when the body starts at rest. */
+  readonly perturb?: { readonly vx: number; readonly vy: number };
+}
+
+/** A fully-described scene plus the determinism receipt for its perturbed-body selection. */
+export interface SceneDescription {
+  /** Every body in the scene, in creation order (statics first per archetype, then dynamics). */
+  readonly bodies: readonly BodyDesc[];
+  /** FNV-1a signature of the shared perturbed-index selection — the cross-arm determinism receipt. */
+  readonly perturbedSignature: string;
+}
+
+/** Default exojs collider restitution (`Collider.ts`: `options.restitution ?? 0`) for shapes exojs leaves unspecified. */
+const DEFAULT_RESTITUTION = 0;
+/** Friction the exojs `staticBox` helper stamps on every static collider. */
+const STATIC_FRICTION = 0.5;
+
+/** Build one static box descriptor — the neutral analogue of exojs `staticBox(...)`. */
+const staticBox = (x: number, y: number, width: number, height: number): BodyDesc => ({
+  type: 'static',
+  x,
+  y,
+  shape: { kind: 'box', width, height },
+  density: 1,
+  friction: STATIC_FRICTION,
+  restitution: DEFAULT_RESTITUTION,
+});
+
+/**
+ * `box-stack`: `columns` independent stacks of boxes settling on a wide static
+ * floor. Transcribes `exojs-physics.ts::buildBoxStack` draw-for-draw: the floor
+ * is added first (no RNG), then one `rng()` jitter is drawn per placed dynamic
+ * body in column-major order.
+ */
+const buildBoxStack = (bodies: BodyDesc[], bodyCount: number, rng: () => number): void => {
+  const rows = 8;
+  const columns = Math.max(1, Math.ceil(bodyCount / rows));
+  const spacing = BODY_SIZE + 6;
+  const floorTop = 1_200;
+  const width = columns * spacing + 200;
+
+  bodies.push(staticBox(width / 2, floorTop + 20, width, 40));
+
+  let placed = 0;
+
+  for (let c = 0; c < columns && placed < bodyCount; c++) {
+    const x = 100 + c * spacing;
+
+    for (let r = 0; r < rows && placed < bodyCount; r++) {
+      const jitter = (rng() - 0.5) * 0.5;
+
+      bodies.push({
+        type: 'dynamic',
+        x: x + jitter,
+        y: floorTop - BODY_SIZE / 2 - 1 - r * BODY_SIZE,
+        shape: { kind: 'box', width: BODY_SIZE, height: BODY_SIZE },
+        density: 1,
+        friction: 0.5,
+        restitution: DEFAULT_RESTITUTION,
+      });
+
+      placed++;
+    }
+  }
+};
+
+/**
+ * `many-dynamic`: a grid of small dynamic circles inside a bounded box, every
+ * body given a deterministic initial impulse. Transcribes
+ * `exojs-physics.ts::buildManyDynamic`: four static walls first (no RNG), then
+ * two `rng()` draws (vx, vy) per perturbed body in ascending index order.
+ */
+const buildManyDynamic = (bodies: BodyDesc[], bodyCount: number, rng: () => number, perturbed: readonly number[]): void => {
+  const radius = BODY_SIZE / 2;
+  const cell = BODY_SIZE + 8;
+  const columns = Math.ceil(Math.sqrt(bodyCount));
+  const side = columns * cell + 80;
+  const wall = 40;
+
+  bodies.push(staticBox(side / 2, side + wall / 2, side + wall * 2, wall)); // floor
+  bodies.push(staticBox(side / 2, -wall / 2, side + wall * 2, wall)); // ceiling
+  bodies.push(staticBox(-wall / 2, side / 2, wall, side)); // left
+  bodies.push(staticBox(side + wall / 2, side / 2, wall, side)); // right
+
+  const perturbedSet = new Set(perturbed);
+
+  for (let i = 0; i < bodyCount; i++) {
+    const col = i % columns;
+    const row = Math.floor(i / columns);
+    const base: BodyDesc = {
+      type: 'dynamic',
+      x: 40 + col * cell + radius,
+      y: 40 + row * cell + radius,
+      shape: { kind: 'circle', radius },
+      density: 1,
+      friction: 0,
+      restitution: 0.4,
+    };
+
+    if (perturbedSet.has(i)) {
+      const vx = (rng() - 0.5) * 2 * PERTURB_SPEED;
+      const vy = (rng() - 0.5) * 2 * PERTURB_SPEED;
+
+      bodies.push({ ...base, perturb: { vx, vy } });
+    } else {
+      bodies.push(base);
+    }
+  }
+};
+
+/**
+ * `mixed-static-dynamic`: a static floor plus a lattice of static peg obstacles,
+ * with dynamic boxes raining from above. Transcribes
+ * `exojs-physics.ts::buildMixed`: floor then pegs (no RNG), then one `rng()`
+ * jitter per dynamic body in index order.
+ */
+const buildMixed = (bodies: BodyDesc[], bodyCount: number, rng: () => number): void => {
+  const spacing = BODY_SIZE + 10;
+  const columns = Math.max(1, Math.ceil(Math.sqrt(bodyCount)));
+  const fieldWidth = columns * spacing + 200;
+  const floorTop = 1_400;
+
+  bodies.push(staticBox(fieldWidth / 2, floorTop + 20, fieldWidth, 40));
+
+  const pegRows = 4;
+
+  for (let pr = 0; pr < pegRows; pr++) {
+    const y = 500 + pr * 200;
+    const offset = pr % 2 === 0 ? 0 : spacing;
+
+    for (let x = 120 + offset; x < fieldWidth - 120; x += spacing * 2) {
+      bodies.push(staticBox(x, y, BODY_SIZE * 2, BODY_SIZE / 2));
+    }
+  }
+
+  for (let i = 0; i < bodyCount; i++) {
+    const col = i % columns;
+    const row = Math.floor(i / columns);
+    const jitter = (rng() - 0.5) * 2;
+
+    bodies.push({
+      type: 'dynamic',
+      x: 120 + col * spacing + jitter,
+      y: 100 - row * spacing,
+      shape: { kind: 'box', width: BODY_SIZE, height: BODY_SIZE },
+      density: 1,
+      friction: 0.3,
+      restitution: 0.1,
+    });
+  }
+};
+
+/**
+ * Describe an archetype's scene as an engine-neutral body list, consuming the
+ * shared RNG in the identical order the native exojs arm does so every arm
+ * simulates the same bodies at the same positions with the same perturbations.
+ *
+ * The two RNG streams mirror `exojs-physics.ts` exactly: the perturbed-body set
+ * is selected via {@link selectMutationIndices} on `createRng(seed)`, and body
+ * placement/velocity jitter is drawn from an independent `createRng(seed ^
+ * 0x5f356495)` stream — same seed, separate instance — so selection and
+ * placement never share a stream position.
+ */
+export const describePhysicsScene = (spec: PhysicsArchetypeSpec, bodyCount: number, seed: number): SceneDescription => {
+  const perturbed = selectMutationIndices(bodyCount, spec.perturbFraction, seed);
+  const rng = createRng(seed ^ 0x5f35_6495);
+  const bodies: BodyDesc[] = [];
+
+  switch (spec.id) {
+    case 'box-stack':
+      buildBoxStack(bodies, bodyCount, rng);
+      break;
+    case 'many-dynamic':
+      buildManyDynamic(bodies, bodyCount, rng, perturbed);
+      break;
+    case 'mixed-static-dynamic':
+      buildMixed(bodies, bodyCount, rng);
+      break;
+  }
+
+  return { bodies, perturbedSignature: mutationSignature(perturbed) };
+};

--- a/packages/exojs-bench/src/physics/driver.ts
+++ b/packages/exojs-bench/src/physics/driver.ts
@@ -10,6 +10,23 @@ import type { PhysicsAdapter, PhysicsCellResult, PhysicsCellSpec } from './Physi
 const NATIVE_PHYSICS_PACKAGE = '@codexo/exojs-physics';
 
 /**
+ * Per-arm methodology disclosure, keyed by the arm's `engine` label. Each arm is
+ * measured at its OWN engine defaults for solver iterations, contact model and
+ * sleeping — those differences are the legitimate quantity the native-vs-adapter
+ * comparison surfaces, so they are stated per arm rather than silently smoothed
+ * (spec §4 fairness). Only the disclosures for arms actually present in a run are
+ * stamped into that run's provenance caveats.
+ */
+const ARM_DISCLOSURES: Readonly<Record<string, string>> = {
+  'exojs-physics':
+    'exojs-physics arm: TGS-Soft solver, 4 sub-steps per fixed step, sleeping ON by default (resting bodies deactivate). Contact count = solid contacts in the world contact graph.',
+  'matter-js':
+    "matter-js arm: constraint solver at matter defaults (6 position / 4 velocity / 2 constraint iterations), sleeping OFF by default (a settled stack keeps paying full solve cost); matter's default per-step air drag (frictionAir) is zeroed so all arms integrate the same pure-gravity field; gravity (px/s²) and perturbation velocity (px/s) are mapped into matter's px-per-step unit model. Contact count = active colliding pairs (engine.pairs.collisionActive), a pair-level proxy, not identical in semantics to the exojs solid-contact count.",
+  rapier:
+    'rapier arm: TGS-Soft solver at rapier defaults (4 solver / 1 internal PGS iterations), auto-sleeping ON; default lengthUnit=1 is fed a px-scale world (tuned for ~1-unit objects), exactly what attaching rapier with pixel coordinates yields. Contact count = collider pairs with a solid narrow-phase manifold (numContacts > 0), deduped.',
+};
+
+/**
  * Catastrophic-regression step budget (ms). The physics domain is CPU-bound and
  * fast; a cell whose last-window median blows past this is a runaway (a
  * pathological body count or an accidental O(n²) regression), so it aborts to
@@ -141,14 +158,21 @@ const runCell = (adapter: PhysicsAdapter, spec: PhysicsCellSpec): PhysicsCellRes
  */
 export const runPhysicsMatrix = (options: {
   adapters?: readonly PhysicsAdapter[];
+  /**
+   * npm package names whose installed versions are recorded in the report header
+   * (one per arm). Defaults to the native physics package alone; the CLI passes
+   * the competitor package names for whichever adapter arms actually resolved, so
+   * a run never claims a version for an arm it did not include.
+   */
+  libraries?: readonly string[];
   filter?: Partial<PhysicsCellSpec>;
   /** Forces every selected cell's timed-step count to this value (smoke/spot-check knob; never a reportable run). */
   timedStepsOverride?: number;
   onCellResult?: PhysicsCellResultSink;
 } = {}): PhysicsMatrixOutcome => {
   const adapters = options.adapters ?? [createExoJsPhysicsAdapter()];
-  const libraries = readLibraryProvenance([NATIVE_PHYSICS_PACKAGE]);
-  const engineVersion = libraries[0]?.version ?? 'unknown';
+  const libraries = readLibraryProvenance(options.libraries ?? [NATIVE_PHYSICS_PACKAGE]);
+  const engineVersion = libraries.find(library => library.name === NATIVE_PHYSICS_PACKAGE)?.version ?? libraries[0]?.version ?? 'unknown';
 
   const allCells = buildPhysicsMatrix(adapters);
   const filtered = options.filter ? applyFilter(allCells, options.filter) : allCells;
@@ -176,15 +200,21 @@ export const runPhysicsMatrix = (options: {
     onCellResult(result);
   }
 
+  // Disclosures only for the arms actually present, in matrix order, de-duplicated.
+  const armEngines = [...new Set(adapters.map(adapter => adapter.engine))];
+  const armCaveats = armEngines.map(engine => ARM_DISCLOSURES[engine]).filter((caveat): caveat is string => caveat !== undefined);
+
   const provenance: PhysicsProvenance = {
     timestamp: new Date().toISOString(),
     engineVersion,
     host: readHostInfo(),
     fixedDelta: STEP_DELTA,
     caveats: [
-      'Step time is CPU wall-clock per world.step() over the timed window (median/p95), measured in one Node process (same-run discipline).',
-      'Single native arm (exojs-physics); matter.js / rapier adapter arms are a separate follow-on and are NOT included here.',
+      'Step time is CPU wall-clock per step() over the timed window (median/p95), measured in one Node process (same-run discipline).',
       'Scenes are warmed to steady state before timing; the per-cell warmupSteps/timedSteps counts are recorded for honesty.',
+      'All arms build the byte-identical scene (bodies, positions, shapes, sizes, static/dynamic split, gravity, perturbed-body set) from the shared deterministic RNG, and the perturbed-body selection is asserted equal across arms before each cell is timed.',
+      'Each arm runs at its own engine defaults for solver iterations, contact model and sleeping — those engine differences are the measured quantity in a native-vs-adapter comparison, disclosed per arm below.',
+      ...armCaveats,
     ],
   };
 

--- a/packages/exojs-bench/src/physics/index.ts
+++ b/packages/exojs-bench/src/physics/index.ts
@@ -9,11 +9,16 @@
 // incremental checkpoint writer, provenance/report skeletons, CLI arg parsing)
 // live under `../shared` and are shared with the rendering domain.
 //
-// The matter.js + rapier adapter arms are a SEPARATE follow-on: add them under
-// `adapters/`, implement the `PhysicsAdapter` interface, and pass them into
-// `runPhysicsMatrix({ adapters })`.
+// The matter.js + rapier adapter arms live under `adapters/` alongside the
+// native arm: each implements the `PhysicsAdapter` interface, builds the shared
+// deterministic scene from `adapters/scene.ts`, and is passed into
+// `runPhysicsMatrix({ adapters })`. Their competitor libraries are loaded lazily
+// via dynamic `import()`, so an unlinked competitor degrades to a skipped arm
+// (the resolver returns `null`) rather than crashing the run.
 
 export { createExoJsPhysicsAdapter } from './adapters/exojs-physics';
+export { createMatterJsAdapter } from './adapters/matter-js';
+export { createRapierAdapter } from './adapters/rapier';
 export { buildPhysicsMatrix, PHYSICS_ARCHETYPES, STEP_DELTA } from './archetypes';
 export { type PhysicsMatrixOutcome, type PhysicsProvenance, runPhysicsMatrix } from './driver';
 export type {

--- a/packages/exojs-bench/src/run.ts
+++ b/packages/exojs-bench/src/run.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path';
 // `./physics` is imported for TYPES only here (erased at runtime); its module
 // graph — the `@codexo/exojs-physics` source arm — is loaded lazily via a
 // dynamic `import()` inside `runPhysicsDomain`, so a rendering run never pays for it.
-import type { PhysicsCellResult, PhysicsCellSpec } from './physics';
+import type { PhysicsAdapter, PhysicsCellResult, PhysicsCellSpec } from './physics';
 import type { ArchetypeId, Backend, CellResult, CellSpec } from './rendering';
 import { runMatrix, writeReport } from './rendering';
 import { parseArgs } from './shared/args';
@@ -156,7 +156,7 @@ const runRenderingDomain = async (args: Map<string, string>): Promise<void> => {
  * step count for a fast spot-check (never a reportable run).
  */
 const runPhysicsDomain = async (args: Map<string, string>): Promise<void> => {
-  const { runPhysicsMatrix, writePhysicsReport } = await import('./physics');
+  const { createExoJsPhysicsAdapter, createMatterJsAdapter, createRapierAdapter, runPhysicsMatrix, writePhysicsReport } = await import('./physics');
 
   const archetypeArg = args.get('archetype');
   const bodiesArg = args.get('bodies');
@@ -205,11 +205,36 @@ const runPhysicsDomain = async (args: Map<string, string>): Promise<void> => {
     `Running physics benchmark: ${archetypeArg ? `archetype=${archetypeArg}` : 'all archetypes'}${bodiesArg ? `, bodies=${bodiesArg}` : ''}${timedStepsOverride !== undefined ? `, frames=${timedStepsOverride} (OVERRIDE — thin sampling, not reportable)` : ''}`,
   );
 
+  // Resolve the arms: the native exojs-physics arm is always present; the matter
+  // and rapier competitor arms are loaded lazily and degrade to a skipped arm
+  // (resolver returns null) when their library was never linked via bench:setup,
+  // so a checkout without the competitor deps still runs the native domain.
+  const adapters: PhysicsAdapter[] = [createExoJsPhysicsAdapter()];
+  const libraries: string[] = ['@codexo/exojs-physics'];
+
+  const matter = await createMatterJsAdapter();
+
+  if (matter !== null) {
+    adapters.push(matter);
+    libraries.push('matter-js');
+  }
+
+  const rapier = await createRapierAdapter();
+
+  if (rapier !== null) {
+    adapters.push(rapier);
+    libraries.push('@dimforge/rapier2d-compat');
+  }
+
+  console.log(`Arms: ${adapters.map(adapter => adapter.engine).join(', ')}`);
+
   // Incremental, crash-safe checkpoint: each cell is persisted the instant it
   // lands, reusing the same shared writer the rendering domain uses.
   const checkpoint = createCheckpointWriter<PhysicsCellResult>(outDir);
 
   const data = runPhysicsMatrix({
+    adapters,
+    libraries,
     ...(isSubset && { filter }),
     ...(timedStepsOverride !== undefined && { timedStepsOverride }),
     onCellResult: result => checkpoint.append(result),


### PR DESCRIPTION
## What

Adds two competitor arms — **matter.js** and **rapier** — to the PHYSICS domain of `@codexo/exojs-bench`, alongside the native `exojs-physics` arm, so a stay-native vs. attach-an-adapter comparison drops in without changing the driver or archetypes.

Depends on the pinned competitor deps from #329 (merged). This PR contains **only adapter code** — no dependency files.

## How each arm matches the archetype

A new engine-neutral `adapters/scene.ts` builds each archetype's body list from the **shared deterministic RNG in the exact draw order** of the native `exojs-physics.ts` arm. matter and rapier both consume it, so all three arms simulate a **byte-identical scene**: same body counts, positions, shapes/sizes, static/dynamic split, gravity, and the same perturbed-body set (routed through the shared `selectMutationIndices`; asserted cross-arm via `mutationSignature`). Coordinate frame is exojs's +Y-down; positions are numerically identical across arms.

## Stepping / unit mapping

- **exojs**: `world.step(1/60)`.
- **matter**: `Engine.update(engine, dt*1000)` (ms). Gravity mapped `px/s² → value·scale·1e6` (px/s² × 0.001 at default scale). Perturbation velocity mapped px/s → matter's px-per-step (`v·dt`). `frictionAir` zeroed so the force field is pure gravity like the other two arms.
- **rapier**: `world.timestep = 1/60; world.step()`. SI-consistent, so px/s² gravity, 1/60 s step, and px/s velocity carry over unchanged.

## Disclosed non-equivalences (per-arm, in the report caveats)

Each arm runs at **its own engine defaults** — the legitimate quantity a native-vs-adapter comparison measures:

- **Solver iterations**: exojs TGS-Soft 4 sub-steps; matter 6/4/2 (position/velocity/constraint); rapier 4 solver / 1 internal PGS.
- **Sleeping**: exojs ON, rapier ON (auto), **matter OFF by default** (a settled matter stack keeps paying full solve cost).
- **rapier lengthUnit = 1** fed a px-scale world (rapier is tuned for ~1-unit objects) — exactly what attaching rapier with pixel coordinates yields.
- **Contact-count semantics differ**: exojs = solid contacts in the contact graph; matter = active colliding pairs; rapier = collider pairs with a solid narrow-phase manifold (deduped). All pair-level, not identical semantics.

## Structural counters

All three arms expose **body count** and **contact count** (no degradation needed). rapier's contact count is gathered once after the timed window, so its O(pairs) cost never taints a step timing.

## Graceful degradation

Both competitor libraries load lazily via dynamic `import()`; an unlinked competitor (checkout that never ran `bench:setup`) degrades to a **skipped arm with a warning**, not a crash.

## Verification

- `verify:quick` passes (typecheck + lint + format + API-docs sync), exit 0.
- Foreground all-arms subsets (`--archetype {box-stack,many-dynamic,mixed-static-dynamic} --bodies 200`): every arm `status: ok`, cross-arm determinism assert passes, body counts identical across arms.
- Native `exojs-physics` arm unchanged.

> Fairness caveat for the reviewer to scrutinize: rapier at `lengthUnit=1` on a px-scale world, and matter's zeroed `frictionAir` (a deliberate deviation from matter's default to keep the force field equal across arms). Both are disclosed in the caveats.
