### PR TITLE
feat(tilemap): sampled chunk provider for procedural generation (Infinite Maps Slice 4a)

### DIFF
--- a/packages/exojs-tilemap/src/SampledChunkSource.ts
+++ b/packages/exojs-tilemap/src/SampledChunkSource.ts
@@ -1,0 +1,69 @@
+import type { ChunkPayload, ChunkSource } from './ChunkSource';
+import type { TileLayer } from './TileLayer';
+import type { ResolvedTile } from './types';
+import { packTile } from './types';
+
+/**
+ * Options for {@link createSampledChunkSource}.
+ * @advanced
+ */
+export interface SampledChunkSourceOptions {
+  /**
+   * Sample a scalar value at a tile coordinate. Called once per tile within
+   * each requested chunk. Must be a pure, deterministic function of
+   * `(tx, ty)` — {@link import('./ChunkStreamer').ChunkStreamer} regenerates
+   * a chunk from scratch via this source whenever it's revisited after
+   * eviction, so a non-deterministic sampler would make previously-visited
+   * terrain silently change underneath the player.
+   */
+  sample(tx: number, ty: number): number;
+  /**
+   * Convert a sampled value (and its tile coordinate, for position-dependent
+   * logic such as river carving or map edges) into a resolved tile, or
+   * `null` for an empty cell. Must be pure and deterministic, same
+   * requirement as {@link sample}.
+   */
+  mapValueToTile(value: number, tx: number, ty: number): ResolvedTile | null;
+}
+
+/**
+ * Build a {@link import('./ChunkStreamer').ChunkStreamer}-ready
+ * {@link ChunkSource} from a caller-supplied sampling function — the
+ * generic mechanism behind procedurally generated tile content (noise,
+ * a heightmap, or any other per-tile-coordinate scalar function). This
+ * module intentionally has no opinion on the sampling algorithm itself
+ * ({@link SampledChunkSourceOptions.sample}/`mapValueToTile` are both
+ * required, not defaulted) — pick or write whatever generation function
+ * fits your game.
+ *
+ * `layer` supplies the target chunk grid ({@link TileLayer.chunkWidth}/
+ * `chunkHeight`) and the tileset list tiles are packed against
+ * ({@link TileLayer.tilesets}) — the same `TileLayer` you'll construct the
+ * `ChunkStreamer` with.
+ * @advanced
+ */
+export function createSampledChunkSource(layer: TileLayer, options: SampledChunkSourceOptions): ChunkSource {
+  return {
+    getChunk(cx: number, cy: number): ChunkPayload | null {
+      const chunkWidth = layer.chunkWidth;
+      const chunkHeight = layer.chunkHeight;
+      const startTx = cx * chunkWidth;
+      const startTy = cy * chunkHeight;
+
+      let out: Uint32Array | null = null;
+      for (let ty = startTy; ty < startTy + chunkHeight; ty++) {
+        for (let tx = startTx; tx < startTx + chunkWidth; tx++) {
+          const value = options.sample(tx, ty);
+          const resolved = options.mapValueToTile(value, tx, ty);
+          if (!resolved) continue;
+
+          out ??= new Uint32Array(chunkWidth * chunkHeight);
+          const tilesetIndex = layer.tilesets.indexOf(resolved.tileset);
+          out[(ty - startTy) * chunkWidth + (tx - startTx)] = packTile(tilesetIndex, resolved.localTileId, resolved.transform);
+        }
+      }
+
+      return out === null ? null : { width: chunkWidth, height: chunkHeight, tiles: out };
+    },
+  };
+}

