### PR TITLE
feat(playground): TS strict-mode editor check + read-only View-as-JS toggle

### DIFF
--- a/site/src/components/Editor.tsx
+++ b/site/src/components/Editor.tsx
@@ -60,6 +60,7 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
     const [selectionLength, setSelectionLength] = useState(0);
     const [dirty, setDirty] = useState(false);
     const [diagnostics, setDiagnostics] = useState<ReadonlyArray<EditorDiagnostic>>([]);
+    const [viewMode, setViewMode] = useState<'source' | 'compiled'>('source');
     // Split (editor left, preview right) is the desktop default; the stored
     // preference is applied after mount so SSR and first client render match.
     // Below 1120px the CSS ignores the mode and always stacks.
@@ -100,6 +101,7 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
         setSourceLoadError(null);
         setPreviewErrors([]);
         setDiagnostics([]);
+        setViewMode('source');
         /* eslint-enable @eslint-react/set-state-in-effect */
 
         if (!activeExample || !selectedVersionId) return;
@@ -225,6 +227,21 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
     const languageLabel = activeExample?.language === 'typescript' ? 'TypeScript' : 'JavaScript';
     const editorLanguage = activeExample?.language === 'typescript' ? 'typescript' : 'javascript';
     const displayPath = getDisplayPath(activeExample);
+    // The toggle only makes sense for a TS example — a "compiled" view of
+    // freeform JS scratch code would just be the same text back.
+    const canToggleView = editorLanguage === 'typescript';
+    const isCompiledView = canToggleView && viewMode === 'compiled';
+    const displayedLanguage = isCompiledView ? 'javascript' : editorLanguage;
+    // executionCode only reads null before the very first successful compile —
+    // once set, it holds the last successful compile even while a newer edit is
+    // still emitting (see getExecutionCode's contract in EditorCode.tsx), so this
+    // placeholder is a first-paint-only case.
+    const displayedSourceCode = isCompiledView ? (executionCode ?? '// Compiling…') : sourceCode;
+    const displayedSourcePath = isCompiledView ? (activeExample?.path ?? null) : displayPath;
+
+    const toggleViewMode = (): void => {
+        setViewMode(mode => (mode === 'source' ? 'compiled' : 'source'));
+    };
 
     return (
         <section className={css(styles, 'root')} data-layout={layout}>
@@ -283,9 +300,10 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
                 <Suspense fallback={<LoadingSpinner centered />}>
                     <EditorCode
                         ref={codeEditorRef}
-                        sourceCode={sourceCode}
-                        sourcePath={displayPath}
-                        language={editorLanguage}
+                        sourceCode={displayedSourceCode}
+                        sourcePath={displayedSourcePath}
+                        language={displayedLanguage}
+                        readOnly={isCompiledView}
                         canReset={Boolean(originalSourceCode && sourceCode !== originalSourceCode)}
                         exampleTitle={activeExample?.title ?? 'Loading...'}
                         selectedVersionId={selectedVersionId}
@@ -296,7 +314,15 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
                         onDirty={setDirty}
                     />
                 </Suspense>
-                <EditorStatusBar line={cursorLine} column={cursorColumn} selectionLength={selectionLength} dirty={dirty} language={languageLabel} />
+                <EditorStatusBar
+                    line={cursorLine}
+                    column={cursorColumn}
+                    selectionLength={selectionLength}
+                    dirty={dirty}
+                    language={languageLabel}
+                    viewMode={canToggleView ? viewMode : undefined}
+                    onToggleViewMode={canToggleView ? toggleViewMode : undefined}
+                />
             </section>
         </section>
     );

--- a/site/src/components/EditorCode.tsx
+++ b/site/src/components/EditorCode.tsx
@@ -201,6 +201,12 @@ export const EditorCode = forwardRef<EditorCodeHandle, EditorCodeProps>(function
         onDirty(false);
     }, [language, onUpdateCode, onDirty, readOnly]);
 
