### PR TITLE
fix(core): dispatch onStateChange for the fresh activation and teardown edges

### DIFF
--- a/site/src/content/api/scene-director.json
+++ b/site/src/content/api/scene-director.json
@@ -977,7 +977,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Fires whenever the active scene's SceneState changes, as (previous, next, scene)."
+          "description": "Fires whenever the active scene's SceneState changes, as (previous, next, scene) — every edge in the state graph, including the initial Preparing → Active activation and the terminal Destroying → Destroyed teardown, not just pause/resume/retention."
         },
         {
           "name": "onStopScene",

--- a/src/core/SceneDirector.ts
+++ b/src/core/SceneDirector.ts
@@ -99,7 +99,12 @@ export class SceneDirector {
   public readonly onPause = new Signal<[Scene]>();
   /** Fires after `resume()` actually transitions the active scene back to `Active`. */
   public readonly onResume = new Signal<[Scene]>();
-  /** Fires whenever the active scene's {@link SceneState} changes, as `(previous, next, scene)`. */
+  /**
+   * Fires whenever the active scene's {@link SceneState} changes, as
+   * `(previous, next, scene)` — every edge in the state graph, including the
+   * initial `Preparing` → `Active` activation and the terminal
+   * `Destroying` → `Destroyed` teardown, not just pause/resume/retention.
+   */
   public readonly onStateChange = new Signal<[SceneState, SceneState, Scene]>();
 
   public constructor(app: Application, scenes?: Record<string, AnySceneConstructor>) {
@@ -494,7 +499,7 @@ export class SceneDirector {
    * `unload()` is never called — and rethrows the original error unchanged.
    */
   private async _prepareScene<Data>(scene: Scene<Data>, data: Data): Promise<SceneScope<Data>> {
-    const scope = new SceneScope(this._app, scene);
+    const scope = new SceneScope(this._app, scene, (previous, next) => this.onStateChange.dispatch(previous, next, scene as Scene));
 
     try {
       await scope.prepare(data);

--- a/src/core/SceneScope.ts
+++ b/src/core/SceneScope.ts
@@ -45,14 +45,16 @@ export class SceneScope<Data = unknown> {
   public readonly audio: SceneAudio;
 
   private readonly _app: Application;
+  private readonly _onStateChange: (previous: SceneState, next: SceneState) => void;
   private _state: SceneState = SceneState.Preparing;
   private _rootsAttached = false;
   private _unloadCalled = false;
   private _destroyCalled = false;
   private _visibleStateBeforeSuspend: SceneState.Active | SceneState.Paused | null = null;
 
-  public constructor(app: Application, scene: Scene<Data>) {
+  public constructor(app: Application, scene: Scene<Data>, onStateChange: (previous: SceneState, next: SceneState) => void = () => {}) {
     this._app = app;
+    this._onStateChange = onStateChange;
     this.scene = scene;
     this.systems = new SystemRegistry();
     this.loader = new SceneLoader(app);
@@ -105,7 +107,10 @@ export class SceneScope<Data = unknown> {
 
   /** Commit this scope as the active scene: `Preparing` → `Active`. Called by the director once the switch boundary is crossed. */
   public activate(): void {
+    const previous = this._state;
+
     this._state = SceneState.Active;
+    this._onStateChange(previous, this._state);
     this.audio._flushPending();
   }
 
@@ -325,7 +330,10 @@ export class SceneScope<Data = unknown> {
       return;
     }
 
+    const previous = this._state;
+
     this._state = SceneState.Destroying;
+    this._onStateChange(previous, this._state);
 
     const errors: unknown[] = [];
 
@@ -339,6 +347,7 @@ export class SceneScope<Data = unknown> {
     this._guard(errors, () => this.scene._teardownInternals());
 
     this._state = SceneState.Destroyed;
+    this._onStateChange(SceneState.Destroying, this._state);
 
     this._reportErrors(errors);
   }
@@ -356,7 +365,10 @@ export class SceneScope<Data = unknown> {
       return;
     }
 
+    const previous = this._state;
+
     this._state = SceneState.Destroying;
+    this._onStateChange(previous, this._state);
 
     const errors: unknown[] = [];
 
@@ -380,6 +392,7 @@ export class SceneScope<Data = unknown> {
     this._guard(errors, () => this.loader.destroy());
 
     this._state = SceneState.Destroyed;
+    this._onStateChange(SceneState.Destroying, this._state);
 
     this._reportErrors(errors);
   }

--- a/test/core/scene-director.test.ts
+++ b/test/core/scene-director.test.ts
@@ -251,6 +251,58 @@ describe('SceneDirector', () => {
     expect(first?.attached).toBe(false);
   });
 
+  test('setScene() dispatches onStateChange for the fresh Preparing to Active activation', async () => {
+    const TestScene = makeSceneClass();
+    const manager = new SceneDirector(createApplicationStub(), { test: TestScene });
+    const onStateChange = vi.fn();
+
+    manager.onStateChange.add(onStateChange);
+
+    await manager.setScene(TestScene);
+    const scene = manager.currentScene;
+
+    expect(onStateChange).toHaveBeenCalledTimes(1);
+    expect(onStateChange).toHaveBeenCalledWith(SceneState.Preparing, SceneState.Active, scene);
+  });
+
+  test('switching scenes dispatches onStateChange for the outgoing scope Destroying and Destroyed transitions', async () => {
+    const First = makeSceneClass();
+    const Second = makeSceneClass();
+    const manager = new SceneDirector(createApplicationStub(), { first: First, second: Second });
+
+    await manager.setScene(First);
+    const first = manager.currentScene;
+    const onStateChange = vi.fn();
+
+    manager.onStateChange.add(onStateChange);
+
+    await manager.setScene(Second);
+    const second = manager.currentScene;
+
+    expect(onStateChange).toHaveBeenCalledTimes(3);
+    expect(onStateChange).toHaveBeenCalledWith(SceneState.Active, SceneState.Destroying, first);
+    expect(onStateChange).toHaveBeenCalledWith(SceneState.Destroying, SceneState.Destroyed, first);
+    expect(onStateChange).toHaveBeenCalledWith(SceneState.Preparing, SceneState.Active, second);
+  });
+
+  test('a failed activation dispatches onStateChange for Preparing to Destroying to Destroyed', async () => {
+    const FailScene = makeSceneClass({
+      init() {
+        throw new Error('init failed');
+      },
+    });
+    const manager = new SceneDirector(createApplicationStub(), { fail: FailScene });
+    const onStateChange = vi.fn();
+
+    manager.onStateChange.add(onStateChange);
+
+    await expect(manager.setScene(FailScene)).rejects.toThrow('init failed');
+
+    expect(onStateChange).toHaveBeenCalledTimes(2);
+    expect(onStateChange).toHaveBeenCalledWith(SceneState.Preparing, SceneState.Destroying, expect.any(Object));
+    expect(onStateChange).toHaveBeenCalledWith(SceneState.Destroying, SceneState.Destroyed, expect.any(Object));
+  });
+
   test('fixedUpdate dispatches to the active scene', async () => {
     const fixedUpdate = vi.fn();
     const TestScene = makeSceneClass({ fixedUpdate });
@@ -457,11 +509,11 @@ describe('SceneDirector', () => {
     const onPause = vi.fn();
     const onStateChange = vi.fn();
 
-    director.onPause.add(onPause);
-    director.onStateChange.add(onStateChange);
-
     await director.setScene(TestScene);
     const scene = director.currentScene;
+
+    director.onPause.add(onPause);
+    director.onStateChange.add(onStateChange);
 
     expect(director.pause()).toBe(true);
     expect(director.state).toBe(SceneState.Paused);

--- a/test/core/scene-scope.test.ts
+++ b/test/core/scene-scope.test.ts
@@ -132,6 +132,19 @@ describe('SceneScope', () => {
       expect(update).toHaveBeenCalledTimes(1);
     });
 
+    test('activate() reports the Preparing to Active transition via the injected onStateChange callback', async () => {
+      const app = createAppStub();
+      const scene = new Scene();
+      const onStateChange = vi.fn();
+      const scope = new SceneScope(app, scene, onStateChange);
+
+      await scope.prepare(undefined);
+      scope.activate();
+
+      expect(onStateChange).toHaveBeenCalledTimes(1);
+      expect(onStateChange).toHaveBeenCalledWith(SceneState.Preparing, SceneState.Active);
+    });
+
     test('a synchronous init() (the common case) passes without a lifecycle error', async () => {
       const app = createAppStub();
       const scene = new Scene();
@@ -206,6 +219,25 @@ describe('SceneScope', () => {
 
       expect(destroySpy).toHaveBeenCalledTimes(1);
     });
+
+    test('reports Preparing to Destroying then Destroying to Destroyed via the injected onStateChange callback', async () => {
+      const app = createAppStub();
+      const scene = Object.assign(new Scene(), {
+        init(): void {
+          throw new Error('init failed');
+        },
+      });
+      const onStateChange = vi.fn();
+      const scope = new SceneScope(app, scene, onStateChange);
+
+      await expect(scope.prepare(undefined)).rejects.toThrow('init failed');
+
+      scope.destroyFailedActivation();
+
+      expect(onStateChange).toHaveBeenCalledTimes(2);
+      expect(onStateChange).toHaveBeenNthCalledWith(1, SceneState.Preparing, SceneState.Destroying);
+      expect(onStateChange).toHaveBeenNthCalledWith(2, SceneState.Destroying, SceneState.Destroyed);
+    });
   });
 
   describe('permanent teardown (definition §17)', () => {
@@ -217,6 +249,23 @@ describe('SceneScope', () => {
 
       return scope;
     };
+
+    test('reports Active to Destroying then Destroying to Destroyed via the injected onStateChange callback', async () => {
+      const app = createAppStub();
+      const scene = new Scene();
+      const onStateChange = vi.fn();
+      const scope = new SceneScope(app, scene, onStateChange);
+
+      await scope.prepare(undefined);
+      scope.activate();
+      onStateChange.mockClear(); // only interested in destroy()'s own transitions here
+
+      await scope.destroy();
+
+      expect(onStateChange).toHaveBeenCalledTimes(2);
+      expect(onStateChange).toHaveBeenNthCalledWith(1, SceneState.Active, SceneState.Destroying);
+      expect(onStateChange).toHaveBeenNthCalledWith(2, SceneState.Destroying, SceneState.Destroyed);
+    });
 
     test('runs in normative order: disable input/interaction, unload(), destroy systems, tweens+audio, inputs+interaction, detach roots, scene.destroy()+internals, loader claims last', async () => {
       const app = createAppStub();


### PR DESCRIPTION
## Summary
- `onStateChange` documented itself as firing for every `SceneState` transition, but only ever fired for pause/resume/suspend/restore — never for a scene's initial `Preparing` -> `Active` activation or its permanent `Destroying` -> `Destroyed` teardown.
- `SceneScope` now takes an injected `onStateChange` callback (mirroring the existing `_getState`/`_getPaused` constructor-injection pattern) and invokes it from `activate()`, `destroy()`, and `destroyFailedActivation()`; `SceneDirector` wires it to the real `Signal`.
- `Destroying` and `Destroyed` fire as two separate dispatches.

## Test plan
- [x] New unit tests in `scene-scope.test.ts` / `scene-director.test.ts` covering the three previously-uncovered dispatch sites (all failed before the fix, pass after)
- [x] Full `exojs` core test project: 5099 passed, 0 failed
- [x] `tsc --noEmit`, `eslint`, `prettier --check` clean on changed files