--- a/packages/exojs-tilemap/src/SampledChunkSource.ts
+++ b/packages/exojs-tilemap/src/SampledChunkSource.ts
@@ -43,6 +43,9 @@ export interface SampledChunkSourceOptions {
  * @advanced
  */
 export function createSampledChunkSource(layer: TileLayer, options: SampledChunkSourceOptions): ChunkSource {
+  const sample = options.sample.bind(options);
+  const mapValueToTile = options.mapValueToTile.bind(options);
+
   return {
     getChunk(cx: number, cy: number): ChunkPayload | null {
       const chunkWidth = layer.chunkWidth;
@@ -53,8 +56,14 @@ export function createSampledChunkSource(layer: TileLayer, options: SampledChunk
       let out: Uint32Array | null = null;
       for (let ty = startTy; ty < startTy + chunkHeight; ty++) {
         for (let tx = startTx; tx < startTx + chunkWidth; tx++) {
-          const value = options.sample(tx, ty);
-          const resolved = options.mapValueToTile(value, tx, ty);
+          // Bounded-layer edge chunks may be smaller than a full chunk
+          // (TileLayer._ensureChunk clamps them); this provider always
+          // samples a full chunk rect, so clamp here instead of letting
+          // _adoptChunk over-report tiles past the layer's declared bounds.
+          if (layer.width !== undefined && layer.height !== undefined && (tx >= layer.width || ty >= layer.height)) continue;
+
+          const value = sample(tx, ty);
+          const resolved = mapValueToTile(value, tx, ty);
           if (!resolved) continue;
 
           out ??= new Uint32Array(chunkWidth * chunkHeight);

--- a/packages/exojs-tilemap/src/public.ts
+++ b/packages/exojs-tilemap/src/public.ts
@@ -78,6 +78,9 @@ export { TileAnimator } from './TileAnimator';
 // Chunk streaming: loads/unloads TileLayer chunks from a View's position via a ChunkSource provider.
 export type { ChunkStreamerOptions } from './ChunkStreamer';
 export { ChunkStreamer } from './ChunkStreamer';
+// Chunk streaming: generic sampling-function-driven ChunkSource for procedural content.
+export type { SampledChunkSourceOptions } from './SampledChunkSource';
+export { createSampledChunkSource } from './SampledChunkSource';
 // Wang autotiling: automatic tile selection based on neighbor bitmasks.
 export type { AutoTileOptions } from './autoTile';
 export { autoTile, refreshCell } from './autoTile';

--- a/packages/exojs-tilemap/test/SampledChunkSource.test.ts
+++ b/packages/exojs-tilemap/test/SampledChunkSource.test.ts
@@ -1,7 +1,8 @@
-import { TextureRegion } from '@codexo/exojs';
+import { TextureRegion, View } from '@codexo/exojs';
 import { type Texture } from '@codexo/exojs';
 import { describe, expect, it, vi } from 'vitest';
 
+import { ChunkStreamer } from '../src/ChunkStreamer';
 import { createSampledChunkSource } from '../src/SampledChunkSource';
 import { TileLayer } from '../src/TileLayer';
 import { TileSet } from '../src/TileSet';
@@ -137,5 +138,25 @@ describe('createSampledChunkSource', () => {
     });
 
     expect(() => source.getChunk(0, 0)).toThrow(/Tileset index -1/);
+  });
+
+  it('tiles installed via ChunkStreamer are readable through TileLayer.getTileAt', () => {
+    const tileset = makeTileset();
+    const layer = makeUnboundedLayer(tileset, 4, 4);
+    const source = createSampledChunkSource(layer, {
+      sample: (tx, ty) => tx + ty,
+      mapValueToTile: value => (value % 2 === 0 ? { tileset, localTileId: 1, transform: TILE_TRANSFORM_IDENTITY } : null),
+    });
+    const view = new View(0, 0, 32, 32);
+    const streamer = new ChunkStreamer(layer, source, view);
+
+    streamer.update();
+
+    // (0,0): sample = 0, even -> resolves to localTileId 1.
+    expect(layer.getTileAt(0, 0)).toEqual({ tileset, localTileId: 1, transform: TILE_TRANSFORM_IDENTITY });
+    // (1,0): sample = 1, odd -> stays empty.
+    expect(layer.getTileAt(1, 0)).toBeNull();
+    // (2,0): sample = 2, even -> resolves to localTileId 1.
+    expect(layer.getTileAt(2, 0)).toEqual({ tileset, localTileId: 1, transform: TILE_TRANSFORM_IDENTITY });
   });
 });

--- a/packages/exojs-tilemap/test/SampledChunkSource.test.ts
+++ b/packages/exojs-tilemap/test/SampledChunkSource.test.ts
@@ -1,0 +1,141 @@
+import { TextureRegion } from '@codexo/exojs';
+import { type Texture } from '@codexo/exojs';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createSampledChunkSource } from '../src/SampledChunkSource';
+import { TileLayer } from '../src/TileLayer';
+import { TileSet } from '../src/TileSet';
+import { TILE_TRANSFORM_IDENTITY, unpackTile } from '../src/types';
+
+function fakeTexture(): Texture {
+  return {
+    width: 512,
+    height: 512,
+    uid: 0,
+    label: 'test',
+    destroy: vi.fn(),
+    destroyed: false,
+  } as unknown as Texture;
+}
+
+function makeTileset(): TileSet {
+  return new TileSet({
+    name: 'tiles',
+    texture: new TextureRegion(fakeTexture(), { x: 0, y: 0, width: 512, height: 512 }),
+    tileWidth: 32,
+    tileHeight: 32,
+    tileCount: 16,
+  });
+}
+
+function makeUnboundedLayer(tileset: TileSet, chunkWidth = 4, chunkHeight = 4): TileLayer {
+  return new TileLayer({
+    id: 0, name: 'l',
+    tileWidth: 16, tileHeight: 16, tilesets: [tileset],
+    chunkWidth, chunkHeight,
+  });
+}
+
+describe('createSampledChunkSource', () => {
+  it('composes a full chunk when every cell resolves to a tile', () => {
+    const tileset = makeTileset();
+    const layer = makeUnboundedLayer(tileset, 2, 2);
+    const source = createSampledChunkSource(layer, {
+      sample: () => 1,
+      mapValueToTile: () => ({ tileset, localTileId: 3, transform: TILE_TRANSFORM_IDENTITY }),
+    });
+
+    const payload = source.getChunk(0, 0);
+
+    expect(payload).not.toBeNull();
+    expect(payload!.width).toBe(2);
+    expect(payload!.height).toBe(2);
+    for (let i = 0; i < 4; i++) {
+      expect(unpackTile(payload!.tiles[i])).toEqual({
+        tilesetIndex: 0,
+        localTileId: 3,
+        transform: TILE_TRANSFORM_IDENTITY,
+      });
+    }
+  });
+
+  it('returns null when mapValueToTile resolves every cell to null', () => {
+    const tileset = makeTileset();
+    const layer = makeUnboundedLayer(tileset, 2, 2);
+    const source = createSampledChunkSource(layer, {
+      sample: () => 0,
+      mapValueToTile: () => null,
+    });
+
+    expect(source.getChunk(0, 0)).toBeNull();
+  });
+
+  it('a mixed chunk leaves unresolved cells at 0 and resolved cells at the correct local index', () => {
+    const tileset = makeTileset();
+    const layer = makeUnboundedLayer(tileset, 2, 2);
+    const source = createSampledChunkSource(layer, {
+      // Only the top-left tile of the chunk (tx=0, ty=0) resolves.
+      sample: (tx, ty) => (tx === 0 && ty === 0 ? 1 : 0),
+      mapValueToTile: value => (value === 1 ? { tileset, localTileId: 5, transform: TILE_TRANSFORM_IDENTITY } : null),
+    });
+
+    const payload = source.getChunk(0, 0)!;
+    expect(unpackTile(payload.tiles[0])).toEqual({ tilesetIndex: 0, localTileId: 5, transform: TILE_TRANSFORM_IDENTITY });
+    expect(payload.tiles[1]).toBe(0);
+    expect(payload.tiles[2]).toBe(0);
+    expect(payload.tiles[3]).toBe(0);
+  });
+
+  it('calls sample/mapValueToTile with correct absolute tile coordinates for a non-origin chunk', () => {
+    const tileset = makeTileset();
+    const layer = makeUnboundedLayer(tileset, 16, 16);
+    const seenCoords: { tx: number; ty: number }[] = [];
+    const source = createSampledChunkSource(layer, {
+      sample: (tx, ty) => {
+        seenCoords.push({ tx, ty });
+        return 0;
+      },
+      mapValueToTile: () => null,
+    });
+
+    source.getChunk(2, 3);
+
+    expect(seenCoords).toHaveLength(256);
+    expect(seenCoords).toContainEqual({ tx: 32, ty: 48 });
+    expect(seenCoords).toContainEqual({ tx: 47, ty: 63 });
+    expect(seenCoords.every(({ tx }) => tx >= 32 && tx <= 47)).toBe(true);
+    expect(seenCoords.every(({ ty }) => ty >= 48 && ty <= 63)).toBe(true);
+  });
+
+  it('calls sample/mapValueToTile with correct negative absolute tile coordinates', () => {
+    const tileset = makeTileset();
+    const layer = makeUnboundedLayer(tileset, 4, 4);
+    const seenCoords: { tx: number; ty: number }[] = [];
+    const source = createSampledChunkSource(layer, {
+      sample: (tx, ty) => {
+        seenCoords.push({ tx, ty });
+        return 0;
+      },
+      mapValueToTile: () => null,
+    });
+
+    source.getChunk(-1, -1);
+
+    expect(seenCoords).toContainEqual({ tx: -4, ty: -4 });
+    expect(seenCoords).toContainEqual({ tx: -1, ty: -1 });
+    expect(seenCoords.every(({ tx }) => tx >= -4 && tx <= -1)).toBe(true);
+    expect(seenCoords.every(({ ty }) => ty >= -4 && ty <= -1)).toBe(true);
+  });
+
+  it('throws when mapValueToTile returns a tile from a tileset not registered on the layer', () => {
+    const registeredTileset = makeTileset();
+    const foreignTileset = makeTileset();
+    const layer = makeUnboundedLayer(registeredTileset, 2, 2);
+    const source = createSampledChunkSource(layer, {
+      sample: () => 1,
+      mapValueToTile: () => ({ tileset: foreignTileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY }),
+    });
+
+    expect(() => source.getChunk(0, 0)).toThrow(/Tileset index -1/);
+  });
+});

--- a/packages/exojs-tilemap/test/SampledChunkSource.test.ts
+++ b/packages/exojs-tilemap/test/SampledChunkSource.test.ts
@@ -140,6 +140,47 @@ describe('createSampledChunkSource', () => {
     expect(() => source.getChunk(0, 0)).toThrow(/Tileset index -1/);
   });
 
+  it('clamps edge-chunk cells past a bounded layer\'s width/height to empty', () => {
+    const tileset = makeTileset();
+    // width=5, height=5 is not a multiple of chunkWidth=4/chunkHeight=4, so
+    // chunk (1, 0) nominally covers tx in [4, 7] but only tx=4 is in-bounds
+    // (valid tx is 0..4).
+    const layer = new TileLayer({
+      id: 0, name: 'l',
+      tileWidth: 16, tileHeight: 16, tilesets: [tileset],
+      chunkWidth: 4, chunkHeight: 4,
+      width: 5, height: 5,
+    });
+    const source = createSampledChunkSource(layer, {
+      // Resolve unconditionally: if the fix were absent, this would fill
+      // the out-of-bounds cells (tx >= 5) with a tile too.
+      sample: () => 1,
+      mapValueToTile: () => ({ tileset, localTileId: 7, transform: TILE_TRANSFORM_IDENTITY }),
+    });
+
+    const payload = source.getChunk(1, 0)!;
+    expect(payload).not.toBeNull();
+    expect(payload.width).toBe(4);
+    expect(payload.height).toBe(4);
+
+    // Local column 0 corresponds to tx=4, which is in-bounds (width=5).
+    for (let localTy = 0; localTy < 4; localTy++) {
+      expect(unpackTile(payload.tiles[localTy * 4 + 0])).toEqual({
+        tilesetIndex: 0,
+        localTileId: 7,
+        transform: TILE_TRANSFORM_IDENTITY,
+      });
+    }
+
+    // Local columns 1-3 correspond to tx=5..7, which are out-of-bounds and
+    // must stay empty despite mapValueToTile resolving unconditionally.
+    for (let localTy = 0; localTy < 4; localTy++) {
+      for (let localTx = 1; localTx < 4; localTx++) {
+        expect(payload.tiles[localTy * 4 + localTx]).toBe(0);
+      }
+    }
+  });
+
   it('tiles installed via ChunkStreamer are readable through TileLayer.getTileAt', () => {
     const tileset = makeTileset();
     const layer = makeUnboundedLayer(tileset, 4, 4);

--- a/site/src/content/api/sampled-chunk-source-options.json
+++ b/site/src/content/api/sampled-chunk-source-options.json
@@ -1,0 +1,215 @@
+{
+  "title": "SampledChunkSourceOptions",
+  "description": "Options for createSampledChunkSource.",
+  "symbol": "SampledChunkSourceOptions",
+  "kind": "interface",
+  "subsystem": "tilemap",
+  "importPath": "@codexo/exojs-tilemap",
+  "tier": "advanced",
+  "memberCount": 2,
+  "counts": {
+    "constructors": 0,
+    "methods": 2,
+    "properties": 0,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Options for createSampledChunkSource."
+      ],
+      "importLine": "import { SampledChunkSourceOptions } from '@codexo/exojs-tilemap'",
+      "sourceLink": null
+    },
+    {
+      "id": "methods",
+      "title": "Methods",
+      "members": [
+        {
+          "name": "mapValueToTile",
+          "signature": "mapValueToTile(value: number, tx: number, ty: number): ResolvedTile | null",
+          "signatureTokens": [
+            {
+              "text": "mapValueToTile",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "value",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "tx",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ty",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ResolvedTile",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "value",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "tx",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "ty",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "ResolvedTile | null",
+          "description": "Convert a sampled value (and its tile coordinate, for position-dependent logic such as river carving or map edges) into a resolved tile, or null for an empty cell. Must be pure and deterministic, same requirement as sample."
+        },
+        {
+          "name": "sample",
+          "signature": "sample(tx: number, ty: number): number",
+          "signatureTokens": [
+            {
+              "text": "sample",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "tx",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ty",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "tx",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "ty",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "number",
+          "description": "Sample a scalar value at a tile coordinate. Called once per tile within each requested chunk. Must be a pure, deterministic function of (tx, ty) — import('./ChunkStreamer').ChunkStreamer regenerates a chunk from scratch via this source whenever it's revisited after eviction, so a non-deterministic sampler would make previously-visited terrain silently change underneath the player."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "packages/exojs-tilemap/src/SampledChunkSource.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/SampledChunkSource.ts"
+      }
+    }
+  ],
+  "sourcePath": "packages/exojs-tilemap/src/SampledChunkSource.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/SampledChunkSource.ts"
+}

--- a/site/src/content/api/tilemap-functions.json
+++ b/site/src/content/api/tilemap-functions.json
@@ -6,10 +6,10 @@
   "subsystem": "tilemap",
   "importPath": "@codexo/exojs-tilemap",
   "tier": "stable",
-  "memberCount": 8,
+  "memberCount": 9,
   "counts": {
     "constructors": 0,
-    "methods": 6,
+    "methods": 7,
     "properties": 2,
     "events": 0
   },
@@ -120,6 +120,74 @@
           ],
           "returnType": "void",
           "description": "Apply Wang autotiling to layer using wangSet. Iterates every cell in the layer. For each cell that belongs to the Wang group, computes a neighbor bitmask and looks up the correct local tile ID from WangSet.blobMap. The layer is mutated in place; cells whose computed bitmask has no mapping in the blobMap are left unchanged. The function performs two passes (snapshot then write) so neighbor tests always reflect the pre-call state regardless of processing order. **Group membership.** With no matchFn, a cell belongs to the group when its tilesetIndex matches WangSet.tilesetIndex and its localTileId is a member of the set. Membership covers every variant the set can produce, so re-running autoTile (or refreshCell) on already-autotiled data is stable. Paint with a tile ID that is a member (a blobMap value, or one listed in WangSetOptions.members). **Blob mode bitmask (bit positions):**  1 | 2 | 4 8 | -- | 16 32 | 64 | 128  Diagonal bits (1, 4, 32, 128) are only set when both adjacent cardinals are also set (the \"corner dependency\" rule that reduces 256 raw combinations to 47 valid blob states). **Edge mode bitmask (bit positions):** Top=1, Right=2, Bottom=4, Left=8."
+        },
+        {
+          "name": "createSampledChunkSource",
+          "signature": "createSampledChunkSource(layer: TileLayer, options: SampledChunkSourceOptions): ChunkSource",
+          "signatureTokens": [
+            {
+              "text": "createSampledChunkSource",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "layer",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TileLayer",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "options",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "SampledChunkSourceOptions",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ChunkSource",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "layer",
+              "type": "TileLayer",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "SampledChunkSourceOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "ChunkSource",
+          "description": "Build a import('./ChunkStreamer').ChunkStreamer-ready ChunkSource from a caller-supplied sampling function — the generic mechanism behind procedurally generated tile content (noise, a heightmap, or any other per-tile-coordinate scalar function). This module intentionally has no opinion on the sampling algorithm itself (SampledChunkSourceOptions.sample/mapValueToTile are both required, not defaulted) — pick or write whatever generation function fits your game. layer supplies the target chunk grid (TileLayer.chunkWidth/ chunkHeight) and the tileset list tiles are packed against (TileLayer.tilesets) — the same TileLayer you'll construct the ChunkStreamer with."
         },
         {
           "name": "packTile",


### PR DESCRIPTION
## Summary

- Adds `createSampledChunkSource(layer, options)` to `@codexo/exojs-tilemap` — a generic, algorithm-agnostic `ChunkSource` for procedurally generated tile content. Callers supply `sample(tx, ty): number` (any scalar field — noise, a heightmap, whatever) and `mapValueToTile(value, tx, ty): ResolvedTile | null` (tileset-specific mapping); the provider handles chunk composition and packing.
- Deliberately ships no noise algorithm and no default tile-mapper — both are required caller callbacks by design (see `.workspace/specs/v0.16-infinite-maps/05-design-slice-4a-sampled-provider.md`'s "Key design decision" section for the reasoning: avoids an unnecessary API commitment to any one generation algorithm, keeps biome/tileset mapping out of engine hands where it inherently doesn't belong).
- First sub-slice of "Infinite Maps Slice 4" (procedural generation). Depends on the already-merged `packTile` public export and `ChunkSource`/`ChunkStreamer` (#376–#378). Deferred to later sub-slices: an opt-in async/worker execution path (4b) and a guide/playground example with a real noise algorithm (4c).

## Test plan

- [x] Unit tests for `createSampledChunkSource`: full-chunk composition, all-null returns null, mixed chunk, coordinate-offset correctness for a non-origin chunk, negative-chunk-coordinate correctness, foreign-tileset throws, bounded-layer edge-chunk clamping (8 tests total)
- [x] End-to-end round-trip test through a real `ChunkStreamer`, verifying tiles land via `TileLayer.getTileAt` — closes a gap the prior slice's final review flagged (no test in the codebase previously exercised the full provider→streamer→layer round trip for any `ChunkSource`)
- [x] Full `pnpm test` green, `pnpm verify:quick` green (typecheck, lint, format, API-docs-sync)
- [x] Subagent-driven implementation with per-task review, all 3 tasks clean on first pass — no fix rounds needed at the task level
- [x] Final whole-branch review (opus) found 1 real Important gap during cross-task/architecture-level analysis that task-scoped review couldn't see: a bounded `TileLayer` with non-multiple-of-chunk-size dimensions could render tiles past its logical extent at an edge chunk (inert for the primary unbounded/infinite-map use case). Fixed same-session with a bounds guard + new regression test; re-review confirmed the fix is correct and hand-traced the coordinate math — verdict: ready to merge, no outstanding findings