### PR TITLE
chore(extensions): drop obsolete erasure casts in aseprite/ldtk descriptors

### DIFF
--- a/packages/exojs-aseprite/src/asepriteExtension.ts
+++ b/packages/exojs-aseprite/src/asepriteExtension.ts
@@ -1,4 +1,4 @@
-import type { AssetBinding, Extension } from '@codexo/exojs/extensions';
+import type { Extension } from '@codexo/exojs/extensions';
 
 import { asepriteBinding } from './asepriteBinding';
 
@@ -15,7 +15,5 @@ import { asepriteBinding } from './asepriteBinding';
  */
 export const asepriteExtension: Extension = Object.freeze({
   id: '@codexo/exojs-aseprite',
-  // Localized erasure cast: typed binding (Options=undefined) meets the
-  // untyped Extension.assets contract here. Runtime behavior is unaffected.
-  assets: [asepriteBinding] as unknown as AssetBinding[],
+  assets: [asepriteBinding],
 });

--- a/packages/exojs-ldtk/src/ldtkExtension.ts
+++ b/packages/exojs-ldtk/src/ldtkExtension.ts
@@ -1,4 +1,4 @@
-import type { AssetBinding, Extension } from '@codexo/exojs/extensions';
+import type { Extension } from '@codexo/exojs/extensions';
 import { tilemapExtension } from '@codexo/exojs-tilemap';
 
 import { ldtkMapBinding } from './ldtkBinding';
@@ -21,7 +21,5 @@ import { ldtkMapBinding } from './ldtkBinding';
 export const ldtkExtension: Extension = Object.freeze({
   id: '@codexo/exojs-ldtk',
   dependencies: [tilemapExtension],
-  // Localized erasure cast: typed binding meets the untyped Extension.assets
-  // contract here. Runtime behaviour is unaffected.
-  assets: [ldtkMapBinding] as unknown as AssetBinding[],
+  assets: [ldtkMapBinding],
 });


### PR DESCRIPTION
`asepriteExtension`/`ldtkExtension` cast their assets array via `as unknown as AssetBinding[]` to bridge a typed-binding vs untyped `Extension.assets` mismatch. The typed contract now accepts the binding directly (verified: both packages typecheck without the cast), so the cast was dead — ESLint flagged it `no-unnecessary-type-assertion`. Removed the cast, the now-unused import, and the comments describing it.

Clears the 2 packages lint warnings. typecheck + lint + format clean.