### PR TITLE
fix(test): register renderer bindings before backend.initialize() in WebGPU browser specs

### DIFF
--- a/test/rendering/browser/webgpu-animated-sprite.test.ts
+++ b/test/rendering/browser/webgpu-animated-sprite.test.ts
@@ -54,8 +54,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-backdrop-blend.test.ts
+++ b/test/rendering/browser/webgpu-backdrop-blend.test.ts
@@ -70,8 +70,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-dpr-resolution.test.ts
+++ b/test/rendering/browser/webgpu-dpr-resolution.test.ts
@@ -41,8 +41,8 @@ const setupBackend = async (logical: number, pixelRatio: number): Promise<WebGpu
 
   const backend = new WebGpuBackend(makeApp(canvas, logical, pixelRatio));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-draw-geometry.test.ts
+++ b/test/rendering/browser/webgpu-draw-geometry.test.ts
@@ -46,8 +46,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-graphics-gradient.test.ts
+++ b/test/rendering/browser/webgpu-graphics-gradient.test.ts
@@ -48,8 +48,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-graphics-solid-fill.test.ts
+++ b/test/rendering/browser/webgpu-graphics-solid-fill.test.ts
@@ -45,8 +45,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-group-uniform.test.ts
+++ b/test/rendering/browser/webgpu-group-uniform.test.ts
@@ -68,8 +68,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-mesh-tint.test.ts
+++ b/test/rendering/browser/webgpu-mesh-tint.test.ts
@@ -54,8 +54,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-nine-slice.test.ts
+++ b/test/rendering/browser/webgpu-nine-slice.test.ts
@@ -55,8 +55,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-particles.test.ts
+++ b/test/rendering/browser/webgpu-particles.test.ts
@@ -60,8 +60,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
   // The particle renderer is not part of the core renderer bindings — the
   // `@codexo/exojs-particles` package materialises it itself via its
   // Extension descriptor. Browser tests construct a bare backend (bypassing

--- a/test/rendering/browser/webgpu-pixel-snap.test.ts
+++ b/test/rendering/browser/webgpu-pixel-snap.test.ts
@@ -63,8 +63,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-render-pipeline.test.ts
+++ b/test/rendering/browser/webgpu-render-pipeline.test.ts
@@ -42,8 +42,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
   canvas.height = 64;
 
   const backend = new WebGpuBackend(makeApp(canvas));
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-render-to-texture.test.ts
+++ b/test/rendering/browser/webgpu-render-to-texture.test.ts
@@ -32,8 +32,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(app);
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-repeating-sprite.test.ts
+++ b/test/rendering/browser/webgpu-repeating-sprite.test.ts
@@ -52,8 +52,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-retained-container.test.ts
+++ b/test/rendering/browser/webgpu-retained-container.test.ts
@@ -93,8 +93,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-retained-instruction-replay.test.ts
+++ b/test/rendering/browser/webgpu-retained-instruction-replay.test.ts
@@ -60,8 +60,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-rotated-mesh.test.ts
+++ b/test/rendering/browser/webgpu-rotated-mesh.test.ts
@@ -56,8 +56,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-rotated-retained-group.test.ts
+++ b/test/rendering/browser/webgpu-rotated-retained-group.test.ts
@@ -57,8 +57,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-shader-filter.test.ts
+++ b/test/rendering/browser/webgpu-shader-filter.test.ts
@@ -50,8 +50,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-single-submit.test.ts
+++ b/test/rendering/browser/webgpu-single-submit.test.ts
@@ -55,8 +55,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-split-viewport.test.ts
+++ b/test/rendering/browser/webgpu-split-viewport.test.ts
@@ -43,8 +43,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-sprite-solid-color.test.ts
+++ b/test/rendering/browser/webgpu-sprite-solid-color.test.ts
@@ -51,8 +51,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-sprite-transform.test.ts
+++ b/test/rendering/browser/webgpu-sprite-transform.test.ts
@@ -73,8 +73,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-stencil-clip.test.ts
+++ b/test/rendering/browser/webgpu-stencil-clip.test.ts
@@ -185,8 +185,8 @@ const setupBackend = async (logicalSize = canvasSize): Promise<WebGpuBackend> =>
 
   const backend = new WebGpuBackend(makeApp(canvas, logicalSize));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-stencil-composition.test.ts
+++ b/test/rendering/browser/webgpu-stencil-composition.test.ts
@@ -77,8 +77,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-text-atlas-upload.test.ts
+++ b/test/rendering/browser/webgpu-text-atlas-upload.test.ts
@@ -50,8 +50,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-texture-batching.test.ts
+++ b/test/rendering/browser/webgpu-texture-batching.test.ts
@@ -51,8 +51,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-tilemap-interleave.test.ts
+++ b/test/rendering/browser/webgpu-tilemap-interleave.test.ts
@@ -40,8 +40,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireTilemapRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-tilemap-snap.test.ts
+++ b/test/rendering/browser/webgpu-tilemap-snap.test.ts
@@ -42,8 +42,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireTilemapRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-tilemap.test.ts
+++ b/test/rendering/browser/webgpu-tilemap.test.ts
@@ -39,8 +39,8 @@ const setupBackend = async (wire: (backend: WebGpuBackend) => void = wireTilemap
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wire(backend);
+  await backend.initialize();
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-video.test.ts
+++ b/test/rendering/browser/webgpu-video.test.ts
@@ -69,8 +69,8 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
 
   const backend = new WebGpuBackend(makeApp(canvas));
 
-  await backend.initialize();
   wireCoreRenderers(backend);
+  await backend.initialize();
 
   return backend;
 };


### PR DESCRIPTION
## What
Closes #303. The shared `setupBackend` test helper, duplicated across 31 WebGPU browser spec files, registered core renderer bindings AFTER calling `backend.initialize()` — diverging from production order (`Application` registers bindings before/during initialize). Fixed in-place across all 31 affected files (chose fix-in-place over extraction: the actual renderer-wiring logic is already centralized in `_coreRenderers.ts`'s `wireCoreRenderers`; only the thin per-file wrapper varies enough — canvas sizes, tilemap-specific wiring, a parameterized callback — that full extraction would touch more surface than this ordering fix warrants).

## Test plan
- [x] `pnpm test:browser:webgpu` — 36 test files, 157 tests, 0 failures