### PR TITLE
fix(bench): batch-breaking archetype breaks batches on every slot tier

### DIFF
--- a/packages/exojs-bench/src/rendering/archetypes.ts
+++ b/packages/exojs-bench/src/rendering/archetypes.ts
@@ -43,12 +43,22 @@ export const ARCHETYPES: readonly ArchetypeSpec[] = [
   // before this fix (8x8px stacked sprites) are not comparable on this
   // archetype.
   { id: 'overdraw', nodeCounts: GPU_BOUND_COUNTS, nestingDepth: 2, textureCount: 1, mutationFraction: 0, cullingEnabled: false },
-  // 24 textures: must exceed BOTH the exojs WebGL2 sprite batcher's 16 slots
-  // (raised from 8 in the F9 follow-up) and typical reference batchers'
-  // 16-texture ceiling, or the archetype stops breaking batches entirely.
-  // NOTE: this changes the benchmark definition — results measured before
-  // 2026-07-11 (textureCount 16) are not comparable on this archetype.
-  { id: 'batch-breaking', nodeCounts: GPU_BOUND_COUNTS, nestingDepth: 2, textureCount: 24, mutationFraction: 0, cullingEnabled: false },
+  // 40 textures: must exceed EVERY sprite-batcher slot ceiling any granted
+  // backend/tier reaches, or the archetype silently stops breaking batches on
+  // the machines that don't. The binding ceiling is the WebGPU sprite batcher's
+  // top texture-slot tier (32, negotiated per device — 8/16/32), which is higher
+  // than the exojs WebGL2 batcher's fixed 16 slots and typical reference
+  // batchers' 16-texture ceiling. A count between 33 and the top tier would keep
+  // breaking batches on WebGL2 and lower WebGPU tiers while collapsing to a
+  // single batch on any 32-slot device — measuring a different code path there
+  // without anyone noticing. 40 stays above the top tier on every granted tier,
+  // so the archetype breaks batches everywhere and stays cross-machine
+  // comparable; the resolved tier is stamped into the report provenance so a
+  // future ceiling change is visible in the data rather than silently
+  // invalidating this archetype. NOTE: this changes the benchmark definition —
+  // results measured with a lower textureCount are not comparable on this
+  // archetype.
+  { id: 'batch-breaking', nodeCounts: GPU_BOUND_COUNTS, nestingDepth: 2, textureCount: 40, mutationFraction: 0, cullingEnabled: false },
 ];
 
 /**

--- a/packages/exojs-bench/src/rendering/driver.ts
+++ b/packages/exojs-bench/src/rendering/driver.ts
@@ -34,7 +34,51 @@ export interface Provenance extends BaseProvenance {
   readonly headless: boolean;
   /** True when the adapter is a software rasterizer — timings are then untrusted. */
   readonly software: boolean;
+  /**
+   * Resolved WebGPU sprite-batch texture-slot tier for this run's adapter (8 /
+   * 16 / 32), or `undefined` for the WebGL2 backend (whose batcher uses a fixed
+   * 16-slot ceiling, not this negotiated tier). Slot-sensitive archetypes (e.g.
+   * `batch-breaking`) measure a different code path depending on this tier, so
+   * stamping it here makes a future ceiling change visible in the data instead
+   * of silently invalidating those archetypes across machines.
+   */
+  readonly slotTier?: number;
 }
