### PR TITLE
feat(tilemap): TileChunkNode retained-batch record/replay on both backends

### DIFF
--- a/packages/exojs-tilemap/src/TileChunk.ts
+++ b/packages/exojs-tilemap/src/TileChunk.ts
@@ -77,6 +77,16 @@ export class TileChunk implements ReadonlyTileChunk {
   private _revision = 0;
 
   /**
+   * Render-node-owned callbacks notified whenever `_revision` advances.
+   * `TileChunkNode.pages` caches geometry against `revision`, but that cache
+   * is only consulted from `render()` — a call the engine skips entirely for
+   * a content-clean subtree under a `RetainedContainer` (Track B). Without
+   * this push, an in-place tile edit after capture would replay stale cached
+   * geometry forever. Package-internal; not part of {@link ReadonlyTileChunk}.
+   */
+  private _dirtyListeners: Set<() => void> | null = null;
+
+  /**
    * @param cx Signed chunk X coordinate (must be finite safe integer).
    * @param cy Signed chunk Y coordinate (must be finite safe integer).
    * @param width Chunk width in tiles (positive safe integer).
@@ -219,6 +229,7 @@ export class TileChunk implements ReadonlyTileChunk {
     this._tiles[i] = packed;
     this._revision++;
     this._empty = null; // invalidate cache
+    this._notifyDirty();
     return true;
   }
 
@@ -232,6 +243,7 @@ export class TileChunk implements ReadonlyTileChunk {
   public _markDirty(): void {
     this._empty = null;
     this._revision++;
+    this._notifyDirty();
   }
 
   /**
@@ -247,5 +259,33 @@ export class TileChunk implements ReadonlyTileChunk {
     this._tiles.fill(0);
     this._revision++;
     this._empty = true;
+    this._notifyDirty();
+  }
+
+  /**
+   * Register a callback invoked synchronously whenever this chunk's revision
+   * advances. Multiple listeners are supported (a chunk may back more than one
+   * `TileChunkNode` — e.g. two `TileLayerNode`s over the same `TileLayer`).
+   * Package-internal: called by `TileChunkNode` to push mutations onto the
+   * scene-node content-revision chain (see the `_dirtyListeners` field).
+   * @internal
+   */
+  public _addDirtyListener(listener: () => void): void {
+    (this._dirtyListeners ??= new Set()).add(listener);
+  }
+
+  /**
+   * Unregister a listener added via {@link _addDirtyListener} (node destroy).
+   * @internal
+   */
+  public _removeDirtyListener(listener: () => void): void {
+    this._dirtyListeners?.delete(listener);
+  }
+
+  private _notifyDirty(): void {
+    if (this._dirtyListeners === null) return;
+    for (const listener of this._dirtyListeners) {
+      listener();
+    }
   }
 }

--- a/packages/exojs-tilemap/src/TileChunkNode.ts
+++ b/packages/exojs-tilemap/src/TileChunkNode.ts
@@ -4,6 +4,7 @@ import { Drawable } from '@codexo/exojs/renderer-sdk';
 import type { ChunkPage } from './chunkGeometry';
 import { buildChunkPages } from './chunkGeometry';
 import type { ReadonlyTileChunk } from './TileChunk';
+import { TileChunk } from './TileChunk';
 import type { TileSet } from './TileSet';
 
 /**
@@ -37,6 +38,18 @@ export class TileChunkNode extends Drawable {
   private _builtRevision = -1;
 
   /**
+   * Bound once so `TileChunk._addDirtyListener`/`_removeDirtyListener` add and
+   * remove the SAME function reference. Pushes the chunk's revision bump onto
+   * this node's own content revision (see `TileChunk._dirtyListeners`) so a
+   * `RetainedContainer` ancestor — which skips walking a content-clean
+   * subtree entirely — observes the mutation and re-collects instead of
+   * replaying stale cached geometry.
+   */
+  private readonly _onChunkDirty = (): void => {
+    this.invalidateContent();
+  };
+
+  /**
    * @param chunk          The readonly chunk this node renders.
    * @param tilesets       The owning layer's tileset array.
    * @param tileWidth      Map/layer tile cell width in pixels.
@@ -68,6 +81,12 @@ export class TileChunkNode extends Drawable {
       chunk.cx * chunkWidthTiles * tileWidth,
       chunk.cy * chunkHeightTiles * tileHeight,
     );
+
+    // `loadedChunks()` always yields the concrete `TileChunk` behind the
+    // readonly view (see TileLayer); the guard is defensive only.
+    if (chunk instanceof TileChunk) {
+      chunk._addDirtyListener(this._onChunkDirty);
+    }
   }
 
   /** The signed chunk coordinates this node renders. */
