### PR TITLE
feat(core): v0.17 migration sweep — physics fixedUpdate, retention/audio fixes, DX gate (Slice G)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,110 @@ All notable changes to ExoJS are documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - Unreleased
+
+The scene-model release. `Application`'s frame loop, scene lifecycle, and
+navigation are rebuilt around a normative multiphase `System` contract, a
+typed scene registry, pause with a per-binding availability policy, and
+retention (suspend a scene instead of destroying it, restore it later without
+re-running `load()`/`init()`). This is a pre-1.0 release and includes
+intentional breaking changes; see **Changed** and **Removed**.
+
+### Added
+
+- **Multiphase `System` contract.** A `System` implements any subset of
+  `fixedUpdate`/`update`/`draw` (previously `update` + `destroy` were
+  required); `app.systems`/`scene.systems` dispatch each phase in ascending
+  `order`, ties broken by insertion order. Structural add/remove during a
+  frame is buffered to the next frame boundary (#390).
+- **Typed scene registry and navigation.** `new Application({ scenes: { game:
+GameScene } })` registers scene constructors; `app.start(GameScene, data?)`
+  and `app.scenes.setScene(GameScene, data?, options?)` take the constructor
+  directly — data and options are inferred from the scene's own generic,
+  rejecting a mismatched or missing payload at compile time. Unregistered or
+  duplicate registrations raise named errors (`UnregisteredSceneError`,
+  `DuplicateSceneRegistrationError`, `InvalidSceneRegistrationError`) (#392,
+  #396).
+- **`app.scenes.pause()`/`resume()`** move the active scene between `Active`
+  and `Paused` (`SceneState`) — the scene keeps drawing while paused but its
+  `update()`/systems stop. Scene input bindings accept `when:
+'active'|'paused'|'always'` (default `'active'`), with edge rules so a
+  press/release pair must both occur in an allowed state to trigger.
+  `this.interaction.capture(root)` confines pointer hit-testing to a subtree
+  for modal UI (#392, #397).
+- **Scene retention.** `setScene(X, { retainCurrent: true })` suspends the
+  outgoing scene instead of destroying it; `app.scenes.restoreScene(X)`
+  reactivates the same instance without re-running `load()`/`init()`,
+  returning to its pre-suspend `Active`/`Paused` state; `releaseScene(X)`
+  permanently ends a retained scene. Concurrent navigation calls are now
+  rejected with `ConcurrentSceneNavigationError` instead of racing silently
+  (#398).
+- **Extension app-system bindings.** An `Extension.systems` binding
+  (`ApplicationSystemBinding`) produces a `System` materialised once per
+  `Application`, after every core manager exists, registered on
+  `app.systems` — extensions can no longer only add renderers/assets/
+  serializers (#399).
+- **`Scene.interaction`/`Scene.audio` facades** (`SceneInteraction`,
+  `SceneAudio`) join the existing `Scene.inputs`/`Scene.tweens` — scene-scoped
+  pointer capture/observation and scene-scoped playback, both auto-cleaned up
+  on scene teardown and suspended/resumed across retention (#391).
+- **`PhysicsWorld.fixedUpdate()`** lets `@codexo/exojs-physics` register
+  directly as a system (`app.systems.add(world, { order: SystemOrder.Physics
+})`) instead of being stepped manually from `Scene.update()`.
+- **Scene-less applications.** `new Application({ /* no scenes */ })` +
+  `app.start()` runs the frame loop with no active scene at all —
+  `app.systems` still ticks and draws.
+
+### Changed
+
+- **BREAKING — `SceneManager` renamed `SceneDirector`, `app.scene` renamed
+  `app.scenes`.**
+- **BREAKING — scene construction and navigation are constructor-based, not
+  instance-based.** `app.start(new GameScene())` → `new Application({ scenes:
+{ game: GameScene } })` + `app.start(GameScene, data?)`;
+  `app.scene.setScene(instance, opts)` → `app.scenes.setScene(Ctor, data?,
+opts?)`; `setScene(null)` is gone (start another scene, or `app.stop()`).
+- **BREAKING — `scene.paused` is no longer a writable field.** Use
+  `app.scenes.pause()`/`resume()`; read `scene.state`.
+- **BREAKING — `load`/`init` hooks take `data`, not a `Loader`.**
+  `load(loader)`/`init(loader)` → `load(data)`/`init(data)`; access the
+  loader via `this.loader`/`this.app.loader`. `init()` must be synchronous
+  (a `Promise`-returning `init` is a dev-mode activation error) — move
+  asynchronous setup into `load()`.
+- **BREAKING — `System.destroy()` is optional**; a system implementing none
+  of `fixedUpdate`/`update`/`draw` is no longer valid (at least one phase is
+  required).
+- **BREAKING — user app systems no longer reserve order `100`-`500`.** Core
+  managers (input/interaction/audio/tweens/rendering) moved out of
+  `app.systems` into an internal prepare stage; any plain `order` value is
+  now safe for user systems.
+- **BREAKING — `scene.systems` is attach-gated.** Register scene systems from
+  `init()` — using `scene.systems` before the scene is attached now throws.
+- **`@codexo/exojs-physics`:** `PhysicsWorld` should be registered as a
+  system rather than stepped manually; `step()` remains available for
+  advanced manual driving.
+
+### Removed
+
+- **BREAKING — `super.destroy()` in a `Scene` subclass is no longer
+  necessary.** The base `Scene.destroy()` is now empty — existing
+  `super.destroy()` calls are harmless but can be deleted.
+
+### Fixed
+
+- **`SceneInteraction.suspend()`/`resume()`** now actually detach/reattach
+  observed roots and captures (previously no-op stubs) — a retained scene no
+  longer keeps receiving pointer dispatch alongside whichever scene is now
+  active.
+- **`SceneAudio.play()`** now gates playback requested while the scope is
+  `Preparing`, queuing it until the scene activates, instead of starting
+  audio for a scene that might never finish activating.
+
+### Docs
+
+- Migrated `examples/` and the `pause-menu`/`cinematics` recipe guides to the
+  v0.17 scene model; added a scene-less application example.
+
 ## [0.15.2] - 2026-07-04
 
 Bugfix release. Ten defects found by the coverage-fleet passes on the v0.16

--- a/docs/superpowers/plans/2026-07-23-v0.17-slice-g-migration-sweep.md
+++ b/docs/superpowers/plans/2026-07-23-v0.17-slice-g-migration-sweep.md
@@ -1,0 +1,2150 @@
+# v0.17 Slice G — Migration Sweep & Docs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close out the v0.17 core-runtime rework (Slices A–F, all merged): migrate `@codexo/exojs-physics` to a native `fixedUpdate()` system, fix two real spec-conformance gaps left behind by earlier slices (`SceneInteraction.suspend/resume`, `SceneAudio`'s `Preparing`-phase gate), add the JSDoc still missing on Slice B/D's new facade methods, sweep two stale example/guide files onto the new API, add a genuinely scene-less example (the DX gate's second showcase), and write the `CHANGELOG.md` v0.17 entry that Slices A–F never added.
+
+**Architecture:** No new subsystems. Every fix reuses an existing pattern already established elsewhere in the same file or a sibling facade: `PhysicsWorld.fixedUpdate()` is a thin wrapper extracted from the existing `step()` loop body; `SceneInteraction.suspend()/resume()` mirrors the reversible push/pop bookkeeping `_releaseCapture()` already does; `SceneAudio`'s Preparing-gate is a small `Voice`-shaped buffering class (`PendingVoice`) flushed once, from `SceneScope.activate()`, mirroring how `SceneInputs` already reads scope state via an injected `() => SceneState` callback.
+
+**Tech Stack:** TypeScript, Vitest, the ExoJS engine (`src/`), `@codexo/exojs-physics` (`packages/exojs-physics/`), the examples catalog (`examples/`, TS-authoritative + generated `.js`), the Astro guide site (`site/src/content/guide/`).
+
+## Global Constraints
+
+- Authoritative spec: `.workspace/specs/exojs-v0.17-final-core-spec/01-implementation-spec.md` §14 (migration inventory), §16 "Slice G" (lines 1055-1060), §17 (release gates). The historical `.workspace/specs/v0.17-core-runtime-model/04-implementation-spec.md` §14.3 is explicitly still-referenced for the physics migration only — do not use it for anything else. **`.workspace/` is gitignored and only exists in the long-lived primary checkout** (`C:\Users\User\Development\exojs`), not in a fresh worktree — read spec files via that absolute path if working from a new worktree.
+- Definition spec (`00-definition-spec.md`) §7.8: "Playback requested during `Preparing` remains gated until activation." §8.2 (implementation spec): `SceneInteraction.suspend()` "disables observations and deactivates captures without destroying them, preserving order; `resume()` restores both."
+- Examples: **`.ts` files are the authoritative source; sibling `.js` files are auto-generated** by `pnpm --filter site examples:sync` (`site/scripts/sync-examples-static.ts`) and must be committed alongside the `.ts` edit — never hand-edit a `.js` example file. `examples/examples.json` is the curated catalog (array order = display order, didactic not alphabetical).
+- Every touched public method needs JSDoc per this repo's convention: lead with what+why in 2-4 lines, no noise `@param`/`@returns`, `@internal` for exported-but-not-public, cross-reference with `{@link}`.
+- Do not touch `SceneManager`/`app.scene` naming or anything already shipped correctly in Slices A–F — this slice only closes the specific gaps enumerated below.
+- Physics package imports the engine via the published boundary (`@codexo/exojs`), never `#core/...` internal aliases — it's a separate package.
+- `pnpm typecheck:examples` / `pnpm typecheck:guides` / `pnpm docs:api:generate` / the full unit suite all gate the final commit (pre-push hook `verify:quick` runs all of them) — Task 10 runs them explicitly first so failures surface before the push, not during it.
+
+---
+
+### Task 1: `PhysicsWorld.fixedUpdate()` — native system support
+
+**Files:**
+
+- Modify: `packages/exojs-physics/src/PhysicsWorld.ts`
+- Test: `packages/exojs-physics/test/world.test.ts`
+
+**Interfaces:**
+
+- Produces: `PhysicsWorld.fixedUpdate(step: Time): void` — satisfies the engine's `System` interface (`fixedUpdate?(step: Time): void`), so `app.systems.add(world, { order: SystemOrder.Physics })` / `scene.systems.add(world, { order: SystemOrder.Physics })` works. Consumed by Task 2's example rewrite.
+- `step(frameDeltaSeconds: number): void` (existing, unchanged signature/behavior) stays as the manual/advanced path.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/exojs-physics/test/world.test.ts` (new `describe` block at the end of the file):
+
+```ts
+describe('PhysicsWorld.fixedUpdate()', () => {
+  it('advances exactly one fixed step per call, matching step() with a delta equal to fixedDelta', () => {
+    const worldA = new PhysicsWorld({ gravity: { x: 0, y: 900 } });
+    const bodyA = worldA.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [new Collider({ shape: new BoxShape(10, 10) })] }));
+
+    const worldB = new PhysicsWorld({ gravity: { x: 0, y: 900 } });
+    const bodyB = worldB.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [new Collider({ shape: new BoxShape(10, 10) })] }));
+
+    worldA.step(1 / 60);
+    worldB.fixedUpdate({ seconds: 1 / 60 } as never);
+
+    expect(bodyB.y).toBeCloseTo(bodyA.y, 10);
+    expect(bodyB.linearVelocityY).toBeCloseTo(bodyA.linearVelocityY, 10);
+  });
+
+  it('is a no-op-safe repeatable call: N fixedUpdate() calls match N step() calls of the same size', () => {
+    const worldA = new PhysicsWorld({ gravity: { x: 0, y: 900 } });
+    const bodyA = worldA.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [new Collider({ shape: new BoxShape(10, 10) })] }));
+
+    const worldB = new PhysicsWorld({ gravity: { x: 0, y: 900 } });
+    const bodyB = worldB.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [new Collider({ shape: new BoxShape(10, 10) })] }));
+
+    for (let i = 0; i < 5; i++) {
+      worldA.step(1 / 60);
+      worldB.fixedUpdate({ seconds: 1 / 60 } as never);
+    }
+
+    expect(bodyB.y).toBeCloseTo(bodyA.y, 8);
+  });
+
+  it('dispatches events after the step, same as step()', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 900 } });
+    const events: string[] = [];
+
+    world.onCollisionStart.add(() => events.push('start'));
+
+    const ground = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 100 }, colliders: [new Collider({ shape: new BoxShape(200, 20) })] }));
+    const box = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [new Collider({ shape: new BoxShape(10, 10) })] }));
+
+    void ground;
+    void box;
+
+    for (let i = 0; i < 60; i++) {
+      world.fixedUpdate({ seconds: 1 / 60 } as never);
+    }
+
+    expect(events).toContain('start');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @codexo/exojs-physics test -- world.test.ts`
+Expected: FAIL — `worldB.fixedUpdate is not a function`.
+
+- [ ] **Step 3: Extract the single-step body into a private helper**
+
+In `packages/exojs-physics/src/PhysicsWorld.ts`, the current `step()` method (lines 429-523) has this shape:
+
+```ts
+public step(frameDeltaSeconds: number): void {
+  this._assertAlive();
+
+  const steps = this.timeStepper.advance(frameDeltaSeconds);
+
+  if (steps > 0) {
+    const subStepCount = this.subStepCount;
+    const h = this.timeStepper.fixedDelta / subStepCount;
+    const gravityX = this.gravity.x;
+    const gravityY = this.gravity.y;
+    const contactHertz = this.contactHertz;
+    const dampingRatio = this.dampingRatio;
+    const hasJoints = this._joints.length > 0;
+    const hasBullets = this._hasBullets();
+
+    for (let step = 0; step < steps; step++) {
+      // Detection runs once per fixed step (collider geometry is already current
+      // from the previous frame's finalize / attach / setTransform). TGS-Soft
+      // reuses the manifolds across the sub-steps below.
+      this._backend.detect(this._colliders);
+
+      // Sleep decision runs after detection (islands need the current contact
+      // set) and before the solver (so sleeping contacts are skipped, and a
+      // sleeping island touched by an awake body is woken first).
+      if (this.enableSleeping) {
+        this._updateSleeping(this.timeStepper.fixedDelta);
+      }
+
+      this._backend.prepareSolve(h, contactHertz, dampingRatio);
+
+      if (hasJoints) {
+        this._prepareJoints(h);
+      }
+
+      if (hasBullets) {
+        this._recordBulletPositions();
+      }
+
+      for (let subStep = 0; subStep < subStepCount; subStep++) {
+        // Integrate gravity/forces over the sub-step (forces persist across
+        // sub-steps; cleared once per frame by `_finalizePosition`).
+        for (const body of this._bodies) {
+          body._integrateVelocity(h, gravityX, gravityY);
+        }
+
+        // Warm-start every sub-step (Box2D-v3 soft step): the relax pass leaves
+        // each contact's normal velocity at zero, so re-applying the
+        // accumulated impulse re-balances exactly this sub-step's gravity — the
+        // impulse converges to the per-sub-step load (m·h·g), not the per-frame
+        // load, which is what keeps tall stacks from pumping energy.
+        this._backend.warmStart();
+
+        if (hasJoints) {
+          this._warmStartJoints();
+        }
+
+        // Main soft-bias velocity solve, integrate positions (accumulating
+        // per-body delta), then the bias-free relax pass. Joints solve right
+        // after the contacts in each pass (contacts are the stiffer constraint).
+        this._backend.solveVelocities(true);
+
+        if (hasJoints) {
+          this._solveJoints(true);
+        }
+
+        for (const body of this._bodies) {
+          body._integratePosition(h);
+        }
+
+        this._backend.solveVelocities(false);
+
+        if (hasJoints) {
+          this._solveJoints(false);
+        }
+      }
+
+      // Separate restitution pass, then write the accumulated delta into each
+      // body's transform and re-sync collider geometry.
+      this._backend.applyRestitution();
+
+      for (const body of this._bodies) {
+        body._finalizePosition();
+      }
+
+      if (hasBullets) {
+        this._advanceBullets();
+      }
+    }
+
+    this._dispatchEvents();
+  }
+
+  this._bindings.sync();
+  this._drainCommands();
+}
+```
+
+Replace it with the same logic split into a private single-step helper plus two thin callers — a pure extraction, no behavioral change:
+
+```ts
+public step(frameDeltaSeconds: number): void {
+  this._assertAlive();
+
+  const steps = this.timeStepper.advance(frameDeltaSeconds);
+
+  if (steps > 0) {
+    const subStepCount = this.subStepCount;
+    const h = this.timeStepper.fixedDelta / subStepCount;
+    const gravityX = this.gravity.x;
+    const gravityY = this.gravity.y;
+    const contactHertz = this.contactHertz;
+    const dampingRatio = this.dampingRatio;
+    const hasJoints = this._joints.length > 0;
+    const hasBullets = this._hasBullets();
+
+    for (let step = 0; step < steps; step++) {
+      this._stepOnce(h, subStepCount, gravityX, gravityY, contactHertz, dampingRatio, hasJoints, hasBullets);
+    }
+
+    this._dispatchEvents();
+  }
+
+  this._bindings.sync();
+  this._drainCommands();
+}
+
+/**
+ * Advance by exactly one fixed step, driven directly by the engine's own
+ * fixed-timestep scheduler when this world is registered as a `System`
+ * (`app.systems.add(world, { order: SystemOrder.Physics })` or the scene
+ * equivalent) — bypasses {@link timeStepper}'s variable-delta accumulator
+ * entirely, since the caller has already decided exactly when a fixed step
+ * occurs. Prefer this over manual {@link step} once the world is
+ * system-registered; `step` remains available for advanced manual driving.
+ */
+public fixedUpdate(_step: Time): void {
+  this._assertAlive();
+
+  const subStepCount = this.subStepCount;
+  const h = this.timeStepper.fixedDelta / subStepCount;
+
+  this._stepOnce(h, subStepCount, this.gravity.x, this.gravity.y, this.contactHertz, this.dampingRatio, this._joints.length > 0, this._hasBullets());
+
+  this._dispatchEvents();
+  this._bindings.sync();
+  this._drainCommands();
+}
+
+private _stepOnce(
+  h: number,
+  subStepCount: number,
+  gravityX: number,
+  gravityY: number,
+  contactHertz: number,
+  dampingRatio: number,
+  hasJoints: boolean,
+  hasBullets: boolean,
+): void {
+  // Detection runs once per fixed step (collider geometry is already current
+  // from the previous frame's finalize / attach / setTransform). TGS-Soft
+  // reuses the manifolds across the sub-steps below.
+  this._backend.detect(this._colliders);
+
+  // Sleep decision runs after detection (islands need the current contact
+  // set) and before the solver (so sleeping contacts are skipped, and a
+  // sleeping island touched by an awake body is woken first).
+  if (this.enableSleeping) {
+    this._updateSleeping(this.timeStepper.fixedDelta);
+  }
+
+  this._backend.prepareSolve(h, contactHertz, dampingRatio);
+
+  if (hasJoints) {
+    this._prepareJoints(h);
+  }
+
+  if (hasBullets) {
+    this._recordBulletPositions();
+  }
+
+  for (let subStep = 0; subStep < subStepCount; subStep++) {
+    // Integrate gravity/forces over the sub-step (forces persist across
+    // sub-steps; cleared once per frame by `_finalizePosition`).
+    for (const body of this._bodies) {
+      body._integrateVelocity(h, gravityX, gravityY);
+    }
+
+    // Warm-start every sub-step (Box2D-v3 soft step): the relax pass leaves
+    // each contact's normal velocity at zero, so re-applying the
+    // accumulated impulse re-balances exactly this sub-step's gravity — the
+    // impulse converges to the per-sub-step load (m·h·g), not the per-frame
+    // load, which is what keeps tall stacks from pumping energy.
+    this._backend.warmStart();
+
+    if (hasJoints) {
+      this._warmStartJoints();
+    }
+
+    // Main soft-bias velocity solve, integrate positions (accumulating
+    // per-body delta), then the bias-free relax pass. Joints solve right
+    // after the contacts in each pass (contacts are the stiffer constraint).
+    this._backend.solveVelocities(true);
+
+    if (hasJoints) {
+      this._solveJoints(true);
+    }
+
+    for (const body of this._bodies) {
+      body._integratePosition(h);
+    }
+
+    this._backend.solveVelocities(false);
+
+    if (hasJoints) {
+      this._solveJoints(false);
+    }
+  }
+
+  // Separate restitution pass, then write the accumulated delta into each
+  // body's transform and re-sync collider geometry.
+  this._backend.applyRestitution();
+
+  for (const body of this._bodies) {
+    body._finalizePosition();
+  }
+
+  if (hasBullets) {
+    this._advanceBullets();
+  }
+}
+```
+
+Add the `Time` import at the top of the file (alongside the existing `import type { SceneNode } from '@codexo/exojs';`):
+
+```ts
+import type { SceneNode, Time } from '@codexo/exojs';
+```
+
+- [ ] **Step 4: Update `step()`'s doc comment**
+
+The doc comment above `step()` (currently lines 397-428) documents driving it from `Scene.fixedUpdate(delta)` or `Scene.update(delta)` manually. Replace the two bullet points describing driving styles:
+
+```
+   * - **`Scene.fixedUpdate(delta)`** (recommended) — the engine's own
+   *   fixed-timestep accumulator already calls this hook a constant number of
+   *   times per rendered frame, so `step` typically consumes exactly one
+   *   sub-step per call. This is the idiomatic hook and keeps physics in step
+   *   with any other fixed-rate game logic.
+   * - **`Scene.update(delta)`** — passing the raw, variable per-frame
+   *   `delta.seconds` straight from the render loop also works correctly:
+   *   `step`'s internal accumulator still produces exactly the right number of
+   *   fixed sub-steps (0, 1 or several) regardless of how irregular the calls
+   *   are. Useful when you don't want a `fixedUpdate` split for anything else.
+```
+
+with:
+
+```
+   * **Prefer registering the world as a system instead**
+   * (`app.systems.add(world, { order: SystemOrder.Physics })` or the scene
+   * equivalent) so {@link fixedUpdate} drives stepping directly from the
+   * engine's own fixed-timestep scheduler — one call per fixed step, no
+   * accumulator duplication. `step` remains available here for manual/advanced
+   * driving (e.g. a fixed-but-non-standard rate, or stepping outside the
+   * normal frame loop entirely): pass any delta and this accumulator converts
+   * it into the right number of fixed sub-steps (0, 1, or several, clamped by
+   * {@link PhysicsWorldOptions.maxSubSteps}).
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm --filter @codexo/exojs-physics test -- world.test.ts`
+Expected: PASS, including the 3 new tests. Also run the full physics package suite to confirm the pure extraction changed nothing: `pnpm --filter @codexo/exojs-physics test`
+Expected: PASS, no regressions.
+
+- [ ] **Step 6: Typecheck the package**
+
+Run: `pnpm --filter @codexo/exojs-physics typecheck`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/exojs-physics/src/PhysicsWorld.ts packages/exojs-physics/test/world.test.ts
+git commit -m "feat(physics): add native PhysicsWorld.fixedUpdate() for system registration (v0.17 Slice G)"
+```
+
+---
+
+### Task 2: Migrate the two physics examples off manual `step()`, fix illegal `async init()`
+
+**Files:**
+
+- Modify: `examples/physics/sprite-follows-body.ts`
+- Modify: `examples/physics/tiled-map-physics-actor.ts`
+
+**Interfaces:**
+
+- Consumes: `PhysicsWorld.fixedUpdate()` (Task 1), `SystemOrder.Physics` (already exists at `src/core/SystemOrder.ts`, re-exported from `@codexo/exojs`).
+
+**Context:** Both files currently declare `override async init(): Promise<void>` — forbidden under the v0.17 sync-`init()` rule (dev-mode throw in `SceneScope.prepare()`). Both also manually call `this.world.step(delta.seconds)` inside `update()`, which is no longer the idiomatic pattern now that `fixedUpdate()` exists.
+
+- [ ] **Step 1: Rewrite `sprite-follows-body.ts`**
+
+Replace the entire file content with:
+
+```ts
+import {
+  Application,
+  Asset,
+  Color,
+  type RenderingContext,
+  Scene,
+  Sprite,
+  SystemOrder,
+  Spritesheet,
+  type SpritesheetData,
+  type Time,
+  Vector,
+} from '@codexo/exojs';
+import { BoxShape, type PhysicsBody, PhysicsWorld } from '@codexo/exojs-physics';
+import { mountControls } from '@examples/runtime';
+
+// The minimal physics binding: `world.attach(node, { ... })` builds a body +
+// collider and binds it to the node in one call. Registering the world as a
+// system (`this.systems.add(this.world, { order: SystemOrder.Physics })`)
+// drives it from the engine's fixed-timestep scheduler — no manual step()
+// call needed. After every fixed step the body's position and rotation are
+// written onto the bound sprite, so the sprite simply "follows the body". A
+// static floor stops the falling actor.
+
+class SpriteFollowsBodyScene extends Scene {
+  private world!: PhysicsWorld;
+  private actor!: Sprite;
+  private actorBody!: PhysicsBody;
+  private floor!: Sprite;
+  private floorY = 0;
+  private settled = 0;
+  private hud!: ReturnType<typeof mountControls>;
+  private spritesheetData!: SpritesheetData;
+
+  override async load(): Promise<void> {
+    this.spritesheetData = (await this.loader.load(Asset.kind('json', assets.demo.spritesheets.platformerCharacters.data))) as SpritesheetData;
+  }
+
+  override init(): void {
+    const app = this.app;
+    if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+    const { width, height } = app.canvas;
+
+    // Gravity in px/s², +Y down — matches the engine's screen space.
+    this.world = new PhysicsWorld({ gravity: { x: 0, y: 1400 } });
+    this.systems.add(this.world, { order: SystemOrder.Physics });
+
+    const characters = new Spritesheet(this.loader.get(assets.demo.spritesheets.platformerCharacters.image), this.spritesheetData);
+
+    this.floorY = height - 80;
+
+    // ── Static floor ──────────────────────────────────────────────────
+    // A wide static body. `world.attach` binds it to the floor sprite, so
+    // the sprite is positioned from the body (no manual placement needed).
+    const floorWidth = width - 120;
+    const floorHeight = 48;
+
+    this.floor = new Sprite(this.loader.get(assets.demo.textures.pixelWhite)).setAnchor(0.5);
+    this.floor.width = floorWidth;
+    this.floor.height = floorHeight;
+    this.floor.tint = new Color(70, 92, 120);
+
+    this.world.attach(this.floor, {
+      type: 'static',
+      position: { x: width / 2, y: this.floorY },
+      shape: new BoxShape(floorWidth, floorHeight),
+    });
+
+    // ── Dynamic actor ─────────────────────────────────────────────────
+    // A dynamic body dropped from above. Its collider is a box sized to the
+    // character art; `world.attach` binds the sprite, so it falls, lands and
+    // tracks the body (position + rotation) every fixed step.
+    this.actor = characters.getFrameSprite('character_beige_front').setAnchor(0.5).setScale(1.1);
+    this.actorBody = this.world.attach(this.actor, {
+      type: 'dynamic',
+      position: { x: width / 2, y: 140 },
+      shape: new BoxShape(70, 90),
+      friction: 0.4,
+      restitution: 0.15,
+    });
+
+    // A small sideways nudge so the landing is visibly dynamic.
+    this.actorBody.applyImpulse(900, 0);
+
+    this.hud = mountControls({
+      title: 'Sprite Follows Body',
+      controls: [{ keys: 'Auto', action: 'actor falls and lands on the floor' }],
+      status: 'Dropping…',
+      hint: 'world.attach(sprite, { … }) creates a body + collider and binds it; the world, registered as a system, writes the body transform onto the sprite every fixed step.',
+    });
+  }
+
+  override update(delta: Time): void {
+    const app = this.app;
+    if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+
+    const { width, height } = app.canvas;
+    const body = this.actorBody;
+    const restingSpeed = Math.hypot(body.linearVelocityX, body.linearVelocityY);
+
+    if (body.y > this.floorY - 60 && restingSpeed < 6) {
+      this.settled += delta.seconds;
+    } else {
+      this.settled = 0;
+    }
+
+    this.hud.setStatus(this.settled > 0 ? `Resting on the floor (${restingSpeed.toFixed(0)} px/s)` : `Falling… y=${body.y.toFixed(0)} px`);
+
+    // Loop: after a short rest (or if it tumbles off-screen) drop it again.
+    if (this.settled > 1.2 || body.y > height + 200 || Math.abs(body.x - width / 2) > width) {
+      this.settled = 0;
+      body.setTransform(new Vector(width / 2, 140), (Math.random() - 0.5) * 0.6);
+      body.linearVelocityX = 0;
+      body.linearVelocityY = 0;
+      body.angularVelocity = 0;
+      body.applyImpulse((Math.random() - 0.5) * 1800, 0);
+    }
+  }
+
+  override draw(context: RenderingContext): void {
+    context.backend.clear();
+    context.render(this.floor);
+    context.render(this.actor);
+  }
+}
+
+const app = new Application({
+  scenes: { SpriteFollowsBodyScene },
+  canvas: {
+    width: 1280,
+    height: 720,
+    mount: document.body,
+    sizingMode: 'fit',
+  },
+  clearColor: new Color(18, 22, 33),
+});
+
+app.start(SpriteFollowsBodyScene);
+```
+
+- [ ] **Step 2: Rewrite `tiled-map-physics-actor.ts`'s `init()` into `load()`+`init()`, and register the world as a system**
+
+The current class fields block and `override async init(): Promise<void> {` opening (lines 27-37) become:
+
+```ts
+class TiledMapPhysicsActorScene extends Scene {
+    private world!: PhysicsWorld;
+    private mapNode!: TileMapNode;
+    private actor!: Sprite;
+    private actorBody!: PhysicsBody;
+    private debug!: PhysicsDebugDraw;
+    private hud!: ReturnType<typeof mountControls>;
+    private tilesTexture!: Awaited<ReturnType<typeof Asset.kind<'texture'>>> extends never ? never : Awaited<ReturnType<Application['loader']['load']>>;
+    private spritesheetData!: SpritesheetData;
+
+    override async load(): Promise<void> {
+        this.tilesTexture = await this.loader.load(Asset.kind('texture', assets.demo.tilesets.map.image));
+        this.spritesheetData = (await this.loader.load(Asset.kind('json', assets.demo.spritesheets.platformerCharacters.data))) as SpritesheetData;
+    }
+
+    override init(): void {
+        const app = this.app;
+        if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
+        this.world = new PhysicsWorld({ gravity: { x: 0, y: 1500 } });
+        this.systems.add(this.world, { order: SystemOrder.Physics });
+```
+
+The conditional type above for `tilesTexture` is unnecessarily convoluted — use the concrete return type instead. Check what `this.loader.load(Asset.kind('texture', ...))` resolves to (grep an existing example that stores this exact call's result in a typed field, e.g. `examples/sprites-textures/texture-loader.ts`, and use that same field type) rather than inventing a conditional type. Declare the field as:
+
+```ts
+    private tilesTexture!: Texture;
+```
+
+adding `Texture` to the top import from `@codexo/exojs` (verify the exact exported name via `grep "export.*class Texture" src/index.ts src/rendering/texture/*.ts` if `Texture` isn't already imported elsewhere in this file).
+
+Continue: replace the body's `const tilesTexture = await this.loader.load(...)` line with a reference to `this.tilesTexture`, and the later `const characters = new Spritesheet(this.loader.get(...), (await this.loader.load(...)) as SpritesheetData)` block with `const characters = new Spritesheet(this.loader.get(assets.demo.spritesheets.platformerCharacters.image), this.spritesheetData);`. Every other line in the body (tileset/layer/map construction, the object-layer bridge, `world.attach`, `PhysicsDebugDraw` construction) is unchanged — only the two awaited values move to `load()` and become field reads in `init()`.
+
+In `update()`, remove the line `this.world.step(delta.seconds);` — physics now advances via the system registration in `init()`. The rest of `update()` (the settle/reset logic reading `body.y`/`body.linearVelocityX` etc.) is unchanged: it still runs after the fixed step(s) for this frame have already advanced the body, so it observes the same up-to-date state as before.
+
+Add `SystemOrder` to the top-level import from `@codexo/exojs` (alongside `Application, Asset, Color, ...`).
+
+- [ ] **Step 3: Regenerate the `.js` siblings**
+
+Run: `cd site && pnpm examples:sync && cd ..`
+Expected: exits 0, rewrites `examples/physics/sprite-follows-body.js` and `examples/physics/tiled-map-physics-actor.js` with the `// Auto-generated from <name>.ts` header.
+
+- [ ] **Step 4: Typecheck the examples**
+
+Run: `pnpm typecheck:examples`
+Expected: no errors for either file. If `tilesTexture`'s type is wrong, fix it based on the actual compiler error (the loader's real return type) rather than guessing further.
+
+- [ ] **Step 5: Lint the generated JS**
+
+Run: `pnpm lint -- examples/physics/sprite-follows-body.js examples/physics/tiled-map-physics-actor.js`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add examples/physics/sprite-follows-body.ts examples/physics/sprite-follows-body.js examples/physics/tiled-map-physics-actor.ts examples/physics/tiled-map-physics-actor.js
+git commit -m "fix(examples): migrate physics examples to native fixedUpdate() + sync init() (v0.17 Slice G)"
+```
+
+---
+
+### Task 3: `SceneInteraction.suspend()`/`resume()` — real implementation
+
+**Files:**
+
+- Modify: `src/core/scene/SceneInteraction.ts`
+- Modify: `src/core/SceneScope.ts`
+- Modify: `test/core/scene/scene-interaction.test.ts`
+- Test: `test/core/scene-scope.test.ts`
+
+**Context:** `SceneScope.suspend()`/`restore()` (shipped in Slice E) already call `this.interaction.suspend()`/`resume()` expecting real behavior, but the methods are no-op stubs. Additionally, `SceneScope` itself never detaches the scene's own automatic root/UI attachment during suspend (only `SceneInteraction`'s `observe()`-tracked roots and captures are in scope for the facade) — without that, a suspended/retained scene's content stays interactive underneath whatever scene is now active, because `InteractionManager.attachRoot`/`detachRoot` register into a shared node registry, not a single-root slot (confirmed at `src/input/InteractionManager.ts:345-361`).
+
+- [ ] **Step 1: Write the failing tests — update the existing scaffold test, add new ones**
+
+In `test/core/scene/scene-interaction.test.ts`, replace the existing scaffold test:
+
+```ts
+test('suspend()/resume() do not throw and do not detach observations (scaffold for a later slice)', () => {
+  const app = createAppStub();
+  const interaction = new SceneInteraction(app);
+
+  interaction.observe(fakeRoot());
+
+  expect(() => interaction.suspend()).not.toThrow();
+  expect(() => interaction.resume()).not.toThrow();
+  expect(app.interaction.detachRoot).not.toHaveBeenCalled();
+});
+```
+
+with:
+
+```ts
+test('suspend() detaches every tracked observation without removing its tracking', () => {
+  const app = createAppStub();
+  const interaction = new SceneInteraction(app);
+  const root = fakeRoot();
+
+  interaction.observe(root);
+  interaction.suspend();
+
+  expect(app.interaction.detachRoot).toHaveBeenCalledWith(root);
+});
+
+test('resume() reattaches every observation suspend() detached', () => {
+  const app = createAppStub();
+  const interaction = new SceneInteraction(app);
+  const root = fakeRoot();
+
+  interaction.observe(root);
+  interaction.suspend();
+  interaction.resume();
+
+  expect(app.interaction.attachRoot).toHaveBeenCalledTimes(2); // once for observe(), once for resume()
+  expect(app.interaction.attachRoot).toHaveBeenLastCalledWith(root);
+});
+
+test('suspend() is idempotent — a second call does not detach again', () => {
+  const app = createAppStub();
+  const interaction = new SceneInteraction(app);
+
+  interaction.observe(fakeRoot());
+  interaction.suspend();
+  (app.interaction.detachRoot as MockInstance).mockClear();
+
+  interaction.suspend();
+
+  expect(app.interaction.detachRoot).not.toHaveBeenCalled();
+});
+
+test('resume() before any suspend() is a no-op', () => {
+  const app = createAppStub();
+  const interaction = new SceneInteraction(app);
+
+  interaction.observe(fakeRoot());
+  (app.interaction.attachRoot as MockInstance).mockClear();
+
+  interaction.resume();
+
+  expect(app.interaction.attachRoot).not.toHaveBeenCalled();
+});
+
+test('an observation released while suspended is not reattached by resume()', () => {
+  const app = createAppStub();
+  const interaction = new SceneInteraction(app);
+  const root = fakeRoot();
+
+  const observation = interaction.observe(root);
+  interaction.suspend();
+  observation.release();
+  (app.interaction.attachRoot as MockInstance).mockClear();
+
+  interaction.resume();
+
+  expect(app.interaction.attachRoot).not.toHaveBeenCalled();
+});
+```
+
+Add to the `describe('SceneInteraction.capture()', ...)` block:
+
+```ts
+test('suspend() pops every active capture; resume() re-pushes them in original order', () => {
+  const app = createAppStub();
+  const interaction = new SceneInteraction(app);
+  const rootA = fakeRoot();
+  const rootB = fakeRoot();
+
+  interaction.capture(rootA);
+  interaction.capture(rootB);
+  (app.interaction.pushInputCapture as MockInstance).mockClear();
+
+  interaction.suspend();
+  expect(app.interaction.popInputCapture).toHaveBeenCalledTimes(2);
+
+  interaction.resume();
+  expect(app.interaction.pushInputCapture).toHaveBeenNthCalledWith(1, rootA);
+  expect(app.interaction.pushInputCapture).toHaveBeenNthCalledWith(2, rootB);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run test/core/scene/scene-interaction.test.ts --reporter=dot`
+Expected: FAIL — the new `suspend()`/`resume()` assertions see zero calls, since the stubs do nothing.
+
+- [ ] **Step 3: Implement real `suspend()`/`resume()` in `SceneInteraction`**
+
+In `src/core/scene/SceneInteraction.ts`, add a `_suspended` field near the existing `_observations`/`_captures` fields:
+
+```ts
+  private readonly _observations = new Set<TrackedObservation>();
+  private readonly _captures: TrackedCapture[] = [];
+  private _suspended = false;
+```
+
+Replace the stub methods:
+
+```ts
+  /**
+   * Disable every tracked observation without detaching it. Reserved for
+   * retention (retained scenes must not keep receiving pointer dispatch
+   * alongside whichever scope is now active). Idempotent.
+   * @internal
+   */
+  public suspend(): void {
+    // Wired by a later slice alongside retained-scene suspension.
+  }
+
+  /** Restore normal dispatch after {@link SceneInteraction.suspend}. @internal */
+  public resume(): void {
+    // Wired by a later slice alongside retained-scene suspension.
+  }
+```
+
+with:
+
+```ts
+  /**
+   * Detach every tracked observation and deactivate every capture (pop it
+   * from the manager's stack) without discarding local tracking, so
+   * {@link SceneInteraction.resume} can restore exactly the same set in the
+   * same order — a retained scene must not keep receiving pointer dispatch
+   * alongside whichever scope is now active (definition §8.2). Idempotent.
+   * @internal
+   */
+  public suspend(): void {
+    if (this._suspended) {
+      return;
+    }
+
+    this._suspended = true;
+
+    for (const observation of this._observations) {
+      this._app.interaction.detachRoot(observation.root);
+    }
+
+    for (let i = this._captures.length - 1; i >= 0; i--) {
+      this._app.interaction.popInputCapture();
+    }
+  }
+
+  /**
+   * Reattach every tracked observation and re-push every tracked capture in
+   * its original order, undoing {@link SceneInteraction.suspend}. Idempotent
+   * — a no-op if not currently suspended.
+   * @internal
+   */
+  public resume(): void {
+    if (!this._suspended) {
+      return;
+    }
+
+    this._suspended = false;
+
+    for (const observation of this._observations) {
+      this._app.interaction.attachRoot(observation.root);
+    }
+
+    for (const capture of this._captures) {
+      this._app.interaction.pushInputCapture(capture.root);
+    }
+  }
+```
+
+- [ ] **Step 4: Run the SceneInteraction tests to verify they pass**
+
+Run: `pnpm vitest run test/core/scene/scene-interaction.test.ts --reporter=dot`
+Expected: PASS, all tests including the new ones.
+
+- [ ] **Step 5: Extract shared root-attach/detach helpers in `SceneScope`, then add suspend/restore handling for the scene's own root+UI**
+
+In `src/core/SceneScope.ts`, `prepare()` currently attaches the automatic root/UI inline:
+
+```ts
+this._app.interaction.attachRoot(this.scene.root);
+
+const ui = this.scene._peekUI();
+
+if (ui !== null) {
+  this._app.interaction.attachUIRoot(ui);
+}
+
+this._rootsAttached = true;
+this.scene.onLoad.dispatch();
+```
+
+and `_detachRoots()` currently reads:
+
+```ts
+  private _detachRoots(): void {
+    if (!this._rootsAttached) {
+      return;
+    }
+
+    this._rootsAttached = false;
+
+    const ui = this.scene._peekUI();
+
+    if (ui !== null) {
+      this._app.interaction.detachUIRoot(ui);
+    }
+
+    this._app.interaction.detachRoot(this.scene.root);
+  }
+```
+
+Extract two private helpers (pure refactor of the above, no behavior change) — add these near `_detachRoots()`:
+
+```ts
+  private _attachAutoRoots(): void {
+    this._app.interaction.attachRoot(this.scene.root);
+
+    const ui = this.scene._peekUI();
+
+    if (ui !== null) {
+      this._app.interaction.attachUIRoot(ui);
+    }
+  }
+
+  private _detachAutoRoots(): void {
+    const ui = this.scene._peekUI();
+
+    if (ui !== null) {
+      this._app.interaction.detachUIRoot(ui);
+    }
+
+    this._app.interaction.detachRoot(this.scene.root);
+  }
+```
+
+Update `prepare()`'s attach block to call the new helper:
+
+```ts
+this._attachAutoRoots();
+
+this._rootsAttached = true;
+this.scene.onLoad.dispatch();
+```
+
+Update `_detachRoots()` to call the new helper:
+
+```ts
+  private _detachRoots(): void {
+    if (!this._rootsAttached) {
+      return;
+    }
+
+    this._rootsAttached = false;
+    this._detachAutoRoots();
+  }
+```
+
+Now update `suspend()`/`restore()` to detach/reattach the automatic root+UI too, guarded by `_rootsAttached` but WITHOUT touching that flag (permanent-teardown eligibility must be unaffected by a suspend/restore cycle). Current `suspend()`:
+
+```ts
+  public suspend(): boolean {
+    if (!canSuspend(this._state)) {
+      return false;
+    }
+
+    this._visibleStateBeforeSuspend = this._state as SceneState.Active | SceneState.Paused;
+    this._state = SceneState.Suspended;
+
+    const errors: unknown[] = [];
+
+    this._guard(errors, () => this.inputs.suspend());
+    this._guard(errors, () => this.interaction.suspend());
+    this._guard(errors, () => this.tweens.suspend());
+    this._guard(errors, () => this.audio.suspend());
+
+    this._reportErrors(errors);
+
+    return true;
+  }
+```
+
+becomes:
+
+```ts
+  public suspend(): boolean {
+    if (!canSuspend(this._state)) {
+      return false;
+    }
+
+    this._visibleStateBeforeSuspend = this._state as SceneState.Active | SceneState.Paused;
+    this._state = SceneState.Suspended;
+
+    const errors: unknown[] = [];
+
+    this._guard(errors, () => this.inputs.suspend());
+    this._guard(errors, () => this.interaction.suspend());
+    this._guard(errors, () => {
+      if (this._rootsAttached) {
+        this._detachAutoRoots();
+      }
+    });
+    this._guard(errors, () => this.tweens.suspend());
+    this._guard(errors, () => this.audio.suspend());
+
+    this._reportErrors(errors);
+
+    return true;
+  }
+```
+
+Current `restore()`:
+
+```ts
+  public restore(): boolean {
+    if (!canRestore(this._state) || this._visibleStateBeforeSuspend === null) {
+      return false;
+    }
+
+    this._state = this._visibleStateBeforeSuspend;
+    this._visibleStateBeforeSuspend = null;
+
+    const errors: unknown[] = [];
+
+    this._guard(errors, () => this.inputs.resume());
+    this._guard(errors, () => this.interaction.resume());
+    this._guard(errors, () => this.tweens.resume());
+    this._guard(errors, () => this.audio.resume());
+
+    this._reportErrors(errors);
+
+    return true;
+  }
+```
+
+becomes:
+
+```ts
+  public restore(): boolean {
+    if (!canRestore(this._state) || this._visibleStateBeforeSuspend === null) {
+      return false;
+    }
+
+    this._state = this._visibleStateBeforeSuspend;
+    this._visibleStateBeforeSuspend = null;
+
+    const errors: unknown[] = [];
+
+    this._guard(errors, () => this.inputs.resume());
+    this._guard(errors, () => this.interaction.resume());
+    this._guard(errors, () => {
+      if (this._rootsAttached) {
+        this._attachAutoRoots();
+      }
+    });
+    this._guard(errors, () => this.tweens.resume());
+    this._guard(errors, () => this.audio.resume());
+
+    this._reportErrors(errors);
+
+    return true;
+  }
+```
+
+- [ ] **Step 6: Write a new test for the SceneScope-level root suspend/restore**
+
+Read `test/core/scene-scope.test.ts` first to match its existing app/interaction stub conventions exactly (it already has suspend/restore tests from Slice E). Add a test in the `suspend()`/`restore()` describe block:
+
+```ts
+  test('suspend() detaches the scene root from interaction, restore() reattaches it', () => {
+    const { scope, app } = /* use this file's existing scope-construction helper, activating the scope first */;
+
+    scope.suspend();
+    expect(app.interaction.detachRoot).toHaveBeenCalledWith(scope.scene.root);
+
+    (app.interaction.attachRoot as MockInstance).mockClear();
+    scope.restore();
+    expect(app.interaction.attachRoot).toHaveBeenCalledWith(scope.scene.root);
+  });
+```
+
+Adapt the exact helper/setup calls to whatever pattern `test/core/scene-scope.test.ts` already uses for constructing an activated `SceneScope` with a mocked `Application` — do not invent a new harness shape; match the file's existing style precisely (read the file's first 60 lines and its nearest existing `suspend()` test before writing this one).
+
+- [ ] **Step 7: Run the full SceneScope test file**
+
+Run: `pnpm vitest run test/core/scene-scope.test.ts test/core/scene/scene-interaction.test.ts --reporter=dot`
+Expected: PASS, no regressions, new tests green.
+
+- [ ] **Step 8: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/core/scene/SceneInteraction.ts src/core/SceneScope.ts test/core/scene/scene-interaction.test.ts test/core/scene-scope.test.ts
+git commit -m "fix(core): real SceneInteraction suspend/resume + detach scene root on retention suspend (v0.17 Slice G)"
+```
+
+---
+
+### Task 4: `SceneAudio` — gate playback during `Preparing`
+
+**Files:**
+
+- Modify: `src/core/scene/SceneAudio.ts`
+- Modify: `src/core/SceneScope.ts`
+- Modify: `test/core/scene/scene-audio.test.ts`
+
+**Context:** Per definition spec §7.8, "Playback requested during `Preparing` remains gated until activation." Currently `SceneAudio.play()` calls `this._app.audio.play(...)` immediately regardless of scope state. `play()` must return a `Voice` synchronously even during `Preparing`, so a `PendingVoice` stand-in buffers `volume`/`bus`/effect writes and starts the real voice once the scope activates.
+
+**Interfaces:**
+
+- Produces: `SceneAudio` constructor gains a second parameter `getState: () => SceneState` (mirrors `SceneInputs`'s existing constructor shape) — `SceneScope` passes `() => this._state`, same as it already does for `SceneInputs`.
+- Produces: `SceneAudio._flushPending(): void` (`@internal`) — called once by `SceneScope.activate()`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Read `test/core/scene/scene-audio.test.ts` first (already inspected: `makeVoice`/`makePausableVoice`/`createAppStub` helpers). Add a new `describe` block at the end of the file:
+
+```ts
+describe('SceneAudio — Preparing gate', () => {
+  test('play() during Preparing does not call app.audio.play yet', () => {
+    const voice = makeVoice();
+    const app = createAppStub(voice);
+    const audio = new SceneAudio(app, () => SceneState.Preparing);
+
+    audio.play(fakePlayable);
+
+    expect(app.audio.play).not.toHaveBeenCalled();
+  });
+
+  test('play() during Preparing returns a Voice-shaped stand-in synchronously', () => {
+    const voice = makeVoice();
+    const app = createAppStub(voice);
+    const audio = new SceneAudio(app, () => SceneState.Preparing);
+
+    const pending = audio.play(fakePlayable);
+
+    expect(pending.ended).toBe(false);
+    expect(typeof pending.stop).toBe('function');
+    expect(typeof pending.fade).toBe('function');
+  });
+
+  test('_flushPending() starts every voice queued during Preparing, applying buffered volume', () => {
+    const voice = makeVoice({ volume: 1 });
+    const app = createAppStub(voice);
+    const audio = new SceneAudio(app, () => SceneState.Preparing);
+
+    const pending = audio.play(fakePlayable, { volume: 0.5 });
+    pending.volume = 0.3;
+
+    audio._flushPending();
+
+    expect(app.audio.play).toHaveBeenCalledTimes(1);
+    expect(voice.volume).toBe(0.3);
+  });
+
+  test('stop() before flush cancels playback — the real voice is never created', () => {
+    const voice = makeVoice();
+    const app = createAppStub(voice);
+    const audio = new SceneAudio(app, () => SceneState.Preparing);
+
+    const pending = audio.play(fakePlayable);
+    pending.stop();
+    audio._flushPending();
+
+    expect(app.audio.play).not.toHaveBeenCalled();
+    expect(pending.ended).toBe(true);
+  });
+
+  test('stop() before flush fires onEnd exactly once', () => {
+    const voice = makeVoice();
+    const app = createAppStub(voice);
+    const audio = new SceneAudio(app, () => SceneState.Preparing);
+    const pending = audio.play(fakePlayable);
+    const onEnd = vi.fn();
+
+    pending.onEnd.add(onEnd);
+    pending.stop();
+    pending.stop();
+
+    expect(onEnd).toHaveBeenCalledTimes(1);
+  });
+
+  test('play() once Active bypasses the gate entirely', () => {
+    const voice = makeVoice();
+    const app = createAppStub(voice);
+    const audio = new SceneAudio(app, () => SceneState.Active);
+
+    const result = audio.play(fakePlayable);
+
+    expect(app.audio.play).toHaveBeenCalledTimes(1);
+    expect(result).toBe(voice);
+  });
+
+  test('destroy() cancels any still-pending (never-flushed) voice', () => {
+    const voice = makeVoice();
+    const app = createAppStub(voice);
+    const audio = new SceneAudio(app, () => SceneState.Preparing);
+
+    const pending = audio.play(fakePlayable);
+    audio.destroy();
+
+    expect(pending.ended).toBe(true);
+    expect(app.audio.play).not.toHaveBeenCalled();
+  });
+});
+```
+
+Add the necessary new import at the top of the test file: `import { SceneState } from '#core/SceneState';`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run test/core/scene/scene-audio.test.ts --reporter=dot`
+Expected: FAIL — `new SceneAudio(app, () => SceneState.Preparing)` doesn't match the current one-argument constructor (TS error before even running, or a runtime mismatch if test types loosely) and none of the gating behavior exists.
+
+- [ ] **Step 3: Implement `PendingVoice` and the Preparing-gate in `SceneAudio`**
+
+Replace the full content of `src/core/scene/SceneAudio.ts` with:
+
+```ts
+import type { AudioBus } from '#audio/AudioBus';
+import { getAudioContext } from '#audio/audio-context';
+import type { AudioEffect } from '#audio/AudioEffect';
+import type { Pausable, Playable, PlayOptions, Voice } from '#audio/Playable';
+import type { Application } from '#core/Application';
+import { SceneState } from '#core/SceneState';
+import { Signal } from '#core/Signal';
+import type { Destroyable } from '#core/types';
+
+const isPausable = (voice: Voice): voice is Voice & Pausable => 'pause' in voice && 'resume' in voice;
+
+/**
+ * Stand-in {@link Voice} returned by {@link SceneAudio.play} while the owning
+ * scope is still `Preparing` (definition §7.8). Buffers `volume`/`bus`/effect
+ * writes and replays them onto the real voice once {@link PendingVoice._flush}
+ * runs at activation; `stop()` before flush cancels playback entirely — the
+ * real voice is never created. Narrower than a real `Voice`: capability
+ * mixins (`Pausable`, `Seekable`, …) are unavailable until flush, and reading
+ * `bus` before flush returns `undefined` (despite the type) unless an
+ * explicit `options.bus` override was given — the manager's default bus
+ * isn't resolvable until the real voice exists. A documented limitation of
+ * Preparing-phase playback, not a general `Voice` capability.
+ * @internal
+ */
+class PendingVoice implements Voice {
+  private _real: Voice | null = null;
+  private _cancelled = false;
+  private _volume: number;
+  private _bus: AudioBus | undefined;
+  private readonly _pendingEffects: AudioEffect[] = [];
+  private readonly _dummyOutput: AudioNode;
+  public readonly onEnd = new Signal();
+
+  public constructor(
+    private readonly _createReal: () => Voice,
+    options: PlayOptions,
+  ) {
+    this._volume = options.volume ?? 1;
+    this._bus = options.bus;
+    this._dummyOutput = getAudioContext().createGain();
+  }
+
+  public get ended(): boolean {
+    return this._real?.ended ?? this._cancelled;
+  }
+
+  public get output(): AudioNode {
+    return this._real?.output ?? this._dummyOutput;
+  }
+
+  public get volume(): number {
+    return this._real?.volume ?? this._volume;
+  }
+
+  public set volume(value: number) {
+    this._volume = value;
+
+    if (this._real) {
+      this._real.volume = value;
+    }
+  }
+
+  public get bus(): AudioBus {
+    return this._real?.bus ?? (this._bus as AudioBus);
+  }
+
+  public set bus(value: AudioBus) {
+    this._bus = value;
+
+    if (this._real) {
+      this._real.bus = value;
+    }
+  }
+
+  public fade(to: number, ms: number): void {
+    if (this._real) {
+      this._real.fade(to, ms);
+    } else {
+      // Nothing is playing yet — best effort is to apply the target volume
+      // immediately once flushed; the ramp itself has nothing to animate.
+      this._volume = to;
+    }
+  }
+
+  public stop(fadeMs?: number): void {
+    if (this._real) {
+      this._real.stop(fadeMs);
+
+      return;
+    }
+
+    if (!this._cancelled) {
+      this._cancelled = true;
+      this.onEnd.dispatch();
+    }
+  }
+
+  public addEffect(effect: AudioEffect): this {
+    if (this._real) {
+      this._real.addEffect(effect);
+    } else {
+      this._pendingEffects.push(effect);
+    }
+
+    return this;
+  }
+
+  public removeEffect(effect: AudioEffect): this {
+    if (this._real) {
+      this._real.removeEffect(effect);
+    } else {
+      const index = this._pendingEffects.indexOf(effect);
+
+      if (index !== -1) {
+        this._pendingEffects.splice(index, 1);
+      }
+    }
+
+    return this;
+  }
+
+  /** Start real playback. No-op if already flushed or cancelled via {@link PendingVoice.stop}. */
+  public _flush(): void {
+    if (this._cancelled || this._real !== null) {
+      return;
+    }
+
+    const real = this._createReal();
+
+    this._real = real;
+    real.volume = this._volume;
+
+    if (this._bus !== undefined) {
+      real.bus = this._bus;
+    }
+
+    for (const effect of this._pendingEffects) {
+      real.addEffect(effect);
+    }
+
+    this._pendingEffects.length = 0;
+    real.onEnd.add(() => this.onEnd.dispatch());
+  }
+}
+
+/**
+ * Scene-bound audio facade. Playback started or added here uses scene
+ * lifetime: every tracked {@link Voice} is stopped when the owning scene ends
+ * permanently. Access via {@link Scene.audio}.
+ *
+ * Delegates entirely to `app.audio` — no second audio graph, just tracking of
+ * what this facade started so it can stop it on teardown (and, for capable
+ * voices, pause/resume it across retention suspension). Playback requested
+ * while the scope is `Preparing` is queued and started once the scope
+ * activates (definition §7.8) — see {@link PendingVoice}.
+ */
+export class SceneAudio implements Destroyable {
+  private readonly _tracked = new Set<Voice>();
+  private readonly _pending = new Set<PendingVoice>();
+  private _suspended: Set<Voice & Pausable> | null = null;
+
+  public constructor(
+    private readonly _app: Application,
+    private readonly _getState: () => SceneState,
+  ) {}
+
+  /**
+   * Play `source` through the application audio manager and track the
+   * resulting {@link Voice} for scene-lifetime cleanup. While the scope is
+   * `Preparing`, returns a {@link PendingVoice} stand-in immediately and
+   * defers the real `app.audio.play(...)` call until activation.
+   */
+  public play(source: Playable, options?: PlayOptions): Voice {
+    if (this._getState() === SceneState.Preparing) {
+      const pending = new PendingVoice(() => this._app.audio.play(source, options ?? {}), options ?? {});
+
+      this._pending.add(pending);
+      this._tracked.add(pending);
+
+      return pending;
+    }
+
+    return this.add(this._app.audio.play(source, options));
+  }
+
+  /** Track an already-created {@link Voice} (e.g. from `app.audio.play(...)`) for scene-lifetime cleanup. Returns it unchanged. */
+  public add(voice: Voice): Voice {
+    this._tracked.add(voice);
+
+    return voice;
+  }
+
+  /**
+   * Start every voice queued by {@link SceneAudio.play} while the scope was
+   * `Preparing`. Called once, by {@link SceneScope.activate}.
+   * @internal
+   */
+  public _flushPending(): void {
+    for (const pending of this._pending) {
+      pending._flush();
+    }
+
+    this._pending.clear();
+  }
+
+  /**
+   * Pause every tracked, currently-playing {@link Pausable} voice, recording
+   * exactly that set so {@link SceneAudio.resume} can restore it. Reserved
+   * for retention suspension — voices without pause support are left
+   * playing, matching the definition's "suspended where supported" contract.
+   * @internal
+   */
+  public suspend(): void {
+    const playing = new Set<Voice & Pausable>();
+
+    for (const voice of this._tracked) {
+      if (!voice.ended && isPausable(voice) && !voice.paused) {
+        voice.pause();
+        playing.add(voice);
+      }
+    }
+
+    this._suspended = playing;
+  }
+
+  /** Resume exactly the voices paused by {@link SceneAudio.suspend}. @internal */
+  public resume(): void {
+    if (this._suspended === null) {
+      return;
+    }
+
+    for (const voice of this._suspended) {
+      if (!voice.ended) {
+        voice.resume();
+      }
+    }
+
+    this._suspended = null;
+  }
+
+  public destroy(): void {
+    for (const voice of this._tracked) {
+      voice.stop();
+    }
+
+    this._tracked.clear();
+    this._suspended = null;
+    this._pending.clear();
+  }
+}
+```
+
+Note `play()` now adds the `PendingVoice` to `_tracked` too (so `destroy()`'s existing `for (const voice of this._tracked) voice.stop();` loop naturally cancels any never-flushed pending voice via `PendingVoice.stop()` — no separate pending-cleanup loop needed in `destroy()`, simpler than the original plan sketch).
+
+- [ ] **Step 4: Update `SceneScope` to pass the state getter and flush on activation**
+
+In `src/core/SceneScope.ts`, the constructor currently reads:
+
+```ts
+this.audio = new SceneAudio(app);
+```
+
+Change to:
+
+```ts
+this.audio = new SceneAudio(app, () => this._state);
+```
+
+`activate()` currently reads:
+
+```ts
+  public activate(): void {
+    this._state = SceneState.Active;
+  }
+```
+
+Change to:
+
+```ts
+  public activate(): void {
+    this._state = SceneState.Active;
+    this.audio._flushPending();
+  }
+```
+
+- [ ] **Step 5: Run the SceneAudio tests to verify they pass**
+
+Run: `pnpm vitest run test/core/scene/scene-audio.test.ts --reporter=dot`
+Expected: PASS, all tests including the 7 new ones. Note the existing tests in this file construct `new SceneAudio(app)` with one argument — since the constructor now requires two, every existing call site in this test file needs `() => SceneState.Active` added as the second argument (the pre-existing tests all assume immediate playback, i.e., Active). Update every `new SceneAudio(app` call in the file to `new SceneAudio(app, () => SceneState.Active`.
+
+- [ ] **Step 6: Run the full scene-scope test file**
+
+Run: `pnpm vitest run test/core/scene-scope.test.ts --reporter=dot`
+Expected: PASS — the constructor call there also needs no change (SceneScope constructs `SceneAudio` internally), but confirm no regression.
+
+- [ ] **Step 7: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/core/scene/SceneAudio.ts src/core/SceneScope.ts test/core/scene/scene-audio.test.ts
+git commit -m "fix(core): gate SceneAudio playback during Preparing via PendingVoice (v0.17 Slice G)"
+```
+
+---
+
+### Task 5: JSDoc — `SceneScope`, `SceneInputs`, `SceneTweens`
+
+**Files:**
+
+- Modify: `src/core/SceneScope.ts`
+- Modify: `src/core/scene/SceneInputs.ts`
+- Modify: `src/core/scene/SceneTweens.ts`
+
+No tests — pure documentation addition, verified by `pnpm docs:api:generate` picking up the new content and `pnpm typecheck` staying clean (JSDoc changes can't break types, but a stray unclosed comment would).
+
+- [ ] **Step 1: Document `SceneScope.fixedUpdate`/`update`/`draw`**
+
+In `src/core/SceneScope.ts`, add a doc comment above each of the three frame methods (the class itself is `@internal`, but these are the exact methods `SceneDirector` forwards every frame to, worth documenting for anyone reading the internal implementation).
+
+Above `public fixedUpdate(step: Time): void {`:
+
+```ts
+/**
+ * Forward one fixed step to the scene and its systems, gated to `Active`
+ * (§3 state table — `fixedUpdate` never runs while `Paused`, unlike
+ * {@link SceneScope.draw}). Warns (dev-only) if `Scene.fixedUpdate` returns
+ * a thenable — the hook must be synchronous.
+ */
+```
+
+Above `public update(delta: Time): void {`:
+
+```ts
+/**
+ * Forward one frame's update to the scene and its systems, gated to
+ * `Active`. Warns (dev-only) if `Scene.update` returns a thenable — the
+ * hook must be synchronous.
+ */
+```
+
+Above `public draw(context: RenderingContext): void {`:
+
+```ts
+/**
+ * Forward one frame's draw to the scene, its systems, then the UI layer —
+ * gated to `Active` or `Paused` (a paused scene keeps rendering while
+ * simulation is frozen). Warns (dev-only) if `Scene.draw` returns a
+ * thenable — the hook must be synchronous.
+ */
+```
+
+- [ ] **Step 2: Document `SceneInputs`'s four factory methods and `destroy()`**
+
+In `src/core/scene/SceneInputs.ts`, above `public onStart(...)`:
+
+```ts
+/**
+ * Fire `callback` on the channel's press edge (value crosses above the
+ * threshold), gated by `options.when` (default `'active'`) and the
+ * director's transition gate. Unbound automatically when the owning scene
+ * ends permanently.
+ */
+```
+
+Above `public onActive(...)`:
+
+```ts
+/** Fire `callback` every frame the channel stays held above the threshold, same `when`/edge-rule gating as {@link SceneInputs.onStart}. */
+```
+
+Above `public onStop(...)`:
+
+```ts
+/** Fire `callback` on the channel's release edge, same `when`/edge-rule gating as {@link SceneInputs.onStart}. */
+```
+
+Above `public onTrigger(...)`:
+
+```ts
+/**
+ * Fire `callback` once a press-then-release completes within the
+ * threshold window — a "tap" or "click" gesture. Both the press and
+ * release edges must have occurred in a `when`-allowed state for the
+ * trigger to fire (definition §13.2): pressing while allowed, then the
+ * scene pausing before release, does not trigger.
+ */
+```
+
+Above `public destroy(): void {`:
+
+```ts
+/** Unbind every tracked binding. Called automatically when the owning scene ends permanently. */
+```
+
+- [ ] **Step 3: Document `SceneTweens.create`/`add`**
+
+In `src/core/scene/SceneTweens.ts`, above `public create<T extends object>(target: T): Tween<T> {`:
+
+```ts
+/** Create a {@link Tween} targeting `target` through the application tween manager, tracked for scene-lifetime cleanup. */
+```
+
+Above `public add(tween: Tween): this {`:
+
+```ts
+/** Track an already-created {@link Tween} (e.g. built via `app.tweens.create(...)`) for scene-lifetime cleanup. Returns `this` for chaining. */
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/SceneScope.ts src/core/scene/SceneInputs.ts src/core/scene/SceneTweens.ts
+git commit -m "docs(core): add missing JSDoc for SceneScope frame methods, SceneInputs factories, SceneTweens (v0.17 Slice G)"
+```
+
+---
+
+### Task 6: New scene-less example (DX gate, second showcase)
+
+**Files:**
+
+- Create: `examples/application-scenes/scene-less-app.ts`
+- Create (generated): `examples/application-scenes/scene-less-app.js`
+- Modify: `examples/examples.json`
+
+**Context:** No example in the repo currently demonstrates `app.start()` with zero scenes registered — the spec's DX gate explicitly wants one such example. `Application.systems` ticks and draws regardless of whether any scene is active, so a scene-less app can render entirely through an app-level system.
+
+- [ ] **Step 1: Create the example**
+
+Write `examples/application-scenes/scene-less-app.ts`:
+
+```ts
+import { Application, Color, Graphics, type RenderingContext } from '@codexo/exojs';
+
+// A scene-less Application: no Scene is ever registered or started. All
+// frame work happens through a single app-level system — useful for utility
+// apps, splash/loading screens, or anything that doesn't need scene
+// lifecycle, retention, or navigation.
+
+const app = new Application({
+  canvas: {
+    width: 1280,
+    height: 720,
+    mount: document.body,
+    sizingMode: 'fit',
+  },
+  clearColor: new Color(18, 22, 33),
+});
+
+const square = new Graphics();
+square.fillColor = new Color(90, 160, 255);
+square.drawRectangle(-40, -40, 80, 80);
+square.setPosition(app.canvas.width / 2, app.canvas.height / 2);
+
+let angle = 0;
+
+app.systems.add({
+  update(delta) {
+    angle += delta.seconds;
+    square.rotation = angle * 40;
+  },
+  draw(context: RenderingContext) {
+    context.backend.clear();
+    context.render(square);
+  },
+});
+
+app.start();
+```
+
+- [ ] **Step 2: Add the catalog entry**
+
+In `examples/examples.json`, the `"application-scenes"` array currently starts:
+
+```json
+    "application-scenes": [
+        {
+            "slug": "scene-lifecycle",
+```
+
+Insert a new first entry before `scene-lifecycle` (this is the most minimal starting point — didactically before the lifecycle walkthrough):
+
+```json
+    "application-scenes": [
+        {
+            "slug": "scene-less-app",
+            "path": "application-scenes/scene-less-app.js",
+            "language": "typescript",
+            "title": "Scene-less App",
+            "description": "Run an Application with no Scene at all — a single app-level system drives update and draw directly, useful for utility apps and splash screens.",
+            "backend": "core",
+            "tags": [
+                "application",
+                "systems"
+            ],
+            "level": "intro"
+        },
+        {
+            "slug": "scene-lifecycle",
+```
+
+- [ ] **Step 3: Regenerate the `.js` sibling**
+
+Run: `cd site && pnpm examples:sync && cd ..`
+Expected: exits 0, creates `examples/application-scenes/scene-less-app.js`.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `pnpm typecheck:examples`
+Expected: no errors.
+
+- [ ] **Step 5: Lint**
+
+Run: `pnpm lint -- examples/application-scenes/scene-less-app.js`
+Expected: no errors.
+
+- [ ] **Step 6: Verify the catalog sync script**
+
+Run: `pnpm --filter site sync-example-capabilities` if this is a separate check (confirm the exact script name first via `grep sync-example-capabilities site/package.json package.json`) — this validates `examples.json` entries against actual example source. If no such standalone check script exists, skip this step; the `typecheck:examples` run in Step 4 plus the site build in Task 10 are sufficient.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add examples/application-scenes/scene-less-app.ts examples/application-scenes/scene-less-app.js examples/examples.json
+git commit -m "feat(examples): add scene-less application example (v0.17 Slice G DX gate)"
+```
+
+---
+
+### Task 7: Guide sweep — `pause-menu.mdx`
+
+**Files:**
+
+- Modify: `site/src/content/guide/recipes/pause-menu.mdx`
+
+**Context:** Entire guide is v0.16-era: writable `scene.paused`, `init(loader)`, instance-based `setScene(new X())`, an unnecessary `super.destroy()` call. This is the guide the spec's §13.5 "Reference workflow" explicitly targets for the pause-input model — bring the Escape binding onto the documented `{ when: 'always' }` pattern too, not just fix syntax.
+
+- [ ] **Step 1: Replace the file content**
+
+Replace the full content of `site/src/content/guide/recipes/pause-menu.mdx` with:
+
+````mdx
+---
+title: 'Pause menu'
+description: 'Pause scene updates while keeping clear visual context for players.'
+---
+
+import ExamplePreview from '../../../components/ExamplePreview.astro';
+import Callout from '../../../components/Callout.astro';
+
+# Pause menu
+
+A pause menu can freeze the game, display a menu overlay, and resume cleanly when dismissed. In ExoJS, this is done entirely within a single scene: call `app.scenes.pause()`/`resume()` to freeze updates, show a pause overlay on `scene.ui`, and reverse both on resume.
+
+## Approach
+
+One scene, one UI layer. The pause overlay (a `Panel` + `Label`) lives on `scene.ui` and is hidden until paused. Pausing stops `update()` and all scene systems while the scene keeps drawing — so the world stays visible behind the overlay. A `BlurFilter` on `scene.root` provides visual separation.
+
+<Callout type="info" title="Tweens keep running while paused">
+  `app.tweens` keeps advancing even while the scene is paused — only `update()` and scene-level systems freeze. That is what lets a blur ramp or menu transition
+  animate smoothly over the frozen world.
+</Callout>
+
+```js
+class GameScene extends Scene {
+  init() {
+    this.player = new Sprite(this.loader.get('image/hero.png'));
+    this.addChild(this.player);
+    // ... game setup ...
+
+    this.blur = new BlurFilter({ radius: 0, quality: 2 });
+
+    // Pause overlay on the UI layer, hidden until paused.
+    this.pausePanel = new Panel({ width: 420, height: 140, cornerRadius: 18, color: new Color(0, 0, 0, 0.6) });
+    this.pausePanel.anchorIn(this.ui, 'center');
+    this.pausePanel.visible = false;
+    this.ui.addChild(this.pausePanel);
+
+    this.pauseLabel = new Label('PAUSED', { fontSize: 56, fontWeight: 'bold' });
+    this.pauseLabel.anchorIn(this.ui, 'center');
+    this.pauseLabel.visible = false;
+    this.ui.addChild(this.pauseLabel);
+
+    // `when: 'always'` keeps this binding live in both Active and Paused —
+    // otherwise a 'active'-only binding (the default) would stop firing
+    // the moment the scene pauses, and Escape could never resume it.
+    this.inputs.onTrigger(Keyboard.Escape, () => this.togglePause(), { when: 'always' });
+  }
+
+  update(delta) {
+    // Not called while paused — the director skips update() + systems.
+    // ... normal game logic ...
+  }
+
+  draw(context) {
+    context.backend.clear(new Color(20, 24, 34));
+    context.render(this.root);
+  }
+
+  destroy() {
+    this.root.clearFilters();
+  }
+
+  togglePause() {
+    const pausing = this.state !== SceneState.Paused;
+
+    if (pausing) {
+      this.app.scenes.pause();
+    } else {
+      this.app.scenes.resume();
+    }
+
+    this.pausePanel.visible = pausing;
+    this.pauseLabel.visible = pausing;
+
+    if (pausing) {
+      this.blur.radius = 0;
+      this.root.filters = [this.blur];
+      this.tweens.create(this.blur).to({ radius: 6 }, 0.35).start();
+    } else {
+      this.root.clearFilters();
+    }
+  }
+}
+
+const app = new Application({ scenes: { GameScene } /* , ...other options */ });
+
+await app.start(GameScene);
+```
+````
+
+<Callout type="warning" title="Clear filters in destroy">
+Any filter you set in `init` or `togglePause` — the `BlurFilter` here — must be cleared in `destroy`. Otherwise it stays attached to `scene.root` and bleeds into the next scene after `app.scenes.setScene(...)`.
+</Callout>
+
+<Callout type="hint" title="Modal menus that must block clicks">
+This recipe's overlay is informational only — `scene.ui` widgets stay clickable regardless of pause state, which is fine here since nothing else is interactive underneath. For a menu that must swallow clicks so they never reach gameplay nodes beneath it, wrap it with `this.interaction.capture(this.pausePanel)` and release the returned handle on resume.
+</Callout>
+
+## How pausing works
+
+`app.scenes.pause()` moves the active scene to `SceneState.Paused`:
+
+- **Freezes `update()`** — the director skips `update()` and all scene-level systems. No game logic runs.
+- **Keeps drawing** — the scene still renders every frame, so the world remains visible behind the overlay.
+- **Tweens on `app.tweens` still run** — the application-level tween manager is unaffected, so blur animations and UI transitions animate smoothly while the game is frozen.
+- **Scene input bindings default to `'active'` only** — pass `{ when: 'paused' }` for a binding that should fire only while paused (e.g. a menu confirm button), or `{ when: 'always' }` for one that must work in both states (the Escape toggle above).
+
+`scene.ui` widgets are always interactive regardless of pause state, so the pause panel's buttons remain clickable during the pause.
+
+## Cleanup
+
+The `destroy` hook clears the blur filter from `scene.root`. Without this, the filter array would linger if the scene is ever replaced via `app.scenes.setScene(...)`. As a rule, any filter applied in `init` or `togglePause` should be cleaned up in `destroy`.
+
+## Switching scenes from the pause menu
+
+If the pause menu offers options like "Return to main menu" or "Quit", use `app.scenes.setScene(...)` to navigate away — it unloads the current scene and loads the next one, optionally with a fade transition:
+
+```js
+// Inside a resume button's onClick handler:
+resumeButton.onClick.add(() => {
+  this.togglePause(); // unpause first
+});
+
+// Inside a "main menu" button's onClick handler:
+mainMenuButton.onClick.add(() => {
+  this.app.scenes.setScene(MainMenuScene, { transition: { type: 'fade' } });
+});
+```
+
+## Examples
+
+<a id="pause-blur"></a>
+<ExamplePreview chapter="showcase" slug="pause-blur" />
+
+A rotating sprite with a pause overlay — press Esc to freeze the game under a blurred background with a PAUSED label, Esc again to resume.
+
+## Where to go next
+
+The next recipe, [Split screen](/ExoJS/en/guide/recipes/split-screen/), covers rendering the same scene from multiple viewpoints into viewport regions.
+
+````
+
+Note: the main fenced block imports `SceneState` implicitly by name (`this.state !== SceneState.Paused`) — since this is prose-illustrative code, not a full runnable file, it doesn't show the import line, matching this guide corpus's existing convention of omitting boilerplate imports in recipe snippets (confirm by checking whether other recipe `.mdx` files' primary snippets show imports — if the convention is inconsistent, add `// SceneState imported from '@codexo/exojs'` as a one-line comment instead of silently assuming it's in scope).
+
+- [ ] **Step 2: Typecheck the guide**
+
+Run: `pnpm typecheck:guides`
+Expected: no errors for `pause-menu.mdx`'s main fenced block (the only non-`no-check` block in the file).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add site/src/content/guide/recipes/pause-menu.mdx
+git commit -m "docs(guide): migrate pause-menu recipe to v0.17 pause API + when-policy (v0.17 Slice G)"
+````
+
+---
+
+### Task 8: Guide sweep — `cinematics.mdx`
+
+**Files:**
+
+- Modify: `site/src/content/guide/recipes/cinematics.mdx`
+
+**Context:** Much smaller than Task 7 — only the `load(loader)`/`init(loader)` hook signatures and two bare `loader.load(...)` calls are stale; every `setScene(...)` call in this file already uses the correct constructor-based form.
+
+- [ ] **Step 1: Fix the main fenced block's hook signatures**
+
+The block starting at line 19 currently reads:
+
+```js
+class CinematicScene extends Scene {
+    async load(loader) {
+        // AudioStream has no bare-path form, so use `.of(...)` — and since
+        // `get(Asset.kind('music', ...))` isn't supported, keep the loaded
+        // instances as direct references instead of looking them up later.
+        [this.bossTexture, this.trackStream] = await Promise.all([
+            loader.load('image/boss.png'),
+            loader.load(Asset.kind('music', 'audio/track.ogg')),
+        ]);
+    }
+
+    init(loader) {
+```
+
+Change to:
+
+```js
+class CinematicScene extends Scene {
+    async load() {
+        // AudioStream has no bare-path form, so use `.of(...)` — and since
+        // `get(Asset.kind('music', ...))` isn't supported, keep the loaded
+        // instances as direct references instead of looking them up later.
+        [this.bossTexture, this.trackStream] = await Promise.all([
+            this.loader.load('image/boss.png'),
+            this.loader.load(Asset.kind('music', 'audio/track.ogg')),
+        ]);
+    }
+
+    init() {
+```
+
+- [ ] **Step 2: Fix the two `no-check` illustrative blocks that still show `init(loader)`**
+
+Line 139 (letterbox overlays section):
+
+```js
+init(loader) {
+    // ... main cinematic setup ...
+```
+
+Change to:
+
+```js
+init() {
+    // ... main cinematic setup ...
+```
+
+Line 167 (skip support section):
+
+```js
+init(loader) {
+    // ... cinematic setup ...
+```
+
+Change to:
+
+```js
+init() {
+    // ... cinematic setup ...
+```
+
+- [ ] **Step 3: Typecheck the guide**
+
+Run: `pnpm typecheck:guides`
+Expected: no errors for `cinematics.mdx`'s main fenced block.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add site/src/content/guide/recipes/cinematics.mdx
+git commit -m "docs(guide): fix stale load(loader)/init(loader) hook signatures in cinematics recipe (v0.17 Slice G)"
+```
+
+---
+
+### Task 9: `CHANGELOG.md` — v0.17 entry
+
+**Files:**
+
+- Modify: `CHANGELOG.md`
+
+**Context:** No Slice A–F merge commit touched `CHANGELOG.md` — Slice G owns the entire v0.17 entry. Format precedent: `## [0.15.0] - 2026-07-02`'s prose lead-in + `### Added`/`### Changed`/`### Removed`/`### Fixed`/`### Docs` sections, bold-lead breaking bullets ending in a PR reference.
+
+- [ ] **Step 1: Add the v0.17 section**
+
+At the top of `CHANGELOG.md`, immediately after the `# Changelog` header (or equivalent top-of-file preamble — read the first ~10 lines of the file first to match its exact preamble format before inserting), insert a new section above the current topmost `## [0.15.2] - ...` (or whatever is currently topmost — re-check with `head -5 CHANGELOG.md` immediately before writing, since this plan may execute after other unrelated patch releases land):
+
+```markdown
+## [0.17.0] - Unreleased
+
+The scene-model release. `Application`'s frame loop, scene lifecycle, and
+navigation are rebuilt around a normative multiphase `System` contract, a
+typed scene registry, pause with a per-binding availability policy, and
+retention (suspend a scene instead of destroying it, restore it later without
+re-running `load()`/`init()`). This is a pre-1.0 release and includes
+intentional breaking changes; see **Changed** and **Removed**.
+
+### Added
+
+- **Multiphase `System` contract.** A `System` implements any subset of
+  `fixedUpdate`/`update`/`draw` (previously `update` + `destroy` were
+  required); `app.systems`/`scene.systems` dispatch each phase in ascending
+  `order`, ties broken by insertion order. Structural add/remove during a
+  frame is buffered to the next frame boundary (#390).
+- **Typed scene registry and navigation.** `new Application({ scenes: { game:
+GameScene } })` registers scene constructors; `app.start(GameScene, data?)`
+  and `app.scenes.setScene(GameScene, data?, options?)` take the constructor
+  directly — data and options are inferred from the scene's own generic,
+  rejecting a mismatched or missing payload at compile time. Unregistered or
+  duplicate registrations raise named errors (`UnregisteredSceneError`,
+  `DuplicateSceneRegistrationError`, `InvalidSceneRegistrationError`) (#392,
+  #396).
+- **`app.scenes.pause()`/`resume()`** move the active scene between `Active`
+  and `Paused` (`SceneState`) — the scene keeps drawing while paused but its
+  `update()`/systems stop. Scene input bindings accept `when:
+'active'|'paused'|'always'` (default `'active'`), with edge rules so a
+  press/release pair must both occur in an allowed state to trigger.
+  `this.interaction.capture(root)` confines pointer hit-testing to a subtree
+  for modal UI (#392, #397).
+- **Scene retention.** `setScene(X, { retainCurrent: true })` suspends the
+  outgoing scene instead of destroying it; `app.scenes.restoreScene(X)`
+  reactivates the same instance without re-running `load()`/`init()`,
+  returning to its pre-suspend `Active`/`Paused` state; `releaseScene(X)`
+  permanently ends a retained scene. Concurrent navigation calls are now
+  rejected with `ConcurrentSceneNavigationError` instead of racing silently
+  (#398).
+- **Extension app-system bindings.** An `Extension.systems` binding
+  (`ApplicationSystemBinding`) produces a `System` materialised once per
+  `Application`, after every core manager exists, registered on
+  `app.systems` — extensions can no longer only add renderers/assets/
+  serializers (#399).
+- **`Scene.interaction`/`Scene.audio` facades** (`SceneInteraction`,
+  `SceneAudio`) join the existing `Scene.inputs`/`Scene.tweens` — scene-scoped
+  pointer capture/observation and scene-scoped playback, both auto-cleaned up
+  on scene teardown and suspended/resumed across retention (#391).
+- **`PhysicsWorld.fixedUpdate()`** lets `@codexo/exojs-physics` register
+  directly as a system (`app.systems.add(world, { order: SystemOrder.Physics
+})`) instead of being stepped manually from `Scene.update()`.
+- **Scene-less applications.** `new Application({ /* no scenes */ })` +
+  `app.start()` runs the frame loop with no active scene at all —
+  `app.systems` still ticks and draws.
+
+### Changed
+
+- **BREAKING — `SceneManager` renamed `SceneDirector`, `app.scene` renamed
+  `app.scenes`.**
+- **BREAKING — scene construction and navigation are constructor-based, not
+  instance-based.** `app.start(new GameScene())` → `new Application({ scenes:
+{ game: GameScene } })` + `app.start(GameScene, data?)`;
+  `app.scene.setScene(instance, opts)` → `app.scenes.setScene(Ctor, data?,
+opts?)`; `setScene(null)` is gone (start another scene, or `app.stop()`).
+- **BREAKING — `scene.paused` is no longer a writable field.** Use
+  `app.scenes.pause()`/`resume()`; read `scene.state`.
+- **BREAKING — `load`/`init` hooks take `data`, not a `Loader`.**
+  `load(loader)`/`init(loader)` → `load(data)`/`init(data)`; access the
+  loader via `this.loader`/`this.app.loader`. `init()` must be synchronous
+  (a `Promise`-returning `init` is a dev-mode activation error) — move
+  asynchronous setup into `load()`.
+- **BREAKING — `System.destroy()` is optional**; a system implementing none
+  of `fixedUpdate`/`update`/`draw` is no longer valid (at least one phase is
+  required).
+- **BREAKING — user app systems no longer reserve order `100`-`500`.** Core
+  managers (input/interaction/audio/tweens/rendering) moved out of
+  `app.systems` into an internal prepare stage; any plain `order` value is
+  now safe for user systems.
+- **BREAKING — `scene.systems` is attach-gated.** Register scene systems from
+  `init()` — using `scene.systems` before the scene is attached now throws.
+- **`@codexo/exojs-physics`:** `PhysicsWorld` should be registered as a
+  system rather than stepped manually; `step()` remains available for
+  advanced manual driving.
+
+### Removed
+
+- **BREAKING — `super.destroy()` in a `Scene` subclass is no longer
+  necessary.** The base `Scene.destroy()` is now empty — existing
+  `super.destroy()` calls are harmless but can be deleted.
+
+### Fixed
+
+- **`SceneInteraction.suspend()`/`resume()`** now actually detach/reattach
+  observed roots and captures (previously no-op stubs) — a retained scene no
+  longer keeps receiving pointer dispatch alongside whichever scene is now
+  active.
+- **`SceneAudio.play()`** now gates playback requested while the scope is
+  `Preparing`, queuing it until the scene activates, instead of starting
+  audio for a scene that might never finish activating.
+
+### Docs
+
+- Migrated `examples/` and the `pause-menu`/`cinematics` recipe guides to the
+  v0.17 scene model; added a scene-less application example.
+```
+
+- [ ] **Step 2: Sanity-check formatting**
+
+Run: `pnpm exec prettier --check CHANGELOG.md` (or `--write` if the repo's markdown formatting is prettier-enforced — confirm via `.prettierignore`/`prettier.config.js` scope first; if `CHANGELOG.md` is excluded from prettier, skip this step).
+Expected: passes, or is out of prettier's scope entirely.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: add v0.17.0 CHANGELOG entry (v0.17 Slice G)"
+```
+
+---
+
+### Task 10: Full verification gate + DX gate checklist
+
+**Files:** None new — verification only.
+
+- [ ] **Step 1: Full typecheck**
+
+Run: `pnpm typecheck && pnpm typecheck:examples && pnpm typecheck:guides && pnpm typecheck:type-tests`
+Expected: no errors.
+
+- [ ] **Step 2: Physics package typecheck**
+
+Run: `pnpm --filter @codexo/exojs-physics typecheck`
+Expected: no errors.
+
+- [ ] **Step 3: Lint with autofix**
+
+Run: `pnpm lint:fix`
+Expected: exits 0.
+
+- [ ] **Step 4: Full unit test suite**
+
+Run: `pnpm test`
+Expected: all projects pass, no regressions outside the files touched in Tasks 1-9.
+
+- [ ] **Step 5: Regenerate API docs**
+
+Run: `pnpm docs:api:generate`
+Expected: exits 0. `git status` — commit any changes under `site/src/content/api/` (the JSDoc added in Task 5, plus any new/changed type surfaces from Tasks 3-4, will regenerate pages).
+
+- [ ] **Step 6: DX gate — read both showcase files fresh and judge**
+
+Read `examples/physics/sprite-follows-body.ts` (Task 2's result) and `examples/application-scenes/scene-less-app.ts` (Task 6's result) as if seeing them for the first time. Compare against what the equivalent v0.16 code would have needed: the physics example no longer calls `world.step()` manually (one line removed, one line added at registration — net wash on line count, but conceptually simpler: "register it and forget it" vs. "remember to step every frame"); the scene-less example has no v0.16 equivalent at all (previously every `Application` required at least an empty `Scene` subclass and an instance-based `start(new EmptyScene())`).
+
+If either file reads as more convoluted than its v0.16 shape rather than less, stop and fix the API seam here — per the plan's Global Constraints, the DX gate is a hard release gate for this slice, not a nice-to-have.
+
+- [ ] **Step 7: Confirm the release-gate checklist (spec §17, Slice-G-relevant bullets)**
+
+- [ ] "examples + guides compile (`typecheck:examples`, `typecheck:guides`)" — confirmed in Step 1.
+- [ ] "API docs regenerated" — confirmed in Step 5.
+- [ ] "DX gate (§16 Slice G) passed" — confirmed in Step 6.
+
+- [ ] **Step 8: Commit any docs regeneration**
+
+```bash
+git add site/src/content/api/
+git status --short
+```
+
+If anything is staged:
+
+```bash
+git commit -m "docs(api): regenerate API docs for Slice G changes"
+```
+
+If nothing is staged, skip.

--- a/examples/application-scenes/scene-less-app.js
+++ b/examples/application-scenes/scene-less-app.js
@@ -1,9 +1,10 @@
 // Auto-generated from scene-less-app.ts — edit the .ts source, not this file.
-import { Application, Color, Graphics } from '@codexo/exojs';
+import { Application, Color, Sprite } from '@codexo/exojs';
 // A scene-less Application: no Scene is ever registered or started. All
 // frame work happens through a single app-level system — useful for utility
 // apps, splash/loading screens, or anything that doesn't need scene
-// lifecycle, retention, or navigation.
+// lifecycle, retention, or navigation. Assets load the same way without a
+// Scene: `app.loader` in place of `this.loader`.
 const app = new Application({
     canvas: {
         width: 1280,
@@ -13,9 +14,10 @@ const app = new Application({
     },
     clearColor: new Color(18, 22, 33),
 });
-const square = new Graphics();
-square.fillColor = new Color(90, 160, 255);
-square.drawRectangle(-40, -40, 80, 80);
+const square = new Sprite(app.loader.get(assets.demo.textures.pixelWhite)).setAnchor(0.5);
+square.width = 80;
+square.height = 80;
+square.tint = new Color(90, 160, 255);
 square.setPosition(app.canvas.width / 2, app.canvas.height / 2);
 let angle = 0;
 app.systems.add({

--- a/examples/application-scenes/scene-less-app.js
+++ b/examples/application-scenes/scene-less-app.js
@@ -1,0 +1,31 @@
+// Auto-generated from scene-less-app.ts — edit the .ts source, not this file.
+import { Application, Color, Graphics } from '@codexo/exojs';
+// A scene-less Application: no Scene is ever registered or started. All
+// frame work happens through a single app-level system — useful for utility
+// apps, splash/loading screens, or anything that doesn't need scene
+// lifecycle, retention, or navigation.
+const app = new Application({
+    canvas: {
+        width: 1280,
+        height: 720,
+        mount: document.body,
+        sizingMode: 'fit',
+    },
+    clearColor: new Color(18, 22, 33),
+});
+const square = new Graphics();
+square.fillColor = new Color(90, 160, 255);
+square.drawRectangle(-40, -40, 80, 80);
+square.setPosition(app.canvas.width / 2, app.canvas.height / 2);
+let angle = 0;
+app.systems.add({
+    update(delta) {
+        angle += delta.seconds;
+        square.rotation = angle * 40;
+    },
+    draw(context) {
+        context.backend.clear();
+        context.render(square);
+    },
+});
+app.start();

--- a/examples/application-scenes/scene-less-app.ts
+++ b/examples/application-scenes/scene-less-app.ts
@@ -1,0 +1,36 @@
+import { Application, Color, Graphics, type RenderingContext } from '@codexo/exojs';
+
+// A scene-less Application: no Scene is ever registered or started. All
+// frame work happens through a single app-level system — useful for utility
+// apps, splash/loading screens, or anything that doesn't need scene
+// lifecycle, retention, or navigation.
+
+const app = new Application({
+    canvas: {
+        width: 1280,
+        height: 720,
+        mount: document.body,
+        sizingMode: 'fit',
+    },
+    clearColor: new Color(18, 22, 33),
+});
+
+const square = new Graphics();
+square.fillColor = new Color(90, 160, 255);
+square.drawRectangle(-40, -40, 80, 80);
+square.setPosition(app.canvas.width / 2, app.canvas.height / 2);
+
+let angle = 0;
+
+app.systems.add({
+    update(delta) {
+        angle += delta.seconds;
+        square.rotation = angle * 40;
+    },
+    draw(context: RenderingContext) {
+        context.backend.clear();
+        context.render(square);
+    },
+});
+
+app.start();

--- a/examples/application-scenes/scene-less-app.ts
+++ b/examples/application-scenes/scene-less-app.ts
@@ -1,9 +1,10 @@
-import { Application, Color, Graphics, type RenderingContext } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Sprite } from '@codexo/exojs';
 
 // A scene-less Application: no Scene is ever registered or started. All
 // frame work happens through a single app-level system — useful for utility
 // apps, splash/loading screens, or anything that doesn't need scene
-// lifecycle, retention, or navigation.
+// lifecycle, retention, or navigation. Assets load the same way without a
+// Scene: `app.loader` in place of `this.loader`.
 
 const app = new Application({
     canvas: {
@@ -15,9 +16,10 @@ const app = new Application({
     clearColor: new Color(18, 22, 33),
 });
 
-const square = new Graphics();
-square.fillColor = new Color(90, 160, 255);
-square.drawRectangle(-40, -40, 80, 80);
+const square = new Sprite(app.loader.get(assets.demo.textures.pixelWhite)).setAnchor(0.5);
+square.width = 80;
+square.height = 80;
+square.tint = new Color(90, 160, 255);
 square.setPosition(app.canvas.width / 2, app.canvas.height / 2);
 
 let angle = 0;

--- a/examples/examples.json
+++ b/examples/examples.json
@@ -5,7 +5,7 @@
             "path": "application-scenes/scene-less-app.js",
             "language": "typescript",
             "title": "Scene-less App",
-            "description": "Run an Application with no Scene at all — a single app-level system drives update and draw directly, useful for utility apps and splash screens.",
+            "description": "Run an Application with no Scene at all — a single app-level system drives update and draw directly, loading and rendering a sprite without ever touching Scene.",
             "backend": "core",
             "tags": [
                 "application",

--- a/examples/examples.json
+++ b/examples/examples.json
@@ -1,6 +1,19 @@
 {
     "application-scenes": [
         {
+            "slug": "scene-less-app",
+            "path": "application-scenes/scene-less-app.js",
+            "language": "typescript",
+            "title": "Scene-less App",
+            "description": "Run an Application with no Scene at all — a single app-level system drives update and draw directly, useful for utility apps and splash screens.",
+            "backend": "core",
+            "tags": [
+                "application",
+                "systems"
+            ],
+            "level": "intro"
+        },
+        {
             "slug": "scene-lifecycle",
             "path": "application-scenes/scene-lifecycle.js",
             "language": "typescript",

--- a/examples/physics/sprite-follows-body.js
+++ b/examples/physics/sprite-follows-body.js
@@ -1,11 +1,14 @@
 // Auto-generated from sprite-follows-body.ts — edit the .ts source, not this file.
-import { Application, Asset, Color, Scene, Sprite, Spritesheet, Vector } from '@codexo/exojs';
+import { Application, Asset, Color, Scene, Sprite, Spritesheet, SystemOrder, Vector } from '@codexo/exojs';
 import { BoxShape, PhysicsWorld } from '@codexo/exojs-physics';
 import { mountControls } from '@examples/runtime';
 // The minimal physics binding: `world.attach(node, { ... })` builds a body +
-// collider and binds it to the node in one call. After every `world.step(...)`
-// the body's position and rotation are written onto the bound sprite, so the
-// sprite simply "follows the body". A static floor stops the falling actor.
+// collider and binds it to the node in one call. Registering the world as a
+// system (`this.systems.add(this.world, { order: SystemOrder.Physics })`)
+// drives it from the engine's fixed-timestep scheduler — no manual step()
+// call needed. After every fixed step the body's position and rotation are
+// written onto the bound sprite, so the sprite simply "follows the body". A
+// static floor stops the falling actor.
 class SpriteFollowsBodyScene extends Scene {
     world;
     actor;
@@ -14,14 +17,19 @@ class SpriteFollowsBodyScene extends Scene {
     floorY = 0;
     settled = 0;
     hud;
-    async init() {
+    spritesheetData;
+    async load() {
+        this.spritesheetData = (await this.loader.load(Asset.kind('json', assets.demo.spritesheets.platformerCharacters.data)));
+    }
+    init() {
         const app = this.app;
         if (app === null)
             throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;
         // Gravity in px/s², +Y down — matches the engine's screen space.
         this.world = new PhysicsWorld({ gravity: { x: 0, y: 1400 } });
-        const characters = new Spritesheet(this.loader.get(assets.demo.spritesheets.platformerCharacters.image), (await this.loader.load(Asset.kind('json', assets.demo.spritesheets.platformerCharacters.data))));
+        this.systems.add(this.world, { order: SystemOrder.Physics });
+        const characters = new Spritesheet(this.loader.get(assets.demo.spritesheets.platformerCharacters.image), this.spritesheetData);
         this.floorY = height - 80;
         // ── Static floor ──────────────────────────────────────────────────
         // A wide static body. `world.attach` binds it to the floor sprite, so
@@ -40,7 +48,7 @@ class SpriteFollowsBodyScene extends Scene {
         // ── Dynamic actor ─────────────────────────────────────────────────
         // A dynamic body dropped from above. Its collider is a box sized to the
         // character art; `world.attach` binds the sprite, so it falls, lands and
-        // tracks the body (position + rotation) every step.
+        // tracks the body (position + rotation) every fixed step.
         this.actor = characters.getFrameSprite('character_beige_front').setAnchor(0.5).setScale(1.1);
         this.actorBody = this.world.attach(this.actor, {
             type: 'dynamic',
@@ -55,15 +63,13 @@ class SpriteFollowsBodyScene extends Scene {
             title: 'Sprite Follows Body',
             controls: [{ keys: 'Auto', action: 'actor falls and lands on the floor' }],
             status: 'Dropping…',
-            hint: 'world.attach(sprite, { … }) creates a body + collider and binds it; world.step writes the body transform onto the sprite each frame.',
+            hint: 'world.attach(sprite, { … }) creates a body + collider and binds it; the world, registered as a system, writes the body transform onto the sprite every fixed step.',
         });
     }
     update(delta) {
         const app = this.app;
         if (app === null)
             throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
-        // Advance the simulation; bound sprites are synced inside step().
-        this.world.step(delta.seconds);
         const { width, height } = app.canvas;
         const body = this.actorBody;
         const restingSpeed = Math.hypot(body.linearVelocityX, body.linearVelocityY);

--- a/examples/physics/sprite-follows-body.ts
+++ b/examples/physics/sprite-follows-body.ts
@@ -1,13 +1,14 @@
-import { Application, Asset, Color, type RenderingContext, Scene, Sprite, Spritesheet, type SpritesheetData, type Time, Vector } from '@codexo/exojs';
+import { Application, Asset, Color, type RenderingContext, Scene, Sprite, Spritesheet, type SpritesheetData, SystemOrder, type Time, Vector } from '@codexo/exojs';
 import { BoxShape, type PhysicsBody, PhysicsWorld } from '@codexo/exojs-physics';
 import { mountControls } from '@examples/runtime';
 
 // The minimal physics binding: `world.attach(node, { ... })` builds a body +
-// collider and binds it to the node in one call. After every `world.step(...)`
-// the body's position and rotation are written onto the bound sprite, so the
-// sprite simply "follows the body". A static floor stops the falling actor.
-
-
+// collider and binds it to the node in one call. Registering the world as a
+// system (`this.systems.add(this.world, { order: SystemOrder.Physics })`)
+// drives it from the engine's fixed-timestep scheduler — no manual step()
+// call needed. After every fixed step the body's position and rotation are
+// written onto the bound sprite, so the sprite simply "follows the body". A
+// static floor stops the falling actor.
 
 class SpriteFollowsBodyScene extends Scene {
     private world!: PhysicsWorld;
@@ -17,19 +18,22 @@ class SpriteFollowsBodyScene extends Scene {
     private floorY = 0;
     private settled = 0;
     private hud!: ReturnType<typeof mountControls>;
+    private spritesheetData!: SpritesheetData;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
+        this.spritesheetData = (await this.loader.load(Asset.kind('json', assets.demo.spritesheets.platformerCharacters.data))) as SpritesheetData;
+    }
+
+    override init(): void {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;
 
         // Gravity in px/s², +Y down — matches the engine's screen space.
         this.world = new PhysicsWorld({ gravity: { x: 0, y: 1400 } });
+        this.systems.add(this.world, { order: SystemOrder.Physics });
 
-        const characters = new Spritesheet(
-            this.loader.get(assets.demo.spritesheets.platformerCharacters.image),
-            (await this.loader.load(Asset.kind('json', assets.demo.spritesheets.platformerCharacters.data))) as SpritesheetData,
-        );
+        const characters = new Spritesheet(this.loader.get(assets.demo.spritesheets.platformerCharacters.image), this.spritesheetData);
 
         this.floorY = height - 80;
 
@@ -53,7 +57,7 @@ class SpriteFollowsBodyScene extends Scene {
         // ── Dynamic actor ─────────────────────────────────────────────────
         // A dynamic body dropped from above. Its collider is a box sized to the
         // character art; `world.attach` binds the sprite, so it falls, lands and
-        // tracks the body (position + rotation) every step.
+        // tracks the body (position + rotation) every fixed step.
         this.actor = characters.getFrameSprite('character_beige_front').setAnchor(0.5).setScale(1.1);
         this.actorBody = this.world.attach(this.actor, {
             type: 'dynamic',
@@ -70,15 +74,13 @@ class SpriteFollowsBodyScene extends Scene {
             title: 'Sprite Follows Body',
             controls: [{ keys: 'Auto', action: 'actor falls and lands on the floor' }],
             status: 'Dropping…',
-            hint: 'world.attach(sprite, { … }) creates a body + collider and binds it; world.step writes the body transform onto the sprite each frame.',
+            hint: 'world.attach(sprite, { … }) creates a body + collider and binds it; the world, registered as a system, writes the body transform onto the sprite every fixed step.',
         });
     }
 
     override update(delta: Time): void {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
-        // Advance the simulation; bound sprites are synced inside step().
-        this.world.step(delta.seconds);
 
         const { width, height } = app.canvas;
         const body = this.actorBody;

--- a/examples/physics/tiled-map-physics-actor.js
+++ b/examples/physics/tiled-map-physics-actor.js
@@ -1,5 +1,5 @@
 // Auto-generated from tiled-map-physics-actor.ts — edit the .ts source, not this file.
-import { Application, Asset, Color, Scene, Spritesheet, TextureRegion, Vector } from '@codexo/exojs';
+import { Application, Asset, Color, Scene, Spritesheet, SystemOrder, TextureRegion, Vector } from '@codexo/exojs';
 import { BoxShape, PhysicsWorld } from '@codexo/exojs-physics';
 import { PhysicsDebugDraw } from '@codexo/exojs-physics/debug';
 import { ObjectKind, ObjectLayer, TILE_TRANSFORM_IDENTITY, TileLayer, TileMap, tilemapExtension, TileMapNode, TileSet } from '@codexo/exojs-tilemap';
@@ -28,17 +28,24 @@ class TiledMapPhysicsActorScene extends Scene {
     actorBody;
     debug;
     hud;
-    async init() {
+    tilesTexture;
+    spritesheetData;
+    async load() {
+        this.tilesTexture = await this.loader.load(Asset.kind('texture', assets.demo.tilesets.map.image));
+        this.spritesheetData = (await this.loader.load(Asset.kind('json', assets.demo.spritesheets.platformerCharacters.data)));
+    }
+    init() {
         const app = this.app;
         if (app === null)
             throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.world = new PhysicsWorld({ gravity: { x: 0, y: 1500 } });
+        this.systems.add(this.world, { order: SystemOrder.Physics });
         // ── Tileset + a single ground tile layer ──────────────────────────
         // The map-pack tilesheet is a uniform 64×64 grid (17 columns), so it
         // works as a classic grid tileset. We only need one solid-looking tile.
         // Await the atlas load: TileSet needs a TextureRegion with real
         // dimensions, so a not-yet-hydrated `loader.get()` handle is not enough.
-        const tilesTexture = await this.loader.load(Asset.kind('texture', assets.demo.tilesets.map.image));
+        const tilesTexture = this.tilesTexture;
         const tileset = new TileSet({
             name: 'map',
             texture: new TextureRegion(tilesTexture, { x: 0, y: 0, width: tilesTexture.width, height: tilesTexture.height }),
@@ -101,7 +108,7 @@ class TiledMapPhysicsActorScene extends Scene {
             });
         }
         // ── Dynamic actor ─────────────────────────────────────────────────
-        const characters = new Spritesheet(this.loader.get(assets.demo.spritesheets.platformerCharacters.image), (await this.loader.load(Asset.kind('json', assets.demo.spritesheets.platformerCharacters.data))));
+        const characters = new Spritesheet(this.loader.get(assets.demo.spritesheets.platformerCharacters.image), this.spritesheetData);
         this.actor = characters.getFrameSprite('character_green_front').setAnchor(0.5);
         this.actorBody = this.world.attach(this.actor, {
             type: 'dynamic',
@@ -115,11 +122,10 @@ class TiledMapPhysicsActorScene extends Scene {
         // is visible on top of the rendered tiles.
         this.debug = new PhysicsDebugDraw(app, this.world, { drawShapes: true, drawCenters: true });
     }
-    update(delta) {
+    update(_delta) {
         const app = this.app;
         if (app === null)
             throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
-        this.world.step(delta.seconds);
         const { width, height } = app.canvas;
         const body = this.actorBody;
         // Loop the demo: nudge the actor again once it settles, and rescue it if

--- a/examples/physics/tiled-map-physics-actor.ts
+++ b/examples/physics/tiled-map-physics-actor.ts
@@ -1,4 +1,4 @@
-import { Application, Asset, Color, type RenderingContext, Scene, Sprite, Spritesheet, type SpritesheetData, TextureRegion, type Time, Vector } from '@codexo/exojs';
+import { Application, Asset, Color, type RenderingContext, Scene, Sprite, Spritesheet, type SpritesheetData, SystemOrder, Texture, TextureRegion, type Time, Vector } from '@codexo/exojs';
 import { BoxShape, type PhysicsBody, PhysicsWorld } from '@codexo/exojs-physics';
 import { PhysicsDebugDraw } from '@codexo/exojs-physics/debug';
 import { ObjectKind, ObjectLayer, type RectangleObject, TILE_TRANSFORM_IDENTITY, TileLayer, TileMap, tilemapExtension, TileMapNode, TileSet } from '@codexo/exojs-tilemap';
@@ -32,18 +32,26 @@ class TiledMapPhysicsActorScene extends Scene {
     private actorBody!: PhysicsBody;
     private debug!: PhysicsDebugDraw;
     private hud!: ReturnType<typeof mountControls>;
+    private tilesTexture!: Texture;
+    private spritesheetData!: SpritesheetData;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
+        this.tilesTexture = await this.loader.load(Asset.kind('texture', assets.demo.tilesets.map.image));
+        this.spritesheetData = (await this.loader.load(Asset.kind('json', assets.demo.spritesheets.platformerCharacters.data))) as SpritesheetData;
+    }
+
+    override init(): void {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.world = new PhysicsWorld({ gravity: { x: 0, y: 1500 } });
+        this.systems.add(this.world, { order: SystemOrder.Physics });
 
         // ── Tileset + a single ground tile layer ──────────────────────────
         // The map-pack tilesheet is a uniform 64×64 grid (17 columns), so it
         // works as a classic grid tileset. We only need one solid-looking tile.
         // Await the atlas load: TileSet needs a TextureRegion with real
         // dimensions, so a not-yet-hydrated `loader.get()` handle is not enough.
-        const tilesTexture = await this.loader.load(Asset.kind('texture', assets.demo.tilesets.map.image));
+        const tilesTexture = this.tilesTexture;
         const tileset = new TileSet({
             name: 'map',
             texture: new TextureRegion(tilesTexture, { x: 0, y: 0, width: tilesTexture.width, height: tilesTexture.height }),
@@ -114,10 +122,7 @@ class TiledMapPhysicsActorScene extends Scene {
         }
 
         // ── Dynamic actor ─────────────────────────────────────────────────
-        const characters = new Spritesheet(
-            this.loader.get(assets.demo.spritesheets.platformerCharacters.image),
-            (await this.loader.load(Asset.kind('json', assets.demo.spritesheets.platformerCharacters.data))) as SpritesheetData,
-        );
+        const characters = new Spritesheet(this.loader.get(assets.demo.spritesheets.platformerCharacters.image), this.spritesheetData);
 
         this.actor = characters.getFrameSprite('character_green_front').setAnchor(0.5);
         this.actorBody = this.world.attach(this.actor, {
@@ -134,10 +139,9 @@ class TiledMapPhysicsActorScene extends Scene {
         this.debug = new PhysicsDebugDraw(app, this.world, { drawShapes: true, drawCenters: true });
     }
 
-    override update(delta: Time): void {
+    override update(_delta: Time): void {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
-        this.world.step(delta.seconds);
 
         const { width, height } = app.canvas;
         const body = this.actorBody;

--- a/packages/exojs-physics/src/PhysicsWorld.ts
+++ b/packages/exojs-physics/src/PhysicsWorld.ts
@@ -1,4 +1,4 @@
-import type { SceneNode } from '@codexo/exojs';
+import type { SceneNode, Time } from '@codexo/exojs';
 import { Signal, Vector } from '@codexo/exojs';
 
 import type { Aabb } from './Aabb';
@@ -401,22 +401,15 @@ export class PhysicsWorld implements BodyOwner {
    * restitution pass, then writes the accumulated motion into each body. Finally
    * dispatches events and writes bound node transforms.
    *
-   * **Fixed timestep against a variable render loop.** `frameDeltaSeconds` does
-   * **not** need to already be a fixed-size delta — `step` owns its own
-   * accumulator ({@link timeStepper}, a `TimeStepper`) that converts whatever
-   * you pass into a whole number of `fixedDelta`-sized sub-steps (dropping any
-   * backlog beyond {@link PhysicsWorldOptions.maxSubSteps} so a slow frame
-   * cannot spiral). Two equally valid ways to drive it:
-   * - **`Scene.fixedUpdate(delta)`** (recommended) — the engine's own
-   *   fixed-timestep accumulator already calls this hook a constant number of
-   *   times per rendered frame, so `step` typically consumes exactly one
-   *   sub-step per call. This is the idiomatic hook and keeps physics in step
-   *   with any other fixed-rate game logic.
-   * - **`Scene.update(delta)`** — passing the raw, variable per-frame
-   *   `delta.seconds` straight from the render loop also works correctly:
-   *   `step`'s internal accumulator still produces exactly the right number of
-   *   fixed sub-steps (0, 1 or several) regardless of how irregular the calls
-   *   are. Useful when you don't want a `fixedUpdate` split for anything else.
+   * **Prefer registering the world as a system instead**
+   * (`app.systems.add(world, { order: SystemOrder.Physics })` or the scene
+   * equivalent) so {@link fixedUpdate} drives stepping directly from the
+   * engine's own fixed-timestep scheduler — one call per fixed step, no
+   * accumulator duplication. `step` remains available here for manual/advanced
+   * driving (e.g. a fixed-but-non-standard rate, or stepping outside the
+   * normal frame loop entirely): pass any delta and this accumulator converts
+   * it into the right number of fixed sub-steps (0, 1, or several, clamped by
+   * {@link PhysicsWorldOptions.maxSubSteps}).
    *
    * Either way the simulation is frame-rate independent and deterministic —
    * the same sequence of deltas replays identically. `timeStepper.alpha`
@@ -442,77 +435,7 @@ export class PhysicsWorld implements BodyOwner {
       const hasBullets = this._hasBullets();
 
       for (let step = 0; step < steps; step++) {
-        // Detection runs once per fixed step (collider geometry is already current
-        // from the previous frame's finalize / attach / setTransform). TGS-Soft
-        // reuses the manifolds across the sub-steps below.
-        this._backend.detect(this._colliders);
-
-        // Sleep decision runs after detection (islands need the current contact
-        // set) and before the solver (so sleeping contacts are skipped, and a
-        // sleeping island touched by an awake body is woken first).
-        if (this.enableSleeping) {
-          this._updateSleeping(this.timeStepper.fixedDelta);
-        }
-
-        this._backend.prepareSolve(h, contactHertz, dampingRatio);
-
-        if (hasJoints) {
-          this._prepareJoints(h);
-        }
-
-        if (hasBullets) {
-          this._recordBulletPositions();
-        }
-
-        for (let subStep = 0; subStep < subStepCount; subStep++) {
-          // Integrate gravity/forces over the sub-step (forces persist across
-          // sub-steps; cleared once per frame by `_finalizePosition`).
-          for (const body of this._bodies) {
-            body._integrateVelocity(h, gravityX, gravityY);
-          }
-
-          // Warm-start every sub-step (Box2D-v3 soft step): the relax pass leaves
-          // each contact's normal velocity at zero, so re-applying the
-          // accumulated impulse re-balances exactly this sub-step's gravity — the
-          // impulse converges to the per-sub-step load (m·h·g), not the per-frame
-          // load, which is what keeps tall stacks from pumping energy.
-          this._backend.warmStart();
-
-          if (hasJoints) {
-            this._warmStartJoints();
-          }
-
-          // Main soft-bias velocity solve, integrate positions (accumulating
-          // per-body delta), then the bias-free relax pass. Joints solve right
-          // after the contacts in each pass (contacts are the stiffer constraint).
-          this._backend.solveVelocities(true);
-
-          if (hasJoints) {
-            this._solveJoints(true);
-          }
-
-          for (const body of this._bodies) {
-            body._integratePosition(h);
-          }
-
-          this._backend.solveVelocities(false);
-
-          if (hasJoints) {
-            this._solveJoints(false);
-          }
-        }
-
-        // Separate restitution pass, then write the accumulated delta into each
-        // body's transform and re-sync collider geometry.
-        this._backend.applyRestitution();
-
-        for (const body of this._bodies) {
-          body._finalizePosition();
-        }
-
-        if (hasBullets) {
-          this._advanceBullets();
-        }
+        this._stepOnce(h, subStepCount, gravityX, gravityY, contactHertz, dampingRatio, hasJoints, hasBullets);
       }
 
       this._dispatchEvents();
@@ -520,6 +443,111 @@ export class PhysicsWorld implements BodyOwner {
 
     this._bindings.sync();
     this._drainCommands();
+  }
+
+  /**
+   * Advance by exactly one fixed step, driven directly by the engine's own
+   * fixed-timestep scheduler when this world is registered as a `System`
+   * (`app.systems.add(world, { order: SystemOrder.Physics })` or the scene
+   * equivalent) — bypasses {@link timeStepper}'s variable-delta accumulator
+   * entirely, since the caller has already decided exactly when a fixed step
+   * occurs. Prefer this over manual {@link step} once the world is
+   * system-registered; `step` remains available for advanced manual driving.
+   */
+  public fixedUpdate(_step: Time): void {
+    this._assertAlive();
+
+    const subStepCount = this.subStepCount;
+    const h = this.timeStepper.fixedDelta / subStepCount;
+
+    this._stepOnce(h, subStepCount, this.gravity.x, this.gravity.y, this.contactHertz, this.dampingRatio, this._joints.length > 0, this._hasBullets());
+
+    this._dispatchEvents();
+    this._bindings.sync();
+    this._drainCommands();
+  }
+
+  private _stepOnce(
+    h: number,
+    subStepCount: number,
+    gravityX: number,
+    gravityY: number,
+    contactHertz: number,
+    dampingRatio: number,
+    hasJoints: boolean,
+    hasBullets: boolean,
+  ): void {
+    // Detection runs once per fixed step (collider geometry is already current
+    // from the previous frame's finalize / attach / setTransform). TGS-Soft
+    // reuses the manifolds across the sub-steps below.
+    this._backend.detect(this._colliders);
+
+    // Sleep decision runs after detection (islands need the current contact
+    // set) and before the solver (so sleeping contacts are skipped, and a
+    // sleeping island touched by an awake body is woken first).
+    if (this.enableSleeping) {
+      this._updateSleeping(this.timeStepper.fixedDelta);
+    }
+
+    this._backend.prepareSolve(h, contactHertz, dampingRatio);
+
+    if (hasJoints) {
+      this._prepareJoints(h);
+    }
+
+    if (hasBullets) {
+      this._recordBulletPositions();
+    }
+
+    for (let subStep = 0; subStep < subStepCount; subStep++) {
+      // Integrate gravity/forces over the sub-step (forces persist across
+      // sub-steps; cleared once per frame by `_finalizePosition`).
+      for (const body of this._bodies) {
+        body._integrateVelocity(h, gravityX, gravityY);
+      }
+
+      // Warm-start every sub-step (Box2D-v3 soft step): the relax pass leaves
+      // each contact's normal velocity at zero, so re-applying the
+      // accumulated impulse re-balances exactly this sub-step's gravity — the
+      // impulse converges to the per-sub-step load (m·h·g), not the per-frame
+      // load, which is what keeps tall stacks from pumping energy.
+      this._backend.warmStart();
+
+      if (hasJoints) {
+        this._warmStartJoints();
+      }
+
+      // Main soft-bias velocity solve, integrate positions (accumulating
+      // per-body delta), then the bias-free relax pass. Joints solve right
+      // after the contacts in each pass (contacts are the stiffer constraint).
+      this._backend.solveVelocities(true);
+
+      if (hasJoints) {
+        this._solveJoints(true);
+      }
+
+      for (const body of this._bodies) {
+        body._integratePosition(h);
+      }
+
+      this._backend.solveVelocities(false);
+
+      if (hasJoints) {
+        this._solveJoints(false);
+      }
+    }
+
+    // Separate restitution pass, then write the accumulated delta into each
+    // body's transform and re-sync collider geometry.
+    this._backend.applyRestitution();
+
+    for (const body of this._bodies) {
+      body._finalizePosition();
+    }
+
+    if (hasBullets) {
+      this._advanceBullets();
+    }
   }
 
   // ── binding ────────────────────────────────────────────────────────────

--- a/packages/exojs-physics/src/PhysicsWorld.ts
+++ b/packages/exojs-physics/src/PhysicsWorld.ts
@@ -453,6 +453,11 @@ export class PhysicsWorld implements BodyOwner {
    * entirely, since the caller has already decided exactly when a fixed step
    * occurs. Prefer this over manual {@link step} once the world is
    * system-registered; `step` remains available for advanced manual driving.
+   * Always advances by exactly {@link timeStepper}'s configured `fixedDelta`,
+   * regardless of the caller's actual fixed-step interval — if the engine's
+   * `Application.fixedTimeStep` doesn't match this world's `fixedDelta`, the
+   * simulation stays deterministic but runs at the wrong wall-clock speed
+   * relative to real time.
    */
   public fixedUpdate(_step: Time): void {
     this._assertAlive();

--- a/packages/exojs-physics/test/world.test.ts
+++ b/packages/exojs-physics/test/world.test.ts
@@ -603,3 +603,53 @@ describe('PhysicsWorld.attach: defaults to the node\'s world position (P2f)', ()
     expect(body.y).toBe(0);
   });
 });
+
+describe('PhysicsWorld.fixedUpdate()', () => {
+  it('advances exactly one fixed step per call, matching step() with a delta equal to fixedDelta', () => {
+    const worldA = new PhysicsWorld({ gravity: { x: 0, y: 900 } });
+    const bodyA = worldA.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [new Collider({ shape: new BoxShape(10, 10) })] }));
+
+    const worldB = new PhysicsWorld({ gravity: { x: 0, y: 900 } });
+    const bodyB = worldB.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [new Collider({ shape: new BoxShape(10, 10) })] }));
+
+    worldA.step(1 / 60);
+    worldB.fixedUpdate({ seconds: 1 / 60 } as never);
+
+    expect(bodyB.y).toBeCloseTo(bodyA.y, 10);
+    expect(bodyB.linearVelocityY).toBeCloseTo(bodyA.linearVelocityY, 10);
+  });
+
+  it('is a no-op-safe repeatable call: N fixedUpdate() calls match N step() calls of the same size', () => {
+    const worldA = new PhysicsWorld({ gravity: { x: 0, y: 900 } });
+    const bodyA = worldA.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [new Collider({ shape: new BoxShape(10, 10) })] }));
+
+    const worldB = new PhysicsWorld({ gravity: { x: 0, y: 900 } });
+    const bodyB = worldB.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [new Collider({ shape: new BoxShape(10, 10) })] }));
+
+    for (let i = 0; i < 5; i++) {
+      worldA.step(1 / 60);
+      worldB.fixedUpdate({ seconds: 1 / 60 } as never);
+    }
+
+    expect(bodyB.y).toBeCloseTo(bodyA.y, 8);
+  });
+
+  it('dispatches events after the step, same as step()', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 900 } });
+    const events: string[] = [];
+
+    world.onCollisionStart.add(() => events.push('start'));
+
+    const ground = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 100 }, colliders: [new Collider({ shape: new BoxShape(200, 20) })] }));
+    const box = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [new Collider({ shape: new BoxShape(10, 10) })] }));
+
+    void ground;
+    void box;
+
+    for (let i = 0; i < 60; i++) {
+      world.fixedUpdate({ seconds: 1 / 60 } as never);
+    }
+
+    expect(events).toContain('start');
+  });
+});

--- a/site/src/content/api/physics-world.json
+++ b/site/src/content/api/physics-world.json
@@ -560,7 +560,7 @@
             }
           ],
           "returnType": "void",
-          "description": "Advance by exactly one fixed step, driven directly by the engine's own fixed-timestep scheduler when this world is registered as a System (app.systems.add(world, { order: SystemOrder.Physics }) or the scene equivalent) — bypasses timeStepper's variable-delta accumulator entirely, since the caller has already decided exactly when a fixed step occurs. Prefer this over manual step once the world is system-registered; step remains available for advanced manual driving."
+          "description": "Advance by exactly one fixed step, driven directly by the engine's own fixed-timestep scheduler when this world is registered as a System (app.systems.add(world, { order: SystemOrder.Physics }) or the scene equivalent) — bypasses timeStepper's variable-delta accumulator entirely, since the caller has already decided exactly when a fixed step occurs. Prefer this over manual step once the world is system-registered; step remains available for advanced manual driving. Always advances by exactly timeStepper's configured fixedDelta, regardless of the caller's actual fixed-step interval — if the engine's Application.fixedTimeStep doesn't match this world's fixedDelta, the simulation stays deterministic but runs at the wrong wall-clock speed relative to real time."
         },
         {
           "name": "forEachAabbHit",

--- a/site/src/content/api/physics-world.json
+++ b/site/src/content/api/physics-world.json
@@ -6,10 +6,10 @@
   "subsystem": "physics",
   "importPath": "@codexo/exojs-physics",
   "tier": "stable",
-  "memberCount": 36,
+  "memberCount": 37,
   "counts": {
     "constructors": 1,
-    "methods": 18,
+    "methods": 19,
     "properties": 13,
     "events": 4
   },
@@ -514,6 +514,53 @@
           ],
           "returnType": "void",
           "description": "Destroy a single collider, recomputing its body's mass. Deferred when called inside a callback."
+        },
+        {
+          "name": "fixedUpdate",
+          "signature": "fixedUpdate(_step: Time): void",
+          "signatureTokens": [
+            {
+              "text": "fixedUpdate",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "_step",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Time",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "_step",
+              "type": "Time",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Advance by exactly one fixed step, driven directly by the engine's own fixed-timestep scheduler when this world is registered as a System (app.systems.add(world, { order: SystemOrder.Physics }) or the scene equivalent) — bypasses timeStepper's variable-delta accumulator entirely, since the caller has already decided exactly when a fixed step occurs. Prefer this over manual step once the world is system-registered; step remains available for advanced manual driving."
         },
         {
           "name": "forEachAabbHit",
@@ -1664,7 +1711,7 @@
             }
           ],
           "returnType": "void",
-          "description": "Advance the world by frameDeltaSeconds. Accumulates into fixed steps; each fixed step runs detection once, then a TGS-Soft sub-step loop (integrate gravity, solve contacts with a soft bias, integrate positions, relax) and a restitution pass, then writes the accumulated motion into each body. Finally dispatches events and writes bound node transforms. **Fixed timestep against a variable render loop.** frameDeltaSeconds does **not** need to already be a fixed-size delta — step owns its own accumulator (timeStepper, a TimeStepper) that converts whatever you pass into a whole number of fixedDelta-sized sub-steps (dropping any backlog beyond PhysicsWorldOptions.maxSubSteps so a slow frame cannot spiral). Two equally valid ways to drive it: - **Scene.fixedUpdate(delta)** (recommended) — the engine's own fixed-timestep accumulator already calls this hook a constant number of times per rendered frame, so step typically consumes exactly one sub-step per call. This is the idiomatic hook and keeps physics in step with any other fixed-rate game logic. - **Scene.update(delta)** — passing the raw, variable per-frame delta.seconds straight from the render loop also works correctly: step's internal accumulator still produces exactly the right number of fixed sub-steps (0, 1 or several) regardless of how irregular the calls are. Useful when you don't want a fixedUpdate split for anything else. Either way the simulation is frame-rate independent and deterministic — the same sequence of deltas replays identically. timeStepper.alpha ([0, 1)) is the leftover sub-step fraction after this call, for callers that want to interpolate a bound node's rendered position between the last two fixed states instead of snapping to the latest one (bindings do not do this automatically — bind always writes the latest fixed-step transform verbatim)."
+          "description": "Advance the world by frameDeltaSeconds. Accumulates into fixed steps; each fixed step runs detection once, then a TGS-Soft sub-step loop (integrate gravity, solve contacts with a soft bias, integrate positions, relax) and a restitution pass, then writes the accumulated motion into each body. Finally dispatches events and writes bound node transforms. **Prefer registering the world as a system instead** (app.systems.add(world, { order: SystemOrder.Physics }) or the scene equivalent) so fixedUpdate drives stepping directly from the engine's own fixed-timestep scheduler — one call per fixed step, no accumulator duplication. step remains available here for manual/advanced driving (e.g. a fixed-but-non-standard rate, or stepping outside the normal frame loop entirely): pass any delta and this accumulator converts it into the right number of fixed sub-steps (0, 1, or several, clamped by PhysicsWorldOptions.maxSubSteps). Either way the simulation is frame-rate independent and deterministic — the same sequence of deltas replays identically. timeStepper.alpha ([0, 1)) is the leftover sub-step fraction after this call, for callers that want to interpolate a bound node's rendered position between the last two fixed states instead of snapping to the latest one (bindings do not do this automatically — bind always writes the latest fixed-step transform verbatim)."
         },
         {
           "name": "unbind",

--- a/site/src/content/guide/recipes/cinematics.mdx
+++ b/site/src/content/guide/recipes/cinematics.mdx
@@ -18,17 +18,17 @@ The key technique: **tween chains and delays**. Each tween starts at a specific 
 
 ```js
 class CinematicScene extends Scene {
-    async load(loader) {
+    async load() {
         // AudioStream has no bare-path form, so use `.of(...)` — and since
         // `get(Asset.kind('music', ...))` isn't supported, keep the loaded
         // instances as direct references instead of looking them up later.
         [this.bossTexture, this.trackStream] = await Promise.all([
-            loader.load('image/boss.png'),
-            loader.load(Asset.kind('music', 'audio/track.ogg')),
+            this.loader.load('image/boss.png'),
+            this.loader.load(Asset.kind('music', 'audio/track.ogg')),
         ]);
     }
 
-    init(loader) {
+    init() {
         // Camera — pans from title position to boss reveal
         this.view = new View(220, 300, 800, 600);
 
@@ -136,7 +136,7 @@ The closing shutter bars animate over the scene, then `setScene(...)` transition
 If you want the shutter bars or subtitle text to stay in screen space and be immune to camera transforms, put them on `scene.ui` instead of rendering them in `draw`:
 
 ```js
-init(loader) {
+init() {
     // ... main cinematic setup ...
 
     // Letterbox bars as UI nodes — always screen-aligned.
@@ -164,7 +164,7 @@ Staggering tweens with `Tween.delay()` is what turns independent animations into
 </Callout>
 
 ```js no-check
-init(loader) {
+init() {
     // ... cinematic setup ...
 
     this.inputs.onTrigger(Keyboard.Space, () => {

--- a/site/src/content/guide/recipes/pause-menu.mdx
+++ b/site/src/content/guide/recipes/pause-menu.mdx
@@ -8,20 +8,20 @@ import Callout from '../../../components/Callout.astro';
 
 # Pause menu
 
-A pause menu can freeze the game, display a menu overlay, and resume cleanly when dismissed. In ExoJS, this is done entirely within a single scene: set `scene.paused = true` to freeze updates, show a pause overlay on `scene.ui`, and reverse both on resume.
+A pause menu can freeze the game, display a menu overlay, and resume cleanly when dismissed. In ExoJS, this is done entirely within a single scene: call `app.scenes.pause()`/`resume()` to freeze updates, show a pause overlay on `scene.ui`, and reverse both on resume.
 
 ## Approach
 
-One scene, one UI layer. The pause overlay (a `Panel` + `Label`) lives on `scene.ui` and is hidden until paused. Toggling `scene.paused` stops `update()` and all scene systems while the scene keeps drawing — so the world stays visible behind the overlay. A `BlurFilter` on `scene.root` provides visual separation.
+One scene, one UI layer. The pause overlay (a `Panel` + `Label`) lives on `scene.ui` and is hidden until paused. Pausing stops `update()` and all scene systems while the scene keeps drawing — so the world stays visible behind the overlay. A `BlurFilter` on `scene.root` provides visual separation.
 
 <Callout type="info" title="Tweens keep running while paused">
-`app.tweens` keeps advancing even when `scene.paused` is `true` — only `update()` and scene-level systems freeze. That is what lets a blur ramp or menu transition animate smoothly over the frozen world.
+`app.tweens` keeps advancing even while the scene is paused — only `update()` and scene-level systems freeze. That is what lets a blur ramp or menu transition animate smoothly over the frozen world.
 </Callout>
 
 ```js
 class GameScene extends Scene {
-    init(loader) {
-        this.player = new Sprite(loader.get('image/hero.png'));
+    init() {
+        this.player = new Sprite(this.loader.get('image/hero.png'));
         this.addChild(this.player);
         // ... game setup ...
 
@@ -38,11 +38,14 @@ class GameScene extends Scene {
         this.pauseLabel.visible = false;
         this.ui.addChild(this.pauseLabel);
 
-        this.inputs.onTrigger(Keyboard.Escape, () => this.togglePause());
+        // `when: 'always'` keeps this binding live in both Active and Paused —
+        // otherwise a 'active'-only binding (the default) would stop firing
+        // the moment the scene pauses, and Escape could never resume it.
+        this.inputs.onTrigger(Keyboard.Escape, () => this.togglePause(), { when: 'always' });
     }
 
     update(delta) {
-        // Not called while paused — SceneDirector skips update() + systems.
+        // Not called while paused — the director skips update() + systems.
         // ... normal game logic ...
     }
 
@@ -53,15 +56,21 @@ class GameScene extends Scene {
 
     destroy() {
         this.root.clearFilters();
-        super.destroy();
     }
 
     togglePause() {
-        this.paused = !this.paused;
-        this.pausePanel.visible = this.paused;
-        this.pauseLabel.visible = this.paused;
+        const pausing = this.state !== SceneState.Paused;
 
-        if (this.paused) {
+        if (pausing) {
+            this.app.scenes.pause();
+        } else {
+            this.app.scenes.resume();
+        }
+
+        this.pausePanel.visible = pausing;
+        this.pauseLabel.visible = pausing;
+
+        if (pausing) {
             this.blur.radius = 0;
             this.root.filters = [this.blur];
             this.tweens.create(this.blur).to({ radius: 6 }, 0.35).start();
@@ -71,22 +80,29 @@ class GameScene extends Scene {
     }
 }
 
-await app.start(new GameScene());
+const app = new Application({ scenes: { GameScene } /* , ...other options */ });
+
+await app.start(GameScene);
 ```
 
 <Callout type="warning" title="Clear filters in destroy">
 Any filter you set in `init` or `togglePause` — the `BlurFilter` here — must be cleared in `destroy`. Otherwise it stays attached to `scene.root` and bleeds into the next scene after `app.scenes.setScene(...)`.
 </Callout>
 
-## How `scene.paused` works
+<Callout type="hint" title="Modal menus that must block clicks">
+This recipe's overlay is informational only — `scene.ui` widgets stay clickable regardless of pause state, which is fine here since nothing else is interactive underneath. For a menu that must swallow clicks so they never reach gameplay nodes beneath it, wrap it with `this.interaction.capture(this.pausePanel)` and release the returned handle on resume.
+</Callout>
 
-Setting `scene.paused = true`:
+## How pausing works
 
-- **Freezes `update()`** — the SceneDirector skips `update()` and all scene-level systems. No game logic runs.
+`app.scenes.pause()` moves the active scene to `SceneState.Paused`:
+
+- **Freezes `update()`** — the director skips `update()` and all scene-level systems. No game logic runs.
 - **Keeps drawing** — the scene still renders every frame, so the world remains visible behind the overlay.
-- **Tweens on `app.tweens` still run** — tween managers at the application level are unaffected, so blur animations and UI transitions animate smoothly while the game is frozen.
+- **Tweens on `app.tweens` still run** — the application-level tween manager is unaffected, so blur animations and UI transitions animate smoothly while the game is frozen.
+- **Scene input bindings default to `'active'` only** — pass `{ when: 'paused' }` for a binding that should fire only while paused (e.g. a menu confirm button), or `{ when: 'always' }` for one that must work in both states (the Escape toggle above).
 
-`scene.ui` widgets are always interactive regardless of `scene.paused`, so the pause panel's buttons remain clickable during the pause.
+`scene.ui` widgets are always interactive regardless of pause state, so the pause panel's buttons remain clickable during the pause.
 
 ## Cleanup
 
@@ -104,7 +120,7 @@ resumeButton.onClick.add(() => {
 
 // Inside a "main menu" button's onClick handler:
 mainMenuButton.onClick.add(() => {
-    this.app.scenes.setScene(new MainMenuScene(), { transition: { type: 'fade' } });
+    this.app.scenes.setScene(MainMenuScene, { transition: { type: 'fade' } });
 });
 ```
 

--- a/src/core/SceneScope.ts
+++ b/src/core/SceneScope.ts
@@ -97,13 +97,7 @@ export class SceneScope<Data = unknown> {
       }
     }
 
-    this._app.interaction.attachRoot(this.scene.root);
-
-    const ui = this.scene._peekUI();
-
-    if (ui !== null) {
-      this._app.interaction.attachUIRoot(ui);
-    }
+    this._attachAutoRoots();
 
     this._rootsAttached = true;
     this.scene.onLoad.dispatch();
@@ -158,6 +152,11 @@ export class SceneScope<Data = unknown> {
 
     this._guard(errors, () => this.inputs.suspend());
     this._guard(errors, () => this.interaction.suspend());
+    this._guard(errors, () => {
+      if (this._rootsAttached) {
+        this._detachAutoRoots();
+      }
+    });
     this._guard(errors, () => this.tweens.suspend());
     this._guard(errors, () => this.audio.suspend());
 
@@ -184,6 +183,11 @@ export class SceneScope<Data = unknown> {
 
     this._guard(errors, () => this.inputs.resume());
     this._guard(errors, () => this.interaction.resume());
+    this._guard(errors, () => {
+      if (this._rootsAttached) {
+        this._attachAutoRoots();
+      }
+    });
     this._guard(errors, () => this.tweens.resume());
     this._guard(errors, () => this.audio.resume());
 
@@ -370,7 +374,20 @@ export class SceneScope<Data = unknown> {
     }
 
     this._rootsAttached = false;
+    this._detachAutoRoots();
+  }
 
+  private _attachAutoRoots(): void {
+    this._app.interaction.attachRoot(this.scene.root);
+
+    const ui = this.scene._peekUI();
+
+    if (ui !== null) {
+      this._app.interaction.attachUIRoot(ui);
+    }
+  }
+
+  private _detachAutoRoots(): void {
     const ui = this.scene._peekUI();
 
     if (ui !== null) {

--- a/src/core/SceneScope.ts
+++ b/src/core/SceneScope.ts
@@ -204,6 +204,12 @@ export class SceneScope<Data = unknown> {
     return true;
   }
 
+  /**
+   * Forward one fixed step to the scene and its systems, gated to `Active`
+   * (§3 state table — `fixedUpdate` never runs while `Paused`, unlike
+   * {@link SceneScope.draw}). Warns (dev-only) if `Scene.fixedUpdate` returns
+   * a thenable — the hook must be synchronous.
+   */
   public fixedUpdate(step: Time): void {
     if (this._state !== SceneState.Active) {
       return;
@@ -232,6 +238,11 @@ export class SceneScope<Data = unknown> {
     }
   }
 
+  /**
+   * Forward one frame's update to the scene and its systems, gated to
+   * `Active`. Warns (dev-only) if `Scene.update` returns a thenable — the
+   * hook must be synchronous.
+   */
   public update(delta: Time): void {
     if (this._state !== SceneState.Active) {
       return;
@@ -260,6 +271,12 @@ export class SceneScope<Data = unknown> {
     }
   }
 
+  /**
+   * Forward one frame's draw to the scene, its systems, then the UI layer —
+   * gated to `Active` or `Paused` (a paused scene keeps rendering while
+   * simulation is frozen). Warns (dev-only) if `Scene.draw` returns a
+   * thenable — the hook must be synchronous.
+   */
   public draw(context: RenderingContext): void {
     if (this._state !== SceneState.Active && this._state !== SceneState.Paused) {
       return;

--- a/src/core/SceneScope.ts
+++ b/src/core/SceneScope.ts
@@ -135,10 +135,14 @@ export class SceneScope<Data = unknown> {
    * Records the pre-suspend state so {@link SceneScope.restore} can return
    * to it. Suspends every facility except the loader — claims are never
    * suspended (definition §14.2), so background asset loading continues.
-   * Every facility call is individually guarded; a single facility's
-   * failure never blocks the state transition or the others, and is
-   * reported through the app error pipeline rather than thrown. Returns
-   * whether the transition happened.
+   * Also detaches the scene's own automatic root and (if materialized) UI
+   * from interaction dispatch, so a retained scene stops receiving pointer
+   * events alongside whichever scope is now active — the same detachment
+   * {@link SceneScope.destroy} performs, just reversible via {@link
+   * SceneScope.restore}. Every facility call is individually guarded; a
+   * single facility's failure never blocks the state transition or the
+   * others, and is reported through the app error pipeline rather than
+   * thrown. Returns whether the transition happened.
    */
   public suspend(): boolean {
     if (!canSuspend(this._state)) {
@@ -168,8 +172,11 @@ export class SceneScope<Data = unknown> {
   /**
    * Restore this scope from retention: `Suspended` → the `Active`/`Paused`
    * state it had before {@link SceneScope.suspend}. `load()`/`init()` do not
-   * run again (definition §14.3). Same error-guarding contract as
-   * {@link SceneScope.suspend}. Returns whether the transition happened.
+   * run again (definition §14.3). Also reattaches the scene's own automatic
+   * root and (if materialized) UI to interaction dispatch, undoing the
+   * detachment {@link SceneScope.suspend} performed. Same error-guarding
+   * contract as {@link SceneScope.suspend}. Returns whether the transition
+   * happened.
    */
   public restore(): boolean {
     if (!canRestore(this._state) || this._visibleStateBeforeSuspend === null) {

--- a/src/core/SceneScope.ts
+++ b/src/core/SceneScope.ts
@@ -59,7 +59,7 @@ export class SceneScope<Data = unknown> {
     this.inputs = new SceneInputs(app, () => this._state);
     this.interaction = new SceneInteraction(app);
     this.tweens = new SceneTweens(app);
-    this.audio = new SceneAudio(app);
+    this.audio = new SceneAudio(app, () => this._state);
 
     scene._attach(app, this);
   }
@@ -106,6 +106,7 @@ export class SceneScope<Data = unknown> {
   /** Commit this scope as the active scene: `Preparing` → `Active`. Called by the director once the switch boundary is crossed. */
   public activate(): void {
     this._state = SceneState.Active;
+    this.audio._flushPending();
   }
 
   /** Pause this scope: `Active` → `Paused`. Returns whether the transition happened. */

--- a/src/core/scene/SceneAudio.ts
+++ b/src/core/scene/SceneAudio.ts
@@ -1,8 +1,149 @@
+import { getAudioContext } from '#audio/audio-context';
+import type { AudioBus } from '#audio/AudioBus';
+import type { AudioEffect } from '#audio/AudioEffect';
 import type { Pausable, Playable, PlayOptions, Voice } from '#audio/Playable';
 import type { Application } from '#core/Application';
+import { SceneState } from '#core/SceneState';
+import { Signal } from '#core/Signal';
 import type { Destroyable } from '#core/types';
 
 const isPausable = (voice: Voice): voice is Voice & Pausable => 'pause' in voice && 'resume' in voice;
+
+/**
+ * Stand-in {@link Voice} returned by {@link SceneAudio.play} while the owning
+ * scope is still `Preparing` (definition §7.8). Buffers `volume`/`bus`/effect
+ * writes and replays them onto the real voice once {@link PendingVoice._flush}
+ * runs at activation; `stop()` before flush cancels playback entirely — the
+ * real voice is never created. Narrower than a real `Voice`: capability
+ * mixins (`Pausable`, `Seekable`, …) are unavailable until flush, and reading
+ * `bus` before flush returns `undefined` (despite the type) unless an
+ * explicit `options.bus` override was given — the manager's default bus
+ * isn't resolvable until the real voice exists. A documented limitation of
+ * Preparing-phase playback, not a general `Voice` capability.
+ * @internal
+ */
+class PendingVoice implements Voice {
+  private _real: Voice | null = null;
+  private _cancelled = false;
+  private _volume: number;
+  private _bus: AudioBus | undefined;
+  private readonly _pendingEffects: AudioEffect[] = [];
+  private readonly _dummyOutput: AudioNode;
+  public readonly onEnd = new Signal();
+
+  public constructor(
+    private readonly _createReal: () => Voice,
+    options: PlayOptions,
+  ) {
+    this._volume = options.volume ?? 1;
+    this._bus = options.bus;
+    this._dummyOutput = getAudioContext().createGain();
+  }
+
+  public get ended(): boolean {
+    return this._real?.ended ?? this._cancelled;
+  }
+
+  public get output(): AudioNode {
+    return this._real?.output ?? this._dummyOutput;
+  }
+
+  public get volume(): number {
+    return this._real?.volume ?? this._volume;
+  }
+
+  public set volume(value: number) {
+    this._volume = value;
+
+    if (this._real) {
+      this._real.volume = value;
+    }
+  }
+
+  public get bus(): AudioBus {
+    return this._real?.bus ?? this._bus!;
+  }
+
+  public set bus(value: AudioBus) {
+    this._bus = value;
+
+    if (this._real) {
+      this._real.bus = value;
+    }
+  }
+
+  public fade(to: number, ms: number): void {
+    if (this._real) {
+      this._real.fade(to, ms);
+    } else {
+      // Nothing is playing yet — best effort is to apply the target volume
+      // immediately once flushed; the ramp itself has nothing to animate.
+      this._volume = to;
+    }
+  }
+
+  public stop(fadeMs?: number): void {
+    if (this._real) {
+      this._real.stop(fadeMs);
+
+      return;
+    }
+
+    if (!this._cancelled) {
+      this._cancelled = true;
+      this.onEnd.dispatch();
+    }
+  }
+
+  public addEffect(effect: AudioEffect): this {
+    if (this._real) {
+      this._real.addEffect(effect);
+    } else {
+      this._pendingEffects.push(effect);
+    }
+
+    return this;
+  }
+
+  public removeEffect(effect: AudioEffect): this {
+    if (this._real) {
+      this._real.removeEffect(effect);
+    } else {
+      const index = this._pendingEffects.indexOf(effect);
+
+      if (index !== -1) {
+        this._pendingEffects.splice(index, 1);
+      }
+    }
+
+    return this;
+  }
+
+  /** Start real playback. No-op if already flushed or cancelled via {@link PendingVoice.stop}. */
+  public _flush(): void {
+    if (this._cancelled || this._real !== null) {
+      return;
+    }
+
+    const real = this._createReal();
+
+    this._real = real;
+    real.volume = this._volume;
+
+    if (this._bus !== undefined) {
+      real.bus = this._bus;
+    }
+
+    for (const effect of this._pendingEffects) {
+      real.addEffect(effect);
+    }
+
+    this._pendingEffects.length = 0;
+    real.onEnd.add((): void => {
+      this.onEnd.dispatch();
+    });
+  }
+}
 
 /**
  * Scene-bound audio facade. Playback started or added here uses scene
@@ -11,17 +152,36 @@ const isPausable = (voice: Voice): voice is Voice & Pausable => 'pause' in voice
  *
  * Delegates entirely to `app.audio` — no second audio graph, just tracking of
  * what this facade started so it can stop it on teardown (and, for capable
- * voices, pause/resume it across retention suspension). Gating playback
- * requested while the scope is `Preparing` is introduced by a later slice.
+ * voices, pause/resume it across retention suspension). Playback requested
+ * while the scope is `Preparing` is queued and started once the scope
+ * activates (definition §7.8) — see {@link PendingVoice}.
  */
 export class SceneAudio implements Destroyable {
   private readonly _tracked = new Set<Voice>();
+  private readonly _pending = new Set<PendingVoice>();
   private _suspended: Set<Voice & Pausable> | null = null;
 
-  public constructor(private readonly _app: Application) {}
+  public constructor(
+    private readonly _app: Application,
+    private readonly _getState: () => SceneState,
+  ) {}
 
-  /** Play `source` through the application audio manager and track the resulting {@link Voice} for scene-lifetime cleanup. */
+  /**
+   * Play `source` through the application audio manager and track the
+   * resulting {@link Voice} for scene-lifetime cleanup. While the scope is
+   * `Preparing`, returns a {@link PendingVoice} stand-in immediately and
+   * defers the real `app.audio.play(...)` call until activation.
+   */
   public play(source: Playable, options?: PlayOptions): Voice {
+    if (this._getState() === SceneState.Preparing) {
+      const pending = new PendingVoice(() => this._app.audio.play(source, options ?? {}), options ?? {});
+
+      this._pending.add(pending);
+      this._tracked.add(pending);
+
+      return pending;
+    }
+
     return this.add(this._app.audio.play(source, options));
   }
 
@@ -30,6 +190,19 @@ export class SceneAudio implements Destroyable {
     this._tracked.add(voice);
 
     return voice;
+  }
+
+  /**
+   * Start every voice queued by {@link SceneAudio.play} while the scope was
+   * `Preparing`. Called once, by {@link SceneScope.activate}.
+   * @internal
+   */
+  public _flushPending(): void {
+    for (const pending of this._pending) {
+      pending._flush();
+    }
+
+    this._pending.clear();
   }
 
   /**
@@ -74,5 +247,6 @@ export class SceneAudio implements Destroyable {
 
     this._tracked.clear();
     this._suspended = null;
+    this._pending.clear();
   }
 }

--- a/src/core/scene/SceneAudio.ts
+++ b/src/core/scene/SceneAudio.ts
@@ -119,10 +119,16 @@ class PendingVoice implements Voice {
     return this;
   }
 
-  /** Start real playback. No-op if already flushed or cancelled via {@link PendingVoice.stop}. */
-  public _flush(): void {
+  /**
+   * Start real playback. No-op if already flushed or cancelled via
+   * {@link PendingVoice.stop}. Returns the newly created real {@link Voice}
+   * so the caller (`SceneAudio._flushPending`) can swap its own tracking to
+   * the capability-bearing voice; returns `null` when there was nothing to
+   * flush.
+   */
+  public _flush(): Voice | null {
     if (this._cancelled || this._real !== null) {
-      return;
+      return null;
     }
 
     const real = this._createReal();
@@ -142,6 +148,8 @@ class PendingVoice implements Voice {
     real.onEnd.add((): void => {
       this.onEnd.dispatch();
     });
+
+    return real;
   }
 }
 
@@ -194,12 +202,20 @@ export class SceneAudio implements Destroyable {
 
   /**
    * Start every voice queued by {@link SceneAudio.play} while the scope was
-   * `Preparing`. Called once, by {@link SceneScope.activate}.
+   * `Preparing`. Called once, by {@link SceneScope.activate}. Swaps each
+   * flushed {@link PendingVoice} wrapper in `_tracked` for the real `Voice`
+   * it created, so `suspend()`/`resume()`/`destroy()` see the
+   * capability-bearing voice — the caller's own reference stays the wrapper,
+   * which forwards to the real voice transparently.
    * @internal
    */
   public _flushPending(): void {
     for (const pending of this._pending) {
-      pending._flush();
+      const real = pending._flush();
+
+      if (real !== null && this._tracked.delete(pending)) {
+        this._tracked.add(real);
+      }
     }
 
     this._pending.clear();

--- a/src/core/scene/SceneInputs.ts
+++ b/src/core/scene/SceneInputs.ts
@@ -63,18 +63,33 @@ export class SceneInputs implements Destroyable {
     private readonly _getState: () => SceneState,
   ) {}
 
+  /**
+   * Fire `callback` on the channel's press edge (value crosses above the
+   * threshold), gated by `options.when` (default `'active'`) and the
+   * director's transition gate. Unbound automatically when the owning scene
+   * ends permanently.
+   */
   public onStart(channel: InputChannel | readonly InputChannel[], callback: (value: number) => void, options?: SceneInputBindingOptions): InputBinding {
     return this._bind('onStart', channel, callback, options);
   }
 
+  /** Fire `callback` every frame the channel stays held above the threshold, same `when`/edge-rule gating as {@link SceneInputs.onStart}. */
   public onActive(channel: InputChannel | readonly InputChannel[], callback: (value: number) => void, options?: SceneInputBindingOptions): InputBinding {
     return this._bind('onActive', channel, callback, options);
   }
 
+  /** Fire `callback` on the channel's release edge, same `when`/edge-rule gating as {@link SceneInputs.onStart}. */
   public onStop(channel: InputChannel | readonly InputChannel[], callback: (value: number) => void, options?: SceneInputBindingOptions): InputBinding {
     return this._bind('onStop', channel, callback, options);
   }
 
+  /**
+   * Fire `callback` once a press-then-release completes within the
+   * threshold window — a "tap" or "click" gesture. Both the press and
+   * release edges must have occurred in a `when`-allowed state for the
+   * trigger to fire (definition §13.2): pressing while allowed, then the
+   * scene pausing before release, does not trigger.
+   */
   public onTrigger(channel: InputChannel | readonly InputChannel[], callback: (value: number) => void, options?: SceneInputBindingOptions): InputBinding {
     return this._bind('onTrigger', channel, callback, options);
   }
@@ -93,6 +108,7 @@ export class SceneInputs implements Destroyable {
     this._suspended = false;
   }
 
+  /** Unbind every tracked binding. Called automatically when the owning scene ends permanently. */
   public destroy(): void {
     for (const binding of this._bindings) {
       binding.unbind();

--- a/src/core/scene/SceneInteraction.ts
+++ b/src/core/scene/SceneInteraction.ts
@@ -57,6 +57,7 @@ interface TrackedCapture extends InteractionCapture {
 export class SceneInteraction implements Destroyable {
   private readonly _observations = new Set<TrackedObservation>();
   private readonly _captures: TrackedCapture[] = [];
+  private _suspended = false;
 
   public constructor(private readonly _app: Application) {}
 
@@ -108,18 +109,49 @@ export class SceneInteraction implements Destroyable {
   }
 
   /**
-   * Disable every tracked observation without detaching it. Reserved for
-   * retention (suspend/resume) — a later slice wires this to actual
-   * suspend/restore transitions.
+   * Detach every tracked observation and deactivate every capture (pop it
+   * from the manager's stack) without discarding local tracking, so
+   * {@link SceneInteraction.resume} can restore exactly the same set in the
+   * same order — a retained scene must not keep receiving pointer dispatch
+   * alongside whichever scope is now active (definition §8.2). Idempotent.
    * @internal
    */
   public suspend(): void {
-    // Wired by a later slice alongside retained-scene suspension.
+    if (this._suspended) {
+      return;
+    }
+
+    this._suspended = true;
+
+    for (const observation of this._observations) {
+      this._app.interaction.detachRoot(observation.root);
+    }
+
+    for (let i = this._captures.length - 1; i >= 0; i--) {
+      this._app.interaction.popInputCapture();
+    }
   }
 
-  /** Restore normal dispatch after {@link SceneInteraction.suspend}. @internal */
+  /**
+   * Reattach every tracked observation and re-push every tracked capture in
+   * its original order, undoing {@link SceneInteraction.suspend}. Idempotent
+   * — a no-op if not currently suspended.
+   * @internal
+   */
   public resume(): void {
-    // Wired by a later slice alongside retained-scene suspension.
+    if (!this._suspended) {
+      return;
+    }
+
+    this._suspended = false;
+
+    for (const observation of this._observations) {
+      this._app.interaction.attachRoot(observation.root);
+    }
+
+    for (const capture of this._captures) {
+      this._app.interaction.pushInputCapture(capture.root);
+    }
   }
 
   public destroy(): void {

--- a/src/core/scene/SceneInteraction.ts
+++ b/src/core/scene/SceneInteraction.ts
@@ -183,6 +183,19 @@ export class SceneInteraction implements Destroyable {
 
     const index = this._captures.indexOf(capture);
 
+    if (this._suspended) {
+      // suspend() already popped every capture off the live manager stack,
+      // and resume() will re-push the full, corrected `_captures` array
+      // from scratch. Touching the manager here (pop/push) would reinstate
+      // this capture's slot on the live stack while the scope is still
+      // dormant — exactly the state leak retention suspension exists to
+      // prevent. Local bookkeeping only; the manager catches up on resume().
+      capture.released = true;
+      this._captures.splice(index, 1);
+
+      return;
+    }
+
     // Pop every still-active capture from the top down through (and
     // including) this one, then re-push everything that was above it, in
     // original order — restores the manager's stack as if `capture` had

--- a/src/core/scene/SceneTweens.ts
+++ b/src/core/scene/SceneTweens.ts
@@ -14,6 +14,7 @@ export class SceneTweens implements Destroyable {
 
   public constructor(private readonly _app: Application) {}
 
+  /** Create a {@link Tween} targeting `target` through the application tween manager, tracked for scene-lifetime cleanup. */
   public create<T extends object>(target: T): Tween<T> {
     const tween = this._app.tweens.create(target);
     this._tweens.add(tween);
@@ -21,6 +22,7 @@ export class SceneTweens implements Destroyable {
     return tween;
   }
 
+  /** Track an already-created {@link Tween} (e.g. built via `app.tweens.create(...)`) for scene-lifetime cleanup. Returns `this` for chaining. */
   public add(tween: Tween): this {
     this._app.tweens.add(tween);
     this._tweens.add(tween);

--- a/test/core/scene-scope.test.ts
+++ b/test/core/scene-scope.test.ts
@@ -440,5 +440,18 @@ describe('SceneScope', () => {
 
       expect(scope.state).toBe(SceneState.Destroyed);
     });
+
+    test('suspend() detaches the scene root from interaction, restore() reattaches it', async () => {
+      const app = createAppStub();
+      const scene = new Scene();
+      const scope = await activate(app, scene);
+
+      scope.suspend();
+      expect(app.interaction.detachRoot).toHaveBeenCalledWith(scope.scene.root);
+
+      (app.interaction.attachRoot as MockInstance).mockClear();
+      scope.restore();
+      expect(app.interaction.attachRoot).toHaveBeenCalledWith(scope.scene.root);
+    });
   });
 });

--- a/test/core/scene/scene-audio.test.ts
+++ b/test/core/scene/scene-audio.test.ts
@@ -205,4 +205,16 @@ describe('SceneAudio — Preparing gate', () => {
     expect(pending.ended).toBe(true);
     expect(app.audio.play).not.toHaveBeenCalled();
   });
+
+  test('_flushPending() swaps the tracked PendingVoice for its real voice, so suspend() can pause it', () => {
+    const real = makePausableVoice({ onEnd: new Signal() });
+    const app = createAppStub(real);
+    const audio = new SceneAudio(app, () => SceneState.Preparing);
+
+    audio.play(fakePlayable);
+    audio._flushPending();
+    audio.suspend();
+
+    expect(real.pause).toHaveBeenCalledTimes(1);
+  });
 });

--- a/test/core/scene/scene-audio.test.ts
+++ b/test/core/scene/scene-audio.test.ts
@@ -1,11 +1,14 @@
 import type { Pausable, Playable, Voice } from '#audio/Playable';
 import type { Application } from '#core/Application';
 import { SceneAudio } from '#core/scene/SceneAudio';
+import { SceneState } from '#core/SceneState';
+import { Signal } from '#core/Signal';
 
 const makeVoice = (overrides: Partial<Voice> = {}): Voice =>
   ({
     stop: vi.fn(),
     ended: false,
+    onEnd: new Signal(),
     ...overrides,
   }) as unknown as Voice;
 
@@ -36,7 +39,7 @@ describe('SceneAudio', () => {
   test('play() delegates to app.audio.play and tracks the returned Voice', () => {
     const voice = makeVoice();
     const app = createAppStub(voice);
-    const audio = new SceneAudio(app);
+    const audio = new SceneAudio(app, () => SceneState.Active);
 
     const result = audio.play(fakePlayable, { volume: 0.5 });
 
@@ -46,7 +49,7 @@ describe('SceneAudio', () => {
 
   test('add() tracks an already-created Voice and returns it unchanged', () => {
     const app = createAppStub(makeVoice());
-    const audio = new SceneAudio(app);
+    const audio = new SceneAudio(app, () => SceneState.Active);
     const externalVoice = makeVoice();
 
     expect(audio.add(externalVoice)).toBe(externalVoice);
@@ -56,7 +59,7 @@ describe('SceneAudio', () => {
     const voiceA = makeVoice();
     const voiceB = makeVoice();
     const app = createAppStub(voiceA);
-    const audio = new SceneAudio(app);
+    const audio = new SceneAudio(app, () => SceneState.Active);
 
     audio.play(fakePlayable);
     audio.add(voiceB);
@@ -73,7 +76,7 @@ describe('SceneAudio', () => {
       const alreadyPaused = makePausableVoice({ paused: true });
       const ended = makePausableVoice({ ended: true });
       const app = createAppStub(playing);
-      const audio = new SceneAudio(app);
+      const audio = new SceneAudio(app, () => SceneState.Active);
 
       audio.add(playing);
       audio.add(alreadyPaused);
@@ -95,7 +98,7 @@ describe('SceneAudio', () => {
     test('leaves a non-Pausable voice playing (suspended "where supported")', () => {
       const nonPausable = makeVoice(); // no pause()/resume()
       const app = createAppStub(nonPausable);
-      const audio = new SceneAudio(app);
+      const audio = new SceneAudio(app, () => SceneState.Active);
 
       audio.add(nonPausable);
 
@@ -106,12 +109,100 @@ describe('SceneAudio', () => {
     test('resume() without a prior suspend() is a no-op', () => {
       const voice = makePausableVoice();
       const app = createAppStub(voice);
-      const audio = new SceneAudio(app);
+      const audio = new SceneAudio(app, () => SceneState.Active);
 
       audio.add(voice);
 
       expect(() => audio.resume()).not.toThrow();
       expect(voice.resume).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('SceneAudio — Preparing gate', () => {
+  test('play() during Preparing does not call app.audio.play yet', () => {
+    const voice = makeVoice();
+    const app = createAppStub(voice);
+    const audio = new SceneAudio(app, () => SceneState.Preparing);
+
+    audio.play(fakePlayable);
+
+    expect(app.audio.play).not.toHaveBeenCalled();
+  });
+
+  test('play() during Preparing returns a Voice-shaped stand-in synchronously', () => {
+    const voice = makeVoice();
+    const app = createAppStub(voice);
+    const audio = new SceneAudio(app, () => SceneState.Preparing);
+
+    const pending = audio.play(fakePlayable);
+
+    expect(pending.ended).toBe(false);
+    expect(typeof pending.stop).toBe('function');
+    expect(typeof pending.fade).toBe('function');
+  });
+
+  test('_flushPending() starts every voice queued during Preparing, applying buffered volume', () => {
+    const voice = makeVoice({ volume: 1 });
+    const app = createAppStub(voice);
+    const audio = new SceneAudio(app, () => SceneState.Preparing);
+
+    const pending = audio.play(fakePlayable, { volume: 0.5 });
+    pending.volume = 0.3;
+
+    audio._flushPending();
+
+    expect(app.audio.play).toHaveBeenCalledTimes(1);
+    expect(voice.volume).toBe(0.3);
+  });
+
+  test('stop() before flush cancels playback — the real voice is never created', () => {
+    const voice = makeVoice();
+    const app = createAppStub(voice);
+    const audio = new SceneAudio(app, () => SceneState.Preparing);
+
+    const pending = audio.play(fakePlayable);
+    pending.stop();
+    audio._flushPending();
+
+    expect(app.audio.play).not.toHaveBeenCalled();
+    expect(pending.ended).toBe(true);
+  });
+
+  test('stop() before flush fires onEnd exactly once', () => {
+    const voice = makeVoice();
+    const app = createAppStub(voice);
+    const audio = new SceneAudio(app, () => SceneState.Preparing);
+    const pending = audio.play(fakePlayable);
+    const onEnd = vi.fn();
+
+    pending.onEnd.add(onEnd);
+    pending.stop();
+    pending.stop();
+
+    expect(onEnd).toHaveBeenCalledTimes(1);
+  });
+
+  test('play() once Active bypasses the gate entirely', () => {
+    const voice = makeVoice();
+    const app = createAppStub(voice);
+    const audio = new SceneAudio(app, () => SceneState.Active);
+
+    const result = audio.play(fakePlayable);
+
+    expect(app.audio.play).toHaveBeenCalledTimes(1);
+    expect(result).toBe(voice);
+  });
+
+  test('destroy() cancels any still-pending (never-flushed) voice', () => {
+    const voice = makeVoice();
+    const app = createAppStub(voice);
+    const audio = new SceneAudio(app, () => SceneState.Preparing);
+
+    const pending = audio.play(fakePlayable);
+    audio.destroy();
+
+    expect(pending.ended).toBe(true);
+    expect(app.audio.play).not.toHaveBeenCalled();
   });
 });

--- a/test/core/scene/scene-interaction.test.ts
+++ b/test/core/scene/scene-interaction.test.ts
@@ -80,15 +80,68 @@ describe('SceneInteraction', () => {
     expect(app.interaction.detachRoot).toHaveBeenCalledTimes(1);
   });
 
-  test('suspend()/resume() do not throw and do not detach observations (scaffold for a later slice)', () => {
+  test('suspend() detaches every tracked observation without removing its tracking', () => {
+    const app = createAppStub();
+    const interaction = new SceneInteraction(app);
+    const root = fakeRoot();
+
+    interaction.observe(root);
+    interaction.suspend();
+
+    expect(app.interaction.detachRoot).toHaveBeenCalledWith(root);
+  });
+
+  test('resume() reattaches every observation suspend() detached', () => {
+    const app = createAppStub();
+    const interaction = new SceneInteraction(app);
+    const root = fakeRoot();
+
+    interaction.observe(root);
+    interaction.suspend();
+    interaction.resume();
+
+    expect(app.interaction.attachRoot).toHaveBeenCalledTimes(2); // once for observe(), once for resume()
+    expect(app.interaction.attachRoot).toHaveBeenLastCalledWith(root);
+  });
+
+  test('suspend() is idempotent — a second call does not detach again', () => {
     const app = createAppStub();
     const interaction = new SceneInteraction(app);
 
     interaction.observe(fakeRoot());
+    interaction.suspend();
+    (app.interaction.detachRoot as MockInstance).mockClear();
 
-    expect(() => interaction.suspend()).not.toThrow();
-    expect(() => interaction.resume()).not.toThrow();
+    interaction.suspend();
+
     expect(app.interaction.detachRoot).not.toHaveBeenCalled();
+  });
+
+  test('resume() before any suspend() is a no-op', () => {
+    const app = createAppStub();
+    const interaction = new SceneInteraction(app);
+
+    interaction.observe(fakeRoot());
+    (app.interaction.attachRoot as MockInstance).mockClear();
+
+    interaction.resume();
+
+    expect(app.interaction.attachRoot).not.toHaveBeenCalled();
+  });
+
+  test('an observation released while suspended is not reattached by resume()', () => {
+    const app = createAppStub();
+    const interaction = new SceneInteraction(app);
+    const root = fakeRoot();
+
+    const observation = interaction.observe(root);
+    interaction.suspend();
+    observation.release();
+    (app.interaction.attachRoot as MockInstance).mockClear();
+
+    interaction.resume();
+
+    expect(app.interaction.attachRoot).not.toHaveBeenCalled();
   });
 });
 
@@ -178,5 +231,23 @@ describe('SceneInteraction.capture()', () => {
     interaction.destroy();
 
     expect(app.interaction.popInputCapture).toHaveBeenCalledTimes(2);
+  });
+
+  test('suspend() pops every active capture; resume() re-pushes them in original order', () => {
+    const app = createAppStub();
+    const interaction = new SceneInteraction(app);
+    const rootA = fakeRoot();
+    const rootB = fakeRoot();
+
+    interaction.capture(rootA);
+    interaction.capture(rootB);
+    (app.interaction.pushInputCapture as MockInstance).mockClear();
+
+    interaction.suspend();
+    expect(app.interaction.popInputCapture).toHaveBeenCalledTimes(2);
+
+    interaction.resume();
+    expect(app.interaction.pushInputCapture).toHaveBeenNthCalledWith(1, rootA);
+    expect(app.interaction.pushInputCapture).toHaveBeenNthCalledWith(2, rootB);
   });
 });

--- a/test/core/scene/scene-interaction.test.ts
+++ b/test/core/scene/scene-interaction.test.ts
@@ -250,4 +250,35 @@ describe('SceneInteraction.capture()', () => {
     expect(app.interaction.pushInputCapture).toHaveBeenNthCalledWith(1, rootA);
     expect(app.interaction.pushInputCapture).toHaveBeenNthCalledWith(2, rootB);
   });
+
+  test('releasing a non-top capture while suspended only updates local bookkeeping; resume() re-pushes the corrected stack', () => {
+    const app = createAppStub();
+    const interaction = new SceneInteraction(app);
+    const rootA = fakeRoot();
+    const rootB = fakeRoot();
+    const rootC = fakeRoot();
+
+    const captureA = interaction.capture(rootA);
+    const captureB = interaction.capture(rootB);
+    const captureC = interaction.capture(rootC);
+
+    interaction.suspend();
+    (app.interaction.popInputCapture as MockInstance).mockClear();
+    (app.interaction.pushInputCapture as MockInstance).mockClear();
+
+    captureB.release(); // out-of-order release while suspended: must not touch the live manager at all
+
+    expect(app.interaction.popInputCapture).not.toHaveBeenCalled();
+    expect(app.interaction.pushInputCapture).not.toHaveBeenCalled();
+    expect(captureA.active).toBe(true);
+    expect(captureB.active).toBe(false);
+    expect(captureC.active).toBe(true);
+
+    interaction.resume();
+
+    // resume() re-pushes the corrected, deduplicated stack from scratch: A then C, not a stale/duplicated sequence.
+    expect(app.interaction.pushInputCapture).toHaveBeenCalledTimes(2);
+    expect(app.interaction.pushInputCapture).toHaveBeenNthCalledWith(1, rootA);
+    expect(app.interaction.pushInputCapture).toHaveBeenNthCalledWith(2, rootC);
+  });
 });


### PR DESCRIPTION
## Summary
Final slice of the v0.17 core-runtime rework (Slices A-F already merged). Closes out the migration:

- **`PhysicsWorld.fixedUpdate()`** (`@codexo/exojs-physics`) — a pure extraction from `step()`'s loop body lets the world register as a native engine `System` (`app.systems.add(world, { order: SystemOrder.Physics })`) instead of being stepped manually; both physics examples migrated off manual stepping and off an illegal `async init()`.
- **Fixed a real bug**: `SceneInteraction.suspend()`/`resume()` were no-op stubs despite the retention feature (shipped in an earlier slice) already depending on them — now they actually detach/reattach observed roots and captures, plus the scene's own root/UI. A follow-up fix (caught by that task's own review) closed a related leak in capture-release-while-suspended.
- **Fixed a second real bug**: `SceneAudio.play()` didn't gate playback requested while a scene is still `Preparing`, per the engine's own spec (§7.8). Added a `PendingVoice` buffering class that defers real playback until scene activation. A whole-branch review caught and fixed a follow-on integration gap: the buffered voice was never swapped for its real voice in `SceneAudio`'s tracked set, so retention's `suspend()` silently skipped pausing audio started during `Preparing`.
- Missing JSDoc added on `SceneScope`/`SceneInputs`/`SceneTweens` public methods.
- New **scene-less application example** (`app.systems.add({...})` + `app.start()` with no `Scene` at all — no v0.16 equivalent existed for this).
- Two guide fixes: `pause-menu.mdx` fully migrated onto the current pause API (including the documented `{ when: 'always' }` input-availability pattern), `cinematics.mdx`'s stale hook signatures fixed.
- `CHANGELOG.md` v0.17.0 entry — no earlier slice in this whole rework had touched it.

## Test plan
- [x] Every task implemented via TDD with its own unit tests; all passed a dedicated spec-compliance + code-quality review (one fix round on Task 3, one on Task 4/whole-branch)
- [x] Full unit suite: 7944/7960 passing (16 pre-existing skips), no regressions
- [x] `pnpm typecheck` / `typecheck:examples` / `typecheck:guides` / `typecheck:type-tests` / physics package typecheck all clean
- [x] DX gate (spec-mandated release gate for this slice): both showcase examples read as genuinely simpler than any v0.16 equivalent, verified independently by the whole-branch reviewer
- [x] Final whole-branch review: found and fixed one cross-task integration gap (SceneAudio/retention), re-verified clean, "ready to merge: yes"
- [x] pre-push gate (`verify:quick`) passed