### PR TITLE
feat(render): incremental transform-row patching for RetainedContainer (Track B slice 4)

### DIFF
--- a/site/src/content/api/retained-container.json
+++ b/site/src/content/api/retained-container.json
@@ -6,10 +6,10 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "advanced",
-  "memberCount": 96,
+  "memberCount": 97,
   "counts": {
     "constructors": 1,
-    "methods": 45,
+    "methods": 46,
     "properties": 37,
     "events": 13
   },
@@ -69,6 +69,53 @@
       "id": "methods",
       "title": "Methods",
       "members": [
+        {
+          "name": "_enqueueDirtyTransformRow",
+          "signature": "_enqueueDirtyTransformRow(node: RenderNode): void",
+          "signatureTokens": [
+            {
+              "text": "_enqueueDirtyTransformRow",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "node",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "RenderNode",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "node",
+              "type": "RenderNode",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Slice 4b seam: a descendant's own transform moved. Queue its row on the fragment; _collectContent patches the queued rows in place on a content/structure-clean frame instead of re-collecting. The group's OWN move does not route here — _markOwnTransformDirty above handles it as a one-matrix group move."
+        },
         {
           "name": "_invalidateBoundsCascade",
           "signature": "_invalidateBoundsCascade(): void",

--- a/src/core/NodeRevision.ts
+++ b/src/core/NodeRevision.ts
@@ -10,18 +10,27 @@ let globalTick = 0;
 export const nextNodeRevision = (): number => ++globalTick;
 
 /**
- * Per-node content/structure revision pair (Track B, `D6`). Bumped at the
- * mutation site and propagated up the parent chain by
- * {@link SceneNode._markContentDirty} / `_markStructureDirty` — see
- * SceneNode.ts. `content` covers transform/tint/visual-source changes;
- * `structure` covers child add/remove/reorder and visibility. A structure
- * change also stamps `content` (conservative: whoever consumes a cached
- * fragment must treat a structural change as content-dirty too).
+ * Per-node content/structure/transform revision triple (Track B, `D6` +
+ * Slice 4a). Bumped at the mutation site and propagated up the parent chain by
+ * {@link SceneNode._markContentDirty} / `_markStructureDirty` /
+ * `_markTransformDirty` — see SceneNode.ts. `content` covers tint/visual-source
+ * changes; `structure` covers child add/remove/reorder and visibility; a
+ * structure change also stamps `content` (conservative: whoever consumes a
+ * cached fragment must treat a structural change as content-dirty too).
+ *
+ * `transform` is an ORTHOGONAL channel (Slice 4a) bumped by own-transform
+ * mutations (position/rotation/scale/skew/origin). It does not stamp `content`
+ * or vice versa: it exists so a {@link RetainedContainer} can distinguish a
+ * transform-only descendant move (patch the group's transform rows in place)
+ * from a content change (re-collect). In Slice 4a own-transform mutations still
+ * ALSO bump `content` (the split is additive, behaviour-neutral); Slice 4b drops
+ * that content co-bump once the row-patch path exists.
  * @internal
  */
 export class NodeRevision {
   private _content = 0;
   private _structure = 0;
+  private _transform = 0;
 
   public get content(): number {
     return this._content;
@@ -31,6 +40,10 @@ export class NodeRevision {
     return this._structure;
   }
 
+  public get transform(): number {
+    return this._transform;
+  }
+
   public touchContent(revision: number): void {
     this._content = revision;
   }
@@ -38,5 +51,9 @@ export class NodeRevision {
   public touchStructure(revision: number): void {
     this._structure = revision;
     this._content = revision;
+  }
+
+  public touchTransform(revision: number): void {
+    this._transform = revision;
   }
 }

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -526,6 +526,15 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
   }
 
   /**
+   * @internal — Slice 4b seam: the nearest enclosing retained transform group
+   * is notified when a descendant's OWN transform moves, so it can patch that
+   * node's group-owned transform row in place (O(1)) instead of re-collecting
+   * the whole subtree. No-op on a plain node; {@link RetainedContainer}
+   * overrides it to enqueue the row on its fragment.
+   */
+  public _enqueueDirtyTransformRow(_node: RenderNode): void {}
+
+  /**
    * Whether this node opts back OUT of a parent transform-group boundary and
    * resolves world-space transforms. Overridden by RenderNode for
    * barrier-effect nodes (filters/mask/clip/cacheAsBitmap), whose effect
@@ -1024,18 +1033,47 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
 
   /**
    * Tail of every own-transform mutation path (position/rotation/scale/origin/
-   * skew). Default: cascade bounds, stamp content-dirty, AND stamp the Slice-4a
-   * transform channel. The transform stamp is ADDITIVE here — content still
-   * bumps, so behaviour is identical to pre-Slice-4a; Slice 4b drops the content
-   * co-bump once {@link RetainedContainer} patches transform rows from the
-   * transform channel. {@link RetainedContainer} overrides this to bump its
-   * group-matrix version instead of invalidating its retained fragment (§4.3).
+   * skew). Cascades bounds (flag-based, revision-independent) and stamps ONLY
+   * the transform channel — NOT content (the Slice-4b flip): an own-transform
+   * move no longer invalidates a retained fragment, so an enclosing
+   * {@link RetainedContainer} keeps its recorded instruction set and patches
+   * just this node's transform row in place ({@link _notifyEnclosingRetainedGroup}).
+   * Content-dirty is now reserved for genuine content changes (tint/blend/
+   * geometry/texture). {@link RetainedContainer} overrides this to bump its
+   * group-matrix version for its OWN move instead (§4.3).
    * @internal
    */
   protected _markOwnTransformDirty(): void {
-    this._invalidateBoundsCascade();
-    this._markContentDirty();
+    // Flag-only bounds cascade (NOT _invalidateBoundsCascade): the Slice-4b flip
+    // means a transform move must refresh ancestor world bounds for culling/
+    // getBounds WITHOUT content-dirtying — the content stamp would invalidate the
+    // retained fragment and defeat the row patch. Consumers that needed the old
+    // content bump on a move (the Wave-3 plain-container static skip) now key on
+    // the transform channel instead (slice 4b part 1).
+    this._invalidateBoundsFlags();
     this._markTransformDirty();
+    this._notifyEnclosingRetainedGroup();
+  }
+
+  /**
+   * Walk to the nearest enclosing transform-group boundary and hand it this
+   * node so it can fast-patch the row (Slice 4b). Stops at the FIRST boundary —
+   * that group owns this node's group-local transform row. Cheap: the walk ends
+   * at the group, not the root, and enqueue is a no-op for a non-retained
+   * boundary. Runs on every own-transform mutation, so it must not allocate.
+   */
+  private _notifyEnclosingRetainedGroup(): void {
+    let ancestor: Container | null = this._parentNode;
+
+    while (ancestor !== null) {
+      if (ancestor._isTransformGroupBoundary) {
+        ancestor._enqueueDirtyTransformRow(this as unknown as RenderNode);
+
+        return;
+      }
+
+      ancestor = ancestor.parent;
+    }
   }
 
   private _setPositionDirty(): void {

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -916,9 +916,25 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
     return this._nodeRevision.structure;
   }
 
+  /**
+   * @internal — aggregate transform-dirty stamp (Slice 4a) for this node's
+   * subtree: own-transform mutations (position/rotation/scale/skew/origin) at
+   * or below. Orthogonal to {@link _contentRevision} — a content change does
+   * not bump it and it does not bump content. Read by {@link RetainedContainer}
+   * to detect a transform-only descendant move (patch rows) vs. a content
+   * change (re-collect). Reading it advances the dirty-walk epoch — same
+   * side-effecting-getter caution as {@link _contentRevision}.
+   */
+  public get _transformRevision(): number {
+    dirtyWalkEpoch++;
+
+    return this._nodeRevision.transform;
+  }
+
   /** Dirty-walk epoch stamps for the F10 early-out — see {@link _markContentDirty}. */
   private _contentWalkEpoch = 0;
   private _structureWalkEpoch = 0;
+  private _transformWalkEpoch = 0;
 
   /**
    * @internal — mark this node's content dirty and propagate the stamp up to
@@ -984,15 +1000,42 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
   }
 
   /**
+   * @internal — mark this node's transform dirty (Slice 4a) and propagate the
+   * stamp up to the root, exactly like {@link _markContentDirty} but on the
+   * orthogonal transform channel (its own walk epoch, keyed independently so a
+   * transform walk and a content walk never block each other). Consumed by
+   * {@link RetainedContainer} to spot a transform-only descendant move.
+   */
+  protected _markTransformDirty(): void {
+    const revision = nextNodeRevision();
+    const epoch = dirtyWalkEpoch;
+
+    this._nodeRevision.touchTransform(revision);
+    this._transformWalkEpoch = epoch;
+
+    let ancestor = this._parentNode;
+
+    while (ancestor !== null && ancestor._transformWalkEpoch !== epoch) {
+      ancestor._nodeRevision.touchTransform(revision);
+      ancestor._transformWalkEpoch = epoch;
+      ancestor = ancestor.parent;
+    }
+  }
+
+  /**
    * Tail of every own-transform mutation path (position/rotation/scale/origin/
-   * skew). Default: cascade bounds and stamp content-dirty — exactly the
-   * pre-Slice-2 behavior. {@link RetainedContainer} overrides this to bump its
+   * skew). Default: cascade bounds, stamp content-dirty, AND stamp the Slice-4a
+   * transform channel. The transform stamp is ADDITIVE here — content still
+   * bumps, so behaviour is identical to pre-Slice-4a; Slice 4b drops the content
+   * co-bump once {@link RetainedContainer} patches transform rows from the
+   * transform channel. {@link RetainedContainer} overrides this to bump its
    * group-matrix version instead of invalidating its retained fragment (§4.3).
    * @internal
    */
   protected _markOwnTransformDirty(): void {
     this._invalidateBoundsCascade();
     this._markContentDirty();
+    this._markTransformDirty();
   }
 
   private _setPositionDirty(): void {

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -268,7 +268,10 @@ export class Container extends RenderNode {
 
     const viewUpdateId = builder.view.updateId;
 
-    if (this._retainedPlan !== null && this._retainedPlan.isClean(this._contentRevision, this._structureRevision, this._transformRevision, viewUpdateId, builder.backend)) {
+    if (
+      this._retainedPlan !== null &&
+      this._retainedPlan.isClean(this._contentRevision, this._structureRevision, this._transformRevision, viewUpdateId, builder.backend)
+    ) {
       if (__DEV__ && this._retainedPlan._devHasDestroyedDrawable()) {
         // P3f: a direct drawable child was destroy()ed but left attached, so
         // no revision bumped and the slot cache still looks clean. Drop the
@@ -364,7 +367,13 @@ export class Container extends RenderNode {
     // retain: a slot candidate this frame, or an already-live cache that must
     // be re-keyed so it cannot go stale-clean.
     if (sawSlotCandidate || this._retainedPlan !== null) {
-      (this._retainedPlan ??= new RetainedPlanCache())._commitCapture(this._contentRevision, this._structureRevision, this._transformRevision, viewUpdateId, builder.backend);
+      (this._retainedPlan ??= new RetainedPlanCache())._commitCapture(
+        this._contentRevision,
+        this._structureRevision,
+        this._transformRevision,
+        viewUpdateId,
+        builder.backend,
+      );
     }
   }
 

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -268,7 +268,7 @@ export class Container extends RenderNode {
 
     const viewUpdateId = builder.view.updateId;
 
-    if (this._retainedPlan !== null && this._retainedPlan.isClean(this._contentRevision, this._structureRevision, viewUpdateId, builder.backend)) {
+    if (this._retainedPlan !== null && this._retainedPlan.isClean(this._contentRevision, this._structureRevision, this._transformRevision, viewUpdateId, builder.backend)) {
       if (__DEV__ && this._retainedPlan._devHasDestroyedDrawable()) {
         // P3f: a direct drawable child was destroy()ed but left attached, so
         // no revision bumped and the slot cache still looks clean. Drop the
@@ -364,7 +364,7 @@ export class Container extends RenderNode {
     // retain: a slot candidate this frame, or an already-live cache that must
     // be re-keyed so it cannot go stale-clean.
     if (sawSlotCandidate || this._retainedPlan !== null) {
-      (this._retainedPlan ??= new RetainedPlanCache())._commitCapture(this._contentRevision, this._structureRevision, viewUpdateId, builder.backend);
+      (this._retainedPlan ??= new RetainedPlanCache())._commitCapture(this._contentRevision, this._structureRevision, this._transformRevision, viewUpdateId, builder.backend);
     }
   }
 

--- a/src/rendering/RetainedContainer.ts
+++ b/src/rendering/RetainedContainer.ts
@@ -115,6 +115,7 @@ export class RetainedContainer extends Container {
   private readonly _liveBoundsChildren: RenderNode[] = [];
   private _aggregateContentRevision = -1;
   private _aggregateStructureRevision = -1;
+  private _aggregateTransformRevision = -1;
 
   /**
    * World AABB of the group: children aggregate in group-local space, so
@@ -134,10 +135,18 @@ export class RetainedContainer extends Container {
 
     const world = this.getGlobalTransform();
 
-    if (this._aggregateContentRevision !== this._contentRevision || this._aggregateStructureRevision !== this._structureRevision) {
+    // Keyed on the transform channel too (Slice 4b): a descendant transform-only
+    // move changes its group-local rect but no longer stamps content (the 4b
+    // flip), so without the transform key the cached aggregate would go stale.
+    if (
+      this._aggregateContentRevision !== this._contentRevision ||
+      this._aggregateStructureRevision !== this._structureRevision ||
+      this._aggregateTransformRevision !== this._transformRevision
+    ) {
       this._rebuildGroupAggregate();
       this._aggregateContentRevision = this._contentRevision;
       this._aggregateStructureRevision = this._structureRevision;
+      this._aggregateTransformRevision = this._transformRevision;
     }
 
     this._bounds.reset().addRect(this._groupAggregate.getRect(), world);

--- a/src/rendering/RetainedContainer.ts
+++ b/src/rendering/RetainedContainer.ts
@@ -5,7 +5,17 @@ import type { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
 import { RetainedGroupFragment } from '#rendering/plan/RetainedGroupFragment';
 
 import { Container } from './Container';
+import type { Drawable } from './Drawable';
+import type { RetainedGroupBundle } from './plan/RetainedInstructionSet';
 import type { RenderNode } from './RenderNode';
+
+/**
+ * Reused scratch for one patched transform row (12 floats = 3 rgba32f texels,
+ * the {@link TransformBuffer} layout: a,b,c,d, tx,ty,0,0, r,g,b,a). Filled and
+ * consumed synchronously inside a single patch call, so one module-level buffer
+ * is safe and allocation-free under churn.
+ */
+const patchRowScratch = new Float32Array(12);
 
 /** Observation window for the S2-D1 retention diagnostic, in fragment builds (~frames). */
 const retainedDiagnosticWindow = 120;
@@ -96,6 +106,17 @@ export class RetainedContainer extends Container {
   protected override _markOwnTransformDirty(): void {
     this._groupVersion = nextNodeRevision();
     this._invalidateBoundsFlags();
+  }
+
+  /**
+   * Slice 4b seam: a descendant's own transform moved. Queue its row on the
+   * fragment; {@link _collectContent} patches the queued rows in place on a
+   * content/structure-clean frame instead of re-collecting. The group's OWN
+   * move does not route here — {@link _markOwnTransformDirty} above handles it
+   * as a one-matrix group move.
+   */
+  public override _enqueueDirtyTransformRow(node: RenderNode): void {
+    this._fragment.enqueueDirtyTransformRow(node);
   }
 
   // ── F12: group-local bounds aggregate cache ─────────────────────────────
@@ -208,6 +229,15 @@ export class RetainedContainer extends Container {
       this._fragment.invalidate();
       this._warnReplayedDestroyed();
     } else if (fragmentClean) {
+      // Slice 4b: a content/structure-clean frame may still carry transform-only
+      // descendant moves (the flip: an own-transform move no longer content-
+      // dirties). The recorded instruction set's baked transform rows are stale
+      // for those nodes — patch the changed rows in place (O(k)), or drop the
+      // recording so entry replay re-reads live transforms this frame.
+      if (this._fragment.hasDirtyTransformRows()) {
+        this._reconcileTransformRows();
+      }
+
       // Fast tier (Slice 3, S3-D2): a valid recorded instruction set splices
       // as an EMPTY scope — the player replays O(batches), the optimizer sees
       // nothing. Falls through the ladder: instruction replay -> entry replay
@@ -265,6 +295,85 @@ export class RetainedContainer extends Container {
     if (!suppressCapture) {
       this._fragment.capture(this._contentRevision, this._structureRevision, builder.backend, builder._peekCurrentScopeEntries());
     }
+  }
+
+  /**
+   * Slice 4b: reconcile the queued transform-only moves against the recorded
+   * instruction set before replay. On the recorded tier the transforms are
+   * baked into the group-owned store, so each moved DIRECT drawable child's row
+   * is patched in place (O(k) rows + one sub-range upload). Any ineligible move
+   * (nested below a sub-container, pixel-snapped, or not a recorded direct draw)
+   * drops the recording, so this frame entry-replays with live transforms and
+   * re-records — correct, O(entries), the rare fallback. On the entry-replay
+   * tier there is nothing to reconcile (transforms are re-read live); the queue
+   * is simply drained.
+   */
+  private _reconcileTransformRows(): void {
+    const set = this._fragment.instructions;
+    const bundle = set?.ownedBundle ?? null;
+
+    if (set === null || !set.hasRecording || bundle === null || typeof bundle._patchTransformRow !== 'function' || bundle.transformRowBase === undefined) {
+      this._fragment.clearDirtyTransformRows();
+
+      return;
+    }
+
+    const base = bundle.transformRowBase;
+
+    for (const node of this._fragment.dirtyTransformRows) {
+      if (!this._patchTransformRow(node, bundle, base)) {
+        // Ineligible: drop the baked recording. `_markCurrentScopeRetained`
+        // will now fail its validity check, so the group falls to entry replay
+        // (live transforms) and re-records this frame.
+        set.invalidate();
+        break;
+      }
+    }
+
+    this._fragment.clearDirtyTransformRows();
+  }
+
+  /**
+   * Patch one moved node's group-local transform row, or return `false` when it
+   * is not fast-patch-eligible (spec §3 eligibility). Eligible: a direct
+   * drawable child, non-snapped, present in the recorded row map. The
+   * group-local matrix is `getGlobalTransform()` composed to this boundary — the
+   * exact value the recorder wrote (S3-D4).
+   */
+  private _patchTransformRow(node: RenderNode, bundle: RetainedGroupBundle, base: number): boolean {
+    if (node.parent !== this) {
+      return false;
+    }
+
+    const drawable = node as unknown as Drawable;
+    const nodeIndex = this._fragment.directDrawNodeIndex(drawable);
+
+    // Snapped nodes are excluded from recording (their instance words are
+    // view-dependent), so a recorded direct child is never snapped — but guard
+    // belt-and-braces: an ineligible node drops to the re-record fallback.
+    if (nodeIndex === undefined || drawable.pixelSnapMode !== 'none') {
+      return false;
+    }
+
+    const matrix = node.getGlobalTransform();
+    const tint = drawable.tint;
+
+    patchRowScratch[0] = matrix.a;
+    patchRowScratch[1] = matrix.b;
+    patchRowScratch[2] = matrix.c;
+    patchRowScratch[3] = matrix.d;
+    patchRowScratch[4] = matrix.x;
+    patchRowScratch[5] = matrix.y;
+    patchRowScratch[6] = 0;
+    patchRowScratch[7] = 0;
+    patchRowScratch[8] = tint.r / 255;
+    patchRowScratch[9] = tint.g / 255;
+    patchRowScratch[10] = tint.b / 255;
+    patchRowScratch[11] = tint.a;
+
+    bundle._patchTransformRow!(nodeIndex - base, patchRowScratch);
+
+    return true;
   }
 
   /**

--- a/src/rendering/plan/RetainedGroupFragment.ts
+++ b/src/rendering/plan/RetainedGroupFragment.ts
@@ -17,6 +17,14 @@ import { isRetainedFragmentRecordable, RetainedInstructionSet } from './Retained
 export interface RetainedFragmentDraw {
   readonly kind: RenderEntryKind.Draw;
   drawable: Drawable;
+  /**
+   * The shared frame-buffer transform row this draw was captured on (Slice 4b).
+   * A group-local row is `nodeIndex - bundle.transformRowBase`; the fast patch
+   * maps a moved direct child back to its group-owned store row through it. The
+   * capture frame and the record frame are the same unchanged subtree, so the
+   * captured index equals the recorded one.
+   */
+  nodeIndex: number;
   seq: number;
   zIndex: number;
   /** Pooled key object, rewritten in place on recapture — never replaced. */
@@ -116,8 +124,61 @@ export class RetainedGroupFragment {
   private _recordable = false;
   private _recordableFor: RenderBackend | null = null;
 
+  // Slice 4b: lazy drawable -> captured shared-row map over the TOP-LEVEL draw
+  // records (the direct drawable children — the only fast-patch-eligible ones).
+  // Built on first lookup after a capture, dropped on the next capture.
+  private _directRowMap: Map<Drawable, number> | null = null;
+
+  // Slice 4b: nodes whose OWN transform moved since the last collect, pushed by
+  // the SceneNode seam through the enclosing group. A Set bounds it to the
+  // distinct moved nodes (O(children) worst case) and dedups repeated moves.
+  private readonly _dirtyTransformRows = new Set<RenderNode>();
+
   public get hasCapture(): boolean {
     return this._hasCapture;
+  }
+
+  /**
+   * The shared transform-buffer row a DIRECT drawable child was captured on
+   * (Slice 4b fast patch), or `undefined` when `drawable` is not a top-level
+   * captured draw (nested in a sub-container, or not in this group). Lazily
+   * builds a drawable→row map over the top-level draw records, rebuilt after
+   * each capture.
+   */
+  public directDrawNodeIndex(drawable: Drawable): number | undefined {
+    if (this._directRowMap === null) {
+      const map = new Map<Drawable, number>();
+
+      for (const entry of this._entries) {
+        if (entry.kind === RenderEntryKind.Draw) {
+          map.set(entry.drawable, entry.nodeIndex);
+        }
+      }
+
+      this._directRowMap = map;
+    }
+
+    return this._directRowMap.get(drawable);
+  }
+
+  /** Slice 4b: record that `node`'s own transform moved (from the SceneNode seam). */
+  public enqueueDirtyTransformRow(node: RenderNode): void {
+    this._dirtyTransformRows.add(node);
+  }
+
+  /** `true` when at least one transform-only move is queued for this frame. */
+  public hasDirtyTransformRows(): boolean {
+    return this._dirtyTransformRows.size > 0;
+  }
+
+  /** The queued moved nodes (insertion order, deduped). */
+  public get dirtyTransformRows(): ReadonlySet<RenderNode> {
+    return this._dirtyTransformRows;
+  }
+
+  /** Drop the queue — after patching them, or after a full re-collect subsumed them. */
+  public clearDirtyTransformRows(): void {
+    this._dirtyTransformRows.clear();
   }
 
   /** The group's instruction set, or `null` if recording was never armed. */
@@ -232,6 +293,10 @@ export class RetainedGroupFragment {
     this._groupCursor = 0;
     this._barrierCursor = 0;
     this._entries.length = 0;
+    this._directRowMap = null;
+    // A full (re)capture reads every child's current transform: any queued
+    // transform-only moves are subsumed and must not double-patch afterwards.
+    this._dirtyTransformRows.clear();
 
     this._snapshotInto(this._entries, entries);
 
@@ -251,6 +316,8 @@ export class RetainedGroupFragment {
     this._releaseDrawableRefs();
     this._hasCapture = false;
     this._entries.length = 0;
+    this._directRowMap = null;
+    this._dirtyTransformRows.clear();
     this._replayedSinceCapture = false;
     this._suppressed = false;
     this._wastedCaptures = 0;
@@ -305,6 +372,7 @@ export class RetainedGroupFragment {
         const record = this._acquireDraw();
 
         record.drawable = command.drawable;
+        record.nodeIndex = command.nodeIndex;
         record.seq = command.seq;
         record.zIndex = command.zIndex;
         copyMaterialKeyInto(record.material, command.material);
@@ -347,6 +415,7 @@ export class RetainedGroupFragment {
     const record: RetainedFragmentDraw = {
       kind: RenderEntryKind.Draw,
       drawable: undefined as unknown as Drawable,
+      nodeIndex: 0,
       seq: 0,
       zIndex: 0,
       material: { rendererId: 0, blendMode: BlendModes.Normal, textureId: -1, shaderId: -1, pipelineKey: 0, bindKey: 0 },

--- a/src/rendering/plan/RetainedInstructionSet.ts
+++ b/src/rendering/plan/RetainedInstructionSet.ts
@@ -30,6 +30,21 @@ export const enum RetainedInstructionKind {
 export interface RetainedGroupBundle {
   /** Monotonic resource generation; a mismatch invalidates referencing sets. */
   readonly generation: number;
+  /**
+   * The shared frame-buffer row the stored transform rows were rebased from
+   * (Slice 4b). A group-local row is `capturedNodeIndex - transformRowBase`.
+   * Absent on backends that do not implement in-place transform patching.
+   */
+  readonly transformRowBase?: number;
+  /**
+   * Slice 4b fast patch: overwrite one group-local transform row in place with
+   * `floats` (12 = 3 rgba32f texels, the `TransformBuffer` row layout) and mark
+   * only its sub-range for upload, WITHOUT bumping the generation (the recorded
+   * instance bytes reference the row by index and stay valid). Absent on
+   * backends without patch support — the caller then falls back to entry replay
+   * (which re-reads live transforms) or a re-record.
+   */
+  _patchTransformRow?(localRow: number, floats: Float32Array): void;
   /** Release the bundle's GPU resources (container destroy / disengage). */
   destroy?(): void;
 }

--- a/src/rendering/plan/RetainedPlanCache.ts
+++ b/src/rendering/plan/RetainedPlanCache.ts
@@ -84,6 +84,7 @@ export class RetainedPlanCache {
   private _poolCursor = 0;
   private _contentRevision = -1;
   private _structureRevision = -1;
+  private _transformRevision = -1;
   private _viewUpdateId = -1;
   private _backend: RenderBackend | null = null;
   private _hasCapture = false;
@@ -92,11 +93,21 @@ export class RetainedPlanCache {
     return this._slots;
   }
 
-  public isClean(contentRevision: number, structureRevision: number, viewUpdateId: number, backend: RenderBackend): boolean {
+  /**
+   * Keyed on transform-revision too (Slice 4b): the cached slots hold each
+   * child's screen-space AABB (`minX..maxY`), so a plain-container child move
+   * must re-collect. Own-transform mutations no longer stamp the content channel
+   * (Slice 4b dropped that co-bump), so without this the skip would replay a
+   * stale extent. Unlike a {@link RetainedContainer} — which patches its rows in
+   * place — the plain-container skip has no per-slot patch path and simply
+   * re-collects, exactly as it did when transform still content-dirtied.
+   */
+  public isClean(contentRevision: number, structureRevision: number, transformRevision: number, viewUpdateId: number, backend: RenderBackend): boolean {
     return (
       this._hasCapture &&
       this._contentRevision === contentRevision &&
       this._structureRevision === structureRevision &&
+      this._transformRevision === transformRevision &&
       this._viewUpdateId === viewUpdateId &&
       this._backend === backend
     );
@@ -133,9 +144,10 @@ export class RetainedPlanCache {
   }
 
   /** Key the capture; only after this does {@link isClean} consider it. */
-  public _commitCapture(contentRevision: number, structureRevision: number, viewUpdateId: number, backend: RenderBackend): void {
+  public _commitCapture(contentRevision: number, structureRevision: number, transformRevision: number, viewUpdateId: number, backend: RenderBackend): void {
     this._contentRevision = contentRevision;
     this._structureRevision = structureRevision;
+    this._transformRevision = transformRevision;
     this._viewUpdateId = viewUpdateId;
     this._backend = backend;
     this._hasCapture = true;

--- a/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
+++ b/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
@@ -125,6 +125,7 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
   private _transformFloats: Float32Array | null = null;
   private _transformRowCapacity = 0;
   private _transformRowCount = 0;
+  private _transformRowBase = 0;
   private _transformTexture: DataTexture<'rgba32f'> | null = null;
 
   // Device-side resources, created lazily at the first capture finalize.
@@ -165,6 +166,16 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
   /** Transform rows stored by the current/last capture. */
   public get transformRowCount(): number {
     return this._transformRowCount;
+  }
+
+  /**
+   * The shared-buffer row the stored rows were rebased from (`range.min` at
+   * capture end, S3-D4). A group-local row is `sharedNodeIndex - base`, so the
+   * Slice-4b fast patch maps a moved node's captured node index back to the
+   * group-owned store without re-recording.
+   */
+  public get transformRowBase(): number {
+    return this._transformRowBase;
   }
 
   /**
@@ -229,6 +240,24 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
     this._transformFloats!.set(source.subarray(firstRow * transformFloatsPerRow, (firstRow + rowCount) * transformFloatsPerRow), 0);
     this._transformTexture.commitRect(0, 0, 3, rowCount);
     this._transformRowCount = rowCount;
+    this._transformRowBase = firstRow;
+  }
+
+  /**
+   * Slice 4b fast patch: overwrite one group-local transform row in place with
+   * `floats` (12 = 3 rgba32f texels, the {@link TransformBuffer} row layout)
+   * and mark ONLY that row's sub-range for upload. Deliberately does NOT bump
+   * the generation — the recorded instance bytes reference this row by index
+   * and stay valid; only the transform behind the index moved. Out-of-range
+   * rows are ignored (a stale queue entry after a recapture shrank the store).
+   */
+  public _patchTransformRow(localRow: number, floats: Float32Array): void {
+    if (this._transformTexture === null || this._transformFloats === null || localRow < 0 || localRow >= this._transformRowCount) {
+      return;
+    }
+
+    this._transformFloats.set(floats.subarray(0, transformFloatsPerRow), localRow * transformFloatsPerRow);
+    this._transformTexture.commitRect(0, localRow, 3, 1);
   }
 
   /** Attach the GL context + accountant the device resources are created against. */

--- a/test/core/scene-node-dirty-walk-epoch.test.ts
+++ b/test/core/scene-node-dirty-walk-epoch.test.ts
@@ -29,9 +29,11 @@ describe('SceneNode dirty-walk epoch early-out (F10)', () => {
     const { root, leaf } = buildChain(depth);
 
     // Consumer read: starts a fresh epoch (like a plan build would).
-    void root._contentRevision;
+    void root._transformRevision;
 
-    const touchSpy = vi.spyOn(NodeRevision.prototype, 'touchContent');
+    // Slice 4b: a transform move stamps the TRANSFORM channel (not content),
+    // and the epoch early-out mirrors the content walk on that channel.
+    const touchSpy = vi.spyOn(NodeRevision.prototype, 'touchTransform');
 
     for (let index = 1; index <= mutations; index++) {
       leaf.setPosition(index, index);
@@ -40,7 +42,7 @@ describe('SceneNode dirty-walk epoch early-out (F10)', () => {
     // First mutation walks the full chain once; every later mutation stops at
     // the first epoch-current ancestor (the leaf's parent), i.e. stamps only
     // the leaf itself. `3 * mutations` slack absorbs the fact that a single
-    // setPosition routes through _markContentDirty more than once.
+    // setPosition routes through _markTransformDirty more than once.
     const stampCount = touchSpy.mock.calls.length;
 
     expect(stampCount).toBeLessThanOrEqual(depth + 1 + 3 * mutations);
@@ -54,12 +56,12 @@ describe('SceneNode dirty-walk epoch early-out (F10)', () => {
   test('correctness: ancestors observe a revision change after batched mutations, and a read re-arms the walk', () => {
     const { root, leaf } = buildChain(5);
 
-    const before = root._contentRevision; // read -> new epoch
+    const before = root._transformRevision; // read -> new epoch
 
     leaf.setPosition(1, 1);
     leaf.setPosition(2, 2); // early-out: root keeps the FIRST stamp
 
-    const afterBatch = root._contentRevision; // consumer observes the change
+    const afterBatch = root._transformRevision; // consumer observes the change
 
     expect(afterBatch).toBeGreaterThan(before);
 
@@ -68,7 +70,7 @@ describe('SceneNode dirty-walk epoch early-out (F10)', () => {
     // would wrongly see the tree as clean.
     leaf.setPosition(3, 3);
 
-    expect(root._contentRevision).toBeGreaterThan(afterBatch);
+    expect(root._transformRevision).toBeGreaterThan(afterBatch);
 
     root.destroy();
   });
@@ -85,18 +87,18 @@ describe('SceneNode dirty-walk epoch early-out (F10)', () => {
     branchA.addChild(leafA);
     branchB.addChild(leafB);
 
-    void root._contentRevision; // fresh epoch
+    void root._transformRevision; // fresh epoch
 
-    const beforeA = branchA._contentRevision;
-    const beforeB = branchB._contentRevision;
+    const beforeA = branchA._transformRevision;
+    const beforeB = branchB._transformRevision;
 
-    void root._contentRevision; // re-arm after the reads above
+    void root._transformRevision; // re-arm after the reads above
 
     leafA.setPosition(1, 1);
     leafB.setPosition(1, 1); // different path: must NOT be early-outed away
 
-    expect(branchA._contentRevision).toBeGreaterThan(beforeA);
-    expect(branchB._contentRevision).toBeGreaterThan(beforeB);
+    expect(branchA._transformRevision).toBeGreaterThan(beforeA);
+    expect(branchB._transformRevision).toBeGreaterThan(beforeB);
 
     root.destroy();
   });
@@ -106,7 +108,7 @@ describe('SceneNode dirty-walk epoch early-out (F10)', () => {
 
     const structureBefore = root._structureRevision; // read -> new epoch
 
-    leaf.setPosition(1, 1); // content walk stamps the chain's CONTENT epoch
+    leaf.invalidateContent(); // content walk stamps the chain's CONTENT epoch
     leaf.visible = false; // structure walk must still stamp structure fully
 
     expect(root._structureRevision).toBeGreaterThan(structureBefore);
@@ -120,7 +122,7 @@ describe('SceneNode dirty-walk epoch early-out (F10)', () => {
     const contentBefore = root._contentRevision; // read -> new epoch
 
     leaf.visible = false; // structure walk: stamps structure AND content
-    leaf.setPosition(1, 1); // content walk may early-out immediately
+    leaf.invalidateContent(); // content walk may early-out immediately
 
     // The consumer still observes a content change relative to its last read.
     expect(root._contentRevision).toBeGreaterThan(contentBefore);
@@ -136,17 +138,17 @@ describe('SceneNode dirty-walk epoch early-out (F10)', () => {
     root.addChild(group);
     group.addChild(leaf);
 
-    const rootBefore = root._contentRevision; // read -> new epoch
-    const groupBefore = group._contentRevision;
+    const rootBefore = root._transformRevision; // read -> new epoch
+    const groupBefore = group._transformRevision;
 
-    void root._contentRevision; // re-arm
+    void root._transformRevision; // re-arm
 
     leaf.setPosition(9, 9);
 
-    // Both the boundary node AND its ancestors above it must be stamped —
-    // no boundary stop in the dirty walk (D7 superseded).
-    expect(group._contentRevision).toBeGreaterThan(groupBefore);
-    expect(root._contentRevision).toBeGreaterThan(rootBefore);
+    // Both the boundary node AND its ancestors above it must be stamped on the
+    // transform channel — no boundary stop in the dirty walk (D7 superseded).
+    expect(group._transformRevision).toBeGreaterThan(groupBefore);
+    expect(root._transformRevision).toBeGreaterThan(rootBefore);
 
     root.destroy();
   });

--- a/test/core/scene-node-revision-invariants.test.ts
+++ b/test/core/scene-node-revision-invariants.test.ts
@@ -22,7 +22,7 @@ class NoopFilter extends Filter {
   }
 }
 
-type DirtyKind = 'content' | 'structure';
+type DirtyKind = 'content' | 'structure' | 'transform';
 
 interface MutatorCase {
   readonly name: string;
@@ -69,36 +69,39 @@ const containerWithSizedChild = (): Container => {
 // without a row here is a review error; a row whose bump assertion fails is an
 // engine bug.
 const cases: readonly MutatorCase[] = [
-  // SceneNode transform family — content-dirty.
-  drawableCase('setPosition', 'content', n => n.setPosition(10, 20)),
+  // SceneNode transform family — transform-dirty ONLY (Slice 4b flip): an
+  // own-transform move stamps the transform channel, not content/structure, so
+  // an enclosing RetainedContainer patches the row instead of re-collecting.
+  drawableCase('setPosition', 'transform', n => n.setPosition(10, 20)),
   // A same-value assignment (cloning the current, default (0,0) position) is
   // correctly a no-op under the equality-guarded vector setter, so the clone
   // is mutated to a different value first to exercise a real change.
-  drawableCase('position setter', 'content', n => {
+  drawableCase('position setter', 'transform', n => {
     const next = n.position.clone();
 
     next.set(next.x + 10, next.y + 20);
     n.position = next;
   }),
-  drawableCase('x setter', 'content', n => (n.x = 5)),
-  drawableCase('y setter', 'content', n => (n.y = 5)),
-  drawableCase('setRotation', 'content', n => n.setRotation(45)),
-  drawableCase('rotation setter', 'content', n => (n.rotation = 45)),
-  drawableCase('setScale', 'content', n => n.setScale(2, 2)),
-  drawableCase('setOrigin', 'content', n => n.setOrigin(4, 4)),
+  drawableCase('x setter', 'transform', n => (n.x = 5)),
+  drawableCase('y setter', 'transform', n => (n.y = 5)),
+  drawableCase('setRotation', 'transform', n => n.setRotation(45)),
+  drawableCase('rotation setter', 'transform', n => (n.rotation = 45)),
+  drawableCase('setScale', 'transform', n => n.setScale(2, 2)),
+  drawableCase('setOrigin', 'transform', n => n.setOrigin(4, 4)),
   // setAnchor derives origin from local bounds (origin = boundsSize *
   // anchor), so it is a no-op against the default zero-size Drawable bounds.
   drawableCase(
     'setAnchor',
-    'content',
+    'transform',
     n => n.setAnchor(0.5, 0.5),
     () => withLocalBounds(new Drawable()),
   ),
-  drawableCase('setSkew', 'content', n => n.setSkew(10, 0)),
-  drawableCase('skewX setter', 'content', n => (n.skewX = 10)),
-  drawableCase('skewY setter', 'content', n => (n.skewY = 10)),
-  drawableCase('move', 'content', n => n.move(1, 1)),
-  drawableCase('rotate', 'content', n => n.rotate(5)),
+  drawableCase('setSkew', 'transform', n => n.setSkew(10, 0)),
+  drawableCase('skewX setter', 'transform', n => (n.skewX = 10)),
+  drawableCase('skewY setter', 'transform', n => (n.skewY = 10)),
+  drawableCase('move', 'transform', n => n.move(1, 1)),
+  drawableCase('rotate', 'transform', n => n.rotate(5)),
+  // zIndex is draw-order, not a spatial transform: still content-dirty.
   drawableCase('zIndex setter', 'content', n => (n.zIndex = 3)),
   // SceneNode cull family — structure-dirty (same class as `visible`: changes
   // WHICH draws a collect emits). These are two of the five audit gaps.
@@ -128,8 +131,10 @@ const cases: readonly MutatorCase[] = [
   // not inside `mutate`, or the structure-dirty assertion below would be
   // polluted by the addChild call rather than reflecting the width/height
   // setter alone.
-  containerCase('width setter', 'content', n => (n.width = 128), containerWithSizedChild),
-  containerCase('height setter', 'content', n => (n.height = 128), containerWithSizedChild),
+  // width/height set the container's SCALE to hit a target extent — a spatial
+  // transform, so transform-dirty after the Slice-4b flip (not content).
+  containerCase('width setter', 'transform', n => (n.width = 128), containerWithSizedChild),
+  containerCase('height setter', 'transform', n => (n.height = 128), containerWithSizedChild),
 ];
 
 // SUBCLASS mutator table (C1, expert review 2026-07-11). The base table above
@@ -198,13 +203,30 @@ describe('revision invariants: every public visual mutator bumps the right revis
 
       const nodeContentBefore = node._contentRevision;
       const nodeStructureBefore = node._structureRevision;
+      const nodeTransformBefore = node._transformRevision;
       const parentContentBefore = parent._contentRevision;
       const parentStructureBefore = parent._structureRevision;
+      const parentTransformBefore = parent._transformRevision;
 
       mutatorCase.mutate(node);
 
+      if (mutatorCase.expects === 'transform') {
+        // Slice 4b: an own-transform move travels the transform channel ONLY —
+        // it must NOT content- or structure-dirty (that decoupling is what lets
+        // a RetainedContainer patch the row instead of re-collecting).
+        expect(node._transformRevision).toBeGreaterThan(nodeTransformBefore);
+        expect(parent._transformRevision).toBeGreaterThan(parentTransformBefore);
+        expect(node._contentRevision).toBe(nodeContentBefore);
+        expect(parent._contentRevision).toBe(parentContentBefore);
+        expect(node._structureRevision).toBe(nodeStructureBefore);
+        expect(parent._structureRevision).toBe(parentStructureBefore);
+        parent.destroy();
+
+        return;
+      }
+
       // Structure implies content (NodeRevision.touchStructure), so content
-      // must advance for BOTH kinds.
+      // must advance for BOTH content and structure kinds.
       expect(node._contentRevision).toBeGreaterThan(nodeContentBefore);
       expect(parent._contentRevision).toBeGreaterThan(parentContentBefore);
 
@@ -298,7 +320,27 @@ describe('revision invariants: RetainedContainer reroutes its OWN transform muta
     group.destroy();
   });
 
-  test("a mutation INSIDE the subtree still content-dirties the group (decoupling is scoped to the group's own transform)", () => {
+  test('a transform-only mutation INSIDE the subtree transform-dirties the group but NOT its content (Slice 4b flip)', () => {
+    const group = new RetainedContainer();
+    const leaf = new Drawable();
+
+    group.addChild(leaf);
+
+    const contentBefore = group._contentRevision;
+    const transformBefore = group._transformRevision;
+
+    leaf.setPosition(3, 3);
+
+    // The decoupling is the whole point of 4b: the group keeps its recorded
+    // fragment (content unchanged) and learns of the move via the transform
+    // channel, which it consumes to patch the row.
+    expect(group._contentRevision).toBe(contentBefore);
+    expect(group._transformRevision).toBeGreaterThan(transformBefore);
+
+    group.destroy();
+  });
+
+  test('a genuine content mutation INSIDE the subtree still content-dirties the group', () => {
     const group = new RetainedContainer();
     const leaf = new Drawable();
 
@@ -306,7 +348,7 @@ describe('revision invariants: RetainedContainer reroutes its OWN transform muta
 
     const before = group._contentRevision;
 
-    leaf.setPosition(3, 3);
+    leaf.setTint(new Color(1, 2, 3));
 
     expect(group._contentRevision).toBeGreaterThan(before);
 
@@ -330,14 +372,13 @@ describe('revision invariants: RetainedContainer reroutes its OWN transform muta
   });
 });
 
-// Slice 4a: the transform-revision channel. Own-transform mutations bump a
-// dedicated `_transformRevision` (propagated to ancestors like content) IN
-// ADDITION to today's content bump — the split is purely additive here, so
-// behaviour is unchanged (fragments still invalidate on a descendant move via
-// the content bump). Slice 4b consumes this channel to patch transform rows
-// and drops the content co-bump. Representative transform mutators only; the
-// full mutator surface is guarded by the content/structure table above.
-describe('revision invariants: transform-revision channel (Slice 4a)', () => {
+// The transform-revision channel (Slice 4a groundwork, Slice 4b flip). An
+// own-transform mutation bumps a dedicated `_transformRevision` (propagated to
+// ancestors like content) and — since the 4b flip — NOT the content channel, so
+// a descendant move no longer invalidates a retained fragment; the group patches
+// the moved node's transform row in place instead. Representative transform
+// mutators only; the full mutator surface is guarded by the table above.
+describe('revision invariants: transform-revision channel (Slice 4a/4b)', () => {
   const transformMutators: ReadonlyArray<readonly [string, (n: Drawable) => void]> = [
     ['setPosition', n => n.setPosition(10, 20)],
     ['setRotation', n => n.setRotation(45)],
@@ -363,8 +404,9 @@ describe('revision invariants: transform-revision channel (Slice 4a)', () => {
 
       expect(node._transformRevision).toBeGreaterThan(nodeTransformBefore);
       expect(parent._transformRevision).toBeGreaterThan(parentTransformBefore);
-      // Behaviour-neutral in 4a: the content channel still bumps too.
-      expect(node._contentRevision).toBeGreaterThan(nodeContentBefore);
+      // Slice 4b: the content channel is now decoupled — a transform move does
+      // NOT bump content (that is what keeps a retained fragment valid).
+      expect(node._contentRevision).toBe(nodeContentBefore);
 
       parent.destroy();
     });

--- a/test/core/scene-node-revision-invariants.test.ts
+++ b/test/core/scene-node-revision-invariants.test.ts
@@ -329,3 +329,82 @@ describe('revision invariants: RetainedContainer reroutes its OWN transform muta
     root.destroy();
   });
 });
+
+// Slice 4a: the transform-revision channel. Own-transform mutations bump a
+// dedicated `_transformRevision` (propagated to ancestors like content) IN
+// ADDITION to today's content bump — the split is purely additive here, so
+// behaviour is unchanged (fragments still invalidate on a descendant move via
+// the content bump). Slice 4b consumes this channel to patch transform rows
+// and drops the content co-bump. Representative transform mutators only; the
+// full mutator surface is guarded by the content/structure table above.
+describe('revision invariants: transform-revision channel (Slice 4a)', () => {
+  const transformMutators: ReadonlyArray<readonly [string, (n: Drawable) => void]> = [
+    ['setPosition', n => n.setPosition(10, 20)],
+    ['setRotation', n => n.setRotation(45)],
+    ['setScale', n => n.setScale(2, 2)],
+    ['setSkew', n => n.setSkew(10, 0)],
+    ['setOrigin', n => n.setOrigin(4, 4)],
+    ['move', n => n.move(1, 1)],
+    ['rotate', n => n.rotate(5)],
+  ];
+
+  for (const [name, mutate] of transformMutators) {
+    test(`${name} bumps _transformRevision on the node and propagates to the parent`, () => {
+      const parent = new Container();
+      const node = new Drawable();
+
+      parent.addChild(node);
+
+      const nodeTransformBefore = node._transformRevision;
+      const parentTransformBefore = parent._transformRevision;
+      const nodeContentBefore = node._contentRevision;
+
+      mutate(node);
+
+      expect(node._transformRevision).toBeGreaterThan(nodeTransformBefore);
+      expect(parent._transformRevision).toBeGreaterThan(parentTransformBefore);
+      // Behaviour-neutral in 4a: the content channel still bumps too.
+      expect(node._contentRevision).toBeGreaterThan(nodeContentBefore);
+
+      parent.destroy();
+    });
+  }
+
+  test('a content-only mutation (setTint) does NOT bump _transformRevision', () => {
+    const parent = new Container();
+    const node = new Drawable();
+
+    parent.addChild(node);
+
+    const nodeTransformBefore = node._transformRevision;
+    const parentTransformBefore = parent._transformRevision;
+    const nodeContentBefore = node._contentRevision;
+
+    node.setTint(new Color(10, 20, 30));
+
+    expect(node._contentRevision).toBeGreaterThan(nodeContentBefore);
+    expect(node._transformRevision).toBe(nodeTransformBefore);
+    expect(parent._transformRevision).toBe(parentTransformBefore);
+
+    parent.destroy();
+  });
+
+  test('a transform mutation does not touch an unrelated sibling subtree', () => {
+    const root = new Container();
+    const parent = new Container();
+    const sibling = new Container();
+    const node = new Drawable();
+
+    root.addChild(parent);
+    root.addChild(sibling);
+    parent.addChild(node);
+
+    const siblingTransformBefore = sibling._transformRevision;
+
+    node.setPosition(7, 7);
+
+    expect(sibling._transformRevision).toBe(siblingTransformBefore);
+
+    root.destroy();
+  });
+});

--- a/test/core/scene-node-revision.test.ts
+++ b/test/core/scene-node-revision.test.ts
@@ -41,7 +41,7 @@ describe('NodeRevision', () => {
 });
 
 describe('SceneNode content/structure revision propagation', () => {
-  test('setPosition bumps content revision on the node and every ancestor up to root', () => {
+  test('setPosition bumps the TRANSFORM revision on the node and every ancestor up to root, NOT content (Slice 4b)', () => {
     const root = new Container();
     const mid = new Container();
     const leaf = new Drawable();
@@ -49,17 +49,21 @@ describe('SceneNode content/structure revision propagation', () => {
     root.addChild(mid);
     mid.addChild(leaf);
 
-    const rootBefore = root._contentRevision;
-    const midBefore = mid._contentRevision;
+    const rootContentBefore = root._contentRevision;
+    const midContentBefore = mid._contentRevision;
+    const rootTransformBefore = root._transformRevision;
+    const midTransformBefore = mid._transformRevision;
     const rootStructureBefore = root._structureRevision;
 
     leaf.setPosition(10, 20);
 
-    expect(leaf._contentRevision).toBeGreaterThan(0);
-    expect(mid._contentRevision).toBeGreaterThan(midBefore);
-    expect(root._contentRevision).toBeGreaterThan(rootBefore);
-    // A pure content change must never advance structure (the addChild calls
-    // above already stamped structure once each — setPosition must not add another).
+    // The flip: a transform move travels the transform channel to the root so a
+    // RetainedContainer ancestor can patch the row, and does NOT content-dirty.
+    expect(leaf._transformRevision).toBeGreaterThan(0);
+    expect(mid._transformRevision).toBeGreaterThan(midTransformBefore);
+    expect(root._transformRevision).toBeGreaterThan(rootTransformBefore);
+    expect(mid._contentRevision).toBe(midContentBefore);
+    expect(root._contentRevision).toBe(rootContentBefore);
     expect(root._structureRevision).toBe(rootStructureBefore);
 
     leaf.destroy();

--- a/test/core/scene-node-transform-group.test.ts
+++ b/test/core/scene-node-transform-group.test.ts
@@ -115,18 +115,25 @@ describe('own-transform dirty seam (_markOwnTransformDirty)', () => {
     node.destroy();
   });
 
-  test("the default seam keeps today's behavior: setPosition is content-dirty and bounds-cascading", () => {
+  test('the default seam (Slice 4b): setPosition is transform-dirty and bounds-cascading, NOT content-dirty', () => {
     const parent = new Container();
     const node = new Drawable();
 
+    node.getLocalBounds().set(0, 0, 16, 16);
     parent.addChild(node);
     parent.getBounds(); // settle bounds flags
 
-    const before = node._contentRevision;
+    const contentBefore = node._contentRevision;
+    const transformBefore = node._transformRevision;
 
     node.setPosition(10, 10);
 
-    expect(node._contentRevision).toBeGreaterThan(before);
+    // The flip: a transform move no longer content-dirties (so a retained
+    // fragment stays valid), but it does stamp the transform channel and
+    // cascade the bounds flag — the parent's world bounds pick up the move.
+    expect(node._contentRevision).toBe(contentBefore);
+    expect(node._transformRevision).toBeGreaterThan(transformBefore);
+    expect(node.getBounds().x).toBe(10); // world bounds recomputed after the move
 
     parent.destroy();
   });

--- a/test/perf/rendering/retained-instruction-webgl2.test.ts
+++ b/test/perf/rendering/retained-instruction-webgl2.test.ts
@@ -206,7 +206,11 @@ describe('WebGL2 retained instruction set: record + splice ladder (Tasks 6/7)', 
       const beginSpy = vi.spyOn(harness.backend, '_beginRetainedCapture');
       const replaySpy = vi.spyOn(harness.backend, '_replayRetainedBatch');
 
-      // Mutation: the dirty frame is a plain collect — no replay, no capture.
+      // Content mutation (Slice 4b: a bare move would be row-patched instead —
+      // exercised by the fast-patch gate below): content-dirty wins, so the
+      // dirty frame is a plain collect — no replay, no capture. The move rides
+      // along so the re-recorded row still carries fresh position data.
+      inside[1]!.invalidateContent();
       inside[1]!.setPosition(80, 80);
 
       const dirty = measureFrame(harness, root);
@@ -399,6 +403,111 @@ describe('WebGL2 retained instruction set: record + splice ladder (Tasks 6/7)', 
       expect(set.isValidFor(backend)).toBe(false);
 
       snapped.destroy();
+    });
+  });
+});
+
+describe('WebGL2 retained instruction set: Slice 4b fast transform-row patch', () => {
+  it('a transform-only direct-child move patches the row in place: replay continues, NO re-record, only the moved row uploads', () => {
+    withHarness(harness => {
+      const { root, group, inside } = buildScene();
+
+      measureFrame(harness, root); // F1 capture
+      measureFrame(harness, root); // F2 record
+      measureFrame(harness, root); // F3 splice
+
+      const beginSpy = vi.spyOn(harness.backend, '_beginRetainedCapture');
+      const replaySpy = vi.spyOn(harness.backend, '_replayRetainedBatch');
+
+      // A pure transform move: content/structure stay clean (the flip), so the
+      // group keeps its recording and patches just this child's row.
+      inside[1]!.setPosition(80, 80);
+
+      const patched = measureFrame(harness, root);
+
+      expect(beginSpy).not.toHaveBeenCalled(); // NO re-record: the recording survives
+      expect(replaySpy).toHaveBeenCalledTimes(1); // still splicing the instruction set
+      expect(patched.instances).toBe(4);
+      expect(patched.uploadedBufferBytes).toBe(32); // only the live outside sprite — group instance bytes untouched
+      expect(patched.transformUploads).toBeGreaterThan(0); // the moved row uploaded
+
+      // The patched group-local row (inside[1] -> local row 1) carries the new
+      // position; its neighbours are untouched (O(k) sub-range, not a re-pack).
+      const rows = bundleOf(group).transformTexture!.buffer;
+
+      expect([rows[1 * 12 + 4], rows[1 * 12 + 5]]).toEqual([80, 80]);
+      expect(rows[0 * 12 + 4]).toBe(10); // inside[0] unchanged
+      expect(rows[2 * 12 + 4]).toBe(110); // inside[2] unchanged
+
+      // And the fast tier keeps splicing on the next frame with no re-record.
+      const steady = measureFrame(harness, root);
+
+      expect(beginSpy).not.toHaveBeenCalled();
+      expect(replaySpy).toHaveBeenCalledTimes(2);
+      expect(steady.instances).toBe(4);
+
+      root.destroy();
+    });
+  });
+
+  it('after a transform-only child move, group.getBounds() reflects the new world AABB (4a bounds re-wiring)', () => {
+    withHarness(harness => {
+      const { root, group, inside } = buildScene();
+
+      measureFrame(harness, root); // F1
+      measureFrame(harness, root); // F2
+      measureFrame(harness, root); // F3
+
+      const before = group.getBounds();
+      const beforeMaxX = before.x + before.width;
+
+      // Move a child far to the +x/+y: the group's world AABB must grow to cover
+      // it even though the move never content-dirtied the fragment.
+      inside[2]!.setPosition(900, 900);
+      measureFrame(harness, root);
+
+      const after = group.getBounds();
+
+      expect(after.x + after.width).toBeGreaterThan(beforeMaxX);
+      // group at (200,200) + child local (900,900) -> world corner ~1100.
+      expect(after.x + after.width).toBeGreaterThanOrEqual(1100);
+
+      root.destroy();
+    });
+  });
+
+  it('an INELIGIBLE move (nested below a plain sub-container) drops off the fast tier and re-records — never a bare patch', () => {
+    withHarness(harness => {
+      const [textureA] = makeTextures(1);
+      const root = new Container();
+      const outside = new Sprite(textureA!);
+      const group = new RetainedContainer();
+      const inner = new Container();
+      const nested = new Sprite(textureA!);
+
+      outside.setPosition(600, 300);
+      root.addChild(outside);
+      nested.setPosition(10, 10);
+      inner.addChild(nested);
+      group.addChild(inner);
+      group.setPosition(200, 200);
+      root.addChild(group);
+
+      measureFrame(harness, root); // F1 capture
+      measureFrame(harness, root); // F2 record
+      measureFrame(harness, root); // F3 splice
+
+      const beginSpy = vi.spyOn(harness.backend, '_beginRetainedCapture');
+
+      // The nested sprite is NOT a direct child of the group, so its row is not
+      // in the direct-draw map: the fast patch bails and drops the recording,
+      // which entry-replays live transforms and re-records the same frame.
+      nested.setPosition(90, 90);
+      measureFrame(harness, root);
+
+      expect(beginSpy).toHaveBeenCalledTimes(1); // re-recorded, not bare-patched
+
+      root.destroy();
     });
   });
 });

--- a/test/rendering/browser/webgl2-retained-instruction-replay.test.ts
+++ b/test/rendering/browser/webgl2-retained-instruction-replay.test.ts
@@ -378,7 +378,7 @@ describe('WebGL2 renderer matrix: retained instruction-set replay cells', () => 
     }
   });
 
-  test('cell 4 — child mutation: fallback to full collect, recapture, then replay of the fresh recording', async () => {
+  test('cell 4 — transform-only child move: fast row-patch on a real GPU, no re-record, pixels track the move', async () => {
     const backend = await createBackend();
     const scene = buildScene();
 
@@ -390,28 +390,27 @@ describe('WebGL2 renderer matrix: retained instruction-set replay cells', () => 
       const beginSpy = vi.spyOn(backend, '_beginRetainedCapture');
       const replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
 
-      // Mutate a child INSIDE the group: the set must never be served stale.
+      // Slice 4b: a pure transform move on a direct child stays content-clean,
+      // so the group keeps its recording and patches just this child's row in
+      // place. The pixel readback is the stale-render guard on a real GPU.
       scene.redSprite.setPosition(32, 0); // world (40,24)-(56,40)
       render(backend, scene.root);
 
-      expect(replaySpy).not.toHaveBeenCalled(); // dirty frame = plain collect
-      expectPixelNear(readPixel(backend, 44, 28), [255, 0, 0, 255]);
+      expect(beginSpy).not.toHaveBeenCalled(); // NO re-record: the recording is patched in place
+      expect(replaySpy).toHaveBeenCalled(); // still splicing the instruction set
+      expectPixelNear(readPixel(backend, 44, 28), [255, 0, 0, 255]); // patched to the NEW spot
       expectPixelNear(readPixel(backend, 12, 28), [0, 0, 0, 255]); // old spot cleared
 
-      // Recovery: entry replay + re-record...
+      // The fast tier keeps splicing the patched row, byte-stable, no re-record.
+      const patchedFrame = readCanvas(backend);
+
       render(backend, scene.root);
 
-      expect(beginSpy).toHaveBeenCalledTimes(1);
-
-      const recordFrame = readCanvas(backend);
-
-      // ...then the fresh recording splices, byte-identical again.
-      render(backend, scene.root);
-
-      expect(replaySpy).toHaveBeenCalled();
-      expect(readCanvas(backend)).toEqual(recordFrame);
+      expect(beginSpy).not.toHaveBeenCalled();
+      expect(replaySpy).toHaveBeenCalledTimes(2);
+      expect(readCanvas(backend)).toEqual(patchedFrame);
       expectPixelNear(readPixel(backend, 44, 28), [255, 0, 0, 255]);
-      expectPixelNear(readPixel(backend, 28, 44), [0, 255, 0, 255]);
+      expectPixelNear(readPixel(backend, 28, 44), [0, 255, 0, 255]); // green sibling untouched
     } finally {
       scene.destroy();
       backend.destroy();

--- a/test/rendering/retained-container.test.ts
+++ b/test/rendering/retained-container.test.ts
@@ -24,6 +24,65 @@ class LeafDrawable extends Drawable {
   }
 }
 
+const fragmentOf = (group: RetainedContainer): RetainedGroupFragment => (group as unknown as { _fragment: RetainedGroupFragment })._fragment;
+
+describe('RetainedContainer: Slice 4b transform-row seam', () => {
+  test('a direct child move enqueues that node on the group fragment', () => {
+    const group = new RetainedContainer();
+    const child = new LeafDrawable('a');
+
+    group.addChild(child);
+    fragmentOf(group).clearDirtyTransformRows(); // drop the add-time churn
+
+    child.setPosition(40, 40);
+
+    expect([...fragmentOf(group).dirtyTransformRows]).toEqual([child]);
+
+    group.destroy();
+  });
+
+  test('a move nested below a plain sub-container still enqueues on the enclosing group', () => {
+    const group = new RetainedContainer();
+    const inner = new Container();
+    const child = new LeafDrawable('deep');
+
+    inner.addChild(child);
+    group.addChild(inner);
+    fragmentOf(group).clearDirtyTransformRows();
+
+    child.setPosition(5, 5);
+
+    expect(fragmentOf(group).dirtyTransformRows.has(child)).toBe(true);
+
+    group.destroy();
+  });
+
+  test("the group's OWN move does not enqueue a row (it is a one-matrix group move)", () => {
+    const group = new RetainedContainer();
+    const child = new LeafDrawable('a');
+
+    group.addChild(child);
+    fragmentOf(group).clearDirtyTransformRows();
+
+    group.setPosition(100, 100);
+
+    expect(fragmentOf(group).hasDirtyTransformRows()).toBe(false);
+
+    group.destroy();
+  });
+
+  test('moving a node outside any group is a no-op (no enclosing boundary)', () => {
+    const root = new Container();
+    const child = new LeafDrawable('free');
+
+    root.addChild(child);
+
+    expect(() => child.setPosition(3, 3)).not.toThrow();
+
+    root.destroy();
+  });
+});
+
 // File-local fake backend (repo convention keeps test harnesses file-local
 // rather than importing them across test files).
 const createTestBackend = (): RenderBackend => {
@@ -196,7 +255,7 @@ describe('RetainedContainer: revision decoupling (spec 4.3)', () => {
     root.destroy();
   });
 
-  test('mutations INSIDE the subtree still content-dirty the container (existing D7 propagation)', () => {
+  test('a CONTENT mutation INSIDE the subtree still content-dirties the container (D7 propagation)', () => {
     const group = new RetainedContainer();
     const leaf = new Drawable();
 
@@ -204,9 +263,28 @@ describe('RetainedContainer: revision decoupling (spec 4.3)', () => {
 
     const before = group._contentRevision;
 
-    leaf.setPosition(3, 3);
+    // Slice 4b: a transform move no longer content-dirties the group (it patches
+    // the row); a genuine content change (tint) still propagates content up.
+    leaf.setTint(new Color(9, 9, 9));
 
     expect(group._contentRevision).toBeGreaterThan(before);
+
+    group.destroy();
+  });
+
+  test('a transform-only mutation INSIDE the subtree does NOT content-dirty the container (Slice 4b flip)', () => {
+    const group = new RetainedContainer();
+    const leaf = new Drawable();
+
+    group.addChild(leaf);
+
+    const contentBefore = group._contentRevision;
+    const transformBefore = group._transformRevision;
+
+    leaf.setPosition(3, 3);
+
+    expect(group._contentRevision).toBe(contentBefore);
+    expect(group._transformRevision).toBeGreaterThan(transformBefore);
 
     group.destroy();
   });
@@ -487,7 +565,8 @@ describe('RetainedContainer: pooled fragment snapshot (Slice 3, F11a)', () => {
     gatherRecords(entriesBefore, recordsBefore);
     expect(recordsBefore.length).toBeGreaterThan(0);
 
-    leafA.setPosition(7, 7); // content-dirty -> recapture on next collect
+    leafA.setTint(new Color(7, 7, 7)); // content-dirty -> recapture on next collect
+    leafA.setPosition(7, 7); // the move rides along so the fresh bounds are observable
 
     const frame2 = collectDraws(root, backend); // frame 2: full collect + pooled recapture
 
@@ -619,7 +698,7 @@ describe('RetainedContainer: invalidation gates and view independence', () => {
     backend.destroy();
   });
 
-  test('a child mutation inside the group forces one full re-collect, then retains again', () => {
+  test('a CONTENT child mutation inside the group forces one full re-collect, then retains again', () => {
     const backend = createTestBackend();
     const root = new Container();
     const group = new RetainedContainer();
@@ -629,14 +708,17 @@ describe('RetainedContainer: invalidation gates and view independence', () => {
     root.addChild(group);
 
     collectDraws(root, backend);
-    leaf.setPosition(7, 7);
-
-    const draws = collectDraws(root, backend);
-
-    expect(draws[0]!.minX).toBe(7); // fresh bounds, not the stale capture
+    // Slice 4b: a transform move would be patched, not re-collected — use a
+    // genuine content change (tint) to force the invalidate -> re-collect rung.
+    leaf.setTint(new Color(200, 0, 0));
 
     const materialSpy = vi.spyOn(leaf, '_getOrComputeMaterialKey');
 
+    collectDraws(root, backend); // dirty frame: full re-collect recomputes the material key
+
+    expect(materialSpy).toHaveBeenCalled();
+
+    materialSpy.mockClear();
     collectDraws(root, backend);
 
     expect(materialSpy).not.toHaveBeenCalled(); // re-retained
@@ -922,7 +1004,9 @@ describe('RetainedContainer: capture suppression under thrash (Slice 3, F11b)', 
     root.addChild(group);
 
     for (let frame = 0; frame < 120; frame++) {
-      leaf.setPosition(frame, 0);
+      // Slice 4b: a move is patched, not invalidating — thrash the CONTENT
+      // channel (a per-frame distinct tint) to exercise the suppression path.
+      leaf.setTint(new Color((frame % 200) + 1, 0, 0));
       collectDraws(root, backend);
     }
 
@@ -947,6 +1031,9 @@ describe('RetainedContainer: capture suppression under thrash (Slice 3, F11b)', 
     root.addChild(group);
 
     for (let frame = 0; frame < 10; frame++) {
+      // Content thrash (tint) keeps every frame dirty; the move rides along so
+      // the fresh-data check can still assert the current position.
+      leaf.setTint(new Color((frame % 200) + 1, 0, 0));
       leaf.setPosition(frame, 0);
 
       const draws = collectDraws(root, backend);
@@ -971,6 +1058,7 @@ describe('RetainedContainer: capture suppression under thrash (Slice 3, F11b)', 
     root.addChild(group);
 
     for (let frame = 0; frame < 8; frame++) {
+      leaf.setTint(new Color((frame % 200) + 1, 0, 0)); // content thrash
       leaf.setPosition(frame, 0);
       collectDraws(root, backend); // thrash: suppression active from frame 3 on
     }
@@ -1016,10 +1104,10 @@ describe('RetainedContainer: capture suppression under thrash (Slice 3, F11b)', 
     // because the previous capture WAS replayed at least once.
     collectDraws(root, backend); // capture 1
     collectDraws(root, backend); // splice
-    leaf.setPosition(5, 5);
+    leaf.setTint(new Color(5, 5, 5)); // single content mutation between replays
     collectDraws(root, backend); // capture 2
     collectDraws(root, backend); // splice
-    leaf.setPosition(9, 9);
+    leaf.setTint(new Color(9, 9, 9));
     collectDraws(root, backend); // capture 3
 
     expect(captureSpy).toHaveBeenCalledTimes(3);
@@ -1051,7 +1139,7 @@ describe('RetainedContainer: dev diagnostic for pathological invalidation (S2-D1
     // 121 collects, each preceded by a child mutation -> every build after
     // the first is an invalidation of an existing capture.
     for (let frame = 0; frame <= 120; frame++) {
-      leaf.setPosition(frame, 0);
+      leaf.setTint(new Color((frame % 200) + 1, 0, 0)); // per-frame content invalidation
       collectDraws(root, backend);
     }
 
@@ -1062,7 +1150,7 @@ describe('RetainedContainer: dev diagnostic for pathological invalidation (S2-D1
 
     // Keep mutating far past the window: still exactly one warning.
     for (let frame = 0; frame < 130; frame++) {
-      leaf.setPosition(frame, 1);
+      leaf.setTint(new Color((frame % 200) + 1, 1, 0));
       collectDraws(root, backend);
     }
 
@@ -1085,7 +1173,7 @@ describe('RetainedContainer: dev diagnostic for pathological invalidation (S2-D1
 
     for (let frame = 0; frame < 300; frame++) {
       if (frame % 10 === 0) {
-        leaf.setPosition(frame, 0); // 10% invalidation rate
+        leaf.setTint(new Color((frame % 200) + 1, 0, 0)); // 10% content invalidation rate
       }
 
       collectDraws(root, backend);

--- a/test/rendering/retained-group-fragment.test.ts
+++ b/test/rendering/retained-group-fragment.test.ts
@@ -16,14 +16,14 @@ const fakeBackendB = {} as RenderBackend;
 
 // A scope entry as the builder's current scope would hold it — the fragment
 // deep-copies it into its own pooled records at capture (Slice 3, F11a).
-const makeScopeDrawEntry = (drawable: Drawable): DrawScopeEntry => ({
+const makeScopeDrawEntry = (drawable: Drawable, nodeIndex = 0): DrawScopeEntry => ({
   kind: RenderEntryKind.Draw,
   seq: 0,
   zIndex: 0,
   command: {
     kind: RenderEntryKind.Draw,
     drawable,
-    nodeIndex: 0,
+    nodeIndex,
     seq: 0,
     zIndex: 0,
     material,
@@ -70,6 +70,59 @@ describe('RetainedGroupFragment', () => {
     expect(fragment.isClean(5, 3, fakeBackendB)).toBe(false); // backend swapped
 
     drawable.destroy();
+  });
+
+  test('captures each top-level draw nodeIndex and looks it up by drawable (Slice 4b row map)', () => {
+    const fragment = new RetainedGroupFragment();
+    const spriteA = new Drawable();
+    const spriteB = new Drawable();
+
+    // Two direct drawable children on shared rows 3 and 5 (a sibling occupied
+    // the earlier rows — the group's rows never start at 0).
+    fragment.capture(1, 1, fakeBackendA, [makeScopeDrawEntry(spriteA, 3), makeScopeDrawEntry(spriteB, 5)]);
+
+    expect((fragment.entries[0] as { nodeIndex: number }).nodeIndex).toBe(3);
+    expect(fragment.directDrawNodeIndex(spriteA)).toBe(3);
+    expect(fragment.directDrawNodeIndex(spriteB)).toBe(5);
+    expect(fragment.directDrawNodeIndex(new Drawable())).toBeUndefined();
+
+    spriteA.destroy();
+    spriteB.destroy();
+  });
+
+  test('directDrawNodeIndex rebuilds after a recapture (fresh row assignment)', () => {
+    const fragment = new RetainedGroupFragment();
+    const sprite = new Drawable();
+
+    fragment.capture(1, 1, fakeBackendA, [makeScopeDrawEntry(sprite, 4)]);
+    expect(fragment.directDrawNodeIndex(sprite)).toBe(4);
+
+    fragment.capture(2, 1, fakeBackendA, [makeScopeDrawEntry(sprite, 9)]);
+    expect(fragment.directDrawNodeIndex(sprite)).toBe(9);
+
+    sprite.destroy();
+  });
+
+  test('dirty-transform-row queue dedups moved nodes and clears (Slice 4b)', () => {
+    const fragment = new RetainedGroupFragment();
+    const a = new Drawable();
+    const b = new Drawable();
+
+    expect(fragment.hasDirtyTransformRows()).toBe(false);
+
+    fragment.enqueueDirtyTransformRow(a);
+    fragment.enqueueDirtyTransformRow(a); // same node twice — deduped
+    fragment.enqueueDirtyTransformRow(b);
+
+    expect(fragment.hasDirtyTransformRows()).toBe(true);
+    expect([...fragment.dirtyTransformRows]).toEqual([a, b]);
+
+    fragment.clearDirtyTransformRows();
+
+    expect(fragment.hasDirtyTransformRows()).toBe(false);
+
+    a.destroy();
+    b.destroy();
   });
 
   test('invalidate() clears the capture', () => {

--- a/test/rendering/retained-instruction-equivalence.test.ts
+++ b/test/rendering/retained-instruction-equivalence.test.ts
@@ -600,9 +600,11 @@ describe('S3-D10 equivalence: instruction replay reproduces the slow-path batch 
     // Ladder to the fully-spliced state (see the collect-switch suite):
     // inner records first while outer thrashes, then outer records with the
     // inner batch verbatim.
-    dynamic.setPosition(1, 2);
+    // Slice 4b: a move on the direct child would be row-patched (outer stays
+    // clean), breaking the thrash cadence — content-dirty the outer instead.
+    dynamic.invalidateContent();
     playFrame(root, backend); // inner records
-    dynamic.setPosition(1, 3);
+    dynamic.invalidateContent();
     playFrame(root, backend); // inner splices, outer suppressed
 
     // F4: outer recovery capture — a genuine slow collect for d's FINAL

--- a/test/rendering/retained-instruction-set.test.ts
+++ b/test/rendering/retained-instruction-set.test.ts
@@ -911,7 +911,9 @@ describe('collect switch: fallback ladder end-to-end (Task 5)', () => {
 
     playFrame(root, backend); // F3: splice
 
-    leaf.setPosition(9, 9);
+    // Slice 4b: a transform move would be row-patched (set stays valid); a
+    // genuine content change is what invalidates the recording + fragment.
+    leaf.invalidateContent();
 
     // F4: dirty -> full collect; the stale recording is gone, nothing replays.
     events.length = 0;
@@ -1007,9 +1009,10 @@ describe('collect switch: fallback ladder end-to-end (Task 5)', () => {
     // F1: everything dirty -> captures, no arming.
     playFrame(root, backend);
 
-    // F2: outer dirty (mutated direct child), inner clean -> inner arms and
-    // records its own set during the outer's full collect.
-    dynamic.setPosition(1, 0);
+    // F2: outer dirty (mutated direct child, content-dirty — Slice 4b: a move
+    // would patch instead), inner clean -> inner arms and records its own set
+    // during the outer's full collect.
+    dynamic.invalidateContent();
     playFrame(root, backend);
 
     expect(innerFragment.instructions?.hasRecording).toBe(true);
@@ -1018,7 +1021,7 @@ describe('collect switch: fallback ladder end-to-end (Task 5)', () => {
 
     // F3: outer dirty again (thrash-suppressed), inner clean + valid set ->
     // inner SPLICES its instructions while the outer collects normally.
-    dynamic.setPosition(2, 0);
+    dynamic.invalidateContent();
     events.length = 0;
     playFrame(root, backend);
 
@@ -1075,9 +1078,9 @@ describe('collect switch: fallback ladder end-to-end (Task 5)', () => {
 
     // Same cadence as above up to the outer capture holding the spliced set.
     playFrame(root, backend); // F1
-    dynamic.setPosition(1, 0);
+    dynamic.invalidateContent(); // content-dirty keeps the OUTER dirty (Slice 4b: a move would patch)
     playFrame(root, backend); // F2: inner records
-    dynamic.setPosition(2, 0);
+    dynamic.invalidateContent();
     playFrame(root, backend); // F3: inner splices, outer suppressed
     playFrame(root, backend); // F4: outer recovery capture (inner record carries the set)
 

--- a/test/rendering/retained-plan-cache.test.ts
+++ b/test/rendering/retained-plan-cache.test.ts
@@ -39,34 +39,43 @@ const makeCommand = (drawable: Drawable, minX = 0): DrawCommand => ({
   maxY: 16,
 });
 
-const captureOne = (cache: RetainedPlanCache, drawable: Drawable, content: number, structure: number, view: number, backend: RenderBackend): void => {
+const captureOne = (
+  cache: RetainedPlanCache,
+  drawable: Drawable,
+  content: number,
+  structure: number,
+  transform: number,
+  view: number,
+  backend: RenderBackend,
+): void => {
   cache._beginCapture();
   cache._appendSlot(0, makeCommand(drawable));
-  cache._commitCapture(content, structure, view, backend);
+  cache._commitCapture(content, structure, transform, view, backend);
 };
 
 describe('RetainedPlanCache', () => {
   test('isClean is false before any capture', () => {
     const cache = new RetainedPlanCache();
 
-    expect(cache.isClean(1, 1, 1, fakeBackendA)).toBe(false);
+    expect(cache.isClean(1, 1, 1, 1, fakeBackendA)).toBe(false);
     expect(cache.slots).toEqual([]);
   });
 
-  test('isClean is true only when content, structure, view, and backend all match the last capture', () => {
+  test('isClean is true only when content, structure, transform, view, and backend all match the last capture', () => {
     const cache = new RetainedPlanCache();
     const drawable = new Drawable();
 
-    captureOne(cache, drawable, 5, 3, 7, fakeBackendA);
+    captureOne(cache, drawable, 5, 3, 2, 7, fakeBackendA);
 
-    expect(cache.isClean(5, 3, 7, fakeBackendA)).toBe(true);
+    expect(cache.isClean(5, 3, 2, 7, fakeBackendA)).toBe(true);
     expect(cache.slots).toHaveLength(1);
     expect(cache.slots[0]!.drawable).toBe(drawable);
 
-    expect(cache.isClean(6, 3, 7, fakeBackendA)).toBe(false); // content changed
-    expect(cache.isClean(5, 4, 7, fakeBackendA)).toBe(false); // structure changed
-    expect(cache.isClean(5, 3, 8, fakeBackendA)).toBe(false); // view moved
-    expect(cache.isClean(5, 3, 7, fakeBackendB)).toBe(false); // backend swapped
+    expect(cache.isClean(6, 3, 2, 7, fakeBackendA)).toBe(false); // content changed
+    expect(cache.isClean(5, 4, 2, 7, fakeBackendA)).toBe(false); // structure changed
+    expect(cache.isClean(5, 3, 9, 7, fakeBackendA)).toBe(false); // transform changed (Slice 4b)
+    expect(cache.isClean(5, 3, 2, 8, fakeBackendA)).toBe(false); // view moved
+    expect(cache.isClean(5, 3, 2, 7, fakeBackendB)).toBe(false); // backend swapped
 
     drawable.destroy();
   });
@@ -75,11 +84,11 @@ describe('RetainedPlanCache', () => {
     const cache = new RetainedPlanCache();
     const drawable = new Drawable();
 
-    captureOne(cache, drawable, 1, 1, 1, fakeBackendA);
+    captureOne(cache, drawable, 1, 1, 1, 1, fakeBackendA);
     cache._beginCapture();
     cache._appendSlot(0, makeCommand(drawable));
 
-    expect(cache.isClean(1, 1, 1, fakeBackendA)).toBe(false);
+    expect(cache.isClean(1, 1, 1, 1, fakeBackendA)).toBe(false);
 
     drawable.destroy();
   });
@@ -88,10 +97,10 @@ describe('RetainedPlanCache', () => {
     const cache = new RetainedPlanCache();
     const drawable = new Drawable();
 
-    captureOne(cache, drawable, 1, 1, 1, fakeBackendA);
+    captureOne(cache, drawable, 1, 1, 1, 1, fakeBackendA);
     cache.invalidate();
 
-    expect(cache.isClean(1, 1, 1, fakeBackendA)).toBe(false);
+    expect(cache.isClean(1, 1, 1, 1, fakeBackendA)).toBe(false);
     expect(cache.slots).toEqual([]);
 
     drawable.destroy();
@@ -101,7 +110,7 @@ describe('RetainedPlanCache', () => {
     const cache = new RetainedPlanCache();
     const drawable = new Drawable();
 
-    captureOne(cache, drawable, 1, 1, 1, fakeBackendA);
+    captureOne(cache, drawable, 1, 1, 1, 1, fakeBackendA);
 
     const slotBefore = cache.slots[0]!;
     const materialBefore = slotBefore.material;
@@ -110,7 +119,7 @@ describe('RetainedPlanCache', () => {
 
     cache._beginCapture();
     cache._appendSlot(3, makeCommand(drawable, 9));
-    cache._commitCapture(2, 1, 1, fakeBackendA);
+    cache._commitCapture(2, 1, 1, 1, fakeBackendA);
 
     expect(cache.slots[0]).toBe(slotBefore); // same pooled record...
     expect(cache.slots[0]!.material).toBe(materialBefore); // ...same pooled key object

--- a/test/rendering/webgl2-retained-group-resources.test.ts
+++ b/test/rendering/webgl2-retained-group-resources.test.ts
@@ -98,6 +98,72 @@ describe('WebGl2RetainedGroupResources: CPU-side capture store (Task 6)', () => 
   });
 });
 
+describe('WebGl2RetainedGroupResources: in-place transform-row patch (Slice 4b)', () => {
+  test('_storeTransformRows records the rebase base; patch overwrites one row and marks only its sub-range dirty', () => {
+    const bundle = new WebGl2RetainedGroupResources();
+    const shared = new Float32Array(8 * 12);
+
+    shared[2 * 12 + 4] = 10; // row 2 -> local 0: tx
+    shared[3 * 12 + 4] = 60; // row 3 -> local 1: tx
+
+    bundle._beginCapture();
+    bundle._storeTransformRows(shared, 2, 2);
+
+    // The rebase base (range.min) is retained so a later patch can map a
+    // shared/captured node index back to its group-local row.
+    expect(bundle.transformRowBase).toBe(2);
+
+    // Drain the store-time full-region dirty flag (the first bind consumes it).
+    bundle.transformTexture!._consumeDirtyRegion();
+
+    const patched = new Float32Array(12);
+
+    patched[4] = 80; // new tx for the moved child
+
+    bundle._patchTransformRow(1, patched);
+
+    // The CPU store reflects the new row without touching its neighbour.
+    expect(bundle.transformTexture!.buffer[1 * 12 + 4]).toBe(80);
+    expect(bundle.transformTexture!.buffer[0 * 12 + 4]).toBe(10);
+
+    // Only row 1 is marked for upload — the headline O(k) sub-range property.
+    const region = bundle.transformTexture!._consumeDirtyRegion();
+
+    expect(region).not.toBeNull();
+    expect({ x: region!.x, y: region!.y, width: region!.width, height: region!.height }).toEqual({ x: 0, y: 1, width: 3, height: 1 });
+  });
+
+  test('a patch does NOT bump the generation (recorded instance bytes stay valid)', () => {
+    const bundle = new WebGl2RetainedGroupResources();
+
+    bundle._beginCapture();
+    bundle._storeTransformRows(new Float32Array(4 * 12), 0, 4);
+
+    const generation = bundle.generation;
+
+    bundle._patchTransformRow(2, new Float32Array(12));
+
+    expect(bundle.generation).toBe(generation);
+  });
+
+  test('patching multiple rows unions their sub-range for a single upload', () => {
+    const bundle = new WebGl2RetainedGroupResources();
+
+    bundle._beginCapture();
+    bundle._storeTransformRows(new Float32Array(8 * 12), 0, 8);
+    bundle.transformTexture!._consumeDirtyRegion();
+
+    bundle._patchTransformRow(2, new Float32Array(12));
+    bundle._patchTransformRow(5, new Float32Array(12));
+
+    const region = bundle.transformTexture!._consumeDirtyRegion();
+
+    expect({ y: region!.y, height: region!.height }).toEqual({ y: 2, height: 4 }); // rows 2..5
+
+    bundle.destroy();
+  });
+});
+
 describe('WebGl2RetainedGroupResources: device resources (Task 6)', () => {
   const createDevice = () => {
     const recorder = new GlRecorder();


### PR DESCRIPTION
## Summary

Track B slice 4: a `RetainedContainer` under churn now costs **O(k-changed)** instead of **O(all-nodes)**. A transform-only descendant move patches just that child's group-owned transform row in place and keeps replaying the recorded instruction set, instead of invalidating the fragment and re-collecting the whole subtree.

Motivated by the bench finding (dynamic-heavy @100k, 7.5% churn: exojs ~117 ms vs Pixi ~9 ms) — exojs rebuilt the entire collect→optimize→pack→transform-upload pipeline over all nodes every frame, and the retained tier gave zero benefit under churn because a descendant move invalidated the fragment.

## Commits (3)

- **4a** (`cf3ea768`) — orthogonal `transform` revision channel in `NodeRevision` + `_transformRevision` getter + `_markTransformDirty` propagation (own walk-epoch), additive/behaviour-neutral.
- **4b part 1** (`38a45dda`) — re-point the content-revision consumers that reacted to a descendant move (`RetainedPlanCache` static-skip, `RetainedContainer` bounds aggregate) onto the transform channel.
- **4b part 2** (`db6d1773`) — the functional flip + fast row-patch (details below).

## The flip (4b part 2)

- `SceneNode._markOwnTransformDirty` drops the content co-bump (it lived inside `_invalidateBoundsCascade`) — a move now stamps only the transform channel + a flag-only bounds cascade, so a retained fragment stays valid. A seam walks to the nearest enclosing group and enqueues the moved node.
- `RetainedGroupFragment` gains a dirty-transform-row queue + a drawable→row map over the captured direct-child draws (`RetainedFragmentDraw.nodeIndex`).
- `RetainedContainer._collectContent` gains a rung above full re-collect: on a content/structure-clean frame with queued moves it patches the changed rows (`getGlobalTransform` composed to the boundary) and keeps splicing. **Ineligible** moves (nested below a sub-container, pixel-snapped, not a recorded direct draw) drop the recording so the frame entry-replays live transforms and re-records — correct, O(entries), never a stale patch.
- `WebGl2RetainedGroupResources._patchTransformRow` overwrites one group-local row and marks only its sub-range for upload, **without** bumping the generation (recorded instance bytes stay valid). Surfaced on the backend-agnostic `RetainedGroupBundle` contract.

**Key safety property:** entry replay re-reads transforms live, so the stale-render risk exists only on the recorded instruction tier — which makes the "drop the recording → entry replay" fallback always correct.

## Verification

- Full core + `rendering-perf` suite green.
- New acceptance gates on the real `WebGl2Backend` + recording GL: a transform-only move replays with **no re-record**, uploads only the moved row, the patched row carries the new position, neighbours untouched; `getBounds()` reflects the move; an ineligible move re-records.
- **Real-GPU pixel gate on Chromium WebGL2** (`webgl2-retained-instruction-replay` cell 4): the moved sprite tracks its new position, old spot cleared, sibling untouched, no re-record — the definitive stale-render guard.
- The revision-invariant table now classifies the transform family as transform-dirty (not content).

## Follow-ups (separate slices, not in this PR)

- **4c** — WebGPU parity (`queue.writeBuffer` the touched rows). The WebGPU bundle does not implement the patch contract yet, so a WebGPU group with a moved child cleanly falls back to entry replay (correct, O(entries)).
- **4d** — browser bench proving dynamic-heavy retained → O(k), targeting Pixi-adjacent.

Design: `.workspace/specs/v0.16-render-track-b/06-design-slice4-incremental-transform.md`