### PR TITLE
ci: run typecheck:examples + typecheck:type-tests in required Typecheck job

### DIFF
--- a/.github/workflows/_ci-checks.yml
+++ b/.github/workflows/_ci-checks.yml
@@ -106,6 +106,18 @@ jobs:
       - name: Typecheck guides
         run: pnpm typecheck:guides
 
+      # #319: the local `verify:quick` pre-push hook also typechecks examples
+      # (strict config, #298) and the standalone type-tests project — CI had
+      # been silently skipping both, so strict-mode example errors merged via
+      # automerge on green required CI and then blocked every contributor's
+      # next `git push` locally. Keep this job's set 1:1 with verify:quick
+      # (test/ci/required-typecheck-lane.test.ts locks the four commands in).
+      - name: Typecheck examples
+        run: pnpm typecheck:examples
+
+      - name: Typecheck type-tests
+        run: pnpm typecheck:type-tests
+
       # Root `pnpm typecheck` only covers src/**; the extension packages own a
       # separate tsconfig each, so typecheck them explicitly.
       - name: Typecheck extension packages

--- a/.github/workflows/_ci-checks.yml
+++ b/.github/workflows/_ci-checks.yml
@@ -106,12 +106,11 @@ jobs:
       - name: Typecheck guides
         run: pnpm typecheck:guides
 
-      # #319: the local `verify:quick` pre-push hook also typechecks examples
-      # (strict config, #298) and the standalone type-tests project — CI had
-      # been silently skipping both, so strict-mode example errors merged via
-      # automerge on green required CI and then blocked every contributor's
-      # next `git push` locally. Keep this job's set 1:1 with verify:quick
-      # (test/ci/required-typecheck-lane.test.ts locks the four commands in).
+      # Keep this job's typecheck set 1:1 with the local verify:quick pre-push
+      # hook, which also typechecks examples (strict config) and the
+      # standalone type-tests project — a required-CI gate weaker than the
+      # local hook lets a class of error merge that then blocks every
+      # contributor's next push.
       - name: Typecheck examples
         run: pnpm typecheck:examples
 

--- a/test/ci/required-typecheck-lane.test.ts
+++ b/test/ci/required-typecheck-lane.test.ts
@@ -7,13 +7,9 @@ import { describe, expect, it } from 'vitest';
  * Locks the required GitHub CI `Typecheck` job (`.github/workflows/_ci-checks.yml`)
  * to run the SAME typecheck set as the local `verify:quick` pre-push hook
  * (`package.json`'s `typecheck && typecheck:guides && typecheck:examples &&
- * typecheck:type-tests && typecheck:packages`). #319: the two gates had
- * drifted — CI skipped `typecheck:examples`, so 5 strict-mode example errors
- * (introduced by #298's `strict: true`) merged via automerge on green
- * required CI, then blocked every contributor's local `git push` (the
- * pre-push hook still ran `typecheck:examples`). `typecheck:type-tests` has
- * the identical gap (present in verify:quick, absent from CI) despite not
- * being named in #319's title.
+ * typecheck:type-tests && typecheck:packages`). If the two gates drift, a
+ * class of error the local hook would have caught can merge on green
+ * required CI and then block every contributor's next local push instead.
  */
 
 const workflowPath = resolve(import.meta.dirname!, '../../.github/workflows/_ci-checks.yml');
@@ -32,7 +28,7 @@ function extractJobBlock(source: string, jobName: string): string {
   return nextJobMatch ? rest.slice(0, nextJobMatch.index) : rest;
 }
 
