### PR TITLE
feat(rendering): WebGPU Text retained-batch record/replay

### DIFF
--- a/src/rendering/RetainedContainer.ts
+++ b/src/rendering/RetainedContainer.ts
@@ -4,12 +4,50 @@ import { nextNodeRevision } from '#core/NodeRevision';
 import { registerTransformGroupBoundary, unregisterTransformGroupBoundary } from '#core/SceneNode';
 import type { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
 import { RetainedGroupFragment } from '#rendering/plan/RetainedGroupFragment';
+import type { RenderBackend } from '#rendering/RenderBackend';
 
 import { Container } from './Container';
 import type { Drawable } from './Drawable';
 import type { RetainedGroupBundle } from './plan/RetainedInstructionSet';
 import type { RenderNode } from './RenderNode';
 import { packTransformRow, TRANSFORM_FLOATS_PER_ROW } from './TransformBuffer';
+
+/**
+ * A backend exposing a renderer registry, structurally — the same narrow
+ * shape `drawCommandUsesSharedTransform` (`plan/RenderCommand.ts`) resolves
+ * through, so both call sites agree on what "the renderer for this drawable"
+ * means without a hard dependency between the two modules.
+ */
+interface BackendWithRendererRegistry {
+  readonly rendererRegistry?: {
+    resolve(drawable: Drawable): unknown;
+  };
+}
+
+/**
+ * Optional per-renderer escape hatch from the generic shared-`TransformBuffer`
+ * row patch (`RetainedGroupBundle._patchTransformRow`): a renderer that packs
+ * its own private per-node data (`_consumesSharedTransform === false`, e.g.
+ * Text — its row format and storage differ from the shared buffer's) implements
+ * this instead, patching whatever it owns directly. `base` is the same
+ * capture-frame direct-draw base {@link RetainedContainer._tryPatchTransformRow}
+ * already computes for the generic path; a renderer whose own indexing scheme
+ * doesn't use it is free to ignore the parameter. Returns `false` when the
+ * node isn't fast-patch-eligible (mirrors the generic path's own eligibility
+ * guards), which drops the recording and falls back to a full re-record —
+ * never wrong pixels, only a missed optimization.
+ *
+ * Renderer-agnostic by design: a WebGL2 implementation of the same renderer
+ * (CPU-side vertex re-bake instead of a GPU buffer write) satisfies this exact
+ * interface unchanged.
+ * @internal
+ */
+export interface OwnTransformRowPatcher {
+  _patchOwnTransformRow(node: RenderNode, bundle: RetainedGroupBundle, base: number): boolean;
+}
+
+const hasOwnTransformRowPatch = (renderer: unknown): renderer is OwnTransformRowPatcher =>
+  typeof (renderer as { _patchOwnTransformRow?: unknown } | null)?._patchOwnTransformRow === 'function';
 
 /**
  * Reused scratch for one patched transform row (3 rgba32f texels, the
@@ -283,7 +321,7 @@ export class RetainedContainer extends Container {
       // for those nodes — patch the changed rows in place (O(k)), or drop the
       // recording so entry replay re-reads live transforms this frame.
       if (this._fragment.hasDirtyTransformRows()) {
-        this._reconcileTransformRows();
+        this._reconcileTransformRows(builder.backend);
       }
 
       // Fast tier (Slice 3, S3-D2): a valid recorded instruction set splices
@@ -356,7 +394,7 @@ export class RetainedContainer extends Container {
    * tier there is nothing to reconcile (transforms are re-read live); the queue
    * is simply drained.
    */
-  private _reconcileTransformRows(): void {
+  private _reconcileTransformRows(backend: RenderBackend): void {
     const set = this._fragment.instructions;
     const bundle = set?.ownedBundle ?? null;
 
@@ -390,7 +428,7 @@ export class RetainedContainer extends Container {
     const patchableBundle: PatchableRetainedGroupBundle = bundle as PatchableRetainedGroupBundle;
 
     for (const node of this._fragment.dirtyTransformRows) {
-      if (!this._tryPatchTransformRow(node, patchableBundle, base)) {
+      if (!this._tryPatchTransformRow(node, backend, patchableBundle, base)) {
         // Ineligible: drop the baked recording. `_markCurrentScopeRetained`
         // will now fail its validity check, so the group falls to entry replay
         // (live transforms) and re-records this frame.
@@ -408,13 +446,36 @@ export class RetainedContainer extends Container {
    * drawable child, non-snapped, present in the recorded row map. The
    * group-local matrix is `getGlobalTransform()` composed to this boundary — the
    * exact value the recorder wrote (S3-D4).
+   *
+   * A renderer that opts out of the shared `TransformBuffer` (its resolved
+   * renderer exposes {@link OwnTransformRowPatcher}, e.g. Text) is dispatched
+   * to its OWN patch method instead of the generic `bundle._patchTransformRow`
+   * below — its row lives in a private, renderer-owned store the generic path
+   * never reads, so calling the generic patch there would silently no-op
+   * against bytes nobody consumes (stale pixels, not a caught failure).
    */
-  private _tryPatchTransformRow(node: RenderNode, bundle: PatchableRetainedGroupBundle, base: number): boolean {
+  private _tryPatchTransformRow(node: RenderNode, backend: RenderBackend, bundle: PatchableRetainedGroupBundle, base: number): boolean {
     if (node.parent !== this) {
       return false;
     }
 
     const drawable = node as unknown as Drawable;
+    const registry = (backend as BackendWithRendererRegistry).rendererRegistry;
+
+    if (registry && typeof registry.resolve === 'function') {
+      try {
+        const renderer = registry.resolve(drawable);
+
+        if (hasOwnTransformRowPatch(renderer)) {
+          return renderer._patchOwnTransformRow(node, bundle, base);
+        }
+      } catch {
+        // No renderer registered for this drawable (custom drawable type) —
+        // fall through to the generic shared-transform patch path below,
+        // unchanged from before this dispatch existed.
+      }
+    }
+
     const nodeIndex = this._fragment.directDrawNodeIndex(drawable);
 
     // Snapped nodes are excluded from recording (their instance words are

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -1109,6 +1109,23 @@ export class WebGpuBackend implements RenderBackend {
   }
 
   /**
+   * The innermost active capture window (S3-D6), or `null` when none is open.
+   * A fresh `WebGpuRetainedCaptureFrame` instance is created per capture-open
+   * call (even across re-records of the same bundle) and discarded at
+   * `_endRetainedCapture`, so its identity is a precise "this specific
+   * open/close cycle" token — lets a renderer that can record at most once per
+   * capture (e.g. Text, whose per-batch replay state isn't keyed for more)
+   * detect a second record attempt within the SAME window via a `WeakSet`,
+   * without needing bundle-level bookkeeping of its own.
+   * @internal
+   */
+  public get _currentRetainedCaptureFrame(): WebGpuRetainedCaptureFrame | null {
+    const frames = this._retainedCaptureFrames;
+
+    return frames.length > 0 ? frames[frames.length - 1]! : null;
+  }
+
+  /**
    * Playback hook: a retained group scope starts recording (contract in
    * RenderPlanPlayer). The pending batch is flushed first so no batch spans
    * into the capture window; the set's grow-only bundle is created (or reused
@@ -1268,6 +1285,7 @@ export class WebGpuBackend implements RenderBackend {
     textures: ReadonlyArray<Texture | RenderTexture | null>,
     slotCount: number,
     geometry: WebGpuRetainedGeometryRef | null = null,
+    rendererData: unknown = null,
   ): void {
     const frames = this._retainedCaptureFrames;
 
@@ -1323,6 +1341,7 @@ export class WebGpuBackend implements RenderBackend {
       batchIndexInBundle: owner.staged.length,
       textures: textureList,
       recordedViews,
+      rendererData,
     };
     // Generation is stamped at capture end (post-growth, official plan-layer
     // seam); the sentinel keeps the set invalid if finalization never runs
@@ -1377,8 +1396,26 @@ export class WebGpuBackend implements RenderBackend {
     const staged = frame.staged;
     let base = 0xffffffff;
     let maxNodeIndex = 0;
+    // A batch whose renderer opts out of the shared transform store
+    // (`_consumesSharedTransform === false`, e.g. Text — its per-instance
+    // "node index" addresses its OWN private data store, not a row in the
+    // shared TransformBuffer) leaves `_scanRetainedNodeIndexRange` a no-op, so
+    // its `minNodeIndex`/`maxNodeIndex` stay at the unset sentinel
+    // (`max < min`). Such batches must not contribute to the shared-range
+    // span below — merging their sentinel into `base`/`maxNodeIndex` would
+    // corrupt the span for every OTHER (shared-transform-consuming) renderer
+    // recorded into the same bundle, and a capture containing ONLY such
+    // batches would otherwise compute a negative `rowCount` and hand
+    // `writeBuffer` a garbage out-of-range copy below.
+    let hasSharedTransformRange = false;
 
     for (const batch of staged) {
+      if (batch.maxNodeIndex < batch.minNodeIndex) {
+        continue;
+      }
+
+      hasSharedTransformRange = true;
+
       if (batch.minNodeIndex < base) {
         base = batch.minNodeIndex;
       }
@@ -1388,7 +1425,7 @@ export class WebGpuBackend implements RenderBackend {
       }
     }
 
-    const rowCount = maxNodeIndex - base + 1;
+    const rowCount = hasSharedTransformRange ? maxNodeIndex - base + 1 : 0;
     const transformBytes = rowCount * retainedTransformSlotBytes;
 
     // Growth is safe against the open pass: a bundle can only be re-recorded
@@ -1401,7 +1438,9 @@ export class WebGpuBackend implements RenderBackend {
       // the cached bytes become immune to frame-local index shifts (S3-D4)
       // and address the group-owned row copy below. Layout-aware — delegated
       // to the renderer that packed the bytes (the payload was already
-      // created at record time, so its renderer is in hand here).
+      // created at record time, so its renderer is in hand here). A
+      // shared-transform opt-out renderer's rebase is a no-op (see above);
+      // `base` is irrelevant to it either way.
       const payload = batch.instruction.payload as WebGpuRetainedBatchPayload;
 
       payload.renderer._rebaseRetainedNodeIndices(batch.bytes, base);
@@ -1410,18 +1449,22 @@ export class WebGpuBackend implements RenderBackend {
       stampRetainedBatchGeneration(batch.instruction);
     }
 
-    // Copy the group's transform rows [base, base + rowCount) — written by
-    // this playback's Phase-1 pre-pass into the frame-scoped CPU buffer —
-    // into the group-owned storage at group-local row 0. Rows carry tint
-    // (texel 2), so tint is covered by the copy.
-    const transformData = this._getTransformStorage().buffer.data;
+    if (hasSharedTransformRange) {
+      // Copy the group's transform rows [base, base + rowCount) — written by
+      // this playback's Phase-1 pre-pass into the frame-scoped CPU buffer —
+      // into the group-owned storage at group-local row 0. Rows carry tint
+      // (texel 2), so tint is covered by the copy.
+      const transformData = this._getTransformStorage().buffer.data;
 
-    device.queue.writeBuffer(bundle.transformBuffer!, 0, transformData.buffer, transformData.byteOffset + base * retainedTransformSlotBytes, transformBytes);
-    this._accountant.recordBufferUpload(frame.totalBytes + transformBytes);
+      device.queue.writeBuffer(bundle.transformBuffer!, 0, transformData.buffer, transformData.byteOffset + base * retainedTransformSlotBytes, transformBytes);
+      this._accountant.recordBufferUpload(frame.totalBytes + transformBytes);
+    } else {
+      this._accountant.recordBufferUpload(frame.totalBytes);
+    }
 
     // Slice 4c: record the rebase base + row count so a later child move can
     // patch its one row in place (O(k)) instead of dropping the recording.
-    bundle._recordTransformRowRange(device, base, rowCount);
+    bundle._recordTransformRowRange(device, hasSharedTransformRange ? base : 0, rowCount);
   }
 
   /**

--- a/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
+++ b/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
@@ -88,6 +88,16 @@ export interface WebGpuRetainedBatchPayload {
    * a recapture, never a replay.
    */
   readonly recordedViews: readonly GPUTextureView[];
+  /**
+   * Opaque, renderer-private data captured alongside this batch (Text opt-in):
+   * for a renderer whose per-instance node index addresses its OWN private
+   * data store rather than the shared transform buffer (`_consumesSharedTransform
+   * === false`), the generic bundle/scan/rebase machinery has nothing to persist
+   * on its behalf — this field is the renderer's own escape hatch to carry
+   * whatever CPU-side snapshot it needs from record time through to replay,
+   * where only the renderer that set it interprets the value.
+   */
+  readonly rendererData?: unknown;
 }
 
 /**

--- a/src/rendering/webgpu/WebGpuTextRenderer.ts
+++ b/src/rendering/webgpu/WebGpuTextRenderer.ts
@@ -2,6 +2,9 @@
 
 import { Matrix } from '#math/Matrix';
 import { packAffineMat3Std140 } from '#rendering/affinePacking';
+import type { RetainedGroupBundle } from '#rendering/plan/RetainedInstructionSet';
+import type { RenderNode } from '#rendering/RenderNode';
+import type { OwnTransformRowPatcher } from '#rendering/RetainedContainer';
 import { type BitmapText } from '#rendering/text/BitmapText';
 import type { TextPageQuads } from '#rendering/text/Text';
 import { Text } from '#rendering/text/Text';
@@ -12,6 +15,15 @@ import type { View } from '#rendering/View';
 import { AbstractWebGpuRenderer } from './AbstractWebGpuRenderer';
 import type { WebGpuBackend } from './WebGpuBackend';
 import { getWebGpuBlendState } from './WebGpuBlendState';
+import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
+import {
+  type WebGpuRetainedBatchPayload,
+  type WebGpuRetainedBatchReplayer,
+  type WebGpuRetainedCaptureFrame,
+  WebGpuRetainedGroupBundle,
+  type WebGpuRetainedNodeIndexRange,
+  type WebGpuRetainedRendererReplayState,
+} from './WebGpuRetainedGroupResources';
 import { stencilContentDepthStencilState } from './WebGpuStencilState';
 
 // ── Node data layout (identical to WebGl2TextRenderer) ───────────────────────
@@ -55,8 +67,72 @@ interface PendingQuad {
 interface BatchDraw {
   readonly shaderType: ShaderType;
   readonly atlasTexture: Texture;
+  readonly firstVertex: number;
+  readonly vertexCount: number;
   readonly firstIndex: number;
   readonly indexCount: number;
+}
+
+/**
+ * Opaque, renderer-private snapshot carried on {@link WebGpuRetainedBatchPayload.rendererData}
+ * for one recorded Text/BitmapText batch (Track B retained-batch record/replay).
+ * Text opts out of the shared `TransformBuffer` (`_consumesSharedTransform ===
+ * false`), so the generic bundle machinery has nothing to persist for it — this
+ * is the renderer's own carrier from record time (`flush()`) through to replay
+ * (`_replayRetainedBatch`), where `TextRetainedReplayState` uploads it into a
+ * persistent, group-owned GPU buffer on first use.
+ */
+interface TextRetainedRendererData {
+  /** Copy of this flush's packed per-node style+transform data (10 vec4s/node, dense, 0-based). */
+  readonly nodeData: Float32Array;
+  readonly nodeCount: number;
+  /** Node `i`'s drawable, parallel to `nodeData`'s dense row `i` — backs the own-transform-move patch lookup. */
+  readonly drawables: ReadonlyArray<Text | BitmapText>;
+  readonly shaderType: ShaderType;
+  readonly quadCount: number;
+}
+
+/**
+ * Per-bundle Text replay state (Track B retained-batch opt-in), parked on
+ * {@link WebGpuRetainedGroupBundle.rendererReplayState} so it shares the
+ * bundle's grow-only / explicitly-freed lifecycle — mirrors Mesh's
+ * `MeshRetainedReplayState`. Holds Text's OWN persistent per-node data buffer
+ * (same 10-vec4/node layout the live path uses) and FrameUniforms buffer,
+ * since Text's row format differs from both the shared `TransformBuffer` row
+ * layout AND the shared 128-byte group UBO {@link WebGpuRetainedGroupBundle}
+ * itself owns (Text's `FrameUniforms` is a 96-byte mat3x3 pair, not the
+ * mat4x4 pair every other retained renderer's shared UBO uses).
+ *
+ * A bundle can hold at most ONE recorded Text batch per capture (`flush()`
+ * poisons rather than recording a second one) — so this state is a single
+ * slot, not a per-batch array: `lastPayload` identifies which recording's
+ * node data currently lives in `nodeDataBuffer`, re-uploaded only when a
+ * fresh recording replaces it.
+ * @internal
+ */
+class TextRetainedReplayState implements WebGpuRetainedRendererReplayState {
+  public uniformBuffer: GPUBuffer | null = null;
+  public nodeDataBuffer: GPUBuffer | null = null;
+  public nodeDataCapacity = 0;
+  public bindGroup: GPUBindGroup | null = null;
+  public readonly uboData = new Float32Array(projectionBytes / Float32Array.BYTES_PER_ELEMENT);
+  public uboWritten = false;
+  public lastPayload: WebGpuRetainedBatchPayload | null = null;
+  public readonly nodeIndexByDrawable = new Map<Text | BitmapText, number>();
+  public drawsInPass: WebGpuActiveRenderPass | null = null;
+
+  public destroy(): void {
+    this.uniformBuffer?.destroy();
+    this.nodeDataBuffer?.destroy();
+    this.uniformBuffer = null;
+    this.nodeDataBuffer = null;
+    this.nodeDataCapacity = 0;
+    this.bindGroup = null;
+    this.uboWritten = false;
+    this.lastPayload = null;
+    this.nodeIndexByDrawable.clear();
+    this.drawsInPass = null;
+  }
 }
 
 // ── WGSL: shared vertex + three fragment entry points ────────────────────────
@@ -250,7 +326,7 @@ fn fragmentColor(in: VertexOutput) -> @location(0) vec4<f32> {
  * batched by (shaderType, atlasPage) to minimise draw calls within a single
  * render pass.
  */
-export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText> {
+export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText> implements WebGpuRetainedBatchReplayer, OwnTransformRowPatcher {
   /**
    * Text packs its world transform into its own per-node data buffer and never
    * reads the shared transform storage, so the plan player skips writing
@@ -258,6 +334,31 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
    * @internal
    */
   public readonly _consumesSharedTransform = false;
+
+  /**
+   * Retained-batch opt-in (Track B extension): a flush whose glyph quads all
+   * share one (shaderType, atlasTexture) — the overwhelmingly common case, one
+   * font/atlas per flush — is a recordable batch. A flush that mixes multiple
+   * distinct (shaderType, atlasTexture) combinations, or a second Text flush
+   * within the same capture window, poisons the capture instead (see
+   * `_tryRecordRetainedBatch`) — always safe, just a missed optimization.
+   * @internal
+   */
+  public readonly _supportsRetainedBatches = true;
+
+  // Retained-batch record-time scratch: which capture windows this renderer
+  // has already recorded a batch into (S3-D6 nesting-safe — a fresh
+  // WebGpuRetainedCaptureFrame instance per capture-open call means a stale
+  // entry can never alias a later, unrelated capture).
+  private readonly _recordedCaptureFrames = new WeakSet<WebGpuRetainedCaptureFrame>();
+
+  // Retained-batch replay-time scratch, reused across replay calls (mirrors
+  // `_projData` below, just sized/shaped for the frame-uniform-only write).
+  private readonly _retainedFrameScratch = new Float32Array(projectionBytes / Float32Array.BYTES_PER_ELEMENT);
+  // Own-transform-move patch scratch: 2 vec4s (transform cols 0-1).
+  private readonly _patchRowScratch = new Float32Array(8);
+  private _retainedQuadIndexBuffer: GPUBuffer | null = null;
+  private _retainedQuadIndexCapacity = 0;
 
   private _device: GPUDevice | null = null;
   private _shaderModule: GPUShaderModule | null = null;
@@ -401,6 +502,7 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
         qj++;
       }
 
+      const batchFirstVertex = packedV;
       const batchFirstIndex = packedI;
       let batchIndexCount = 0;
 
@@ -432,6 +534,8 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
       batches.push({
         shaderType: first.shaderType,
         atlasTexture: first.atlasTexture,
+        firstVertex: batchFirstVertex,
+        vertexCount: packedV - batchFirstVertex,
         firstIndex: batchFirstIndex,
         indexCount: batchIndexCount,
       });
@@ -444,6 +548,10 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     this._ensureGpuIndexBuffer(device, packedI);
     device.queue.writeBuffer(this._vertexBuffer!, 0, this._vertexData, 0, packedV * vertexStrideBytes);
     device.queue.writeBuffer(this._indexBuffer!, 0, this._indexData.buffer, 0, packedI * 2);
+
+    if (backend._retainedCaptureActive) {
+      this._tryRecordRetainedBatch(backend, batches);
+    }
 
     const format = backend.renderTargetFormat;
     const stencil = backend._passCoordinator.stencilActive;
@@ -600,11 +708,14 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     this._nodeBuffer?.destroy();
     this._vertexBuffer?.destroy();
     this._indexBuffer?.destroy();
+    this._retainedQuadIndexBuffer?.destroy();
 
     this._projBuffer = null;
     this._nodeBuffer = null;
     this._vertexBuffer = null;
     this._indexBuffer = null;
+    this._retainedQuadIndexBuffer = null;
+    this._retainedQuadIndexCapacity = 0;
     this._nodeBufferCapacity = 0;
     this._vertexBufferCapacity = 0;
     this._indexBufferCapacity = 0;
@@ -920,5 +1031,337 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     this._textureKeyMap.clear();
     this._textureKeyCounter = 0;
     this._nodeCount = 0;
+  }
+
+  // ── Retained-batch record/replay (Track B extension) ─────────────────────
+  // Text's per-vertex "node index" addresses its OWN dense, per-flush node
+  // buffer (packed above), never a row in the shared `TransformBuffer` — so,
+  // unlike every other retained renderer, its instance bytes carry no index
+  // the generic bundle/scan/rebase machinery can meaningfully rebase. Both
+  // hooks below are true no-ops; the renderer instead carries its own node
+  // data end-to-end via `WebGpuRetainedBatchPayload.rendererData`, uploaded
+  // into a group-owned buffer (`TextRetainedReplayState`) on first replay.
+
+  /** @internal See {@link WebGpuRetainedBatchReplayer._scanRetainedNodeIndexRange}. */
+  public _scanRetainedNodeIndexRange(_bytes: Uint8Array, _range: WebGpuRetainedNodeIndexRange): void {
+    // Deliberately does not touch `_range`: widening it here would corrupt
+    // the shared-transform-row span `WebGpuBackend._finalizeRetainedCapture`
+    // computes across every OTHER (shared-transform-consuming) renderer's
+    // batches recorded into the same bundle this capture.
+  }
+
+  /** @internal See {@link WebGpuRetainedBatchReplayer._rebaseRetainedNodeIndices}. */
+  public _rebaseRetainedNodeIndices(_bytes: Uint8Array, _base: number): void {
+    // Deliberately does not touch `_bytes`: Text's node indices are already
+    // correct as packed (dense, 0-based, matching the parallel `rendererData`
+    // uploaded alongside them) and have no relationship to the shared-buffer
+    // rebase `base`.
+  }
+
+  /**
+   * Stage this flush's ONE batch for retained replay, or poison the active
+   * capture(s) when this flush is not a clean single-batch recording.
+   * `TextRetainedReplayState` holds at most one recorded batch per bundle per
+   * capture window (identified via `backend._currentRetainedCaptureFrame`,
+   * unique per capture-open call) — a flush spanning multiple distinct
+   * (shaderType, atlasTexture) combinations, or a second Text flush within the
+   * same window, would need a second slot this design doesn't provide.
+   * Poisoning is always safe: the group falls back to entry replay for this
+   * frame only, never wrong pixels.
+   */
+  private _tryRecordRetainedBatch(backend: WebGpuBackend, batches: readonly BatchDraw[]): void {
+    const frame = backend._currentRetainedCaptureFrame;
+
+    if (frame === null) {
+      return;
+    }
+
+    if (batches.length !== 1 || this._recordedCaptureFrames.has(frame)) {
+      backend._poisonActiveRetainedCaptures();
+
+      return;
+    }
+
+    const batch = batches[0]!;
+    const vertexByteLength = batch.vertexCount * vertexStrideBytes;
+    // Copy: `_vertexData`/`_nodeDataArray` are reused (overwritten) next flush.
+    const vertexBytes = this._vertexData.slice(batch.firstVertex * vertexStrideBytes, batch.firstVertex * vertexStrideBytes + vertexByteLength);
+    const nodeData = this._nodeDataArray.slice(0, this._nodeCount * nodeFloats);
+    const drawables = [...this._nodeIndexMap.keys()];
+
+    const rendererData: TextRetainedRendererData = {
+      nodeData,
+      nodeCount: this._nodeCount,
+      drawables,
+      shaderType: batch.shaderType,
+      quadCount: batch.indexCount / 6,
+    };
+
+    backend._recordRetainedBatch(this, vertexBytes, vertexByteLength, this._nodeCount, BlendModes.Normal, [batch.atlasTexture], 1, null, rendererData);
+
+    this._recordedCaptureFrames.add(frame);
+  }
+
+  /**
+   * Replay one recorded Text batch from its group-owned bundle into the OPEN
+   * pass. STATE is resolved live — pipeline, FrameUniforms (projection +
+   * group) from the live view/group, the texture binding; DATA is reused —
+   * the group-owned vertex bytes (`bundle.instanceBuffer` at
+   * `payload.byteOffset`), the renderer-owned static quad-index pattern, and
+   * Text's own persisted per-node style+transform buffer (uploaded once per
+   * recording, on first replay).
+   * @internal
+   */
+  public _replayRetainedBatch(payload: WebGpuRetainedBatchPayload): void {
+    const backend = this._backend;
+    const device = this._device;
+    const bundle = payload.bundle;
+    const data = payload.rendererData as TextRetainedRendererData | null;
+
+    if (
+      backend === null ||
+      device === null ||
+      data === null ||
+      !(bundle instanceof WebGpuRetainedGroupBundle) ||
+      !bundle.isReady ||
+      bundle.instanceBuffer === null
+    ) {
+      return;
+    }
+
+    // Drain any pending live text draws first so replay draws follow them in
+    // order (mirrors NineSlice/Mesh).
+    this.flush();
+
+    const scissor = backend.getScissorRect();
+
+    if (scissor !== null && (scissor.width <= 0 || scissor.height <= 0)) {
+      return;
+    }
+
+    const coordinator = backend._passCoordinator;
+    const state = this._getTextReplayState(bundle, device);
+
+    if (state.lastPayload !== payload) {
+      this._uploadRetainedNodeData(state, device, data);
+      state.lastPayload = payload;
+    }
+
+    const view = backend.view;
+    const scratch = this._retainedFrameScratch;
+
+    packAffineMat3Std140(view.getTransform(), scratch, 0);
+    packAffineMat3Std140(backend.renderGroupTransform ?? Matrix.identity, scratch, 12);
+
+    let uboDirty = !state.uboWritten;
+
+    if (!uboDirty) {
+      for (let i = 0; i < scratch.length; i++) {
+        if (scratch[i] !== state.uboData[i]) {
+          uboDirty = true;
+          break;
+        }
+      }
+    }
+
+    if (uboDirty) {
+      const activePass = coordinator.activePass;
+
+      if (activePass !== null && state.drawsInPass === activePass) {
+        // Rewriting FrameUniforms would retroactively re-project this
+        // bundle's draws already recorded into the open pass: end it first.
+        coordinator.endPass();
+        state.drawsInPass = null;
+      }
+
+      state.uboData.set(scratch);
+      state.uboWritten = true;
+      device.queue.writeBuffer(state.uniformBuffer!, 0, state.uboData.buffer, state.uboData.byteOffset, projectionBytes);
+    }
+
+    // Text's own recording always stages exactly one `Texture` (the atlas
+    // page — see `_tryRecordRetainedBatch`'s `[batch.atlasTexture]`), never a
+    // `RenderTexture`; the payload's shared type is wider only because other
+    // renderers can target one.
+    const textureBindGroup = this._getTexBindGroup(device, backend, payload.textures[0]! as Texture);
+    const frameBindGroup = this._getTextReplayBindGroup(state, device);
+    const indexBuffer = this._ensureRetainedQuadIndexBuffer(device, data.quadCount);
+
+    const active = coordinator.acquirePass();
+    const pass = active.pass;
+
+    pass.setPipeline(this._getPipeline(data.shaderType, backend.renderTargetFormat, coordinator.stencilActive));
+    pass.setBindGroup(0, frameBindGroup);
+    pass.setBindGroup(1, textureBindGroup);
+    pass.setVertexBuffer(0, bundle.instanceBuffer, payload.byteOffset);
+    pass.setIndexBuffer(indexBuffer, 'uint16');
+    pass.drawIndexed(data.quadCount * 6, 1, 0, 0, 0);
+
+    state.drawsInPass = active;
+    backend.stats.batches++;
+    backend.stats.drawCalls++;
+  }
+
+  /**
+   * Own-transform-move O(1) patch ({@link OwnTransformRowPatcher}): recompute
+   * only the moved node's transform-column pair (2 of its 10 vec4s) via
+   * `getGlobalTransform()` (group-local — {@link RetainedContainer} composes
+   * up to the enclosing boundary only) and `queue.writeBuffer` just that row's
+   * byte range in the persisted node-data buffer. `base` (the shared-buffer
+   * direct-draw base) is irrelevant to Text's own dense local indexing and is
+   * unused. Returns `false` (ineligible — falls back to a full re-record) when
+   * `bundle` isn't a WebGPU bundle with a live Text replay state, or `node`
+   * wasn't part of the recorded batch.
+   * @internal
+   */
+  public _patchOwnTransformRow(node: RenderNode, bundle: RetainedGroupBundle, _base: number): boolean {
+    const device = this._device;
+
+    if (device === null || !(bundle instanceof WebGpuRetainedGroupBundle)) {
+      return false;
+    }
+
+    const state = bundle.rendererReplayState;
+
+    if (!(state instanceof TextRetainedReplayState) || state.nodeDataBuffer === null) {
+      return false;
+    }
+
+    const drawable = node as unknown as Text | BitmapText;
+    const localIndex = state.nodeIndexByDrawable.get(drawable);
+
+    if (localIndex === undefined) {
+      return false;
+    }
+
+    // `toArray` returns a fixed Float32Array(9); indices 0..8 are always valid
+    // (mirrors `_packNodeData`'s transform packing above).
+    const m = drawable.getGlobalTransform().toArray(false);
+    const row = this._patchRowScratch;
+
+    row[0] = m[0]!;
+    row[1] = m[1]!;
+    row[2] = m[2]!;
+    row[3] = m[6]!;
+    row[4] = m[3]!;
+    row[5] = m[4]!;
+    row[6] = m[5]!;
+    row[7] = m[7]!;
+
+    const byteOffset = localIndex * nodeFloats * 4;
+
+    device.queue.writeBuffer(state.nodeDataBuffer, byteOffset, row.buffer, row.byteOffset, row.byteLength);
+
+    return true;
+  }
+
+  private _getTextReplayState(bundle: WebGpuRetainedGroupBundle, device: GPUDevice): TextRetainedReplayState {
+    const existing = bundle.rendererReplayState;
+    const state = existing instanceof TextRetainedReplayState ? existing : new TextRetainedReplayState();
+
+    if (existing !== state) {
+      bundle.rendererReplayState = state;
+    }
+
+    if (state.uniformBuffer === null) {
+      state.uniformBuffer = device.createBuffer({
+        label: 'WebGpuTextRenderer/retained-uniform',
+        size: projectionBytes,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+      });
+      state.bindGroup = null;
+    }
+
+    return state;
+  }
+
+  private _uploadRetainedNodeData(state: TextRetainedReplayState, device: GPUDevice, data: TextRetainedRendererData): void {
+    const requiredBytes = data.nodeCount * nodeFloats * 4;
+
+    if (state.nodeDataBuffer === null || state.nodeDataCapacity < requiredBytes) {
+      let capacity = Math.max(state.nodeDataCapacity, nodeFloats * 4);
+
+      while (capacity < requiredBytes) capacity *= 2;
+
+      state.nodeDataBuffer?.destroy();
+      state.nodeDataBuffer = device.createBuffer({
+        label: 'WebGpuTextRenderer/retained-node-data',
+        size: capacity,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+      });
+      state.nodeDataCapacity = capacity;
+      state.bindGroup = null;
+    }
+
+    if (requiredBytes > 0) {
+      device.queue.writeBuffer(state.nodeDataBuffer, 0, data.nodeData.buffer, data.nodeData.byteOffset, requiredBytes);
+    }
+
+    state.nodeIndexByDrawable.clear();
+
+    for (let i = 0; i < data.drawables.length; i++) {
+      state.nodeIndexByDrawable.set(data.drawables[i]!, i);
+    }
+  }
+
+  private _getTextReplayBindGroup(state: TextRetainedReplayState, device: GPUDevice): GPUBindGroup {
+    if (state.bindGroup !== null) {
+      return state.bindGroup;
+    }
+
+    state.bindGroup = device.createBindGroup({
+      label: 'WebGpuTextRenderer/retained-frame-bind-group',
+      layout: this._frameBindGroupLayout!,
+      entries: [
+        { binding: 0, resource: { buffer: state.uniformBuffer! } },
+        { binding: 1, resource: { buffer: state.nodeDataBuffer! } },
+      ],
+    });
+
+    return state.bindGroup;
+  }
+
+  /**
+   * Renderer-owned, grow-only index buffer holding the deterministic
+   * `[0,1,2,0,2,3] + 4*i` quad pattern up to `quadCount` quads — glyph quad
+   * indices are ALWAYS this exact pattern (`buildTextPageQuads` never packs
+   * anything else), so replay never needs to persist per-batch index bytes;
+   * one shared, ever-growing buffer serves every recorded Text batch on this
+   * renderer, exactly like `WebGpuNineSliceSpriteRenderer`'s static per-quad
+   * index buffer serves every nine-slice instance.
+   */
+  private _ensureRetainedQuadIndexBuffer(device: GPUDevice, quadCount: number): GPUBuffer {
+    if (this._retainedQuadIndexBuffer !== null && this._retainedQuadIndexCapacity >= quadCount) {
+      return this._retainedQuadIndexBuffer;
+    }
+
+    let capacity = Math.max(this._retainedQuadIndexCapacity, 64);
+
+    while (capacity < quadCount) capacity *= 2;
+
+    const indices = new Uint16Array(capacity * 6);
+
+    for (let i = 0; i < capacity; i++) {
+      const baseV = i * 4;
+      const o = i * 6;
+
+      indices[o + 0] = baseV;
+      indices[o + 1] = baseV + 1;
+      indices[o + 2] = baseV + 2;
+      indices[o + 3] = baseV;
+      indices[o + 4] = baseV + 2;
+      indices[o + 5] = baseV + 3;
+    }
+
+    this._retainedQuadIndexBuffer?.destroy();
+    this._retainedQuadIndexBuffer = device.createBuffer({
+      label: 'WebGpuTextRenderer/retained-quad-indices',
+      size: indices.byteLength,
+      usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
+    });
+    device.queue.writeBuffer(this._retainedQuadIndexBuffer, 0, indices.buffer, 0, indices.byteLength);
+    this._retainedQuadIndexCapacity = capacity;
+
+    return this._retainedQuadIndexBuffer;
   }
 }

--- a/test/rendering/browser/webgpu-text-retained-instruction-replay.test.ts
+++ b/test/rendering/browser/webgpu-text-retained-instruction-replay.test.ts
@@ -1,0 +1,353 @@
+/**
+ * WebGPU renderer-matrix browser tests — Text retained instruction-set
+ * replay (Track B extension, Task 1).
+ *
+ * Text is the first retained renderer that opts OUT of the shared
+ * `TransformBuffer` (`_consumesSharedTransform === false`): it packs its own
+ * private per-node style+transform buffer, so the group-owned
+ * `TextRetainedReplayState` (node data buffer, FrameUniforms buffer, own
+ * quad-index buffer) is the entire replay mechanism — there is no shared-row
+ * rebase to get wrong here, but there IS a real risk of stale/garbage node
+ * data or a wrong bind group if the replay-time upload/patch logic is broken.
+ * These tests reproduce the record frame's pixels exactly through a REAL
+ * WebGPU device and pin the own-transform-move O(1) patch against real GPU
+ * validation.
+ *
+ * CI guarantees a real WebGPU adapter; tests only skip when the software
+ * adapter drops the device mid-test (same convention as the other WebGPU
+ * browser specs).
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import type { RetainedGroupFragment } from '#rendering/plan/RetainedGroupFragment';
+import type { RenderNode } from '#rendering/RenderNode';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { resetDefaultGlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
+import { Text } from '#rendering/text/Text';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+import { WebGpuTextRenderer } from '#rendering/webgpu/WebGpuTextRenderer';
+
+import { wireCoreRenderers } from './_coreRenderers';
+import { getBackendDevice } from './webgpu-test-helpers';
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 96;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: {
+      canvas: { width: canvasSize, height: canvasSize },
+      clearColor: Color.black,
+    },
+  }) as unknown as Application;
+
+const setupBackend = async (): Promise<WebGpuBackend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  wireCoreRenderers(backend);
+  await backend.initialize();
+
+  return backend;
+};
+
+const readCanvas = (backend: WebGpuBackend): ((x: number, y: number, w?: number, h?: number) => Uint8ClampedArray) => {
+  const source = backend.context.canvas as HTMLCanvasElement;
+  const readback = document.createElement('canvas');
+
+  readback.width = canvasSize;
+  readback.height = canvasSize;
+
+  const ctx = readback.getContext('2d');
+
+  if (!ctx) {
+    throw new Error('2D context is required for canvas readback.');
+  }
+
+  ctx.drawImage(source, 0, 0);
+
+  return (x: number, y: number, w = 1, h = 1): Uint8ClampedArray => ctx.getImageData(Math.floor(x), Math.floor(y), w, h).data;
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 12): void => {
+  for (let index = 0; index < 4; index++) {
+    expect(Math.abs(actual[index] - expected[index])).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+/** Render a frame through the real plan path inside a validation error scope. */
+const renderScene = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
+  const device = getBackendDevice(backend);
+
+  device.pushErrorScope('validation');
+
+  let validationError: GPUError | null;
+
+  try {
+    backend.resetStats();
+    backend.clear(Color.black);
+    root.render(backend);
+    backend.flush();
+    validationError = await device.popErrorScope();
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+
+  expect(validationError).toBeNull();
+
+  return true;
+};
+
+interface FragmentCarrier {
+  _fragment: RetainedGroupFragment;
+}
+
+const fragmentOf = (group: RetainedContainer): RetainedGroupFragment => (group as unknown as FragmentCarrier)._fragment;
+
+/**
+ * A single, large, bright-white block-ish glyph over a black background: at
+ * this font size a wide uppercase letter fills enough of its cell that a
+ * region sampled a few pixels in from its top-left corner is reliably ink,
+ * not anti-aliased edge — avoiding brittle single-pixel glyph-shape guesses.
+ */
+const buildScene = (): { root: Container; group: RetainedContainer; text: Text; destroy: () => void } => {
+  const root = new Container();
+  const group = new RetainedContainer();
+  const text = new Text('MW', { fillColor: Color.white, fontSize: 40 });
+
+  text.setPosition(4, 4);
+  group.addChild(text);
+  group.setPosition(8, 8);
+  root.addChild(group);
+
+  const destroy = (): void => {
+    root.destroy();
+  };
+
+  return { root, group, text, destroy };
+};
+
+const inkProbe = (readPixel: ReturnType<typeof readCanvas>): RgbaTuple => {
+  const px = readPixel(20, 24);
+
+  return [px[0]!, px[1]!, px[2]!, px[3]!];
+};
+
+describe('WebGPU renderer matrix: Text retained instruction replay cells', () => {
+  beforeEach(() => resetDefaultGlyphAtlasPool());
+  afterEach(() => resetDefaultGlyphAtlasPool());
+
+  test('cell 1 — Text opts in and replay reproduces the record frame exactly (fast/slow equivalence)', async ctx => {
+    const backend = await setupBackend();
+    const scene = buildScene();
+
+    try {
+      expect(new WebGpuTextRenderer()._supportsRetainedBatches).toBe(true);
+
+      if (!(await renderScene(ctx, backend, scene.root))) return; // F1: capture
+      if (!(await renderScene(ctx, backend, scene.root))) return; // F2: record (slow path)
+
+      expect(fragmentOf(scene.group).instructions?.hasRecording).toBe(true);
+
+      const ink = inkProbe(readCanvas(backend));
+
+      // Glyph ink must be visible somewhere in the probed region (not still
+      // pure background) — otherwise the whole comparison below is vacuous.
+      expect(ink).not.toEqual([0, 0, 0, 255]);
+
+      const recordRegion = readCanvas(backend)(0, 0, canvasSize, canvasSize);
+
+      if (!(await renderScene(ctx, backend, scene.root))) return; // F3: replay (fast path)
+
+      const replayRegion = readCanvas(backend)(0, 0, canvasSize, canvasSize);
+
+      expect(replayRegion).toEqual(recordRegion);
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 2 — camera pan on the cached path: replayed glyph pixels track the live view', async ctx => {
+    const backend = await setupBackend();
+    const scene = buildScene();
+
+    try {
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderScene(ctx, backend, scene.root))) return;
+      }
+
+      const before = inkProbe(readCanvas(backend));
+
+      expect(before).not.toEqual([0, 0, 0, 255]);
+
+      const recordedInstruction = fragmentOf(scene.group).instructions!.instructions[0];
+
+      backend.view.setCenter(backend.view.center.x + 16, backend.view.center.y);
+
+      if (!(await renderScene(ctx, backend, scene.root))) return;
+
+      // No recapture: the SAME recorded instruction object still replays —
+      // only the live projection uniform changed.
+      expect(fragmentOf(scene.group).instructions!.instructions[0]).toBe(recordedInstruction);
+      expect(fragmentOf(scene.group).instructions!.hasRecording).toBe(true);
+
+      const readPixel = readCanvas(backend);
+
+      // Panning the camera 16px right moves scene content 16px left on screen.
+      const panned: RgbaTuple = [readPixel(4, 24)[0]!, readPixel(4, 24)[1]!, readPixel(4, 24)[2]!, readPixel(4, 24)[3]!];
+
+      expect(panned).not.toEqual([0, 0, 0, 255]);
+      expectPixelNear(panned, before, 40);
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 3 — group move on the cached path relocates glyph pixels WITHOUT recapture', async ctx => {
+    const backend = await setupBackend();
+    const scene = buildScene();
+
+    try {
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderScene(ctx, backend, scene.root))) return;
+      }
+
+      const recordedInstruction = fragmentOf(scene.group).instructions!.instructions[0];
+
+      scene.group.setPosition(28, 8);
+
+      if (!(await renderScene(ctx, backend, scene.root))) return;
+
+      expect(fragmentOf(scene.group).instructions!.instructions[0]).toBe(recordedInstruction);
+      expect(fragmentOf(scene.group).instructions!.hasRecording).toBe(true);
+
+      const readPixel = readCanvas(backend);
+      const moved: RgbaTuple = [readPixel(40, 24)[0]!, readPixel(40, 24)[1]!, readPixel(40, 24)[2]!, readPixel(40, 24)[3]!];
+      const oldSpot: RgbaTuple = [readPixel(20, 24)[0]!, readPixel(20, 24)[1]!, readPixel(20, 24)[2]!, readPixel(20, 24)[3]!];
+
+      expect(moved).not.toEqual([0, 0, 0, 255]);
+      expectPixelNear(oldSpot, [0, 0, 0, 255], 4);
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 4 — an own-transform move patches the node-data row in place (O(1)) — no re-record', async ctx => {
+    const backend = await setupBackend();
+    const scene = buildScene();
+
+    try {
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderScene(ctx, backend, scene.root))) return;
+      }
+
+      const recordedInstruction = fragmentOf(scene.group).instructions!.instructions[0];
+
+      scene.text.setPosition(24, 4);
+
+      if (!(await renderScene(ctx, backend, scene.root))) return;
+
+      // The O(1) patch rewrites the persisted row in place — the SAME
+      // recorded instruction object replays; a full re-record would have
+      // produced a fresh instruction from a fresh `_recordRetainedBatch` call.
+      expect(fragmentOf(scene.group).instructions!.instructions[0]).toBe(recordedInstruction);
+      expect(fragmentOf(scene.group).instructions!.hasRecording).toBe(true);
+
+      const readPixel = readCanvas(backend);
+      const moved: RgbaTuple = [readPixel(40, 24)[0]!, readPixel(40, 24)[1]!, readPixel(40, 24)[2]!, readPixel(40, 24)[3]!];
+      const oldSpot: RgbaTuple = [readPixel(20, 24)[0]!, readPixel(20, 24)[1]!, readPixel(20, 24)[2]!, readPixel(20, 24)[3]!];
+
+      expect(moved).not.toEqual([0, 0, 0, 255]);
+      expectPixelNear(oldSpot, [0, 0, 0, 255], 4);
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 5 — a content change forces a full re-record and replays the new content', async ctx => {
+    const backend = await setupBackend();
+    const scene = buildScene();
+
+    try {
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderScene(ctx, backend, scene.root))) return;
+      }
+
+      expect(fragmentOf(scene.group).instructions?.hasRecording).toBe(true);
+
+      scene.text.text = 'X';
+
+      if (!(await renderScene(ctx, backend, scene.root))) return; // content-dirty frame
+
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderScene(ctx, backend, scene.root))) return;
+      }
+
+      expect(fragmentOf(scene.group).instructions?.hasRecording).toBe(true);
+
+      const ink = inkProbe(readCanvas(backend));
+
+      expect(ink).not.toEqual([0, 0, 0, 255]);
+    } finally {
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 6 — deliberate break: a neutered _replayRetainedBatch drops the retained draw and diverges', async ctx => {
+    const backend = await setupBackend();
+    const scene = buildScene();
+    const original = WebGpuTextRenderer.prototype._replayRetainedBatch;
+
+    try {
+      for (let frame = 0; frame < 2; frame++) {
+        if (!(await renderScene(ctx, backend, scene.root))) return;
+      } // F1 capture, F2 record
+
+      expect(fragmentOf(scene.group).instructions?.hasRecording).toBe(true);
+
+      const recordDraws = backend.stats.drawCalls;
+      const recordInk = inkProbe(readCanvas(backend));
+
+      expect(recordInk).not.toEqual([0, 0, 0, 255]);
+
+      // F3 (static, no scene change): the fast/instruction-replay tier is the
+      // ONLY path that can reach this frame's draw — no move, no content
+      // change, nothing to reconcile — so `backend.stats.drawCalls` only
+      // increments if `_replayRetainedBatch` actually ran. A neutered version
+      // that never acquires a pass or issues `drawIndexed` leaves it at 0.
+      WebGpuTextRenderer.prototype._replayRetainedBatch = function (): void {};
+
+      if (!(await renderScene(ctx, backend, scene.root))) return; // F3: broken replay
+
+      expect(backend.stats.drawCalls).toBe(0);
+      expect(backend.stats.drawCalls).not.toBe(recordDraws);
+    } finally {
+      WebGpuTextRenderer.prototype._replayRetainedBatch = original;
+      scene.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/text-retained-webgpu.test.ts
+++ b/test/rendering/text-retained-webgpu.test.ts
@@ -1,0 +1,607 @@
+/**
+ * WebGPU Text retained-batch record/replay (Track B extension, Task 1).
+ *
+ * Text is the first retained renderer that opts OUT of the shared
+ * `TransformBuffer` (`_consumesSharedTransform === false`) — its per-vertex
+ * "node index" addresses its OWN private per-node style+transform buffer, so
+ * the generic bundle/scan/rebase machinery has nothing to persist for it.
+ * These tests pin the renderer-owned mechanism that replaces it end to end:
+ *
+ * - `_supportsRetainedBatches` opt-in: record on the second clean frame,
+ *   replay without re-collecting glyph quads on the third,
+ * - camera pan and group move replay for free (no recorded-byte touch),
+ * - an own-transform move patches the node's row in `TextRetainedReplayState`
+ *   in place (O(1)) instead of a full re-record,
+ * - a content change forces a full re-record,
+ * - a flush spanning two distinct atlas textures poisons the capture rather
+ *   than corrupting or silently dropping data (falls back to entry replay),
+ * - the `WebGpuBackend._finalizeRetainedCapture` guard: a Text-only capture
+ *   never issues a bogus shared-transform-row copy (the bug this task's
+ *   investigation found and fixed upstream of the renderer work),
+ * - deliberate-break mutation proofs on `_replayRetainedBatch` and
+ *   `_patchOwnTransformRow` (both interface-required, public hooks).
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { materializeRendererBindings } from '#extensions/materialize';
+import { Container } from '#rendering/Container';
+import { buildCoreRendererBindings } from '#rendering/coreRendererBindings';
+import type { RetainedGroupFragment } from '#rendering/plan/RetainedGroupFragment';
+import type { RenderNode } from '#rendering/RenderNode';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { Text } from '#rendering/text/Text';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+import { WebGpuRetainedGroupBundle } from '#rendering/webgpu/WebGpuRetainedGroupResources';
+import { WebGpuTextRenderer } from '#rendering/webgpu/WebGpuTextRenderer';
+
+interface LabeledBuffer {
+  readonly label: string;
+  destroy(): void;
+}
+
+interface CapturedWrite {
+  readonly label: string;
+  readonly bufferOffset: number;
+  readonly bytes: Uint8Array;
+}
+
+interface CapturedDraw {
+  readonly indexCount: number;
+  readonly instanceCount: number;
+}
+
+interface MockWebGpuEnvironment {
+  readonly canvas: HTMLCanvasElement;
+  submitCount(): number;
+  writes(): readonly CapturedWrite[];
+  draws(): readonly CapturedDraw[];
+  restore(): void;
+}
+
+const globalStubs: ReadonlyArray<readonly [string, unknown]> = [
+  ['GPUBufferUsage', { COPY_DST: 1, INDEX: 2, UNIFORM: 4, VERTEX: 8, STORAGE: 16, COPY_SRC: 32 }],
+  ['GPUShaderStage', { VERTEX: 1, FRAGMENT: 2 }],
+  ['GPUColorWrite', { ALL: 0xf }],
+  ['GPUTextureUsage', { COPY_DST: 1, TEXTURE_BINDING: 2, RENDER_ATTACHMENT: 4, COPY_SRC: 8 }],
+];
+
+const captureWriteBytes = (data: ArrayBuffer | ArrayBufferView, dataOffset?: number, size?: number): Uint8Array => {
+  if (data instanceof ArrayBuffer) {
+    const byteOffset = dataOffset ?? 0;
+    const byteLength = size ?? data.byteLength - byteOffset;
+
+    return new Uint8Array(data.slice(byteOffset, byteOffset + byteLength));
+  }
+
+  const view = data as unknown as { buffer: ArrayBuffer; byteOffset: number; byteLength: number; BYTES_PER_ELEMENT?: number };
+  const elementBytes = view.BYTES_PER_ELEMENT ?? 1;
+  const start = view.byteOffset + (dataOffset ?? 0) * elementBytes;
+  const length = size !== undefined ? size * elementBytes : view.byteLength - (dataOffset ?? 0) * elementBytes;
+
+  return new Uint8Array(view.buffer.slice(start, start + length));
+};
+
+const createMockWebGpuEnvironment = (): MockWebGpuEnvironment => {
+  const previousGpu = Object.getOwnPropertyDescriptor(navigator, 'gpu');
+  const previousGlobals = globalStubs.map(([name]) => [name, Object.getOwnPropertyDescriptor(globalThis, name)] as const);
+  const previousCanvasGetContext = Object.getOwnPropertyDescriptor(HTMLCanvasElement.prototype, 'getContext');
+
+  let submitCount = 0;
+  const writes: CapturedWrite[] = [];
+  const draws: CapturedDraw[] = [];
+
+  const glyphCtx = {
+    font: '',
+    textBaseline: 'alphabetic',
+    fillStyle: '#ffffff',
+    measureText: (_text: string) =>
+      ({
+        width: 10,
+        actualBoundingBoxLeft: 0,
+        actualBoundingBoxRight: 9,
+        actualBoundingBoxAscent: 13,
+        actualBoundingBoxDescent: 3,
+        fontBoundingBoxAscent: 14,
+        fontBoundingBoxDescent: 4,
+      }) as TextMetrics,
+    fillText: (): void => {},
+    clearRect: (): void => {},
+    fillRect: (): void => {},
+    drawImage: (): void => {},
+    getImageData: (_x: number, _y: number, w: number, h: number) => ({ data: new Uint8ClampedArray(w * h * 4), width: w, height: h }),
+  } as unknown as CanvasRenderingContext2D;
+
+  const pass = {
+    setPipeline: (): void => {},
+    setBindGroup: (): void => {},
+    setVertexBuffer: (): void => {},
+    setIndexBuffer: (): void => {},
+    setScissorRect: (): void => {},
+    pushDebugGroup: (): void => {},
+    popDebugGroup: (): void => {},
+    draw: (): void => {},
+    drawIndexed: (indexCount: number, instanceCount: number): void => {
+      draws.push({ indexCount, instanceCount });
+    },
+    end: (): void => {},
+  };
+  const encoder = {
+    beginRenderPass: () => pass,
+    finish: () => ({ label: 'command-buffer' }) as unknown as GPUCommandBuffer,
+  };
+  const queue = {
+    writeBuffer: (buffer: LabeledBuffer, bufferOffset: number, data: ArrayBuffer | ArrayBufferView, dataOffset?: number, size?: number): void => {
+      writes.push({ label: buffer.label, bufferOffset, bytes: captureWriteBytes(data, dataOffset, size) });
+    },
+    submit: (): void => {
+      submitCount++;
+    },
+    copyExternalImageToTexture: (): void => {},
+    writeTexture: (): void => {},
+  };
+  const device = {
+    createShaderModule: () => ({}) as GPUShaderModule,
+    createBindGroupLayout: () => ({}) as GPUBindGroupLayout,
+    createPipelineLayout: () => ({}) as GPUPipelineLayout,
+    createBindGroup: () => ({}) as GPUBindGroup,
+    createRenderPipeline: () => ({}) as GPURenderPipeline,
+    createCommandEncoder: () => encoder as unknown as GPUCommandEncoder,
+    createBuffer: (descriptor: GPUBufferDescriptor): GPUBuffer =>
+      ({
+        label: descriptor.label ?? '',
+        destroy: (): void => {},
+      }) as unknown as GPUBuffer,
+    createTexture: (): GPUTexture => {
+      const view = {} as GPUTextureView;
+
+      return {
+        destroy: (): void => {},
+        createView: () => view,
+      } as unknown as GPUTexture;
+    },
+    createSampler: () => ({}) as GPUSampler,
+    lost: new Promise<GPUDeviceLostInfo>(() => {}),
+    queue,
+  } as unknown as GPUDevice;
+  const context = {
+    configure: (): void => {},
+    unconfigure: (): void => {},
+    getCurrentTexture: () =>
+      ({
+        createView: () => ({}) as GPUTextureView,
+      }) as unknown as GPUTexture,
+  } as unknown as GPUCanvasContext;
+  const gpu = {
+    requestAdapter: async () =>
+      ({
+        requestDevice: async () => device,
+      }) as unknown as GPUAdapter,
+    getPreferredCanvasFormat: () => 'bgra8unorm' as GPUTextureFormat,
+  } as unknown as GPU;
+  const canvas = document.createElement('canvas');
+
+  Object.defineProperty(navigator, 'gpu', { configurable: true, value: gpu });
+
+  for (const [name, value] of globalStubs) {
+    Object.defineProperty(globalThis, name, { configurable: true, value });
+  }
+
+  // Glyph rasterization (GlyphAtlas) creates its OWN canvases and reads a '2d'
+  // context — stub it at the prototype level. The WebGPU surface canvas below
+  // shadows this with an instance-level override for 'webgpu'.
+  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value: (type: string) => (type === '2d' ? glyphCtx : null),
+  });
+
+  Object.defineProperty(canvas, 'getContext', {
+    configurable: true,
+    value: (contextType: string) => (contextType === 'webgpu' ? context : null),
+  });
+
+  return {
+    canvas,
+    submitCount: () => submitCount,
+    writes: () => writes,
+    draws: () => draws,
+    restore: (): void => {
+      if (previousGpu) {
+        Object.defineProperty(navigator, 'gpu', previousGpu);
+      } else {
+        Object.defineProperty(navigator, 'gpu', { configurable: true, value: undefined });
+      }
+
+      for (const [name, descriptor] of previousGlobals) {
+        if (descriptor) {
+          Object.defineProperty(globalThis, name, descriptor);
+        } else {
+          Object.defineProperty(globalThis, name, { configurable: true, value: undefined });
+        }
+      }
+
+      if (previousCanvasGetContext) {
+        Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', previousCanvasGetContext);
+      }
+    },
+  };
+};
+
+const createBackend = async (environment: MockWebGpuEnvironment): Promise<WebGpuBackend> => {
+  const app = {
+    canvas: environment.canvas,
+    options: {
+      canvas: { width: 128, height: 128 },
+      clearColor: Color.black,
+    },
+  } as unknown as Application;
+  const backend = new WebGpuBackend(app);
+
+  materializeRendererBindings(backend, buildCoreRendererBindings({}));
+  await backend.initialize();
+
+  return backend;
+};
+
+const renderFrame = (backend: WebGpuBackend, root: RenderNode): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+  root.render(backend);
+  backend.flush();
+};
+
+interface FragmentCarrier {
+  _fragment: RetainedGroupFragment;
+}
+
+const fragmentOf = (group: RetainedContainer): RetainedGroupFragment => (group as unknown as FragmentCarrier)._fragment;
+
+const instanceLabel = 'sprite:retained-instance-buffer';
+const sharedTransformLabel = 'sprite:retained-transform-buffer';
+const nodeDataLabel = 'WebGpuTextRenderer/retained-node-data';
+const textUniformLabel = 'WebGpuTextRenderer/retained-uniform';
+
+const countLabel = (writes: readonly CapturedWrite[], label: string, from = 0): number => {
+  let count = 0;
+
+  for (let index = from; index < writes.length; index++) {
+    if (writes[index]!.label === label) {
+      count++;
+    }
+  }
+
+  return count;
+};
+
+/** "Hi" → 2 glyphs → 2 quads → 8 vertices, 12 indices (matches the existing webgpu-backend.test.ts fixture). */
+const buildTextGroup = (): { root: Container; group: RetainedContainer; text: Text } => {
+  const root = new Container();
+  const group = new RetainedContainer();
+  const text = new Text('Hi', { fontSize: 16 });
+
+  group.setPosition(8, 8);
+  group.addChild(text);
+  root.addChild(group);
+
+  return { root, group, text };
+};
+
+describe('WebGPU Text retained-batch record/replay', () => {
+  test('opts in, records on the second clean frame, replays without re-collecting glyph quads', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createBackend(environment);
+      const { root, group } = buildTextGroup();
+
+      expect(new WebGpuTextRenderer()._supportsRetainedBatches).toBe(true);
+
+      renderFrame(backend, root); // F1: capture (no recording yet)
+
+      expect(fragmentOf(group).instructions).toBeNull();
+
+      renderFrame(backend, root); // F2: record
+
+      const recordedSet = fragmentOf(group).instructions;
+
+      expect(recordedSet?.hasRecording).toBe(true);
+      expect(countLabel(environment.writes(), instanceLabel)).toBe(1);
+      expect(countLabel(environment.writes(), nodeDataLabel)).toBe(0); // uploaded lazily, on first REPLAY
+
+      // A Text-only capture must never issue the shared-transform-row copy —
+      // the WebGpuBackend._finalizeRetainedCapture guard this task added.
+      expect(countLabel(environment.writes(), sharedTransformLabel)).toBe(0);
+
+      const drawsBefore = environment.draws().length;
+
+      renderFrame(backend, root); // F3: replay
+
+      expect(countLabel(environment.writes(), nodeDataLabel)).toBe(1); // first replay uploads once
+      expect(countLabel(environment.writes(), textUniformLabel)).toBeGreaterThanOrEqual(1);
+
+      const replayDraws = environment.draws().slice(drawsBefore);
+
+      expect(replayDraws).toEqual([{ indexCount: 12, instanceCount: 1 }]);
+
+      const mark = environment.writes().length;
+
+      renderFrame(backend, root); // F4: static replay — no node-data re-upload
+
+      expect(countLabel(environment.writes(), nodeDataLabel, mark)).toBe(0);
+      expect(countLabel(environment.writes(), instanceLabel, mark)).toBe(0);
+      expect(fragmentOf(group).instructions).toBe(recordedSet);
+
+      root.destroy();
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('camera pan and group move replay without touching recorded vertex or node-data bytes', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createBackend(environment);
+      const { root, group } = buildTextGroup();
+
+      renderFrame(backend, root); // F1: capture
+      renderFrame(backend, root); // F2: record
+      renderFrame(backend, root); // F3: replay (first node-data upload)
+
+      const recordedSet = fragmentOf(group).instructions;
+
+      expect(recordedSet?.hasRecording).toBe(true);
+
+      group.setPosition(40, 40);
+
+      let mark = environment.writes().length;
+
+      renderFrame(backend, root);
+
+      expect(fragmentOf(group).instructions).toBe(recordedSet);
+      expect(countLabel(environment.writes(), instanceLabel, mark)).toBe(0);
+      expect(countLabel(environment.writes(), nodeDataLabel, mark)).toBe(0);
+      expect(countLabel(environment.writes(), textUniformLabel, mark)).toBe(1);
+
+      backend.view.setCenter(backend.view.center.x + 16, backend.view.center.y);
+      mark = environment.writes().length;
+
+      renderFrame(backend, root);
+
+      expect(countLabel(environment.writes(), instanceLabel, mark)).toBe(0);
+      expect(countLabel(environment.writes(), nodeDataLabel, mark)).toBe(0);
+      expect(countLabel(environment.writes(), textUniformLabel, mark)).toBe(1);
+
+      root.destroy();
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('an own-transform move patches the node-data row in place (O(1)) — no re-record', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createBackend(environment);
+      const { root, group, text } = buildTextGroup();
+
+      renderFrame(backend, root); // F1: capture
+      renderFrame(backend, root); // F2: record
+      renderFrame(backend, root); // F3: replay (first node-data upload)
+
+      const recordedSet = fragmentOf(group).instructions;
+      const bundle = recordedSet?.ownedBundle as WebGpuRetainedGroupBundle;
+
+      expect(recordedSet?.hasRecording).toBe(true);
+      expect(bundle).toBeInstanceOf(WebGpuRetainedGroupBundle);
+
+      const generation = bundle.generation;
+      const mark = environment.writes().length;
+
+      text.setPosition(4, 4);
+      renderFrame(backend, root);
+
+      // No re-record: neither the vertex stream nor the whole node-data block
+      // is re-uploaded.
+      expect(countLabel(environment.writes(), instanceLabel, mark)).toBe(0);
+
+      // Exactly one small patch write into the node-data buffer: 2 vec4s (32
+      // bytes) at the moved node's row offset (row 0, the only node).
+      const patchWrites = environment
+        .writes()
+        .slice(mark)
+        .filter(write => write.label === nodeDataLabel);
+
+      expect(patchWrites).toHaveLength(1);
+      expect(patchWrites[0]!.bytes.byteLength).toBe(32);
+      expect(patchWrites[0]!.bufferOffset).toBe(0);
+
+      expect(bundle.generation).toBe(generation);
+      expect(fragmentOf(group).instructions).toBe(recordedSet);
+      expect(fragmentOf(group).instructions?.hasRecording).toBe(true);
+
+      root.destroy();
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('a content change forces a full re-record', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createBackend(environment);
+      const { root, group, text } = buildTextGroup();
+
+      renderFrame(backend, root); // F1: capture
+      renderFrame(backend, root); // F2: record
+
+      const recordedSet = fragmentOf(group).instructions;
+
+      expect(recordedSet?.hasRecording).toBe(true);
+
+      text.text = 'Hi!';
+      renderFrame(backend, root); // F3: content-dirty — drops the recording
+
+      expect(fragmentOf(group).instructions?.hasRecording).not.toBe(true);
+
+      renderFrame(backend, root); // F4: re-record against the new content
+
+      expect(fragmentOf(group).instructions?.hasRecording).toBe(true);
+
+      root.destroy();
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('a flush producing more than one (shaderType, atlasTexture) batch poisons the capture instead of recording it', async () => {
+    const environment = createMockWebGpuEnvironment();
+    // Force the multi-batch branch deterministically (getting real content to
+    // land in two distinct atlas pages/shader types in one flush is an
+    // implementation detail of glyph packing this test shouldn't depend on):
+    // duplicate whatever batches[] a real flush actually produced before
+    // handing it to the private recorder this task added.
+    const originalTryRecord = (
+      WebGpuTextRenderer.prototype as unknown as {
+        _tryRecordRetainedBatch: (this: WebGpuTextRenderer, backend: WebGpuBackend, batches: readonly unknown[]) => void;
+      }
+    )._tryRecordRetainedBatch;
+
+    try {
+      const backend = await createBackend(environment);
+      const { root, group } = buildTextGroup();
+
+      (
+        WebGpuTextRenderer.prototype as unknown as {
+          _tryRecordRetainedBatch: (this: WebGpuTextRenderer, backend: WebGpuBackend, batches: readonly unknown[]) => void;
+        }
+      )._tryRecordRetainedBatch = function (backend: WebGpuBackend, batches: readonly unknown[]): void {
+        originalTryRecord.call(this, backend, [...batches, ...batches]);
+      };
+
+      renderFrame(backend, root); // F1: capture
+      renderFrame(backend, root); // F2: would-be record — poisoned instead (synthetic 2-batch flush)
+
+      const set = fragmentOf(group).instructions;
+
+      // A poisoned window's plan-level key still looks committed
+      // (`hasRecording`/`isValidFor`) — the backend applies its own veto on
+      // top (mirrors the existing Sprite poison test in
+      // webgpu-retained-record-replay.test.ts): `_validateRetainedInstructionSet`
+      // must reject it so the group never replays the incomplete recording.
+      expect(set?.hasRecording).toBe(true);
+      expect(set !== null && set !== undefined && backend._validateRetainedInstructionSet(set)).toBe(false);
+
+      // Still renders correctly every frame (entry replay), never crashes.
+      const drawsBefore = environment.draws().length;
+
+      renderFrame(backend, root);
+
+      expect(environment.draws().length).toBeGreaterThan(drawsBefore);
+
+      root.destroy();
+      backend.destroy();
+    } finally {
+      (WebGpuTextRenderer.prototype as unknown as { _tryRecordRetainedBatch: unknown })._tryRecordRetainedBatch = originalTryRecord;
+      environment.restore();
+    }
+  });
+
+  describe('deliberate-break mutation proofs', () => {
+    test('a neutered _replayRetainedBatch stops issuing the retained draw', async () => {
+      const environment = createMockWebGpuEnvironment();
+      const original = WebGpuTextRenderer.prototype._replayRetainedBatch;
+
+      try {
+        const backend = await createBackend(environment);
+        const { root, group } = buildTextGroup();
+
+        renderFrame(backend, root); // F1: capture
+        renderFrame(backend, root); // F2: record
+
+        expect(fragmentOf(group).instructions?.hasRecording).toBe(true);
+
+        WebGpuTextRenderer.prototype._replayRetainedBatch = function (): void {};
+
+        const drawsBefore = environment.draws().length;
+
+        renderFrame(backend, root); // F3: would-be replay — neutered, draws nothing
+
+        expect(environment.draws().slice(drawsBefore)).toEqual([]);
+
+        WebGpuTextRenderer.prototype._replayRetainedBatch = original;
+
+        const drawsAfterRestore = environment.draws().length;
+
+        renderFrame(backend, root); // F4: restored — replays again
+
+        expect(environment.draws().slice(drawsAfterRestore)).toEqual([{ indexCount: 12, instanceCount: 1 }]);
+
+        root.destroy();
+        backend.destroy();
+      } finally {
+        WebGpuTextRenderer.prototype._replayRetainedBatch = original;
+        environment.restore();
+      }
+    });
+
+    test('a neutered _patchOwnTransformRow forces a full re-record instead of the O(1) patch', async () => {
+      const environment = createMockWebGpuEnvironment();
+      const original = WebGpuTextRenderer.prototype._patchOwnTransformRow;
+
+      try {
+        const backend = await createBackend(environment);
+        const { root, group, text } = buildTextGroup();
+
+        renderFrame(backend, root); // F1: capture
+        renderFrame(backend, root); // F2: record
+        renderFrame(backend, root); // F3: replay
+
+        expect(fragmentOf(group).instructions?.hasRecording).toBe(true);
+
+        WebGpuTextRenderer.prototype._patchOwnTransformRow = (): boolean => false;
+
+        text.setPosition(4, 4);
+
+        let mark = environment.writes().length;
+
+        // `_tryPatchTransformRow` (RetainedContainer) invalidates the
+        // recording the SAME frame it discovers the patch is ineligible, and
+        // the fragment is still content/structure-clean, so it re-records
+        // immediately within this one `renderFrame` call (no extra frame
+        // needed) — a full re-record re-uploads the vertex stream, which the
+        // cheap O(1) patch never touches.
+        renderFrame(backend, root);
+
+        expect(countLabel(environment.writes(), instanceLabel, mark)).toBeGreaterThan(0);
+        expect(fragmentOf(group).instructions?.hasRecording).toBe(true);
+
+        WebGpuTextRenderer.prototype._patchOwnTransformRow = original;
+
+        renderFrame(backend, root); // replay the fresh recording once
+
+        const bundle = fragmentOf(group).instructions?.ownedBundle as WebGpuRetainedGroupBundle;
+        const generation = bundle.generation;
+
+        mark = environment.writes().length;
+        text.setPosition(8, 8);
+        renderFrame(backend, root); // restored — O(1) patch again, no re-record
+
+        expect(bundle.generation).toBe(generation);
+        expect(countLabel(environment.writes(), instanceLabel, mark)).toBe(0);
+        expect(countLabel(environment.writes(), nodeDataLabel, mark)).toBe(1);
+
+        root.destroy();
+        backend.destroy();
+      } finally {
+        WebGpuTextRenderer.prototype._patchOwnTransformRow = original;
+        environment.restore();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What
Extends Track B retained-batch record/replay to Text/BitmapText on WebGPU. Text is the first retained renderer that opts out of the shared `TransformBuffer` (`_consumesSharedTransform === false`) — it packs its own private per-node style+transform buffer instead — so unlike Sprite/NineSlice/Mesh there is no shared node-index row to rebase.

A new `TextRetainedReplayState` (parked on the group bundle's `rendererReplayState` slot, mirroring Mesh's UBO pattern) persists that private buffer per recorded batch, uploaded lazily on first replay via a new opaque `rendererData` payload field on `WebGpuRetainedBatchPayload`. A flush is recordable only when it produces exactly one `(shaderType, atlasTexture)` batch and no other Text flush has already recorded into the same capture window; anything else poisons the capture rather than risking corrupted/aliased replay state — falling back to entry replay for that frame only, never wrong pixels.

**Bug found and fixed along the way:** `WebGpuBackend._finalizeRetainedCapture`'s shared-transform-row span computation assumed every recorded batch contributes a real node-index range. That breaks for a capture made up entirely of shared-transform opt-out batches (Text-only) — the sentinel range never updates, driving a negative `rowCount` into a `queue.writeBuffer` call with a garbage offset/size. The fix excludes such batches from the span and skips the shared-row copy entirely when nothing in the capture needs it.

A node's own transform move gets an O(1) row patch (2 of Text's 10 vec4s) via a new renderer-agnostic `OwnTransformRowPatcher` interface that `RetainedContainer._tryPatchTransformRow` dispatches to ahead of the generic shared-buffer patch. The interface is deliberately backend-agnostic (takes the shared `RetainedGroupBundle`, not a WebGPU-specific type) so a future WebGL2 Text implementation can reuse the exact same shape. Camera pan and group move replay for free via `getGlobalTransform()` stopping at the enclosing `RetainedContainer` boundary, unaffected by this change.

## Test plan
- [x] Deliberate-break proofs (both interface-required, public hooks — `_scanRetainedNodeIndexRange`/`_rebaseRetainedNodeIndices` are legitimate no-ops for this renderer, documented as such): neutered `_replayRetainedBatch` (draw stops issuing), neutered `_patchOwnTransformRow` (forces a full re-record instead of the O(1) patch) — both confirmed red, restored, confirmed green
- [x] Node-level record/replay tests (`test/rendering/text-retained-webgpu.test.ts`): opt-in + record/replay round-trip, camera pan / group move (zero recorded-byte writes), own-transform move (exact single 32-byte patch write), content change (full re-record), multi-batch-per-flush poison guard
- [x] Real-GPU WebGPU browser tests (`test/rendering/browser/webgpu-text-retained-instruction-replay.test.ts`): byte/pixel-identical replay, camera pan, group move, own-transform-move (O(1) patch via same-instruction-object proof), content-change re-record, deliberate-break pixel proof — all against a real WebGPU device (validation-clean)
- [x] Full regression: WebGPU browser suite 40/40 files, 174/174 tests unchanged; full node/jsdom suite 4934/4939 passing (the 2 failures are pre-existing, unrelated `dist/` build-artifact version-staleness in `production-stripping.test.ts`)
- [x] `pnpm verify:quick` clean (typecheck, guides, examples, type-tests, packages, lint, format, API-docs sync)