### PR TITLE
fix(rendering,text): reset bounds and invalidate content revision on empty-text transition

### DIFF
--- a/src/rendering/text/BitmapText.ts
+++ b/src/rendering/text/BitmapText.ts
@@ -263,7 +263,15 @@ export class BitmapText extends AbstractText {
   private _rebuild(): void {
     this._pageQuads = [];
     this._textBounds = { width: 0, height: 0 };
-    if (this._text.length === 0) return;
+    if (this._text.length === 0) {
+      // Empty transition: reset the extent and route through the content-dirty
+      // contract like the non-empty path below, so a BitmapText going empty
+      // does not leave a stale local bounds / un-dirtied revision behind for
+      // culling, hit-testing, or an instruction-set cache of prior geometry.
+      this.getLocalBounds().set(0, 0, 0, 0);
+      this._invalidateBoundsCascade();
+      return;
+    }
 
     // Derive a TextLayoutStyle from the BMFont descriptor + scale.
     // Setting fontSize = fontData.lineHeight * scale makes computedLineHeight

--- a/src/rendering/text/Text.ts
+++ b/src/rendering/text/Text.ts
@@ -216,6 +216,13 @@ export class Text extends AbstractText {
     this._textBounds = { width: 0, height: 0 };
 
     if (this._text.length === 0) {
+      // Empty transition: reset the extent and route through the content-dirty
+      // contract, exactly like the non-empty path below. Without this a Text
+      // going empty keeps its old local bounds and bumps no revision, so
+      // culling / hit-testing / the retained group aggregate read a stale
+      // extent, and any instruction-set cache of the prior geometry stays live.
+      this.getLocalBounds().set(0, 0, 0, 0);
+      this._invalidateBoundsCascade();
       this._style.consumeDirty();
       return;
     }
@@ -227,6 +234,10 @@ export class Text extends AbstractText {
     const placements = layoutText(this._text, this._style, this._layout, atlas);
 
     if (placements.length === 0) {
+      // Same empty-transition contract as above: no glyphs placed, so reset the
+      // extent and content-dirty rather than leaving a stale non-empty bounds.
+      this.getLocalBounds().set(0, 0, 0, 0);
+      this._invalidateBoundsCascade();
       this._style.consumeDirty();
       return;
     }

--- a/test/rendering/text/bitmap-text.test.ts
+++ b/test/rendering/text/bitmap-text.test.ts
@@ -104,6 +104,19 @@ describe('BitmapText', () => {
     expect(text.pageQuads).toHaveLength(0);
   });
 
+  test('setting text to empty string resets the local bounds extent', () => {
+    const text = new BitmapText('AB', makeFont());
+    expect(text.getLocalBounds().width).toBeGreaterThan(0);
+    expect(text.getLocalBounds().height).toBeGreaterThan(0);
+
+    // Empty transition must reset the extent rather than leave the stale
+    // non-empty bounds behind (culling / hit-testing / retained aggregate).
+    text.text = '';
+
+    expect(text.getLocalBounds().width).toBe(0);
+    expect(text.getLocalBounds().height).toBe(0);
+  });
+
   test('text setter triggers rebuild', () => {
     const text = new BitmapText('A', makeFont());
     const first = text.pageQuads[0];

--- a/test/rendering/text/text.test.ts
+++ b/test/rendering/text/text.test.ts
@@ -149,6 +149,20 @@ describe('Text', () => {
     expect(text.pageQuads).toHaveLength(0);
   });
 
+  test('setting text to empty string resets the local bounds extent', () => {
+    const text = new Text('Hello');
+    expect(text.getLocalBounds().width).toBeGreaterThan(0);
+    expect(text.getLocalBounds().height).toBeGreaterThan(0);
+
+    // Empty transition must reset the extent, not leave the stale non-empty
+    // bounds behind (which would corrupt culling / hit-testing / the retained
+    // group aggregate and keep any cached prior geometry live).
+    text.text = '';
+
+    expect(text.getLocalBounds().width).toBe(0);
+    expect(text.getLocalBounds().height).toBe(0);
+  });
+
   test('style getter returns the current TextStyle', () => {
     const style = new TextStyle({ fontSize: 20 });
     const text = new Text('Hi');


### PR DESCRIPTION
## Summary
- `Text._rebuild`/`BitmapText._rebuild` early-returned on the empty-string / zero-placement transition *before* resetting local bounds or calling `_invalidateBoundsCascade()` (→ `_markContentDirty()`). A node going from non-empty to empty text kept stale non-empty bounds and bumped no content revision — corrupting culling, hit-testing, and the `RetainedContainer` transform-group aggregate (which is revision-keyed).
- This is a real, independent bug today, unrelated to any retained-batch caching work — found while investigating whether Text could support Track B Slice-3 instruction-set caching (it can't without its own dedicated subsystem, tracked separately; this fix is a safe, independently valuable prerequisite either way).
- Fix: both early-return paths now reset local bounds to zero and call `_invalidateBoundsCascade()`, matching the non-empty path's existing behavior.

## Test plan
- [x] `text.test.ts` + `bitmap-text.test.ts`: 49 passed (incl. 2 new bounds-reset-on-empty-transition tests)
- [x] Full retained regression sweep (retained-container, retained-container-reparent, retained-group-fragment, retained-subtree-skip, retained-instruction-equivalence, retained-plan-cache, webgl2-retained-group-resources, webgpu-retained-record-replay, retained-transform-patch-scaling, interaction-retained-group): 140 passed
- [x] `test/rendering/plan` + `test/rendering/text` broad sweep: 272 passed
- [x] `tsc --noEmit`, `eslint`, `prettier --check` clean