+    // `onMount` runs once, so the addCommand closures below would otherwise
+    // capture the initial (never-read-only) triggerRefresh forever; read this
+    // ref instead so they always see the current readOnly-guarded version.
+    const triggerRefreshRef = useRef(triggerRefresh);
+    triggerRefreshRef.current = triggerRefresh;
+
     useImperativeHandle(
         ref,
         () => ({
@@ -251,9 +257,9 @@ export const EditorCode = forwardRef<EditorCodeHandle, EditorCodeProps>(function
             }),
         );
 
-        editor.addCommand(monacoApi.KeyMod.CtrlCmd | monacoApi.KeyCode.Enter, () => void triggerRefresh());
+        editor.addCommand(monacoApi.KeyMod.CtrlCmd | monacoApi.KeyCode.Enter, () => void triggerRefreshRef.current());
         if (typeof monacoApi.KeyCode.KeyS === 'number') {
-            editor.addCommand(monacoApi.KeyMod.CtrlCmd | monacoApi.KeyCode.KeyS, () => void triggerRefresh());
+            editor.addCommand(monacoApi.KeyMod.CtrlCmd | monacoApi.KeyCode.KeyS, () => void triggerRefreshRef.current());
         }
 
         onCursorChange({ lineNumber: 1, column: 1, selectionLength: 0 });

--- a/site/src/components/EditorCode.tsx
+++ b/site/src/components/EditorCode.tsx
@@ -630,7 +630,7 @@ async function fetchTypingsManifest(relativePath: string): Promise<ReadonlyArray
 
 function configureLanguageDefaults(): void {
     const tsApi = (monaco.languages as unknown as { typescript: MonacoTypeScriptApi }).typescript;
-    const compilerOptions = {
+    const sharedCompilerOptions = {
         allowJs: true,
         allowNonTsExtensions: true,
         allowSyntheticDefaultImports: true,
@@ -639,12 +639,25 @@ function configureLanguageDefaults(): void {
         module: tsApi.ModuleKind.ESNext,
         moduleResolution: tsApi.ModuleResolutionKind.NodeJs,
         noEmit: true,
-        noImplicitAny: false,
-        noImplicitThis: false,
-        strict: false,
         target: tsApi.ScriptTarget.ES2020,
         baseUrl: 'file:///',
         paths: { '@/*': ['node_modules/@codexo/exojs/dist/esm/*'] },
+    };
+    // TS examples are strict-clean at the source of truth (tsconfig.examples.json,
+    // enforced by `pnpm typecheck:examples`) — mirror that here so editing one in
+    // the Playground surfaces the same errors CI would.
+    const tsCompilerOptions = {
+        ...sharedCompilerOptions,
+        strict: true,
+    };
+    // JS mode is a deliberate low-friction path for writing/pasting plain JS with
+    // no TypeScript background — checkJs (above) still catches real type errors;
+    // only "add an annotation" strict-mode noise is suppressed.
+    const jsCompilerOptions = {
+        ...sharedCompilerOptions,
+        noImplicitAny: false,
+        noImplicitThis: false,
+        strict: false,
     };
     const diagnosticsOptions = {
         noSemanticValidation: false,
@@ -654,8 +667,8 @@ function configureLanguageDefaults(): void {
 
     tsApi.javascriptDefaults.setEagerModelSync(true);
     tsApi.typescriptDefaults.setEagerModelSync(true);
-    tsApi.javascriptDefaults.setCompilerOptions(compilerOptions);
-    tsApi.typescriptDefaults.setCompilerOptions(compilerOptions);
+    tsApi.javascriptDefaults.setCompilerOptions(jsCompilerOptions);
+    tsApi.typescriptDefaults.setCompilerOptions(tsCompilerOptions);
     tsApi.javascriptDefaults.setDiagnosticsOptions(diagnosticsOptions);
     tsApi.typescriptDefaults.setDiagnosticsOptions(diagnosticsOptions);
 

--- a/site/src/components/EditorCode.tsx
+++ b/site/src/components/EditorCode.tsx
@@ -48,6 +48,7 @@ export interface EditorCodeProps {
     canReset: boolean;
     exampleTitle: string;
     language: 'javascript' | 'typescript';
+    readOnly?: boolean;
     selectedVersionId: string;
     sourceCode: string | null;
     sourcePath: string | null;
@@ -111,6 +112,7 @@ export const EditorCode = forwardRef<EditorCodeHandle, EditorCodeProps>(function
         onDirty,
         onResetCode,
         onUpdateCode,
+        readOnly = false,
         selectedVersionId,
         sourceCode,
         sourcePath,
@@ -176,6 +178,9 @@ export const EditorCode = forwardRef<EditorCodeHandle, EditorCodeProps>(function
     );
 
     const triggerRefresh = useCallback(async (): Promise<void> => {
+        // A read-only buffer shows already-compiled JS, not new source — refreshing
+        // from it would feed that compiled text back into `sourceCode` upstream.
+        if (readOnly) return;
         const editor = editorRef.current;
         if (!editor) return;
         const code = editor.getValue();
@@ -194,7 +199,7 @@ export const EditorCode = forwardRef<EditorCodeHandle, EditorCodeProps>(function
         }
         onUpdateCode({ code, executionCode });
         onDirty(false);
-    }, [language, onUpdateCode, onDirty]);
+    }, [language, onUpdateCode, onDirty, readOnly]);
 
     useImperativeHandle(
         ref,
@@ -372,6 +377,7 @@ export const EditorCode = forwardRef<EditorCodeHandle, EditorCodeProps>(function
                             lineNumbersMinChars: 4,
                             minimap: { enabled: false },
                             overviewRulerLanes: 0,
+                            readOnly,
                             renderValidationDecorations: 'on',
                             scrollBeyondLastLine: false,
                             tabSize: 4,

--- a/site/src/components/EditorCode.tsx
+++ b/site/src/components/EditorCode.tsx
@@ -299,6 +299,7 @@ export const EditorCode = forwardRef<EditorCodeHandle, EditorCodeProps>(function
 
     const importCode = (): void => {
         setShowMenu(false);
+        if (readOnly) return;
         fileInputRef.current?.click();
     };
 
@@ -323,11 +324,12 @@ export const EditorCode = forwardRef<EditorCodeHandle, EditorCodeProps>(function
                         className={cx(css(styles, 'auto-button'), autoRefresh && css(styles, 'auto-button--active'))}
                         type="button"
                         title="Auto-refresh the preview on every code change (800ms debounce)"
+                        disabled={readOnly}
                         onClick={() => setAutoRefresh(value => !value)}
                     >
                         auto-run
                     </button>
-                    <button className={css(styles, 'more-button')} data-action="refresh" type="button" title="Refresh preview (Ctrl+Enter)" onClick={() => void triggerRefresh()}>
+                    <button className={css(styles, 'more-button')} data-action="refresh" type="button" title="Refresh preview (Ctrl+Enter)" disabled={readOnly} onClick={() => void triggerRefresh()}>
                         <svg viewBox="0 0 16 16" width="1em" height="1em" style={{ display: 'block' }} fill="currentColor" aria-hidden="true">
                             <path fillRule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z" />
                             <path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z" />
@@ -351,7 +353,7 @@ export const EditorCode = forwardRef<EditorCodeHandle, EditorCodeProps>(function
                             <button className={css(styles, 'menu-item')} role="menuitem" onClick={exportCode}>
                                 Export Code
                             </button>
-                            <button className={css(styles, 'menu-item')} role="menuitem" onClick={importCode}>
+                            <button className={css(styles, 'menu-item')} role="menuitem" disabled={readOnly} onClick={importCode}>
                                 Import Code
                             </button>
                             <button className={css(styles, 'menu-item')} role="menuitem" data-variant="danger" disabled={!canReset} onClick={resetCode}>

--- a/site/src/components/EditorStatusBar.module.scss
+++ b/site/src/components/EditorStatusBar.module.scss
@@ -61,3 +61,25 @@
         display: none;
     }
 }
+
+.chip--view-toggle {
+    appearance: none;
+    background: transparent;
+    border: 1px solid var(--line-soft);
+    border-radius: 999px;
+    padding: 0.05rem 0.5rem;
+    color: inherit;
+    font: inherit;
+    letter-spacing: inherit;
+    cursor: pointer;
+}
+
+.chip--view-toggle:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.chip--view-toggle:focus-visible {
+    outline: 2px solid var(--accent-line);
+    outline-offset: 2px;
+}

--- a/site/src/components/EditorStatusBar.tsx
+++ b/site/src/components/EditorStatusBar.tsx
@@ -6,10 +6,12 @@ export interface EditorStatusBarProps {
     dirty: boolean;
     language: string;
     line: number;
+    onToggleViewMode?: () => void;
     selectionLength: number;
+    viewMode?: 'source' | 'compiled';
 }
 
-export function EditorStatusBar({ column, dirty, language, line, selectionLength }: EditorStatusBarProps): JSX.Element {
+export function EditorStatusBar({ column, dirty, language, line, onToggleViewMode, selectionLength, viewMode }: EditorStatusBarProps): JSX.Element {
     return (
         <div className={css(styles, 'root')}>
             <div className={css(styles, 'left')}>
@@ -17,6 +19,16 @@ export function EditorStatusBar({ column, dirty, language, line, selectionLength
                     <span className={css(styles, 'lang-dot')} aria-hidden="true" />
                     <span>{language}</span>
                 </span>
+                {onToggleViewMode && (
+                    <button
+                        type="button"
+                        className={cx(css(styles, 'chip'), css(styles, 'chip--view-toggle'))}
+                        onClick={onToggleViewMode}
+                        title="Toggle between the TypeScript source and its compiled JavaScript"
+                    >
+                        {viewMode === 'compiled' ? 'View: compiled JS' : 'View: TS source'}
+                    </button>
+                )}
             </div>
             <div className={css(styles, 'right')}>
                 {selectionLength > 0 && <span className={cx(css(styles, 'chip'), css(styles, 'chip--selection'))}>{selectionLength} selected</span>}


### PR DESCRIPTION
## What

Closes #314. Two related changes to the Playground's Monaco editor:

1. **TS/JS strictness split** — TypeScript examples are now checked in-editor with `strict: true`, matching `tsconfig.examples.json` (the same rigor `pnpm typecheck:examples` already enforces on the committed catalog). JavaScript scratch-editing stays relaxed on purpose — it's a deliberate low-friction path for people trying exojs with no TypeScript background; `checkJs` still catches real type errors, only "add an annotation" strict-mode noise is suppressed.
2. **Read-only "View as JS" toggle** — TS examples were already silently compiled to JS on every edit (to run the live preview); this exposes that already-computed value as a toggleable, read-only view in the same editor pane, so users can see/copy the plain-JS equivalent without a bundler. No new compile path — reuses the existing `executionCode` state.

## Design

Full design/spec + implementation plan (not committed, `.workspace/` is gitignored in this repo): brainstormed and planned via `superpowers:brainstorming` → `superpowers:writing-plans`, executed via `superpowers:subagent-driven-development` (fresh implementer + reviewer subagent per task, one whole-branch review at the end).

## Commits

- `fix(playground): check TS examples with strict:true, keep JS relaxed`
- `feat(playground): add read-only View-as-JS toggle for TS examples`
- `fix(playground): keep readOnly guard live across keyboard refresh shortcuts` — a task-review catch: Ctrl+Enter/Ctrl+S read a stale mount-time closure and bypassed the new `readOnly` guard, risking silent overwrite of the real TS source with compiled JS.
- `fix(playground): disable mutating toolbar controls while viewing compiled JS` — a final-review catch: the refresh/auto-run/Import-Code toolbar controls didn't reflect the read-only state.

## Test plan

No automated test suite exists for these React components (`site/src/components`). Verified via:
- [x] `pnpm --filter @codexo/exojs-examples check-ts` — clean (this worktree has an unrelated 11-error environment baseline on Monaco's JSX typing, confirmed present pre-change and absent in the main checkout/CI; no new errors introduced)
- [x] `pnpm eslint` / `pnpm prettier --check` on all touched files — clean
- [x] Manual + headless-browser (Playwright) verification per task: strict-mode TS diagnostics fire correctly, JS mode stays relaxed, toggle shows/hides correctly per example language, read-only guard holds across toolbar button, keyboard shortcuts, and the toolbar's mutating controls
- [x] Full pre-push `verify:quick` gate (repo-wide typecheck/lint/format/API-docs-sync) passed