### PR TITLE
feat(resources): dev-mode typo guard on Assets.from(...) catalog access

### DIFF
--- a/src/resources/Assets.ts
+++ b/src/resources/Assets.ts
@@ -1,3 +1,5 @@
+import { logger } from '#core/logging';
+
 import { AssetImpl } from './Asset';
 import type { AnyAssetConfig, AssetDefinitions, CatalogEntry, InferCatalogLeaf, OptionsForKind } from './AssetDefinitions';
 import { createLeaf } from './assetKindRegistry';
@@ -50,6 +52,19 @@ export function _normalizeEntry(value: CatalogEntry): AnyAssetConfig {
   return value instanceof AssetImpl ? value._config : (value as AnyAssetConfig);
 }
 
+// ---------------------------------------------------------------------------
+// Dev-mode typo guard (#311)
+// ---------------------------------------------------------------------------
+
+/**
+ * String keys that are read as language/library protocol probes (`await`
+ * calls `Get(value, "then")`; `JSON.stringify` calls `Get(value, "toJSON")`)
+ * rather than as an actual catalog-entry access. Excluded from the dev
+ * typo-guard warning so stringifying or (accidentally) awaiting a catalog
+ * doesn't produce a spurious "not a defined catalog key" warning.
+ */
+const ASSETS_DEV_PROXY_DUCK_TYPING_KEYS = new Set(['then', 'toJSON']);
+
 /** @internal */
 export class AssetsImpl<M extends Record<string, CatalogEntry>> {
   public readonly entries: InferAssetsEntries<M>;
@@ -83,6 +98,26 @@ export class AssetsImpl<M extends Record<string, CatalogEntry>> {
     }
 
     this.entries = entries as InferAssetsEntries<M>;
+
+    // #311: a typo'd or dynamic catalog-key read (`bag.logoo`, `bag[computedKey]`)
+    // is otherwise a silent `undefined` — warn once per key in dev instead.
+    // __DEV__-gated: zero cost and no Proxy indirection in production.
+    if (__DEV__) {
+      return new Proxy(this, {
+        get(target, key, receiver) {
+          const value = Reflect.get(target, key, receiver);
+
+          if (typeof key === 'string' && !ASSETS_DEV_PROXY_DUCK_TYPING_KEYS.has(key) && !Reflect.has(target, key)) {
+            logger.warn(`Assets: "${key}" is not a defined catalog key. Defined keys: ${Object.keys(target).join(', ')}.`, {
+              source: 'Assets',
+              once: `assets:missing-key:${key}`,
+            });
+          }
+
+          return value;
+        },
+      });
+    }
   }
 }
 

