### PR TITLE
feat(rendering): retained-batch record/replay for the RepeatingSprite renderer

### DIFF
--- a/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
@@ -5,11 +5,12 @@ import { computeShaderTiling, type RepeatingSpriteQuad } from '#rendering/sprite
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { RepeatMode } from '#rendering/texture/repeat';
 import { Texture } from '#rendering/texture/Texture';
-import { type BlendModes, BufferTypes, BufferUsage, RenderingPrimitives, ScaleModes, WrapModes } from '#rendering/types';
+import { BlendModes, BufferTypes, BufferUsage, RenderingPrimitives, ScaleModes, WrapModes } from '#rendering/types';
 
 import { AbstractWebGl2Renderer } from './AbstractWebGl2Renderer';
 import type { WebGl2Backend } from './WebGl2Backend';
 import { WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
+import type { WebGl2RetainedBatchPayload, WebGl2RetainedBatchReplayer, WebGl2RetainedNodeIndexRange } from './WebGl2RetainedGroupResources';
 import { createWebGl2ShaderProgram } from './WebGl2ShaderProgram';
 import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './WebGl2VertexArrayObject';
 
@@ -158,7 +159,27 @@ interface RendererConnection {
 }
 
 /** Instanced renderer for {@link RepeatingSprite} using WebGL2. Handles both shader and geometry paths internally. */
-export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<RepeatingSprite> {
+export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<RepeatingSprite> implements WebGl2RetainedBatchReplayer {
+  /**
+   * Retained-batch capability opt-in (Track B Slice 3, S3-D5.1). Only the
+   * GEOMETRY path (TextureRegion source) is recorded: its 32-byte instance
+   * layout matches the sprite/NineSlice batch shape (node index at word 7 of
+   * the 8-word instance), so it records and replays exactly like the sprite
+   * renderer — a mixed group of sprites and geometry-path repeating sprites
+   * shares one bundle and one group transform texture.
+   *
+   * The SHADER path (bare {@link Texture} source) uses a distinct 40-byte
+   * stride AND a per-batch wrap-mode sampler; the generalized instruction
+   * seam carries no per-batch metadata channel for the path discriminant or
+   * the wrap modes, so a shader-path draw inside a capture window POISONS it
+   * — the group degrades to the (correct) entry-replay tier, exactly as it
+   * did before this renderer opted in. Pixel-snapped draws are excluded for
+   * the same reason the sprite renderer excludes them (view-dependent
+   * instance words).
+   * @internal
+   */
+  public readonly _supportsRetainedBatches = true;
+
   private readonly _shaderPathShader: Shader;
   private readonly _geoPathShader: Shader;
   private readonly _batchSize: number;
@@ -193,10 +214,20 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
   private _connection: RendererConnection | null = null;
 
   private readonly _transformUnitScratch = new Int32Array([transformTextureUnit]);
+  private readonly _textureUnitScratch = new Int32Array([0]);
   private readonly _snapBounds = new Rectangle();
   private _currentView: unknown = null;
   private _currentViewId = -1;
   private _currentGroupTransformId = -1;
+
+  // Retained-replay reusable scratch + dedicated view/group uniform tracking
+  // for the geo shader — kept SEPARATE from the live-flush state above so a
+  // replay never marks the live projection "already staged" and leaves the
+  // shader-path program holding a stale projection.
+  private readonly _recordTextureScratch: Array<Texture | RenderTexture | null> = [null];
+  private _replayView: unknown = null;
+  private _replayViewId = -1;
+  private _replayGroupTransformId = -1;
 
   public constructor(batchSize: number) {
     super();
@@ -234,6 +265,15 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
     }
 
     const backend = this.getBackend();
+
+    // Retained recording (Track B Slice 3): only the geometry path is
+    // replayable. A shader-path or pixel-snapped draw inside an active capture
+    // cannot be replayed from group-owned resources, so poison the window —
+    // the group falls back to entry replay (correct, never stale) rather than
+    // replaying an incomplete or wrap-less instruction stream.
+    if (backend._isRetainedCapturing && (strategy === 'shader' || sprite.pixelSnapMode !== 'none')) {
+      backend._poisonRetainedCaptures();
+    }
 
     if (this._currentTexture !== texture) {
       this._currentTexture = texture;
@@ -480,7 +520,151 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
     backend.stats.batches++;
     backend.stats.drawCalls++;
 
+    // Retained recording (Track B Slice 3): while a capture window is open,
+    // hand the exact packed geometry-path words of this flush to the backend —
+    // byte-identical to what just drew. A single base texture binds to unit 0,
+    // so the recorded slot list is one entry. Shader-path batches are never
+    // recorded (render() poisoned the window if one appeared).
+    if (backend._isRetainedCapturing && this._currentTexture !== null) {
+      this._recordTextureScratch[0] = this._currentTexture;
+      backend._recordRetainedBatch(
+        this,
+        this._geoU32.subarray(0, this._geoQuadCount * geoWordsPerInstance),
+        this._geoQuadCount,
+        this._currentBlendMode ?? BlendModes.Normal,
+        this._recordTextureScratch,
+        1,
+      );
+    }
+
     this._geoQuadCount = 0;
+  }
+
+  // ── Retained-batch record/replay (Track B Slice 3) ───────────────────────
+  // Only geometry-path batches reach here (see _supportsRetainedBatches). Their
+  // 32-byte layout puts the node index at word 7 of the 8-word instance — the
+  // same position the sprite renderer uses — so scan/rebase mirror it exactly.
+
+  /** @internal See {@link WebGl2RetainedBatchReplayer._scanRetainedNodeIndexRange}. */
+  public _scanRetainedNodeIndexRange(payload: WebGl2RetainedBatchPayload, range: WebGl2RetainedNodeIndexRange): void {
+    const words = payload.bundle.instanceWords;
+    const start = payload.byteOffset / Uint32Array.BYTES_PER_ELEMENT;
+
+    for (let i = 0; i < payload.instanceCount; i++) {
+      // In-bounds: the payload's word range was appended to the bundle store.
+      const node = words[start + i * geoWordsPerInstance + 7]!;
+
+      if (node < range.min) {
+        range.min = node;
+      }
+
+      if (node > range.max) {
+        range.max = node;
+      }
+    }
+  }
+
+  /** @internal See {@link WebGl2RetainedBatchReplayer._rebaseRetainedNodeIndices} (S3-D4: group-local indices). */
+  public _rebaseRetainedNodeIndices(payload: WebGl2RetainedBatchPayload, base: number): void {
+    const words = payload.bundle.instanceWords;
+    const start = payload.byteOffset / Uint32Array.BYTES_PER_ELEMENT;
+
+    for (let i = 0; i < payload.instanceCount; i++) {
+      const index = start + i * geoWordsPerInstance + 7;
+
+      // In-bounds: see the scan above.
+      words[index] = (words[index]! - base) >>> 0;
+    }
+  }
+
+  /**
+   * Point the batch VAO's per-instance attributes at the bundle's persistent
+   * instance buffer for the geometry-path layout (same attributes/locations as
+   * the live `_geoVao` in {@link onConnect}), based at the batch's byte offset.
+   * @internal
+   */
+  public _configureRetainedVao(payload: WebGl2RetainedBatchPayload): void {
+    const gl = this.getBackend().context;
+    const buffer = payload.bundle.instanceBuffer;
+    const vao = payload.vao;
+
+    if (buffer === null || vao === null) {
+      throw new Error('WebGl2RepeatingSpriteRenderer: retained batch VAO configuration requires an uploaded bundle.');
+    }
+
+    const base = payload.byteOffset;
+
+    vao
+      .addAttribute(buffer, this._geoPathShader.getAttribute('a_quadBounds'), gl.FLOAT, false, geoStrideBytes, base + 0, false, 1)
+      .addAttribute(buffer, this._geoPathShader.getAttribute('a_uvBounds'), gl.UNSIGNED_SHORT, true, geoStrideBytes, base + 16, false, 1)
+      .addAttribute(buffer, this._geoPathShader.getAttribute('a_color'), gl.UNSIGNED_BYTE, true, geoStrideBytes, base + 24, false, 1)
+      .addAttribute(buffer, this._geoPathShader.getAttribute('a_nodeIndex'), gl.UNSIGNED_INT, false, geoStrideBytes, base + 28, true, 1);
+  }
+
+  /**
+   * Replay one recorded geometry-path batch: all STATE resolved live (blend,
+   * `u_projection` from the live view, `u_group` from the live composed group
+   * matrix, the single base texture on unit 0) and only DATA cached (instance
+   * bytes via the per-batch VAO, group-owned transform texture on the shared
+   * transform unit). Mirrors {@link WebGl2SpriteRenderer._replayRetainedBatch}.
+   * @internal
+   */
+  public _replayRetainedBatch(payload: WebGl2RetainedBatchPayload): void {
+    const backend = this.getBackendOrNull();
+    const vao = payload.vao;
+    const transformTexture = payload.bundle.transformTexture;
+
+    if (backend === null || vao === null || transformTexture === null) {
+      // Defensive: a bundle in this state never validates (generation), so a
+      // spliced replay cannot reach here; skip rather than crash mid-frame.
+      return;
+    }
+
+    if (payload.blendMode !== this._currentBlendMode) {
+      this._currentBlendMode = payload.blendMode;
+    }
+
+    backend.setBlendMode(payload.blendMode);
+    this._stageGeoReplayUniforms(backend);
+
+    // In-bounds: the geometry path records exactly one base texture (slot 0).
+    backend.bindTexture(payload.textures[0]!, 0);
+
+    // The group-owned transform texture replaces the shared frame buffer on the
+    // SAME unit/sampler — zero GLSL changes (S3-D4). The next live flush
+    // re-binds the shared texture via bindTransformBufferTexture.
+    backend.bindTexture(transformTexture, transformTextureUnit);
+
+    this._geoPathShader.getUniform('u_texture').setValue(this._textureUnitScratch);
+    this._geoPathShader.getUniform('u_transforms').setValue(this._transformUnitScratch);
+    this._geoPathShader.sync();
+
+    backend.bindVertexArrayObject(vao);
+    vao.drawInstanced(4, 0, payload.instanceCount, RenderingPrimitives.TriangleStrip);
+  }
+
+  /**
+   * Stage `u_projection` (live view) and `u_group` (live composed group matrix)
+   * on the geometry-path shader for a retained replay. Dedicated view/group
+   * tracking (not the live-flush stamps) so a replay never suppresses the live
+   * flush's own projection write to the shader-path program.
+   */
+  private _stageGeoReplayUniforms(backend: WebGl2Backend): void {
+    const view = backend.view;
+
+    if (this._replayView !== view || this._replayViewId !== view.updateId) {
+      this._replayView = view;
+      this._replayViewId = view.updateId;
+      this._geoPathShader.getUniform('u_projection').setValue(view.getTransform().toArray(false));
+    }
+
+    if (this._geoPathShader.uniforms.has('u_group') && this._replayGroupTransformId !== backend.renderGroupTransformId) {
+      this._replayGroupTransformId = backend.renderGroupTransformId;
+
+      const groupTransform = backend.renderGroupTransform;
+
+      this._geoPathShader.getUniform('u_group').setValue(groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3);
+    }
   }
 
   private _resetBatchState(): void {
@@ -576,6 +760,10 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
     this._currentView = null;
     this._currentViewId = -1;
     this._currentGroupTransformId = -1;
+    this._replayView = null;
+    this._replayViewId = -1;
+    this._replayGroupTransformId = -1;
+    this._recordTextureScratch[0] = null;
     this._resetBatchState();
   }
 

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -44,10 +44,12 @@ import { WebGpuPassCoordinator } from './WebGpuPassCoordinator';
 import {
   retainedTransformSlotBytes,
   type WebGpuRetainedBatchPayload,
+  type WebGpuRetainedBatchReplayer,
   WebGpuRetainedCaptureFrame,
   WebGpuRetainedGroupBundle,
+  type WebGpuRetainedNodeIndexRange,
 } from './WebGpuRetainedGroupResources';
-import { baseSpriteBatchTextureSlots, maxSpriteBatchTextureSlots, type WebGpuSpriteRenderer } from './WebGpuSpriteRenderer';
+import { baseSpriteBatchTextureSlots, maxSpriteBatchTextureSlots } from './WebGpuSpriteRenderer';
 import { WebGpuTransformStorage } from './WebGpuTransformStorage';
 
 interface ManagedWebGpuTextureState {
@@ -203,6 +205,10 @@ export class WebGpuBackend implements RenderBackend {
   private readonly _retainedCaptureFrames: WebGpuRetainedCaptureFrame[] = [];
   private readonly _retainedBundles = new Set<WebGpuRetainedGroupBundle>();
   private readonly _rejectedRetainedSets = new WeakSet<RetainedInstructionSet>();
+  // Reused across per-batch scans at record time (S3-D4) to avoid an
+  // allocation per flush; the renderer-agnostic counterpart of WebGL2's
+  // capture-end `_retainedIndexRange` (WebGPU scans per batch, not per capture).
+  private readonly _retainedBatchIndexRange: WebGpuRetainedNodeIndexRange = { min: 0, max: 0 };
   // Render-error surface (S3 diagnostics): dedupe keys for onRenderError, and
   // the bound uncapturederror listener (re-installed by _initialize after
   // device-loss recovery).
@@ -1161,7 +1167,8 @@ export class WebGpuBackend implements RenderBackend {
    * the OPEN pass (no end/submit at group boundaries on the cached path,
    * B-06). All state — pipeline, projection/group uniforms, texture bindings
    * — is resolved live; only the recorded data is reused. Dispatches to the
-   * sprite renderer that recorded the batch.
+   * renderer that recorded the batch (any {@link WebGpuRetainedBatchReplayer},
+   * not just the sprite renderer).
    * @internal
    */
   public _replayRetainedBatch(batch: RetainedBatchInstruction): void {
@@ -1179,7 +1186,7 @@ export class WebGpuBackend implements RenderBackend {
     // flush-time visibility decision (mask/scissor) can drop the batch.
     this._stats.submittedNodes += batch.instanceCount;
     this._setActiveRenderer(payload.renderer);
-    payload.renderer._replayRecordedSpriteBatch(payload);
+    payload.renderer._replayRetainedBatch(payload);
   }
 
   /**
@@ -1244,14 +1251,15 @@ export class WebGpuBackend implements RenderBackend {
   }
 
   /**
-   * Stage one recorded sprite flush (called by the sprite renderer while a
-   * capture window is active): copies the packed instance bytes (owned by the
-   * INNERMOST capture's bundle, S3-D6), resolves the recorded texture views,
-   * and appends one shared instruction to every active set.
+   * Stage one recorded renderer flush (called by any capable renderer, e.g.
+   * the sprite renderer, while a capture window is active): copies the
+   * packed instance bytes (owned by the INNERMOST capture's bundle, S3-D6),
+   * resolves the recorded texture views, and appends one shared instruction
+   * to every active set.
    * @internal
    */
-  public _recordRetainedSpriteBatch(
-    renderer: WebGpuSpriteRenderer,
+  public _recordRetainedBatch(
+    replayer: WebGpuRetainedBatchReplayer,
     instanceData: ArrayBuffer,
     byteLength: number,
     instanceCount: number,
@@ -1276,24 +1284,14 @@ export class WebGpuBackend implements RenderBackend {
 
     bytes.set(new Uint8Array(instanceData, 0, byteLength));
 
-    // Scan the frame-global node indices (word 7 of each 8-word instance) so
-    // capture end can rebase them group-local and copy the row range once.
-    const words = new Uint32Array(bytes.buffer);
-    let minNodeIndex = 0xffffffff;
-    let maxNodeIndex = 0;
+    // Scan the frame-global node indices so capture end can rebase them
+    // group-local and copy the row range once. Layout-aware (word offset,
+    // stride) — delegated to the renderer that packed the bytes.
+    const range = this._retainedBatchIndexRange;
 
-    for (let i = 7; i < words.length; i += 8) {
-      // In-bounds: i < words.length via the loop guard.
-      const nodeIndex = words[i]!;
-
-      if (nodeIndex < minNodeIndex) {
-        minNodeIndex = nodeIndex;
-      }
-
-      if (nodeIndex > maxNodeIndex) {
-        maxNodeIndex = nodeIndex;
-      }
-    }
+    range.min = 0xffffffff;
+    range.max = 0;
+    replayer._scanRetainedNodeIndexRange(bytes, range);
 
     const textureList: Array<Texture | RenderTexture> = [];
     const recordedViews: GPUTextureView[] = [];
@@ -1312,7 +1310,7 @@ export class WebGpuBackend implements RenderBackend {
     }
 
     const payload: WebGpuRetainedBatchPayload = {
-      renderer,
+      renderer: replayer,
       bundle: owner.bundle,
       byteOffset: owner.totalBytes,
       instanceCount,
@@ -1332,7 +1330,7 @@ export class WebGpuBackend implements RenderBackend {
       payload,
     };
 
-    owner.staged.push({ bytes, byteOffset: owner.totalBytes, minNodeIndex, maxNodeIndex, instruction });
+    owner.staged.push({ bytes, byteOffset: owner.totalBytes, minNodeIndex: range.min, maxNodeIndex: range.max, instruction });
     owner.totalBytes += byteLength;
 
     for (const frame of frames) {
@@ -1393,15 +1391,14 @@ export class WebGpuBackend implements RenderBackend {
     bundle.ensureCapacity(device, frame.totalBytes, transformBytes);
 
     for (const batch of staged) {
-      // Rebase word 7 (nodeIndex) of every 8-word instance to group-local
-      // indices — the cached bytes become immune to frame-local index shifts
-      // (S3-D4) and address the group-owned row copy below.
-      const words = new Uint32Array(batch.bytes.buffer, batch.bytes.byteOffset, batch.bytes.byteLength / Uint32Array.BYTES_PER_ELEMENT);
+      // Rebase this batch's instance node indices to group-local indices —
+      // the cached bytes become immune to frame-local index shifts (S3-D4)
+      // and address the group-owned row copy below. Layout-aware — delegated
+      // to the renderer that packed the bytes (the payload was already
+      // created at record time, so its renderer is in hand here).
+      const payload = batch.instruction.payload as WebGpuRetainedBatchPayload;
 
-      for (let i = 7; i < words.length; i += 8) {
-        // In-bounds: i < words.length via the loop guard.
-        words[i] = words[i]! - base;
-      }
+      payload.renderer._rebaseRetainedNodeIndices(batch.bytes, base);
 
       device.queue.writeBuffer(bundle.instanceBuffer!, batch.byteOffset, batch.bytes.buffer, batch.bytes.byteOffset, batch.bytes.byteLength);
       stampRetainedBatchGeneration(batch.instruction);

--- a/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
@@ -15,6 +15,13 @@ import { AbstractWebGpuRenderer } from './AbstractWebGpuRenderer';
 import type { WebGpuBackend } from './WebGpuBackend';
 import { getWebGpuBlendState } from './WebGpuBlendState';
 import { WebGpuInstanceArena } from './WebGpuInstanceArena';
+import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
+import {
+  retainedGroupUniformBytes,
+  type WebGpuRetainedBatchPayload,
+  type WebGpuRetainedBatchReplayer,
+  type WebGpuRetainedNodeIndexRange,
+} from './WebGpuRetainedGroupResources';
 import { stencilContentDepthStencilState } from './WebGpuStencilState';
 
 // ---------------------------------------------------------------------------
@@ -149,7 +156,23 @@ function repeatModeToAddressMode(mode: RepeatMode): GPUAddressMode {
 }
 
 /** Instanced renderer for {@link RepeatingSprite} using WebGPU. */
-export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<RepeatingSprite> {
+export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<RepeatingSprite> implements WebGpuRetainedBatchReplayer {
+  /**
+   * Retained-batch capability opt-in (Track B Slice 3, S3-D5.1). Only the
+   * GEOMETRY path (TextureRegion source) is recorded: its 32-byte instance
+   * layout (node index at word 7 of the 8-word instance) matches the sprite
+   * renderer's batch shape exactly, so it records and replays through the
+   * same generalized seam. The SHADER path (bare Texture source) uses a
+   * distinct 40-byte stride AND a per-batch wrap-mode sampler that the
+   * generalized instruction payload carries no metadata for — a shader-path
+   * draw inside a capture window POISONS it instead, degrading the group to
+   * the (correct) entry-replay tier rather than replaying with the wrong
+   * sampler. Pixel-snapped draws are excluded for the same reason the sprite
+   * renderer excludes them (view-dependent instance words).
+   * @internal
+   */
+  public readonly _supportsRetainedBatches = true;
+
   private readonly _projData = new Float32Array(projectionByteLength / Float32Array.BYTES_PER_ELEMENT);
   // Projection-uniform skip state: a matching (view identity, view.updateId,
   // group-transform id) triple means the shared UBO already holds this flush's
@@ -210,6 +233,15 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
   private _currentPath: 'shader' | 'geometry' | null = null;
   // Reusable scratch for device-snapped bounds ('geometry' mode).
   private readonly _snapBounds = new Rectangle();
+
+  // Retained-batch record/replay scratch (Track B Slice 3). One-texture list
+  // reused for every geometry-path record call; the group matrix scratch and
+  // the open pass a replay last drew into mirror WebGpuSpriteRenderer's own
+  // (separate from the live-flush projection tracking above, so a replay
+  // never marks the live projection "already staged").
+  private readonly _recordTextureScratch: Array<Texture | RenderTexture | null> = [null];
+  private readonly _stagedReplayGroupData = new Float32Array(16);
+  private _lastReplayPass: WebGpuActiveRenderPass | null = null;
 
   protected onConnect(backend: WebGpuBackend): void {
     if (this._device) return;
@@ -302,6 +334,8 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     this._currentModeX = null;
     this._currentModeY = null;
     this._currentPath = null;
+    this._recordTextureScratch[0] = null;
+    this._lastReplayPass = null;
   }
 
   public render(sprite: RepeatingSprite): void {
@@ -316,6 +350,16 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     const blendMode = sprite.blendMode;
     const modeX = sprite.modeX;
     const modeY = sprite.modeY;
+
+    // Retained recording (Track B Slice 3): only the geometry path is
+    // replayable (see _supportsRetainedBatches). A shader-path or
+    // pixel-snapped draw inside an active capture window cannot be replayed
+    // from group-owned resources, so poison the window — the group falls
+    // back to entry replay (correct, never stale) instead of a replay that is
+    // either missing the wrap-mode sampler or holding view-dependent bytes.
+    if ((strategy === 'shader' || sprite.pixelSnapMode !== 'none') && backend._retainedCaptureActive) {
+      backend._poisonActiveRetainedCaptures();
+    }
 
     const hasData = this._shaderQuadCount > 0 || this._geoQuadCount > 0;
 
@@ -635,6 +679,168 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     pass.setIndexBuffer(this._indexBuffer, 'uint16');
     pass.drawIndexed(indicesPerInstance, this._geoQuadCount, 0, 0, 0);
 
+    backend.stats.batches++;
+    backend.stats.drawCalls++;
+
+    // Retained recording (Track B Slice 3): while a capture window is open,
+    // hand the exact packed geometry-path bytes of this flush to the backend —
+    // byte-identical to what just drew. A single base texture binds to group(1),
+    // so the recorded slot list is one entry. Shader-path batches never reach
+    // here (render() poisoned the window if one appeared).
+    if (backend._retainedCaptureActive && this._currentTexture !== null && this._currentBlendMode !== null) {
+      this._recordTextureScratch[0] = this._currentTexture;
+      backend._recordRetainedBatch(
+        this,
+        this._geoInstData,
+        this._geoQuadCount * geoStrideBytes,
+        this._geoQuadCount,
+        this._currentBlendMode,
+        this._recordTextureScratch,
+        1,
+      );
+    }
+  }
+
+  // ── Retained-batch record/replay (Track B Slice 3) ───────────────────────
+  // Only geometry-path batches ever reach here (see _supportsRetainedBatches).
+  // Their 32-byte (8-word) layout puts the node index at word 7 — the same
+  // position WebGpuSpriteRenderer uses — so scan/rebase mirror it exactly.
+
+  /** @internal See {@link WebGpuRetainedBatchReplayer._scanRetainedNodeIndexRange}. */
+  public _scanRetainedNodeIndexRange(bytes: Uint8Array, range: WebGpuRetainedNodeIndexRange): void {
+    const words = new Uint32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / Uint32Array.BYTES_PER_ELEMENT);
+
+    for (let i = 7; i < words.length; i += 8) {
+      // In-bounds: i < words.length via the loop guard.
+      const nodeIndex = words[i]!;
+
+      if (nodeIndex < range.min) {
+        range.min = nodeIndex;
+      }
+
+      if (nodeIndex > range.max) {
+        range.max = nodeIndex;
+      }
+    }
+  }
+
+  /** @internal See {@link WebGpuRetainedBatchReplayer._rebaseRetainedNodeIndices} (S3-D4: group-local indices). */
+  public _rebaseRetainedNodeIndices(bytes: Uint8Array, base: number): void {
+    const words = new Uint32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / Uint32Array.BYTES_PER_ELEMENT);
+
+    for (let i = 7; i < words.length; i += 8) {
+      // In-bounds: i < words.length via the loop guard.
+      words[i] = words[i]! - base;
+    }
+  }
+
+  /**
+   * Replay one recorded geometry-path batch from its group-owned bundle into
+   * the OPEN pass. All STATE is resolved live (pipeline via the existing
+   * `_getPipeline('geo', ...)` cache, texture bind group(1) via the existing
+   * texture-bind-group cache — resolving re-syncs dirty texture content, the
+   * group's 128-byte UBO written only when its content changed) and only DATA
+   * is cached (instance bytes, group transform storage). Mirrors
+   * {@link WebGpuSpriteRenderer._replayRecordedSpriteBatch}.
+   * @internal
+   */
+  public _replayRetainedBatch(payload: WebGpuRetainedBatchPayload): void {
+    const backend = this._backend;
+    const device = this._device;
+    const bundle = payload.bundle;
+
+    if (!backend || !device || this._indexBuffer === null || !bundle.isReady) {
+      return;
+    }
+
+    // Drain any pending live batch into the open pass first (defensive — the
+    // group boundary already flushed; flush() never ends the pass on the geo
+    // default path and guards its own shared-UBO hazards).
+    this.flush();
+
+    // Match the live path's visibility handling: a fully-clipped scissor
+    // draws nothing (the batch stays recorded; visibility is live per frame).
+    const scissor = backend.getScissorRect();
+
+    if (scissor !== null && (scissor.width <= 0 || scissor.height <= 0)) {
+      return;
+    }
+
+    const coordinator = backend._passCoordinator;
+    let activePass = coordinator.activePass;
+    const passHasDraws =
+      activePass !== null && ((this._instanceArena.cursor > 0 && this._instanceArena.tracksPass(activePass)) || this._lastReplayPass === activePass);
+
+    // Same-frame texture mutation guard: resolving the bindings below re-
+    // uploads mutated content on the queue timeline BEFORE the deferred
+    // submit, which would retroactively change draws already recorded into
+    // the open pass. End (submit) the pass first so they keep the
+    // pre-mutation content.
+    if (passHasDraws) {
+      for (const texture of payload.textures) {
+        if (backend._textureUploadWouldMutate(texture)) {
+          coordinator.endPass();
+          this._instanceArena.resetPass();
+          break;
+        }
+      }
+    }
+
+    // In-bounds: the geometry path records exactly one base texture (slot 0).
+    // Geometry path uses the backend's default (clamp) sampler — same as the
+    // live flush — so resolving through getTextureBinding reuses the live cache.
+    const texture = payload.textures[0]!;
+    const binding = backend.getTextureBinding(texture);
+    const textureBindGroup = this._getOrCreateTextureBindGroup(device, texture, binding.view, binding.sampler, 'repeating-sprite:texture-bind-group:geo');
+
+    // Group UBO: skip the write while (view, updateId, group bytes) match what
+    // the buffer holds; guard the double-replay aliasing case first.
+    const view = backend.view;
+    const scratch = this._stagedReplayGroupData;
+
+    packAffineMat4(backend.renderGroupTransform ?? Matrix.identity, scratch, 0);
+
+    let uboDirty = !bundle.uboWritten || bundle.uboView !== view || bundle.uboViewUpdateId !== view.updateId;
+
+    if (!uboDirty) {
+      for (let i = 0; i < 16; i++) {
+        if (scratch[i] !== bundle.uboData[16 + i]) {
+          uboDirty = true;
+          break;
+        }
+      }
+    }
+
+    if (uboDirty) {
+      activePass = coordinator.activePass;
+
+      if (activePass !== null && bundle.drawsInPass === activePass) {
+        // Rewriting the UBO would retroactively re-project this bundle's
+        // draws already recorded into the open pass: end it first.
+        coordinator.endPass();
+        this._instanceArena.resetPass();
+      }
+
+      packAffineMat4(view.getTransform(), bundle.uboData, 0);
+      bundle.uboData.set(scratch, 16);
+      bundle.uboView = view;
+      bundle.uboViewUpdateId = view.updateId;
+      bundle.uboWritten = true;
+      device.queue.writeBuffer(bundle.uniformBuffer!, 0, bundle.uboData.buffer, bundle.uboData.byteOffset, retainedGroupUniformBytes);
+    }
+
+    const active = coordinator.acquirePass();
+    const pass = active.pass;
+
+    pass.setPipeline(this._getPipeline('geo', payload.blendMode, backend.renderTargetFormat, coordinator.stencilActive));
+    pass.setBindGroup(0, bundle.getBindGroup(device, this._uniformBindGroupLayout!));
+    pass.setBindGroup(1, textureBindGroup);
+    pass.setVertexBuffer(0, bundle.instanceBuffer, payload.byteOffset);
+    pass.setIndexBuffer(this._indexBuffer, 'uint16');
+    pass.drawIndexed(indicesPerInstance, payload.instanceCount, 0, 0, 0);
+
+    bundle.drawsInPass = active;
+    this._lastReplayPass = active;
     backend.stats.batches++;
     backend.stats.drawCalls++;
   }

--- a/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
+++ b/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
@@ -2,13 +2,13 @@
 
 import type { GpuResourceAccountant } from '#rendering/GpuResourceAccountant';
 import type { RetainedBatchInstruction, RetainedGroupBundle, RetainedInstructionSet } from '#rendering/plan/RetainedInstructionSet';
+import type { Renderer } from '#rendering/Renderer';
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { Texture } from '#rendering/texture/Texture';
 import type { BlendModes } from '#rendering/types';
 import type { View } from '#rendering/View';
 
 import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
-import type { WebGpuSpriteRenderer } from './WebGpuSpriteRenderer';
 
 /** Bytes of one transform slot (3 × vec4<f32>, matches the WGSL `TransformSlot`). */
 export const retainedTransformSlotBytes = 48;
@@ -17,16 +17,16 @@ export const retainedTransformSlotBytes = 48;
 export const retainedGroupUniformBytes = 128;
 
 /**
- * Backend-owned replay descriptor for one recorded sprite flush (Track B
+ * Backend-owned replay descriptor for one recorded renderer flush (Track B
  * Slice 3, S3-D1). Carried as the opaque `payload` of a
  * {@link RetainedBatchInstruction}; everything here is DATA — all state
  * (pipeline, projection/group uniforms, texture bindings) is resolved live at
- * replay by {@link WebGpuSpriteRenderer._replayRecordedSpriteBatch}.
+ * replay by the owning {@link WebGpuRetainedBatchReplayer._replayRetainedBatch}.
  * @internal
  */
 export interface WebGpuRetainedBatchPayload {
-  /** The sprite renderer that recorded (and replays) this batch. */
-  readonly renderer: WebGpuSpriteRenderer;
+  /** The renderer that recorded (and replays) this batch. */
+  readonly renderer: WebGpuRetainedBatchReplayer;
   /** The bundle whose group-owned buffers hold this batch's data. */
   readonly bundle: WebGpuRetainedGroupBundle;
   /** Byte offset of this batch's instances inside the bundle's instance buffer. */
@@ -43,6 +43,45 @@ export interface WebGpuRetainedBatchPayload {
    * a recapture, never a replay.
    */
   readonly recordedViews: readonly GPUTextureView[];
+}
+
+/**
+ * Mutable node-index range scratch used at record time (S3-D4), the WebGPU
+ * counterpart of `WebGl2RetainedNodeIndexRange`. Unlike WebGL2 (which scans
+ * the shared bundle store at capture END, once ranges over every batch are
+ * known), WebGPU scans each batch's freshly-packed bytes immediately at
+ * record time, per batch — so the range here is scoped to ONE batch, not the
+ * whole capture; the backend takes the min/max across all per-batch ranges to
+ * get the capture-wide rebase base.
+ * @internal
+ */
+export interface WebGpuRetainedNodeIndexRange {
+  min: number;
+  max: number;
+}
+
+/**
+ * Renderer-side contract for recorded-batch finalization and replay on WebGPU
+ * (the WebGPU counterpart of `WebGl2RetainedBatchReplayer`). The bundle/stage
+ * stores raw instance bytes; only the renderer that packed them knows the
+ * layout (where the node index lives, how many words per instance), so the
+ * backend delegates the layout-aware steps here per batch — mirroring the
+ * WebGL2 seam, adapted to WebGPU's byte-staging flow (record-time scan on
+ * freshly-packed bytes, finalize-time rebase on the staged copy, rather than
+ * WebGL2's capture-end scan/rebase against a live bundle store).
+ *
+ * Extends {@link Renderer} so the backend can drive replay through the same
+ * active-renderer bookkeeping (`_setActiveRenderer` calls `flush()` on
+ * renderer switch) it already uses for live playback.
+ * @internal
+ */
+export interface WebGpuRetainedBatchReplayer extends Renderer {
+  /** Widen `range` to cover every shared-transform row `bytes` (one batch's packed instances) references. */
+  _scanRetainedNodeIndexRange(bytes: Uint8Array, range: WebGpuRetainedNodeIndexRange): void;
+  /** Rewrite `bytes`' instance node indices in place to group-local (`index - base`). */
+  _rebaseRetainedNodeIndices(bytes: Uint8Array, base: number): void;
+  /** Replay the batch: live state (pipeline, uniforms, textures), cached data (bytes, transforms). */
+  _replayRetainedBatch(payload: WebGpuRetainedBatchPayload): void;
 }
 
 /** One sprite flush staged during a capture window, finalized at capture end. @internal */

--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -16,7 +16,12 @@ import type { WebGpuBackend } from './WebGpuBackend';
 import { getWebGpuBlendState } from './WebGpuBlendState';
 import { WebGpuInstanceArena } from './WebGpuInstanceArena';
 import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
-import { retainedGroupUniformBytes, type WebGpuRetainedBatchPayload } from './WebGpuRetainedGroupResources';
+import {
+  retainedGroupUniformBytes,
+  type WebGpuRetainedBatchPayload,
+  type WebGpuRetainedBatchReplayer,
+  type WebGpuRetainedNodeIndexRange,
+} from './WebGpuRetainedGroupResources';
 import { stencilContentDepthStencilState } from './WebGpuStencilState';
 import {
   collectScalarUniforms,
@@ -276,7 +281,7 @@ interface CustomSpriteResources {
   baseTextureBindGroups: WeakMap<Texture | RenderTexture, { group: GPUBindGroup; view: GPUTextureView }>;
 }
 
-export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
+export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> implements WebGpuRetainedBatchReplayer {
   /** Retained-batch capability flag (Track B Slice 3, S3-D5.1): the default path records/replays flush-level batches. */
   public readonly _supportsRetainedBatches = true;
 
@@ -742,7 +747,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
       if (isCustom) {
         backend._poisonActiveRetainedCaptures();
       } else if (this._currentBlendMode !== null) {
-        backend._recordRetainedSpriteBatch(
+        backend._recordRetainedBatch(
           this,
           this._instanceData,
           this._instanceCount * instanceStrideBytes,
@@ -857,6 +862,42 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     return this._transformBindGroup;
   }
 
+  // ── Retained-batch record/replay (Track B Slice 3, Tasks 9/10) ────────────
+  // The bundle/stage stores raw instance bytes; this renderer owns the
+  // 32-byte (8-word) layout, so the layout-aware finalize steps (node-index
+  // scan/rebase) and the replay dispatch live here — the WebGPU counterpart
+  // of WebGl2SpriteRenderer's `_scanRetainedNodeIndexRange` /
+  // `_rebaseRetainedNodeIndices` / `_replayRetainedBatch`.
+
+  /** @internal See {@link WebGpuRetainedBatchReplayer._scanRetainedNodeIndexRange}. */
+  public _scanRetainedNodeIndexRange(bytes: Uint8Array, range: WebGpuRetainedNodeIndexRange): void {
+    const words = new Uint32Array(bytes.buffer);
+
+    for (let i = 7; i < words.length; i += 8) {
+      // In-bounds: i < words.length via the loop guard. nodeIndex is the last
+      // word of the 32-byte (8-word) instance layout.
+      const nodeIndex = words[i]!;
+
+      if (nodeIndex < range.min) {
+        range.min = nodeIndex;
+      }
+
+      if (nodeIndex > range.max) {
+        range.max = nodeIndex;
+      }
+    }
+  }
+
+  /** @internal See {@link WebGpuRetainedBatchReplayer._rebaseRetainedNodeIndices} (S3-D4: group-local indices). */
+  public _rebaseRetainedNodeIndices(bytes: Uint8Array, base: number): void {
+    const words = new Uint32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / Uint32Array.BYTES_PER_ELEMENT);
+
+    for (let i = 7; i < words.length; i += 8) {
+      // In-bounds: i < words.length via the loop guard.
+      words[i] = words[i]! - base;
+    }
+  }
+
   /**
    * Replay one recorded batch from its group-owned bundle into the OPEN pass
    * (Track B Slice 3, Task 10 / S3-D7). Reuses only recorded DATA (instance
@@ -878,7 +919,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
    * on the cached path do not fragment the single-submit frame (B-06).
    * @internal
    */
-  public _replayRecordedSpriteBatch(payload: WebGpuRetainedBatchPayload): void {
+  public _replayRetainedBatch(payload: WebGpuRetainedBatchPayload): void {
     const backend = this._backend;
     const device = this._device;
     const bundle = payload.bundle;
@@ -978,7 +1019,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> {
     backend.stats.drawCalls++;
   }
 
-  /** Scratch for the packed group matrix compared at replay (see `_replayRecordedSpriteBatch`). */
+  /** Scratch for the packed group matrix compared at replay (see `_replayRetainedBatch`). */
   private readonly _stagedReplayGroupData = new Float32Array(16);
 
   public destroy(): void {

--- a/test/rendering/browser/webgl2-repeating-sprite-retained.test.ts
+++ b/test/rendering/browser/webgl2-repeating-sprite-retained.test.ts
@@ -1,0 +1,407 @@
+/**
+ * WebGL2 renderer-matrix browser tests — RepeatingSprite retained instruction-
+ * set replay (Track B Slice 3 follow-up: extending the flush-level batch
+ * cache to RepeatingSprite).
+ *
+ * Only the GEOMETRY path (TextureRegion source) is recordable — its 32-byte
+ * instance layout matches the sprite/NineSlice batch shape exactly (node
+ * index at word 7 of the 8-word instance), so it shares the sprite renderer's
+ * group-owned bundle and replay seam. Cells:
+ *
+ * 1. tier byte-equality (collect / entry-replay-record / instruction-replay
+ *    all produce identical frames),
+ * 2. the load-bearing correctness gate this follow-up exists for: a scroll-
+ *    offset mutation AFTER a batch was recorded must never replay STALE
+ *    tiling — `RepeatingSprite.setOffset` marks geometry dirty and calls
+ *    `invalidateCache()`, which bumps the node's content revision and
+ *    propagates it through the `RetainedContainer` boundary, forcing a
+ *    recapture before the next replay,
+ * 3. a SHADER-path (bare Texture) RepeatingSprite inside a capture window
+ *    poisons it (`_supportsRetainedBatches` only covers the geometry path) —
+ *    the group must never reach the replay tier, staying pixel-correct on
+ *    the live entry-replay tier across mutations instead.
+ *
+ * Run via:  pnpm test:browser:webgl
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import type { RenderNode } from '#rendering/RenderNode';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { RepeatingSprite } from '#rendering/sprite/RepeatingSprite';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { TextureRegion } from '#rendering/texture/TextureRegion';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+
+// ---------------------------------------------------------------------------
+// Shader mocks — same convention as webgl2-retained-instruction-replay.test.ts:
+// the vitest shaderPlugin stubs every .vert/.frag import to "", but
+// WebGl2Backend#initialize connects the renderer registry eagerly, so the
+// Sprite/Mesh/Text shaders wireCoreRenderers() registers need valid GLSL even
+// though this file never renders Mesh/Text. RepeatingSprite's own GLSL is
+// authored inline in WebGl2RepeatingSpriteRenderer.ts (not an import), so it
+// needs no mock here.
+// ---------------------------------------------------------------------------
+
+const shaderSources = vi.hoisted(() => ({
+  spriteVert: `#version 300 es
+precision mediump float;
+in vec4 a_localBounds;
+in vec4 a_uvBounds;
+in vec4 a_color;
+in uint a_textureSlot;
+in uint a_nodeIndex;
+uniform mat3 u_projection;
+uniform mat3 u_group;
+uniform sampler2D u_transforms;
+out vec2 v_uv;
+out vec4 v_color;
+flat out uint v_textureSlot;
+void main() {
+  vec2 local;
+  if (gl_VertexID == 0) local = vec2(a_localBounds.x, a_localBounds.y);
+  else if (gl_VertexID == 1) local = vec2(a_localBounds.z, a_localBounds.y);
+  else if (gl_VertexID == 2) local = vec2(a_localBounds.x, a_localBounds.w);
+  else local = vec2(a_localBounds.z, a_localBounds.w);
+  vec2 uv;
+  if (gl_VertexID == 0) uv = vec2(a_uvBounds.x, a_uvBounds.y);
+  else if (gl_VertexID == 1) uv = vec2(a_uvBounds.z, a_uvBounds.y);
+  else if (gl_VertexID == 2) uv = vec2(a_uvBounds.x, a_uvBounds.w);
+  else uv = vec2(a_uvBounds.z, a_uvBounds.w);
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
+  vec3 clip = u_projection * u_group * vec3(world, 1.0);
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
+}`,
+
+  meshVert: `#version 300 es
+precision mediump float;
+in vec2 a_position;
+in vec2 a_texcoord;
+in vec4 a_color;
+in uint a_nodeIndex;
+uniform mat3 u_projection;
+uniform sampler2D u_transforms;
+out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
+void main() {
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  mat3 t = mat3(m0.x,m0.z,0.0, m0.y,m0.w,0.0, m1.x,m1.y,1.0);
+  vec3 world = t * vec3(a_position, 1.0);
+  vec3 clip = u_projection * world;
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = a_texcoord; v_color = a_color;
+  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+}`,
+
+  meshFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv; in vec4 v_color; in vec4 v_tint;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() { outColor = texture(u_texture, v_uv) * v_color * v_tint; }`,
+
+  textVert: `#version 300 es
+precision mediump float;
+layout(location = 0) in vec2 a_position;
+layout(location = 1) in vec2 a_texcoord;
+layout(location = 2) in float a_nodeIndex;
+uniform mat3 u_projection;
+uniform mat3 u_group;
+out vec2 v_uv;
+void main() {
+  float ni = a_nodeIndex;
+  vec3 clip = u_projection * u_group * vec3(a_position + vec2(ni * 0.0), 1.0);
+  gl_Position = vec4(clip.xy, 0.0, 1.0); v_uv = a_texcoord;
+}`,
+
+  textFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() { outColor = texture(u_texture, v_uv); }`,
+}));
+
+vi.mock('#rendering/webgl2/glsl/sprite.vert', () => ({ default: shaderSources.spriteVert }));
+vi.mock('#rendering/webgl2/glsl/sprite.frag', async () => ({ default: (await import('./_spriteFragMock')).createSpriteFragMockSource('v_uv') }));
+vi.mock('#rendering/webgl2/glsl/mesh.vert', () => ({ default: shaderSources.meshVert }));
+vi.mock('#rendering/webgl2/glsl/mesh.frag', () => ({ default: shaderSources.meshFrag }));
+vi.mock('#rendering/webgl2/glsl/text.vert', () => ({ default: shaderSources.textVert }));
+vi.mock('#rendering/webgl2/glsl/text-color.frag', () => ({ default: shaderSources.textFrag }));
+vi.mock('#rendering/webgl2/glsl/text-msdf.frag', () => ({ default: shaderSources.textFrag }));
+vi.mock('#rendering/webgl2/glsl/text-sdf.frag', () => ({ default: shaderSources.textFrag }));
+
+// ---------------------------------------------------------------------------
+// Infrastructure helpers
+// ---------------------------------------------------------------------------
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const createBackend = async (): Promise<WebGl2Backend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const app: Application = {
+    canvas,
+    options: {
+      clearColor: Color.black,
+      canvas: { width: canvasSize, height: canvasSize },
+      rendering: {
+        debug: false,
+        webglAttributes: {
+          alpha: false,
+          antialias: false,
+          premultipliedAlpha: false,
+          preserveDrawingBuffer: true,
+          stencil: false,
+          depth: false,
+        },
+        spriteRendererBatchSize: 1024,
+        particleRendererBatchSize: 1024,
+      },
+    },
+  } as unknown as Application;
+
+  const backend = new WebGl2Backend(app);
+
+  await backend.initialize();
+  wireCoreRenderers(backend, app.options.rendering);
+
+  return backend;
+};
+
+const render = (backend: WebGl2Backend, node: RenderNode): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+  node.render(backend);
+  backend.flush();
+};
+
+const readPixel = (backend: WebGl2Backend, x: number, y: number): RgbaTuple => {
+  const buf = new Uint8Array(4);
+  const gl = backend.context;
+
+  gl.readPixels(Math.floor(x), backend.renderTarget.height - Math.floor(y) - 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+
+  return [buf[0], buf[1], buf[2], buf[3]];
+};
+
+/** Full-framebuffer snapshot for byte-identical tier comparisons. */
+const readCanvas = (backend: WebGl2Backend): Uint8Array => {
+  const buf = new Uint8Array(canvasSize * canvasSize * 4);
+  const gl = backend.context;
+
+  gl.readPixels(0, 0, canvasSize, canvasSize, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+
+  return buf;
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 8): void => {
+  for (let i = 0; i < 4; i++) {
+    expect(Math.abs(actual[i] - expected[i])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+/** A 16x8 source: left half red (x 0..8), right half green (x 8..16). */
+const createStripedTexture = (): Texture => {
+  const src = document.createElement('canvas');
+
+  src.width = 16;
+  src.height = 8;
+
+  const ctx = src.getContext('2d')!;
+
+  ctx.fillStyle = '#ff0000';
+  ctx.fillRect(0, 0, 8, 8);
+  ctx.fillStyle = '#00ff00';
+  ctx.fillRect(8, 0, 8, 8);
+
+  return new Texture(src);
+};
+
+const createSolidTexture = (color: string, width = 16, height = 16): Texture => {
+  const src = document.createElement('canvas');
+
+  src.width = width;
+  src.height = height;
+
+  const ctx = src.getContext('2d')!;
+
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, width, height);
+
+  return new Texture(src);
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WebGL2 renderer matrix: RepeatingSprite retained instruction-set replay', () => {
+  test('cell 1 — geometry-path retained replay is byte-identical to the entry-replay and collect tiers', async () => {
+    const backend = await createBackend();
+    const blue = createSolidTexture('#0000ff');
+    const striped = createStripedTexture();
+    const region = new TextureRegion(striped, { x: 0, y: 0, width: 16, height: 8 });
+    const root = new Container();
+    const outside = new Sprite(blue);
+    const group = new RetainedContainer();
+    // destW == srcW (16) with modeX 'repeat' + fitX 'clip' => a SINGLE segment
+    // spanning the full destination, sampling the region's full UV range.
+    const repeating = new RepeatingSprite(region, { width: 16, height: 8, modeX: 'repeat', fitX: 'clip', modeY: 'stretch' });
+
+    outside.setPosition(48, 0);
+    root.addChild(outside);
+    group.addChild(repeating);
+    group.setPosition(8, 24);
+    root.addChild(group);
+
+    const replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+    try {
+      render(backend, root); // F1 — full collect + fragment capture
+
+      const collectFrame = readCanvas(backend);
+
+      expect(replaySpy).not.toHaveBeenCalled();
+      expectPixelNear(readPixel(backend, 12, 28), [255, 0, 0, 255]); // red half
+      expectPixelNear(readPixel(backend, 20, 28), [0, 255, 0, 255]); // green half
+
+      render(backend, root); // F2 — entry replay + instruction recording
+
+      const recordFrame = readCanvas(backend);
+
+      expect(replaySpy).not.toHaveBeenCalled();
+
+      render(backend, root); // F3 — instruction splice: recorded batch replays
+
+      const replayFrame = readCanvas(backend);
+
+      expect(replaySpy).toHaveBeenCalled();
+      expect(recordFrame).toEqual(collectFrame);
+      expect(replayFrame).toEqual(recordFrame);
+    } finally {
+      root.destroy();
+      blue.destroy();
+      striped.destroy();
+    }
+  });
+
+  test('cell 2 — a scroll-offset mutation after capture is never served STALE tiling by the replay tier', async () => {
+    const backend = await createBackend();
+    const blue = createSolidTexture('#0000ff');
+    const striped = createStripedTexture();
+    const region = new TextureRegion(striped, { x: 0, y: 0, width: 16, height: 8 });
+    const root = new Container();
+    const outside = new Sprite(blue);
+    const group = new RetainedContainer();
+    const repeating = new RepeatingSprite(region, { width: 16, height: 8, modeX: 'repeat', fitX: 'clip', modeY: 'stretch' });
+
+    outside.setPosition(48, 0);
+    root.addChild(outside);
+    group.addChild(repeating);
+    group.setPosition(8, 24);
+    root.addChild(group);
+
+    try {
+      render(backend, root); // F1 capture
+      render(backend, root); // F2 record
+      render(backend, root); // F3 splice — now on the fast tier
+
+      let replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+      render(backend, root); // steady replay before the mutation
+
+      expect(replaySpy).toHaveBeenCalled();
+      expectPixelNear(readPixel(backend, 12, 28), [255, 0, 0, 255]); // red half (dest 0..8)
+      expectPixelNear(readPixel(backend, 20, 28), [0, 255, 0, 255]); // green half (dest 8..16)
+
+      // Scroll by half the source width: 'repeat' wraps modulo srcLen, so the
+      // sampled window shifts by exactly half a period and the two halves
+      // SWAP. `setOffset` marks geometry dirty on this (geometry-path) sprite
+      // and calls `invalidateCache()`, which bumps the node's content revision
+      // and propagates it through the RetainedContainer boundary — the
+      // fragment's `isClean()` check must fail on the next collect, forcing a
+      // recapture instead of replaying the OLD (pre-swap) cached bytes.
+      repeating.setOffset(8, 0);
+      render(backend, root); // dirty collect (content revision changed)
+      render(backend, root); // recapture with the new bytes
+      render(backend, root); // splice of the fresh recording
+
+      replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+      render(backend, root); // steady replay AFTER the mutation
+
+      expect(replaySpy).toHaveBeenCalled(); // still on the fast tier — recaptured, not abandoned
+      // If the replay served the STALE pre-offset bytes, these two assertions
+      // would read the OLD (unswapped) colors instead.
+      expectPixelNear(readPixel(backend, 12, 28), [0, 255, 0, 255]); // now green (was red)
+      expectPixelNear(readPixel(backend, 20, 28), [255, 0, 0, 255]); // now red (was green)
+      expectPixelNear(readPixel(backend, 52, 8), [0, 0, 255, 255]); // live sibling unaffected
+    } finally {
+      root.destroy();
+      blue.destroy();
+      striped.destroy();
+    }
+  });
+
+  test('cell 3 — a shader-path RepeatingSprite inside a capture window poisons it: never reaches the replay tier, stays pixel-correct on live entry-replay across mutations', async () => {
+    const backend = await createBackend();
+    const blue = createSolidTexture('#0000ff');
+    const striped = createStripedTexture(); // bare Texture source -> shader path
+    const root = new Container();
+    const outside = new Sprite(blue);
+    const group = new RetainedContainer();
+    const repeating = new RepeatingSprite(striped, { width: 16, height: 8, modeX: 'repeat', fitX: 'clip', modeY: 'stretch' });
+
+    outside.setPosition(48, 0);
+    root.addChild(outside);
+    group.addChild(repeating);
+    group.setPosition(8, 24);
+    root.addChild(group);
+
+    const replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+    try {
+      // Render many frames, including a scroll mutation — the shader path
+      // never records/replays a batch (S3-D5.1: _supportsRetainedBatches only
+      // covers the geometry path here), so the group must stay correct via
+      // the (poisoned, permanently-entry-replay) live path the whole time.
+      for (let i = 0; i < 4; i++) {
+        render(backend, root);
+      }
+
+      expectPixelNear(readPixel(backend, 12, 28), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(backend, 20, 28), [0, 255, 0, 255]);
+
+      repeating.setOffset(8, 0);
+
+      for (let i = 0; i < 4; i++) {
+        render(backend, root);
+      }
+
+      expectPixelNear(readPixel(backend, 12, 28), [0, 255, 0, 255]);
+      expectPixelNear(readPixel(backend, 20, 28), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(backend, 52, 8), [0, 0, 255, 255]);
+
+      expect(replaySpy).not.toHaveBeenCalled();
+    } finally {
+      root.destroy();
+      blue.destroy();
+      striped.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgpu-repeating-sprite-retained.test.ts
+++ b/test/rendering/browser/webgpu-repeating-sprite-retained.test.ts
@@ -1,0 +1,321 @@
+/**
+ * WebGPU renderer-matrix browser tests — RepeatingSprite retained instruction-
+ * set replay (Track B Slice 3 follow-up: extending the flush-level batch
+ * cache to RepeatingSprite).
+ *
+ * Only the GEOMETRY path (TextureRegion source) is recordable — its 32-byte
+ * instance layout matches the sprite batch shape exactly (node index at word
+ * 7 of the 8-word instance), so it shares the sprite renderer's group-owned
+ * bundle and replay seam. Cells:
+ *
+ * 1. tier equality (collect / entry-replay-record / instruction-replay all
+ *    produce the same pixels),
+ * 2. the load-bearing correctness gate this follow-up exists for: a scroll-
+ *    offset mutation AFTER a batch was recorded must never replay STALE
+ *    tiling — `RepeatingSprite.setOffset` marks geometry dirty and calls
+ *    `invalidateCache()`, which bumps the node's content revision and
+ *    propagates it through the `RetainedContainer` boundary, forcing a
+ *    recapture before the next replay,
+ * 3. a SHADER-path (bare Texture) RepeatingSprite inside a capture window
+ *    poisons it (`_supportsRetainedBatches` only covers the geometry path) —
+ *    the group must never reach the replay tier, staying pixel-correct on
+ *    the live entry-replay tier across mutations instead.
+ *
+ * CI guarantees a real WebGPU adapter; tests only skip when the software
+ * adapter drops the device mid-test (same convention as the other WebGPU
+ * browser specs).
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import type { RenderNode } from '#rendering/RenderNode';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { RepeatingSprite } from '#rendering/sprite/RepeatingSprite';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { TextureRegion } from '#rendering/texture/TextureRegion';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+import { getBackendDevice } from './webgpu-test-helpers';
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: {
+      canvas: { width: canvasSize, height: canvasSize },
+      clearColor: Color.black,
+    },
+  }) as unknown as Application;
+
+const setupBackend = async (): Promise<WebGpuBackend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  wireCoreRenderers(backend);
+  await backend.initialize();
+
+  return backend;
+};
+
+/** A 16x8 source: left half red (x 0..8), right half green (x 8..16). */
+const createStripedTexture = (): Texture => {
+  const source = document.createElement('canvas');
+
+  source.width = 16;
+  source.height = 8;
+
+  const context = source.getContext('2d')!;
+
+  context.fillStyle = '#ff0000';
+  context.fillRect(0, 0, 8, 8);
+  context.fillStyle = '#00ff00';
+  context.fillRect(8, 0, 8, 8);
+
+  return new Texture(source);
+};
+
+const createSolidTexture = (color: string, size = 8): Texture => {
+  const source = document.createElement('canvas');
+
+  source.width = size;
+  source.height = size;
+
+  const context = source.getContext('2d');
+
+  if (!context) {
+    throw new Error('2D context is required to create test textures.');
+  }
+
+  context.fillStyle = color;
+  context.fillRect(0, 0, size, size);
+
+  return new Texture(source);
+};
+
+const readCanvas = (backend: WebGpuBackend): ((x: number, y: number) => RgbaTuple) => {
+  const source = backend.context.canvas as HTMLCanvasElement;
+  const readback = document.createElement('canvas');
+
+  readback.width = canvasSize;
+  readback.height = canvasSize;
+
+  const ctx = readback.getContext('2d');
+
+  if (!ctx) {
+    throw new Error('2D context is required for canvas readback.');
+  }
+
+  ctx.drawImage(source, 0, 0);
+
+  return (x: number, y: number): RgbaTuple => {
+    const { data } = ctx.getImageData(Math.floor(x), Math.floor(y), 1, 1);
+
+    return [data[0], data[1], data[2], data[3]];
+  };
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 12): void => {
+  for (let index = 0; index < 4; index++) {
+    expect(Math.abs(actual[index] - expected[index])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+// Render a frame through the real plan path inside a validation error scope.
+// Returns false when the device dropped mid-test (the caller should bail).
+const renderScene = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
+  const device = getBackendDevice(backend);
+
+  device.pushErrorScope('validation');
+
+  let validationError: GPUError | null;
+
+  try {
+    backend.resetStats();
+    backend.clear(Color.black);
+    root.render(backend);
+    backend.flush();
+    validationError = await device.popErrorScope();
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+
+  expect(validationError).toBeNull();
+
+  return true;
+};
+
+describe('WebGPU renderer matrix: RepeatingSprite retained instruction-set replay', () => {
+  test('cell 1 — geometry-path retained replay reproduces the entry-replay/record tier pixels', async ctx => {
+    const backend = await setupBackend();
+    const blue = createSolidTexture('#0000ff', 16); // 16x16 so (52,8) safely samples inside its 48..64 x 0..16 bounds
+    const striped = createStripedTexture();
+    const region = new TextureRegion(striped, { x: 0, y: 0, width: 16, height: 8 });
+    const root = new Container();
+    const outside = new Sprite(blue);
+    const group = new RetainedContainer();
+    const repeating = new RepeatingSprite(region, { width: 16, height: 8, modeX: 'repeat', fitX: 'clip', modeY: 'stretch' });
+
+    outside.setPosition(48, 0);
+    root.addChild(outside);
+    group.addChild(repeating);
+    group.setPosition(8, 24);
+    root.addChild(group);
+
+    try {
+      if (!(await renderScene(ctx, backend, root))) return; // F1 dirty collect + capture
+      if (!(await renderScene(ctx, backend, root))) return; // F2 entry replay + record
+
+      let readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(12, 28), [255, 0, 0, 255]); // red half
+      expectPixelNear(readPixel(20, 28), [0, 255, 0, 255]); // green half
+
+      const replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+      if (!(await renderScene(ctx, backend, root))) return; // F3 instruction splice
+
+      expect(replaySpy).toHaveBeenCalled();
+      readPixel = readCanvas(backend);
+      expectPixelNear(readPixel(12, 28), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(20, 28), [0, 255, 0, 255]);
+    } finally {
+      root.destroy();
+      blue.destroy();
+      striped.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 2 — a scroll-offset mutation after capture is never served STALE tiling by the replay tier', async ctx => {
+    const backend = await setupBackend();
+    const blue = createSolidTexture('#0000ff', 16); // 16x16 so (52,8) safely samples inside its 48..64 x 0..16 bounds
+    const striped = createStripedTexture();
+    const region = new TextureRegion(striped, { x: 0, y: 0, width: 16, height: 8 });
+    const root = new Container();
+    const outside = new Sprite(blue);
+    const group = new RetainedContainer();
+    const repeating = new RepeatingSprite(region, { width: 16, height: 8, modeX: 'repeat', fitX: 'clip', modeY: 'stretch' });
+
+    outside.setPosition(48, 0);
+    root.addChild(outside);
+    group.addChild(repeating);
+    group.setPosition(8, 24);
+    root.addChild(group);
+
+    try {
+      if (!(await renderScene(ctx, backend, root))) return; // F1 capture
+      if (!(await renderScene(ctx, backend, root))) return; // F2 record
+      if (!(await renderScene(ctx, backend, root))) return; // F3 splice — fast tier
+
+      let replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+      if (!(await renderScene(ctx, backend, root))) return; // steady replay before mutation
+
+      expect(replaySpy).toHaveBeenCalled();
+      let readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(12, 28), [255, 0, 0, 255]); // red half (dest 0..8)
+      expectPixelNear(readPixel(20, 28), [0, 255, 0, 255]); // green half (dest 8..16)
+
+      // Scroll by half the source width: 'repeat' wraps modulo srcLen, so the
+      // sampled window shifts half a period and the two halves SWAP.
+      // `setOffset` marks geometry dirty and calls `invalidateCache()`, which
+      // bumps the node's content revision and propagates it through the
+      // RetainedContainer boundary — the fragment must recapture rather than
+      // replay the OLD (pre-swap) cached bytes.
+      repeating.setOffset(8, 0);
+
+      if (!(await renderScene(ctx, backend, root))) return; // dirty collect (content revision changed)
+      if (!(await renderScene(ctx, backend, root))) return; // recapture with the new bytes
+      if (!(await renderScene(ctx, backend, root))) return; // splice of the fresh recording
+
+      replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+      if (!(await renderScene(ctx, backend, root))) return; // steady replay AFTER the mutation
+
+      expect(replaySpy).toHaveBeenCalled(); // still on the fast tier — recaptured, not abandoned
+      readPixel = readCanvas(backend);
+      // If the replay served the STALE pre-offset bytes, these two assertions
+      // would read the OLD (unswapped) colors instead.
+      expectPixelNear(readPixel(12, 28), [0, 255, 0, 255]); // now green (was red)
+      expectPixelNear(readPixel(20, 28), [255, 0, 0, 255]); // now red (was green)
+      expectPixelNear(readPixel(52, 8), [0, 0, 255, 255]); // live sibling unaffected
+    } finally {
+      root.destroy();
+      blue.destroy();
+      striped.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 3 — a shader-path RepeatingSprite inside a capture window poisons it: never reaches the replay tier, stays pixel-correct on live entry-replay across mutations', async ctx => {
+    const backend = await setupBackend();
+    const blue = createSolidTexture('#0000ff', 16); // 16x16 so (52,8) safely samples inside its 48..64 x 0..16 bounds
+    const striped = createStripedTexture(); // bare Texture source -> shader path
+    const root = new Container();
+    const outside = new Sprite(blue);
+    const group = new RetainedContainer();
+    const repeating = new RepeatingSprite(striped, { width: 16, height: 8, modeX: 'repeat', fitX: 'clip', modeY: 'stretch' });
+
+    outside.setPosition(48, 0);
+    root.addChild(outside);
+    group.addChild(repeating);
+    group.setPosition(8, 24);
+    root.addChild(group);
+
+    const replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+    try {
+      // Several frames, including a scroll mutation — the shader path never
+      // records/replays a batch (S3-D5.1: _supportsRetainedBatches only
+      // covers the geometry path here), so the group must stay correct via
+      // the (poisoned, permanently-entry-replay) live path the whole time.
+      for (let i = 0; i < 4; i++) {
+        if (!(await renderScene(ctx, backend, root))) return;
+      }
+
+      let readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(12, 28), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(20, 28), [0, 255, 0, 255]);
+
+      repeating.setOffset(8, 0);
+
+      for (let i = 0; i < 4; i++) {
+        if (!(await renderScene(ctx, backend, root))) return;
+      }
+
+      readPixel = readCanvas(backend);
+      expectPixelNear(readPixel(12, 28), [0, 255, 0, 255]);
+      expectPixelNear(readPixel(20, 28), [255, 0, 0, 255]);
+      expectPixelNear(readPixel(52, 8), [0, 0, 255, 255]);
+
+      expect(replaySpy).not.toHaveBeenCalled();
+    } finally {
+      root.destroy();
+      blue.destroy();
+      striped.destroy();
+      backend.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds retained-batch record/replay support (Track B Slice 3) to the RepeatingSprite renderer's geometry path (TextureRegion source) on both WebGL2 and WebGPU, mirroring the Sprite renderer's seam.
- RepeatingSprite has two internal draw paths sharing one flush loop: a geometry path (fits the sprite-shaped seam as-is) and a shader path (bare Texture source, different stride + wrap-mode sampler, needs a seam extension). Only the geometry path is recorded; any capture containing a shader-path or pixel-snapped draw is poisoned and cleanly falls back to the existing entry-replay tier — no regression, no stale pixels, same defensive pattern the sprite renderers use for custom materials.
- Confirmed tiling mutations (offset/mode/fit/size setters) all call `invalidateCache()` → `_markContentDirty()`, so a recorded instruction set correctly invalidates before any tiling change could replay stale — verified with a dedicated mutation-proof test.

## Test plan
- [x] Existing suites unmodified: WebGL2 31/31, WebGPU 29/29 pass
- [x] New tests: `webgl2-repeating-sprite-retained.test.ts` (3/3), `webgpu-repeating-sprite-retained.test.ts` (3/3) — byte/pixel equality, tiling-offset-after-capture mutation-proof cell, shader-path-poisons-capture cell
- [x] `tsc --noEmit`, `eslint` clean