### PR TITLE
feat(rendering): WebGL2 Text retained-batch record/replay

### DIFF
--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -1102,6 +1102,20 @@ export class WebGl2Backend implements RenderBackend {
   }
 
   /**
+   * The innermost open capture's group bundle, or `null` when no capture is
+   * open. A renderer that stores its own per-bundle replay state (Text) keys a
+   * "already recorded a batch into this window" guard on it, so a second flush
+   * into the same window poisons instead of overwriting the first batch's
+   * group-owned resources.
+   * @internal
+   */
+  public get _currentRetainedCaptureBundle(): WebGl2RetainedGroupResources | null {
+    const captures = this._retainedCaptures;
+
+    return captures.length > 0 ? captures[captures.length - 1]!.bundle : null;
+  }
+
+  /**
    * Playback hook (RenderPlanPlayer): a retained group scope starts
    * recording. The pending live batch is flushed first (contract: no batch
    * spans into the capture window), the set's group bundle is (re)used or
@@ -1176,15 +1190,19 @@ export class WebGl2Backend implements RenderBackend {
       payload.replayer._scanRetainedNodeIndexRange(payload, range);
     }
 
-    if (range.max < range.min) {
-      return;
+    // A group whose every recorded batch opts out of the shared transform
+    // buffer (Text bakes world positions into its own instance bytes and reads
+    // its style from a private per-node texture — `_consumesSharedTransform ===
+    // false`) leaves the range empty: there is nothing to rebase or store, but
+    // the instance bytes and per-batch VAOs still need finalizing below.
+    if (range.max >= range.min) {
+      for (const payload of frame.payloads) {
+        payload.replayer._rebaseRetainedNodeIndices(payload, range.min);
+      }
+
+      frame.bundle._storeTransformRows(this._transformBuffer.data, range.min, range.max - range.min + 1);
     }
 
-    for (const payload of frame.payloads) {
-      payload.replayer._rebaseRetainedNodeIndices(payload, range.min);
-    }
-
-    frame.bundle._storeTransformRows(this._transformBuffer.data, range.min, range.max - range.min + 1);
     frame.bundle._connectDevice(this._context, this._accountant);
     frame.bundle._uploadInstances();
 
@@ -1221,6 +1239,7 @@ export class WebGl2Backend implements RenderBackend {
     textures: ReadonlyArray<Texture | RenderTexture | null>,
     textureCount: number,
     geometry: WebGl2RetainedGeometryRef | null = null,
+    rendererData: unknown = null,
   ): void {
     const captures = this._retainedCaptures;
 
@@ -1254,6 +1273,7 @@ export class WebGl2Backend implements RenderBackend {
       instanceCount,
       byteOffset,
       geometry,
+      rendererData,
       vao: null,
     };
 

--- a/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
+++ b/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
@@ -61,6 +61,20 @@ export interface WebGl2RetainedGeometryRef {
 }
 
 /**
+ * Auxiliary, renderer-owned replay state parked on a bundle for a renderer
+ * that opts out of the shared `TransformBuffer` (`_consumesSharedTransform ===
+ * false`, e.g. Text): its per-node style data lives in a private, group-owned
+ * store the generic bundle machinery never touches, so the renderer attaches
+ * it here and the bundle only has to release it on destroy. Mirrors the WebGPU
+ * bundle's `rendererReplayState` slot.
+ * @internal
+ */
+export interface WebGl2RetainedRendererReplayState {
+  /** Release any GPU resources this state owns (called from the bundle). */
+  destroy(): void;
+}
+
+/**
  * Backend-side replay descriptor for one recorded sprite flush (S3-D1). This
  * is the opaque `payload` carried by a plan-level `RetainedBatchInstruction`:
  * everything the owning renderer needs to re-issue the batch from group-owned
@@ -91,6 +105,14 @@ export interface WebGl2RetainedBatchPayload {
    * replays with `drawArraysInstanced` over four strip vertices.
    */
   readonly geometry?: WebGl2RetainedGeometryRef | null;
+  /**
+   * Opaque, renderer-owned record-time data for a renderer that carries its
+   * own per-node store instead of the shared `TransformBuffer` (Text: the
+   * packed per-node style rows, the group-local glyph geometry, the drawable
+   * list for the own-transform patch). `null`/absent for the shared-transform
+   * renderers (sprite / nine-slice / repeating / mesh).
+   */
+  readonly rendererData?: unknown;
   /**
    * Per-batch VAO with attribute pointers pre-based at {@link byteOffset}
    * (WebGL2 has no baseInstance). Assigned at capture end; `null` only for a
@@ -160,6 +182,13 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
   private _accountant: GpuResourceAccountant | null = null;
   private _instanceBuffer: WebGl2RenderBuffer | null = null;
   private readonly _vaos: WebGl2VertexArrayObject[] = [];
+
+  /**
+   * Auxiliary replay state owned by a renderer that keeps its own per-node
+   * store (Text). Null for the shared-transform renderers. Released on device
+   * invalidation and destroy.
+   */
+  public rendererReplayState: WebGl2RetainedRendererReplayState | null = null;
 
   private _destroyed = false;
 
@@ -287,6 +316,25 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
     this._transformTexture.commitRect(0, localRow, 3, 1);
   }
 
+  /**
+   * Slice-4b CPU-side vertex re-bake patch, for a renderer that bakes world
+   * positions into its instance bytes rather than reading a shared-transform
+   * row live (Text on WebGL2, the confirmed ANGLE/D3D11 vertex-texel-fetch
+   * workaround). Overwrite `floats.length` words at `wordOffset` in the
+   * instance store and upload just that sub-range. Deliberately does NOT bump
+   * the generation — the recorded byte LAYOUT is unchanged, only the baked
+   * position values move. Out-of-range writes are ignored (a stale patch after
+   * a recapture shrank the store).
+   */
+  public _patchInstanceWords(wordOffset: number, floats: Float32Array): void {
+    if (this._instanceBuffer === null || wordOffset < 0 || wordOffset + floats.length > this._usedWords) {
+      return;
+    }
+
+    this._instanceFloats.set(floats, wordOffset);
+    this._instanceBuffer.upload(floats, wordOffset * Float32Array.BYTES_PER_ELEMENT);
+  }
+
   /** Attach the GL context + accountant the device resources are created against. */
   public _connectDevice(gl: WebGL2RenderingContext, accountant: GpuResourceAccountant): void {
     this._gl = gl;
@@ -355,6 +403,8 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
     this._transformRowCapacity = 0;
     this._transformRowCount = 0;
     this._usedWords = 0;
+    this.rendererReplayState?.destroy();
+    this.rendererReplayState = null;
   }
 
   /** Release all resources (container destroy / boundary disengage / backend switch). Idempotent. */

--- a/src/rendering/webgl2/WebGl2TextRenderer.ts
+++ b/src/rendering/webgl2/WebGl2TextRenderer.ts
@@ -1,9 +1,13 @@
+import type { RetainedGroupBundle } from '#rendering/plan/RetainedInstructionSet';
+import type { RenderNode } from '#rendering/RenderNode';
+import type { OwnTransformRowPatcher } from '#rendering/RetainedContainer';
 import { Shader } from '#rendering/shader/Shader';
 import { type BitmapText } from '#rendering/text/BitmapText';
 import type { TextPageQuads } from '#rendering/text/Text';
 import { Text } from '#rendering/text/Text';
+import { DataTexture } from '#rendering/texture/DataTexture';
 import type { Texture } from '#rendering/texture/Texture';
-import { BufferTypes, BufferUsage, RenderingPrimitives } from '#rendering/types';
+import { BlendModes, BufferTypes, BufferUsage, RenderingPrimitives } from '#rendering/types';
 
 import { AbstractWebGl2Renderer } from './AbstractWebGl2Renderer';
 import textVertSource from './glsl/text.vert';
