### PR TITLE
fix(input): re-index world-space interactive descendants on RetainedContainer move

### DIFF
--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -12,6 +12,14 @@ export interface InteractionHooks {
   _notifyNodeRemoved(node: RenderNode): void;
   _notifyInteractiveChanged(node: RenderNode, becameInteractive: boolean): void;
   _notifyBoundsInvalidated(node: RenderNode): void;
+  /**
+   * Called when a transform-group boundary ({@link RetainedContainer}) moves as
+   * a whole. Nodes anchored to the group are hit-tested live and need no action;
+   * this exists for the group's world-space (escaped, non-anchored) interactive
+   * descendants, which are indexed in the world quadtree with bounds captured at
+   * insert time and would otherwise go stale after the group move.
+   */
+  _notifyTransformGroupMoved(group: RenderNode): void;
 }
 
 /**

--- a/src/input/InteractionManager.ts
+++ b/src/input/InteractionManager.ts
@@ -103,6 +103,19 @@ export class InteractionManager implements InteractionHooks, System {
   // Items stored in the quadtree, keyed by node for fast removal.
   private _quadtreeItems = new Map<RenderNode, QuadtreeItem<IndexedNode>>();
 
+  // Quadtree-indexed (non-anchored) world-space interactive nodes grouped by the
+  // nearest transform-group boundary they live under. Their world bounds follow
+  // that group's own moves without any per-node bounds invalidation reaching
+  // them, so a group move must mark exactly this set stale (see
+  // `_notifyTransformGroupMoved`). Anchored descendants are hit-tested live and
+  // are deliberately absent. Kept O(1) on the common case: a group with no such
+  // descendants has no entry.
+  private readonly _groupWorldDescendants = new Map<RenderNode, Set<RenderNode>>();
+
+  // Reverse index: a world-space indexed node -> the boundary group it is filed
+  // under in `_groupWorldDescendants` (for O(1) removal on re-index/unregister).
+  private readonly _nodeBoundaryGroup = new Map<RenderNode, RenderNode>();
+
   // Running insertion-order counter used to break hit-test ties.
   private _quadtreeOrderCounter = 0;
 
@@ -122,6 +135,7 @@ export class InteractionManager implements InteractionHooks, System {
     _notifyNodeRemoved: () => {},
     _notifyInteractiveChanged: () => {},
     _notifyBoundsInvalidated: () => {},
+    _notifyTransformGroupMoved: () => {},
   };
 
   /** Service bundle installed on a scene's UI layer; shares focus with the world stage. */
