### PR TITLE
fix: close two review-fleet papercuts (#312 lint, #306 double-log)

### DIFF
--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -820,14 +820,22 @@ export class Application {
    * frame loop, and the backend already deduplicates them.
    */
   private _handleAsyncRenderError(error: RenderError): void {
-    this._reportError(error, false);
+    // The backend already logged this at its first occurrence (and dedupes
+    // repeats), so the shared pipeline must NOT log it a second time (#306).
+    this._reportError(error, false, true);
   }
 
-  /** Shared error-pipeline steps: log, ring buffer, `onError`, dev banner. */
-  private _reportError(error: Error, fatal: boolean): void {
+  /**
+   * Shared error-pipeline steps: log, ring buffer, `onError`, dev banner.
+   * `alreadyLogged` skips the console log for errors the backend logged at
+   * source (async render errors) so they are not double-logged (#306).
+   */
+  private _reportError(error: Error, fatal: boolean, alreadyLogged = false): void {
     const isRenderError = error instanceof RenderError;
 
-    logger.error(error.message, { source: isRenderError ? 'rendering' : 'core', error });
+    if (!alreadyLogged) {
+      logger.error(error.message, { source: isRenderError ? 'rendering' : 'core', error });
+    }
 
     this._recentErrors.push({
       time: Date.now(),

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -268,10 +268,7 @@ export class Container extends RenderNode {
 
     const viewUpdateId = builder.view.updateId;
 
-    if (
-      this._retainedPlan !== null &&
-      this._retainedPlan.isClean(this._contentRevision, this._structureRevision, this._transformRevision, viewUpdateId, builder.backend)
-    ) {
+    if (this._retainedPlan?.isClean(this._contentRevision, this._structureRevision, this._transformRevision, viewUpdateId, builder.backend)) {
       if (__DEV__ && this._retainedPlan._devHasDestroyedDrawable()) {
         // P3f: a direct drawable child was destroy()ed but left attached, so
         // no revision bumped and the slot cache still looks clean. Drop the
@@ -307,7 +304,7 @@ export class Container extends RenderNode {
     for (let index = 0; index < this._children.length; index++) {
       const slot = slots[slotIndex];
 
-      if (slot !== undefined && slot.childIndex === index) {
+      if (slot?.childIndex === index) {
         builder._replayRetainedDraw(slot);
         slotIndex++;
       } else {

--- a/test/core/application-frame-guard.test.ts
+++ b/test/core/application-frame-guard.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { Application, ApplicationStatus } from '#core/Application';
+import { logger } from '#core/logging';
 import { Time } from '#core/Time';
 
 const overlaySpies = vi.hoisted(() => ({
@@ -326,6 +327,21 @@ describe('Application frame guard', () => {
       handler(new Error('another'));
       handler(new Error('yet another'));
       expect(app.status).toBe(ApplicationStatus.Running);
+    });
+
+    test('does NOT log an async render error a second time — the backend already logged it at source (#306)', () => {
+      const handler = (app.backend.onRenderError.add as unknown as MockInstance).mock.calls[0]![0] as (error: Error) => void;
+      const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+
+      try {
+        handler(new Error('uncaptured validation error'));
+
+        // The pipeline still records + dispatches, but must not re-log.
+        expect(errorSpy).not.toHaveBeenCalled();
+        expect(app.recentErrors).toHaveLength(1);
+      } finally {
+        errorSpy.mockRestore();
+      }
     });
   });
 });


### PR DESCRIPTION
Two small, independent review-fleet papercuts.

## #312 — lint:strict red on main
`Container._collectContent` / `_replayRetainedChildren` had two `x !== null && x.prop` conditions that tripped `prefer-optional-chain`, making `lint:strict` (`--max-warnings=0`, a release gate) red on main. Rewritten as optional chains with identical semantics: `_retainedPlan?.isClean(...)` short-circuits to a falsy `undefined` when null (isClean returns boolean); `slot?.childIndex === index` matches a numeric loop index that is never undefined. `eslint --max-warnings=0 Container.ts` is now clean.

## #306 — async render errors logged twice
The backend logs an async render error at first occurrence (and dedupes repeats); `Application._reportError` then logged it again. Added an `alreadyLogged` flag so `_handleAsyncRenderError` skips the redundant console log while keeping the ring buffer, `onError` dispatch, and dev banner. Frame-guard errors (not backend-logged) still log. Regression test asserts single-log and was verified to fail without the fix.

Closes #312, closes #306. typecheck + lint clean; frame-guard suite green.