-describe('CI required Typecheck job matches the local verify:quick typecheck set (#319)', () => {
+describe('CI required Typecheck job matches the local verify:quick typecheck set', () => {
   const source = readFileSync(workflowPath, 'utf8');
   const typecheckJob = extractJobBlock(source, 'typecheck');
 
@@ -44,11 +40,11 @@ describe('CI required Typecheck job matches the local verify:quick typecheck set
     expect(typecheckJob).toContain('pnpm typecheck:guides');
   });
 
-  it('runs `pnpm typecheck:examples` — the strict examples config #319 found CI was skipping', () => {
+  it('runs `pnpm typecheck:examples` (strict examples config)', () => {
     expect(typecheckJob).toContain('pnpm typecheck:examples');
   });
 
-  it('runs `pnpm typecheck:type-tests` — same drift class as typecheck:examples, also gated locally by verify:quick', () => {
+  it('runs `pnpm typecheck:type-tests`', () => {
     expect(typecheckJob).toContain('pnpm typecheck:type-tests');
   });
 });

--- a/test/ci/required-typecheck-lane.test.ts
+++ b/test/ci/required-typecheck-lane.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Locks the required GitHub CI `Typecheck` job (`.github/workflows/_ci-checks.yml`)
+ * to run the SAME typecheck set as the local `verify:quick` pre-push hook
+ * (`package.json`'s `typecheck && typecheck:guides && typecheck:examples &&
+ * typecheck:type-tests && typecheck:packages`). #319: the two gates had
+ * drifted — CI skipped `typecheck:examples`, so 5 strict-mode example errors
+ * (introduced by #298's `strict: true`) merged via automerge on green
+ * required CI, then blocked every contributor's local `git push` (the
+ * pre-push hook still ran `typecheck:examples`). `typecheck:type-tests` has
+ * the identical gap (present in verify:quick, absent from CI) despite not
+ * being named in #319's title.
+ */
+
+const workflowPath = resolve(import.meta.dirname!, '../../.github/workflows/_ci-checks.yml');
+
+/** Extracts the `jobs.<jobName>` block's raw YAML text (up to the next top-level job key or EOF). */
+function extractJobBlock(source: string, jobName: string): string {
+  const headerRe = new RegExp(`\\n {2}${jobName}:\\n`);
+  const startMatch = headerRe.exec(source);
+  if (!startMatch) {
+    throw new Error(`job "${jobName}" not found in ${workflowPath}`);
+  }
+
+  const rest = source.slice(startMatch.index + startMatch[0].length);
+  const nextJobMatch = /\n {2}[a-zA-Z][\w-]*:\n/.exec(rest);
+
+  return nextJobMatch ? rest.slice(0, nextJobMatch.index) : rest;
+}
+
+describe('CI required Typecheck job matches the local verify:quick typecheck set (#319)', () => {
+  const source = readFileSync(workflowPath, 'utf8');
+  const typecheckJob = extractJobBlock(source, 'typecheck');
+
+  it('runs `pnpm typecheck` (root src/**)', () => {
+    expect(typecheckJob).toContain('pnpm typecheck\n');
+  });
+
+  it('runs `pnpm typecheck:guides`', () => {
+    expect(typecheckJob).toContain('pnpm typecheck:guides');
+  });
+
+  it('runs `pnpm typecheck:examples` — the strict examples config #319 found CI was skipping', () => {
+    expect(typecheckJob).toContain('pnpm typecheck:examples');
+  });
+
+  it('runs `pnpm typecheck:type-tests` — same drift class as typecheck:examples, also gated locally by verify:quick', () => {
+    expect(typecheckJob).toContain('pnpm typecheck:type-tests');
+  });
+});


### PR DESCRIPTION
## Summary
- The required GitHub CI `Typecheck` job ran `typecheck` + `typecheck:guides` + the extension packages' typecheck, but not `typecheck:examples` or `typecheck:type-tests` — unlike the local `verify:quick` pre-push hook, which runs all four.
- The gates had drifted: PR #307 merged via automerge on green required CI while introducing 5 `typecheck:examples` errors under the `strict: true` config #298 enabled, which then blocked every contributor's local `git push` (pre-push still ran `typecheck:examples`). Fixed reactively in #318, but nothing stopped it recurring — and `typecheck:type-tests` had the identical, still-unfixed gap.
- Adds both missing steps to the `Typecheck` job so CI matches `verify:quick` 1:1.
- New `test/ci/required-typecheck-lane.test.ts` reads the workflow YAML directly (same pattern as `test/build-defines/production-stripping.test.ts`, which reads `rollup.config.ts`) and locks all four typecheck commands into the job, so this drift can't reappear silently.

Closes #319.

## Test plan
- [x] New `test/ci/required-typecheck-lane.test.ts` fails before the fix (missing `typecheck:examples`/`typecheck:type-tests` steps), passes after.
- [x] `pnpm typecheck`, lint, and `prettier --check` clean on the changed files.
- [x] `pnpm verify:quick` clean via the pre-push hook.