### PR TITLE
feat(rendering): retained-batch record/replay for the NineSlice renderer

### DIFF
--- a/src/rendering/webgl2/WebGl2NineSliceSpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2NineSliceSpriteRenderer.ts
@@ -3,12 +3,13 @@ import type { NineSliceQuad } from '#rendering/sprite/nineSlice';
 import type { NineSliceSprite } from '#rendering/sprite/NineSliceSprite';
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { Texture } from '#rendering/texture/Texture';
-import { type BlendModes, BufferTypes, BufferUsage, RenderingPrimitives } from '#rendering/types';
+import { BlendModes, BufferTypes, BufferUsage, RenderingPrimitives } from '#rendering/types';
 import type { View } from '#rendering/View';
 
 import { AbstractWebGl2Renderer } from './AbstractWebGl2Renderer';
 import type { WebGl2Backend } from './WebGl2Backend';
 import { WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
+import type { WebGl2RetainedBatchPayload, WebGl2RetainedBatchReplayer, WebGl2RetainedNodeIndexRange } from './WebGl2RetainedGroupResources';
 import { createWebGl2ShaderProgram } from './WebGl2ShaderProgram';
 import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './WebGl2VertexArrayObject';
 
@@ -84,7 +85,19 @@ interface NineSliceRendererConnection {
 }
 
 /** Instanced renderer for {@link NineSliceSprite} using WebGL2. */
-export class WebGl2NineSliceSpriteRenderer extends AbstractWebGl2Renderer<NineSliceSprite> {
+export class WebGl2NineSliceSpriteRenderer extends AbstractWebGl2Renderer<NineSliceSprite> implements WebGl2RetainedBatchReplayer {
+  /**
+   * Retained-batch capability opt-in (Track B Slice 3, S3-D5.1): a nine-slice
+   * group's per-flush instanced batches (fixed 32-byte layout, node index at
+   * word 7 — the same seam as the sprite renderer) can be recorded into a
+   * group's instruction set and replayed from group-owned resources.
+   * Pixel-snapped draws are excluded by the collect-time recordability
+   * predicate (and belt-and-braces poisoning in {@link render}); nine-slice
+   * has no custom-material path to exclude.
+   * @internal
+   */
+  public readonly _supportsRetainedBatches = true;
+
   private readonly _shader: Shader;
   private readonly _batchSize: number;
   private readonly _instanceData: ArrayBuffer;
@@ -92,6 +105,12 @@ export class WebGl2NineSliceSpriteRenderer extends AbstractWebGl2Renderer<NineSl
   private readonly _instanceUint32: Uint32Array;
 
   private readonly _transformUnitScratch: Int32Array = new Int32Array([transformTextureUnit]);
+  // Pinned unit index for the single base texture sampler (unit 0), reused by
+  // the live flush and retained replay so both stay allocation-free.
+  private readonly _baseTextureUnitScratch: Int32Array = new Int32Array([0]);
+  // Reused single-slot texture list handed to the backend at record time; the
+  // nine-slice batch always binds exactly one base texture (slot 0).
+  private readonly _recordTextures: Array<Texture | RenderTexture | null> = [null];
 
   private _quadIndex = 0;
   private _maxNodeIndex = 0;
@@ -117,6 +136,17 @@ export class WebGl2NineSliceSpriteRenderer extends AbstractWebGl2Renderer<NineSl
 
   public render(sprite: NineSliceSprite): void {
     const backend = this.getBackend();
+
+    // Belt-and-braces for retained recording (S3-D5.3): the collect-time
+    // recordability predicate excludes pixel-snapped draws from ever arming a
+    // capture (snapped instance words are view-dependent). If one still arrives
+    // inside an active capture window, poison the recording so the resulting
+    // set can never validate — degrading to entry replay instead of wrong
+    // pixels. Nine-slice has no custom-material path to guard.
+    if (backend._isRetainedCapturing && sprite.pixelSnapMode !== 'none') {
+      backend._poisonRetainedCaptures();
+    }
+
     let quads: readonly NineSliceQuad[] = sprite.quads;
 
     if (sprite.pixelSnapMode === 'geometry') {
@@ -233,6 +263,50 @@ export class WebGl2NineSliceSpriteRenderer extends AbstractWebGl2Renderer<NineSl
       return;
     }
 
+    this._stageViewUniforms(backend);
+
+    if (this._currentTexture !== null) {
+      this._shader.getUniform('u_texture').setValue(this._baseTextureUnitScratch);
+    }
+
+    backend.bindTransformBufferTexture(transformTextureUnit, this._maxNodeIndex + 1);
+    this._shader.getUniform('u_transforms').setValue(this._transformUnitScratch);
+
+    this._shader.sync();
+    backend.bindVertexArrayObject(vao);
+    instanceBuffer.upload(this._instanceFloat32.subarray(0, this._quadIndex * wordsPerInstance));
+    vao.drawInstanced(4, 0, this._quadIndex, RenderingPrimitives.TriangleStrip);
+    backend.stats.batches++;
+    backend.stats.drawCalls++;
+
+    // Retained recording (Slice 3): while a capture window is open, hand the
+    // exact packed instance words of this flush to the backend — byte-identical
+    // to what just drew, no duplicated packing logic. The nine-slice batch
+    // always binds a single base texture (slot 0); a pixel-snapped draw already
+    // poisoned the capture in render().
+    if (backend._isRetainedCapturing && this._currentTexture !== null) {
+      this._recordTextures[0] = this._currentTexture;
+      backend._recordRetainedBatch(
+        this,
+        this._instanceUint32.subarray(0, this._quadIndex * wordsPerInstance),
+        this._quadIndex,
+        this._currentBlendMode ?? BlendModes.Normal,
+        this._recordTextures,
+        1,
+      );
+    }
+
+    this._quadIndex = 0;
+    this._maxNodeIndex = 0;
+  }
+
+  /**
+   * Stage `u_projection` (live view) and `u_group` (live composed group matrix)
+   * on the shader, guarded by the cached view/group stamps. Shared by the live
+   * flush path and retained-batch replay — replay resolves exactly the same
+   * live state a slow-path flush would (S3-D1).
+   */
+  private _stageViewUniforms(backend: WebGl2Backend): void {
     const view = backend.view;
 
     if (this._currentView !== view || this._currentViewId !== view.updateId) {
@@ -248,23 +322,122 @@ export class WebGl2NineSliceSpriteRenderer extends AbstractWebGl2Renderer<NineSl
 
       this._shader.getUniform('u_group').setValue(groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3);
     }
+  }
 
-    if (this._currentTexture !== null) {
-      this._shader.getUniform('u_texture').setValue(new Int32Array([0]));
+  // ── Retained-batch record/replay (Track B Slice 3) ───────────────────────
+  // The bundle stores raw instance bytes; this renderer owns the 32-byte
+  // layout (node index at word 7), so the layout-aware finalize steps
+  // (node-index scan/rebase, VAO attribute wiring) and the replay dispatch
+  // live here — mirroring WebGl2SpriteRenderer's seam, adapted to nine-slice's
+  // single-texture, per-instance-tint attribute set.
+
+  /** @internal See {@link WebGl2RetainedBatchReplayer._scanRetainedNodeIndexRange}. */
+  public _scanRetainedNodeIndexRange(payload: WebGl2RetainedBatchPayload, range: WebGl2RetainedNodeIndexRange): void {
+    const words = payload.bundle.instanceWords;
+    const start = payload.byteOffset / Uint32Array.BYTES_PER_ELEMENT;
+
+    for (let i = 0; i < payload.instanceCount; i++) {
+      // In-bounds: the payload's word range was appended to the bundle store.
+      // nodeIndex is the last word of the 32-byte (8-word) instance layout.
+      const node = words[start + i * wordsPerInstance + 7]!;
+
+      if (node < range.min) {
+        range.min = node;
+      }
+
+      if (node > range.max) {
+        range.max = node;
+      }
+    }
+  }
+
+  /** @internal See {@link WebGl2RetainedBatchReplayer._rebaseRetainedNodeIndices} (S3-D4: group-local indices). */
+  public _rebaseRetainedNodeIndices(payload: WebGl2RetainedBatchPayload, base: number): void {
+    const words = payload.bundle.instanceWords;
+    const start = payload.byteOffset / Uint32Array.BYTES_PER_ELEMENT;
+
+    for (let i = 0; i < payload.instanceCount; i++) {
+      const index = start + i * wordsPerInstance + 7;
+
+      // In-bounds: see the scan above.
+      words[index] = (words[index]! - base) >>> 0;
+    }
+  }
+
+  /**
+   * Point the batch VAO's per-instance attributes at the bundle's persistent
+   * instance buffer, based at the batch's byte offset (WebGL2 has no
+   * baseInstance, hence one small VAO per recorded batch). Same attribute
+   * set/locations as the live VAO in {@link onConnect}.
+   * @internal
+   */
+  public _configureRetainedVao(payload: WebGl2RetainedBatchPayload): void {
+    const gl = this.getBackend().context;
+    const buffer = payload.bundle.instanceBuffer;
+    const vao = payload.vao;
+
+    if (buffer === null || vao === null) {
+      throw new Error('WebGl2NineSliceSpriteRenderer: retained batch VAO configuration requires an uploaded bundle.');
     }
 
-    backend.bindTransformBufferTexture(transformTextureUnit, this._maxNodeIndex + 1);
+    const base = payload.byteOffset;
+
+    vao
+      .addAttribute(buffer, this._shader.getAttribute('a_quadBounds'), gl.FLOAT, false, instanceStrideBytes, base + 0, false, 1)
+      .addAttribute(buffer, this._shader.getAttribute('a_uvBounds'), gl.UNSIGNED_SHORT, true, instanceStrideBytes, base + 16, false, 1)
+      .addAttribute(buffer, this._shader.getAttribute('a_color'), gl.UNSIGNED_BYTE, true, instanceStrideBytes, base + 24, false, 1)
+      .addAttribute(buffer, this._shader.getAttribute('a_nodeIndex'), gl.UNSIGNED_INT, false, instanceStrideBytes, base + 28, true, 1);
+  }
+
+  /**
+   * Replay one recorded batch: all STATE is resolved live — blend mode via the
+   * backend's dedup, `u_projection`/`u_group` from the live view + composed
+   * group matrix (the camera-pan / group-move win), the single base texture
+   * bound to unit 0 by recorded slot order — and only the DATA is cached: the
+   * instance bytes in the bundle buffer (bound through the per-batch VAO) and
+   * the group-owned transform texture on the shared transform unit. The backend
+   * hook flushed any pending live batch before dispatching here and bumps the
+   * stats from the instruction descriptor.
+   * @internal
+   */
+  public _replayRetainedBatch(payload: WebGl2RetainedBatchPayload): void {
+    const backend = this.getBackendOrNull();
+    const vao = payload.vao;
+    const transformTexture = payload.bundle.transformTexture;
+
+    if (backend === null || vao === null || transformTexture === null) {
+      // Defensive: a bundle in this state never validates (generation), so a
+      // spliced replay cannot reach here; skip rather than crash mid-frame.
+      return;
+    }
+
+    // Keep this renderer's blend tracking in sync so the next live batch still
+    // detects its own blend changes correctly.
+    if (payload.blendMode !== this._currentBlendMode) {
+      this._currentBlendMode = payload.blendMode;
+    }
+
+    backend.setBlendMode(payload.blendMode);
+    this._stageViewUniforms(backend);
+
+    const textures = payload.textures;
+
+    for (let i = 0; i < textures.length; i++) {
+      // In-bounds: i < textures.length.
+      backend.bindTexture(textures[i]!, i);
+    }
+
+    this._shader.getUniform('u_texture').setValue(this._baseTextureUnitScratch);
+
+    // The group-owned transform store replaces the shared frame buffer on the
+    // SAME unit/sampler — zero GLSL changes (S3-D4). The next live flush
+    // re-binds the shared texture through bindTransformBufferTexture.
+    backend.bindTexture(transformTexture, transformTextureUnit);
     this._shader.getUniform('u_transforms').setValue(this._transformUnitScratch);
 
     this._shader.sync();
     backend.bindVertexArrayObject(vao);
-    instanceBuffer.upload(this._instanceFloat32.subarray(0, this._quadIndex * wordsPerInstance));
-    vao.drawInstanced(4, 0, this._quadIndex, RenderingPrimitives.TriangleStrip);
-    backend.stats.batches++;
-    backend.stats.drawCalls++;
-
-    this._quadIndex = 0;
-    this._maxNodeIndex = 0;
+    vao.drawInstanced(4, 0, payload.instanceCount, RenderingPrimitives.TriangleStrip);
   }
 
   protected onConnect(backend: WebGl2Backend): void {

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -44,10 +44,12 @@ import { WebGpuPassCoordinator } from './WebGpuPassCoordinator';
 import {
   retainedTransformSlotBytes,
   type WebGpuRetainedBatchPayload,
+  type WebGpuRetainedBatchReplayer,
   WebGpuRetainedCaptureFrame,
   WebGpuRetainedGroupBundle,
+  type WebGpuRetainedNodeIndexRange,
 } from './WebGpuRetainedGroupResources';
-import { baseSpriteBatchTextureSlots, maxSpriteBatchTextureSlots, type WebGpuSpriteRenderer } from './WebGpuSpriteRenderer';
+import { baseSpriteBatchTextureSlots, maxSpriteBatchTextureSlots } from './WebGpuSpriteRenderer';
 import { WebGpuTransformStorage } from './WebGpuTransformStorage';
 
 interface ManagedWebGpuTextureState {
@@ -203,6 +205,10 @@ export class WebGpuBackend implements RenderBackend {
   private readonly _retainedCaptureFrames: WebGpuRetainedCaptureFrame[] = [];
   private readonly _retainedBundles = new Set<WebGpuRetainedGroupBundle>();
   private readonly _rejectedRetainedSets = new WeakSet<RetainedInstructionSet>();
+  // Reused across per-batch scans at record time (S3-D4) to avoid an
+  // allocation per flush; the renderer-agnostic counterpart of WebGL2's
+  // capture-end `_retainedIndexRange` (WebGPU scans per batch, not per capture).
+  private readonly _retainedBatchIndexRange: WebGpuRetainedNodeIndexRange = { min: 0, max: 0 };
   // Render-error surface (S3 diagnostics): dedupe keys for onRenderError, and
   // the bound uncapturederror listener (re-installed by _initialize after
   // device-loss recovery).
@@ -1161,7 +1167,8 @@ export class WebGpuBackend implements RenderBackend {
    * the OPEN pass (no end/submit at group boundaries on the cached path,
    * B-06). All state — pipeline, projection/group uniforms, texture bindings
    * — is resolved live; only the recorded data is reused. Dispatches to the
-   * sprite renderer that recorded the batch.
+   * renderer that recorded the batch (any {@link WebGpuRetainedBatchReplayer},
+   * not just the sprite renderer).
    * @internal
    */
   public _replayRetainedBatch(batch: RetainedBatchInstruction): void {
@@ -1179,7 +1186,7 @@ export class WebGpuBackend implements RenderBackend {
     // flush-time visibility decision (mask/scissor) can drop the batch.
     this._stats.submittedNodes += batch.instanceCount;
     this._setActiveRenderer(payload.renderer);
-    payload.renderer._replayRecordedSpriteBatch(payload);
+    payload.renderer._replayRetainedBatch(payload);
   }
 
   /**
@@ -1244,14 +1251,15 @@ export class WebGpuBackend implements RenderBackend {
   }
 
   /**
-   * Stage one recorded sprite flush (called by the sprite renderer while a
-   * capture window is active): copies the packed instance bytes (owned by the
-   * INNERMOST capture's bundle, S3-D6), resolves the recorded texture views,
-   * and appends one shared instruction to every active set.
+   * Stage one recorded renderer flush (called by any capable renderer, e.g.
+   * the sprite renderer, while a capture window is active): copies the
+   * packed instance bytes (owned by the INNERMOST capture's bundle, S3-D6),
+   * resolves the recorded texture views, and appends one shared instruction
+   * to every active set.
    * @internal
    */
-  public _recordRetainedSpriteBatch(
-    renderer: WebGpuSpriteRenderer,
+  public _recordRetainedBatch(
+    replayer: WebGpuRetainedBatchReplayer,
     instanceData: ArrayBuffer,
     byteLength: number,
     instanceCount: number,
@@ -1276,24 +1284,14 @@ export class WebGpuBackend implements RenderBackend {
 
     bytes.set(new Uint8Array(instanceData, 0, byteLength));
 
-    // Scan the frame-global node indices (word 7 of each 8-word instance) so
-    // capture end can rebase them group-local and copy the row range once.
-    const words = new Uint32Array(bytes.buffer);
-    let minNodeIndex = 0xffffffff;
-    let maxNodeIndex = 0;
+    // Scan the frame-global node indices so capture end can rebase them
+    // group-local and copy the row range once. Layout-aware (word offset,
+    // stride) — delegated to the renderer that packed the bytes.
+    const range = this._retainedBatchIndexRange;
 
-    for (let i = 7; i < words.length; i += 8) {
-      // In-bounds: i < words.length via the loop guard.
-      const nodeIndex = words[i]!;
-
-      if (nodeIndex < minNodeIndex) {
-        minNodeIndex = nodeIndex;
-      }
-
-      if (nodeIndex > maxNodeIndex) {
-        maxNodeIndex = nodeIndex;
-      }
-    }
+    range.min = 0xffffffff;
+    range.max = 0;
+    replayer._scanRetainedNodeIndexRange(bytes, range);
 
     const textureList: Array<Texture | RenderTexture> = [];
     const recordedViews: GPUTextureView[] = [];
@@ -1312,7 +1310,7 @@ export class WebGpuBackend implements RenderBackend {
     }
 
     const payload: WebGpuRetainedBatchPayload = {
-      renderer,
+      renderer: replayer,
       bundle: owner.bundle,
       byteOffset: owner.totalBytes,
       instanceCount,
@@ -1332,7 +1330,7 @@ export class WebGpuBackend implements RenderBackend {
       payload,
     };
 
-    owner.staged.push({ bytes, byteOffset: owner.totalBytes, minNodeIndex, maxNodeIndex, instruction });
+    owner.staged.push({ bytes, byteOffset: owner.totalBytes, minNodeIndex: range.min, maxNodeIndex: range.max, instruction });
     owner.totalBytes += byteLength;
 
     for (const frame of frames) {
@@ -1393,15 +1391,14 @@ export class WebGpuBackend implements RenderBackend {
     bundle.ensureCapacity(device, frame.totalBytes, transformBytes);
 
     for (const batch of staged) {
-      // Rebase word 7 (nodeIndex) of every 8-word instance to group-local
-      // indices — the cached bytes become immune to frame-local index shifts
-      // (S3-D4) and address the group-owned row copy below.
-      const words = new Uint32Array(batch.bytes.buffer, batch.bytes.byteOffset, batch.bytes.byteLength / Uint32Array.BYTES_PER_ELEMENT);
+      // Rebase this batch's instance node indices to group-local indices —
+      // the cached bytes become immune to frame-local index shifts (S3-D4)
+      // and address the group-owned row copy below. Layout-aware — delegated
+      // to the renderer that packed the bytes (the payload was already
+      // created at record time, so its renderer is in hand here).
+      const payload = batch.instruction.payload as WebGpuRetainedBatchPayload;
 
-      for (let i = 7; i < words.length; i += 8) {
-        // In-bounds: i < words.length via the loop guard.
-        words[i] = words[i]! - base;
-      }
+      payload.renderer._rebaseRetainedNodeIndices(batch.bytes, base);
 
       device.queue.writeBuffer(bundle.instanceBuffer!, batch.byteOffset, batch.bytes.buffer, batch.bytes.byteOffset, batch.bytes.byteLength);
       stampRetainedBatchGeneration(batch.instruction);

--- a/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
@@ -13,6 +13,13 @@ import { AbstractWebGpuRenderer } from './AbstractWebGpuRenderer';
 import type { WebGpuBackend } from './WebGpuBackend';
 import { getWebGpuBlendState } from './WebGpuBlendState';
 import { WebGpuInstanceArena } from './WebGpuInstanceArena';
+import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
+import {
+  retainedGroupUniformBytes,
+  type WebGpuRetainedBatchPayload,
+  type WebGpuRetainedBatchReplayer,
+  type WebGpuRetainedNodeIndexRange,
+} from './WebGpuRetainedGroupResources';
 import { stencilContentDepthStencilState } from './WebGpuStencilState';
 
 /** WGSL source for the nine-slice sprite pipeline. @internal */
@@ -92,7 +99,18 @@ const indicesPerInstance = 6;
 const quadIndices = new Uint16Array([0, 1, 2, 0, 2, 3]);
 
 /** Instanced renderer for {@link NineSliceSprite} using WebGPU. */
-export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSliceSprite> {
+export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSliceSprite> implements WebGpuRetainedBatchReplayer {
+  /**
+   * Retained-batch capability flag (Track B Slice 3, S3-D5.1): a nine-slice
+   * group's per-flush instanced batches (fixed 32-byte layout, node index at
+   * word 7 — the same seam as the sprite renderer) record and replay from
+   * group-owned resources. Pixel-snapped draws are excluded by the collect-time
+   * recordability predicate (and belt-and-braces poisoning in {@link render});
+   * nine-slice has no custom-material path to exclude.
+   * @internal
+   */
+  public readonly _supportsRetainedBatches = true;
+
   private readonly _projectionData = new Float32Array(projectionByteLength / Float32Array.BYTES_PER_ELEMENT);
   // Projection-uniform skip state: a matching (view identity, view.updateId,
   // group-transform id) triple means the shared UBO already holds this flush's
@@ -133,6 +151,16 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
   private _maxNodeIndex = 0;
   private _currentBlendMode: BlendModes | null = null;
   private _currentTexture: Texture | RenderTexture | null = null;
+
+  // ── Retained-batch replay state (Track B Slice 3, S3-D7) ─────────────────
+  // The open pass replayed retained batches were last recorded into — feeds
+  // the "does the open pass already hold draws?" checks alongside the arena.
+  private _lastReplayPass: WebGpuActiveRenderPass | null = null;
+  // Scratch for the packed group matrix compared at replay (see _replayRetainedBatch).
+  private readonly _stagedReplayGroupData = new Float32Array(16);
+  // Reused single-slot texture list handed to the backend at record time; the
+  // nine-slice batch always binds exactly one base texture (slot 0).
+  private readonly _recordTextures: Array<Texture | RenderTexture | null> = [null];
 
   protected onConnect(backend: WebGpuBackend): void {
     if (this._device) {
@@ -207,6 +235,7 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     this._maxNodeIndex = 0;
     this._currentBlendMode = null;
     this._currentTexture = null;
+    this._lastReplayPass = null;
   }
 
   public render(sprite: NineSliceSprite): void {
@@ -214,6 +243,14 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
 
     if (backend === null) {
       return;
+    }
+
+    // Defensive (S3-D5.3): pixel-snapped instance words are view-dependent —
+    // the recordability predicate excludes them at collect time, so a snapped
+    // nine-slice inside a capture window means the stream cannot be replayed.
+    // Nine-slice has no custom-material path to guard.
+    if (sprite.pixelSnapMode !== 'none' && backend._retainedCaptureActive) {
+      backend._poisonActiveRetainedCaptures();
     }
 
     let quads: readonly NineSliceQuad[] = sprite.quads;
@@ -412,6 +449,26 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
       backend._passCoordinator.acquirePass();
     }
 
+    // Retained capture (Track B Slice 3): while a capture window is active,
+    // additionally stage this batch's exact packed bytes into the group-owned
+    // bundle — the recorded data IS the drawn data, byte-identical by
+    // construction. Recorded regardless of the live visibility decision above
+    // (mask/scissor), since visibility is re-evaluated live at replay. The
+    // nine-slice batch always binds a single base texture (slot 0); a
+    // pixel-snapped draw already poisoned the capture in render().
+    if (this._quadIndex > 0 && backend._retainedCaptureActive && this._currentBlendMode !== null && this._currentTexture !== null) {
+      this._recordTextures[0] = this._currentTexture;
+      backend._recordRetainedBatch(
+        this,
+        this._instanceData,
+        this._quadIndex * instanceStrideBytes,
+        this._quadIndex,
+        this._currentBlendMode,
+        this._recordTextures,
+        1,
+      );
+    }
+
     // Batch flushes no longer submit; the backend ends the pass at boundaries.
     this._quadIndex = 0;
     this._maxNodeIndex = 0;
@@ -439,6 +496,154 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     });
 
     return this._transformBindGroup;
+  }
+
+  // ── Retained-batch record/replay (Track B Slice 3) ───────────────────────
+  // The bundle/stage stores raw instance bytes; this renderer owns the 32-byte
+  // (8-word) layout (node index at word 7), so the layout-aware finalize steps
+  // (node-index scan/rebase) and the replay dispatch live here — mirroring
+  // WebGpuSpriteRenderer's seam, adapted to nine-slice's single-texture path.
+
+  /** @internal See {@link WebGpuRetainedBatchReplayer._scanRetainedNodeIndexRange}. */
+  public _scanRetainedNodeIndexRange(bytes: Uint8Array, range: WebGpuRetainedNodeIndexRange): void {
+    const words = new Uint32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / Uint32Array.BYTES_PER_ELEMENT);
+
+    for (let i = 7; i < words.length; i += 8) {
+      // In-bounds: i < words.length via the loop guard. nodeIndex is the last
+      // word of the 32-byte (8-word) instance layout.
+      const nodeIndex = words[i]!;
+
+      if (nodeIndex < range.min) {
+        range.min = nodeIndex;
+      }
+
+      if (nodeIndex > range.max) {
+        range.max = nodeIndex;
+      }
+    }
+  }
+
+  /** @internal See {@link WebGpuRetainedBatchReplayer._rebaseRetainedNodeIndices} (S3-D4: group-local indices). */
+  public _rebaseRetainedNodeIndices(bytes: Uint8Array, base: number): void {
+    const words = new Uint32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / Uint32Array.BYTES_PER_ELEMENT);
+
+    for (let i = 7; i < words.length; i += 8) {
+      // In-bounds: i < words.length via the loop guard.
+      words[i] = words[i]! - base;
+    }
+  }
+
+  /**
+   * Replay one recorded batch from its group-owned bundle into the OPEN pass
+   * (Track B Slice 3, S3-D7). Reuses only recorded DATA (instance bytes,
+   * transform rows, texture, blend mode); every piece of STATE is resolved
+   * live — pipeline via the `_getPipeline` cache, the group(1) texture bind
+   * group via the live texture-set cache (resolving re-syncs dirty content),
+   * and the group's 128-byte UBO (projection from the live view + the live
+   * player-composed group matrix) written only when its content changed. The
+   * same-frame double-replay hazard (one group under two views while the open
+   * pass already holds this bundle's draws) ends the pass first. The shared
+   * per-flush projection UBO is never touched, so group boundaries on the
+   * cached path do not fragment the single-submit frame (B-06).
+   * @internal
+   */
+  public _replayRetainedBatch(payload: WebGpuRetainedBatchPayload): void {
+    const backend = this._backend;
+    const device = this._device;
+    const bundle = payload.bundle;
+
+    if (!backend || !device || this._indexBuffer === null || !bundle.isReady) {
+      return;
+    }
+
+    // Drain any pending live batch into the open pass first (defensive — the
+    // group boundary already flushed; flush() never ends the pass on the
+    // default path and guards its own shared-UBO hazards).
+    this.flush();
+
+    // Match the live path's visibility handling: a fully-clipped scissor draws
+    // nothing (the batch stays recorded; visibility is live per frame).
+    const scissor = backend.getScissorRect();
+
+    if (scissor !== null && (scissor.width <= 0 || scissor.height <= 0)) {
+      return;
+    }
+
+    const coordinator = backend._passCoordinator;
+    let activePass = coordinator.activePass;
+    const passHasDraws =
+      activePass !== null && ((this._instanceArena.cursor > 0 && this._instanceArena.tracksPass(activePass)) || this._lastReplayPass === activePass);
+
+    // Same-frame texture mutation guard (S3-D7): resolving the bindings below
+    // re-uploads mutated content on the queue timeline BEFORE the deferred
+    // submit, which would retroactively change draws already recorded into the
+    // open pass. End (submit) the pass first so they keep the pre-mutation
+    // content.
+    if (passHasDraws) {
+      for (const texture of payload.textures) {
+        if (backend._textureUploadWouldMutate(texture)) {
+          coordinator.endPass();
+          this._instanceArena.resetPass();
+          break;
+        }
+      }
+    }
+
+    // Resolve the single base texture LIVE through the texture bind-group cache
+    // (syncs dirty content, adopts refreshed views/samplers). The recorded
+    // batch always has exactly one texture (slot 0).
+    const textureBindGroup = this._getOrCreateTextureBindGroup(device, backend, payload.textures[0]!);
+
+    // Group UBO: skip the write while (view, updateId, group bytes) match what
+    // the buffer holds; guard the double-replay aliasing case first.
+    const view = backend.view;
+    const scratch = this._stagedReplayGroupData;
+
+    packAffineMat4(backend.renderGroupTransform ?? Matrix.identity, scratch, 0);
+
+    let uboDirty = !bundle.uboWritten || bundle.uboView !== view || bundle.uboViewUpdateId !== view.updateId;
+
+    if (!uboDirty) {
+      for (let i = 0; i < 16; i++) {
+        if (scratch[i] !== bundle.uboData[16 + i]) {
+          uboDirty = true;
+          break;
+        }
+      }
+    }
+
+    if (uboDirty) {
+      activePass = coordinator.activePass;
+
+      if (activePass !== null && bundle.drawsInPass === activePass) {
+        // Rewriting the UBO would retroactively re-project this bundle's draws
+        // already recorded into the open pass: end it first.
+        coordinator.endPass();
+        this._instanceArena.resetPass();
+      }
+
+      packAffineMat4(view.getTransform(), bundle.uboData, 0);
+      bundle.uboData.set(scratch, 16);
+      bundle.uboView = view;
+      bundle.uboViewUpdateId = view.updateId;
+      bundle.uboWritten = true;
+      device.queue.writeBuffer(bundle.uniformBuffer!, 0, bundle.uboData.buffer, bundle.uboData.byteOffset, retainedGroupUniformBytes);
+    }
+
+    const active = coordinator.acquirePass();
+    const pass = active.pass;
+
+    pass.setPipeline(this._getPipeline(payload.blendMode, backend.renderTargetFormat, coordinator.stencilActive));
+    pass.setBindGroup(0, bundle.getBindGroup(device, this._uniformBindGroupLayout!));
+    pass.setBindGroup(1, textureBindGroup);
+    pass.setVertexBuffer(0, bundle.instanceBuffer, payload.byteOffset);
+    pass.setIndexBuffer(this._indexBuffer, 'uint16');
+    pass.drawIndexed(indicesPerInstance, payload.instanceCount, 0, 0, 0);
+
+    bundle.drawsInPass = active;
+    this._lastReplayPass = active;
+    backend.stats.batches++;
+    backend.stats.drawCalls++;
   }
 
   /**

--- a/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
+++ b/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
@@ -2,13 +2,13 @@
 
 import type { GpuResourceAccountant } from '#rendering/GpuResourceAccountant';
 import type { RetainedBatchInstruction, RetainedGroupBundle, RetainedInstructionSet } from '#rendering/plan/RetainedInstructionSet';
+import type { Renderer } from '#rendering/Renderer';
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { Texture } from '#rendering/texture/Texture';
 import type { BlendModes } from '#rendering/types';
 import type { View } from '#rendering/View';
 
 import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
-import type { WebGpuSpriteRenderer } from './WebGpuSpriteRenderer';
 
 /** Bytes of one transform slot (3 × vec4<f32>, matches the WGSL `TransformSlot`). */
 export const retainedTransformSlotBytes = 48;
@@ -17,16 +17,16 @@ export const retainedTransformSlotBytes = 48;
 export const retainedGroupUniformBytes = 128;
 
 /**
- * Backend-owned replay descriptor for one recorded sprite flush (Track B
+ * Backend-owned replay descriptor for one recorded renderer flush (Track B
  * Slice 3, S3-D1). Carried as the opaque `payload` of a
  * {@link RetainedBatchInstruction}; everything here is DATA — all state
  * (pipeline, projection/group uniforms, texture bindings) is resolved live at
- * replay by {@link WebGpuSpriteRenderer._replayRecordedSpriteBatch}.
+ * replay by the owning {@link WebGpuRetainedBatchReplayer._replayRetainedBatch}.
  * @internal
  */
 export interface WebGpuRetainedBatchPayload {
-  /** The sprite renderer that recorded (and replays) this batch. */
-  readonly renderer: WebGpuSpriteRenderer;
+  /** The renderer that recorded (and replays) this batch. */
+  readonly renderer: WebGpuRetainedBatchReplayer;
   /** The bundle whose group-owned buffers hold this batch's data. */
   readonly bundle: WebGpuRetainedGroupBundle;
   /** Byte offset of this batch's instances inside the bundle's instance buffer. */
@@ -43,6 +43,45 @@ export interface WebGpuRetainedBatchPayload {
    * a recapture, never a replay.
    */
   readonly recordedViews: readonly GPUTextureView[];
+}
+
+/**
+ * Mutable node-index range scratch used at record time (S3-D4), the WebGPU
+ * counterpart of `WebGl2RetainedNodeIndexRange`. Unlike WebGL2 (which scans
+ * the shared bundle store at capture END, once ranges over every batch are
+ * known), WebGPU scans each batch's freshly-packed bytes immediately at
+ * record time, per batch — so the range here is scoped to ONE batch, not the
+ * whole capture; the backend takes the min/max across all per-batch ranges to
+ * get the capture-wide rebase base.
+ * @internal
+ */
+export interface WebGpuRetainedNodeIndexRange {
+  min: number;
+  max: number;
+}
+
+/**
+ * Renderer-side contract for recorded-batch finalization and replay on WebGPU
+ * (the WebGPU counterpart of `WebGl2RetainedBatchReplayer`). The bundle/stage
+ * stores raw instance bytes; only the renderer that packed them knows the
+ * layout (where the node index lives, how many words per instance), so the
+ * backend delegates the layout-aware steps here per batch — mirroring the
+ * WebGL2 seam, adapted to WebGPU's byte-staging flow (record-time scan on
+ * freshly-packed bytes, finalize-time rebase on the staged copy, rather than
+ * WebGL2's capture-end scan/rebase against a live bundle store).
+ *
+ * Extends {@link Renderer} so the backend can drive replay through the same
+ * active-renderer bookkeeping (`_setActiveRenderer` calls `flush()` on
+ * renderer switch) it already uses for live playback.
+ * @internal
+ */
+export interface WebGpuRetainedBatchReplayer extends Renderer {
+  /** Widen `range` to cover every shared-transform row `bytes` (one batch's packed instances) references. */
+  _scanRetainedNodeIndexRange(bytes: Uint8Array, range: WebGpuRetainedNodeIndexRange): void;
+  /** Rewrite `bytes`' instance node indices in place to group-local (`index - base`). */
+  _rebaseRetainedNodeIndices(bytes: Uint8Array, base: number): void;
+  /** Replay the batch: live state (pipeline, uniforms, textures), cached data (bytes, transforms). */
+  _replayRetainedBatch(payload: WebGpuRetainedBatchPayload): void;
 }
 
 /** One sprite flush staged during a capture window, finalized at capture end. @internal */

--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -16,7 +16,12 @@ import type { WebGpuBackend } from './WebGpuBackend';
 import { getWebGpuBlendState } from './WebGpuBlendState';
 import { WebGpuInstanceArena } from './WebGpuInstanceArena';
 import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
-import { retainedGroupUniformBytes, type WebGpuRetainedBatchPayload } from './WebGpuRetainedGroupResources';
+import {
+  retainedGroupUniformBytes,
+  type WebGpuRetainedBatchPayload,
+  type WebGpuRetainedBatchReplayer,
+  type WebGpuRetainedNodeIndexRange,
+} from './WebGpuRetainedGroupResources';
 import { stencilContentDepthStencilState } from './WebGpuStencilState';
 import {
   collectScalarUniforms,
@@ -276,7 +281,7 @@ interface CustomSpriteResources {
   baseTextureBindGroups: WeakMap<Texture | RenderTexture, { group: GPUBindGroup; view: GPUTextureView }>;
 }
 
-export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
+export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> implements WebGpuRetainedBatchReplayer {
   /** Retained-batch capability flag (Track B Slice 3, S3-D5.1): the default path records/replays flush-level batches. */
   public readonly _supportsRetainedBatches = true;
 
@@ -742,7 +747,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
       if (isCustom) {
         backend._poisonActiveRetainedCaptures();
       } else if (this._currentBlendMode !== null) {
-        backend._recordRetainedSpriteBatch(
+        backend._recordRetainedBatch(
           this,
           this._instanceData,
           this._instanceCount * instanceStrideBytes,
@@ -857,6 +862,42 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     return this._transformBindGroup;
   }
 
+  // ── Retained-batch record/replay (Track B Slice 3, Tasks 9/10) ────────────
+  // The bundle/stage stores raw instance bytes; this renderer owns the
+  // 32-byte (8-word) layout, so the layout-aware finalize steps (node-index
+  // scan/rebase) and the replay dispatch live here — the WebGPU counterpart
+  // of WebGl2SpriteRenderer's `_scanRetainedNodeIndexRange` /
+  // `_rebaseRetainedNodeIndices` / `_replayRetainedBatch`.
+
+  /** @internal See {@link WebGpuRetainedBatchReplayer._scanRetainedNodeIndexRange}. */
+  public _scanRetainedNodeIndexRange(bytes: Uint8Array, range: WebGpuRetainedNodeIndexRange): void {
+    const words = new Uint32Array(bytes.buffer);
+
+    for (let i = 7; i < words.length; i += 8) {
+      // In-bounds: i < words.length via the loop guard. nodeIndex is the last
+      // word of the 32-byte (8-word) instance layout.
+      const nodeIndex = words[i]!;
+
+      if (nodeIndex < range.min) {
+        range.min = nodeIndex;
+      }
+
+      if (nodeIndex > range.max) {
+        range.max = nodeIndex;
+      }
+    }
+  }
+
+  /** @internal See {@link WebGpuRetainedBatchReplayer._rebaseRetainedNodeIndices} (S3-D4: group-local indices). */
+  public _rebaseRetainedNodeIndices(bytes: Uint8Array, base: number): void {
+    const words = new Uint32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / Uint32Array.BYTES_PER_ELEMENT);
+
+    for (let i = 7; i < words.length; i += 8) {
+      // In-bounds: i < words.length via the loop guard.
+      words[i] = words[i]! - base;
+    }
+  }
+
   /**
    * Replay one recorded batch from its group-owned bundle into the OPEN pass
    * (Track B Slice 3, Task 10 / S3-D7). Reuses only recorded DATA (instance
@@ -878,7 +919,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
    * on the cached path do not fragment the single-submit frame (B-06).
    * @internal
    */
-  public _replayRecordedSpriteBatch(payload: WebGpuRetainedBatchPayload): void {
+  public _replayRetainedBatch(payload: WebGpuRetainedBatchPayload): void {
     const backend = this._backend;
     const device = this._device;
     const bundle = payload.bundle;
@@ -978,7 +1019,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     backend.stats.drawCalls++;
   }
 
-  /** Scratch for the packed group matrix compared at replay (see `_replayRecordedSpriteBatch`). */
+  /** Scratch for the packed group matrix compared at replay (see `_replayRetainedBatch`). */
   private readonly _stagedReplayGroupData = new Float32Array(16);
 
   public destroy(): void {

--- a/test/rendering/browser/webgl2-nine-slice-retained-instruction-replay.test.ts
+++ b/test/rendering/browser/webgl2-nine-slice-retained-instruction-replay.test.ts
@@ -1,0 +1,427 @@
+/**
+ * WebGL2 renderer-matrix browser tests — NineSlice retained instruction-set
+ * replay (Track B Slice 3).
+ *
+ * The nine-slice counterpart of `webgl2-retained-instruction-replay.test.ts`:
+ * a retained group whose playback was recorded replays through
+ * `_replayRetainedBatch` from group-owned resources (persistent instance
+ * buffer + group transform texture) and must produce BYTE-IDENTICAL frames to
+ * the entry-replay slow path. A nine-slice node expands to MANY quad-instances
+ * that all share one transform-buffer row, so the group-local node-index
+ * rebase (S3-D4) and the per-batch byte offset are load-bearing in every
+ * assertion: a live sprite OUTSIDE (and before) the group keeps the group's
+ * shared rows starting at a non-zero frame-global index, so a broken rebase
+ * (or a wrong byte offset) fetches the wrong / out-of-range transform row and
+ * the full-canvas byte comparison fails.
+ *
+ * The nine-slice renderer uses inline GLSL (no `.vert`/`.frag` imports), so it
+ * needs no shader mock; the Sprite/Mesh/Text mocks below only exist so
+ * `wireCoreRenderers()` can eagerly compile every registered renderer.
+ *
+ * Run via:  pnpm test:browser:webgl
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import type { RenderNode } from '#rendering/RenderNode';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { NineSliceSprite } from '#rendering/sprite/NineSliceSprite';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+
+// ---------------------------------------------------------------------------
+// Shader mocks (Sprite/Mesh/Text — the nine-slice renderer uses inline GLSL).
+// The sprite vertex mock keeps u_group so the OUTSIDE sprite stays correct
+// under camera-pan / group-move cells; the transform texel 2 carries its tint.
+// ---------------------------------------------------------------------------
+
+const shaderSources = vi.hoisted(() => ({
+  spriteVert: `#version 300 es
+precision mediump float;
+in vec4 a_localBounds;
+in vec4 a_uvBounds;
+in vec4 a_color;
+in uint a_textureSlot;
+in uint a_nodeIndex;
+uniform mat3 u_projection;
+uniform mat3 u_group;
+uniform sampler2D u_transforms;
+out vec2 v_uv;
+out vec4 v_color;
+flat out uint v_textureSlot;
+void main() {
+  vec2 local;
+  if (gl_VertexID == 0) local = vec2(a_localBounds.x, a_localBounds.y);
+  else if (gl_VertexID == 1) local = vec2(a_localBounds.z, a_localBounds.y);
+  else if (gl_VertexID == 2) local = vec2(a_localBounds.x, a_localBounds.w);
+  else local = vec2(a_localBounds.z, a_localBounds.w);
+  vec2 uv;
+  if (gl_VertexID == 0) uv = vec2(a_uvBounds.x, a_uvBounds.y);
+  else if (gl_VertexID == 1) uv = vec2(a_uvBounds.z, a_uvBounds.y);
+  else if (gl_VertexID == 2) uv = vec2(a_uvBounds.x, a_uvBounds.w);
+  else uv = vec2(a_uvBounds.z, a_uvBounds.w);
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
+  vec3 clip = u_projection * u_group * vec3(world, 1.0);
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
+}`,
+
+  meshVert: `#version 300 es
+precision mediump float;
+in vec2 a_position;
+in vec2 a_texcoord;
+in vec4 a_color;
+in uint a_nodeIndex;
+uniform mat3 u_projection;
+uniform sampler2D u_transforms;
+out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
+void main() {
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  mat3 t = mat3(m0.x,m0.z,0.0, m0.y,m0.w,0.0, m1.x,m1.y,1.0);
+  vec3 world = t * vec3(a_position, 1.0);
+  vec3 clip = u_projection * world;
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = a_texcoord; v_color = a_color;
+  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+}`,
+
+  meshFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv; in vec4 v_color; in vec4 v_tint;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() { outColor = texture(u_texture, v_uv) * v_color * v_tint; }`,
+
+  textVert: `#version 300 es
+precision mediump float;
+layout(location = 0) in vec2 a_position;
+layout(location = 1) in vec2 a_texcoord;
+layout(location = 2) in float a_nodeIndex;
+uniform mat3 u_projection;
+uniform mat3 u_group;
+out vec2 v_uv;
+void main() {
+  float ni = a_nodeIndex;
+  vec3 clip = u_projection * u_group * vec3(a_position + vec2(ni * 0.0), 1.0);
+  gl_Position = vec4(clip.xy, 0.0, 1.0); v_uv = a_texcoord;
+}`,
+
+  textFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() { outColor = texture(u_texture, v_uv); }`,
+}));
+
+vi.mock('#rendering/webgl2/glsl/sprite.vert', () => ({ default: shaderSources.spriteVert }));
+vi.mock('#rendering/webgl2/glsl/sprite.frag', async () => ({ default: (await import('./_spriteFragMock')).createSpriteFragMockSource('v_uv') }));
+vi.mock('#rendering/webgl2/glsl/mesh.vert', () => ({ default: shaderSources.meshVert }));
+vi.mock('#rendering/webgl2/glsl/mesh.frag', () => ({ default: shaderSources.meshFrag }));
+vi.mock('#rendering/webgl2/glsl/text.vert', () => ({ default: shaderSources.textVert }));
+vi.mock('#rendering/webgl2/glsl/text-color.frag', () => ({ default: shaderSources.textFrag }));
+vi.mock('#rendering/webgl2/glsl/text-msdf.frag', () => ({ default: shaderSources.textFrag }));
+vi.mock('#rendering/webgl2/glsl/text-sdf.frag', () => ({ default: shaderSources.textFrag }));
+
+// ---------------------------------------------------------------------------
+// Infrastructure helpers (shared shape with the sprite retained-replay cells).
+// ---------------------------------------------------------------------------
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const createBackend = async (): Promise<WebGl2Backend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const app: Application = {
+    canvas,
+    options: {
+      clearColor: Color.black,
+      canvas: { width: canvasSize, height: canvasSize },
+      rendering: {
+        debug: false,
+        webglAttributes: {
+          alpha: false,
+          antialias: false,
+          premultipliedAlpha: false,
+          preserveDrawingBuffer: true,
+          stencil: false,
+          depth: false,
+        },
+        spriteRendererBatchSize: 1024,
+        particleRendererBatchSize: 1024,
+      },
+    },
+  } as unknown as Application;
+
+  const backend = new WebGl2Backend(app);
+
+  await backend.initialize();
+  wireCoreRenderers(backend, app.options.rendering);
+
+  return backend;
+};
+
+const render = (backend: WebGl2Backend, node: RenderNode): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+  node.render(backend);
+  backend.flush();
+};
+
+const readPixel = (backend: WebGl2Backend, x: number, y: number): RgbaTuple => {
+  const buf = new Uint8Array(4);
+  const gl = backend.context;
+
+  gl.readPixels(Math.floor(x), backend.renderTarget.height - Math.floor(y) - 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+
+  return [buf[0], buf[1], buf[2], buf[3]];
+};
+
+/** Full-framebuffer snapshot for byte-identical tier comparisons (S3-D10). */
+const readCanvas = (backend: WebGl2Backend): Uint8Array => {
+  const buf = new Uint8Array(canvasSize * canvasSize * 4);
+  const gl = backend.context;
+
+  gl.readPixels(0, 0, canvasSize, canvasSize, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+
+  return buf;
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 8): void => {
+  for (let i = 0; i < 4; i++) {
+    expect(Math.abs(actual[i] - expected[i])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+const createSolidTexture = (color: string, width = 16, height = 16): Texture => {
+  const src = document.createElement('canvas');
+
+  src.width = width;
+  src.height = height;
+
+  const ctx = src.getContext('2d')!;
+
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, width, height);
+
+  return new Texture(src);
+};
+
+/**
+ * Standard cell scene: one live sprite OUTSIDE (and before) the retained
+ * group so the group's shared transform rows never start at row 0 — the
+ * group-local node-index rebase (S3-D4) is load-bearing in every pixel
+ * assertion, and the replay path interleaves with a live batch every frame.
+ *
+ * The group holds two nine-slice nodes with DISTINCT textures, so each records
+ * its own single-texture batch (nine-slice binds one base texture per flush) —
+ * exercising per-batch byte offsets across more than one recorded batch. Every
+ * nine-slice node fills a 16x16 solid rect (slices/border 4 over a 16x16
+ * source), 9 quad-instances sharing one transform row.
+ *
+ * Layout (canvas 64x64): blue outside sprite at (48,0)-(64,16); group at
+ * (8,24) with a red nine-slice at group-local (0,0) -> world (8,24)-(24,40)
+ * and a green nine-slice at group-local (16,16) -> world (24,40)-(40,56).
+ */
+const buildScene = () => {
+  const blue = createSolidTexture('#0000ff');
+  const red = createSolidTexture('#ff0000');
+  const green = createSolidTexture('#00ff00');
+  const root = new Container();
+  const outside = new Sprite(blue);
+  const group = new RetainedContainer();
+  const redNine = new NineSliceSprite(red, { slices: 4, border: 4, width: 16, height: 16 });
+  const greenNine = new NineSliceSprite(green, { slices: 4, border: 4, width: 16, height: 16 });
+
+  outside.setPosition(48, 0);
+  root.addChild(outside);
+
+  greenNine.setPosition(16, 16);
+  group.addChild(redNine);
+  group.addChild(greenNine);
+  group.setPosition(8, 24);
+  root.addChild(group);
+
+  const destroy = (): void => {
+    root.destroy();
+    blue.destroy();
+    red.destroy();
+    green.destroy();
+  };
+
+  return { root, group, redNine, greenNine, destroy };
+};
+
+const expectBaseScenePixels = (backend: WebGl2Backend): void => {
+  expectPixelNear(readPixel(backend, 52, 8), [0, 0, 255, 255]); // live outside sprite
+  expectPixelNear(readPixel(backend, 12, 28), [255, 0, 0, 255]); // red nine-slice inside the group
+  expectPixelNear(readPixel(backend, 28, 44), [0, 255, 0, 255]); // green nine-slice inside the group
+  expectPixelNear(readPixel(backend, 4, 60), [0, 0, 0, 255]); // background
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WebGL2 renderer matrix: NineSlice retained instruction-set replay cells', () => {
+  test('cell 1 — the nine-slice instruction-replay tier is byte-identical to the entry-replay and collect tiers', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+    const beginSpy = vi.spyOn(backend, '_beginRetainedCapture');
+    const replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+    try {
+      // F1 — full collect + fragment capture (slow tier).
+      render(backend, scene.root);
+
+      const collectFrame = readCanvas(backend);
+
+      expectBaseScenePixels(backend);
+      expect(replaySpy).not.toHaveBeenCalled();
+
+      // F2 — entry replay + instruction recording (the recording source).
+      render(backend, scene.root);
+
+      const recordFrame = readCanvas(backend);
+
+      expect(beginSpy).toHaveBeenCalledTimes(1);
+      expect(replaySpy).not.toHaveBeenCalled();
+
+      // F3/F4 — instruction splice: recorded nine-slice batches replay from
+      // group-owned resources. Same bytes, same rows (group-local rebase),
+      // same live uniforms -> byte-identical.
+      render(backend, scene.root);
+
+      const replayFrame = readCanvas(backend);
+
+      expect(replaySpy).toHaveBeenCalled();
+
+      render(backend, scene.root);
+
+      const steadyFrame = readCanvas(backend);
+
+      expect(beginSpy).toHaveBeenCalledTimes(1); // never re-recorded
+      expectBaseScenePixels(backend);
+      expect(recordFrame).toEqual(collectFrame);
+      expect(replayFrame).toEqual(recordFrame);
+      expect(steadyFrame).toEqual(recordFrame);
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 2 — camera pan on the replay path: live projection, no recapture', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+
+    try {
+      render(backend, scene.root); // F1 capture
+      render(backend, scene.root); // F2 record
+      render(backend, scene.root); // F3 splice
+
+      const beginSpy = vi.spyOn(backend, '_beginRetainedCapture');
+      const replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+      // Pan the camera 16px right: everything must appear 16px further left.
+      backend.view.setCenter(backend.view.center.x + 16, backend.view.center.y);
+      render(backend, scene.root);
+
+      expect(beginSpy).not.toHaveBeenCalled(); // replay, not recapture
+      expect(replaySpy).toHaveBeenCalled();
+      expectPixelNear(readPixel(backend, 36, 8), [0, 0, 255, 255]); // outside sprite 32..48
+      expectPixelNear(readPixel(backend, 4, 28), [255, 0, 0, 255]); // red now at 0..8 visible
+      expectPixelNear(readPixel(backend, 12, 44), [0, 255, 0, 255]); // green now 8..24
+      expectPixelNear(readPixel(backend, 28, 28), [0, 0, 0, 255]); // old red spot is background
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 3 — group move on the replay path: one live group matrix relocates the cached nine-slice batches', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+
+    try {
+      render(backend, scene.root); // F1 capture
+      render(backend, scene.root); // F2 record
+      render(backend, scene.root); // F3 splice
+
+      const beginSpy = vi.spyOn(backend, '_beginRetainedCapture');
+      const replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+      // Move the WHOLE group: content revisions untouched (a group move is
+      // decoupled by design), so the set keeps replaying — via live u_group.
+      scene.group.setPosition(24, 8);
+      render(backend, scene.root);
+
+      expect(beginSpy).not.toHaveBeenCalled();
+      expect(replaySpy).toHaveBeenCalled();
+      expectPixelNear(readPixel(backend, 28, 12), [255, 0, 0, 255]); // red 24..40 x 8..24
+      expectPixelNear(readPixel(backend, 44, 28), [0, 255, 0, 255]); // green 40..56 x 24..40
+      expectPixelNear(readPixel(backend, 12, 28), [0, 0, 0, 255]); // old red spot is background
+      expectPixelNear(readPixel(backend, 52, 8), [0, 0, 255, 255]); // live sprite unaffected
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 4 — transform-only nine-slice child move: fast row-patch on a real GPU relocates all 9 quads, no re-record', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+
+    try {
+      render(backend, scene.root); // F1 capture
+      render(backend, scene.root); // F2 record
+      render(backend, scene.root); // F3 splice
+
+      const beginSpy = vi.spyOn(backend, '_beginRetainedCapture');
+      const replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+      // Slice 4b: a pure transform move on a direct child stays content-clean,
+      // so the group keeps its recording and patches just this child's shared
+      // transform row in place — all 9 quad-instances that reference it move
+      // together. The pixel readback is the stale-render guard on a real GPU.
+      scene.redNine.setPosition(32, 0); // world (40,24)-(56,40)
+      render(backend, scene.root);
+
+      expect(beginSpy).not.toHaveBeenCalled(); // NO re-record: the recording is patched in place
+      // Two distinct-texture nine-slice nodes record as TWO single-texture
+      // batches (nine-slice binds one base texture per flush), so each replayed
+      // frame splices both — proving per-batch byte offsets across >1 batch.
+      expect(replaySpy).toHaveBeenCalledTimes(2); // one frame, two batches
+      expectPixelNear(readPixel(backend, 48, 28), [255, 0, 0, 255]); // patched to the NEW spot
+      expectPixelNear(readPixel(backend, 12, 28), [0, 0, 0, 255]); // old spot cleared
+
+      // The fast tier keeps splicing the patched rows, byte-stable, no re-record.
+      const patchedFrame = readCanvas(backend);
+
+      render(backend, scene.root);
+
+      expect(beginSpy).not.toHaveBeenCalled();
+      expect(replaySpy).toHaveBeenCalledTimes(4); // second frame, two more batch replays
+      expect(readCanvas(backend)).toEqual(patchedFrame);
+      expectPixelNear(readPixel(backend, 48, 28), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(backend, 28, 44), [0, 255, 0, 255]); // green sibling untouched
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgpu-nine-slice-retained-instruction-replay.test.ts
+++ b/test/rendering/browser/webgpu-nine-slice-retained-instruction-replay.test.ts
@@ -1,0 +1,312 @@
+/**
+ * WebGPU renderer-matrix browser tests — NineSlice retained instruction-set
+ * replay (Track B Slice 3).
+ *
+ * The nine-slice counterpart of `webgpu-retained-instruction-replay.test.ts`.
+ * A nine-slice node expands to MANY quad-instances that all share one
+ * transform-storage row, so the group-local node-index rebase (S3-D4) and the
+ * per-batch byte offset are load-bearing: a live sprite OUTSIDE (and before)
+ * the retained group keeps the group's shared rows starting at a non-zero
+ * frame-global index, and the group holds two DISTINCT-texture nine-slices
+ * (nine-slice binds one base texture per flush → two recorded batches). The
+ * replay tier must reproduce the record frame's pixels exactly; a broken
+ * rebase (or wrong byte offset) fetches the wrong / out-of-range storage row
+ * and the probes diverge.
+ *
+ * CI guarantees a real WebGPU adapter; tests only skip when the software
+ * adapter drops the device mid-test (same convention as the other WebGPU
+ * browser specs).
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import type { RetainedGroupFragment } from '#rendering/plan/RetainedGroupFragment';
+import type { RenderNode } from '#rendering/RenderNode';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { NineSliceSprite } from '#rendering/sprite/NineSliceSprite';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+import { getBackendDevice } from './webgpu-test-helpers';
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: {
+      canvas: { width: canvasSize, height: canvasSize },
+      clearColor: Color.black,
+    },
+  }) as unknown as Application;
+
+const setupBackend = async (): Promise<WebGpuBackend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  wireCoreRenderers(backend);
+  await backend.initialize();
+
+  return backend;
+};
+
+const createSolidTexture = (color: string, size = 16): Texture => {
+  const source = document.createElement('canvas');
+
+  source.width = size;
+  source.height = size;
+
+  const context = source.getContext('2d');
+
+  if (!context) {
+    throw new Error('2D context is required to create test textures.');
+  }
+
+  context.fillStyle = color;
+  context.fillRect(0, 0, size, size);
+
+  return new Texture(source);
+};
+
+const readCanvas = (backend: WebGpuBackend): ((x: number, y: number) => RgbaTuple) => {
+  const source = backend.context.canvas as HTMLCanvasElement;
+  const readback = document.createElement('canvas');
+
+  readback.width = canvasSize;
+  readback.height = canvasSize;
+
+  const ctx = readback.getContext('2d');
+
+  if (!ctx) {
+    throw new Error('2D context is required for canvas readback.');
+  }
+
+  ctx.drawImage(source, 0, 0);
+
+  return (x: number, y: number): RgbaTuple => {
+    const { data } = ctx.getImageData(Math.floor(x), Math.floor(y), 1, 1);
+
+    return [data[0], data[1], data[2], data[3]];
+  };
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 12): void => {
+  for (let index = 0; index < 4; index++) {
+    expect(Math.abs(actual[index] - expected[index])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+// Render a frame through the real plan path inside a validation error scope.
+// Returns false when the device dropped mid-test (the caller should bail).
+const renderScene = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
+  const device = getBackendDevice(backend);
+
+  device.pushErrorScope('validation');
+
+  let validationError: GPUError | null;
+
+  try {
+    backend.resetStats();
+    backend.clear(Color.black);
+    root.render(backend);
+    backend.flush();
+    validationError = await device.popErrorScope();
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+
+  expect(validationError).toBeNull();
+
+  return true;
+};
+
+const hexToRgba = (hex: string): RgbaTuple => [parseInt(hex.slice(1, 3), 16), parseInt(hex.slice(3, 5), 16), parseInt(hex.slice(5, 7), 16), 255];
+
+interface FragmentCarrier {
+  _fragment: RetainedGroupFragment;
+}
+
+const fragmentOf = (group: RetainedContainer): RetainedGroupFragment => (group as unknown as FragmentCarrier)._fragment;
+
+/**
+ * Standard cell scene, mirroring the WebGL2 nine-slice retained cells: a live
+ * blue sprite OUTSIDE (and before) the group at (48,0)-(64,16) keeps the
+ * group-local rebase load-bearing; the group at (8,24) holds a red nine-slice
+ * at group-local (0,0) -> world (8,24)-(24,40) and a green nine-slice at
+ * group-local (16,16) -> world (24,40)-(40,56). Each nine-slice fills a 16x16
+ * solid rect (slices/border 4 over a 16x16 source), 9 quad-instances sharing
+ * one storage row, and binds its own texture -> two recorded batches.
+ */
+const buildScene = () => {
+  const blue = createSolidTexture('#0000ff');
+  const red = createSolidTexture('#ff0000');
+  const green = createSolidTexture('#00ff00');
+  const root = new Container();
+  const outside = new Sprite(blue);
+  const group = new RetainedContainer();
+  const redNine = new NineSliceSprite(red, { slices: 4, border: 4, width: 16, height: 16 });
+  const greenNine = new NineSliceSprite(green, { slices: 4, border: 4, width: 16, height: 16 });
+
+  outside.setPosition(48, 0);
+  root.addChild(outside);
+
+  greenNine.setPosition(16, 16);
+  group.addChild(redNine);
+  group.addChild(greenNine);
+  group.setPosition(8, 24);
+  root.addChild(group);
+
+  const destroy = (): void => {
+    root.destroy();
+    blue.destroy();
+    red.destroy();
+    green.destroy();
+  };
+
+  return { root, group, redNine, greenNine, destroy };
+};
+
+describe('WebGPU renderer matrix: NineSlice retained instruction replay cells', () => {
+  test('cell 1 — nine-slice replay is pixel-identical to the record frame (fast/slow equivalence)', async ctx => {
+    const backend = await setupBackend();
+    const scene = buildScene();
+
+    try {
+      // F1: dirty collect + capture.
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return;
+      }
+
+      // F2: clean entry replay + record — this IS the slow path's output.
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return;
+      }
+
+      expect(fragmentOf(scene.group).instructions?.hasRecording).toBe(true);
+
+      const probes: ReadonlyArray<readonly [number, number, string]> = [
+        [56, 8, '#0000ff'], // live outside sprite
+        [16, 32, '#ff0000'], // red nine-slice (batch 1)
+        [32, 48, '#00ff00'], // green nine-slice (batch 2)
+      ];
+      let readPixel = readCanvas(backend);
+      const slowPixels = probes.map(([x, y]) => readPixel(x, y));
+
+      for (let i = 0; i < probes.length; i++) {
+        expectPixelNear(slowPixels[i]!, hexToRgba(probes[i]![2]));
+      }
+
+      // F3: instruction replay — must be identical to the record frame.
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return;
+      }
+
+      readPixel = readCanvas(backend);
+
+      for (let i = 0; i < probes.length; i++) {
+        expectPixelNear(readPixel(probes[i]![0], probes[i]![1]), slowPixels[i]!, 0);
+      }
+
+      // Background stays clear on the replay tier (no stray out-of-range row).
+      expectPixelNear(readPixel(4, 60), [0, 0, 0, 255]);
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 2 — camera pan on the cached path: replayed nine-slice pixels track the live view', async ctx => {
+    const backend = await setupBackend();
+    const scene = buildScene();
+
+    try {
+      // Reach the fast tier (F1 capture, F2 record, F3 replay).
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderScene(ctx, backend, scene.root))) {
+          return;
+        }
+      }
+
+      let readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(16, 32), [255, 0, 0, 255]);
+
+      // Pan the camera 16px right: replayed content must appear 16px further
+      // left — projection is resolved live at replay (S3-D1).
+      backend.view.setCenter(backend.view.center.x + 16, backend.view.center.y);
+
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return;
+      }
+
+      readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(40, 8), [0, 0, 255, 255]); // outside sprite 32..48
+      expectPixelNear(readPixel(4, 32), [255, 0, 0, 255]); // red now 0..8 visible
+      expectPixelNear(readPixel(12, 48), [0, 255, 0, 255]); // green now 8..24
+      expectPixelNear(readPixel(16, 32), [0, 0, 0, 255]); // old red spot is background
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 3 — group move on the cached path relocates nine-slice pixels WITHOUT recapture', async ctx => {
+    const backend = await setupBackend();
+    const scene = buildScene();
+
+    try {
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderScene(ctx, backend, scene.root))) {
+          return;
+        }
+      }
+
+      let readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(16, 32), [255, 0, 0, 255]);
+
+      // The recorded batch instruction must survive the move untouched: a
+      // group move only changes the live-composed group matrix (S3-D6).
+      const recordedBatch = fragmentOf(scene.group).instructions!.instructions[0];
+
+      scene.group.setPosition(32, 32);
+
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return;
+      }
+
+      expect(fragmentOf(scene.group).instructions!.instructions[0]).toBe(recordedBatch);
+      expect(fragmentOf(scene.group).instructions!.hasRecording).toBe(true);
+
+      readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(40, 40), [255, 0, 0, 255]); // red 32..48 x 32..48
+      expectPixelNear(readPixel(56, 56), [0, 255, 0, 255]); // green 48..64 x 48..64
+      expectPixelNear(readPixel(16, 32), [0, 0, 0, 255]); // old red spot is background
+      expectPixelNear(readPixel(56, 8), [0, 0, 255, 255]); // live sprite unaffected
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds retained-batch record/replay support (Track B Slice 3) to the NineSliceSprite renderer on both WebGL2 and WebGPU, mirroring the Sprite renderer's seam (`_supportsRetainedBatches = true` + the four replayer hooks).
- NineSlice's draw structure (fixed-stride instanced quads, no per-node geometry) fits the existing sprite-shaped bundle/payload cleanly — no shared-infra changes needed, unlike Mesh (separate investigation, deferred).

## Test plan
- [x] 243 node unit tests passed (retained-instruction-set/equivalence, webgl2-group-resources, webgpu-retained-record-replay, NineSliceSprite, retained-container family)
- [x] `tsc --noEmit`, `eslint`, `prettier --check` clean
- [x] 27 WebGL2 browser pixel tests passed (real GPU), including new `webgl2-nine-slice-retained-instruction-replay.test.ts` (byte-identical replay, camera pan, group move, in-place transform-row patch)
- [x] 25 WebGPU browser pixel tests passed (real GPU via SwiftShader), including new `webgpu-nine-slice-retained-instruction-replay.test.ts`
- [x] Mutation-proof: temporarily neutered the rebase hook, confirmed the new tests fail, restored and re-verified green