### PR TITLE
fix(ldtk): resolve relPaths against a relative .ldtk source (#316)

### DIFF
--- a/packages/exojs-ldtk/src/loadLdtkMap.ts
+++ b/packages/exojs-ldtk/src/loadLdtkMap.ts
@@ -6,16 +6,7 @@ import type { LdtkData, LdtkLevel, LdtkTilesetDef } from './LdtkData';
 import { getLdtkLevelEntries } from './ldtkLevelEntries';
 import type { LdtkMap } from './LdtkMap';
 import { ldtkToTileMap } from './ldtkToTileMap';
-
-// ── URL resolution ────────────────────────────────────────────────────────────
-
-/**
- * Resolve a tileset-relative path against the base `.ldtk` URL.
- * Mirrors the approach used by the Tiled adapter.
- */
-function resolveLdtkUrl(relPath: string, baseUrl: string): string {
-  return new URL(relPath, baseUrl).href;
-}
+import { resolveLdtkUrl } from './url';
 
 // ── Tileset loading ───────────────────────────────────────────────────────────
 
@@ -29,7 +20,8 @@ async function loadLdtkTileset(
   ldtkSource: string,
   context: AssetLoaderContext,
 ): Promise<TileSet | null> {
-  if (!def.relPath) return null;
+  // No atlas image (null or empty relPath): skip — tiles cannot render.
+  if (def.relPath === null || def.relPath === '') return null;
 
   const imageUrl = resolveLdtkUrl(def.relPath, ldtkSource);
   const texture = await context.loader.load(Asset.kind('texture', imageUrl));
@@ -85,7 +77,10 @@ async function loadExternalLevel(
   ldtkSource: string,
   context: AssetLoaderContext,
 ): Promise<LdtkLevel> {
-  if (level.layerInstances !== null || !level.externalRelPath) return level;
+  // Already-inlined level, or no external file to fetch: return as-is.
+  if (level.layerInstances !== null || level.externalRelPath === undefined || level.externalRelPath === '') {
+    return level;
+  }
 
   const externalUrl = resolveLdtkUrl(level.externalRelPath, ldtkSource);
   // Typed without deep validation (fetchJson<T> is an unvalidated assertion,

--- a/packages/exojs-ldtk/src/url.ts
+++ b/packages/exojs-ldtk/src/url.ts
@@ -1,0 +1,47 @@
+// Relative-path resolution for LDtk source references (.ldtk → tileset image,
+// .ldtk → external .ldtkl level). LDtk stores every cross-file reference as a
+// path relative to the file that contains it; ExoJS asset sources are themselves
+// often relative (resolved against an asset root configured outside the Loader),
+// so plain `new URL(ref, base)` cannot be used directly when `base` has no
+// scheme — it throws `Invalid URL`. Mirrors the Tiled adapter's `resolveTiledUrl`.
+
+/** Matches references that are already absolute and must not be re-resolved: scheme:, protocol-relative `//`, root-relative `/`, and data/blob URLs. */
+const ABSOLUTE_REF = /^(?:[a-z][a-z\d+.-]*:|\/\/|\/)/i;
+
+/** Matches a base that is itself an absolute URL with a scheme. */
+const ABSOLUTE_BASE = /^[a-z][a-z\d+.-]*:/i;
+
+/** Synthetic origin used to borrow `URL`'s `../`/`./` collapsing for relative bases. */
+const SYNTHETIC_ORIGIN = 'https://exojs.invalid/';
+
+/**
+ * Resolves `ref` (a path read from an LDtk file, e.g. a tileset `relPath` or a
+ * level `externalRelPath`) relative to `base` (the resolved location of the
+ * file that referenced it).
+ *
+ * - If `ref` is already absolute (scheme, protocol- or root-relative, or a
+ *   `data:`/`blob:` URL), it is returned unchanged.
+ * - If `base` is an absolute URL, standard `new URL(ref, base)` resolution is
+ *   used.
+ * - Otherwise both are relative ExoJS asset paths; `../`/`./` segments are
+ *   collapsed via a synthetic origin and the result is returned relative again.
+ *
+ * @internal
+ */
+export function resolveLdtkUrl(ref: string, base: string): string {
+  if (ABSOLUTE_REF.test(ref)) {
+    return ref;
+  }
+
+  if (ABSOLUTE_BASE.test(base)) {
+    return new URL(ref, base).href;
+  }
+
+  const resolved = new URL(ref, SYNTHETIC_ORIGIN + base.replace(/^\/+/, ''));
+  const relative = resolved.href.slice(SYNTHETIC_ORIGIN.length);
+
+  // A root-relative base must produce a root-relative result again — dropping
+  // the leading slash would make the browser re-resolve the reference against
+  // the document base URL (e.g. `/site/assets/x.png` → `/site/site/assets/…`).
+  return base.startsWith('/') ? `/${relative}` : relative;
+}

--- a/packages/exojs-ldtk/test/load-ldtk-map.test.ts
+++ b/packages/exojs-ldtk/test/load-ldtk-map.test.ts
@@ -534,11 +534,11 @@ describe('loadLdtkMap — atlas too small for any tile', () => {
   });
 });
 
-describe('loadLdtkMap — URL resolution is absolute-base-only (characterization)', () => {
-  // resolveLdtkUrl uses `new URL(relPath, baseUrl)` directly, which throws when
-  // the base URL is relative. Unlike the Tiled adapter, LDtk does NOT tolerate a
-  // relative .ldtk source when a tileset carries a relPath. See report note.
-  const fixture: LdtkData = {
+describe('loadLdtkMap — relative-source URL resolution (#316)', () => {
+  // resolveLdtkUrl now mirrors the Tiled adapter: a tileset relPath resolves
+  // against a RELATIVE .ldtk source without throwing, collapsing ../ / ./ and
+  // staying relative in the result.
+  const makeFixture = (relPath: string): LdtkData => ({
     jsonVersion: '1.5.3',
     defaultGridSize: 16,
     defs: {
@@ -546,7 +546,7 @@ describe('loadLdtkMap — URL resolution is absolute-base-only (characterization
         {
           uid: 1,
           identifier: 'Atlas',
-          relPath: 'tiles.png',
+          relPath,
           tileGridSize: 16,
           pxWid: 64,
           pxHei: 64,
@@ -555,11 +555,31 @@ describe('loadLdtkMap — URL resolution is absolute-base-only (characterization
       layers: [],
     },
     levels: [],
-  };
+  });
 
-  it('rejects when the source is a relative URL and a tileset has a relPath', async () => {
-    const { context } = makeContext({ 'world.ldtk': fixture });
-    await expect(loadLdtkMap('world.ldtk', context)).rejects.toThrow(/Invalid URL/);
+  it('resolves a tileset relPath against a relative .ldtk source instead of throwing', async () => {
+    const { context, loaderLoad } = makeContext({ 'maps/world.ldtk': makeFixture('tiles.png') });
+
+    await expect(loadLdtkMap('maps/world.ldtk', context)).resolves.toBeDefined();
+
+    // The texture is requested at the source-relative path, still relative.
+    expect(loaderLoad).toHaveBeenCalledWith(Asset.kind('texture', 'maps/tiles.png'));
+  });
+
+  it('collapses ../ segments in a relPath against a relative source', async () => {
+    const { context, loaderLoad } = makeContext({ 'maps/world.ldtk': makeFixture('../art/tiles.png') });
+
+    await loadLdtkMap('maps/world.ldtk', context);
+
+    expect(loaderLoad).toHaveBeenCalledWith(Asset.kind('texture', 'art/tiles.png'));
+  });
+
+  it('still resolves against an absolute source (unchanged behaviour)', async () => {
+    const { context, loaderLoad } = makeContext({ 'https://example.com/maps/world.ldtk': makeFixture('tiles.png') });
+
+    await loadLdtkMap('https://example.com/maps/world.ldtk', context);
+
+    expect(loaderLoad).toHaveBeenCalledWith(Asset.kind('texture', 'https://example.com/maps/tiles.png'));
   });
 });
 


### PR DESCRIPTION
`loadLdtkMap` resolved tileset `relPath` / external-level `externalRelPath` with a bare `new URL(relPath, baseUrl)`, which throws `Invalid URL` when the `.ldtk` source is itself relative — the common case (ExoJS asset sources resolve against an asset root outside the Loader). So an LDtk map loaded by a relative path threw the moment a tileset carried a relPath.

Extracted `resolveLdtkUrl` into `src/url.ts` with the same robust logic the Tiled adapter already ships (`resolveTiledUrl`): absolute refs pass through, absolute bases use native `new URL`, a relative base collapses `../`/`./` via a synthetic origin and stays relative. Also made the empty/null relPath guards explicit (clears 2 `strict-boolean-expressions` warnings on the same code).

TDD: replaced the prior "absolute-base-only" characterization test (which asserted the throw) with three tests — relative source resolves, `../` collapses, absolute source unchanged — verified to fail before the fix. Full ldtk suite green (140).

Closes #316.