### PR TITLE
fix(render): two stale-render bugs in RetainedContainer transform-row patch (slice 4b)

### DIFF
--- a/src/rendering/RetainedContainer.ts
+++ b/src/rendering/RetainedContainer.ts
@@ -313,12 +313,27 @@ export class RetainedContainer extends Container {
     const bundle = set?.ownedBundle ?? null;
 
     if (set === null || !set.hasRecording || bundle === null || typeof bundle._patchTransformRow !== 'function' || bundle.transformRowBase === undefined) {
+      // The set holds a recording whose baked transform rows we cannot patch
+      // (a backend without row-patch support — e.g. WebGPU before slice 4c),
+      // yet a transform-only move must still take effect. Drop the recording so
+      // `_markCurrentScopeRetained` fails validation and the group falls to
+      // entry replay (live transforms) + re-record this frame. Without this the
+      // group keeps splicing the stale rows and the moved node renders frozen.
+      if (set?.hasRecording) {
+        set.invalidate();
+      }
+
       this._fragment.clearDirtyTransformRows();
 
       return;
     }
 
-    const base = bundle.transformRowBase;
+    // The group-local row origin is the fragment's CAPTURE-frame (F1) minimum
+    // draw index — NOT `bundle.transformRowBase` (the record-frame F2 rebase
+    // base). The two frames can start the group at different absolute rows, and
+    // the store rows are group-local, so only the F1 subtree base maps a
+    // captured index to its store row (see directDrawBaseNodeIndex).
+    const base = this._fragment.directDrawBaseNodeIndex();
 
     for (const node of this._fragment.dirtyTransformRows) {
       if (!this._patchTransformRow(node, bundle, base)) {

--- a/src/rendering/plan/RetainedGroupFragment.ts
+++ b/src/rendering/plan/RetainedGroupFragment.ts
@@ -128,6 +128,10 @@ export class RetainedGroupFragment {
   // records (the direct drawable children — the only fast-patch-eligible ones).
   // Built on first lookup after a capture, dropped on the next capture.
   private _directRowMap: Map<Drawable, number> | null = null;
+  // The smallest nodeIndex among the top-level draw records — the group's own
+  // shared-buffer base at CAPTURE (F1) time. Group-local row = nodeIndex minus
+  // this. Computed with the row map; -1 when there are no direct draws.
+  private _directRowMinIndex = -1;
 
   // Slice 4b: nodes whose OWN transform moved since the last collect, pushed by
   // the SceneNode seam through the enclosing group. A Set bounds it to the
@@ -146,19 +150,49 @@ export class RetainedGroupFragment {
    * each capture.
    */
   public directDrawNodeIndex(drawable: Drawable): number | undefined {
-    if (this._directRowMap === null) {
-      const map = new Map<Drawable, number>();
+    this._ensureDirectRowMap();
 
-      for (const entry of this._entries) {
-        if (entry.kind === RenderEntryKind.Draw) {
-          map.set(entry.drawable, entry.nodeIndex);
-        }
-      }
+    return this._directRowMap!.get(drawable);
+  }
 
-      this._directRowMap = map;
+  /**
+   * The group's own shared-transform-buffer base at CAPTURE (F1): the smallest
+   * nodeIndex among the top-level draw records. A patched node's group-local
+   * store row is `directDrawNodeIndex(node) - directDrawBaseNodeIndex()`.
+   *
+   * This is deliberately the CAPTURE-frame min, NOT the bundle's record-frame
+   * rebase base (`transformRowBase`): the two frames can start the group at
+   * different absolute rows (a sibling before the group changing its row count
+   * between capture and record), and the group-local position of each child is
+   * a property of the unchanged subtree — captured here — not of the absolute
+   * base. Using the record-frame base offsets every patch by the delta.
+   */
+  public directDrawBaseNodeIndex(): number {
+    this._ensureDirectRowMap();
+
+    return this._directRowMinIndex;
+  }
+
+  private _ensureDirectRowMap(): void {
+    if (this._directRowMap !== null) {
+      return;
     }
 
-    return this._directRowMap.get(drawable);
+    const map = new Map<Drawable, number>();
+    let min = -1;
+
+    for (const entry of this._entries) {
+      if (entry.kind === RenderEntryKind.Draw) {
+        map.set(entry.drawable, entry.nodeIndex);
+
+        if (min === -1 || entry.nodeIndex < min) {
+          min = entry.nodeIndex;
+        }
+      }
+    }
+
+    this._directRowMap = map;
+    this._directRowMinIndex = min;
   }
 
   /** Slice 4b: record that `node`'s own transform moved (from the SceneNode seam). */

--- a/test/perf/rendering/retained-instruction-webgl2.test.ts
+++ b/test/perf/rendering/retained-instruction-webgl2.test.ts
@@ -160,6 +160,45 @@ describe('WebGL2 retained instruction set: record + splice ladder (Tasks 6/7)', 
     });
   });
 
+  it('patches the correct store row when the group base shifts between capture and record (CRITICAL-2 regression)', () => {
+    withHarness(harness => {
+      const { root, outside, group, inside } = buildScene();
+
+      // F1 (capture): `outside` is visible and occupies shared row 0, so the
+      // group's children capture at rows 1,2,3 (groupBase = 1).
+      measureFrame(harness, root);
+
+      // Between capture and record, hide `outside`. This does NOT dirty the
+      // group (a sibling's structure change is off the group's subtree), so the
+      // group stays clean and records on F2 — but now its children start at row
+      // 0 (groupBase shifts 1 -> 0). The node->row map still holds the F1
+      // indices (1,2,3); the store is rebased to the F2 base (0). The patch must
+      // use the F1 subtree-local origin, not the F2 bundle base, or every
+      // patched row is off by the base delta.
+      outside.visible = false;
+
+      measureFrame(harness, root); // F2 record (shifted base)
+      measureFrame(harness, root); // F3 splice
+
+      const bundle = bundleOf(group);
+
+      // Sanity: with `outside` hidden the group owns exactly its 3 rows from 0.
+      expect(bundle.transformRowCount).toBe(3);
+
+      // Move the FIRST inside child; it must land in store row 0 (its group-
+      // local position), not row 1 (which the off-by-base bug would target).
+      measureFrame(harness, root, () => inside[0]!.setPosition(99, 99));
+
+      const rows = bundle.transformTexture!.buffer;
+
+      expect([rows[0 * 12 + 4], rows[0 * 12 + 5]]).toEqual([99, 99]); // moved child
+      expect([rows[1 * 12 + 4], rows[1 * 12 + 5]]).toEqual([60, 60]); // untouched
+      expect([rows[2 * 12 + 4], rows[2 * 12 + 5]]).toEqual([110, 110]); // untouched
+
+      root.destroy();
+    });
+  });
+
   it('camera pan and group move replay WITHOUT recapture (the Wave-4 win survives the fast tier)', () => {
     withHarness(harness => {
       const { root, group } = buildScene();

--- a/test/rendering/retained-instruction-set.test.ts
+++ b/test/rendering/retained-instruction-set.test.ts
@@ -940,6 +940,49 @@ describe('collect switch: fallback ladder end-to-end (Task 5)', () => {
     backend.destroy();
   });
 
+  test('a transform-only child move on a backend WITHOUT row-patch support drops the recording (no stale splice) — CRITICAL-1 regression', () => {
+    // The fake bundle has no `_patchTransformRow` — the WebGPU shape (4c not
+    // built). A recorded group's baked transform rows cannot be patched, so a
+    // transform-only descendant move MUST drop the recording and fall to entry
+    // replay (live transforms), never keep splicing the stale rows.
+    const { backend, events } = createRecordingBackend();
+    const root = new Container();
+    const group = new RetainedContainer();
+    const leaf = new RecordableLeaf('a');
+
+    group.addChild(leaf);
+    root.addChild(group);
+
+    const fragment = (group as unknown as FragmentCarrier)._fragment;
+
+    playFrame(root, backend); // F1: capture
+    playFrame(root, backend); // F2: record
+    playFrame(root, backend); // F3: splice
+
+    expect(fragment.instructions!.hasRecording).toBe(true);
+
+    leaf.setPosition(37, 41); // transform-only move; bundle cannot patch rows
+
+    // F4: the stale recording must be dropped -> entry replay draws the moved
+    // leaf LIVE (flush), re-records this frame; crucially NO stale splice.
+    events.length = 0;
+    playFrame(root, backend);
+
+    expect(events.some(e => e.startsWith('replay:'))).toBe(false); // no stale splice
+    expect(events).toContain('flush:a'); // drew the moved leaf live
+    expect(events.filter(e => e === 'beginCapture')).toHaveLength(1); // re-recorded
+
+    // F5: the fresh recording splices again — the moved leaf is now baked in.
+    events.length = 0;
+    playFrame(root, backend);
+
+    expect(events.some(e => e.startsWith('replay:'))).toBe(true);
+    expect(events).not.toContain('beginCapture');
+
+    root.destroy();
+    backend.destroy();
+  });
+
   test('a non-recordable fragment (unflagged renderer) never arms recording — Slice-2 entry replay forever', () => {
     const { backend, events } = createRecordingBackend();
     const root = new Container();


### PR DESCRIPTION
Adversarial re-review of the merged slice-4 patch path (#335, opus + sonnet + fable in parallel) surfaced **two independent stale/wrong-pixel bugs**, both silent (no crash, shipped suite green). Fixed TDD-first; each ships a regression test that reproduces the bug.

## CRITICAL 1 — WebGPU (and any non-patch backend): moved nodes render frozen
A transform-only descendant move on a **recorded** group kept splicing the stale baked rows — the moved node rendered frozen until an unrelated content/structure change dropped the fragment. `_reconcileTransformRows` drained the dirty queue but did **not** drop the recording when the bundle lacks `_patchTransformRow` (the WebGPU shape — 4c not on main). `_markCurrentScopeRetained` then still validated and replayed the stale set. The slice-4 commit promised "a backend without patch support falls back to entry replay" — the guard branch omitted the `set.invalidate()` that makes that true.

**Fix:** drop the recording in that guard → entry replay (live transforms) + re-record. Live on current main.

## CRITICAL 2 — WebGL2 (backend-agnostic): patch targets the wrong store row
When the group's absolute transform-buffer base shifts between the capture frame (F1) and the record frame (F2) — e.g. a sibling **before** the group toggling visibility / culling in-out without dirtying the group — the patch used `nodeIndex_F1 - transformRowBase_F2`, off by the base delta. Wrong row clobbered, or out-of-range silently dropped; error persists for the life of the recording.

**Fix:** the group-local row is a property of the unchanged subtree — subtract the fragment's own F1 minimum draw index (`directDrawBaseNodeIndex`), not the bundle's F2 rebase base. Lives in the shared `RetainedContainer`/fragment layer, so it fixes **both** backends; WebGPU (slice 4c) inherits the correct base automatically.

## Verification
- New regression test per bug (fake non-patch bundle for CRIT-1; base-shift scene for CRIT-2), each reproduces the bug before the fix.
- Full `exojs` node suite green (only the 2 pre-existing `production-stripping` build-artifact failures remain, unrelated).
- Typecheck + lint clean.

Non-critical quality findings from the same review (un-amortized notify walk, per-frame Set churn, duplicated row packing) are tracked separately for a follow-up cleanup, not in this PR.