+
+/**
+ * Sprite-batch texture-slot tiers the WebGPU renderer quantizes to. Mirrors the
+ * engine's `resolveSpriteBatchTextureSlots` (WebGpuSpriteRenderer): the batcher
+ * sizes its multi-texture bind group to
+ * `min(maxSampledTexturesPerShaderStage, maxSamplersPerShaderStage)` on the
+ * granted device, quantized DOWN to one of these tiers (capped at 32). Every
+ * conformant device reaches at least 16; adapters granting 32+ reach 32. Kept in
+ * sync with the engine by hand — this Node-side driver does not import engine
+ * source. Stamped into provenance so a slot-sensitive archetype's measured code
+ * path is auditable per run.
+ */
+const SPRITE_BATCH_SLOT_TIERS = [8, 16, 32] as const;
+
+/**
+ * Resolve the sprite-batch slot tier from an adapter's texture/sampler limits,
+ * or `null` when the limits are unavailable (a non-conformant adapter exposing
+ * no limits object — real devices always report them).
+ */
+const resolveSlotTier = (maxSampledTextures: number | null, maxSamplers: number | null): number | null => {
+  if (maxSampledTextures === null || maxSamplers === null) {
+    return null;
+  }
+
+  const available = Math.min(maxSampledTextures, maxSamplers);
+  let tier: number = SPRITE_BATCH_SLOT_TIERS[0];
+
+  for (const candidate of SPRITE_BATCH_SLOT_TIERS) {
+    if (available >= candidate) {
+      tier = candidate;
+    }
+  }
+
+  return tier;
+};
 
 /** Minimal surface of the programmatic Vite dev server the driver consumes. */
 interface ViteDevServer {
@@ -332,6 +376,8 @@ interface WebGpuIdentity {
   readonly usable: boolean;
   /** Explanation attached to each cell when the adapter is unusable. */
   readonly note: string;
+  /** Resolved sprite-batch slot tier for this adapter (8/16/32), or `null` when no adapter/limits were available. */
+  readonly slotTier: number | null;
 }
 
 /**
@@ -362,6 +408,10 @@ const readWebGpuAdapter = async (page: import('playwright').Page): Promise<WebGp
     }
 
     const info = adapter.info ?? ({} as GPUAdapterInfo);
+    // Adapter texture/sampler limits drive the sprite batcher's slot tier: the
+    // engine requests up to min(adapterLimit, 32) of each at device creation, so
+    // the granted device's tier is fully determined by these adapter limits.
+    const limits = (adapter as { limits?: GPUSupportedLimits }).limits;
 
     return {
       present: true as const,
@@ -370,17 +420,19 @@ const readWebGpuAdapter = async (page: import('playwright').Page): Promise<WebGp
       architecture: info.architecture ?? '',
       device: info.device ?? '',
       description: info.description ?? '',
+      maxSampledTextures: typeof limits?.maxSampledTexturesPerShaderStage === 'number' ? limits.maxSampledTexturesPerShaderStage : null,
+      maxSamplers: typeof limits?.maxSamplersPerShaderStage === 'number' ? limits.maxSamplersPerShaderStage : null,
     };
   });
 
   if (!probe.present) {
-    return { adapter: 'navigator.gpu is undefined', usable: false, note: 'WebGPU unavailable: navigator.gpu is undefined' };
+    return { adapter: 'navigator.gpu is undefined', usable: false, note: 'WebGPU unavailable: navigator.gpu is undefined', slotTier: null };
   }
 
   if (!probe.acquired) {
     const reason = probe.error.length > 0 ? `requestAdapter failed: ${probe.error}` : 'requestAdapter returned null';
 
-    return { adapter: `no-webgpu-adapter (${reason})`, usable: false, note: `WebGPU unavailable: ${reason}` };
+    return { adapter: `no-webgpu-adapter (${reason})`, usable: false, note: `WebGPU unavailable: ${reason}`, slotTier: null };
   }
 
   const identity = [probe.vendor, probe.architecture, probe.device, probe.description]
@@ -388,12 +440,13 @@ const readWebGpuAdapter = async (page: import('playwright').Page): Promise<WebGp
     .filter(part => part.length > 0)
     .join(' ');
   const adapter = identity.length > 0 ? identity : 'webgpu-adapter (info masked)';
+  const slotTier = resolveSlotTier(probe.maxSampledTextures, probe.maxSamplers);
 
   if (SOFTWARE_WEBGPU_PATTERN.test(adapter)) {
-    return { adapter, usable: false, note: `WebGPU software adapter refused: ${adapter}` };
+    return { adapter, usable: false, note: `WebGPU software adapter refused: ${adapter}`, slotTier };
   }
 
-  return { adapter, usable: true, note: '' };
+  return { adapter, usable: true, note: '', slotTier };
 };
 
 /** A cell that could not be measured: zeroed timings/structure, `unavailable` status, and an explanatory note. */
@@ -624,6 +677,10 @@ const runBackend = async (options: {
           // honesty bit would wrongly taint the WebGL2 timings. The software identity
           // is preserved in `adapter` and each cell's note instead.
           software: false,
+          // Resolved sprite-batch slot tier for this adapter, so a slot-sensitive
+          // archetype's measured code path is auditable per run. Omitted when no
+          // adapter/limits were available (the cells are then `unavailable` anyway).
+          ...(typeof webgpuIdentity?.slotTier === 'number' && { slotTier: webgpuIdentity.slotTier }),
         }
       : {
           adapter: renderer ?? 'no-webgl2-context',

--- a/packages/exojs-bench/src/rendering/report.ts
+++ b/packages/exojs-bench/src/rendering/report.ts
@@ -117,6 +117,16 @@ const toMarkdown = (data: ReportData): string => {
   for (const entry of data.provenance) {
     lines.push(`### ${entry.backend}`, '');
     lines.push(`- Adapter (GPU): ${entry.adapter}`);
+
+    // Sprite-batch slot tier (WebGPU only): the negotiated texture-slot ceiling
+    // (8/16/32) the sprite batcher resolved for this adapter. Recorded so a
+    // slot-sensitive archetype (e.g. `batch-breaking`) is auditable — a reader
+    // can see whether this run's tier is below the archetype's textureCount (so
+    // batches actually broke) or a future ceiling change lifted the tier past it.
+    if (entry.slotTier !== undefined) {
+      lines.push(`- Sprite-batch slot tier: ${entry.slotTier}`);
+    }
+
     lines.push(`- Flags: ${entry.flags.map(flag => `\`${flag}\``).join(' ')}`);
     lines.push(`- Headless: ${String(entry.headless)}`);
     lines.push(`- Engine version: ${entry.engineVersion}`);


### PR DESCRIPTION
## What
Closes #308. Since #281 lifted the WebGPU sprite batcher's texture ceiling to 16/32 slots (negotiated per-device), the `batch-breaking` archetype's `textureCount: 24` no longer breaks batches on any WebGPU device landing on the 32-slot tier — the archetype silently started measuring a different (single-batch) code path on those devices, while WebGL2/lower-tier WebGPU still saw the old behavior. This makes cross-machine/CI-runner baseline comparisons non-comparable without anyone noticing the semantic shift.

This is an explicit re-baseline event — old vs. new baseline numbers for this archetype are not comparable.

Fixture moved since the issue was filed: now `packages/exojs-bench/src/rendering/archetypes.ts` (run via `pnpm perf:baseline`), not `test/perf/baseline/`.

## Changes
- Raised `textureCount` to 40 (breaks batches above every 8/16/32 slot tier)
- Computed the resolved slot tier from the WebGPU adapter's texture/sampler limits (mirroring the engine's `resolveSpriteBatchTextureSlots`) and stamped it into `Provenance` → results.json + Markdown (WebGPU-only), so future tier changes are visible in the data instead of silently invalidating the archetype

## Test plan
- [x] Subset run on real NVIDIA adapter (webgl2+webgpu): archetype builds/runs at 40 textures, drawCalls=61 (batches break), provenance reports `slotTier: 16`
- [x] 46 bench unit tests pass
- [x] Lint + typecheck clean on changed files

## Known follow-ups (noted, not blocking)
- The slot tier is read from the driver's probe adapter (requested `high-performance`) while the engine requests with no power preference — on a multi-GPU host these could theoretically pick different adapters; single-GPU/CI unaffected.
- Tier constants are hand-synced in the Node driver (can't import engine source there) — a future engine tier change needs updating both places.