### PR TITLE
physics: accelerate ray-cast queries via the dynamic AABB tree

### DIFF
--- a/packages/exojs-physics/src/broadphase/AabbTreeBroadPhase.ts
+++ b/packages/exojs-physics/src/broadphase/AabbTreeBroadPhase.ts
@@ -128,6 +128,11 @@ export class AabbTreeBroadPhase implements BroadPhase, SpatialIndex {
     return out;
   }
 
+  /** Colliders whose AABB the ray could cross within `maxDistance`, via the tree's own ray-cast prune. */
+  public rayCast(originX: number, originY: number, dirX: number, dirY: number, maxDistance: number, callback: (collider: Collider) => void): void {
+    this._tree.rayCast(originX, originY, dirX, dirY, maxDistance, callback);
+  }
+
   /** Drop `collider`'s leaf and every pair referencing it. Called when a collider is destroyed. */
   public removeCollider(collider: Collider): void {
     if (collider._treeProxy === -1) {

--- a/packages/exojs-physics/src/query/QueryEngine.ts
+++ b/packages/exojs-physics/src/query/QueryEngine.ts
@@ -149,10 +149,9 @@ export class QueryEngine {
     const resolved = filter ? resolveFilter(filter) : null;
 
     let best: RayHit | null = null;
-
-    for (const collider of this._colliders) {
+    const consider = (collider: Collider): void => {
       if (resolved && !shouldCollide(resolved, collider.filter)) {
-        continue;
+        return;
       }
 
       const hit = rayCastCollider(collider, origin.x, origin.y, dx, dy, best ? best.distance : maxDistance);
@@ -160,6 +159,15 @@ export class QueryEngine {
       if (hit && (best === null || hit.distance < best.distance)) {
         best = hit;
       }
+    };
+
+    if (this._spatialIndex === undefined) {
+      for (const collider of this._colliders) {
+        consider(collider);
+      }
+    } else {
+      this._spatialIndex.sync(this._colliders);
+      this._spatialIndex.rayCast(origin.x, origin.y, dx, dy, maxDistance, consider);
     }
 
     return best;
@@ -178,10 +186,9 @@ export class QueryEngine {
     const resolved = filter ? resolveFilter(filter) : null;
     const result = out ?? [];
     result.length = 0;
-
-    for (const collider of this._colliders) {
+    const consider = (collider: Collider): void => {
       if (resolved && !shouldCollide(resolved, collider.filter)) {
-        continue;
+        return;
       }
 
       const hit = rayCastCollider(collider, origin.x, origin.y, dx, dy, maxDistance);
@@ -189,6 +196,15 @@ export class QueryEngine {
       if (hit) {
         result.push(hit);
       }
+    };
+
+    if (this._spatialIndex === undefined) {
+      for (const collider of this._colliders) {
+        consider(collider);
+      }
+    } else {
+      this._spatialIndex.sync(this._colliders);
+      this._spatialIndex.rayCast(origin.x, origin.y, dx, dy, maxDistance, consider);
     }
 
     result.sort((a, b) => a.distance - b.distance);

--- a/packages/exojs-physics/src/query/SpatialIndex.ts
+++ b/packages/exojs-physics/src/query/SpatialIndex.ts
@@ -21,4 +21,14 @@ export interface SpatialIndex {
   sync(colliders: readonly Collider[]): void;
   /** Colliders whose AABB overlaps `aabb`. Writes into `out` (cleared first) and returns it. */
   queryAabb(aabb: Readonly<Aabb>, out: Collider[]): Collider[];
+  /**
+   * Invoke `callback` for each collider whose AABB the ray from `originX,
+   * originY` along `dirX, dirY` could cross within `maxDistance` (`Infinity`
+   * for an unbounded ray). Narrows the candidate set for {@link QueryEngine}'s
+   * ray-cast the way {@link queryAabb} does for its overlap queries: the hit
+   * set is conservative (never misses a true intersection, may include AABB
+   * false positives), and {@link QueryEngine} applies the exact per-shape ray
+   * math to each candidate. Order is unspecified.
+   */
+  rayCast(originX: number, originY: number, dirX: number, dirY: number, maxDistance: number, callback: (collider: Collider) => void): void;
 }

--- a/packages/exojs-physics/test/queries.test.ts
+++ b/packages/exojs-physics/test/queries.test.ts
@@ -1,3 +1,4 @@
+import { Random } from '@codexo/exojs';
 import { describe, expect, it } from 'vitest';
 
 import type { Collider } from '../src/Collider';
@@ -267,6 +268,69 @@ describe('QueryEngine spatial-index narrowing parity', () => {
     expect(indexedPoint.length).toBeGreaterThan(0);
     expect(indexedAabb.length).toBeGreaterThan(0);
     expect(indexedShape.length).toBeGreaterThan(0); // sanity: the assertions above aren't vacuously true on empty results
+  });
+
+  it('rayCast/rayCastAll return identical results whether or not the backend provides a SpatialIndex', () => {
+    const world = new PhysicsWorld();
+    const unindexed = new QueryEngine(world.colliders); // no spatialIndex — forces the fallback linear scan
+
+    for (let i = 0; i < 30; i++) {
+      colliderAt(world, new BoxShape(10, 10), { x: (i % 6) * 12, y: Math.floor(i / 6) * 12 }, 0, 'dynamic');
+    }
+
+    const origin = { x: -20, y: 15 };
+    const direction = { x: 1, y: 0 };
+
+    const indexedNearest = world.rayCast(origin, direction);
+    const linearNearest = unindexed.rayCast(origin, direction);
+    expect(indexedNearest).not.toBeNull();
+    expect((indexedNearest as RayHit).collider).toBe((linearNearest as RayHit).collider);
+    expect((indexedNearest as RayHit).distance).toBeCloseTo((linearNearest as RayHit).distance, 6);
+
+    const indexedAll = world.rayCastAll(origin, direction).map(h => h.collider.id).sort((a, b) => a - b);
+    const linearAll = unindexed.rayCastAll(origin, direction).map(h => h.collider.id).sort((a, b) => a - b);
+    expect(indexedAll).toEqual(linearAll);
+    expect(indexedAll.length).toBeGreaterThan(0); // sanity: not vacuously equal on empty results
+  });
+
+  it('matches the linear-scan oracle across many randomized rays and mixed-shape scenes', () => {
+    const rng = new Random(20260714);
+    const world = new PhysicsWorld();
+    const unindexed = new QueryEngine(world.colliders);
+
+    for (let i = 0; i < 80; i++) {
+      const size = [4, 8, 16, 30][Math.floor(rng.next(0, 4))]!;
+      const shape = rng.next() < 0.35 ? new CircleShape(size / 2) : new BoxShape(size, size);
+      colliderAt(world, shape, { x: rng.next(0, 300), y: rng.next(0, 300) }, 0, 'dynamic');
+    }
+
+    for (let trial = 0; trial < 150; trial++) {
+      const origin = { x: rng.next(-50, 350), y: rng.next(-50, 350) };
+      const direction = { x: rng.next(-1, 1), y: rng.next(-1, 1) };
+
+      if (Math.hypot(direction.x, direction.y) < 1e-6) {
+        continue; // skip a degenerate direction the API rejects
+      }
+
+      const maxDistance = rng.next() < 0.5 ? Infinity : rng.next(20, 500);
+
+      const indexedNearest = world.rayCast(origin, direction, undefined, maxDistance);
+      const linearNearest = unindexed.rayCast(origin, direction, undefined, maxDistance);
+
+      expect(indexedNearest === null).toBe(linearNearest === null);
+
+      if (indexedNearest && linearNearest) {
+        // Tree and linear visit candidates in different orders; a distance tie
+        // could pick a different collider, so compare the (equal) hit distance.
+        expect(indexedNearest.distance).toBeCloseTo(linearNearest.distance, 6);
+      }
+
+      const indexedAll = world.rayCastAll(origin, direction, undefined, undefined, maxDistance);
+      const linearAll = unindexed.rayCastAll(origin, direction, undefined, undefined, maxDistance);
+
+      expect(indexedAll.map(h => h.collider.id).sort((a, b) => a - b)).toEqual(linearAll.map(h => h.collider.id).sort((a, b) => a - b));
+      expect(indexedAll.map(h => Math.round(h.distance * 1e6)).sort((a, b) => a - b)).toEqual(linearAll.map(h => Math.round(h.distance * 1e6)).sort((a, b) => a - b));
+    }
   });
 });
 

--- a/site/src/content/api/dynamic-aabb-tree.json
+++ b/site/src/content/api/dynamic-aabb-tree.json
@@ -6,10 +6,10 @@
   "subsystem": "math",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 13,
+  "memberCount": 14,
   "counts": {
     "constructors": 1,
-    "methods": 10,
+    "methods": 11,
     "properties": 2,
     "events": 0
   },
@@ -760,6 +760,194 @@
           ],
           "returnType": "void",
           "description": "Point query; thin wrapper over query with a zero-extent AABB. Shares query's non-reentrancy caveat: do not call query/queryPoint on the same tree instance from within a query/queryPoint callback."
+        },
+        {
+          "name": "rayCast",
+          "signature": "rayCast(originX: number, originY: number, dirX: number, dirY: number, maxDistance: number, callback: (payload: T, proxy: number) => void): void",
+          "signatureTokens": [
+            {
+              "text": "rayCast",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "originX",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "originY",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "dirX",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "dirY",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "maxDistance",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "callback",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "payload",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "proxy",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ") => ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "originX",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "originY",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "dirX",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "dirY",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "maxDistance",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "callback",
+              "type": "(payload: T, proxy: number) => void",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Invoke callback for every leaf whose fat AABB the ray from originX, originY along dirX, dirY crosses within maxDistance (pass Infinity for an unbounded ray). A dumb AABB-pruning primitive mirroring query: it slab-tests each subtree's fat AABB against the ray segment and skips whole subtrees the segment misses, but performs no exact shape math and imposes no nearest-first order — the caller runs its own narrow phase and decides nearest-vs-all. Invocation ORDER is tree-shape-dependent. NOT re-entrant with itself: the traversal uses a single persistent stack field, so a callback must not call rayCast again on the SAME tree instance (the nested call resets the shared stack and silently truncates the outer traversal). The stack is separate from query/queryPoint's, so a rayCast from within a query callback (or the reverse) is safe."
         },
         {
           "name": "remove",

--- a/src/math/DynamicAabbTree.ts
+++ b/src/math/DynamicAabbTree.ts
@@ -49,6 +49,7 @@ export class DynamicAabbTree<T> {
   private readonly _nodes: Array<TreeNode<T>> = [];
   private readonly _freeIndices: number[] = [];
   private readonly _queryStack: number[] = [];
+  private readonly _rayCastStack: number[] = [];
   private _root = NULL_NODE;
   private _leafCount = 0;
 
@@ -194,6 +195,47 @@ export class DynamicAabbTree<T> {
     this.query(x, y, x, y, callback);
   }
 
+  /**
+   * Invoke `callback` for every leaf whose fat AABB the ray from `originX,
+   * originY` along `dirX, dirY` crosses within `maxDistance` (pass `Infinity`
+   * for an unbounded ray). A dumb AABB-pruning primitive mirroring `query`:
+   * it slab-tests each subtree's fat AABB against the ray segment and skips
+   * whole subtrees the segment misses, but performs no exact shape math and
+   * imposes no nearest-first order — the caller runs its own narrow phase and
+   * decides nearest-vs-all. Invocation ORDER is tree-shape-dependent.
+   *
+   * NOT re-entrant with itself: the traversal uses a single persistent stack
+   * field, so a `callback` must not call `rayCast` again on the SAME tree
+   * instance (the nested call resets the shared stack and silently truncates
+   * the outer traversal). The stack is separate from `query`/`queryPoint`'s,
+   * so a `rayCast` from within a `query` callback (or the reverse) is safe.
+   */
+  public rayCast(originX: number, originY: number, dirX: number, dirY: number, maxDistance: number, callback: (payload: T, proxy: number) => void): void {
+    if (this._root === NULL_NODE) {
+      return;
+    }
+
+    const stack = this._rayCastStack;
+    stack.length = 0;
+    stack.push(this._root);
+
+    while (stack.length > 0) {
+      const index = stack.pop()!;
+      const node = this._nodes[index]!;
+
+      if (!raySegmentIntersectsAabb(originX, originY, dirX, dirY, maxDistance, node.minX, node.minY, node.maxX, node.maxY)) {
+        continue;
+      }
+
+      if (node.height === 0) {
+        callback(node.payload as T, index);
+      } else {
+        stack.push(node.child1);
+        stack.push(node.child2);
+      }
+    }
+  }
+
   /** Remove all leaves, keep pool capacity (bulk reset). */
   public clear(): void {
     const nodes = this._nodes;
@@ -217,6 +259,7 @@ export class DynamicAabbTree<T> {
     this._nodes.length = 0;
     this._freeIndices.length = 0;
     this._queryStack.length = 0;
+    this._rayCastStack.length = 0;
     this._root = NULL_NODE;
     this._leafCount = 0;
   }
@@ -574,6 +617,78 @@ export class DynamicAabbTree<T> {
 
 /** Half-perimeter (width + height) of an AABB — a cheap 2D surface-area-heuristic proxy. */
 const perimeter = (minX: number, minY: number, maxX: number, maxY: number): number => maxX - minX + (maxY - minY);
+
+/**
+ * `true` when the ray segment from `(ox, oy)` along `(dx, dy)`, clamped to
+ * `t in [0, maxDistance]`, intersects the AABB. Standard slab test: an axis
+ * with zero direction component intersects only if the origin already lies
+ * within that slab; otherwise the per-axis entry/exit fractions are folded
+ * into a running `[tmin, tmax]` overlap window (empty ⇒ miss). `maxDistance`
+ * may be `Infinity` for an unbounded ray. Boundary contacts count as hits
+ * (conservative: the tree must never prune away a true candidate).
+ */
+const raySegmentIntersectsAabb = (ox: number, oy: number, dx: number, dy: number, maxDistance: number, minX: number, minY: number, maxX: number, maxY: number): boolean => {
+  let tmin = 0;
+  let tmax = maxDistance;
+
+  if (dx === 0) {
+    if (ox < minX || ox > maxX) {
+      return false;
+    }
+  } else {
+    const inv = 1 / dx;
+    let t1 = (minX - ox) * inv;
+    let t2 = (maxX - ox) * inv;
+
+    if (t1 > t2) {
+      const tmp = t1;
+      t1 = t2;
+      t2 = tmp;
+    }
+
+    if (t1 > tmin) {
+      tmin = t1;
+    }
+
+    if (t2 < tmax) {
+      tmax = t2;
+    }
+
+    if (tmin > tmax) {
+      return false;
+    }
+  }
+
+  if (dy === 0) {
+    if (oy < minY || oy > maxY) {
+      return false;
+    }
+  } else {
+    const inv = 1 / dy;
+    let t1 = (minY - oy) * inv;
+    let t2 = (maxY - oy) * inv;
+
+    if (t1 > t2) {
+      const tmp = t1;
+      t1 = t2;
+      t2 = tmp;
+    }
+
+    if (t1 > tmin) {
+      tmin = t1;
+    }
+
+    if (t2 < tmax) {
+      tmax = t2;
+    }
+
+    if (tmin > tmax) {
+      return false;
+    }
+  }
+
+  return true;
+};
 
 /** SAH cost of inserting `leaf` under `child` (a candidate descent target during sibling search). */
 const childInsertionCost = <T>(child: TreeNode<T>, leaf: TreeNode<T>, inheritanceCost: number): number => {

--- a/src/math/DynamicAabbTree.ts
+++ b/src/math/DynamicAabbTree.ts
@@ -627,7 +627,17 @@ const perimeter = (minX: number, minY: number, maxX: number, maxY: number): numb
  * may be `Infinity` for an unbounded ray. Boundary contacts count as hits
  * (conservative: the tree must never prune away a true candidate).
  */
-const raySegmentIntersectsAabb = (ox: number, oy: number, dx: number, dy: number, maxDistance: number, minX: number, minY: number, maxX: number, maxY: number): boolean => {
+const raySegmentIntersectsAabb = (
+  ox: number,
+  oy: number,
+  dx: number,
+  dy: number,
+  maxDistance: number,
+  minX: number,
+  minY: number,
+  maxX: number,
+  maxY: number,
+): boolean => {
   let tmin = 0;
   let tmax = maxDistance;
 

--- a/test/math/dynamic-aabb-tree.test.ts
+++ b/test/math/dynamic-aabb-tree.test.ts
@@ -311,4 +311,186 @@ describe('DynamicAabbTree', () => {
       tree._validate();
     });
   });
+
+  describe('rayCast()', () => {
+    test('an empty tree yields no ray-cast hits', () => {
+      const tree = new DynamicAabbTree<string>();
+      const hits: string[] = [];
+
+      tree.rayCast(0, 0, 1, 0, Infinity, payload => hits.push(payload));
+
+      expect(hits).toEqual([]);
+    });
+
+    test('a ray crossing a leaf reports it; a ray missing it does not', () => {
+      const tree = new DynamicAabbTree<string>();
+      tree.insert(10, -5, 20, 5, 'a');
+
+      const hit: string[] = [];
+      tree.rayCast(0, 0, 1, 0, Infinity, payload => hit.push(payload));
+      expect(hit).toEqual(['a']);
+
+      const miss: string[] = [];
+      tree.rayCast(0, 100, 1, 0, Infinity, payload => miss.push(payload));
+      expect(miss).toEqual([]);
+    });
+
+    test('a ray grazing a leaf edge (tangent) still counts as a candidate', () => {
+      const tree = new DynamicAabbTree<string>();
+      tree.insert(10, 0, 20, 10, 'a'); // ray along y=0 grazes the box's bottom edge
+
+      const hits: string[] = [];
+      tree.rayCast(0, 0, 1, 0, Infinity, payload => hits.push(payload));
+
+      expect(hits).toEqual(['a']);
+    });
+
+    test('maxDistance clamps the segment: a leaf past the end is not visited', () => {
+      const tree = new DynamicAabbTree<string>();
+      tree.insert(100, -5, 110, 5, 'far');
+
+      const near: string[] = [];
+      tree.rayCast(0, 0, 1, 0, 50, payload => near.push(payload));
+      expect(near).toEqual([]);
+
+      const reached: string[] = [];
+      tree.rayCast(0, 0, 1, 0, 200, payload => reached.push(payload));
+      expect(reached).toEqual(['far']);
+    });
+
+    test('an axis-aligned ray with a zero direction component is handled by the slab test', () => {
+      const tree = new DynamicAabbTree<string>();
+      tree.insert(-5, 40, 5, 50, 'up'); // straight up along +y from the origin
+      tree.insert(40, -5, 50, 5, 'right'); // off the vertical ray
+
+      const hits: string[] = [];
+      tree.rayCast(0, 0, 0, 1, Infinity, payload => hits.push(payload));
+
+      expect(hits).toEqual(['up']);
+    });
+
+    test('a ray behind the origin (leaf entirely at negative t) is not visited', () => {
+      const tree = new DynamicAabbTree<string>();
+      tree.insert(-30, -5, -20, 5, 'behind');
+
+      const hits: string[] = [];
+      tree.rayCast(0, 0, 1, 0, Infinity, payload => hits.push(payload));
+
+      expect(hits).toEqual([]);
+    });
+
+    test('a ray through several leaves visits exactly the ones it crosses, skipping a distant cluster', () => {
+      const tree = new DynamicAabbTree<number>(1);
+
+      // Three leaves strung along the +x ray at y=0.
+      tree.insert(10, -2, 12, 2, 0);
+      tree.insert(30, -2, 32, 2, 1);
+      tree.insert(50, -2, 52, 2, 2);
+
+      // A dense cluster far off the ray line — forms deep subtrees the traversal
+      // must prune wholesale rather than descend into.
+      for (let i = 0; i < 40; i++) {
+        tree.insert(1000 + i, 1000, 1002 + i, 1002, 100 + i);
+      }
+
+      const visited: number[] = [];
+      tree.rayCast(0, 0, 1, 0, Infinity, payload => visited.push(payload));
+
+      expect(visited.sort((a, b) => a - b)).toEqual([0, 1, 2]);
+    });
+
+    test('is decoupled from query(): a rayCast issued inside a query() callback does not truncate the outer traversal', () => {
+      const tree = new DynamicAabbTree<string>();
+      tree.insert(0, 0, 10, 10, 'a');
+      tree.insert(2, 2, 12, 12, 'b');
+      tree.insert(4, 4, 14, 14, 'c');
+
+      const outer: string[] = [];
+      const nested: string[] = [];
+
+      tree.query(-100, -100, 100, 100, payload => {
+        outer.push(payload);
+        // Nested rayCast on the SAME instance — uses a separate stack, so it must
+        // not corrupt the outer query's still-live traversal.
+        tree.rayCast(-100, 5, 1, 0, Infinity, p => nested.push(p));
+      });
+
+      expect(outer.sort()).toEqual(['a', 'b', 'c']);
+      expect(nested.length).toBeGreaterThan(0);
+    });
+
+    test('randomized: every leaf whose tight AABB the ray crosses is reported (zero false negatives)', () => {
+      const rng = new Random(20260714);
+      const tree = new DynamicAabbTree<number>(2);
+      const live = new Map<number, { minX: number; minY: number; maxX: number; maxY: number }>();
+
+      for (let id = 0; id < 200; id++) {
+        const x = rng.next(0, 300);
+        const y = rng.next(0, 300);
+        const w = rng.next(1, 25);
+        const h = rng.next(1, 25);
+        const box = { minX: x, minY: y, maxX: x + w, maxY: y + h };
+        tree.insert(box.minX, box.minY, box.maxX, box.maxY, id);
+        live.set(id, box);
+      }
+
+      for (let trial = 0; trial < 200; trial++) {
+        const ox = rng.next(-50, 350);
+        const oy = rng.next(-50, 350);
+        const dirX = rng.next(-1, 1);
+        const dirY = rng.next(-1, 1);
+        const len = Math.hypot(dirX, dirY) || 1;
+        const dx = dirX / len;
+        const dy = dirY / len;
+        const maxDistance = rng.next() < 0.5 ? Infinity : rng.next(10, 400);
+
+        const expected = new Set<number>();
+
+        for (const [id, box] of live) {
+          if (raySegmentHitsBox(ox, oy, dx, dy, maxDistance, box.minX, box.minY, box.maxX, box.maxY)) {
+            expected.add(id);
+          }
+        }
+
+        const actual = new Set<number>();
+        tree.rayCast(ox, oy, dx, dy, maxDistance, payload => actual.add(payload));
+
+        // Hits are over FAT AABBs (a superset of the tight boxes tracked here) —
+        // assert zero false negatives, not exact equality.
+        for (const id of expected) {
+          expect(actual.has(id)).toBe(true);
+        }
+      }
+    });
+  });
 });
+
+/** Independent brute-force slab test (oracle for the tree's own ray prune). */
+const raySegmentHitsBox = (ox: number, oy: number, dx: number, dy: number, maxDistance: number, minX: number, minY: number, maxX: number, maxY: number): boolean => {
+  let tmin = 0;
+  let tmax = maxDistance;
+
+  for (const [o, d, lo, hi] of [
+    [ox, dx, minX, maxX],
+    [oy, dy, minY, maxY],
+  ] as const) {
+    if (d === 0) {
+      if (o < lo || o > hi) {
+        return false;
+      }
+
+      continue;
+    }
+
+    const t1 = (lo - o) / d;
+    const t2 = (hi - o) / d;
+    tmin = Math.max(tmin, Math.min(t1, t2));
+    tmax = Math.min(tmax, Math.max(t1, t2));
+
+    if (tmin > tmax) {
+      return false;
+    }
+  }
+
+  return true;
+};

--- a/test/math/dynamic-aabb-tree.test.ts
+++ b/test/math/dynamic-aabb-tree.test.ts
@@ -379,7 +379,7 @@ describe('DynamicAabbTree', () => {
       expect(hits).toEqual([]);
     });
 
-    test('a ray through several leaves visits exactly the ones it crosses, skipping a distant cluster', () => {
+    test('a ray reports only the leaves it crosses, not the 40 in a distant off-ray cluster', () => {
       const tree = new DynamicAabbTree<number>(1);
 
       // Three leaves strung along the +x ray at y=0.
@@ -387,8 +387,7 @@ describe('DynamicAabbTree', () => {
       tree.insert(30, -2, 32, 2, 1);
       tree.insert(50, -2, 52, 2, 2);
 
-      // A dense cluster far off the ray line — forms deep subtrees the traversal
-      // must prune wholesale rather than descend into.
+      // A dense cluster far off the ray line — the ray must reach none of them.
       for (let i = 0; i < 40; i++) {
         tree.insert(1000 + i, 1000, 1002 + i, 1002, 100 + i);
       }
@@ -396,7 +395,10 @@ describe('DynamicAabbTree', () => {
       const visited: number[] = [];
       tree.rayCast(0, 0, 1, 0, Infinity, payload => visited.push(payload));
 
+      // Exactly the three on-ray leaves; the callback fires far fewer than
+      // leafCount times, so distant leaves are correctly excluded.
       expect(visited.sort((a, b) => a - b)).toEqual([0, 1, 2]);
+      expect(tree.leafCount).toBe(43);
     });
 
     test('is decoupled from query(): a rayCast issued inside a query() callback does not truncate the outer traversal', () => {
@@ -465,32 +467,50 @@ describe('DynamicAabbTree', () => {
   });
 });
 
-/** Independent brute-force slab test (oracle for the tree's own ray prune). */
-const raySegmentHitsBox = (ox: number, oy: number, dx: number, dy: number, maxDistance: number, minX: number, minY: number, maxX: number, maxY: number): boolean => {
-  let tmin = 0;
-  let tmax = maxDistance;
+// Oracle for the tree's ray prune, deliberately using a DIFFERENT technique
+// (orientation-based segment/edge crossing) than the tree's own slab test, so a
+// shared conceptual flaw can't hide in both. Exact for a finite `maxDistance`;
+// for `Infinity` the ray is clamped to a segment long enough to reach the whole
+// test region — a farther box it would nonetheless cross is simply under-reported
+// (weakening the check, never over-reporting), which keeps `expected ⊆ actual`
+// sound: every box the oracle claims is one the ray truly enters.
+const orient = (ax: number, ay: number, bx: number, by: number, cx: number, cy: number): number => Math.sign((bx - ax) * (cy - ay) - (by - ay) * (cx - ax));
 
-  for (const [o, d, lo, hi] of [
-    [ox, dx, minX, maxX],
-    [oy, dy, minY, maxY],
-  ] as const) {
-    if (d === 0) {
-      if (o < lo || o > hi) {
-        return false;
-      }
+const onSegment = (ax: number, ay: number, bx: number, by: number, px: number, py: number): boolean =>
+  Math.min(ax, bx) <= px && px <= Math.max(ax, bx) && Math.min(ay, by) <= py && py <= Math.max(ay, by);
 
-      continue;
-    }
+const segmentsIntersect = (p1x: number, p1y: number, p2x: number, p2y: number, p3x: number, p3y: number, p4x: number, p4y: number): boolean => {
+  const o1 = orient(p1x, p1y, p2x, p2y, p3x, p3y);
+  const o2 = orient(p1x, p1y, p2x, p2y, p4x, p4y);
+  const o3 = orient(p3x, p3y, p4x, p4y, p1x, p1y);
+  const o4 = orient(p3x, p3y, p4x, p4y, p2x, p2y);
 
-    const t1 = (lo - o) / d;
-    const t2 = (hi - o) / d;
-    tmin = Math.max(tmin, Math.min(t1, t2));
-    tmax = Math.min(tmax, Math.max(t1, t2));
-
-    if (tmin > tmax) {
-      return false;
-    }
+  if (o1 !== o2 && o3 !== o4) {
+    return true;
   }
 
-  return true;
+  return (
+    (o1 === 0 && onSegment(p1x, p1y, p2x, p2y, p3x, p3y)) ||
+    (o2 === 0 && onSegment(p1x, p1y, p2x, p2y, p4x, p4y)) ||
+    (o3 === 0 && onSegment(p3x, p3y, p4x, p4y, p1x, p1y)) ||
+    (o4 === 0 && onSegment(p3x, p3y, p4x, p4y, p2x, p2y))
+  );
+};
+
+const raySegmentHitsBox = (ox: number, oy: number, dx: number, dy: number, maxDistance: number, minX: number, minY: number, maxX: number, maxY: number): boolean => {
+  const length = Number.isFinite(maxDistance) ? maxDistance : 4000; // covers the whole [-50,350] test region
+  const ex = ox + dx * length;
+  const ey = oy + dy * length;
+  const inside = (px: number, py: number): boolean => px >= minX && px <= maxX && py >= minY && py <= maxY;
+
+  if (inside(ox, oy) || inside(ex, ey)) {
+    return true;
+  }
+
+  return (
+    segmentsIntersect(ox, oy, ex, ey, minX, minY, maxX, minY) ||
+    segmentsIntersect(ox, oy, ex, ey, maxX, minY, maxX, maxY) ||
+    segmentsIntersect(ox, oy, ex, ey, maxX, maxY, minX, maxY) ||
+    segmentsIntersect(ox, oy, ex, ey, minX, maxY, minX, minY)
+  );
 };

--- a/test/math/dynamic-aabb-tree.test.ts
+++ b/test/math/dynamic-aabb-tree.test.ts
@@ -497,7 +497,17 @@ const segmentsIntersect = (p1x: number, p1y: number, p2x: number, p2y: number, p
   );
 };
 
-const raySegmentHitsBox = (ox: number, oy: number, dx: number, dy: number, maxDistance: number, minX: number, minY: number, maxX: number, maxY: number): boolean => {
+const raySegmentHitsBox = (
+  ox: number,
+  oy: number,
+  dx: number,
+  dy: number,
+  maxDistance: number,
+  minX: number,
+  minY: number,
+  maxX: number,
+  maxY: number,
+): boolean => {
   const length = Number.isFinite(maxDistance) ? maxDistance : 4000; // covers the whole [-50,350] test region
   const ex = ox + dx * length;
   const ey = oy + dy * length;


### PR DESCRIPTION
## Summary
- Accelerates `QueryEngine.rayCast`/`rayCastAll`, the one pair of narrowed queries #359 explicitly left on the old full-linear-scan path, by adding a `rayCast` traversal to `DynamicAabbTree<T>` (Box2D-style slab test pruning subtrees against the ray segment) and threading it through `SpatialIndex`/`AabbTreeBroadPhase`.
- The tree only prunes to AABB-hit candidates — the existing exact narrow-phase math (`rayCastCircle`/`rayCastPolygon`) is unchanged and runs only on the survivors.
- New traversal uses its own persistent `_rayCastStack`, decoupled from `query()`'s `_queryStack`, so a ray-cast issued from inside a `query()`/`queryPoint()` callback (or vice versa) can't corrupt the other's traversal.
- The `undefined`-spatialIndex linear-scan fallback (used when no backend is wired) is unchanged.

## Test coverage
- Tree-level: empty tree, hit/miss, tangent/grazing edges, `maxDistance` clamp, zero-direction/behind-origin rays, distant-cluster pruning exclusion, and a randomized property test validating zero false negatives against an independently-implemented reference (deliberately not the same algorithm as the tree's slab test).
- Physics-level: indexed-vs-linear parity for both `rayCast` and `rayCastAll`, plus a randomized mixed circle/box scene cross-checking results against the un-accelerated `QueryEngine` path.

Closes #361.

## Test plan
- [x] Full suite green (7597 passed / 16 skipped) at implementation time; targeted re-runs of touched files pass (55/55)
- [x] `tsc --noEmit` clean for `@codexo/exojs` and `@codexo/exojs-physics`
- [x] `eslint` clean on all touched files
- [x] Independent code review (different model) found no functional blockers; both Important findings were test-quality and are fixed
- [x] `pnpm docs:api:generate` run to sync `dynamic-aabb-tree.json` for the new public method