@@ -253,6 +267,8 @@ export class InteractionManager implements InteractionHooks, System {
     this._staleNodes.clear();
     this._quadtreeItems.clear();
     this._anchoredNodes.clear();
+    this._groupWorldDescendants.clear();
+    this._nodeBoundaryGroup.clear();
     this._dirty = false;
 
     if (this._quadtree !== null) {
@@ -382,6 +398,28 @@ export class InteractionManager implements InteractionHooks, System {
    */
   public _notifyBoundsInvalidated(node: RenderNode): void {
     if (this._interactiveNodes.has(node)) {
+      this._staleNodes.add(node);
+    }
+  }
+
+  /**
+   * Called when a transform-group boundary moves as a whole. Its anchored
+   * descendants are hit-tested live and need nothing; its world-space (escaped,
+   * non-anchored) interactive descendants are indexed in the quadtree with
+   * bounds captured at insert time, so mark exactly those stale to force a
+   * re-insert at their new world position before the next hit-test. O(1) when
+   * the group has no such descendants (the common camera-pan case).
+   *
+   * @internal
+   */
+  public _notifyTransformGroupMoved(group: RenderNode): void {
+    const descendants = this._groupWorldDescendants.get(group);
+
+    if (descendants === undefined) {
+      return;
+    }
+
+    for (const node of descendants) {
       this._staleNodes.add(node);
     }
   }
@@ -766,6 +804,7 @@ export class InteractionManager implements InteractionHooks, System {
     this._interactiveNodes.delete(node);
     this._staleNodes.delete(node);
     this._anchoredNodes.delete(node);
+    this._clearGroupMembership(node);
 
     const item = this._quadtreeItems.get(node);
 
@@ -792,6 +831,10 @@ export class InteractionManager implements InteractionHooks, System {
       return;
     }
 
+    // Drop any prior group filing (a re-index may re-bucket this node between the
+    // quadtree and the anchored side list, or under a different boundary).
+    this._clearGroupMembership(node);
+
     if (node._resolveTransformGroupAnchor() !== null) {
       this._anchoredNodes.set(node, order);
 
@@ -810,6 +853,60 @@ export class InteractionManager implements InteractionHooks, System {
 
     this._quadtree.insert(item);
     this._quadtreeItems.set(node, item);
+
+    // A world-space node living under a transform-group boundary is indexed with
+    // world bounds that follow the group's own moves; file it so a group move
+    // can mark it stale (see `_notifyTransformGroupMoved`). A node with no
+    // boundary ancestor moves only on its own bounds invalidation — no filing.
+    const group = this._nearestBoundaryAncestor(node);
+
+    if (group !== null) {
+      let descendants = this._groupWorldDescendants.get(group);
+
+      if (descendants === undefined) {
+        descendants = new Set<RenderNode>();
+        this._groupWorldDescendants.set(group, descendants);
+      }
+
+      descendants.add(node);
+      this._nodeBoundaryGroup.set(node, group);
+    }
+  }
+
+  /** Remove `node` from its transform-group filing, dropping the group entry when it empties. */
+  private _clearGroupMembership(node: RenderNode): void {
+    const group = this._nodeBoundaryGroup.get(node);
+
+    if (group === undefined) {
+      return;
+    }
+
+    this._nodeBoundaryGroup.delete(node);
+
+    const descendants = this._groupWorldDescendants.get(group);
+
+    if (descendants !== undefined) {
+      descendants.delete(node);
+
+      if (descendants.size === 0) {
+        this._groupWorldDescendants.delete(group);
+      }
+    }
+  }
+
+  /** Nearest ancestor that is an engaged transform-group boundary, or null. */
+  private _nearestBoundaryAncestor(node: RenderNode): RenderNode | null {
+    let ancestor: RenderNode | null = node.parent;
+
+    while (ancestor !== null) {
+      if (ancestor._isTransformGroupBoundary) {
+        return ancestor;
+      }
+
+      ancestor = ancestor.parent;
+    }
+
+    return null;
   }
 
   /**

--- a/src/rendering/RetainedContainer.ts
+++ b/src/rendering/RetainedContainer.ts
@@ -116,6 +116,12 @@ export class RetainedContainer extends Container {
   protected override _markOwnTransformDirty(): void {
     this._groupVersion = nextNodeRevision();
     this._invalidateBoundsFlags();
+
+    // The whole group moved: anchored interactive descendants are hit-tested
+    // live, but world-space (escaped) ones are indexed in the world quadtree
+    // with bounds captured at insert time and must be re-indexed. The manager
+    // resolves exactly that set in O(1) (no-op when the group has none).
+    this._getStage()?.interaction._notifyTransformGroupMoved(this);
   }
 
   /**

--- a/test/input/focus.test.ts
+++ b/test/input/focus.test.ts
@@ -17,6 +17,7 @@ const noopInteraction: InteractionHooks = {
   _notifyNodeRemoved() {},
   _notifyInteractiveChanged() {},
   _notifyBoundsInvalidated() {},
+  _notifyTransformGroupMoved() {},
 };
 
 /** Build a minimal Application mock wired to a real Scene root + a FocusManager. */

--- a/test/input/interaction-retained-group.test.ts
+++ b/test/input/interaction-retained-group.test.ts
@@ -6,6 +6,7 @@ import type { InputManager } from '#input/InputManager';
 import { InteractionManager } from '#input/InteractionManager';
 import type { Pointer } from '#input/Pointer';
 import { Vector } from '#math/Vector';
+import { Container } from '#rendering/Container';
 import { Drawable } from '#rendering/Drawable';
 import { RetainedContainer } from '#rendering/RetainedContainer';
 
@@ -296,6 +297,93 @@ describe('InteractionManager: hit-testing children of a translated RetainedConta
 
     expect(groupHandler).toHaveBeenCalledTimes(1);
     expect(worldHandler).not.toHaveBeenCalled();
+
+    im.destroy();
+    scene.root.destroy();
+  });
+
+  test('moving the group re-indexes a non-anchored (barrier-effect) world-space child so hits track it', () => {
+    const { app, scene, signals } = createApp();
+    const im = new InteractionManager(app);
+
+    im.attachRoot(scene.root);
+
+    const group = new RetainedContainer();
+    const child = makeSprite();
+
+    // A barrier effect (cacheAsBitmap) pushes the child OUT of the transform
+    // group: it resolves world-space transforms and is therefore indexed in the
+    // world quadtree (not the anchored side list). Its quadtree bucket is keyed
+    // on its bounds at insertion time.
+    child.cacheAsBitmap = true;
+    group.addChild(child);
+    scene.addChild(group);
+    child.interactive = true;
+
+    const handler = vi.fn();
+
+    child.onPointerDown.add(handler);
+
+    // Identity group: the child's world rect is 0..50 — a click there hits.
+    signals.onPointerDown.dispatch(makePointer({ x: 25, y: 25 }));
+    im.update();
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    handler.mockClear();
+
+    // Move the group. The child follows in world space (200..250 x 100..150),
+    // but its quadtree entry still buckets it at 0..50 unless the group move
+    // re-indexes it. A click at its NEW rendered position must hit.
+    group.setPosition(200, 100);
+
+    signals.onPointerDown.dispatch(makePointer({ x: 225, y: 125 }));
+    im.update();
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    handler.mockClear();
+
+    // ...and a click at the child's OLD position must now miss.
+    signals.onPointerDown.dispatch(makePointer({ x: 25, y: 25 }));
+    im.update();
+    expect(handler).not.toHaveBeenCalled();
+
+    im.destroy();
+    scene.root.destroy();
+  });
+
+  test('moving the group re-indexes a non-anchored world-space DESCENDANT (grandchild under a barrier child)', () => {
+    const { app, scene, signals } = createApp();
+    const im = new InteractionManager(app);
+
+    im.attachRoot(scene.root);
+
+    const group = new RetainedContainer();
+    const barrierChild = new Container();
+    const grandChild = makeSprite();
+
+    // The barrier child escapes the group, taking its whole subtree to world
+    // space with it — so the interactive grandchild is world-quadtree-indexed.
+    barrierChild.cacheAsBitmap = true;
+    barrierChild.addChild(grandChild);
+    group.addChild(barrierChild);
+    scene.addChild(group);
+    grandChild.interactive = true;
+
+    const handler = vi.fn();
+
+    grandChild.onPointerDown.add(handler);
+
+    signals.onPointerDown.dispatch(makePointer({ x: 25, y: 25 }));
+    im.update();
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    handler.mockClear();
+
+    group.setPosition(200, 100);
+
+    signals.onPointerDown.dispatch(makePointer({ x: 225, y: 125 }));
+    im.update();
+    expect(handler).toHaveBeenCalledTimes(1);
 
     im.destroy();
     scene.root.destroy();

--- a/test/rendering/retained-container.test.ts
+++ b/test/rendering/retained-container.test.ts
@@ -1537,6 +1537,7 @@ describe('RetainedContainer: deep-barrier escape scoped to the offending sub-bra
         _notifyNodeRemoved: () => {},
         _notifyInteractiveChanged: () => {},
         _notifyBoundsInvalidated: (node: unknown) => invalidated.push(node),
+        _notifyTransformGroupMoved: () => {},
       },
       focus: { _notifyNodeRemoved: () => {} },
       app: {},

--- a/test/ui/scroll-container.test.ts
+++ b/test/ui/scroll-container.test.ts
@@ -34,6 +34,7 @@ const makeStage = (pointerPos: { x: number; y: number } | null | undefined = nul
     _notifyNodeRemoved: vi.fn(),
     _notifyInteractiveChanged: vi.fn(),
     _notifyBoundsInvalidated: vi.fn(),
+    _notifyTransformGroupMoved: vi.fn(),
   };
   const focus: Stage['focus'] = {
     focused: null,


### PR DESCRIPTION
## What
Closes #305. Non-anchored world-space interactive descendants of a `RetainedContainer` (barrier-effect direct children and #289-style escaped branches) were quadtree-indexed with bounds snapshotted at insert time. A whole-group move shifted their rendered position without any per-node bounds invalidation reaching them, so broad-phase hit-testing missed them at their new position.

Fix: `InteractionManager` files each quadtree-indexed node under its nearest transform-group boundary; `RetainedContainer._markOwnTransformDirty` calls a new `_notifyTransformGroupMoved` hook that marks exactly that group's world-space descendants stale (O(1) when none — the anchored camera-pan case is untouched).

## Test plan
- [x] 2 new tests (barrier-child + grandchild-under-barrier), verified red before the fix
- [x] Full exojs suite: 4885 pass / 15 skip
- [x] typecheck + lint + format clean

## Known follow-up (out of scope)
A deeply-nested case (an escapee under group A, itself anchored inside group B, where only B moves) isn't covered — esoteric, outside this issue's scope.