### PR TITLE
fix(docs,extensions): generate ExtensionRegistry API page + export SerializerBinding

### DIFF
--- a/site/scripts/build-api.ts
+++ b/site/scripts/build-api.ts
@@ -19,6 +19,7 @@ type Subsystem =
     | 'audio'
     | 'core'
     | 'debug'
+    | 'extensions'
     | 'input'
     | 'ldtk'
     | 'math'
@@ -38,6 +39,7 @@ const SUBSYSTEMS: ReadonlyArray<Subsystem> = [
     'audio',
     'core',
     'debug',
+    'extensions',
     'input',
     'ldtk',
     'math',
@@ -520,7 +522,9 @@ const renderReflectionBody = (reflection: any): ReflectionBody => {
 const entryPointTitle = (reflection: any): string => {
     const sourcePath = normalizePath(reflection.sources?.[0]?.fileName ?? '');
     const subsystem = guessSubsystem(sourcePath);
-    return subsystem === 'debug' ? '@codexo/exojs/debug' : '@codexo/exojs';
+    if (subsystem === 'debug') return '@codexo/exojs/debug';
+    if (subsystem === 'extensions') return '@codexo/exojs/extensions';
+    return '@codexo/exojs';
 };
 
 const ensureCleanOutput = (): void => {
@@ -791,8 +795,11 @@ const build = async (): Promise<void> => {
     ensureCleanOutput();
     const usedSlugs = new Set<string>();
 
-    // 1. Core (+ debug subpath).
-    const coreProject = await convertEntryPoints(['src/index.ts', 'src/debug/index.ts'], 'tsconfig.json');
+    // 1. Core (+ debug and extensions subpaths).
+    const coreProject = await convertEntryPoints(
+        ['src/index.ts', 'src/debug/index.ts', 'src/extensions/index.ts'],
+        'tsconfig.json',
+    );
     const coreNamespaces = new Map<string, any>(collectNamespaces(coreProject).map((ns: any) => [ns.name, ns]));
     let coreCount = 0;
     const coreDocumentable = collectSymbols(coreProject);

--- a/site/src/content/api/asset-binding.json
+++ b/site/src/content/api/asset-binding.json
@@ -1,0 +1,297 @@
+{
+  "title": "AssetBinding",
+  "description": "Binds an asset type and its lookup keys to a loader-local handler factory. `create(loader)` is called once per Loader at Application construction, producing an AssetHandler instance that the Loader owns for its entire lifetime. The handler may hold loader-local state (Workers, WASM modules, parsed caches). `Result` is the produced asset instance type (e.g. `TileMap`). `Options` is the typed options object, defaulting to `undefined` (no options). The runtime `type` field must be a constructor that produces `Result`; the handler returned by `create` must also produce `Result` — both relationships are enforced by TypeScript. Use `satisfies AssetBinding<MyAsset, MyLoadOptions>` on an object literal to get typed options in the handler and enforce the result type without repeating it.",
+  "symbol": "AssetBinding",
+  "kind": "interface",
+  "subsystem": "extensions",
+  "importPath": "@codexo/exojs/extensions",
+  "tier": "advanced",
+  "memberCount": 6,
+  "counts": {
+    "constructors": 0,
+    "methods": 1,
+    "properties": 5,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Binds an asset type and its lookup keys to a loader-local handler factory. `create(loader)` is called once per Loader at Application construction, producing an AssetHandler instance that the Loader owns for its entire lifetime. The handler may hold loader-local state (Workers, WASM modules, parsed caches).",
+        "`Result` is the produced asset instance type (e.g. `TileMap`). `Options` is the typed options object, defaulting to `undefined` (no options). The runtime `type` field must be a constructor that produces `Result`; the handler returned by `create` must also produce `Result` — both relationships are enforced by TypeScript.",
+        "Use `satisfies AssetBinding<MyAsset, MyLoadOptions>` on an object literal to get typed options in the handler and enforce the result type without repeating it."
+      ],
+      "importLine": "import { AssetBinding } from '@codexo/exojs/extensions'",
+      "sourceLink": null
+    },
+    {
+      "id": "methods",
+      "title": "Methods",
+      "members": [
+        {
+          "name": "create",
+          "signature": "create(loader: Loader): AssetHandler<Result, Options>",
+          "signatureTokens": [
+            {
+              "text": "create",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "loader",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Loader",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "AssetHandler",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Result",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Options",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [
+            {
+              "name": "loader",
+              "type": "Loader",
+              "optional": false
+            }
+          ],
+          "returnType": "AssetHandler<Result, Options>",
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "extensions",
+          "signature": "extensions?: readonly string[]",
+          "signatureTokens": [
+            {
+              "text": "extensions",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "kind",
+          "signature": "kind?: keyof AssetDefinitions",
+          "signatureTokens": [
+            {
+              "text": "kind",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "keyof AssetDefinitions",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "The AssetDefinitions key this binding produces. When present, the binding was built by defineAsset, which registered the kind's placeholder strategy and suffix→kind inference GLOBALLY at import (so loader-free Assets.from resolves it). Purely informational on the binding itself — materializeAssetBindings does not consume it."
+        },
+        {
+          "name": "seamless",
+          "signature": "seamless?: SeamlessAdapter<Result>",
+          "signatureTokens": [
+            {
+              "text": "seamless",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "SeamlessAdapter",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Result",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Optional seamless-handle adapter (asset-system v2), registered alongside the handler."
+        },
+        {
+          "name": "type",
+          "signature": "type: AssetConstructor<Result>",
+          "signatureTokens": [
+            {
+              "text": "type",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "AssetConstructor",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Result",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "typeNames",
+          "signature": "typeNames?: readonly string[]",
+          "signatureTokens": [
+            {
+              "text": "typeNames",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Config-map type names that resolve to this handler, e.g. ['tiledMap']. Most bindings declare exactly one name; a binding may declare several when a single asset type is reachable under multiple aliases (e.g. ['vtt', 'srt']). Each name maps the config-map form { type: '<name>', source } to this handler."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/extensions/Extension.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/extensions/Extension.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/extensions/Extension.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/extensions/Extension.ts"
+}

--- a/site/src/content/api/asset-handler.json
+++ b/site/src/content/api/asset-handler.json
@@ -1,0 +1,326 @@
+{
+  "title": "AssetHandler",
+  "description": "A loader-local instance produced by AssetBinding.create; owned and destroyed by the Loader. May hold state. Called once per `loader.load(...)` invocation. Sub-assets loaded via `context.loader.load(...)` are owned by the Loader's cache — NOT by this handler or the asset returned by `load`.",
+  "symbol": "AssetHandler",
+  "kind": "interface",
+  "subsystem": "extensions",
+  "importPath": "@codexo/exojs/extensions",
+  "tier": "advanced",
+  "memberCount": 4,
+  "counts": {
+    "constructors": 0,
+    "methods": 4,
+    "properties": 0,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "A loader-local instance produced by AssetBinding.create; owned and destroyed by the Loader. May hold state. Called once per `loader.load(...)` invocation. Sub-assets loaded via `context.loader.load(...)` are owned by the Loader's cache — NOT by this handler or the asset returned by `load`."
+      ],
+      "importLine": "import { AssetHandler } from '@codexo/exojs/extensions'",
+      "sourceLink": null
+    },
+    {
+      "id": "methods",
+      "title": "Methods",
+      "members": [
+        {
+          "name": "createFromBytes",
+          "signature": "createFromBytes?(bytes: ArrayBuffer, options?: Options): Promise<Result>",
+          "signatureTokens": [
+            {
+              "text": "createFromBytes",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "bytes",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ArrayBuffer",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "options",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Options",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Promise",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Result",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [
+            {
+              "name": "bytes",
+              "type": "ArrayBuffer",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "Options",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Result>",
+          "description": "Optionally produce the asset directly from in-memory bytes, bypassing the network and cache. This is what lets the type be packed into an asset container (Loader.loadContainer — one fetch yields N assets): the loader hands the handler the asset's slice instead of a URL. Implement it when the asset can be built from its raw bytes alone (the factory-backed core handlers do). Omit it when loading needs a URL fetch, sub-asset resolution, or anything bytes alone cannot supply — such types cannot be embedded in a container and raise a clear error if attempted."
+        },
+        {
+          "name": "destroy",
+          "signature": "destroy?(): void",
+          "signatureTokens": [
+            {
+              "text": "destroy",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "void",
+          "description": ""
+        },
+        {
+          "name": "getIdentityKey",
+          "signature": "getIdentityKey?(request: AssetLoadRequest<Options>): string",
+          "signatureTokens": [
+            {
+              "text": "getIdentityKey",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "request",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "AssetLoadRequest",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Options",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "request",
+              "type": "AssetLoadRequest<Options>",
+              "optional": false
+            }
+          ],
+          "returnType": "string",
+          "description": "Returns the deterministic identity key used for in-flight deduplication and loaded-resource reuse (and cache/resource-store identity where applicable). Include every option that **changes the produced resource** (format, locale, variant, color space, decoding mode, strictness when it affects output). Exclude control-only values that do not alter the resource (callbacks, AbortSignal, logger, request priority, timeout). Do **not** use JSON.stringify(request.options) — property-order instability, control-only field inclusion, and unbounded key size make it unsuitable. Explicitly select the identity-relevant fields instead. The Loader namespaces the key with the asset type, so the returned string may be type-local. Omit this hook to use the default (source-only) identity."
+        },
+        {
+          "name": "load",
+          "signature": "load(request: AssetLoadRequest<Options>, context: AssetLoaderContext): Promise<Result>",
+          "signatureTokens": [
+            {
+              "text": "load",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "request",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "AssetLoadRequest",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Options",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "context",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "AssetLoaderContext",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Promise",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Result",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [
+            {
+              "name": "request",
+              "type": "AssetLoadRequest<Options>",
+              "optional": false
+            },
+            {
+              "name": "context",
+              "type": "AssetLoaderContext",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Result>",
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/extensions/Extension.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/extensions/Extension.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/extensions/Extension.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/extensions/Extension.ts"
+}

--- a/site/src/content/api/asset-load-request.json
+++ b/site/src/content/api/asset-load-request.json
@@ -3,8 +3,8 @@
   "description": "Per-load request passed to AssetHandler.load and AssetHandler.getIdentityKey. `Options` is `undefined` by default — a handler without typed options receives `request.options: undefined`. A handler with typed options receives `request.options: Options | undefined` (options remain optional even when typed).",
   "symbol": "AssetLoadRequest",
   "kind": "interface",
-  "subsystem": "core",
-  "importPath": "@codexo/exojs",
+  "subsystem": "extensions",
+  "importPath": "@codexo/exojs/extensions",
   "tier": "advanced",
   "memberCount": 2,
   "counts": {
@@ -22,7 +22,7 @@
         "Per-load request passed to AssetHandler.load and AssetHandler.getIdentityKey.",
         "`Options` is `undefined` by default — a handler without typed options receives `request.options: undefined`. A handler with typed options receives `request.options: Options | undefined` (options remain optional even when typed)."
       ],
-      "importLine": "import { AssetLoadRequest } from '@codexo/exojs'",
+      "importLine": "import { AssetLoadRequest } from '@codexo/exojs/extensions'",
       "sourceLink": null
     },
     {

--- a/site/src/content/api/extension-registry.json
+++ b/site/src/content/api/extension-registry.json
@@ -1,0 +1,265 @@
+{
+  "title": "ExtensionRegistry",
+  "description": "Process-wide static catalogue of Extension descriptors. Stores descriptors only — never Application, backend, GPU, or loader instances — and is read exactly once per Application (at construction). Not read in any hot path. Extension authors import from `@codexo/exojs/extensions`: import { ExtensionRegistry } from '@codexo/exojs/extensions';",
+  "symbol": "ExtensionRegistry",
+  "kind": "class",
+  "subsystem": "extensions",
+  "importPath": "@codexo/exojs/extensions",
+  "tier": "advanced",
+  "memberCount": 4,
+  "counts": {
+    "constructors": 0,
+    "methods": 4,
+    "properties": 0,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Process-wide static catalogue of Extension descriptors. Stores descriptors only — never Application, backend, GPU, or loader instances — and is read exactly once per Application (at construction). Not read in any hot path.",
+        "Extension authors import from `@codexo/exojs/extensions`: import { ExtensionRegistry } from '@codexo/exojs/extensions';"
+      ],
+      "importLine": "import { ExtensionRegistry } from '@codexo/exojs/extensions'",
+      "sourceLink": null
+    },
+    {
+      "id": "methods",
+      "title": "Methods",
+      "members": [
+        {
+          "name": "get",
+          "signature": "get(id: string): Readonly<Extension> | undefined",
+          "signatureTokens": [
+            {
+              "text": "get",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "id",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Readonly",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Extension",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "undefined",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "id",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Readonly<Extension> | undefined",
+          "description": "Return the registered descriptor for id, or undefined if none is registered."
+        },
+        {
+          "name": "has",
+          "signature": "has(id: string): boolean",
+          "signatureTokens": [
+            {
+              "text": "has",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "id",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "id",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "description": "Report whether an extension with id is currently registered."
+        },
+        {
+          "name": "list",
+          "signature": "list(): readonly Readonly<Extension>[]",
+          "signatureTokens": [
+            {
+              "text": "list",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Readonly",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Extension",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": "readonly Readonly<Extension>[]",
+          "description": "List all registered descriptors in registration order. Returns a cached readonly view — no allocation on repeated calls while the registry is unchanged; the cache is invalidated only by a new register call."
+        },
+        {
+          "name": "register",
+          "signature": "register(extension: Extension): void",
+          "signatureTokens": [
+            {
+              "text": "register",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "extension",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Extension",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "extension",
+              "type": "Extension",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Register an extension descriptor. Idempotent for the *same object* under the same id (no-op). Throws if a *different* object is already registered under that id — this detects duplicate package installations."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/extensions/ExtensionRegistry.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/extensions/ExtensionRegistry.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/extensions/ExtensionRegistry.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/extensions/ExtensionRegistry.ts"
+}

--- a/site/src/content/api/extension.json
+++ b/site/src/content/api/extension.json
@@ -3,8 +3,8 @@
   "description": "An ExoJS extension: an immutable descriptor that contributes renderer bindings, asset bindings and/or serializer bindings. Holds no Application, backend, GPU, or loader instances. Register via ExtensionRegistry.register (official packages do this as an import side effect), or pass explicitly via ApplicationOptions.extensions.",
   "symbol": "Extension",
   "kind": "interface",
-  "subsystem": "core",
-  "importPath": "@codexo/exojs",
+  "subsystem": "extensions",
+  "importPath": "@codexo/exojs/extensions",
   "tier": "advanced",
   "memberCount": 5,
   "counts": {
@@ -21,7 +21,7 @@
       "paragraphs": [
         "An ExoJS extension: an immutable descriptor that contributes renderer bindings, asset bindings and/or serializer bindings. Holds no Application, backend, GPU, or loader instances. Register via ExtensionRegistry.register (official packages do this as an import side effect), or pass explicitly via ApplicationOptions.extensions."
       ],
-      "importLine": "import { Extension } from '@codexo/exojs'",
+      "importLine": "import { Extension } from '@codexo/exojs/extensions'",
       "sourceLink": null
     },
     {

--- a/site/src/content/api/renderer-binding.json
+++ b/site/src/content/api/renderer-binding.json
@@ -1,0 +1,180 @@
+{
+  "title": "RendererBinding",
+  "description": "Binds one or more drawable constructors to a renderer factory. Pure descriptor — no active renderer, no GPU resources, no side effects until `create` is called once per backend during Application construction. `targets` must contain at least one entry. All targets share the single renderer instance produced by `create`. Returning `undefined` from `create` means the backend is unsupported; the entire binding is skipped for that backend.",
+  "symbol": "RendererBinding",
+  "kind": "interface",
+  "subsystem": "extensions",
+  "importPath": "@codexo/exojs/extensions",
+  "tier": "advanced",
+  "memberCount": 2,
+  "counts": {
+    "constructors": 0,
+    "methods": 1,
+    "properties": 1,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Binds one or more drawable constructors to a renderer factory. Pure descriptor — no active renderer, no GPU resources, no side effects until `create` is called once per backend during Application construction.",
+        "`targets` must contain at least one entry. All targets share the single renderer instance produced by `create`. Returning `undefined` from `create` means the backend is unsupported; the entire binding is skipped for that backend."
+      ],
+      "importLine": "import { RendererBinding } from '@codexo/exojs/extensions'",
+      "sourceLink": null
+    },
+    {
+      "id": "methods",
+      "title": "Methods",
+      "members": [
+        {
+          "name": "create",
+          "signature": "create(backend: RenderBackend): Renderer<RenderBackend, Target> | undefined",
+          "signatureTokens": [
+            {
+              "text": "create",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "backend",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "RenderBackend",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Renderer",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "RenderBackend",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Target",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "undefined",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "backend",
+              "type": "RenderBackend",
+              "optional": false
+            }
+          ],
+          "returnType": "Renderer<RenderBackend, Target> | undefined",
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "targets",
+          "signature": "targets: readonly DrawableConstructor<Target>[]",
+          "signatureTokens": [
+            {
+              "text": "targets",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "DrawableConstructor",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Target",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/extensions/Extension.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/extensions/Extension.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/extensions/Extension.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/extensions/Extension.ts"
+}

--- a/site/src/content/api/serializer-binding.json
+++ b/site/src/content/api/serializer-binding.json
@@ -1,0 +1,138 @@
+{
+  "title": "SerializerBinding",
+  "description": "Binds a SceneNode type to a NodeSerializer under a stable type name, so an extension's own node types participate in Scene.serialize/Scene.deserialize. Pure descriptor — the serializer is a stateless write/read pair, materialised into the scene serialization registry once at Application construction. `target` is the constructor serialize resolves via prototype walk; `typeName` is the tag written to JSON and the key deserialize resolves by. Mirrors the shape of RendererBinding/AssetBinding.",
+  "symbol": "SerializerBinding",
+  "kind": "interface",
+  "subsystem": "extensions",
+  "importPath": "@codexo/exojs/extensions",
+  "tier": "advanced",
+  "memberCount": 3,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 3,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Binds a SceneNode type to a NodeSerializer under a stable type name, so an extension's own node types participate in Scene.serialize/Scene.deserialize. Pure descriptor — the serializer is a stateless write/read pair, materialised into the scene serialization registry once at Application construction.",
+        "`target` is the constructor serialize resolves via prototype walk; `typeName` is the tag written to JSON and the key deserialize resolves by. Mirrors the shape of RendererBinding/AssetBinding."
+      ],
+      "importLine": "import { SerializerBinding } from '@codexo/exojs/extensions'",
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "serializer",
+          "signature": "serializer: NodeSerializer<T>",
+          "signatureTokens": [
+            {
+              "text": "serializer",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "NodeSerializer",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "target",
+          "signature": "target: SceneNodeConstructor<T>",
+          "signatureTokens": [
+            {
+              "text": "target",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "SceneNodeConstructor",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "typeName",
+          "signature": "typeName: string",
+          "signatureTokens": [
+            {
+              "text": "typeName",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/extensions/Extension.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/extensions/Extension.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/extensions/Extension.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/extensions/Extension.ts"
+}

--- a/site/src/lib/api-reference.ts
+++ b/site/src/lib/api-reference.ts
@@ -2,7 +2,7 @@ import type { CollectionEntry } from 'astro:content';
 
 export type ApiEntry = CollectionEntry<'api'>;
 
-export const API_SUBSYSTEM_ORDER = ['core', 'rendering', 'ui', 'input', 'audio', 'animation', 'resources', 'math', 'debug', 'particles', 'tilemap', 'tiled', 'physics', 'aseprite', 'ldtk'] as const;
+export const API_SUBSYSTEM_ORDER = ['core', 'rendering', 'ui', 'input', 'audio', 'animation', 'resources', 'math', 'extensions', 'debug', 'particles', 'tilemap', 'tiled', 'physics', 'aseprite', 'ldtk'] as const;
 
 export type ApiSubsystem = (typeof API_SUBSYSTEM_ORDER)[number];
 
@@ -46,6 +46,10 @@ export const API_SUBSYSTEM_META: Record<ApiSubsystem, { label: string; descripti
     debug: {
         label: 'Debug / Tooling',
         description: 'Debug layers, overlays, and inspection helpers.',
+    },
+    extensions: {
+        label: 'Extensions',
+        description: 'The extension system: renderer/asset/serializer bindings and the extension registry.',
     },
     tilemap: {
         label: 'Tilemap (official extension)',

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -1,9 +1,2 @@
-export type {
-  AssetBinding,
-  AssetHandler,
-  AssetLoadRequest,
-  Extension,
-  RendererBinding,
-  SerializerBinding,
-} from './Extension';
+export type { AssetBinding, AssetHandler, AssetLoadRequest, Extension, RendererBinding, SerializerBinding } from './Extension';
 export { ExtensionRegistry } from './ExtensionRegistry';

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -1,2 +1,9 @@
-export type { AssetBinding, AssetHandler, AssetLoadRequest, Extension, RendererBinding } from './Extension';
+export type {
+  AssetBinding,
+  AssetHandler,
+  AssetLoadRequest,
+  Extension,
+  RendererBinding,
+  SerializerBinding,
+} from './Extension';
 export { ExtensionRegistry } from './ExtensionRegistry';


### PR DESCRIPTION
## What
Closes #304. `ExtensionRegistry` had no generated API-reference page because `build-api.ts`'s entry-point list omitted the `extensions` subpath; separately, `SerializerBinding` (defined in `src/extensions/Extension.ts`, used by `Extension.serializers`) was not re-exported from `src/extensions/index.ts`, so its type was unnameable from the package's public entry point.

Note: #299 (API-docs generator scrambling inherited-member descriptions, e.g. `Container.blur()`) was investigated as part of this same task but could not be reproduced — a full corpus scan across all 684 generated pages found no name-collision mismatch, and the generator resolves comments per-reflection via TypeDoc's own tree, not by a name-keyed lookup that could scramble like the issue describes. Left open for a human decision on whether #299 is stale/already resolved elsewhere.

## Test plan
- [x] Root `pnpm typecheck` clean
- [x] `pnpm docs:api:check` — in sync
- [x] Inspected `extension-registry.json` and `serializer-binding.json` directly — both correct