### PR TITLE
chore: drop issue-number references from code comments

### DIFF
--- a/site/src/content/api/data-texture.json
+++ b/site/src/content/api/data-texture.json
@@ -893,7 +893,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run — a destroyed texture must not be bound (#310)."
+          "description": "true once destroy has run — a destroyed texture must not be bound."
         },
         {
           "name": "error",

--- a/site/src/content/api/texture.json
+++ b/site/src/content/api/texture.json
@@ -693,7 +693,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run — a destroyed texture must not be bound (#310)."
+          "description": "true once destroy has run — a destroyed texture must not be bound."
         },
         {
           "name": "error",

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -92,7 +92,7 @@ export class Container extends RenderNode {
       return this;
     }
 
-    // #310: attaching an already-destroyed node is otherwise silent — it renders
+    // Attaching an already-destroyed node is otherwise silent — it renders
     // nothing (the collect dev-guard skips it) or replays freed state. Warn once
     // in dev at the attach site, the earliest clear use-after-destroy signal.
     if (__DEV__ && child.destroyed) {

--- a/src/rendering/sprite/Sprite.ts
+++ b/src/rendering/sprite/Sprite.ts
@@ -246,7 +246,7 @@ export class Sprite extends Drawable {
    * Call {@link updateTexture} explicitly when you mutate the source.
    */
   public setTexture(texture: Texture | RenderTexture | null): this {
-    // #310: binding a destroyed texture is otherwise silent (it samples freed
+    // Binding a destroyed texture is otherwise silent (it samples freed
     // GPU state or renders nothing). Warn once in dev at the assignment site.
     if (__DEV__ && texture !== null && 'destroyed' in texture && texture.destroyed) {
       logger.warn(

--- a/src/rendering/texture/Texture.ts
+++ b/src/rendering/texture/Texture.ts
@@ -325,7 +325,7 @@ export class Texture {
     return this;
   }
 
-  /** `true` once {@link destroy} has run — a destroyed texture must not be bound (#310). */
+  /** `true` once {@link destroy} has run — a destroyed texture must not be bound. */
   public get destroyed(): boolean {
     return this._isDestroyed;
   }

--- a/src/resources/Assets.ts
+++ b/src/resources/Assets.ts
@@ -53,7 +53,7 @@ export function _normalizeEntry(value: CatalogEntry): AnyAssetConfig {
 }
 
 // ---------------------------------------------------------------------------
-// Dev-mode typo guard (#311)
+// Dev-mode typo guard
 // ---------------------------------------------------------------------------
 
 /**
@@ -70,8 +70,7 @@ const ASSETS_DEV_PROXY_DUCK_TYPING_KEYS = new Set(['then', 'toJSON']);
  * unrelated catalogs missing the SAME key name must each get their own
  * diagnostic — a global dedup key would silently swallow the second
  * catalog's warning after the first one fires, defeating the point of the
- * guard (adversarial review, 2026-07-13: opus and fable both independently
- * flagged this).
+ * guard.
  */
 let assetsDevProxyInstanceCounter = 0;
 
@@ -109,7 +108,7 @@ export class AssetsImpl<M extends Record<string, CatalogEntry>> {
 
     this.entries = entries as InferAssetsEntries<M>;
 
-    // #311: a typo'd or dynamic catalog-key read (`bag.logoo`, `bag[computedKey]`)
+    // A typo'd or dynamic catalog-key read (`bag.logoo`, `bag[computedKey]`)
     // is otherwise a silent `undefined` — warn once per key in dev instead.
     // __DEV__-gated: zero cost and no Proxy indirection in production.
     if (__DEV__) {

--- a/test/core/scene.test.ts
+++ b/test/core/scene.test.ts
@@ -139,10 +139,10 @@ describe('Scene', () => {
     expect(backendDraw).not.toHaveBeenCalledWith(uiSprite);
   });
 
-  // #313: Scene.app is a throwing non-null accessor (like Scene.inputs/tweens/
+  // Scene.app is a throwing non-null accessor (like Scene.inputs/tweens/
   // loader), not `Application | null` — the framework guarantees attachment
   // before any lifecycle hook, so scene code never needs a null guard.
-  describe('app accessor (#313)', () => {
+  describe('app accessor', () => {
     const fakeApp = { id: 'app' } as unknown as import('#core/Application').Application;
 
     test('throws when accessed before the scene is attached', () => {

--- a/test/rendering/container.test.ts
+++ b/test/rendering/container.test.ts
@@ -82,11 +82,11 @@ describe('Container', () => {
     expect(container.children).toEqual([third, first, second]);
   });
 
-  // #310: using a destroyed node is otherwise silent — warn once (dev only) at
+  // Using a destroyed node is otherwise silent — warn once (dev only) at
   // the attach site, the earliest clear signal of use-after-destroy. Asserted
   // through a sink (which honours the logger's `once` dedup), not a warn spy
   // (which would count calls before dedup).
-  describe('destroyed-child guard (#310)', () => {
+  describe('destroyed-child guard', () => {
     let entries: string[];
     let removeSink: () => void;
 

--- a/test/rendering/sprite/sprite.test.ts
+++ b/test/rendering/sprite/sprite.test.ts
@@ -91,9 +91,9 @@ describe('Sprite', () => {
     });
   });
 
-  // #310: binding a destroyed texture is otherwise silent — warn once (dev) at
+  // Binding a destroyed texture is otherwise silent — warn once (dev) at
   // the assignment site. Asserted via a sink (honours the logger's `once` dedup).
-  describe('destroyed-texture guard (#310)', () => {
+  describe('destroyed-texture guard', () => {
     const destroyedTexture = (): Texture => ({ width: 16, height: 16, flipY: false, destroyed: true, updateSource: () => undefined }) as unknown as Texture;
 
     let entries: string[];

--- a/test/resources/assets.test.ts
+++ b/test/resources/assets.test.ts
@@ -65,7 +65,7 @@ describe('Assets.from bare-string inference', () => {
   });
 });
 
-describe('Assets dev-mode typo guard (#311)', () => {
+describe('Assets dev-mode typo guard', () => {
   let entries: string[];
   let removeSink: () => void;
 


### PR DESCRIPTION
## Summary
- Removes issue-number references (`#310`, `#311`, `#313`) from inline comments, JSDoc, and `describe()` block labels in `src/rendering/Container.ts`, `src/rendering/sprite/Sprite.ts`, `src/rendering/texture/Texture.ts`, `src/resources/Assets.ts`, `test/core/scene.test.ts`, `test/rendering/container.test.ts`, `test/rendering/sprite/sprite.test.ts`, `test/resources/assets.test.ts`.
- Rewrites the explanatory prose to stay self-contained without the reference — a comment should explain the WHY (invariant, failure mode) directly, not point at an issue number that gets closed and stops being resolvable context.
- No behavior change: comments/docs/test labels only. API docs regenerated for the `Texture.destroyed` JSDoc wording tweak.

## Test plan
- [x] All touched test files pass (`scene.test.ts`, `container.test.ts`, `sprite.test.ts`, `assets.test.ts` — 56/56).
- [x] `pnpm typecheck`, lint, `prettier --check`, `docs:api:check` all clean.
- [x] `pnpm verify:quick` clean via the pre-push hook.