### PR TITLE
feat(core): scene-transition redesign, Slice 2 — Ready state & facility dormancy

### DIFF
--- a/docs/superpowers/plans/2026-07-23-scene-transition-slice-2-ready-facility-dormancy.md
+++ b/docs/superpowers/plans/2026-07-23-scene-transition-slice-2-ready-facility-dormancy.md
@@ -83,7 +83,7 @@ test/core/
 
 - Produces: `SceneState.Ready` (new enum member, string value `'ready'`). `canSuspend`/`canRestore`/`canDestroy` signatures unchanged — only their JSDoc gains a note about `Ready`. Consumed by every later task in this plan.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Add to `test/core/scene-state.test.ts`, inside the existing `describe('SceneState guards', ...)` block:
 
@@ -114,12 +114,12 @@ test('is a string enum (never const enum) — values are readable at runtime', (
 });
 ```
 
-- [ ] **Step 2: Run to verify it fails**
+- [x] **Step 2: Run to verify it fails**
 
 Run: `pnpm vitest run test/core/scene-state.test.ts`
 Expected: FAIL — `SceneState.Ready` is `undefined`.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 Replace the full contents of `src/core/SceneState.ts`:
 
@@ -188,12 +188,12 @@ export function canDestroy(state: SceneState): boolean {
 }
 ```
 
-- [ ] **Step 4: Run to verify it passes**
+- [x] **Step 4: Run to verify it passes**
 
 Run: `pnpm vitest run test/core/scene-state.test.ts`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/core/SceneState.ts test/core/scene-state.test.ts
@@ -215,7 +215,7 @@ git commit -m "feat(core): add SceneState.Ready"
 
 Verified against the current file (`src/core/Signal.ts:104-119`): `dispatch()` has no `try`/`catch` around the listener loop, never reaches `this._dispatching = false` if a listener throws (no `finally`), and never processes `_pendingRemoves` in that case either — exactly the three defects spec §2.2.1 names.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Add to `test/core/signal.test.ts`, as a new top-level `describe` block:
 
@@ -324,12 +324,12 @@ describe('dispatchIsolated', () => {
 });
 ```
 
-- [ ] **Step 2: Run to verify it fails**
+- [x] **Step 2: Run to verify it fails**
 
 Run: `pnpm vitest run test/core/signal.test.ts`
 Expected: FAIL — `signal.dispatchIsolated is not a function`.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `src/core/Signal.ts`, add immediately after the existing `dispatch()` method (before `destroy()`):
 
@@ -403,17 +403,17 @@ In `src/core/Signal.ts`, add immediately after the existing `dispatch()` method 
   }
 ```
 
-- [ ] **Step 4: Run to verify it passes**
+- [x] **Step 4: Run to verify it passes**
 
 Run: `pnpm vitest run test/core/signal.test.ts`
 Expected: PASS.
 
-- [ ] **Step 5: Typecheck**
+- [x] **Step 5: Typecheck**
 
 Run: `pnpm typecheck`
 Expected: clean.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/core/Signal.ts test/core/signal.test.ts
@@ -435,7 +435,7 @@ git commit -m "feat(core): Signal.dispatchIsolated for exception-isolated lifecy
 
 Verified (`InteractionManager.update()`, `src/input/InteractionManager.ts:303-304`) that the app-wide interaction dispatch gate is already `state !== Active` (an inverse check, not an allowlist) — it already treats `Ready` correctly with zero changes needed. `SceneInputs.gatedStates`, by contrast, is an explicit blocklist and does need `Ready` added.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Add two rows to the existing table-driven test in `test/core/scene/scene-inputs.test.ts` (`describe('SceneInputs — when policy availability matrix', ...)`), in the `test.each([...])` array:
 
@@ -446,12 +446,12 @@ Add two rows to the existing table-driven test in `test/core/scene/scene-inputs.
 
 (Insert alongside the existing `SceneState.Preparing`/`SceneState.Suspended` rows — same table, same assertion shape.)
 
-- [ ] **Step 2: Run to verify it fails**
+- [x] **Step 2: Run to verify it fails**
 
 Run: `pnpm vitest run test/core/scene/scene-inputs.test.ts`
 Expected: FAIL — with `state = Ready`, `whenPolicyAllows` does not gate (since `gatedStates` doesn't contain it yet), so `onActive` fires when it shouldn't.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `src/core/scene/SceneInputs.ts`, change:
 
@@ -465,12 +465,12 @@ to:
 const gatedStates = new Set<SceneState>([SceneState.Preparing, SceneState.Ready, SceneState.Suspended, SceneState.Destroying, SceneState.Destroyed]);
 ```
 
-- [ ] **Step 4: Run to verify it passes**
+- [x] **Step 4: Run to verify it passes**
 
 Run: `pnpm vitest run test/core/scene/scene-inputs.test.ts`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/core/scene/SceneInputs.ts test/core/scene/scene-inputs.test.ts
@@ -493,7 +493,7 @@ git commit -m "fix(core): gate SceneInputs dispatch during Ready"
 
 Per spec §4.2: `Preparing`/`Ready`/`Suspended` → `PendingVoice` (buffered); `Active` → real `Voice` immediately; `Destroying`/`Destroyed` → reject (dev-mode lifecycle error; production falls back to an inert, already-`ended` stand-in rather than crashing a teardown path).
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Add to `test/core/scene/scene-audio.test.ts`, as a new `describe` block after the existing `describe('SceneAudio — Preparing gate', ...)`:
 
@@ -551,12 +551,12 @@ describe('SceneAudio — dormancy gate widens to Ready/Suspended, rejects Destro
 });
 ```
 
-- [ ] **Step 2: Run to verify it fails**
+- [x] **Step 2: Run to verify it fails**
 
 Run: `pnpm vitest run test/core/scene/scene-audio.test.ts`
 Expected: FAIL — `Suspended`/`Destroying`/`Destroyed` currently fall through to `this.add(this._app.audio.play(...))` (the "real voice immediately" branch), since today's check is only `=== SceneState.Preparing`.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `src/core/scene/SceneAudio.ts`, replace the `play()` method:
 
@@ -634,17 +634,17 @@ with:
   }
 ```
 
-- [ ] **Step 4: Run to verify it passes**
+- [x] **Step 4: Run to verify it passes**
 
 Run: `pnpm vitest run test/core/scene/scene-audio.test.ts`
 Expected: PASS.
 
-- [ ] **Step 5: Typecheck**
+- [x] **Step 5: Typecheck**
 
 Run: `pnpm typecheck`
 Expected: clean.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/core/scene/SceneAudio.ts test/core/scene/scene-audio.test.ts
@@ -667,7 +667,7 @@ Today `TweenSequencer._manager` is `private readonly`, set once in the construct
 
 No dedicated test for this task alone — it has no independent observable behavior until Task 6 exercises it (constructing a manager-less sequencer, calling `.start()` on it, confirming nothing ticks, then calling `_attachManager()` and confirming it now does). Verified by `pnpm typecheck` only here.
 
-- [ ] **Step 1: Implement**
+- [x] **Step 1: Implement**
 
 In `src/animation/TweenSequencer.ts`, change:
 
@@ -696,12 +696,12 @@ Add, immediately after the constructor:
   }
 ```
 
-- [ ] **Step 2: Typecheck**
+- [x] **Step 2: Typecheck**
 
 Run: `pnpm typecheck`
 Expected: clean (no behavior change yet — nothing calls `_attachManager` until Task 6).
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add src/animation/TweenSequencer.ts
@@ -729,7 +729,7 @@ git commit -m "feat(animation): TweenSequencer._attachManager (mirrors Tween._at
 - `add()` while not `Active`: the tween may already be genuinely live (constructed via `app.tweens.create()` directly and handed here) — transferring ownership means pausing it immediately if it's currently `Active`-state (mirrors the existing `suspend()`/`restore()` pause idiom exactly), tracked in a new `_coldPaused` set, resumed at the next `Active` transition only if still in the exact state this left it in. The tween is still attached to the manager immediately (harmless once paused — `Tween.update()` no-ops for a non-`Active`-state tween regardless of whether it's present in the manager's array).
 - **Known, accepted, pre-existing-class limitation (not introduced by this change):** a caller who retains their own direct reference to a tween handed to `add()` can still call `.start()`/`.resume()` on it directly, bypassing the facade — exactly the same limitation the existing retention `suspend()`/`resume()` already has for any externally-held `Voice`/`Tween` reference. Not solvable without proxying every returned object; documented, not fixed, here.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 First, update every existing `new SceneTweens(app)` call site in `test/core/scene/scene-tweens.test.ts` to `new SceneTweens(app, () => SceneState.Active)` (the constructor is about to gain a required second parameter, and every existing test exercises the "live" facade — passing `Active` keeps their current behavior/assertions unchanged). Add the import:
 
@@ -853,12 +853,12 @@ import { Tween } from '#animation/Tween';
 import { TweenSequencer } from '#animation/TweenSequencer';
 ```
 
-- [ ] **Step 2: Run to verify it fails**
+- [x] **Step 2: Run to verify it fails**
 
 Run: `pnpm vitest run test/core/scene/scene-tweens.test.ts`
 Expected: FAIL — `SceneTweens` constructor doesn't accept a second argument yet (and even ignoring that, `create()`/`add()`/`createSequencer()` don't consult it).
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 Replace the full contents of `src/core/scene/SceneTweens.ts`:
 
@@ -1216,17 +1216,17 @@ import { TweenSequencer } from '#animation/TweenSequencer';
 
 and use `TweenSequencer` directly as the type everywhere `TweenSequencerType` appears above (`Map<TweenSequencer, ...>`, `Set<TweenSequencer>`, return types). Re-read the class body above with that single substitution before saving the file — this plan wrote it with a placeholder alias only to keep the value/type distinction visible while explaining the diff; the real file must not import the same module twice.
 
-- [ ] **Step 4: Run to verify it passes**
+- [x] **Step 4: Run to verify it passes**
 
 Run: `pnpm vitest run test/core/scene/scene-tweens.test.ts`
 Expected: PASS.
 
-- [ ] **Step 5: Typecheck + lint**
+- [x] **Step 5: Typecheck + lint**
 
 Run: `pnpm typecheck && pnpm eslint src/core/scene/SceneTweens.ts test/core/scene/scene-tweens.test.ts`
 Expected: clean.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/core/scene/SceneTweens.ts test/core/scene/scene-tweens.test.ts
@@ -1250,7 +1250,7 @@ Verified (`SceneScope.ts:453-460` today): `_attachAutoRoots()` calls `this._app.
 
 **Design:** replace the single `_suspended` boolean with a per-entry `attached: boolean` flag. `observe()`/`capture()` consult `getState() === Active` at call time: if live, attach immediately (as today); if not, track without attaching. `suspend()` detaches every currently-attached entry (setting `attached = false`) without discarding tracking. `resume()` attaches every entry that isn't currently attached, in tracking order — this single operation correctly covers both a fresh activation flushing cold registrations and a retention restore reinstating what `suspend()` detached, since by the time either runs every entry is uniformly in the same attached/unattached state (entries only ever attach while truly `Active`, and `suspend()` uniformly clears them all together — see the inline comment in the implementation for why a mixed state can't arise in practice). Releasing a never-attached entry must not call the app-wide detach/pop functions at all.
 
-- [ ] **Step 1: Update every existing call site, then write the failing tests**
+- [x] **Step 1: Update every existing call site, then write the failing tests**
 
 In `test/core/scene/scene-interaction.test.ts`, replace every occurrence of:
 
@@ -1377,12 +1377,12 @@ describe('SceneInteraction — dormancy (registration while not Active)', () => 
 });
 ```
 
-- [ ] **Step 2: Run to verify it fails**
+- [x] **Step 2: Run to verify it fails**
 
 Run: `pnpm vitest run test/core/scene/scene-interaction.test.ts`
 Expected: FAIL — `SceneInteraction` doesn't accept a second constructor argument, and `observe()`/`capture()` attach unconditionally.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 Replace the full contents of `src/core/scene/SceneInteraction.ts`:
 
@@ -1647,17 +1647,17 @@ export class SceneInteraction implements Destroyable {
 }
 ```
 
-- [ ] **Step 4: Run to verify it passes**
+- [x] **Step 4: Run to verify it passes**
 
 Run: `pnpm vitest run test/core/scene/scene-interaction.test.ts`
 Expected: PASS.
 
-- [ ] **Step 5: Typecheck + lint**
+- [x] **Step 5: Typecheck + lint**
 
 Run: `pnpm typecheck && pnpm eslint src/core/scene/SceneInteraction.ts test/core/scene/scene-interaction.test.ts`
 Expected: clean.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/core/scene/SceneInteraction.ts test/core/scene/scene-interaction.test.ts
@@ -1682,7 +1682,7 @@ No dedicated new test in this task — `Scene.onActivate`/`onSuspend` have no in
 
 **Note on Slice 1 overlap:** a parallel Slice 1 agent may be adding an `AppLike` second generic to this same file. This task's edits are confined to the signal-declaration region (lines ~62–69 today) and `_teardownInternals()` (lines ~415–424 today) — neither touches the class's generic parameter list (`export class Scene<Data = void> { ... }`) or the `app` getter. If a merge conflict does occur, it will be localized and mechanical (two independent hunks in the same file), not a semantic conflict.
 
-- [ ] **Step 1: Implement — remove `onLoad`/`onUnload`, add `onActivate`/`onSuspend`**
+- [x] **Step 1: Implement — remove `onLoad`/`onUnload`, add `onActivate`/`onSuspend`**
 
 In `src/core/Scene.ts`, change:
 
@@ -1751,12 +1751,12 @@ to:
   }
 ```
 
-- [ ] **Step 2: Typecheck**
+- [x] **Step 2: Typecheck**
 
 Run: `pnpm typecheck`
 Expected: FAIL — `examples/application-scenes/scene-lifecycle.ts` still references `this.onLoad`/`this.onUnload`.
 
-- [ ] **Step 3: Fix the example**
+- [x] **Step 3: Fix the example**
 
 In `examples/application-scenes/scene-lifecycle.ts`, change the comment block and the two signal registrations. Replace:
 
