### PR TITLE
perf(render): close remaining slice-4 transform-patch nitpicks

### DIFF
--- a/src/rendering/RetainedContainer.ts
+++ b/src/rendering/RetainedContainer.ts
@@ -166,18 +166,26 @@ export class RetainedContainer extends Container {
 
     const world = this.getGlobalTransform();
 
+    // Read each side-effecting revision getter once (not once per comparison
+    // AND once per assignment): every read bumps the shared dirty-walk epoch
+    // (SceneNode._contentRevision et al.), so a Local avoids doubling this
+    // call's contribution to that walk.
+    const contentRevision = this._contentRevision;
+    const structureRevision = this._structureRevision;
+    const transformRevision = this._transformRevision;
+
     // Keyed on the transform channel too (Slice 4b): a descendant transform-only
     // move changes its group-local rect but no longer stamps content (the 4b
     // flip), so without the transform key the cached aggregate would go stale.
     if (
-      this._aggregateContentRevision !== this._contentRevision ||
-      this._aggregateStructureRevision !== this._structureRevision ||
-      this._aggregateTransformRevision !== this._transformRevision
+      this._aggregateContentRevision !== contentRevision ||
+      this._aggregateStructureRevision !== structureRevision ||
+      this._aggregateTransformRevision !== transformRevision
     ) {
       this._rebuildGroupAggregate();
-      this._aggregateContentRevision = this._contentRevision;
-      this._aggregateStructureRevision = this._structureRevision;
-      this._aggregateTransformRevision = this._transformRevision;
+      this._aggregateContentRevision = contentRevision;
+      this._aggregateStructureRevision = structureRevision;
+      this._aggregateTransformRevision = transformRevision;
     }
 
     this._bounds.reset().addRect(this._groupAggregate.getRect(), world);
@@ -298,6 +306,16 @@ export class RetainedContainer extends Container {
       this._children[index]!._collect(builder, index);
     }
 
+    // This full collect just read every child's transform live, so any rows
+    // queued before this frame are subsumed — moot whether or not a capture
+    // actually runs below. Without this, a thrash-suppressed frame (F11b)
+    // skips `capture()` (the queue's other drain site) and the queue keeps
+    // strong-referencing moved nodes — including ones removed meanwhile —
+    // until suppression ends.
+    if (this._fragment.hasDirtyTransformRows()) {
+      this._fragment.clearDirtyTransformRows();
+    }
+
     if (__DEV__) {
       this._trackRetention(invalidated);
     }
@@ -321,8 +339,12 @@ export class RetainedContainer extends Container {
   private _reconcileTransformRows(): void {
     const set = this._fragment.instructions;
     const bundle = set?.ownedBundle ?? null;
+    // Narrowed here, once: `patch` is the live capability object for the rest
+    // of this method AND whatever it hands off to — no callee needs its own
+    // non-null assertion to reuse a guard this scope already proved.
+    const patch = bundle?.transformPatch;
 
-    if (set === null || !set.hasRecording || bundle === null || typeof bundle._patchTransformRow !== 'function' || bundle.transformRowBase === undefined) {
+    if (set === null || !set.hasRecording || bundle === null || patch === undefined) {
       // The set holds a recording whose baked transform rows we cannot patch
       // (a backend without row-patch support — e.g. WebGPU before slice 4c),
       // yet a transform-only move must still take effect. Drop the recording so
@@ -339,14 +361,14 @@ export class RetainedContainer extends Container {
     }
 
     // The group-local row origin is the fragment's CAPTURE-frame (F1) minimum
-    // draw index — NOT `bundle.transformRowBase` (the record-frame F2 rebase
-    // base). The two frames can start the group at different absolute rows, and
-    // the store rows are group-local, so only the F1 subtree base maps a
-    // captured index to its store row (see directDrawBaseNodeIndex).
+    // draw index — NOT `patch.rowBase` (the record-frame F2 rebase base). The
+    // two frames can start the group at different absolute rows, and the store
+    // rows are group-local, so only the F1 subtree base maps a captured index
+    // to its store row (see directDrawBaseNodeIndex).
     const base = this._fragment.directDrawBaseNodeIndex();
 
     for (const node of this._fragment.dirtyTransformRows) {
-      if (!this._patchTransformRow(node, bundle, base)) {
+      if (!this._tryPatchTransformRow(node, patch, base)) {
         // Ineligible: drop the baked recording. `_markCurrentScopeRetained`
         // will now fail its validity check, so the group falls to entry replay
         // (live transforms) and re-records this frame.
@@ -364,8 +386,12 @@ export class RetainedContainer extends Container {
    * drawable child, non-snapped, present in the recorded row map. The
    * group-local matrix is `getGlobalTransform()` composed to this boundary — the
    * exact value the recorder wrote (S3-D4).
+   *
+   * Named distinctly from the {@link RetainedGroupBundle.transformPatch}
+   * `patchRow` it calls (`this` vs. `patch` was the same name on two
+   * different things — a rename-target footgun, not just a style nit).
    */
-  private _patchTransformRow(node: RenderNode, bundle: RetainedGroupBundle, base: number): boolean {
+  private _tryPatchTransformRow(node: RenderNode, patch: NonNullable<RetainedGroupBundle['transformPatch']>, base: number): boolean {
     if (node.parent !== this) {
       return false;
     }
@@ -381,7 +407,7 @@ export class RetainedContainer extends Container {
     }
 
     packTransformRow(patchRowScratch, 0, node.getGlobalTransform(), drawable.tint);
-    bundle._patchTransformRow!(nodeIndex - base, patchRowScratch);
+    patch.patchRow(nodeIndex - base, patchRowScratch);
 
     return true;
   }

--- a/src/rendering/plan/RetainedInstructionSet.ts
+++ b/src/rendering/plan/RetainedInstructionSet.ts
@@ -31,20 +31,28 @@ export interface RetainedGroupBundle {
   /** Monotonic resource generation; a mismatch invalidates referencing sets. */
   readonly generation: number;
   /**
-   * The shared frame-buffer row the stored transform rows were rebased from
-   * (Slice 4b). A group-local row is `capturedNodeIndex - transformRowBase`.
-   * Absent on backends that do not implement in-place transform patching.
+   * Slice 4b/4c fast in-place transform-row patch capability, bundled as one
+   * object rather than two independent optionals: `rowBase` and `patchRow`
+   * only ever make sense together, so a caller that finds one is guaranteed
+   * the other — no combined "has base but no patch fn" state is representable.
+   * Absent on backends that do not implement in-place transform patching —
+   * the caller then falls back to entry replay (re-reads live transforms) or
+   * a re-record.
    */
-  readonly transformRowBase?: number;
-  /**
-   * Slice 4b fast patch: overwrite one group-local transform row in place with
-   * `floats` (12 = 3 rgba32f texels, the `TransformBuffer` row layout) and mark
-   * only its sub-range for upload, WITHOUT bumping the generation (the recorded
-   * instance bytes reference the row by index and stay valid). Absent on
-   * backends without patch support — the caller then falls back to entry replay
-   * (which re-reads live transforms) or a re-record.
-   */
-  _patchTransformRow?(localRow: number, floats: Float32Array): void;
+  readonly transformPatch?: {
+    /**
+     * The shared frame-buffer row the stored transform rows were rebased from
+     * (Slice 4b). A group-local row is `capturedNodeIndex - rowBase`.
+     */
+    readonly rowBase: number;
+    /**
+     * Overwrite one group-local transform row in place with `floats` (12 = 3
+     * rgba32f texels, the `TransformBuffer` row layout) and mark only its
+     * sub-range for upload, WITHOUT bumping the generation (the recorded
+     * instance bytes reference the row by index and stay valid).
+     */
+    patchRow(localRow: number, floats: Float32Array): void;
+  };
   /** Release the bundle's GPU resources (container destroy / disengage). */
   destroy?(): void;
 }

--- a/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
+++ b/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
@@ -137,7 +137,23 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
 
   private _destroyed = false;
 
-  public constructor(private readonly _onDestroyed: ((bundle: WebGl2RetainedGroupResources) => void) | null = null) {}
+  /**
+   * Built once at construction (not per-frame): a getter/method pair closing
+   * over `this` so the {@link transformPatch} capability object is a stable
+   * reference — the reconcile hot path reads it every clean frame with
+   * pending moves and must not allocate.
+   */
+  private readonly _transformPatch: NonNullable<RetainedGroupBundle['transformPatch']>;
+
+  public constructor(private readonly _onDestroyed: ((bundle: WebGl2RetainedGroupResources) => void) | null = null) {
+    // Arrow functions close over the constructor's own `this` (the instance),
+    // so `rowBase` reads live state without aliasing `this` to a local.
+    this._transformPatch = Object.defineProperty(
+      { patchRow: (localRow: number, floats: Float32Array): void => this._patchTransformRow(localRow, floats) },
+      'rowBase',
+      { enumerable: true, get: (): number => this._transformRowBase },
+    ) as NonNullable<RetainedGroupBundle['transformPatch']>;
+  }
 
   /** Monotonic resource generation (see {@link RetainedGroupBundle.generation}). */
   public get generation(): number {
@@ -177,6 +193,11 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
    */
   public get transformRowBase(): number {
     return this._transformRowBase;
+  }
+
+  /** {@link RetainedGroupBundle.transformPatch} — this backend always supports it. */
+  public get transformPatch(): NonNullable<RetainedGroupBundle['transformPatch']> {
+    return this._transformPatch;
   }
 
   /**

--- a/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
+++ b/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
@@ -144,9 +144,25 @@ export class WebGpuRetainedGroupBundle implements RetainedGroupBundle {
   /** The open pass this bundle's replayed draws were last recorded into. */
   public drawsInPass: WebGpuActiveRenderPass | null = null;
 
+  /**
+   * Built once at construction (not per-frame): a getter/method pair closing
+   * over `this` so the {@link transformPatch} capability object is a stable
+   * reference — the reconcile hot path reads it every clean frame with
+   * pending moves and must not allocate.
+   */
+  private readonly _transformPatch: NonNullable<RetainedGroupBundle['transformPatch']>;
+
   public constructor(accountant: GpuResourceAccountant, onRelease: (bundle: WebGpuRetainedGroupBundle) => void) {
     this._accountant = accountant;
     this._onRelease = onRelease;
+
+    // Arrow functions close over the constructor's own `this` (the instance),
+    // so `rowBase` reads live state without aliasing `this` to a local.
+    this._transformPatch = Object.defineProperty(
+      { patchRow: (localRow: number, floats: Float32Array): void => this._patchTransformRow(localRow, floats) },
+      'rowBase',
+      { enumerable: true, get: (): number => this._transformRowBase },
+    ) as NonNullable<RetainedGroupBundle['transformPatch']>;
   }
 
   /** Monotonic resource generation (see {@link RetainedGroupBundle}). */
@@ -170,6 +186,11 @@ export class WebGpuRetainedGroupBundle implements RetainedGroupBundle {
    */
   public get transformRowBase(): number {
     return this._transformRowBase;
+  }
+
+  /** {@link RetainedGroupBundle.transformPatch} — this backend always supports it. */
+  public get transformPatch(): NonNullable<RetainedGroupBundle['transformPatch']> {
+    return this._transformPatch;
   }
 
   public get uniformBuffer(): GPUBuffer | null {


### PR DESCRIPTION
## What

Closes the remaining non-critical nitpicks from the fable adversarial re-review of #335 (tracked in memory as the slice-4 cleanup backlog; F1/F2/F3/F5 were already fixed via #338).

- Merge `RetainedGroupBundle.transformRowBase`/`_patchTransformRow` into a single optional `transformPatch` capability object, so a caller can never see one half without the other.
- Pass the already-narrowed patch function into the row-patch helper instead of asserting non-null on a guard proved in a different method.
- Rename `RetainedContainer`'s private `_patchTransformRow` to `_tryPatchTransformRow` to stop shadowing the bundle method of the same name.
- Read the three side-effecting revision getters (`_contentRevision`/`_structureRevision`/`_transformRevision`) once per `updateBounds()` call instead of twice, halving this call site's contribution to the shared dirty-walk epoch.
- Drain the queued transform-row moves after every full collect, not only when a capture actually runs, so a thrash-suppressed frame (F11b) doesn't keep holding strong refs to moved (possibly since-removed) nodes.

No behavior change — same eligibility rules, same fallback-to-entry-replay semantics, just narrower types and one less leak-let.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm eslint` on changed files
- [x] `pnpm prettier --check` on changed files
- [x] Node unit tests: retained-container, retained-group-fragment, retained-instruction-set/equivalence, retained-plan-cache, retained-subtree-skip, pixel-snap, webgl2/webgpu retained-group-resources — all passing
- [x] Browser tests (Chromium WebGL2 + WebGPU): retained-container, retained-instruction-replay, rotated-retained-group, group-uniform — all passing
- [x] Full pre-push `verify:quick` gate passed