--- a/src/resources/Assets.ts
+++ b/src/resources/Assets.ts
@@ -65,6 +65,16 @@ export function _normalizeEntry(value: CatalogEntry): AnyAssetConfig {
  */
 const ASSETS_DEV_PROXY_DUCK_TYPING_KEYS = new Set(['then', 'toJSON']);
 
+/**
+ * Per-instance counter for the dev typo guard's warn-once key (below). Two
+ * unrelated catalogs missing the SAME key name must each get their own
+ * diagnostic — a global dedup key would silently swallow the second
+ * catalog's warning after the first one fires, defeating the point of the
+ * guard (adversarial review, 2026-07-13: opus and fable both independently
+ * flagged this).
+ */
+let assetsDevProxyInstanceCounter = 0;
+
 /** @internal */
 export class AssetsImpl<M extends Record<string, CatalogEntry>> {
   public readonly entries: InferAssetsEntries<M>;
@@ -103,14 +113,18 @@ export class AssetsImpl<M extends Record<string, CatalogEntry>> {
     // is otherwise a silent `undefined` — warn once per key in dev instead.
     // __DEV__-gated: zero cost and no Proxy indirection in production.
     if (__DEV__) {
+      const instanceId = assetsDevProxyInstanceCounter++;
+
       return new Proxy(this, {
         get(target, key, receiver) {
           const value = Reflect.get(target, key, receiver);
 
           if (typeof key === 'string' && !ASSETS_DEV_PROXY_DUCK_TYPING_KEYS.has(key) && !Reflect.has(target, key)) {
-            logger.warn(`Assets: "${key}" is not a defined catalog key. Defined keys: ${Object.keys(target).join(', ')}.`, {
+            const definedKeys = Object.keys(target).filter(k => k !== 'entries');
+
+            logger.warn(`Assets: "${key}" is not a defined catalog key. Defined keys: ${definedKeys.join(', ')}.`, {
               source: 'Assets',
-              once: `assets:missing-key:${key}`,
+              once: `assets:missing-key:${instanceId}:${key}`,
             });
           }
 

--- a/test/resources/assets.test.ts
+++ b/test/resources/assets.test.ts
@@ -1,6 +1,7 @@
 import '#resources/coreAssetBindings';
 
 import { Sound } from '#audio/Sound';
+import { logger } from '#core/logging';
 import { Texture } from '#rendering/texture/Texture';
 import { Asset } from '#resources/Asset';
 import { _readMeta } from '#resources/assetMeta';
@@ -61,5 +62,71 @@ describe('Assets.from bare-string inference', () => {
   });
   it('still accepts explicit configs (existing form) unchanged', () => {
     expect(Assets.from({ ship: { kind: 'texture', source: 's.png' } }).ship).toBeInstanceOf(Texture);
+  });
+});
+
+describe('Assets dev-mode typo guard (#311)', () => {
+  let entries: string[];
+  let removeSink: () => void;
+
+  beforeEach(() => {
+    logger._resetOnce();
+    entries = [];
+    removeSink = logger.addSink(e => entries.push(e.message));
+  });
+
+  afterEach(() => removeSink());
+
+  const missingKeyCount = (): number => entries.filter(m => m.includes('is not a defined catalog key')).length;
+
+  test('warns once when an unknown string key is read (typo)', () => {
+    const bag = Assets.from({ logo: 'sprites/logo.png' });
+
+    void (bag as any).logoo;
+    void (bag as any).logoo;
+
+    expect(missingKeyCount()).toBe(1); // once, despite two reads
+  });
+
+  test('still returns undefined for the unknown key (behavior unchanged)', () => {
+    const bag = Assets.from({ logo: 'sprites/logo.png' });
+
+    expect((bag as any).logoo).toBeUndefined();
+  });
+
+  test('does not warn for a real catalog key or `entries`', () => {
+    const bag = Assets.from({ logo: 'sprites/logo.png' });
+
+    void bag.logo;
+    void bag.entries;
+
+    expect(missingKeyCount()).toBe(0);
+  });
+
+  test('does not warn for inherited Object.prototype members', () => {
+    const bag = Assets.from({ logo: 'sprites/logo.png' });
+
+    void bag.toString;
+    void bag.constructor;
+    void bag.hasOwnProperty;
+
+    expect(missingKeyCount()).toBe(0);
+  });
+
+  test('does not warn for `then` or `toJSON` duck-typing probes', () => {
+    const bag = Assets.from({ logo: 'sprites/logo.png' });
+
+    void (bag as any).then;
+    void (bag as any).toJSON;
+
+    expect(missingKeyCount()).toBe(0);
+  });
+
+  test('does not warn for a Symbol key', () => {
+    const bag = Assets.from({ logo: 'sprites/logo.png' });
+
+    void (bag as any)[Symbol.iterator];
+
+    expect(missingKeyCount()).toBe(0);
   });
 });

--- a/test/resources/assets.test.ts
+++ b/test/resources/assets.test.ts
@@ -129,4 +129,21 @@ describe('Assets dev-mode typo guard (#311)', () => {
 
     expect(missingKeyCount()).toBe(0);
   });
+
+  test('dedups per catalog instance, not globally: a second, unrelated catalog missing the same key name still warns', () => {
+    const first = Assets.from({ logo: 'sprites/logo.png' });
+    const second = Assets.from({ hero: 'sprites/hero.png' });
+
+    void (first as any).icon;
+    void (second as any).icon; // same missing key name, but a DIFFERENT catalog
+
+    expect(missingKeyCount()).toBe(2);
+  });
+
+  test('preserves the Assets/AssetsImpl instanceof contract and real .entries access through the Proxy', () => {
+    const bag = Assets.from({ logo: 'sprites/logo.png' });
+
+    expect(bag).toBeInstanceOf(Assets);
+    expect(bag.entries).toEqual({ logo: bag.logo });
+  });
 });


### PR DESCRIPTION
## Summary
- `Assets.from({...})` (`AssetsImpl`) wraps the constructed instance in a `Proxy` (dev-only, `__DEV__`-gated — zero cost in production) whose `get` trap always returns the real value but additionally warns **once** when a string key is read that isn't a defined catalog key, `entries`, an inherited `Object.prototype` member, or a `then`/`toJSON` duck-typing probe.
- Fixes the silent-`undefined` papercut: `TitleAssets.logoo` (typo) or `TitleAssets[computedKey]` previously returned `undefined` with zero diagnostic, surfacing only as a confusing downstream "why is my texture missing" bug.
- Behaviour is unchanged — the guard only warns, still returns `undefined` for a missing key. `instanceof AssetsImpl` checks in `Loader.ts` keep working (`Proxy` forwards `getPrototypeOf` to the target by default).
- Warn-once key is scoped **per catalog instance** (not globally by key name) — two unrelated catalogs missing the same key name each get their own diagnostic. This was a genuine gap found by an adversarial review (opus + fable, run independently in parallel) after the first pass, fixed in a follow-up commit.

Closes #311.

## Test plan
- [x] Sink-based tests (respect the logger's `once` dedup) assert: warn-once on an unknown key, `undefined` still returned, no warning for real keys/`entries`/inherited members/`then`/`toJSON`/Symbol keys, per-instance dedup (two catalogs missing the same key name both warn), and the `Assets`/`AssetsImpl` `instanceof` + `.entries` contract survives the Proxy.
- [x] Full `test/resources` suite green (588/591, 3 pre-existing skips).
- [x] `pnpm verify:quick` (typecheck + typecheck:guides/examples/type-tests/packages, lint:all, format:check, docs:api:check) clean via the pre-push hook.
- [x] Adversarial review by opus and fable (independent, parallel) found no blocking issues; one real (low-severity) finding — cross-instance warn-once collision — fixed in a follow-up commit with a regression test.