### PR TITLE
chore(examples): re-sync derived example capabilities (#300)

### DIFF
--- a/examples/examples.json
+++ b/examples/examples.json
@@ -76,6 +76,7 @@
                 "pause"
             ],
             "capabilities": [
+                "pointer",
                 "keyboard"
             ],
             "level": "intro"
@@ -1404,9 +1405,6 @@
                 "animation",
                 "audio"
             ],
-            "capabilities": [
-                "audio"
-            ],
             "level": "intro"
         },
         {
@@ -1422,8 +1420,7 @@
                 "audio"
             ],
             "capabilities": [
-                "pointer",
-                "audio"
+                "pointer"
             ],
             "level": "intermediate"
         },
@@ -1469,6 +1466,7 @@
                 "scene"
             ],
             "capabilities": [
+                "pointer",
                 "keyboard"
             ],
             "level": "intermediate"
@@ -1732,7 +1730,10 @@
                 "sprite",
                 "rendering"
             ],
-            "level": "intermediate"
+            "level": "intermediate",
+            "capabilities": [
+                "audio"
+            ]
         },
         {
             "slug": "video-drawable",
@@ -1746,7 +1747,9 @@
                 "rendering"
             ],
             "capabilities": [
-                "pointer"
+                "pointer",
+                "keyboard",
+                "audio"
             ],
             "level": "advanced"
         }


### PR DESCRIPTION
`sync-example-capabilities.ts` derives each example's `capabilities` from its source (imported subpaths, audio API surface, input usage). The committed `examples.json` had drifted from what the script derives — so every unrelated sync run produced spurious diffs on ~6 entries (stale `audio`, missing `pointer`).

This regenerates the catalog to match the script's deterministic output. Verified idempotent: a second and third run over the regenerated tree produce a byte-identical file (no diff), so the sync is now a no-op until an example's source actually changes — closing the "re-running the sync reorders/changes unrelated entries" complaint.

Closes #300.