### PR TITLE
fix(rendering): Sprite from a not-yet-loaded texture no longer gets NaN scale (#309)

### DIFF
--- a/src/rendering/sprite/Sprite.ts
+++ b/src/rendering/sprite/Sprite.ts
@@ -115,7 +115,12 @@ export class Sprite extends Drawable {
   }
 
   public set width(value: number) {
-    this.scale.x = value / this._textureFrame.width;
+    // A not-yet-loaded texture has a 0-wide frame; dividing by it would poison
+    // scale with NaN (and, being NaN, never recover). Keep the current scale
+    // until real dimensions arrive — the load self-heal (#309) resets the frame.
+    if (this._textureFrame.width !== 0) {
+      this.scale.x = value / this._textureFrame.width;
+    }
   }
 
   public get height(): number {
@@ -123,7 +128,9 @@ export class Sprite extends Drawable {
   }
 
   public set height(value: number) {
-    this.scale.y = value / this._textureFrame.height;
+    if (this._textureFrame.height !== 0) {
+      this.scale.y = value / this._textureFrame.height;
+    }
   }
 
   /**
@@ -244,12 +251,41 @@ export class Sprite extends Drawable {
 
       if (texture !== null) {
         this.resetTextureFrame();
+        this._scheduleTextureLoadHeal(texture);
       }
 
       this.invalidateCache();
     }
 
     return this;
+  }
+
+  /**
+   * A deferred texture handle starts 0×0 until its payload loads, so the frame
+   * reset above snapped to a 0×0 frame. Re-reset once it becomes ready so the
+   * sprite picks up the real dimensions (#309). Guarded against a texture swap
+   * or destroy between now and the resolution, and against RenderTextures /
+   * already-ready textures (no `loaded` promise to wait on).
+   */
+  private _scheduleTextureLoadHeal(texture: Texture | RenderTexture): void {
+    if (!('ready' in texture) || texture.ready || !('loaded' in texture)) {
+      return;
+    }
+
+    void this._healOnTextureLoad(texture);
+  }
+
+  private async _healOnTextureLoad(texture: Texture): Promise<void> {
+    try {
+      await texture.loaded;
+    } catch {
+      return; // failed load shows Texture.missing; nothing to heal
+    }
+
+    // Guard against a texture swap or destroy between scheduling and resolution.
+    if (this._texture === texture && !this.destroyed) {
+      this.resetTextureFrame();
+    }
   }
 
   /** Signal the GPU backend that the underlying texture source has changed and reset the frame to full dimensions. */

--- a/test/rendering/sprite/sprite.test.ts
+++ b/test/rendering/sprite/sprite.test.ts
@@ -35,6 +35,62 @@ describe('Sprite', () => {
     });
   });
 
+  describe('not-yet-loaded texture (#309)', () => {
+    // A deferred texture handle (loader.get(...)) starts 0x0 until its payload
+    // arrives. Constructing a Sprite from one must not divide size by a zero
+    // frame and poison scale with NaN, and the sprite must pick up the real
+    // dimensions once the load resolves.
+    const makeDeferredTexture = () => {
+      let resolve!: () => void;
+      const loaded = new Promise<Texture>(res => {
+        resolve = () => res(texture);
+      });
+      const texture = {
+        width: 0,
+        height: 0,
+        flipY: false,
+        ready: false,
+        loaded,
+        updateSource: () => undefined,
+      } as unknown as Texture;
+
+      return {
+        texture,
+        finishLoad: (w: number, h: number) => {
+          (texture as unknown as { width: number; height: number; ready: boolean }).width = w;
+          (texture as unknown as { width: number; height: number; ready: boolean }).height = h;
+          (texture as unknown as { width: number; height: number; ready: boolean }).ready = true;
+          resolve();
+        },
+      };
+    };
+
+    test('constructing from a 0x0 texture keeps a finite (identity) scale — no NaN', () => {
+      const sprite = new Sprite(makeTexture(0, 0));
+
+      expect(Number.isNaN(sprite.scale.x)).toBe(false);
+      expect(Number.isNaN(sprite.scale.y)).toBe(false);
+      expect(sprite.scale.x).toBe(1);
+      expect(sprite.scale.y).toBe(1);
+    });
+
+    test('self-heals the frame + size when the deferred texture finishes loading', async () => {
+      const { texture, finishLoad } = makeDeferredTexture();
+      const sprite = new Sprite(texture);
+
+      expect(sprite.textureFrame.width).toBe(0);
+
+      finishLoad(40, 20);
+      await texture.loaded;
+      await Promise.resolve(); // flush the .then microtask
+
+      expect(sprite.textureFrame.width).toBe(40);
+      expect(sprite.textureFrame.height).toBe(20);
+      expect(Number.isNaN(sprite.scale.x)).toBe(false);
+      expect(sprite.width).toBe(40);
+    });
+  });
+
   describe('updateTexture', () => {
     test('is a no-op when no texture is assigned', () => {
       const sprite = new Sprite(null);


### PR DESCRIPTION
A deferred texture handle (`loader.get(...)`) starts 0×0 until its payload loads. Constructing a `Sprite` from one ran `resetTextureFrame` against a 0-wide frame, and the width/height setters did `value / frameWidth` = `0/0` = **NaN** — poisoning `scale` permanently (NaN never recovers, so every later size read stayed NaN and the sprite rendered nothing/garbage). It never self-healed when the texture finished loading.

## Fix (two parts)
- **No NaN**: the `width`/`height` setters skip the divide when the frame dimension is 0, keeping the current (identity) scale instead of producing NaN.
- **Self-heal on load**: `setTexture` schedules a re-`resetTextureFrame()` when the texture's `loaded` promise resolves, so the sprite picks up real dimensions once the payload arrives. Guarded against a texture swap/destroy between schedule and resolution, a failed load (shows `Texture.missing`), and skipped for already-ready textures / RenderTextures (nothing to await).

## Verification
TDD — both tests (no-NaN on a 0×0 construct; self-heal after load) were verified to fail without the fix. Sprite + animated-sprite suites green (294); typecheck + lint + format clean.

Closes #309.