### PR TITLE
fix(examples,audio): smoke-test triage — asset-kind idiom + AudioBus race

### DIFF
--- a/examples/audio-basics/audio-buses.js
+++ b/examples/audio-basics/audio-buses.js
@@ -1,5 +1,5 @@
 // Auto-generated from audio-buses.ts — edit the .ts source, not this file.
-import { Application, Asset, Assets, Color, Graphics, Scene, Text } from '@codexo/exojs';
+import { Application, Asset, Color, Graphics, Scene, Text } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 const app = new Application({
     canvas: {
@@ -44,7 +44,7 @@ class AudioBusesScene extends Scene {
         this.rowY = rows.map((_, i) => height * 0.34 + i * 90);
         this.sfxButton = { x: width / 2 - 150, y: height * 0.74, w: 300, h: 36 };
         // AudioStream has no seamless adapter — await it explicitly.
-        const { music } = await this.loader.load(Assets.from({ music: Asset.kind('music', assets.demo.audio.musicLoop) }));
+        const music = await this.loader.load(Asset.kind('music', assets.demo.audio.musicLoop));
         this.music = music;
         // Path-only get() infers Sound from the .ogg extension — sidesteps a
         // compile-time overload ambiguity between Sound and the Json token form

--- a/examples/audio-basics/audio-buses.ts
+++ b/examples/audio-basics/audio-buses.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Assets, AudioStream, Color, Graphics, type RenderingContext, Scene, Sound, Text } from '@codexo/exojs';
+import { Application, Asset, AudioStream, Color, Graphics, type RenderingContext, Scene, Sound, Text } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -48,7 +48,7 @@ class AudioBusesScene extends Scene {
         this.sfxButton = { x: width / 2 - 150, y: height * 0.74, w: 300, h: 36 };
 
         // AudioStream has no seamless adapter — await it explicitly.
-        const { music } = await this.loader.load(Assets.from({ music: Asset.kind('music', assets.demo.audio.musicLoop) }));
+        const music = await this.loader.load(Asset.kind('music', assets.demo.audio.musicLoop));
         this.music = music;
         // Path-only get() infers Sound from the .ogg extension — sidesteps a
         // compile-time overload ambiguity between Sound and the Json token form

--- a/examples/audio-basics/crossfade-tracks.js
+++ b/examples/audio-basics/crossfade-tracks.js
@@ -1,5 +1,5 @@
 // Auto-generated from crossfade-tracks.ts — edit the .ts source, not this file.
-import { Application, Asset, Assets, Color, crossFade, Graphics, Scene, Text } from '@codexo/exojs';
+import { Application, Asset, Color, crossFade, Graphics, Scene, Text } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 const app = new Application({
     canvas: {
@@ -44,11 +44,13 @@ class CrossfadeTracksScene extends Scene {
         this.meterAX = width * 0.33 - METER_W / 2;
         this.meterBX = width * 0.67 - METER_W / 2;
         this.meterBaseY = height * 0.82;
-        // AudioStream has no seamless adapter — await it explicitly. Both tracks
-        // loop; the crossfade only swaps which one is audible.
-        const tracks = await this.loader.load(Assets.from({ a: Asset.kind('music', assets.demo.audio.musicA), b: Asset.kind('music', assets.demo.audio.musicB) }));
-        this.trackA = tracks.a;
-        this.trackB = tracks.b;
+        // AudioStream is a non-leaf resource kind (no seamless placeholder), so each
+        // track is loaded directly through `Asset.kind('music', ...)` and awaited. Both
+        // tracks loop; the crossfade only swaps which one is audible.
+        [this.trackA, this.trackB] = await Promise.all([
+            this.loader.load(Asset.kind('music', assets.demo.audio.musicA)),
+            this.loader.load(Asset.kind('music', assets.demo.audio.musicB)),
+        ]);
         this.graphics = new Graphics();
         this.labelA = new Text('Track A', { fillColor: Color.white, fontSize: 22, align: 'center' })
             .setAnchor(0.5, 0.5)

--- a/examples/audio-basics/crossfade-tracks.ts
+++ b/examples/audio-basics/crossfade-tracks.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Assets, AudioStream, Color, crossFade, Graphics, type RenderingContext, Scene, Text, type Voice } from '@codexo/exojs';
+import { Application, Asset, AudioStream, Color, crossFade, Graphics, type RenderingContext, Scene, Text, type Voice } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -49,11 +49,13 @@ class CrossfadeTracksScene extends Scene {
         this.meterBX = width * 0.67 - METER_W / 2;
         this.meterBaseY = height * 0.82;
 
-        // AudioStream has no seamless adapter — await it explicitly. Both tracks
-        // loop; the crossfade only swaps which one is audible.
-        const tracks = await this.loader.load(Assets.from({ a: Asset.kind('music', assets.demo.audio.musicA), b: Asset.kind('music', assets.demo.audio.musicB) }));
-        this.trackA = tracks.a;
-        this.trackB = tracks.b;
+        // AudioStream is a non-leaf resource kind (no seamless placeholder), so each
+        // track is loaded directly through `Asset.kind('music', ...)` and awaited. Both
+        // tracks loop; the crossfade only swaps which one is audible.
+        [this.trackA, this.trackB] = await Promise.all([
+            this.loader.load(Asset.kind('music', assets.demo.audio.musicA)),
+            this.loader.load(Asset.kind('music', assets.demo.audio.musicB)),
+        ]);
 
         this.graphics = new Graphics();
         this.labelA = new Text('Track A', { fillColor: Color.white, fontSize: 22, align: 'center' })

--- a/examples/audio-basics/music-loop.js
+++ b/examples/audio-basics/music-loop.js
@@ -1,5 +1,5 @@
 // Auto-generated from music-loop.ts — edit the .ts source, not this file.
-import { Application, Asset, Assets, Color, Graphics, Scene, Text } from '@codexo/exojs';
+import { Application, Asset, Color, Graphics, Scene, Text } from '@codexo/exojs';
 import { mountControlPanel, mountControls } from '@examples/runtime';
 const app = new Application({
     canvas: {
@@ -29,9 +29,10 @@ class MusicLoopScene extends Scene {
         this.bar = { x: width * 0.15, y: height * 0.5, w: width * 0.7, h: 28 };
         // A single streaming track — the browser's media pipeline loops it
         // seamlessly when `loop` is on, so no duplicate/silent track is needed.
-        // AudioStream has no seamless adapter — await it explicitly.
-        const { track } = await this.loader.load(Assets.from({ track: Asset.kind('music', assets.demo.audio.musicLoop) }));
-        this.music = track;
+        // AudioStream is a non-leaf resource kind (no seamless placeholder), so it
+        // is loaded directly through `Asset.kind('music', ...)` and awaited rather
+        // than adopted from an `Assets.from` catalog leaf.
+        this.music = await this.loader.load(Asset.kind('music', assets.demo.audio.musicLoop));
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically — play() returns the Voice now,
         // and all live control (volume, rate, loop, seek) lives on it.

--- a/examples/audio-basics/music-loop.ts
+++ b/examples/audio-basics/music-loop.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Assets, AudioStream, Color, Graphics, type Loopable, type Pausable, type RatePitched, type RenderingContext, Scene, type Seekable, Text, type Voice } from '@codexo/exojs';
+import { Application, Asset, AudioStream, Color, Graphics, type Loopable, type Pausable, type RatePitched, type RenderingContext, Scene, type Seekable, Text, type Voice } from '@codexo/exojs';
 import { mountControlPanel, mountControls } from '@examples/runtime';
 
 const app = new Application({
@@ -32,9 +32,10 @@ class MusicLoopScene extends Scene {
 
         // A single streaming track — the browser's media pipeline loops it
         // seamlessly when `loop` is on, so no duplicate/silent track is needed.
-        // AudioStream has no seamless adapter — await it explicitly.
-        const { track } = await this.loader.load(Assets.from({ track: Asset.kind('music', assets.demo.audio.musicLoop) }));
-        this.music = track;
+        // AudioStream is a non-leaf resource kind (no seamless placeholder), so it
+        // is loaded directly through `Asset.kind('music', ...)` and awaited rather
+        // than adopted from an `Assets.from` catalog leaf.
+        this.music = await this.loader.load(Asset.kind('music', assets.demo.audio.musicLoop));
 
         // Core defers playback until the AudioContext unlocks on the first
         // gesture, then starts automatically — play() returns the Voice now,

--- a/examples/audio-fx/compressor.js
+++ b/examples/audio-fx/compressor.js
@@ -1,5 +1,5 @@
 // Auto-generated from compressor.ts — edit the .ts source, not this file.
-import { Application, Asset, Assets, Color, Graphics, Scene, Text } from '@codexo/exojs';
+import { Application, Asset, Color, Graphics, Scene, Text } from '@codexo/exojs';
 import { CompressorEffect } from '@codexo/exojs-audio-fx';
 import { mountControls } from '@examples/runtime';
 const app = new Application({
@@ -47,7 +47,7 @@ class CompressorScene extends Scene {
         this.rowY = sliders.map((_, i) => height * 0.26 + i * 90);
         this.meterY = this.rowY[this.rowY.length - 1] + 100;
         // AudioStream has no seamless adapter — await it explicitly.
-        const { music } = await this.loader.load(Assets.from({ music: Asset.kind('music', 'audio/demo-loop-main.ogg') }));
+        const music = await this.loader.load(Asset.kind('music', 'audio/demo-loop-main.ogg'));
         this.music = music;
         this.filter = new CompressorEffect();
         app.audio.music.addEffect(this.filter);

--- a/examples/audio-fx/compressor.ts
+++ b/examples/audio-fx/compressor.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Assets, AudioStream, Color, Graphics, type RenderingContext, Scene, Text } from '@codexo/exojs';
+import { Application, Asset, AudioStream, Color, Graphics, type RenderingContext, Scene, Text } from '@codexo/exojs';
 import { CompressorEffect } from '@codexo/exojs-audio-fx';
 import { mountControls } from '@examples/runtime';
 
@@ -59,7 +59,7 @@ class CompressorScene extends Scene {
         this.meterY = this.rowY[this.rowY.length - 1] + 100;
 
         // AudioStream has no seamless adapter — await it explicitly.
-        const { music } = await this.loader.load(Assets.from({ music: Asset.kind('music', 'audio/demo-loop-main.ogg') }));
+        const music = await this.loader.load(Asset.kind('music', 'audio/demo-loop-main.ogg'));
         this.music = music;
         this.filter = new CompressorEffect();
         app.audio.music.addEffect(this.filter);

--- a/examples/audio-fx/ducking.js
+++ b/examples/audio-fx/ducking.js
@@ -1,5 +1,5 @@
 // Auto-generated from ducking.ts — edit the .ts source, not this file.
-import { Application, Asset, Assets, AudioBus, Color, Graphics, Scene, Text } from '@codexo/exojs';
+import { Application, Asset, AudioBus, Color, Graphics, Scene, Text } from '@codexo/exojs';
 import { AudioAnalyser, DuckingEffect } from '@codexo/exojs-audio-fx';
 import { mountControls } from '@examples/runtime';
 const app = new Application({
@@ -42,7 +42,7 @@ class DuckingScene extends Scene {
         this.musicBarY = height * 0.42;
         this.voiceBarY = height * 0.55;
         // AudioStream has no seamless adapter — await it explicitly.
-        const { music } = await this.loader.load(Assets.from({ music: Asset.kind('music', assets.demo.audio.musicLoop) }));
+        const music = await this.loader.load(Asset.kind('music', assets.demo.audio.musicLoop));
         this.music = music;
         // Path-only get() infers Sound from the .ogg extension — sidesteps a
         // compile-time overload ambiguity between Sound and the Json token form

--- a/examples/audio-fx/ducking.ts
+++ b/examples/audio-fx/ducking.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Assets, AudioBus, AudioStream, Color, Graphics, type RenderingContext, Scene, Sound, Text } from '@codexo/exojs';
+import { Application, Asset, AudioBus, AudioStream, Color, Graphics, type RenderingContext, Scene, Sound, Text } from '@codexo/exojs';
 import { AudioAnalyser, DuckingEffect } from '@codexo/exojs-audio-fx';
 import { mountControls } from '@examples/runtime';
 
@@ -45,7 +45,7 @@ class DuckingScene extends Scene {
         this.voiceBarY = height * 0.55;
 
         // AudioStream has no seamless adapter — await it explicitly.
-        const { music } = await this.loader.load(Assets.from({ music: Asset.kind('music', assets.demo.audio.musicLoop) }));
+        const music = await this.loader.load(Asset.kind('music', assets.demo.audio.musicLoop));
         this.music = music;
         // Path-only get() infers Sound from the .ogg extension — sidesteps a
         // compile-time overload ambiguity between Sound and the Json token form

--- a/examples/beat-detection/beat-sync-pulse.js
+++ b/examples/beat-detection/beat-sync-pulse.js
@@ -1,5 +1,5 @@
 // Auto-generated from beat-sync-pulse.ts — edit the .ts source, not this file.
-import { Application, Asset, Assets, Color, Scene, Sprite, Text, Vector } from '@codexo/exojs';
+import { Application, Asset, Color, Scene, Sprite, Text, Vector } from '@codexo/exojs';
 import { BeatDetector } from '@codexo/exojs-audio-fx';
 import { AlphaFadeOverLifetime, BurstSpawn, ConeDirection, Constant, particlesExtension, ParticleSystem, } from '@codexo/exojs-particles';
 import { mountControlPanel, mountControls } from '@examples/runtime';
@@ -33,7 +33,7 @@ class BeatSyncPulseScene extends Scene {
             throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;
         // AudioStream has no seamless adapter — await it explicitly.
-        const { track } = await this.loader.load(Assets.from({ track: Asset.kind('music', 'audio/demo-loop-main.ogg') }));
+        const track = await this.loader.load(Asset.kind('music', 'audio/demo-loop-main.ogg'));
         this.music = track;
         this.sprite = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5).setPosition(width / 2, height / 2);
         this.hud = mountControls({

--- a/examples/beat-detection/beat-sync-pulse.ts
+++ b/examples/beat-detection/beat-sync-pulse.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Assets, AudioStream, Color, type RenderingContext, Scene, Sprite, Text, type Time, Vector } from '@codexo/exojs';
+import { Application, Asset, AudioStream, Color, type RenderingContext, Scene, Sprite, Text, type Time, Vector } from '@codexo/exojs';
 import { BeatDetector } from '@codexo/exojs-audio-fx';
 import {
     AlphaFadeOverLifetime,
@@ -42,7 +42,7 @@ class BeatSyncPulseScene extends Scene {
         const { width, height } = app.canvas;
 
         // AudioStream has no seamless adapter — await it explicitly.
-        const { track } = await this.loader.load(Assets.from({ track: Asset.kind('music', 'audio/demo-loop-main.ogg') }));
+        const track = await this.loader.load(Asset.kind('music', 'audio/demo-loop-main.ogg'));
         this.music = track;
         this.sprite = new Sprite(this.loader.get('image/ship-a.png')).setAnchor(0.5).setPosition(width / 2, height / 2);
 

--- a/examples/beat-detection/frequency-bands.js
+++ b/examples/beat-detection/frequency-bands.js
@@ -1,5 +1,5 @@
 // Auto-generated from frequency-bands.ts — edit the .ts source, not this file.
-import { Application, Asset, Assets, Color, Graphics, Scene, Text } from '@codexo/exojs';
+import { Application, Asset, Color, Graphics, Scene, Text } from '@codexo/exojs';
 import { AudioAnalyser } from '@codexo/exojs-audio-fx';
 import { mountControls } from '@examples/runtime';
 const app = new Application({
@@ -46,7 +46,7 @@ class FrequencyBandsScene extends Scene {
         if (app === null)
             throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         // AudioStream has no seamless adapter — await it explicitly.
-        const { track } = await this.loader.load(Assets.from({ track: Asset.kind('music', 'audio/demo-loop-main.ogg') }));
+        const track = await this.loader.load(Asset.kind('music', 'audio/demo-loop-main.ogg'));
         this.music = track;
         this.analyser = new AudioAnalyser({ fftSize: 2048, smoothingTimeConstant: 0.75 });
         this.analyser.source = app.audio.music;

--- a/examples/beat-detection/frequency-bands.ts
+++ b/examples/beat-detection/frequency-bands.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Assets, AudioStream, Color, Graphics, type RenderingContext, Scene, Text } from '@codexo/exojs';
+import { Application, Asset, AudioStream, Color, Graphics, type RenderingContext, Scene, Text } from '@codexo/exojs';
 import { AudioAnalyser } from '@codexo/exojs-audio-fx';
 import { mountControls } from '@examples/runtime';
 
@@ -49,7 +49,7 @@ class FrequencyBandsScene extends Scene {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         // AudioStream has no seamless adapter — await it explicitly.
-        const { track } = await this.loader.load(Assets.from({ track: Asset.kind('music', 'audio/demo-loop-main.ogg') }));
+        const track = await this.loader.load(Asset.kind('music', 'audio/demo-loop-main.ogg'));
         this.music = track;
 
         this.analyser = new AudioAnalyser({ fftSize: 2048, smoothingTimeConstant: 0.75 });

--- a/examples/beat-detection/tempo-tracking.js
+++ b/examples/beat-detection/tempo-tracking.js
@@ -1,5 +1,5 @@
 // Auto-generated from tempo-tracking.ts — edit the .ts source, not this file.
-import { Application, Asset, Assets, Color, Graphics, Scene, Text } from '@codexo/exojs';
+import { Application, Asset, Color, Graphics, Scene, Text } from '@codexo/exojs';
 import { BeatDetector } from '@codexo/exojs-audio-fx';
 import { mountControls } from '@examples/runtime';
 const app = new Application({
@@ -34,7 +34,7 @@ class TempoTrackingScene extends Scene {
         const { width, height } = app.canvas;
         const marginX = width * 0.08;
         // AudioStream has no seamless adapter — await it explicitly.
-        const { track } = await this.loader.load(Assets.from({ track: Asset.kind('music', 'audio/demo-loop-main.ogg') }));
+        const track = await this.loader.load(Asset.kind('music', 'audio/demo-loop-main.ogg'));
         this.music = track;
         this.detector = new BeatDetector();
         this.detector.source = app.audio.music;

--- a/examples/beat-detection/tempo-tracking.ts
+++ b/examples/beat-detection/tempo-tracking.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Assets, AudioStream, Color, Graphics, type RenderingContext, Scene, Text, type Time } from '@codexo/exojs';
+import { Application, Asset, AudioStream, Color, Graphics, type RenderingContext, Scene, Text, type Time } from '@codexo/exojs';
 import { BeatDetector } from '@codexo/exojs-audio-fx';
 import { mountControls } from '@examples/runtime';
 
@@ -36,7 +36,7 @@ class TempoTrackingScene extends Scene {
         const marginX = width * 0.08;
 
         // AudioStream has no seamless adapter — await it explicitly.
-        const { track } = await this.loader.load(Assets.from({ track: Asset.kind('music', 'audio/demo-loop-main.ogg') }));
+        const track = await this.loader.load(Asset.kind('music', 'audio/demo-loop-main.ogg'));
         this.music = track;
 
         this.detector = new BeatDetector();

--- a/examples/showcase/audio-reactive-particles.js
+++ b/examples/showcase/audio-reactive-particles.js
@@ -25,12 +25,15 @@ class AudioReactiveParticlesScene extends Scene {
     cone;
     hud;
     tapPrompt;
-    init() {
+    async init() {
         const app = this.app;
         if (app === null)
             throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;
-        this.music = this.loader.get(Asset.kind('music', assets.demo.audio.musicLoop));
+        // AudioStream is a non-leaf resource kind (no seamless placeholder), so it
+        // is loaded directly through `Asset.kind('music', ...)` and awaited rather
+        // than fetched synchronously via `get()`.
+        this.music = await this.loader.load(Asset.kind('music', assets.demo.audio.musicLoop));
         // Two parallel taps of the same track: the analyser gives per-band
         // energy (drives emission), the detector gives beats (recolours).
         this.analyser = new AudioAnalyser({ fftSize: 1024, source: app.audio.music });

--- a/examples/showcase/audio-reactive-particles.ts
+++ b/examples/showcase/audio-reactive-particles.ts
@@ -35,12 +35,15 @@ class AudioReactiveParticlesScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
     private tapPrompt!: Text;
 
-    override init(): void {
+    override async init(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;
 
-        this.music = this.loader.get(Asset.kind('music', assets.demo.audio.musicLoop));
+        // AudioStream is a non-leaf resource kind (no seamless placeholder), so it
+        // is loaded directly through `Asset.kind('music', ...)` and awaited rather
+        // than fetched synchronously via `get()`.
+        this.music = await this.loader.load(Asset.kind('music', assets.demo.audio.musicLoop));
 
         // Two parallel taps of the same track: the analyser gives per-band
         // energy (drives emission), the detector gives beats (recolours).

--- a/examples/showcase/audio-visualisation.js
+++ b/examples/showcase/audio-visualisation.js
@@ -24,12 +24,15 @@ class AudioVisualisationScene extends Scene {
     screen;
     hud;
     tapPrompt;
-    init() {
+    async init() {
         const app = this.app;
         if (app === null)
             throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;
-        this.music = this.loader.get(Asset.kind('music', assets.demo.audio.musicLoop));
+        // AudioStream is a non-leaf resource kind (no seamless placeholder), so it
+        // is loaded directly through `Asset.kind('music', ...)` and awaited rather
+        // than fetched synchronously via `get()`.
+        this.music = await this.loader.load(Asset.kind('music', assets.demo.audio.musicLoop));
         // One analyser tap for spectrum/waveform, one beat detector for the
         // beat-pulse ring. Both read the music bus the stream plays through,
         // without altering playback.

--- a/examples/showcase/audio-visualisation.ts
+++ b/examples/showcase/audio-visualisation.ts
@@ -26,12 +26,15 @@ class AudioVisualisationScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
     private tapPrompt!: Text;
 
-    override init(): void {
+    override async init(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;
 
-        this.music = this.loader.get(Asset.kind('music', assets.demo.audio.musicLoop));
+        // AudioStream is a non-leaf resource kind (no seamless placeholder), so it
+        // is loaded directly through `Asset.kind('music', ...)` and awaited rather
+        // than fetched synchronously via `get()`.
+        this.music = await this.loader.load(Asset.kind('music', assets.demo.audio.musicLoop));
 
         // One analyser tap for spectrum/waveform, one beat detector for the
         // beat-pulse ring. Both read the music bus the stream plays through,

--- a/examples/showcase/boss-intro-cinematic.js
+++ b/examples/showcase/boss-intro-cinematic.js
@@ -25,7 +25,7 @@ class BossIntroCinematicScene extends Scene {
     tapPrompt;
     width = 0;
     height = 0;
-    init() {
+    async init() {
         const app = this.app;
         if (app === null)
             throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
@@ -45,7 +45,10 @@ class BossIntroCinematicScene extends Scene {
             .setScale(0.4)
             .setPosition(width * 0.62, height / 2)
             .setTint(new Color(255, 130, 130));
-        this.music = this.loader.get(Asset.kind('music', assets.demo.music.loopMain));
+        // AudioStream is a non-leaf resource kind (no seamless placeholder), so it
+        // is loaded directly through `Asset.kind('music', ...)` and awaited rather
+        // than fetched synchronously via `get()`.
+        this.music = await this.loader.load(Asset.kind('music', assets.demo.music.loopMain));
         this.hud = mountControls({
             title: 'Boss Intro Cinematic',
             controls: [

--- a/examples/showcase/boss-intro-cinematic.ts
+++ b/examples/showcase/boss-intro-cinematic.ts
@@ -28,7 +28,7 @@ class BossIntroCinematicScene extends Scene {
     private width = 0;
     private height = 0;
 
-    override init(): void {
+    override async init(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;
@@ -48,7 +48,10 @@ class BossIntroCinematicScene extends Scene {
             .setScale(0.4)
             .setPosition(width * 0.62, height / 2)
             .setTint(new Color(255, 130, 130));
-        this.music = this.loader.get(Asset.kind('music', assets.demo.music.loopMain));
+        // AudioStream is a non-leaf resource kind (no seamless placeholder), so it
+        // is loaded directly through `Asset.kind('music', ...)` and awaited rather
+        // than fetched synchronously via `get()`.
+        this.music = await this.loader.load(Asset.kind('music', assets.demo.music.loopMain));
 
         this.hud = mountControls({
             title: 'Boss Intro Cinematic',

--- a/examples/showcase/low-band-camera-shake.js
+++ b/examples/showcase/low-band-camera-shake.js
@@ -19,12 +19,15 @@ class LowBandCameraShakeScene extends Scene {
     sprite;
     hud;
     tapPrompt;
-    init() {
+    async init() {
         const app = this.app;
         if (app === null)
             throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;
-        this.music = this.loader.get(Asset.kind('music', assets.demo.audio.musicLoop));
+        // AudioStream is a non-leaf resource kind (no seamless placeholder), so it
+        // is loaded directly through `Asset.kind('music', ...)` and awaited rather
+        // than fetched synchronously via `get()`.
+        this.music = await this.loader.load(Asset.kind('music', assets.demo.audio.musicLoop));
         this.analyser = new AudioAnalyser({ fftSize: 1024, source: app.audio.music });
         this.view = new View(width / 2, height / 2, width, height);
         this.sprite = new Sprite(this.loader.get(assets.demo.textures.shipA)).setAnchor(0.5).setScale(3).setPosition(width / 2, height / 2);

--- a/examples/showcase/low-band-camera-shake.ts
+++ b/examples/showcase/low-band-camera-shake.ts
@@ -21,12 +21,15 @@ class LowBandCameraShakeScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
     private tapPrompt!: Text;
 
-    override init(): void {
+    override async init(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;
 
-        this.music = this.loader.get(Asset.kind('music', assets.demo.audio.musicLoop));
+        // AudioStream is a non-leaf resource kind (no seamless placeholder), so it
+        // is loaded directly through `Asset.kind('music', ...)` and awaited rather
+        // than fetched synchronously via `get()`.
+        this.music = await this.loader.load(Asset.kind('music', assets.demo.audio.musicLoop));
         this.analyser = new AudioAnalyser({ fftSize: 1024, source: app.audio.music });
         this.view = new View(width / 2, height / 2, width, height);
         this.sprite = new Sprite(this.loader.get(assets.demo.textures.shipA)).setAnchor(0.5).setScale(3).setPosition(width / 2, height / 2);

--- a/examples/showcase/vinyl-record.js
+++ b/examples/showcase/vinyl-record.js
@@ -21,12 +21,15 @@ class VinylRecordScene extends Scene {
     rpm = 0;
     hud;
     tapPrompt;
-    init() {
+    async init() {
         const app = this.app;
         if (app === null)
             throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;
-        this.music = this.loader.get(Asset.kind('music', assets.demo.audio.musicLoop));
+        // AudioStream is a non-leaf resource kind (no seamless placeholder), so it
+        // is loaded directly through `Asset.kind('music', ...)` and awaited rather
+        // than fetched synchronously via `get()`.
+        this.music = await this.loader.load(Asset.kind('music', assets.demo.audio.musicLoop));
         this.analyser = new AudioAnalyser({ fftSize: 1024, source: app.audio.music });
         this.disc = new Graphics();
         this.bars = new Graphics();

--- a/examples/showcase/vinyl-record.ts
+++ b/examples/showcase/vinyl-record.ts
@@ -23,12 +23,15 @@ class VinylRecordScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
     private tapPrompt!: Text;
 
-    override init(): void {
+    override async init(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;
 
-        this.music = this.loader.get(Asset.kind('music', assets.demo.audio.musicLoop));
+        // AudioStream is a non-leaf resource kind (no seamless placeholder), so it
+        // is loaded directly through `Asset.kind('music', ...)` and awaited rather
+        // than fetched synchronously via `get()`.
+        this.music = await this.loader.load(Asset.kind('music', assets.demo.audio.musicLoop));
         this.analyser = new AudioAnalyser({ fftSize: 1024, source: app.audio.music });
         this.disc = new Graphics();
         this.bars = new Graphics();

--- a/examples/sprites-textures/video-drawable.js
+++ b/examples/sprites-textures/video-drawable.js
@@ -1,5 +1,5 @@
 // Auto-generated from video-drawable.ts — edit the .ts source, not this file.
-import { Application, Asset, Assets, Color, Keyboard, Scene, Sprite } from '@codexo/exojs';
+import { Application, Asset, Color, Keyboard, Scene, Sprite } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 // Every video in the asset catalog, switchable at runtime with the number
 // keys. Only the first entry is fetched up front — the others lazy-load on
@@ -32,11 +32,11 @@ class VideoDrawableScene extends Scene {
         if (app === null)
             throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;
-        // Video has no seamless adapter (unlike Texture/Sound), so it is
-        // awaited via `load()` rather than fetched synchronously via `get()`.
-        const loaded = await this.loader.load(Assets.from({ [VIDEOS[0].name]: Asset.kind('video', VIDEOS[0].url) }));
+        // Video is a non-leaf resource kind (no seamless placeholder, unlike
+        // Texture/Sound), so it is loaded directly through `Asset.kind('video', ...)`
+        // and awaited rather than fetched synchronously via `get()`.
+        this.video = await this.loader.load(Asset.kind('video', VIDEOS[0].url));
         this.loadedVideos.add(VIDEOS[0].name);
-        this.video = loaded[VIDEOS[0].name];
         this.configureVideo();
         // A sprite composited on top of the live video texture — the same scene
         // graph draws video frames and regular sprites side by side. Texture IS
@@ -84,11 +84,11 @@ class VideoDrawableScene extends Scene {
         this.switching = true;
         this.hud.setStatus(`Loading — ${entry.label}…`);
         try {
-            const loaded = await this.loader.load(Assets.from({ [entry.name]: Asset.kind('video', entry.url) }));
+            const loaded = await this.loader.load(Asset.kind('video', entry.url));
             this.loadedVideos.add(entry.name);
             this.video.pause();
             this.videoIdx = idx;
-            this.video = loaded[entry.name];
+            this.video = loaded;
             this.configureVideo();
             this.video.play();
             this.hud.setStatus(`Playing — ${entry.label}`);

--- a/examples/sprites-textures/video-drawable.ts
+++ b/examples/sprites-textures/video-drawable.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Assets, Color, Keyboard, type RenderingContext, Scene, Sprite, Texture, type Time, Video } from '@codexo/exojs';
+import { Application, Asset, Color, Keyboard, type RenderingContext, Scene, Sprite, Texture, type Time, Video } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 // Every video in the asset catalog, switchable at runtime with the number
@@ -35,12 +35,12 @@ class VideoDrawableScene extends Scene {
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;
 
-        // Video has no seamless adapter (unlike Texture/Sound), so it is
-        // awaited via `load()` rather than fetched synchronously via `get()`.
-        const loaded = await this.loader.load(Assets.from({ [VIDEOS[0].name]: Asset.kind('video', VIDEOS[0].url) }));
+        // Video is a non-leaf resource kind (no seamless placeholder, unlike
+        // Texture/Sound), so it is loaded directly through `Asset.kind('video', ...)`
+        // and awaited rather than fetched synchronously via `get()`.
+        this.video = await this.loader.load(Asset.kind('video', VIDEOS[0].url));
         this.loadedVideos.add(VIDEOS[0].name);
 
-        this.video = loaded[VIDEOS[0].name];
         this.configureVideo();
 
         // A sprite composited on top of the live video texture — the same scene
@@ -92,11 +92,11 @@ class VideoDrawableScene extends Scene {
         this.switching = true;
         this.hud.setStatus(`Loading — ${entry.label}…`);
         try {
-            const loaded = await this.loader.load(Assets.from({ [entry.name]: Asset.kind('video', entry.url) }));
+            const loaded = await this.loader.load(Asset.kind('video', entry.url));
             this.loadedVideos.add(entry.name);
             this.video.pause();
             this.videoIdx = idx;
-            this.video = loaded[entry.name];
+            this.video = loaded;
             this.configureVideo();
             this.video.play();
             this.hud.setStatus(`Playing — ${entry.label}`);

--- a/src/audio/AudioBus.ts
+++ b/src/audio/AudioBus.ts
@@ -20,6 +20,22 @@ interface AudioBusSetup {
 }
 
 /**
+ * Probe whether `effect` has finished creating its underlying node(s). Every
+ * built-in `AudioEffect` throws a descriptive error from `inputNode`/`outputNode`
+ * when accessed before its own (possibly deferred) setup has run — this reads
+ * that as a plain boolean instead of letting `_rebuildEffectChain` throw.
+ */
+function _isEffectReady(effect: AudioEffect): boolean {
+  try {
+    void effect.inputNode;
+    void effect.outputNode;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Hierarchical mixer node in the engine's audio routing graph. Each bus
  * owns three Web Audio nodes (input gain, optional effect chain, stereo
  * pan, output gain) and routes its output into its parent's input — the
@@ -295,9 +311,26 @@ export class AudioBus {
     };
   }
 
-  private _rebuildEffectChain(): void {
+  private _rebuildEffectChain(retried = false): void {
     if (!this._setup) return;
     const { inputNode, panNode } = this._setup;
+
+    // An effect attached via `addEffect()` before the shared AudioContext became
+    // ready may not have finished its OWN setup yet: `onAudioContextReady`
+    // dispatches to every registered listener in a single synchronous pass, and
+    // this bus's listener — typically registered early, e.g. at AudioManager
+    // construction — can run before an attached effect's listener (registered
+    // later, e.g. from a Scene's async `init()`). Touching that effect's
+    // `inputNode`/`outputNode` here would throw ("not yet initialized").
+    // Retrying once on a microtask is sufficient: by then every listener queued
+    // for that same dispatch pass — including the effect's own setup — has
+    // already run. An effect still not ready after the retry is a genuine
+    // caller error (e.g. a custom effect that never wires itself up) and is
+    // left to throw naturally instead of retrying forever.
+    if (!retried && this._effects.some(effect => !_isEffectReady(effect))) {
+      queueMicrotask(() => this._rebuildEffectChain(true));
+      return;
+    }
 
     // Disconnect current chain
     inputNode.disconnect();


### PR DESCRIPTION
## What
Triages #315 (`test:examples:smoke` had 20 pre-existing failures cited: music/video asset-kind-registry gaps, headless-WebGPU texture issues).

Actual first clean run showed 14 failures (not 20), all asset-kind-registry — no WebGPU failures reproduced in this environment (see Concern below).

- **14 fixed**: `AudioStream`/`Video` are non-leaf asset kinds with no seamless placeholder, so `Assets.from()`/`loader.get()` reject them by design. 13 examples used the wrong idiom; switched to `await loader.load(Asset.kind('music'|'video', url))`, matching the pattern already used correctly for `svg`/`font`/`bmFont`.
- **2 fixed (real engine bug, surfaced once the above was fixed)**: `AudioBus._rebuildEffectChain` could touch an attached effect's `inputNode` before that effect's own `onAudioContextReady` listener had run — a registration-order race in a shared one-shot signal. Fixed with a bounded microtask retry in `AudioBus.ts`.
- **0 skipped-with-reason**: the "headless-WebGPU texture" failure bucket from the issue never appeared — this sandbox's headless Chromium exposed a working WebGPU adapter throughout.

## Test plan
- [x] Full smoke suite: 127/127 pass (was 14 failing before)
- [x] AudioBus fix verified against 433 audio + 1236 audio-fx + all AudioBus unit tests (all green)

## Concern for a human
The observed failure count (14) and composition (zero WebGPU failures) don't match the issue's cited 20 with a WebGPU bucket. Possibly a different environment/GPU config originally, or transient flake. Worth a second run on `main` to confirm the WebGPU bucket is genuinely gone rather than just not reproduced here.