### PR TITLE
refactor(rendering,webgpu): generalize retained-batch record/replay to a renderer-agnostic interface

### DIFF
--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -44,10 +44,12 @@ import { WebGpuPassCoordinator } from './WebGpuPassCoordinator';
 import {
   retainedTransformSlotBytes,
   type WebGpuRetainedBatchPayload,
+  type WebGpuRetainedBatchReplayer,
   WebGpuRetainedCaptureFrame,
   WebGpuRetainedGroupBundle,
+  type WebGpuRetainedNodeIndexRange,
 } from './WebGpuRetainedGroupResources';
-import { baseSpriteBatchTextureSlots, maxSpriteBatchTextureSlots, type WebGpuSpriteRenderer } from './WebGpuSpriteRenderer';
+import { baseSpriteBatchTextureSlots, maxSpriteBatchTextureSlots } from './WebGpuSpriteRenderer';
 import { WebGpuTransformStorage } from './WebGpuTransformStorage';
 
 interface ManagedWebGpuTextureState {
@@ -203,6 +205,10 @@ export class WebGpuBackend implements RenderBackend {
   private readonly _retainedCaptureFrames: WebGpuRetainedCaptureFrame[] = [];
   private readonly _retainedBundles = new Set<WebGpuRetainedGroupBundle>();
   private readonly _rejectedRetainedSets = new WeakSet<RetainedInstructionSet>();
+  // Reused across per-batch scans at record time (S3-D4) to avoid an
+  // allocation per flush; the renderer-agnostic counterpart of WebGL2's
+  // capture-end `_retainedIndexRange` (WebGPU scans per batch, not per capture).
+  private readonly _retainedBatchIndexRange: WebGpuRetainedNodeIndexRange = { min: 0, max: 0 };
   // Render-error surface (S3 diagnostics): dedupe keys for onRenderError, and
   // the bound uncapturederror listener (re-installed by _initialize after
   // device-loss recovery).
@@ -1161,7 +1167,8 @@ export class WebGpuBackend implements RenderBackend {
    * the OPEN pass (no end/submit at group boundaries on the cached path,
    * B-06). All state — pipeline, projection/group uniforms, texture bindings
    * — is resolved live; only the recorded data is reused. Dispatches to the
-   * sprite renderer that recorded the batch.
+   * renderer that recorded the batch (any {@link WebGpuRetainedBatchReplayer},
+   * not just the sprite renderer).
    * @internal
    */
   public _replayRetainedBatch(batch: RetainedBatchInstruction): void {
@@ -1179,7 +1186,7 @@ export class WebGpuBackend implements RenderBackend {
     // flush-time visibility decision (mask/scissor) can drop the batch.
     this._stats.submittedNodes += batch.instanceCount;
     this._setActiveRenderer(payload.renderer);
-    payload.renderer._replayRecordedSpriteBatch(payload);
+    payload.renderer._replayRetainedBatch(payload);
   }
 
   /**
@@ -1244,14 +1251,15 @@ export class WebGpuBackend implements RenderBackend {
   }
 
   /**
-   * Stage one recorded sprite flush (called by the sprite renderer while a
-   * capture window is active): copies the packed instance bytes (owned by the
-   * INNERMOST capture's bundle, S3-D6), resolves the recorded texture views,
-   * and appends one shared instruction to every active set.
+   * Stage one recorded renderer flush (called by any capable renderer, e.g.
+   * the sprite renderer, while a capture window is active): copies the
+   * packed instance bytes (owned by the INNERMOST capture's bundle, S3-D6),
+   * resolves the recorded texture views, and appends one shared instruction
+   * to every active set.
    * @internal
    */
-  public _recordRetainedSpriteBatch(
-    renderer: WebGpuSpriteRenderer,
+  public _recordRetainedBatch(
+    replayer: WebGpuRetainedBatchReplayer,
     instanceData: ArrayBuffer,
     byteLength: number,
     instanceCount: number,
@@ -1276,24 +1284,14 @@ export class WebGpuBackend implements RenderBackend {
 
     bytes.set(new Uint8Array(instanceData, 0, byteLength));
 
-    // Scan the frame-global node indices (word 7 of each 8-word instance) so
-    // capture end can rebase them group-local and copy the row range once.
-    const words = new Uint32Array(bytes.buffer);
-    let minNodeIndex = 0xffffffff;
-    let maxNodeIndex = 0;
+    // Scan the frame-global node indices so capture end can rebase them
+    // group-local and copy the row range once. Layout-aware (word offset,
+    // stride) — delegated to the renderer that packed the bytes.
+    const range = this._retainedBatchIndexRange;
 
-    for (let i = 7; i < words.length; i += 8) {
-      // In-bounds: i < words.length via the loop guard.
-      const nodeIndex = words[i]!;
-
-      if (nodeIndex < minNodeIndex) {
-        minNodeIndex = nodeIndex;
-      }
-
-      if (nodeIndex > maxNodeIndex) {
-        maxNodeIndex = nodeIndex;
-      }
-    }
+    range.min = 0xffffffff;
+    range.max = 0;
+    replayer._scanRetainedNodeIndexRange(bytes, range);
 
     const textureList: Array<Texture | RenderTexture> = [];
     const recordedViews: GPUTextureView[] = [];
@@ -1312,7 +1310,7 @@ export class WebGpuBackend implements RenderBackend {
     }
 
     const payload: WebGpuRetainedBatchPayload = {
-      renderer,
+      renderer: replayer,
       bundle: owner.bundle,
       byteOffset: owner.totalBytes,
       instanceCount,
@@ -1332,7 +1330,7 @@ export class WebGpuBackend implements RenderBackend {
       payload,
     };
 
-    owner.staged.push({ bytes, byteOffset: owner.totalBytes, minNodeIndex, maxNodeIndex, instruction });
+    owner.staged.push({ bytes, byteOffset: owner.totalBytes, minNodeIndex: range.min, maxNodeIndex: range.max, instruction });
     owner.totalBytes += byteLength;
 
     for (const frame of frames) {
@@ -1393,15 +1391,14 @@ export class WebGpuBackend implements RenderBackend {
     bundle.ensureCapacity(device, frame.totalBytes, transformBytes);
 
     for (const batch of staged) {
-      // Rebase word 7 (nodeIndex) of every 8-word instance to group-local
-      // indices — the cached bytes become immune to frame-local index shifts
-      // (S3-D4) and address the group-owned row copy below.
-      const words = new Uint32Array(batch.bytes.buffer, batch.bytes.byteOffset, batch.bytes.byteLength / Uint32Array.BYTES_PER_ELEMENT);
+      // Rebase this batch's instance node indices to group-local indices —
+      // the cached bytes become immune to frame-local index shifts (S3-D4)
+      // and address the group-owned row copy below. Layout-aware — delegated
+      // to the renderer that packed the bytes (the payload was already
+      // created at record time, so its renderer is in hand here).
+      const payload = batch.instruction.payload as WebGpuRetainedBatchPayload;
 
-      for (let i = 7; i < words.length; i += 8) {
-        // In-bounds: i < words.length via the loop guard.
-        words[i] = words[i]! - base;
-      }
+      payload.renderer._rebaseRetainedNodeIndices(batch.bytes, base);
 
       device.queue.writeBuffer(bundle.instanceBuffer!, batch.byteOffset, batch.bytes.buffer, batch.bytes.byteOffset, batch.bytes.byteLength);
       stampRetainedBatchGeneration(batch.instruction);

--- a/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
+++ b/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
@@ -2,13 +2,13 @@
 
 import type { GpuResourceAccountant } from '#rendering/GpuResourceAccountant';
 import type { RetainedBatchInstruction, RetainedGroupBundle, RetainedInstructionSet } from '#rendering/plan/RetainedInstructionSet';
+import type { Renderer } from '#rendering/Renderer';
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { Texture } from '#rendering/texture/Texture';
 import type { BlendModes } from '#rendering/types';
 import type { View } from '#rendering/View';
 
 import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
-import type { WebGpuSpriteRenderer } from './WebGpuSpriteRenderer';
 
 /** Bytes of one transform slot (3 × vec4<f32>, matches the WGSL `TransformSlot`). */
 export const retainedTransformSlotBytes = 48;
@@ -17,16 +17,16 @@ export const retainedTransformSlotBytes = 48;
 export const retainedGroupUniformBytes = 128;
 
 /**
- * Backend-owned replay descriptor for one recorded sprite flush (Track B
+ * Backend-owned replay descriptor for one recorded renderer flush (Track B
  * Slice 3, S3-D1). Carried as the opaque `payload` of a
  * {@link RetainedBatchInstruction}; everything here is DATA — all state
  * (pipeline, projection/group uniforms, texture bindings) is resolved live at
- * replay by {@link WebGpuSpriteRenderer._replayRecordedSpriteBatch}.
+ * replay by the owning {@link WebGpuRetainedBatchReplayer._replayRetainedBatch}.
  * @internal
  */
 export interface WebGpuRetainedBatchPayload {
-  /** The sprite renderer that recorded (and replays) this batch. */
-  readonly renderer: WebGpuSpriteRenderer;
+  /** The renderer that recorded (and replays) this batch. */
+  readonly renderer: WebGpuRetainedBatchReplayer;
   /** The bundle whose group-owned buffers hold this batch's data. */
   readonly bundle: WebGpuRetainedGroupBundle;
   /** Byte offset of this batch's instances inside the bundle's instance buffer. */
@@ -43,6 +43,45 @@ export interface WebGpuRetainedBatchPayload {
    * a recapture, never a replay.
    */
   readonly recordedViews: readonly GPUTextureView[];
+}
+
+/**
+ * Mutable node-index range scratch used at record time (S3-D4), the WebGPU
+ * counterpart of `WebGl2RetainedNodeIndexRange`. Unlike WebGL2 (which scans
+ * the shared bundle store at capture END, once ranges over every batch are
+ * known), WebGPU scans each batch's freshly-packed bytes immediately at
+ * record time, per batch — so the range here is scoped to ONE batch, not the
+ * whole capture; the backend takes the min/max across all per-batch ranges to
+ * get the capture-wide rebase base.
+ * @internal
+ */
+export interface WebGpuRetainedNodeIndexRange {
+  min: number;
+  max: number;
+}
+
+/**
+ * Renderer-side contract for recorded-batch finalization and replay on WebGPU
+ * (the WebGPU counterpart of `WebGl2RetainedBatchReplayer`). The bundle/stage
+ * stores raw instance bytes; only the renderer that packed them knows the
+ * layout (where the node index lives, how many words per instance), so the
+ * backend delegates the layout-aware steps here per batch — mirroring the
+ * WebGL2 seam, adapted to WebGPU's byte-staging flow (record-time scan on
+ * freshly-packed bytes, finalize-time rebase on the staged copy, rather than
+ * WebGL2's capture-end scan/rebase against a live bundle store).
+ *
+ * Extends {@link Renderer} so the backend can drive replay through the same
+ * active-renderer bookkeeping (`_setActiveRenderer` calls `flush()` on
+ * renderer switch) it already uses for live playback.
+ * @internal
+ */
+export interface WebGpuRetainedBatchReplayer extends Renderer {
+  /** Widen `range` to cover every shared-transform row `bytes` (one batch's packed instances) references. */
+  _scanRetainedNodeIndexRange(bytes: Uint8Array, range: WebGpuRetainedNodeIndexRange): void;
+  /** Rewrite `bytes`' instance node indices in place to group-local (`index - base`). */
+  _rebaseRetainedNodeIndices(bytes: Uint8Array, base: number): void;
+  /** Replay the batch: live state (pipeline, uniforms, textures), cached data (bytes, transforms). */
+  _replayRetainedBatch(payload: WebGpuRetainedBatchPayload): void;
 }
 
 /** One sprite flush staged during a capture window, finalized at capture end. @internal */

--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -16,7 +16,12 @@ import type { WebGpuBackend } from './WebGpuBackend';
 import { getWebGpuBlendState } from './WebGpuBlendState';
 import { WebGpuInstanceArena } from './WebGpuInstanceArena';
 import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
-import { retainedGroupUniformBytes, type WebGpuRetainedBatchPayload } from './WebGpuRetainedGroupResources';
+import {
+  retainedGroupUniformBytes,
+  type WebGpuRetainedBatchPayload,
+  type WebGpuRetainedBatchReplayer,
+  type WebGpuRetainedNodeIndexRange,
+} from './WebGpuRetainedGroupResources';
 import { stencilContentDepthStencilState } from './WebGpuStencilState';
 import {
   collectScalarUniforms,
@@ -276,7 +281,7 @@ interface CustomSpriteResources {
   baseTextureBindGroups: WeakMap<Texture | RenderTexture, { group: GPUBindGroup; view: GPUTextureView }>;
 }
 
-export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
+export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> implements WebGpuRetainedBatchReplayer {
   /** Retained-batch capability flag (Track B Slice 3, S3-D5.1): the default path records/replays flush-level batches. */
   public readonly _supportsRetainedBatches = true;
 
@@ -742,7 +747,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
       if (isCustom) {
         backend._poisonActiveRetainedCaptures();
       } else if (this._currentBlendMode !== null) {
-        backend._recordRetainedSpriteBatch(
+        backend._recordRetainedBatch(
           this,
           this._instanceData,
           this._instanceCount * instanceStrideBytes,
@@ -857,6 +862,42 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     return this._transformBindGroup;
   }
 
+  // ── Retained-batch record/replay (Track B Slice 3, Tasks 9/10) ────────────
+  // The bundle/stage stores raw instance bytes; this renderer owns the
+  // 32-byte (8-word) layout, so the layout-aware finalize steps (node-index
+  // scan/rebase) and the replay dispatch live here — the WebGPU counterpart
+  // of WebGl2SpriteRenderer's `_scanRetainedNodeIndexRange` /
+  // `_rebaseRetainedNodeIndices` / `_replayRetainedBatch`.
+
+  /** @internal See {@link WebGpuRetainedBatchReplayer._scanRetainedNodeIndexRange}. */
+  public _scanRetainedNodeIndexRange(bytes: Uint8Array, range: WebGpuRetainedNodeIndexRange): void {
+    const words = new Uint32Array(bytes.buffer);
+
+    for (let i = 7; i < words.length; i += 8) {
+      // In-bounds: i < words.length via the loop guard. nodeIndex is the last
+      // word of the 32-byte (8-word) instance layout.
+      const nodeIndex = words[i]!;
+
+      if (nodeIndex < range.min) {
+        range.min = nodeIndex;
+      }
+
+      if (nodeIndex > range.max) {
+        range.max = nodeIndex;
+      }
+    }
+  }
+
+  /** @internal See {@link WebGpuRetainedBatchReplayer._rebaseRetainedNodeIndices} (S3-D4: group-local indices). */
+  public _rebaseRetainedNodeIndices(bytes: Uint8Array, base: number): void {
+    const words = new Uint32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / Uint32Array.BYTES_PER_ELEMENT);
+
+    for (let i = 7; i < words.length; i += 8) {
+      // In-bounds: i < words.length via the loop guard.
+      words[i] = words[i]! - base;
+    }
+  }
+
   /**
    * Replay one recorded batch from its group-owned bundle into the OPEN pass
    * (Track B Slice 3, Task 10 / S3-D7). Reuses only recorded DATA (instance
@@ -878,7 +919,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
    * on the cached path do not fragment the single-submit frame (B-06).
    * @internal
    */
-  public _replayRecordedSpriteBatch(payload: WebGpuRetainedBatchPayload): void {
+  public _replayRetainedBatch(payload: WebGpuRetainedBatchPayload): void {
     const backend = this._backend;
     const device = this._device;
     const bundle = payload.bundle;
@@ -978,7 +1019,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     backend.stats.drawCalls++;
   }
 
-  /** Scratch for the packed group matrix compared at replay (see `_replayRecordedSpriteBatch`). */
+  /** Scratch for the packed group matrix compared at replay (see `_replayRetainedBatch`). */
   private readonly _stagedReplayGroupData = new Float32Array(16);
 
   public destroy(): void {


### PR DESCRIPTION
## Summary
- Extracts the WebGPU retained-batch record/replay path (Track B Slice 3) behind a new `WebGpuRetainedBatchReplayer` interface, mirroring the already-generic WebGL2 `WebGl2RetainedBatchReplayer` pattern.
- `WebGpuBackend`/`WebGpuRetainedGroupResources` previously hard-wired this to the concrete `WebGpuSpriteRenderer` class; this is a pure seam-extraction with no behavioral change, unblocking follow-up workstreams to add retained-batch support to Mesh/Text/NineSlice/RepeatingSprite renderers without touching the same central backend files.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on touched files
- [x] Unit tests (`vitest --project=exojs`): 151 passed (webgpu-retained-record-replay, retained-instruction-set/equivalence, retained-container, retained-group-fragment, retained-plan-cache, retained-subtree-skip, retained-container-reparent, webgl2-retained-group-resources)
- [x] WebGPU browser pixel lane (real SwiftShader GPU): 19 + 21 passed (webgpu-retained-instruction-replay, webgpu-retained-container, webgpu-rotated-retained-group, webgpu-animated-sprite, webgpu-custom-sprite-material, webgpu-repeating-sprite, webgpu-sprite-solid-color, webgpu-sprite-transform)
- [x] `git diff --stat` confirms only the three intended WebGPU files touched (no WebGL2/plan-layer changes)