### PR TITLE
feat(rendering,core)!: safe scene-graph mutations — frozen Container.children, read-only SceneNode.parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,11 +167,15 @@ data?)` or `app.start('game', data?)`; `app.scene.setScene(instance, opts)`
   system rather than stepped manually; `step()` remains available for
   advanced manual driving.
 - **BREAKING — `Container.children` returns a frozen snapshot, not the
-  live array.** `container.children.push(x)` (or any other direct
-  mutation) now throws — mutate the scene graph only through `addChild`/
-  `addChildAt`/`removeChild`/`removeChildAt`/`removeChildren`. The
-  returned `readonly RenderNode[]` is cached and reuses the same
-  reference across reads until the next structural change.
+  live array.** `container.children.push(x)` and other mutating array
+  methods now throw in normal (strict-mode) usage — mutate the scene
+  graph only through `addChild`/`addChildAt`/`removeChild`/
+  `removeChildAt`/`removeChildren`. The returned `readonly RenderNode[]`
+  is cached and reuses the same reference across reads until the next
+  structural change; a reference held before that change keeps
+  reflecting the old membership (`const kids = c.children;
+  c.removeChild(x); kids` still contains `x`) — it does not update
+  in place.
 - **BREAKING — `SceneNode.parent` is no longer directly writable.** The
   public setter is removed; reparenting happens exclusively through the
   same `Container` mutation methods, which now use an internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,7 +174,7 @@ data?)` or `app.start('game', data?)`; `app.scene.setScene(instance, opts)`
   is cached and reuses the same reference across reads until the next
   structural change; a reference held before that change keeps
   reflecting the old membership (`const kids = c.children;
-  c.removeChild(x); kids` still contains `x`) — it does not update
+c.removeChild(x); kids` still contains `x`) — it does not update
   in place.
 - **BREAKING — `SceneNode.parent` is no longer directly writable.** The
   public setter is removed; reparenting happens exclusively through the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,16 @@ data?)` or `app.start('game', data?)`; `app.scene.setScene(instance, opts)`
 - **`@codexo/exojs-physics`:** `PhysicsWorld` should be registered as a
   system rather than stepped manually; `step()` remains available for
   advanced manual driving.
+- **BREAKING — `Container.children` returns a frozen snapshot, not the
+  live array.** `container.children.push(x)` (or any other direct
+  mutation) now throws — mutate the scene graph only through `addChild`/
+  `addChildAt`/`removeChild`/`removeChildAt`/`removeChildren`. The
+  returned `readonly RenderNode[]` is cached and reuses the same
+  reference across reads until the next structural change.
+- **BREAKING — `SceneNode.parent` is no longer directly writable.** The
+  public setter is removed; reparenting happens exclusively through the
+  same `Container` mutation methods, which now use an internal
+  `_setParent()` path.
 
 ### Removed
 

