### PR TITLE
fix(examples): register ParticleSystem as a native System

### DIFF
--- a/examples/beat-detection/beat-sync-pulse.js
+++ b/examples/beat-detection/beat-sync-pulse.js
@@ -28,6 +28,7 @@ class BeatSyncPulseScene extends Scene {
             hint: 'The ring and particle burst fire on each detected beat.',
         });
         this.particles = new ParticleSystem(this.loader.get('image/particle-light.png'), { capacity: 3500 });
+        this.systems.add(this.particles);
         this.particles.setPosition(width / 2, height / 2);
         this.burst = new BurstSpawn({
             schedule: [{ time: 0, count: 90 }],
@@ -68,7 +69,6 @@ class BeatSyncPulseScene extends Scene {
     update(delta) {
         this.pulse = Math.max(0, this.pulse - delta.seconds * 1.2);
         this.sprite.setScale(1 + this.pulse);
-        this.particles.update(delta);
     }
     draw(context) {
         const app = this.app;

--- a/examples/beat-detection/beat-sync-pulse.ts
+++ b/examples/beat-detection/beat-sync-pulse.ts
@@ -40,6 +40,7 @@ class BeatSyncPulseScene extends Scene {
         });
 
         this.particles = new ParticleSystem(this.loader.get('image/particle-light.png'), { capacity: 3500 });
+        this.systems.add(this.particles);
         this.particles.setPosition(width / 2, height / 2);
         this.burst = new BurstSpawn({
             schedule: [{ time: 0, count: 90 }],
@@ -85,7 +86,6 @@ class BeatSyncPulseScene extends Scene {
     override update(delta: Time): void {
         this.pulse = Math.max(0, this.pulse - delta.seconds * 1.2);
         this.sprite.setScale(1 + this.pulse);
-        this.particles.update(delta);
     }
 
     override draw(context: RenderingContext): void {

--- a/examples/particles/bonfire.js
+++ b/examples/particles/bonfire.js
@@ -10,6 +10,7 @@ class BonfireScene extends Scene {
             throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;
         this.fireSystem = new ParticleSystem(this.loader.get(assets.demo.textures.particleFlame));
+        this.systems.add(this.fireSystem);
         this.fireSystem.setPosition(width * 0.5, height * 0.75);
         this.fireSystem.setBlendMode(BlendModes.Additive);
         this.fireSystem.addSpawnModule(new RateSpawn({
@@ -23,6 +24,7 @@ class BonfireScene extends Scene {
             { t: 1, color: new Color(0, 0, 0, 0) },
         ])));
         this.smokeSystem = new ParticleSystem(this.loader.get(assets.demo.textures.particleSmoke));
+        this.systems.add(this.smokeSystem);
         this.smokeSystem.setPosition(width * 0.5, height * 0.75 - 40);
         this.smokeSystem.setBlendMode(BlendModes.Normal);
         this.smokeSystem.addSpawnModule(new RateSpawn({
@@ -35,10 +37,6 @@ class BonfireScene extends Scene {
             { t: 0, color: new Color(120, 100, 80, 0.4) },
             { t: 1, color: new Color(60, 55, 50, 0) },
         ])));
-    }
-    update(delta) {
-        this.fireSystem.update(delta);
-        this.smokeSystem.update(delta);
     }
     draw(context) {
         context.backend.clear();

--- a/examples/particles/bonfire.ts
+++ b/examples/particles/bonfire.ts
@@ -1,4 +1,4 @@
-import { Application, BlendModes, Color, type RenderingContext, Scene, type Time } from '@codexo/exojs';
+import { Application, BlendModes, Color, type RenderingContext, Scene } from '@codexo/exojs';
 import {
     ColorGradient,
     ColorOverLifetime,
@@ -23,6 +23,7 @@ class BonfireScene extends Scene {
         const { width, height } = app.canvas;
 
         this.fireSystem = new ParticleSystem(this.loader.get(assets.demo.textures.particleFlame));
+        this.systems.add(this.fireSystem);
         this.fireSystem.setPosition(width * 0.5, height * 0.75);
         this.fireSystem.setBlendMode(BlendModes.Additive);
 
@@ -45,6 +46,7 @@ class BonfireScene extends Scene {
         );
 
         this.smokeSystem = new ParticleSystem(this.loader.get(assets.demo.textures.particleSmoke));
+        this.systems.add(this.smokeSystem);
         this.smokeSystem.setPosition(width * 0.5, height * 0.75 - 40);
         this.smokeSystem.setBlendMode(BlendModes.Normal);
 
@@ -65,11 +67,6 @@ class BonfireScene extends Scene {
                 ]),
             ),
         );
-    }
-
-    override update(delta: Time): void {
-        this.fireSystem.update(delta);
-        this.smokeSystem.update(delta);
     }
 
     override draw(context: RenderingContext): void {

--- a/examples/particles/cursor-attractor-particles.js
+++ b/examples/particles/cursor-attractor-particles.js
@@ -17,6 +17,7 @@ class CursorAttractorParticlesScene extends Scene {
             throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;
         this.system = new ParticleSystem(this.loader.get(assets.demo.textures.particleLight), { capacity: 32000 });
+        this.systems.add(this.system);
         this.system.setPosition(width / 2, height / 2);
         this.system.addSpawnModule(new RateSpawn({
             rate: new Constant(2200),
@@ -77,9 +78,6 @@ class CursorAttractorParticlesScene extends Scene {
             this.repeller.strength = forceStrength;
             this.hud.setStatus('Mode: Repel');
         }
-    }
-    update(delta) {
-        this.system.update(delta);
     }
     draw(context) {
         context.backend.clear();

--- a/examples/particles/cursor-attractor-particles.ts
+++ b/examples/particles/cursor-attractor-particles.ts
@@ -1,4 +1,4 @@
-import { Application, Color, type RenderingContext, Scene, type Time, Vector } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, Vector } from '@codexo/exojs';
 import {
     AlphaFadeOverLifetime,
     AttractToPoint,
@@ -30,6 +30,7 @@ class CursorAttractorParticlesScene extends Scene {
         const { width, height } = app.canvas;
 
         this.system = new ParticleSystem(this.loader.get(assets.demo.textures.particleLight), { capacity: 32000 });
+        this.systems.add(this.system);
         this.system.setPosition(width / 2, height / 2);
 
         this.system.addSpawnModule(
@@ -103,10 +104,6 @@ class CursorAttractorParticlesScene extends Scene {
             this.repeller.strength = forceStrength;
             this.hud.setStatus('Mode: Repel');
         }
-    }
-
-    override update(delta: Time): void {
-        this.system.update(delta);
     }
 
     override draw(context: RenderingContext): void {

--- a/examples/particles/custom-wgsl-module.js
+++ b/examples/particles/custom-wgsl-module.js
@@ -48,6 +48,7 @@ class CustomWgslModuleScene extends Scene {
             throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;
         this.system = new ParticleSystem(this.loader.get(assets.demo.textures.particleLight), { capacity: 26000 });
+        this.systems.add(this.system);
         this.system.setPosition(width / 2, height - 60);
         this.system.addSpawnModule(new RateSpawn({
             rate: new Constant(1800),
@@ -65,8 +66,7 @@ class CustomWgslModuleScene extends Scene {
             hint: 'The SwayModule supplies both a CPU apply() and a GPU wgsl() body; the system picks one.',
         });
     }
-    update(delta) {
-        this.system.update(delta);
+    update(_delta) {
         // gpuMode is only meaningful after the first update() compiled the
         // pipeline. Report it once it has settled.
         if (!this.reportedMode) {

--- a/examples/particles/custom-wgsl-module.ts
+++ b/examples/particles/custom-wgsl-module.ts
@@ -63,6 +63,7 @@ class CustomWgslModuleScene extends Scene {
         const { width, height } = app.canvas;
 
         this.system = new ParticleSystem(this.loader.get(assets.demo.textures.particleLight), { capacity: 26000 });
+        this.systems.add(this.system);
         this.system.setPosition(width / 2, height - 60);
         this.system.addSpawnModule(
             new RateSpawn({
@@ -84,9 +85,7 @@ class CustomWgslModuleScene extends Scene {
         });
     }
 
-    override update(delta: Time): void {
-        this.system.update(delta);
-
+    override update(_delta: Time): void {
         // gpuMode is only meaningful after the first update() compiled the
         // pipeline. Report it once it has settled.
         if (!this.reportedMode) {

--- a/examples/particles/emitter-basics.js
+++ b/examples/particles/emitter-basics.js
@@ -11,6 +11,7 @@ class EmitterBasicsScene extends Scene {
             throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;
         this.system = new ParticleSystem(this.loader.get(assets.demo.textures.particleLight), { capacity: 4000 });
+        this.systems.add(this.system);
         this.system.setPosition(width / 2, height - 80);
         // Rate, lifetime, and a cone-shaped velocity spread: a fountain that
         // shoots upward (-π/2) with a ±36° spread and 70–180 px/s speed.
@@ -43,9 +44,6 @@ class EmitterBasicsScene extends Scene {
             status: 'Rate 180/s · lifetime 0.6–1.4s · gravity',
             hint: 'RateSpawn drives emission; ScaleOverLifetime sizes and ColorOverLifetime tints each particle as it ages.',
         });
-    }
-    update(delta) {
-        this.system.update(delta);
     }
     draw(context) {
         context.backend.clear();

--- a/examples/particles/emitter-basics.ts
+++ b/examples/particles/emitter-basics.ts
@@ -1,4 +1,4 @@
-import { Application, Color, type RenderingContext, Scene, type Time } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene } from '@codexo/exojs';
 import {
     ApplyForce,
     ColorGradient,
@@ -26,6 +26,7 @@ class EmitterBasicsScene extends Scene {
         const { width, height } = app.canvas;
 
         this.system = new ParticleSystem(this.loader.get(assets.demo.textures.particleLight), { capacity: 4000 });
+        this.systems.add(this.system);
         this.system.setPosition(width / 2, height - 80);
 
         // Rate, lifetime, and a cone-shaped velocity spread: a fountain that
@@ -73,10 +74,6 @@ class EmitterBasicsScene extends Scene {
             status: 'Rate 180/s · lifetime 0.6–1.4s · gravity',
             hint: 'RateSpawn drives emission; ScaleOverLifetime sizes and ColorOverLifetime tints each particle as it ages.',
         });
-    }
-
-    override update(delta: Time): void {
-        this.system.update(delta);
     }
 
     override draw(context: RenderingContext): void {

--- a/examples/particles/fireworks.js
+++ b/examples/particles/fireworks.js
@@ -43,6 +43,7 @@ class FireworksScene extends Scene {
         // Single explosion system shared by every detonation. We reposition and
         // re-tint a single BurstSpawn, then reset() it to fire one burst.
         this.explosions = new ParticleSystem(this.rocketTexture, { capacity: 16384 });
+        this.systems.add(this.explosions);
         this.explosions.setBlendMode(BlendModes.Additive);
         this.burstPosition = new Vector(0, 0);
         this.burst = new BurstSpawn({
@@ -113,7 +114,6 @@ class FireworksScene extends Scene {
                 this.updateStatus();
             }
         }
-        this.explosions.update(delta);
     }
     draw(context) {
         context.backend.clear();

--- a/examples/particles/fireworks.ts
+++ b/examples/particles/fireworks.ts
@@ -66,6 +66,7 @@ class FireworksScene extends Scene {
         // Single explosion system shared by every detonation. We reposition and
         // re-tint a single BurstSpawn, then reset() it to fire one burst.
         this.explosions = new ParticleSystem(this.rocketTexture, { capacity: 16384 });
+        this.systems.add(this.explosions);
         this.explosions.setBlendMode(BlendModes.Additive);
 
         this.burstPosition = new Vector(0, 0);
@@ -158,8 +159,6 @@ class FireworksScene extends Scene {
                 this.updateStatus();
             }
         }
-
-        this.explosions.update(delta);
     }
 
     override draw(context: RenderingContext): void {

--- a/examples/particles/gpu-particles.js
+++ b/examples/particles/gpu-particles.js
@@ -11,6 +11,7 @@ class GpuParticlesScene extends Scene {
             throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;
         this.system = new ParticleSystem(this.loader.get('image/particle-light.png'), { capacity: CAPACITY });
+        this.systems.add(this.system);
         this.system.setPosition(width / 2, height - 80);
         this.system.addSpawnModule(new RateSpawn({
             rate: new Constant(RATE),
@@ -27,8 +28,7 @@ class GpuParticlesScene extends Scene {
                 : 'WebGL2 CPU fallback — a smaller budget keeps the CPU integrator smooth.',
         });
     }
-    update(delta) {
-        this.system.update(delta);
+    update(_delta) {
         const backend = this.system.gpuMode ? 'WebGPU (GPU compute)' : 'WebGL2 (CPU fallback)';
         this.hud.setStatus(`${this.system.aliveCount.toLocaleString()} live / ${CAPACITY.toLocaleString()} cap · ${backend}`);
     }

--- a/examples/particles/gpu-particles.ts
+++ b/examples/particles/gpu-particles.ts
@@ -21,6 +21,7 @@ class GpuParticlesScene extends Scene {
         const { width, height } = app.canvas;
 
         this.system = new ParticleSystem(this.loader.get('image/particle-light.png'), { capacity: CAPACITY });
+        this.systems.add(this.system);
         this.system.setPosition(width / 2, height - 80);
         this.system.addSpawnModule(
             new RateSpawn({
@@ -41,9 +42,7 @@ class GpuParticlesScene extends Scene {
         });
     }
 
-    override update(delta: Time): void {
-        this.system.update(delta);
-
+    override update(_delta: Time): void {
         const backend = this.system.gpuMode ? 'WebGPU (GPU compute)' : 'WebGL2 (CPU fallback)';
 
         this.hud.setStatus(`${this.system.aliveCount.toLocaleString()} live / ${CAPACITY.toLocaleString()} cap · ${backend}`);

--- a/examples/performance/particle-stress.js
+++ b/examples/performance/particle-stress.js
@@ -100,9 +100,10 @@ class ParticleStressScene extends Scene {
             { t: 0, v: 1 },
             { t: 1, v: 0 },
         ])));
+        this.systems.add(system);
         return { instance: system, baseX: config.x, baseY: config.y };
     }
-    update(delta) {
+    update(_delta) {
         const app = this.app;
         if (app === null)
             throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
@@ -112,7 +113,6 @@ class ParticleStressScene extends Scene {
             const wave = time + i * 1.2;
             entry.instance.setPosition(entry.baseX + Math.sin(wave * 1.4) * 18, entry.baseY + Math.cos(wave * 1.7) * 10);
             entry.instance.rotation = Math.sin(wave * 0.9) * 5;
-            entry.instance.update(delta);
         }
     }
     draw(context) {
@@ -125,8 +125,10 @@ class ParticleStressScene extends Scene {
         this.destroySystems();
     }
     destroySystems() {
-        for (const entry of this.particleSystems)
-            entry.instance?.destroy();
+        // The particle systems are registered via `this.systems.add(...)`
+        // (see `buildSystem`), so `SystemRegistry.destroy()` — invoked
+        // automatically during scene teardown — destroys each of them; no
+        // manual destroy loop needed here.
         this.particleSystems = null;
         this.sharedTexture = null;
     }

--- a/examples/performance/particle-stress.ts
+++ b/examples/performance/particle-stress.ts
@@ -141,10 +141,12 @@ class ParticleStressScene extends Scene {
             ),
         );
 
+        this.systems.add(system);
+
         return { instance: system, baseX: config.x, baseY: config.y };
     }
 
-    override update(delta: Time): void {
+    override update(_delta: Time): void {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const time = app.activeTime.seconds;
@@ -155,7 +157,6 @@ class ParticleStressScene extends Scene {
 
             entry.instance.setPosition(entry.baseX + Math.sin(wave * 1.4) * 18, entry.baseY + Math.cos(wave * 1.7) * 10);
             entry.instance.rotation = Math.sin(wave * 0.9) * 5;
-            entry.instance.update(delta);
         }
     }
 
@@ -172,7 +173,10 @@ class ParticleStressScene extends Scene {
     }
 
     private destroySystems(): void {
-        for (const entry of this.particleSystems) entry.instance?.destroy();
+        // The particle systems are registered via `this.systems.add(...)`
+        // (see `buildSystem`), so `SystemRegistry.destroy()` — invoked
+        // automatically during scene teardown — destroys each of them; no
+        // manual destroy loop needed here.
         this.particleSystems = null!;
         this.sharedTexture = null!;
     }

--- a/examples/showcase/audio-reactive-particles.js
+++ b/examples/showcase/audio-reactive-particles.js
@@ -30,6 +30,7 @@ class AudioReactiveParticlesScene extends Scene {
         this.detector = new BeatDetector();
         this.detector.source = app.audio.music;
         this.ps = new ParticleSystem(this.loader.get(assets.demo.textures.particleLight), { capacity: 6000 });
+        this.systems.add(this.ps);
         this.ps.setPosition(width / 2, height / 2);
         // The rate (density) and the cone speed range (spread) are mutated every
         // frame from live audio energy. Starting both near zero means a silent
@@ -66,7 +67,7 @@ class AudioReactiveParticlesScene extends Scene {
         // gesture, then starts automatically — play() returns the Voice now.
         this.musicVoice = app.audio.play(this.music, { loop: true, volume: 0.8 });
     }
-    update(delta) {
+    update(_delta) {
         // Low band (bass) drives how MANY particles spawn this second.
         const low = this.analyser.getBandEnergy(20, 180);
         // High band (treble) drives how WIDE the velocity cone fans out.
@@ -79,7 +80,6 @@ class AudioReactiveParticlesScene extends Scene {
         if (this.musicVoice) {
             this.hud.setStatus(`bass ${(low * 100) | 0}%  treble ${(high * 100) | 0}%`);
         }
-        this.ps.update(delta);
     }
     draw(context) {
         const app = this.app;

--- a/examples/showcase/audio-reactive-particles.ts
+++ b/examples/showcase/audio-reactive-particles.ts
@@ -43,6 +43,7 @@ class AudioReactiveParticlesScene extends Scene {
         this.detector.source = app.audio.music;
 
         this.ps = new ParticleSystem(this.loader.get(assets.demo.textures.particleLight), { capacity: 6000 });
+        this.systems.add(this.ps);
         this.ps.setPosition(width / 2, height / 2);
 
         // The rate (density) and the cone speed range (spread) are mutated every
@@ -85,7 +86,7 @@ class AudioReactiveParticlesScene extends Scene {
         this.musicVoice = app.audio.play(this.music, { loop: true, volume: 0.8 });
     }
 
-    override update(delta: Time): void {
+    override update(_delta: Time): void {
         // Low band (bass) drives how MANY particles spawn this second.
         const low = this.analyser.getBandEnergy(20, 180);
         // High band (treble) drives how WIDE the velocity cone fans out.
@@ -101,8 +102,6 @@ class AudioReactiveParticlesScene extends Scene {
         if (this.musicVoice) {
             this.hud.setStatus(`bass ${(low * 100) | 0}%  treble ${(high * 100) | 0}%`);
         }
-
-        this.ps.update(delta);
     }
 
     override draw(context: RenderingContext): void {

--- a/examples/showcase/gamepad-spaceship.js
+++ b/examples/showcase/gamepad-spaceship.js
@@ -27,6 +27,7 @@ class GamepadSpaceshipScene extends Scene {
         this.engine = app.audio.play(new AudioGenerator({ type: 'sawtooth', frequency: 90 }), { volume: 0 });
         this.fx = new Graphics();
         this.particles = new ParticleSystem(this.loader.get(assets.demo.textures.particleSpark), { capacity: 4000 });
+        this.systems.add(this.particles);
         this.burst = new BurstSpawn({
             schedule: [{ time: 0, count: 60 }],
             lifetime: new Constant(0.5),
@@ -137,7 +138,6 @@ class GamepadSpaceshipScene extends Scene {
                 }
             }
         }
-        this.particles.update(delta);
     }
     wrap(point, width, height) {
         if (point.x < -24)

--- a/examples/showcase/gamepad-spaceship.ts
+++ b/examples/showcase/gamepad-spaceship.ts
@@ -55,6 +55,7 @@ class GamepadSpaceshipScene extends Scene {
         this.fx = new Graphics();
 
         this.particles = new ParticleSystem(this.loader.get(assets.demo.textures.particleSpark), { capacity: 4000 });
+        this.systems.add(this.particles);
         this.burst = new BurstSpawn({
             schedule: [{ time: 0, count: 60 }],
             lifetime: new Constant(0.5),
@@ -183,8 +184,6 @@ class GamepadSpaceshipScene extends Scene {
                 }
             }
         }
-
-        this.particles.update(delta);
     }
 
     private wrap(point: { x: number; y: number }, width: number, height: number): void {

--- a/examples/showcase/screen-shake-on-explosion.js
+++ b/examples/showcase/screen-shake-on-explosion.js
@@ -13,6 +13,7 @@ class ScreenShakeOnExplosionScene extends Scene {
         const { width, height } = app.canvas;
         this.view = new View(width / 2, height / 2, width, height);
         this.ps = new ParticleSystem(this.loader.get('image/particle-light.png'), { capacity: 5000 });
+        this.systems.add(this.ps);
         this.ps.setPosition(width / 2, height / 2);
         this.burstPos = new Vector(0, 0);
         this.burst = new BurstSpawn({
@@ -29,9 +30,6 @@ class ScreenShakeOnExplosionScene extends Scene {
             this.burst.reset();
             this.view.shake(22, 280, { frequency: 26, decay: true });
         });
-    }
-    update(delta) {
-        this.ps.update(delta);
     }
     draw(context) {
         context.backend.clear();

--- a/examples/showcase/screen-shake-on-explosion.ts
+++ b/examples/showcase/screen-shake-on-explosion.ts
@@ -1,4 +1,4 @@
-import { Application, Color, type RenderingContext, Scene, type Time, Vector, View } from '@codexo/exojs';
+import { Application, Color, type RenderingContext, Scene, Vector, View } from '@codexo/exojs';
 import {
     AlphaFadeOverLifetime,
     BurstSpawn,
@@ -23,6 +23,7 @@ class ScreenShakeOnExplosionScene extends Scene {
 
         this.view = new View(width / 2, height / 2, width, height);
         this.ps = new ParticleSystem(this.loader.get('image/particle-light.png'), { capacity: 5000 });
+        this.systems.add(this.ps);
         this.ps.setPosition(width / 2, height / 2);
         this.burstPos = new Vector(0, 0);
         this.burst = new BurstSpawn({
@@ -39,10 +40,6 @@ class ScreenShakeOnExplosionScene extends Scene {
             this.burst.reset();
             this.view.shake(22, 280, { frequency: 26, decay: true });
         });
-    }
-
-    override update(delta: Time): void {
-        this.ps.update(delta);
     }
 
     override draw(context: RenderingContext): void {


### PR DESCRIPTION
## Summary
Migrates all 11 `ParticleSystem` example usages off manual `.update(delta)` driving onto proper `System` registration (`this.systems.add(...)`), mirroring the same pattern already established for `PhysicsWorld`.

- `ParticleSystem.update(delta: Time): this` already structurally satisfies the engine's `System.update?(delta: Time): void` — no engine or package source change needed, this is purely an examples-catalog migration.
- Rendering is untouched (`ParticleSystem` is a `Drawable`, rendered via the normal scene-graph traversal).
- `examples/performance/particle-stress.ts` (3 particle systems, procedural emitter motion set each frame before the particle-sim advance) required verifying frame-ordering is preserved — scene's own `update()` always runs before `scene.systems.update()`, so moving `.update()` to System registration keeps the existing behavior intact. Its manual `destroy()` loop was removed as redundant once `SystemRegistry` handles teardown automatically (confirmed `ParticleSystem.destroy()` is idempotent).

## Test plan
- [x] `pnpm typecheck:examples` clean
- [x] `pnpm lint` on all 11 generated `.js` siblings — 0 errors
- [x] `pnpm --filter @codexo/exojs-particles test` — 154/154 passing
- [x] Task review: spec-compliant, no Critical/Important findings — implementer's self-corrected deviations (4 files kept non-empty `update()`, contrary to the initial task assumption) independently re-verified against the diff and engine source (frame-dispatch order in `SceneScope.ts`, destroy-chain idempotency)
- [x] pre-push gate (`verify:quick`) passed