### PR TITLE
feat(rendering): dev warn-once guards for use-after-destroy

### DIFF
--- a/site/src/content/api/data-texture.json
+++ b/site/src/content/api/data-texture.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 36,
+  "memberCount": 37,
   "counts": {
     "constructors": 1,
     "methods": 12,
-    "properties": 23,
+    "properties": 24,
     "events": 0
   },
   "sections": [
@@ -873,6 +873,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run — a destroyed texture must not be bound (#310)."
         },
         {
           "name": "error",

--- a/site/src/content/api/texture.json
+++ b/site/src/content/api/texture.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 32,
+  "memberCount": 33,
   "counts": {
     "constructors": 1,
     "methods": 10,
-    "properties": 21,
+    "properties": 22,
     "events": 0
   },
   "sections": [
@@ -673,6 +673,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run — a destroyed texture must not be bound (#310)."
         },
         {
           "name": "error",

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -1,4 +1,5 @@
 import { invariant } from '#core/dev';
+import { logger } from '#core/logging';
 import type { Stage } from '#core/Stage';
 import { removeArrayItems } from '#core/utils';
 import { RenderEntryKind } from '#rendering/plan/RenderCommand';
@@ -89,6 +90,16 @@ export class Container extends RenderNode {
 
     if (child === this) {
       return this;
+    }
+
+    // #310: attaching an already-destroyed node is otherwise silent — it renders
+    // nothing (the collect dev-guard skips it) or replays freed state. Warn once
+    // in dev at the attach site, the earliest clear use-after-destroy signal.
+    if (__DEV__ && child.destroyed) {
+      logger.warn(
+        'Container.addChild(): the child has already been destroy()ed — using a destroyed node is a no-op at best and stale state at worst. Create a fresh node instead of re-adding a destroyed one.',
+        { source: 'rendering', once: 'container:add-destroyed-child' },
+      );
     }
 
     // Reject reparenting an ancestor of this container as a child: it would

--- a/src/rendering/sprite/Sprite.ts
+++ b/src/rendering/sprite/Sprite.ts
@@ -246,6 +246,15 @@ export class Sprite extends Drawable {
    * Call {@link updateTexture} explicitly when you mutate the source.
    */
   public setTexture(texture: Texture | RenderTexture | null): this {
+    // #310: binding a destroyed texture is otherwise silent (it samples freed
+    // GPU state or renders nothing). Warn once in dev at the assignment site.
+    if (__DEV__ && texture !== null && 'destroyed' in texture && texture.destroyed) {
+      logger.warn(
+        'Sprite.setTexture(): the texture has already been destroy()ed — a destroyed texture samples freed state or renders nothing. Assign a live texture instead.',
+        { source: 'Sprite', once: 'sprite:set-destroyed-texture' },
+      );
+    }
+
     if (this._texture !== texture) {
       this._texture = texture;
 

--- a/src/rendering/texture/Texture.ts
+++ b/src/rendering/texture/Texture.ts
@@ -88,6 +88,7 @@ export class Texture {
   private _version = 0;
   private _source: TextureSource = null;
   private _size: Size = new Size(0, 0);
+  private _isDestroyed = false;
   private readonly _destroyListeners: Set<() => void> = new Set<() => void>();
   /** @internal — load lifecycle, driven by the Loader's seamless pipeline. */
   public readonly _loadState = new LoadState<Texture>();
@@ -324,6 +325,11 @@ export class Texture {
     return this;
   }
 
+  /** `true` once {@link destroy} has run — a destroyed texture must not be bound (#310). */
+  public get destroyed(): boolean {
+    return this._isDestroyed;
+  }
+
   public destroy(): void {
     for (const listener of [...this._destroyListeners]) {
       listener();
@@ -332,6 +338,7 @@ export class Texture {
     this._destroyListeners.clear();
     this._size.destroy();
     this._source = null;
+    this._isDestroyed = true;
   }
 
   private _touch(): void {

--- a/test/rendering/container.test.ts
+++ b/test/rendering/container.test.ts
@@ -1,4 +1,5 @@
-﻿import { SceneNode } from '#core/SceneNode';
+﻿import { logger } from '#core/logging';
+import { SceneNode } from '#core/SceneNode';
 import { Container } from '#rendering/Container';
 import { Drawable } from '#rendering/Drawable';
 import { Graphics } from '#rendering/primitives/Graphics';
@@ -79,5 +80,42 @@ describe('Container', () => {
     container.setChildIndex(third, 0);
 
     expect(container.children).toEqual([third, first, second]);
+  });
+
+  // #310: using a destroyed node is otherwise silent — warn once (dev only) at
+  // the attach site, the earliest clear signal of use-after-destroy. Asserted
+  // through a sink (which honours the logger's `once` dedup), not a warn spy
+  // (which would count calls before dedup).
+  describe('destroyed-child guard (#310)', () => {
+    let entries: string[];
+    let removeSink: () => void;
+
+    beforeEach(() => {
+      logger._resetOnce(); // fresh once-state per test (dedup is process-wide)
+      entries = [];
+      removeSink = logger.addSink(e => entries.push(e.message));
+    });
+
+    afterEach(() => removeSink());
+
+    const destroyedCount = (): number => entries.filter(m => m.includes('destroyed')).length;
+
+    test('warns exactly once even when multiple destroyed nodes are attached', () => {
+      const container = new Container();
+
+      for (let i = 0; i < 3; i++) {
+        const child = new DummyDrawable();
+        child.destroy();
+        container.addChild(child);
+      }
+
+      expect(destroyedCount()).toBe(1); // once, despite 3 destroyed attaches
+    });
+
+    test('does not warn when a live node is added', () => {
+      new Container().addChild(new DummyDrawable());
+
+      expect(destroyedCount()).toBe(0);
+    });
   });
 });

--- a/test/rendering/sprite/sprite.test.ts
+++ b/test/rendering/sprite/sprite.test.ts
@@ -91,6 +91,38 @@ describe('Sprite', () => {
     });
   });
 
+  // #310: binding a destroyed texture is otherwise silent — warn once (dev) at
+  // the assignment site. Asserted via a sink (honours the logger's `once` dedup).
+  describe('destroyed-texture guard (#310)', () => {
+    const destroyedTexture = (): Texture => ({ width: 16, height: 16, flipY: false, destroyed: true, updateSource: () => undefined }) as unknown as Texture;
+
+    let entries: string[];
+    let removeSink: () => void;
+
+    beforeEach(() => {
+      logger._resetOnce();
+      entries = [];
+      removeSink = logger.addSink(e => entries.push(e.message));
+    });
+
+    afterEach(() => removeSink());
+
+    const destroyedCount = (): number => entries.filter(m => m.includes('destroyed')).length;
+
+    test('warns once when a destroyed texture is assigned', () => {
+      new Sprite(null).setTexture(destroyedTexture());
+      new Sprite(null).setTexture(destroyedTexture());
+
+      expect(destroyedCount()).toBe(1); // once, despite two destroyed assignments
+    });
+
+    test('does not warn for a live texture', () => {
+      new Sprite(makeTexture(16, 16));
+
+      expect(destroyedCount()).toBe(0);
+    });
+  });
+
   describe('updateTexture', () => {
     test('is a no-op when no texture is assigned', () => {
       const sprite = new Sprite(null);


### PR DESCRIPTION
## Summary
- `Container.addChild` warns (dev-only, once) when attaching an already-destroyed `SceneNode`.
- `Sprite.setTexture` warns (dev-only, once) when binding an already-destroyed `Texture`; adds a new `Texture.destroyed` getter (parallels `SceneNode.destroyed` from #295), narrowed via `'destroyed' in texture` so `RenderTexture` (no such flag) stays type-safe.
- Behaviour is unchanged — guards only warn; the existing collect-time dev guard from #295 still skips destroyed drawables during retained replay.
- API docs regenerated for the new `Texture.destroyed` getter.

Closes #310.

## Test plan
- [x] Sink-based tests (respect the logger's `once` dedup) assert warn-once on misuse and silence on live objects, for both `Container.addChild` and `Sprite.setTexture`.
- [x] Full sprite/container/texture test suites green.
- [x] `typecheck` + `lint` clean.
- [x] `docs:api:generate` re-run, diff committed.