### PR TITLE
fix(tilemap): enforce image-layer ID uniqueness within the kind

### DIFF
--- a/packages/exojs-tilemap/src/TileMap.ts
+++ b/packages/exojs-tilemap/src/TileMap.ts
@@ -188,7 +188,9 @@ export class TileMap {
     }
 
     if (options.imageLayers) {
-      this._imageLayers.push(...options.imageLayers);
+      for (const layer of options.imageLayers) {
+        this._addImageLayer(layer);
+      }
     }
 
     this._documentOrder.push(...this._buildDocumentOrder(options.documentOrder));
@@ -413,12 +415,25 @@ export class TileMap {
   /**
    * Add an image layer after construction. Appended to both {@link
    * imageLayers} and the end of {@link renderableLayers}'s document order.
+   * @throws If an image layer with the same ID already exists. An ID shared
+   *   with a *tile* layer is permitted — the two kinds keep separate ID
+   *   spaces, and all internal bookkeeping is instance-based.
    */
   public addImageLayer(layer: ImageLayer): void {
     this._checkDestroyed();
-    this._imageLayers.push(layer);
+    this._addImageLayer(layer);
     this._documentOrder.push(layer);
     this._revision++;
+  }
+
+  /** Shared by the constructor and {@link addImageLayer}: enforce ID uniqueness within the image-layer kind. */
+  private _addImageLayer(layer: ImageLayer): void {
+    if (this._imageLayers.some(existing => existing.id === layer.id)) {
+      throw new Error(
+        `Image layer ID ${layer.id} already exists in map "${this.name}".`,
+      );
+    }
+    this._imageLayers.push(layer);
   }
 
   /**

--- a/packages/exojs-tilemap/test/tilemap.test.ts
+++ b/packages/exojs-tilemap/test/tilemap.test.ts
@@ -1869,10 +1869,12 @@ describe('TileMap', () => {
   });
 
   it('documentOrder throws when two image layers share an ID (same-kind duplicate degenerate input)', () => {
-    // Nothing validates image-layer id uniqueness, so this pair can coexist.
-    // Both `1` and `7` are covered by documentOrder's id-set checks even
-    // though there are 3 layer instances total (1 tile + 2 image) — the
-    // count mismatch must still throw instead of silently dropping one.
+    // Image-layer IDs are unique within their kind since the constructor
+    // enforces it, so this degenerate pair is rejected before documentOrder
+    // validation even runs. The count-mismatch check inside
+    // _buildDocumentOrder stays as an unreachable-by-public-API invariant
+    // guard; this test pins that the input still throws rather than
+    // silently dropping an instance.
     const tileA = new TileLayer({ id: 1, name: 'ground', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] });
     const imageA = new ImageLayer({ id: 7, name: 'bg', image: 'bg.png' });
     const imageB = new ImageLayer({ id: 7, name: 'bg2', image: 'bg2.png' });
@@ -1883,7 +1885,7 @@ describe('TileMap', () => {
       layers: [tileA],
       imageLayers: [imageA, imageB],
       documentOrder: [1, 7],
-    })).toThrow(/documentOrder has 2 entries but map .* has 3 tile\/image layer instances/i);
+    })).toThrow(/Image layer ID 7 already exists/);
   });
 
   it('a cross-kind duplicate ID is NOT rejected when documentOrder is omitted (fallback order is unambiguous by construction)', () => {
@@ -1956,28 +1958,18 @@ describe('TileMap', () => {
     expect(map.renderableLayers.map(l => l.id)).toEqual([1, 2]);
   });
 
-  it('removeImageLayer on a duplicate-id degenerate fallback map never corrupts the order tail', () => {
-    // Built WITHOUT documentOrder, so the fallback path (unambiguous by
-    // construction) is exercised. Two image layers share id 7; removing the
-    // resolved instance twice must not delete an unrelated order entry via
-    // an unguarded splice(-1, 1) once indexOf(layer) can no longer find it.
-    const tileA = new TileLayer({ id: 1, name: 'ground', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] });
-    const tileB = new TileLayer({ id: 2, name: 'walls', width: 64, height: 64, tileWidth: 32, tileHeight: 32, tilesets: [ts] });
+  it('duplicate image-layer IDs are rejected in fallback maps too (splice guards stay as defense-in-depth)', () => {
+    // The removeImageLayer order-tail-corruption scenario required two image
+    // layers sharing an id; the constructor now rejects that input outright,
+    // so the guarded splice in the remove paths is defense-in-depth for an
+    // unreachable state rather than a load-bearing fix.
     const imageA = new ImageLayer({ id: 7, name: 'bg', image: 'bg.png' });
     const imageB = new ImageLayer({ id: 7, name: 'bg2', image: 'bg2.png' });
-    const map = new TileMap({
+    expect(() => new TileMap({
       width: 64, height: 64,
       tileWidth: 32, tileHeight: 32,
-      tilesets: [ts],
-      layers: [tileA, tileB],
       imageLayers: [imageA, imageB],
-    });
-
-    map.removeImageLayer(7);
-    map.removeImageLayer(7);
-
-    expect(map.renderableLayers).toContain(tileA);
-    expect(map.renderableLayers).toContain(tileB);
+    })).toThrow(/Image layer ID 7 already exists/);
   });
 
   it('addImageLayer appends the layer to imageLayers and renderableLayers order', () => {
@@ -1991,6 +1983,28 @@ describe('TileMap', () => {
     map.addImageLayer(image);
     expect(map.imageLayers).toEqual([image]);
     expect(map.renderableLayers.map(l => l.id)).toEqual([1, 2]);
+  });
+
+  it('constructing a map with two image layers sharing an ID throws', () => {
+    const imageA = new ImageLayer({ id: 7, name: 'bg', image: 'bg.png' });
+    const imageB = new ImageLayer({ id: 7, name: 'bg2', image: 'bg2.png' });
+    expect(() => new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      imageLayers: [imageA, imageB],
+    })).toThrow(/Image layer ID 7 already exists/);
+  });
+
+  it('addImageLayer throws when an image layer with the same ID already exists', () => {
+    const map = new TileMap({
+      width: 64, height: 64,
+      tileWidth: 32, tileHeight: 32,
+      imageLayers: [new ImageLayer({ id: 7, name: 'bg', image: 'bg.png' })],
+    });
+    expect(() => map.addImageLayer(new ImageLayer({ id: 7, name: 'bg2', image: 'bg2.png' })))
+      .toThrow(/Image layer ID 7 already exists/);
+    // A cross-kind collision (image ID matching a TILE layer ID) stays valid —
+    // pinned separately by the cross-kind tests above.
   });
 
   it('addImageLayer increments revision, matching addLayer/addObjectLayer', () => {


### PR DESCRIPTION
## Summary

Closes the deferred owner decision from #386: duplicate IDs **within** the image-layer kind are now rejected (at construction and in `addImageLayer`), mirroring the tile-layer side's existing `_addLayer` check. Previously they were tolerated degenerate input where `getImageLayerNodeById`/`ByName` lookups resolved first-match and could diverge.

- **Cross-kind ID collisions stay valid** (tile and image layers keep separate ID spaces; all internal bookkeeping is instance-based since #386) — pinned by the existing cross-kind tests, which remain green unchanged.
- The #386 count-mismatch check and the guarded remove-path splices stay in place as defense-in-depth for now-unreachable states; the two degenerate-input tests were updated to assert the new earlier throw (intent preserved: degenerate input throws instead of silently dropping an instance).

## Verification

TDD (2 new RED tests → GREEN); tilemap suite 506/506; lint 0 errors; `docs:api:check` in sync (the generator does not render `@throws` on this surface — no JSON delta).