### PR TITLE
fix(core): golden-spec conformance hardening for the scene-transition redesign (v0.17 Slice 9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,7 @@ data?)` or `app.start('game', data?)`; `app.scene.setScene(instance, opts)`
   resolving via an undocumented `retained → preloaded → active` priority.
 - **BREAKING — the `transition` option no longer accepts a config object.**
   `{ transition: { type: 'fade', duration: 250 } }` →
-  `{ transition: new FadeSceneTransition({ duration: 250 }) }` — note
+  `{ transition: new FadeSceneTransition(undefined, { duration: 250 }) }` — note
   `duration` is now milliseconds, not seconds. `SceneTransition` is a class
   (abstract base + `FadeSceneTransition`/`CrossFadeSceneTransition`/
   `SlideSceneTransition`/`PhasedSceneTransition`), not a union type.

--- a/packages/exojs-react/src/Scenes.tsx
+++ b/packages/exojs-react/src/Scenes.tsx
@@ -74,7 +74,7 @@ export interface ScenesProps {
  * import { FadeSceneTransition } from '@codexo/exojs';
  *
  * <ExoCanvas>
- *   <Scenes active={screen} transition={new FadeSceneTransition({ duration: 300 })}>
+ *   <Scenes active={screen} transition={new FadeSceneTransition(undefined, { duration: 300 })}>
  *     <Scene name="title" component={TitleScene} />
  *     <Scene name="game" component={GameScene}>
  *       <Hud />

--- a/packages/exojs-react/test/Scenes.test.tsx
+++ b/packages/exojs-react/test/Scenes.test.tsx
@@ -79,7 +79,7 @@ describe('<Scenes> / <Scene> / useActiveScene', () => {
 
     // A real SceneTransition instance — the wrapper only forwards it to the
     // director's change(), so its concrete behavior is irrelevant here.
-    const transition = new FadeSceneTransition({ duration: 300 });
+    const transition = new FadeSceneTransition(undefined, { duration: 300 });
     view.rerender(<Tree app={app} active="game" transition={transition} />);
 
     await waitFor(() => expect(app.scenes.change).toHaveBeenCalled());

--- a/site/src/content/api/application.json
+++ b/site/src/content/api/application.json
@@ -6,10 +6,10 @@
   "subsystem": "core",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 50,
+  "memberCount": 51,
   "counts": {
     "constructors": 1,
-    "methods": 9,
+    "methods": 10,
     "properties": 32,
     "events": 8
   },
@@ -206,7 +206,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": "Tear down every owned subsystem (loader, the core managers — input, interaction, audio, tweens, rendering — the app system registry, backend, scene director, all clocks, all signals) and release event listeners. The application instance is unusable after this call."
+          "description": "Tear down every owned subsystem (loader, the core managers — input, interaction, audio, tweens, rendering — the app system registry, backend, scene director, all clocks, all signals) and release event listeners. The application instance is unusable after this call. Fires the RAF halt synchronously (so no further frame runs after this call returns) but the rest of teardown runs as a background async chain, awaited internally: scenes — including every retained and preloaded scope, and any scene's own async unload() — is fully disposed FIRST, before the Loader, rendering context, audio manager, or backend are destroyed, so a scene's teardown code never touches an already-destroyed dependency. This intentionally does not route through the public Application.stop, which fire-and-forgets its own scene-clear — that would race against scenes._dispose()'s own active-scope teardown for ownership of the same scope. destroy() instead halts the frame loop directly and lets scenes._dispose() own scene teardown entirely."
         },
         {
           "name": "resize",
@@ -470,6 +470,134 @@
         },
         {
           "name": "start",
+          "signature": "start(target: K, args: ChangeSceneArgs<InferSceneData<Registry[K]>>): Promise<Application<Registry>>",
+          "signatureTokens": [
+            {
+              "text": "start",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "target",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "K",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "args",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ChangeSceneArgs",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "InferSceneData",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Registry",
+              "kind": "type"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "K",
+              "kind": "type"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Promise",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Application",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Registry",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [
+            {
+              "name": "target",
+              "type": "K",
+              "optional": false
+            },
+            {
+              "name": "args",
+              "type": "ChangeSceneArgs<InferSceneData<Registry[K]>>",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Application<Registry>>",
+          "description": "Initialize the render backend, await capability detection, activate target — a registered string key, or a constructor registered in ApplicationOptions.scenes — and start the per-frame loop. Idempotent — if the application is already running the call is a no-op. On error the status returns to Stopped and the error propagates."
+        },
+        {
+          "name": "start",
           "signature": "start(target: C, args: ChangeSceneArgs<InferSceneData<C>>): Promise<Application<Registry>>",
           "signatureTokens": [
             {
@@ -582,7 +710,7 @@
             }
           ],
           "returnType": "Promise<Application<Registry>>",
-          "description": "Initialize the render backend, await capability detection, activate target (a constructor registered in ApplicationOptions.scenes), and start the per-frame loop. Idempotent — if the application is already running the call is a no-op. On error the status returns to Stopped and the error propagates."
+          "description": "Initialize the render backend, await capability detection, and start the per-frame loop without activating a scene. Use start(target, data?) to start directly into a registered scene. Idempotent — if the application is already running the call is a no-op. On error the status returns to Stopped and the error propagates."
         },
         {
           "name": "stop",

--- a/site/src/content/api/fade-scene-transition.json
+++ b/site/src/content/api/fade-scene-transition.json
@@ -6,10 +6,10 @@
   "subsystem": "core",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 13,
+  "memberCount": 14,
   "counts": {
     "constructors": 1,
-    "methods": 8,
+    "methods": 9,
     "properties": 4,
     "events": 0
   },
@@ -153,6 +153,35 @@
           "description": "Called by the Director — do not call directly. Dispatches to SceneTransition.createSession, which is protected so it does not clutter a beginner's view of a transition subclass while still being callable from Director code that does not share this class's hierarchy."
         },
         {
+          "name": "createPhaseState",
+          "signature": "createPhaseState(): FadePhaseState",
+          "signatureTokens": [
+            {
+              "text": "createPhaseState",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "FadePhaseState",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": "FadePhaseState",
+          "description": "Allocate this navigation's session-scoped mutable scratch state (reused Sprite/Matrix/Color/etc — anything enter()/exit() mutates per draw). Called once per session, never shared across navigations or with the definition instance itself, which must stay fully immutable so it can be reused (even concurrently) across arbitrarily many navigations. Default: no scratch state needed (void)."
+        },
+        {
           "name": "createSession",
           "signature": "createSession(environment: SceneTransitionEnvironment): SceneTransitionSession",
           "signatureTokens": [
@@ -201,7 +230,7 @@
         },
         {
           "name": "enter",
-          "signature": "enter(context: SceneTransitionPhaseContext): void",
+          "signature": "enter(context: SceneTransitionPhaseContext, state: FadePhaseState): void",
           "signatureTokens": [
             {
               "text": "enter",
@@ -224,6 +253,22 @@
               "kind": "type"
             },
             {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "state",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "FadePhaseState",
+              "kind": "type"
+            },
+            {
               "text": ")",
               "kind": "punctuation"
             },
@@ -241,6 +286,11 @@
               "name": "context",
               "type": "SceneTransitionPhaseContext",
               "optional": false
+            },
+            {
+              "name": "state",
+              "type": "FadePhaseState",
+              "optional": false
             }
           ],
           "returnType": "void",
@@ -248,7 +298,7 @@
         },
         {
           "name": "exit",
-          "signature": "exit(context: SceneTransitionPhaseContext): void",
+          "signature": "exit(context: SceneTransitionPhaseContext, state: FadePhaseState): void",
           "signatureTokens": [
             {
               "text": "exit",
@@ -271,6 +321,22 @@
               "kind": "type"
             },
             {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "state",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "FadePhaseState",
+              "kind": "type"
+            },
+            {
               "text": ")",
               "kind": "punctuation"
             },
@@ -287,6 +353,11 @@
             {
               "name": "context",
               "type": "SceneTransitionPhaseContext",
+              "optional": false
+            },
+            {
+              "name": "state",
+              "type": "FadePhaseState",
               "optional": false
             }
           ],
@@ -447,7 +518,7 @@
         },
         {
           "name": "runPhase",
-          "signature": "runPhase(phase: \"enter\" | \"exit\", context: SceneTransitionPhaseContext): void",
+          "signature": "runPhase(phase: \"enter\" | \"exit\", context: SceneTransitionPhaseContext, state: FadePhaseState): void",
           "signatureTokens": [
             {
               "text": "runPhase",
@@ -494,6 +565,22 @@
               "kind": "type"
             },
             {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "state",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "FadePhaseState",
+              "kind": "type"
+            },
+            {
               "text": ")",
               "kind": "punctuation"
             },
@@ -515,6 +602,11 @@
             {
               "name": "context",
               "type": "SceneTransitionPhaseContext",
+              "optional": false
+            },
+            {
+              "name": "state",
+              "type": "FadePhaseState",
               "optional": false
             }
           ],

--- a/site/src/content/api/phased-scene-transition.json
+++ b/site/src/content/api/phased-scene-transition.json
@@ -6,10 +6,10 @@
   "subsystem": "core",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 12,
+  "memberCount": 13,
   "counts": {
     "constructors": 1,
-    "methods": 8,
+    "methods": 9,
     "properties": 3,
     "events": 0
   },
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(options: PhasedSceneTransitionOptions): PhasedSceneTransition",
+          "signature": "new(options: PhasedSceneTransitionOptions): PhasedSceneTransition<PhaseState>",
           "signatureTokens": [
             {
               "text": "new",
@@ -63,6 +63,18 @@
             {
               "text": "PhasedSceneTransition",
               "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "PhaseState",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
             }
           ],
           "params": [
@@ -72,7 +84,7 @@
               "optional": false
             }
           ],
-          "returnType": "PhasedSceneTransition",
+          "returnType": "PhasedSceneTransition<PhaseState>",
           "description": "Public — an abstract class with a protected constructor is still not directly instantiable (that's what abstract already does), but a *protected* constructor is inherited: a concrete subclass that declares no constructor of its own (the common case — e.g. a FlashTransition with only enter()/exit()) would inherit it and become uninstantiable from outside the module. Public keeps every minimal subclass usable with zero boilerplate."
         }
       ],
@@ -132,6 +144,35 @@
           "description": "Called by the Director — do not call directly. Dispatches to SceneTransition.createSession, which is protected so it does not clutter a beginner's view of a transition subclass while still being callable from Director code that does not share this class's hierarchy."
         },
         {
+          "name": "createPhaseState",
+          "signature": "createPhaseState(): PhaseState",
+          "signatureTokens": [
+            {
+              "text": "createPhaseState",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "PhaseState",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": "PhaseState",
+          "description": "Allocate this navigation's session-scoped mutable scratch state (reused Sprite/Matrix/Color/etc — anything enter()/exit() mutates per draw). Called once per session, never shared across navigations or with the definition instance itself, which must stay fully immutable so it can be reused (even concurrently) across arbitrarily many navigations. Default: no scratch state needed (void)."
+        },
+        {
           "name": "createSession",
           "signature": "createSession(environment: SceneTransitionEnvironment): SceneTransitionSession",
           "signatureTokens": [
@@ -180,7 +221,7 @@
         },
         {
           "name": "enter",
-          "signature": "enter(_context: SceneTransitionPhaseContext): void",
+          "signature": "enter(_context: SceneTransitionPhaseContext, _state: PhaseState): void",
           "signatureTokens": [
             {
               "text": "enter",
@@ -203,6 +244,22 @@
               "kind": "type"
             },
             {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "_state",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "PhaseState",
+              "kind": "type"
+            },
+            {
               "text": ")",
               "kind": "punctuation"
             },
@@ -220,6 +277,11 @@
               "name": "_context",
               "type": "SceneTransitionPhaseContext",
               "optional": false
+            },
+            {
+              "name": "_state",
+              "type": "PhaseState",
+              "optional": false
             }
           ],
           "returnType": "void",
@@ -227,7 +289,7 @@
         },
         {
           "name": "exit",
-          "signature": "exit(_context: SceneTransitionPhaseContext): void",
+          "signature": "exit(_context: SceneTransitionPhaseContext, _state: PhaseState): void",
           "signatureTokens": [
             {
               "text": "exit",
@@ -250,6 +312,22 @@
               "kind": "type"
             },
             {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "_state",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "PhaseState",
+              "kind": "type"
+            },
+            {
               "text": ")",
               "kind": "punctuation"
             },
@@ -266,6 +344,11 @@
             {
               "name": "_context",
               "type": "SceneTransitionPhaseContext",
+              "optional": false
+            },
+            {
+              "name": "_state",
+              "type": "PhaseState",
               "optional": false
             }
           ],
@@ -473,7 +556,7 @@
         },
         {
           "name": "runPhase",
-          "signature": "runPhase(phase: \"enter\" | \"exit\", context: SceneTransitionPhaseContext): void",
+          "signature": "runPhase(phase: \"enter\" | \"exit\", context: SceneTransitionPhaseContext, state: PhaseState): void",
           "signatureTokens": [
             {
               "text": "runPhase",
@@ -520,6 +603,22 @@
               "kind": "type"
             },
             {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "state",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "PhaseState",
+              "kind": "type"
+            },
+            {
               "text": ")",
               "kind": "punctuation"
             },
@@ -541,6 +640,11 @@
             {
               "name": "context",
               "type": "SceneTransitionPhaseContext",
+              "optional": false
+            },
+            {
+              "name": "state",
+              "type": "PhaseState",
               "optional": false
             }
           ],

--- a/site/src/content/api/slide-scene-transition.json
+++ b/site/src/content/api/slide-scene-transition.json
@@ -6,10 +6,10 @@
   "subsystem": "core",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 14,
+  "memberCount": 15,
   "counts": {
     "constructors": 1,
-    "methods": 8,
+    "methods": 9,
     "properties": 5,
     "events": 0
   },
@@ -132,6 +132,35 @@
           "description": "Called by the Director — do not call directly. Dispatches to SceneTransition.createSession, which is protected so it does not clutter a beginner's view of a transition subclass while still being callable from Director code that does not share this class's hierarchy."
         },
         {
+          "name": "createPhaseState",
+          "signature": "createPhaseState(): SlidePhaseState",
+          "signatureTokens": [
+            {
+              "text": "createPhaseState",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "SlidePhaseState",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": "SlidePhaseState",
+          "description": "Allocate this navigation's session-scoped mutable scratch state (reused Sprite/Matrix/Color/etc — anything enter()/exit() mutates per draw). Called once per session, never shared across navigations or with the definition instance itself, which must stay fully immutable so it can be reused (even concurrently) across arbitrarily many navigations. Default: no scratch state needed (void)."
+        },
+        {
           "name": "createSession",
           "signature": "createSession(environment: SceneTransitionEnvironment): SceneTransitionSession",
           "signatureTokens": [
@@ -180,7 +209,7 @@
         },
         {
           "name": "enter",
-          "signature": "enter(context: SceneTransitionPhaseContext): void",
+          "signature": "enter(context: SceneTransitionPhaseContext, state: SlidePhaseState): void",
           "signatureTokens": [
             {
               "text": "enter",
@@ -203,6 +232,22 @@
               "kind": "type"
             },
             {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "state",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "SlidePhaseState",
+              "kind": "type"
+            },
+            {
               "text": ")",
               "kind": "punctuation"
             },
@@ -220,6 +265,11 @@
               "name": "context",
               "type": "SceneTransitionPhaseContext",
               "optional": false
+            },
+            {
+              "name": "state",
+              "type": "SlidePhaseState",
+              "optional": false
             }
           ],
           "returnType": "void",
@@ -227,7 +277,7 @@
         },
         {
           "name": "exit",
-          "signature": "exit(context: SceneTransitionPhaseContext): void",
+          "signature": "exit(context: SceneTransitionPhaseContext, state: SlidePhaseState): void",
           "signatureTokens": [
             {
               "text": "exit",
@@ -250,6 +300,22 @@
               "kind": "type"
             },
             {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "state",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "SlidePhaseState",
+              "kind": "type"
+            },
+            {
               "text": ")",
               "kind": "punctuation"
             },
@@ -266,6 +332,11 @@
             {
               "name": "context",
               "type": "SceneTransitionPhaseContext",
+              "optional": false
+            },
+            {
+              "name": "state",
+              "type": "SlidePhaseState",
               "optional": false
             }
           ],
@@ -473,7 +544,7 @@
         },
         {
           "name": "runPhase",
-          "signature": "runPhase(phase: \"enter\" | \"exit\", context: SceneTransitionPhaseContext): void",
+          "signature": "runPhase(phase: \"enter\" | \"exit\", context: SceneTransitionPhaseContext, state: SlidePhaseState): void",
           "signatureTokens": [
             {
               "text": "runPhase",
@@ -520,6 +591,22 @@
               "kind": "type"
             },
             {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "state",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "SlidePhaseState",
+              "kind": "type"
+            },
+            {
               "text": ")",
               "kind": "punctuation"
             },
@@ -541,6 +628,11 @@
             {
               "name": "context",
               "type": "SceneTransitionPhaseContext",
+              "optional": false
+            },
+            {
+              "name": "state",
+              "type": "SlidePhaseState",
               "optional": false
             }
           ],

--- a/site/src/content/guide/assets/loading-and-resources.mdx
+++ b/site/src/content/guide/assets/loading-and-resources.mdx
@@ -315,14 +315,18 @@ class BootScene extends Scene {
     }
 
     unload() {
-        this.loader.onLoadComplete.remove(this._onLoadComplete);
+        // this.app is still valid here — unload() runs before the scene is
+        // detached (see Scene.attached below).
+        this.app.loader.onLoadComplete.remove(this._onLoadComplete);
     }
 
     _enterGame() {
+        // Check this.attached first — it never throws, unlike this.state,
+        // which throws once the scene has been fully detached (destroyed).
         // this.state is 'active' only while this scene is still the one
-        // driving the screen — a suspended, unloading, or already-destroyed
-        // BootScene must not navigate.
-        if (this.state !== 'active') {
+        // driving the screen — suspended, unloading, or detached must not
+        // navigate.
+        if (!this.attached || this.state !== 'active') {
             return;
         }
 

--- a/site/src/content/guide/assets/loading-and-resources.mdx
+++ b/site/src/content/guide/assets/loading-and-resources.mdx
@@ -283,6 +283,54 @@ class BootScene extends Scene {
 
 Unlike `LoadingQueue.onProgress`, which you attach to the return value of one `loader.load(...)` call, these four are properties on the `Loader` itself — subscribe once (for example in your boot scene's `init`) and they report every foreground load for the lifetime of that loader.
 
+### Guard the final navigation
+
+`onLoadComplete` can fire after this scene is no longer the active one — a
+scene switch away from `BootScene` while a load is still in flight, or an
+app-level `stop()`/`destroy()` mid-load, are both real cases. Check
+`this.state` before navigating away, and unsubscribe from the loader
+signals in `unload()` so a listener from a torn-down scene never fires
+`change()` against a Director that has since moved on:
+
+```js
+class BootScene extends Scene {
+    init(loader) {
+        this._onLoadComplete = () => {
+            this.progressBar.visible = false;
+            this._enterGame();
+        };
+
+        loader.onLoadStart.add((key, url) => {
+            this.progressBar.visible = true;
+        });
+        loader.onLoadProgress.add((loaded, total, key) => {
+            this.progressBar.value = loaded / total;
+        });
+        loader.onLoadError.add((key, error) => {
+            console.warn(`Failed to load "${key}":`, error);
+        });
+        loader.onLoadComplete.add(this._onLoadComplete);
+
+        loader.load(TitleAssets);
+    }
+
+    unload() {
+        this.loader.onLoadComplete.remove(this._onLoadComplete);
+    }
+
+    _enterGame() {
+        // this.state is 'active' only while this scene is still the one
+        // driving the screen — a suspended, unloading, or already-destroyed
+        // BootScene must not navigate.
+        if (this.state !== 'active') {
+            return;
+        }
+
+        this.app.scenes.change(GameScene);
+    }
+}
+```
+
 ## Status channel instead of throwing
 
 For `Texture`, `Sound`, and the data tokens, the path (or `X.of(...)` reference) *is* the identity — there's no separate alias to register or forget. Every handle and `AssetRef` exposes the same small status contract:

--- a/site/src/content/guide/integrations/react.mdx
+++ b/site/src/content/guide/integrations/react.mdx
@@ -161,7 +161,12 @@ Each `<Scene>` takes a unique `name`, the scene `component` class to instantiate
 `children` that render as the active scene's overlay. The `transition` (a `SceneTransition`
 instance — e.g. `new FadeSceneTransition(undefined, { duration: 300 })`, `duration` in milliseconds) only
 applies to switches, not the first start.
-If `active` matches no `<Scene>`, the active scene is cleared.
+If `active` matches no `<Scene>`, the underlying engine scene is left running
+untouched (there is no public API to clear it mid-lifetime) — only the
+React-rendered HUD overlay is cleared, and a console warning is logged. This
+is a caller mismatch (an `active` name with no matching `<Scene>`), not a
+supported "show nothing" path — check `active` against your actual `<Scene
+name="...">` declarations if you see the warning.
 
 `useActiveScene()` reads the live scene instance from the nearest `<Scenes>`, so an overlay can
 react to scene state:

--- a/site/src/content/guide/integrations/react.mdx
+++ b/site/src/content/guide/integrations/react.mdx
@@ -146,7 +146,7 @@ import { TitleScene, GameScene } from './scenes';
 function Game({ screen }: { screen: 'title' | 'game' }) {
   return (
     <ExoCanvas options={{ canvas: { width: 1280, height: 720 } }} style={{ width: 1280, height: 720 }}>
-      <Scenes active={screen} transition={new FadeSceneTransition({ duration: 300 })}>
+      <Scenes active={screen} transition={new FadeSceneTransition(undefined, { duration: 300 })}>
         <Scene name="title" component={TitleScene} />
         <Scene name="game" component={GameScene}>
           <Hud />
@@ -159,7 +159,7 @@ function Game({ screen }: { screen: 'title' | 'game' }) {
 
 Each `<Scene>` takes a unique `name`, the scene `component` class to instantiate, and optional
 `children` that render as the active scene's overlay. The `transition` (a `SceneTransition`
-instance — e.g. `new FadeSceneTransition({ duration: 300 })`, `duration` in milliseconds) only
+instance — e.g. `new FadeSceneTransition(undefined, { duration: 300 })`, `duration` in milliseconds) only
 applies to switches, not the first start.
 If `active` matches no `<Scene>`, the active scene is cleared.
 
@@ -233,7 +233,7 @@ export function App() {
       options={{ canvas: { width: 1280, height: 720 } }}
       style={{ width: 1280, height: 720 }}
     >
-      <Scenes active={screen} transition={new FadeSceneTransition({ duration: 300 })}>
+      <Scenes active={screen} transition={new FadeSceneTransition(undefined, { duration: 300 })}>
         <Scene name="title" component={TitleScene}>
           <button style={{ position: 'absolute', inset: 0 }} onClick={() => setScreen('game')}>
             Start

--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -740,6 +740,7 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
 
         this._status = ApplicationStatus.Running;
       } catch (error) {
+        this._stopFrameLoop();
         this._status = ApplicationStatus.Stopped;
         throw error;
       }
@@ -1221,6 +1222,18 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
    * interaction, audio, tweens, rendering — the app system registry, backend,
    * scene director, all clocks, all signals) and release event listeners. The
    * application instance is unusable after this call.
+   *
+   * Fires the RAF halt synchronously (so no further frame runs after this
+   * call returns) but the rest of teardown runs as a background async chain,
+   * awaited internally: `scenes` — including every retained and preloaded
+   * scope, and any scene's own async `unload()` — is fully disposed FIRST,
+   * before the Loader, rendering context, audio manager, or backend are
+   * destroyed, so a scene's teardown code never touches an already-destroyed
+   * dependency. This intentionally does not route through the public
+   * {@link Application.stop}, which fire-and-forgets its own scene-clear —
+   * that would race against `scenes._dispose()`'s own active-scope teardown
+   * for ownership of the same scope. `destroy()` instead halts the frame
+   * loop directly and lets `scenes._dispose()` own scene teardown entirely.
    */
   public destroy(): void {
     this._destroyed = true;
@@ -1232,7 +1245,33 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
     this._resizeObserver?.disconnect();
     this._resizeObserver = null;
 
-    this.stop();
+    if (this._frameLoopActive) {
+      if (this._status === ApplicationStatus.Running) {
+        this._status = ApplicationStatus.Halting;
+      }
+
+      this._stopFrameLoop();
+    }
+
+    this._status = ApplicationStatus.Stopped;
+
+    void this._disposeManagedResources();
+  }
+
+  /**
+   * @internal Awaited teardown, in order: `scenes` fully disposed first
+   * (active + every retained + every preloaded scope, including each one's
+   * own async `unload()`) — then every other owned subsystem, then clocks,
+   * then Signals. See {@link Application.destroy}'s doc comment for why
+   * scenes go first.
+   */
+  private async _disposeManagedResources(): Promise<void> {
+    try {
+      await this.scenes._dispose();
+    } catch (error) {
+      logger.error('Application.destroy() failed to fully dispose SceneDirector.', { source: 'Application', ...(error instanceof Error && { error }) });
+    }
+
     this.loader.destroy();
     this.focus.destroy();
     this.systems.destroy();
@@ -1245,7 +1284,6 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
     this.interaction.destroy();
     this.input.destroy();
     this._backend.destroy();
-    this.scenes.destroy();
     this._startupClock.destroy();
     this._activeClock.destroy();
     this._frameClock.destroy();

--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -1273,7 +1273,10 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
 
     this._status = ApplicationStatus.Stopped;
 
-    void this._disposeManagedResources();
+    void this._disposeManagedResources().catch((error: unknown) => {
+      logger.error('Application.destroy() failed during teardown.', { source: 'Application', ...(error instanceof Error && { error }) });
+      this.onError?.dispatch(error instanceof Error ? error : new Error(String(error)));
+    });
   }
 
   /**

--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -33,7 +33,15 @@ import { computeLetterboxLayout } from './letterbox';
 import { hello, logger } from './logging';
 import { Perf } from './Perf';
 import { SceneDirector } from './SceneDirector';
-import { type AnySceneConstructor, type ChangeSceneArgs, type InferSceneData, SceneNavigationAbortedError, type SceneRegistryShape } from './SceneTypes';
+import {
+  type AnySceneConstructor,
+  type ChangeSceneArgs,
+  type InferSceneData,
+  type NavigableSceneConstructor,
+  type RegistryKeyOf,
+  SceneNavigationAbortedError,
+  type SceneRegistryShape,
+} from './SceneTypes';
 import { defaultSerializationRegistry, SerializationRegistry } from './serialization/SerializationRegistry';
 import { Signal } from './Signal';
 import { SystemRegistry } from './SystemRegistry';
@@ -687,13 +695,14 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
   public async start(): Promise<this>;
   /**
    * Initialize the render backend, await capability detection, activate
-   * `target` (a constructor registered in `ApplicationOptions.scenes`), and
-   * start the per-frame loop. Idempotent — if the application is already
-   * running the call is a no-op. On error the status returns to `Stopped`
-   * and the error propagates.
+   * `target` — a registered string key, or a constructor registered in
+   * `ApplicationOptions.scenes` — and start the per-frame loop. Idempotent —
+   * if the application is already running the call is a no-op. On error the
+   * status returns to `Stopped` and the error propagates.
    */
-  public async start<C extends AnySceneConstructor>(target: C, ...args: ChangeSceneArgs<InferSceneData<C>>): Promise<this>;
-  public async start(target?: AnySceneConstructor, ...args: readonly unknown[]): Promise<this> {
+  public async start<K extends RegistryKeyOf<Registry>>(target: K, ...args: ChangeSceneArgs<InferSceneData<Registry[K]>>): Promise<this>;
+  public async start<C extends NavigableSceneConstructor<Registry>>(target: C, ...args: ChangeSceneArgs<InferSceneData<C>>): Promise<this>;
+  public async start(target?: AnySceneConstructor | string, ...args: readonly unknown[]): Promise<this> {
     invariant(!this._destroyed, 'Application.start() was called after destroy(). Construct a new Application instead of reusing a destroyed one.');
 
     if (this._status === ApplicationStatus.Stopped) {
@@ -735,7 +744,16 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
         this._capabilities = await capabilitiesPromise;
 
         if (target !== undefined) {
-          await this.scenes.change(target, ...(args as ChangeSceneArgs<InferSceneData<typeof target>>));
+          // `target`'s implementation-level type is a union (registered key
+          // OR constructor) — TS overload resolution does not distribute
+          // over a union-typed argument, so the cast picks the constructor
+          // overload purely for compile-time dispatch; SceneDirector.change()'s
+          // own single implementation signature already accepts both shapes
+          // and forwards whichever one was actually passed at runtime.
+          await this.scenes.change(
+            target as NavigableSceneConstructor<Registry>,
+            ...(args as ChangeSceneArgs<InferSceneData<NavigableSceneConstructor<Registry>>>),
+          );
         }
 
         this._status = ApplicationStatus.Running;

--- a/src/core/PhasedSceneTransition.ts
+++ b/src/core/PhasedSceneTransition.ts
@@ -88,7 +88,7 @@ export interface SceneTransitionPhaseContext {
  * for this common case.
  * @stable
  */
-export abstract class PhasedSceneTransition extends SceneTransition {
+export abstract class PhasedSceneTransition<PhaseState = void> extends SceneTransition {
   public readonly duration: number;
   public readonly easing: EasingFunction;
   public readonly placement: 'scene' | 'screen';
@@ -125,11 +125,34 @@ export abstract class PhasedSceneTransition extends SceneTransition {
   /** Declare this phase's render-resource requirements. See {@link SceneTransitionPhaseRequirements}. */
   protected abstract getPhaseRequirements(phase: 'enter' | 'exit', context: SceneTransitionContext): SceneTransitionPhaseRequirements;
 
+  /**
+   * Allocate this navigation's session-scoped mutable scratch state (reused
+   * `Sprite`/`Matrix`/`Color`/etc — anything `enter()`/`exit()` mutates per
+   * draw). Called once per session, never shared across navigations or with
+   * the definition instance itself, which must stay fully immutable so it
+   * can be reused (even concurrently) across arbitrarily many navigations.
+   * Default: no scratch state needed (`void`).
+   */
+  protected createPhaseState(): PhaseState {
+    return undefined as PhaseState;
+  }
+
+  /**
+   * @internal Public forwarder for {@link PhasedSceneTransition.createPhaseState} —
+   * mirrors {@link PhasedSceneTransition.getRequirementsForPhase}'s existing
+   * pattern: `PhasedSceneTransitionSession` (and a composed sibling
+   * instance) is not a subclass of this class and cannot call the
+   * `protected` hook directly.
+   */
+  public _createPhaseStateForSession(): PhaseState {
+    return this.createPhaseState();
+  }
+
   /** Draw one frame of the `enter` phase. No-op by default — override for a visible enter effect. */
-  protected enter(_context: SceneTransitionPhaseContext): void {}
+  protected enter(_context: SceneTransitionPhaseContext, _state: PhaseState): void {}
 
   /** Draw one frame of the `exit` phase. No-op by default — override for a visible exit effect. */
-  protected exit(_context: SceneTransitionPhaseContext): void {}
+  protected exit(_context: SceneTransitionPhaseContext, _state: PhaseState): void {}
 
   public override getRequirements(context: SceneTransitionContext): SceneTransitionRequirements {
     return mergeSceneTransitionRequirements(this.getRequirementsForPhase('exit', context), this.getRequirementsForPhase('enter', context));
@@ -145,11 +168,11 @@ export abstract class PhasedSceneTransition extends SceneTransition {
    * hooks directly. Authors override `enter()`/`exit()`; nothing else calls
    * them directly.
    */
-  public runPhase(phase: 'enter' | 'exit', context: SceneTransitionPhaseContext): void {
+  public runPhase(phase: 'enter' | 'exit', context: SceneTransitionPhaseContext, state: PhaseState): void {
     if (phase === 'enter') {
-      this.enter(context);
+      this.enter(context, state);
     } else {
-      this.exit(context);
+      this.exit(context, state);
     }
   }
 
@@ -177,12 +200,19 @@ export class PhasedSceneTransitionSession implements SceneTransitionSession {
   private _elapsedMs = 0;
   /** Reusable sprite for the direct→texture identity-composite fallback — session-owned, never shared with the phase definitions. */
   private readonly _identitySprite = new Sprite(null);
+  private readonly _exitPhaseState: unknown;
+  private readonly _enterPhaseState: unknown;
 
   public constructor(
-    private readonly _exitPhase: PhasedSceneTransition,
-    private readonly _enterPhase: PhasedSceneTransition,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exit and enter may be different PhasedSceneTransition<PhaseState> instantiations (composition); the session itself is untyped over PhaseState, matching its @internal status.
+    private readonly _exitPhase: PhasedSceneTransition<any>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private readonly _enterPhase: PhasedSceneTransition<any>,
     private readonly _environment: SceneTransitionEnvironment,
-  ) {}
+  ) {
+    this._exitPhaseState = this._exitPhase._createPhaseStateForSession();
+    this._enterPhaseState = this._enterPhase._createPhaseStateForSession();
+  }
 
   public get done(): boolean {
     return this._phaseState === 'done';
@@ -239,6 +269,7 @@ export class PhasedSceneTransitionSession implements SceneTransitionSession {
     // timing ever changes.
     const phase: 'enter' | 'exit' = this._phaseState === 'enter' || this._phaseState === 'done' ? 'enter' : 'exit';
     const activePhase = phase === 'enter' ? this._enterPhase : this._exitPhase;
+    const activePhaseState = phase === 'enter' ? this._enterPhaseState : this._exitPhaseState;
 
     // Direct -> texture identity-composite promotion (spec §3.9.1): when the
     // SESSION-WIDE requirements were promoted to `currentFrame: 'texture'` by
@@ -265,7 +296,7 @@ export class PhasedSceneTransitionSession implements SceneTransitionSession {
     const easedProgress = activePhase.easing(progress);
     const presence = phase === 'enter' ? easedProgress : 1 - easedProgress;
 
-    activePhase.runPhase(phase, { phase, progress, easedProgress, presence, frame, rendering: context });
+    activePhase.runPhase(phase, { phase, progress, easedProgress, presence, frame, rendering: context }, activePhaseState);
   }
 
   public destroy(): void {

--- a/src/core/PhasedSceneTransition.ts
+++ b/src/core/PhasedSceneTransition.ts
@@ -1,6 +1,7 @@
 import { Ease } from '#animation/Easing';
 import type { EasingFunction } from '#animation/types';
 import type { RenderingContext } from '#rendering/RenderingContext';
+import { Sprite } from '#rendering/sprite/Sprite';
 
 import {
   SceneTransition,
@@ -174,6 +175,8 @@ type PhasedTransitionPhaseState = 'exit' | 'holding' | 'enter' | 'done';
 export class PhasedSceneTransitionSession implements SceneTransitionSession {
   private _phaseState: PhasedTransitionPhaseState = 'exit';
   private _elapsedMs = 0;
+  /** Reusable sprite for the direct→texture identity-composite fallback — session-owned, never shared with the phase definitions. */
+  private readonly _identitySprite = new Sprite(null);
 
   public constructor(
     private readonly _exitPhase: PhasedSceneTransition,
@@ -236,6 +239,28 @@ export class PhasedSceneTransitionSession implements SceneTransitionSession {
     // timing ever changes.
     const phase: 'enter' | 'exit' = this._phaseState === 'enter' || this._phaseState === 'done' ? 'enter' : 'exit';
     const activePhase = phase === 'enter' ? this._enterPhase : this._exitPhase;
+
+    // Direct -> texture identity-composite promotion (spec §3.9.1): when the
+    // SESSION-WIDE requirements were promoted to `currentFrame: 'texture'` by
+    // the OTHER phase, but this phase itself only declared `direct` (or
+    // `none`), the live surface was redirected into `frame.current` for the
+    // whole session — never drawn straight to the screen at any point — so
+    // this phase must draw an unmodified 1:1 copy of it before its own
+    // effect runs, or the screen shows nothing for this phase's entire
+    // duration. Detected by comparing THIS phase's own declared requirement
+    // (not the merged session-wide one) against whether `frame.current` is
+    // actually populated: if this phase didn't ask for `texture` but a
+    // texture showed up anyway, it was promoted by its sibling.
+    const ownRequirements = activePhase.getRequirementsForPhase(phase, this._environment.context);
+
+    if (frame.current !== null && ownRequirements.currentFrame !== 'texture') {
+      this._identitySprite.texture = frame.current;
+      this._identitySprite.x = 0;
+      this._identitySprite.y = 0;
+      this._identitySprite.tint.a = 1;
+      context.render(this._identitySprite, { view: context.screenView });
+    }
+
     const progress = activePhase.duration === 0 ? 1 : Math.min(1, this._elapsedMs / activePhase.duration);
     const easedProgress = activePhase.easing(progress);
     const presence = phase === 'enter' ? easedProgress : 1 - easedProgress;

--- a/src/core/SceneDirector.ts
+++ b/src/core/SceneDirector.ts
@@ -459,11 +459,16 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
 
         this._activeScope = null;
         this._activeScopeTarget = null;
+
+        // onChangeScene fires before outgoing teardown starts (and therefore
+        // before onStopScene, dispatched inside _disposeScene) — matches
+        // change()/restore()'s order (new-scene signals before the outgoing
+        // scope's), and _forceClearActiveSceneAfterAbort()'s equivalent.
+        this.onChangeScene.dispatchIsolated(error => this._reportLifecycleError(error), null);
+
         // Outgoing teardown backgrounds (same contract as change()/restore());
         // awaited last via `_awaitPendingOutgoingTeardown`.
         this._pendingOutgoingTeardown = previousScope !== null ? this._disposeScene(previousScope) : null;
-
-        this.onChangeScene.dispatchIsolated(error => this._reportLifecycleError(error), null);
 
         return Promise.resolve();
       };
@@ -1045,6 +1050,22 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
     // the session gone and bails instead of mutating `_activeScope` behind us.
     this._abortInFlightNavigation(new SceneTransitionLifecycleError('aborted'));
 
+    // A prior committed switch's outgoing scope may still be tearing down in
+    // the background (`change()`/`restore()`/`_clearScene()` await this same
+    // promise last, via `_awaitPendingOutgoingTeardown`) — wait for it before
+    // touching any other manager, or `destroy()`'s documented guarantee
+    // ("scenes fully disposed first, including any scene's own async
+    // unload()") is false whenever destroy() follows close behind a switch
+    // or a fire-and-forget `stop()`.
+    try {
+      await this._awaitPendingOutgoingTeardown();
+    } catch (error) {
+      logger.error('SceneDirector.destroy() failed to await a pending outgoing scene teardown.', {
+        source: 'SceneDirector',
+        ...(error instanceof Error && { error }),
+      });
+    }
+
     const activeScope = this._activeScope;
 
     this._activeScope = null;
@@ -1520,11 +1541,23 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
     this._activeEnvironment = null;
     this._sessionAction = null;
     this._sessionSettle = null;
-    this._releaseTransitionResources(this._sessionResources);
+
+    const resources = this._sessionResources;
+
     this._sessionResources = null;
     this._inputGateDepth--;
 
     try {
+      // Guarded like session.destroy() below — release() can throw (a
+      // backend releaseRenderTexture call against a lost/destroyed backend)
+      // and must never skip settle() any more than a throwing session or a
+      // throwing onError listener may.
+      try {
+        this._releaseTransitionResources(resources);
+      } catch (error) {
+        this._app.onError.dispatchIsolated(() => {}, error instanceof Error ? error : new Error(String(error)));
+      }
+
       try {
         session.destroy();
       } catch (error) {
@@ -1588,12 +1621,32 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
       release: () => {
         this._app.onResize.remove(onResize);
 
+        // Each release is independently guarded — one texture's release
+        // throwing (e.g. against a lost/destroyed backend) must not skip
+        // the other's, or the un-released texture leaks. The caller
+        // (_finishActiveSession) already isolates a throw from this whole
+        // method; re-thrown here so that isolation still observes a failure
+        // happened, after both releases were attempted.
+        let firstError: unknown;
+
         if (outgoingSnapshot !== null) {
-          this._app.backend.releaseRenderTexture(outgoingSnapshot);
+          try {
+            this._app.backend.releaseRenderTexture(outgoingSnapshot);
+          } catch (error) {
+            firstError = error;
+          }
         }
 
         if (currentTexture !== null) {
-          this._app.backend.releaseRenderTexture(currentTexture);
+          try {
+            this._app.backend.releaseRenderTexture(currentTexture);
+          } catch (error) {
+            firstError ??= error;
+          }
+        }
+
+        if (firstError !== undefined) {
+          throw firstError instanceof Error ? firstError : new Error('SceneDirector: releasing transition resources failed', { cause: firstError });
         }
       },
     };

--- a/src/core/SceneDirector.ts
+++ b/src/core/SceneDirector.ts
@@ -936,7 +936,19 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
    * frame by {@link Application.update} to decide draw order.
    */
   public _transitionPlacement(): 'scene' | 'screen' | null {
-    return this._activeSession?.placement ?? null;
+    const session = this._activeSession;
+
+    if (session === null) {
+      return null;
+    }
+
+    try {
+      return session.placement;
+    } catch (error) {
+      this._finishActiveSession({ ok: false, error });
+
+      return null;
+    }
   }
 
   /**
@@ -1431,7 +1443,21 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
     const session = this._activeSession;
     const environment = this._activeEnvironment;
 
-    if (session === null || environment === null || !session.done) {
+    if (session === null || environment === null) {
+      return;
+    }
+
+    let done: boolean;
+
+    try {
+      done = session.done;
+    } catch (error) {
+      this._finishActiveSession({ ok: false, error });
+
+      return;
+    }
+
+    if (!done) {
       return;
     }
 

--- a/src/core/SceneDirector.ts
+++ b/src/core/SceneDirector.ts
@@ -324,14 +324,22 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
         const scene = claimedEntry !== null ? (claimedEntry.scope.scene as Scene) : new resolvedTarget();
         const newScope = claimedEntry !== null ? await this._awaitClaimedPreload(claimedEntry) : await this._prepareScene(scene, data);
 
-        // Generalized §3.7 concurrency guard, covering BOTH a session-driven
-        // commit (the old `sessionAtStart !== null && this._activeSession !==
-        // sessionAtStart` check) and a direct (non-transitioned) commit, which
-        // previously had no abort checkpoint at all: `_navigationGeneration`
-        // is bumped by every real `_abortInFlightNavigation` call regardless
-        // of whether a session existed, so comparing it alone subsumes the
-        // old session-identity check.
-        if (this._navigationGeneration !== generationAtStart) {
+        // §3.7 concurrency guard, combining TWO checks — neither subsumes the
+        // other:
+        //   • The generation term catches an abort routed through
+        //     `_abortInFlightNavigation` (the only caller that bumps
+        //     `_navigationGeneration`), including a direct (non-transitioned)
+        //     commit that previously had no abort checkpoint at all.
+        //   • The session-identity term catches a session that self-terminated
+        //     DURING this async prepare window WITHOUT going through
+        //     `_abortInFlightNavigation` — i.e. `session.update()`/`render()`
+        //     threw, or the session reported `done` before commit. Those paths
+        //     call `_finishActiveSession` directly (clearing `_activeSession`
+        //     and rejecting the navigation) but do NOT bump the generation, so
+        //     the generation term alone would miss them and let this closure
+        //     mutate `_activeScope`/dispatch signals for an already-rejected
+        //     navigation.
+        if (this._navigationGeneration !== generationAtStart || (sessionAtStart !== null && this._activeSession !== sessionAtStart)) {
           // Guarded (unlike the commit path below, which lets a genuine
           // failure propagate to _performSessionCommit's catch): this
           // disposal runs for a navigation that has already settled — its

--- a/src/core/SceneDirector.ts
+++ b/src/core/SceneDirector.ts
@@ -1561,7 +1561,17 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
     const outgoingSnapshot =
       requirements.outgoingFrame === 'snapshot' && this._activeScope !== null ? this._captureOutgoingSnapshot(this._activeScope, width, height) : null;
 
-    const currentTexture = requirements.currentFrame === 'texture' ? this._app.backend.acquireRenderTexture(width, height) : null;
+    let currentTexture: RenderTexture | null = null;
+
+    try {
+      currentTexture = requirements.currentFrame === 'texture' ? this._app.backend.acquireRenderTexture(width, height) : null;
+    } catch (error) {
+      if (outgoingSnapshot !== null) {
+        this._app.backend.releaseRenderTexture(outgoingSnapshot);
+      }
+
+      throw error;
+    }
 
     const onResize = (): void => {
       currentTexture?.setSize(this._app.canvas.width, this._app.canvas.height);
@@ -1592,7 +1602,13 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
   private _captureOutgoingSnapshot(scope: SceneScope, width: number, height: number): RenderTexture {
     const snapshot = this._app.backend.acquireRenderTexture(width, height);
 
-    this._app.rendering._renderSurfaceInto(snapshot, this._app.clearColor, () => scope.draw(this._app.rendering));
+    try {
+      this._app.rendering._renderSurfaceInto(snapshot, this._app.clearColor, () => scope.draw(this._app.rendering));
+    } catch (error) {
+      this._app.backend.releaseRenderTexture(snapshot);
+
+      throw error;
+    }
 
     return snapshot;
   }

--- a/src/core/SceneDirector.ts
+++ b/src/core/SceneDirector.ts
@@ -32,6 +32,7 @@ import {
   RetainedSceneNotFoundError,
   type SceneInstanceKind,
   SceneInstanceNotFoundError,
+  SceneNavigationAbortedError,
   type SceneRegistryIndex,
   type SceneRegistryShape,
   type UnloadOptions,
@@ -160,6 +161,8 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
   private _sessionResources: TransitionResources | null = null;
   private _inputGateDepth = 0;
   private _navigationInFlight = false;
+  private _navigationGeneration = 0;
+  private _destroyed = false;
 
   /** Fires whenever the active scene changes (set or clear). Payload is the new scene, or `null` when cleared. */
   public readonly onChangeScene = new Signal<[Scene | null]>();
@@ -317,26 +320,22 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
         // Captured before the prepare `await`: the session driving this
         // commit, or `null` on the direct fast path (no session at all).
         const sessionAtStart = this._activeSession;
+        const generationAtStart = this._navigationGeneration;
         const scene = claimedEntry !== null ? (claimedEntry.scope.scene as Scene) : new resolvedTarget();
         const newScope = claimedEntry !== null ? await this._awaitClaimedPreload(claimedEntry) : await this._prepareScene(scene, data);
 
-        // §3.7 concurrency guard. `_prepareScene`/`_awaitClaimedPreload` above
-        // can await the incoming scene's `load()`/`init()` across several
-        // frames (or a slow preload); a frame-loop stop
-        // (`_abortInFlightNavigation`) can fire during that window — a scene's
-        // own `load()` hook calling `app.stop()`, or a fatal frame error —
-        // settling and rejecting this navigation while this continuation is
-        // still suspended. Committing the switch now would activate the
-        // incoming scene and tear the outgoing one down for a navigation the
-        // app already reported aborted. Detect it (the session that drove
-        // this commit is gone) and bail, tearing the freshly-prepared,
-        // never-activated Ready scope down (Ready-scope cleanup, §3.5.1 —
-        // `unload()` runs, `onStopScene` does not).
-        if (sessionAtStart !== null && this._activeSession !== sessionAtStart) {
+        // Generalized §3.7 concurrency guard, covering BOTH a session-driven
+        // commit (the old `sessionAtStart !== null && this._activeSession !==
+        // sessionAtStart` check) and a direct (non-transitioned) commit, which
+        // previously had no abort checkpoint at all: `_navigationGeneration`
+        // is bumped by every real `_abortInFlightNavigation` call regardless
+        // of whether a session existed, so comparing it alone subsumes the
+        // old session-identity check.
+        if (this._navigationGeneration !== generationAtStart) {
           // Guarded (unlike the commit path below, which lets a genuine
           // failure propagate to _performSessionCommit's catch): this
           // disposal runs for a navigation that has already settled — its
-          // session was aborted moments ago, so _finishActiveSession's
+          // session (if any) was aborted moments ago, so _finishActiveSession's
           // `session === null` guard makes any catch further up a no-op,
           // silently dropping the error instead of surfacing it. Report it
           // through the same error pipeline every other guarded disposal in
@@ -353,13 +352,22 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
             this._app.onError.dispatch(normalized);
           }
 
+          if (sessionAtStart === null) {
+            // Direct (non-transitioned) navigation — nothing else will
+            // reject change()'s own promise on abort (a session-driven
+            // commit's rejection instead comes from the session's own
+            // outer promise via `_finishActiveSession`), so this bail must
+            // throw itself.
+            throw new SceneNavigationAbortedError();
+          }
+
           return;
         }
 
         const previousScope = this._activeScope;
         const previousTarget = this._activeScopeTarget;
         const outgoing = previousScope === null ? null : { scope: previousScope, target: previousTarget! };
-        const { teardown, pendingStopScene } = this._navigation.beginOutgoingDisposition(outgoing, options.suspendCurrent ?? false);
+        const { pendingStopScene } = this._navigation.prepareOutgoingDisposition(outgoing, options.suspendCurrent ?? false);
 
         this._activeScope = newScope;
         this._activeScopeTarget = resolvedTarget;
@@ -368,11 +376,13 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
         this.onChangeScene.dispatchIsolated(error => this._reportLifecycleError(error), scene as Scene);
         this.onStartScene.dispatchIsolated(error => this._reportLifecycleError(error), scene as Scene);
 
-        // Not rollback-able (definition §3.5, steps 8-9). Outgoing teardown
-        // settles in the background while the session keeps playing; the
-        // navigation awaits it last via `_awaitPendingOutgoingTeardown`.
-        this._navigation.finishOutgoingDisposition(pendingStopScene);
-        this._pendingOutgoingTeardown = teardown;
+        // Not rollback-able (definition §3.5, steps 8-9). `onStopScene` fires
+        // here — after the incoming scope is fully live — and ONLY THEN does
+        // outgoing teardown actually start; it settles in the background
+        // while the session keeps playing, and the navigation awaits it last
+        // via `_awaitPendingOutgoingTeardown`.
+        this._navigation.dispatchStopScene(pendingStopScene);
+        this._pendingOutgoingTeardown = this._navigation.beginOutgoingTeardown(pendingStopScene);
       };
 
       const resolvedTransition = resolveSceneTransitionSelection('change', options.transition, this._registry.defaultTransitions.get(resolvedTarget));
@@ -384,11 +394,30 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
         // Pre-commit abort restoration (spec §3.5.1), mirroring restore()'s
         // `_retained` restoration. Only when `commitSwitch` never started:
         // once it has, it owns the claimed scope (commit, prepare-failure
-        // cleanup, or the §3.7 race-guard teardown above all handle it), and
+        // cleanup, or the generation-mismatch bail above all handle it), and
         // re-adding a consumed/destroyed scope here would corrupt `_preloaded`.
+        //
+        // Even when `commitSwitch` never started, only restore the claim if
+        // nothing newer has since claimed this slot (a fresh `preload()` call
+        // for the same target, registered while this one was in flight) and
+        // the Director itself is not mid-`_dispose()` (which will tear
+        // `_preloaded` down itself — resurrecting a claim here would leak it
+        // past that teardown).
         if (!commitStarted && claimedEntry !== null) {
-          claimedEntry.status = 'ready';
-          this._preloaded.set(resolvedTarget, claimedEntry);
+          if (!this._destroyed && !this._preloaded.has(resolvedTarget)) {
+            claimedEntry.status = 'ready';
+            this._preloaded.set(resolvedTarget, claimedEntry);
+          } else {
+            void this._disposeScene(claimedEntry.scope, { dispatchStopScene: false }).catch(disposeError => {
+              const normalized = disposeError instanceof Error ? disposeError : new Error(String(disposeError));
+
+              logger.error('SceneDirector.change() failed to dispose an aborted claimed preload that could not be restored.', {
+                source: 'SceneDirector',
+                error: normalized,
+              });
+              this._app.onError.dispatch(normalized);
+            });
+          }
         }
 
         throw error;
@@ -532,7 +561,7 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
           const previousScope = this._activeScope;
           const previousTarget = this._activeScopeTarget;
           const outgoing = previousScope === null ? null : { scope: previousScope, target: previousTarget! };
-          const { teardown, pendingStopScene } = this._navigation.beginOutgoingDisposition(outgoing, options.suspendCurrent ?? false);
+          const { pendingStopScene } = this._navigation.prepareOutgoingDisposition(outgoing, options.suspendCurrent ?? false);
           const previousState = retainedScope.state;
 
           committed = true;
@@ -540,11 +569,14 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
           this._activeScopeTarget = resolvedTarget;
           retainedScope.restore();
 
-          this.onChangeScene.dispatchIsolated(error => this._reportLifecycleError(error), retainedScope.scene as Scene);
+          // Order per spec: Scene.onActivate (fired synchronously inside
+          // retainedScope.restore() above) -> Director.onStateChange ->
+          // Director.onChangeScene.
           this.onStateChange.dispatchIsolated(error => this._reportLifecycleError(error), previousState, retainedScope.state, retainedScope.scene as Scene);
+          this.onChangeScene.dispatchIsolated(error => this._reportLifecycleError(error), retainedScope.scene as Scene);
 
-          this._navigation.finishOutgoingDisposition(pendingStopScene);
-          this._pendingOutgoingTeardown = teardown;
+          this._navigation.dispatchStopScene(pendingStopScene);
+          this._pendingOutgoingTeardown = this._navigation.beginOutgoingTeardown(pendingStopScene);
 
           return Promise.resolve();
         };
@@ -977,6 +1009,8 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
    * regardless of any in-flight navigation (definition §10.6).
    */
   public async _dispose(): Promise<void> {
+    this._destroyed = true;
+
     // Abort any in-flight transition session first, through the same public
     // entry point every frame-loop stop uses (§3.7). A no-op when nothing is
     // in flight; otherwise `_finishActiveSession` owns the full synchronous
@@ -1052,6 +1086,8 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
    * closure (the only navigation whose commit has an async prepare step).
    */
   public _abortInFlightNavigation(reason: Error): boolean {
+    this._navigationGeneration++;
+
     if (this._activeSession === null) {
       return false;
     }

--- a/src/core/SceneDirector.ts
+++ b/src/core/SceneDirector.ts
@@ -1524,16 +1524,24 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
     this._inputGateDepth--;
 
     try {
-      session.destroy();
-    } catch (error) {
-      this._app.onError.dispatch(error instanceof Error ? error : new Error(String(error)));
-    }
+      try {
+        session.destroy();
+      } catch (error) {
+        // dispatchIsolated with a no-op onError callback: an onError
+        // listener itself throwing must never propagate out of this method
+        // and skip `settle()` below — Signal.dispatchIsolated already
+        // isolates a throwing LISTENER; the no-op callback here additionally
+        // isolates a throwing onError CALLBACK, which a plain `.dispatch()`
+        // would not.
+        this._app.onError.dispatchIsolated(() => {}, error instanceof Error ? error : new Error(String(error)));
+      }
 
-    if (!outcome.ok) {
-      this._app.onError.dispatch(outcome.error instanceof Error ? outcome.error : new Error(String(outcome.error)));
+      if (!outcome.ok) {
+        this._app.onError.dispatchIsolated(() => {}, outcome.error instanceof Error ? outcome.error : new Error(String(outcome.error)));
+      }
+    } finally {
+      settle(outcome);
     }
-
-    settle(outcome);
   }
 
   /**

--- a/src/core/SceneDirector.ts
+++ b/src/core/SceneDirector.ts
@@ -24,6 +24,7 @@ import {
   type ChangeSceneOptions,
   ConcurrentSceneNavigationError,
   type InferSceneData,
+  type NavigableSceneConstructor,
   type PreloadArgs,
   type RegistryKeyOf,
   resolvePreloadArgs,
@@ -258,7 +259,7 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
    * first).
    */
   public async change<K extends RegistryKeyOf<Registry>>(target: K, ...args: ChangeSceneArgs<InferSceneData<Registry[K]>>): Promise<this>;
-  public async change<C extends AnySceneConstructor>(target: C, ...args: ChangeSceneArgs<InferSceneData<C>>): Promise<this>;
+  public async change<C extends NavigableSceneConstructor<Registry>>(target: C, ...args: ChangeSceneArgs<InferSceneData<C>>): Promise<this>;
   public async change(target: AnySceneConstructor | string, ...args: readonly unknown[]): Promise<this> {
     const options = ((args[0] as ChangeSceneOptions<unknown> | undefined) ?? {}) as ChangeSceneOptions<unknown>;
     const data = (options as { data?: unknown }).data;
@@ -529,7 +530,7 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
    * when `target` has no retained instance.
    */
   public async restore<K extends RegistryKeyOf<Registry>>(target: K, options?: RestoreSceneOptions): Promise<this>;
-  public async restore<C extends AnySceneConstructor>(target: C, options?: RestoreSceneOptions): Promise<this>;
+  public async restore<C extends NavigableSceneConstructor<Registry>>(target: C, options?: RestoreSceneOptions): Promise<this>;
   public async restore(target: AnySceneConstructor | string, options: RestoreSceneOptions = {}): Promise<this> {
     const resolvedTarget = this._resolveNavigationTarget(target);
     const retainedScope = this._retained.get(resolvedTarget);

--- a/src/core/SceneDirector.ts
+++ b/src/core/SceneDirector.ts
@@ -1010,11 +1010,14 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
    * @internal Awaited teardown, in order: abort any in-flight transition
    * session (destroy it, reject its navigation) → destroy the active scope
    * (guarded, errors reported) → destroy every retained scope in reverse
-   * insertion order (guarded, errors reported) → destroy every Signal.
-   * Signals are destroyed last so scene teardown (`unload()`, `onStopScene`
-   * listeners) can still use them while it runs. Does not participate in
-   * the `_navigationInFlight` guard — teardown must always proceed
-   * regardless of any in-flight navigation (definition §10.6).
+   * insertion order (guarded, errors reported) → destroy every preloaded-
+   * but-never-consumed scope in reverse insertion order (each entry marked
+   * `cancelling` and awaited before disposal, guarded, errors reported,
+   * `onStopScene` never dispatched since it was never activated) → destroy
+   * every Signal. Signals are destroyed last so scene teardown (`unload()`,
+   * `onStopScene` listeners) can still use them while it runs. Does not
+   * participate in the `_navigationInFlight` guard — teardown must always
+   * proceed regardless of any in-flight navigation (definition §10.6).
    */
   public async _dispose(): Promise<void> {
     this._destroyed = true;
@@ -1051,6 +1054,35 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
         await this._disposeScene(scope);
       } catch (error) {
         logger.error('SceneDirector.destroy() failed to destroy a retained scene.', { source: 'SceneDirector', ...(error instanceof Error && { error }) });
+      }
+    }
+
+    // Preloaded-but-never-consumed scopes are Director-owned activations
+    // (spec: preloaded scopes are Director-owned, must not be restored or
+    // left behind at Director teardown) — never touched by the loops above.
+    // In reverse insertion order for symmetry with `_retained`. Marked
+    // `cancelling` first, mirroring `_discardStalePreload`/`_unloadPreloaded`,
+    // so a `preload()`/`change()` claim racing this teardown sees it and
+    // skips the entry instead of claiming a scope mid-destroy.
+    const preloadedInReverseInsertionOrder = [...this._preloaded.entries()].reverse();
+
+    this._preloaded.clear();
+
+    for (const [, entry] of preloadedInReverseInsertionOrder) {
+      entry.status = 'cancelling';
+
+      try {
+        await entry.ready;
+      } catch {
+        // prepare() failed — _runPreloadPrepare()'s own catch already ran
+        // the failed-preparation cleanup. Nothing further to do.
+        continue;
+      }
+
+      try {
+        await this._disposeScene(entry.scope, { dispatchStopScene: false });
+      } catch (error) {
+        logger.error('SceneDirector.destroy() failed to destroy a preloaded scene.', { source: 'SceneDirector', ...(error instanceof Error && { error }) });
       }
     }
 

--- a/src/core/SceneTypes.ts
+++ b/src/core/SceneTypes.ts
@@ -107,8 +107,18 @@ export type ConstructorOf<R extends SceneRegistration<AnySceneConstructor>> = R 
  * default generic on `Application`/`SceneDirector`). Without this
  * conditional, an unconstrained `C extends AnySceneConstructor` accepted any
  * constructor even with a populated registry present, giving no
- * compile-time rejection of an unregistered scene (the dev-only
+ * compile-time signal for an unregistered scene at all (the dev-only
  * {@link UnregisteredSceneError} runtime check was the only guard).
+ *
+ * **Structural-typing caveat:** this rejects an unregistered constructor
+ * only when it is structurally distinguishable from every registered one —
+ * concretely, when it has a `Data` type (or other members) the registered
+ * constructors lack. Two `Scene` subclasses that declare no members of
+ * their own (the same shape as bare `Scene`) are structurally identical, so
+ * an unregistered empty scene passed where a registered empty scene is
+ * expected still compiles; TypeScript's structural type system cannot tell
+ * them apart. The dev-only {@link UnregisteredSceneError} runtime check
+ * remains the only guard that is complete in every case.
  */
 export type NavigableSceneConstructor<Registry> = keyof Registry extends never
   ? AnySceneConstructor

--- a/src/core/SceneTypes.ts
+++ b/src/core/SceneTypes.ts
@@ -97,6 +97,23 @@ export type RegistryKeyOf<Registry> = Extract<keyof Registry, string>;
  */
 export type ConstructorOf<R extends SceneRegistration<AnySceneConstructor>> = R extends { scene: infer C } ? C : R;
 
+/**
+ * The constructor union `Application.start()`/`SceneDirector.change()`/
+ * `SceneDirector.restore()` accept as a *constructor* target (as opposed to
+ * a registered string key): every registered constructor, unwrapping the
+ * `{ scene, transition? }` descriptor form via {@link ConstructorOf}, when
+ * `Registry` has at least one key — or any {@link AnySceneConstructor} when
+ * `Registry` is the empty default (`{}`, scene-less / registry-less use, the
+ * default generic on `Application`/`SceneDirector`). Without this
+ * conditional, an unconstrained `C extends AnySceneConstructor` accepted any
+ * constructor even with a populated registry present, giving no
+ * compile-time rejection of an unregistered scene (the dev-only
+ * {@link UnregisteredSceneError} runtime check was the only guard).
+ */
+export type NavigableSceneConstructor<Registry> = keyof Registry extends never
+  ? AnySceneConstructor
+  : { [K in keyof Registry]: Registry[K] extends { scene: infer C } ? C : Registry[K] }[keyof Registry];
+
 /* eslint-disable @typescript-eslint/no-explicit-any -- ApplicationLike/ApplicationOf must accept `Application<any>` and an abstract constructor's erased argument list; see spec §6.2. */
 /**
  * Anything that resolves to a concrete {@link Application} instance type: the

--- a/src/core/scene/SceneNavigationTransaction.ts
+++ b/src/core/scene/SceneNavigationTransaction.ts
@@ -10,11 +10,9 @@ export interface OutgoingScope {
   readonly target: AnySceneConstructor;
 }
 
-/** Result of {@link SceneNavigationTransaction.beginOutgoingDisposition}. */
+/** Result of {@link SceneNavigationTransaction.prepareOutgoingDisposition}. */
 export interface OutgoingDisposition {
-  /** Resolves once the outgoing scope's permanent teardown has fully settled. Already resolved when there was no outgoing scope, or it was suspended instead of torn down. */
-  readonly teardown: Promise<void>;
-  /** The scope `finishOutgoingDisposition` must still dispatch `onStopScene` for, or `null` when there is nothing to dispatch (no outgoing scope, or it was suspended instead). */
+  /** The scope about to be permanently torn down, or `null` when there is nothing to tear down (no outgoing scope, or it was suspended instead). Pass to {@link SceneNavigationTransaction.dispatchStopScene} then {@link SceneNavigationTransaction.beginOutgoingTeardown}, in that order. */
   readonly pendingStopScene: SceneScope | null;
 }
 
@@ -28,6 +26,15 @@ export interface OutgoingDisposition {
  * signals it dispatches through, both handed in at construction —
  * `SceneDirector` remains the sole owner of `_activeScope`/
  * `_activeScopeTarget`/`_retained` itself.
+ *
+ * Split into three steps — `prepareOutgoingDisposition` →
+ * `dispatchStopScene` → `beginOutgoingTeardown` — rather than one call,
+ * so the caller can interleave incoming-scope activation and
+ * `onChangeScene`/`onStartScene` dispatch BETWEEN deciding the outgoing
+ * scope's fate and actually starting its teardown (spec: the outgoing
+ * scope must be marked/suspended before the incoming scope activates, but
+ * `Scene.unload()` must not start running until after `onStopScene` has
+ * fired for it, which itself must fire after the incoming scope is live).
  */
 export class SceneNavigationTransaction {
   public constructor(
@@ -38,20 +45,19 @@ export class SceneNavigationTransaction {
   ) {}
 
   /**
-   * Commit the outgoing scope's fate as part of an atomic switch (§3.5 step
-   * 5): suspend and retain it under `outgoing.target` when `suspendCurrent`
-   * is set (dispatching `onStateChange` for the edge, guarded via
-   * `Signal.dispatchIsolated` — a throwing listener is reported, never
-   * thrown back), otherwise begin its permanent teardown (`scope.destroy()`,
-   * which synchronously flips it to `Destroying` before this method
-   * returns) and hand back the still-settling teardown promise plus the
-   * scope `finishOutgoingDisposition` must still dispatch `onStopScene` for.
-   * No-op (an already-resolved teardown, `null` pending-stop-scene) when
-   * `outgoing` is `null`. Never throws.
+   * Decide the outgoing scope's fate (§3.5 step 5) WITHOUT starting its
+   * teardown: suspend and retain it under `outgoing.target` when
+   * `suspendCurrent` is set (dispatching `onStateChange` for the edge
+   * immediately — suspension has no `unload()`/`onStopScene` to sequence
+   * against), otherwise return it as `pendingStopScene` for the caller to
+   * pass to {@link SceneNavigationTransaction.dispatchStopScene} and
+   * {@link SceneNavigationTransaction.beginOutgoingTeardown} once it has
+   * finished activating the incoming scope. No-op (`pendingStopScene: null`)
+   * when `outgoing` is `null`. Never throws.
    */
-  public beginOutgoingDisposition(outgoing: OutgoingScope | null, suspendCurrent: boolean): OutgoingDisposition {
+  public prepareOutgoingDisposition(outgoing: OutgoingScope | null, suspendCurrent: boolean): OutgoingDisposition {
     if (outgoing === null) {
-      return { teardown: Promise.resolve(), pendingStopScene: null };
+      return { pendingStopScene: null };
     }
 
     if (suspendCurrent) {
@@ -61,24 +67,38 @@ export class SceneNavigationTransaction {
       this._retained.set(outgoing.target, outgoing.scope);
       this._onStateChange.dispatchIsolated(this._reportError, previousState, outgoing.scope.state, outgoing.scope.scene as Scene);
 
-      return { teardown: Promise.resolve(), pendingStopScene: null };
+      return { pendingStopScene: null };
     }
 
-    return { teardown: outgoing.scope.destroy(), pendingStopScene: outgoing.scope };
+    return { pendingStopScene: outgoing.scope };
   }
 
   /**
-   * Not-rollback-able step 8: dispatch `onStopScene` for a just-committed
-   * permanent switch's outgoing scope — guarded via
-   * `Signal.dispatchIsolated`, never throws back to the caller (the switch
-   * already committed; a throwing listener here cannot un-commit it). No-op
-   * when `pendingStopScene` is `null`.
+   * Dispatch `onStopScene` for a scope about to be permanently torn down —
+   * guarded via `Signal.dispatchIsolated`, never throws back to the caller.
+   * Call AFTER the incoming scope has activated and its own
+   * `onChangeScene`/`onStartScene` have fired, and BEFORE
+   * {@link SceneNavigationTransaction.beginOutgoingTeardown} (`onStopScene`'s
+   * own contract: "fires just before a scene is unloaded"). No-op when
+   * `pendingStopScene` is `null`.
    */
-  public finishOutgoingDisposition(pendingStopScene: SceneScope | null): void {
+  public dispatchStopScene(pendingStopScene: SceneScope | null): void {
     if (pendingStopScene === null) {
       return;
     }
 
     this._onStopScene.dispatchIsolated(this._reportError, pendingStopScene.scene as Scene);
+  }
+
+  /**
+   * Not-rollback-able step 8: actually start `pendingStopScene`'s permanent
+   * teardown (`scope.destroy()`, which synchronously flips it to
+   * `Destroying` and begins running `Scene.unload()` before this method
+   * returns). Call AFTER {@link SceneNavigationTransaction.dispatchStopScene}.
+   * Returns the still-settling teardown promise — already resolved when
+   * `pendingStopScene` is `null`.
+   */
+  public beginOutgoingTeardown(pendingStopScene: SceneScope | null): Promise<void> {
+    return pendingStopScene === null ? Promise.resolve() : pendingStopScene.destroy();
   }
 }

--- a/src/core/transitions/FadeSceneTransition.ts
+++ b/src/core/transitions/FadeSceneTransition.ts
@@ -8,6 +8,13 @@ import {
 import { Matrix } from '#math/Matrix';
 import { QuadGeometry } from '#rendering/geometry/QuadGeometry';
 
+/** Per-session scratch state for {@link FadeSceneTransition} — never shared with the (immutable, reusable-across-navigations) definition instance. */
+interface FadePhaseState {
+  readonly quad: QuadGeometry;
+  readonly transform: Matrix;
+  readonly tint: Color;
+}
+
 /**
  * Fade to a color, switch scenes, fade back in. `placement: 'screen'`,
  * `currentFrame: 'direct'`, `outgoingFrame: 'none'` — the live surface
@@ -16,16 +23,9 @@ import { QuadGeometry } from '#rendering/geometry/QuadGeometry';
  * (definition spec §8).
  * @stable
  */
-export class FadeSceneTransition extends PhasedSceneTransition {
+export class FadeSceneTransition extends PhasedSceneTransition<FadePhaseState> {
   /** The color faded to. Default {@link Color.black}. */
   public readonly color: Color;
-
-  /** Reusable unit quad — scaled/translated to the screen bounds every draw, never reallocated. */
-  private readonly _quad = new QuadGeometry();
-  /** Reusable world matrix mutated per draw instead of allocated per frame. */
-  private readonly _transform = new Matrix();
-  /** Reusable tint mutated per draw — {@link color}'s RGB plus this frame's alpha. */
-  private readonly _tint = new Color();
 
   public constructor(color: Color = Color.black, options: PhasedSceneTransitionOptions = {}) {
     super(options);
@@ -36,24 +36,28 @@ export class FadeSceneTransition extends PhasedSceneTransition {
     return { outgoingFrame: 'none', currentFrame: 'direct' };
   }
 
-  protected override enter(context: SceneTransitionPhaseContext): void {
-    this._draw(context);
+  protected override createPhaseState(): FadePhaseState {
+    return { quad: new QuadGeometry(), transform: new Matrix(), tint: new Color() };
   }
 
-  protected override exit(context: SceneTransitionPhaseContext): void {
-    this._draw(context);
+  protected override enter(context: SceneTransitionPhaseContext, state: FadePhaseState): void {
+    this._draw(context, state);
+  }
+
+  protected override exit(context: SceneTransitionPhaseContext, state: FadePhaseState): void {
+    this._draw(context, state);
   }
 
   /** Draw a full-screen quad tinted with {@link color} at `alpha = 1 - presence` — shared by both `enter()` and `exit()`, which are symmetric. */
-  private _draw(context: SceneTransitionPhaseContext): void {
+  private _draw(context: SceneTransitionPhaseContext, state: FadePhaseState): void {
     const bounds = context.rendering.screenView.getBounds();
     const width = bounds.right - bounds.left;
     const height = bounds.bottom - bounds.top;
 
-    this._transform.set(width, 0, bounds.left, 0, height, bounds.top);
-    this._tint.copy(this.color);
-    this._tint.a = 1 - context.presence;
+    state.transform.set(width, 0, bounds.left, 0, height, bounds.top);
+    state.tint.copy(this.color);
+    state.tint.a = 1 - context.presence;
 
-    context.rendering.drawGeometry(this._quad, this._transform, { tint: this._tint });
+    context.rendering.drawGeometry(state.quad, state.transform, { tint: state.tint });
   }
 }

--- a/src/core/transitions/SlideSceneTransition.ts
+++ b/src/core/transitions/SlideSceneTransition.ts
@@ -41,6 +41,12 @@ const oppositeDirection: Record<SlideDirection, SlideDirection> = {
   down: 'up',
 };
 
+/** Per-session scratch state for {@link SlideSceneTransition} — never shared with the (immutable, reusable-across-navigations) definition instance, and never retains a texture past the session that assigned it. */
+interface SlidePhaseState {
+  readonly currentSprite: Sprite;
+  readonly snapshotSprite: Sprite;
+}
+
 /**
  * Directional slide transition — covers menu/inventory/page-style navigation
  * (definition spec §8). Three modes:
@@ -54,23 +60,9 @@ const oppositeDirection: Record<SlideDirection, SlideDirection> = {
  *   edge over a frozen snapshot of the (already-gone) outgoing scene.
  * @stable
  */
-export class SlideSceneTransition extends PhasedSceneTransition {
+export class SlideSceneTransition extends PhasedSceneTransition<SlidePhaseState> {
   public readonly direction: SlideDirection;
   public readonly mode: SlideMode;
-
-  /**
-   * Reusable sprite for the animated "current" surface (the live outgoing
-   * texture during `exit()`, the live incoming texture during `enter()`) —
-   * mutated per draw, never reallocated.
-   */
-  private readonly _currentSprite = new Sprite(null);
-  /**
-   * Reusable sprite for `mode: 'cover'`'s frozen outgoing snapshot, held
-   * separately from {@link _currentSprite} because `cover`'s `enter()` draws
-   * both in the same frame — reusing one instance for both would have the
-   * second draw overwrite the first before it renders.
-   */
-  private readonly _snapshotSprite = new Sprite(null);
 
   public constructor(options: SlideSceneTransitionOptions = {}) {
     super(options);
@@ -91,7 +83,11 @@ export class SlideSceneTransition extends PhasedSceneTransition {
     return phase === 'exit' ? { outgoingFrame: 'none', currentFrame: 'direct' } : { outgoingFrame: 'snapshot', currentFrame: 'texture' };
   }
 
-  protected override exit(context: SceneTransitionPhaseContext): void {
+  protected override createPhaseState(): SlidePhaseState {
+    return { currentSprite: new Sprite(null), snapshotSprite: new Sprite(null) };
+  }
+
+  protected override exit(context: SceneTransitionPhaseContext, state: SlidePhaseState): void {
     if (this.mode === 'cover') {
       return; // static — the outgoing scene stays put, untouched, until commit
     }
@@ -102,20 +98,20 @@ export class SlideSceneTransition extends PhasedSceneTransition {
       return;
     }
 
-    this._drawSliding(context, this._currentSprite, context.frame.current, this.direction);
+    this._drawSliding(context, state.currentSprite, context.frame.current, this.direction);
   }
 
-  protected override enter(context: SceneTransitionPhaseContext): void {
+  protected override enter(context: SceneTransitionPhaseContext, state: SlidePhaseState): void {
     if (this.mode === 'reveal') {
       return; // nothing left to animate — the reveal already happened during exit
     }
 
     if (this.mode === 'cover' && context.frame.outgoing !== null) {
-      this._snapshotSprite.texture = context.frame.outgoing;
-      this._snapshotSprite.x = 0;
-      this._snapshotSprite.y = 0;
-      this._snapshotSprite.tint.a = 1;
-      context.rendering.render(this._snapshotSprite, { view: context.rendering.screenView });
+      state.snapshotSprite.texture = context.frame.outgoing;
+      state.snapshotSprite.x = 0;
+      state.snapshotSprite.y = 0;
+      state.snapshotSprite.tint.a = 1;
+      context.rendering.render(state.snapshotSprite, { view: context.rendering.screenView });
     }
 
     if (context.frame.current === null) {
@@ -128,7 +124,7 @@ export class SlideSceneTransition extends PhasedSceneTransition {
     // incoming content comes from the other side in every animated mode.
     const entryDirection = oppositeDirection[this.direction];
 
-    this._drawSliding(context, this._currentSprite, context.frame.current, entryDirection);
+    this._drawSliding(context, state.currentSprite, context.frame.current, entryDirection);
   }
 
   /** Draw `texture` via `sprite`, offset along `direction`'s axis by `distance * (1 - presence) * sign`. */

--- a/test/core/application-extension-systems.test.ts
+++ b/test/core/application-extension-systems.test.ts
@@ -120,7 +120,7 @@ describe('Application app-system extension bindings (Slice F)', () => {
     appB.destroy();
   });
 
-  test('app.destroy() destroys the extension system, in reverse registration order with a later user system', () => {
+  test('app.destroy() destroys the extension system, in reverse registration order with a later user system', async () => {
     const order: string[] = [];
     const extSystem: System = { update: vi.fn(), destroy: () => order.push('extension') };
     const binding: ApplicationSystemBinding = { create: () => extSystem };
@@ -131,6 +131,13 @@ describe('Application app-system extension bindings (Slice F)', () => {
     app.systems.add(userSystem);
 
     app.destroy();
+
+    // destroy() now disposes `scenes` first, awaited internally, before the
+    // rest of teardown (including `systems.destroy()`) runs — give that
+    // background chain a few microtask turns to settle.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
 
     expect(order).toEqual(['user', 'extension']);
   });

--- a/test/core/application-on-frame.test.ts
+++ b/test/core/application-on-frame.test.ts
@@ -9,7 +9,7 @@
 interface OnFrameTestHarness {
   readonly Application: typeof import('#core/Application').Application;
   readonly ApplicationStatus: typeof import('#core/Application').ApplicationStatus;
-  readonly sceneDirector: { update: MockInstance; setScene: MockInstance; destroy: MockInstance };
+  readonly sceneDirector: { update: MockInstance; setScene: MockInstance; destroy: MockInstance; _dispose: MockInstance };
   readonly backend: {
     flush: MockInstance;
     resetStats: MockInstance;
@@ -41,6 +41,7 @@ const loadOnFrameHarness = async (): Promise<OnFrameTestHarness> => {
     update: vi.fn(),
     setScene: vi.fn().mockResolvedValue(undefined),
     destroy: vi.fn(),
+    _dispose: vi.fn().mockResolvedValue(undefined),
   };
   // Plain object that satisfies the onKeyDown Signal shape needed by DebugOverlay
   // (Application itself doesn't use onKeyDown in its constructor, so a minimal stub suffices).
@@ -215,6 +216,13 @@ describe('Application.onFrame', () => {
     expect(app.onFrame.count).toBeGreaterThan(0);
 
     app.destroy();
+
+    // destroy() disposes scenes first, awaited internally in a background
+    // async chain, before the rest of teardown (including onFrame.destroy())
+    // runs — give it a few microtask turns to settle.
+    for (let i = 0; i < 16 && app.onFrame.count > 0; i++) {
+      await Promise.resolve();
+    }
 
     expect(app.onFrame.count).toBe(0);
   });

--- a/test/core/application-start.test.ts
+++ b/test/core/application-start.test.ts
@@ -114,4 +114,46 @@ describe('Application.start() — scene-less and constructor overloads', () => {
     await expect(app.start(UnregisteredScene)).rejects.toThrow(/is not registered in ApplicationOptions\.scenes/);
     app.destroy();
   });
+
+  test('start() failure stops the frame loop instead of leaving it running forever', async () => {
+    class FailingLoadScene extends Scene {
+      public override load(): void {
+        throw new Error('load failed');
+      }
+    }
+    const app = new Application({ backend: { type: 'webgl2' }, scenes: { fail: FailingLoadScene } });
+
+    await expect(app.start(FailingLoadScene)).rejects.toThrow('load failed');
+
+    expect((app as unknown as { _frameLoopActive: boolean })._frameLoopActive).toBe(false);
+
+    app.destroy();
+  });
+
+  test('destroy() fully disposes the active scene before destroying the loader/rendering/audio/backend', async () => {
+    const order: string[] = [];
+
+    class OrderCheckScene extends Scene {
+      public override async unload(): Promise<void> {
+        order.push('scene.unload:start');
+        await Promise.resolve();
+        order.push('scene.unload:end');
+      }
+    }
+
+    const app = new Application({ backend: { type: 'webgl2' }, scenes: { check: OrderCheckScene } });
+
+    vi.spyOn(app.loader, 'destroy').mockImplementation(() => order.push('loader.destroy'));
+    vi.spyOn(app.tweens, 'destroy').mockImplementation(() => order.push('tweens.destroy'));
+
+    await app.start(OrderCheckScene);
+
+    app.destroy();
+
+    for (let i = 0; i < 32 && order.length < 4; i++) {
+      await Promise.resolve();
+    }
+
+    expect(order).toEqual(['scene.unload:start', 'scene.unload:end', 'loader.destroy', 'tweens.destroy']);
+  });
 });

--- a/test/core/scene-director.test.ts
+++ b/test/core/scene-director.test.ts
@@ -2327,6 +2327,41 @@ describe('SceneDirector._abortInFlightNavigation() (Slice 7 Group B, §3.7)', ()
     expect(director._abortInFlightNavigation(new SceneNavigationAbortedError())).toBe(false);
   });
 
+  test('rejects a direct (non-transitioned) change() when the frame loop stops mid-prepare', async () => {
+    const app = createApplicationStub();
+    const First = makeSceneClass();
+    let resolveLoad!: () => void;
+    const SlowLoad = makeSceneClass({
+      load: () =>
+        new Promise<void>(resolve => {
+          resolveLoad = resolve;
+        }),
+    });
+    const director = new SceneDirector(app, { first: First, slow: SlowLoad });
+
+    await director.change(First);
+    const firstInstance = director.currentScene;
+
+    // Direct fast path: commitSwitch runs immediately and is now suspended
+    // awaiting SlowLoad.load(). No transition session is involved.
+    const navigation = director.change(SlowLoad);
+
+    void navigation.catch(() => undefined);
+    await Promise.resolve(); // let commitSwitch reach its prepare await
+
+    // SlowLoad's load()/init() is still pending — abort now, exactly what
+    // Application._stopFrameLoop() does on stop()/a fatal frame error. There
+    // is no session, so this returns false but still bumps the generation.
+    expect(director._abortInFlightNavigation(new SceneNavigationAbortedError())).toBe(false);
+
+    // Unblock load() so commitSwitch's continuation resumes: it must observe
+    // the generation bump and reject rather than commit the switch.
+    resolveLoad();
+
+    await expect(navigation).rejects.toThrow(SceneNavigationAbortedError);
+    expect(director.currentScene).toBe(firstInstance); // outgoing scene untouched
+  });
+
   test('a claimed _preloaded entry is restored (status "ready", back in _preloaded) when the change() consuming it is aborted pre-commit', async () => {
     const app = createApplicationStub();
     const GameScene = makeSceneClass();

--- a/test/core/scene-director.test.ts
+++ b/test/core/scene-director.test.ts
@@ -409,6 +409,23 @@ describe('SceneDirector', () => {
     expect(unload).toHaveBeenCalledTimes(1);
   });
 
+  test("_clearScene() dispatches onChangeScene(null) before onStopScene — matches change()/restore()'s new-scene-signals-before-outgoing-teardown order", async () => {
+    const app = createApplicationStub();
+    const TestScene = makeSceneClass();
+    const manager = new SceneDirector(app, { test: TestScene });
+    const order: string[] = [];
+
+    manager.onChangeScene.add(() => order.push('onChangeScene'));
+    manager.onStopScene.add(() => order.push('onStopScene'));
+
+    await manager.change(TestScene);
+    order.length = 0; // clear the change()-triggered dispatches above
+
+    await manager._clearScene();
+
+    expect(order).toEqual(['onChangeScene', 'onStopScene']);
+  });
+
   test('rejects setScene() targeting an unregistered constructor', async () => {
     class UnregisteredScene extends Scene {}
     const manager = new SceneDirector(createApplicationStub(), {});
@@ -806,6 +823,64 @@ describe('SceneDirector — concurrent navigation', () => {
 });
 
 describe('SceneDirector — post-commit signal isolation', () => {
+  test('change(): outgoing unload() starts only after the incoming scope activates and onChangeScene/onStartScene/onStopScene fire, in that order', async () => {
+    const app = createApplicationStub();
+    const order: string[] = [];
+    const FirstScene = makeSceneClass({
+      unload: async () => {
+        order.push('outgoing.unload:start');
+        await Promise.resolve();
+        order.push('outgoing.unload:end');
+      },
+    });
+    const SecondScene = makeSceneClass();
+    const director = new SceneDirector(app, { first: FirstScene, second: SecondScene });
+
+    director.onChangeScene.add(scene => {
+      if (scene instanceof SecondScene) order.push('onChangeScene');
+    });
+    director.onStartScene.add(scene => {
+      if (scene instanceof SecondScene) order.push('onStartScene');
+    });
+    director.onStopScene.add(scene => {
+      if (scene instanceof FirstScene) order.push('onStopScene');
+    });
+
+    await director.change(FirstScene);
+    order.length = 0; // clear the first change()'s own dispatches
+
+    await director.change(SecondScene);
+
+    // The incoming scope's own signals fire, fully, before the outgoing
+    // scope's unload() is even started — not just before it settles.
+    expect(order).toEqual(['onChangeScene', 'onStartScene', 'onStopScene', 'outgoing.unload:start', 'outgoing.unload:end']);
+  });
+
+  test('restore(): signal order is onStateChange before onChangeScene for the restored scene (Scene.onActivate -> Director.onStateChange -> Director.onChangeScene)', async () => {
+    const app = createApplicationStub();
+    const FirstScene = makeSceneClass();
+    const SecondScene = makeSceneClass();
+    const director = new SceneDirector(app, { first: FirstScene, second: SecondScene });
+    const order: string[] = [];
+
+    await director.change(FirstScene);
+    await director.change(SecondScene, { suspendCurrent: true }); // retains First
+
+    // Every SceneScope dispatches onStateChange for its own lifecycle
+    // transitions (Preparing->Active, ->Destroying, etc.) — restore() here
+    // also permanently ends the outgoing SecondScene, which fires several
+    // onStateChange events of its own. Only the restored FirstScene's own
+    // Suspended->Active edge is the one this test's ordering claim is about.
+    director.onStateChange.add((_previous, _next, scene) => {
+      if (scene instanceof FirstScene) order.push('onStateChange');
+    });
+    director.onChangeScene.add(() => order.push('onChangeScene'));
+
+    await director.restore(FirstScene);
+
+    expect(order).toEqual(['onStateChange', 'onChangeScene']);
+  });
+
   test('a throwing onStopScene listener does not roll back — the switch stays committed and change() still resolves', async () => {
     const app = createApplicationStub();
     const FirstScene = makeSceneClass();
@@ -925,6 +1000,41 @@ describe('SceneDirector — destroy() / _dispose()', () => {
 
     // Active (Third) first, then retained in reverse insertion order: Second before First.
     expect(order).toEqual(['ThirdScene', 'SecondScene', 'FirstScene']);
+  });
+
+  test('_dispose() awaits a pending outgoing teardown left in flight by a fire-and-forget _clearScene() (Application.stop() then destroy())', async () => {
+    const app = createApplicationStub();
+    let resolveUnload!: () => void;
+    const FirstScene = makeSceneClass({
+      unload: () =>
+        new Promise<void>(resolve => {
+          resolveUnload = resolve;
+        }),
+    });
+    const director = new SceneDirector(app, { first: FirstScene });
+
+    await director.change(FirstScene);
+
+    // Fire-and-forget, matching Application.stop()'s real usage — the
+    // caller does not await _clearScene() before calling destroy()/_dispose().
+    void director._clearScene();
+
+    const disposePromise = director._dispose();
+    let disposeSettled = false;
+
+    void disposePromise.then(() => {
+      disposeSettled = true;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(disposeSettled).toBe(false); // _dispose() must not resolve while unload() is still pending
+
+    resolveUnload();
+    await disposePromise;
+
+    expect(disposeSettled).toBe(true);
   });
 
   test('destroy() (sync façade) fires _dispose() without the caller awaiting it', async () => {
@@ -2030,6 +2140,45 @@ describe('SceneDirector — transition lifecycle contract', () => {
     tick(manager, app);
 
     await expect(navigation).rejects.toThrow(SceneTransitionLifecycleError);
+  });
+
+  test('settles the navigation promise even when releasing transition resources throws', async () => {
+    const app = createApplicationStub();
+    const First = makeSceneClass();
+    const Second = makeSceneClass();
+    const manager = new SceneDirector(app, { first: First, second: Second });
+
+    await manager.change(First);
+
+    (app.backend.releaseRenderTexture as MockInstance).mockImplementation(() => {
+      throw new Error('releaseRenderTexture exploded');
+    });
+
+    let environmentRef: SceneTransitionEnvironment | null = null;
+    const session = new FakeSession();
+    const transition = new (class extends SceneTransition {
+      public getRequirements(): SceneTransitionRequirements {
+        return { outgoingFrame: 'none', currentFrame: 'texture' };
+      }
+      protected override createSession(environment: SceneTransitionEnvironment): SceneTransitionSession {
+        environmentRef = environment;
+
+        return session;
+      }
+    })();
+
+    const navigation = manager.change(Second, { transition });
+
+    environmentRef?.commit();
+    tick(manager, app);
+    await settle();
+    session.done = true;
+    tick(manager, app);
+
+    // Without the fix, release() throwing inside _finishActiveSession (which
+    // ran outside its try/finally) would skip settle() and this would hang
+    // until the test's timeout instead of resolving.
+    await expect(navigation).resolves.toBe(manager);
   });
 
   test('post-commit session failure (update throws) rejects the navigation but the new scene stays live', async () => {

--- a/test/core/scene-director.test.ts
+++ b/test/core/scene-director.test.ts
@@ -1740,6 +1740,66 @@ describe('SceneDirector — transition resource provisioning (§3.4, §3.7a)', (
     await navigation;
   });
 
+  test('releases the acquired snapshot texture if capturing it throws', async () => {
+    const app = createApplicationStub();
+    const First = makeSceneClass({
+      draw: () => {
+        throw new Error('draw exploded');
+      },
+    });
+    const Second = makeSceneClass();
+    const manager = new SceneDirector(app, { first: First, second: Second });
+
+    await manager.change(First);
+
+    const session = new FakeSession();
+    const transition = new (class extends SceneTransition {
+      public getRequirements(): SceneTransitionRequirements {
+        return { outgoingFrame: 'snapshot', currentFrame: 'none' };
+      }
+      protected override createSession(): SceneTransitionSession {
+        return session;
+      }
+    })();
+
+    await expect(manager.change(Second, { transition })).rejects.toThrow('draw exploded');
+    expect(app.backend.releaseRenderTexture).toHaveBeenCalled();
+  });
+
+  test('releases an already-acquired snapshot texture if acquiring the current texture then fails', async () => {
+    const app = createApplicationStub();
+    const First = makeSceneClass();
+    const Second = makeSceneClass();
+    const manager = new SceneDirector(app, { first: First, second: Second });
+
+    await manager.change(First);
+
+    let acquireCalls = 0;
+
+    (app.backend.acquireRenderTexture as MockInstance).mockImplementation((width: number, height: number) => {
+      acquireCalls++;
+
+      if (acquireCalls === 2) {
+        throw new Error('second acquire exploded');
+      }
+
+      return new RenderTexture(width, height);
+    });
+
+    const session = new FakeSession();
+    const transition = new (class extends SceneTransition {
+      public getRequirements(): SceneTransitionRequirements {
+        return { outgoingFrame: 'snapshot', currentFrame: 'texture' };
+      }
+      protected override createSession(): SceneTransitionSession {
+        return session;
+      }
+    })();
+
+    await expect(manager.change(Second, { transition })).rejects.toThrow('second acquire exploded');
+    expect(app.backend.releaseRenderTexture).toHaveBeenCalledTimes(1); // the snapshot, released after the second acquire failed
+  });
+
   test('outgoingFrame: "snapshot" is skipped (frame.outgoing stays null) when there is no outgoing scene', async () => {
     const app = createApplicationStub();
     const First = makeSceneClass();

--- a/test/core/scene-director.test.ts
+++ b/test/core/scene-director.test.ts
@@ -1524,6 +1524,77 @@ describe('SceneDirector — transition session driving', () => {
     // Post-commit failure: the new scene stays live, never rolled back.
     expect(manager.currentScene).toBeInstanceOf(OtherScene);
   });
+
+  test('a session that self-terminates (update() throws) mid-commit — after commitSwitch began its async prepare but before it resolved — does NOT activate the incoming scene once prepare later resolves (§3.7 session-identity guard)', async () => {
+    const app = createApplicationStub();
+    const First = makeSceneClass();
+
+    // Incoming scene whose load() we hold open, keeping commitSwitch suspended
+    // inside its prepare() window while the session keeps being driven.
+    let resolveLoad!: () => void;
+    const incomingInit = vi.fn();
+    const Second = makeSceneClass({
+      load: () =>
+        new Promise<void>(resolve => {
+          resolveLoad = resolve;
+        }),
+      init: incomingInit,
+    });
+    const manager = new SceneDirector(app, { first: First, second: Second });
+
+    await manager.change(First);
+    const firstInstance = manager.currentScene;
+
+    let environmentRef: SceneTransitionEnvironment | null = null;
+    const session = new FakeSession();
+    const transition = new (class extends SceneTransition {
+      public getRequirements(): SceneTransitionRequirements {
+        return { outgoingFrame: 'none', currentFrame: 'none' };
+      }
+      protected override createSession(environment: SceneTransitionEnvironment): SceneTransitionSession {
+        environmentRef = environment;
+
+        return session;
+      }
+    })();
+
+    const navigation = manager.change(Second, { transition });
+
+    // The session requests commit; this tick kicks off commitSwitch, which then
+    // suspends on the incoming scene's still-pending load() — the async prepare
+    // window this bug lives in.
+    environmentRef?.commit();
+    tick(manager, app);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(incomingInit).not.toHaveBeenCalled(); // still mid-load(): prepare hasn't resolved
+    expect(manager.currentScene).toBe(firstInstance); // not switched yet
+
+    // The session self-terminates DURING that window WITHOUT going through
+    // `_abortInFlightNavigation`: `session.update()` throws, so
+    // `_updateTransition` calls `_finishActiveSession` directly — rejecting the
+    // navigation and clearing `_activeSession`, but NOT bumping
+    // `_navigationGeneration`. The generation term of the §3.7 guard therefore
+    // cannot detect this; only the session-identity term can.
+    session.update = () => {
+      throw new Error('session update blew up mid-prepare');
+    };
+    tick(manager, app);
+
+    // The navigation rejects from the session's own thrown error (settled by
+    // `_finishActiveSession`), not from a second error thrown by commitSwitch.
+    await expect(navigation).rejects.toThrow('session update blew up mid-prepare');
+
+    // Now prepare finally resolves and commitSwitch's continuation resumes. Its
+    // §3.7 guard must hit the session-identity bail (generation is unchanged, so
+    // the generation term alone would MISS this) and dispose the freshly-prepared
+    // scope instead of activating it.
+    resolveLoad();
+    await settle();
+
+    expect(incomingInit).toHaveBeenCalledTimes(1); // prepare did run to completion (reached Ready) ...
+    expect(manager.currentScene).toBe(firstInstance); // ... but the incoming scene was NEVER activated
+  });
 });
 
 describe('SceneDirector — transition resource provisioning (§3.4, §3.7a)', () => {

--- a/test/core/scene-director.test.ts
+++ b/test/core/scene-director.test.ts
@@ -959,6 +959,60 @@ describe('SceneDirector — destroy() / _dispose()', () => {
 
     void pending.catch(() => {});
   });
+
+  test('_dispose() destroys a Ready (never-consumed) preloaded scope', async () => {
+    const app = createApplicationStub();
+    const PreloadedScene = makeSceneClass();
+    const director = new SceneDirector(app, { preloaded: PreloadedScene });
+    const destroySpy = vi.spyOn(Scene.prototype, 'destroy');
+    const stopSceneSpy = vi.fn();
+
+    director.onStopScene.add(stopSceneSpy);
+
+    await director.preload(PreloadedScene); // reaches Ready but is never consumed by change()
+
+    await director._dispose();
+
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+    expect(stopSceneSpy).not.toHaveBeenCalled(); // never activated — onStopScene must not fire for it
+
+    destroySpy.mockRestore();
+  });
+
+  test('_dispose() waits for an in-flight preload to settle, then destroys it without concurrent teardown', async () => {
+    const app = createApplicationStub();
+    let resolveLoad!: () => void;
+    const initSpy = vi.fn();
+    const destroySpy = vi.spyOn(Scene.prototype, 'destroy');
+    const SlowScene = makeSceneClass({
+      load: () =>
+        new Promise<void>(resolve => {
+          resolveLoad = resolve;
+        }),
+      init: initSpy,
+    });
+    const director = new SceneDirector(app, { slow: SlowScene });
+
+    const preloadPromise = director.preload(SlowScene);
+    const disposePromise = director._dispose();
+
+    // Still mid-load() — _dispose() must be waiting on prepare() to settle,
+    // not tearing anything down concurrently.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(destroySpy).not.toHaveBeenCalled();
+    expect(initSpy).not.toHaveBeenCalled(); // load() hasn't even resolved yet
+
+    resolveLoad();
+
+    await expect(preloadPromise).resolves.toBeUndefined(); // prepare() itself still succeeds
+    await disposePromise;
+
+    expect(initSpy).toHaveBeenCalledTimes(1); // prepare() ran to completion (reached Ready), not aborted mid-way
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+
+    destroySpy.mockRestore();
+  });
 });
 
 describe('SceneDirector — key-based navigation', () => {

--- a/test/core/scene-director.test.ts
+++ b/test/core/scene-director.test.ts
@@ -1945,6 +1945,33 @@ describe('SceneDirector — transition lifecycle contract', () => {
     expect(session.destroyCallCount).toBe(1);
   });
 
+  test('settles the navigation promise even when an onError listener throws', async () => {
+    const app = createApplicationStub();
+    const First = makeSceneClass();
+    const Second = makeSceneClass();
+    const manager = new SceneDirector(app, { first: First, second: Second });
+
+    await manager.change(First);
+
+    app.onError.add(() => {
+      throw new Error('listener exploded');
+    });
+
+    const session = new FakeSession();
+    const transition = new FakeTransition(session);
+
+    const navigation = manager.change(Second, { transition });
+
+    // done === true before commit() was ever called -> a 'done-before-commit'
+    // lifecycle error, which is exactly what previously hit the unguarded
+    // onError.dispatch() and, with a throwing listener, would have skipped
+    // settle() and left `navigation` hanging forever.
+    session.done = true;
+    tick(manager, app);
+
+    await expect(navigation).rejects.toThrow(SceneTransitionLifecycleError);
+  });
+
   test('post-commit session failure (update throws) rejects the navigation but the new scene stays live', async () => {
     const app = createApplicationStub();
     const First = makeSceneClass();

--- a/test/core/scene-director.test.ts
+++ b/test/core/scene-director.test.ts
@@ -1771,6 +1771,79 @@ describe('SceneDirector — transition resource provisioning (§3.4, §3.7a)', (
     await expect(navigation).rejects.toThrow(SceneTransitionLifecycleError);
   });
 
+  test('finishes the active session (not hangs) when session.done throws', async () => {
+    const app = createApplicationStub();
+    const First = makeSceneClass();
+    const Second = makeSceneClass();
+    const manager = new SceneDirector(app, { first: First, second: Second });
+
+    await manager.change(First);
+
+    class ThrowingDoneSession implements SceneTransitionSession {
+      public placement: 'scene' | 'screen' = 'screen';
+
+      public get done(): boolean {
+        throw new Error('done getter exploded');
+      }
+
+      public update(): void {}
+      public render(): void {}
+      public destroy(): void {}
+    }
+
+    const transition = new (class extends SceneTransition {
+      public getRequirements(): SceneTransitionRequirements {
+        return { outgoingFrame: 'none', currentFrame: 'none' };
+      }
+      protected override createSession(): SceneTransitionSession {
+        return new ThrowingDoneSession();
+      }
+    })();
+
+    const navigation = manager.change(Second, { transition });
+
+    manager._renderTransition(app.rendering);
+
+    await expect(navigation).rejects.toThrow('done getter exploded');
+    expect(manager._transitionPlacement()).toBeNull(); // session was torn down, not left dangling
+  });
+
+  test('finishes the active session (not hangs) when session.placement throws', async () => {
+    const app = createApplicationStub();
+    const First = makeSceneClass();
+    const Second = makeSceneClass();
+    const manager = new SceneDirector(app, { first: First, second: Second });
+
+    await manager.change(First);
+
+    class ThrowingPlacementSession implements SceneTransitionSession {
+      public done = false;
+
+      public get placement(): 'scene' | 'screen' {
+        throw new Error('placement getter exploded');
+      }
+
+      public update(): void {}
+      public render(): void {}
+      public destroy(): void {}
+    }
+
+    const transition = new (class extends SceneTransition {
+      public getRequirements(): SceneTransitionRequirements {
+        return { outgoingFrame: 'none', currentFrame: 'none' };
+      }
+      protected override createSession(): SceneTransitionSession {
+        return new ThrowingPlacementSession();
+      }
+    })();
+
+    const navigation = manager.change(Second, { transition });
+
+    expect(manager._transitionPlacement()).toBeNull();
+
+    await expect(navigation).rejects.toThrow('placement getter exploded');
+  });
+
   test('the pooled "current" texture resizes when the canvas resizes mid-session', async () => {
     const app = createApplicationStub();
     const TestScene = makeSceneClass();

--- a/test/core/scene/scene-navigation-transaction.test.ts
+++ b/test/core/scene/scene-navigation-transaction.test.ts
@@ -29,21 +29,20 @@ const makeFakeScope = (state: SceneState = SceneState.Active): SceneScope & { st
 };
 
 describe('SceneNavigationTransaction', () => {
-  describe('beginOutgoingDisposition()', () => {
-    test('with no outgoing scope, resolves immediately with a null pendingStopScene', () => {
+  describe('prepareOutgoingDisposition()', () => {
+    test('with no outgoing scope, returns a null pendingStopScene', () => {
       const retained = new Map<AnySceneConstructor, SceneScope>();
       const onStopScene = new Signal<[Scene]>();
       const onStateChange = new Signal<[SceneState, SceneState, Scene]>();
       const reportError = vi.fn();
       const transaction = new SceneNavigationTransaction(retained, onStopScene, onStateChange, reportError);
 
-      const result = transaction.beginOutgoingDisposition(null, false);
+      const result = transaction.prepareOutgoingDisposition(null, false);
 
       expect(result.pendingStopScene).toBeNull();
-      return expect(result.teardown).resolves.toBeUndefined();
     });
 
-    test('suspendCurrent: true suspends the outgoing scope, retains it, and dispatches onStateChange — no pending onStopScene', async () => {
+    test('suspendCurrent: true suspends the outgoing scope, retains it, and dispatches onStateChange — no pending onStopScene', () => {
       const retained = new Map<AnySceneConstructor, SceneScope>();
       const onStopScene = new Signal<[Scene]>();
       const onStateChange = new Signal<[SceneState, SceneState, Scene]>();
@@ -54,16 +53,15 @@ describe('SceneNavigationTransaction', () => {
 
       onStateChange.add(onStateChangeSpy);
 
-      const result = transaction.beginOutgoingDisposition({ scope, target: FakeTarget }, true);
+      const result = transaction.prepareOutgoingDisposition({ scope, target: FakeTarget }, true);
 
       expect(scope.suspend).toHaveBeenCalledTimes(1);
       expect(retained.get(FakeTarget)).toBe(scope);
       expect(onStateChangeSpy).toHaveBeenCalledWith(SceneState.Active, SceneState.Suspended, scope.scene);
       expect(result.pendingStopScene).toBeNull();
-      await expect(result.teardown).resolves.toBeUndefined();
     });
 
-    test('suspendCurrent: false begins permanent teardown and returns the scope as pendingStopScene', () => {
+    test('suspendCurrent: false returns the scope as pendingStopScene WITHOUT starting its teardown', () => {
       const retained = new Map<AnySceneConstructor, SceneScope>();
       const onStopScene = new Signal<[Scene]>();
       const onStateChange = new Signal<[SceneState, SceneState, Scene]>();
@@ -71,9 +69,9 @@ describe('SceneNavigationTransaction', () => {
       const transaction = new SceneNavigationTransaction(retained, onStopScene, onStateChange, reportError);
       const scope = makeFakeScope(SceneState.Active);
 
-      const result = transaction.beginOutgoingDisposition({ scope, target: FakeTarget }, false);
+      const result = transaction.prepareOutgoingDisposition({ scope, target: FakeTarget }, false);
 
-      expect(scope.destroy).toHaveBeenCalledTimes(1);
+      expect(scope.destroy).not.toHaveBeenCalled();
       expect(result.pendingStopScene).toBe(scope);
       expect(retained.has(FakeTarget)).toBe(false);
     });
@@ -91,19 +89,36 @@ describe('SceneNavigationTransaction', () => {
         throw failure;
       });
 
-      expect(() => transaction.beginOutgoingDisposition({ scope, target: FakeTarget }, true)).not.toThrow();
+      expect(() => transaction.prepareOutgoingDisposition({ scope, target: FakeTarget }, true)).not.toThrow();
       expect(retained.get(FakeTarget)).toBe(scope);
       expect(reportError).toHaveBeenCalledWith(failure);
     });
+
+    test('does not start teardown until beginOutgoingTeardown is called', () => {
+      const onStopScene = new Signal<[Scene]>();
+      const onStateChange = new Signal<[SceneState, SceneState, Scene]>();
+      const reportError = vi.fn();
+      const transaction = new SceneNavigationTransaction(new Map(), onStopScene, onStateChange, reportError);
+      const scope = makeFakeScope(SceneState.Active);
+
+      const { pendingStopScene } = transaction.prepareOutgoingDisposition({ scope, target: FakeTarget }, false);
+
+      expect(scope.destroy).not.toHaveBeenCalled();
+
+      transaction.dispatchStopScene(pendingStopScene);
+      transaction.beginOutgoingTeardown(pendingStopScene);
+
+      expect(scope.destroy).toHaveBeenCalledTimes(1);
+    });
   });
 
-  describe('finishOutgoingDisposition()', () => {
+  describe('dispatchStopScene()', () => {
     test('with null, is a no-op', () => {
       const onStopScene = new Signal<[Scene]>();
       const dispatchSpy = vi.spyOn(onStopScene, 'dispatch');
       const transaction = new SceneNavigationTransaction(new Map(), onStopScene, new Signal<[SceneState, SceneState, Scene]>(), vi.fn());
 
-      expect(() => transaction.finishOutgoingDisposition(null)).not.toThrow();
+      expect(() => transaction.dispatchStopScene(null)).not.toThrow();
       expect(dispatchSpy).not.toHaveBeenCalled();
     });
 
@@ -114,7 +129,7 @@ describe('SceneNavigationTransaction', () => {
       const scope = makeFakeScope(SceneState.Destroying);
 
       onStopScene.add(onStopSceneSpy);
-      transaction.finishOutgoingDisposition(scope);
+      transaction.dispatchStopScene(scope);
 
       expect(onStopSceneSpy).toHaveBeenCalledWith(scope.scene);
     });
@@ -130,8 +145,26 @@ describe('SceneNavigationTransaction', () => {
         throw failure;
       });
 
-      expect(() => transaction.finishOutgoingDisposition(scope)).not.toThrow();
+      expect(() => transaction.dispatchStopScene(scope)).not.toThrow();
       expect(reportError).toHaveBeenCalledWith(failure);
+    });
+  });
+
+  describe('beginOutgoingTeardown()', () => {
+    test('with null, resolves immediately without tearing anything down', () => {
+      const transaction = new SceneNavigationTransaction(new Map(), new Signal<[Scene]>(), new Signal<[SceneState, SceneState, Scene]>(), vi.fn());
+
+      return expect(transaction.beginOutgoingTeardown(null)).resolves.toBeUndefined();
+    });
+
+    test('with a scope, starts its permanent teardown and returns the settling promise', async () => {
+      const transaction = new SceneNavigationTransaction(new Map(), new Signal<[Scene]>(), new Signal<[SceneState, SceneState, Scene]>(), vi.fn());
+      const scope = makeFakeScope(SceneState.Destroying);
+
+      const teardown = transaction.beginOutgoingTeardown(scope);
+
+      expect(scope.destroy).toHaveBeenCalledTimes(1);
+      await expect(teardown).resolves.toBeUndefined();
     });
   });
 });

--- a/test/core/transitions/fade-scene-transition.test.ts
+++ b/test/core/transitions/fade-scene-transition.test.ts
@@ -1,7 +1,8 @@
 import { Ease } from '#animation/Easing';
 import { Color } from '#core/Color';
 import type { SceneTransitionPhaseContext, SceneTransitionPhaseRequirements } from '#core/PhasedSceneTransition';
-import type { SceneTransitionContext } from '#core/SceneTransition';
+import type { SceneTransitionContext, SceneTransitionEnvironment } from '#core/SceneTransition';
+import { Time } from '#core/Time';
 import { FadeSceneTransition } from '#core/transitions/FadeSceneTransition';
 import type { Matrix } from '#math/Matrix';
 import { QuadGeometry } from '#rendering/geometry/QuadGeometry';
@@ -12,11 +13,13 @@ import { QuadGeometry } from '#rendering/geometry/QuadGeometry';
 // PhasedSceneTransition's own session machinery (already covered by Slice 6's
 // test suite).
 class TestableFadeSceneTransition extends FadeSceneTransition {
+  private readonly _testState = this._createPhaseStateForSession();
+
   public callEnter(context: SceneTransitionPhaseContext): void {
-    this.enter(context);
+    this.enter(context, this._testState);
   }
   public callExit(context: SceneTransitionPhaseContext): void {
-    this.exit(context);
+    this.exit(context, this._testState);
   }
   public callGetPhaseRequirements(phase: 'enter' | 'exit', context: SceneTransitionContext): SceneTransitionPhaseRequirements {
     return this.getPhaseRequirements(phase, context);
@@ -44,6 +47,27 @@ const stubContext = (overrides: Partial<SceneTransitionPhaseContext> = {}): Scen
 });
 
 const navContext: SceneTransitionContext = { operation: 'change', hasOutgoingScene: true, hasIncomingScene: true };
+
+// Minimal SceneTransitionEnvironment for driving a real session through
+// FadeSceneTransition.beginSession().
+class TestEnvironment implements SceneTransitionEnvironment {
+  public readonly context = navContext;
+  private _committed = false;
+  private _commitRequested = false;
+
+  public get commitRequested(): boolean {
+    return this._commitRequested;
+  }
+
+  public get committed(): boolean {
+    return this._committed;
+  }
+
+  public commit(): void {
+    this._commitRequested = true;
+    this._committed = true;
+  }
+}
 
 describe('FadeSceneTransition', () => {
   test('defaults: color black, duration 220, linear easing, placement screen', () => {
@@ -123,5 +147,31 @@ describe('FadeSceneTransition', () => {
 
     const [, , options] = drawGeometry.mock.calls[0] as [QuadGeometry, Matrix, { tint: Color }];
     expect(options.tint.a).toBe(1);
+  });
+
+  test('does not share mutable scratch state between two sessions of the same reused definition', () => {
+    const shared = new FadeSceneTransition();
+    const sessionA = shared.beginSession(new TestEnvironment());
+    const sessionB = shared.beginSession(new TestEnvironment());
+
+    // Drive A to a different presence than B, then render both — if they
+    // shared one Color/Matrix/QuadGeometry on the definition, the second
+    // render() call would clobber the first's tint alpha before A's draw
+    // call actually reads it back.
+    sessionA.update(new Time(50));
+    sessionB.update(new Time(10));
+
+    const drawGeometryA = vi.fn();
+    const drawGeometryB = vi.fn();
+
+    sessionA.render(stubRendering(drawGeometryA), { outgoing: null, current: null, committed: false });
+    sessionB.render(stubRendering(drawGeometryB), { outgoing: null, current: null, committed: false });
+
+    const [quadA, , optionsA] = drawGeometryA.mock.calls[0] as [QuadGeometry, Matrix, { tint: Color }];
+    const [quadB, , optionsB] = drawGeometryB.mock.calls[0] as [QuadGeometry, Matrix, { tint: Color }];
+
+    expect(quadA).not.toBe(quadB); // different object identity — proves no shared scratch QuadGeometry
+    expect(optionsA.tint).not.toBe(optionsB.tint); // different object identity — proves no shared scratch Color
+    expect(optionsA.tint.a).not.toBeCloseTo(optionsB.tint.a); // different progress -> different alpha, would have been clobbered if shared
   });
 });

--- a/test/core/transitions/slide-scene-transition.test.ts
+++ b/test/core/transitions/slide-scene-transition.test.ts
@@ -5,13 +5,18 @@ import { SlideSceneTransition } from '#core/transitions/SlideSceneTransition';
 import type { Sprite } from '#rendering/sprite/Sprite';
 
 // Exposes the protected authoring hooks through public wrappers — same
-// pattern as FadeSceneTransition's test suite (Task 1).
+// pattern as FadeSceneTransition's test suite (Task 1). Scratch state is
+// created once per instance and reused across callEnter()/callExit() calls
+// on that same instance — matching how a real session drives one phase's
+// state across its own frames.
 class TestableSlideSceneTransition extends SlideSceneTransition {
+  private readonly _testState = this._createPhaseStateForSession();
+
   public callEnter(context: SceneTransitionPhaseContext): void {
-    this.enter(context);
+    this.enter(context, this._testState);
   }
   public callExit(context: SceneTransitionPhaseContext): void {
-    this.exit(context);
+    this.exit(context, this._testState);
   }
   public callGetPhaseRequirements(phase: 'enter' | 'exit', context: SceneTransitionContext): SceneTransitionPhaseRequirements {
     return this.getPhaseRequirements(phase, context);

--- a/test/core/transitions/slide-scene-transition.test.ts
+++ b/test/core/transitions/slide-scene-transition.test.ts
@@ -1,5 +1,6 @@
 import type { SceneTransitionPhaseContext, SceneTransitionPhaseRequirements } from '#core/PhasedSceneTransition';
-import type { SceneTransitionContext } from '#core/SceneTransition';
+import type { SceneTransitionContext, SceneTransitionEnvironment } from '#core/SceneTransition';
+import { Time } from '#core/Time';
 import { SlideSceneTransition } from '#core/transitions/SlideSceneTransition';
 import type { Sprite } from '#rendering/sprite/Sprite';
 
@@ -18,6 +19,28 @@ class TestableSlideSceneTransition extends SlideSceneTransition {
 }
 
 const navContext: SceneTransitionContext = { operation: 'change', hasOutgoingScene: true, hasIncomingScene: true };
+
+// Minimal SceneTransitionEnvironment for driving a real session through
+// SlideSceneTransition.beginSession() — mirrors phased-scene-transition.test.ts's
+// own TestEnvironment fixture (a fake that settles commit() synchronously).
+class TestEnvironment implements SceneTransitionEnvironment {
+  public readonly context = navContext;
+  private _committed = false;
+  private _commitRequested = false;
+
+  public get commitRequested(): boolean {
+    return this._commitRequested;
+  }
+
+  public get committed(): boolean {
+    return this._committed;
+  }
+
+  public commit(): void {
+    this._commitRequested = true;
+    this._committed = true;
+  }
+}
 
 // The real SceneTransitionPhaseContext['rendering'] is a RenderingContext.
 // SlideSceneTransition draws a Sprite via rendering.render(sprite, { view }),
@@ -113,6 +136,23 @@ describe('SlideSceneTransition', () => {
       expect(node.x).toBe(0);
       expect(node.y).toBe(-600);
     });
+
+    test('no identity-composite draw through a real session — both phases already declare currentFrame texture themselves, so the promotion branch never fires', () => {
+      const slide = new SlideSceneTransition({ mode: 'push', duration: 100 });
+      const environment = new TestEnvironment();
+      const session = slide.beginSession(environment);
+      const render = vi.fn();
+      const rendering = stubRendering(render);
+      const currentTexture = { current: true } as never;
+
+      session.update(new Time(1));
+      session.render(rendering, { outgoing: null, current: currentTexture, committed: false });
+
+      // Exactly the phase's own slide draw — no extra identity-composite
+      // call ahead of it, since push's exit already declares `texture`
+      // itself (ownRequirements.currentFrame === 'texture').
+      expect(render).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('mode: reveal', () => {
@@ -132,6 +172,32 @@ describe('SlideSceneTransition', () => {
 
       expect(render).not.toHaveBeenCalled();
     });
+
+    test('composites frame.current unchanged during the enter phase — the session-wide requirement was promoted to texture by the exit phase, but enter itself only declared direct', () => {
+      const slide = new SlideSceneTransition({ mode: 'reveal', duration: 100 });
+      const environment = new TestEnvironment();
+      const session = slide.beginSession(environment);
+      const render = vi.fn();
+      const rendering = stubRendering(render);
+      const currentTexture = { current: true } as never;
+
+      // Drive past exit (100ms) — requests commit — then one more update()
+      // to observe `committed` and switch into the enter phase.
+      session.update(new Time(100));
+      session.update(new Time(1));
+
+      session.render(rendering, { outgoing: null, current: currentTexture, committed: true });
+
+      // reveal mode's enter() is an intentional no-op — without the
+      // identity-composite fix, render() was never called here and the
+      // screen showed only clear color for the whole enter phase.
+      expect(render).toHaveBeenCalledTimes(1);
+      const [drawnSprite] = render.mock.calls[0] as [Sprite];
+      expect(drawnSprite.texture).toBe(currentTexture);
+      expect(drawnSprite.x).toBe(0);
+      expect(drawnSprite.y).toBe(0);
+      expect(drawnSprite.tint.a).toBe(1);
+    });
   });
 
   describe('mode: cover', () => {
@@ -150,6 +216,29 @@ describe('SlideSceneTransition', () => {
       slide.callExit(stubContext({ phase: 'exit', presence: 1, rendering }));
 
       expect(render).not.toHaveBeenCalled();
+    });
+
+    test('composites frame.current unchanged during the exit phase — the session-wide requirement was promoted to texture by the enter phase, but exit itself only declared direct', () => {
+      const slide = new SlideSceneTransition({ mode: 'cover', duration: 100 });
+      const environment = new TestEnvironment();
+      const session = slide.beginSession(environment);
+      const render = vi.fn();
+      const rendering = stubRendering(render);
+      const currentTexture = { current: true } as never;
+
+      session.update(new Time(1));
+      session.render(rendering, { outgoing: null, current: currentTexture, committed: false });
+
+      // cover mode's exit() is an intentional no-op (the outgoing scene
+      // stays static) — without the identity-composite fix, render() was
+      // never called here and the screen showed only clear color for the
+      // whole exit phase.
+      expect(render).toHaveBeenCalledTimes(1);
+      const [drawnSprite] = render.mock.calls[0] as [Sprite];
+      expect(drawnSprite.texture).toBe(currentTexture);
+      expect(drawnSprite.x).toBe(0);
+      expect(drawnSprite.y).toBe(0);
+      expect(drawnSprite.tint.a).toBe(1);
     });
 
     test('enter() draws the frozen outgoing snapshot at full opacity behind the sliding incoming texture', () => {

--- a/test/type-tests/application-registry.type-test.ts
+++ b/test/type-tests/application-registry.type-test.ts
@@ -40,4 +40,22 @@ new Application({ scenes: { bad: NotAScene } });
 // @ts-expect-error — NotAScene is not a Scene subclass constructor
 new Application({ scenes: { bad: { scene: NotAScene } } });
 
+// start() accepts a registered string key directly (no cast/bridge type).
+void typedApp.start('title');
+void typedApp.start('game', { data: { level: 1 } });
+
+// start()'s constructor overload is constrained to the registry
+// (NavigableSceneConstructor<Registry>) — an unregistered constructor is
+// rejected at compile time, not just by the dev-only UnregisteredSceneError
+// runtime check. A data-bearing registry entry is needed to observe this —
+// an empty, data-less scene subclass would be structurally identical to
+// TitleScene (structural typing can't tell two empty classes apart) and TS
+// would accept it despite not being registered; typedApp's registered
+// GameScene (with GameData) gives a genuine structural difference to check
+// against instead.
+class UnregisteredScene extends Scene<{ readonly totallyDifferent: string }> {}
+
+// @ts-expect-error — UnregisteredScene is not in typedApp's registry; start() must reject it at compile time.
+void typedApp.start(UnregisteredScene);
+
 export {};

--- a/test/type-tests/scene-director-registry.type-test.ts
+++ b/test/type-tests/scene-director-registry.type-test.ts
@@ -48,4 +48,22 @@ void registryDirector.change('title', { transition: {} });
 // @ts-expect-error — {} is not a valid SceneTransitionSelection
 void registryDirector.restore('title', { transition: {} });
 
+// change()/restore()'s constructor overload is constrained to the registry
+// (NavigableSceneConstructor<Registry>) — an unregistered constructor is
+// rejected at compile time, not just by the dev-only UnregisteredSceneError
+// runtime check. A data-bearing registry entry is needed to observe this: a
+// registry containing only structurally-empty scenes (like VoidScene above)
+// can never meaningfully reject anything, because structural typing can't
+// tell two empty classes apart — any Scene subclass satisfies "no members
+// required." GameScene's Data shape gives a genuine structural difference
+// to check against.
+declare const gameOnlyDirector: SceneDirector<{ game: typeof GameScene }>;
+
+class UnregisteredScene extends Scene<{ readonly totallyDifferent: string }> {}
+
+// @ts-expect-error — UnregisteredScene is not in gameOnlyDirector's registry; change() must reject it at compile time.
+void gameOnlyDirector.change(UnregisteredScene);
+// @ts-expect-error — UnregisteredScene is not in gameOnlyDirector's registry; restore() must reject it at compile time.
+void gameOnlyDirector.restore(UnregisteredScene);
+
 export {};


### PR DESCRIPTION
## Summary

An external golden-spec conformance review of the 8-slice scene-transition redesign (#404-411) found 13/14 confirmed defects (4 blockers, several High/Medium, plus doc/API mismatches) despite green CI — green CI proved the existing tests pass, not that the full normative contract was exercised. This PR closes all 12 findings from that review, then an independent whole-branch review (opus) of this PR's own diff found further gaps in the fixes themselves, which are also closed here.

### The 4 blockers
- `direct → texture` identity-composite promotion was missing in `PhasedSceneTransitionSession`, breaking the shipped `SlideSceneTransition` in `reveal`/`cover` modes (only clear color rendered for the no-op phase's half of the transition).
- Preloaded scopes leaked on `SceneDirector.destroy()`; `Application.destroy()`'s teardown order was backwards (Loader/Rendering/Audio/Backend destroyed before `scenes.destroy()`, fire-and-forget) — scene `unload()`/facility teardown could run against already-destroyed services.
- The abort contract only covered active transition sessions — a direct (no-transition) navigation wasn't aborted by `stop()` and could commit into a stopped frame loop; a failed `start()` left the RAF loop running forever.
- A throwing `Application.onError` listener hung the navigation promise forever (unguarded `onError.dispatch()` calls before `settle()`, not in a `finally`).

### Also fixed
- Outgoing `Scene.unload()` now starts only after the incoming scope activates and its signals fire (was starting too early, contradicting `onStopScene`'s own contract).
- `restore()`'s signal order corrected to `onStateChange` → `onChangeScene`.
- `SceneTransitionSession.done`/`.placement` getters are now guarded against throwing.
- Transition texture provisioning releases already-acquired resources on partial failure.
- `FadeSceneTransition`/`SlideSceneTransition`'s mutable scratch state moved off the shared (reusable-across-navigations) definition instance into per-session state.
- `Application.start()` gained the documented-but-never-shipped key-based overload (`app.start('key')`); `change()`/`restore()`'s constructor overload is now constrained to the registry.
- Doc/API fixes: `FadeSceneTransition` constructor examples (`duration` belongs in the options argument, not positional `color`), a guard-before-navigate pattern for the loading-screen guide, a corrected description of the React `<Scenes>` mismatched-`active`-prop behavior.

### Second-pass fixes (from an independent review of this PR's own diff)
- `Application.destroy()`'s fire-and-forget teardown had no `.catch()` — a throw from any manager's `destroy()` became an unhandled rejection instead of being reported.
- `SceneDirector._dispose()` never awaited a pending outgoing-scope teardown left in flight by a prior fire-and-forget `_clearScene()` (exactly `Application.stop()`'s real usage pattern) — `destroy()`'s "scenes fully disposed first" guarantee was false in that shape.
- `_finishActiveSession()`'s resource release ran outside the `try`/`finally` guarding `settle()` — a throwing release could hang the navigation promise forever, the exact class of bug the onError-isolation fix above was about.
- `_clearScene()` dispatched signals in the wrong order relative to `change()`/`restore()`/`_forceClearActiveSceneAfterAbort()`.
- The new loading-guide example itself had two bugs (wrong facility for loader signals; throwing `this.state` check instead of the non-throwing `this.attached` probe).
- A test harness mock was missing `_dispose`, silently masking the actual async teardown path it appeared to test.

## Test plan
- [x] `pnpm test` — full suite green (8143 passed)
- [x] `pnpm verify:quick` — clean (typecheck, lint, format, API-docs-sync)
- [x] `pnpm typecheck:examples` / `:packages` / `:type-tests` / `:guides` — all clean
- [x] New regression tests for every fix above, including two ordering guarantees that previously had no test coverage at all
- [x] Independent whole-branch review (opus) of the fix commits themselves, with its own findings closed in a follow-up commit