### PR TITLE
fix(bench): wall-clock cell cap + per-arm isolation, and production engine build

### DIFF
--- a/packages/exojs-bench/src/rendering/driver.ts
+++ b/packages/exojs-bench/src/rendering/driver.ts
@@ -430,16 +430,68 @@ const runCellInPage = async (page: import('playwright').Page, spec: CellSpec): P
 };
 
 /**
- * Runs one backend's full cell list in a single browser session, invoking
- * `onCellResult` after EACH cell so the caller can checkpoint it, and returning
- * that backend's provenance stamp plus the collected results.
+ * Node-side wall-clock cap on a single cell. The in-page harness bounds warmup
+ * and the timed loop, but those guards only fire BETWEEN frames — they cannot
+ * interrupt a frame that never returns. A weak arm can accumulate GPU-driver
+ * state across its cells until one heavy cell stalls the driver mid-frame
+ * (observed: Excalibur wedging on 25k full-viewport overdraw / batch-breaking),
+ * freezing the page with no in-page recovery possible. This cap lets the DRIVER
+ * abandon such a cell as `unavailable` and relaunch the browser, so one
+ * pathological cell can never hang the whole matrix. Set far above the heaviest
+ * TRUSTED cell (~15-25s with the in-page warmup cap + timed abort), so it only
+ * ever trips on a genuine wedge.
+ */
+const CELL_TIMEOUT_MS = 60_000;
+
+/** Sentinel returned by {@link runCellOrWedge} when a cell exceeds {@link CELL_TIMEOUT_MS}. */
+const CELL_WEDGED = Symbol('cell-wedged');
+
+/**
+ * Run one cell, resolving to {@link CELL_WEDGED} if it does not finish within
+ * {@link CELL_TIMEOUT_MS} — the page is then presumed frozen and its browser must
+ * be relaunched. The still-pending evaluate is left to reject when the browser
+ * closes; its rejection is swallowed so it never surfaces as an unhandled
+ * rejection (`runCellInPage` already never rejects on a normal cell error).
+ */
+const runCellOrWedge = async (page: import('playwright').Page, spec: CellSpec): Promise<CellResult | typeof CELL_WEDGED> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<typeof CELL_WEDGED>(resolvePromise => {
+    timer = setTimeout(() => resolvePromise(CELL_WEDGED), CELL_TIMEOUT_MS);
+  });
+
+  const run = runCellInPage(page, spec).then(result => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+
+    return result;
+  });
+
+  // Swallow the abandoned evaluate's eventual rejection (the browser close after a
+  // wedge rejects it) so it never surfaces as an unhandled rejection.
+  run.catch(() => {
+    /* intentionally ignored */
+  });
+
+  return Promise.race([run, timeout]);
+};
+
+/**
+ * Runs one backend's cell list, isolating each arm in its OWN browser session and
+ * each cell behind a wall-clock timeout. Invokes `onCellResult` after EACH cell so
+ * the caller can checkpoint it, and returns the backend's provenance plus results.
  *
- * The whole per-backend matrix still runs in ONE page/session: cross-session
- * timing comparison is invalid (JIT warmth, GPU clock state and allocator state
- * all differ between sessions), so every cell is driven through the same page
- * via repeated `__runBaselineCell` calls rather than reloading between cells.
- * For WebGPU the adapter identity is read first; a null or software adapter
- * emits every cell as `unavailable` rather than measuring a software rasterizer.
+ * Isolation model (why not one shared session): timing is measured PER CELL — each
+ * cell fully `init`s and `teardown`s its arm — so a shared session buys only warm
+ * JIT/prebundle, not comparability, while it lets one arm's leaked GPU/driver state
+ * wedge a LATER arm's (or its own later) cell. Each arm therefore gets a fresh
+ * browser (Vite prebundle is server-side, so relaunch is cheap), and any cell that
+ * WEDGES (`CELL_TIMEOUT_MS`) is abandoned as `unavailable` with the browser
+ * relaunched for the arm's remaining cells. The matrix always completes; a
+ * pathological arm loses only its wedging cells, each disclosed in the report.
+ *
+ * For WebGPU the adapter identity is read once; a null or software adapter emits
+ * every cell as `unavailable` rather than measuring a software rasterizer.
  */
 const runBackend = async (options: {
   baseUrl: string;
@@ -450,87 +502,125 @@ const runBackend = async (options: {
 }): Promise<{ provenance: Provenance; results: CellResult[] }> => {
   const { baseUrl, backend, cells, engineVersion, onCellResult } = options;
   const flags = backend === 'webgpu' ? WEBGPU_LAUNCH_FLAGS : LAUNCH_FLAGS;
-  const browser = await chromium.launch({ channel: 'chromium', headless: true, args: [...flags] });
 
-  try {
-    const page = await browser.newPage();
+  // Group cells by arm (engine|config) in first-seen order so each arm runs in its
+  // own browser session, isolated from every other arm's accumulated state.
+  const armOrder: string[] = [];
+  const armGroups = new Map<string, CellSpec[]>();
 
-    await page.goto(baseUrl, { waitUntil: 'load' });
-    await page.waitForFunction(() => typeof globalThis.__runBaselineCell === 'function');
+  for (const cell of cells) {
+    const key = `${cell.engine}|${cell.config}`;
+    const group = armGroups.get(key);
 
-    const timestamp = new Date().toISOString();
-    const results: CellResult[] = [];
-    const collect = (result: CellResult): void => {
-      results.push(result);
-      onCellResult(result);
-    };
+    if (group === undefined) {
+      armGroups.set(key, [cell]);
+      armOrder.push(key);
+    } else {
+      group.push(cell);
+    }
+  }
 
-    if (backend === 'webgpu') {
-      const identity = await readWebGpuAdapter(page);
-      const provenance: Provenance = {
-        adapter: identity.adapter,
-        backend,
-        flags,
-        headless: true,
-        engineVersion,
-        timestamp,
-        // Kept false even for a software adapter: those cells are emitted
-        // `unavailable` (no timings), so nothing here is an untrusted number, and
-        // flipping the shared honesty bit would wrongly taint the WebGL2 timings
-        // in the same report. The software identity is preserved in `adapter` and
-        // each cell's note instead.
-        software: false,
-      };
+  const timestamp = new Date().toISOString();
+  const results: CellResult[] = [];
+  const collect = (result: CellResult): void => {
+    results.push(result);
+    onCellResult(result);
+  };
 
-      if (!identity.usable) {
-        for (const cell of cells) {
-          collect(unavailableCell(cell, identity.note));
+  // WebGL2 renderer string, captured from `#stage`'s OWN context (review B8) the
+  // moment the FIRST ok cell has created it. `null` until then; a run with no ok
+  // cell keeps the `no-webgl2-context` provenance below. WebGPU adapter identity is
+  // read once and reused across every arm's session (same GPU, same flags).
+  let renderer: string | null = null;
+  let webgpuIdentity: WebGpuIdentity | null = null;
+
+  for (const key of armOrder) {
+    let remaining = armGroups.get(key)!;
+
+    // One browser per pass; a mid-arm wedge breaks out, closes it, and the outer
+    // loop relaunches a fresh one for whatever cells are left.
+    while (remaining.length > 0) {
+      const browser = await chromium.launch({ channel: 'chromium', headless: true, args: [...flags] });
+      let relaunch = false;
+
+      try {
+        const page = await browser.newPage();
+
+        await page.goto(baseUrl, { waitUntil: 'load' });
+        await page.waitForFunction(() => typeof globalThis.__runBaselineCell === 'function');
+
+        if (backend === 'webgpu') {
+          webgpuIdentity ??= await readWebGpuAdapter(page);
+
+          if (!webgpuIdentity.usable) {
+            for (const cell of remaining) {
+              collect(unavailableCell(cell, webgpuIdentity.note));
+            }
+
+            remaining = [];
+          }
         }
 
-        return { provenance, results };
+        while (remaining.length > 0) {
+          const cell = remaining[0]!;
+          const outcome = await runCellOrWedge(page, cell);
+
+          if (outcome === CELL_WEDGED) {
+            collect(
+              unavailableCell(
+                cell,
+                `cell wedged the browser (no result after ${CELL_TIMEOUT_MS}ms — a mid-frame GPU-driver stall the in-page guards cannot interrupt); isolated as unavailable, browser relaunched for the arm's remaining cells`,
+              ),
+            );
+            remaining = remaining.slice(1);
+            relaunch = true;
+            break;
+          }
+
+          collect(outcome);
+
+          if (backend === 'webgl2' && renderer === null && outcome.status === 'ok') {
+            renderer = await readRendererInPage(page);
+          }
+
+          remaining = remaining.slice(1);
+        }
+      } finally {
+        await browser.close();
       }
 
-      for (const cell of cells) {
-        collect(await runCellInPage(page, cell));
+      if (!relaunch) {
+        break;
       }
-
-      return { provenance, results };
     }
-
-    // Read the WebGL2 renderer string from `#stage`'s OWN context (review B8),
-    // captured the moment the FIRST successful cell has created it — NOT after
-    // the whole backend has run. The arms share one `#stage` canvas/context, and
-    // a competitor arm (Pixi runs last) tears down by LOSING that context on
-    // `destroy`; reading at the end would then see `no-webgl2-context` and lose
-    // the real adapter identity + software-rasterizer honesty bit. The first arm
-    // is always ExoJS, whose `init` creates the very context every later cell
-    // reuses, so this reads the exact context the measured cells ran on.
-    let renderer = 'no-webgl2-context';
-
-    for (const cell of cells) {
-      const result = await runCellInPage(page, cell);
-
-      collect(result);
-
-      if (renderer === 'no-webgl2-context' && result.status === 'ok') {
-        renderer = await readRendererInPage(page);
-      }
-    }
-
-    const provenance: Provenance = {
-      adapter: renderer,
-      backend,
-      flags,
-      headless: true,
-      engineVersion,
-      timestamp,
-      software: isSoftwareRenderer(renderer),
-    };
-
-    return { provenance, results };
-  } finally {
-    await browser.close();
   }
+
+  const provenance: Provenance =
+    backend === 'webgpu'
+      ? {
+          adapter: webgpuIdentity?.adapter ?? 'no-webgpu-adapter',
+          backend,
+          flags,
+          headless: true,
+          engineVersion,
+          timestamp,
+          // False even for a software adapter: those cells are emitted `unavailable`
+          // (no timings), so nothing here is an untrusted number, and flipping the
+          // honesty bit would wrongly taint the WebGL2 timings. The software identity
+          // is preserved in `adapter` and each cell's note instead.
+          software: false,
+        }
+      : {
+          adapter: renderer ?? 'no-webgl2-context',
+          backend,
+          flags,
+          headless: true,
+          engineVersion,
+          timestamp,
+          software: renderer !== null && isSoftwareRenderer(renderer),
+        };
+
+  return { provenance, results };
 };
 
 /** Full outcome of a matrix run: per-backend provenance, competitor-library provenance, and every cell result. */

--- a/packages/exojs-bench/src/rendering/driver.ts
+++ b/packages/exojs-bench/src/rendering/driver.ts
@@ -181,6 +181,21 @@ const realShaderPlugin = {
 };
 
 /**
+ * `__DEV__` value the engine graph is compiled with for the benchmark.
+ *
+ * MUST be `false`: the competitor arms are pre-bundled from their published npm
+ * dist (`optimizeDeps.include`), i.e. their PRODUCTION builds with dev-only
+ * guards already stripped. Measuring exojs source with `__DEV__=true` therefore
+ * pits an unshipped dev build (per-frame dev diagnostics — e.g.
+ * `RetainedGroupFragment._devHasDestroyedDrawable`, a full O(captured-drawables)
+ * scan every clean retained frame) against competitors' prod builds. That
+ * asymmetry inflated the exojs numbers by 20-30x on the static-heavy retained
+ * arm alone (2.3 ms vs the real ~0.1 ms prod floor). `false` compiles the same
+ * path a shipped exojs game runs, making the cross-arm comparison apples-to-apples.
+ */
+const ENGINE_DEV_BUILD = false;
+
+/**
  * Installs the compile-time build flags (`__DEV__`, `__VERSION__`,
  * `__REVISION__`) as real globals before any engine module evaluates. Vite's
  * `define` replaces literal references, but modules pre-bundled by esbuild's
@@ -194,7 +209,7 @@ const devGlobalsPlugin = (version: string) => ({
       {
         tag: 'script',
         injectTo: 'head-prepend',
-        children: `globalThis.__DEV__=true;globalThis.__VERSION__=${JSON.stringify(version)};globalThis.__REVISION__="baseline";`,
+        children: `globalThis.__DEV__=${String(ENGINE_DEV_BUILD)};globalThis.__VERSION__=${JSON.stringify(version)};globalThis.__REVISION__="baseline";`,
       },
     ];
   },
@@ -261,7 +276,7 @@ const startViteServer = async (version: string): Promise<ViteDevServer> => {
     // source still resolves to local `.ts` files via the `#*` alias and is never
     // pre-bundled.
     optimizeDeps: { noDiscovery: true, include: resolvableCompetitors() },
-    define: { __DEV__: 'true', __VERSION__: JSON.stringify(version), __REVISION__: JSON.stringify('baseline') },
+    define: { __DEV__: String(ENGINE_DEV_BUILD), __VERSION__: JSON.stringify(version), __REVISION__: JSON.stringify('baseline') },
     plugins: [realShaderPlugin, devGlobalsPlugin(version)],
   });
 

--- a/packages/exojs-bench/src/rendering/page/harness.ts
+++ b/packages/exojs-bench/src/rendering/page/harness.ts
@@ -24,7 +24,30 @@ const STAGE_HEIGHT = 720;
  * the id stays `stage` so the driver's provenance read still finds it.
  */
 const freshStageCanvas = (): HTMLCanvasElement => {
-  document.getElementById('stage')?.remove();
+  const previous = document.getElementById('stage');
+
+  // Removing the canvas element does NOT free its WebGL context — that waits on
+  // GC, which is non-deterministic. Across the ~90-cell WebGL2 matrix the orphaned
+  // contexts pile up past the browser's live-context cap (~16) and a later cell's
+  // init/renderFrame wedges indefinitely (the observed cell-87 freeze: the excalibur
+  // arm's `engine.dispose()` drops references but never loses the GL context, so
+  // each excalibur cell leaked one). Force-lose the PREVIOUS cell's context here —
+  // one cell after it ran, so the driver's post-first-ok-cell provenance read
+  // (`readRendererInPage`) still finds a live context — which deterministically
+  // frees that context's GPU resources regardless of what the arm's teardown did.
+  // webgl2 and webgl1 (Phaser renders WebGL1) are both handled; a webgpu cell has
+  // no webgl context here and is skipped.
+  if (previous instanceof HTMLCanvasElement) {
+    // `getContext('webgl2')` returns the existing context when one is present
+    // (it never creates a second); falling back to `'webgl'` covers Phaser's
+    // WebGL1 canvas. A webgpu (or context-less) canvas yields null on both and is
+    // left untouched.
+    const gl = previous.getContext('webgl2') ?? previous.getContext('webgl');
+
+    gl?.getExtension('WEBGL_lose_context')?.loseContext();
+  }
+
+  previous?.remove();
 
   const canvas = document.createElement('canvas');
 
@@ -56,6 +79,35 @@ const FRAME_BUDGET_MS = 200;
  * samples, never a bogus single-frame "median".
  */
 const ABORT_WINDOW = 3;
+/**
+ * Wall-clock cap on the synchronous warmup phase (ms). Warmup runs
+ * `spec.warmupFrames` — scaled UP with node count (review B7) — to settle
+ * shader-compile / texture-upload / JIT before timing, but that frame COUNT
+ * assumes cheap frames. A pathological cell (a weak arm under 25k full-viewport
+ * overdraw renders multi-second frames) turned a 25-frame warmup into a 10+
+ * minute stall with no bound: the timed loop has `shouldAbort`, warmup had
+ * nothing. Cap warmup by TIME instead — an engine is fully warm within a few
+ * frames, and once cumulative warmup passes this budget the cell is either
+ * already deep into cheap frames (so it hit `warmupFrames` first and this never
+ * bound) or rendering multi-second frames (so it will abort in the timed phase —
+ * more warmup is wasted work). Set well above the worst TRUSTED warmup
+ * (`warmupFrames` × `FRAME_BUDGET_MS` ≈ 8s at the abort edge), so a cell that
+ * produces a trusted timing never has its warmup truncated; only catastrophic
+ * cells are cut short — to a single frame, since one such frame alone blows the
+ * budget.
+ */
+const WARMUP_BUDGET_MS = 10_000;
+/**
+ * Single-frame hard-abort threshold for the timed loop (10× `FRAME_BUDGET_MS`).
+ * `shouldAbort`'s median-of-last-`ABORT_WINDOW` rule deliberately never aborts on
+ * ONE slow frame (review B9: a lone GC/scheduler spike must not fake a runaway).
+ * But a frame at 10× the budget is not a spike — no realistic blip turns a
+ * sub-200ms cell into a 2s frame — it is a catastrophically slow cell that WILL
+ * abort regardless. Aborting after the first such frame, rather than waiting for
+ * three, cuts a weak arm's heaviest cells from minutes to seconds with the SAME
+ * `exceeded` verdict; the B9 median rule still governs every borderline case.
+ */
+const HARD_FRAME_BUDGET_MS = FRAME_BUDGET_MS * 10;
 
 /**
  * Reduce accumulated structural totals to per-frame figures. Draw/bind/upload
@@ -417,15 +469,29 @@ export const runCell = async (adapter: EngineAdapter, spec: CellSpec, canvas: HT
       );
     }
 
+    // Warmup is bounded by BOTH frame count and wall-clock (see WARMUP_BUDGET_MS):
+    // a pathologically slow cell stops warming after its first frame instead of
+    // grinding through every warmupFrame, while a normal cell hits its full frame
+    // budget long before the deadline.
+    const warmupDeadline = performance.now() + WARMUP_BUDGET_MS;
+
     for (let frame = 0; frame < spec.warmupFrames; frame++) {
       adapter.mutate(frame);
       adapter.renderFrame();
+
+      if (performance.now() >= warmupDeadline) {
+        break;
+      }
     }
 
     probe.reset();
 
     const rafDeltasMs: number[] = [];
     let exceeded = false;
+    // Set to the human-readable reason the moment the cell aborts, so the two
+    // abort paths (single-frame hard cap vs. sustained-median) each explain
+    // themselves precisely instead of the note being reconstructed after the fact.
+    let abortNote: string | null = null;
 
     await new Promise<void>((resolve, reject) => {
       let frame = 0;
@@ -454,10 +520,24 @@ export const runCell = async (adapter: EngineAdapter, spec: CellSpec, canvas: HT
 
           frame++;
 
+          const lastMs = timer.samples[timer.samples.length - 1]!;
+
+          // Hard single-frame abort: a frame at 10x budget is catastrophic, not a
+          // spike, so abort now rather than waiting for the ABORT_WINDOW median
+          // (see HARD_FRAME_BUDGET_MS). Keeps a weak arm's heaviest cells to a
+          // single timed frame.
+          if (lastMs > HARD_FRAME_BUDGET_MS) {
+            exceeded = true;
+            abortNote = `a single timed frame took ${lastMs.toFixed(1)}ms (> ${HARD_FRAME_BUDGET_MS}ms hard cap, ${HARD_FRAME_BUDGET_MS / FRAME_BUDGET_MS}x the ${FRAME_BUDGET_MS}ms budget); cell aborted after ${frame} frame(s) — median/p95 below rest on ${frame} sample(s)`;
+            resolve();
+            return;
+          }
+
           // B9 — abort on a sustained slowdown, not a single spike (see
           // `shouldAbort`'s doc comment for the full rationale).
           if (shouldAbort(timer.samples, FRAME_BUDGET_MS, ABORT_WINDOW)) {
             exceeded = true;
+            abortNote = `the trailing ${ABORT_WINDOW}-frame median exceeded ${FRAME_BUDGET_MS}ms; cell aborted after ${frame} frame(s) — median/p95 below rest on ${frame} sample(s), not a single-frame artifact`;
             resolve();
             return;
           }
@@ -503,9 +583,7 @@ export const runCell = async (adapter: EngineAdapter, spec: CellSpec, canvas: HT
     const frameMsP95 = frameSamplesMs.length > 0 ? percentile(frameSamplesMs, 95) : null;
 
     const notes = [
-      exceeded
-        ? `the trailing ${ABORT_WINDOW}-frame median exceeded ${FRAME_BUDGET_MS}ms; cell aborted after ${measuredFrames} frame(s) — median/p95 below rest on ${measuredFrames} sample(s), not a single-frame artifact`
-        : unevenNote,
+      exceeded ? abortNote : unevenNote,
       structuralNote,
       gpuUsable ? gpuTimer.note : NO_GPU_TIMER_NOTE,
     ].filter((value): value is string => value !== null);

--- a/packages/exojs-bench/src/run.ts
+++ b/packages/exojs-bench/src/run.ts
@@ -41,6 +41,7 @@ const runRenderingDomain = async (args: Map<string, string>): Promise<void> => {
   const archetypeArg = args.get('archetype');
   const nodesArg = args.get('nodes');
   const framesArg = args.get('frames');
+  const engineArg = args.get('engine');
   const outDir = resolve(args.get('out') ?? DEFAULT_OUT_DIR);
 
   const backends: readonly Backend[] = backendArg ? (backendArg.split(',').map(value => value.trim()) as Backend[]) : DEFAULT_BACKENDS;
@@ -52,6 +53,10 @@ const runRenderingDomain = async (args: Map<string, string>): Promise<void> => {
 
   if (archetypeArg !== undefined) {
     filter.archetype = archetypeArg as ArchetypeId;
+  }
+
+  if (engineArg !== undefined) {
+    filter.engine = engineArg;
   }
 
   if (nodesArg !== undefined) {
@@ -84,14 +89,14 @@ const runRenderingDomain = async (args: Map<string, string>): Promise<void> => {
     timedFramesOverride = frames;
   }
 
-  const isSubset = backendArg !== undefined || archetypeArg !== undefined || nodesArg !== undefined || timedFramesOverride !== undefined;
+  const isSubset = backendArg !== undefined || archetypeArg !== undefined || nodesArg !== undefined || engineArg !== undefined || timedFramesOverride !== undefined;
 
   if (isSubset) {
     console.warn('SUBSET RUN — not a reportable comparison (see the same-session rule).');
   }
 
   console.log(
-    `Running rendering benchmark: backends=[${backends.join(', ')}]${archetypeArg ? `, archetype=${archetypeArg}` : ''}${nodesArg ? `, nodes=${nodesArg}` : ''}${timedFramesOverride !== undefined ? `, frames=${timedFramesOverride} (OVERRIDE — thin sampling, not reportable)` : ''}`,
+    `Running rendering benchmark: backends=[${backends.join(', ')}]${engineArg ? `, engine=${engineArg}` : ''}${archetypeArg ? `, archetype=${archetypeArg}` : ''}${nodesArg ? `, nodes=${nodesArg}` : ''}${timedFramesOverride !== undefined ? `, frames=${timedFramesOverride} (OVERRIDE — thin sampling, not reportable)` : ''}`,
   );
 
   // Incremental, crash-safe checkpoint: each cell is persisted the instant it


### PR DESCRIPTION
@
## Summary

Two independent bench-harness robustness/methodology fixes, one commit each.

### 1. Wall-clock cell cap + per-arm browser isolation
A weak arm can accumulate GPU-driver state across its cells until one heavy cell stalls the driver mid-frame (observed: Excalibur wedging on 25k overdraw / batch-breaking), freezing the page with no in-page recovery — the in-page guards only fire *between* frames. Adds a driver-side `CELL_TIMEOUT_MS` cap that abandons a wedged cell as `unavailable` and relaunches its browser, and runs each arm in its own browser session (timing is per-cell, so a shared session buys only warm JIT, not comparability, while letting one arm leak state into a later arm). The matrix always completes; a pathological arm loses only its wedging cells, each disclosed.

### 2. Production engine build (`__DEV__=false`)
The competitor arms are pre-bundled from their published npm dist — their **production** builds. Compiling exojs source with `__DEV__=true` pitted an unshipped **dev** build against them: per-frame dev diagnostics (e.g. `RetainedGroupFragment._devHasDestroyedDrawable`, a full O(captured-drawables) scan every clean retained frame) inflated the exojs numbers **20–30×** on the static-heavy retained arm alone — measured **2.31 ms** vs the real **~0.1 ms** prod floor (**0.235 ms** confirmed in-browser after this change). `ENGINE_DEV_BUILD=false` threads through both the injected global and the Vite `define` so the engine graph compiles the path a shipped game runs.

## Verification
- `verify:quick` + bench typecheck green (pre-push hook).
- In-browser smoke (RTX 5070 Ti, WebGL2, real GPU): static-heavy retained @100k dropped 2.31 ms → **0.235 ms**; dynamic-heavy @100k measured exojs 115.6 ms / retained 117.1 ms / **pixi 9.2 ms**.

## Note
All previously measured exojs cells were dev-biased — the **full matrix must be re-measured** (prod build) before any number is published.
@