--- a/site/src/content/api/button.json
+++ b/site/src/content/api/button.json
@@ -2683,7 +2683,7 @@
         },
         {
           "name": "children",
-          "signature": "children: RenderNode[]",
+          "signature": "children: readonly RenderNode[]",
           "signatureTokens": [
             {
               "text": "children",
@@ -2691,6 +2691,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
               "kind": "punctuation"
             },
             {
@@ -2704,7 +2712,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Snapshot of the current children in document order. Frozen and cached — repeated reads return the same array reference until the next structural change (addChild/removeChild/setChildIndex/ swapChildren/etc.), which invalidates it. A reference to a previous snapshot is unaffected by later changes — it keeps reflecting the child list as it was at the time of the read. Mutating methods (push, splice, ...) throw in normal (strict-mode) usage; go through addChild/removeChild instead so parent linkage, stage propagation, and bounds invalidation stay consistent."
         },
         {
           "name": "clip",

--- a/site/src/content/api/container.json
+++ b/site/src/content/api/container.json
@@ -2346,7 +2346,7 @@
         },
         {
           "name": "children",
-          "signature": "children: RenderNode[]",
+          "signature": "children: readonly RenderNode[]",
           "signatureTokens": [
             {
               "text": "children",
@@ -2354,6 +2354,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
               "kind": "punctuation"
             },
             {
@@ -2367,7 +2375,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Snapshot of the current children in document order. Frozen and cached — repeated reads return the same array reference until the next structural change (addChild/removeChild/setChildIndex/ swapChildren/etc.), which invalidates it. A reference to a previous snapshot is unaffected by later changes — it keeps reflecting the child list as it was at the time of the read. Mutating methods (push, splice, ...) throw in normal (strict-mode) usage; go through addChild/removeChild instead so parent linkage, stage propagation, and bounds invalidation stay consistent."
         },
         {
           "name": "clip",

--- a/site/src/content/api/graphics.json
+++ b/site/src/content/api/graphics.json
@@ -3857,7 +3857,7 @@
         },
         {
           "name": "children",
-          "signature": "children: RenderNode[]",
+          "signature": "children: readonly RenderNode[]",
           "signatureTokens": [
             {
               "text": "children",
@@ -3865,6 +3865,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
               "kind": "punctuation"
             },
             {
@@ -3878,7 +3886,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Snapshot of the current children in document order. Frozen and cached — repeated reads return the same array reference until the next structural change (addChild/removeChild/setChildIndex/ swapChildren/etc.), which invalidates it. A reference to a previous snapshot is unaffected by later changes — it keeps reflecting the child list as it was at the time of the read. Mutating methods (push, splice, ...) throw in normal (strict-mode) usage; go through addChild/removeChild instead so parent linkage, stage propagation, and bounds invalidation stay consistent."
         },
         {
           "name": "clip",

--- a/site/src/content/api/htmltext.json
+++ b/site/src/content/api/htmltext.json
@@ -2590,7 +2590,7 @@
         },
         {
           "name": "children",
-          "signature": "children: RenderNode[]",
+          "signature": "children: readonly RenderNode[]",
           "signatureTokens": [
             {
               "text": "children",
@@ -2598,6 +2598,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
               "kind": "punctuation"
             },
             {
@@ -2611,7 +2619,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Snapshot of the current children in document order. Frozen and cached — repeated reads return the same array reference until the next structural change (addChild/removeChild/setChildIndex/ swapChildren/etc.), which invalidates it. A reference to a previous snapshot is unaffected by later changes — it keeps reflecting the child list as it was at the time of the read. Mutating methods (push, splice, ...) throw in normal (strict-mode) usage; go through addChild/removeChild instead so parent linkage, stage propagation, and bounds invalidation stay consistent."
         },
         {
           "name": "clip",

--- a/site/src/content/api/image-layer-node.json
+++ b/site/src/content/api/image-layer-node.json
@@ -2365,7 +2365,7 @@
         },
         {
           "name": "children",
-          "signature": "children: RenderNode[]",
+          "signature": "children: readonly RenderNode[]",
           "signatureTokens": [
             {
               "text": "children",
@@ -2373,6 +2373,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
               "kind": "punctuation"
             },
             {
@@ -2386,7 +2394,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Snapshot of the current children in document order. Frozen and cached — repeated reads return the same array reference until the next structural change (addChild/removeChild/setChildIndex/ swapChildren/etc.), which invalidates it. A reference to a previous snapshot is unaffected by later changes — it keeps reflecting the child list as it was at the time of the read. Mutating methods (push, splice, ...) throw in normal (strict-mode) usage; go through addChild/removeChild instead so parent linkage, stage propagation, and bounds invalidation stay consistent."
         },
         {
           "name": "clip",

--- a/site/src/content/api/label.json
+++ b/site/src/content/api/label.json
@@ -2704,7 +2704,7 @@
         },
         {
           "name": "children",
-          "signature": "children: RenderNode[]",
+          "signature": "children: readonly RenderNode[]",
           "signatureTokens": [
             {
               "text": "children",
@@ -2712,6 +2712,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
               "kind": "punctuation"
             },
             {
@@ -2725,7 +2733,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Snapshot of the current children in document order. Frozen and cached — repeated reads return the same array reference until the next structural change (addChild/removeChild/setChildIndex/ swapChildren/etc.), which invalidates it. A reference to a previous snapshot is unaffected by later changes — it keeps reflecting the child list as it was at the time of the read. Mutating methods (push, splice, ...) throw in normal (strict-mode) usage; go through addChild/removeChild instead so parent linkage, stage propagation, and bounds invalidation stay consistent."
         },
         {
           "name": "clip",

--- a/site/src/content/api/panel.json
+++ b/site/src/content/api/panel.json
@@ -2746,7 +2746,7 @@
         },
         {
           "name": "children",
-          "signature": "children: RenderNode[]",
+          "signature": "children: readonly RenderNode[]",
           "signatureTokens": [
             {
               "text": "children",
@@ -2754,6 +2754,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
               "kind": "punctuation"
             },
             {
@@ -2767,7 +2775,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Snapshot of the current children in document order. Frozen and cached — repeated reads return the same array reference until the next structural change (addChild/removeChild/setChildIndex/ swapChildren/etc.), which invalidates it. A reference to a previous snapshot is unaffected by later changes — it keeps reflecting the child list as it was at the time of the read. Mutating methods (push, splice, ...) throw in normal (strict-mode) usage; go through addChild/removeChild instead so parent linkage, stage propagation, and bounds invalidation stay consistent."
         },
         {
           "name": "clip",

--- a/site/src/content/api/progress-bar.json
+++ b/site/src/content/api/progress-bar.json
@@ -2683,7 +2683,7 @@
         },
         {
           "name": "children",
-          "signature": "children: RenderNode[]",
+          "signature": "children: readonly RenderNode[]",
           "signatureTokens": [
             {
               "text": "children",
@@ -2691,6 +2691,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
               "kind": "punctuation"
             },
             {
@@ -2704,7 +2712,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Snapshot of the current children in document order. Frozen and cached — repeated reads return the same array reference until the next structural change (addChild/removeChild/setChildIndex/ swapChildren/etc.), which invalidates it. A reference to a previous snapshot is unaffected by later changes — it keeps reflecting the child list as it was at the time of the read. Mutating methods (push, splice, ...) throw in normal (strict-mode) usage; go through addChild/removeChild instead so parent linkage, stage propagation, and bounds invalidation stay consistent."
         },
         {
           "name": "clip",

--- a/site/src/content/api/retained-container.json
+++ b/site/src/content/api/retained-container.json
@@ -2422,7 +2422,7 @@
         },
         {
           "name": "children",
-          "signature": "children: RenderNode[]",
+          "signature": "children: readonly RenderNode[]",
           "signatureTokens": [
             {
               "text": "children",
@@ -2430,6 +2430,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
               "kind": "punctuation"
             },
             {
@@ -2443,7 +2451,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Snapshot of the current children in document order. Frozen and cached — repeated reads return the same array reference until the next structural change (addChild/removeChild/setChildIndex/ swapChildren/etc.), which invalidates it. A reference to a previous snapshot is unaffected by later changes — it keeps reflecting the child list as it was at the time of the read. Mutating methods (push, splice, ...) throw in normal (strict-mode) usage; go through addChild/removeChild instead so parent linkage, stage propagation, and bounds invalidation stay consistent."
         },
         {
           "name": "clip",

--- a/site/src/content/api/scroll-container.json
+++ b/site/src/content/api/scroll-container.json
@@ -2842,7 +2842,7 @@
         },
         {
           "name": "children",
-          "signature": "children: RenderNode[]",
+          "signature": "children: readonly RenderNode[]",
           "signatureTokens": [
             {
               "text": "children",
@@ -2850,6 +2850,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
               "kind": "punctuation"
             },
             {
@@ -2863,7 +2871,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Snapshot of the current children in document order. Frozen and cached — repeated reads return the same array reference until the next structural change (addChild/removeChild/setChildIndex/ swapChildren/etc.), which invalidates it. A reference to a previous snapshot is unaffected by later changes — it keeps reflecting the child list as it was at the time of the read. Mutating methods (push, splice, ...) throw in normal (strict-mode) usage; go through addChild/removeChild instead so parent linkage, stage propagation, and bounds invalidation stay consistent."
         },
         {
           "name": "clip",

--- a/site/src/content/api/stack.json
+++ b/site/src/content/api/stack.json
@@ -2759,7 +2759,7 @@
         },
         {
           "name": "children",
-          "signature": "children: RenderNode[]",
+          "signature": "children: readonly RenderNode[]",
           "signatureTokens": [
             {
               "text": "children",
@@ -2767,6 +2767,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
               "kind": "punctuation"
             },
             {
@@ -2780,7 +2788,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Snapshot of the current children in document order. Frozen and cached — repeated reads return the same array reference until the next structural change (addChild/removeChild/setChildIndex/ swapChildren/etc.), which invalidates it. A reference to a previous snapshot is unaffected by later changes — it keeps reflecting the child list as it was at the time of the read. Mutating methods (push, splice, ...) throw in normal (strict-mode) usage; go through addChild/removeChild instead so parent linkage, stage propagation, and bounds invalidation stay consistent."
         },
         {
           "name": "clip",

--- a/site/src/content/api/tile-layer-node.json
+++ b/site/src/content/api/tile-layer-node.json
@@ -2419,7 +2419,7 @@
         },
         {
           "name": "children",
-          "signature": "children: RenderNode[]",
+          "signature": "children: readonly RenderNode[]",
           "signatureTokens": [
             {
               "text": "children",
@@ -2427,6 +2427,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
               "kind": "punctuation"
             },
             {
@@ -2440,7 +2448,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Snapshot of the current children in document order. Frozen and cached — repeated reads return the same array reference until the next structural change (addChild/removeChild/setChildIndex/ swapChildren/etc.), which invalidates it. A reference to a previous snapshot is unaffected by later changes — it keeps reflecting the child list as it was at the time of the read. Mutating methods (push, splice, ...) throw in normal (strict-mode) usage; go through addChild/removeChild instead so parent linkage, stage propagation, and bounds invalidation stay consistent."
         },
         {
           "name": "clip",

--- a/site/src/content/api/tile-map-band.json
+++ b/site/src/content/api/tile-map-band.json
@@ -2366,7 +2366,7 @@
         },
         {
           "name": "children",
-          "signature": "children: RenderNode[]",
+          "signature": "children: readonly RenderNode[]",
           "signatureTokens": [
             {
               "text": "children",
@@ -2374,6 +2374,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
               "kind": "punctuation"
             },
             {
@@ -2387,7 +2395,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Snapshot of the current children in document order. Frozen and cached — repeated reads return the same array reference until the next structural change (addChild/removeChild/setChildIndex/ swapChildren/etc.), which invalidates it. A reference to a previous snapshot is unaffected by later changes — it keeps reflecting the child list as it was at the time of the read. Mutating methods (push, splice, ...) throw in normal (strict-mode) usage; go through addChild/removeChild instead so parent linkage, stage propagation, and bounds invalidation stay consistent."
         },
         {
           "name": "clip",

--- a/site/src/content/api/tile-map-node.json
+++ b/site/src/content/api/tile-map-node.json
@@ -2481,7 +2481,7 @@
         },
         {
           "name": "children",
-          "signature": "children: RenderNode[]",
+          "signature": "children: readonly RenderNode[]",
           "signatureTokens": [
             {
               "text": "children",
@@ -2489,6 +2489,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
               "kind": "punctuation"
             },
             {
@@ -2502,7 +2510,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Snapshot of the current children in document order. Frozen and cached — repeated reads return the same array reference until the next structural change (addChild/removeChild/setChildIndex/ swapChildren/etc.), which invalidates it. A reference to a previous snapshot is unaffected by later changes — it keeps reflecting the child list as it was at the time of the read. Mutating methods (push, splice, ...) throw in normal (strict-mode) usage; go through addChild/removeChild instead so parent linkage, stage propagation, and bounds invalidation stay consistent."
         },
         {
           "name": "clip",

--- a/site/src/content/api/uiroot.json
+++ b/site/src/content/api/uiroot.json
@@ -2345,7 +2345,7 @@
         },
         {
           "name": "children",
-          "signature": "children: RenderNode[]",
+          "signature": "children: readonly RenderNode[]",
           "signatureTokens": [
             {
               "text": "children",
@@ -2353,6 +2353,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
               "kind": "punctuation"
             },
             {
@@ -2366,7 +2374,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Snapshot of the current children in document order. Frozen and cached — repeated reads return the same array reference until the next structural change (addChild/removeChild/setChildIndex/ swapChildren/etc.), which invalidates it. A reference to a previous snapshot is unaffected by later changes — it keeps reflecting the child list as it was at the time of the read. Mutating methods (push, splice, ...) throw in normal (strict-mode) usage; go through addChild/removeChild instead so parent linkage, stage propagation, and bounds invalidation stay consistent."
         },
         {
           "name": "clip",

--- a/site/src/content/api/widget.json
+++ b/site/src/content/api/widget.json
@@ -2666,7 +2666,7 @@
         },
         {
           "name": "children",
-          "signature": "children: RenderNode[]",
+          "signature": "children: readonly RenderNode[]",
           "signatureTokens": [
             {
               "text": "children",
@@ -2674,6 +2674,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
               "kind": "punctuation"
             },
             {
@@ -2687,7 +2695,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Snapshot of the current children in document order. Frozen and cached — repeated reads return the same array reference until the next structural change (addChild/removeChild/setChildIndex/ swapChildren/etc.), which invalidates it. A reference to a previous snapshot is unaffected by later changes — it keeps reflecting the child list as it was at the time of the read. Mutating methods (push, splice, ...) throw in normal (strict-mode) usage; go through addChild/removeChild instead so parent linkage, stage propagation, and bounds invalidation stay consistent."
         },
         {
           "name": "clip",

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -297,7 +297,11 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
     return this._parentNode;
   }
 
-  public set parent(parent: Container | null) {
+  /**
+   * Set this node's parent without going through {@link Container.addChild}.
+   * @internal
+   */
+  public _setParent(parent: Container | null): void {
     this._parentNode = parent;
   }
 

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -27,6 +27,8 @@ import { RenderNode } from './RenderNode';
  * @stable
  */
 export class Container extends RenderNode {
+  // Subclasses mutating this directly must also set `_childrenView = null`,
+  // or the public `children` snapshot silently desyncs from the true list.
   protected readonly _children: RenderNode[] = [];
   private _retainedPlan: RetainedPlanCache | null = null;
   private _childrenView: readonly RenderNode[] | null = null;
@@ -35,8 +37,10 @@ export class Container extends RenderNode {
    * Snapshot of the current children in document order. Frozen and cached —
    * repeated reads return the same array reference until the next
    * structural change (`addChild`/`removeChild`/`setChildIndex`/
-   * `swapChildren`/etc.), which invalidates it. The returned array cannot
-   * be mutated (`push`, index assignment, ... throw); go through
+   * `swapChildren`/etc.), which invalidates it. A reference to a previous
+   * snapshot is unaffected by later changes — it keeps reflecting the child
+   * list as it was at the time of the read. Mutating methods (`push`,
+   * `splice`, ...) throw in normal (strict-mode) usage; go through
    * `addChild`/`removeChild` instead so parent linkage, stage propagation,
    * and bounds invalidation stay consistent.
    */
@@ -206,6 +210,11 @@ export class Container extends RenderNode {
     const child = this._children[index];
 
     removeArrayItems(this._children, index, 1);
+    // Invalidate the children-view cache immediately after the array write,
+    // before any of the notify calls below can run user code (e.g. an
+    // onBlur handler) that reads `container.children` — otherwise that read
+    // would observe a stale snapshot still containing `child`.
+    this._childrenView = null;
 
     if (child?.parent === this) {
       // Cascade bounds up BEFORE clearing parent so the walk reaches this node.
@@ -217,7 +226,6 @@ export class Container extends RenderNode {
       child._setStage(null);
     }
 
-    this._childrenView = null;
     this.invalidateCache();
     this._markStructureDirty();
 

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -29,9 +29,19 @@ import { RenderNode } from './RenderNode';
 export class Container extends RenderNode {
   protected readonly _children: RenderNode[] = [];
   private _retainedPlan: RetainedPlanCache | null = null;
+  private _childrenView: readonly RenderNode[] | null = null;
 
-  public get children(): RenderNode[] {
-    return this._children;
+  /**
+   * Snapshot of the current children in document order. Frozen and cached —
+   * repeated reads return the same array reference until the next
+   * structural change (`addChild`/`removeChild`/`setChildIndex`/
+   * `swapChildren`/etc.), which invalidates it. The returned array cannot
+   * be mutated (`push`, index assignment, ... throw); go through
+   * `addChild`/`removeChild` instead so parent linkage, stage propagation,
+   * and bounds invalidation stay consistent.
+   */
+  public get children(): readonly RenderNode[] {
+    return (this._childrenView ??= Object.freeze(this._children.slice()));
   }
 
   public get width(): number {
@@ -119,6 +129,7 @@ export class Container extends RenderNode {
 
     child.parent = this;
     this._children.splice(index, 0, child);
+    this._childrenView = null;
     this.invalidateCache();
     this._markStructureDirty();
 
@@ -138,6 +149,7 @@ export class Container extends RenderNode {
 
       this._children[firstIndex] = secondChild;
       this._children[secondIndex] = firstChild;
+      this._childrenView = null;
       this.invalidateCache();
       this._markStructureDirty();
     }
@@ -163,6 +175,7 @@ export class Container extends RenderNode {
     removeArrayItems(this._children, this.getChildIndex(child), 1);
 
     this._children.splice(index, 0, child);
+    this._childrenView = null;
     this.invalidateCache();
     this._markStructureDirty();
 
@@ -204,6 +217,7 @@ export class Container extends RenderNode {
       child._setStage(null);
     }
 
+    this._childrenView = null;
     this.invalidateCache();
     this._markStructureDirty();
 
@@ -239,6 +253,7 @@ export class Container extends RenderNode {
     }
 
     removeArrayItems(this._children, begin, range);
+    this._childrenView = null;
     this.invalidateCache();
     this._markStructureDirty();
 

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -127,7 +127,7 @@ export class Container extends RenderNode {
       child.parent.removeChild(child);
     }
 
-    child.parent = this;
+    child._setParent(this);
     this._children.splice(index, 0, child);
     this._childrenView = null;
     this.invalidateCache();
@@ -210,7 +210,7 @@ export class Container extends RenderNode {
     if (child?.parent === this) {
       // Cascade bounds up BEFORE clearing parent so the walk reaches this node.
       this._invalidateBoundsCascade();
-      child.parent = null;
+      child._setParent(null);
       child._invalidateSubtreeTransform();
       this._stage?.interaction._notifyNodeRemoved(child);
       this._stage?.focus._notifyNodeRemoved(child);
@@ -244,7 +244,7 @@ export class Container extends RenderNode {
       const child = this._children[i];
 
       if (child?.parent === this) {
-        child.parent = null;
+        child._setParent(null);
         child._invalidateSubtreeTransform();
         this._stage?.interaction._notifyNodeRemoved(child);
         this._stage?.focus._notifyNodeRemoved(child);

--- a/test/rendering/container.test.ts
+++ b/test/rendering/container.test.ts
@@ -119,3 +119,48 @@ describe('Container', () => {
     });
   });
 });
+
+describe('Container children view', () => {
+  test('returns the same array reference across repeated reads with no structural change', () => {
+    const container = new Container();
+    container.addChild(new DummyDrawable());
+
+    expect(container.children).toBe(container.children);
+  });
+
+  test.each([
+    { name: 'addChild', mutate: (c: Container) => c.addChild(new DummyDrawable()) },
+    { name: 'removeChildAt', mutate: (c: Container) => c.removeChildAt(0) },
+    { name: 'removeChildren', mutate: (c: Container) => c.removeChildren() },
+    { name: 'setChildIndex', mutate: (c: Container) => c.setChildIndex(c.getChildAt(1), 0) },
+    { name: 'swapChildren', mutate: (c: Container) => c.swapChildren(c.getChildAt(0), c.getChildAt(1)) },
+  ])('invalidates the cached view on $name', ({ mutate }) => {
+    const container = new Container();
+    container.addChild(new DummyDrawable());
+    container.addChild(new DummyDrawable());
+    const before = container.children;
+
+    mutate(container);
+
+    expect(container.children).not.toBe(before);
+  });
+
+  test('is a real Array — Array.isArray, length, and indexed access all work like before', () => {
+    const container = new Container();
+    const first = new DummyDrawable();
+    container.addChild(first);
+
+    expect(Array.isArray(container.children)).toBe(true);
+    expect(container.children.length).toBe(1);
+    expect(container.children[0]).toBe(first);
+  });
+
+  test('mutating children directly is rejected at both the type level and at runtime', () => {
+    const container = new Container();
+
+    expect(() => {
+      // @ts-expect-error — `children` is `readonly RenderNode[]`; mutate via addChild/removeChild instead.
+      container.children.push(new DummyDrawable());
+    }).toThrow(TypeError);
+  });
+});

--- a/test/rendering/container.test.ts
+++ b/test/rendering/container.test.ts
@@ -1,9 +1,13 @@
-﻿import { logger } from '#core/logging';
+﻿import type { Application } from '#core/Application';
+import { logger } from '#core/logging';
 import { SceneNode } from '#core/SceneNode';
+import type { InteractionHooks, Stage } from '#core/Stage';
+import { FocusManager } from '#input/FocusManager';
 import { Container } from '#rendering/Container';
 import { Drawable } from '#rendering/Drawable';
 import { Graphics } from '#rendering/primitives/Graphics';
 import type { RenderBackend } from '#rendering/RenderBackend';
+import type { RenderNode } from '#rendering/RenderNode';
 
 class DummyDrawable extends Drawable {
   public override render(_backend: RenderBackend): this {
@@ -224,5 +228,59 @@ describe('Container children view', () => {
       // @ts-expect-error — `children` is `readonly RenderNode[]`; mutate via addChild/removeChild instead.
       container.children.push(new DummyDrawable());
     }).toThrow(TypeError);
+  });
+
+  // Regression for the whole-branch review finding: removeChildAt used to
+  // splice `_children` and run every removal side effect (bounds cascade,
+  // _setParent(null), interaction notify, focus notify) BEFORE invalidating
+  // `_childrenView` — invalidation was the very last statement in the
+  // method. The stage's focus manager's `_notifyNodeRemoved` synchronously
+  // dispatches the public `onBlur` signal, i.e. arbitrary user code, from
+  // inside that window. A handler reading `container.children` from onBlur
+  // would therefore see the STALE cached snapshot (still containing the
+  // node being removed). This test focuses the child being removed so
+  // `onBlur` fires synchronously from inside `removeChildAt`, and asserts
+  // the handler already observes the post-removal list — which only holds
+  // if the cache was invalidated before the focus notify runs, not merely
+  // by the time `removeChildAt` returns.
+  test('the children-view cache is already invalidated when a synchronous onBlur handler runs during removeChildAt', () => {
+    const noopInteraction: InteractionHooks = {
+      _notifyNodeAdded() {},
+      _notifyNodeRemoved() {},
+      _notifyInteractiveChanged() {},
+      _notifyBoundsInvalidated() {},
+      _notifyTransformGroupMoved() {},
+    };
+    const stubInput = { onKeyDown: { add() {}, remove() {} }, onKeyUp: { add() {}, remove() {} } };
+    const focusApp = { input: stubInput } as unknown as Application;
+    const focus = new FocusManager(focusApp);
+    const stage: Stage = { interaction: noopInteraction, focus };
+
+    const container = new Container();
+    container._setStage(stage);
+
+    const child = new DummyDrawable();
+    child.focusable = true;
+    container.addChild(child);
+    focus.focus(child);
+
+    // Populate the cache BEFORE removal — without this, `_childrenView` is
+    // still null going into removeChildAt and the getter would compute a
+    // fresh (already-correct) array on first read regardless of where the
+    // invalidation line sits, silently defeating the regression check.
+    const before = container.children;
+    expect(before).toContain(child);
+
+    let seenDuringBlur: readonly RenderNode[] | undefined;
+    child.onBlur.add(() => {
+      seenDuringBlur = container.children;
+    });
+
+    container.removeChildAt(0);
+
+    expect(seenDuringBlur).toBeDefined();
+    expect(seenDuringBlur).not.toBe(before);
+    expect(seenDuringBlur).not.toContain(child);
+    expect(seenDuringBlur!.length).toBe(0);
   });
 });

--- a/test/rendering/container.test.ts
+++ b/test/rendering/container.test.ts
@@ -50,6 +50,68 @@ describe('Container', () => {
     expect(container.children.length).toBe(0);
   });
 
+  test('addChild sets the child parent via the internal _setParent path', () => {
+    const container = new Container();
+    const child = new DummyDrawable();
+
+    container.addChild(child);
+
+    expect(child.parent).toBe(container);
+  });
+
+  test('parent has no public setter — assigning it throws, not just a type error', () => {
+    const container = new Container();
+    const child = new DummyDrawable();
+
+    expect(() => {
+      // @ts-expect-error — `parent` has no public setter; use addChild/removeChild.
+      child.parent = container;
+    }).toThrow(TypeError);
+
+    expect(child.parent).toBeNull();
+  });
+
+  test('random add/remove/setChildIndex sequences keep parent and children-view invariants consistent', () => {
+    // Spec-mandated property test (deterministic seeded PRNG, no flakiness):
+    // after every mutation in a long random sequence, every node in
+    // container.children must have .parent === container, and every node
+    // NOT in container.children must not. This exercises exactly the code
+    // paths this task touches (_setParent calls in addChildAt/removeChildAt,
+    // _childrenView invalidation in setChildIndex) under adversarial ordering.
+    const container = new Container();
+    const pool = Array.from({ length: 8 }, () => new DummyDrawable());
+    let seed = 42;
+    const random = (): number => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed / 0x7fffffff;
+    };
+
+    for (let step = 0; step < 200; step++) {
+      const action = Math.floor(random() * 3);
+
+      if (action === 0 || container.children.length === 0) {
+        const child = pool[Math.floor(random() * pool.length)]!;
+        if (child.parent !== container) {
+          container.addChild(child);
+        }
+      } else if (action === 1) {
+        container.removeChildAt(Math.floor(random() * container.children.length));
+      } else if (container.children.length > 1) {
+        container.setChildIndex(container.getChildAt(0), Math.floor(random() * container.children.length));
+      }
+
+      for (const child of container.children) {
+        expect(child.parent).toBe(container);
+      }
+
+      for (const candidate of pool) {
+        if (!container.children.includes(candidate)) {
+          expect(candidate.parent).not.toBe(container);
+        }
+      }
+    }
+  });
+
   test('removeChildren clears parent references in range', () => {
     const container = new Container();
     const first = new DummyDrawable();

--- a/test/type-tests/scene-graph-mutation.type-test.ts
+++ b/test/type-tests/scene-graph-mutation.type-test.ts
@@ -1,5 +1,5 @@
-import { Container } from '#rendering/Container';
-import { RenderNode } from '#rendering/RenderNode';
+import type { Container } from '#rendering/Container';
+import type { RenderNode } from '#rendering/RenderNode';
 
 declare const container: Container;
 declare const node: RenderNode;

--- a/test/type-tests/scene-graph-mutation.type-test.ts
+++ b/test/type-tests/scene-graph-mutation.type-test.ts
@@ -1,0 +1,23 @@
+import { Container } from '#rendering/Container';
+import { RenderNode } from '#rendering/RenderNode';
+
+declare const container: Container;
+declare const node: RenderNode;
+declare const otherContainer: Container;
+
+// `Container.children` is `readonly RenderNode[]` — mutating array methods
+// are not on the type, so calling them must be rejected at compile time
+// (they also throw at runtime against the frozen snapshot; see
+// Container.test.ts for the runtime guard).
+// @ts-expect-error — children is readonly RenderNode[]; push() does not exist on it
+container.children.push(node);
+// @ts-expect-error — children is readonly RenderNode[]; splice() does not exist on it
+container.children.splice(0, 1);
+
+// `SceneNode.parent` (inherited by RenderNode/Container) has no public
+// setter anymore — reparenting goes exclusively through Container's
+// addChild/removeChild, which route through the internal _setParent().
+// @ts-expect-error — parent has no public setter
+node.parent = otherContainer;
+
+export {};


### PR DESCRIPTION
## Summary

Closes the top-priority pre-1.0 footgun identified by an external architecture audit: two public APIs let callers bypass `Container.addChild`/`removeChild` bookkeeping entirely.

- **`Container.children`** returned the internal live array — `container.children.push(x)` silently corrupted the scene graph (no parent linkage, no stage propagation, no bounds invalidation). It now returns a frozen, lazily-cached `readonly RenderNode[]` snapshot, invalidated on every structural mutation.
- **`SceneNode.parent`** had a public setter — `node.parent = x` reassigned scene-graph ownership with none of `addChild`'s side effects. The setter is removed; `Container`'s three internal call sites now use a new `@internal _setParent()` method, mirroring the existing `_setStage()` idiom.

Both are documented as breaking changes under the still-unreleased `[0.17.0]` CHANGELOG section — no version bump.

## Test plan

- [x] `pnpm test:core` — 327 test files, 5302 tests passing, 0 failures
- [x] `pnpm typecheck` / `pnpm typecheck:type-tests` — clean, including new `test/type-tests/scene-graph-mutation.type-test.ts` proving both breaking changes are enforced at the type level
- [x] `pnpm docs:api:check` — generated API docs regenerated and in sync
- [x] Deterministic seeded-PRNG property test exercising 200 random `addChild`/`removeChildAt`/`setChildIndex` sequences, asserting parent/children-view invariants hold after every step
- [x] Regression test proving `removeChildAt`'s cache invalidation happens before any synchronous side-effecting callback (e.g. `onBlur`) can observe a stale snapshot
- [x] `pnpm verify:quick` — all gates pass (pre-push hook)
- [x] Implemented via subagent-driven-development: 3 tasks, each independently reviewed, plus a final whole-branch review (1 Critical + 2 Important findings, all fixed and re-reviewed clean)

Design: `.workspace/specs/2026-07-25-scene-graph-mutation-safety-design.md` (local, not part of this diff)