### PR TITLE
feat(render): WebGPU in-place transform-row patch for RetainedContainer (Track B slice 4c)

### DIFF
--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -1415,6 +1415,10 @@ export class WebGpuBackend implements RenderBackend {
 
     device.queue.writeBuffer(bundle.transformBuffer!, 0, transformData.buffer, transformData.byteOffset + base * retainedTransformSlotBytes, transformBytes);
     this._accountant.recordBufferUpload(frame.totalBytes + transformBytes);
+
+    // Slice 4c: record the rebase base + row count so a later child move can
+    // patch its one row in place (O(k)) instead of dropping the recording.
+    bundle._recordTransformRowRange(device, base, rowCount);
   }
 
   /**

--- a/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
+++ b/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
@@ -117,6 +117,13 @@ export class WebGpuRetainedGroupBundle implements RetainedGroupBundle {
   private _instanceCapacity = 0;
   private _transformBuffer: GPUBuffer | null = null;
   private _transformCapacity = 0;
+  // Slice 4c in-place patch state: the shared-buffer row the stored rows were
+  // rebased from, how many rows the store currently holds (bounds guard), and
+  // the device whose queue the sub-range write goes through. All set at capture
+  // finalize; cleared on device loss so a late patch cannot touch a dead buffer.
+  private _transformRowBase = 0;
+  private _transformRowCount = 0;
+  private _patchDevice: GPUDevice | null = null;
   private _uniformBuffer: GPUBuffer | null = null;
   private _bindGroup: GPUBindGroup | null = null;
   private _bindGroupLayout: GPUBindGroupLayout | null = null;
@@ -153,6 +160,16 @@ export class WebGpuRetainedGroupBundle implements RetainedGroupBundle {
 
   public get transformBuffer(): GPUBuffer | null {
     return this._transformBuffer;
+  }
+
+  /**
+   * The shared frame-buffer row the stored transform rows were rebased from
+   * (Slice 4c, {@link RetainedGroupBundle.transformRowBase}). A group-local row
+   * is `capturedNodeIndex - transformRowBase`; the reconciler maps a moved
+   * node's captured index back to the group-owned storage without re-recording.
+   */
+  public get transformRowBase(): number {
+    return this._transformRowBase;
   }
 
   public get uniformBuffer(): GPUBuffer | null {
@@ -216,6 +233,45 @@ export class WebGpuRetainedGroupBundle implements RetainedGroupBundle {
   }
 
   /**
+   * Record the group-local transform range this capture just uploaded (Slice
+   * 4c): the shared-buffer rebase `base`, the `rowCount` now living in the
+   * storage buffer, and the `device` whose queue a later in-place patch writes
+   * through. Called by the backend right after it copies the rows into the
+   * group-owned storage buffer.
+   */
+  public _recordTransformRowRange(device: GPUDevice, base: number, rowCount: number): void {
+    this._patchDevice = device;
+    this._transformRowBase = base;
+    this._transformRowCount = rowCount;
+  }
+
+  /**
+   * Slice 4c fast patch: overwrite one group-local transform row in place with
+   * `floats` (12 = one `TransformSlot`, the {@link TransformBuffer} row layout)
+   * via a single `queue.writeBuffer` of that row's 48-byte sub-range. Mirrors
+   * {@link WebGl2RetainedGroupResources._patchTransformRow}: deliberately does
+   * NOT bump the generation — the recorded instance bytes reference this row by
+   * index and stay valid; only the transform behind the index moved.
+   *
+   * Out-of-range rows are ignored (a stale queue entry after a recapture shrank
+   * the store), as is any patch before a range is recorded or after device loss
+   * (`_transformBuffer`/`_patchDevice` null).
+   */
+  public _patchTransformRow(localRow: number, floats: Float32Array): void {
+    if (this._transformBuffer === null || this._patchDevice === null || localRow < 0 || localRow >= this._transformRowCount) {
+      return;
+    }
+
+    this._patchDevice.queue.writeBuffer(
+      this._transformBuffer,
+      localRow * retainedTransformSlotBytes,
+      floats.buffer,
+      floats.byteOffset,
+      retainedTransformSlotBytes,
+    );
+  }
+
+  /**
    * The bind group(0) pairing the group UBO with the group transform storage,
    * against the sprite renderer's existing uniform layout. Cached; rebuilt
    * when a buffer or the layout (device restore) changed identity.
@@ -256,6 +312,8 @@ export class WebGpuRetainedGroupBundle implements RetainedGroupBundle {
     this._uniformBuffer = null;
     this._instanceCapacity = 0;
     this._transformCapacity = 0;
+    this._transformRowCount = 0;
+    this._patchDevice = null;
     this._bindGroup = null;
     this._bindGroupLayout = null;
     this._generation++;

--- a/test/rendering/browser/webgpu-retained-container.test.ts
+++ b/test/rendering/browser/webgpu-retained-container.test.ts
@@ -501,4 +501,70 @@ describe('WebGPU renderer matrix: RetainedContainer cells', () => {
       backend.destroy();
     }
   });
+
+  // Slice 4c: once the recording is ARMED (needs a clean record frame + a
+  // replay frame first), a direct child move no longer drops the recording and
+  // re-records — it patches that one transform row in place via a single
+  // queue.writeBuffer sub-range. Cell 3 above moves the child before the
+  // recording exists (2 frames), so it records the moved position and never
+  // exercises the patch; this cell arms first, then moves. The node test
+  // (webgpu-retained-record-replay.test.ts) pins the O(k) write pattern against
+  // a mock device; here we prove the sub-range write renders correctly on a
+  // real adapter AND that the recording is kept (not re-recorded).
+  test('cell 9 — a child move AFTER the recording is armed patches the row in place, real GPU (Slice 4c)', async ctx => {
+    const backend = await setupBackend();
+    const texture = createSolidTexture('#ff0000', 16);
+    const root = new Container();
+    const group = new RetainedContainer();
+    const sprite = new Sprite(texture);
+
+    interface FragmentCarrier {
+      _fragment: { instructions: { hasRecording: boolean } | null };
+    }
+
+    const instructionsOf = (): { hasRecording: boolean } | null => (group as unknown as FragmentCarrier)._fragment.instructions;
+
+    try {
+      group.addChild(sprite);
+      root.addChild(group);
+
+      // Arm the fast tier: F1 capture → F2 record → F3 replay.
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderScene(ctx, backend, root))) {
+          return;
+        }
+      }
+
+      const armed = instructionsOf();
+
+      expect(armed?.hasRecording).toBe(true);
+
+      let readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(8, 8), [255, 0, 0, 255]);
+
+      // Move the direct child: this routes through the in-place patch.
+      sprite.setPosition(24, 24);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      // The recording is the SAME object and still armed — a fallback would
+      // have dropped it and re-recorded.
+      expect(instructionsOf()).toBe(armed);
+      expect(instructionsOf()?.hasRecording).toBe(true);
+
+      // The patched transform row is live on the real adapter: the sprite is at
+      // its new position, the old one is cleared.
+      readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(32, 32), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(8, 8), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
 });

--- a/test/rendering/webgpu-retained-record-replay.test.ts
+++ b/test/rendering/webgpu-retained-record-replay.test.ts
@@ -466,6 +466,73 @@ describe('WebGPU retained record/replay: fallback ladder + B-06 submit collapse'
     }
   });
 
+  test('a child move patches ONE transform row in place (O(k)) — no re-record, no generation bump (Slice 4c, WebGL2 parity)', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createBackend(environment);
+      const texture = createCanvasTexture();
+      const { root, groups } = buildGroupScene(texture, 1);
+      const group = groups[0]!;
+      const mover = group.children[0] as Sprite;
+
+      renderFrame(backend, root); // F1: capture
+      renderFrame(backend, root); // F2: record
+      renderFrame(backend, root); // F3: replay (bundle finalized, rows stored)
+
+      const recordedSet = fragmentOf(group).instructions;
+      const bundle = recordedSet?.ownedBundle as WebGpuRetainedGroupBundle;
+
+      expect(recordedSet?.hasRecording).toBe(true);
+      expect(bundle).toBeInstanceOf(WebGpuRetainedGroupBundle);
+      // The rebase base is now exposed (undefined before 4c → plan fell back).
+      expect(bundle.transformRowBase).toBeTypeOf('number');
+
+      const generation = bundle.generation;
+      const mark = environment.writes().length;
+      const drawsBefore = environment.draws().length;
+      const submitsBefore = environment.submitCount();
+
+      // Move a DIRECT CHILD (not the group). The recorded instance bytes still
+      // reference its row by index, so the fast path patches that one row in
+      // place instead of dropping the recording and re-recording (the pre-4c
+      // WebGPU behaviour: entry-replay + re-record).
+      mover.setPosition(4, 4);
+      renderFrame(backend, root);
+
+      // No re-record: the instance buffer is untouched.
+      expect(countLabel(environment.writes(), retainedInstanceLabel, mark)).toBe(0);
+      // The group matrix did not change, so its UBO is not rewritten either.
+      expect(countLabel(environment.writes(), retainedUniformLabel, mark)).toBe(0);
+
+      // Exactly one 48-byte transform sub-range write (a single TransformSlot),
+      // aligned to a slot boundary — the headline O(k) property vs. the O(rows)
+      // full-range re-upload of a recapture.
+      const patchWrites = environment
+        .writes()
+        .slice(mark)
+        .filter(write => write.label === retainedTransformLabel);
+
+      expect(patchWrites).toHaveLength(1);
+      expect(patchWrites[0]!.bytes.byteLength).toBe(48);
+      expect(patchWrites[0]!.bufferOffset % 48).toBe(0);
+      expect(patchWrites[0]!.bufferOffset).toBeLessThan(2 * 48);
+
+      // Recording stayed valid (no generation bump) and still replays in one submit.
+      expect(bundle.generation).toBe(generation);
+      expect(fragmentOf(group).instructions).toBe(recordedSet);
+      expect(fragmentOf(group).instructions?.hasRecording).toBe(true);
+      expect(environment.submitCount() - submitsBefore).toBe(1);
+      expect(environment.draws().slice(drawsBefore)).toEqual([{ instanceCount: 2 }]);
+
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
   test('grow-only bundle: a same-size recapture keeps the generation, growth bumps it, replay resumes after both', async () => {
     const environment = createMockWebGpuEnvironment();
 
@@ -487,10 +554,12 @@ describe('WebGPU retained record/replay: fallback ladder + B-06 submit collapse'
 
       renderFrame(backend, root); // F3: replay
 
-      // Same-shaped recapture (child move): buffers are reused in place.
+      // Child move: as of Slice 4c this fast-patches the row in place rather
+      // than recapturing — either way the bundle is reused and its generation
+      // stays put (a patch never bumps it, a same-size recapture reuses buffers).
       mover.setPosition(4, 4);
-      renderFrame(backend, root); // dirty collect
-      renderFrame(backend, root); // re-record into the SAME buffers
+      renderFrame(backend, root); // patch (reconcile) + replay
+      renderFrame(backend, root); // static replay
 
       expect(fragmentOf(group).instructions?.ownedBundle).toBe(bundle);
       expect((bundle as WebGpuRetainedGroupBundle).generation).toBe(initialGeneration);
@@ -636,9 +705,10 @@ describe('WebGpuRetainedGroupBundle: resource lifecycle', () => {
     }
   });
 
-  const createFakeDevice = (): { device: GPUDevice; created: string[]; destroyed: string[] } => {
+  const createFakeDevice = (): { device: GPUDevice; created: string[]; destroyed: string[]; writes: CapturedWrite[] } => {
     const created: string[] = [];
     const destroyed: string[] = [];
+    const writes: CapturedWrite[] = [];
     const device = {
       createBuffer: (descriptor: GPUBufferDescriptor): GPUBuffer => {
         created.push(descriptor.label ?? '');
@@ -651,9 +721,14 @@ describe('WebGpuRetainedGroupBundle: resource lifecycle', () => {
         } as unknown as GPUBuffer;
       },
       createBindGroup: () => ({}) as GPUBindGroup,
+      queue: {
+        writeBuffer: (buffer: LabeledBuffer, bufferOffset: number, data: ArrayBuffer | ArrayBufferView, dataOffset?: number, size?: number): void => {
+          writes.push({ label: buffer.label, bufferOffset, bytes: captureWriteBytes(data, dataOffset, size) });
+        },
+      },
     } as unknown as GPUDevice;
 
-    return { device, created, destroyed };
+    return { device, created, destroyed, writes };
   };
 
   test('device loss invalidates: buffers dropped without destroy, generation bumped, accounting freed', () => {
@@ -724,5 +799,83 @@ describe('WebGpuRetainedGroupBundle: resource lifecycle', () => {
 
     expect(created.length).toBe(createdAfterFirst + 1);
     expect(bundle.generation).toBe(generation + 1);
+  });
+
+  test('transformRowBase defaults to 0 before any capture is finalized (Slice 4c)', () => {
+    const stats = createRenderStats();
+    const accountant = new GpuResourceAccountant(stats);
+    const bundle = new WebGpuRetainedGroupBundle(accountant, () => {});
+
+    expect(bundle.transformRowBase).toBe(0);
+  });
+
+  test('patch writes one 48-byte slot at localRow*48 and does NOT bump the generation (Slice 4c)', () => {
+    const stats = createRenderStats();
+    const accountant = new GpuResourceAccountant(stats);
+    const bundle = new WebGpuRetainedGroupBundle(accountant, () => {});
+    const { device, writes } = createFakeDevice();
+
+    // Finalize a 3-row transform range rebased from shared row 5.
+    bundle.ensureCapacity(device, 256, 3 * 48);
+    bundle._recordTransformRowRange(device, 5, 3);
+
+    expect(bundle.transformRowBase).toBe(5);
+
+    const generation = bundle.generation;
+    const mark = writes.length;
+    const floats = new Float32Array(12);
+
+    floats[4] = 42; // tx
+
+    bundle._patchTransformRow!(1, floats);
+
+    const patchWrites = writes.slice(mark).filter(write => write.label === 'sprite:retained-transform-buffer');
+
+    expect(patchWrites).toHaveLength(1);
+    expect(patchWrites[0]!.bufferOffset).toBe(48); // localRow 1 * 48
+    expect(patchWrites[0]!.bytes.byteLength).toBe(48);
+    expect(new Float32Array(patchWrites[0]!.bytes.buffer)[4]).toBe(42);
+    // A patch keeps the recorded instance bytes valid: never bump.
+    expect(bundle.generation).toBe(generation);
+  });
+
+  test('patch ignores out-of-range rows and no-ops before a range is recorded (Slice 4c)', () => {
+    const stats = createRenderStats();
+    const accountant = new GpuResourceAccountant(stats);
+    const bundle = new WebGpuRetainedGroupBundle(accountant, () => {});
+    const { device, writes } = createFakeDevice();
+
+    // Before any range is recorded: row count is 0 → every patch is a no-op.
+    bundle._patchTransformRow!(0, new Float32Array(12));
+
+    expect(writes).toHaveLength(0);
+
+    bundle.ensureCapacity(device, 256, 2 * 48);
+    bundle._recordTransformRowRange(device, 0, 2);
+
+    const mark = writes.length;
+
+    bundle._patchTransformRow!(2, new Float32Array(12)); // == rowCount, out of range
+    bundle._patchTransformRow!(-1, new Float32Array(12));
+
+    expect(writes.slice(mark)).toHaveLength(0);
+  });
+
+  test('device loss clears the patch range so a stale patch cannot write a dead buffer (Slice 4c)', () => {
+    const stats = createRenderStats();
+    const accountant = new GpuResourceAccountant(stats);
+    const bundle = new WebGpuRetainedGroupBundle(accountant, () => {});
+    const { device, writes } = createFakeDevice();
+
+    bundle.ensureCapacity(device, 256, 2 * 48);
+    bundle._recordTransformRowRange(device, 0, 2);
+    bundle.invalidateDeviceState(false);
+
+    const mark = writes.length;
+
+    bundle._patchTransformRow!(0, new Float32Array(12));
+
+    expect(bundle.transformRowBase).toBe(0);
+    expect(writes.slice(mark)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Backend parity for the slice-4 transform-row fast patch: WebGPU now patches a moved RetainedContainer child's group-local transform row in place (`queue.writeBuffer` sub-range, no generation bump), matching the WebGL2 path shipped in #335. Closes the backend gap that made a transform-only move on a recorded WebGPU group re-collect every frame.

## What it adds
- `WebGpuRetainedGroupBundle`: `transformRowBase` getter + `_patchTransformRow(localRow, floats)` writing a single 48-byte sub-range into the group transform storage buffer via `queue.writeBuffer`, deliberately without bumping the generation (recorded instance bytes stay valid). `_recordTransformRowRange` sets base/rowCount/device at capture finalize; the range is cleared on device loss so a late patch cannot touch a dead buffer.
- `WebGpuBackend._finalizeRetainedCapture` records the row range after the transform `writeBuffer`.
- Plan layer unchanged — it was already backend-agnostic (`typeof _patchTransformRow === 'function' && transformRowBase !== undefined`).

## Interaction with the #337 critical fixes
The shared reconciler (`RetainedContainer`) now derives the group-local row from the fragment's own capture-frame base (`directDrawBaseNodeIndex`), not the bundle's record-frame `transformRowBase` — so the CRITICAL-2 base-shift fix applies to WebGPU automatically. WebGPU's store is rebased by the same F2 `range.min` as WebGL2, so the F1 subtree base maps identically. `transformRowBase` here is now only the capability signal the guard checks.

## Verification
- Node test (real backend, mock device) pins the `writeBuffer` pattern, bounds guard, no-generation-bump, and base — 14/14.
- Real SwiftShader headless WebGPU browser cell (armed recording → child move → pixel follows, recording object unchanged) — 9/9.
- Full `exojs` node suite green (only the 2 pre-existing `production-stripping` build-artifact failures remain). Typecheck + lint + format clean.