@@ -107,6 +126,10 @@ export class TileChunkNode extends Drawable {
   }
 
   public override destroy(): void {
+    if (this._chunk instanceof TileChunk) {
+      this._chunk._removeDirtyListener(this._onChunkDirty);
+    }
+
     this._pages = [];
     this._builtRevision = -1;
 

--- a/packages/exojs-tilemap/src/webgl2/WebGl2TileChunkRenderer.ts
+++ b/packages/exojs-tilemap/src/webgl2/WebGl2TileChunkRenderer.ts
@@ -1,7 +1,17 @@
-import type { Texture, View, WebGl2Backend, WebGl2RenderBufferRuntime, WebGl2VertexArrayObjectRuntime } from '@codexo/exojs/renderer-sdk';
+import type {
+  RenderTexture,
+  Texture,
+  View,
+  WebGl2Backend,
+  WebGl2RenderBufferRuntime,
+  WebGl2RetainedBatchPayload,
+  WebGl2RetainedBatchReplayer,
+  WebGl2RetainedNodeIndexRange,
+  WebGl2VertexArrayObjectRuntime,
+} from '@codexo/exojs/renderer-sdk';
 import {
   AbstractWebGl2Renderer,
-  type BlendModes,
+  BlendModes,
   BufferTypes,
   BufferUsage,
   createWebGl2ShaderProgram,
@@ -20,6 +30,7 @@ import type { TileChunkNode } from '../TileChunkNode';
 const instanceStrideBytes = 32;
 const wordsPerInstance = instanceStrideBytes / Uint32Array.BYTES_PER_ELEMENT;
 const transformTextureUnit = 1;
+const identityGroupMat3 = new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
 
 // Tile word packing: transform-buffer row in the low 29 bits, diagonal flip in
 // bit 29. flipX/flipY are baked into the UV bounds at write time; the shader
@@ -39,6 +50,7 @@ layout(location = 2) in vec4 a_color;        // RGBA tint (layer opacity in alph
 layout(location = 3) in uint a_tileWord;     // transform row (bits 0..28) | diagonal (bit 29)
 
 uniform mat3 u_projection;
+uniform mat3 u_group;
 uniform sampler2D u_transforms;              // shared per-frame transform buffer (2 texels/row)
 
 out vec2 v_texcoord;
@@ -62,7 +74,7 @@ void main(void) {
     float worldX = (m0.x * localX) + (m0.y * localY) + m1.x;
     float worldY = (m0.z * localX) + (m0.w * localY) + m1.y;
 
-    gl_Position = vec4((u_projection * vec3(worldX, worldY, 1.0)).xy, 0.0, 1.0);
+    gl_Position = vec4((u_projection * u_group * vec3(worldX, worldY, 1.0)).xy, 0.0, 1.0);
 
     // Tile orientation: the diagonal flip transposes the corner-coordinate axes
     // before the UV corner is selected; flipX/flipY are already baked into the
@@ -107,7 +119,18 @@ interface TileRendererConnection {
  * orientation-neutral and never re-uploaded for a camera pan.
  * @internal
  */
-export class WebGl2TileChunkRenderer extends AbstractWebGl2Renderer<TileChunkNode> {
+export class WebGl2TileChunkRenderer extends AbstractWebGl2Renderer<TileChunkNode> implements WebGl2RetainedBatchReplayer {
+  /**
+   * Retained-batch capability opt-in (Track B): a tile chunk's per-flush
+   * instanced batches (fixed 32-byte layout, tile word at word 7) can be
+   * recorded into a group's instruction set and replayed from group-owned
+   * resources. Pixel-snapped draws are excluded by the collect-time
+   * recordability predicate (and belt-and-braces poisoning in {@link render});
+   * tile chunks have no custom-material path to exclude.
+   * @internal
+   */
+  public readonly _supportsRetainedBatches = true;
+
   private readonly _shader: Shader;
   private readonly _batchSize: number;
   private readonly _instanceData: ArrayBuffer;
@@ -115,6 +138,12 @@ export class WebGl2TileChunkRenderer extends AbstractWebGl2Renderer<TileChunkNod
   private readonly _instanceUint32: Uint32Array;
 
   private readonly _transformUnitScratch: Int32Array = new Int32Array([transformTextureUnit]);
+  // Pinned unit index for the single tileset texture sampler (unit 0), reused
+  // by the live flush and retained replay so both stay allocation-free.
+  private readonly _baseTextureUnitScratch: Int32Array = new Int32Array([0]);
+  // Reused single-slot texture list handed to the backend at record time; a
+  // tile chunk batch always binds exactly one tileset texture (slot 0).
+  private readonly _recordTextures: Array<Texture | RenderTexture | null> = [null];
 
   private _quadIndex = 0;
   private _maxNodeIndex = 0;
@@ -122,6 +151,7 @@ export class WebGl2TileChunkRenderer extends AbstractWebGl2Renderer<TileChunkNod
   private _currentTexture: Texture | null = null;
   private _currentView: View | null = null;
   private _currentViewId = -1;
+  private _currentGroupTransformId = -1;
 
   private _instanceBuffer: WebGl2RenderBuffer | null = null;
   private _vao: WebGl2VertexArrayObject | null = null;
@@ -145,6 +175,16 @@ export class WebGl2TileChunkRenderer extends AbstractWebGl2Renderer<TileChunkNod
     }
 
     const backend = this.getBackend();
+
+    // Belt-and-braces for retained recording: the collect-time recordability
+    // predicate already excludes pixel-snapped draws from ever arming a
+    // capture. If one still arrives inside an active capture window, poison
+    // the recording so the resulting set can never validate — degrading to
+    // entry replay instead of wrong pixels.
+    if (backend._isRetainedCapturing && node.pixelSnapMode !== 'none') {
+      backend._poisonRetainedCaptures();
+    }
+
     const blendMode = node.blendMode;
     const tintRgba = node.tint.toRgba();
 
@@ -277,16 +317,10 @@ export class WebGl2TileChunkRenderer extends AbstractWebGl2Renderer<TileChunkNod
       return;
     }
 
-    const view = backend.view;
-
-    if (this._currentView !== view || this._currentViewId !== view.updateId) {
-      this._currentView = view;
-      this._currentViewId = view.updateId;
-      this._shader.getUniform('u_projection').setValue(view.getTransform().toArray(false));
-    }
+    this._stageViewUniforms(backend);
 
     if (this._currentTexture !== null) {
-      this._shader.getUniform('u_texture').setValue(new Int32Array([0]));
+      this._shader.getUniform('u_texture').setValue(this._baseTextureUnitScratch);
     }
 
     backend.bindTransformBufferTexture(transformTextureUnit, this._maxNodeIndex + 1);
@@ -299,8 +333,179 @@ export class WebGl2TileChunkRenderer extends AbstractWebGl2Renderer<TileChunkNod
     backend.stats.batches++;
     backend.stats.drawCalls++;
 
+    // Retained recording (Track B): while a capture window is open, hand the
+    // exact packed instance words of this flush to the backend — byte-
+    // identical to what just drew. A batch always binds a single tileset
+    // texture (slot 0); a pixel-snapped node already poisoned the capture in
+    // render().
+    if (backend._isRetainedCapturing && this._currentTexture !== null) {
+      this._recordTextures[0] = this._currentTexture;
+      backend._recordRetainedBatch(
+        this,
+        this._instanceUint32.subarray(0, this._quadIndex * wordsPerInstance),
+        this._quadIndex,
+        this._currentBlendMode ?? BlendModes.Normal,
+        this._recordTextures,
+        1,
+      );
+    }
+
     this._quadIndex = 0;
     this._maxNodeIndex = 0;
+  }
+
+  /**
+   * Stage `u_projection` (live view) and `u_group` (live composed group
+   * matrix) on the shader, guarded by cached view/group stamps. Shared by the
+   * live flush path and retained-batch replay — replay resolves exactly the
+   * same live state a slow-path flush would.
+   */
+  private _stageViewUniforms(backend: WebGl2Backend): void {
+    const view = backend.view;
+
+    if (this._currentView !== view || this._currentViewId !== view.updateId) {
+      this._currentView = view;
+      this._currentViewId = view.updateId;
+      this._shader.getUniform('u_projection').setValue(view.getTransform().toArray(false));
+    }
+
+    if (this._currentGroupTransformId !== backend.renderGroupTransformId) {
+      this._currentGroupTransformId = backend.renderGroupTransformId;
+
+      const groupTransform = backend.renderGroupTransform;
+
+      this._shader.getUniform('u_group').setValue(groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3);
+    }
+  }
+
+  // ── Retained-batch record/replay (Track B) ────────────────────────────────
+  // The bundle stores raw instance bytes; this renderer owns the 32-byte
+  // layout (tile word at word 7: transform row in bits 0..28, diagonal flip in
+  // bit 29), so the layout-aware finalize steps (node-index scan/rebase, VAO
+  // attribute wiring) and the replay dispatch live here — mirroring
+  // WebGl2NineSliceSpriteRenderer's seam.
+
+  /** @internal See {@link WebGl2RetainedBatchReplayer._scanRetainedNodeIndexRange}. */
+  public _scanRetainedNodeIndexRange(payload: WebGl2RetainedBatchPayload, range: WebGl2RetainedNodeIndexRange): void {
+    const words = payload.bundle.instanceWords;
+    const start = payload.byteOffset / Uint32Array.BYTES_PER_ELEMENT;
+
+    for (let i = 0; i < payload.instanceCount; i++) {
+      // In-bounds: the payload's word range was appended to the bundle store.
+      // The tile word is the last word of the 32-byte (8-word) instance
+      // layout; only the low 29 bits address the transform buffer row — the
+      // diagonal-flip flag (bit 29) is orientation, not a row index.
+      const row = words[start + i * wordsPerInstance + 7]! & TILE_ROW_MASK;
+
+      if (row < range.min) {
+        range.min = row;
+      }
+
+      if (row > range.max) {
+        range.max = row;
+      }
+    }
+  }
+
+  /** @internal See {@link WebGl2RetainedBatchReplayer._rebaseRetainedNodeIndices} (group-local indices). */
+  public _rebaseRetainedNodeIndices(payload: WebGl2RetainedBatchPayload, base: number): void {
+    const words = payload.bundle.instanceWords;
+    const start = payload.byteOffset / Uint32Array.BYTES_PER_ELEMENT;
+
+    for (let i = 0; i < payload.instanceCount; i++) {
+      const index = start + i * wordsPerInstance + 7;
+      // In-bounds: see the scan above. Rebase ONLY the row field; the
+      // diagonal-flip bit must survive untouched or tile orientation corrupts.
+      const word = words[index]!;
+      const diagonal = word & TILE_DIAGONAL_BIT;
+      const row = word & TILE_ROW_MASK;
+
+      words[index] = (diagonal | ((row - base) & TILE_ROW_MASK)) >>> 0;
+    }
+  }
+
+  /**
+   * Point the batch VAO's per-instance attributes at the bundle's persistent
+   * instance buffer, based at the batch's byte offset (WebGL2 has no
+   * baseInstance, hence one small VAO per recorded batch). Same attribute
+   * set/locations as the live VAO in {@link onConnect}.
+   * @internal
+   */
+  public _configureRetainedVao(payload: WebGl2RetainedBatchPayload): void {
+    const gl = this.getBackend().context;
+    const buffer = payload.bundle.instanceBuffer;
+    const vao = payload.vao;
+
+    if (buffer === null || vao === null) {
+      throw new Error('WebGl2TileChunkRenderer: retained batch VAO configuration requires an uploaded bundle.');
+    }
+
+    const base = payload.byteOffset;
+
+    vao
+      .addAttribute(buffer, this._shader.getAttribute('a_quadBounds'), gl.FLOAT, false, instanceStrideBytes, base + 0, false, 1)
+      .addAttribute(buffer, this._shader.getAttribute('a_uvBounds'), gl.UNSIGNED_SHORT, true, instanceStrideBytes, base + 16, false, 1)
+      .addAttribute(buffer, this._shader.getAttribute('a_color'), gl.UNSIGNED_BYTE, true, instanceStrideBytes, base + 24, false, 1)
+      .addAttribute(buffer, this._shader.getAttribute('a_tileWord'), gl.UNSIGNED_INT, false, instanceStrideBytes, base + 28, true, 1);
+  }
+
+  /**
+   * Replay one recorded batch: all STATE is resolved live — blend mode via
+   * the backend's dedup, `u_projection`/`u_group` from the live view + live
+   * composed group matrix (the camera-pan / group-move win), the single
+   * tileset texture bound to unit 0 by recorded slot order — and only the
+   * DATA is cached: the instance bytes in the bundle buffer (bound through
+   * the per-batch VAO) and the group-owned transform texture on the shared
+   * transform unit. The backend hook flushed any pending live batch before
+   * dispatching here and bumps the stats from the instruction descriptor.
+   * @internal
+   */
+  public _replayRetainedBatch(payload: WebGl2RetainedBatchPayload): void {
+    const backend = this.getBackendOrNull();
+    const vao = payload.vao;
+    const transformTexture = payload.bundle.transformTexture;
+
+    if (backend === null || vao === null || transformTexture === null) {
+      // Defensive: a bundle in this state never validates (generation), so a
+      // spliced replay cannot reach here; skip rather than crash mid-frame.
+      return;
+    }
+
+    if (payload.blendMode !== this._currentBlendMode) {
+      this._currentBlendMode = payload.blendMode;
+    }
+
+    backend.setBlendMode(payload.blendMode);
+    this._stageViewUniforms(backend);
+
+    const textures = payload.textures;
+
+    for (let i = 0; i < textures.length; i++) {
+      // In-bounds: i < textures.length.
+      backend.bindTexture(textures[i]!, i);
+    }
+
+    // Keep the live path's redundant-bind-skip cache coherent (a live
+    // TileChunkNode outside the group and the replayed batches inside it
+    // share this one renderer instance): unit 0 now actually holds this
+    // batch's texture, bypassing render()'s `_currentTexture` check, so the
+    // NEXT live draw must see the true bound texture or it wrongly skips its
+    // own bind and renders with this batch's leftover texture.
+    if (textures.length > 0) {
+      this._currentTexture = textures[0] as Texture;
+    }
+
+    this._shader.getUniform('u_texture').setValue(this._baseTextureUnitScratch);
+
+    // The group-owned transform store replaces the shared frame buffer on the
+    // SAME unit/sampler — zero GLSL changes. The next live flush re-binds the
+    // shared texture through bindTransformBufferTexture.
+    backend.bindTexture(transformTexture, transformTextureUnit);
+    this._shader.getUniform('u_transforms').setValue(this._transformUnitScratch);
+
+    this._shader.sync();
+    backend.bindVertexArrayObject(vao);
+    vao.drawInstanced(4, 0, payload.instanceCount, RenderingPrimitives.TriangleStrip);
   }
 
   protected onConnect(backend: WebGl2Backend): void {
@@ -332,6 +537,7 @@ export class WebGl2TileChunkRenderer extends AbstractWebGl2Renderer<TileChunkNod
     this._currentTexture = null;
     this._currentView = null;
     this._currentViewId = -1;
+    this._currentGroupTransformId = -1;
     this._quadIndex = 0;
     this._maxNodeIndex = 0;
   }

--- a/packages/exojs-tilemap/src/webgpu/WebGpuTileChunkRenderer.ts
+++ b/packages/exojs-tilemap/src/webgpu/WebGpuTileChunkRenderer.ts
@@ -1,14 +1,30 @@
 /// <reference types="@webgpu/types" />
 
-import type { BlendModes, WebGpuBackend } from '@codexo/exojs/renderer-sdk';
-import { AbstractWebGpuRenderer, getWebGpuBlendState, stencilContentDepthStencilState, Texture } from '@codexo/exojs/renderer-sdk';
+import { Matrix } from '@codexo/exojs';
+import type {
+  RenderTexture,
+  WebGpuActiveRenderPass,
+  WebGpuRetainedBatchPayload,
+  WebGpuRetainedBatchReplayer,
+  WebGpuRetainedNodeIndexRange,
+} from '@codexo/exojs/renderer-sdk';
+import type { View, WebGpuBackend } from '@codexo/exojs/renderer-sdk';
+import {
+  AbstractWebGpuRenderer,
+  type BlendModes,
+  getWebGpuBlendState,
+  packAffineMat4,
+  retainedGroupUniformBytes,
+  stencilContentDepthStencilState,
+  Texture,
+} from '@codexo/exojs/renderer-sdk';
 
 import type { TileQuad } from '../chunkGeometry';
 import type { TileChunkNode } from '../TileChunkNode';
 
 const instanceStrideBytes = 32;
 const wordsPerInstance = instanceStrideBytes / Uint32Array.BYTES_PER_ELEMENT; // = 8
-const projectionByteLength = 64;
+const projectionByteLength = 128;
 const initialBatchCapacity = 256;
 const indicesPerInstance = 6;
 const quadIndices = new Uint16Array([0, 1, 2, 0, 2, 3]);
@@ -19,6 +35,7 @@ const TILE_DIAGONAL_BIT = 0x20000000;
 const tileShaderSource = `
 struct ProjectionUniforms {
     matrix: mat4x4<f32>,
+    group: mat4x4<f32>,
 };
 
 struct TransformSlot {
@@ -68,7 +85,7 @@ fn vertexMain(input: VertexInput, @builtin(vertex_index) vid: u32) -> VertexOutp
     let worldX = slot.m0.x * localX + slot.m0.y * localY + slot.m1.x;
     let worldY = slot.m0.z * localX + slot.m0.w * localY + slot.m1.y;
 
-    output.position = projection.matrix * vec4<f32>(worldX, worldY, 0.0, 1.0);
+    output.position = projection.matrix * projection.group * vec4<f32>(worldX, worldY, 0.0, 1.0);
 
     // Tile orientation: diagonal transposes the corner-coordinate axes; flipX/Y
     // are baked into the UV corner ordering by the CPU writer.
@@ -103,8 +120,25 @@ fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
  * instance buffer grows on demand rather than flushing in fixed runs.
  * @internal
  */
-export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNode> {
+export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNode> implements WebGpuRetainedBatchReplayer {
+  /**
+   * Retained-batch capability opt-in (Track B): a tile chunk's per-flush
+   * instanced batches (fixed 32-byte layout, tile word at word 7) record and
+   * replay from group-owned resources. Pixel-snapped draws are excluded by
+   * the collect-time recordability predicate (and belt-and-braces poisoning
+   * in {@link render}); tile chunks have no custom-material path to exclude.
+   * @internal
+   */
+  public readonly _supportsRetainedBatches = true;
+
   private readonly _projectionData = new Float32Array(projectionByteLength / Float32Array.BYTES_PER_ELEMENT);
+  // Projection-uniform skip state: a matching (view identity, view.updateId,
+  // group-transform id) triple means the shared UBO already holds this
+  // flush's projection, so the 128-byte write is skipped.
+  private _writtenView: View | null = null;
+  private _writtenViewUpdateId = -1;
+  private _writtenGroupTransformId = -1;
+  private _hasWrittenProjection = false;
 
   private _device: GPUDevice | null = null;
   private _shaderModule: GPUShaderModule | null = null;
@@ -121,11 +155,23 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
   private _instanceFloat32 = new Float32Array(this._instanceData);
   private _instanceUint32 = new Uint32Array(this._instanceData);
   private readonly _pipelines = new Map<string, GPURenderPipeline>();
+  // group(1) texture bind groups cached per texture (mirrors the sprite/
+  // nine-slice renderers): resolving `backend.getTextureBinding` is what
+  // syncs a dirty/mutated texture's content to the GPU, so it must run every
+  // flush/replay even when the bind group itself is served from cache.
+  private _textureBindGroups = new WeakMap<Texture | RenderTexture, { group: GPUBindGroup; view: GPUTextureView; sampler: GPUSampler }>();
 
   private _quadIndex = 0;
   private _maxNodeIndex = 0;
   private _currentBlendMode: BlendModes | null = null;
   private _currentTexture: Texture | null = null;
+
+  // ── Retained-batch replay state ───────────────────────────────────────────
+  private _lastReplayPass: WebGpuActiveRenderPass | null = null;
+  private readonly _stagedReplayGroupData = new Float32Array(16);
+  // Reused single-slot texture list handed to the backend at record time; a
+  // tile chunk batch always binds exactly one tileset texture (slot 0).
+  private readonly _recordTextures: Array<Texture | RenderTexture | null> = [null];
 
   protected onConnect(backend: WebGpuBackend): void {
     if (this._device) {
@@ -174,6 +220,9 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
     this._indexBuffer = null;
     this._transformBindGroup = null;
     this._transformStorageBuffer = null;
+    // Bind groups belong to the (possibly lost) device; drop the cache so
+    // reconnect rebuilds them against the fresh device.
+    this._textureBindGroups = new WeakMap<Texture | RenderTexture, { group: GPUBindGroup; view: GPUTextureView; sampler: GPUSampler }>();
     this._uniformBuffer = null;
     this._pipelineLayout = null;
     this._textureBindGroupLayout = null;
@@ -189,6 +238,11 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
     this._maxNodeIndex = 0;
     this._currentBlendMode = null;
     this._currentTexture = null;
+    this._writtenView = null;
+    this._writtenViewUpdateId = -1;
+    this._writtenGroupTransformId = -1;
+    this._hasWrittenProjection = false;
+    this._lastReplayPass = null;
   }
 
   public render(node: TileChunkNode): void {
@@ -196,6 +250,15 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
 
     if (backend === null) {
       return;
+    }
+
+    // Belt-and-braces for retained recording: the collect-time recordability
+    // predicate already excludes pixel-snapped draws from ever arming a
+    // capture. If one still arrives inside an active capture window, poison
+    // the recording so the resulting set can never validate — degrading to
+    // entry replay instead of wrong pixels.
+    if (node.pixelSnapMode !== 'none' && backend._retainedCaptureActive) {
+      backend._poisonActiveRetainedCaptures();
     }
 
     const pages = node.pages;
@@ -308,10 +371,29 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
       return;
     }
 
-    const viewMatrix = backend.view.getTransform();
+    // ProjectionUniforms layout: mat4x4 projection + mat4x4 group, packed via
+    // the shared canonical (non-transposed) column order (same layout as the
+    // sprite/nine-slice renderers' group UBO, S3-D4/S3-D7 parity). The write
+    // is skipped when the UBO already holds this exact (view, updateId,
+    // group-id) state.
+    const view = backend.view;
 
-    this._projectionData.set([viewMatrix.a, viewMatrix.c, 0, 0, viewMatrix.b, viewMatrix.d, 0, 0, 0, 0, 1, 0, viewMatrix.x, viewMatrix.y, 0, viewMatrix.z]);
-    device.queue.writeBuffer(uniformBuffer, 0, this._projectionData.buffer, this._projectionData.byteOffset, this._projectionData.byteLength);
+    if (
+      !this._hasWrittenProjection ||
+      this._writtenView !== view ||
+      this._writtenViewUpdateId !== view.updateId ||
+      this._writtenGroupTransformId !== backend.renderGroupTransformId
+    ) {
+      packAffineMat4(view.getTransform(), this._projectionData, 0);
+      packAffineMat4(backend.renderGroupTransform ?? Matrix.identity, this._projectionData, 16);
+
+      this._writtenView = view;
+      this._writtenViewUpdateId = view.updateId;
+      this._writtenGroupTransformId = backend.renderGroupTransformId;
+      this._hasWrittenProjection = true;
+
+      device.queue.writeBuffer(uniformBuffer, 0, this._projectionData.buffer, this._projectionData.byteOffset, this._projectionData.byteLength);
+    }
 
     const scissor = backend.getScissorRect();
     const maskClipsAll = scissor !== null && (scissor.width <= 0 || scissor.height <= 0);
@@ -323,7 +405,7 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
 
       const storage = backend.getTransformStorageBuffer(this._maxNodeIndex + 1);
       const transformBindGroup = this._getOrCreateTransformBindGroup(device, uniformBuffer, storage.buffer);
-      const textureBindGroup = this._createTextureBindGroup(device, backend, this._currentTexture);
+      const textureBindGroup = this._getOrCreateTextureBindGroup(device, backend, this._currentTexture);
 
       const stencil = backend._passCoordinator.stencilActive;
       const pipeline = this._getPipeline(this._currentBlendMode, backend.renderTargetFormat, stencil);
@@ -337,6 +419,26 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
 
       backend.stats.batches++;
       backend.stats.drawCalls++;
+    }
+
+    // Retained capture: while a capture window is active, additionally stage
+    // this batch's exact packed bytes into the group-owned bundle — the
+    // recorded data IS the drawn data, byte-identical by construction.
+    // Recorded regardless of the live visibility decision above (mask/
+    // scissor), since visibility is re-evaluated live at replay. A batch
+    // always binds a single tileset texture (slot 0); a pixel-snapped node
+    // already poisoned the capture in render().
+    if (this._quadIndex > 0 && backend._retainedCaptureActive && this._currentBlendMode !== null && this._currentTexture !== null) {
+      this._recordTextures[0] = this._currentTexture;
+      backend._recordRetainedBatch(
+        this,
+        this._instanceData,
+        this._quadIndex * instanceStrideBytes,
+        this._quadIndex,
+        this._currentBlendMode,
+        this._recordTextures,
+        1,
+      );
     }
 
     backend._passCoordinator.endPass();
@@ -368,16 +470,181 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
     return this._transformBindGroup;
   }
 
-  private _createTextureBindGroup(device: GPUDevice, backend: WebGpuBackend, texture: Texture): GPUBindGroup {
-    const binding = backend.getTextureBinding(texture);
+  /**
+   * Build (or reuse) the group(1) texture bind group for `texture`. The
+   * binding is resolved BEFORE the cache lookup on purpose: resolving is what
+   * syncs a dirty/mutated texture's content to the GPU, so it must run every
+   * flush/replay even when the bind group itself is served from cache.
+   */
+  private _getOrCreateTextureBindGroup(device: GPUDevice, backend: WebGpuBackend, texture: Texture | RenderTexture): GPUBindGroup {
+    const { view, sampler } = backend.getTextureBinding(texture);
+    const cached = this._textureBindGroups.get(texture);
 
-    return device.createBindGroup({
+    if (cached?.view === view && cached.sampler === sampler) {
+      return cached.group;
+    }
+
+    const group = device.createBindGroup({
       layout: this._textureBindGroupLayout!,
       entries: [
-        { binding: 0, resource: binding.view },
-        { binding: 1, resource: binding.sampler },
+        { binding: 0, resource: view },
+        { binding: 1, resource: sampler },
       ],
     });
+
+    this._textureBindGroups.set(texture, { group, view, sampler });
+
+    return group;
+  }
+
+  // ── Retained-batch record/replay (Track B) ────────────────────────────────
+  // The bundle/stage stores raw instance bytes; this renderer owns the
+  // 32-byte (8-word) layout (tile word at word 7: transform row in bits
+  // 0..28, diagonal flip in bit 29), so the layout-aware finalize steps
+  // (node-index scan/rebase) and the replay dispatch live here — mirroring
+  // WebGpuNineSliceSpriteRenderer's seam.
+
+  /** @internal See {@link WebGpuRetainedBatchReplayer._scanRetainedNodeIndexRange}. */
+  public _scanRetainedNodeIndexRange(bytes: Uint8Array, range: WebGpuRetainedNodeIndexRange): void {
+    const words = new Uint32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / Uint32Array.BYTES_PER_ELEMENT);
+
+    for (let i = 7; i < words.length; i += 8) {
+      // In-bounds: i < words.length via the loop guard. The tile word is the
+      // last word of the 32-byte (8-word) instance layout; only the low 29
+      // bits address the transform buffer row.
+      const row = words[i]! & TILE_ROW_MASK;
+
+      if (row < range.min) {
+        range.min = row;
+      }
+
+      if (row > range.max) {
+        range.max = row;
+      }
+    }
+  }
+
+  /** @internal See {@link WebGpuRetainedBatchReplayer._rebaseRetainedNodeIndices} (group-local indices). */
+  public _rebaseRetainedNodeIndices(bytes: Uint8Array, base: number): void {
+    const words = new Uint32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / Uint32Array.BYTES_PER_ELEMENT);
+
+    for (let i = 7; i < words.length; i += 8) {
+      // In-bounds: i < words.length via the loop guard. Rebase ONLY the row
+      // field; the diagonal-flip bit must survive untouched or tile
+      // orientation corrupts.
+      const word = words[i]!;
+      const diagonal = word & TILE_DIAGONAL_BIT;
+      const row = word & TILE_ROW_MASK;
+
+      words[i] = (diagonal | ((row - base) & TILE_ROW_MASK)) >>> 0;
+    }
+  }
+
+  /**
+   * Replay one recorded batch from its group-owned bundle into the OPEN pass.
+   * Reuses only recorded DATA (instance bytes, transform rows, texture, blend
+   * mode); every piece of STATE is resolved live — pipeline via the
+   * `_getPipeline` cache, the group(1) texture bind group via the live
+   * texture-set cache (resolving re-syncs dirty content), and the group's
+   * 128-byte UBO (projection from the live view + the live composed group
+   * matrix) written only when its content changed. The same-frame
+   * double-replay hazard (one group under two views while the open pass
+   * already holds this bundle's draws) ends the pass first.
+   * @internal
+   */
+  public _replayRetainedBatch(payload: WebGpuRetainedBatchPayload): void {
+    const backend = this._backend;
+    const device = this._device;
+    const bundle = payload.bundle;
+
+    if (!backend || !device || this._indexBuffer === null || !bundle.isReady) {
+      return;
+    }
+
+    // Drain any pending live batch first (defensive — the group boundary
+    // already flushed; flush() is a no-op when nothing is pending).
+    this.flush();
+
+    // Match the live path's visibility handling: a fully-clipped scissor
+    // draws nothing (the batch stays recorded; visibility is live per frame).
+    const scissor = backend.getScissorRect();
+
+    if (scissor !== null && (scissor.width <= 0 || scissor.height <= 0)) {
+      return;
+    }
+
+    const coordinator = backend._passCoordinator;
+    let activePass = coordinator.activePass;
+    const passHasDraws = activePass !== null && this._lastReplayPass === activePass;
+
+    // Same-frame texture mutation guard: resolving the bindings below
+    // re-uploads mutated content on the queue timeline BEFORE the deferred
+    // submit, which would retroactively change draws already recorded into
+    // the open pass. End (submit) the pass first so they keep the
+    // pre-mutation content.
+    if (passHasDraws) {
+      for (const texture of payload.textures) {
+        if (backend._textureUploadWouldMutate(texture)) {
+          coordinator.endPass();
+          break;
+        }
+      }
+    }
+
+    // Resolve the single tileset texture LIVE through the texture bind-group
+    // cache (syncs dirty content, adopts refreshed views/samplers). The
+    // recorded batch always has exactly one texture (slot 0).
+    const textureBindGroup = this._getOrCreateTextureBindGroup(device, backend, payload.textures[0]!);
+
+    // Group UBO: skip the write while (view, updateId, group bytes) match
+    // what the buffer holds; guard the double-replay aliasing case first.
+    const view = backend.view;
+    const scratch = this._stagedReplayGroupData;
+
+    packAffineMat4(backend.renderGroupTransform ?? Matrix.identity, scratch, 0);
+
+    let uboDirty = !bundle.uboWritten || bundle.uboView !== view || bundle.uboViewUpdateId !== view.updateId;
+
+    if (!uboDirty) {
+      for (let i = 0; i < 16; i++) {
+        if (scratch[i] !== bundle.uboData[16 + i]) {
+          uboDirty = true;
+          break;
+        }
+      }
+    }
+
+    if (uboDirty) {
+      activePass = coordinator.activePass;
+
+      if (activePass !== null && bundle.drawsInPass === activePass) {
+        // Rewriting the UBO would retroactively re-project this bundle's
+        // draws already recorded into the open pass: end it first.
+        coordinator.endPass();
+      }
+
+      packAffineMat4(view.getTransform(), bundle.uboData, 0);
+      bundle.uboData.set(scratch, 16);
+      bundle.uboView = view;
+      bundle.uboViewUpdateId = view.updateId;
+      bundle.uboWritten = true;
+      device.queue.writeBuffer(bundle.uniformBuffer!, 0, bundle.uboData.buffer, bundle.uboData.byteOffset, retainedGroupUniformBytes);
+    }
+
+    const active = coordinator.acquirePass();
+    const pass = active.pass;
+
+    pass.setPipeline(this._getPipeline(payload.blendMode, backend.renderTargetFormat, coordinator.stencilActive));
+    pass.setBindGroup(0, bundle.getBindGroup(device, this._uniformBindGroupLayout!));
+    pass.setBindGroup(1, textureBindGroup);
+    pass.setVertexBuffer(0, bundle.instanceBuffer, payload.byteOffset);
+    pass.setIndexBuffer(this._indexBuffer, 'uint16');
+    pass.drawIndexed(indicesPerInstance, payload.instanceCount, 0, 0, 0);
+
+    bundle.drawsInPass = active;
+    this._lastReplayPass = active;
+    backend.stats.batches++;
+    backend.stats.drawCalls++;
   }
 
   private _getPipeline(blendMode: BlendModes, format: GPUTextureFormat, stencil: boolean): GPURenderPipeline {

--- a/packages/exojs-tilemap/test/tile-chunk-content-invalidation.test.ts
+++ b/packages/exojs-tilemap/test/tile-chunk-content-invalidation.test.ts
@@ -1,0 +1,151 @@
+import { TextureRegion } from '@codexo/exojs';
+import { type Texture } from '@codexo/exojs';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { TileChunkNode } from '../src/TileChunkNode';
+import { TileLayer } from '../src/TileLayer';
+import { TileLayerNode } from '../src/TileLayerNode';
+import { TileSet } from '../src/TileSet';
+import { TILE_TRANSFORM_IDENTITY } from '../src/types';
+
+/**
+ * Track B retained-batch record/replay for `TileChunkNode` relies on the
+ * engine's content-revision contract: `RetainedContainer` skips walking (and
+ * re-collecting) a content-CLEAN subtree entirely, splicing the previously
+ * captured/recorded draw range instead. `TileChunkNode.pages` caches geometry
+ * against `chunk.revision`, but that cache is only consulted from `render()` —
+ * a call the engine never makes on a content-clean frame. Without an explicit
+ * push from the chunk's mutation site to `SceneNode._markContentDirty()`, an
+ * in-place tile edit after a group capture would replay stale geometry
+ * forever. These tests pin the wiring (`TileChunk._addDirtyListener` ->
+ * `TileChunkNode.invalidateContent()`) directly, independent of a real GPU
+ * backend — see the browser suites for the full retained-replay pixel proof.
+ */
+
+function fakeTexture(width = 512, height = 512): Texture {
+  return {
+    width,
+    height,
+    flipY: false,
+    uid: 0,
+    label: 'test',
+    destroy: vi.fn(),
+    destroyed: false,
+  } as unknown as Texture;
+}
+
+function makeTileset(name = 'tiles'): TileSet {
+  return new TileSet({
+    name,
+    texture: new TextureRegion(fakeTexture(), { x: 0, y: 0, width: 512, height: 512 }),
+    tileWidth: 32,
+    tileHeight: 32,
+    tileCount: 16,
+  });
+}
+
+/** Read the internal aggregate content revision the engine keys retained captures on. */
+function contentRevisionOf(node: TileChunkNode): number {
+  return (node as unknown as { _contentRevision: number })._contentRevision;
+}
+
+describe('TileChunk mutation -> TileChunkNode content-dirty wiring', () => {
+  it('setTileAt on an existing chunk bumps the owning TileChunkNode content revision', () => {
+    const tileset = makeTileset();
+    const layer = new TileLayer({ id: 1, name: 'l', width: 4, height: 4, tileWidth: 32, tileHeight: 32, tilesets: [tileset] });
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+
+    const node = new TileLayerNode(layer);
+    const chunkNode = node.chunkNodes[0]!;
+    const before = contentRevisionOf(chunkNode);
+
+    layer.setTileAt(1, 1, { tileset, localTileId: 1, transform: TILE_TRANSFORM_IDENTITY });
+
+    expect(contentRevisionOf(chunkNode)).toBeGreaterThan(before);
+  });
+
+  it('clearTileAt on an existing chunk bumps the owning TileChunkNode content revision', () => {
+    const tileset = makeTileset();
+    const layer = new TileLayer({ id: 1, name: 'l', width: 4, height: 4, tileWidth: 32, tileHeight: 32, tilesets: [tileset] });
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+
+    const node = new TileLayerNode(layer);
+    const chunkNode = node.chunkNodes[0]!;
+    const before = contentRevisionOf(chunkNode);
+
+    layer.clearTileAt(0, 0);
+
+    expect(contentRevisionOf(chunkNode)).toBeGreaterThan(before);
+  });
+
+  it('fillRect / clearRect bulk mutations bump the content revision exactly once each', () => {
+    const tileset = makeTileset();
+    const layer = new TileLayer({ id: 1, name: 'l', width: 4, height: 4, tileWidth: 32, tileHeight: 32, tilesets: [tileset] });
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+
+    const node = new TileLayerNode(layer);
+    const chunkNode = node.chunkNodes[0]!;
+
+    const afterFirstTile = contentRevisionOf(chunkNode);
+
+    layer.fillRect(0, 0, 2, 2, { tileset, localTileId: 2, transform: TILE_TRANSFORM_IDENTITY });
+    expect(contentRevisionOf(chunkNode)).toBeGreaterThan(afterFirstTile);
+
+    const afterFill = contentRevisionOf(chunkNode);
+
+    layer.clearRect(0, 0, 2, 2);
+    expect(contentRevisionOf(chunkNode)).toBeGreaterThan(afterFill);
+  });
+
+  it('a no-op write (same tile value) does NOT bump the content revision', () => {
+    const tileset = makeTileset();
+    const layer = new TileLayer({ id: 1, name: 'l', width: 4, height: 4, tileWidth: 32, tileHeight: 32, tilesets: [tileset] });
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+
+    const node = new TileLayerNode(layer);
+    const chunkNode = node.chunkNodes[0]!;
+    const before = contentRevisionOf(chunkNode);
+
+    // Writing the identical tile at the identical cell: TileChunk._setRawAt
+    // returns false and must not fire the dirty listener.
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+
+    expect(contentRevisionOf(chunkNode)).toBe(before);
+  });
+
+  it('destroy() unregisters the listener: a later mutation of the (still-live) chunk no longer touches the destroyed node', () => {
+    const tileset = makeTileset();
+    const layer = new TileLayer({ id: 1, name: 'l', width: 4, height: 4, tileWidth: 32, tileHeight: 32, tilesets: [tileset] });
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+
+    const node = new TileLayerNode(layer);
+    const chunkNode = node.chunkNodes[0]!;
+    const invalidateSpy = vi.spyOn(chunkNode, 'invalidateContent');
+
+    chunkNode.destroy();
+
+    // The chunk itself is untouched by destroying the render node (documented:
+    // `TileLayerNode` never owns the `TileLayer`/chunk data).
+    layer.setTileAt(1, 1, { tileset, localTileId: 3, transform: TILE_TRANSFORM_IDENTITY });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it('two TileLayerNodes over the same TileLayer both observe a mutation (multi-listener support)', () => {
+    const tileset = makeTileset();
+    const layer = new TileLayer({ id: 1, name: 'l', width: 4, height: 4, tileWidth: 32, tileHeight: 32, tilesets: [tileset] });
+    layer.setTileAt(0, 0, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+
+    const nodeA = new TileLayerNode(layer);
+    const nodeB = new TileLayerNode(layer);
+    const chunkA = nodeA.chunkNodes[0]!;
+    const chunkB = nodeB.chunkNodes[0]!;
+    const beforeA = contentRevisionOf(chunkA);
+    const beforeB = contentRevisionOf(chunkB);
+
+    layer.setTileAt(0, 0, { tileset, localTileId: 5, transform: TILE_TRANSFORM_IDENTITY });
+
+    expect(contentRevisionOf(chunkA)).toBeGreaterThan(beforeA);
+    expect(contentRevisionOf(chunkB)).toBeGreaterThan(beforeB);
+  });
+});

--- a/src/renderer-sdk.ts
+++ b/src/renderer-sdk.ts
@@ -11,9 +11,11 @@
 // internal and intentionally NOT exported here: they are coupled to internal
 // sprite/mesh data paths and are not a stable subclassing surface pre-1.0.
 
+export { packAffineMat4 } from '#rendering/affinePacking';
 export { Drawable } from '#rendering/Drawable';
 export type { PixelSnapMode } from '#rendering/pixelSnap';
 export type { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
+export type { RetainedGroupBundle } from '#rendering/plan/RetainedInstructionSet';
 export type { RenderBackend } from '#rendering/RenderBackend';
 export { RenderBackendType } from '#rendering/RenderBackendType';
 export type { DrawableConstructor, Renderer } from '#rendering/Renderer';
@@ -21,6 +23,7 @@ export { RendererRegistry } from '#rendering/RendererRegistry';
 export type { ShaderProgram } from '#rendering/shader/Shader';
 export { Shader } from '#rendering/shader/Shader';
 export { Spritesheet } from '#rendering/sprite/Spritesheet';
+export { RenderTexture } from '#rendering/texture/RenderTexture';
 export { Texture } from '#rendering/texture/Texture';
 export { BlendModes, BufferTypes, BufferUsage, RenderingPrimitives } from '#rendering/types';
 export { View } from '#rendering/View';
@@ -29,6 +32,12 @@ export { AbstractWebGl2Renderer } from '#rendering/webgl2/AbstractWebGl2Renderer
 export { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
 export type { WebGl2RenderBufferRuntime } from '#rendering/webgl2/WebGl2RenderBuffer';
 export { WebGl2RenderBuffer } from '#rendering/webgl2/WebGl2RenderBuffer';
+export type {
+  WebGl2RetainedBatchPayload,
+  WebGl2RetainedBatchReplayer,
+  WebGl2RetainedGeometryRef,
+  WebGl2RetainedNodeIndexRange,
+} from '#rendering/webgl2/WebGl2RetainedGroupResources';
 export { WebGl2ShaderBlock } from '#rendering/webgl2/WebGl2ShaderBlock';
 export { createWebGl2ShaderProgram } from '#rendering/webgl2/WebGl2ShaderProgram';
 export type { WebGl2VertexArrayObjectRuntime } from '#rendering/webgl2/WebGl2VertexArrayObject';
@@ -38,4 +47,12 @@ export type { ComputeBinding } from '#rendering/webgpu/compute/index';
 export { WebGpuComputePipeline, WebGpuStorageBuffer } from '#rendering/webgpu/compute/index';
 export { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 export { getWebGpuBlendState } from '#rendering/webgpu/WebGpuBlendState';
+export type { WebGpuActiveRenderPass } from '#rendering/webgpu/WebGpuPassCoordinator';
+export {
+  retainedGroupUniformBytes,
+  type WebGpuRetainedBatchPayload,
+  type WebGpuRetainedBatchReplayer,
+  type WebGpuRetainedGeometryRef,
+  type WebGpuRetainedNodeIndexRange,
+} from '#rendering/webgpu/WebGpuRetainedGroupResources';
 export { stencilContentDepthStencilState } from '#rendering/webgpu/WebGpuStencilState';

--- a/test/rendering/browser/webgl2-tilemap-retained-instruction-replay.test.ts
+++ b/test/rendering/browser/webgl2-tilemap-retained-instruction-replay.test.ts
@@ -1,0 +1,348 @@
+/**
+ * WebGL2 renderer-matrix browser tests — TileChunkNode retained instruction-set
+ * replay (Track B).
+ *
+ * A retained group holding TileMapNode(s) whose playback was recorded replays
+ * through `_replayRetainedBatch` from group-owned resources (persistent
+ * instance buffer + group transform texture) and must produce BYTE-IDENTICAL
+ * frames to the entry-replay slow path. A live TileMapNode OUTSIDE the group
+ * keeps the group's shared transform rows starting at a non-zero frame-global
+ * index, so the group-local tile-word rebase (row bits 0..28, diagonal bit 29
+ * preserved) is load-bearing in every assertion: a broken rebase (or a wrong
+ * byte offset) fetches the wrong / out-of-range transform row and the
+ * full-canvas byte comparison fails.
+ *
+ * The renderer uses inline GLSL, so no shader-file mocks are required, and the
+ * scene only emits TileChunkNode drawables, so no core renderers are wired.
+ *
+ * Run via:  pnpm test:browser:webgl
+ */
+
+import { TILE_TRANSFORM_IDENTITY, TileLayer, TileMap, TileMapNode, TileSet } from '@codexo/exojs-tilemap';
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import type { RenderNode } from '#rendering/RenderNode';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { Texture } from '#rendering/texture/Texture';
+import { TextureRegion } from '#rendering/texture/TextureRegion';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import { wireTilemapRenderers } from './_tilemapScene';
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const createBackend = async (): Promise<WebGl2Backend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const app: Application = {
+    canvas,
+    options: {
+      clearColor: Color.black,
+      canvas: { width: canvasSize, height: canvasSize },
+      rendering: {
+        debug: false,
+        webglAttributes: {
+          alpha: false,
+          antialias: false,
+          premultipliedAlpha: false,
+          preserveDrawingBuffer: true,
+          stencil: false,
+          depth: false,
+        },
+      },
+    },
+  } as unknown as Application;
+
+  const backend = new WebGl2Backend(app);
+
+  await backend.initialize();
+  wireTilemapRenderers(backend);
+
+  return backend;
+};
+
+const render = (backend: WebGl2Backend, node: RenderNode): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+  node.render(backend);
+  backend.flush();
+};
+
+const readPixel = (backend: WebGl2Backend, x: number, y: number): RgbaTuple => {
+  const buf = new Uint8Array(4);
+  const gl = backend.context;
+
+  gl.readPixels(Math.floor(x), backend.renderTarget.height - Math.floor(y) - 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+
+  return [buf[0], buf[1], buf[2], buf[3]];
+};
+
+/** Full-framebuffer snapshot for byte-identical tier comparisons. */
+const readCanvas = (backend: WebGl2Backend): Uint8Array => {
+  const buf = new Uint8Array(canvasSize * canvasSize * 4);
+  const gl = backend.context;
+
+  gl.readPixels(0, 0, canvasSize, canvasSize, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+
+  return buf;
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 12): void => {
+  for (let i = 0; i < 4; i++) {
+    expect(Math.abs(actual[i] - expected[i])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+const createSolidTexture = (color: string, size = 16): Texture => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = size;
+  canvas.height = size;
+
+  const ctx = canvas.getContext('2d')!;
+
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, size, size);
+
+  return new Texture(canvas);
+};
+
+interface Scene {
+  readonly root: Container;
+  readonly group: RetainedContainer;
+  readonly redLayer: TileLayer;
+  readonly greenLayer: TileLayer;
+  readonly destroy: () => void;
+}
+
+/**
+ * Standard cell scene: one live TileMapNode OUTSIDE (and before) the retained
+ * group so the group's shared transform rows never start at row 0 — the
+ * group-local tile-word rebase is load-bearing in every pixel assertion, and
+ * the replay path interleaves with a live batch every frame.
+ *
+ * The group holds two 16x16 single-tile TileMapNodes with DISTINCT tileset
+ * textures, so each records its own single-texture batch — exercising
+ * per-batch byte offsets across more than one recorded batch (mirrors the
+ * nine-slice retained-replay cells).
+ *
+ * Layout (canvas 64x64): blue outside tile at (48,0)-(64,16); group at
+ * (8,24) with a red tile at group-local (0,0) -> world (8,24)-(24,40) and a
+ * green tile at group-local (16,16) -> world (24,40)-(40,56).
+ */
+const buildScene = (): Scene => {
+  const blue = createSolidTexture('#0000ff');
+  const red = createSolidTexture('#ff0000');
+  const green = createSolidTexture('#00ff00');
+
+  const tsBlue = new TileSet({
+    name: 'blue',
+    texture: new TextureRegion(blue, { x: 0, y: 0, width: 16, height: 16 }),
+    tileWidth: 16,
+    tileHeight: 16,
+    tileCount: 1,
+  });
+  const tsRed = new TileSet({
+    name: 'red',
+    texture: new TextureRegion(red, { x: 0, y: 0, width: 16, height: 16 }),
+    tileWidth: 16,
+    tileHeight: 16,
+    tileCount: 1,
+  });
+  const tsGreen = new TileSet({
+    name: 'green',
+    texture: new TextureRegion(green, { x: 0, y: 0, width: 16, height: 16 }),
+    tileWidth: 16,
+    tileHeight: 16,
+    tileCount: 1,
+  });
+
+  const outsideLayer = new TileLayer({ id: 1, name: 'l', width: 1, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tsBlue] });
+  outsideLayer.setTileAt(0, 0, { tileset: tsBlue, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+  const outsideMap = new TileMap({ name: 'outside', width: 1, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tsBlue], layers: [outsideLayer] });
+  const outside = new TileMapNode(outsideMap);
+
+  const redLayer = new TileLayer({ id: 1, name: 'l', width: 1, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tsRed] });
+  redLayer.setTileAt(0, 0, { tileset: tsRed, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+  const redMap = new TileMap({ name: 'red', width: 1, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tsRed], layers: [redLayer] });
+  const redNode = new TileMapNode(redMap);
+
+  const greenLayer = new TileLayer({ id: 1, name: 'l', width: 1, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tsGreen] });
+  greenLayer.setTileAt(0, 0, { tileset: tsGreen, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+  const greenMap = new TileMap({ name: 'green', width: 1, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tsGreen], layers: [greenLayer] });
+  const greenNode = new TileMapNode(greenMap);
+
+  const root = new Container();
+  const group = new RetainedContainer();
+
+  outside.setPosition(48, 0);
+  root.addChild(outside);
+
+  redNode.setPosition(0, 0);
+  greenNode.setPosition(16, 16);
+  group.addChild(redNode);
+  group.addChild(greenNode);
+  group.setPosition(8, 24);
+  root.addChild(group);
+
+  const destroy = (): void => {
+    root.destroy();
+    blue.destroy();
+    red.destroy();
+    green.destroy();
+  };
+
+  return { root, group, redLayer, greenLayer, destroy };
+};
+
+const expectBaseScenePixels = (backend: WebGl2Backend): void => {
+  expectPixelNear(readPixel(backend, 52, 8), [0, 0, 255, 255]); // live outside tile
+  expectPixelNear(readPixel(backend, 12, 28), [255, 0, 0, 255]); // red tile inside the group
+  expectPixelNear(readPixel(backend, 28, 44), [0, 255, 0, 255]); // green tile inside the group
+  expectPixelNear(readPixel(backend, 4, 60), [0, 0, 0, 255]); // background
+};
+
+describe('WebGL2 renderer matrix: TileChunkNode retained instruction-set replay cells', () => {
+  test('cell 1 — the tile-chunk instruction-replay tier is byte-identical to the entry-replay and collect tiers', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+    const beginSpy = vi.spyOn(backend, '_beginRetainedCapture');
+    const replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+    try {
+      render(backend, scene.root); // F1 — full collect + fragment capture (slow tier)
+
+      const collectFrame = readCanvas(backend);
+
+      expectBaseScenePixels(backend);
+      expect(replaySpy).not.toHaveBeenCalled();
+
+      render(backend, scene.root); // F2 — entry replay + instruction recording
+
+      const recordFrame = readCanvas(backend);
+
+      expect(beginSpy).toHaveBeenCalledTimes(1);
+      expect(replaySpy).not.toHaveBeenCalled();
+
+      render(backend, scene.root); // F3 — instruction splice: recorded batches replay
+
+      const replayFrame = readCanvas(backend);
+
+      expect(replaySpy).toHaveBeenCalled();
+
+      render(backend, scene.root); // F4 — steady state
+
+      const steadyFrame = readCanvas(backend);
+
+      expect(beginSpy).toHaveBeenCalledTimes(1); // never re-recorded
+      expectBaseScenePixels(backend);
+      expect(recordFrame).toEqual(collectFrame);
+      expect(replayFrame).toEqual(recordFrame);
+      expect(steadyFrame).toEqual(recordFrame);
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 2 — camera pan on the replay path: live projection, no recapture', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+
+    try {
+      render(backend, scene.root);
+      render(backend, scene.root);
+      render(backend, scene.root);
+
+      const beginSpy = vi.spyOn(backend, '_beginRetainedCapture');
+      const replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+      backend.view.setCenter(backend.view.center.x + 16, backend.view.center.y);
+      render(backend, scene.root);
+
+      expect(beginSpy).not.toHaveBeenCalled();
+      expect(replaySpy).toHaveBeenCalled();
+      expectPixelNear(readPixel(backend, 36, 8), [0, 0, 255, 255]); // outside tile 32..48
+      expectPixelNear(readPixel(backend, 4, 28), [255, 0, 0, 255]); // red now 0..8
+      expectPixelNear(readPixel(backend, 12, 44), [0, 255, 0, 255]); // green now 8..24
+      expectPixelNear(readPixel(backend, 28, 28), [0, 0, 0, 255]); // old red spot is background
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 3 — group move on the replay path: one live group matrix relocates the cached tile batches', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+
+    try {
+      render(backend, scene.root);
+      render(backend, scene.root);
+      render(backend, scene.root);
+
+      const beginSpy = vi.spyOn(backend, '_beginRetainedCapture');
+      const replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+      scene.group.setPosition(24, 8);
+      render(backend, scene.root);
+
+      expect(beginSpy).not.toHaveBeenCalled();
+      expect(replaySpy).toHaveBeenCalled();
+      expectPixelNear(readPixel(backend, 28, 12), [255, 0, 0, 255]); // red 24..40 x 8..24
+      expectPixelNear(readPixel(backend, 44, 28), [0, 255, 0, 255]); // green 40..56 x 24..40
+      expectPixelNear(readPixel(backend, 12, 28), [0, 0, 0, 255]); // old red spot is background
+      expectPixelNear(readPixel(backend, 52, 8), [0, 0, 255, 255]); // live outside tile unaffected
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 4 — content mutation after capture: an edited tile is reflected, never replayed stale', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+
+    try {
+      render(backend, scene.root); // F1 capture
+      render(backend, scene.root); // F2 record
+      render(backend, scene.root); // F3 splice (recorded tier active)
+
+      // Edit a tile INSIDE the already-recorded group: clearing it must not
+      // replay the stale (red) geometry — the chunk revision bump must reach
+      // `_markContentDirty()` on the owning TileChunkNode so the group
+      // content-dirties and re-collects instead of splicing the previous
+      // instruction set. A dirty frame drops the recording but does not
+      // re-arm it (record-on-first-CLEAN-frame policy), so the pixel proof
+      // lands on this frame and the re-record proof lands one frame later.
+      scene.redLayer.clearTileAt(0, 0);
+      render(backend, scene.root); // dirty re-collect: drops the stale recording
+
+      expectPixelNear(readPixel(backend, 12, 28), [0, 0, 0, 255]); // cleared: background, not stale red
+      expectPixelNear(readPixel(backend, 28, 44), [0, 255, 0, 255]); // untouched sibling still correct
+      expectPixelNear(readPixel(backend, 52, 8), [0, 0, 255, 255]); // live outside tile unaffected
+
+      const beginSpy = vi.spyOn(backend, '_beginRetainedCapture');
+      const replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+      render(backend, scene.root); // clean entry-replay + re-arm record
+
+      expect(beginSpy).toHaveBeenCalledTimes(1);
+
+      render(backend, scene.root); // instruction splice of the NEW (post-edit) recording
+
+      expect(replaySpy).toHaveBeenCalled();
+      expectPixelNear(readPixel(backend, 12, 28), [0, 0, 0, 255]);
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgpu-tilemap-retained-instruction-replay.test.ts
+++ b/test/rendering/browser/webgpu-tilemap-retained-instruction-replay.test.ts
@@ -1,0 +1,378 @@
+/**
+ * WebGPU renderer-matrix browser tests — TileChunkNode retained instruction-set
+ * replay (Track B).
+ *
+ * The WebGPU counterpart of `webgl2-tilemap-retained-instruction-replay.test.ts`.
+ * A live TileMapNode OUTSIDE (and before) the retained group keeps the group's
+ * shared transform-storage rows starting at a non-zero frame-global index, and
+ * the group holds two DISTINCT-texture single-tile TileMapNodes (a batch always
+ * binds one tileset texture → two recorded batches). The replay tier must
+ * reproduce the record frame's pixels exactly; a broken tile-word rebase (or
+ * wrong byte offset) fetches the wrong / out-of-range storage row and the
+ * probes diverge.
+ *
+ * CI guarantees a real WebGPU adapter; tests only skip when the software
+ * adapter drops the device mid-test (same convention as the other WebGPU
+ * browser specs).
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import { TILE_TRANSFORM_IDENTITY, TileLayer, TileMap, TileMapNode, TileSet } from '@codexo/exojs-tilemap';
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import type { RenderNode } from '#rendering/RenderNode';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { Texture } from '#rendering/texture/Texture';
+import { TextureRegion } from '#rendering/texture/TextureRegion';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { wireTilemapRenderers } from './_tilemapScene';
+import { getBackendDevice } from './webgpu-test-helpers';
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 64;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: { canvas: { width: canvasSize, height: canvasSize }, clearColor: Color.black },
+  }) as unknown as Application;
+
+const setupBackend = async (): Promise<WebGpuBackend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  wireTilemapRenderers(backend);
+  await backend.initialize();
+
+  return backend;
+};
+
+const createSolidTexture = (color: string, size = 16): Texture => {
+  const source = document.createElement('canvas');
+
+  source.width = size;
+  source.height = size;
+
+  const context = source.getContext('2d');
+
+  if (!context) {
+    throw new Error('2D context is required to create test textures.');
+  }
+
+  context.fillStyle = color;
+  context.fillRect(0, 0, size, size);
+
+  return new Texture(source);
+};
+
+const readCanvas = (backend: WebGpuBackend): ((x: number, y: number) => RgbaTuple) => {
+  const source = backend.context.canvas as HTMLCanvasElement;
+  const readback = document.createElement('canvas');
+
+  readback.width = canvasSize;
+  readback.height = canvasSize;
+
+  const ctx = readback.getContext('2d');
+
+  if (!ctx) {
+    throw new Error('2D context is required for canvas readback.');
+  }
+
+  ctx.drawImage(source, 0, 0);
+
+  return (x: number, y: number): RgbaTuple => {
+    const { data } = ctx.getImageData(Math.floor(x), Math.floor(y), 1, 1);
+
+    return [data[0], data[1], data[2], data[3]];
+  };
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 18): void => {
+  for (let index = 0; index < 4; index++) {
+    expect(Math.abs(actual[index] - expected[index])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+// Render a frame through the real plan path inside a validation error scope.
+// Returns false when the device dropped mid-test (the caller should bail).
+const renderScene = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
+  const device = getBackendDevice(backend);
+
+  device.pushErrorScope('validation');
+
+  let validationError: GPUError | null;
+
+  try {
+    backend.resetStats();
+    backend.clear(Color.black);
+    root.render(backend);
+    backend.flush();
+    validationError = await device.popErrorScope();
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+
+  expect(validationError).toBeNull();
+
+  return true;
+};
+
+interface Scene {
+  readonly root: Container;
+  readonly group: RetainedContainer;
+  readonly redLayer: TileLayer;
+  readonly destroy: () => void;
+}
+
+/**
+ * Mirrors the WebGL2 tile-chunk retained cells: a live blue tile OUTSIDE (and
+ * before) the group at (48,0)-(64,16) keeps the group-local rebase load-
+ * bearing; the group at (8,24) holds a red 16x16 tile at group-local (0,0) ->
+ * world (8,24)-(24,40) and a green 16x16 tile at group-local (16,16) -> world
+ * (24,40)-(40,56). Distinct tileset textures -> two recorded batches.
+ */
+const buildScene = (): Scene => {
+  const blue = createSolidTexture('#0000ff');
+  const red = createSolidTexture('#ff0000');
+  const green = createSolidTexture('#00ff00');
+
+  const tsBlue = new TileSet({
+    name: 'blue',
+    texture: new TextureRegion(blue, { x: 0, y: 0, width: 16, height: 16 }),
+    tileWidth: 16,
+    tileHeight: 16,
+    tileCount: 1,
+  });
+  const tsRed = new TileSet({
+    name: 'red',
+    texture: new TextureRegion(red, { x: 0, y: 0, width: 16, height: 16 }),
+    tileWidth: 16,
+    tileHeight: 16,
+    tileCount: 1,
+  });
+  const tsGreen = new TileSet({
+    name: 'green',
+    texture: new TextureRegion(green, { x: 0, y: 0, width: 16, height: 16 }),
+    tileWidth: 16,
+    tileHeight: 16,
+    tileCount: 1,
+  });
+
+  const outsideLayer = new TileLayer({ id: 1, name: 'l', width: 1, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tsBlue] });
+  outsideLayer.setTileAt(0, 0, { tileset: tsBlue, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+  const outsideMap = new TileMap({ name: 'outside', width: 1, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tsBlue], layers: [outsideLayer] });
+  const outside = new TileMapNode(outsideMap);
+
+  const redLayer = new TileLayer({ id: 1, name: 'l', width: 1, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tsRed] });
+  redLayer.setTileAt(0, 0, { tileset: tsRed, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+  const redMap = new TileMap({ name: 'red', width: 1, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tsRed], layers: [redLayer] });
+  const redNode = new TileMapNode(redMap);
+
+  const greenLayer = new TileLayer({ id: 1, name: 'l', width: 1, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tsGreen] });
+  greenLayer.setTileAt(0, 0, { tileset: tsGreen, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+  const greenMap = new TileMap({ name: 'green', width: 1, height: 1, tileWidth: 16, tileHeight: 16, tilesets: [tsGreen], layers: [greenLayer] });
+  const greenNode = new TileMapNode(greenMap);
+
+  const root = new Container();
+  const group = new RetainedContainer();
+
+  outside.setPosition(48, 0);
+  root.addChild(outside);
+
+  redNode.setPosition(0, 0);
+  greenNode.setPosition(16, 16);
+  group.addChild(redNode);
+  group.addChild(greenNode);
+  group.setPosition(8, 24);
+  root.addChild(group);
+
+  const destroy = (): void => {
+    root.destroy();
+    blue.destroy();
+    red.destroy();
+    green.destroy();
+  };
+
+  return { root, group, redLayer, destroy };
+};
+
+describe('WebGPU renderer matrix: TileChunkNode retained instruction replay cells', () => {
+  test('cell 1 — tile-chunk replay is pixel-identical to the record frame (fast/slow equivalence)', async ctx => {
+    const backend = await setupBackend();
+    const scene = buildScene();
+
+    try {
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return; // F1
+      }
+
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return; // F2: record
+      }
+
+      const probes: ReadonlyArray<readonly [number, number, RgbaTuple]> = [
+        [56, 8, [0, 0, 255, 255]], // live outside tile
+        [16, 32, [255, 0, 0, 255]], // red tile (batch 1)
+        [32, 48, [0, 255, 0, 255]], // green tile (batch 2)
+      ];
+      let readPixel = readCanvas(backend);
+      const slowPixels = probes.map(([x, y]) => readPixel(x, y));
+
+      for (let i = 0; i < probes.length; i++) {
+        expectPixelNear(slowPixels[i]!, probes[i]![2]);
+      }
+
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return; // F3: instruction replay
+      }
+
+      readPixel = readCanvas(backend);
+
+      for (let i = 0; i < probes.length; i++) {
+        expectPixelNear(readPixel(probes[i]![0], probes[i]![1]), slowPixels[i]!, 0);
+      }
+
+      expectPixelNear(readPixel(4, 60), [0, 0, 0, 255]); // background stays clear
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 2 — camera pan on the cached path: replayed tile pixels track the live view', async ctx => {
+    const backend = await setupBackend();
+    const scene = buildScene();
+
+    try {
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderScene(ctx, backend, scene.root))) {
+          return;
+        }
+      }
+
+      let readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(16, 32), [255, 0, 0, 255]);
+
+      backend.view.setCenter(backend.view.center.x + 16, backend.view.center.y);
+
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return;
+      }
+
+      readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(40, 8), [0, 0, 255, 255]); // outside tile 32..48
+      expectPixelNear(readPixel(4, 32), [255, 0, 0, 255]); // red now 0..8 visible
+      expectPixelNear(readPixel(12, 48), [0, 255, 0, 255]); // green now 8..24
+      expectPixelNear(readPixel(16, 32), [0, 0, 0, 255]); // old red spot is background
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 3 — group move on the cached path relocates tile pixels WITHOUT recapture', async ctx => {
+    const backend = await setupBackend();
+    const scene = buildScene();
+
+    try {
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderScene(ctx, backend, scene.root))) {
+          return;
+        }
+      }
+
+      let readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(16, 32), [255, 0, 0, 255]);
+
+      scene.group.setPosition(32, 32);
+
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return;
+      }
+
+      readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(40, 40), [255, 0, 0, 255]); // red 32..48 x 32..48
+      expectPixelNear(readPixel(56, 56), [0, 255, 0, 255]); // green 48..64 x 48..64
+      expectPixelNear(readPixel(16, 32), [0, 0, 0, 255]); // old red spot is background
+      expectPixelNear(readPixel(56, 8), [0, 0, 255, 255]); // live sprite unaffected
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 4 — content mutation after capture: an edited tile is reflected, never replayed stale', async ctx => {
+    const backend = await setupBackend();
+    const scene = buildScene();
+
+    try {
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderScene(ctx, backend, scene.root))) {
+          return;
+        }
+      }
+
+      let readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(16, 32), [255, 0, 0, 255]);
+
+      // Edit a tile INSIDE the already-recorded group: the chunk revision bump
+      // must reach `_markContentDirty()` on the owning TileChunkNode, so the
+      // group content-dirties and re-records instead of splicing stale bytes.
+      scene.redLayer.clearTileAt(0, 0);
+
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return;
+      }
+
+      readPixel = readCanvas(backend);
+
+      expectPixelNear(readPixel(16, 32), [0, 0, 0, 255]); // cleared: background, not stale red
+      expectPixelNear(readPixel(32, 48), [0, 255, 0, 255]); // untouched sibling still correct
+      expectPixelNear(readPixel(56, 8), [0, 0, 255, 255]); // live outside tile unaffected
+
+      // Record-on-first-CLEAN-frame policy: the dirty frame above dropped the
+      // stale recording but did not re-arm it; the re-record proof lands here.
+      const beginSpy = vi.spyOn(backend, '_beginRetainedCapture');
+      const replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return; // clean entry-replay + re-arm record
+      }
+
+      expect(beginSpy).toHaveBeenCalledTimes(1);
+
+      if (!(await renderScene(ctx, backend, scene.root))) {
+        return; // instruction splice of the NEW (post-edit) recording
+      }
+
+      expect(replaySpy).toHaveBeenCalled();
+      readPixel = readCanvas(backend);
+      expectPixelNear(readPixel(16, 32), [0, 0, 0, 255]);
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Track B retained-batch record/replay support to `WebGl2TileChunkRenderer` and `WebGpuTileChunkRenderer`, mirroring the NineSlice seam: instance batches record into a retained group's instruction set and replay from group-owned resources (persistent instance buffer + group transform store).
- The packed tile word's transform row (bits 0..28) is rebased group-local on capture; the diagonal-flip flag (bit 29) is preserved untouched — a wrong rebase here would corrupt either the transform lookup or silently drop tile orientation.
- `src/renderer-sdk.ts` gains additive exports (`WebGl2RetainedBatchPayload`/`Replayer`/`NodeIndexRange`, the WebGPU equivalents, `RenderTexture`, `packAffineMat4`, `WebGpuActiveRenderPass`) so the tilemap package can implement the hooks entirely through the public renderer-sdk surface.

## Prerequisite fixes (found during investigation, required for correctness)

- **Content-mutation invalidation gap:** `TileChunk` mutations (`setTileAt`/`clearTileAt`/`fillRect`/`clearRect`) never reached `SceneNode._markContentDirty()` on the owning `TileChunkNode`. A `RetainedContainer` skips walking a content-clean subtree entirely, so an in-place tile edit after capture would have replayed stale geometry forever. `TileChunk` now supports dirty listeners; `TileChunkNode` registers one at construction and calls `invalidateContent()` on mutation.
- **Missing `u_group` composition:** neither tile-chunk shader folded in the retained group's `u_group` matrix, so a `TileChunkNode` nested in *any* `RetainedContainer` rendered at the wrong position — even without retained-batch capture. Both shaders now compose `u_group` exactly like the sprite/nine-slice renderers.
- **Stale texture-bind cache (found via browser pixel testing):** `WebGl2TileChunkRenderer._replayRetainedBatch` bound the tileset texture directly, bypassing the live path's redundant-bind-skip cache (`_currentTexture`). A live `TileChunkNode` sharing the renderer instance with replayed grouped nodes could render with a stale bound texture on a later frame. Fixed by updating `_currentTexture` after a replay's texture bind.

## Test plan

- [x] jsdom unit tests: `TileChunk` → `TileChunkNode` dirty-listener wiring (6 tests, multi-listener support, no-op-write suppression, destroy unregisters).
- [x] WebGL2 browser pixel tests: byte-identical replay across collect/record/replay/steady tiers, camera pan, group move, content-mutation-after-capture (2 distinct-texture batches, non-zero row base via a live sibling outside the group).
- [x] WebGPU browser pixel tests: same matrix.
- [x] Deliberate-break mutation-proof: neutered `_rebaseRetainedNodeIndices` on both backends, confirmed the relevant tests fail, restored, confirmed green again.
- [x] Full regression: jsdom suite (415 files / 7582 tests), full WebGL2 browser suite (44 files / 246 tests), full WebGPU browser suite (40 files / 172 tests) — all green, zero regressions to Sprite/NineSlice/RepeatingSprite/Mesh.
- [x] `pnpm verify:quick` (typecheck + guides + examples + type-tests + packages + lint:all + format:check + docs:api:check) — clean.