### PR TITLE
feat(core)!: Scene.app throwing non-null accessor + Scene.attached (#313)

### DIFF
--- a/site/src/content/api/scene.json
+++ b/site/src/content/api/scene.json
@@ -6,11 +6,11 @@
   "subsystem": "core",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 23,
+  "memberCount": 24,
   "counts": {
     "constructors": 1,
     "methods": 12,
-    "properties": 8,
+    "properties": 9,
     "events": 2
   },
   "sections": [
@@ -690,7 +690,7 @@
         },
         {
           "name": "app",
-          "signature": "app: Application | null",
+          "signature": "app: Application",
           "signatureTokens": [
             {
               "text": "app",
@@ -703,19 +703,32 @@
             {
               "text": "Application",
               "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "The Application this scene is attached to. The framework attaches a scene before any lifecycle hook (init/update/draw) runs, so scene code can read this.app inside those hooks without a null guard — consistent with Scene.inputs/Scene.tweens/Scene.loader. Throws if accessed before the scene is attached (e.g. in a constructor). Use Scene.attached for the rare \"is it attached yet?\" check that must not throw."
+        },
+        {
+          "name": "attached",
+          "signature": "attached: boolean",
+          "signatureTokens": [
+            {
+              "text": "attached",
+              "kind": "name"
             },
             {
-              "text": " | ",
+              "text": ": ",
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "boolean",
               "kind": "keyword"
             }
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "true once the scene is attached to an Application — a non-throwing lifecycle probe (see Scene.app)."
         },
         {
           "name": "inputs",

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -32,19 +32,19 @@ class SceneInputs implements Destroyable {
   public constructor(private readonly _scene: Scene) {}
 
   public onStart(channel: InputChannel | readonly InputChannel[], callback: (value: number) => void, options?: InputBindingOptions): InputBinding {
-    return this._track(this._scene.app!.input.onStart(channel, callback, options));
+    return this._track(this._scene.app.input.onStart(channel, callback, options));
   }
 
   public onActive(channel: InputChannel | readonly InputChannel[], callback: (value: number) => void, options?: InputBindingOptions): InputBinding {
-    return this._track(this._scene.app!.input.onActive(channel, callback, options));
+    return this._track(this._scene.app.input.onActive(channel, callback, options));
   }
 
   public onStop(channel: InputChannel | readonly InputChannel[], callback: (value: number) => void, options?: InputBindingOptions): InputBinding {
-    return this._track(this._scene.app!.input.onStop(channel, callback, options));
+    return this._track(this._scene.app.input.onStop(channel, callback, options));
   }
 
   public onTrigger(channel: InputChannel | readonly InputChannel[], callback: (value: number) => void, options?: InputBindingOptions): InputBinding {
-    return this._track(this._scene.app!.input.onTrigger(channel, callback, options));
+    return this._track(this._scene.app.input.onTrigger(channel, callback, options));
   }
 
   public destroy(): void {
@@ -72,14 +72,14 @@ class SceneTweens implements Destroyable {
   public constructor(private readonly _scene: Scene) {}
 
   public create<T extends object>(target: T): Tween<T> {
-    const tween = this._scene.app!.tweens.create(target);
+    const tween = this._scene.app.tweens.create(target);
     this._tweens.add(tween);
 
     return tween;
   }
 
   public add(tween: Tween): this {
-    this._scene.app!.tweens.add(tween);
+    this._scene.app.tweens.add(tween);
     this._tweens.add(tween);
 
     return this;
@@ -107,7 +107,7 @@ class SceneLoader implements Destroyable {
   public constructor(private readonly _scene: Scene) {}
 
   private get _loader(): Loader {
-    return this._scene.app!.loader;
+    return this._scene.app.loader;
   }
 
   public get<S extends string>(path: LoadByPath<S> extends Texture | Sound ? S : never, options?: unknown): LoadByPath<S>;
@@ -184,12 +184,31 @@ export class Scene {
   private _systems: SystemRegistry | null = null;
   private readonly _disposal = new DisposalScope();
 
-  public get app(): Application | null {
+  /**
+   * The {@link Application} this scene is attached to. The framework attaches a
+   * scene before any lifecycle hook (`init`/`update`/`draw`) runs, so scene code
+   * can read `this.app` inside those hooks without a null guard — consistent
+   * with {@link Scene.inputs}/{@link Scene.tweens}/{@link Scene.loader}.
+   *
+   * Throws if accessed before the scene is attached (e.g. in a constructor). Use
+   * {@link Scene.attached} for the rare "is it attached yet?" check that must not
+   * throw.
+   */
+  public get app(): Application {
+    if (this._app === null) {
+      throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+    }
+
     return this._app;
   }
 
   public set app(app: Application | null) {
     this._app = app;
+  }
+
+  /** `true` once the scene is attached to an {@link Application} — a non-throwing lifecycle probe (see {@link Scene.app}). */
+  public get attached(): boolean {
+    return this._app !== null;
   }
 
   /**

--- a/test/core/scene-manager.test.ts
+++ b/test/core/scene-manager.test.ts
@@ -115,7 +115,7 @@ describe('SceneManager', () => {
     expect(manager.currentScene).toBeNull();
     expect(unload).toHaveBeenCalledTimes(1);
     expect(destroySpy).toHaveBeenCalledTimes(1);
-    expect(scene.app).toBeNull();
+    expect(scene.attached).toBe(false);
     expect(changeSpy).not.toHaveBeenCalled();
   });
 
@@ -140,7 +140,7 @@ describe('SceneManager', () => {
     expect(load).toHaveBeenCalledTimes(1);
     expect(unload).toHaveBeenCalledTimes(1);
     expect(destroySpy).toHaveBeenCalledTimes(1);
-    expect(scene.app).toBeNull();
+    expect(scene.attached).toBe(false);
     expect(changeSpy).not.toHaveBeenCalled();
   });
 
@@ -159,7 +159,7 @@ describe('SceneManager', () => {
     await expect(manager.setScene(scene)).rejects.toThrow('Failed to initialize scene: init failed. Cleanup also failed: cleanup failed.');
     expect(manager.currentScene).toBeNull();
     expect(destroySpy).toHaveBeenCalledTimes(1);
-    expect(scene.app).toBeNull();
+    expect(scene.attached).toBe(false);
   });
 
   test('does not leak unhandled rejections when destroy() unload fails', async () => {

--- a/test/core/scene.test.ts
+++ b/test/core/scene.test.ts
@@ -138,4 +138,38 @@ describe('Scene', () => {
     expect(backendDraw).toHaveBeenCalledWith(worldSprite);
     expect(backendDraw).not.toHaveBeenCalledWith(uiSprite);
   });
+
+  // #313: Scene.app is a throwing non-null accessor (like Scene.inputs/tweens/
+  // loader), not `Application | null` — the framework guarantees attachment
+  // before any lifecycle hook, so scene code never needs a null guard.
+  describe('app accessor (#313)', () => {
+    const fakeApp = { id: 'app' } as unknown as import('#core/Application').Application;
+
+    test('throws when accessed before the scene is attached', () => {
+      const scene = new Scene();
+
+      expect(() => scene.app).toThrow(/unavailable before the scene is attached to an Application/);
+    });
+
+    test('returns the Application once attached', () => {
+      const scene = new Scene();
+
+      scene.app = fakeApp;
+
+      expect(scene.app).toBe(fakeApp);
+    });
+
+    test('attached reflects lifecycle without throwing (the legitimate null check)', () => {
+      const scene = new Scene();
+
+      expect(scene.attached).toBe(false);
+
+      scene.app = fakeApp;
+      expect(scene.attached).toBe(true);
+
+      scene.app = null;
+      expect(scene.attached).toBe(false);
+      expect(() => scene.app).toThrow();
+    });
+  });
 });


### PR DESCRIPTION
**BREAKING.** `Scene.app` was typed `Application | null`, though the framework guarantees a scene is attached before any lifecycle hook (`init`/`update`/`draw`). That forced a null guard on every `this.app` access — of 573 strict-mode errors across the example catalog (PR #298), **334 (58%)** were `TS2531` on `this.app`.

## Change
- `Scene.app` now returns `Application` and **throws** if read before attachment — consistent with the existing throwing accessors `Scene.inputs`/`tweens`/`loader`.
- New `Scene.attached: boolean` — the non-throwing probe for the rare legitimate "is it attached yet?" check (replaces the old `scene.app === null` idiom).
- The stricter type let TS drop **7 now-dead `this._scene.app!`** non-null assertions in SceneInputs/SceneTweens/SceneLoader — the internal counterpart of the example papercut.

## Migration
`scene.app === null` → `!scene.attached`. Direct `this.app.foo` access in lifecycle hooks no longer needs a guard.

## Verification
TDD: new app-accessor tests (throws unattached / returns attached / attached probe); the 3 SceneManager cleanup-path assertions that checked `scene.app` for null moved to `scene.attached`. Engine + examples typecheck clean, Scene.ts lint:strict-clean, docs regenerated.

Closes #313.