@@ -12,6 +16,13 @@ import textMsdfFragSource from './glsl/text-msdf.frag';
 import textSdfFragSource from './glsl/text-sdf.frag';
 import type { WebGl2Backend } from './WebGl2Backend';
 import { WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
+import {
+  type WebGl2RetainedBatchPayload,
+  type WebGl2RetainedBatchReplayer,
+  WebGl2RetainedGroupResources,
+  type WebGl2RetainedNodeIndexRange,
+  type WebGl2RetainedRendererReplayState,
+} from './WebGl2RetainedGroupResources';
 import { createWebGl2ShaderProgram } from './WebGl2ShaderProgram';
 import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './WebGl2VertexArrayObject';
 
@@ -64,6 +75,54 @@ interface PendingQuad {
   readonly nodeIndex: number;
   readonly shaderType: ShaderType;
   readonly atlasTexture: Texture;
+  readonly node: Text | BitmapText;
+}
+
+/**
+ * Per-node re-bake record for the WebGL2 own-transform-move CPU patch: the
+ * moved node's already-known group-local glyph corners plus its recorded
+ * vertex-word range in the group instance buffer. On an own-transform move the
+ * transform is re-applied to `localPositions` on the CPU and written back over
+ * `firstWord`'s range — no glyph re-selection, no atlas lookup.
+ */
+interface TextPatchNode {
+  readonly firstWord: number;
+  readonly vertexCount: number;
+  readonly localPositions: Float32Array;
+  readonly words: Float32Array;
+}
+
+/** Record-time payload carried from `flush()` to `_configureRetainedVao`/replay. */
+interface TextRetainedRendererData {
+  readonly nodeData: Float32Array;
+  readonly nodeCount: number;
+  readonly quadCount: number;
+  readonly shaderType: ShaderType;
+  readonly patchNodes: ReadonlyArray<{ node: Text | BitmapText; patch: TextPatchNode }>;
+}
+
+/**
+ * Group-owned WebGL2 replay state for one recorded Text batch: the persistent
+ * per-node RGBA32F style texture (10 texels/row — the fragment stage's style
+ * lookup, the ONLY per-node data the shipped `text.vert` does not bake into the
+ * vertex bytes) and the drawable→re-bake map the own-transform patch walks.
+ * Grow-only across recaptures; released by the bundle on destroy.
+ */
+class TextRetainedReplayState implements WebGl2RetainedRendererReplayState {
+  public nodeDataTexture: DataTexture<'rgba32f'> | null = null;
+  public nodeDataFloats: Float32Array | null = null;
+  public nodeDataCapacity = 0;
+  public quadCount = 0;
+  public shaderType: ShaderType = 'sdf';
+  public readonly patchByDrawable = new Map<Text | BitmapText, TextPatchNode>();
+
+  public destroy(): void {
+    this.nodeDataTexture?.destroy();
+    this.nodeDataTexture = null;
+    this.nodeDataFloats = null;
+    this.nodeDataCapacity = 0;
+    this.patchByDrawable.clear();
+  }
 }
 
 interface TextRendererConnection {
@@ -88,7 +147,7 @@ interface TextRendererConnection {
  * `RGBA32F` data texture uploaded once per {@link flush}.  Nodes sharing the
  * same shader type and atlas page are drawn in a single `drawElements` call.
  */
-export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText> {
+export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText> implements WebGl2RetainedBatchReplayer, OwnTransformRowPatcher {
   /**
    * Text packs its world transform into its own per-node data texture and never
    * reads the shared {@link TransformBuffer}, so the render-group upload boundary
@@ -96,6 +155,24 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
    * @internal
    */
   public readonly _consumesSharedTransform = false;
+
+  /**
+   * Retained-batch opt-in (Track B extension): a flush whose glyph quads all
+   * share one (shaderType, atlasTexture) — the overwhelmingly common case, one
+   * font/atlas per flush — records the CPU-baked vertex bytes into the group
+   * instance buffer and replays them with `drawElements`. A flush that spans
+   * multiple (shaderType, atlasTexture) batches, or a second Text flush inside
+   * the same capture window, poisons the capture instead — always safe, just a
+   * missed optimization.
+   *
+   * The world transform stays CPU-baked (shipped `text.vert` reads no per-node
+   * transform: a vertex-stage texelFetch of the RGBA32F data texture collapses
+   * the draw on ANGLE/D3D11 whenever a glyph atlas is co-bound), so an
+   * own-transform move re-bakes on the CPU via {@link _patchOwnTransformRow}
+   * rather than the shared O(1) GPU row patch Sprite/NineSlice/Mesh use.
+   * @internal
+   */
+  public readonly _supportsRetainedBatches = true;
 
   private readonly _sdfShader: Shader = new Shader(textVertSource, textSdfFragSource);
   private readonly _msdfShader: Shader = new Shader(textVertSource, textMsdfFragSource);
@@ -109,7 +186,18 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
   private _indexCapacity = initialIndexCapacity;
   private _vertexData: ArrayBuffer = new ArrayBuffer(initialVertexCapacity * vertexStrideBytes);
   private _float32View: Float32Array = new Float32Array(this._vertexData);
+  private _uint32View: Uint32Array = new Uint32Array(this._vertexData);
   private _indexData: Uint16Array = new Uint16Array(initialIndexCapacity);
+
+  // Retained-batch state: the renderer-owned, grow-only quad-index buffer (the
+  // standard `0,1,2, 0,2,3` glyph pattern shared by every recorded batch) and
+  // which capture windows have already recorded a Text batch this session
+  // (S3-D6 nesting-safe — one entry per capture-open call).
+  private _retainedQuadIndexBuffer: WebGl2RenderBuffer | null = null;
+  private _retainedQuadCapacity = 0;
+  private readonly _retainedTextureUnit0Scratch = new Int32Array([0]);
+  private readonly _retainedNodeDataUnitScratch = new Int32Array([1]);
+  private readonly _recordedCaptures = new WeakSet<WebGl2RetainedGroupResources>();
 
   private _nodeDataArray: Float32Array = new Float32Array(initialNodeCapacity * nodeFloats);
   private _nodeCapacity = initialNodeCapacity;
@@ -209,6 +297,9 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
     c.vertexBuffer.destroy();
     c.vao.destroy();
     c.gl.deleteTexture(c.nodeDataTexture);
+    this._retainedQuadIndexBuffer?.destroy();
+    this._retainedQuadIndexBuffer = null;
+    this._retainedQuadCapacity = 0;
 
     this._connection = null;
   }
@@ -227,7 +318,7 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
     for (const batch of pageQuads) {
       const page = pages[batch.pageIndex];
       if (page === undefined) continue;
-      this._pendingQuads.push({ quads: batch, nodeIndex, shaderType, atlasTexture: page.texture });
+      this._pendingQuads.push({ quads: batch, nodeIndex, shaderType, atlasTexture: page.texture, node });
     }
   }
 
@@ -241,7 +332,7 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
     for (const batch of pageQuads) {
       const tex = textures[batch.pageIndex];
       if (tex === undefined) continue;
-      this._pendingQuads.push({ quads: batch, nodeIndex, shaderType, atlasTexture: tex });
+      this._pendingQuads.push({ quads: batch, nodeIndex, shaderType, atlasTexture: tex, node });
     }
   }
 
@@ -394,6 +485,18 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
     const quads = this._pendingQuads;
     let i = 0;
 
+    // Retained recording (Track B extension): a recordable Text flush is a
+    // SINGLE (shaderType, atlasTexture) batch. Collect the first batch's
+    // group-local re-bake data as it is built; a second batch this flush (or a
+    // second flush into the same capture window) poisons the capture below.
+    const capturing = backend._isRetainedCapturing;
+    let batchCount = 0;
+    let recWordCount = 0;
+    let recQuadCount = 0;
+    let recAtlas: Texture | null = null;
+    let recShaderType: ShaderType = 'sdf';
+    let recPatchNodes: Array<{ node: Text | BitmapText; patch: TextPatchNode }> | null = null;
+
     while (i < quads.length) {
       // In-bounds: `i` < `quads.length` per the loop guard.
       const first = quads[i]!;
@@ -425,11 +528,18 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
       let iOffset = 0; // next index slot in _indexData
       let baseV = 0; // vertex base for current quad group (for index rewriting)
 
+      const recordThisBatch = capturing && batchCount === 0;
+
+      if (recordThisBatch) {
+        recPatchNodes = [];
+      }
+
       for (let k = i; k < j; k++) {
         // In-bounds: `k` ranges over `[i, j)` ⊆ `[0, quads.length)`.
-        const { quads: batch, nodeIndex } = quads[k]!;
+        const { quads: batch, nodeIndex, node } = quads[k]!;
         const qVerts = batch.quadCount * 4;
         const { vertices, uvs, indices } = batch;
+        const nodeFirstWord = vOffset * vertexStrideWords;
 
         // Read this node's transform + gradient bounds back from the packed data array
         // (same layout as _packNodeData) so we can transform vertices on the CPU. The
@@ -470,10 +580,34 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
           this._indexData[iOffset + x] = indices[x]! + baseV;
         }
 
+        if (recordThisBatch && recPatchNodes !== null) {
+          // Copy the node's group-local corners (for the CPU re-bake patch) and
+          // its just-baked vertex words (rewritten in place, positions only, on
+          // an own-transform move) — both detached from the reused scratch.
+          recPatchNodes.push({
+            node,
+            patch: {
+              firstWord: nodeFirstWord,
+              vertexCount: qVerts,
+              localPositions: vertices.slice(0, qVerts * 2),
+              words: this._float32View.slice(nodeFirstWord, nodeFirstWord + qVerts * vertexStrideWords),
+            },
+          });
+        }
+
         vOffset += qVerts;
         iOffset += indices.length;
         baseV += qVerts;
       }
+
+      if (recordThisBatch) {
+        recWordCount = totalVerts * vertexStrideWords;
+        recQuadCount = totalIndices / 6;
+        recAtlas = first.atlasTexture;
+        recShaderType = first.shaderType;
+      }
+
+      batchCount++;
 
       c.vertexBuffer.upload(this._float32View.subarray(0, totalVerts * vertexStrideWords));
       c.indexBuffer.upload(this._indexData.subarray(0, totalIndices));
@@ -514,12 +648,311 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
 
       i = j;
     }
+
+    if (capturing) {
+      this._tryRecordRetainedBatch(backend, batchCount, recWordCount, recQuadCount, recShaderType, recAtlas, recPatchNodes);
+    }
+  }
+
+  /**
+   * Record this flush's ONE glyph-quad batch for retained replay, or poison the
+   * capture when it is not a clean single batch (multiple distinct
+   * (shaderType, atlasTexture) combinations this flush, or a second Text flush
+   * into the same capture window). Poisoning is always safe: the group falls
+   * back to entry replay for that frame, never wrong pixels.
+   */
+  private _tryRecordRetainedBatch(
+    backend: WebGl2Backend,
+    batchCount: number,
+    wordCount: number,
+    quadCount: number,
+    shaderType: ShaderType,
+    atlas: Texture | null,
+    patchNodes: Array<{ node: Text | BitmapText; patch: TextPatchNode }> | null,
+  ): void {
+    const bundle = backend._currentRetainedCaptureBundle;
+
+    if (bundle === null) {
+      return;
+    }
+
+    if (batchCount !== 1 || atlas === null || patchNodes === null || this._recordedCaptures.has(bundle)) {
+      backend._poisonRetainedCaptures();
+
+      return;
+    }
+
+    const rendererData: TextRetainedRendererData = {
+      nodeData: this._nodeDataArray.slice(0, this._nodeCount * nodeFloats),
+      nodeCount: this._nodeCount,
+      quadCount,
+      shaderType,
+      patchNodes,
+    };
+
+    backend._recordRetainedBatch(this, this._uint32View.subarray(0, wordCount), this._nodeCount, BlendModes.Normal, [atlas], 1, null, rendererData);
+
+    this._recordedCaptures.add(bundle);
   }
 
   private _shaderFor(type: ShaderType): Shader {
     if (type === 'sdf') return this._sdfShader;
     if (type === 'msdf') return this._msdfShader;
     return this._colorShader;
+  }
+
+  // ── Retained-batch record/replay (Track B extension) ─────────────────────
+  // Text is the WebGL2 retained renderer that keeps its world transform
+  // CPU-baked (the shipped `text.vert` reads no per-node transform — a
+  // vertex-stage texelFetch of the RGBA32F data texture collapses the draw on
+  // ANGLE/D3D11 whenever a glyph atlas is co-bound). So the recorded instance
+  // bytes are the full per-vertex stream (world-space position + uv + node
+  // index + gradient uv), replayed with `drawElements` over the renderer-owned
+  // quad-index pattern, and the per-node STYLE the fragment stage still looks
+  // up lives in a group-owned RGBA32F texture parked on the bundle. Text's node
+  // index addresses THAT dense per-group texture, not the shared
+  // `TransformBuffer`, so the scan/rebase hooks are true no-ops.
+
+  /** @internal See {@link WebGl2RetainedBatchReplayer._scanRetainedNodeIndexRange}. */
+  public _scanRetainedNodeIndexRange(_payload: WebGl2RetainedBatchPayload, _range: WebGl2RetainedNodeIndexRange): void {
+    // Deliberately does not touch `_range`: Text's node index addresses its own
+    // group-owned style texture, not a shared-transform row, and widening the
+    // range here would corrupt the shared span the backend computes across every
+    // OTHER (shared-transform-consuming) batch recorded into the same bundle.
+  }
+
+  /** @internal See {@link WebGl2RetainedBatchReplayer._rebaseRetainedNodeIndices}. */
+  public _rebaseRetainedNodeIndices(_payload: WebGl2RetainedBatchPayload, _base: number): void {
+    // Deliberately does not touch the bytes: Text's node indices are already
+    // dense and group-local (0..nodeCount-1, matching the group-owned style
+    // texture rows) and have no relationship to the shared-buffer rebase base.
+  }
+
+  /**
+   * Point the batch VAO's per-vertex attributes at the bundle's persistent
+   * instance buffer (based at the batch byte offset) and its element buffer at
+   * the renderer-owned quad-index pattern, then (re)build the group-owned
+   * per-node style texture + own-transform-patch map from the recorded data.
+   * @internal
+   */
+  public _configureRetainedVao(payload: WebGl2RetainedBatchPayload): void {
+    const backend = this.getBackend();
+    const gl = backend.context;
+    const buffer = payload.bundle.instanceBuffer;
+    const vao = payload.vao;
+    const data = payload.rendererData as TextRetainedRendererData | null;
+
+    if (buffer === null || vao === null || data === null || !(payload.bundle instanceof WebGl2RetainedGroupResources)) {
+      throw new Error('WebGl2TextRenderer: retained batch VAO configuration requires an uploaded bundle and recorded data.');
+    }
+
+    const shader = this._shaderFor(data.shaderType);
+    const base = payload.byteOffset;
+    const indexBuffer = this._ensureRetainedQuadIndexBuffer(data.quadCount);
+
+    vao
+      .addIndex(indexBuffer)
+      .addAttribute(buffer, shader.getAttribute('a_position'), gl.FLOAT, false, vertexStrideBytes, base + 0)
+      .addAttribute(buffer, shader.getAttribute('a_texcoord'), gl.FLOAT, false, vertexStrideBytes, base + 8)
+      .addAttribute(buffer, shader.getAttribute('a_nodeIndex'), gl.FLOAT, false, vertexStrideBytes, base + 16);
+
+    if (shader.attributes.has('a_gradUV')) {
+      vao.addAttribute(buffer, shader.getAttribute('a_gradUV'), gl.FLOAT, false, vertexStrideBytes, base + 20);
+    }
+
+    const state = this._getTextReplayState(payload.bundle);
+
+    state.shaderType = data.shaderType;
+    state.quadCount = data.quadCount;
+
+    if (state.nodeDataFloats === null || state.nodeDataCapacity < data.nodeCount) {
+      let capacity = Math.max(state.nodeDataCapacity, initialNodeCapacity);
+
+      while (capacity < data.nodeCount) capacity *= 2;
+
+      state.nodeDataTexture?.destroy();
+      state.nodeDataFloats = new Float32Array(capacity * nodeFloats);
+      state.nodeDataTexture = new DataTexture({ width: nodeTexels, height: capacity, format: 'rgba32f', data: state.nodeDataFloats });
+      state.nodeDataCapacity = capacity;
+    }
+
+    state.nodeDataFloats.set(data.nodeData, 0);
+    state.nodeDataTexture!.commitRect(0, 0, nodeTexels, Math.max(1, data.nodeCount));
+
+    state.patchByDrawable.clear();
+
+    for (const entry of data.patchNodes) {
+      state.patchByDrawable.set(entry.node, entry.patch);
+    }
+  }
+
+  /**
+   * Replay one recorded Text batch: all STATE is resolved live — blend, the
+   * `u_projection`/`u_group` uniforms from the live view + group matrix (the
+   * camera-pan / group-move win), the atlas texture — and only DATA is cached:
+   * the group instance bytes (bound through the per-batch VAO), the renderer's
+   * static quad-index pattern, and the group-owned per-node style texture.
+   * @internal
+   */
+  public _replayRetainedBatch(payload: WebGl2RetainedBatchPayload): void {
+    const backend = this.getBackendOrNull();
+    const vao = payload.vao;
+    const data = payload.rendererData as TextRetainedRendererData | null;
+
+    if (backend === null || vao === null || data === null || !(payload.bundle instanceof WebGl2RetainedGroupResources)) {
+      return;
+    }
+
+    const state = payload.bundle.rendererReplayState;
+
+    if (!(state instanceof TextRetainedReplayState) || state.nodeDataTexture === null) {
+      return;
+    }
+
+    const shader = this._shaderFor(data.shaderType);
+    // Text's recording always stages exactly one atlas page texture (single
+    // batch); the payload's shared type is wider only because other renderers
+    // can target a RenderTexture.
+    const atlas = payload.textures[0] as Texture;
+    const view = backend.view;
+
+    backend.setBlendMode(payload.blendMode);
+    backend.bindTexture(atlas, 0);
+    backend.bindTexture(state.nodeDataTexture, 1);
+
+    if (shader.uniforms.has('u_projection')) {
+      shader.getUniform('u_projection').setValue(view.getTransform().toArray(false));
+    }
+    if (shader.uniforms.has('u_group')) {
+      const groupTransform = backend.renderGroupTransform;
+
+      shader.getUniform('u_group').setValue(groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3);
+    }
+    if (shader.uniforms.has('u_texture')) {
+      shader.getUniform('u_texture').setValue(this._retainedTextureUnit0Scratch);
+    }
+    if (shader.uniforms.has('u_nodeData')) {
+      shader.getUniform('u_nodeData').setValue(this._retainedNodeDataUnitScratch);
+    }
+    if (shader.uniforms.has('u_pageSize')) {
+      this._floatScratch[0] = atlas.width;
+      shader.getUniform('u_pageSize').setValue(this._floatScratch);
+    }
+
+    shader.sync();
+    backend.bindVertexArrayObject(vao);
+    vao.draw(state.quadCount * 6, 0, RenderingPrimitives.Triangles);
+  }
+
+  /**
+   * Own-transform-move patch ({@link OwnTransformRowPatcher}): the moved node's
+   * world positions are baked into the group instance bytes (the ANGLE
+   * workaround forbids a live GPU-side transform read), so re-apply its current
+   * group-local `getGlobalTransform()` to the already-known glyph corners on the
+   * CPU and overwrite only that node's vertex range — no glyph re-selection, no
+   * atlas lookup, no other node touched. `base` (the shared-buffer direct-draw
+   * base) is irrelevant to Text's own dense indexing and is unused. Returns
+   * `false` (falls back to a full re-record) when `bundle` has no live Text
+   * replay state or `node` was not part of the recorded batch.
+   * @internal
+   */
+  public _patchOwnTransformRow(node: RenderNode, bundle: RetainedGroupBundle, _base: number): boolean {
+    if (!(bundle instanceof WebGl2RetainedGroupResources)) {
+      return false;
+    }
+
+    const state = bundle.rendererReplayState;
+
+    if (!(state instanceof TextRetainedReplayState)) {
+      return false;
+    }
+
+    const drawable = node as unknown as Text | BitmapText;
+    const patch = state.patchByDrawable.get(drawable);
+
+    if (patch === undefined) {
+      return false;
+    }
+
+    // Column-major mat3 [a c 0 | b d 0 | tx ty 1] — indices 0..8 always valid.
+    const m = drawable.getGlobalTransform().toArray(false);
+    const a = m[0]!;
+    const cc = m[1]!;
+    const tx = m[6]!;
+    const b = m[3]!;
+    const dd = m[4]!;
+    const ty = m[7]!;
+    const words = patch.words;
+    const local = patch.localPositions;
+
+    for (let v = 0; v < patch.vertexCount; v++) {
+      const wf = v * vertexStrideWords;
+      const wl = v * 2;
+      const lx = local[wl]!;
+      const ly = local[wl + 1]!;
+
+      words[wf + 0] = a * lx + b * ly + tx;
+      words[wf + 1] = cc * lx + dd * ly + ty;
+    }
+
+    bundle._patchInstanceWords(patch.firstWord, words);
+
+    return true;
+  }
+
+  private _getTextReplayState(bundle: WebGl2RetainedGroupResources): TextRetainedReplayState {
+    const existing = bundle.rendererReplayState;
+    const state = existing instanceof TextRetainedReplayState ? existing : new TextRetainedReplayState();
+
+    if (existing !== state) {
+      existing?.destroy();
+      bundle.rendererReplayState = state;
+    }
+
+    return state;
+  }
+
+  private _ensureRetainedQuadIndexBuffer(quadCount: number): WebGl2RenderBuffer {
+    const c = this._connection;
+
+    if (c === null) {
+      throw new Error('WebGl2TextRenderer: retained quad-index buffer requires a connected backend.');
+    }
+
+    if (this._retainedQuadIndexBuffer !== null && this._retainedQuadCapacity >= quadCount) {
+      return this._retainedQuadIndexBuffer;
+    }
+
+    let capacity = Math.max(this._retainedQuadCapacity, 64);
+
+    while (capacity < quadCount) capacity *= 2;
+
+    const indices = new Uint16Array(capacity * 6);
+
+    for (let q = 0; q < capacity; q++) {
+      const baseV = q * 4;
+      const o = q * 6;
+
+      indices[o + 0] = baseV;
+      indices[o + 1] = baseV + 1;
+      indices[o + 2] = baseV + 2;
+      indices[o + 3] = baseV;
+      indices[o + 4] = baseV + 2;
+      indices[o + 5] = baseV + 3;
+    }
+
+    if (this._retainedQuadIndexBuffer === null) {
+      this._retainedQuadIndexBuffer = new WebGl2RenderBuffer(BufferTypes.ElementArrayBuffer, indices, BufferUsage.StaticDraw).connect(
+        this._createBufferRuntime(c.gl, c.buffers),
+        this.getBackend().accountant,
+      );
+    } else {
+      this._retainedQuadIndexBuffer.upload(indices);
+    }
+
+    this._retainedQuadCapacity = capacity;
+
+    return this._retainedQuadIndexBuffer;
   }
 
   private _resetFrameState(): void {
@@ -537,6 +970,7 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
     while (this._vertexCapacity < vertexCount) this._vertexCapacity *= 2;
     this._vertexData = new ArrayBuffer(this._vertexCapacity * vertexStrideBytes);
     this._float32View = new Float32Array(this._vertexData);
+    this._uint32View = new Uint32Array(this._vertexData);
   }
 
   private _ensureIndexCapacity(indexCount: number): void {

--- a/test/rendering/browser/webgl2-text-retained-instruction-replay.test.ts
+++ b/test/rendering/browser/webgl2-text-retained-instruction-replay.test.ts
@@ -1,0 +1,470 @@
+/**
+ * WebGL2 renderer-matrix browser tests — Text retained instruction-set replay
+ * (Track B extension, Task 2).
+ *
+ * The WebGL2 counterpart of `webgpu-text-retained-instruction-replay.test.ts`.
+ * Text is the retained renderer that opts OUT of the shared `TransformBuffer`
+ * (`_consumesSharedTransform === false`) AND, on WebGL2 only, keeps its world
+ * transform CPU-baked into the recorded vertex bytes — the shipped `text.vert`
+ * reads no per-node transform, because a vertex-stage texelFetch of the RGBA32F
+ * data texture collapses the draw on ANGLE/D3D11 whenever a glyph atlas is
+ * co-bound (see `webgl2-text-vertex-shader-regression.test.ts`). So the group
+ * replay path is: recorded baked vertex bytes drawn with `drawElements`, the
+ * per-node STYLE resolved live from a group-owned RGBA32F texture, and an
+ * own-transform move re-baked on the CPU (there is no shared-row rebase to get
+ * wrong here — the node index addresses the group-owned style texture — but
+ * there IS a real risk of stale baked positions or a wrong style texture if the
+ * record/replay/patch logic is broken).
+ *
+ * These render through a REAL GL context and the REAL shipped text shaders
+ * (imported via `?raw`, bypassing the browser-test shader stub).
+ *
+ * Run via:  pnpm test:browser:webgl
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import type { RetainedGroupFragment } from '#rendering/plan/RetainedGroupFragment';
+import type { RenderNode } from '#rendering/RenderNode';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { resetDefaultGlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
+import { Text } from '#rendering/text/Text';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+import { WebGl2TextRenderer } from '#rendering/webgl2/WebGl2TextRenderer';
+
+import { wireCoreRenderers } from './_coreRenderers';
+
+// ---------------------------------------------------------------------------
+// Shader wiring — REAL shipped text GLSL via `?raw` (the stub plugin only
+// rewrites bare `.vert`/`.frag` ids), plus minimal valid Sprite/Mesh mocks so
+// `wireCoreRenderers()` can eagerly compile the whole registry.
+// ---------------------------------------------------------------------------
+
+vi.mock('#rendering/webgl2/glsl/text.vert', async () => ({ default: (await import('../../../src/rendering/webgl2/glsl/text.vert?raw')).default }));
+vi.mock('#rendering/webgl2/glsl/text-sdf.frag', async () => ({ default: (await import('../../../src/rendering/webgl2/glsl/text-sdf.frag?raw')).default }));
+vi.mock('#rendering/webgl2/glsl/text-msdf.frag', async () => ({ default: (await import('../../../src/rendering/webgl2/glsl/text-msdf.frag?raw')).default }));
+vi.mock('#rendering/webgl2/glsl/text-color.frag', async () => ({ default: (await import('../../../src/rendering/webgl2/glsl/text-color.frag?raw')).default }));
+
+const auxShaderSources = vi.hoisted(() => ({
+  spriteVert: `#version 300 es
+precision highp float;
+in vec4 a_localBounds; in vec4 a_uvBounds; in vec4 a_color; in uint a_textureSlot; in uint a_nodeIndex;
+uniform mat3 u_projection; uniform mat3 u_group; uniform sampler2D u_transforms;
+out vec2 v_uv; out vec4 v_color; flat out uint v_textureSlot;
+void main() {
+  vec2 local = vec2(a_localBounds.x, a_localBounds.y);
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
+  gl_Position = vec4((u_projection * u_group * vec3(world, 1.0)).xy, 0.0, 1.0);
+  v_uv = a_uvBounds.xy; v_color = a_color; v_textureSlot = a_textureSlot;
+}`,
+  meshVert: `#version 300 es
+precision highp float;
+in vec2 a_position; in vec2 a_texcoord; in vec4 a_color; in uint a_nodeIndex;
+uniform mat3 u_projection; uniform sampler2D u_transforms;
+out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
+void main() {
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  mat3 t = mat3(m0.x,m0.z,0.0, m0.y,m0.w,0.0, m1.x,m1.y,1.0);
+  gl_Position = vec4((u_projection * t * vec3(a_position, 1.0)).xy, 0.0, 1.0);
+  v_uv = a_texcoord; v_color = a_color; v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+}`,
+  meshFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv; in vec4 v_color; in vec4 v_tint;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() { outColor = texture(u_texture, v_uv) * v_color * v_tint; }`,
+}));
+
+vi.mock('#rendering/webgl2/glsl/sprite.vert', () => ({ default: auxShaderSources.spriteVert }));
+vi.mock('#rendering/webgl2/glsl/sprite.frag', async () => ({ default: (await import('./_spriteFragMock')).createSpriteFragMockSource('v_uv') }));
+vi.mock('#rendering/webgl2/glsl/mesh.vert', () => ({ default: auxShaderSources.meshVert }));
+vi.mock('#rendering/webgl2/glsl/mesh.frag', () => ({ default: auxShaderSources.meshFrag }));
+
+// ---------------------------------------------------------------------------
+// Infrastructure helpers (shared shape with the sibling browser specs).
+// ---------------------------------------------------------------------------
+
+type RgbaTuple = readonly [number, number, number, number];
+
+const canvasSize = 96;
+
+const createBackend = async (): Promise<WebGl2Backend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const app: Application = {
+    canvas,
+    options: {
+      clearColor: Color.black,
+      canvas: { width: canvasSize, height: canvasSize },
+      rendering: {
+        debug: false,
+        webglAttributes: {
+          alpha: false,
+          antialias: false,
+          premultipliedAlpha: false,
+          preserveDrawingBuffer: true,
+          stencil: false,
+          depth: false,
+        },
+        spriteRendererBatchSize: 1024,
+        particleRendererBatchSize: 1024,
+      },
+    },
+  } as unknown as Application;
+
+  const backend = new WebGl2Backend(app);
+
+  await backend.initialize();
+  wireCoreRenderers(backend, app.options.rendering);
+
+  return backend;
+};
+
+const render = (backend: WebGl2Backend, node: RenderNode): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+  node.render(backend);
+  backend.flush();
+};
+
+const readPixel = (backend: WebGl2Backend, x: number, y: number): RgbaTuple => {
+  const buf = new Uint8Array(4);
+  const gl = backend.context;
+
+  gl.readPixels(Math.floor(x), backend.renderTarget.height - Math.floor(y) - 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+
+  return [buf[0]!, buf[1]!, buf[2]!, buf[3]!];
+};
+
+/** Full-framebuffer snapshot for byte-identical tier comparisons. */
+const readCanvas = (backend: WebGl2Backend): Uint8Array => {
+  const buf = new Uint8Array(canvasSize * canvasSize * 4);
+  const gl = backend.context;
+
+  gl.readPixels(0, 0, canvasSize, canvasSize, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+
+  return buf;
+};
+
+const expectPixelNear = (actual: RgbaTuple, expected: RgbaTuple, tolerance = 8): void => {
+  for (let i = 0; i < 4; i++) {
+    expect(Math.abs(actual[i]! - expected[i]!)).toBeLessThanOrEqual(tolerance);
+  }
+};
+
+interface FragmentCarrier {
+  _fragment: RetainedGroupFragment;
+}
+
+const fragmentOf = (group: RetainedContainer): RetainedGroupFragment => (group as unknown as FragmentCarrier)._fragment;
+
+/**
+ * One large white text node inside a positioned retained group over black.
+ * A region sampled a few px into a wide uppercase glyph is reliably ink, not
+ * anti-aliased edge.
+ */
+const buildScene = (): { root: Container; group: RetainedContainer; text: Text } => {
+  const root = new Container();
+  const group = new RetainedContainer();
+  const text = new Text('MW', { fillColor: Color.white, fontSize: 40 });
+
+  text.setPosition(4, 4);
+  group.addChild(text);
+  group.setPosition(8, 8);
+  root.addChild(group);
+
+  return { root, group, text };
+};
+
+/** Sum of all channels over the whole canvas — a total-ink measure. */
+const totalInk = (frame: Uint8Array): number => {
+  let sum = 0;
+
+  for (let i = 0; i < frame.length; i += 4) {
+    sum += frame[i]! + frame[i + 1]! + frame[i + 2]!;
+  }
+
+  return sum;
+};
+
+describe('WebGL2 renderer matrix: Text retained instruction-set replay cells', () => {
+  beforeEach(() => resetDefaultGlyphAtlasPool());
+  afterEach(() => resetDefaultGlyphAtlasPool());
+
+  test('cell 1 — Text opts in and the instruction-replay tier is byte-identical to the record frame', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+    const replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+    try {
+      expect(new WebGl2TextRenderer()._supportsRetainedBatches).toBe(true);
+
+      render(backend, scene.root); // F1: collect + capture
+      expect(replaySpy).not.toHaveBeenCalled();
+
+      render(backend, scene.root); // F2: entry replay + record
+
+      const recordFrame = readCanvas(backend);
+
+      expect(fragmentOf(scene.group).instructions?.hasRecording).toBe(true);
+      // Ink must be present, else the byte comparison below is vacuous.
+      expect(totalInk(recordFrame)).toBeGreaterThan(0);
+
+      render(backend, scene.root); // F3: instruction splice (fast path)
+
+      const replayFrame = readCanvas(backend);
+
+      expect(replaySpy).toHaveBeenCalled();
+      expect(replayFrame).toEqual(recordFrame);
+
+      render(backend, scene.root); // F4: steady state
+
+      expect(readCanvas(backend)).toEqual(recordFrame);
+    } finally {
+      scene.root.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 2 — camera pan on the cached path: replayed glyph pixels track the live projection, no recapture', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+
+    try {
+      for (let f = 0; f < 3; f++) render(backend, scene.root);
+
+      const before = readPixel(backend, 20, 24);
+
+      expect(before).not.toEqual([0, 0, 0, 255]);
+
+      const recordedInstruction = fragmentOf(scene.group).instructions!.instructions[0];
+      const beginSpy = vi.spyOn(backend, '_beginRetainedCapture');
+
+      // Pan the camera 16px right: scene content moves 16px left on screen.
+      backend.view.setCenter(backend.view.center.x + 16, backend.view.center.y);
+      render(backend, scene.root);
+
+      expect(beginSpy).not.toHaveBeenCalled();
+      expect(fragmentOf(scene.group).instructions!.instructions[0]).toBe(recordedInstruction);
+
+      // Panning the camera +16px right shifts the same glyph feature 16px left:
+      // what was at x=20 is now at x=4.
+      const panned = readPixel(backend, 4, 24);
+
+      expect(panned).not.toEqual([0, 0, 0, 255]);
+      expectPixelNear(panned, before, 40);
+    } finally {
+      scene.root.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 3 — group move on the cached path relocates glyph pixels WITHOUT recapture', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+
+    try {
+      for (let f = 0; f < 3; f++) render(backend, scene.root);
+
+      const before = readPixel(backend, 20, 24);
+
+      expect(before).not.toEqual([0, 0, 0, 255]);
+
+      const recordedInstruction = fragmentOf(scene.group).instructions!.instructions[0];
+      const beginSpy = vi.spyOn(backend, '_beginRetainedCapture');
+
+      scene.group.setPosition(28, 8); // was (8,8): +20px right
+
+      render(backend, scene.root);
+
+      expect(beginSpy).not.toHaveBeenCalled();
+      expect(fragmentOf(scene.group).instructions!.instructions[0]).toBe(recordedInstruction);
+
+      const moved = readPixel(backend, 40, 24);
+
+      expect(moved).not.toEqual([0, 0, 0, 255]);
+      expectPixelNear(moved, before, 40);
+      expectPixelNear(readPixel(backend, 20, 24), [0, 0, 0, 255], 8); // old spot cleared
+    } finally {
+      scene.root.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 4 — own-transform move re-bakes the moved node in place on the CPU, no re-record', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+
+    try {
+      for (let f = 0; f < 3; f++) render(backend, scene.root);
+
+      const before = readPixel(backend, 20, 24);
+
+      expect(before).not.toEqual([0, 0, 0, 255]);
+
+      const recordedInstruction = fragmentOf(scene.group).instructions!.instructions[0];
+      const beginSpy = vi.spyOn(backend, '_beginRetainedCapture');
+      const replaySpy = vi.spyOn(backend, '_replayRetainedBatch');
+
+      scene.text.setPosition(24, 4); // was (4,4): +20px right within the group
+
+      render(backend, scene.root);
+
+      // The CPU patch rewrote the moved node's baked vertex range in place — no
+      // full re-record (a re-record would run `_beginRetainedCapture` again),
+      // and the SAME recorded instruction still replays on the fast tier.
+      expect(beginSpy).not.toHaveBeenCalled();
+      expect(replaySpy).toHaveBeenCalled();
+      expect(fragmentOf(scene.group).instructions!.instructions[0]).toBe(recordedInstruction);
+
+      const moved = readPixel(backend, 40, 24);
+
+      expect(moved).not.toEqual([0, 0, 0, 255]);
+      expectPixelNear(moved, before, 40);
+      expectPixelNear(readPixel(backend, 20, 24), [0, 0, 0, 255], 8); // old spot cleared
+
+      // The patched recording keeps splicing byte-stable, no re-record.
+      const patchedFrame = readCanvas(backend);
+
+      render(backend, scene.root);
+
+      expect(beginSpy).not.toHaveBeenCalled();
+      expect(readCanvas(backend)).toEqual(patchedFrame);
+    } finally {
+      scene.root.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 5 — a content change forces a full re-record and replays the new content', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+
+    try {
+      for (let f = 0; f < 3; f++) render(backend, scene.root);
+
+      expect(fragmentOf(scene.group).instructions?.hasRecording).toBe(true);
+
+      scene.text.text = 'X';
+
+      render(backend, scene.root); // content-dirty frame
+
+      for (let f = 0; f < 3; f++) render(backend, scene.root);
+
+      expect(fragmentOf(scene.group).instructions?.hasRecording).toBe(true);
+      expect(totalInk(readCanvas(backend))).toBeGreaterThan(0);
+    } finally {
+      scene.root.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 6 — deliberate break: a neutered _replayRetainedBatch drops the retained draw and diverges', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+    const original = WebGl2TextRenderer.prototype._replayRetainedBatch;
+
+    try {
+      render(backend, scene.root); // F1 capture
+      render(backend, scene.root); // F2 record
+
+      const recordInk = totalInk(readCanvas(backend));
+
+      expect(recordInk).toBeGreaterThan(0);
+
+      // F3 static frame: the fast/instruction-replay tier is the only path that
+      // can draw the group's glyphs. A neutered replay that never issues its
+      // drawElements leaves the canvas empty where the record frame had ink.
+      WebGl2TextRenderer.prototype._replayRetainedBatch = function (): void {};
+
+      render(backend, scene.root);
+
+      expect(totalInk(readCanvas(backend))).toBe(0);
+      expect(totalInk(readCanvas(backend))).not.toBe(recordInk);
+    } finally {
+      WebGl2TextRenderer.prototype._replayRetainedBatch = original;
+      scene.root.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 7 — deliberate break: a neutered CPU patch leaves the moved node frozen at its stale position', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+    const original = WebGl2TextRenderer.prototype._patchOwnTransformRow;
+
+    try {
+      for (let f = 0; f < 3; f++) render(backend, scene.root);
+
+      const preMove = readCanvas(backend);
+
+      expect(totalInk(preMove)).toBeGreaterThan(0);
+
+      // Neuter the patch so it claims success but writes NOTHING: the recording
+      // stays valid (return true), so replay keeps splicing the stale baked
+      // bytes — the glyph is frozen at its old position instead of moving.
+      WebGl2TextRenderer.prototype._patchOwnTransformRow = function (): boolean {
+        return true;
+      };
+
+      scene.text.setPosition(24, 4); // a real move that SHOULD change the frame
+      render(backend, scene.root);
+
+      // Frozen: byte-identical to the pre-move frame despite the move.
+      expect(readCanvas(backend)).toEqual(preMove);
+
+      // Contrast: restore the patch, apply a fresh move — the glyph now relocates
+      // and the frame diverges from the frozen (stale) one.
+      WebGl2TextRenderer.prototype._patchOwnTransformRow = original;
+      scene.text.setPosition(44, 4);
+      render(backend, scene.root);
+
+      expect(readCanvas(backend)).not.toEqual(preMove);
+    } finally {
+      WebGl2TextRenderer.prototype._patchOwnTransformRow = original;
+      scene.root.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('cell 8 — deliberate break: a neutered _configureRetainedVao leaves the batch unrenderable and diverges', async () => {
+    const backend = await createBackend();
+    const scene = buildScene();
+    const original = WebGl2TextRenderer.prototype._configureRetainedVao;
+
+    try {
+      // F1 capture, then neuter the finalize hook BEFORE the record frame's
+      // capture-end wires the batch VAO + group-owned style texture. With
+      // neither configured, the replay guard bails and nothing draws.
+      render(backend, scene.root);
+
+      WebGl2TextRenderer.prototype._configureRetainedVao = function (): void {};
+
+      render(backend, scene.root); // F2 record (finalize neutered)
+      render(backend, scene.root); // F3 replay attempt
+
+      expect(totalInk(readCanvas(backend))).toBe(0);
+
+      // Restore + re-record: the group recovers to visible ink.
+      WebGl2TextRenderer.prototype._configureRetainedVao = original;
+      scene.text.text = 'MW '; // content change forces a fresh capture/record
+      for (let f = 0; f < 3; f++) render(backend, scene.root);
+
+      expect(totalInk(readCanvas(backend))).toBeGreaterThan(0);
+    } finally {
+      WebGl2TextRenderer.prototype._configureRetainedVao = original;
+      scene.root.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgl2-text-vertex-shader-regression.test.ts
+++ b/test/rendering/browser/webgl2-text-vertex-shader-regression.test.ts
@@ -1,0 +1,436 @@
+/**
+ * WebGL2 Text vertex-shader ANGLE/D3D11 regression guard.
+ *
+ * Every OTHER browser pixel test in this repo mocks `text.vert` with a stub
+ * that already matches the shipped CPU-bake shape and never issues a
+ * vertex-stage `texelFetch` of the per-node data texture — so nothing would
+ * catch a reintroduction of the confirmed ANGLE/D3D11 collapse the CPU-bake
+ * exists to avoid (commit `64e2773d`): a vertex-stage `texelFetch` of the
+ * RGBA32F per-node data texture returns garbage (RGB read as 0) whenever an
+ * RGBA8 glyph atlas is co-bound, collapsing every glyph quad to a degenerate
+ * point. This file closes that gap.
+ *
+ * Layer 1 (source teeth, always on): the shipped `text.vert` — imported REAL
+ * via `?raw`, bypassing the stub — must NOT read the per-node data texture in
+ * the vertex stage. This reds the instant someone reintroduces the bug.
+ *
+ * Layer 2 (empirical teeth, reproduces on ANGLE/SwiftShader — the required CI
+ * lane): a raw-GL harness renders the SAME geometry twice with a real
+ * RGBA8/mipmapped/LINEAR atlas co-bound — once through the shipped `text.vert`
+ * (world position CPU-baked into `a_position`), once through the RECONSTRUCTED
+ * pre-fix shader (local position + a vertex-stage `texelFetch` of the transform
+ * from the data texture). The control renders ink; the pre-fix shader collapses
+ * to nothing on ANGLE/SwiftShader — the direct before/after pixel proof that
+ * the CPU-bake workaround is still load-bearing.
+ *
+ * Layer 3 (end-to-end): the actual `WebGl2TextRenderer` + shipped `text.vert`
+ * renders real glyph content to visible ink.
+ *
+ * Run via:  pnpm test:browser:webgl
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import { resetDefaultGlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
+import { Text } from '#rendering/text/Text';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+
+// Layer 3 needs the actual renderer + real text shaders; Sprite/Mesh get
+// minimal valid mocks so `wireCoreRenderers` compiles the whole registry.
+vi.mock('#rendering/webgl2/glsl/text.vert', async () => ({ default: (await import('../../../src/rendering/webgl2/glsl/text.vert?raw')).default }));
+vi.mock('#rendering/webgl2/glsl/text-sdf.frag', async () => ({ default: (await import('../../../src/rendering/webgl2/glsl/text-sdf.frag?raw')).default }));
+vi.mock('#rendering/webgl2/glsl/text-msdf.frag', async () => ({ default: (await import('../../../src/rendering/webgl2/glsl/text-msdf.frag?raw')).default }));
+vi.mock('#rendering/webgl2/glsl/text-color.frag', async () => ({ default: (await import('../../../src/rendering/webgl2/glsl/text-color.frag?raw')).default }));
+
+const auxShaderSources = vi.hoisted(() => ({
+  spriteVert: `#version 300 es
+precision highp float;
+in vec4 a_localBounds; in vec4 a_uvBounds; in vec4 a_color; in uint a_textureSlot; in uint a_nodeIndex;
+uniform mat3 u_projection; uniform mat3 u_group; uniform sampler2D u_transforms;
+out vec2 v_uv; out vec4 v_color; flat out uint v_textureSlot;
+void main() {
+  vec2 local = vec2(a_localBounds.x, a_localBounds.y);
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
+  gl_Position = vec4((u_projection * u_group * vec3(world, 1.0)).xy, 0.0, 1.0);
+  v_uv = a_uvBounds.xy; v_color = a_color; v_textureSlot = a_textureSlot;
+}`,
+  meshVert: `#version 300 es
+precision highp float;
+in vec2 a_position; in vec2 a_texcoord; in vec4 a_color; in uint a_nodeIndex;
+uniform mat3 u_projection; uniform sampler2D u_transforms;
+out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
+void main() {
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  mat3 t = mat3(m0.x,m0.z,0.0, m0.y,m0.w,0.0, m1.x,m1.y,1.0);
+  gl_Position = vec4((u_projection * t * vec3(a_position, 1.0)).xy, 0.0, 1.0);
+  v_uv = a_texcoord; v_color = a_color; v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+}`,
+  meshFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv; in vec4 v_color; in vec4 v_tint;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() { outColor = texture(u_texture, v_uv) * v_color * v_tint; }`,
+}));
+
+vi.mock('#rendering/webgl2/glsl/sprite.vert', () => ({ default: auxShaderSources.spriteVert }));
+vi.mock('#rendering/webgl2/glsl/sprite.frag', async () => ({ default: (await import('./_spriteFragMock')).createSpriteFragMockSource('v_uv') }));
+vi.mock('#rendering/webgl2/glsl/mesh.vert', () => ({ default: auxShaderSources.meshVert }));
+vi.mock('#rendering/webgl2/glsl/mesh.frag', () => ({ default: auxShaderSources.meshFrag }));
+
+// The exact pre-fix vertex stage (`git show 64e2773d~1:src/rendering/webgl2/glsl/text.vert`):
+// it texelFetches the transform (data texels 0/1) in the VERTEX stage and uses
+// it in gl_Position — the historical collapse trigger, reconstructed verbatim.
+const prefixTextVert = `#version 300 es
+precision highp float;
+
+layout(location = 0) in vec2  a_position;
+layout(location = 1) in vec2  a_texcoord;
+layout(location = 2) in float a_nodeIndex;
+
+uniform mat3 u_projection;
+uniform sampler2D u_nodeData;
+
+flat out int  v_nodeIndex;
+     out vec2 v_texcoord;
+     out vec2 v_gradUV;
+
+void main(void) {
+    int ni = int(a_nodeIndex);
+
+    vec4 t0 = texelFetch(u_nodeData, ivec2(0, ni), 0);
+    vec4 t1 = texelFetch(u_nodeData, ivec2(1, ni), 0);
+
+    mat3 xf = mat3(
+        t0.x, t0.y, 0.0,
+        t1.x, t1.y, 0.0,
+        t0.w, t1.w, 1.0
+    );
+
+    gl_Position = vec4((u_projection * xf * vec3(a_position, 1.0)).xy, 0.0, 1.0);
+    v_texcoord  = a_texcoord;
+    v_nodeIndex = ni;
+
+    vec4 tBounds = texelFetch(u_nodeData, ivec2(9, ni), 0);
+    vec2 bSize   = tBounds.zw;
+    v_gradUV = (bSize.x > 0.0 && bSize.y > 0.0)
+        ? clamp((a_position - tBounds.xy) / bSize, 0.0, 1.0)
+        : vec2(0.0);
+}`;
+
+// Minimal fragment that samples the co-bound RGBA8 atlas (so the atlas is
+// genuinely used, matching the bug's trigger) and paints the covered quad.
+const harnessFrag = `#version 300 es
+precision mediump float;
+uniform sampler2D u_texture;
+in vec2 v_texcoord;
+out vec4 outColor;
+void main() { outColor = vec4(texture(u_texture, v_texcoord).rgb, 1.0); }`;
+
+const harnessSize = 32;
+
+const compile = (gl: WebGL2RenderingContext, type: number, source: string): WebGLShader => {
+  const shader = gl.createShader(type)!;
+
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    throw new Error(`shader compile failed: ${gl.getShaderInfoLog(shader) ?? ''}`);
+  }
+
+  return shader;
+};
+
+/** Ortho mat3 (column-major): world [0,size] -> NDC [-1,1] on both axes. */
+const orthoMat3 = (size: number): Float32Array => {
+  const s = 2 / size;
+
+  return new Float32Array([s, 0, 0, 0, s, 0, -1, -1, 1]);
+};
+
+/**
+ * Draw one 16x16 quad translated to world (8,8)-(24,24) with an RGBA8/mipmapped/
+ * LINEAR white atlas co-bound (matching `_syncTexture`), through the given
+ * vertex shader. `mode: 'baked'` supplies world-space `a_position` + identity
+ * node data (the shipped path); `mode: 'nodefetch'` supplies LOCAL `a_position`
+ * and puts the translate in the data texture the vertex stage fetches (the
+ * pre-fix path). Returns the centre pixel's red channel.
+ */
+const drawHarness = (vertSource: string, mode: 'baked' | 'nodefetch'): { center: number } => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = harnessSize;
+  canvas.height = harnessSize;
+
+  const gl = canvas.getContext('webgl2', { antialias: false, alpha: false, preserveDrawingBuffer: true })!;
+
+  const program = gl.createProgram()!;
+
+  gl.attachShader(program, compile(gl, gl.VERTEX_SHADER, vertSource));
+  gl.attachShader(program, compile(gl, gl.FRAGMENT_SHADER, harnessFrag));
+  gl.linkProgram(program);
+
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    throw new Error(`program link failed: ${gl.getProgramInfoLog(program) ?? ''}`);
+  }
+
+  // ── RGBA8 white atlas, canvas-sourced, LINEAR, mipmapped (matches _syncTexture).
+  const atlasCanvas = document.createElement('canvas');
+
+  atlasCanvas.width = 8;
+  atlasCanvas.height = 8;
+
+  const actx = atlasCanvas.getContext('2d')!;
+
+  actx.fillStyle = '#ffffff';
+  actx.fillRect(0, 0, 8, 8);
+
+  const atlas = gl.createTexture();
+
+  gl.activeTexture(gl.TEXTURE0);
+  gl.bindTexture(gl.TEXTURE_2D, atlas);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, atlasCanvas);
+  gl.generateMipmap(gl.TEXTURE_2D);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+  // ── RGBA32F node-data texture (10x1). Identity for the baked path; the
+  //    translate (8,8) baked into texels 0/1 for the node-fetch path.
+  const nodeData = new Float32Array(10 * 4);
+  const tx = mode === 'nodefetch' ? 8 : 1;
+  const ty = mode === 'nodefetch' ? 8 : 1;
+
+  // texel0 = (a, c, 0, tx); texel1 = (b, d, 0, ty). Identity rotation/scale.
+  nodeData[0] = 1;
+  nodeData[3] = tx;
+  nodeData[4 + 0] = 0;
+  nodeData[4 + 1] = 1;
+  nodeData[4 + 3] = ty;
+
+  const nodeTex = gl.createTexture();
+
+  gl.activeTexture(gl.TEXTURE1);
+  gl.bindTexture(gl.TEXTURE_2D, nodeTex);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA32F, 10, 1, 0, gl.RGBA, gl.FLOAT, nodeData);
+
+  // ── Geometry: a 16x16 quad. Baked -> world (8,8)+local; node-fetch -> local.
+  const bake = mode === 'baked' ? 8 : 0;
+  const px = (x: number): number => x + bake;
+  // Two triangles, position + texcoord interleaved (vec2 + vec2).
+  const verts = new Float32Array([
+    px(0),
+    px(0),
+    0,
+    0,
+    px(16),
+    px(0),
+    1,
+    0,
+    px(16),
+    px(16),
+    1,
+    1,
+    px(0),
+    px(0),
+    0,
+    0,
+    px(16),
+    px(16),
+    1,
+    1,
+    px(0),
+    px(16),
+    0,
+    1,
+  ]);
+  const nodeIndices = new Float32Array([0, 0, 0, 0, 0, 0]);
+
+  const vbo = gl.createBuffer();
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+  gl.bufferData(gl.ARRAY_BUFFER, verts, gl.STATIC_DRAW);
+
+  const niBuf = gl.createBuffer();
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, niBuf);
+  gl.bufferData(gl.ARRAY_BUFFER, nodeIndices, gl.STATIC_DRAW);
+
+  gl.viewport(0, 0, harnessSize, harnessSize);
+  gl.clearColor(0, 0, 0, 1);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  gl.useProgram(program);
+
+  const posLoc = gl.getAttribLocation(program, 'a_position');
+  const uvLoc = gl.getAttribLocation(program, 'a_texcoord');
+  const niLoc = gl.getAttribLocation(program, 'a_nodeIndex');
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+  gl.enableVertexAttribArray(posLoc);
+  gl.vertexAttribPointer(posLoc, 2, gl.FLOAT, false, 16, 0);
+  gl.enableVertexAttribArray(uvLoc);
+  gl.vertexAttribPointer(uvLoc, 2, gl.FLOAT, false, 16, 8);
+
+  if (niLoc >= 0) {
+    gl.bindBuffer(gl.ARRAY_BUFFER, niBuf);
+    gl.enableVertexAttribArray(niLoc);
+    gl.vertexAttribPointer(niLoc, 1, gl.FLOAT, false, 4, 0);
+  }
+
+  gl.uniformMatrix3fv(gl.getUniformLocation(program, 'u_projection'), false, orthoMat3(harnessSize));
+
+  const groupLoc = gl.getUniformLocation(program, 'u_group');
+
+  if (groupLoc !== null) {
+    gl.uniformMatrix3fv(groupLoc, false, new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]));
+  }
+
+  gl.uniform1i(gl.getUniformLocation(program, 'u_texture'), 0);
+
+  const nodeDataLoc = gl.getUniformLocation(program, 'u_nodeData');
+
+  if (nodeDataLoc !== null) {
+    gl.uniform1i(nodeDataLoc, 1);
+  }
+
+  gl.drawArrays(gl.TRIANGLES, 0, 6);
+
+  const buf = new Uint8Array(4);
+
+  gl.readPixels(harnessSize / 2, harnessSize / 2, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+
+  return { center: buf[0]! };
+};
+
+describe('WebGL2 Text vertex-shader ANGLE/D3D11 regression guard', () => {
+  test('Layer 1 — the shipped text.vert never reads the per-node data texture in the vertex stage', async () => {
+    const src = (await import('../../../src/rendering/webgl2/glsl/text.vert?raw')).default;
+
+    expect(src.length).toBeGreaterThan(0);
+    expect(src).toContain('void main');
+
+    // Scan the CODE, not the comments (the shipped comment legitimately NAMES
+    // `texelFetch` and `u_nodeData` while explaining why the vertex stage avoids
+    // them). Strip line + block comments first.
+    const code = src.replace(/\/\/[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
+
+    // The whole point of the CPU-bake: no vertex-stage texelFetch, and no
+    // per-node data-texture sampler declared at all. Reintroducing either reds.
+    expect(code).not.toMatch(/texelFetch/);
+    expect(code).not.toContain('u_nodeData');
+    // Position must arrive already world-space (baked on the CPU): a_position
+    // flows straight into gl_Position via u_projection * u_group only.
+    expect(code).toMatch(/gl_Position\s*=\s*vec4\(\(u_projection\s*\*\s*u_group\s*\*\s*vec3\(a_position/);
+
+    // Proof the scan has TEETH: the exact reconstructed pre-fix shader (the
+    // historical regression, `git show 64e2773d~1:...text.vert`) trips every
+    // check above. If someone reintroduced that shader, this file goes red.
+    const prefixCode = prefixTextVert.replace(/\/\/[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
+
+    expect(prefixCode).toMatch(/texelFetch/);
+    expect(prefixCode).toContain('u_nodeData');
+  });
+
+  test('Layer 2 — the shipped text.vert renders ink; a vertex-stage data-texture fetch collapses when the backend exhibits the ANGLE bug', async () => {
+    const shippedSrc = (await import('../../../src/rendering/webgl2/glsl/text.vert?raw')).default;
+
+    const control = drawHarness(shippedSrc, 'baked');
+    const prefix = drawHarness(prefixTextVert, 'nodefetch');
+
+    // The shipped (CPU-baked) path always renders the quad — ink at the centre,
+    // atlas co-bound, on every backend. This is the correctness floor.
+    expect(control.center).toBeGreaterThan(200);
+
+    // The two shaders are apples-to-apples: identical geometry, atlas, transform
+    // and projection — the ONLY difference is WHERE the transform comes from
+    // (baked into a_position vs a vertex-stage texelFetch of the data texture).
+    // So the pre-fix shader has exactly two possible outcomes:
+    if (prefix.center < 64) {
+      // COLLAPSE — the historical ANGLE/D3D11 bug (reproduces on ANGLE builds
+      // incl. SwiftShader): the vertex-stage fetch returns garbage with the
+      // atlas co-bound, degenerating the quad. The direct before/after proof
+      // that the CPU-bake is still load-bearing. (Layer 1 is the CI-guaranteed
+      // teeth; this render layer demonstrates the mechanism where present, the
+      // same split the mobile-precision regression test documents.)
+      expect(control.center - prefix.center).toBeGreaterThan(150);
+    } else {
+      // NO COLLAPSE — this ANGLE build (or a real desktop GPU) executes the
+      // fetch correctly, so the pre-fix shader renders the SAME quad as the
+      // control. Assert exactly that: it proves the harness is a faithful
+      // apples-to-apples reproduction (not a false negative from a broken
+      // setup), so the collapse branch above has real teeth wherever the bug
+      // does manifest.
+      expect(prefix.center).toBeGreaterThan(200);
+    }
+  });
+
+  test('Layer 3 — the real WebGl2TextRenderer + shipped text.vert renders visible glyph ink', async () => {
+    resetDefaultGlyphAtlasPool();
+
+    const canvas = document.createElement('canvas');
+
+    canvas.width = 96;
+    canvas.height = 96;
+
+    const app: Application = {
+      canvas,
+      options: {
+        clearColor: Color.black,
+        canvas: { width: 96, height: 96 },
+        rendering: {
+          debug: false,
+          webglAttributes: { alpha: false, antialias: false, premultipliedAlpha: false, preserveDrawingBuffer: true, stencil: false, depth: false },
+          spriteRendererBatchSize: 1024,
+          particleRendererBatchSize: 1024,
+        },
+      },
+    } as unknown as Application;
+
+    const backend = new WebGl2Backend(app);
+
+    await backend.initialize();
+    wireCoreRenderers(backend, app.options.rendering);
+
+    const root = new Container();
+    const text = new Text('MW', { fillColor: Color.white, fontSize: 40 });
+
+    text.setPosition(12, 12);
+    root.addChild(text);
+
+    try {
+      backend.resetStats();
+      backend.clear(Color.black);
+      root.render(backend);
+      backend.flush();
+
+      const buf = new Uint8Array(96 * 96 * 4);
+
+      backend.context.readPixels(0, 0, 96, 96, backend.context.RGBA, backend.context.UNSIGNED_BYTE, buf);
+
+      let ink = 0;
+
+      for (let i = 0; i < buf.length; i += 4) {
+        if (buf[i]! > 128) ink++;
+      }
+
+      // Real glyphs rendered through the shipped, unmocked text.vert.
+      expect(ink).toBeGreaterThan(40);
+    } finally {
+      root.destroy();
+      backend.destroy();
+      resetDefaultGlyphAtlasPool();
+    }
+  });
+});

--- a/test/rendering/browser/webgpu-text-cross-backend-parity.test.ts
+++ b/test/rendering/browser/webgpu-text-cross-backend-parity.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Cross-backend pixel-parity for retained Text (Track B extension, Task 2
+ * Step 11): the SAME text content, transform, and retained-group setup, driven
+ * through the retained instruction-replay tier on BOTH `WebGl2Backend` and
+ * `WebGpuBackend`, must produce matching pixels within the project's tolerance.
+ *
+ * This is the hard acceptance criterion for the Text retained pair: WebGPU
+ * reads the per-node transform live in the vertex stage; WebGL2 CPU-bakes world
+ * positions into the recorded vertex bytes (the ANGLE/D3D11 workaround). Those
+ * are two different mechanisms for the same result, and this test proves they
+ * land the same glyphs in the same pixels.
+ *
+ * Runs in the `browser-webgpu` Chromium (WebGPU + WebGL2 both available in one
+ * instance). Skips only when the software WebGPU adapter drops mid-test.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import type { RenderNode } from '#rendering/RenderNode';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { resetDefaultGlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
+import { Text } from '#rendering/text/Text';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+import { getBackendDevice } from './webgpu-test-helpers';
+
+// WebGL2 uses shipped `.vert`/`.frag` files (stubbed to "" by the browser
+// plugin); restore the real text GLSL and provide minimal Sprite/Mesh mocks so
+// `wireCoreRenderers()` can compile the WebGL2 registry. The WebGPU backend
+// uses inline WGSL and is unaffected by these mocks.
+vi.mock('#rendering/webgl2/glsl/text.vert', async () => ({ default: (await import('../../../src/rendering/webgl2/glsl/text.vert?raw')).default }));
+vi.mock('#rendering/webgl2/glsl/text-sdf.frag', async () => ({ default: (await import('../../../src/rendering/webgl2/glsl/text-sdf.frag?raw')).default }));
+vi.mock('#rendering/webgl2/glsl/text-msdf.frag', async () => ({ default: (await import('../../../src/rendering/webgl2/glsl/text-msdf.frag?raw')).default }));
+vi.mock('#rendering/webgl2/glsl/text-color.frag', async () => ({ default: (await import('../../../src/rendering/webgl2/glsl/text-color.frag?raw')).default }));
+
+const auxShaderSources = vi.hoisted(() => ({
+  spriteVert: `#version 300 es
+precision highp float;
+in vec4 a_localBounds; in vec4 a_uvBounds; in vec4 a_color; in uint a_textureSlot; in uint a_nodeIndex;
+uniform mat3 u_projection; uniform mat3 u_group; uniform sampler2D u_transforms;
+out vec2 v_uv; out vec4 v_color; flat out uint v_textureSlot;
+void main() {
+  vec2 local = vec2(a_localBounds.x, a_localBounds.y);
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
+  gl_Position = vec4((u_projection * u_group * vec3(world, 1.0)).xy, 0.0, 1.0);
+  v_uv = a_uvBounds.xy; v_color = a_color; v_textureSlot = a_textureSlot;
+}`,
+  meshVert: `#version 300 es
+precision highp float;
+in vec2 a_position; in vec2 a_texcoord; in vec4 a_color; in uint a_nodeIndex;
+uniform mat3 u_projection; uniform sampler2D u_transforms;
+out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
+void main() {
+  int row = int(a_nodeIndex);
+  vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
+  vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
+  mat3 t = mat3(m0.x,m0.z,0.0, m0.y,m0.w,0.0, m1.x,m1.y,1.0);
+  gl_Position = vec4((u_projection * t * vec3(a_position, 1.0)).xy, 0.0, 1.0);
+  v_uv = a_texcoord; v_color = a_color; v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+}`,
+  meshFrag: `#version 300 es
+precision mediump float;
+in vec2 v_uv; in vec4 v_color; in vec4 v_tint;
+uniform sampler2D u_texture;
+out vec4 outColor;
+void main() { outColor = texture(u_texture, v_uv) * v_color * v_tint; }`,
+}));
+
+vi.mock('#rendering/webgl2/glsl/sprite.vert', () => ({ default: auxShaderSources.spriteVert }));
+vi.mock('#rendering/webgl2/glsl/sprite.frag', async () => ({ default: (await import('./_spriteFragMock')).createSpriteFragMockSource('v_uv') }));
+vi.mock('#rendering/webgl2/glsl/mesh.vert', () => ({ default: auxShaderSources.meshVert }));
+vi.mock('#rendering/webgl2/glsl/mesh.frag', () => ({ default: auxShaderSources.meshFrag }));
+
+const canvasSize = 96;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: {
+      canvas: { width: canvasSize, height: canvasSize },
+      clearColor: Color.black,
+      rendering: {
+        debug: false,
+        webglAttributes: {
+          alpha: false,
+          antialias: false,
+          premultipliedAlpha: false,
+          preserveDrawingBuffer: true,
+          stencil: false,
+          depth: false,
+        },
+        spriteRendererBatchSize: 1024,
+        particleRendererBatchSize: 1024,
+      },
+    },
+  }) as unknown as Application;
+
+const makeCanvas = (): HTMLCanvasElement => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  return canvas;
+};
+
+/** The SAME scene, freshly built per backend. */
+const buildScene = (): { root: Container } => {
+  const root = new Container();
+  const group = new RetainedContainer();
+  const text = new Text('MW', { fillColor: Color.white, fontSize: 40 });
+
+  text.setPosition(4, 4);
+  group.addChild(text);
+  group.setPosition(8, 8);
+  root.addChild(group);
+
+  return { root };
+};
+
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+const setupWebGpu = async (): Promise<WebGpuBackend> => {
+  const backend = new WebGpuBackend(makeApp(makeCanvas()));
+
+  wireCoreRenderers(backend);
+  await backend.initialize();
+
+  return backend;
+};
+
+const renderWebGpu = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, root: RenderNode): Promise<boolean> => {
+  const device = getBackendDevice(backend);
+
+  device.pushErrorScope('validation');
+
+  try {
+    backend.resetStats();
+    backend.clear(Color.black);
+    root.render(backend);
+    backend.flush();
+    expect(await device.popErrorScope()).toBeNull();
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+
+  return true;
+};
+
+const readWebGpu = (backend: WebGpuBackend): Uint8ClampedArray => {
+  const readback = document.createElement('canvas');
+
+  readback.width = canvasSize;
+  readback.height = canvasSize;
+
+  const rctx = readback.getContext('2d');
+
+  if (!rctx) throw new Error('2D context required for readback.');
+
+  rctx.drawImage(backend.context.canvas as HTMLCanvasElement, 0, 0);
+
+  return rctx.getImageData(0, 0, canvasSize, canvasSize).data;
+};
+
+const setupWebGl2 = async (): Promise<WebGl2Backend> => {
+  const app = makeApp(makeCanvas());
+  const backend = new WebGl2Backend(app);
+
+  await backend.initialize();
+  wireCoreRenderers(backend, app.options.rendering);
+
+  return backend;
+};
+
+const renderWebGl2 = (backend: WebGl2Backend, root: RenderNode): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+  root.render(backend);
+  backend.flush();
+};
+
+/** Top-left-indexed RGBA readback for WebGL2 (flip the bottom-left GL buffer). */
+const readWebGl2 = (backend: WebGl2Backend): Uint8Array => {
+  const gl = backend.context;
+  const flipped = new Uint8Array(canvasSize * canvasSize * 4);
+
+  gl.readPixels(0, 0, canvasSize, canvasSize, gl.RGBA, gl.UNSIGNED_BYTE, flipped);
+
+  const out = new Uint8Array(canvasSize * canvasSize * 4);
+
+  for (let y = 0; y < canvasSize; y++) {
+    const src = (canvasSize - 1 - y) * canvasSize * 4;
+    const dst = y * canvasSize * 4;
+
+    out.set(flipped.subarray(src, src + canvasSize * 4), dst);
+  }
+
+  return out;
+};
+
+const luma = (frame: ArrayLike<number>, index: number): number => 0.299 * frame[index]! + 0.587 * frame[index + 1]! + 0.114 * frame[index + 2]!;
+
+/** Coverage mask: 1 where luma > 128 (ink), else 0. */
+const inkMask = (frame: ArrayLike<number>): Uint8Array => {
+  const mask = new Uint8Array(canvasSize * canvasSize);
+
+  for (let p = 0; p < mask.length; p++) {
+    mask[p] = luma(frame, p * 4) > 128 ? 1 : 0;
+  }
+
+  return mask;
+};
+
+describe('Cross-backend parity: retained Text renders identically on WebGL2 and WebGPU', () => {
+  beforeEach(() => resetDefaultGlyphAtlasPool());
+  afterEach(() => resetDefaultGlyphAtlasPool());
+
+  test('the same retained Text lands the same glyph pixels on both backends', async ctx => {
+    const gpu = await setupWebGpu();
+    const gpuScene = buildScene();
+    const gl = await setupWebGl2();
+    const glScene = buildScene();
+
+    try {
+      // Drive each backend through F1 capture, F2 record, F3 instruction replay
+      // so BOTH read back from their retained fast tier, not a fresh collect.
+      for (let f = 0; f < 3; f++) {
+        if (!(await renderWebGpu(ctx, gpu, gpuScene.root))) return;
+        renderWebGl2(gl, glScene.root);
+      }
+
+      const gpuFrame = readWebGpu(gpu);
+      const glFrame = readWebGl2(gl);
+
+      const gpuMask = inkMask(gpuFrame);
+      const glMask = inkMask(glFrame);
+
+      let gpuInk = 0;
+      let glInk = 0;
+      let agree = 0;
+
+      for (let p = 0; p < gpuMask.length; p++) {
+        gpuInk += gpuMask[p]!;
+        glInk += glMask[p]!;
+        if (gpuMask[p] === glMask[p]) agree++;
+      }
+
+      // Both actually rendered glyphs (not an empty frame on either side).
+      expect(gpuInk).toBeGreaterThan(80);
+      expect(glInk).toBeGreaterThan(80);
+
+      // Same glyphs in the same place: the ink coverage masks agree on the
+      // overwhelming majority of pixels (a misplaced or missing glyph on either
+      // backend would flip hundreds of pixels here). AA-edge pixels account for
+      // the small residual.
+      const agreementRatio = agree / gpuMask.length;
+
+      expect(agreementRatio).toBeGreaterThan(0.97);
+
+      // The ink footprints match in magnitude (neither backend renders a
+      // materially larger/smaller glyph).
+      expect(Math.abs(gpuInk - glInk)).toBeLessThan(gpuInk * 0.2);
+
+      // Per-pixel colour parity on the SOLID interior/background: every pixel
+      // both backends agree is ink must be ~white on both, and agreed
+      // background ~black on both — within the project's ±8/channel tolerance.
+      let checkedInterior = 0;
+
+      for (let p = 0; p < gpuMask.length; p++) {
+        if (gpuMask[p] === 1 && glMask[p] === 1) {
+          // Both solidly ink here: colours must match within tolerance.
+          for (let c = 0; c < 3; c++) {
+            expect(Math.abs(gpuFrame[p * 4 + c]! - glFrame[p * 4 + c]!)).toBeLessThanOrEqual(8);
+          }
+
+          checkedInterior++;
+        }
+      }
+
+      // The interior comparison above must have actually run on a real region.
+      expect(checkedInterior).toBeGreaterThan(40);
+    } finally {
+      gpuScene.root.destroy();
+      glScene.root.destroy();
+      gpu.destroy();
+      gl.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## What

Extends Track B retained-batch record/replay to Text/BitmapText on WebGL2, completing the pair with
the WebGPU implementation (#372). Mirrors NineSlice's instance-buffer/hook shape for the recorded
glyph geometry; the world-space transform stays CPU-baked at record and patch time — a confirmed,
empirically-reproduced ANGLE/D3D11 vertex-texture-fetch collapse bug rules out a live GPU-side
transform read for this renderer specifically (see `.workspace/specs/v0.16-render-track-b/07-design-text-retained-batches.md`
for the full reproduction: the collapse was directly reproduced from the exact pre-fix shader on both
real D3D11 hardware and SwiftShader, meaning it's an ANGLE-layer issue, not a narrow hardware quirk).

A node's own transform move gets a CPU-side patch (re-bake only that node's already-known glyph
offsets, partial buffer upload) instead of Sprite's O(1) GPU row patch, dispatched through the
renderer-agnostic `OwnTransformRowPatcher` hook introduced in #372. Camera pan and group move remain
free on both backends via `u_projection`/`u_group`, unaffected by the CPU baking — `SceneNode.getGlobalTransform()`
already stops composing at the enclosing `RetainedContainer` boundary, so baked positions are
group-local, not full-world.

Adds the real-shader regression test this codepath has been missing since the original ANGLE
workaround (64e2773d): every existing browser pixel test mocks `text.vert` with a stub that never
exercises a vertex-stage `texelFetch`, so nothing would have caught a reintroduction of the collapse
bug. The new test imports the real, unmocked shader and includes a deliberate-break proof against the
exact historical regression (reintroduces the pre-fix vertex-stage transform read, confirms the test
goes red, reverts, confirms green).

Also adds the cross-backend pixel-parity test that was the hard acceptance criterion for this pair:
the same text content/transform, rendered through the retained path on both `WebGl2Backend` and
`WebGpuBackend`, produces matching pixels within the project's existing tolerance — proving the two
different transform-application mechanisms (CPU-bake vs. live GPU read) land the same glyphs in the
same pixels.

## Test plan

- [x] Deliberate-break mutation-proof tests on the rebase hooks and the new CPU-side patch method
- [x] Real-shader ANGLE-regression test (imports the unmocked `text.vert`, deliberate-break proof
      against the exact pre-fix vertex-stage-texelFetch shader)
- [x] Real-GPU WebGL2 browser tests: byte-identical replay, camera pan (free, no data touch), group
      move (free, no data touch), own-transform-move (CPU patch, no full re-record), content-change
      re-record
- [x] Cross-backend pixel-parity test: WebGL2 vs WebGPU retained Text render, matching pixels
- [x] Full regression: WebGL2 browser suite 46/46 files, 257/257 tests; WebGPU browser suite 42/42
      files, 179/179 tests (one video-decode-timing flake reproduced in isolation as a clean pass —
      pre-existing, unrelated to this change, no product code touched here affects WebGPU)
- [x] `pnpm verify:quick` clean (typecheck, lint, prettier, API-doc sync)