### PR TITLE
chore(bench): path-gated local pre-push typecheck for exojs-bench

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -13,10 +13,16 @@
 #                 never published until the same checks CI runs have all
 #                 passed locally.
 #
+# Also, on branch pushes only: a path-gated `@codexo/exojs-bench` typecheck
+# (see the block below verify:quick — it is intentionally NOT part of
+# verify:quick/CI; see packages/exojs-bench/README.md for why).
+#
 # Refs being pushed are read from stdin in the format:
 #   <local_ref> <local_sha> <remote_ref> <remote_sha>
 is_tag_push=0
 is_branch_push=0
+push_head_sha=""
+push_base_sha=""
 null_sha="0000000000000000000000000000000000000000"
 
 while read local_ref local_sha remote_ref remote_sha; do
@@ -24,7 +30,15 @@ while read local_ref local_sha remote_ref remote_sha; do
     [ "$local_sha" = "$null_sha" ] && continue
     case "$remote_ref" in
         refs/tags/*) is_tag_push=1 ;;
-        *)           is_branch_push=1 ;;
+        *)
+            is_branch_push=1
+            # Only the last pushed branch ref wins when a push carries several
+            # refs at once — same simplification the pre-existing boolean
+            # flags above already make; a multi-branch push is a rare edge
+            # case and this hook is a convenience, not a hard gate.
+            push_head_sha="$local_sha"
+            [ "$remote_sha" != "$null_sha" ] && push_base_sha="$remote_sha"
+            ;;
     esac
 done
 
@@ -34,4 +48,44 @@ if [ "$is_tag_push" = "1" ]; then
 elif [ "$is_branch_push" = "1" ]; then
     echo "[pre-push] running verify:quick (static CI-parity gates)"
     npm run verify:quick || exit 1
+fi
+
+# Path-gated bench typecheck. @codexo/exojs-bench is deliberately kept out of
+# verify:quick / CI: its competitor devDependencies (pixi/phaser/excalibur/
+# matter/rapier) only resolve via `bench:setup`'s `pnpm install --dir
+# competitors --ignore-workspace`, which bypasses pnpm-workspace.yaml's
+# minimumReleaseAge supply-chain gate — installing that inside the shared-CI
+# trust boundary is exactly what we don't want. So this hook is the only
+# automated backstop, and it stays cheap for everyone else:
+#   - fires ONLY when the pushed commits touch packages/exojs-bench/** (zero
+#     cost otherwise — no diff, no pnpm call);
+#   - only runs the actual typecheck when the competitor deps are already
+#     linked locally (never forces the ~235MB bench:setup install on push —
+#     that would punish a push just because the optional deps aren't there
+#     yet, so it prints a warning and skips instead of failing).
+# Residual gap (see packages/exojs-bench/README.md): an engine API change
+# under src/ that breaks the bench adapters' types, without ALSO touching
+# packages/exojs-bench/**, is not caught here.
+if [ "$is_branch_push" = "1" ] && [ -n "$push_head_sha" ]; then
+    if [ -z "$push_base_sha" ]; then
+        # New branch / no remote tracking ref yet — fall back to the
+        # merge-base with origin/main so the check still has a diff range.
+        push_base_sha=$(git merge-base "$push_head_sha" origin/main 2>/dev/null || true)
+    fi
+
+    bench_changed=""
+    if [ -n "$push_base_sha" ]; then
+        bench_changed=$(git diff --name-only "$push_base_sha" "$push_head_sha" -- packages/exojs-bench 2>/dev/null)
+    fi
+
+    if [ -n "$bench_changed" ]; then
+        if [ -e packages/exojs-bench/node_modules/pixi.js ]; then
+            echo "[pre-push] packages/exojs-bench changed — running bench typecheck"
+            pnpm --filter @codexo/exojs-bench typecheck || exit 1
+        else
+            echo "[pre-push] WARNING: packages/exojs-bench changed but its competitor deps aren't linked locally."
+            echo "[pre-push] Run 'pnpm --filter @codexo/exojs-bench bench:setup' (or 'pnpm typecheck:bench') to type-check it, then push again."
+            echo "[pre-push] Skipping bench typecheck for this push (not blocking)."
+        fi
+    fi
 fi

--- a/packages/exojs-bench/README.md
+++ b/packages/exojs-bench/README.md
@@ -1,0 +1,63 @@
+# @codexo/exojs-bench
+
+Private, reproducible cross-library rendering/physics benchmark harness for ExoJS.
+Not published. Compares ExoJS against competitor libraries (Pixi, Phaser,
+Excalibur, matter-js, rapier2d-compat) kept in an isolated `competitors/`
+manifest — see `competitors/package.json` and `competitors/link.mjs` for why
+they're excluded from the workspace install.
+
+## Setup
+
+```sh
+pnpm --filter @codexo/exojs-bench bench:setup   # installs + links the competitor libs (one-time, ~235MB)
+pnpm --filter @codexo/exojs-bench bench         # runs the benchmark
+```
+
+## Why this package is out of required CI
+
+`bench:setup` runs `pnpm install --dir competitors --ignore-workspace`. That
+`--ignore-workspace` install:
+
+- resolves a **separate lockfile** outside `pnpm-workspace.yaml`, so it
+  bypasses the root workspace's `minimumReleaseAge` supply-chain quarantine
+  (see `pnpm-workspace.yaml`) — a version bump here needs a manual release-age
+  sanity check instead of the automatic gate everything else gets;
+- pulls in ~235MB of competitor libraries that a normal contributor should
+  never have to download just to typecheck their own PR.
+
+Running that inside the shared-CI trust boundary (a required, always-on gate)
+would mean every contributor's PR — and the shared CI runners — install and
+trust third-party libraries whose only purpose is being compared against, not
+shipped. So `@codexo/exojs-bench` is deliberately excluded from
+`typecheck:packages` / `verify:quick` / CI. A standalone `typecheck:bench`
+root script exists for on-demand/manual runs:
+
+```sh
+pnpm typecheck:bench   # bench:setup + typecheck, in one step
+```
+
+## Local backstop: the pre-push hook
+
+`.husky/pre-push` runs a **path-gated, local-only** check on branch pushes:
+
+- it fires **only** when the commits being pushed touch
+  `packages/exojs-bench/**` — zero cost for every other push;
+- if the competitor deps are already linked locally (i.e.
+  `packages/exojs-bench/node_modules/pixi.js` exists from a prior
+  `bench:setup`), it runs `pnpm --filter @codexo/exojs-bench typecheck` and
+  **fails the push** on a type error;
+- if they aren't linked, it prints a warning telling you to run `bench:setup`
+  and **skips without failing** — an optional, uninstalled dependency should
+  never block an unrelated push.
+
+## Known gap
+
+This is a local, path-gated backstop, not a CI gate — it only runs on the
+machine that pushes a bench-touching commit, and only if that machine has
+already run `bench:setup`. An **engine API change under `src/`** that breaks
+the bench adapters' types, without a commit that also touches
+`packages/exojs-bench/**`, is **not** caught by this hook (or by CI). This is
+an accepted trade-off to keep the bench package's ~235MB of competitor
+dependencies out of the shared-CI trust boundary entirely. A future
+self-hosted-GPU bench tier (see the engine's perf-tracking roadmap) is the
+right place to run a full, unconditional `typecheck:bench` as a real backstop.


### PR DESCRIPTION
## What

`@codexo/exojs-bench` is deliberately kept out of the required CI gate
(`typecheck:packages` / `verify:quick`): its `bench:setup` step installs the
competitor libraries (pixi/phaser/excalibur/matter/rapier) via
`pnpm install --dir competitors --ignore-workspace`, which resolves a separate
lockfile **outside** `pnpm-workspace.yaml` and so bypasses the workspace's
`minimumReleaseAge` supply-chain quarantine. Pulling ~235 MB of compare-only
third-party libraries into the shared-CI trust boundary just to type-check a
bench package is the wrong trade — but the consequence was that bench type
errors reached `main` uncaught.

This adds a **local, non-blocking backstop** instead of a shared-CI workflow.

## How

`.husky/pre-push`, on branch pushes only:

1. Diffs the pushed commit range and runs the bench check **only** when the
   commits touch `packages/exojs-bench/**` (zero cost for every other push).
   New branches with no remote tracking ref fall back to the merge-base with
   `origin/main` for the diff range.
2. If the competitor deps are already linked locally
   (`packages/exojs-bench/node_modules/pixi.js` exists from a prior
   `bench:setup`), it runs `pnpm --filter @codexo/exojs-bench typecheck` and
   **fails the push** on a type error.
3. If they aren't linked, it prints a warning pointing at
   `bench:setup` / `typecheck:bench` and **skips without failing** — an
   optional, uninstalled dependency must never block an unrelated push.

`packages/exojs-bench/README.md` documents the rationale and the known gap.

## Why not a shared-CI lane

No shared-CI workflow is added. A competitor library's breaking change or a
flaky `--ignore-workspace` competitor install can therefore never turn an
unrelated contributor's PR red, and the shared runners never install
compare-only third-party libraries. The trade-off (documented in the README):
an `src/` engine API change that breaks the bench adapters **without** also
touching `packages/exojs-bench/**` is not caught by this hook.

## Known gap

Local, path-gated backstop only — it runs on the machine pushing a
bench-touching commit, and only type-checks when that machine has already run
`bench:setup`. See the README for the residual gap and the future
self-hosted-GPU bench tier as the right place for an unconditional
`typecheck:bench`.

## Verification

- `pnpm run verify:quick` passes (0 errors; only pre-existing warnings).
- The pre-push hook self-tested on this very push: it detected the
  `packages/exojs-bench/README.md` change, found competitor deps unlinked, and
  printed the warning + skipped without failing.
- Shell syntax checked (`sh -n`) and all branches (bench/non-bench,
  linked/unlinked, new-branch merge-base fallback) dry-run simulated.