### PR TITLE
fix(rendering): texture-load heal no longer clobbers explicitly narrowed frames

### DIFF
--- a/src/rendering/sprite/Sprite.ts
+++ b/src/rendering/sprite/Sprite.ts
@@ -291,8 +291,12 @@ export class Sprite extends Drawable {
       return; // failed load shows Texture.missing; nothing to heal
     }
 
-    // Guard against a texture swap or destroy between scheduling and resolution.
-    if (this._texture === texture && !this.destroyed) {
+    // Guard against a texture swap or destroy between scheduling and resolution —
+    // and against an explicit frame set in the meantime (a Spritesheet slicing
+    // frames out of a still-loading atlas). The schedule-time reset above left a
+    // 0×0 frame, so a non-empty frame here means someone chose one deliberately;
+    // only heal the untouched case.
+    if (this._texture === texture && !this.destroyed && this._textureFrame.width === 0 && this._textureFrame.height === 0) {
       this.resetTextureFrame();
     }
   }

--- a/test/rendering/sprite/sprite.test.ts
+++ b/test/rendering/sprite/sprite.test.ts
@@ -89,6 +89,36 @@ describe('Sprite', () => {
       expect(Number.isNaN(sprite.scale.x)).toBe(false);
       expect(sprite.width).toBe(40);
     });
+
+    test('an explicit frame set while the texture is loading survives hydration', async () => {
+      const { texture, finishLoad } = makeDeferredTexture();
+      const sprite = new Sprite(texture);
+
+      sprite.setTextureFrame(new Rectangle(64, 0, 32, 32));
+
+      finishLoad(128, 128);
+      await texture.loaded;
+      await Promise.resolve(); // flush the .then microtask
+
+      expect(sprite.textureFrame.x).toBe(64);
+      expect(sprite.textureFrame.y).toBe(0);
+      expect(sprite.textureFrame.width).toBe(32);
+      expect(sprite.textureFrame.height).toBe(32);
+    });
+
+    test('heals to the full texture frame when no explicit frame was set before hydration', async () => {
+      const { texture, finishLoad } = makeDeferredTexture();
+      const sprite = new Sprite(texture);
+
+      finishLoad(128, 128);
+      await texture.loaded;
+      await Promise.resolve(); // flush the .then microtask
+
+      expect(sprite.textureFrame.x).toBe(0);
+      expect(sprite.textureFrame.y).toBe(0);
+      expect(sprite.textureFrame.width).toBe(128);
+      expect(sprite.textureFrame.height).toBe(128);
+    });
   });
 
   // Binding a destroyed texture is otherwise silent — warn once (dev) at


### PR DESCRIPTION
## Root cause

A `Sprite` constructed from a still-loading texture schedules a heal (the deferred-handle fix that keeps a sprite from staying 0×0): once the texture hydrates, `_healOnTextureLoad` reset the frame to the full texture. It did so unconditionally — clobbering any frame explicitly narrowed in the meantime. `Spritesheet.addFrame` does exactly that (construct sprite, then `setTextureFrame(rect)`), so every spritesheet sliced from a not-yet-awaited atlas rendered the **whole atlas** per sprite. Reproduced in ~5 merged examples (e.g. `tile-chunks-and-bands`, `sprite-follows-body`).

## Fix

The schedule-time `resetTextureFrame()` on an unhydrated texture leaves a 0×0 frame (`Texture._size` starts 0×0 until load). A non-empty frame at hydration time therefore means someone chose it deliberately — the heal now only fires when the frame is still 0×0. One-condition change; the original heal behavior (bare sprite from deferred texture) is preserved and pinned by test.

## Verification

- TDD: explicit-frame-survives case failed before the guard (frame reset to full texture), passes after; bare-heal case passes before and after.
- `pnpm test:core`: 307 files / 4943 tests green.
- Empirical: screenshot of the merged `tile-chunks-and-bands` example post-fix shows the explorer as a single character sprite (previously the full ~15-character atlas grid) — **zero example edits needed**, which was the point of fixing at engine altitude.