### PR TITLE
fix(physics): swept-SAT no longer treats exact tangency as a blocking hit

### DIFF
--- a/packages/exojs-physics/src/collision/sweep.ts
+++ b/packages/exojs-physics/src/collision/sweep.ts
@@ -345,8 +345,10 @@ const sweptSatAxes = (
     }
 
     if (dn > -eps && dn < eps) {
-      // No relative motion along this axis: separated here means never touching.
-      if (maxA < minB || maxB < minA) {
+      // No relative motion along this axis: separated — or exactly touching,
+      // which the discrete narrow phase already treats as no contact — here
+      // means never in contact.
+      if (maxA <= minB || maxB <= minA) {
         return false;
       }
 
@@ -370,8 +372,11 @@ const sweptSatAxes = (
       state.tLeave = exit;
     }
 
-    if (state.tEnter > state.tLeave) {
-      return false; // Separated on one axis before overlapping on another.
+    if (state.tEnter >= state.tLeave) {
+      // Separated on one axis before overlapping on another. Equality is an
+      // exact graze (separation touches 0 but never goes negative), which the
+      // discrete narrow phase classifies as no contact.
+      return false;
     }
   }
 

--- a/packages/exojs-physics/test/ccd.test.ts
+++ b/packages/exojs-physics/test/ccd.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
+import { type SweepHit, sweepProxies } from '../src/collision/sweep';
 import { BoxShape, CircleShape, PhysicsBody, PhysicsWorld } from '../src/index';
+import { colliderAt } from './support';
 
 /**
  * Continuous collision detection / bullet-mode.
@@ -400,5 +402,59 @@ describe('continuous collision (swept shape, not just the centre)', () => {
       world.step(FRAME);
     }
     expect(world._ccdSweepTests).toBeGreaterThan(0);
+  });
+});
+
+describe('swept SAT — exact tangency is not a blocking hit', () => {
+  /**
+   * The discrete narrow phase treats a separation of exactly 0 (touching, not
+   * overlapping) as no contact; the swept SAT must classify the same boundary
+   * configurations the same way, or a grazing bullet gets a spurious stop
+   * where the discrete phase sees no overlap.
+   */
+
+  const hit: SweepHit = { t: 0, normalX: 0, normalY: 0 };
+
+  it('a box sliding exactly along another box face (separation 0) reports no hit', () => {
+    const world = new PhysicsWorld();
+    const target = colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 }); // spans y ∈ [−5, 5]
+    // End pose spans y ∈ [5, 15]: its bottom face touches the target's top face
+    // exactly (separation 0 on the y axis, which has no relative motion) while
+    // the x intervals sweep across each other.
+    const moving = colliderAt(world, new BoxShape(10, 10), { x: 20, y: 10 });
+
+    expect(sweepProxies(moving, 40, 0, target, hit)).toBe(false);
+  });
+
+  it('the same slide with 1px of overlap is still a hit (face normal against the motion)', () => {
+    const world = new PhysicsWorld();
+    const target = colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
+    const moving = colliderAt(world, new BoxShape(10, 10), { x: 20, y: 9 }); // overlaps y ∈ [4, 5]
+
+    expect(sweepProxies(moving, 40, 0, target, hit)).toBe(true);
+    expect(hit.t).toBeCloseTo(0.25, 6); // moving x-span [−25, −15] → its leading face meets x = −5 at t = 0.25
+    expect(hit.normalX).toBeCloseTo(-1, 6);
+    expect(hit.normalY).toBeCloseTo(0, 6);
+  });
+
+  it('a diagonal corner-to-corner graze (zero-width overlap window) reports no hit', () => {
+    const world = new PhysicsWorld();
+    const target = colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
+    // Swept from (20, 0) to (0, 20): the moving box's bottom-left corner slides
+    // along the line x + y = 10 and touches the target's (5, 5) corner at
+    // exactly t = 0.5 — separation reaches 0 for one instant, never negative.
+    const moving = colliderAt(world, new BoxShape(10, 10), { x: 0, y: 20 });
+
+    expect(sweepProxies(moving, -20, 20, target, hit)).toBe(false);
+  });
+
+  it('the same diagonal path shifted 1px into the corner is still a hit', () => {
+    const world = new PhysicsWorld();
+    const target = colliderAt(world, new BoxShape(10, 10), { x: 0, y: 0 });
+    const moving = colliderAt(world, new BoxShape(10, 10), { x: 0, y: 19 }); // corner path clips (5, 5)
+
+    expect(sweepProxies(moving, -20, 20, target, hit)).toBe(true);
+    expect(hit.t).toBeGreaterThan(0);
+    expect(hit.t).toBeLessThanOrEqual(1);
   });
 });


### PR DESCRIPTION
## What
Closes #302. Swept-SAT continuous collision treated an exact separation of `0` (bodies exactly touching, not overlapping) as a blocking hit — inconsistent with the discrete narrow phase (`collidePolygons`), which treats `separation >= 0` as no contact. Hardened the swept-SAT tangency check to agree with the discrete convention.

## Test plan
- [x] 4 new regression tests in `packages/exojs-physics/test/ccd.test.ts` (2 exact-tangency grazes → no hit, 2 penetrating companions → hit)
- [x] Full exojs-physics suite: 247/247 pass
- [x] New tests verified red against the pre-fix code