### PR TITLE
feat(core): extension application systems (v0.17 Slice F)

### DIFF
--- a/docs/superpowers/plans/2026-07-20-v0.17-slice-f-extension-systems.md
+++ b/docs/superpowers/plans/2026-07-20-v0.17-slice-f-extension-systems.md
@@ -1,0 +1,786 @@
+# v0.17 Slice F — Extension Application Systems Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an `Extension` contribute app-level `System` instances (`ApplicationSystemBinding`), materialized once per `Application` after every core manager exists, registered on `app.systems`, destroyed by the existing reverse-registration-order teardown.
+
+**Architecture:** Mirrors the three existing extension binding kinds (`RendererBinding`, `AssetBinding`, `SerializerBinding`) exactly: a new field on `Extension`, a new array on `ExtensionSnapshot` (collected/frozen/flattened by `buildSnapshot`/`freezeExtension`), and a new `materializeXxxBindings`-shaped function called once from the `Application` constructor. No new abstraction — reuses the pre-existing `SystemRegistry` (`app.systems`) verbatim for storage, ordering, and destruction.
+
+**Tech Stack:** TypeScript, Vitest, existing ExoJS extension-system source (`src/extensions/`) and core (`src/core/Application.ts`, `src/core/SystemRegistry.ts`).
+
+## Global Constraints
+
+- Authoritative spec: `.workspace/specs/exojs-v0.17-final-core-spec/01-implementation-spec.md` §12 (lines 847-870) and §16 "Slice F" (lines 1052-1053). Do not consult `.workspace/specs/v0.17-core-runtime-model/` — that folder is historical and its slice lettering is superseded.
+- No scene-system bindings, no scene property injection from extensions (definition §19) — this slice is `app.systems` only. Do not touch `Scene`/`SceneScope`/`SceneDirector`.
+- `create(app)` must be called only after every core manager exists on `app` (input, focus, interaction, scenes, audio, tweens, systems, rendering) — so a binding can safely read `app.input`, `app.interaction`, etc.
+- `undefined` returned from `create()` means "skip for this application" — not an error.
+- Two `Application` instances built from the same `Extension` object must get two independent `System` instances (`create()` runs once per Application, not once globally).
+- Extension systems are destroyed via the pre-existing `SystemRegistry.destroy()` reverse-registration-order teardown — do not add new destruction logic.
+- JSDoc: only exported/public API needs it; `@internal` for exported-but-not-public; lead with what+why; no noise `@param`/`@returns`; see `feedback-jsdoc-conventions` conventions reproduced inline in Task 1/3.
+- Import order is enforced by `eslint-plugin-simple-import-sort` — don't hand-order imports precisely, run `pnpm lint:fix` in the final task instead.
+- Public-API JSDoc changes require regenerating API docs (`pnpm docs:api:generate`) before the final commit, or the push hook blocks.
+
+---
+
+### Task 1: `ApplicationSystemBinding` type + `Extension.systems` field
+
+**Files:**
+- Modify: `src/extensions/Extension.ts`
+
+**Interfaces:**
+- Produces: `export interface ApplicationSystemBinding { create(app: Application): System | undefined; }` — Task 2 (snapshot) and Task 3 (materialize) both import this type from `#extensions/Extension`.
+- Produces: `Extension.systems?: readonly ApplicationSystemBinding[]` — the fourth binding-kind field, alongside the existing `renderers`/`assets`/`serializers`.
+
+- [ ] **Step 1: Add the `Application` and `System` type imports**
+
+At the top of `src/extensions/Extension.ts`, the import block currently reads:
+
+```ts
+import type { SceneNode } from '#core/SceneNode';
+import type { NodeSerializer } from '#core/serialization/NodeSerializer';
+import type { SceneNodeConstructor } from '#core/serialization/SerializationRegistry';
+import type { Drawable } from '#rendering/Drawable';
+import type { RenderBackend } from '#rendering/RenderBackend';
+import type { DrawableConstructor, Renderer } from '#rendering/Renderer';
+import type { AssetDefinitions } from '#resources/AssetDefinitions';
+import type { AssetConstructor } from '#resources/FactoryRegistry';
+import type { AssetLoaderContext, Loader } from '#resources/Loader';
+import type { SeamlessAdapter } from '#resources/seamless';
+```
+
+Change it to:
+
+```ts
+import type { Application } from '#core/Application';
+import type { SceneNode } from '#core/SceneNode';
+import type { System } from '#core/System';
+import type { NodeSerializer } from '#core/serialization/NodeSerializer';
+import type { SceneNodeConstructor } from '#core/serialization/SerializationRegistry';
+import type { Drawable } from '#rendering/Drawable';
+import type { RenderBackend } from '#rendering/RenderBackend';
+import type { DrawableConstructor, Renderer } from '#rendering/Renderer';
+import type { AssetDefinitions } from '#resources/AssetDefinitions';
+import type { AssetConstructor } from '#resources/FactoryRegistry';
+import type { AssetLoaderContext, Loader } from '#resources/Loader';
+import type { SeamlessAdapter } from '#resources/seamless';
+```
+
+(`Application.ts` imports from `#extensions/materialize`/`#extensions/snapshot`, so this is a type-only cycle — already the established, safe pattern in this codebase; `import type` erases at build time.)
+
+- [ ] **Step 2: Add the `ApplicationSystemBinding` interface**
+
+Immediately after the `SerializerBinding` interface (the block ending `}` right before `/**\n * An ExoJS extension...`), insert:
+
+```ts
+/**
+ * Produces an app-level {@link System} for one {@link Application} instance,
+ * or `undefined` to opt out for that instance. `create(app)` runs once per
+ * Application, after every core manager already exists on `app` — safe to
+ * read {@link Application.input}, {@link Application.interaction}, etc. The
+ * returned system is registered on {@link Application.systems} exactly like
+ * a user-added system, including reverse-order destruction. Extensions never
+ * inject scene-level systems or augment scenes — app-level only.
+ * @advanced
+ */
+export interface ApplicationSystemBinding {
+  create(app: Application): System | undefined;
+}
+```
+
+- [ ] **Step 3: Add the `systems` field to `Extension`**
+
+The `Extension` interface currently reads:
+
+```ts
+export interface Extension {
+  readonly id: string;
+  readonly dependencies?: readonly Extension[];
+  readonly renderers?: readonly RendererBinding[];
+  readonly assets?: readonly AssetBinding[];
+  readonly serializers?: readonly SerializerBinding[];
+}
+```
+
+Change it to:
+
+```ts
+export interface Extension {
+  readonly id: string;
+  readonly dependencies?: readonly Extension[];
+  readonly renderers?: readonly RendererBinding[];
+  readonly assets?: readonly AssetBinding[];
+  readonly serializers?: readonly SerializerBinding[];
+  readonly systems?: readonly ApplicationSystemBinding[];
+}
+```
+
+Also update the class-level doc comment directly above (currently "An ExoJS extension: an immutable descriptor that contributes renderer bindings, asset bindings and/or serializer bindings.") to read "...renderer bindings, asset bindings, serializer bindings and/or app-level systems."
+
+- [ ] **Step 4: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: no errors (this is a pure type addition; nothing consumes the new field yet).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/extensions/Extension.ts
+git commit -m "feat(core): add ApplicationSystemBinding + Extension.systems (v0.17 Slice F)"
+```
+
+---
+
+### Task 2: `snapshot.ts` — collect, freeze, flatten `systems` bindings
+
+**Files:**
+- Modify: `src/extensions/snapshot.ts`
+- Modify: `test/extensions/snapshot.test.ts`
+
+**Interfaces:**
+- Consumes: `ApplicationSystemBinding` from Task 1 (`#extensions/Extension`, or relative `./Extension` inside `snapshot.ts`).
+- Produces: `ExtensionSnapshot.systems: readonly ApplicationSystemBinding[]` — Task 3's `materializeApplicationSystems` and Task 4's `Application` constructor both read `snapshot.systems`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Open `test/extensions/snapshot.test.ts`. Change the `'EMPTY_SNAPSHOT has empty arrays'` test from:
+
+```ts
+  it('EMPTY_SNAPSHOT has empty arrays', () => {
+    expect(EMPTY_SNAPSHOT.extensions).toHaveLength(0);
+    expect(EMPTY_SNAPSHOT.renderers).toHaveLength(0);
+    expect(EMPTY_SNAPSHOT.assets).toHaveLength(0);
+  });
+```
+
+to:
+
+```ts
+  it('EMPTY_SNAPSHOT has empty arrays', () => {
+    expect(EMPTY_SNAPSHOT.extensions).toHaveLength(0);
+    expect(EMPTY_SNAPSHOT.renderers).toHaveLength(0);
+    expect(EMPTY_SNAPSHOT.assets).toHaveLength(0);
+    expect(EMPTY_SNAPSHOT.systems).toHaveLength(0);
+  });
+```
+
+Then, right after the existing `'buildSnapshot flattens asset bindings from multiple extensions'` test, add:
+
+```ts
+  it('buildSnapshot flattens system bindings from multiple extensions', () => {
+    const binding1 = { create: () => undefined };
+    const binding2 = { create: () => undefined };
+    const extA: Extension = { id: 'a', systems: [binding1] };
+    const extB: Extension = { id: 'b', systems: [binding2] };
+    const snapshot = buildSnapshot([extA, extB]);
+    expect(snapshot.systems).toHaveLength(2);
+    expect(snapshot.systems[0]).toBe(binding1);
+    expect(snapshot.systems[1]).toBe(binding2);
+  });
+
+  it('buildSnapshot freezes system bindings', () => {
+    const binding = { create: () => undefined };
+    const ext: Extension = { id: 'frozen-systems', systems: [binding] };
+    buildSnapshot([ext]);
+    expect(Object.isFrozen(binding)).toBe(true);
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run test/extensions/snapshot.test.ts --reporter=dot`
+Expected: FAIL — `EMPTY_SNAPSHOT.systems` is `undefined`, `snapshot.systems` does not exist, `Object.isFrozen(binding)` is `false` (nothing freezes it yet).
+
+- [ ] **Step 3: Implement `systems` in `ExtensionSnapshot`**
+
+`src/extensions/snapshot.ts` line 1 currently reads:
+
+```ts
+import type { AssetBinding, Extension, RendererBinding, SerializerBinding } from './Extension';
+```
+
+Change to:
+
+```ts
+import type { ApplicationSystemBinding, AssetBinding, Extension, RendererBinding, SerializerBinding } from './Extension';
+```
+
+The `ExtensionSnapshot` interface:
+
+```ts
+export interface ExtensionSnapshot {
+  readonly extensions: ReadonlyArray<Readonly<Extension>>;
+  readonly renderers: readonly RendererBinding[];
+  readonly assets: readonly AssetBinding[];
+  readonly serializers: readonly SerializerBinding[];
+}
+```
+
+becomes:
+
+```ts
+export interface ExtensionSnapshot {
+  readonly extensions: ReadonlyArray<Readonly<Extension>>;
+  readonly renderers: readonly RendererBinding[];
+  readonly assets: readonly AssetBinding[];
+  readonly serializers: readonly SerializerBinding[];
+  readonly systems: readonly ApplicationSystemBinding[];
+}
+```
+
+`emptySnapshot`:
+
+```ts
+const emptySnapshot: ExtensionSnapshot = Object.freeze({
+  extensions: Object.freeze([]),
+  renderers: Object.freeze([]),
+  assets: Object.freeze([]),
+  serializers: Object.freeze([]),
+});
+```
+
+becomes:
+
+```ts
+const emptySnapshot: ExtensionSnapshot = Object.freeze({
+  extensions: Object.freeze([]),
+  renderers: Object.freeze([]),
+  assets: Object.freeze([]),
+  serializers: Object.freeze([]),
+  systems: Object.freeze([]),
+});
+```
+
+- [ ] **Step 4: Freeze `ext.systems` in `freezeExtension`**
+
+In `freezeExtension`, right after the existing `if (ext.serializers) { ... }` block (ends `}` before the closing `}` of the function), add:
+
+```ts
+  if (ext.systems) {
+    Object.freeze(ext.systems);
+
+    for (const binding of ext.systems) {
+      Object.freeze(binding);
+    }
+  }
+```
+
+- [ ] **Step 5: Flatten `systems` in `buildSnapshot`**
+
+The flattening block in `buildSnapshot` currently reads:
+
+```ts
+  const renderers: RendererBinding[] = [];
+  const assets: AssetBinding[] = [];
+  const serializers: SerializerBinding[] = [];
+
+  for (const ext of ordered) {
+    if (ext.renderers) {
+      for (const binding of ext.renderers) {
+        renderers.push(binding);
+      }
+    }
+
+    if (ext.assets) {
+      for (const binding of ext.assets) {
+        assets.push(binding);
+      }
+    }
+
+    if (ext.serializers) {
+      for (const binding of ext.serializers) {
+        serializers.push(binding);
+      }
+    }
+  }
+
+  return Object.freeze({
+    extensions: Object.freeze(ordered),
+    renderers: Object.freeze(renderers),
+    assets: Object.freeze(assets),
+    serializers: Object.freeze(serializers),
+  });
+```
+
+Change to:
+
+```ts
+  const renderers: RendererBinding[] = [];
+  const assets: AssetBinding[] = [];
+  const serializers: SerializerBinding[] = [];
+  const systems: ApplicationSystemBinding[] = [];
+
+  for (const ext of ordered) {
+    if (ext.renderers) {
+      for (const binding of ext.renderers) {
+        renderers.push(binding);
+      }
+    }
+
+    if (ext.assets) {
+      for (const binding of ext.assets) {
+        assets.push(binding);
+      }
+    }
+
+    if (ext.serializers) {
+      for (const binding of ext.serializers) {
+        serializers.push(binding);
+      }
+    }
+
+    if (ext.systems) {
+      for (const binding of ext.systems) {
+        systems.push(binding);
+      }
+    }
+  }
+
+  return Object.freeze({
+    extensions: Object.freeze(ordered),
+    renderers: Object.freeze(renderers),
+    assets: Object.freeze(assets),
+    serializers: Object.freeze(serializers),
+    systems: Object.freeze(systems),
+  });
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pnpm vitest run test/extensions/snapshot.test.ts --reporter=dot`
+Expected: PASS, all tests including the two new ones.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/extensions/snapshot.ts test/extensions/snapshot.test.ts
+git commit -m "feat(core): collect Extension.systems bindings in ExtensionSnapshot (v0.17 Slice F)"
+```
+
+---
+
+### Task 3: `materializeApplicationSystems`
+
+**Files:**
+- Modify: `src/extensions/materialize.ts`
+- Create: `test/extensions/application-system-materialisation.test.ts`
+
+**Interfaces:**
+- Consumes: `ApplicationSystemBinding` (Task 1), `ExtensionSnapshot.systems` (Task 2).
+- Produces: `export function materializeApplicationSystems(app: Application, bindings: readonly ApplicationSystemBinding[]): void` — Task 4's `Application` constructor calls this exact signature.
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `test/extensions/application-system-materialisation.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Application } from '#core/Application';
+import type { System } from '#core/System';
+import { SystemRegistry } from '#core/SystemRegistry';
+import type { ApplicationSystemBinding } from '#extensions/Extension';
+import { materializeApplicationSystems } from '#extensions/materialize';
+import { resetExtensionRegistryForTesting } from '#extensions/testing';
+
+function createStubApp(): Application & { systems: SystemRegistry } {
+  return { systems: new SystemRegistry() } as unknown as Application & { systems: SystemRegistry };
+}
+
+describe('materializeApplicationSystems', () => {
+  beforeEach(() => {
+    resetExtensionRegistryForTesting();
+  });
+
+  it('registers the system produced by a binding', () => {
+    const app = createStubApp();
+    const system: System = { update: vi.fn() };
+    const binding: ApplicationSystemBinding = { create: () => system };
+
+    materializeApplicationSystems(app, [binding]);
+
+    expect(app.systems.has(system)).toBe(true);
+  });
+
+  it('create() is called exactly once per binding, with the application', () => {
+    const app = createStubApp();
+    const system: System = { update: vi.fn() };
+    const createFn = vi.fn(() => system);
+    const binding: ApplicationSystemBinding = { create: createFn };
+
+    materializeApplicationSystems(app, [binding]);
+
+    expect(createFn).toHaveBeenCalledTimes(1);
+    expect(createFn).toHaveBeenCalledWith(app);
+  });
+
+  it('skips a binding whose create() returns undefined, without throwing', () => {
+    const app = createStubApp();
+    const binding: ApplicationSystemBinding = { create: () => undefined };
+
+    expect(() => materializeApplicationSystems(app, [binding])).not.toThrow();
+    expect(app.systems.size).toBe(0);
+  });
+
+  it('registers systems from multiple bindings, skipping only the undefined ones', () => {
+    const app = createStubApp();
+    const systemA: System = { update: vi.fn() };
+    const systemC: System = { update: vi.fn() };
+    const bindings: ApplicationSystemBinding[] = [{ create: () => systemA }, { create: () => undefined }, { create: () => systemC }];
+
+    materializeApplicationSystems(app, bindings);
+
+    expect(app.systems.size).toBe(2);
+    expect(app.systems.has(systemA)).toBe(true);
+    expect(app.systems.has(systemC)).toBe(true);
+  });
+
+  it('two applications receive independent system instances from the same binding', () => {
+    const appA = createStubApp();
+    const appB = createStubApp();
+    const systemA: System = { update: vi.fn() };
+    const systemB: System = { update: vi.fn() };
+    let callCount = 0;
+    const binding: ApplicationSystemBinding = { create: () => (callCount++ === 0 ? systemA : systemB) };
+
+    materializeApplicationSystems(appA, [binding]);
+    materializeApplicationSystems(appB, [binding]);
+
+    expect(appA.systems.has(systemA)).toBe(true);
+    expect(appA.systems.has(systemB)).toBe(false);
+    expect(appB.systems.has(systemB)).toBe(true);
+    expect(appB.systems.has(systemA)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run test/extensions/application-system-materialisation.test.ts --reporter=dot`
+Expected: FAIL with `materializeApplicationSystems is not a function` (or a module-resolution error) — it does not exist yet.
+
+- [ ] **Step 3: Implement `materializeApplicationSystems`**
+
+`src/extensions/materialize.ts` currently starts:
+
+```ts
+import type { SerializationRegistry } from '#core/serialization/SerializationRegistry';
+import type { RenderBackend } from '#rendering/RenderBackend';
+import type { DrawableConstructor } from '#rendering/Renderer';
+import type { AssetConstructor } from '#resources/FactoryRegistry';
+import type { Loader } from '#resources/Loader';
+
+import type { AssetBinding, AssetHandler, RendererBinding, SerializerBinding } from './Extension';
+```
+
+Change to:
+
+```ts
+import type { Application } from '#core/Application';
+import type { SerializationRegistry } from '#core/serialization/SerializationRegistry';
+import type { RenderBackend } from '#rendering/RenderBackend';
+import type { DrawableConstructor } from '#rendering/Renderer';
+import type { AssetConstructor } from '#resources/FactoryRegistry';
+import type { Loader } from '#resources/Loader';
+
+import type { ApplicationSystemBinding, AssetBinding, AssetHandler, RendererBinding, SerializerBinding } from './Extension';
+```
+
+At the end of the file, after `materializeSerializerBindings`, add:
+
+```ts
+/**
+ * Materialise all app-system bindings onto {@link Application.systems}.
+ * Called once per Application, after every core manager already exists on
+ * `app` — a binding's `create(app)` may safely read them. A binding
+ * returning `undefined` opts out for this application and is skipped.
+ * @internal
+ */
+export function materializeApplicationSystems(app: Application, bindings: readonly ApplicationSystemBinding[]): void {
+  for (const binding of bindings) {
+    const system = binding.create(app);
+
+    if (system === undefined) continue;
+
+    app.systems.add(system);
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run test/extensions/application-system-materialisation.test.ts --reporter=dot`
+Expected: PASS, all 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/extensions/materialize.ts test/extensions/application-system-materialisation.test.ts
+git commit -m "feat(core): add materializeApplicationSystems (v0.17 Slice F)"
+```
+
+---
+
+### Task 4: Wire into `Application` + integration tests
+
+**Files:**
+- Modify: `src/core/Application.ts`
+- Create: `test/core/application-extension-systems.test.ts`
+
+**Interfaces:**
+- Consumes: `materializeApplicationSystems` (Task 3), `this._snapshot.systems` (Task 2, already-existing `this._snapshot: ExtensionSnapshot` field on `Application`).
+
+- [ ] **Step 1: Write the failing integration test file**
+
+Create `test/core/application-extension-systems.test.ts`. Copy the WebGL2-backend-only mock harness verbatim from `test/core/application-start.test.ts` (same file already in the repo, same mock shape — do not invent a different stub):
+
+```ts
+/**
+ * Real Application integration tests for the v0.17 Slice F app-system
+ * extension bindings (implementation spec §12). Only the WebGL2 backend is
+ * mocked (kept out of jsdom) — input, interaction, focus, audio, tweens, and
+ * the app SystemRegistry all run for real.
+ */
+
+import { Application } from '#core/Application';
+import type { System } from '#core/System';
+import type { ApplicationSystemBinding, Extension } from '#extensions/Extension';
+
+vi.mock('#rendering/webgl2/WebGl2Backend', () => ({
+  WebGl2Backend: vi.fn().mockImplementation(function () {
+    return {
+      onContextLost: { add: vi.fn() },
+      onContextRestored: { add: vi.fn() },
+      onRenderError: { add: vi.fn(), destroy: vi.fn() },
+      stats: {
+        frameTimeMs: 0,
+        drawCalls: 0,
+        culledNodes: 0,
+        submittedNodes: 0,
+        batches: 0,
+        renderPasses: 0,
+        renderTargetChanges: 0,
+        frame: 0,
+        rawFrameDeltaMs: 0,
+      },
+      resetStats: vi.fn().mockReturnThis(),
+      flush: vi.fn().mockReturnThis(),
+      initialize: vi.fn().mockResolvedValue(undefined),
+      destroy: vi.fn(),
+      resize: vi.fn().mockReturnThis(),
+      view: { getBounds: vi.fn() },
+      renderTarget: {},
+      backendType: 'webgl2',
+      setView: vi.fn().mockReturnThis(),
+      draw: vi.fn().mockReturnThis(),
+      execute: vi.fn().mockReturnThis(),
+      clear: vi.fn().mockReturnThis(),
+      pushScissorRect: vi.fn().mockReturnThis(),
+      popScissorRect: vi.fn().mockReturnThis(),
+      acquireRenderTexture: vi.fn(),
+      releaseRenderTexture: vi.fn().mockReturnThis(),
+      composeWithAlphaMask: vi.fn().mockReturnThis(),
+    };
+  }),
+}));
+
+let rafSpy: MockInstance;
+
+beforeEach(() => {
+  rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockReturnValue(1 as unknown as ReturnType<typeof requestAnimationFrame>);
+});
+
+afterEach(() => {
+  rafSpy.mockRestore();
+});
+
+describe('Application app-system extension bindings (Slice F)', () => {
+  test('create() runs after every core manager exists', () => {
+    let seenApp: Application | undefined;
+    const binding: ApplicationSystemBinding = {
+      create: app => {
+        seenApp = app;
+        return undefined;
+      },
+    };
+    const ext: Extension = { id: 'probe', systems: [binding] };
+    const app = new Application({ backend: { type: 'webgl2' }, extensions: [ext] });
+
+    expect(seenApp).toBe(app);
+    expect(seenApp?.input).toBeDefined();
+    expect(seenApp?.interaction).toBeDefined();
+    expect(seenApp?.focus).toBeDefined();
+    expect(seenApp?.audio).toBeDefined();
+    expect(seenApp?.tweens).toBeDefined();
+    expect(seenApp?.scenes).toBeDefined();
+    app.destroy();
+  });
+
+  test('the returned system is registered on app.systems', () => {
+    const system: System = { update: vi.fn() };
+    const binding: ApplicationSystemBinding = { create: () => system };
+    const ext: Extension = { id: 'counter', systems: [binding] };
+    const app = new Application({ backend: { type: 'webgl2' }, extensions: [ext] });
+
+    expect(app.systems.has(system)).toBe(true);
+    app.destroy();
+  });
+
+  test('a binding returning undefined is skipped, not an error', () => {
+    const binding: ApplicationSystemBinding = { create: () => undefined };
+    const ext: Extension = { id: 'opt-out', systems: [binding] };
+
+    expect(() => new Application({ backend: { type: 'webgl2' }, extensions: [ext] })).not.toThrow();
+  });
+
+  test('two applications built from the same extension get independent system instances', () => {
+    const created: System[] = [];
+    const binding: ApplicationSystemBinding = {
+      create: () => {
+        const system: System = { update: vi.fn() };
+        created.push(system);
+        return system;
+      },
+    };
+    const ext: Extension = { id: 'per-app', systems: [binding] };
+
+    const appA = new Application({ backend: { type: 'webgl2' }, extensions: [ext] });
+    const appB = new Application({ backend: { type: 'webgl2' }, extensions: [ext] });
+
+    expect(created).toHaveLength(2);
+    expect(appA.systems.has(created[0]!)).toBe(true);
+    expect(appA.systems.has(created[1]!)).toBe(false);
+    expect(appB.systems.has(created[1]!)).toBe(true);
+    expect(appB.systems.has(created[0]!)).toBe(false);
+
+    appA.destroy();
+    appB.destroy();
+  });
+
+  test('app.destroy() destroys the extension system, in reverse registration order with a later user system', () => {
+    const order: string[] = [];
+    const extSystem: System = { update: vi.fn(), destroy: () => order.push('extension') };
+    const binding: ApplicationSystemBinding = { create: () => extSystem };
+    const ext: Extension = { id: 'destroy-order', systems: [binding] };
+    const app = new Application({ backend: { type: 'webgl2' }, extensions: [ext] });
+
+    const userSystem: System = { update: vi.fn(), destroy: () => order.push('user') };
+    app.systems.add(userSystem);
+
+    app.destroy();
+
+    expect(order).toEqual(['user', 'extension']);
+  });
+
+  test('a renderer-only extension is unaffected — app.systems stays empty', () => {
+    const ext: Extension = { id: 'renderer-only', renderers: [] };
+    const app = new Application({ backend: { type: 'webgl2' }, extensions: [ext] });
+
+    expect(app.systems.size).toBe(0);
+    app.destroy();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run test/core/application-extension-systems.test.ts --reporter=dot`
+Expected: FAIL — `app.systems.has(system)` is `false` (nothing materializes `extensions[].systems` yet); the "runs after every core manager" test fails because `create()` is never called (binding is parsed into the snapshot but never consumed).
+
+- [ ] **Step 3: Wire `materializeApplicationSystems` into the `Application` constructor**
+
+In `src/core/Application.ts`, the import line:
+
+```ts
+import { materializeAssetBindings, materializeRendererBindings, materializeSerializerBindings } from '#extensions/materialize';
+```
+
+becomes:
+
+```ts
+import { materializeApplicationSystems, materializeAssetBindings, materializeRendererBindings, materializeSerializerBindings } from '#extensions/materialize';
+```
+
+At the end of the constructor, the tail currently reads:
+
+```ts
+    this.onVisibilityChange.add(visible => {
+      this._audio._applyVisibility(visible);
+    });
+  }
+```
+
+Change to:
+
+```ts
+    this.onVisibilityChange.add(visible => {
+      this._audio._applyVisibility(visible);
+    });
+
+    // Every core manager exists by this point, so app-system bindings can capture references to them.
+    materializeApplicationSystems(this, this._snapshot.systems);
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run test/core/application-extension-systems.test.ts --reporter=dot`
+Expected: PASS, all 6 tests.
+
+- [ ] **Step 5: Run the full extensions + core test directories as a regression check**
+
+Run: `pnpm vitest run test/extensions test/core --reporter=dot`
+Expected: PASS, no regressions in either directory.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/Application.ts test/core/application-extension-systems.test.ts
+git commit -m "feat(core): materialize extension app-systems in Application constructor (v0.17 Slice F)"
+```
+
+---
+
+### Task 5: Full verification gate + docs regen
+
+**Files:**
+- None new — verification only, plus whatever `pnpm docs:api:generate` writes under `site/src/content/api/`.
+
+- [ ] **Step 1: Full typecheck**
+
+Run: `pnpm typecheck`
+Expected: no errors.
+
+- [ ] **Step 2: Lint with autofix (resolves import ordering across all four touched/created files)**
+
+Run: `pnpm lint:fix`
+Expected: exits 0. If it reformats import order, re-run `pnpm typecheck` to confirm nothing broke.
+
+- [ ] **Step 3: Full unit test suite**
+
+Run: `pnpm test`
+Expected: all projects pass, no regressions outside the four files touched in Tasks 1-4.
+
+- [ ] **Step 4: Regenerate API docs (Task 1 added public JSDoc: `ApplicationSystemBinding`, `Extension.systems`)**
+
+Run: `pnpm docs:api:generate`
+Expected: exits 0. Check `git status` — if it wrote/modified files under `site/src/content/api/`, they must be committed (the push hook blocks otherwise per this repo's JSDoc-change convention).
+
+- [ ] **Step 5: Commit any docs changes**
+
+```bash
+git add site/src/content/api/
+git status --short
+```
+
+If there are staged changes:
+
+```bash
+git commit -m "docs(api): regenerate API docs for ApplicationSystemBinding (v0.17 Slice F)"
+```
+
+If `git status --short` shows nothing staged, skip the commit — no doc changes were generated.
+
+- [ ] **Step 6: Confirm release-gate checklist (spec §17, the two Slice-F-relevant bullets)**
+
+- [ ] "extensions gain app-system bindings" — Task 4's tests confirm this.
+- [ ] "no scene injection/augmentation" — confirmed by inspection: no file under `src/core/Scene*.ts` was touched by this plan.

--- a/docs/superpowers/plans/2026-07-20-v0.17-slice-f-extension-systems.md
+++ b/docs/superpowers/plans/2026-07-20-v0.17-slice-f-extension-systems.md
@@ -25,9 +25,11 @@
 ### Task 1: `ApplicationSystemBinding` type + `Extension.systems` field
 
 **Files:**
+
 - Modify: `src/extensions/Extension.ts`
 
 **Interfaces:**
+
 - Produces: `export interface ApplicationSystemBinding { create(app: Application): System | undefined; }` — Task 2 (snapshot) and Task 3 (materialize) both import this type from `#extensions/Extension`.
 - Produces: `Extension.systems?: readonly ApplicationSystemBinding[]` — the fourth binding-kind field, alongside the existing `renderers`/`assets`/`serializers`.
 
@@ -133,10 +135,12 @@ git commit -m "feat(core): add ApplicationSystemBinding + Extension.systems (v0.
 ### Task 2: `snapshot.ts` — collect, freeze, flatten `systems` bindings
 
 **Files:**
+
 - Modify: `src/extensions/snapshot.ts`
 - Modify: `test/extensions/snapshot.test.ts`
 
 **Interfaces:**
+
 - Consumes: `ApplicationSystemBinding` from Task 1 (`#extensions/Extension`, or relative `./Extension` inside `snapshot.ts`).
 - Produces: `ExtensionSnapshot.systems: readonly ApplicationSystemBinding[]` — Task 3's `materializeApplicationSystems` and Task 4's `Application` constructor both read `snapshot.systems`.
 
@@ -145,44 +149,44 @@ git commit -m "feat(core): add ApplicationSystemBinding + Extension.systems (v0.
 Open `test/extensions/snapshot.test.ts`. Change the `'EMPTY_SNAPSHOT has empty arrays'` test from:
 
 ```ts
-  it('EMPTY_SNAPSHOT has empty arrays', () => {
-    expect(EMPTY_SNAPSHOT.extensions).toHaveLength(0);
-    expect(EMPTY_SNAPSHOT.renderers).toHaveLength(0);
-    expect(EMPTY_SNAPSHOT.assets).toHaveLength(0);
-  });
+it('EMPTY_SNAPSHOT has empty arrays', () => {
+  expect(EMPTY_SNAPSHOT.extensions).toHaveLength(0);
+  expect(EMPTY_SNAPSHOT.renderers).toHaveLength(0);
+  expect(EMPTY_SNAPSHOT.assets).toHaveLength(0);
+});
 ```
 
 to:
 
 ```ts
-  it('EMPTY_SNAPSHOT has empty arrays', () => {
-    expect(EMPTY_SNAPSHOT.extensions).toHaveLength(0);
-    expect(EMPTY_SNAPSHOT.renderers).toHaveLength(0);
-    expect(EMPTY_SNAPSHOT.assets).toHaveLength(0);
-    expect(EMPTY_SNAPSHOT.systems).toHaveLength(0);
-  });
+it('EMPTY_SNAPSHOT has empty arrays', () => {
+  expect(EMPTY_SNAPSHOT.extensions).toHaveLength(0);
+  expect(EMPTY_SNAPSHOT.renderers).toHaveLength(0);
+  expect(EMPTY_SNAPSHOT.assets).toHaveLength(0);
+  expect(EMPTY_SNAPSHOT.systems).toHaveLength(0);
+});
 ```
 
 Then, right after the existing `'buildSnapshot flattens asset bindings from multiple extensions'` test, add:
 
 ```ts
-  it('buildSnapshot flattens system bindings from multiple extensions', () => {
-    const binding1 = { create: () => undefined };
-    const binding2 = { create: () => undefined };
-    const extA: Extension = { id: 'a', systems: [binding1] };
-    const extB: Extension = { id: 'b', systems: [binding2] };
-    const snapshot = buildSnapshot([extA, extB]);
-    expect(snapshot.systems).toHaveLength(2);
-    expect(snapshot.systems[0]).toBe(binding1);
-    expect(snapshot.systems[1]).toBe(binding2);
-  });
+it('buildSnapshot flattens system bindings from multiple extensions', () => {
+  const binding1 = { create: () => undefined };
+  const binding2 = { create: () => undefined };
+  const extA: Extension = { id: 'a', systems: [binding1] };
+  const extB: Extension = { id: 'b', systems: [binding2] };
+  const snapshot = buildSnapshot([extA, extB]);
+  expect(snapshot.systems).toHaveLength(2);
+  expect(snapshot.systems[0]).toBe(binding1);
+  expect(snapshot.systems[1]).toBe(binding2);
+});
 
-  it('buildSnapshot freezes system bindings', () => {
-    const binding = { create: () => undefined };
-    const ext: Extension = { id: 'frozen-systems', systems: [binding] };
-    buildSnapshot([ext]);
-    expect(Object.isFrozen(binding)).toBe(true);
-  });
+it('buildSnapshot freezes system bindings', () => {
+  const binding = { create: () => undefined };
+  const ext: Extension = { id: 'frozen-systems', systems: [binding] };
+  buildSnapshot([ext]);
+  expect(Object.isFrozen(binding)).toBe(true);
+});
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -255,13 +259,13 @@ const emptySnapshot: ExtensionSnapshot = Object.freeze({
 In `freezeExtension`, right after the existing `if (ext.serializers) { ... }` block (ends `}` before the closing `}` of the function), add:
 
 ```ts
-  if (ext.systems) {
-    Object.freeze(ext.systems);
+if (ext.systems) {
+  Object.freeze(ext.systems);
 
-    for (const binding of ext.systems) {
-      Object.freeze(binding);
-    }
+  for (const binding of ext.systems) {
+    Object.freeze(binding);
   }
+}
 ```
 
 - [ ] **Step 5: Flatten `systems` in `buildSnapshot`**
@@ -269,79 +273,79 @@ In `freezeExtension`, right after the existing `if (ext.serializers) { ... }` bl
 The flattening block in `buildSnapshot` currently reads:
 
 ```ts
-  const renderers: RendererBinding[] = [];
-  const assets: AssetBinding[] = [];
-  const serializers: SerializerBinding[] = [];
+const renderers: RendererBinding[] = [];
+const assets: AssetBinding[] = [];
+const serializers: SerializerBinding[] = [];
 
-  for (const ext of ordered) {
-    if (ext.renderers) {
-      for (const binding of ext.renderers) {
-        renderers.push(binding);
-      }
-    }
-
-    if (ext.assets) {
-      for (const binding of ext.assets) {
-        assets.push(binding);
-      }
-    }
-
-    if (ext.serializers) {
-      for (const binding of ext.serializers) {
-        serializers.push(binding);
-      }
+for (const ext of ordered) {
+  if (ext.renderers) {
+    for (const binding of ext.renderers) {
+      renderers.push(binding);
     }
   }
 
-  return Object.freeze({
-    extensions: Object.freeze(ordered),
-    renderers: Object.freeze(renderers),
-    assets: Object.freeze(assets),
-    serializers: Object.freeze(serializers),
-  });
+  if (ext.assets) {
+    for (const binding of ext.assets) {
+      assets.push(binding);
+    }
+  }
+
+  if (ext.serializers) {
+    for (const binding of ext.serializers) {
+      serializers.push(binding);
+    }
+  }
+}
+
+return Object.freeze({
+  extensions: Object.freeze(ordered),
+  renderers: Object.freeze(renderers),
+  assets: Object.freeze(assets),
+  serializers: Object.freeze(serializers),
+});
 ```
 
 Change to:
 
 ```ts
-  const renderers: RendererBinding[] = [];
-  const assets: AssetBinding[] = [];
-  const serializers: SerializerBinding[] = [];
-  const systems: ApplicationSystemBinding[] = [];
+const renderers: RendererBinding[] = [];
+const assets: AssetBinding[] = [];
+const serializers: SerializerBinding[] = [];
+const systems: ApplicationSystemBinding[] = [];
 
-  for (const ext of ordered) {
-    if (ext.renderers) {
-      for (const binding of ext.renderers) {
-        renderers.push(binding);
-      }
-    }
-
-    if (ext.assets) {
-      for (const binding of ext.assets) {
-        assets.push(binding);
-      }
-    }
-
-    if (ext.serializers) {
-      for (const binding of ext.serializers) {
-        serializers.push(binding);
-      }
-    }
-
-    if (ext.systems) {
-      for (const binding of ext.systems) {
-        systems.push(binding);
-      }
+for (const ext of ordered) {
+  if (ext.renderers) {
+    for (const binding of ext.renderers) {
+      renderers.push(binding);
     }
   }
 
-  return Object.freeze({
-    extensions: Object.freeze(ordered),
-    renderers: Object.freeze(renderers),
-    assets: Object.freeze(assets),
-    serializers: Object.freeze(serializers),
-    systems: Object.freeze(systems),
-  });
+  if (ext.assets) {
+    for (const binding of ext.assets) {
+      assets.push(binding);
+    }
+  }
+
+  if (ext.serializers) {
+    for (const binding of ext.serializers) {
+      serializers.push(binding);
+    }
+  }
+
+  if (ext.systems) {
+    for (const binding of ext.systems) {
+      systems.push(binding);
+    }
+  }
+}
+
+return Object.freeze({
+  extensions: Object.freeze(ordered),
+  renderers: Object.freeze(renderers),
+  assets: Object.freeze(assets),
+  serializers: Object.freeze(serializers),
+  systems: Object.freeze(systems),
+});
 ```
 
 - [ ] **Step 6: Run tests to verify they pass**
@@ -361,10 +365,12 @@ git commit -m "feat(core): collect Extension.systems bindings in ExtensionSnapsh
 ### Task 3: `materializeApplicationSystems`
 
 **Files:**
+
 - Modify: `src/extensions/materialize.ts`
 - Create: `test/extensions/application-system-materialisation.test.ts`
 
 **Interfaces:**
+
 - Consumes: `ApplicationSystemBinding` (Task 1), `ExtensionSnapshot.systems` (Task 2).
 - Produces: `export function materializeApplicationSystems(app: Application, bindings: readonly ApplicationSystemBinding[]): void` — Task 4's `Application` constructor calls this exact signature.
 
@@ -523,10 +529,12 @@ git commit -m "feat(core): add materializeApplicationSystems (v0.17 Slice F)"
 ### Task 4: Wire into `Application` + integration tests
 
 **Files:**
+
 - Modify: `src/core/Application.ts`
 - Create: `test/core/application-extension-systems.test.ts`
 
 **Interfaces:**
+
 - Consumes: `materializeApplicationSystems` (Task 3), `this._snapshot.systems` (Task 2, already-existing `this._snapshot: ExtensionSnapshot` field on `Application`).
 
 - [ ] **Step 1: Write the failing integration test file**
@@ -743,6 +751,7 @@ git commit -m "feat(core): materialize extension app-systems in Application cons
 ### Task 5: Full verification gate + docs regen
 
 **Files:**
+
 - None new — verification only, plus whatever `pnpm docs:api:generate` writes under `site/src/content/api/`.
 
 - [ ] **Step 1: Full typecheck**

--- a/site/src/content/api/application-system-binding.json
+++ b/site/src/content/api/application-system-binding.json
@@ -1,0 +1,105 @@
+{
+  "title": "ApplicationSystemBinding",
+  "description": "Produces an app-level System for one Application instance, or `undefined` to opt out for that instance. `create(app)` runs once per Application, after every core manager already exists on `app` — safe to read Application.input, Application.interaction, etc. The returned system is registered on Application.systems exactly like a user-added system, including reverse-order destruction. Extensions never inject scene-level systems or augment scenes — app-level only.",
+  "symbol": "ApplicationSystemBinding",
+  "kind": "interface",
+  "subsystem": "extensions",
+  "importPath": "@codexo/exojs/extensions",
+  "tier": "advanced",
+  "memberCount": 1,
+  "counts": {
+    "constructors": 0,
+    "methods": 1,
+    "properties": 0,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Produces an app-level System for one Application instance, or `undefined` to opt out for that instance. `create(app)` runs once per Application, after every core manager already exists on `app` — safe to read Application.input, Application.interaction, etc. The returned system is registered on Application.systems exactly like a user-added system, including reverse-order destruction. Extensions never inject scene-level systems or augment scenes — app-level only."
+      ],
+      "importLine": "import { ApplicationSystemBinding } from '@codexo/exojs/extensions'",
+      "sourceLink": null
+    },
+    {
+      "id": "methods",
+      "title": "Methods",
+      "members": [
+        {
+          "name": "create",
+          "signature": "create(app: Application): System | undefined",
+          "signatureTokens": [
+            {
+              "text": "create",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "app",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Application",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "System",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "undefined",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "app",
+              "type": "Application",
+              "optional": false
+            }
+          ],
+          "returnType": "System | undefined",
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/extensions/Extension.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/extensions/Extension.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/extensions/Extension.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/extensions/Extension.ts"
+}

--- a/site/src/content/api/extension.json
+++ b/site/src/content/api/extension.json
@@ -1,16 +1,16 @@
 {
   "title": "Extension",
-  "description": "An ExoJS extension: an immutable descriptor that contributes renderer bindings, asset bindings and/or serializer bindings. Holds no Application, backend, GPU, or loader instances. Register via ExtensionRegistry.register (official packages do this as an import side effect), or pass explicitly via ApplicationOptions.extensions.",
+  "description": "An ExoJS extension: an immutable descriptor that contributes renderer bindings, asset bindings, serializer bindings and/or app-level systems. Holds no Application, backend, GPU, or loader instances. Register via ExtensionRegistry.register (official packages do this as an import side effect), or pass explicitly via ApplicationOptions.extensions.",
   "symbol": "Extension",
   "kind": "interface",
   "subsystem": "extensions",
   "importPath": "@codexo/exojs/extensions",
   "tier": "advanced",
-  "memberCount": 5,
+  "memberCount": 6,
   "counts": {
     "constructors": 0,
     "methods": 0,
-    "properties": 5,
+    "properties": 6,
     "events": 0
   },
   "sections": [
@@ -19,7 +19,7 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "An ExoJS extension: an immutable descriptor that contributes renderer bindings, asset bindings and/or serializer bindings. Holds no Application, backend, GPU, or loader instances. Register via ExtensionRegistry.register (official packages do this as an import side effect), or pass explicitly via ApplicationOptions.extensions."
+        "An ExoJS extension: an immutable descriptor that contributes renderer bindings, asset bindings, serializer bindings and/or app-level systems. Holds no Application, backend, GPU, or loader instances. Register via ExtensionRegistry.register (official packages do this as an import side effect), or pass explicitly via ApplicationOptions.extensions."
       ],
       "importLine": "import { Extension } from '@codexo/exojs/extensions'",
       "sourceLink": null
@@ -231,6 +231,43 @@
             {
               "text": ">",
               "kind": "punctuation"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "systems",
+          "signature": "systems?: readonly ApplicationSystemBinding[]",
+          "signatureTokens": [
+            {
+              "text": "systems",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ApplicationSystemBinding",
+              "kind": "type"
             },
             {
               "text": "[]",

--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -2,7 +2,7 @@ import { TweenManager } from '#animation/TweenManager';
 import { AudioManager } from '#audio/AudioManager';
 import type { Extension } from '#extensions/Extension';
 import { getGlobalSnapshotInternal } from '#extensions/ExtensionRegistry';
-import { materializeAssetBindings, materializeRendererBindings, materializeSerializerBindings } from '#extensions/materialize';
+import { materializeApplicationSystems, materializeAssetBindings, materializeRendererBindings, materializeSerializerBindings } from '#extensions/materialize';
 import { buildSnapshot, type ExtensionSnapshot } from '#extensions/snapshot';
 import { FocusManager } from '#input/FocusManager';
 import type { GamepadDefinition } from '#input/GamepadDefinitions';
@@ -476,6 +476,9 @@ export class Application {
     this.onVisibilityChange.add(visible => {
       this._audio._applyVisibility(visible);
     });
+
+    // Every core manager exists by this point, so app-system bindings can capture references to them.
+    materializeApplicationSystems(this, this._snapshot.systems);
   }
 
   public get status(): ApplicationStatus {

--- a/src/extensions/Extension.ts
+++ b/src/extensions/Extension.ts
@@ -1,8 +1,8 @@
 import type { Application } from '#core/Application';
 import type { SceneNode } from '#core/SceneNode';
-import type { System } from '#core/System';
 import type { NodeSerializer } from '#core/serialization/NodeSerializer';
 import type { SceneNodeConstructor } from '#core/serialization/SerializationRegistry';
+import type { System } from '#core/System';
 import type { Drawable } from '#rendering/Drawable';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import type { DrawableConstructor, Renderer } from '#rendering/Renderer';

--- a/src/extensions/Extension.ts
+++ b/src/extensions/Extension.ts
@@ -1,4 +1,6 @@
+import type { Application } from '#core/Application';
 import type { SceneNode } from '#core/SceneNode';
+import type { System } from '#core/System';
 import type { NodeSerializer } from '#core/serialization/NodeSerializer';
 import type { SceneNodeConstructor } from '#core/serialization/SerializationRegistry';
 import type { Drawable } from '#rendering/Drawable';
@@ -138,10 +140,24 @@ export interface SerializerBinding<T extends SceneNode = SceneNode> {
 }
 
 /**
+ * Produces an app-level {@link System} for one {@link Application} instance,
+ * or `undefined` to opt out for that instance. `create(app)` runs once per
+ * Application, after every core manager already exists on `app` — safe to
+ * read {@link Application.input}, {@link Application.interaction}, etc. The
+ * returned system is registered on {@link Application.systems} exactly like
+ * a user-added system, including reverse-order destruction. Extensions never
+ * inject scene-level systems or augment scenes — app-level only.
+ * @advanced
+ */
+export interface ApplicationSystemBinding {
+  create(app: Application): System | undefined;
+}
+
+/**
  * An ExoJS extension: an immutable descriptor that contributes renderer bindings,
- * asset bindings and/or serializer bindings. Holds no Application, backend, GPU,
- * or loader instances. Register via {@link ExtensionRegistry.register} (official
- * packages do this as an import side effect), or pass explicitly via
+ * asset bindings, serializer bindings and/or app-level systems. Holds no Application,
+ * backend, GPU, or loader instances. Register via {@link ExtensionRegistry.register}
+ * (official packages do this as an import side effect), or pass explicitly via
  * {@link ApplicationOptions.extensions}.
  * @advanced
  */
@@ -151,4 +167,5 @@ export interface Extension {
   readonly renderers?: readonly RendererBinding[];
   readonly assets?: readonly AssetBinding[];
   readonly serializers?: readonly SerializerBinding[];
+  readonly systems?: readonly ApplicationSystemBinding[];
 }

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -1,2 +1,2 @@
-export type { AssetBinding, AssetHandler, AssetLoadRequest, Extension, RendererBinding, SerializerBinding } from './Extension';
+export type { ApplicationSystemBinding, AssetBinding, AssetHandler, AssetLoadRequest, Extension, RendererBinding, SerializerBinding } from './Extension';
 export { ExtensionRegistry } from './ExtensionRegistry';

--- a/src/extensions/materialize.ts
+++ b/src/extensions/materialize.ts
@@ -1,10 +1,11 @@
+import type { Application } from '#core/Application';
 import type { SerializationRegistry } from '#core/serialization/SerializationRegistry';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import type { DrawableConstructor } from '#rendering/Renderer';
 import type { AssetConstructor } from '#resources/FactoryRegistry';
 import type { Loader } from '#resources/Loader';
 
-import type { AssetBinding, AssetHandler, RendererBinding, SerializerBinding } from './Extension';
+import type { ApplicationSystemBinding, AssetBinding, AssetHandler, RendererBinding, SerializerBinding } from './Extension';
 
 /**
  * Materialise all renderer bindings into the backend's renderer registry.
@@ -97,5 +98,22 @@ export function materializeAssetBindings(loader: Loader, bindings: readonly Asse
 export function materializeSerializerBindings(registry: SerializationRegistry, bindings: readonly SerializerBinding[]): void {
   for (const binding of bindings) {
     registry.register(binding.typeName, binding.target, binding.serializer);
+  }
+}
+
+/**
+ * Materialise all app-system bindings onto {@link Application.systems}.
+ * Called once per Application, after every core manager already exists on
+ * `app` — a binding's `create(app)` may safely read them. A binding
+ * returning `undefined` opts out for this application and is skipped.
+ * @internal
+ */
+export function materializeApplicationSystems(app: Application, bindings: readonly ApplicationSystemBinding[]): void {
+  for (const binding of bindings) {
+    const system = binding.create(app);
+
+    if (system === undefined) continue;
+
+    app.systems.add(system);
   }
 }

--- a/src/extensions/snapshot.ts
+++ b/src/extensions/snapshot.ts
@@ -1,4 +1,4 @@
-import type { AssetBinding, Extension, RendererBinding, SerializerBinding } from './Extension';
+import type { ApplicationSystemBinding, AssetBinding, Extension, RendererBinding, SerializerBinding } from './Extension';
 
 // @internal
 export interface ExtensionSnapshot {
@@ -6,6 +6,7 @@ export interface ExtensionSnapshot {
   readonly renderers: readonly RendererBinding[];
   readonly assets: readonly AssetBinding[];
   readonly serializers: readonly SerializerBinding[];
+  readonly systems: readonly ApplicationSystemBinding[];
 }
 
 // Shared empty singleton — zero allocation for extensions: [] selection.
@@ -14,6 +15,7 @@ const emptySnapshot: ExtensionSnapshot = Object.freeze({
   renderers: Object.freeze([]),
   assets: Object.freeze([]),
   serializers: Object.freeze([]),
+  systems: Object.freeze([]),
 });
 
 export { emptySnapshot as EMPTY_SNAPSHOT };
@@ -66,6 +68,14 @@ export function freezeExtension(ext: Extension): void {
     Object.freeze(ext.serializers);
 
     for (const binding of ext.serializers) {
+      Object.freeze(binding);
+    }
+  }
+
+  if (ext.systems) {
+    Object.freeze(ext.systems);
+
+    for (const binding of ext.systems) {
       Object.freeze(binding);
     }
   }
@@ -138,6 +148,7 @@ export function buildSnapshot(input: readonly Extension[]): ExtensionSnapshot {
   const renderers: RendererBinding[] = [];
   const assets: AssetBinding[] = [];
   const serializers: SerializerBinding[] = [];
+  const systems: ApplicationSystemBinding[] = [];
 
   for (const ext of ordered) {
     if (ext.renderers) {
@@ -157,6 +168,12 @@ export function buildSnapshot(input: readonly Extension[]): ExtensionSnapshot {
         serializers.push(binding);
       }
     }
+
+    if (ext.systems) {
+      for (const binding of ext.systems) {
+        systems.push(binding);
+      }
+    }
   }
 
   return Object.freeze({
@@ -164,5 +181,6 @@ export function buildSnapshot(input: readonly Extension[]): ExtensionSnapshot {
     renderers: Object.freeze(renderers),
     assets: Object.freeze(assets),
     serializers: Object.freeze(serializers),
+    systems: Object.freeze(systems),
   });
 }

--- a/test/core/application-extension-systems.test.ts
+++ b/test/core/application-extension-systems.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Real Application integration tests for the v0.17 Slice F app-system
+ * extension bindings (implementation spec §12). Only the WebGL2 backend is
+ * mocked (kept out of jsdom) — input, interaction, focus, audio, tweens, and
+ * the app SystemRegistry all run for real.
+ */
+
+import { Application } from '#core/Application';
+import type { System } from '#core/System';
+import type { ApplicationSystemBinding, Extension } from '#extensions/Extension';
+
+vi.mock('#rendering/webgl2/WebGl2Backend', () => ({
+  WebGl2Backend: vi.fn().mockImplementation(function () {
+    return {
+      onContextLost: { add: vi.fn() },
+      onContextRestored: { add: vi.fn() },
+      onRenderError: { add: vi.fn(), destroy: vi.fn() },
+      stats: {
+        frameTimeMs: 0,
+        drawCalls: 0,
+        culledNodes: 0,
+        submittedNodes: 0,
+        batches: 0,
+        renderPasses: 0,
+        renderTargetChanges: 0,
+        frame: 0,
+        rawFrameDeltaMs: 0,
+      },
+      resetStats: vi.fn().mockReturnThis(),
+      flush: vi.fn().mockReturnThis(),
+      initialize: vi.fn().mockResolvedValue(undefined),
+      destroy: vi.fn(),
+      resize: vi.fn().mockReturnThis(),
+      view: { getBounds: vi.fn() },
+      renderTarget: {},
+      backendType: 'webgl2',
+      setView: vi.fn().mockReturnThis(),
+      draw: vi.fn().mockReturnThis(),
+      execute: vi.fn().mockReturnThis(),
+      clear: vi.fn().mockReturnThis(),
+      pushScissorRect: vi.fn().mockReturnThis(),
+      popScissorRect: vi.fn().mockReturnThis(),
+      acquireRenderTexture: vi.fn(),
+      releaseRenderTexture: vi.fn().mockReturnThis(),
+      composeWithAlphaMask: vi.fn().mockReturnThis(),
+    };
+  }),
+}));
+
+let rafSpy: MockInstance;
+
+beforeEach(() => {
+  rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockReturnValue(1 as unknown as ReturnType<typeof requestAnimationFrame>);
+});
+
+afterEach(() => {
+  rafSpy.mockRestore();
+});
+
+describe('Application app-system extension bindings (Slice F)', () => {
+  test('create() runs after every core manager exists', () => {
+    let seenApp: Application | undefined;
+    const binding: ApplicationSystemBinding = {
+      create: app => {
+        seenApp = app;
+        return undefined;
+      },
+    };
+    const ext: Extension = { id: 'probe', systems: [binding] };
+    const app = new Application({ backend: { type: 'webgl2' }, extensions: [ext] });
+
+    expect(seenApp).toBe(app);
+    expect(seenApp?.input).toBeDefined();
+    expect(seenApp?.interaction).toBeDefined();
+    expect(seenApp?.focus).toBeDefined();
+    expect(seenApp?.audio).toBeDefined();
+    expect(seenApp?.tweens).toBeDefined();
+    expect(seenApp?.scenes).toBeDefined();
+    app.destroy();
+  });
+
+  test('the returned system is registered on app.systems', () => {
+    const system: System = { update: vi.fn() };
+    const binding: ApplicationSystemBinding = { create: () => system };
+    const ext: Extension = { id: 'counter', systems: [binding] };
+    const app = new Application({ backend: { type: 'webgl2' }, extensions: [ext] });
+
+    expect(app.systems.has(system)).toBe(true);
+    app.destroy();
+  });
+
+  test('a binding returning undefined is skipped, not an error', () => {
+    const binding: ApplicationSystemBinding = { create: () => undefined };
+    const ext: Extension = { id: 'opt-out', systems: [binding] };
+
+    expect(() => new Application({ backend: { type: 'webgl2' }, extensions: [ext] })).not.toThrow();
+  });
+
+  test('two applications built from the same extension get independent system instances', () => {
+    const created: System[] = [];
+    const binding: ApplicationSystemBinding = {
+      create: () => {
+        const system: System = { update: vi.fn() };
+        created.push(system);
+        return system;
+      },
+    };
+    const ext: Extension = { id: 'per-app', systems: [binding] };
+
+    const appA = new Application({ backend: { type: 'webgl2' }, extensions: [ext] });
+    const appB = new Application({ backend: { type: 'webgl2' }, extensions: [ext] });
+
+    expect(created).toHaveLength(2);
+    expect(appA.systems.has(created[0]!)).toBe(true);
+    expect(appA.systems.has(created[1]!)).toBe(false);
+    expect(appB.systems.has(created[1]!)).toBe(true);
+    expect(appB.systems.has(created[0]!)).toBe(false);
+
+    appA.destroy();
+    appB.destroy();
+  });
+
+  test('app.destroy() destroys the extension system, in reverse registration order with a later user system', () => {
+    const order: string[] = [];
+    const extSystem: System = { update: vi.fn(), destroy: () => order.push('extension') };
+    const binding: ApplicationSystemBinding = { create: () => extSystem };
+    const ext: Extension = { id: 'destroy-order', systems: [binding] };
+    const app = new Application({ backend: { type: 'webgl2' }, extensions: [ext] });
+
+    const userSystem: System = { update: vi.fn(), destroy: () => order.push('user') };
+    app.systems.add(userSystem);
+
+    app.destroy();
+
+    expect(order).toEqual(['user', 'extension']);
+  });
+
+  test('a renderer-only extension is unaffected — app.systems stays empty', () => {
+    const ext: Extension = { id: 'renderer-only', renderers: [] };
+    const app = new Application({ backend: { type: 'webgl2' }, extensions: [ext] });
+
+    expect(app.systems.size).toBe(0);
+    app.destroy();
+  });
+});

--- a/test/core/application-lifecycle.test.ts
+++ b/test/core/application-lifecycle.test.ts
@@ -187,6 +187,7 @@ const loadHarness = async (options: LifecycleHarnessOptions = {}): Promise<Lifec
     }),
   }));
   vi.doMock('#extensions/materialize', () => ({
+    materializeApplicationSystems: vi.fn(),
     materializeAssetBindings: options.materializeAssetBindings ?? vi.fn(),
     materializeRendererBindings: options.materializeRendererBindings ?? vi.fn(),
     materializeSerializerBindings: options.materializeSerializerBindings ?? vi.fn(),

--- a/test/core/application-on-frame.test.ts
+++ b/test/core/application-on-frame.test.ts
@@ -70,6 +70,7 @@ const loadOnFrameHarness = async (): Promise<OnFrameTestHarness> => {
     }),
   }));
   vi.doMock('#extensions/materialize', () => ({
+    materializeApplicationSystems: vi.fn(),
     materializeAssetBindings: vi.fn(),
     materializeRendererBindings: vi.fn(),
     materializeSerializerBindings: vi.fn(),

--- a/test/core/application.test.ts
+++ b/test/core/application.test.ts
@@ -140,6 +140,7 @@ const loadApplicationHarness = async (
     Loader: LoaderMock,
   }));
   vi.doMock('#extensions/materialize', () => ({
+    materializeApplicationSystems: vi.fn(),
     materializeAssetBindings: vi.fn(),
     materializeRendererBindings: vi.fn(),
     materializeSerializerBindings: vi.fn(),

--- a/test/core/focus-visibility.test.ts
+++ b/test/core/focus-visibility.test.ts
@@ -97,6 +97,7 @@ const loadHarness = async (): Promise<FocusVisibilityHarness> => {
     }),
   }));
   vi.doMock('#extensions/materialize', () => ({
+    materializeApplicationSystems: vi.fn(),
     materializeAssetBindings: vi.fn(),
     materializeRendererBindings: vi.fn(),
     materializeSerializerBindings: vi.fn(),

--- a/test/extensions/application-system-materialisation.test.ts
+++ b/test/extensions/application-system-materialisation.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Application } from '#core/Application';
+import type { System } from '#core/System';
+import { SystemRegistry } from '#core/SystemRegistry';
+import type { ApplicationSystemBinding } from '#extensions/Extension';
+import { materializeApplicationSystems } from '#extensions/materialize';
+import { resetExtensionRegistryForTesting } from '#extensions/testing';
+
+function createStubApp(): Application & { systems: SystemRegistry } {
+  return { systems: new SystemRegistry() } as unknown as Application & { systems: SystemRegistry };
+}
+
+describe('materializeApplicationSystems', () => {
+  beforeEach(() => {
+    resetExtensionRegistryForTesting();
+  });
+
+  it('registers the system produced by a binding', () => {
+    const app = createStubApp();
+    const system: System = { update: vi.fn() };
+    const binding: ApplicationSystemBinding = { create: () => system };
+
+    materializeApplicationSystems(app, [binding]);
+
+    expect(app.systems.has(system)).toBe(true);
+  });
+
+  it('create() is called exactly once per binding, with the application', () => {
+    const app = createStubApp();
+    const system: System = { update: vi.fn() };
+    const createFn = vi.fn(() => system);
+    const binding: ApplicationSystemBinding = { create: createFn };
+
+    materializeApplicationSystems(app, [binding]);
+
+    expect(createFn).toHaveBeenCalledTimes(1);
+    expect(createFn).toHaveBeenCalledWith(app);
+  });
+
+  it('skips a binding whose create() returns undefined, without throwing', () => {
+    const app = createStubApp();
+    const binding: ApplicationSystemBinding = { create: () => undefined };
+
+    expect(() => materializeApplicationSystems(app, [binding])).not.toThrow();
+    expect(app.systems.size).toBe(0);
+  });
+
+  it('registers systems from multiple bindings, skipping only the undefined ones', () => {
+    const app = createStubApp();
+    const systemA: System = { update: vi.fn() };
+    const systemC: System = { update: vi.fn() };
+    const bindings: ApplicationSystemBinding[] = [{ create: () => systemA }, { create: () => undefined }, { create: () => systemC }];
+
+    materializeApplicationSystems(app, bindings);
+
+    expect(app.systems.size).toBe(2);
+    expect(app.systems.has(systemA)).toBe(true);
+    expect(app.systems.has(systemC)).toBe(true);
+  });
+
+  it('two applications receive independent system instances from the same binding', () => {
+    const appA = createStubApp();
+    const appB = createStubApp();
+    const systemA: System = { update: vi.fn() };
+    const systemB: System = { update: vi.fn() };
+    let callCount = 0;
+    const binding: ApplicationSystemBinding = { create: () => (callCount++ === 0 ? systemA : systemB) };
+
+    materializeApplicationSystems(appA, [binding]);
+    materializeApplicationSystems(appB, [binding]);
+
+    expect(appA.systems.has(systemA)).toBe(true);
+    expect(appA.systems.has(systemB)).toBe(false);
+    expect(appB.systems.has(systemB)).toBe(true);
+    expect(appB.systems.has(systemA)).toBe(false);
+  });
+});

--- a/test/extensions/snapshot.test.ts
+++ b/test/extensions/snapshot.test.ts
@@ -19,6 +19,7 @@ describe('ExtensionSnapshot', () => {
     expect(EMPTY_SNAPSHOT.extensions).toHaveLength(0);
     expect(EMPTY_SNAPSHOT.renderers).toHaveLength(0);
     expect(EMPTY_SNAPSHOT.assets).toHaveLength(0);
+    expect(EMPTY_SNAPSHOT.systems).toHaveLength(0);
   });
 
   it('global snapshot returns same object on repeated calls (cache hit)', () => {
@@ -64,6 +65,24 @@ describe('ExtensionSnapshot', () => {
     };
     const snapshot = buildSnapshot([extA, extB]);
     expect(snapshot.assets).toHaveLength(2);
+  });
+
+  it('buildSnapshot flattens system bindings from multiple extensions', () => {
+    const binding1 = { create: () => undefined };
+    const binding2 = { create: () => undefined };
+    const extA: Extension = { id: 'a', systems: [binding1] };
+    const extB: Extension = { id: 'b', systems: [binding2] };
+    const snapshot = buildSnapshot([extA, extB]);
+    expect(snapshot.systems).toHaveLength(2);
+    expect(snapshot.systems[0]).toBe(binding1);
+    expect(snapshot.systems[1]).toBe(binding2);
+  });
+
+  it('buildSnapshot freezes system bindings', () => {
+    const binding = { create: () => undefined };
+    const ext: Extension = { id: 'frozen-systems', systems: [binding] };
+    buildSnapshot([ext]);
+    expect(Object.isFrozen(binding)).toBe(true);
   });
 
   it('buildSnapshot de-duplicates same id + same object (no-op)', () => {

--- a/test/rendering/webgl2-backend.test.ts
+++ b/test/rendering/webgl2-backend.test.ts
@@ -142,6 +142,7 @@ describe('Application.setCursor', () => {
       }),
     }));
     vi.doMock('#extensions/materialize', () => ({
+      materializeApplicationSystems: vi.fn(),
       materializeAssetBindings: vi.fn(),
       materializeRendererBindings: vi.fn(),
       materializeSerializerBindings: vi.fn(),


### PR DESCRIPTION
## Summary
- Extensions can now contribute app-level `System` instances via `ApplicationSystemBinding`, materialized once per `Application` after every core manager exists (input/focus/interaction/scenes/audio/tweens) and registered on `app.systems`, following the existing `RendererBinding`/`AssetBinding`/`SerializerBinding` pattern exactly (implementation spec §12).
- No scene-system bindings or scene property injection — app-level only, per spec §19.
- `Extension.systems` bindings whose `create()` returns `undefined` are skipped without error; two `Application` instances built from the same `Extension` object get independent `System` instances; extension systems are destroyed by the pre-existing `SystemRegistry.destroy()` reverse-registration-order teardown.

## Test plan
- [x] New unit tests for `buildSnapshot`/`freezeExtension` collecting/freezing/flattening `systems` bindings (`test/extensions/snapshot.test.ts`)
- [x] New unit tests for `materializeApplicationSystems` (`test/extensions/application-system-materialisation.test.ts`)
- [x] New `Application` integration tests: core-manager-availability ordering, registration, opt-out, per-instance independence, reverse-order destruction, renderer-only extensions unaffected (`test/core/application-extension-systems.test.ts`)
- [x] Full unit suite: 7927 passed, 16 skipped (pre-existing, unrelated)
- [x] `pnpm typecheck`, `pnpm lint:fix`, `pnpm docs:api:generate` all clean
- [x] pre-push gate (`verify:quick`) passed