@@ -1806,17 +1806,17 @@ this.onSuspend.add(() => {
 
 Apply the identical change (same comment text, same two `add()` blocks, adjusted for the file's already-compiled JS syntax — no type annotations) to `examples/application-scenes/scene-lifecycle.js`.
 
-- [ ] **Step 4: Run to verify it passes**
+- [x] **Step 4: Run to verify it passes**
 
 Run: `pnpm typecheck && pnpm typecheck:examples`
 Expected: clean.
 
-- [ ] **Step 5: Lint**
+- [x] **Step 5: Lint**
 
 Run: `pnpm eslint src/core/Scene.ts examples/application-scenes/scene-lifecycle.js examples/application-scenes/scene-lifecycle.ts`
 Expected: clean.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/core/Scene.ts examples/application-scenes/scene-lifecycle.ts examples/application-scenes/scene-lifecycle.js
@@ -1864,7 +1864,7 @@ Suspend (Active → Suspended):
   (Director.onStateChange: dispatched by SceneDirector's _suspendAndRetain, Task 10 — unaffected call site, just converted to isolated dispatch)
 ```
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 In `test/core/scene-scope.test.ts`, first update the import line to include `Ready`, no change needed (imports `SceneState` as a whole already). Then apply the following rewrites.
 
@@ -2025,12 +2025,12 @@ test('restore() flushes pending audio and dispatches Scene.onActivate', async ()
 });
 ```
 
-- [ ] **Step 2: Run to verify it fails**
+- [x] **Step 2: Run to verify it fails**
 
 Run: `pnpm vitest run test/core/scene-scope.test.ts`
 Expected: FAIL — `prepare()` still ends in `Preparing`, `activate()` still transitions directly from `Preparing`, `scene.onActivate`/`onSuspend` don't exist yet on the `Scene` instances constructed by these tests (they do — Task 8 already added them — but `SceneScope` doesn't dispatch them yet).
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `src/core/SceneScope.ts`, replace `prepare()`:
 
@@ -2332,22 +2332,22 @@ to:
  */
 ```
 
-- [ ] **Step 4: Run to verify it passes**
+- [x] **Step 4: Run to verify it passes**
 
 Run: `pnpm vitest run test/core/scene-scope.test.ts`
 Expected: PASS.
 
-- [ ] **Step 5: Typecheck + lint**
+- [x] **Step 5: Typecheck + lint**
 
 Run: `pnpm typecheck && pnpm eslint src/core/SceneScope.ts test/core/scene-scope.test.ts`
 Expected: clean.
 
-- [ ] **Step 6: Run the full core suite to catch any other test relying on the old Preparing→Active edge**
+- [x] **Step 6: Run the full core suite to catch any other test relying on the old Preparing→Active edge**
 
 Run: `pnpm test:core`
 Expected: FAIL only in `test/core/scene-director.test.ts` (three tests assert the exact `(Preparing, Active, scene)` `onStateChange` tuple / call count that no longer occurs — fixed in Task 10). No other file should fail; if one does, stop and investigate before continuing (do not proceed to Task 10 with an unexplained failure elsewhere).
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add src/core/SceneScope.ts test/core/scene-scope.test.ts
@@ -2379,7 +2379,7 @@ Six call sites convert from `.dispatch(...)` to `.dispatchIsolated(error => this
 
 This is a **deliberate behavior change**, per spec §2.2.1: today, a throwing `onStopScene`/`onStateChange` listener genuinely propagates and triggers `_rollbackSwitch()` — exercised by the two existing tests in `describe('SceneDirector — switch-phase rollback', ...)`. After this change, those listeners' exceptions are isolated (reported via `Application.onError`, dispatch continues), so they can no longer trigger a rollback. Those two tests are rewritten below, per the spec's own explicit instruction, into tests of the new (correct) behavior.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 **1a.** Update the two `onStateChange`-count assertions affected by Task 9's `Preparing → Ready → Active` split. Replace (around line 258–270):
 
@@ -2594,12 +2594,12 @@ test('a throwing onChangeScene/onStartScene listener does not abort setScene() o
 });
 ```
 
-- [ ] **Step 2: Run to verify it fails**
+- [x] **Step 2: Run to verify it fails**
 
 Run: `pnpm vitest run test/core/scene-director.test.ts`
 Expected: FAIL — the rewritten tests expect isolation/completion; today's unguarded `.dispatch()` calls still propagate and roll back.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `src/core/SceneDirector.ts`, add the private helper, placed just above `_prepareScene`:
 
@@ -2749,17 +2749,17 @@ to:
   public readonly onStateChange = new Signal<[SceneState, SceneState, Scene]>();
 ```
 
-- [ ] **Step 4: Run to verify it passes**
+- [x] **Step 4: Run to verify it passes**
 
 Run: `pnpm vitest run test/core/scene-director.test.ts`
 Expected: PASS.
 
-- [ ] **Step 5: Typecheck + lint**
+- [x] **Step 5: Typecheck + lint**
 
 Run: `pnpm typecheck && pnpm eslint src/core/SceneDirector.ts test/core/scene-director.test.ts`
 Expected: clean.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/core/SceneDirector.ts test/core/scene-director.test.ts
@@ -2778,27 +2778,27 @@ the old (now removed) throw-triggers-rollback behavior."
 
 **Files:** none (verification only).
 
-- [ ] **Step 1: Full core test suite**
+- [x] **Step 1: Full core test suite**
 
 Run: `pnpm test:core`
 Expected: PASS, 0 failures. Compare the file/test counts against the baseline (318 files / 5083 tests before this slice) — expect the counts to have grown by the new tests added across Tasks 1–10, with no file count decrease.
 
-- [ ] **Step 2: Full typecheck (including examples)**
+- [x] **Step 2: Full typecheck (including examples)**
 
 Run: `pnpm typecheck && pnpm typecheck:examples && pnpm typecheck:type-tests`
 Expected: clean.
 
-- [ ] **Step 3: Full lint**
+- [x] **Step 3: Full lint**
 
 Run: `pnpm lint:all`
 Expected: clean.
 
-- [ ] **Step 4: Format check**
+- [x] **Step 4: Format check**
 
 Run: `pnpm format:check`
 Expected: clean. If it fails on files this slice touched, run `pnpm format` and re-stage.
 
-- [ ] **Step 5: Regenerate and check API docs**
+- [x] **Step 5: Regenerate and check API docs**
 
 `Scene.onActivate`/`Scene.onSuspend` are new public exports; `Scene.onLoad`/`Scene.onUnload` are removed ones. Run:
 
@@ -2814,12 +2814,12 @@ pnpm docs:api:check
 
 Expected: clean (no drift between the generator's output and what's committed).
 
-- [ ] **Step 6: Grep sweep for any remaining `onLoad`/`onUnload` reference**
+- [x] **Step 6: Grep sweep for any remaining `onLoad`/`onUnload` reference**
 
 Run: `grep -rn "\.onLoad\b\|\.onUnload\b" src/ test/ examples/ site/ docs/superpowers 2>/dev/null | grep -v "Loader\|resources/Loader"`
 Expected: no output referring to `Scene.onLoad`/`Scene.onUnload` (the `Loader.onLoad`-style hits from `src/resources/Loader.ts`, if any, are a distinct, unrelated signal and must remain — the grep's `-v` filter excludes that file already; double-check nothing else slipped through).
 
-- [ ] **Step 7: Commit any formatting fixups**
+- [x] **Step 7: Commit any formatting fixups**
 
 ```bash
 git add -A
@@ -2828,7 +2828,7 @@ git commit -m "chore: format + docs:api:generate for Slice 2 (Ready state & faci
 
 (Skip this commit if Steps 4–5 produced no changes.)
 
-- [ ] **Step 8: Update this plan's checkboxes**
+- [x] **Step 8: Update this plan's checkboxes**
 
 Mark every completed task's checkboxes `[x]` in this file and commit:
 

--- a/examples/application-scenes/scene-lifecycle.js
+++ b/examples/application-scenes/scene-lifecycle.js
@@ -7,10 +7,10 @@ import { Application, Color, Scene, Text, Time, Timer } from '@codexo/exojs';
 //                        value assets), then build the scene graph.
 //   - `destroy()`     — one-shot teardown, called once when the scene is
 //                        finally popped off the stack.
-// `update`/`draw` run every frame in between. Two signals bracket the same
-// span from the outside: `onLoad` fires right after `init()` resolves (the
-// scene is about to become active) and `onUnload` fires right before
-// `destroy()` runs (the scene is about to deactivate) — a hook point for
+// `update`/`draw` run every frame in between. Two signals bracket
+// activation from the outside: `onActivate` fires once the scene becomes
+// visible (fresh activation or a retention restore) and `onSuspend` fires
+// if the scene is ever retained instead of destroyed — a hook point for
 // cross-cutting concerns (audio cues, analytics, HUD toggles) that shouldn't
 // live inside `init`/`destroy` themselves.
 class LifecycleScene extends Scene {
@@ -29,11 +29,11 @@ class LifecycleScene extends Scene {
         //   const texture = this.loader.get('ship.png');
         //   const data = (await this.loader.load(Asset.kind('json', 'level.json'))) as LevelData;
         this.events = ['init'];
-        this.onLoad.add(() => {
-            this.events.push('onLoad');
+        this.onActivate.add(() => {
+            this.events.push('onActivate');
         });
-        this.onUnload.add(() => {
-            this.events.push('onUnload');
+        this.onSuspend.add(() => {
+            this.events.push('onSuspend');
         });
         this.timer = new Timer(Time.fromSeconds(1), true);
         this.text = new Text('', { fillColor: Color.white, fontSize: 18 });

--- a/examples/application-scenes/scene-lifecycle.ts
+++ b/examples/application-scenes/scene-lifecycle.ts
@@ -9,10 +9,10 @@ import { Application, Asset, Color, type RenderingContext, Scene, Text, Time, Ti
 //                        value assets), then build the scene graph.
 //   - `destroy()`     — one-shot teardown, called once when the scene is
 //                        finally popped off the stack.
-// `update`/`draw` run every frame in between. Two signals bracket the same
-// span from the outside: `onLoad` fires right after `init()` resolves (the
-// scene is about to become active) and `onUnload` fires right before
-// `destroy()` runs (the scene is about to deactivate) — a hook point for
+// `update`/`draw` run every frame in between. Two signals bracket
+// activation from the outside: `onActivate` fires once the scene becomes
+// visible (fresh activation or a retention restore) and `onSuspend` fires
+// if the scene is ever retained instead of destroyed — a hook point for
 // cross-cutting concerns (audio cues, analytics, HUD toggles) that shouldn't
 // live inside `init`/`destroy` themselves.
 class LifecycleScene extends Scene {
@@ -33,12 +33,12 @@ class LifecycleScene extends Scene {
         //   const data = (await this.loader.load(Asset.kind('json', 'level.json'))) as LevelData;
         this.events = ['init'];
 
-        this.onLoad.add(() => {
-            this.events.push('onLoad');
+        this.onActivate.add(() => {
+            this.events.push('onActivate');
         });
 
-        this.onUnload.add(() => {
-            this.events.push('onUnload');
+        this.onSuspend.add(() => {
+            this.events.push('onSuspend');
         });
 
         this.timer = new Timer(Time.fromSeconds(1), true);

--- a/site/src/content/api/scene-director.json
+++ b/site/src/content/api/scene-director.json
@@ -1135,7 +1135,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Fires whenever the active scene's SceneState changes, as (previous, next, scene) — every edge in the state graph, including the initial Preparing → Active activation and the terminal Destroying → Destroyed teardown, not just pause/resume/retention."
+          "description": "Fires whenever a scene's SceneState changes, as (previous, next, scene) — every edge in the state graph, including Preparing → Ready, Ready → Active, and the terminal Destroying → Destroyed teardown, not just pause/resume/retention. Pure observation: a throwing listener is reported through Application.onError and never aborts the transition or blocks the remaining listeners (definition §2.2/§2.2.1)."
         },
         {
           "name": "onStopScene",

--- a/site/src/content/api/scene-state.json
+++ b/site/src/content/api/scene-state.json
@@ -1,12 +1,12 @@
 {
   "title": "SceneState",
-  "description": "Lifecycle state of one Scene activation, owned by its internal `SceneScope` and exposed read-only via Scene.state. State is read-only from user code — it changes only in response to director-driven lifecycle events: activation, retention (suspend/restore), and teardown. Pause is not a state — it is an orthogonal flag that only applies while `Active`; see Scene.paused. | State | fixed/update | draw | input & interaction | |---|---:|---:|---| | `Preparing` | no | no | registrations accepted, dispatch gated | | `Active` (not paused) | yes | yes | active | | `Active` (paused) | no | yes | pause-policy filtered | | `Suspended` | no | no | disabled | | `Destroying` / `Destroyed` | no | no | disabled |",
+  "description": "Lifecycle state of one Scene activation, owned by its internal `SceneScope` and exposed read-only via Scene.state. State is read-only from user code — it changes only in response to director-driven lifecycle events: preparation, activation, retention (suspend/restore), and teardown. Pause is not a state — it is an orthogonal flag that only applies while `Active`; see Scene.paused. | State | fixed/update | draw | input & interaction | meaning | |---|---:|---:|---|---| | `Preparing` | no | no | registrations accepted, dispatch gated | `load()`/`init()` running | | `Ready` | no | no | registrations accepted, dispatch gated | fully prepared, never yet activated | | `Active` (not paused) | yes | yes | active | live | | `Active` (paused) | no | yes | pause-policy filtered | live, simulation frozen | | `Suspended` | no | no | registrations accepted, dispatch gated | previously active, retained | | `Destroying` / `Destroyed` | no | no | disabled | permanent teardown |",
   "symbol": "SceneState",
   "kind": "enum",
   "subsystem": "core",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 5,
+  "memberCount": 6,
   "counts": {
     "constructors": 0,
     "methods": 0,
@@ -19,8 +19,8 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "Lifecycle state of one Scene activation, owned by its internal `SceneScope` and exposed read-only via Scene.state. State is read-only from user code — it changes only in response to director-driven lifecycle events: activation, retention (suspend/restore), and teardown. Pause is not a state — it is an orthogonal flag that only applies while `Active`; see Scene.paused.",
-        "| State | fixed/update | draw | input & interaction | |---|---:|---:|---| | `Preparing` | no | no | registrations accepted, dispatch gated | | `Active` (not paused) | yes | yes | active | | `Active` (paused) | no | yes | pause-policy filtered | | `Suspended` | no | no | disabled | | `Destroying` / `Destroyed` | no | no | disabled |"
+        "Lifecycle state of one Scene activation, owned by its internal `SceneScope` and exposed read-only via Scene.state. State is read-only from user code — it changes only in response to director-driven lifecycle events: preparation, activation, retention (suspend/restore), and teardown. Pause is not a state — it is an orthogonal flag that only applies while `Active`; see Scene.paused.",
+        "| State | fixed/update | draw | input & interaction | meaning | |---|---:|---:|---|---| | `Preparing` | no | no | registrations accepted, dispatch gated | `load()`/`init()` running | | `Ready` | no | no | registrations accepted, dispatch gated | fully prepared, never yet activated | | `Active` (not paused) | yes | yes | active | live | | `Active` (paused) | no | yes | pause-policy filtered | live, simulation frozen | | `Suspended` | no | no | registrations accepted, dispatch gated | previously active, retained | | `Destroying` / `Destroyed` | no | no | disabled | permanent teardown |"
       ],
       "importLine": "import { SceneState } from '@codexo/exojs'",
       "sourceLink": null
@@ -74,6 +74,19 @@
           "signatureTokens": [
             {
               "text": "Preparing",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "Ready",
+          "signature": "Ready",
+          "signatureTokens": [
+            {
+              "text": "Ready",
               "kind": "name"
             }
           ],

--- a/site/src/content/api/scene.json
+++ b/site/src/content/api/scene.json
@@ -952,11 +952,11 @@
       "title": "Events",
       "members": [
         {
-          "name": "onLoad",
-          "signature": "onLoad: Signal<[]>",
+          "name": "onActivate",
+          "signature": "onActivate: Signal<[]>",
           "signatureTokens": [
             {
-              "text": "onLoad",
+              "text": "onActivate",
               "kind": "name"
             },
             {
@@ -986,7 +986,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Dispatched after the scene finishes loading (after load() and init() complete)."
+          "description": "Dispatched after this scene becomes Active — a fresh activation (Ready → Active) or a retention restore (Suspended → Active). Exceptions thrown by a listener are isolated: reported through Application.onError, never propagated back to whatever triggered the activation, and never able to block the remaining listeners or the activation itself."
         },
         {
           "name": "onPause",
@@ -1063,11 +1063,11 @@
           "description": "Dispatched after this scene's Scene.paused flag is cleared. Same event as SceneDirector.onResume, exposed directly on the scene for convenience."
         },
         {
-          "name": "onUnload",
-          "signature": "onUnload: Signal<[]>",
+          "name": "onSuspend",
+          "signature": "onSuspend: Signal<[]>",
           "signatureTokens": [
             {
-              "text": "onUnload",
+              "text": "onSuspend",
               "kind": "name"
             },
             {
@@ -1097,7 +1097,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Dispatched when the scene is about to be unloaded."
+          "description": "Dispatched after this scene is suspended for retention (Active → Suspended). Same exception-isolation contract as Scene.onActivate."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/signal.json
+++ b/site/src/content/api/signal.json
@@ -6,10 +6,10 @@
   "subsystem": "core",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 9,
+  "memberCount": 10,
   "counts": {
     "constructors": 1,
-    "methods": 7,
+    "methods": 8,
     "properties": 1,
     "events": 0
   },
@@ -243,6 +243,94 @@
           ],
           "returnType": "this",
           "description": "Notify every registered listener in registration order. Returning false from a handler stops dispatch to the remaining listeners for this call. Listeners may safely remove themselves or others during dispatch — removals are deferred until after the current iteration completes."
+        },
+        {
+          "name": "dispatchIsolated",
+          "signature": "dispatchIsolated(onError: (error: unknown) => void, params: Args): this",
+          "signatureTokens": [
+            {
+              "text": "dispatchIsolated",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "onError",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "error",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "unknown",
+              "kind": "keyword"
+            },
+            {
+              "text": ") => ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "params",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Args",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "onError",
+              "type": "(error: unknown) => void",
+              "optional": false
+            },
+            {
+              "name": "params",
+              "type": "Args",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": "Notify every registered listener in registration order, isolating each listener's exceptions individually instead of letting the first throw abort the whole dispatch — used for lifecycle signals (Scene.onActivate/onSuspend, SceneDirector.onStateChange/ onChangeScene/onStartScene/onStopScene) where a listener must never be able to abort a state transition that already happened, or silently prevent every listener registered after it from running. A throwing listener is reported to onError (itself guarded — a throwing onError callback never propagates back into this dispatch) and dispatch continues to the remaining listeners. A handler returning false still short-circuits the rest of the dispatch exactly as Signal.dispatch does — that contract is unaffected; only a *throw* is isolated. _dispatching/pending-removes bookkeeping is guaranteed via finally, so a throw here can never corrupt a later dispatch()/add()/remove() call on this Signal the way an unguarded throw inside Signal.dispatch would."
         },
         {
           "name": "has",

--- a/src/animation/TweenSequencer.ts
+++ b/src/animation/TweenSequencer.ts
@@ -58,7 +58,7 @@ export enum TweenSequencerState {
 export class TweenSequencer {
   private readonly _stages: Stage[] = [];
   private _state: TweenSequencerState = TweenSequencerState.Idle;
-  private readonly _manager: TweenManager | null;
+  private _manager: TweenManager | null;
 
   /** Index into `_stages` for the current pass (0-based). */
   private _currentStageIndex = 0;
@@ -81,6 +81,17 @@ export class TweenSequencer {
 
   public constructor(manager?: TweenManager) {
     this._manager = manager ?? null;
+  }
+
+  /**
+   * Attach this sequencer to a manager after construction — used by
+   * `SceneTweens` to bind a cold (buffered) sequencer, constructed without
+   * a manager while its owning scope was dormant, once the scope becomes
+   * `Active`. Mirrors {@link Tween._attachManager}.
+   * @internal
+   */
+  public _attachManager(manager: TweenManager): void {
+    this._manager = manager;
   }
 
   // ── State ────────────────────────────────────────────────────────────────

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -73,10 +73,21 @@ export class Scene<Data = void, AppLike extends ApplicationLike = Application> {
   protected _app: ApplicationOf<AppLike> | null = null;
   protected readonly _root = new Container();
 
-  /** Dispatched after the scene finishes loading (after load() and init() complete). */
-  public readonly onLoad = new Signal();
-  /** Dispatched when the scene is about to be unloaded. */
-  public readonly onUnload = new Signal();
+  /**
+   * Dispatched after this scene becomes `Active` — a fresh activation
+   * (`Ready` → `Active`) or a retention restore (`Suspended` → `Active`).
+   * Exceptions thrown by a listener are isolated: reported through
+   * {@link Application.onError}, never propagated back to whatever
+   * triggered the activation, and never able to block the remaining
+   * listeners or the activation itself.
+   */
+  public readonly onActivate = new Signal();
+  /**
+   * Dispatched after this scene is suspended for retention
+   * (`Active` → `Suspended`). Same exception-isolation contract as
+   * {@link Scene.onActivate}.
+   */
+  public readonly onSuspend = new Signal();
   /** Dispatched after this scene's {@link Scene.paused} flag is set. Same event as {@link SceneDirector.onPause}, exposed directly on the scene for convenience. */
   public readonly onPause = new Signal();
   /** Dispatched after this scene's {@link Scene.paused} flag is cleared. Same event as {@link SceneDirector.onResume}, exposed directly on the scene for convenience. */
@@ -436,8 +447,8 @@ export class Scene<Data = void, AppLike extends ApplicationLike = Application> {
    */
   public _teardownInternals(): void {
     this._disposal.destroy();
-    this.onLoad.destroy();
-    this.onUnload.destroy();
+    this.onActivate.destroy();
+    this.onSuspend.destroy();
     this.onPause.destroy();
     this.onResume.destroy();
     this._root.destroy();

--- a/src/core/SceneDirector.ts
+++ b/src/core/SceneDirector.ts
@@ -108,10 +108,13 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
   /** Fires after `resume()` actually clears the active scene's `paused` flag. */
   public readonly onResume = new Signal<[Scene]>();
   /**
-   * Fires whenever the active scene's {@link SceneState} changes, as
-   * `(previous, next, scene)` — every edge in the state graph, including the
-   * initial `Preparing` → `Active` activation and the terminal
+   * Fires whenever a scene's {@link SceneState} changes, as
+   * `(previous, next, scene)` — every edge in the state graph, including
+   * `Preparing` → `Ready`, `Ready` → `Active`, and the terminal
    * `Destroying` → `Destroyed` teardown, not just pause/resume/retention.
+   * Pure observation: a throwing listener is reported through
+   * {@link Application.onError} and never aborts the transition or blocks
+   * the remaining listeners (definition §2.2/§2.2.1).
    */
   public readonly onStateChange = new Signal<[SceneState, SceneState, Scene]>();
 
@@ -197,8 +200,8 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
 
       newScope.activate();
 
-      this.onChangeScene.dispatch(scene as Scene);
-      this.onStartScene.dispatch(scene as Scene);
+      this.onChangeScene.dispatchIsolated(error => this._reportLifecycleError(error), scene as Scene);
+      this.onStartScene.dispatchIsolated(error => this._reportLifecycleError(error), scene as Scene);
     }, options.transition);
 
     return this;
@@ -222,7 +225,7 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
         await this._disposeScene(previousScope);
       }
 
-      this.onChangeScene.dispatch(null);
+      this.onChangeScene.dispatchIsolated(error => this._reportLifecycleError(error), null);
     });
 
     return this;
@@ -271,8 +274,8 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
 
         retainedScope.restore();
 
-        this.onChangeScene.dispatch(retainedScope.scene as Scene);
-        this.onStateChange.dispatch(previousState, retainedScope.state, retainedScope.scene as Scene);
+        this.onChangeScene.dispatchIsolated(error => this._reportLifecycleError(error), retainedScope.scene as Scene);
+        this.onStateChange.dispatchIsolated(error => this._reportLifecycleError(error), previousState, retainedScope.state, retainedScope.scene as Scene);
       }, options.transition);
     } catch (error) {
       // Any failure (including a rejected concurrent-navigation guard, or
@@ -503,6 +506,21 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
   }
 
   /**
+   * Report an exception thrown by a lifecycle Signal listener — used as the
+   * `onError` callback for every `dispatchIsolated` call in this class
+   * (definition §2.2/§2.2.1): logged, then forwarded to
+   * {@link Application.onError}. Never propagates itself; `Signal.dispatchIsolated`
+   * additionally guards against a throwing `onError` callback, but this
+   * implementation does not throw regardless.
+   */
+  private _reportLifecycleError(error: unknown): void {
+    const normalized = error instanceof Error ? error : new Error(String(error));
+
+    logger.error('A SceneDirector lifecycle signal listener threw.', { source: 'SceneDirector', error: normalized });
+    this._app.onError.dispatch(normalized);
+  }
+
+  /**
    * Construct a `SceneScope` for `scene` and run its activation sequence
    * (attach → `Preparing` → `load()` → `init()`). On failure, runs the
    * definition §16 failed-activation cleanup — engine-managed registrations
@@ -510,7 +528,9 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
    * `unload()` is never called — and rethrows the original error unchanged.
    */
   private async _prepareScene<Data>(scene: Scene<Data>, data: Data): Promise<SceneScope<Data>> {
-    const scope = new SceneScope(this._app, scene, (previous, next) => this.onStateChange.dispatch(previous, next, scene as Scene));
+    const scope = new SceneScope(this._app, scene, (previous, next) =>
+      this.onStateChange.dispatchIsolated(error => this._reportLifecycleError(error), previous, next, scene as Scene),
+    );
 
     try {
       await scope.prepare(data);
@@ -532,7 +552,7 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
 
   /** Permanently end `scope`'s scene: dispatch {@link SceneDirector.onStopScene}, then run the scope's teardown sequence (definition §17). */
   private async _disposeScene(scope: SceneScope): Promise<void> {
-    this.onStopScene.dispatch(scope.scene as Scene);
+    this.onStopScene.dispatchIsolated(error => this._reportLifecycleError(error), scope.scene as Scene);
     await scope.destroy();
   }
 
@@ -571,7 +591,7 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
     scope.suspend();
     this._retained.set(target, scope);
 
-    this.onStateChange.dispatch(previousState, scope.state, scope.scene as Scene);
+    this.onStateChange.dispatchIsolated(error => this._reportLifecycleError(error), previousState, scope.state, scope.scene as Scene);
   }
 
   /**

--- a/src/core/SceneScope.ts
+++ b/src/core/SceneScope.ts
@@ -27,12 +27,15 @@ const isThenable = (value: unknown): boolean => value instanceof Promise;
 
 /**
  * Internal owner of one {@link Scene} activation: constructs and attaches the
- * scene's facilities, runs `load()`/`init()`, gates per-frame dispatch by
- * {@link SceneState}, supports retention ({@link SceneScope.suspend} /
- * {@link SceneScope.restore}), and runs permanent teardown in the normative
- * order. Not exported from the package root — `Scene` and `SceneDirector`
- * are the public surface; this class is their shared internal implementation
- * detail.
+ * scene's facilities, runs `load()`/`init()` (ending in {@link
+ * SceneState.Ready} — a cold checkpoint before any facility produces an
+ * application-wide effect), commits `Ready`/`Suspended` → `Active` via
+ * {@link SceneScope.activate}/{@link SceneScope.restore}, gates per-frame
+ * dispatch by {@link SceneState}, supports retention ({@link
+ * SceneScope.suspend}/{@link SceneScope.restore}), and runs permanent
+ * teardown in the normative order. Not exported from the package root —
+ * `Scene` and `SceneDirector` are the public surface; this class is their
+ * shared internal implementation detail.
  * @internal
  */
 export class SceneScope<Data = unknown> {
@@ -63,8 +66,8 @@ export class SceneScope<Data = unknown> {
       () => this._state,
       () => this._paused,
     );
-    this.interaction = new SceneInteraction(app);
-    this.tweens = new SceneTweens(app);
+    this.interaction = new SceneInteraction(app, () => this._state);
+    this.tweens = new SceneTweens(app, () => this._state);
     this.audio = new SceneAudio(app, () => this._state);
 
     scene._attach(app, this);
@@ -81,10 +84,12 @@ export class SceneScope<Data = unknown> {
 
   /**
    * Run `load()` then `init()` (definition §5.1 steps 5–7). Leaves the scope
-   * in `Preparing` on success — the caller commits the switch and calls
-   * {@link SceneScope.activate} once the previous scene has been disposed.
-   * Throws the original `load()`/`init()` error, or a dev-only lifecycle
-   * error when `init()` returns a thenable (it must be synchronous).
+   * in `Ready` on success — a cold checkpoint that produces no
+   * application-wide effect yet (definition §4.1/§4.2). The caller commits
+   * the switch and calls {@link SceneScope.activate} once the previous scene
+   * has been disposed. Throws the original `load()`/`init()` error, or a
+   * dev-only lifecycle error when `init()` returns a thenable (it must be
+   * synchronous).
    */
   public async prepare(data: Data): Promise<void> {
     await this.scene.load(data);
@@ -108,19 +113,37 @@ export class SceneScope<Data = unknown> {
       }
     }
 
-    this._attachAutoRoots();
+    const previous = this._state;
 
-    this._rootsAttached = true;
-    this.scene.onLoad.dispatch();
+    this._state = SceneState.Ready;
+    this._onStateChange(previous, this._state);
   }
 
-  /** Commit this scope as the active scene: `Preparing` → `Active`. Called by the director once the switch boundary is crossed. */
+  /**
+   * Commit this scope as the active scene: `Ready` → `Active` (definition
+   * §2.1's fresh-activation ordering). Called by the director once the
+   * switch boundary is crossed. Attaches the scene's automatic root/UI to
+   * interaction dispatch and flushes every facility registration buffered
+   * while dormant (definition §4.1/§4.2) before dispatching
+   * {@link Scene.onActivate}, then reports the state change last.
+   */
   public activate(): void {
     const previous = this._state;
 
     this._state = SceneState.Active;
+
+    const errors: unknown[] = [];
+
+    this._guard(errors, () => this._attachAutoRoots());
+    this._rootsAttached = true;
+    this._guard(errors, () => this.interaction.resume());
+    this._guard(errors, () => this.tweens.activate());
+    this._guard(errors, () => this.audio._flushPending());
+    this._guard(errors, () => this.scene.onActivate.dispatchIsolated(error => this._reportError(error)));
+
+    this._reportErrors(errors);
+
     this._onStateChange(previous, this._state);
-    this.audio._flushPending();
   }
 
   /**
@@ -205,6 +228,7 @@ export class SceneScope<Data = unknown> {
     });
     this._guard(errors, () => this.tweens.suspend());
     this._guard(errors, () => this.audio.suspend());
+    this._guard(errors, () => this.scene.onSuspend.dispatchIsolated(error => this._reportError(error)));
 
     this._reportErrors(errors);
 
@@ -238,6 +262,8 @@ export class SceneScope<Data = unknown> {
     });
     this._guard(errors, () => this.tweens.restore());
     this._guard(errors, () => this.audio.restore());
+    this._guard(errors, () => this.audio._flushPending());
+    this._guard(errors, () => this.scene.onActivate.dispatchIsolated(error => this._reportError(error)));
 
     this._reportErrors(errors);
 
@@ -412,7 +438,6 @@ export class SceneScope<Data = unknown> {
 
     if (!this._unloadCalled) {
       this._unloadCalled = true;
-      this._guard(errors, () => this.scene.onUnload.dispatch());
       await this._guardAsync(errors, () => this.scene.unload());
     }
 
@@ -486,12 +511,16 @@ export class SceneScope<Data = unknown> {
     }
   }
 
+  private _reportError(error: unknown): void {
+    const normalized = error instanceof Error ? error : new Error(String(error));
+
+    logger.error('A SceneScope cleanup stage failed.', { source: 'SceneScope', error: normalized });
+    this._app.onError.dispatch(normalized);
+  }
+
   private _reportErrors(errors: unknown[]): void {
     for (const error of errors) {
-      const normalized = error instanceof Error ? error : new Error(String(error));
-
-      logger.error('A SceneScope cleanup stage failed.', { source: 'SceneScope', error: normalized });
-      this._app.onError.dispatch(normalized);
+      this._reportError(error);
     }
   }
 }

--- a/src/core/SceneScope.ts
+++ b/src/core/SceneScope.ts
@@ -134,8 +134,10 @@ export class SceneScope<Data = unknown> {
 
     const errors: unknown[] = [];
 
-    this._guard(errors, () => this._attachAutoRoots());
-    this._rootsAttached = true;
+    this._guard(errors, () => {
+      this._attachAutoRoots();
+      this._rootsAttached = true;
+    });
     this._guard(errors, () => this.interaction.resume());
     this._guard(errors, () => this.tweens.activate());
     this._guard(errors, () => this.audio._flushPending());
@@ -514,7 +516,7 @@ export class SceneScope<Data = unknown> {
   private _reportError(error: unknown): void {
     const normalized = error instanceof Error ? error : new Error(String(error));
 
-    logger.error('A SceneScope cleanup stage failed.', { source: 'SceneScope', error: normalized });
+    logger.error('A SceneScope lifecycle stage failed.', { source: 'SceneScope', error: normalized });
     this._app.onError.dispatch(normalized);
   }
 

--- a/src/core/SceneState.ts
+++ b/src/core/SceneState.ts
@@ -2,21 +2,35 @@
  * Lifecycle state of one {@link Scene} activation, owned by its internal
  * `SceneScope` and exposed read-only via {@link Scene.state}. State is
  * read-only from user code — it changes only in response to director-driven
- * lifecycle events: activation, retention (suspend/restore), and teardown.
- * Pause is not a state — it is an orthogonal flag that only applies while
- * `Active`; see {@link Scene.paused}.
+ * lifecycle events: preparation, activation, retention (suspend/restore),
+ * and teardown. Pause is not a state — it is an orthogonal flag that only
+ * applies while `Active`; see {@link Scene.paused}.
  *
- * | State | fixed/update | draw | input & interaction |
- * |---|---:|---:|---|
- * | `Preparing` | no | no | registrations accepted, dispatch gated |
- * | `Active` (not paused) | yes | yes | active |
- * | `Active` (paused) | no | yes | pause-policy filtered |
- * | `Suspended` | no | no | disabled |
- * | `Destroying` / `Destroyed` | no | no | disabled |
+ * | State | fixed/update | draw | input & interaction | meaning |
+ * |---|---:|---:|---|---|
+ * | `Preparing` | no | no | registrations accepted, dispatch gated | `load()`/`init()` running |
+ * | `Ready` | no | no | registrations accepted, dispatch gated | fully prepared, never yet activated |
+ * | `Active` (not paused) | yes | yes | active | live |
+ * | `Active` (paused) | no | yes | pause-policy filtered | live, simulation frozen |
+ * | `Suspended` | no | no | registrations accepted, dispatch gated | previously active, retained |
+ * | `Destroying` / `Destroyed` | no | no | disabled | permanent teardown |
  */
 export enum SceneState {
   /** `load()` or `init()` is running. Facilities accept registrations, but nothing dispatches, ticks, or plays yet. */
   Preparing = 'preparing',
+  /**
+   * Fully prepared (`load()`/`init()` both completed) but never yet
+   * activated — a genuine, cold checkpoint between preparation and going
+   * live. Facilities keep accepting registrations (definition §4.2), but
+   * still nothing dispatches, ticks, plays, or produces any
+   * application-wide runtime effect. Transient for an ordinary activation
+   * (immediately followed by {@link SceneScope.activate}); can be
+   * longer-lived for a pre-warmed scene in a later slice. Not
+   * suspend-eligible — see {@link canSuspend}: a `Ready` scope that is
+   * discarded before ever activating is torn down via `destroy()` directly,
+   * never via {@link SceneScope.suspend}.
+   */
+  Ready = 'ready',
   /** Normal visible scene: fixed/update/draw all run, input and interaction dispatch normally — unless {@link Scene.paused} is set, which freezes fixed/update. */
   Active = 'active',
   /** Retained but inactive: no fixed/update/draw, no scene input or interaction dispatch. */
@@ -27,7 +41,12 @@ export enum SceneState {
   Destroyed = 'destroyed',
 }
 
-/** `true` when the scene can be suspended for retention (`Active` → `Suspended`). */
+/**
+ * `true` when the scene can be suspended for retention (`Active` →
+ * `Suspended`). Deliberately excludes `Ready`: a scope that finished
+ * preparing but was never activated has nothing live to suspend — it is
+ * discarded via `destroy()` instead (see {@link SceneState.Ready}).
+ */
 export function canSuspend(state: SceneState): boolean {
   return state === SceneState.Active;
 }

--- a/src/core/Signal.ts
+++ b/src/core/Signal.ts
@@ -175,9 +175,6 @@ export class Signal<Args extends unknown[] = []> {
             // the lifecycle dispatch that triggered it.
           }
 
-          // Listener threw; mark it for removal so it's not called again
-          (this._pendingRemoves ??= []).push(this._handlers[i]!);
-
           continue;
         }
 

--- a/src/core/Signal.ts
+++ b/src/core/Signal.ts
@@ -133,6 +133,77 @@ export class Signal<Args extends unknown[] = []> {
     return this;
   }
 
+  /**
+   * Notify every registered listener in registration order, isolating each
+   * listener's exceptions individually instead of letting the first throw
+   * abort the whole dispatch — used for lifecycle signals
+   * (`Scene.onActivate`/`onSuspend`, `SceneDirector.onStateChange`/
+   * `onChangeScene`/`onStartScene`/`onStopScene`) where a listener must
+   * never be able to abort a state transition that already happened, or
+   * silently prevent every listener registered after it from running.
+   *
+   * A throwing listener is reported to `onError` (itself guarded — a
+   * throwing `onError` callback never propagates back into this dispatch)
+   * and dispatch continues to the remaining listeners. A handler returning
+   * `false` still short-circuits the rest of the dispatch exactly as
+   * {@link Signal.dispatch} does — that contract is unaffected; only a
+   * *throw* is isolated. `_dispatching`/pending-removes bookkeeping is
+   * guaranteed via `finally`, so a throw here can never corrupt a later
+   * `dispatch()`/`add()`/`remove()` call on this Signal the way an
+   * unguarded throw inside {@link Signal.dispatch} would.
+   */
+  public dispatchIsolated(onError: (error: unknown) => void, ...params: Args): this {
+    const length = this._handlers.length;
+
+    if (!length) {
+      return this;
+    }
+
+    this._dispatching = true;
+
+    try {
+      for (let i = 0; i < length; i++) {
+        let result: void | boolean;
+
+        try {
+          result = this._handlers[i]!(...params);
+        } catch (error) {
+          try {
+            onError(error);
+          } catch {
+            // A throwing onError listener must never propagate back into
+            // the lifecycle dispatch that triggered it.
+          }
+
+          // Listener threw; mark it for removal so it's not called again
+          (this._pendingRemoves ??= []).push(this._handlers[i]!);
+
+          continue;
+        }
+
+        if (result === false) {
+          break;
+        }
+      }
+    } finally {
+      this._dispatching = false;
+
+      if (this._pendingRemoves !== null) {
+        for (const handler of this._pendingRemoves) {
+          const index = this._handlers.indexOf(handler);
+
+          if (index !== -1) {
+            removeArrayItems(this._handlers, index, 1);
+          }
+        }
+
+        this._pendingRemoves = null;
+      }
+    }
+
+    return this;
+  }
+
   public destroy(): void {
     this._handlers.length = 0;
     this._pendingRemoves = null;

--- a/src/core/scene/SceneAudio.ts
+++ b/src/core/scene/SceneAudio.ts
@@ -207,11 +207,30 @@ export class SceneAudio implements Destroyable {
   /**
    * Play `source` through the application audio manager and track the
    * resulting {@link Voice} for scene-lifetime cleanup. While the scope is
-   * `Preparing`, returns a {@link PendingVoice} stand-in immediately and
-   * defers the real `app.audio.play(...)` call until activation.
+   * `Preparing`, `Ready`, or `Suspended`, returns a {@link PendingVoice}
+   * stand-in immediately and defers the real `app.audio.play(...)` call
+   * until (re)activation — including a call made while already `Suspended`
+   * (definition §4.2: a new registration while dormant must buffer, not
+   * play for real, regardless of how the scope became dormant). While
+   * `Destroying`/`Destroyed`, rejects instead: a dev build throws a clear
+   * lifecycle error (playback requested during permanent teardown can
+   * never be scheduled); a production build returns an inert, already-
+   * `ended` stand-in rather than crashing a teardown path.
    */
   public play(source: Playable, options?: SceneAudioPlayOptions): Voice {
-    if (this._getState() === SceneState.Preparing) {
+    const state = this._getState();
+
+    if (state === SceneState.Destroying || state === SceneState.Destroyed) {
+      if (__DEV__) {
+        throw new Error(
+          'SceneAudio.play() was called while the owning scene is being destroyed (state is "destroying"/"destroyed") — playback requested during permanent teardown can never be scheduled.',
+        );
+      }
+
+      return this._createDeadVoice(options ?? {});
+    }
+
+    if (state !== SceneState.Active) {
       const pending = new PendingVoice(() => this._app.audio.play(source, options ?? {}), options ?? {});
 
       this._pending.add(pending);
@@ -221,6 +240,23 @@ export class SceneAudio implements Destroyable {
     }
 
     return this.add(this._app.audio.play(source, options), options);
+  }
+
+  /**
+   * Production-build fallback for {@link SceneAudio.play} called during
+   * `Destroying`/`Destroyed`: an already-cancelled {@link PendingVoice}
+   * whose `_createReal` callback is never invoked (a cancelled voice is
+   * never flushed) — inert, but Voice-shaped, so calling code that doesn't
+   * dev-guard its `play()` calls doesn't crash mid-teardown.
+   */
+  private _createDeadVoice(options: SceneAudioPlayOptions): Voice {
+    const dead = new PendingVoice(() => {
+      throw new Error('SceneAudio: a dead voice (created during Destroying/Destroyed) must never be flushed.');
+    }, options);
+
+    dead.stop();
+
+    return dead;
   }
 
   /** Track an already-created {@link Voice} (e.g. from `app.audio.play(...)`) for scene-lifetime cleanup. Returns it unchanged. */

--- a/src/core/scene/SceneInputs.ts
+++ b/src/core/scene/SceneInputs.ts
@@ -12,7 +12,7 @@ export interface SceneInputBindingOptions extends InputBindingOptions {
   readonly when?: SceneInputAvailability;
 }
 
-const gatedStates = new Set<SceneState>([SceneState.Preparing, SceneState.Suspended, SceneState.Destroying, SceneState.Destroyed]);
+const gatedStates = new Set<SceneState>([SceneState.Preparing, SceneState.Ready, SceneState.Suspended, SceneState.Destroying, SceneState.Destroyed]);
 
 function whenPolicyAllows(when: SceneInputAvailability, state: SceneState, paused: boolean): boolean {
   if (gatedStates.has(state)) {

--- a/src/core/scene/SceneInteraction.ts
+++ b/src/core/scene/SceneInteraction.ts
@@ -1,4 +1,5 @@
 import type { Application } from '#core/Application';
+import { SceneState } from '#core/SceneState';
 import type { Destroyable } from '#core/types';
 import type { RenderNode } from '#rendering/RenderNode';
 
@@ -31,11 +32,15 @@ export interface InteractionCapture extends Destroyable {
 
 interface TrackedObservation extends InteractionObservation {
   readonly root: RenderNode;
+  /** Whether this observation currently reached `app.interaction` — false while created/left dormant. */
+  attached: boolean;
   released: boolean;
 }
 
 interface TrackedCapture extends InteractionCapture {
   readonly root: RenderNode;
+  /** Whether this capture is currently pushed onto `app.interaction`'s stack — false while created/left dormant. */
+  attached: boolean;
   released: boolean;
 }
 
@@ -53,25 +58,45 @@ interface TrackedCapture extends InteractionCapture {
  * detach/release on teardown. Pause-aware dispatch gating (state
  * Active/Paused, transition gate) is enforced once, centrally, in
  * {@link InteractionManager.update} — not duplicated here.
+ *
+ * While the owning scope is not `Active` (`Preparing`, `Ready`, or
+ * `Suspended`), `observe()`/`capture()` track their registration locally but
+ * never reach `app.interaction` — including a call made while already
+ * `Suspended` (definition §4.2). {@link SceneInteraction.resume} attaches
+ * everything not yet attached, in tracking order, on the next transition
+ * into `Active` (fresh activation or retention restore alike).
  */
 export class SceneInteraction implements Destroyable {
   private readonly _observations = new Set<TrackedObservation>();
   private readonly _captures: TrackedCapture[] = [];
-  private _suspended = false;
 
-  public constructor(private readonly _app: Application) {}
+  public constructor(
+    private readonly _app: Application,
+    private readonly _getState: () => SceneState,
+  ) {}
+
+  private _isLive(): boolean {
+    return this._getState() === SceneState.Active;
+  }
 
   /**
    * Attach `root` to interaction dispatch (pointer/focus routing), so its
-   * interactive descendants start receiving events. Returns a handle to
-   * detach it early; otherwise it is detached automatically when the scene
-   * ends permanently.
+   * interactive descendants start receiving events — immediately if the
+   * owning scope is currently `Active`, otherwise buffered until it next
+   * becomes `Active` (see the class doc). Returns a handle to detach it
+   * early; otherwise it is detached automatically when the scene ends
+   * permanently.
    */
   public observe(root: RenderNode): InteractionObservation {
-    this._app.interaction.attachRoot(root);
+    const live = this._isLive();
+
+    if (live) {
+      this._app.interaction.attachRoot(root);
+    }
 
     const observation: TrackedObservation = {
       root,
+      attached: live,
       released: false,
       release: () => this._release(observation),
       destroy: () => this._release(observation),
@@ -88,13 +113,19 @@ export class SceneInteraction implements Destroyable {
    * that must swallow clicks outside itself. Nested captures use
    * last-created priority; releasing any capture (not only the most recent)
    * restores the stack to its state as if that capture had never been
-   * created, preserving the relative order of the rest.
+   * created, preserving the relative order of the rest. Buffered until the
+   * owning scope is `Active`, same as {@link SceneInteraction.observe}.
    */
   public capture(root: RenderNode): InteractionCapture {
-    this._app.interaction.pushInputCapture(root);
+    const live = this._isLive();
+
+    if (live) {
+      this._app.interaction.pushInputCapture(root);
+    }
 
     const capture: TrackedCapture = {
       root,
+      attached: live,
       released: false,
       release: () => this._releaseCapture(capture),
       destroy: () => this._releaseCapture(capture),
@@ -109,48 +140,54 @@ export class SceneInteraction implements Destroyable {
   }
 
   /**
-   * Detach every tracked observation and deactivate every capture (pop it
-   * from the manager's stack) without discarding local tracking, so
-   * {@link SceneInteraction.resume} can restore exactly the same set in the
-   * same order — a retained scene must not keep receiving pointer dispatch
-   * alongside whichever scope is now active (definition §8.2). Idempotent.
+   * Detach every currently-attached observation and pop every
+   * currently-attached capture off the manager's stack, without discarding
+   * local tracking — so {@link SceneInteraction.resume} can reattach exactly
+   * the same set in the same order. A retained scene must not keep
+   * receiving pointer dispatch alongside whichever scope is now active
+   * (definition §4.2). A no-op for anything created while already dormant
+   * (never reached `app.interaction` in the first place). Idempotent.
    * @internal
    */
   public suspend(): void {
-    if (this._suspended) {
-      return;
-    }
-
-    this._suspended = true;
-
     for (const observation of this._observations) {
-      this._app.interaction.detachRoot(observation.root);
+      if (observation.attached) {
+        this._app.interaction.detachRoot(observation.root);
+        observation.attached = false;
+      }
     }
 
     for (let i = this._captures.length - 1; i >= 0; i--) {
-      this._app.interaction.popInputCapture();
+      const capture = this._captures[i]!;
+
+      if (capture.attached) {
+        this._app.interaction.popInputCapture();
+        capture.attached = false;
+      }
     }
   }
 
   /**
-   * Reattach every tracked observation and re-push every tracked capture in
-   * its original order, undoing {@link SceneInteraction.suspend}. Idempotent
-   * — a no-op if not currently suspended.
+   * Attach every observation and push every capture not currently attached
+   * to `app.interaction`, in tracking order — covers both a fresh
+   * activation flushing whatever was registered while dormant, and a
+   * retention restore reinstating whatever {@link SceneInteraction.suspend}
+   * detached. Idempotent — already-attached entries are left alone.
    * @internal
    */
   public resume(): void {
-    if (!this._suspended) {
-      return;
-    }
-
-    this._suspended = false;
-
     for (const observation of this._observations) {
-      this._app.interaction.attachRoot(observation.root);
+      if (!observation.attached) {
+        this._app.interaction.attachRoot(observation.root);
+        observation.attached = true;
+      }
     }
 
     for (const capture of this._captures) {
-      this._app.interaction.pushInputCapture(capture.root);
+      if (!capture.attached) {
+        this._app.interaction.pushInputCapture(capture.root);
+        capture.attached = true;
+      }
     }
   }
 
@@ -173,7 +210,10 @@ export class SceneInteraction implements Destroyable {
 
     observation.released = true;
     this._observations.delete(observation);
-    this._app.interaction.detachRoot(observation.root);
+
+    if (observation.attached) {
+      this._app.interaction.detachRoot(observation.root);
+    }
   }
 
   private _releaseCapture(capture: TrackedCapture): void {
@@ -183,27 +223,28 @@ export class SceneInteraction implements Destroyable {
 
     const index = this._captures.indexOf(capture);
 
-    if (this._suspended) {
-      // suspend() already popped every capture off the live manager stack,
-      // and resume() will re-push the full, corrected `_captures` array
-      // from scratch. Touching the manager here (pop/push) would reinstate
-      // this capture's slot on the live stack while the scope is still
-      // dormant — exactly the state leak retention suspension exists to
-      // prevent. Local bookkeeping only; the manager catches up on resume().
+    if (!capture.attached) {
+      // Never reached app.interaction (created while dormant, or currently
+      // detached by suspend()) — local bookkeeping only; the manager's
+      // stack was never touched for this capture in the first place.
       capture.released = true;
       this._captures.splice(index, 1);
 
       return;
     }
 
-    // Pop every still-active capture from the top down through (and
-    // including) this one, then re-push everything that was above it, in
-    // original order — restores the manager's stack as if `capture` had
-    // never existed, without needing a manager-level "remove at index" API.
+    // Every capture from `index` onward is attached together in practice —
+    // captures only ever attach while genuinely Active, and suspend()
+    // detaches the entire array together, so a mix of attached/unattached
+    // entries above an attached one cannot arise. Pop every capture from
+    // the top down through (and including) this one, then re-push
+    // everything that was above it, in original order — restores the
+    // manager's stack as if `capture` had never existed.
     const above = this._captures.slice(index + 1);
 
     for (let i = this._captures.length - 1; i >= index; i--) {
       this._app.interaction.popInputCapture();
+      this._captures[i]!.attached = false;
     }
 
     capture.released = true;
@@ -211,6 +252,7 @@ export class SceneInteraction implements Destroyable {
 
     for (const entry of above) {
       this._app.interaction.pushInputCapture(entry.root);
+      entry.attached = true;
     }
   }
 }

--- a/src/core/scene/SceneTweens.ts
+++ b/src/core/scene/SceneTweens.ts
@@ -1,7 +1,9 @@
-import type { Tween } from '#animation/Tween';
-import { type TweenSequencer, TweenSequencerState } from '#animation/TweenSequencer';
+import { Tween } from '#animation/Tween';
+import { TweenSequencer } from '#animation/TweenSequencer';
+import { TweenSequencerState } from '#animation/TweenSequencer';
 import { TweenState } from '#animation/types';
 import type { Application } from '#core/Application';
+import { SceneState } from '#core/SceneState';
 import type { Destroyable } from '#core/types';
 
 /** Availability of a tracked tween/sequencer relative to the owning scene's pause state. Default `'always'`. */
@@ -26,10 +28,24 @@ export interface SceneTweenOptions {
  * Scene-bound tween facade. Tweens and sequencers created or added here are
  * automatically stopped when the owning scene ends permanently. Access via
  * {@link Scene.tweens}.
+ *
+ * While the owning scope is not `Active` (`Preparing`, `Ready`, or
+ * `Suspended`), `create()`/`createSequencer()` construct their result
+ * without attaching it to the application-wide `TweenManager` at all, so a
+ * synchronous `.start()` call made while dormant produces zero
+ * application-wide effect (definition §4.2) — the manager only begins
+ * driving it once the scope becomes `Active` and this facade flushes it in.
+ * `add()` (which may be handed an already-live tween) instead pauses it
+ * immediately if needed, resuming it on activation only if it is still in
+ * the exact state this left it in — the same idiom already used by
+ * {@link SceneTweens.suspend}/{@link SceneTweens.restore} for retention.
  */
 export class SceneTweens implements Destroyable {
   private readonly _tweens = new Map<Tween, SceneTweenAvailability>();
   private readonly _sequencers = new Map<TweenSequencer, SceneTweenAvailability>();
+  private readonly _cold = new Set<Tween>();
+  private readonly _coldPaused = new Set<Tween>();
+  private readonly _coldSequencers = new Set<TweenSequencer>();
   private _suspendedTweens: Set<Tween> | null = null;
   private _suspendedSequencers: Set<TweenSequencer> | null = null;
   private _frozenTweens: Set<Tween> | null = null;
@@ -37,32 +53,82 @@ export class SceneTweens implements Destroyable {
   private _frozenSequencers: Set<TweenSequencer> | null = null;
   private _thawedSequencers: Set<TweenSequencer> | null = null;
 
-  public constructor(private readonly _app: Application) {}
+  public constructor(
+    private readonly _app: Application,
+    private readonly _getState: () => SceneState,
+  ) {}
 
-  /** Create a {@link Tween} targeting `target` through the application tween manager, tracked for scene-lifetime cleanup. */
+  /**
+   * Create a {@link Tween} targeting `target`, tracked for scene-lifetime
+   * cleanup. While the owning scope is not `Active`, the tween is
+   * constructed directly (not through `app.tweens.create`) so it is never
+   * attached to the application-wide manager until activation — see the
+   * class doc.
+   */
   public create<T extends object>(target: T, options?: SceneTweenOptions): Tween<T> {
+    const when = options?.when ?? 'always';
+
+    if (this._getState() !== SceneState.Active) {
+      const tween = new Tween(target);
+
+      this._tweens.set(tween, when);
+      this._cold.add(tween);
+
+      return tween;
+    }
+
     const tween = this._app.tweens.create(target);
-    this._tweens.set(tween, options?.when ?? 'always');
+
+    this._tweens.set(tween, when);
 
     return tween;
   }
 
-  /** Track an already-created {@link Tween} (e.g. built via `app.tweens.create(...)`) for scene-lifetime cleanup. Returns `this` for chaining. */
+  /**
+   * Track an already-created {@link Tween} (e.g. built via
+   * `app.tweens.create(...)`) for scene-lifetime cleanup. Passing a tween
+   * that is already running transfers runtime ownership to this facade —
+   * while the owning scope is not `Active`, that means pausing it
+   * immediately (mirrors {@link SceneTweens.suspend}'s own pattern),
+   * resumed on activation only if it is still in the exact state this left
+   * it in. Returns `this` for chaining.
+   */
   public add(tween: Tween, options?: SceneTweenOptions): this {
+    const when = options?.when ?? 'always';
+
     this._app.tweens.add(tween);
-    this._tweens.set(tween, options?.when ?? 'always');
+    this._tweens.set(tween, when);
+
+    if (this._getState() !== SceneState.Active && tween.state === TweenState.Active) {
+      tween.pause();
+      this._coldPaused.add(tween);
+    }
 
     return this;
   }
 
   /**
-   * Create a {@link TweenSequencer} through the application tween manager,
-   * tracked for scene-lifetime cleanup exactly like {@link SceneTweens.create}
-   * — auto-stopped on scene teardown and suspended/restored across retention.
+   * Create a {@link TweenSequencer}, tracked for scene-lifetime cleanup
+   * exactly like {@link SceneTweens.create} — auto-stopped on scene
+   * teardown and suspended/restored across retention. While the owning
+   * scope is not `Active`, constructed without a manager (same reasoning as
+   * {@link SceneTweens.create}) and bound to the real one at activation.
    */
   public createSequencer(options?: SceneTweenOptions): TweenSequencer {
+    const when = options?.when ?? 'always';
+
+    if (this._getState() !== SceneState.Active) {
+      const sequencer = new TweenSequencer();
+
+      this._sequencers.set(sequencer, when);
+      this._coldSequencers.add(sequencer);
+
+      return sequencer;
+    }
+
     const sequencer = this._app.tweens.createSequencer();
-    this._sequencers.set(sequencer, options?.when ?? 'always');
+
+    this._sequencers.set(sequencer, when);
 
     return sequencer;
   }
@@ -97,8 +163,30 @@ export class SceneTweens implements Destroyable {
     this._suspendedSequencers = runningSequencers;
   }
 
-  /** Restore exactly the tweens/sequencers paused by {@link SceneTweens.suspend}. @internal */
+  /**
+   * Called by `SceneScope` whenever this scope becomes `Active` — a fresh
+   * activation flushing whatever was created while `Ready` (or a still-cold
+   * `Suspended` registration), or a retention restore reinstating whatever
+   * {@link SceneTweens.suspend} paused. Both converge on the same
+   * operation: attach every cold tween/sequencer to the app-wide manager
+   * (in whatever state it's currently in), then resume exactly the set
+   * `suspend()` paused and exactly the set `add()` paused while dormant —
+   * each only if still in the exact state this facade left it in.
+   * @internal
+   */
   public restore(): void {
+    for (const tween of this._cold) {
+      this._app.tweens.add(tween);
+    }
+
+    this._cold.clear();
+
+    for (const sequencer of this._coldSequencers) {
+      sequencer._attachManager(this._app.tweens);
+    }
+
+    this._coldSequencers.clear();
+
     if (this._suspendedTweens !== null) {
       for (const tween of this._suspendedTweens) {
         if (tween.state === TweenState.Paused) {
@@ -118,6 +206,24 @@ export class SceneTweens implements Destroyable {
 
       this._suspendedSequencers = null;
     }
+
+    for (const tween of this._coldPaused) {
+      if (tween.state === TweenState.Paused) {
+        tween.resume();
+      }
+    }
+
+    this._coldPaused.clear();
+  }
+
+  /**
+   * Alias for {@link SceneTweens.restore}, used by `SceneScope.activate()`
+   * for the fresh-activation edge (`Ready`/`Suspended` → `Active`) — kept as
+   * a distinctly-named entry point so call sites read naturally regardless
+   * of which transition triggered them; both do the identical work. @internal
+   */
+  public activate(): void {
+    this.restore();
   }
 
   /**
@@ -223,6 +329,9 @@ export class SceneTweens implements Destroyable {
 
     this._tweens.clear();
     this._sequencers.clear();
+    this._cold.clear();
+    this._coldPaused.clear();
+    this._coldSequencers.clear();
     this._suspendedTweens = null;
     this._suspendedSequencers = null;
     this._frozenTweens = null;

--- a/test/core/scene-director.test.ts
+++ b/test/core/scene-director.test.ts
@@ -256,7 +256,7 @@ describe('SceneDirector', () => {
     expect(first?.attached).toBe(false);
   });
 
-  test('setScene() dispatches onStateChange for the fresh Preparing to Active activation', async () => {
+  test('setScene() dispatches onStateChange for Preparing to Ready, then Ready to Active', async () => {
     const TestScene = makeSceneClass();
     const manager = new SceneDirector(createApplicationStub(), { test: TestScene });
     const onStateChange = vi.fn();
@@ -266,11 +266,12 @@ describe('SceneDirector', () => {
     await manager.setScene(TestScene);
     const scene = manager.currentScene;
 
-    expect(onStateChange).toHaveBeenCalledTimes(1);
-    expect(onStateChange).toHaveBeenCalledWith(SceneState.Preparing, SceneState.Active, scene);
+    expect(onStateChange).toHaveBeenCalledTimes(2);
+    expect(onStateChange).toHaveBeenNthCalledWith(1, SceneState.Preparing, SceneState.Ready, scene);
+    expect(onStateChange).toHaveBeenNthCalledWith(2, SceneState.Ready, SceneState.Active, scene);
   });
 
-  test('switching scenes dispatches onStateChange for the outgoing scope Destroying and Destroyed transitions', async () => {
+  test('switching scenes dispatches onStateChange for the outgoing scope Destroying and Destroyed transitions, and the incoming Preparing→Ready→Active', async () => {
     const First = makeSceneClass();
     const Second = makeSceneClass();
     const manager = new SceneDirector(createApplicationStub(), { first: First, second: Second });
@@ -284,10 +285,11 @@ describe('SceneDirector', () => {
     await manager.setScene(Second);
     const second = manager.currentScene;
 
-    expect(onStateChange).toHaveBeenCalledTimes(3);
+    expect(onStateChange).toHaveBeenCalledTimes(4);
     expect(onStateChange).toHaveBeenCalledWith(SceneState.Active, SceneState.Destroying, first);
     expect(onStateChange).toHaveBeenCalledWith(SceneState.Destroying, SceneState.Destroyed, first);
-    expect(onStateChange).toHaveBeenCalledWith(SceneState.Preparing, SceneState.Active, second);
+    expect(onStateChange).toHaveBeenCalledWith(SceneState.Preparing, SceneState.Ready, second);
+    expect(onStateChange).toHaveBeenCalledWith(SceneState.Ready, SceneState.Active, second);
   });
 
   test('a failed activation dispatches onStateChange for Preparing to Destroying to Destroyed', async () => {
@@ -893,28 +895,30 @@ describe('SceneDirector — concurrent navigation', () => {
 });
 
 describe('SceneDirector — switch-phase rollback', () => {
-  test('a throwing onStopScene listener rolls back to the previous scope and rethrows', async () => {
+  test('a throwing onStopScene listener no longer aborts the switch — isolated, reported via onError, switch completes (definition §2.2.1)', async () => {
     const app = createApplicationStub();
     const FirstScene = makeSceneClass();
     const SecondScene = makeSceneClass();
     const director = new SceneDirector(app, { first: FirstScene, second: SecondScene });
 
     await director.setScene(FirstScene);
-    const firstInstance = director.currentScene;
 
     const failure = new Error('onStopScene listener failed');
+    const errorSpy = vi.fn();
 
     director.onStopScene.add(() => {
       throw failure;
     });
+    app.onError.add(errorSpy);
 
-    await expect(director.setScene(SecondScene)).rejects.toThrow(failure);
+    await expect(director.setScene(SecondScene)).resolves.toBe(director);
 
-    expect(director.currentScene).toBe(firstInstance); // rolled back
+    expect(director.currentScene).toBeInstanceOf(SecondScene);
     expect(director.state).toBe(SceneState.Active);
+    expect(errorSpy).toHaveBeenCalledWith(failure);
   });
 
-  test('a throwing onStopScene listener during a retainCurrent switch un-suspends the previous scope', async () => {
+  test('a throwing onStateChange listener during a retainCurrent switch no longer un-suspends the previous scope — isolated, reported via onError, retention completes', async () => {
     const app = createApplicationStub();
     const FirstScene = makeSceneClass();
     const SecondScene = makeSceneClass();
@@ -924,16 +928,45 @@ describe('SceneDirector — switch-phase rollback', () => {
     const firstInstance = director.currentScene;
 
     const failure = new Error('onStateChange listener failed');
+    const errorSpy = vi.fn();
 
     director.onStateChange.add(() => {
       throw failure;
     });
+    app.onError.add(errorSpy);
 
-    await expect(director.setScene(SecondScene, { retainCurrent: true })).rejects.toThrow(failure);
+    await expect(director.setScene(SecondScene, { retainCurrent: true })).resolves.toBe(director);
 
-    expect(director.currentScene).toBe(firstInstance);
-    expect(firstInstance?.state).toBe(SceneState.Active); // un-suspended, not left dangling in _retained
-    await expect(director.restoreScene(FirstScene)).rejects.toThrow(RetainedSceneNotFoundError); // proves it's NOT in _retained
+    expect(director.currentScene).toBeInstanceOf(SecondScene);
+    expect(firstInstance?.state).toBe(SceneState.Suspended); // retained normally, not rolled back
+    expect(errorSpy).toHaveBeenCalledWith(failure);
+
+    await expect(director.restoreScene(FirstScene)).resolves.toBe(director); // proves it IS in _retained
+  });
+
+  test('a throwing onChangeScene/onStartScene listener does not abort setScene() or block later listeners', async () => {
+    const app = createApplicationStub();
+    const TestScene = makeSceneClass();
+    const director = new SceneDirector(app, { test: TestScene });
+    const errorSpy = vi.fn();
+    const laterChangeListener = vi.fn();
+    const laterStartListener = vi.fn();
+
+    director.onChangeScene.add(() => {
+      throw new Error('onChangeScene listener failed');
+    });
+    director.onChangeScene.add(laterChangeListener);
+    director.onStartScene.add(() => {
+      throw new Error('onStartScene listener failed');
+    });
+    director.onStartScene.add(laterStartListener);
+    app.onError.add(errorSpy);
+
+    await expect(director.setScene(TestScene)).resolves.toBe(director);
+
+    expect(laterChangeListener).toHaveBeenCalledTimes(1);
+    expect(laterStartListener).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/test/core/scene-scope.test.ts
+++ b/test/core/scene-scope.test.ts
@@ -61,7 +61,7 @@ describe('SceneScope', () => {
       expect(events).toEqual(['load:facilities-available', 'init:facilities-available']);
     });
 
-    test('runs load() then init() in order (definition §5.1), attaches roots, and dispatches onLoad only after both complete', async () => {
+    test('runs load() then init() in order (definition §5.1), ends in Ready — no facility attachment or Scene signal yet', async () => {
       const app = createAppStub();
       const events: string[] = [];
 
@@ -79,14 +79,17 @@ describe('SceneScope', () => {
 
       const scene = new RecordingScene();
 
-      scene.onLoad.add(() => events.push('onLoad'));
+      scene.onActivate.add(() => events.push('onActivate'));
 
       const scope = new SceneScope(app, scene);
 
       await scope.prepare(undefined);
 
-      expect(events).toEqual(['load:start', 'load:end', 'init', 'onLoad']);
-      expect(app.interaction.attachRoot).toHaveBeenCalledWith(scene.root);
+      expect(events).toEqual(['load:start', 'load:end', 'init']);
+      expect(scope.state).toBe(SceneState.Ready);
+      // Roots/onActivate are deferred to activate() — the Ready checkpoint
+      // itself produces no application-wide effect (definition §4.1/§4.2).
+      expect(app.interaction.attachRoot).not.toHaveBeenCalled();
     });
 
     test('the same data instance is passed to both load() and init()', async () => {
@@ -114,16 +117,17 @@ describe('SceneScope', () => {
       expect(seen[1]).toBe(data);
     });
 
-    test('activate() transitions Preparing to Active; frame methods only dispatch once Active', async () => {
+    test('activate() transitions Ready to Active; frame methods only dispatch once Active', async () => {
       const app = createAppStub();
       const update = vi.fn();
       const scene = Object.assign(new Scene(), { update });
       const scope = new SceneScope(app, scene);
 
       await scope.prepare(undefined);
+      expect(scope.state).toBe(SceneState.Ready);
 
       scope.update(new Time(16));
-      expect(update).not.toHaveBeenCalled(); // still Preparing
+      expect(update).not.toHaveBeenCalled(); // still Ready
 
       scope.activate();
       expect(scope.state).toBe(SceneState.Active);
@@ -132,17 +136,66 @@ describe('SceneScope', () => {
       expect(update).toHaveBeenCalledTimes(1);
     });
 
-    test('activate() reports the Preparing to Active transition via the injected onStateChange callback', async () => {
+    test('activate() attaches the scene root to interaction dispatch (deferred from prepare(), definition §4.1)', async () => {
+      const app = createAppStub();
+      const scene = new Scene();
+      const scope = new SceneScope(app, scene);
+
+      await scope.prepare(undefined);
+      expect(app.interaction.attachRoot).not.toHaveBeenCalled();
+
+      scope.activate();
+      expect(app.interaction.attachRoot).toHaveBeenCalledWith(scene.root);
+    });
+
+    test('activate() dispatches Scene.onActivate after facility activation, before reporting the state change', async () => {
+      const app = createAppStub();
+      const scene = new Scene();
+      const events: string[] = [];
+      const scope = new SceneScope(app, scene, () => events.push('onStateChange'));
+
+      vi.spyOn(app.interaction, 'attachRoot').mockImplementation(() => events.push('attachRoot'));
+      scene.onActivate.add(() => events.push('onActivate'));
+
+      await scope.prepare(undefined);
+      events.length = 0;
+      scope.activate();
+
+      expect(events).toEqual(['attachRoot', 'onActivate', 'onStateChange']);
+    });
+
+    test('prepare() reports Preparing to Ready, activate() reports Ready to Active, via the injected onStateChange callback', async () => {
       const app = createAppStub();
       const scene = new Scene();
       const onStateChange = vi.fn();
       const scope = new SceneScope(app, scene, onStateChange);
 
       await scope.prepare(undefined);
+      expect(onStateChange).toHaveBeenCalledTimes(1);
+      expect(onStateChange).toHaveBeenNthCalledWith(1, SceneState.Preparing, SceneState.Ready);
+
+      scope.activate();
+      expect(onStateChange).toHaveBeenCalledTimes(2);
+      expect(onStateChange).toHaveBeenNthCalledWith(2, SceneState.Ready, SceneState.Active);
+    });
+
+    test('a throwing Scene.onActivate listener is reported through the app error pipeline and does not block activation', async () => {
+      const app = createAppStub();
+      const scene = new Scene();
+      const errorSpy = vi.fn();
+
+      app.onError.add(errorSpy);
+      scene.onActivate.add(() => {
+        throw new Error('onActivate listener failed');
+      });
+
+      const scope = new SceneScope(app, scene);
+
+      await scope.prepare(undefined);
       scope.activate();
 
-      expect(onStateChange).toHaveBeenCalledTimes(1);
-      expect(onStateChange).toHaveBeenCalledWith(SceneState.Preparing, SceneState.Active);
+      expect(scope.state).toBe(SceneState.Active);
+      expect(errorSpy).toHaveBeenCalledWith(expect.objectContaining({ message: 'onActivate listener failed' }));
     });
 
     test('a synchronous init() (the common case) passes without a lifecycle error', async () => {
@@ -411,6 +464,36 @@ describe('SceneScope', () => {
 
       expect(scope.suspend()).toBe(false);
       expect(scope.state).toBe(SceneState.Preparing);
+    });
+
+    test('suspend() dispatches Scene.onSuspend after facility suspension', async () => {
+      const app = createAppStub();
+      const scene = new Scene();
+      const scope = await activate(app, scene);
+      const events: string[] = [];
+
+      vi.spyOn(scope.interaction, 'suspend').mockImplementation(() => events.push('interaction.suspend'));
+      scene.onSuspend.add(() => events.push('onSuspend'));
+
+      scope.suspend();
+
+      expect(events).toEqual(['interaction.suspend', 'onSuspend']);
+    });
+
+    test('restore() flushes pending audio and dispatches Scene.onActivate', async () => {
+      const app = createAppStub();
+      const scene = new Scene();
+      const scope = await activate(app, scene);
+      const events: string[] = [];
+
+      scope.suspend();
+
+      vi.spyOn(scope.audio, '_flushPending').mockImplementation(() => events.push('audio._flushPending'));
+      scene.onActivate.add(() => events.push('onActivate'));
+
+      scope.restore();
+
+      expect(events).toEqual(['audio._flushPending', 'onActivate']);
     });
 
     test('restore() returns to Active when suspended from Active', async () => {

--- a/test/core/scene-state.test.ts
+++ b/test/core/scene-state.test.ts
@@ -9,6 +9,18 @@ describe('SceneState guards', () => {
     expect(canSuspend(SceneState.Destroyed)).toBe(false);
   });
 
+  test('canSuspend is false for Ready — a scope that never activated has nothing live to suspend', () => {
+    expect(canSuspend(SceneState.Ready)).toBe(false);
+  });
+
+  test('canRestore is false for Ready', () => {
+    expect(canRestore(SceneState.Ready)).toBe(false);
+  });
+
+  test('canDestroy is true for Ready', () => {
+    expect(canDestroy(SceneState.Ready)).toBe(true);
+  });
+
   test('canDestroy is true from every state except Destroying and Destroyed', () => {
     expect(canDestroy(SceneState.Preparing)).toBe(true);
     expect(canDestroy(SceneState.Active)).toBe(true);
@@ -27,6 +39,7 @@ describe('SceneState guards', () => {
 
   test('is a string enum (never const enum) — values are readable at runtime', () => {
     expect(SceneState.Preparing).toBe('preparing');
+    expect(SceneState.Ready).toBe('ready');
     expect(SceneState.Active).toBe('active');
     expect(SceneState.Suspended).toBe('suspended');
     expect(SceneState.Destroying).toBe('destroying');

--- a/test/core/scene/scene-audio.test.ts
+++ b/test/core/scene/scene-audio.test.ts
@@ -305,3 +305,55 @@ describe('SceneAudio — Preparing gate', () => {
     expect(real.pause).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('SceneAudio — dormancy gate widens to Ready/Suspended, rejects Destroying/Destroyed', () => {
+  test('play() during Ready buffers a PendingVoice, same as Preparing', () => {
+    const voice = makeVoice();
+    const app = createAppStub(voice);
+    const audio = new SceneAudio(app, () => SceneState.Ready);
+
+    const pending = audio.play(fakePlayable);
+
+    expect(app.audio.play).not.toHaveBeenCalled();
+    expect(pending.ended).toBe(false);
+  });
+
+  test('play() during Suspended buffers a PendingVoice (a new registration while already dormant, not just Preparing/Ready)', () => {
+    const voice = makeVoice();
+    const app = createAppStub(voice);
+    const audio = new SceneAudio(app, () => SceneState.Suspended);
+
+    const pending = audio.play(fakePlayable);
+
+    expect(app.audio.play).not.toHaveBeenCalled();
+    expect(pending.ended).toBe(false);
+  });
+
+  test('_flushPending() started during Suspended starts for real once flushed', () => {
+    const voice = makeVoice();
+    const app = createAppStub(voice);
+    const audio = new SceneAudio(app, () => SceneState.Suspended);
+
+    audio.play(fakePlayable);
+    audio._flushPending();
+
+    expect(app.audio.play).toHaveBeenCalledTimes(1);
+  });
+
+  test('play() during Destroying, in dev builds, throws a lifecycle error and never buffers or plays', () => {
+    const voice = makeVoice();
+    const app = createAppStub(voice);
+    const audio = new SceneAudio(app, () => SceneState.Destroying);
+
+    expect(() => audio.play(fakePlayable)).toThrow(/destroy/i);
+    expect(app.audio.play).not.toHaveBeenCalled();
+  });
+
+  test('play() during Destroyed, in dev builds, throws a lifecycle error', () => {
+    const voice = makeVoice();
+    const app = createAppStub(voice);
+    const audio = new SceneAudio(app, () => SceneState.Destroyed);
+
+    expect(() => audio.play(fakePlayable)).toThrow(/destroy/i);
+  });
+});

--- a/test/core/scene/scene-inputs.test.ts
+++ b/test/core/scene/scene-inputs.test.ts
@@ -107,6 +107,8 @@ describe('SceneInputs — when policy availability matrix', () => {
     ['always', SceneState.Active, true, true],
     ['active', SceneState.Preparing, false, false],
     ['always', SceneState.Preparing, false, false],
+    ['active', SceneState.Ready, false, false],
+    ['always', SceneState.Ready, false, false],
     ['active', SceneState.Suspended, false, false],
     ['always', SceneState.Suspended, false, false],
   ] as const)('when: "%s" at state %s, paused %s allows onActive dispatch: %s', (when, state, paused, expected) => {

--- a/test/core/scene/scene-interaction.test.ts
+++ b/test/core/scene/scene-interaction.test.ts
@@ -1,5 +1,6 @@
 import type { Application } from '#core/Application';
 import { SceneInteraction } from '#core/scene/SceneInteraction';
+import { SceneState } from '#core/SceneState';
 import type { RenderNode } from '#rendering/RenderNode';
 
 const createAppStub = (): Application =>
@@ -17,7 +18,7 @@ const fakeRoot = (): RenderNode => ({ id: Symbol('root') }) as unknown as Render
 describe('SceneInteraction', () => {
   test('observe() delegates to app.interaction.attachRoot', () => {
     const app = createAppStub();
-    const interaction = new SceneInteraction(app);
+    const interaction = new SceneInteraction(app, () => SceneState.Active);
     const root = fakeRoot();
 
     interaction.observe(root);
@@ -27,7 +28,7 @@ describe('SceneInteraction', () => {
 
   test('release() detaches the observed root and is idempotent', () => {
     const app = createAppStub();
-    const interaction = new SceneInteraction(app);
+    const interaction = new SceneInteraction(app, () => SceneState.Active);
     const root = fakeRoot();
 
     const observation = interaction.observe(root);
@@ -42,7 +43,7 @@ describe('SceneInteraction', () => {
 
   test('destroy() on the observation is an alias for release()', () => {
     const app = createAppStub();
-    const interaction = new SceneInteraction(app);
+    const interaction = new SceneInteraction(app, () => SceneState.Active);
     const root = fakeRoot();
 
     const observation = interaction.observe(root);
@@ -53,7 +54,7 @@ describe('SceneInteraction', () => {
 
   test('destroy() on the facade releases every remaining observation', () => {
     const app = createAppStub();
-    const interaction = new SceneInteraction(app);
+    const interaction = new SceneInteraction(app, () => SceneState.Active);
     const rootA = fakeRoot();
     const rootB = fakeRoot();
 
@@ -69,7 +70,7 @@ describe('SceneInteraction', () => {
 
   test('destroy() does not re-release an already-released observation', () => {
     const app = createAppStub();
-    const interaction = new SceneInteraction(app);
+    const interaction = new SceneInteraction(app, () => SceneState.Active);
     const root = fakeRoot();
 
     const observation = interaction.observe(root);
@@ -82,7 +83,7 @@ describe('SceneInteraction', () => {
 
   test('suspend() detaches every tracked observation without removing its tracking', () => {
     const app = createAppStub();
-    const interaction = new SceneInteraction(app);
+    const interaction = new SceneInteraction(app, () => SceneState.Active);
     const root = fakeRoot();
 
     interaction.observe(root);
@@ -93,7 +94,7 @@ describe('SceneInteraction', () => {
 
   test('resume() reattaches every observation suspend() detached', () => {
     const app = createAppStub();
-    const interaction = new SceneInteraction(app);
+    const interaction = new SceneInteraction(app, () => SceneState.Active);
     const root = fakeRoot();
 
     interaction.observe(root);
@@ -106,7 +107,7 @@ describe('SceneInteraction', () => {
 
   test('suspend() is idempotent — a second call does not detach again', () => {
     const app = createAppStub();
-    const interaction = new SceneInteraction(app);
+    const interaction = new SceneInteraction(app, () => SceneState.Active);
 
     interaction.observe(fakeRoot());
     interaction.suspend();
@@ -119,7 +120,7 @@ describe('SceneInteraction', () => {
 
   test('resume() before any suspend() is a no-op', () => {
     const app = createAppStub();
-    const interaction = new SceneInteraction(app);
+    const interaction = new SceneInteraction(app, () => SceneState.Active);
 
     interaction.observe(fakeRoot());
     (app.interaction.attachRoot as MockInstance).mockClear();
@@ -131,7 +132,7 @@ describe('SceneInteraction', () => {
 
   test('an observation released while suspended is not reattached by resume()', () => {
     const app = createAppStub();
-    const interaction = new SceneInteraction(app);
+    const interaction = new SceneInteraction(app, () => SceneState.Active);
     const root = fakeRoot();
 
     const observation = interaction.observe(root);
@@ -148,7 +149,7 @@ describe('SceneInteraction', () => {
 describe('SceneInteraction.capture()', () => {
   test('capture() pushes the root onto the manager capture stack', () => {
     const app = createAppStub();
-    const interaction = new SceneInteraction(app);
+    const interaction = new SceneInteraction(app, () => SceneState.Active);
     const root = fakeRoot();
 
     interaction.capture(root);
@@ -158,7 +159,7 @@ describe('SceneInteraction.capture()', () => {
 
   test('release() pops the top capture and is idempotent', () => {
     const app = createAppStub();
-    const interaction = new SceneInteraction(app);
+    const interaction = new SceneInteraction(app, () => SceneState.Active);
     const capture = interaction.capture(fakeRoot());
 
     capture.release();
@@ -171,7 +172,7 @@ describe('SceneInteraction.capture()', () => {
 
   test('destroy() on the capture is an alias for release()', () => {
     const app = createAppStub();
-    const interaction = new SceneInteraction(app);
+    const interaction = new SceneInteraction(app, () => SceneState.Active);
     const capture = interaction.capture(fakeRoot());
 
     capture.destroy();
@@ -180,7 +181,7 @@ describe('SceneInteraction.capture()', () => {
 
   test('nested captures: releasing the top restores the previous one (net stack effect)', () => {
     const app = createAppStub();
-    const interaction = new SceneInteraction(app);
+    const interaction = new SceneInteraction(app, () => SceneState.Active);
     const rootA = fakeRoot();
     const rootB = fakeRoot();
 
@@ -199,7 +200,7 @@ describe('SceneInteraction.capture()', () => {
 
   test('releasing a non-top capture pops down to it, removes it, and re-pushes the ones above in order', () => {
     const app = createAppStub();
-    const interaction = new SceneInteraction(app);
+    const interaction = new SceneInteraction(app, () => SceneState.Active);
     const rootA = fakeRoot();
     const rootB = fakeRoot();
     const rootC = fakeRoot();
@@ -223,7 +224,7 @@ describe('SceneInteraction.capture()', () => {
 
   test('destroy() on the facade releases every remaining capture', () => {
     const app = createAppStub();
-    const interaction = new SceneInteraction(app);
+    const interaction = new SceneInteraction(app, () => SceneState.Active);
 
     interaction.capture(fakeRoot());
     interaction.capture(fakeRoot());
@@ -235,7 +236,7 @@ describe('SceneInteraction.capture()', () => {
 
   test('suspend() pops every active capture; resume() re-pushes them in original order', () => {
     const app = createAppStub();
-    const interaction = new SceneInteraction(app);
+    const interaction = new SceneInteraction(app, () => SceneState.Active);
     const rootA = fakeRoot();
     const rootB = fakeRoot();
 
@@ -253,7 +254,7 @@ describe('SceneInteraction.capture()', () => {
 
   test('releasing a non-top capture while suspended only updates local bookkeeping; resume() re-pushes the corrected stack', () => {
     const app = createAppStub();
-    const interaction = new SceneInteraction(app);
+    const interaction = new SceneInteraction(app, () => SceneState.Active);
     const rootA = fakeRoot();
     const rootB = fakeRoot();
     const rootC = fakeRoot();
@@ -280,5 +281,106 @@ describe('SceneInteraction.capture()', () => {
     expect(app.interaction.pushInputCapture).toHaveBeenCalledTimes(2);
     expect(app.interaction.pushInputCapture).toHaveBeenNthCalledWith(1, rootA);
     expect(app.interaction.pushInputCapture).toHaveBeenNthCalledWith(2, rootC);
+  });
+});
+
+describe('SceneInteraction — dormancy (registration while not Active)', () => {
+  test('observe() while Ready tracks the observation but never calls app.interaction.attachRoot', () => {
+    const app = createAppStub();
+    const interaction = new SceneInteraction(app, () => SceneState.Ready);
+    const root = fakeRoot();
+
+    interaction.observe(root);
+
+    expect(app.interaction.attachRoot).not.toHaveBeenCalled();
+  });
+
+  test('releasing an observation created while dormant never calls app.interaction.detachRoot', () => {
+    const app = createAppStub();
+    const interaction = new SceneInteraction(app, () => SceneState.Ready);
+    const root = fakeRoot();
+
+    const observation = interaction.observe(root);
+    observation.release();
+
+    expect(app.interaction.detachRoot).not.toHaveBeenCalled();
+  });
+
+  test('resume() attaches every observation registered while dormant, in registration order', () => {
+    const app = createAppStub();
+    let state: SceneState = SceneState.Ready;
+    const interaction = new SceneInteraction(app, () => state);
+    const rootA = fakeRoot();
+    const rootB = fakeRoot();
+
+    interaction.observe(rootA);
+    interaction.observe(rootB);
+
+    expect(app.interaction.attachRoot).not.toHaveBeenCalled();
+
+    state = SceneState.Active;
+    interaction.resume();
+
+    expect(app.interaction.attachRoot).toHaveBeenNthCalledWith(1, rootA);
+    expect(app.interaction.attachRoot).toHaveBeenNthCalledWith(2, rootB);
+  });
+
+  test('resume() is idempotent — calling it twice does not re-attach an already-attached observation', () => {
+    const app = createAppStub();
+    let state: SceneState = SceneState.Ready;
+    const interaction = new SceneInteraction(app, () => state);
+    const root = fakeRoot();
+
+    interaction.observe(root);
+
+    state = SceneState.Active;
+    interaction.resume();
+    interaction.resume();
+
+    expect(app.interaction.attachRoot).toHaveBeenCalledTimes(1);
+  });
+
+  test('capture() while Suspended (a new registration while already dormant) buffers instead of pushing', () => {
+    const app = createAppStub();
+    const interaction = new SceneInteraction(app, () => SceneState.Suspended);
+    const root = fakeRoot();
+
+    interaction.capture(root);
+
+    expect(app.interaction.pushInputCapture).not.toHaveBeenCalled();
+  });
+
+  test('suspend() then resume() re-pushes captures in original order', () => {
+    const app = createAppStub();
+    let state: SceneState = SceneState.Active;
+    const interaction = new SceneInteraction(app, () => state);
+    const rootA = fakeRoot();
+    const rootB = fakeRoot();
+
+    interaction.capture(rootA);
+    interaction.capture(rootB);
+    (app.interaction.pushInputCapture as MockInstance).mockClear();
+
+    state = SceneState.Suspended;
+    interaction.suspend();
+    expect(app.interaction.popInputCapture).toHaveBeenCalledTimes(2);
+
+    state = SceneState.Active;
+    interaction.resume();
+
+    expect(app.interaction.pushInputCapture).toHaveBeenNthCalledWith(1, rootA);
+    expect(app.interaction.pushInputCapture).toHaveBeenNthCalledWith(2, rootB);
+  });
+
+  test('releasing a still-dormant capture never touches the app-wide capture stack', () => {
+    const app = createAppStub();
+    const interaction = new SceneInteraction(app, () => SceneState.Ready);
+    const root = fakeRoot();
+
+    const capture = interaction.capture(root);
+    capture.release();
+
+    expect(app.interaction.pushInputCapture).not.toHaveBeenCalled();
+    expect(app.interaction.popInputCapture).not.toHaveBeenCalled();
   });
 });

--- a/test/core/scene/scene-tweens.test.ts
+++ b/test/core/scene/scene-tweens.test.ts
@@ -1,5 +1,8 @@
+import { Tween } from '#animation/Tween';
+import { TweenSequencer } from '#animation/TweenSequencer';
 import type { Application } from '#core/Application';
 import { SceneTweens } from '#core/scene/SceneTweens';
+import { SceneState } from '#core/SceneState';
 
 const createAppStub = (createResult: unknown, sequencerResult?: unknown): Application =>
   ({
@@ -37,7 +40,7 @@ describe('SceneTweens', () => {
   test('create() delegates to app.tweens.create and tracks the returned Tween', () => {
     const tween = makeStubTween();
     const app = createAppStub(tween);
-    const tweens = new SceneTweens(app);
+    const tweens = new SceneTweens(app, () => SceneState.Active);
     const target = {};
 
     const result = tweens.create(target);
@@ -48,7 +51,7 @@ describe('SceneTweens', () => {
 
   test('add() tracks an already-created Tween via app.tweens.add', () => {
     const app = createAppStub(makeStubTween());
-    const tweens = new SceneTweens(app);
+    const tweens = new SceneTweens(app, () => SceneState.Active);
     const external = makeStubTween();
 
     expect(tweens.add(external as never)).toBe(tweens);
@@ -59,7 +62,7 @@ describe('SceneTweens', () => {
     const tweenA = makeStubTween();
     const tweenB = makeStubTween();
     const app = createAppStub(tweenA);
-    const tweens = new SceneTweens(app);
+    const tweens = new SceneTweens(app, () => SceneState.Active);
 
     tweens.create({});
     tweens.add(tweenB as never);
@@ -74,7 +77,7 @@ describe('SceneTweens', () => {
     test('delegates to app.tweens.createSequencer and tracks the returned sequencer', () => {
       const sequencer = makeStubSequencer();
       const app = createAppStub(makeStubTween(), sequencer);
-      const tweens = new SceneTweens(app);
+      const tweens = new SceneTweens(app, () => SceneState.Active);
 
       const result = tweens.createSequencer();
 
@@ -85,7 +88,7 @@ describe('SceneTweens', () => {
     test('destroy() stops every tracked sequencer', () => {
       const sequencer = makeStubSequencer();
       const app = createAppStub(makeStubTween(), sequencer);
-      const tweens = new SceneTweens(app);
+      const tweens = new SceneTweens(app, () => SceneState.Active);
 
       tweens.createSequencer();
       tweens.destroy();
@@ -96,7 +99,7 @@ describe('SceneTweens', () => {
     test('suspend()/restore() covers tracked sequencers exactly like tweens', () => {
       const sequencer = makeStubSequencer('active');
       const app = createAppStub(makeStubTween(), sequencer);
-      const tweens = new SceneTweens(app);
+      const tweens = new SceneTweens(app, () => SceneState.Active);
 
       tweens.createSequencer();
 
@@ -114,7 +117,7 @@ describe('SceneTweens', () => {
       const alreadyPaused = makeStubTween('paused');
       const complete = makeStubTween('complete');
       const app = createAppStub(active);
-      const tweens = new SceneTweens(app);
+      const tweens = new SceneTweens(app, () => SceneState.Active);
 
       tweens.create({});
       tweens.add(alreadyPaused as never);
@@ -136,7 +139,7 @@ describe('SceneTweens', () => {
     test('restore() without a prior suspend() is a no-op', () => {
       const tween = makeStubTween('active');
       const app = createAppStub(tween);
-      const tweens = new SceneTweens(app);
+      const tweens = new SceneTweens(app, () => SceneState.Active);
 
       tweens.add(tween as never);
 
@@ -147,7 +150,7 @@ describe('SceneTweens', () => {
     test('a second suspend() call overwrites the tracked suspended set — an already-paused tween is not re-recorded', () => {
       const tween = makeStubTween('active');
       const app = createAppStub(tween);
-      const tweens = new SceneTweens(app);
+      const tweens = new SceneTweens(app, () => SceneState.Active);
 
       tweens.add(tween as never);
 
@@ -170,7 +173,7 @@ describe('SceneTweens', () => {
     test('when:"active" tween is frozen on pause() and resumed on resume()', () => {
       const tween = makeStubTween('active');
       const app = createAppStub(tween);
-      const tweens = new SceneTweens(app);
+      const tweens = new SceneTweens(app, () => SceneState.Active);
 
       tweens.create({}, { when: 'active' });
 
@@ -184,7 +187,7 @@ describe('SceneTweens', () => {
     test('when:"paused" tween (already sitting paused) is woken on pause() and re-frozen on resume()', () => {
       const tween = makeStubTween('paused');
       const app = createAppStub(tween);
-      const tweens = new SceneTweens(app);
+      const tweens = new SceneTweens(app, () => SceneState.Active);
 
       tweens.add(tween as never, { when: 'paused' });
 
@@ -198,7 +201,7 @@ describe('SceneTweens', () => {
     test('when:"always" (default) tween is never touched by pause()/resume()', () => {
       const tween = makeStubTween('active');
       const app = createAppStub(tween);
-      const tweens = new SceneTweens(app);
+      const tweens = new SceneTweens(app, () => SceneState.Active);
 
       tweens.create({});
 
@@ -212,7 +215,7 @@ describe('SceneTweens', () => {
     test('resume() does not resume a when:"active" tween the user paused manually in between', () => {
       const tween = makeStubTween('active');
       const app = createAppStub(tween);
-      const tweens = new SceneTweens(app);
+      const tweens = new SceneTweens(app, () => SceneState.Active);
 
       tweens.create({}, { when: 'active' });
 
@@ -228,7 +231,7 @@ describe('SceneTweens', () => {
     test('covers sequencers exactly like tweens', () => {
       const sequencer = makeStubSequencer('active');
       const app = createAppStub(makeStubTween(), sequencer);
-      const tweens = new SceneTweens(app);
+      const tweens = new SceneTweens(app, () => SceneState.Active);
 
       tweens.createSequencer({ when: 'active' });
 
@@ -238,5 +241,110 @@ describe('SceneTweens', () => {
       tweens.resume();
       expect(sequencer.resume).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+describe('SceneTweens — dormancy (create/add/createSequencer while not Active)', () => {
+  test('create() while Ready does not call app.tweens.create — the tween is never attached to the app-wide manager', () => {
+    const app = createAppStub(makeStubTween());
+    const tweens = new SceneTweens(app, () => SceneState.Ready);
+    const target = { x: 0 };
+
+    const tween = tweens.create(target);
+
+    expect(app.tweens.create).not.toHaveBeenCalled();
+    expect(tween).toBeInstanceOf(Tween);
+  });
+
+  test('a real Tween created and started while Ready produces no application-wide effect until activation', () => {
+    const app = createAppStub(makeStubTween());
+    let state: SceneState = SceneState.Ready;
+    const tweens = new SceneTweens(app, () => state);
+    const target = { x: 0 };
+
+    const tween = tweens.create(target).to({ x: 100 }, 1);
+
+    tween.start();
+    tween.update(0.5); // manual update — proves the app-wide manager never drives it
+
+    // The real app-wide manager was never told about this tween at all.
+    expect(app.tweens.add).not.toHaveBeenCalled();
+
+    state = SceneState.Active;
+    tweens.activate();
+
+    expect(app.tweens.add).toHaveBeenCalledWith(tween);
+  });
+
+  test('activate() attaches every cold tween to the app-wide manager, in whatever state it is currently in', () => {
+    const app = createAppStub(makeStubTween());
+    let state: SceneState = SceneState.Ready;
+    const tweens = new SceneTweens(app, () => state);
+
+    const idleTween = tweens.create({});
+
+    state = SceneState.Active;
+    tweens.activate();
+
+    expect(app.tweens.add).toHaveBeenCalledWith(idleTween);
+  });
+
+  test('add() while Suspended pauses an already-Active tween immediately and resumes it on activate() only if still Paused', () => {
+    const running = makeStubTween('active');
+    const app = createAppStub(makeStubTween());
+    let state: SceneState = SceneState.Suspended;
+    const tweens = new SceneTweens(app, () => state);
+
+    tweens.add(running as never);
+
+    expect(running.pause).toHaveBeenCalledTimes(1);
+
+    state = SceneState.Active;
+    tweens.activate();
+
+    expect(running.resume).toHaveBeenCalledTimes(1);
+  });
+
+  test('add() while Suspended does not resume a tween the caller stopped in the meantime', () => {
+    const running = makeStubTween('active');
+    const app = createAppStub(makeStubTween());
+    let state: SceneState = SceneState.Suspended;
+    const tweens = new SceneTweens(app, () => state);
+
+    tweens.add(running as never);
+    running.state = 'stopped'; // caller stopped it directly while still dormant
+
+    state = SceneState.Active;
+    tweens.activate();
+
+    expect(running.resume).not.toHaveBeenCalled();
+  });
+
+  test('createSequencer() while Ready constructs without a manager — start() does not tick', () => {
+    const sequencer = makeStubSequencer();
+    const app = createAppStub(makeStubTween(), sequencer as never);
+    let state: SceneState = SceneState.Ready;
+    const tweens = new SceneTweens(app, () => state);
+
+    const created = tweens.createSequencer();
+
+    expect(app.tweens.createSequencer).not.toHaveBeenCalled();
+    expect(created).toBeInstanceOf(TweenSequencer);
+
+    state = SceneState.Active;
+    tweens.activate();
+  });
+
+  test('create()/add()/createSequencer() delegate immediately, as before, once Active', () => {
+    const stubTween = makeStubTween();
+    const stubSequencer = makeStubSequencer();
+    const app = createAppStub(stubTween, stubSequencer as never);
+    const tweens = new SceneTweens(app, () => SceneState.Active);
+
+    tweens.create({});
+    tweens.createSequencer();
+
+    expect(app.tweens.create).toHaveBeenCalledTimes(1);
+    expect(app.tweens.createSequencer).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/core/signal.test.ts
+++ b/test/core/signal.test.ts
@@ -133,15 +133,21 @@ describe('dispatchIsolated', () => {
     expect(calls).toEqual(['a']);
   });
 
-  it('_dispatching is always cleared via finally, even after a throw — a later dispatch is not corrupted', () => {
+  it('_dispatching is always cleared via finally, even after a throw — remove()/add() work normally afterward', () => {
     const signal = new Signal();
-    const calls: string[] = [];
+    const thrower = (): void => {
+      throw new Error('boom');
+    };
 
-    signal.add(() => {
-      throw new Error('first dispatch boom');
-    });
-
+    signal.add(thrower);
     signal.dispatchIsolated(() => {});
+
+    expect(signal.has(thrower)).toBe(true); // isolation does not remove the listener
+
+    signal.remove(thrower);
+    expect(signal.has(thrower)).toBe(false); // removal applies immediately — proves _dispatching was cleared, not left stuck true (which would defer this removal into _pendingRemoves instead)
+
+    const calls: string[] = [];
 
     signal.add(() => calls.push('second-dispatch-listener'));
     signal.dispatch();

--- a/test/core/signal.test.ts
+++ b/test/core/signal.test.ts
@@ -83,3 +83,106 @@ describe('Signal', () => {
     expect(received).toEqual([[42, 'hello']]);
   });
 });
+
+describe('dispatchIsolated', () => {
+  it('calls onError and continues to the remaining listeners when one throws', () => {
+    const signal = new Signal();
+    const calls: string[] = [];
+    const errors: unknown[] = [];
+    const failure = new Error('listener boom');
+
+    signal.add(() => calls.push('a'));
+    signal.add(() => {
+      throw failure;
+    });
+    signal.add(() => calls.push('c'));
+
+    signal.dispatchIsolated(error => errors.push(error));
+
+    expect(calls).toEqual(['a', 'c']);
+    expect(errors).toEqual([failure]);
+  });
+
+  it('a throwing onError itself never propagates out of dispatchIsolated', () => {
+    const signal = new Signal();
+
+    signal.add(() => {
+      throw new Error('listener boom');
+    });
+
+    expect(() =>
+      signal.dispatchIsolated(() => {
+        throw new Error('onError boom');
+      }),
+    ).not.toThrow();
+  });
+
+  it('a handler returning false still short-circuits the remaining listeners (unaffected by isolation)', () => {
+    const signal = new Signal();
+    const calls: string[] = [];
+
+    signal.add(() => {
+      calls.push('a');
+
+      return false;
+    });
+    signal.add(() => calls.push('b'));
+
+    signal.dispatchIsolated(() => {});
+
+    expect(calls).toEqual(['a']);
+  });
+
+  it('_dispatching is always cleared via finally, even after a throw — a later dispatch is not corrupted', () => {
+    const signal = new Signal();
+    const calls: string[] = [];
+
+    signal.add(() => {
+      throw new Error('first dispatch boom');
+    });
+
+    signal.dispatchIsolated(() => {});
+
+    signal.add(() => calls.push('second-dispatch-listener'));
+    signal.dispatch();
+
+    expect(calls).toEqual(['second-dispatch-listener']);
+  });
+
+  it('a listener removing itself mid-dispatch (via isolated dispatch) is still deferred correctly', () => {
+    const signal = new Signal();
+    const calls: string[] = [];
+    let selfRemoving: () => void;
+
+    selfRemoving = () => {
+      calls.push('self');
+      signal.remove(selfRemoving);
+    };
+
+    signal.add(selfRemoving);
+    signal.add(() => calls.push('other'));
+
+    signal.dispatchIsolated(() => {});
+    expect(calls).toEqual(['self', 'other']);
+    expect(signal.has(selfRemoving)).toBe(false);
+
+    calls.length = 0;
+    signal.dispatchIsolated(() => {});
+    expect(calls).toEqual(['other']);
+  });
+
+  it('returns this for chaining', () => {
+    const signal = new Signal();
+
+    expect(signal.dispatchIsolated(() => {})).toBe(signal);
+  });
+
+  it('is a no-op (does not call onError) when there are no listeners', () => {
+    const signal = new Signal();
+    const onError = vi.fn();
+
+    signal.dispatchIsolated(onError);
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/test/core/signal.test.ts
+++ b/test/core/signal.test.ts
@@ -158,9 +158,7 @@ describe('dispatchIsolated', () => {
   it('a listener removing itself mid-dispatch (via isolated dispatch) is still deferred correctly', () => {
     const signal = new Signal();
     const calls: string[] = [];
-    let selfRemoving: () => void;
-
-    selfRemoving = () => {
+    const selfRemoving: () => void = () => {
       calls.push('self');
       signal.remove(selfRemoving);
     };


### PR DESCRIPTION
## Summary

Slice 2 of the scene-transition redesign (see `docs/superpowers/plans/2026-07-23-scene-transition-slice-2-ready-facility-dormancy.md`, follows Slice 1 / #404):

- Inserts a genuine `SceneState.Ready` checkpoint between `Preparing` and `Active` — `SceneScope.prepare()` now ends in `Ready`, `SceneScope.activate()` commits `Ready`/`Suspended` → `Active`.
- Makes every scene-bound facility (`SceneInputs`, `SceneInteraction`, `SceneAudio`, `SceneTweens`) dormant while the owning scope is not `Active`: registrations are accepted but produce zero application-wide runtime effect until activation, flushed on the next transition into `Active` (fresh activation or retention restore alike).
- Replaces `Scene.onLoad`/`Scene.onUnload` with `Scene.onActivate`/`Scene.onSuspend`.
- Adds `Signal.dispatchIsolated(onError, ...params)` — isolates each listener's exceptions individually (per-dispatch only, listener stays registered) instead of letting the first throw abort the whole dispatch or corrupt bookkeeping. Wired into every `SceneScope`/`SceneDirector` lifecycle signal, so a throwing listener can no longer abort a navigation or trigger `_rollbackSwitch()` — it's reported via `Application.onError` instead.

Implemented via `superpowers:subagent-driven-development` — 11 tasks, fresh implementer + reviewer subagent per task, one final whole-branch review (opus). Two genuine plan/test contradictions were found during implementation (both required a human decision, not silent implementer guesses): `dispatchIsolated` must not permanently remove a throwing listener (one brief test was wrong), and a missing `events.length = 0` reset in one `SceneScope` test.

## Test plan

- [x] `pnpm test:core` — 5131/5146 passing, 15 skipped, 0 failures
- [x] `pnpm typecheck && pnpm typecheck:examples && pnpm typecheck:type-tests` — clean
- [x] `pnpm lint:all` / `pnpm format:check` — clean
- [x] `pnpm docs:api:generate && pnpm docs:api:check` — clean, `Scene.onActivate`/`onSuspend` reflected, `onLoad`/`onUnload` removed
- [x] `pnpm verify:quick` — clean
- [x] Final whole-branch review (opus): no Critical/Important findings, ready to merge