### PR TITLE
feat(rendering): retained-batch record/replay for the Mesh renderer

### DIFF
--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -44,6 +44,7 @@ import {
   type WebGl2RecordedTextureState,
   type WebGl2RetainedBatchPayload,
   type WebGl2RetainedBatchReplayer,
+  type WebGl2RetainedGeometryRef,
   WebGl2RetainedGroupResources,
   type WebGl2RetainedNodeIndexRange,
 } from './WebGl2RetainedGroupResources';
@@ -1219,6 +1220,7 @@ export class WebGl2Backend implements RenderBackend {
     blendMode: BlendModes,
     textures: ReadonlyArray<Texture | RenderTexture | null>,
     textureCount: number,
+    geometry: WebGl2RetainedGeometryRef | null = null,
   ): void {
     const captures = this._retainedCaptures;
 
@@ -1251,6 +1253,7 @@ export class WebGl2Backend implements RenderBackend {
       recordedTextureState,
       instanceCount,
       byteOffset,
+      geometry,
       vao: null,
     };
 

--- a/src/rendering/webgl2/WebGl2MeshRenderer.ts
+++ b/src/rendering/webgl2/WebGl2MeshRenderer.ts
@@ -13,6 +13,7 @@ import fragmentSource from './glsl/mesh.frag';
 import vertexSource from './glsl/mesh.vert';
 import type { WebGl2Backend } from './WebGl2Backend';
 import { WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
+import type { WebGl2RetainedBatchPayload, WebGl2RetainedBatchReplayer, WebGl2RetainedNodeIndexRange } from './WebGl2RetainedGroupResources';
 import { createWebGl2ShaderProgram } from './WebGl2ShaderProgram';
 import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './WebGl2VertexArrayObject';
 
@@ -63,7 +64,18 @@ interface StaticGeometryCacheEntry {
   indexCount: number;
 }
 
-export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> {
+export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> implements WebGl2RetainedBatchReplayer {
+  /**
+   * Retained-batch opt-in (Track B Slice 3, S3-D5.1): the default-path static
+   * instanced draw ({@link _drawStaticBatch}) is a flush-level batch the group
+   * recorder can capture and replay. Custom-material and dynamic-geometry
+   * meshes never take that path — they poison any open capture instead (see
+   * {@link _drawDynamicInstancedSingle}) so the group degrades to entry replay.
+   */
+  public readonly _supportsRetainedBatches = true;
+  /** Reusable single-slot texture list handed to the recorder (avoids a per-batch array). */
+  private readonly _retainedTextureScratch: [Texture | RenderTexture] = [Texture.white];
+
   private readonly _defaultShader: Shader = new Shader(vertexSource, fragmentSource);
   private readonly _customShaders = new Map<Material, Shader>();
   private readonly _compatibilityCache = new Map<Shader, boolean>();
@@ -341,6 +353,16 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> {
   }
 
   private _drawDynamicInstancedSingle(draw: PendingMeshDraw, backend: WebGl2Backend, connection: MeshRendererConnection): void {
+    // A dynamic-geometry (non-static) mesh cannot be recorded — its geometry
+    // is not the shared, persistent buffer a retained batch references. The
+    // recordability predicate (S3-D5) admits it (material === null, snap none),
+    // so poison any open capture: the group's set never validates and it stays
+    // on the correct entry-replay tier. Belt-and-braces, mirroring the sprite
+    // renderer's custom-material poison.
+    if (backend._isRetainedCapturing) {
+      backend._poisonRetainedCaptures();
+    }
+
     const nodeIndex = draw.command?.nodeIndex ?? 0;
 
     if (draw.command === null) {
@@ -415,6 +437,17 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> {
 
     backend.stats.batches++;
     backend.stats.drawCalls++;
+
+    // Retained recording (Track B Slice 3, mesh opt-in): while a capture window
+    // is open, hand this flush's per-instance node-index stream and a reference
+    // to the SHARED, persistent geometry to the backend. The geometry
+    // (vertex+index buffers) is NOT copied into the group bundle — only the
+    // node-index words are group-owned. `cacheEntry` is structurally a
+    // WebGl2RetainedGeometryRef (vertexBuffer/indexBuffer/indexCount).
+    if (backend._isRetainedCapturing) {
+      this._retainedTextureScratch[0] = first.texture;
+      backend._recordRetainedBatch(this, this._nodeIndexData.subarray(0, count), count, first.blendMode, this._retainedTextureScratch, 1, cacheEntry);
+    }
   }
 
   private _drawLegacyImmediate(draw: PendingMeshDraw, backend: WebGl2Backend, connection: MeshRendererConnection): void {
@@ -505,6 +538,134 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> {
     }
 
     shader.sync();
+  }
+
+  // ── Retained-batch record/replay (Track B Slice 3, mesh opt-in) ──────────
+  // Mesh's recordable draw is an INDEXED instanced draw: shared per-Geometry
+  // vertex+index buffers (referenced via `payload.geometry`, never copied into
+  // the group bundle) plus a group-owned per-instance node-index stream (one
+  // u32/instance in the bundle instance buffer). Only the node-index words are
+  // group-local, so the layout-aware scan/rebase read word 0 of each 1-word
+  // instance — the mesh counterpart of the sprite's word-7-of-8 layout.
+
+  /** @internal See {@link WebGl2RetainedBatchReplayer._scanRetainedNodeIndexRange}. */
+  public _scanRetainedNodeIndexRange(payload: WebGl2RetainedBatchPayload, range: WebGl2RetainedNodeIndexRange): void {
+    const words = payload.bundle.instanceWords;
+    const start = payload.byteOffset / Uint32Array.BYTES_PER_ELEMENT;
+
+    for (let i = 0; i < payload.instanceCount; i++) {
+      // In-bounds: the payload's node-index words were appended to the store.
+      const node = words[start + i]!;
+
+      if (node < range.min) {
+        range.min = node;
+      }
+
+      if (node > range.max) {
+        range.max = node;
+      }
+    }
+  }
+
+  /** @internal See {@link WebGl2RetainedBatchReplayer._rebaseRetainedNodeIndices} (S3-D4: group-local indices). */
+  public _rebaseRetainedNodeIndices(payload: WebGl2RetainedBatchPayload, base: number): void {
+    const words = payload.bundle.instanceWords;
+    const start = payload.byteOffset / Uint32Array.BYTES_PER_ELEMENT;
+
+    for (let i = 0; i < payload.instanceCount; i++) {
+      const index = start + i;
+
+      // In-bounds: see the scan above.
+      words[index] = (words[index]! - base) >>> 0;
+    }
+  }
+
+  /**
+   * Wire the batch VAO: per-vertex geometry attributes from the SHARED,
+   * persistent geometry buffers ({@link WebGl2RetainedBatchPayload.geometry}),
+   * that geometry's index buffer, and the per-instance node-index attribute
+   * from the group bundle's instance buffer based at `payload.byteOffset`
+   * (WebGL2 has no baseInstance). Same attribute set/locations as the live
+   * static-batch VAO in {@link _getOrCreateStaticGeometryVao}.
+   * @internal
+   */
+  public _configureRetainedVao(payload: WebGl2RetainedBatchPayload): void {
+    const gl = this.getBackend().context;
+    const geometry = payload.geometry;
+    const instanceBuffer = payload.bundle.instanceBuffer;
+    const vao = payload.vao;
+
+    if (geometry === null || geometry === undefined || instanceBuffer === null || vao === null) {
+      throw new Error('WebGl2MeshRenderer: retained batch VAO configuration requires geometry and an uploaded bundle.');
+    }
+
+    const shader = this._defaultShader;
+
+    vao
+      .addIndex(geometry.indexBuffer)
+      .addAttribute(geometry.vertexBuffer, shader.getAttribute('a_position'), gl.FLOAT, false, vertexStrideBytes, 0)
+      .addAttribute(geometry.vertexBuffer, shader.getAttribute('a_texcoord'), gl.FLOAT, false, vertexStrideBytes, 8)
+      .addAttribute(geometry.vertexBuffer, shader.getAttribute('a_color'), gl.UNSIGNED_BYTE, true, vertexStrideBytes, 16)
+      .addAttribute(instanceBuffer, shader.getAttribute('a_nodeIndex'), gl.UNSIGNED_INT, false, Uint32Array.BYTES_PER_ELEMENT, payload.byteOffset, true, 1);
+  }
+
+  /**
+   * Replay one recorded default-path mesh batch: all STATE is resolved live —
+   * blend mode, `u_projection` from the live view, `u_group` from the live
+   * composed group matrix (the camera-pan / group-move win), the texture — and
+   * only DATA is cached: the SHARED geometry (vertex+index buffers), the
+   * group-owned node-index stream (through the per-batch VAO), and the
+   * group-owned transform texture on the shared transform unit. Drawn indexed
+   * (`drawElementsInstanced`), unlike the sprite path's `drawArraysInstanced`.
+   * @internal
+   */
+  public _replayRetainedBatch(payload: WebGl2RetainedBatchPayload): void {
+    const backend = this.getBackendOrNull();
+    const vao = payload.vao;
+    const geometry = payload.geometry;
+    const transformTexture = payload.bundle.transformTexture;
+
+    if (backend === null || vao === null || geometry === null || geometry === undefined || transformTexture === null) {
+      // Defensive: a bundle in this state never validates (generation), so a
+      // spliced replay cannot reach here; skip rather than crash mid-frame.
+      return;
+    }
+
+    const shader = this._defaultShader;
+
+    // Keep this renderer's blend tracking in sync, then apply unconditionally
+    // (another renderer may have changed the GL blend state between batches).
+    if (payload.blendMode !== this._currentBlendMode) {
+      this._currentBlendMode = payload.blendMode;
+    }
+
+    backend.setBlendMode(payload.blendMode);
+
+    if (shader.uniforms.has('u_projection')) {
+      shader.getUniform('u_projection').setValue(backend.view.getTransform().toArray(false));
+    }
+
+    if (shader.uniforms.has('u_group')) {
+      const groupTransform = backend.renderGroupTransform;
+
+      shader.getUniform('u_group').setValue(groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3);
+    }
+
+    if (shader.uniforms.has('u_texture')) {
+      shader.getUniform('u_texture').setValue(this._textureUnitScratch);
+      // In-bounds: mesh batches record exactly one texture slot.
+      backend.bindTexture(payload.textures[0]!, 0);
+    }
+
+    backend.bindTexture(transformTexture, transformTextureUnit);
+
+    if (shader.uniforms.has('u_transforms')) {
+      shader.getUniform('u_transforms').setValue(this._transformUnitScratch);
+    }
+
+    shader.sync();
+    backend.bindVertexArrayObject(vao);
+    vao.drawInstanced(geometry.indexCount, 0, payload.instanceCount, RenderingPrimitives.Triangles);
   }
 
   private _canBatchStatic(draw: PendingMeshDraw): boolean {

--- a/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
+++ b/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
@@ -43,6 +43,24 @@ export interface WebGl2RecordedTextureState {
 }
 
 /**
+ * Reference to the renderer-owned, persistent, SHARED geometry an indexed
+ * retained batch draws (Track B Slice 3 mesh opt-in). The vertex + index
+ * buffers live in the recording renderer's own long-lived cache (the mesh
+ * renderer's `_staticGeometryCache`, uploaded once per `Geometry`, shared
+ * across frames/groups); the group bundle stores only the thin per-instance
+ * node-index stream, never the geometry bytes. Absent (`geometry` omitted /
+ * `null`) for the self-contained instance-stream renderers (sprite / nine-
+ * slice / repeating), whose batch VAO carries no index buffer and draws with
+ * `drawArraysInstanced` — the existing path, unchanged.
+ * @internal
+ */
+export interface WebGl2RetainedGeometryRef {
+  readonly vertexBuffer: WebGl2RenderBuffer;
+  readonly indexBuffer: WebGl2RenderBuffer;
+  readonly indexCount: number;
+}
+
+/**
  * Backend-side replay descriptor for one recorded sprite flush (S3-D1). This
  * is the opaque `payload` carried by a plan-level `RetainedBatchInstruction`:
  * everything the owning renderer needs to re-issue the batch from group-owned
@@ -65,6 +83,14 @@ export interface WebGl2RetainedBatchPayload {
   readonly instanceCount: number;
   /** Byte offset of this batch's instance data inside the bundle's instance buffer. */
   readonly byteOffset: number;
+  /**
+   * Shared, persistent geometry for an INDEXED batch (mesh opt-in): the
+   * renderer-owned vertex + index buffers this batch's node-index stream
+   * instances. `null`/absent for the self-contained instance-stream renderers
+   * (sprite / nine-slice / repeating), whose VAO carries no index buffer and
+   * replays with `drawArraysInstanced` over four strip vertices.
+   */
+  readonly geometry?: WebGl2RetainedGeometryRef | null;
   /**
    * Per-batch VAO with attribute pointers pre-based at {@link byteOffset}
    * (WebGL2 has no baseInstance). Assigned at capture end; `null` only for a
@@ -438,17 +464,31 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
             gl.vertexAttribDivisor(attribute.location, attribute.divisor);
           }
 
+          // Indexed batches (mesh opt-in) carry an index buffer; capturing its
+          // ELEMENT_ARRAY_BUFFER binding into this VAO is what lets replay use
+          // drawElementsInstanced. Sprite/nine-slice/repeating VAOs have no
+          // index buffer, so this is a no-op for them (drawArrays path).
+          vao.indexBuffer?.bind();
+
           appliedVersion = vao.version;
         }
       },
       unbind: (): void => {
         gl.bindVertexArray(null);
       },
-      draw: (_vao, size, start, type): void => {
-        gl.drawArrays(type, start, size);
+      draw: (vao, size, start, type): void => {
+        if (vao.indexBuffer !== null) {
+          gl.drawElements(type, size, gl.UNSIGNED_SHORT, start);
+        } else {
+          gl.drawArrays(type, start, size);
+        }
       },
-      drawInstanced: (_vao, count, start, instanceCount, type): void => {
-        gl.drawArraysInstanced(type, start, count, instanceCount);
+      drawInstanced: (vao, count, start, instanceCount, type): void => {
+        if (vao.indexBuffer !== null) {
+          gl.drawElementsInstanced(type, count, gl.UNSIGNED_SHORT, start, instanceCount);
+        } else {
+          gl.drawArraysInstanced(type, start, count, instanceCount);
+        }
       },
       destroy: (vao): void => {
         gl.deleteVertexArray(handle);

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -46,6 +46,7 @@ import {
   type WebGpuRetainedBatchPayload,
   type WebGpuRetainedBatchReplayer,
   WebGpuRetainedCaptureFrame,
+  type WebGpuRetainedGeometryRef,
   WebGpuRetainedGroupBundle,
   type WebGpuRetainedNodeIndexRange,
 } from './WebGpuRetainedGroupResources';
@@ -1266,6 +1267,7 @@ export class WebGpuBackend implements RenderBackend {
     blendMode: BlendModes,
     textures: ReadonlyArray<Texture | RenderTexture | null>,
     slotCount: number,
+    geometry: WebGpuRetainedGeometryRef | null = null,
   ): void {
     const frames = this._retainedCaptureFrames;
 
@@ -1315,6 +1317,10 @@ export class WebGpuBackend implements RenderBackend {
       byteOffset: owner.totalBytes,
       instanceCount,
       blendMode,
+      geometry,
+      // This batch's ordinal within the owning bundle — the group-owned UBO
+      // slot an indexed replayer writes with dynamic offset (sprite ignores it).
+      batchIndexInBundle: owner.staged.length,
       textures: textureList,
       recordedViews,
     };

--- a/src/rendering/webgpu/WebGpuMeshRenderer.ts
+++ b/src/rendering/webgpu/WebGpuMeshRenderer.ts
@@ -10,10 +10,19 @@ import type { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { Texture } from '#rendering/texture/Texture';
 import { Texture as TextureClass } from '#rendering/texture/Texture';
 import { BlendModes } from '#rendering/types';
+import type { View } from '#rendering/View';
 
 import { AbstractWebGpuRenderer } from './AbstractWebGpuRenderer';
 import type { WebGpuBackend } from './WebGpuBackend';
 import { getWebGpuBlendState } from './WebGpuBlendState';
+import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
+import type {
+  WebGpuRetainedBatchPayload,
+  WebGpuRetainedBatchReplayer,
+  WebGpuRetainedGroupBundle,
+  WebGpuRetainedNodeIndexRange,
+  WebGpuRetainedRendererReplayState,
+} from './WebGpuRetainedGroupResources';
 import { stencilContentDepthStencilState } from './WebGpuStencilState';
 import {
   collectScalarUniforms,
@@ -244,7 +253,53 @@ interface CustomShaderResources {
 const meshUniformAlignment = 256;
 const maxCustomTextureSlots = 7; // user texture uniforms; group 2 binding 1..N
 
-export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
+/**
+ * Per-bundle mesh replay state (Track B Slice 3 mesh opt-in, option (a)). Parked
+ * on the group bundle's {@link WebGpuRetainedGroupBundle.rendererReplayState} so
+ * it shares the bundle's grow-only / explicitly-freed lifecycle. Holds the mesh
+ * group(0) `TransformUniforms` UBO (one dynamic-offset slot per recorded batch,
+ * because the per-batch premultiply flag differs) + its bind group, plus the
+ * same-frame double-replay hazard trackers as the bundle's own sprite UBO.
+ * @internal
+ */
+class MeshRetainedReplayState implements WebGpuRetainedRendererReplayState {
+  public uniformBuffer: GPUBuffer | null = null;
+  public uniformSlotCapacity = 0;
+  public bindGroup: GPUBindGroup | null = null;
+  public bindGroupUniform: GPUBuffer | null = null;
+  public bindGroupTransform: GPUBuffer | null = null;
+  // The (view, updateId) the currently-written slots were projected for; a
+  // change while this bundle's draws sit in the open pass is the RT+main
+  // double-replay hazard and ends the pass first (mirrors the sprite UBO guard).
+  public uboView: View | null = null;
+  public uboViewUpdateId = -1;
+  public drawsInPass: WebGpuActiveRenderPass | null = null;
+
+  public destroy(): void {
+    this.uniformBuffer?.destroy();
+    this.uniformBuffer = null;
+    this.uniformSlotCapacity = 0;
+    this.bindGroup = null;
+    this.bindGroupUniform = null;
+    this.bindGroupTransform = null;
+    this.uboView = null;
+    this.uboViewUpdateId = -1;
+    this.drawsInPass = null;
+  }
+}
+
+export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements WebGpuRetainedBatchReplayer {
+  /**
+   * Retained-batch opt-in (Track B Slice 3, S3-D5.1): the default static
+   * INSTANCED draw (runs of ≥2 same-geometry meshes) is a recordable
+   * flush-level batch. Single meshes take the CPU-baked default path (view
+   * baked into vertices — uncacheable) and custom-material meshes their own
+   * path; both poison any open capture so the group degrades to entry replay.
+   */
+  public readonly _supportsRetainedBatches = true;
+  /** Reusable single-slot texture list handed to the recorder (avoids a per-batch array). */
+  private readonly _retainedTextureScratch: [Texture | RenderTexture] = [TextureClass.white];
+
   private readonly _combinedTransform: Matrix = new Matrix();
   private readonly _drawCalls: MeshDrawCall[] = [];
   private readonly _pipelines = new Map<string, GPURenderPipeline>();
@@ -271,6 +326,14 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
   private _instancedNodeIndexBuffer: GPUBuffer | null = null;
   private _instancedNodeIndexBufferCapacity = 0;
   private _instancedNodeIndexData: Uint32Array = new Uint32Array(0);
+  // Per-frame write cursor into the shared node-index buffer (bytes). Multiple
+  // instanced batches in one flush go into ONE submit, so each MUST occupy a
+  // DISTINCT sub-range — writing them all at offset 0 aliases: the first
+  // batch's draw would read the last batch's node indices at submit time.
+  // Reset at the start of each flush; `_instancedNodeIndexByteOffset` holds the
+  // offset the most recent upload wrote at (for the draw + retained record).
+  private _instancedNodeIndexFrameBytes = 0;
+  private _instancedNodeIndexByteOffset = 0;
   private _instancedTransformBindGroup: GPUBindGroup | null = null;
   private _instancedTransformStorageBuffer: GPUBuffer | null = null;
   private _uniformAlignment = 256;
@@ -473,6 +536,12 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
     const defaultDrawCalls = this._drawCallCount - this._totalCustomDraws();
     this._ensureUniformCapacity(defaultDrawCalls);
     this._ensureInstancedUniformCapacity(this._drawCallCount);
+    // Every instanced batch this frame gets a distinct node-index sub-range;
+    // size the buffer to the frame total upfront (an upper bound — not every
+    // draw is instanced) so no mid-loop realloc invalidates a written range,
+    // and reset the per-frame write cursor.
+    this._ensureInstancedNodeIndexCapacity(this._drawCallCount);
+    this._instancedNodeIndexFrameBytes = 0;
 
     // Phase 3: pack default-path vertex/index/uniform data.
     const defaultUniformBytes = defaultDrawCalls * this._uniformAlignment;
@@ -627,6 +696,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
           }
 
           const maxNodeIndex = this._uploadInstancedNodeIndices(i, batchLength);
+          const nodeIndexByteOffset = this._instancedNodeIndexByteOffset;
           const storage = backend.getTransformStorageBuffer(maxNodeIndex + 1);
 
           this._writeInstancedUniformSlot(instancedDrawCursor, backend, dc.premultiplySample);
@@ -645,12 +715,33 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
           }
 
           pass.setVertexBuffer(0, staticGeometry.vertexBuffer);
-          pass.setVertexBuffer(1, instanceNodeIndexBuffer);
+          pass.setVertexBuffer(1, instanceNodeIndexBuffer, nodeIndexByteOffset);
           pass.setIndexBuffer(staticGeometry.indexBuffer, 'uint16');
           pass.drawIndexed(staticGeometry.indexCount, batchLength);
 
           backend.stats.batches++;
           backend.stats.drawCalls++;
+
+          // Retained recording (mesh opt-in): hand this instanced flush's
+          // per-instance node-index stream + a reference to the SHARED,
+          // persistent geometry to the recorder. Geometry bytes are never
+          // copied into the group bundle — only the node-index words are
+          // group-owned. `staticGeometry` is structurally a
+          // WebGpuRetainedGeometryRef (vertexBuffer/indexBuffer/indexCount).
+          if (backend._retainedCaptureActive) {
+            this._retainedTextureScratch[0] = dc.texture;
+            backend._recordRetainedBatch(
+              this,
+              // Real ArrayBuffer: `_instancedNodeIndexData` is a plain Uint32Array.
+              this._instancedNodeIndexData.buffer as ArrayBuffer,
+              batchLength * Uint32Array.BYTES_PER_ELEMENT,
+              batchLength,
+              dc.blendMode,
+              this._retainedTextureScratch,
+              1,
+              staticGeometry,
+            );
+          }
 
           defaultDrawCursor += batchLength;
           instancedDrawCursor++;
@@ -659,6 +750,15 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
         }
 
         // ----- Default path -----
+        // A single (non-batched) mesh renders through the CPU-baked default
+        // pipeline (view * group folded into vertex positions), which is
+        // view-dependent and cannot be cached — poison any open capture so the
+        // group degrades to entry replay. Belt-and-braces (mirrors WebGL2's
+        // dynamic-single poison); the predicate admits material-less meshes.
+        if (backend._retainedCaptureActive) {
+          backend._poisonActiveRetainedCaptures();
+        }
+
         const needsPipeline = lastShader !== 'default' || dc.blendMode !== lastBlendMode || renderTargetFormat !== lastFormat;
 
         if (needsPipeline) {
@@ -684,6 +784,13 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
         defaultDrawCursor++;
       } else {
         // ----- Custom path -----
+        // Custom-material meshes re-upload user uniforms live at flush; the
+        // recordability predicate excludes them, but poison defensively so a
+        // capture that slipped through never replays a stale, uncaptured draw.
+        if (backend._retainedCaptureActive) {
+          backend._poisonActiveRetainedCaptures();
+        }
+
         const resources = this._customShaders.get(dc.customShader)!;
         const needsPipeline = lastShader !== dc.customShader || dc.blendMode !== lastBlendMode || renderTargetFormat !== lastFormat;
 
@@ -1083,6 +1190,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
   }
 
   private _uploadInstancedNodeIndices(startIndex: number, batchLength: number): number {
+    // The frame-total capacity is ensured once in flush(); this is a floor.
     this._ensureInstancedNodeIndexCapacity(batchLength);
 
     let maxNodeIndex = 0;
@@ -1098,13 +1206,20 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
       }
     }
 
+    // Write into this frame's next free sub-range so each batch's draw reads its
+    // OWN indices at submit time (the byte offset is 4-aligned: u32 elements).
+    const byteOffset = this._instancedNodeIndexFrameBytes;
+
     this._device!.queue.writeBuffer(
       this._instancedNodeIndexBuffer!,
-      0,
+      byteOffset,
       this._instancedNodeIndexData.buffer,
       this._instancedNodeIndexData.byteOffset,
       batchLength * Uint32Array.BYTES_PER_ELEMENT,
     );
+
+    this._instancedNodeIndexByteOffset = byteOffset;
+    this._instancedNodeIndexFrameBytes = byteOffset + batchLength * Uint32Array.BYTES_PER_ELEMENT;
 
     return maxNodeIndex;
   }
@@ -1179,6 +1294,213 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> {
     data[24] = premultiplySample ? 1 : 0;
 
     this._device!.queue.writeBuffer(this._instancedUniformBuffer!, slot * this._uniformAlignment, data.buffer, data.byteOffset, transformUniformByteLength);
+  }
+
+  // ── Retained-batch record/replay (Track B Slice 3, mesh opt-in) ──────────
+  // Mesh's recordable draw is an INDEXED instanced draw: shared per-Geometry
+  // vertex+index buffers (referenced via `payload.geometry`, never copied into
+  // the group bundle) plus a group-owned per-instance node-index stream (one
+  // u32/instance in the bundle instance buffer). The node index is the entire
+  // per-instance record, so scan/rebase walk the whole u32 stream.
+
+  /** @internal See {@link WebGpuRetainedBatchReplayer._scanRetainedNodeIndexRange}. */
+  public _scanRetainedNodeIndexRange(bytes: Uint8Array, range: WebGpuRetainedNodeIndexRange): void {
+    const words = new Uint32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / Uint32Array.BYTES_PER_ELEMENT);
+
+    for (let i = 0; i < words.length; i++) {
+      const node = words[i]!;
+
+      if (node < range.min) {
+        range.min = node;
+      }
+
+      if (node > range.max) {
+        range.max = node;
+      }
+    }
+  }
+
+  /** @internal See {@link WebGpuRetainedBatchReplayer._rebaseRetainedNodeIndices} (S3-D4: group-local indices). */
+  public _rebaseRetainedNodeIndices(bytes: Uint8Array, base: number): void {
+    const words = new Uint32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / Uint32Array.BYTES_PER_ELEMENT);
+
+    for (let i = 0; i < words.length; i++) {
+      words[i] = words[i]! - base;
+    }
+  }
+
+  /**
+   * Replay one recorded default-path mesh batch into the OPEN pass (B-06). All
+   * STATE is resolved live — the instanced pipeline, `TransformUniforms`
+   * (projection + group) from the live view/group, the per-batch premultiply
+   * flag, the texture — and only DATA is reused: the SHARED geometry
+   * (vertex + index buffers), the group-owned node-index stream (bundle vertex
+   * buffer 1 at `payload.byteOffset`), and the group-owned transform storage
+   * (bind group(0) binding 1). Drawn indexed (`drawIndexed`).
+   * @internal
+   */
+  public _replayRetainedBatch(payload: WebGpuRetainedBatchPayload): void {
+    const backend = this._backend;
+    const device = this._device;
+    const bundle = payload.bundle;
+    const geometry = payload.geometry;
+
+    if (
+      backend === null ||
+      device === null ||
+      geometry === null ||
+      geometry === undefined ||
+      !bundle.isReady ||
+      bundle.instanceBuffer === null ||
+      bundle.transformBuffer === null
+    ) {
+      // Defensive: such a bundle never validates (generation), so a spliced
+      // replay cannot reach here; skip rather than crash mid-frame.
+      return;
+    }
+
+    // Drain any pending live mesh draws first so replay draws follow them in
+    // order — the backend only flushes the OUTGOING renderer on a switch, so a
+    // mesh already active before the group would still hold pending draws.
+    this.flush();
+
+    // A fully-clipped scissor draws nothing (visibility is live per frame).
+    const scissor = backend.getScissorRect();
+
+    if (scissor !== null && (scissor.width <= 0 || scissor.height <= 0)) {
+      return;
+    }
+
+    const coordinator = backend._passCoordinator;
+    const state = this._getMeshReplayState(bundle);
+    const texture = payload.textures[0]!;
+    const slot = payload.batchIndexInBundle ?? 0;
+
+    // Size the group-owned UBO to cover this slot. Growth destroys the old
+    // buffer — if this bundle's earlier draws are already in the open pass they
+    // reference it, so end (submit) that pass first (rare: first replay frame /
+    // batch-count increase). Slots replay in ascending order, so once sized no
+    // further growth happens this frame.
+    this._ensureMeshReplayUniformCapacity(state, device, coordinator, slot + 1);
+
+    // Same-frame texture-mutation guard (S3-D7): resolving the texture binding
+    // may re-upload mutated content on the queue timeline before the deferred
+    // submit, retroactively changing draws already in the open pass. End it
+    // first so those draws keep their pre-mutation content.
+    let activePass = coordinator.activePass;
+
+    if (activePass !== null && state.drawsInPass === activePass && backend._textureUploadWouldMutate(texture)) {
+      coordinator.endPass();
+      state.drawsInPass = null;
+    }
+
+    // UBO write guard: rewriting this bundle's slots re-projects them. If the
+    // live view changed while this bundle's draws are already in the open pass
+    // (RenderTexture + main double replay under different views), end it first.
+    const view = backend.view;
+
+    if (state.uboView !== view || state.uboViewUpdateId !== view.updateId) {
+      activePass = coordinator.activePass;
+
+      if (activePass !== null && state.drawsInPass === activePass) {
+        coordinator.endPass();
+        state.drawsInPass = null;
+      }
+
+      state.uboView = view;
+      state.uboViewUpdateId = view.updateId;
+    }
+
+    // Write this batch's UBO slot: live projection + group + per-batch flag.
+    const data = this._instancedUniformScratch;
+
+    data.fill(0);
+    packAffineMat3Std140(view.getTransform(), data, 0);
+    packAffineMat3Std140(backend.renderGroupTransform ?? Matrix.identity, data, 12);
+    data[24] = backend.shouldPremultiplyTextureSample(texture) ? 1 : 0;
+    device.queue.writeBuffer(state.uniformBuffer!, slot * this._uniformAlignment, data.buffer, data.byteOffset, transformUniformByteLength);
+
+    const textureBindGroup = this._getTextureBindGroup(backend, texture);
+    const bindGroup = this._getMeshReplayBindGroup(state, device, bundle.transformBuffer);
+
+    const active = coordinator.acquirePass();
+    const pass = active.pass;
+
+    pass.setPipeline(this._getInstancedPipeline({ blendMode: payload.blendMode, format: backend.renderTargetFormat, stencil: coordinator.stencilActive }));
+    pass.setBindGroup(0, bindGroup, [slot * this._uniformAlignment]);
+    pass.setBindGroup(1, textureBindGroup);
+    pass.setVertexBuffer(0, geometry.vertexBuffer);
+    pass.setVertexBuffer(1, bundle.instanceBuffer, payload.byteOffset);
+    pass.setIndexBuffer(geometry.indexBuffer, 'uint16');
+    pass.drawIndexed(geometry.indexCount, payload.instanceCount);
+
+    state.drawsInPass = active;
+    backend.stats.batches++;
+    backend.stats.drawCalls++;
+  }
+
+  private _getMeshReplayState(bundle: WebGpuRetainedGroupBundle): MeshRetainedReplayState {
+    const existing = bundle.rendererReplayState;
+
+    if (existing instanceof MeshRetainedReplayState) {
+      return existing;
+    }
+
+    const state = new MeshRetainedReplayState();
+
+    bundle.rendererReplayState = state;
+
+    return state;
+  }
+
+  private _ensureMeshReplayUniformCapacity(
+    state: MeshRetainedReplayState,
+    device: GPUDevice,
+    coordinator: WebGpuBackend['_passCoordinator'],
+    slots: number,
+  ): void {
+    if (state.uniformBuffer !== null && state.uniformSlotCapacity >= slots) {
+      return;
+    }
+
+    // Draws already recorded into the open pass reference the buffer about to
+    // be destroyed; submit them before replacing it.
+    if (state.drawsInPass !== null && state.drawsInPass === coordinator.activePass) {
+      coordinator.endPass();
+      state.drawsInPass = null;
+    }
+
+    const capacitySlots = Math.max(slots, state.uniformSlotCapacity * 2 || 1);
+
+    state.uniformBuffer?.destroy();
+    state.uniformBuffer = device.createBuffer({
+      label: 'mesh:retained-uniform-buffer',
+      size: capacitySlots * this._uniformAlignment,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    state.uniformSlotCapacity = capacitySlots;
+    // The UBO identity changed → the cached bind group is stale.
+    state.bindGroup = null;
+    state.bindGroupUniform = null;
+  }
+
+  private _getMeshReplayBindGroup(state: MeshRetainedReplayState, device: GPUDevice, transformBuffer: GPUBuffer): GPUBindGroup {
+    if (state.bindGroup !== null && state.bindGroupUniform === state.uniformBuffer && state.bindGroupTransform === transformBuffer) {
+      return state.bindGroup;
+    }
+
+    state.bindGroup = device.createBindGroup({
+      label: 'mesh:retained-transform-bind-group',
+      layout: this._instancedTransformBindGroupLayout!,
+      entries: [
+        { binding: 0, resource: { buffer: state.uniformBuffer!, size: transformUniformByteLength } },
+        { binding: 1, resource: { buffer: transformBuffer } },
+      ],
+    });
+    state.bindGroupUniform = state.uniformBuffer;
+    state.bindGroupTransform = transformBuffer;
+
+    return state.bindGroup;
   }
 
   private _getOrCreateInstancedTransformBindGroup(storageBuffer: GPUBuffer): GPUBindGroup {

--- a/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
+++ b/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
@@ -13,6 +13,36 @@ import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
 /** Bytes of one transform slot (3 × vec4<f32>, matches the WGSL `TransformSlot`). */
 export const retainedTransformSlotBytes = 48;
 
+/**
+ * Reference to the renderer-owned, persistent, SHARED geometry an indexed
+ * retained batch draws (mesh opt-in). The vertex + index buffers live in the
+ * recording renderer's own long-lived cache (the mesh renderer's
+ * `_staticGeometryCache`, one buffer pair per `Geometry`, shared across
+ * frames/groups); the group bundle stores only the thin per-instance
+ * node-index stream, never the geometry bytes.
+ * @internal
+ */
+export interface WebGpuRetainedGeometryRef {
+  readonly vertexBuffer: GPUBuffer;
+  readonly indexBuffer: GPUBuffer;
+  readonly indexCount: number;
+}
+
+/**
+ * Auxiliary, renderer-owned GPU state a replayer may attach to a bundle
+ * (option (a) of the mesh generalization). Sprite/nine-slice/repeating leave
+ * it null and drive replay entirely from the bundle's own sprite-layout UBO;
+ * the mesh renderer parks its group(0) `TransformUniforms` UBO + bind group
+ * here so the bundle can dispose it on device loss / destroy — giving the
+ * mesh UBO the same grow-only, explicitly-freed lifecycle as the bundle's own
+ * buffers WITHOUT the bundle needing to know the mesh layout.
+ * @internal
+ */
+export interface WebGpuRetainedRendererReplayState {
+  /** Release any GPU buffers this state owns (called from the bundle). */
+  destroy(): void;
+}
+
 /** Bytes of the per-group uniform buffer (projection mat4 + group mat4, S3-D7). */
 export const retainedGroupUniformBytes = 128;
 
@@ -33,6 +63,21 @@ export interface WebGpuRetainedBatchPayload {
   readonly byteOffset: number;
   readonly instanceCount: number;
   readonly blendMode: BlendModes;
+  /**
+   * Shared, persistent geometry for an INDEXED batch (mesh opt-in): the
+   * renderer-owned vertex + index buffers this batch's node-index stream
+   * instances. `null`/absent for the self-contained instance-stream renderers
+   * (sprite / nine-slice / repeating), which bind the renderer's own quad
+   * index buffer and one vertex buffer.
+   */
+  readonly geometry?: WebGpuRetainedGeometryRef | null;
+  /**
+   * This batch's index within its OWNING bundle's recording (generic per-batch
+   * ordinal; `owner.staged.length` at record time). Indexed renderers use it as
+   * the group-owned uniform slot for their per-batch dynamic-offset UBO write;
+   * the self-contained instance-stream renderers ignore it.
+   */
+  readonly batchIndexInBundle?: number;
   /** Slot-ordered batch textures; bind group(1) is re-resolved live from these. */
   readonly textures: ReadonlyArray<Texture | RenderTexture>;
   /**
@@ -182,6 +227,13 @@ export class WebGpuRetainedGroupBundle implements RetainedGroupBundle {
   public uboViewUpdateId = -1;
   /** The open pass this bundle's replayed draws were last recorded into. */
   public drawsInPass: WebGpuActiveRenderPass | null = null;
+  /**
+   * Auxiliary replay state owned by an indexed-geometry replayer (mesh). Null
+   * for the sprite-layout renderers, which use this bundle's own UBO/bind
+   * group. Disposed on device loss / destroy so the renderer's group(0) UBO
+   * follows the bundle's lifecycle (S3-D3 grow-only, freed on teardown).
+   */
+  public rendererReplayState: WebGpuRetainedRendererReplayState | null = null;
 
   public constructor(accountant: GpuResourceAccountant, onRelease: (bundle: WebGpuRetainedGroupBundle) => void) {
     this._accountant = accountant;
@@ -360,6 +412,9 @@ export class WebGpuRetainedGroupBundle implements RetainedGroupBundle {
     this.uboView = null;
     this.uboViewUpdateId = -1;
     this.drawsInPass = null;
+    // The mesh replayer's group(0) UBO belonged to the dropped device state.
+    this.rendererReplayState?.destroy();
+    this.rendererReplayState = null;
 
     if (this._accountedBytes > 0) {
       this._accountant.free(this._accountedBytes);

--- a/test/rendering/browser/webgl2-mesh-retained-instruction-replay.test.ts
+++ b/test/rendering/browser/webgl2-mesh-retained-instruction-replay.test.ts
@@ -1,0 +1,515 @@
+/**
+ * WebGL2 renderer-matrix browser tests — Mesh retained instruction-set replay
+ * (Track B Slice 3, mesh opt-in).
+ *
+ * The mesh counterpart of `webgl2-nine-slice-retained-instruction-replay.test.ts`.
+ * Mesh's recordable draw is structurally different from the self-contained
+ * instance-stream renderers (sprite / nine-slice / repeating): it is an INDEXED
+ * instanced draw over a SHARED, persistent per-`Geometry` vertex+index buffer
+ * (the mesh renderer's `_staticGeometryCache`, referenced not copied) plus a
+ * thin group-owned per-instance node-index stream. Replay therefore drives
+ * `drawElementsInstanced` over the group's own node-index buffer + the shared
+ * geometry, and must produce BYTE-IDENTICAL frames to the entry-replay slow
+ * path.
+ *
+ * A live sprite OUTSIDE (and before) the group keeps the group's shared
+ * transform rows starting at a non-zero frame-global index, so the group-local
+ * node-index rebase (S3-D4) is load-bearing in every assertion — the final cell
+ * neuters the rebase hook and proves the frame then diverges.
+ *
+ * The group holds two same-geometry mesh runs with DISTINCT textures (2 red +
+ * 2 green), so each run records its own single-texture INSTANCED batch (>= 2
+ * instances, the recordable path on both backends) — exercising per-batch byte
+ * offsets across more than one recorded batch, all sharing ONE geometry buffer.
+ *
+ * Run via:  pnpm test:browser:webgl
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import { Geometry } from '#rendering/geometry/Geometry';
+import { Mesh } from '#rendering/mesh/Mesh';
+import type { RenderNode } from '#rendering/RenderNode';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+import { WebGl2MeshRenderer } from '#rendering/webgl2/WebGl2MeshRenderer';
+
+import { wireCoreRenderers } from './_coreRenderers';
+
+// ---------------------------------------------------------------------------
+// Shader mocks. The mesh instanced mock is FAITHFUL to the real instanced mesh
+// shader: it applies u_projection * u_group * (transform-row * position) and
+// modulates by the vertex color and the transform-row tint (texel 2), so the
+// camera-pan / group-move cells exercise the live u_group / u_projection reads.
+// ---------------------------------------------------------------------------
+
+const shaderSources = vi.hoisted(() => ({
+  spriteVert: `#version 300 es
+precision mediump float;
+in vec4 a_localBounds;
+in vec4 a_uvBounds;
+in vec4 a_color;
+in uint a_textureSlot;
+in uint a_nodeIndex;
+uniform mat3 u_projection;
+uniform mat3 u_group;
+uniform sampler2D u_transforms;
+out vec2 v_uv;
+out vec4 v_color;
+flat out uint v_textureSlot;
+void main() {
+  vec2 local;
+  if (gl_VertexID == 0) local = vec2(a_localBounds.x, a_localBounds.y);
+  else if (gl_VertexID == 1) local = vec2(a_localBounds.z, a_localBounds.y);
+  else if (gl_VertexID == 2) local = vec2(a_localBounds.x, a_localBounds.w);
+  else local = vec2(a_localBounds.z, a_localBounds.w);
+  vec2 uv;
+  if (gl_VertexID == 0) uv = vec2(a_uvBounds.x, a_uvBounds.y);
+  else if (gl_VertexID == 1) uv = vec2(a_uvBounds.z, a_uvBounds.y);
+  else if (gl_VertexID == 2) uv = vec2(a_uvBounds.x, a_uvBounds.w);
+  else uv = vec2(a_uvBounds.z, a_uvBounds.w);
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
+  vec3 clip = u_projection * u_group * vec3(world, 1.0);
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
+}`,
+
+  meshVert: `#version 300 es
+precision mediump float;
+in vec2 a_position;
+in vec2 a_texcoord;
+in vec4 a_color;
+in uint a_nodeIndex;
+uniform mat3 u_projection;
+uniform mat3 u_group;
+uniform sampler2D u_transforms;
+out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
+void main() {
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  vec2 world = vec2(m0.x * a_position.x + m0.y * a_position.y + m1.x, m0.z * a_position.x + m0.w * a_position.y + m1.y);
+  vec3 clip = u_projection * u_group * vec3(world, 1.0);
+  gl_Position = vec4(clip.xy, 0.0, 1.0);
+  v_uv = a_texcoord; v_color = a_color;
+  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+}`,
+
+  meshFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv; in vec4 v_color; in vec4 v_tint;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() { outColor = texture(u_texture, v_uv) * v_color * v_tint; }`,
+
+  textVert: `#version 300 es
+precision mediump float;
+layout(location = 0) in vec2 a_position;
+layout(location = 1) in vec2 a_texcoord;
+layout(location = 2) in float a_nodeIndex;
+uniform mat3 u_projection;
+uniform mat3 u_group;
+out vec2 v_uv;
+void main() {
+  float ni = a_nodeIndex;
+  vec3 clip = u_projection * u_group * vec3(a_position + vec2(ni * 0.0), 1.0);
+  gl_Position = vec4(clip.xy, 0.0, 1.0); v_uv = a_texcoord;
+}`,
+
+  textFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() { outColor = texture(u_texture, v_uv); }`,
+}));
+
+vi.mock('#rendering/webgl2/glsl/sprite.vert', () => ({ default: shaderSources.spriteVert }));
+vi.mock('#rendering/webgl2/glsl/sprite.frag', async () => ({ default: (await import('./_spriteFragMock')).createSpriteFragMockSource('v_uv') }));
+vi.mock('#rendering/webgl2/glsl/mesh.vert', () => ({ default: shaderSources.meshVert }));
+vi.mock('#rendering/webgl2/glsl/mesh.frag', () => ({ default: shaderSources.meshFrag }));
+vi.mock('#rendering/webgl2/glsl/text.vert', () => ({ default: shaderSources.textVert }));
+vi.mock('#rendering/webgl2/glsl/text-color.frag', () => ({ default: shaderSources.textFrag }));
+vi.mock('#rendering/webgl2/glsl/text-msdf.frag', () => ({ default: shaderSources.textFrag }));
+vi.mock('#rendering/webgl2/glsl/text-sdf.frag', () => ({ default: shaderSources.textFrag }));
+
+// ---------------------------------------------------------------------------
+// Infrastructure helpers (shared shape with the sprite/nine-slice cells).
+// ---------------------------------------------------------------------------
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const createBackend = async (): Promise<WebGl2Backend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const app: Application = {
+    canvas,
+    options: {
+      clearColor: Color.black,
+      canvas: { width: canvasSize, height: canvasSize },
+      rendering: {
+        debug: false,
+        webglAttributes: {
+          alpha: false,
+          antialias: false,
+          premultipliedAlpha: false,
+          preserveDrawingBuffer: true,
+          stencil: false,
+          depth: false,
+        },
+        spriteRendererBatchSize: 1024,
+        particleRendererBatchSize: 1024,
+      },
+    },
+  } as unknown as Application;
+
+  const backend = new WebGl2Backend(app);
+
+  await backend.initialize();
+  wireCoreRenderers(backend, app.options.rendering);
+
+  return backend;
+};
+
+const render = (backend: WebGl2Backend, node: RenderNode): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+  node.render(backend);
+  backend.flush();
+};
+
+const readPixel = (backend: WebGl2Backend, x: number, y: number): RgbaTuple => {
+  const buf = new Uint8Array(4);
+  const gl = backend.context;
+
+  gl.readPixels(Math.floor(x), backend.renderTarget.height - Math.floor(y) - 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+
+  return [buf[0], buf[1], buf[2], buf[3]];
+};
+
+/** Full-framebuffer snapshot for byte-identical tier comparisons (S3-D10). */
+const readCanvas = (backend: WebGl2Backend): Uint8Array => {
+  const buf = new Uint8Array(canvasSize * canvasSize * 4);
+  const gl = backend.context;
+
+  gl.readPixels(0, 0, canvasSize, canvasSize, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+
+  return buf;
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 8): void => {
+  for (let i = 0; i < 4; i++) {
+    expect(Math.abs(actual[i] - expected[i])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+const createSolidTexture = (color: string, width = 16, height = 16): Texture => {
+  const src = document.createElement('canvas');
+
+  src.width = width;
+  src.height = height;
+
+  const ctx = src.getContext('2d')!;
+
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, width, height);
+
+  return new Texture(src);
+};
+
+/** A 16x16 textured quad geometry (usage 'static' by default). */
+const createQuadGeometry = (): Geometry => {
+  const stride = 16; // vec2 position (8) + vec2 texcoord (8)
+  const buffer = new ArrayBuffer(4 * stride);
+  const view = new DataView(buffer);
+  const verts = [
+    { x: 0, y: 0, u: 0, v: 0 },
+    { x: 16, y: 0, u: 1, v: 0 },
+    { x: 16, y: 16, u: 1, v: 1 },
+    { x: 0, y: 16, u: 0, v: 1 },
+  ];
+
+  verts.forEach((vert, i) => {
+    const base = i * stride;
+
+    view.setFloat32(base + 0, vert.x, true);
+    view.setFloat32(base + 4, vert.y, true);
+    view.setFloat32(base + 8, vert.u, true);
+    view.setFloat32(base + 12, vert.v, true);
+  });
+
+  return new Geometry({
+    attributes: [
+      { name: 'a_position', size: 2, type: 'f32', normalized: false, offset: 0 },
+      { name: 'a_texcoord', size: 2, type: 'f32', normalized: false, offset: 8 },
+    ],
+    vertexData: buffer,
+    stride,
+    indices: new Uint16Array([0, 1, 2, 0, 2, 3]),
+  });
+};
+
+/**
+ * Standard cell scene: one live sprite OUTSIDE (and before) the retained group
+ * so the group's shared transform rows never start at row 0 — the group-local
+ * node-index rebase (S3-D4) is load-bearing in every pixel assertion.
+ *
+ * The group holds 4 meshes sharing ONE quad geometry: two red (one instanced
+ * batch of 2) then two green (a second instanced batch of 2). Two batches
+ * exercise per-batch byte offsets into the group node-index buffer; the shared
+ * geometry buffer is referenced by both (never copied into the bundle).
+ *
+ * Layout (canvas 64x64): blue outside sprite at (48,0)-(64,16); group at (8,24)
+ * with red quads at group-local (0,0)/(16,0) and green quads at (0,16)/(16,16).
+ */
+const buildScene = () => {
+  const blue = createSolidTexture('#0000ff');
+  const red = createSolidTexture('#ff0000');
+  const green = createSolidTexture('#00ff00');
+  const geometry = createQuadGeometry();
+  const root = new Container();
+  const outside = new Sprite(blue);
+  const group = new RetainedContainer();
+  const redA = new Mesh({ geometry, texture: red });
+  const redB = new Mesh({ geometry, texture: red });
+  const greenA = new Mesh({ geometry, texture: green });
+  const greenB = new Mesh({ geometry, texture: green });
+
+  outside.setPosition(48, 0);
+  root.addChild(outside);
+
+  redB.setPosition(16, 0);
+  greenA.setPosition(0, 16);
+  greenB.setPosition(16, 16);
+  group.addChild(redA);
+  group.addChild(redB);
+  group.addChild(greenA);
+  group.addChild(greenB);
+  group.setPosition(8, 24);
+  root.addChild(group);
+
+  const destroy = (): void => {
+    root.destroy();
+    geometry.destroy();
+    blue.destroy();
+    red.destroy();
+    green.destroy();
+  };
+
+  return { root, group, redA, redB, greenA, greenB, destroy };
+};
+
+const expectBaseScenePixels = (backend: WebGl2Backend): void => {
+  expectPixelNear(readPixel(backend, 52, 8), [0, 0, 255, 255]); // live outside sprite
+  expectPixelNear(readPixel(backend, 16, 32), [255, 0, 0, 255]); // redA (8,24)-(24,40)
+  expectPixelNear(readPixel(backend, 32, 32), [255, 0, 0, 255]); // redB (24,24)-(40,40)
+  expectPixelNear(readPixel(backend, 16, 48), [0, 255, 0, 255]); // greenA (8,40)-(24,56)
+  expectPixelNear(readPixel(backend, 32, 48), [0, 255, 0, 255]); // greenB (24,40)-(40,56)
+  expectPixelNear(readPixel(backend, 58, 58), [0, 0, 0, 255]); // background
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WebGL2 renderer matrix: Mesh retained instruction-set replay cells', () => {
+  test('cell 1 — the mesh instruction-replay tier is byte-identical to the entry-replay and collect tiers', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+    const beginSpy = vi.spyOn(backend, '_beginRetainedCapture');
+    const replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+    try {
+      // F1 — full collect + fragment capture (slow tier).
+      render(backend, scene.root);
+
+      const collectFrame = readCanvas(backend);
+
+      expectBaseScenePixels(backend);
+      expect(replaySpy).not.toHaveBeenCalled();
+
+      // F2 — entry replay + instruction recording (the recording source).
+      render(backend, scene.root);
+
+      const recordFrame = readCanvas(backend);
+
+      expect(beginSpy).toHaveBeenCalledTimes(1);
+      expect(replaySpy).not.toHaveBeenCalled();
+
+      // F3/F4 — instruction splice: recorded mesh batches replay indexed from
+      // group-owned resources (node-index stream) + the shared geometry. Same
+      // bytes, same rows (group-local rebase), same live uniforms -> identical.
+      render(backend, scene.root);
+
+      const replayFrame = readCanvas(backend);
+
+      expect(replaySpy).toHaveBeenCalledTimes(2); // two batches (red run, green run)
+
+      render(backend, scene.root);
+
+      const steadyFrame = readCanvas(backend);
+
+      expect(beginSpy).toHaveBeenCalledTimes(1); // never re-recorded
+      expectBaseScenePixels(backend);
+      expect(recordFrame).toEqual(collectFrame);
+      expect(replayFrame).toEqual(recordFrame);
+      expect(steadyFrame).toEqual(recordFrame);
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 2 — camera pan on the replay path: live projection, no recapture', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+
+    try {
+      render(backend, scene.root); // F1 capture
+      render(backend, scene.root); // F2 record
+      render(backend, scene.root); // F3 splice
+
+      const beginSpy = vi.spyOn(backend, '_beginRetainedCapture');
+      const replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+      // Pan the camera 16px right: everything must appear 16px further left.
+      backend.view.setCenter(backend.view.center.x + 16, backend.view.center.y);
+      render(backend, scene.root);
+
+      expect(beginSpy).not.toHaveBeenCalled(); // replay, not recapture
+      expect(replaySpy).toHaveBeenCalledTimes(2);
+      expectPixelNear(readPixel(backend, 36, 8), [0, 0, 255, 255]); // outside sprite 32..48
+      expectPixelNear(readPixel(backend, 16, 32), [255, 0, 0, 255]); // redB shifted to 8..24
+      expectPixelNear(readPixel(backend, 16, 48), [0, 255, 0, 255]); // greenB shifted to 8..24
+      expectPixelNear(readPixel(backend, 58, 32), [0, 0, 0, 255]); // background
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 3 — group move on the replay path: one live group matrix relocates the cached mesh batches', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+
+    try {
+      render(backend, scene.root); // F1 capture
+      render(backend, scene.root); // F2 record
+      render(backend, scene.root); // F3 splice
+
+      const beginSpy = vi.spyOn(backend, '_beginRetainedCapture');
+      const replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+      // Move the WHOLE group +16px right: content revisions untouched (a group
+      // move is decoupled by design), so the set keeps replaying via live u_group.
+      scene.group.setPosition(24, 24);
+      render(backend, scene.root);
+
+      expect(beginSpy).not.toHaveBeenCalled();
+      expect(replaySpy).toHaveBeenCalledTimes(2);
+      expectPixelNear(readPixel(backend, 32, 32), [255, 0, 0, 255]); // redA now (24,24)-(40,40)
+      expectPixelNear(readPixel(backend, 32, 48), [0, 255, 0, 255]); // greenA now (24,40)-(40,56)
+      expectPixelNear(readPixel(backend, 16, 32), [0, 0, 0, 255]); // old red spot cleared
+      expectPixelNear(readPixel(backend, 52, 8), [0, 0, 255, 255]); // live sprite unaffected
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 4 — transform-only mesh child move: fast row-patch on a real GPU relocates one instance, no re-record', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+
+    try {
+      render(backend, scene.root); // F1 capture
+      render(backend, scene.root); // F2 record
+      render(backend, scene.root); // F3 splice
+
+      const beginSpy = vi.spyOn(backend, '_beginRetainedCapture');
+      const replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+      // Slice 4b: a pure transform move on a direct child stays content-clean,
+      // so the group keeps its recording and patches just this child's shared
+      // transform row in place. redA and redB share ONE batch but reference
+      // DISTINCT rows, so only redA moves — the per-instance row rebase and the
+      // in-place patch are both load-bearing here.
+      scene.redA.setPosition(0, 32); // group-local (0,32) -> world (8,56)-(24,72), off-canvas bottom
+      render(backend, scene.root);
+
+      expect(beginSpy).not.toHaveBeenCalled(); // NO re-record: the recording is patched in place
+      expect(replaySpy).toHaveBeenCalledTimes(2); // one frame, two batches
+      expectPixelNear(readPixel(backend, 16, 32), [0, 0, 0, 255]); // redA's old spot cleared
+      expectPixelNear(readPixel(backend, 32, 32), [255, 0, 0, 255]); // redB (same batch) untouched
+      expectPixelNear(readPixel(backend, 16, 48), [0, 255, 0, 255]); // greenA untouched
+
+      const patchedFrame = readCanvas(backend);
+
+      render(backend, scene.root);
+
+      expect(beginSpy).not.toHaveBeenCalled();
+      expect(replaySpy).toHaveBeenCalledTimes(4); // second frame, two more batch replays
+      expect(readCanvas(backend)).toEqual(patchedFrame);
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 5 — deliberate break: a neutered node-index rebase fetches the wrong rows and diverges', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+    const original = WebGl2MeshRenderer.prototype._rebaseRetainedNodeIndices;
+
+    try {
+      // Baseline: correct replay is byte-identical to the record frame.
+      render(backend, scene.root); // F1 capture
+      render(backend, scene.root); // F2 record
+
+      const recordFrame = readCanvas(backend);
+
+      render(backend, scene.root); // F3 splice (correct rebase)
+
+      expect(readCanvas(backend)).toEqual(recordFrame);
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+
+    // A live sprite before the group means the group's rows start at a non-zero
+    // frame-global base; the group-owned transform texture only holds rows
+    // [0, N). Skipping the group-local rebase leaves the cached node indices
+    // frame-global, so replay fetches out-of-range / wrong rows -> the frame
+    // must diverge from the correct record frame.
+    const brokenBackend = await createBackend();
+    const brokenScene = buildScene();
+
+    try {
+      WebGl2MeshRenderer.prototype._rebaseRetainedNodeIndices = function (): void {};
+
+      render(brokenBackend, brokenScene.root); // F1 capture
+      render(brokenBackend, brokenScene.root); // F2 record
+
+      const recordFrame = readCanvas(brokenBackend);
+
+      render(brokenBackend, brokenScene.root); // F3 splice (broken rebase)
+
+      expect(readCanvas(brokenBackend)).not.toEqual(recordFrame);
+    } finally {
+      WebGl2MeshRenderer.prototype._rebaseRetainedNodeIndices = original;
+      brokenScene.destroy();
+      brokenBackend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgpu-mesh-retained-instruction-replay.test.ts
+++ b/test/rendering/browser/webgpu-mesh-retained-instruction-replay.test.ts
@@ -1,0 +1,429 @@
+/**
+ * WebGPU renderer-matrix browser tests — Mesh retained instruction-set replay
+ * (Track B Slice 3, mesh opt-in).
+ *
+ * The mesh counterpart of `webgpu-nine-slice-retained-instruction-replay.test.ts`.
+ * Mesh's recordable draw is an INDEXED instanced draw over a SHARED, persistent
+ * per-`Geometry` vertex+index buffer plus a group-owned per-instance node-index
+ * stream; replay binds the mesh renderer's own group(0) `TransformUniforms` UBO
+ * (parked on the bundle) + the group transform storage and issues
+ * `drawIndexed`. The replay tier must reproduce the record frame's pixels
+ * exactly. A live sprite OUTSIDE (and before) the group keeps the group's
+ * shared storage rows starting at a non-zero frame-global index, so the
+ * group-local node-index rebase (S3-D4) is load-bearing — the final cell
+ * neuters it and proves the probes diverge.
+ *
+ * The group holds two same-geometry mesh runs with DISTINCT textures (2 red +
+ * 2 green) → two recorded INSTANCED batches (each >= 2 instances, the
+ * recordable WebGPU path), sharing ONE geometry buffer.
+ *
+ * CI guarantees a real WebGPU adapter; tests only skip when the software
+ * adapter drops the device mid-test (same convention as the other WebGPU specs).
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import { Geometry } from '#rendering/geometry/Geometry';
+import { Mesh } from '#rendering/mesh/Mesh';
+import type { RetainedGroupFragment } from '#rendering/plan/RetainedGroupFragment';
+import type { RenderNode } from '#rendering/RenderNode';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+import { WebGpuMeshRenderer } from '#rendering/webgpu/WebGpuMeshRenderer';
+
+import { wireCoreRenderers } from './_coreRenderers';
+import { getBackendDevice } from './webgpu-test-helpers';
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: {
+      canvas: { width: canvasSize, height: canvasSize },
+      clearColor: Color.black,
+    },
+  }) as unknown as Application;
+
+const setupBackend = async (): Promise<WebGpuBackend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  wireCoreRenderers(backend);
+  await backend.initialize();
+
+  return backend;
+};
+
+const createSolidTexture = (color: string, size = 16): Texture => {
+  const source = document.createElement('canvas');
+
+  source.width = size;
+  source.height = size;
+
+  const context = source.getContext('2d');
+
+  if (!context) {
+    throw new Error('2D context is required to create test textures.');
+  }
+
+  context.fillStyle = color;
+  context.fillRect(0, 0, size, size);
+
+  return new Texture(source);
+};
+
+/** A 16x16 textured quad geometry (usage 'static' by default). */
+const createQuadGeometry = (): Geometry => {
+  const stride = 16; // vec2 position (8) + vec2 texcoord (8)
+  const buffer = new ArrayBuffer(4 * stride);
+  const view = new DataView(buffer);
+  const verts = [
+    { x: 0, y: 0, u: 0, v: 0 },
+    { x: 16, y: 0, u: 1, v: 0 },
+    { x: 16, y: 16, u: 1, v: 1 },
+    { x: 0, y: 16, u: 0, v: 1 },
+  ];
+
+  verts.forEach((vert, i) => {
+    const base = i * stride;
+
+    view.setFloat32(base + 0, vert.x, true);
+    view.setFloat32(base + 4, vert.y, true);
+    view.setFloat32(base + 8, vert.u, true);
+    view.setFloat32(base + 12, vert.v, true);
+  });
+
+  return new Geometry({
+    attributes: [
+      { name: 'a_position', size: 2, type: 'f32', normalized: false, offset: 0 },
+      { name: 'a_texcoord', size: 2, type: 'f32', normalized: false, offset: 8 },
+    ],
+    vertexData: buffer,
+    stride,
+    indices: new Uint16Array([0, 1, 2, 0, 2, 3]),
+  });
+};
+
+const readCanvas = (backend: WebGpuBackend): ((x: number, y: number) => RgbaTuple) => {
+  const source = backend.context.canvas as HTMLCanvasElement;
+  const readback = document.createElement('canvas');
+
+  readback.width = canvasSize;
+  readback.height = canvasSize;
+
+  const ctx = readback.getContext('2d');
+
+  if (!ctx) {
+    throw new Error('2D context is required for canvas readback.');
+  }
+
+  ctx.drawImage(source, 0, 0);
+
+  return (x: number, y: number): RgbaTuple => {
+    const { data } = ctx.getImageData(Math.floor(x), Math.floor(y), 1, 1);
+
+    return [data[0], data[1], data[2], data[3]];
+  };
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 12): void => {
+  for (let index = 0; index < 4; index++) {
+    expect(Math.abs(actual[index] - expected[index])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+// Render a frame through the real plan path inside a validation error scope.
+// Returns false when the device dropped mid-test (the caller should bail).
+const renderScene = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
+  const device = getBackendDevice(backend);
+
+  device.pushErrorScope('validation');
+
+  let validationError: GPUError | null;
+
+  try {
+    backend.resetStats();
+    backend.clear(Color.black);
+    root.render(backend);
+    backend.flush();
+    validationError = await device.popErrorScope();
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+
+  expect(validationError).toBeNull();
+
+  return true;
+};
+
+const hexToRgba = (hex: string): RgbaTuple => [parseInt(hex.slice(1, 3), 16), parseInt(hex.slice(3, 5), 16), parseInt(hex.slice(5, 7), 16), 255];
+
+interface FragmentCarrier {
+  _fragment: RetainedGroupFragment;
+}
+
+const fragmentOf = (group: RetainedContainer): RetainedGroupFragment => (group as unknown as FragmentCarrier)._fragment;
+
+/**
+ * Standard cell scene, mirroring the WebGL2 mesh retained cells: a live blue
+ * sprite OUTSIDE (and before) the group at (48,0)-(64,16) keeps the group-local
+ * rebase load-bearing; the group at (8,24) holds four meshes sharing ONE quad
+ * geometry — two red (one instanced batch of 2) then two green (a second
+ * instanced batch of 2). Group-local positions: redA (0,0), redB (16,0),
+ * greenA (0,16), greenB (16,16).
+ */
+const buildScene = () => {
+  const blue = createSolidTexture('#0000ff');
+  const red = createSolidTexture('#ff0000');
+  const green = createSolidTexture('#00ff00');
+  const geometry = createQuadGeometry();
+  const root = new Container();
+  const outside = new Sprite(blue);
+  const group = new RetainedContainer();
+  const redA = new Mesh({ geometry, texture: red });
+  const redB = new Mesh({ geometry, texture: red });
+  const greenA = new Mesh({ geometry, texture: green });
+  const greenB = new Mesh({ geometry, texture: green });
+
+  outside.setPosition(48, 0);
+  root.addChild(outside);
+
+  redB.setPosition(16, 0);
+  greenA.setPosition(0, 16);
+  greenB.setPosition(16, 16);
+  group.addChild(redA);
+  group.addChild(redB);
+  group.addChild(greenA);
+  group.addChild(greenB);
+  group.setPosition(8, 24);
+  root.addChild(group);
+
+  const destroy = (): void => {
+    root.destroy();
+    geometry.destroy();
+    blue.destroy();
+    red.destroy();
+    green.destroy();
+  };
+
+  return { root, group, redA, redB, greenA, greenB, destroy };
+};
+
+describe('WebGPU renderer matrix: Mesh retained instruction replay cells', () => {
+  test('cell 1 — mesh replay is pixel-identical to the record frame (fast/slow equivalence)', async ctx => {
+    const backend = await setupBackend();
+    const scene = buildScene();
+
+    try {
+      // F1: dirty collect + capture.
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return;
+      }
+
+      // F2: clean entry replay + record — this IS the slow path's output.
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return;
+      }
+
+      expect(fragmentOf(scene.group).instructions?.hasRecording).toBe(true);
+
+      const probes: ReadonlyArray<readonly [number, number, string]> = [
+        [56, 8, '#0000ff'], // live outside sprite
+        [16, 32, '#ff0000'], // redA (batch 1)
+        [32, 32, '#ff0000'], // redB (batch 1)
+        [16, 48, '#00ff00'], // greenA (batch 2)
+        [32, 48, '#00ff00'], // greenB (batch 2)
+      ];
+      let readPixel = readCanvas(backend);
+      const slowPixels = probes.map(([x, y]) => readPixel(x, y));
+
+      for (let i = 0; i < probes.length; i++) {
+        expectPixelNear(slowPixels[i]!, hexToRgba(probes[i]![2]));
+      }
+
+      // F3: instruction replay — must be identical to the record frame.
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return;
+      }
+
+      readPixel = readCanvas(backend);
+
+      for (let i = 0; i < probes.length; i++) {
+        expectPixelNear(readPixel(probes[i]![0], probes[i]![1]), slowPixels[i]!, 0);
+      }
+
+      // Background stays clear on the replay tier (no stray out-of-range row).
+      expectPixelNear(readPixel(58, 58), [0, 0, 0, 255]);
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 2 — camera pan on the cached path: replayed mesh pixels track the live view', async ctx => {
+    const backend = await setupBackend();
+    const scene = buildScene();
+
+    try {
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderScene(ctx, backend, scene.root))) {
+          return;
+        }
+      }
+
+      let readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(16, 32), [255, 0, 0, 255]);
+
+      // Pan the camera 16px right: replayed content must appear 16px further
+      // left — projection is resolved live at replay (S3-D1).
+      backend.view.setCenter(backend.view.center.x + 16, backend.view.center.y);
+
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return;
+      }
+
+      readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(40, 8), [0, 0, 255, 255]); // outside sprite 32..48
+      expectPixelNear(readPixel(16, 32), [255, 0, 0, 255]); // redB shifted to 8..24
+      expectPixelNear(readPixel(16, 48), [0, 255, 0, 255]); // greenB shifted to 8..24
+      expectPixelNear(readPixel(58, 32), [0, 0, 0, 255]); // background
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 3 — group move on the cached path relocates mesh pixels WITHOUT recapture', async ctx => {
+    const backend = await setupBackend();
+    const scene = buildScene();
+
+    try {
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderScene(ctx, backend, scene.root))) {
+          return;
+        }
+      }
+
+      // The recorded batch instruction must survive the move untouched: a
+      // group move only changes the live-composed group matrix (S3-D6).
+      const recordedBatch = fragmentOf(scene.group).instructions!.instructions[0];
+
+      scene.group.setPosition(24, 24);
+
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return;
+      }
+
+      expect(fragmentOf(scene.group).instructions!.instructions[0]).toBe(recordedBatch);
+      expect(fragmentOf(scene.group).instructions!.hasRecording).toBe(true);
+
+      const readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(32, 32), [255, 0, 0, 255]); // redA now (24,24)-(40,40)
+      expectPixelNear(readPixel(32, 48), [0, 255, 0, 255]); // greenA now (24,40)-(40,56)
+      expectPixelNear(readPixel(16, 32), [0, 0, 0, 255]); // old red spot is background
+      expectPixelNear(readPixel(56, 8), [0, 0, 255, 255]); // live sprite unaffected
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 4 — transform-only mesh child move: in-place storage-row patch relocates one instance, no recapture', async ctx => {
+    const backend = await setupBackend();
+    const scene = buildScene();
+
+    try {
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderScene(ctx, backend, scene.root))) {
+          return;
+        }
+      }
+
+      const recordedBatch = fragmentOf(scene.group).instructions!.instructions[0];
+
+      // Slice 4c: a pure transform move on a direct child stays content-clean,
+      // so the recording is patched in place (no recapture). redA and redB share
+      // ONE batch but reference DISTINCT storage rows, so only redA moves.
+      scene.redA.setPosition(0, 32); // group-local (0,32) -> world (8,56), off-canvas bottom
+
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return;
+      }
+
+      expect(fragmentOf(scene.group).instructions!.instructions[0]).toBe(recordedBatch); // patched, not re-recorded
+      expect(fragmentOf(scene.group).instructions!.hasRecording).toBe(true);
+
+      const readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(16, 32), [0, 0, 0, 255]); // redA's old spot cleared
+      expectPixelNear(readPixel(32, 32), [255, 0, 0, 255]); // redB (same batch) untouched
+      expectPixelNear(readPixel(16, 48), [0, 255, 0, 255]); // greenA untouched
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 5 — deliberate break: a neutered node-index rebase fetches the wrong storage rows and diverges', async ctx => {
+    const backend = await setupBackend();
+    const scene = buildScene();
+    const original = WebGpuMeshRenderer.prototype._rebaseRetainedNodeIndices;
+
+    try {
+      // A live sprite before the group means the group's storage rows start at a
+      // non-zero frame-global base; the group-owned storage only holds rows
+      // [0, N). Skipping the rebase leaves the cached node indices frame-global,
+      // so replay fetches the wrong / out-of-range rows -> the frame diverges.
+
+      WebGpuMeshRenderer.prototype._rebaseRetainedNodeIndices = function (): void {};
+
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return;
+      } // F1 capture
+
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return;
+      } // F2 record
+
+      const record = readCanvas(backend);
+      const recordRed = record(16, 32);
+
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return;
+      } // F3 broken replay
+
+      const replay = readCanvas(backend);
+
+      // redA's probe must no longer read the recorded red: the broken rebase
+      // moved / dropped its instance.
+      expect(replay(16, 32)).not.toEqual(recordRed);
+    } finally {
+      WebGpuMeshRenderer.prototype._rebaseRetainedNodeIndices = original;
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Generalizes the retained-batch (Track B Slice 3) infra on both backends to support indexed-geometry draws, then adds `_supportsRetainedBatches` record/replay to the Mesh renderer on top of it.
- WebGL2: the bundle VAO runtime gained an indexed-draw branch (`drawElements(Instanced)` alongside the existing `drawArrays(Instanced)` path used by Sprite/NineSlice/RepeatingSprite, untouched).
- WebGPU: the bundle keeps its existing sprite `ProjectionUniforms` UBO/bind-group untouched; a new optional `bundle.rendererReplayState` slot lets Mesh park its own dynamic-offset `TransformUniforms` UBO/bind-group there, sharing the bundle's grow-only lifecycle without the bundle knowing the mesh-specific layout.
- Mesh's recorded data is only the per-instance node-index stream + group-owned transform rows — the actual vertex/index geometry stays referenced from the existing shared, persistent `_staticGeometryCache`, never copied.
- Found and fixed a pre-existing WebGPU bug along the way: multi-batch flushes wrote every batch's node-index stream to GPU buffer offset 0, so the first batch's draw could read the last batch's indices. Fixed with a per-frame byte cursor giving each batch a distinct sub-range.

## Test plan
- [x] Regression gate (before/after, must be unchanged): 210/210 node-level tests, 47/47 WebGL2 browser, 42/42 WebGPU browser (Sprite/NineSlice/RepeatingSprite retained families)
- [x] New `webgl2-mesh-retained-instruction-replay.test.ts`: 5/5 (byte-identical equivalence, camera pan, group move, transform-row patch, deliberate-break with rebase hook neutered)
- [x] New `webgpu-mesh-retained-instruction-replay.test.ts`: 5/5 (same 5 cells, WebGPU storage-row patch variant)
- [x] `tsc --noEmit`, `eslint`, `prettier --check` clean on all touched files