### PR TITLE
perf(render): slice-4 transform-move seam cleanups (fable review follow-up)

### DIFF
--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -74,6 +74,34 @@ const orientedCorners = [new Vector(), new Vector(), new Vector(), new Vector()]
 let dirtyWalkEpoch = 1;
 
 /**
+ * Process-wide count of live transform-group boundaries ({@link RetainedContainer}).
+ * The Slice-4b transform-move seam ({@link SceneNode._notifyEnclosingRetainedGroup})
+ * walks to the nearest boundary on EVERY own-transform mutation; when no boundary
+ * exists anywhere (the common case — most scenes use no RetainedContainer) that
+ * walk would run to the root for nothing. Gating on this count makes the seam O(1)
+ * for boundary-free scenes. Maintained by RetainedContainer's construct/destroy via
+ * {@link registerTransformGroupBoundary}/{@link unregisterTransformGroupBoundary}.
+ *
+ * Invariant: this must never UNDER-count (a missed enqueue is a stale-render bug),
+ * so it counts from construction — a boundary that is constructed but never attached
+ * only makes the seam over-walk (correctness-safe), and a skipped destroy keeps the
+ * count high (also safe).
+ */
+let transformGroupBoundaryCount = 0;
+
+/** @internal — a transform-group boundary was created; arm the Slice-4b move seam. */
+export const registerTransformGroupBoundary = (): void => {
+  transformGroupBoundaryCount++;
+};
+
+/** @internal — a transform-group boundary was destroyed; disarm if it was the last. */
+export const unregisterTransformGroupBoundary = (): void => {
+  if (transformGroupBoundaryCount > 0) {
+    transformGroupBoundaryCount--;
+  }
+};
+
+/**
  * Sentinel `parentVersion` used by {@link SceneNode.getGlobalTransform} when
  * NOTHING above this node contributes to its world matrix — the node is a
  * root, or its parent is an engaged transform-group boundary the node does not
@@ -946,6 +974,16 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
   private _transformWalkEpoch = 0;
 
   /**
+   * @internal — Slice-4b dirty-transform-row dedup stamp: the enclosing group's
+   * dirty-row epoch at the last time this node was enqueued. Compared against
+   * that group's current epoch to skip a second push in the same collect cycle
+   * (see {@link RetainedGroupFragment.enqueueDirtyTransformRow}). The epoch is a
+   * globally unique monotonic value, so a stale stamp can never falsely match a
+   * different cycle — a false dedup would drop a move (stale render).
+   */
+  public _dirtyRowStamp = 0;
+
+  /**
    * @internal — mark this node's content dirty and propagate the stamp up to
    * the root. The walk deliberately runs THROUGH transform-group boundaries
    * (nested retained snapshots key on ancestor revisions — plan decision D7
@@ -1058,11 +1096,16 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
   /**
    * Walk to the nearest enclosing transform-group boundary and hand it this
    * node so it can fast-patch the row (Slice 4b). Stops at the FIRST boundary —
-   * that group owns this node's group-local transform row. Cheap: the walk ends
-   * at the group, not the root, and enqueue is a no-op for a non-retained
-   * boundary. Runs on every own-transform mutation, so it must not allocate.
+   * that group owns this node's group-local transform row. Runs on every
+   * own-transform mutation, so it must not allocate — and short-circuits when
+   * no boundary exists anywhere (the common case), turning the walk into a
+   * single count check for boundary-free scenes.
    */
   private _notifyEnclosingRetainedGroup(): void {
+    if (transformGroupBoundaryCount === 0) {
+      return;
+    }
+
     let ancestor: Container | null = this._parentNode;
 
     while (ancestor !== null) {

--- a/src/rendering/RetainedContainer.ts
+++ b/src/rendering/RetainedContainer.ts
@@ -1,6 +1,7 @@
 import { Bounds } from '#core/Bounds';
 import { logger } from '#core/logging';
 import { nextNodeRevision } from '#core/NodeRevision';
+import { registerTransformGroupBoundary, unregisterTransformGroupBoundary } from '#core/SceneNode';
 import type { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
 import { RetainedGroupFragment } from '#rendering/plan/RetainedGroupFragment';
 
@@ -8,14 +9,15 @@ import { Container } from './Container';
 import type { Drawable } from './Drawable';
 import type { RetainedGroupBundle } from './plan/RetainedInstructionSet';
 import type { RenderNode } from './RenderNode';
+import { packTransformRow, TRANSFORM_FLOATS_PER_ROW } from './TransformBuffer';
 
 /**
- * Reused scratch for one patched transform row (12 floats = 3 rgba32f texels,
- * the {@link TransformBuffer} layout: a,b,c,d, tx,ty,0,0, r,g,b,a). Filled and
- * consumed synchronously inside a single patch call, so one module-level buffer
- * is safe and allocation-free under churn.
+ * Reused scratch for one patched transform row (3 rgba32f texels, the
+ * {@link TransformBuffer} layout). Filled and consumed synchronously inside a
+ * single patch call, so one module-level buffer is safe and allocation-free
+ * under churn.
  */
-const patchRowScratch = new Float32Array(12);
+const patchRowScratch = new Float32Array(TRANSFORM_FLOATS_PER_ROW);
 
 /** Observation window for the S2-D1 retention diagnostic, in fragment builds (~frames). */
 const retainedDiagnosticWindow = 120;
@@ -74,6 +76,14 @@ export class RetainedContainer extends Container {
   private _devFragmentInvalidations = 0;
   private _devRetentionWarned = false;
   private _devDestroyedWarned = false;
+
+  public constructor() {
+    super();
+    // Arm the Slice-4b transform-move seam: while at least one boundary is live,
+    // own-transform mutations walk to their enclosing group (see SceneNode's
+    // transformGroupBoundaryCount). Balanced by destroy().
+    registerTransformGroupBoundary();
+  }
 
   /**
    * The boundary is ALWAYS engaged (F13/R3 superseded the whole-group
@@ -370,22 +380,7 @@ export class RetainedContainer extends Container {
       return false;
     }
 
-    const matrix = node.getGlobalTransform();
-    const tint = drawable.tint;
-
-    patchRowScratch[0] = matrix.a;
-    patchRowScratch[1] = matrix.b;
-    patchRowScratch[2] = matrix.c;
-    patchRowScratch[3] = matrix.d;
-    patchRowScratch[4] = matrix.x;
-    patchRowScratch[5] = matrix.y;
-    patchRowScratch[6] = 0;
-    patchRowScratch[7] = 0;
-    patchRowScratch[8] = tint.r / 255;
-    patchRowScratch[9] = tint.g / 255;
-    patchRowScratch[10] = tint.b / 255;
-    patchRowScratch[11] = tint.a;
-
+    packTransformRow(patchRowScratch, 0, node.getGlobalTransform(), drawable.tint);
     bundle._patchTransformRow!(nodeIndex - base, patchRowScratch);
 
     return true;
@@ -404,6 +399,12 @@ export class RetainedContainer extends Container {
    * and drops the fragment), or destroy the whole group at once.
    */
   public override destroy(): void {
+    // Balance the constructor's boundary registration exactly once (destroy may
+    // be called more than once; `destroyed` flips only on the first super call).
+    if (!this.destroyed) {
+      unregisterTransformGroupBoundary();
+    }
+
     // dispose(): invalidates AND releases the retained GPU bundle (Slice 3, S3-D3).
     this._fragment.dispose();
     this._groupAggregate.destroy();

--- a/src/rendering/TransformBuffer.ts
+++ b/src/rendering/TransformBuffer.ts
@@ -1,13 +1,43 @@
 import type { Color } from '#core/Color';
 import type { Matrix } from '#math/Matrix';
 
-const floatsPerSlot = 12;
+/**
+ * Floats per transform+tint row (3 rgba32f texels): the single source of truth
+ * for the layout shared by {@link TransformBuffer}, the retained group transform
+ * store, and the Slice-4b in-place row patch.
+ */
+export const TRANSFORM_FLOATS_PER_ROW = 12;
+
+const floatsPerSlot = TRANSFORM_FLOATS_PER_ROW;
 const initialCapacity = 16;
 const hashPrime = 0x01000193;
 const hashOffset = 0x811c9dc5;
 
 const hashFloatScratch = new Float32Array(1);
 const hashUintScratch = new Uint32Array(hashFloatScratch.buffer);
+
+/**
+ * Write one transform+tint row into `target` at `offset` in the canonical layout
+ * (a,b,c,d, tx,ty,0,0, r/255,g/255,b/255,a). The single packer shared by
+ * {@link TransformBuffer.write} and the Slice-4b row patch, so the frame buffer
+ * and a patched retained row stay bit-identical by construction — a layout change
+ * lands in exactly one place.
+ * @internal
+ */
+export const packTransformRow = (target: Float32Array, offset: number, transform: Matrix, tint: Color): void => {
+  target[offset + 0] = transform.a;
+  target[offset + 1] = transform.b;
+  target[offset + 2] = transform.c;
+  target[offset + 3] = transform.d;
+  target[offset + 4] = transform.x;
+  target[offset + 5] = transform.y;
+  target[offset + 6] = 0;
+  target[offset + 7] = 0;
+  target[offset + 8] = tint.r / 255;
+  target[offset + 9] = tint.g / 255;
+  target[offset + 10] = tint.b / 255;
+  target[offset + 11] = tint.a;
+};
 
 /** @internal */
 export interface TransformBufferFrameSnapshot {
@@ -179,20 +209,8 @@ export class TransformBuffer {
     this._ensureCapacity(slot + 1);
 
     const offset = slot * floatsPerSlot;
-    const data = this._data;
 
-    data[offset + 0] = transform.a;
-    data[offset + 1] = transform.b;
-    data[offset + 2] = transform.c;
-    data[offset + 3] = transform.d;
-    data[offset + 4] = transform.x;
-    data[offset + 5] = transform.y;
-    data[offset + 6] = 0;
-    data[offset + 7] = 0;
-    data[offset + 8] = tint.r / 255;
-    data[offset + 9] = tint.g / 255;
-    data[offset + 10] = tint.b / 255;
-    data[offset + 11] = tint.a;
+    packTransformRow(this._data, offset, transform, tint);
 
     if (slot >= this._count) {
       this._count = slot + 1;
@@ -209,6 +227,8 @@ export class TransformBuffer {
     }
 
     this._frameHash = this._mix(this._frameHash, slot);
+
+    const data = this._data;
 
     for (let i = 0; i < floatsPerSlot; i++) {
       // In-bounds: offset..offset+floatsPerSlot-1 is the just-written slot.

--- a/src/rendering/plan/RetainedGroupFragment.ts
+++ b/src/rendering/plan/RetainedGroupFragment.ts
@@ -72,6 +72,15 @@ export interface RetainedFragmentBarrier {
 export type RetainedFragmentEntry = RetainedFragmentDraw | RetainedFragmentGroup | RetainedFragmentBarrier;
 
 /**
+ * Process-wide monotonic epoch for the Slice-4b dirty-transform-row dedup
+ * (see {@link RetainedGroupFragment}). Each fragment reset claims a fresh value,
+ * so a node's dedup stamp from any earlier cycle — this fragment's or another's
+ * — can never equal a fragment's current epoch, making a false dedup (a dropped
+ * move → stale render) impossible.
+ */
+let nextDirtyRowEpoch = 1;
+
+/**
  * Whole-command-range fragment cache for one {@link RetainedContainer}
  * (Track B Slice 2, spec §4.2). Keyed on the subtree's aggregate
  * content/structure revision and the backend identity — deliberately NOT on
@@ -134,9 +143,13 @@ export class RetainedGroupFragment {
   private _directRowMinIndex = -1;
 
   // Slice 4b: nodes whose OWN transform moved since the last collect, pushed by
-  // the SceneNode seam through the enclosing group. A Set bounds it to the
-  // distinct moved nodes (O(children) worst case) and dedups repeated moves.
-  private readonly _dirtyTransformRows = new Set<RenderNode>();
+  // the SceneNode seam through the enclosing group. A plain array (not a Set):
+  // `length = 0` on reset retains capacity, so the add-k/reset-per-frame churn
+  // cycle allocates nothing in steady state (unlike Set.clear). Dedup is O(1)
+  // via a per-node epoch stamp keyed on `_dirtyRowEpoch` — a globally unique
+  // value bumped on every reset, so a stale stamp never falsely dedups.
+  private readonly _dirtyTransformRows: RenderNode[] = [];
+  private _dirtyRowEpoch = nextDirtyRowEpoch++;
 
   public get hasCapture(): boolean {
     return this._hasCapture;
@@ -197,22 +210,31 @@ export class RetainedGroupFragment {
 
   /** Slice 4b: record that `node`'s own transform moved (from the SceneNode seam). */
   public enqueueDirtyTransformRow(node: RenderNode): void {
-    this._dirtyTransformRows.add(node);
+    // O(1) dedup: skip a repeat push in the same cycle without scanning.
+    if (node._dirtyRowStamp === this._dirtyRowEpoch) {
+      return;
+    }
+
+    node._dirtyRowStamp = this._dirtyRowEpoch;
+    this._dirtyTransformRows.push(node);
   }
 
   /** `true` when at least one transform-only move is queued for this frame. */
   public hasDirtyTransformRows(): boolean {
-    return this._dirtyTransformRows.size > 0;
+    return this._dirtyTransformRows.length > 0;
   }
 
   /** The queued moved nodes (insertion order, deduped). */
-  public get dirtyTransformRows(): ReadonlySet<RenderNode> {
+  public get dirtyTransformRows(): readonly RenderNode[] {
     return this._dirtyTransformRows;
   }
 
   /** Drop the queue — after patching them, or after a full re-collect subsumed them. */
   public clearDirtyTransformRows(): void {
-    this._dirtyTransformRows.clear();
+    // length = 0 retains the backing store (no realloc next frame); a fresh
+    // epoch invalidates every prior dedup stamp in O(1).
+    this._dirtyTransformRows.length = 0;
+    this._dirtyRowEpoch = nextDirtyRowEpoch++;
   }
 
   /** The group's instruction set, or `null` if recording was never armed. */
@@ -330,7 +352,7 @@ export class RetainedGroupFragment {
     this._directRowMap = null;
     // A full (re)capture reads every child's current transform: any queued
     // transform-only moves are subsumed and must not double-patch afterwards.
-    this._dirtyTransformRows.clear();
+    this.clearDirtyTransformRows();
 
     this._snapshotInto(this._entries, entries);
 
@@ -351,7 +373,7 @@ export class RetainedGroupFragment {
     this._hasCapture = false;
     this._entries.length = 0;
     this._directRowMap = null;
-    this._dirtyTransformRows.clear();
+    this.clearDirtyTransformRows();
     this._replayedSinceCapture = false;
     this._suppressed = false;
     this._wastedCaptures = 0;

--- a/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
+++ b/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
@@ -3,12 +3,13 @@ import type { RetainedGroupBundle } from '#rendering/plan/RetainedInstructionSet
 import { DataTexture } from '#rendering/texture/DataTexture';
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { Texture } from '#rendering/texture/Texture';
+import { TRANSFORM_FLOATS_PER_ROW } from '#rendering/TransformBuffer';
 import { type BlendModes, BufferTypes, BufferUsage, RenderingPrimitives } from '#rendering/types';
 
 import { WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
 import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './WebGl2VertexArrayObject';
 
-const transformFloatsPerRow = 12;
+const transformFloatsPerRow = TRANSFORM_FLOATS_PER_ROW;
 const initialInstanceWordCapacity = 256;
 const initialTransformRowCapacity = 16;
 

--- a/test/rendering/retained-container.test.ts
+++ b/test/rendering/retained-container.test.ts
@@ -52,7 +52,7 @@ describe('RetainedContainer: Slice 4b transform-row seam', () => {
 
     child.setPosition(5, 5);
 
-    expect(fragmentOf(group).dirtyTransformRows.has(child)).toBe(true);
+    expect(fragmentOf(group).dirtyTransformRows.includes(child)).toBe(true);
 
     group.destroy();
   });
@@ -80,6 +80,27 @@ describe('RetainedContainer: Slice 4b transform-row seam', () => {
     expect(() => child.setPosition(3, 3)).not.toThrow();
 
     root.destroy();
+  });
+
+  test('the move seam re-arms across a group destroy (boundary-count balance)', () => {
+    // With no live boundary the seam short-circuits; a child under a group must
+    // still enqueue after another group elsewhere has been destroyed (the global
+    // count must balance construct/destroy exactly, never leaving it stuck at 0).
+    const throwaway = new RetainedContainer();
+
+    throwaway.destroy();
+
+    const group = new RetainedContainer();
+    const child = new LeafDrawable('a');
+
+    group.addChild(child);
+    fragmentOf(group).clearDirtyTransformRows();
+
+    child.setPosition(7, 7);
+
+    expect(fragmentOf(group).dirtyTransformRows.includes(child)).toBe(true);
+
+    group.destroy();
   });
 });
 


### PR DESCRIPTION
Non-critical perf/hygiene findings from the slice-4 re-review (fable lens). All behaviour-neutral — full `exojs` suite green (only the 2 pre-existing `production-stripping` build-artifact failures remain), typecheck + lint clean. Follows the two critical fixes in #337.

## F1 — notify-walk tax on every app
`SceneNode._notifyEnclosingRetainedGroup` runs on every own-transform mutation and, with no `RetainedContainer` anywhere (the common case), walked to the **root** for nothing — a global cost on the mutation hot path this slice was meant to make cheaper. Now gated on a process-wide count of live transform-group boundaries (maintained by `RetainedContainer` construct/destroy), making the seam a single count check for boundary-free scenes. The count only ever over-walks (correctness-safe); it never under-counts (a missed enqueue would be a stale-render bug).

## F2/F3 — per-frame allocation under churn
The dirty-row queue was a `Set` whose `clear()` swaps in a fresh backing store — re-allocating every frame under exactly the churn this tier targets. Replaced with a plain array reset via `length = 0` (retains capacity) plus O(1) dedup via a per-node epoch stamp keyed on a globally unique monotonic epoch, so a stale stamp can never falsely dedup (no dropped move). Removes the per-frame iterator allocation in the patch loop too.

## F5 — row-packing duplicated in 3 places
The 12-float transform+tint row layout was hand-packed in `TransformBuffer.write` and the patch path, with the width `12` encoded independently three more times. Extracted `packTransformRow` + `TRANSFORM_FLOATS_PER_ROW` from `TransformBuffer` as the single source of truth, used by both the frame buffer and the retained row patch — so they stay bit-identical by construction and a layout change lands in exactly one place.

## Not included
Nitpicks from the same review (side-effecting revision getters read twice, capability-contract co-travel, suppressed-frame queue drain) are tracked for a later pass.