### PR TITLE
ci: make Codecov coverage upload non-fatal without a token (Dependabot PRs)

### DIFF
--- a/.github/workflows/_ci-checks.yml
+++ b/.github/workflows/_ci-checks.yml
@@ -224,9 +224,12 @@ jobs:
         with:
           files: ./coverage/lcov.info
           flags: unit
-          # Loud on purpose: the upload failed silently for months (empty token
-          # in the reusable workflow) and nobody noticed.
-          fail_ci_if_error: true
+          # Loud on purpose when a token is present (the upload failed silently
+          # for months and nobody noticed), but non-fatal when it is absent:
+          # Dependabot / fork PRs run without repository secrets, so a strict
+          # upload would fail Required CI on a green test run (only the codecov
+          # step fails: "Token required because branch is protected").
+          fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: Exoridus/ExoJS
 
@@ -300,7 +303,9 @@ jobs:
         with:
           files: ./coverage/lcov.info
           flags: browser
-          fail_ci_if_error: true
+          # Non-fatal without a token (Dependabot / fork PRs) — see the unit
+          # coverage upload above for the rationale.
+          fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to Codecov


### PR DESCRIPTION
## Problem

Dependabot PRs (e.g. #317) are blocked by Required CI even though every test passes. The failing step is the **Codecov coverage upload**, not the tests:

```
error -- Upload queued for processing failed: {"message":"Token required because branch is protected"}
==> Failed to run upload-coverage
##[error]Process completed with exit code 1.
```

Dependabot (and fork) PRs run without repository secrets by GitHub design, so `CODECOV_TOKEN` is empty. The two coverage uploads use `fail_ci_if_error: true`, so the empty-token upload failure fails the whole `Unit Tests` / `Browser Tests` job, which fails `Required CI`. `main` is unaffected (it has the token).

## Fix

Gate `fail_ci_if_error` on token presence for the two `codecov/codecov-action` coverage uploads:

```yaml
fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
```

- Token present (normal PRs, `main`): strict — the original "loud on real upload failures" intent is preserved.
- Token absent (Dependabot / fork PRs): non-fatal — a green test run no longer fails on a coverage-upload step it structurally cannot complete.

The `codecov/test-results-action` uploads were already `fail_ci_if_error: false`; only the two coverage uploads changed.

Unblocks #317 and future Dependabot bumps. Related: the earlier `secrets: inherit` root-cause work on the reusable workflow.