### PR TITLE
refactor(resources): extract AssetTypeRegistry from Loader (Loader split, Slice 1/4)

### DIFF
--- a/src/resources/AssetTypeRegistry.ts
+++ b/src/resources/AssetTypeRegistry.ts
@@ -93,6 +93,12 @@ export class AssetTypeRegistry {
     }
 
     // All validation passed — install atomically.
+    // Localized type-erasure boundary: the internal registry uses a flat config
+    // `{ source, ...fields }`. The public AssetHandler<Result, Options> interface
+    // uses `AssetLoadRequest<Options> = { source, options? }`. This single `toRequest`
+    // helper is the only place where the erased flat config is cast to the typed
+    // request — justified by the `AssetBinding<Result, Options>` contract that
+    // associates this handler's Options with the registered constructor.
     const toRequest = (config: unknown): AssetLoadRequest<Options> => {
       const { source, ...rest } = config as { source: string } & Record<string, unknown>;
 
@@ -120,7 +126,8 @@ export class AssetTypeRegistry {
       this._extensionMap.set(ext, keys.type);
     }
 
-    // Own this handler for lifecycle management.
+    // Own this handler for lifecycle management. Cast to the erased AssetHandler
+    // for storage; destroy() is the only method called on entries in this array.
     this._boundHandlers.push(handler as AssetHandler);
 
     if (keys.seamless !== undefined) {

--- a/src/resources/AssetTypeRegistry.ts
+++ b/src/resources/AssetTypeRegistry.ts
@@ -1,0 +1,256 @@
+import type { AssetHandler, AssetLoadRequest } from '#extensions/Extension';
+
+import type { Asset } from './Asset';
+import type { AssetFactory } from './AssetFactory';
+import type { AssetConstructor } from './FactoryRegistry';
+import { FactoryRegistry } from './FactoryRegistry';
+import type { AssetLoaderContext } from './Loader';
+import type { SeamlessAdapter } from './seamless';
+
+/** Stored entry for handler-based asset bindings (via `bindAsset`). */
+export interface HandlerEntry {
+  load: (config: unknown, ctx: AssetLoaderContext) => Promise<unknown>;
+  /** Optional discriminator for in-flight identity keying; overrides source-only default. */
+  getIdentityKey?: (config: unknown) => string;
+  /** Optional byte-source constructor used by container loading (bypasses fetch). */
+  createFromBytes?: (bytes: ArrayBuffer, options?: unknown) => Promise<unknown>;
+}
+
+/**
+ * Owns constructor-based asset type identification for a {@link Loader}
+ * instance: registered factories, type-name and file-extension mappings,
+ * `bindAsset` handlers, seamless-adapter bindings, and per-instance type IDs
+ * / key derivation. Extracted from `Loader` (Loader split, Slice 1) — every
+ * method here is a direct, behavior-preserving relocation.
+ */
+export class AssetTypeRegistry {
+  private readonly _factories = new FactoryRegistry();
+  private readonly _assetTypeMap = new Map<string, AssetConstructor>();
+  private readonly _typeIds = new WeakMap<AssetConstructor, number>();
+  private readonly _handlerFunctions = new Map<AssetConstructor, HandlerEntry>();
+  private readonly _extensionMap = new Map<string, AssetConstructor>();
+  private readonly _boundHandlers: AssetHandler[] = [];
+  private readonly _seamlessAdapters = new Map<AssetConstructor, SeamlessAdapter<unknown>>();
+  private _nextTypeId = 1;
+
+  /** Registers a factory for `type`. Prototype-chain aware — see {@link FactoryRegistry}. */
+  public register<T>(type: AssetConstructor<T>, factory: AssetFactory<T>): void {
+    this._factories.register(type, factory);
+  }
+
+  /** Registers the seamless-handle adapter for `type`. One adapter per type. */
+  public registerSeamlessAdapter<T>(type: AssetConstructor<T>, adapter: SeamlessAdapter<T>): void {
+    if (this._seamlessAdapters.has(type)) {
+      throw new Error(`A seamless adapter is already registered for ${this._describeType(type)}.`);
+    }
+
+    this._seamlessAdapters.set(type, adapter);
+  }
+
+  /**
+   * Atomically bind all keys for one AssetBinding to a pre-created handler.
+   * Validates all keys BEFORE mutating any map. Any already-registered key
+   * throws before any mutation.
+   */
+  public bindAsset<Result = unknown, Options = undefined>(
+    keys: { type: AssetConstructor<Result>; typeNames?: readonly string[]; extensions?: readonly string[]; seamless?: SeamlessAdapter<Result> },
+    handler: AssetHandler<Result, Options>,
+  ): void {
+    const normalizedExts: string[] = [];
+    const resolvedNames: string[] = keys.typeNames !== undefined ? [...keys.typeNames] : [];
+
+    // Normalise extension keys
+    for (const ext of keys.extensions ?? []) {
+      normalizedExts.push(ext.replace(/^\./, '').toLowerCase());
+    }
+
+    // Validate: detect duplicates within this binding
+    const seenExts = new Set<string>();
+
+    for (const ext of normalizedExts) {
+      if (seenExts.has(ext)) {
+        throw new Error(`Duplicate extension key ".${ext}" within a single asset binding.`);
+      }
+
+      seenExts.add(ext);
+    }
+
+    // Validate: detect conflicts with already-registered keys — throw before any mutation
+    if (this._handlerFunctions.has(keys.type)) {
+      throw new Error(`An asset handler is already registered for ${keys.type.name}.`);
+    }
+
+    for (const name of resolvedNames) {
+      if (this._assetTypeMap.has(name)) {
+        throw new Error(`Asset type name "${name}" is already registered.`);
+      }
+    }
+
+    for (const ext of normalizedExts) {
+      if (this._extensionMap.has(ext)) {
+        throw new Error(`File extension ".${ext}" is already mapped to an asset type.`);
+      }
+    }
+
+    // All validation passed — install atomically.
+    const toRequest = (config: unknown): AssetLoadRequest<Options> => {
+      const { source, ...rest } = config as { source: string } & Record<string, unknown>;
+
+      if (Object.keys(rest).length === 0) {
+        return { source };
+      }
+
+      return { source, options: rest as Options };
+    };
+
+    const boundIdentityKey = handler.getIdentityKey?.bind(handler);
+    const boundCreateFromBytes = handler.createFromBytes?.bind(handler);
+
+    this._handlerFunctions.set(keys.type, {
+      load: (config, ctx) => handler.load(toRequest(config), ctx),
+      ...(boundIdentityKey && { getIdentityKey: (config: unknown) => boundIdentityKey(toRequest(config)) }),
+      ...(boundCreateFromBytes && { createFromBytes: (bytes: ArrayBuffer, options?: unknown) => boundCreateFromBytes(bytes, options as Options) }),
+    });
+
+    for (const name of resolvedNames) {
+      this._assetTypeMap.set(name, keys.type);
+    }
+
+    for (const ext of normalizedExts) {
+      this._extensionMap.set(ext, keys.type);
+    }
+
+    // Own this handler for lifecycle management.
+    this._boundHandlers.push(handler as AssetHandler);
+
+    if (keys.seamless !== undefined) {
+      this.registerSeamlessAdapter(keys.type, keys.seamless);
+    }
+  }
+
+  /** Returns true if a handler or factory is already registered for the given constructor. */
+  public hasLoadable(type: AssetConstructor): boolean {
+    return this._handlerFunctions.has(type) || this._factories.has(type);
+  }
+
+  /** Returns true if a type-name mapping is already registered. */
+  public hasAssetType(typeName: string): boolean {
+    return this._assetTypeMap.has(typeName);
+  }
+
+  /** Returns true if a file extension is already mapped to an asset type. Extension is normalised (leading dot stripped, lower-cased). */
+  public hasExtension(ext: string): boolean {
+    return this._extensionMap.has(ext.replace(/^\./, '').toLowerCase());
+  }
+
+  /** Returns true if a plain `register()` factory exists for `type` (not a `bindAsset` handler). */
+  public hasFactory(type: AssetConstructor): boolean {
+    return this._factories.has(type);
+  }
+
+  /** Resolves the `register()`-based factory for `type`. Throws if none is registered — see {@link FactoryRegistry.resolve}. */
+  public resolveFactory<T>(type: AssetConstructor<T>): AssetFactory<T> {
+    return this._factories.resolve(type);
+  }
+
+  /** The `bindAsset` handler entry for `type`, or `undefined`. */
+  public getHandler(type: AssetConstructor): HandlerEntry | undefined {
+    return this._handlerFunctions.get(type);
+  }
+
+  /** The seamless adapter registered for `type`, or `undefined`. */
+  public getSeamlessAdapter(type: AssetConstructor): SeamlessAdapter<unknown> | undefined {
+    return this._seamlessAdapters.get(type);
+  }
+
+  /** Returns true if a seamless adapter is registered for `type`. */
+  public hasSeamlessAdapter(type: AssetConstructor): boolean {
+    return this._seamlessAdapters.has(type);
+  }
+
+  /** Resolves a registered type-name (from `bindAsset`'s `typeNames`) to its constructor. */
+  public resolveTypeName(name: string): AssetConstructor | undefined {
+    return this._assetTypeMap.get(name);
+  }
+
+  /** @internal */
+  public _getTypeId(type: AssetConstructor): number {
+    let typeId = this._typeIds.get(type);
+
+    if (typeId === undefined) {
+      typeId = this._nextTypeId++;
+      this._typeIds.set(type, typeId);
+    }
+
+    return typeId;
+  }
+
+  /** @internal */
+  public _key(type: AssetConstructor, alias: string): string {
+    return `${this._getTypeId(type)}:${alias}`;
+  }
+
+  /** @internal */
+  public _identityKey(type: AssetConstructor, source: string): string {
+    return `id:${this._getTypeId(type)}:${source}`;
+  }
+
+  /**
+   * Resolves the effective identity key for an `Asset<T>` reference. For
+   * handler types with `getIdentityKey`, the config-sensitive discriminator
+   * is used; otherwise source is the discriminator (same as `_identityKey`).
+   * @internal
+   */
+  public _resolveAssetIdentityKey(type: AssetConstructor, asset: Asset<unknown>): string {
+    const rawConfig = asset._config as Record<string, unknown>;
+    const handlerEntry = this._handlerFunctions.get(type);
+    const discriminator = handlerEntry?.getIdentityKey?.(rawConfig) ?? asset.source;
+
+    return `id:${this._getTypeId(type)}:${discriminator}`;
+  }
+
+  /**
+   * Resolve the registered asset type for a path by matching the basename's
+   * dot-suffixes longest-first: `hero.aseprite.json` tries `aseprite.json`
+   * before `json`. Query/hash suffixes are ignored.
+   * @internal
+   */
+  public _resolveExtensionType(path: string): AssetConstructor | undefined {
+    const [withoutQueryHash = ''] = path.split(/[?#]/, 1);
+    const basename = withoutQueryHash.split('/').pop() ?? '';
+    const parts = basename.split('.');
+
+    for (let i = 1; i < parts.length; i++) {
+      const ctor = this._extensionMap.get(parts.slice(i).join('.').toLowerCase());
+
+      if (ctor !== undefined) {
+        return ctor;
+      }
+    }
+
+    return undefined;
+  }
+
+  /** @internal */
+  public _describeType(type: AssetConstructor): string {
+    return type.name.length > 0 ? type.name : '(anonymous type)';
+  }
+
+  /** Destroys the factory registry, destroys every bound `bindAsset` handler (deduplicated by identity), and clears handler/adapter maps. */
+  public destroy(): void {
+    this._factories.destroy();
+
+    const destroyedHandlers = new Set<AssetHandler>();
+
+    for (const handler of this._boundHandlers) {
+      if (!destroyedHandlers.has(handler)) {
+        destroyedHandlers.add(handler);
+        handler.destroy?.();
+      }
+    }
+
+    this._boundHandlers.length = 0;
+    this._handlerFunctions.clear();
+    this._seamlessAdapters.clear();
+  }
+}

--- a/src/resources/AssetTypeRegistry.ts
+++ b/src/resources/AssetTypeRegistry.ts
@@ -236,10 +236,13 @@ export class AssetTypeRegistry {
     return type.name.length > 0 ? type.name : '(anonymous type)';
   }
 
-  /** Destroys the factory registry, destroys every bound `bindAsset` handler (deduplicated by identity), and clears handler/adapter maps. */
-  public destroy(): void {
+  /** Destroys the `register()`-based factory registry. */
+  public destroyFactories(): void {
     this._factories.destroy();
+  }
 
+  /** Destroys every bound `bindAsset` handler (deduplicated by identity) and clears handler/adapter maps. */
+  public destroyHandlers(): void {
     const destroyedHandlers = new Set<AssetHandler>();
 
     for (const handler of this._boundHandlers) {
@@ -252,5 +255,11 @@ export class AssetTypeRegistry {
     this._boundHandlers.length = 0;
     this._handlerFunctions.clear();
     this._seamlessAdapters.clear();
+  }
+
+  /** Destroys the factory registry and every bound handler — see {@link destroyFactories}/{@link destroyHandlers}. */
+  public destroy(): void {
+    this.destroyFactories();
+    this.destroyHandlers();
   }
 }

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -1,7 +1,7 @@
 import type { Sound } from '#audio/Sound';
 import { logger } from '#core/logging';
 import { Signal } from '#core/Signal';
-import type { AssetHandler, AssetLoadRequest } from '#extensions/Extension';
+import type { AssetHandler } from '#extensions/Extension';
 import { type BmFont } from '#rendering/text/BmFont';
 import type { Texture } from '#rendering/texture/Texture';
 
@@ -22,12 +22,12 @@ import { createLeaf } from './assetKindRegistry';
 import { _readMeta } from './assetMeta';
 import { AssetRef } from './AssetRef';
 import { _normalizeEntry, type Assets, AssetsImpl, type InferAssetsProperties } from './Assets';
+import { AssetTypeRegistry, type HandlerEntry } from './AssetTypeRegistry';
 import { CacheFirstStrategy } from './CacheFirstStrategy';
 import type { CacheStore } from './CacheStore';
 import type { CacheStrategy } from './CacheStrategy';
 import { resolveKindByPath } from './extensionKindRegistry';
 import type { AssetConstructor } from './FactoryRegistry';
-import { FactoryRegistry } from './FactoryRegistry';
 import { LoadingQueue } from './LoadingQueue';
 import type { SeamlessAdapter } from './seamless';
 import { BinaryAsset, CsvAsset, FontAsset, type ImageAsset, Json, SubtitleAsset, type SvgAsset, TextAsset, WasmAsset, XmlAsset } from './tokens';
@@ -220,15 +220,6 @@ interface QueueEntry {
   readonly options?: unknown;
 }
 
-/** Stored entry for handler-based asset bindings (via `bindAsset`). */
-interface HandlerEntry {
-  load: (config: unknown, ctx: AssetLoaderContext) => Promise<unknown>;
-  /** Optional discriminator for in-flight identity keying; overrides source-only default. */
-  getIdentityKey?: (config: unknown) => string;
-  /** Optional byte-source constructor used by container loading (bypasses fetch). */
-  createFromBytes?: (bytes: ArrayBuffer, options?: unknown) => Promise<unknown>;
-}
-
 // ---------------------------------------------------------------------------
 // Loader
 // ---------------------------------------------------------------------------
@@ -258,8 +249,7 @@ interface HandlerEntry {
  * ```
  */
 export class Loader {
-  private readonly _registry = new FactoryRegistry();
-  private readonly _assetTypeMap = new Map<string, AssetConstructor>();
+  private readonly _typeRegistry = new AssetTypeRegistry();
   private readonly _resources = new Map<AssetConstructor, Map<string, unknown>>();
   // Reverse lookup: loaded resource object → the (type, source) it was first
   // stored under. Backs {@link Loader.keyFor} for scene serialization. A
@@ -267,7 +257,6 @@ export class Loader {
   // (primitive results like parsed JSON/text are not keyable → null).
   private readonly _resourceKeys = new WeakMap<object, { type: AssetConstructor; source: string }>();
   private readonly _inFlight = new Map<string, Promise<unknown>>();
-  private readonly _typeIds = new WeakMap<AssetConstructor, number>();
   private readonly _preventStoreKeys = new Set<string>();
   private readonly _stores: readonly CacheStore[];
   private readonly _cacheStrategy: CacheStrategy;
@@ -279,13 +268,6 @@ export class Loader {
   private readonly _identityKeyToAliases = new Map<string, Set<string>>();
   // In-flight promises keyed by identity (source-based) for cross-alias dedup
   private readonly _inFlightByIdentity = new Map<string, Promise<unknown>>();
-  // Handler entries bound via bindAsset (the AssetBinding handler form)
-  private readonly _handlerFunctions = new Map<AssetConstructor, HandlerEntry>();
-  // Maps lower-case file extensions (without dot) to the constructor to use
-  private readonly _extensionMap = new Map<string, AssetConstructor>();
-
-  // Handlers registered via bindAsset — owned for their full lifecycle
-  private readonly _boundHandlers: AssetHandler[] = [];
 
   // ── Seamless deferred handles (asset-system v2) ───────────────────────────
   // Adapter per seamless type; handles pending or failed, keyed by _key(type, source).
@@ -303,7 +285,6 @@ export class Loader {
   // fully-released source does not pin its evicted 0×0 `Texture`/`Sound` for the
   // loader's lifetime (audit A4); `_deferredFinalization` prunes the emptied
   // entry once the GC reclaims the last handle.
-  private readonly _seamlessAdapters = new Map<AssetConstructor, SeamlessAdapter<unknown>>();
   private readonly _deferred = new Map<string, { readonly handles: WeakHandleSet; readonly options: unknown }>();
 
   // Prunes a deferred entry once the GC reclaims a handle registered under its
@@ -360,7 +341,6 @@ export class Loader {
   private _basePath: string;
   private _fetchOptions: RequestInit;
   private _concurrency: number;
-  private _nextTypeId = 1;
 
   private _fgBatchActive = 0;
   private _fgBatchLoaded = 0;
@@ -409,7 +389,7 @@ export class Loader {
    * for the same constructor.
    */
   public register<T>(type: AssetConstructor<T>, factory: AssetFactory<T>): this {
-    this._registry.register(type, factory);
+    this._typeRegistry.register(type, factory);
 
     return this;
   }
@@ -420,11 +400,7 @@ export class Loader {
    * @advanced
    */
   public registerSeamlessAdapter<T>(type: AssetConstructor<T>, adapter: SeamlessAdapter<T>): this {
-    if (this._seamlessAdapters.has(type)) {
-      throw new Error(`A seamless adapter is already registered for ${this._describeType(type)}.`);
-    }
-
-    this._seamlessAdapters.set(type, adapter);
+    this._typeRegistry.registerSeamlessAdapter(type, adapter);
 
     return this;
   }
@@ -450,7 +426,7 @@ export class Loader {
 
     // Resolve every type up front so an unknown type fails before any asset is stored.
     const resolved = entries.map(entry => {
-      const type = this._assetTypeMap.get(entry.type);
+      const type = this._typeRegistry.resolveTypeName(entry.type);
 
       if (!type) {
         throw new Error(`Container "${url}" references unknown asset type "${entry.type}".`);
@@ -598,7 +574,7 @@ export class Loader {
     // 2b. Extension-based: single path string with no type token
     if (typeof arg0 === 'string' && arg1 === undefined) {
       const path = arg0;
-      let ctor = this._resolveExtensionType(path);
+      let ctor = this._typeRegistry._resolveExtensionType(path);
 
       // Value-kind fallback: a bare path whose suffix maps to a value kind
       // resolves the raw value via the value token (asset-system v2 §4.4).
@@ -616,7 +592,7 @@ export class Loader {
       // FontAsset requires a family option — infer it from the filename when not provided
       const options: unknown = ctor === FontAsset ? { family: (path.split('/').pop()?.split(/[?#]/)[0] ?? '').replace(/\.[^.]+$/, '') } : undefined;
 
-      this._claim(this._key(ctor, path), ctor, path, claimer);
+      this._claim(this._typeRegistry._key(ctor, path), ctor, path, claimer);
       this._onFgBatchStart(path, path);
       let notifyFn: ((success: boolean) => void) | null = null;
       const promise = this._loadSingle(ctor, path, options).then(
@@ -844,14 +820,14 @@ export class Loader {
 
     if (typeof typeOrPath === 'string') {
       const path = typeOrPath;
-      const ctor = this._resolveExtensionType(path);
+      const ctor = this._typeRegistry._resolveExtensionType(path);
 
       if (ctor !== undefined) {
-        const pathAdapter = this._seamlessAdapters.get(ctor);
+        const pathAdapter = this._typeRegistry.getSeamlessAdapter(ctor);
 
         if (pathAdapter !== undefined) {
           const handle = this._getSeamless(ctor, pathAdapter, path, source);
-          this._claim(this._key(ctor, path), ctor, path, claimer);
+          this._claim(this._typeRegistry._key(ctor, path), ctor, path, claimer);
 
           return handle;
         }
@@ -865,7 +841,7 @@ export class Loader {
 
       if (valueToken !== undefined) {
         const ref = this._getRef(valueToken, path, source);
-        this._claim(this._key(valueToken, path), valueToken, path, claimer);
+        this._claim(this._typeRegistry._key(valueToken, path), valueToken, path, claimer);
 
         return ref;
       }
@@ -875,7 +851,7 @@ export class Loader {
         throw new Error(`Loader: no type registered for any extension of "${path}". Register one via defineAsset() (its extensions).`);
       }
 
-      throw new Error(`Loader: type ${this._describeType(ctor)} inferred from "${path}" has no seamless adapter — use load() instead.`);
+      throw new Error(`Loader: type ${this._typeRegistry._describeType(ctor)} inferred from "${path}" has no seamless adapter — use load() instead.`);
     }
 
     // Not a container, meta-leaf, or path string: a Loadable type token.
@@ -891,7 +867,7 @@ export class Loader {
       throw new Error(`Missing resource "${src}" for type ${ctor.name}.`);
     }
 
-    this._claim(this._key(ctor, src), ctor, src, claimer);
+    this._claim(this._typeRegistry._key(ctor, src), ctor, src, claimer);
 
     return typeMap.get(src);
   }
@@ -916,7 +892,7 @@ export class Loader {
   public release(handle: object): void;
   public release(type: AssetConstructor, source: string): void;
   public release(handleOrType: object | AssetConstructor, source?: string): void {
-    const key = typeof source === 'string' ? this._key(handleOrType as AssetConstructor, source) : this._handleKeys.get(handleOrType);
+    const key = typeof source === 'string' ? this._typeRegistry._key(handleOrType as AssetConstructor, source) : this._handleKeys.get(handleOrType);
 
     if (key !== undefined) {
       this._release(key, this._rootClaimer);
@@ -968,11 +944,11 @@ export class Loader {
   public unload(arg0: unknown, arg1?: unknown): this {
     if (arg0 instanceof AssetImpl) {
       const asset = arg0 as Asset<unknown>;
-      const ctor = this._assetTypeMap.get(asset.kind);
+      const ctor = this._typeRegistry.resolveTypeName(asset.kind);
 
       if (!ctor) return this;
 
-      const identityKey = this._resolveAssetIdentityKey(ctor, asset);
+      const identityKey = this._typeRegistry._resolveAssetIdentityKey(ctor, asset);
       const aliasSet = this._identityKeyToAliases.get(identityKey);
 
       if (aliasSet && aliasSet.size > 0) {
@@ -1010,7 +986,7 @@ export class Loader {
 
   private _unloadOne(type: Loadable, alias: string): this {
     const ctor = type;
-    const aliasKey = this._key(ctor, alias);
+    const aliasKey = this._typeRegistry._key(ctor, alias);
 
     // Snapshot BEFORE the delete: a key whose resource is already stored has a
     // SETTLED fetch — any lingering `_inFlight` entry for it is stale (its
@@ -1080,7 +1056,7 @@ export class Loader {
     // honoring "does not cancel in-flight fetches".
     const settledKeys = new Set<string>();
     for (const [ctor, typeMap] of this._resources) {
-      for (const alias of typeMap.keys()) settledKeys.add(this._key(ctor, alias));
+      for (const alias of typeMap.keys()) settledKeys.add(this._typeRegistry._key(ctor, alias));
     }
 
     for (const typeMap of this._resources.values()) {
@@ -1207,89 +1183,7 @@ export class Loader {
     keys: { type: AssetConstructor<Result>; typeNames?: readonly string[]; extensions?: readonly string[]; seamless?: SeamlessAdapter<Result> },
     handler: AssetHandler<Result, Options>,
   ): void {
-    const normalizedExts: string[] = [];
-    const resolvedNames: string[] = keys.typeNames !== undefined ? [...keys.typeNames] : [];
-
-    // Normalise extension keys
-    for (const ext of keys.extensions ?? []) {
-      normalizedExts.push(ext.replace(/^\./, '').toLowerCase());
-    }
-
-    // Validate: detect duplicates within this binding
-    const seenExts = new Set<string>();
-
-    for (const ext of normalizedExts) {
-      if (seenExts.has(ext)) {
-        throw new Error(`Duplicate extension key ".${ext}" within a single asset binding.`);
-      }
-
-      seenExts.add(ext);
-    }
-
-    // Validate: detect conflicts with already-registered keys — throw before any mutation
-    if (this._handlerFunctions.has(keys.type)) {
-      throw new Error(`An asset handler is already registered for ${keys.type.name}.`);
-    }
-
-    for (const name of resolvedNames) {
-      if (this._assetTypeMap.has(name)) {
-        throw new Error(`Asset type name "${name}" is already registered.`);
-      }
-    }
-
-    for (const ext of normalizedExts) {
-      if (this._extensionMap.has(ext)) {
-        throw new Error(`File extension ".${ext}" is already mapped to an asset type.`);
-      }
-    }
-
-    // All validation passed — install atomically.
-    //
-    // Localized type-erasure boundary: the internal Loader uses a flat config
-    // `{ source, ...fields }`. The public AssetHandler<Result, Options> interface
-    // uses `AssetLoadRequest<Options> = { source, options? }`. This single `toRequest`
-    // helper is the only place where the erased flat config is cast to the typed
-    // request — justified by the `AssetBinding<Result, Options>` contract that
-    // associates this handler's Options with the registered constructor.
-    //
-    // `options` is intentionally omitted (not set to `undefined`) when the flat
-    // config carries no extra fields, keeping the object compatible with a future
-    // `exactOptionalPropertyTypes` migration.
-    const toRequest = (config: unknown): AssetLoadRequest<Options> => {
-      const { source, ...rest } = config as { source: string } & Record<string, unknown>;
-
-      if (Object.keys(rest).length === 0) {
-        return { source };
-      }
-
-      return { source, options: rest as Options };
-    };
-
-    const boundIdentityKey = handler.getIdentityKey?.bind(handler);
-    const boundCreateFromBytes = handler.createFromBytes?.bind(handler);
-
-    this._handlerFunctions.set(keys.type, {
-      load: (config, ctx) => handler.load(toRequest(config), ctx),
-      ...(boundIdentityKey && { getIdentityKey: (config: unknown) => boundIdentityKey(toRequest(config)) }),
-      ...(boundCreateFromBytes && { createFromBytes: (bytes: ArrayBuffer, options?: unknown) => boundCreateFromBytes(bytes, options as Options) }),
-    });
-
-    for (const name of resolvedNames) {
-      this._assetTypeMap.set(name, keys.type);
-    }
-
-    for (const ext of normalizedExts) {
-      this._extensionMap.set(ext, keys.type);
-    }
-
-    // Own this handler for lifecycle management.
-    // Cast to the erased AssetHandler for storage; destroy() is the only method
-    // called on entries in this array.
-    this._boundHandlers.push(handler as AssetHandler);
-
-    if (keys.seamless !== undefined) {
-      this.registerSeamlessAdapter(keys.type, keys.seamless);
-    }
+    this._typeRegistry.bindAsset(keys, handler);
   }
 
   /**
@@ -1297,7 +1191,7 @@ export class Loader {
    * @advanced
    */
   public hasLoadable(type: AssetConstructor): boolean {
-    return this._handlerFunctions.has(type) || this._registry.has(type);
+    return this._typeRegistry.hasLoadable(type);
   }
 
   /**
@@ -1305,7 +1199,7 @@ export class Loader {
    * @advanced
    */
   public hasAssetType(typeName: string): boolean {
-    return this._assetTypeMap.has(typeName);
+    return this._typeRegistry.hasAssetType(typeName);
   }
 
   /**
@@ -1314,7 +1208,7 @@ export class Loader {
    * @advanced
    */
   public hasExtension(ext: string): boolean {
-    return this._extensionMap.has(ext.replace(/^\./, '').toLowerCase());
+    return this._typeRegistry.hasExtension(ext);
   }
 
   // -----------------------------------------------------------------------
@@ -1330,33 +1224,20 @@ export class Loader {
    * registered via `bindAsset`.
    */
   public destroy(): void {
-    this._registry.destroy();
+    this._typeRegistry.destroy();
 
     for (const store of this._stores) {
       store.destroy();
     }
 
-    // Call destroy on all bound handlers (deduplicated by identity)
-    const destroyedHandlers = new Set<AssetHandler>();
-
-    for (const handler of this._boundHandlers) {
-      if (!destroyedHandlers.has(handler)) {
-        destroyedHandlers.add(handler);
-        handler.destroy?.();
-      }
-    }
-
-    this._boundHandlers.length = 0;
     this._resources.clear();
     this._inFlight.clear();
     this._preventStoreKeys.clear();
     this._inFlightByIdentity.clear();
     this._aliasKeyToIdentityKey.clear();
     this._identityKeyToAliases.clear();
-    this._handlerFunctions.clear();
     this._deferred.clear();
     this._refs.clear();
-    this._seamlessAdapters.clear();
     this._backgroundQueue.length = 0;
     this.onProgress.destroy();
     this.onLoaded.destroy();
@@ -1392,7 +1273,7 @@ export class Loader {
       throw new Error('Loader._adopt: value is not an Assets.from() leaf (no assetMeta).');
     }
 
-    const ctor = this._assetTypeMap.get(meta.kind);
+    const ctor = this._typeRegistry.resolveTypeName(meta.kind);
 
     if (ctor === undefined) {
       throw new Error(`Loader._adopt: no constructor registered for kind "${meta.kind}".`);
@@ -1404,7 +1285,7 @@ export class Loader {
     const leafState = (handle as { _loadState?: { value: string; begin(): void } })._loadState;
     if (leafState?.value === 'idle') leafState.begin();
 
-    const key = this._key(ctor, meta.src);
+    const key = this._typeRegistry._key(ctor, meta.src);
 
     if (handle instanceof AssetRef) {
       const existingRef = this._refs.get(key);
@@ -1474,7 +1355,7 @@ export class Loader {
       // donor was itself registered here at store time, so the entry already
       // exists (its representative stays canonical); the co-handle only ever
       // joins, never displaces it.
-      const adapter = this._seamlessAdapters.get(ctor);
+      const adapter = this._typeRegistry.getSeamlessAdapter(ctor);
 
       adapter?.fill(handle, stored);
 
@@ -1507,7 +1388,7 @@ export class Loader {
       return stored;
     }
 
-    const key = this._key(type, source);
+    const key = this._typeRegistry._key(type, source);
     const entry = this._deferred.get(key);
 
     if (entry !== undefined) {
@@ -1557,7 +1438,7 @@ export class Loader {
 
   /** Value-asset twin of {@link _getSeamless}: stable ref, options first-wins, retry-on-failed. */
   private _getRef(type: AssetConstructor, source: string, options?: unknown): AssetRef<unknown> {
-    const key = this._key(type, source);
+    const key = this._typeRegistry._key(type, source);
     const entry = this._refs.get(key);
 
     if (entry !== undefined) {
@@ -1617,7 +1498,7 @@ export class Loader {
    */
   private _enqueueBackgroundFetch(type: AssetConstructor, source: string, options: unknown): void {
     if (this._hasResource(type, source)) return;
-    if (this._inFlight.has(this._key(type, source))) return;
+    if (this._inFlight.has(this._typeRegistry._key(type, source))) return;
     if (this._isQueuedInBackground(type, source)) return;
 
     if (this._backgroundQueue.length === 0 && this._backgroundActive === 0) {
@@ -1650,7 +1531,7 @@ export class Loader {
       this._evicted.delete(key);
 
       // The handle was re-armed to 'loading' during eviction; just re-drive the fetch.
-      if (this._seamlessAdapters.has(type)) {
+      if (this._typeRegistry.hasSeamlessAdapter(type)) {
         this._startSeamlessFetch(type, source, this._deferred.get(key)?.options);
       }
     }
@@ -1710,7 +1591,7 @@ export class Loader {
    * @internal
    */
   private _evictKey(key: string, type: AssetConstructor, source: string): void {
-    const adapter = this._seamlessAdapters.get(type);
+    const adapter = this._typeRegistry.getSeamlessAdapter(type);
     const stored = this._resources.get(type)?.get(source);
 
     if (adapter !== undefined && stored !== undefined) {
@@ -1756,7 +1637,7 @@ export class Loader {
 
     // Drop a not-yet-started background entry (only possible while still queued;
     // once _startBackgroundEntry ran it is in _inFlight and cannot be cancelled).
-    const queued = this._backgroundQueue.findIndex(entry => this._key(entry.type, entry.alias) === key);
+    const queued = this._backgroundQueue.findIndex(entry => this._typeRegistry._key(entry.type, entry.alias) === key);
 
     if (queued !== -1) {
       this._backgroundQueue.splice(queued, 1);
@@ -1771,7 +1652,7 @@ export class Loader {
       }
     }
 
-    const key = this._key(type, alias);
+    const key = this._typeRegistry._key(type, alias);
 
     if (this._inFlight.has(key)) {
       return this._inFlight.get(key);
@@ -1798,7 +1679,7 @@ export class Loader {
 
     const itemPromises = items.map(({ alias, asset }) => {
       this._onFgBatchStart(alias, asset.source);
-      const ctor = this._assetTypeMap.get(asset.kind);
+      const ctor = this._typeRegistry.resolveTypeName(asset.kind);
 
       if (!ctor) {
         // Must call _notifyItem(false) so LoadingProgress doesn't remain stuck.
@@ -1816,7 +1697,7 @@ export class Loader {
         );
       }
 
-      this._claim(this._key(ctor, alias), ctor, alias, claimer);
+      this._claim(this._typeRegistry._key(ctor, alias), ctor, alias, claimer);
 
       return this._loadSingleAsset(ctor, alias, asset).then(
         resource => {
@@ -1900,10 +1781,10 @@ export class Loader {
 
     // Identity key: use handler's getIdentityKey if provided (config-sensitive dedup),
     // otherwise fall back to source-based identity (correct for URL-only assets).
-    const handlerEntry = this._handlerFunctions.get(type);
+    const handlerEntry = this._typeRegistry.getHandler(type);
     const discriminator = handlerEntry?.getIdentityKey?.(rawConfig) ?? source;
-    const identityKey = `id:${this._getTypeId(type)}:${discriminator}`;
-    const aliasKey = this._key(type, alias);
+    const identityKey = `id:${this._typeRegistry._getTypeId(type)}:${discriminator}`;
+    const aliasKey = this._typeRegistry._key(type, alias);
 
     // Register alias → identity mapping for unload() semantics
     this._aliasKeyToIdentityKey.set(aliasKey, identityKey);
@@ -1943,7 +1824,7 @@ export class Loader {
           const failedAliases = this._identityKeyToAliases.get(identityKey);
           if (failedAliases) {
             for (const fa of failedAliases) {
-              const faKey = this._key(type, fa);
+              const faKey = this._typeRegistry._key(type, fa);
               this._aliasKeyToIdentityKey.delete(faKey);
               this._preventStoreKeys.delete(faKey);
             }
@@ -2031,13 +1912,13 @@ export class Loader {
    * bytes. The backing path for {@link loadContainer}.
    */
   private async _injectSource(type: AssetConstructor, alias: string, bytes: ArrayBuffer, options?: unknown): Promise<void> {
-    const handlerEntry = this._handlerFunctions.get(type);
+    const handlerEntry = this._typeRegistry.getHandler(type);
     let resource: unknown;
 
     if (handlerEntry?.createFromBytes) {
       resource = await handlerEntry.createFromBytes(bytes, options);
-    } else if (this._registry.has(type)) {
-      resource = await this._registry.resolve(type).create(bytes, options);
+    } else if (this._typeRegistry.hasFactory(type)) {
+      resource = await this._typeRegistry.resolveFactory(type).create(bytes, options);
     } else {
       throw new Error(`Asset type "${type.name}" cannot be built from container bytes (no createFromBytes handler).`);
     }
@@ -2053,13 +1934,13 @@ export class Loader {
    * honor `bindAsset` handlers identically.
    */
   private _dispatchFetch(type: AssetConstructor, alias: string, path: string, options?: unknown): Promise<unknown> {
-    const handlerEntry = this._handlerFunctions.get(type);
+    const handlerEntry = this._typeRegistry.getHandler(type);
 
     if (!handlerEntry) {
       return this._fetch(type, alias, path, options);
     }
 
-    const identityKey = this._identityKey(type, path);
+    const identityKey = this._typeRegistry._identityKey(type, path);
     const config: Record<string, unknown> = { source: path };
 
     if (options !== null && options !== undefined && typeof options === 'object') {
@@ -2072,7 +1953,7 @@ export class Loader {
   }
 
   private async _fetch(type: AssetConstructor, alias: string, path: string, options?: unknown): Promise<unknown> {
-    const factory = this._registry.resolve(type);
+    const factory = this._typeRegistry.resolveFactory(type);
     const url = this._resolveUrl(path);
 
     try {
@@ -2141,7 +2022,7 @@ export class Loader {
       if (!entry) {
         continue;
       }
-      const key = this._key(entry.type, entry.alias);
+      const key = this._typeRegistry._key(entry.type, entry.alias);
 
       if (this._hasResource(entry.type, entry.alias) || this._inFlight.has(key)) {
         this._backgroundLoaded++;
@@ -2185,7 +2066,7 @@ export class Loader {
     this._trackInFlight(entry.type, entry.alias, this._dispatchFetch(entry.type, entry.alias, entry.path, entry.options))
       .catch(error => {
         const err = this._normalizeError(error);
-        const key2 = this._key(entry.type, entry.alias);
+        const key2 = this._typeRegistry._key(entry.type, entry.alias);
 
         if (!this._deferred.has(key2) && !this._refs.has(key2)) {
           this.onError.dispatch(entry.type, entry.alias, err);
@@ -2200,7 +2081,7 @@ export class Loader {
   }
 
   private _trackInFlight(type: AssetConstructor, alias: string, promise: Promise<unknown>): Promise<unknown> {
-    const key = this._key(type, alias);
+    const key = this._typeRegistry._key(type, alias);
     const trackedPromise = promise.finally(() => {
       // Clear only our OWN entry: a superseding load (e.g. a reclaim re-fetch
       // after an eviction dropped and re-added this key) may already own the
@@ -2227,7 +2108,7 @@ export class Loader {
     const deferredEntry = this._deferred.get(key);
 
     if (deferredEntry !== undefined) {
-      const adapter = this._seamlessAdapters.get(type);
+      const adapter = this._typeRegistry.getSeamlessAdapter(type);
 
       // Fail EVERY in-flight handle for the key so all co-adopters settle.
       for (const handle of deferredEntry.handles) {
@@ -2326,7 +2207,7 @@ export class Loader {
       return;
     }
 
-    logger.warn(`get(${this._describeType(type)}, "${source}"): conflicting options ignored — the first call's options win.`, {
+    logger.warn(`get(${this._typeRegistry._describeType(type)}, "${source}"): conflicting options ignored — the first call's options win.`, {
       source: 'Loader',
       once: `loader:seamless-options:${key}`,
     });
@@ -2434,16 +2315,12 @@ export class Loader {
     return error instanceof Error ? error : new Error(String(error));
   }
 
-  private _describeType(type: AssetConstructor): string {
-    return type.name.length > 0 ? type.name : '(anonymous type)';
-  }
-
   private _hasResource(type: AssetConstructor, alias: string): boolean {
     return this._resources.get(type)?.has(alias) ?? false;
   }
 
   private _storeResource(type: AssetConstructor, alias: string, resource: unknown): unknown {
-    const key = this._key(type, alias);
+    const key = this._typeRegistry._key(type, alias);
 
     if (this._preventStoreKeys.delete(key)) {
       // The asset was unloaded while its fetch was in flight. A deferred handle
@@ -2453,7 +2330,7 @@ export class Loader {
       const preventedEntry = this._deferred.get(key);
 
       if (preventedEntry !== undefined) {
-        const adapter = this._seamlessAdapters.get(type);
+        const adapter = this._typeRegistry.getSeamlessAdapter(type);
         const unloadError = new Error(`Asset "${alias}" was unloaded while its fetch was in flight.`);
 
         for (const handle of preventedEntry.handles) {
@@ -2482,7 +2359,7 @@ export class Loader {
     let filledDeferredHandle = false;
 
     if (deferredEntry !== undefined) {
-      const adapter = this._seamlessAdapters.get(type);
+      const adapter = this._typeRegistry.getSeamlessAdapter(type);
       let representative: object | undefined;
 
       // Fill EVERY in-flight handle for the key from the single decoded donor
@@ -2555,7 +2432,7 @@ export class Loader {
     // set. A resource that already came from a deferred handle is a member
     // already; a plain `load()` donor (no prior get()) is added here. Held
     // weakly, so a fully-released source does not pin its evicted payload (A4).
-    if (typeof resource === 'object' && resource !== null && this._seamlessAdapters.has(type) && this._deferred.get(key) === undefined) {
+    if (typeof resource === 'object' && resource !== null && this._typeRegistry.hasSeamlessAdapter(type) && this._deferred.get(key) === undefined) {
       this._createDeferredEntry(key, resource);
     }
 
@@ -2576,39 +2453,6 @@ export class Loader {
     return resource;
   }
 
-  private _getTypeId(type: AssetConstructor): number {
-    let typeId = this._typeIds.get(type);
-
-    if (typeId === undefined) {
-      typeId = this._nextTypeId++;
-      this._typeIds.set(type, typeId);
-    }
-
-    return typeId;
-  }
-
-  private _key(type: AssetConstructor, alias: string): string {
-    return `${this._getTypeId(type)}:${alias}`;
-  }
-
-  private _identityKey(type: AssetConstructor, source: string): string {
-    return `id:${this._getTypeId(type)}:${source}`;
-  }
-
-  /**
-   * Resolves the effective identity key for an `Asset<T>` reference, mirroring
-   * the logic used in `_loadSingleAsset`.
-   *
-   * For handler types with `getIdentityKey`, the config-sensitive discriminator
-   * is used; otherwise source is the discriminator (same as `_identityKey`).
-   */
-  private _resolveAssetIdentityKey(type: AssetConstructor, asset: Asset<unknown>): string {
-    const rawConfig = asset._config as Record<string, unknown>;
-    const handlerEntry = this._handlerFunctions.get(type);
-    const discriminator = handlerEntry?.getIdentityKey?.(rawConfig) ?? asset.source;
-    return `id:${this._getTypeId(type)}:${discriminator}`;
-  }
-
   private _resolveUrl(path: string): string {
     if (path.startsWith('http://') || path.startsWith('https://') || path.startsWith('//') || path.startsWith('/')) {
       return path;
@@ -2617,24 +2461,4 @@ export class Loader {
     return `${this._basePath}${path}`;
   }
 
-  /**
-   * Resolve the registered asset type for a path by matching the basename's
-   * dot-suffixes longest-first (Entscheidung #14): `hero.aseprite.json` tries
-   * `aseprite.json` before `json`. Query/hash suffixes are ignored.
-   */
-  private _resolveExtensionType(path: string): AssetConstructor | undefined {
-    const [withoutQueryHash = ''] = path.split(/[?#]/, 1);
-    const basename = withoutQueryHash.split('/').pop() ?? '';
-    const parts = basename.split('.');
-
-    for (let i = 1; i < parts.length; i++) {
-      const ctor = this._extensionMap.get(parts.slice(i).join('.').toLowerCase());
-
-      if (ctor !== undefined) {
-        return ctor;
-      }
-    }
-
-    return undefined;
-  }
 }

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -1224,11 +1224,13 @@ export class Loader {
    * registered via `bindAsset`.
    */
   public destroy(): void {
-    this._typeRegistry.destroy();
+    this._typeRegistry.destroyFactories();
 
     for (const store of this._stores) {
       store.destroy();
     }
+
+    this._typeRegistry.destroyHandlers();
 
     this._resources.clear();
     this._inFlight.clear();

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -1224,6 +1224,8 @@ export class Loader {
    * registered via `bindAsset`.
    */
   public destroy(): void {
+    // Order matters: bound-handler destroy must run after store destroy (mirrors
+    // the original inline teardown order) — see the regression test in loader.test.ts.
     this._typeRegistry.destroyFactories();
 
     for (const store of this._stores) {
@@ -1784,8 +1786,7 @@ export class Loader {
     // Identity key: use handler's getIdentityKey if provided (config-sensitive dedup),
     // otherwise fall back to source-based identity (correct for URL-only assets).
     const handlerEntry = this._typeRegistry.getHandler(type);
-    const discriminator = handlerEntry?.getIdentityKey?.(rawConfig) ?? source;
-    const identityKey = `id:${this._typeRegistry._getTypeId(type)}:${discriminator}`;
+    const identityKey = this._typeRegistry._resolveAssetIdentityKey(type, asset);
     const aliasKey = this._typeRegistry._key(type, alias);
 
     // Register alias → identity mapping for unload() semantics
@@ -2462,5 +2463,4 @@ export class Loader {
 
     return `${this._basePath}${path}`;
   }
-
 }

--- a/test/core/scene-loader-catalog.test.ts
+++ b/test/core/scene-loader-catalog.test.ts
@@ -69,7 +69,7 @@ describe('SceneLoader catalog adopt', () => {
     await assets.ship.loaded;
     expect(assets.ship.loadState).toBe('ready');
 
-    const key = loader['_key'](Texture, 'ship.png');
+    const key = loader['_typeRegistry']['_key'](Texture, 'ship.png');
     expect(loader['_claims'].get(key)?.scopes.size).toBe(1);
 
     sceneLoader.destroy();
@@ -88,7 +88,7 @@ describe('SceneLoader catalog adopt', () => {
     expect(assets.ship.loadState).toBe('ready');
     expect(assets.ship).toBeInstanceOf(Texture);
 
-    const key = loader['_key'](Texture, 'ship.png');
+    const key = loader['_typeRegistry']['_key'](Texture, 'ship.png');
     expect(loader['_claims'].get(key)?.scopes.size).toBe(1);
 
     sceneLoader.destroy();
@@ -108,7 +108,7 @@ describe('SceneLoader catalog adopt', () => {
     expect(result).toBe(assets.ship); // resource leaf resolves to the healed handle itself
     expect(assets.ship.loadState).toBe('ready');
 
-    const key = loader['_key'](Texture, 'ship.png');
+    const key = loader['_typeRegistry']['_key'](Texture, 'ship.png');
     expect(loader['_claims'].get(key)?.scopes.size).toBe(1);
 
     sceneLoader.destroy();

--- a/test/resources/asset-type-registry.test.ts
+++ b/test/resources/asset-type-registry.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { AssetTypeRegistry } from '#resources/AssetTypeRegistry';
+import type { AssetFactory } from '#resources/AssetFactory';
+
+class TypeA {}
+class TypeB {}
+
+function fakeFactory<T>(create: () => T): AssetFactory<T> {
+  return {
+    storageName: 'test',
+    process: async (r: Response) => r,
+    create: async () => create(),
+    destroy: vi.fn(),
+  };
+}
+
+describe('AssetTypeRegistry', () => {
+  test('register/hasFactory/resolveFactory round-trip', () => {
+    const registry = new AssetTypeRegistry();
+    const factory = fakeFactory(() => new TypeA());
+
+    expect(registry.hasFactory(TypeA)).toBe(false);
+    registry.register(TypeA, factory);
+    expect(registry.hasFactory(TypeA)).toBe(true);
+    expect(registry.resolveFactory(TypeA)).toBe(factory);
+  });
+
+  test('registerSeamlessAdapter throws on a duplicate registration for the same type', () => {
+    const registry = new AssetTypeRegistry();
+    const adapter = { createPlaceholder: vi.fn(), stateOf: vi.fn(), begin: vi.fn(), fill: vi.fn(), fail: vi.fn(), evict: vi.fn() };
+
+    registry.registerSeamlessAdapter(TypeA, adapter as never);
+    expect(() => registry.registerSeamlessAdapter(TypeA, adapter as never)).toThrow(/already registered/);
+  });
+
+  test('hasSeamlessAdapter/getSeamlessAdapter reflect registration', () => {
+    const registry = new AssetTypeRegistry();
+    const adapter = { createPlaceholder: vi.fn(), stateOf: vi.fn(), begin: vi.fn(), fill: vi.fn(), fail: vi.fn(), evict: vi.fn() };
+
+    expect(registry.hasSeamlessAdapter(TypeA)).toBe(false);
+    registry.registerSeamlessAdapter(TypeA, adapter as never);
+    expect(registry.hasSeamlessAdapter(TypeA)).toBe(true);
+    expect(registry.getSeamlessAdapter(TypeA)).toBe(adapter);
+  });
+
+  test('bindAsset registers type names and extensions atomically, and validates before mutating', () => {
+    const registry = new AssetTypeRegistry();
+    const handler = { load: vi.fn(async () => ({})) };
+
+    registry.bindAsset({ type: TypeA, typeNames: ['type-a'], extensions: ['ta'] }, handler);
+
+    expect(registry.hasAssetType('type-a')).toBe(true);
+    expect(registry.hasExtension('.ta')).toBe(true);
+    expect(registry.hasLoadable(TypeA)).toBe(true);
+    expect(registry.getHandler(TypeA)).toBeDefined();
+  });
+
+  test('bindAsset throws on a duplicate handler for the same type, without touching unrelated state', () => {
+    const registry = new AssetTypeRegistry();
+    const handler = { load: vi.fn(async () => ({})) };
+
+    registry.bindAsset({ type: TypeA, typeNames: ['type-a'] }, handler);
+
+    expect(() => registry.bindAsset({ type: TypeA, typeNames: ['type-a-again'] }, handler)).toThrow(/already registered/);
+    // The failed second call must not have registered its type name.
+    expect(registry.hasAssetType('type-a-again')).toBe(false);
+  });
+
+  test('bindAsset throws on a duplicate type name across different types, validated before any mutation', () => {
+    const registry = new AssetTypeRegistry();
+    const handler = { load: vi.fn(async () => ({})) };
+
+    registry.bindAsset({ type: TypeA, typeNames: ['shared-name'] }, handler);
+
+    const otherHandler = { load: vi.fn(async () => ({})) };
+    expect(() => registry.bindAsset({ type: TypeB, typeNames: ['shared-name'] }, otherHandler)).toThrow(/already registered/);
+    expect(registry.hasLoadable(TypeB)).toBe(false);
+  });
+
+  test('bindAsset registers a seamless adapter when keys.seamless is provided', () => {
+    const registry = new AssetTypeRegistry();
+    const handler = { load: vi.fn(async () => ({})) };
+    const adapter = { createPlaceholder: vi.fn(), stateOf: vi.fn(), begin: vi.fn(), fill: vi.fn(), fail: vi.fn(), evict: vi.fn() };
+
+    registry.bindAsset({ type: TypeA, seamless: adapter as never }, handler);
+
+    expect(registry.hasSeamlessAdapter(TypeA)).toBe(true);
+  });
+
+  test('_key/_identityKey derive stable, distinct per-type-per-alias keys', () => {
+    const registry = new AssetTypeRegistry();
+
+    expect(registry._key(TypeA, 'a.png')).toBe(registry._key(TypeA, 'a.png'));
+    expect(registry._key(TypeA, 'a.png')).not.toBe(registry._key(TypeB, 'a.png'));
+    expect(registry._identityKey(TypeA, 'a.png')).not.toBe(registry._key(TypeA, 'a.png'));
+  });
+
+  test('_resolveExtensionType matches the longest registered dot-suffix first', () => {
+    const registry = new AssetTypeRegistry();
+    const handler = { load: vi.fn(async () => ({})) };
+
+    registry.bindAsset({ type: TypeA, extensions: ['json'] }, handler);
+    registry.bindAsset({ type: TypeB, extensions: ['aseprite.json'] }, handler);
+
+    expect(registry._resolveExtensionType('hero.aseprite.json')).toBe(TypeB);
+    expect(registry._resolveExtensionType('plain.json')).toBe(TypeA);
+    expect(registry._resolveExtensionType('no-extension-match.xyz')).toBeUndefined();
+  });
+
+  test('_describeType falls back to a placeholder name for an anonymous constructor', () => {
+    const registry = new AssetTypeRegistry();
+    const Anonymous = (() => class {})();
+
+    expect(registry._describeType(Anonymous)).toBe('(anonymous type)');
+    expect(registry._describeType(TypeA)).toBe('TypeA');
+  });
+
+  test('destroy() destroys every bound handler exactly once, even if bound under multiple names', () => {
+    const registry = new AssetTypeRegistry();
+    const destroy = vi.fn();
+    const handler = { load: vi.fn(async () => ({})), destroy };
+
+    registry.bindAsset({ type: TypeA }, handler);
+    registry.destroy();
+
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(registry.hasLoadable(TypeA)).toBe(false);
+  });
+});

--- a/test/resources/asset-type-registry.test.ts
+++ b/test/resources/asset-type-registry.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, vi } from 'vitest';
 
-import { AssetTypeRegistry } from '#resources/AssetTypeRegistry';
 import type { AssetFactory } from '#resources/AssetFactory';
+import { AssetTypeRegistry } from '#resources/AssetTypeRegistry';
 
 class TypeA {}
 class TypeB {}

--- a/test/resources/catalog-adopt.test.ts
+++ b/test/resources/catalog-adopt.test.ts
@@ -235,7 +235,7 @@ describe('Loader._adopt', () => {
     // silently couldn't resolve the key and the claim leaked. release(handle)
     // always targets the app-lifetime root claimer (same scope loader.get()
     // claimed under above), so it must now actually drop that scope.
-    const key = loader['_key'](Texture, 'x.png');
+    const key = loader['_typeRegistry']['_key'](Texture, 'x.png');
     expect(loader['_claims'].get(key)?.scopes.has(loader['_rootClaimer'])).toBe(true);
 
     loader.release(leaf);
@@ -290,7 +290,7 @@ describe('Loader._adopt', () => {
     expect(leaf.value).toEqual({ hp: 3 });
 
     // Bug: release(handle) couldn't resolve the key for this branch either.
-    const key = loader['_key'](Json, 'cfg.json');
+    const key = loader['_typeRegistry']['_key'](Json, 'cfg.json');
     expect(loader['_claims'].get(key)?.scopes.has(loader['_rootClaimer'])).toBe(true);
 
     loader.release(leaf);

--- a/test/resources/loader-claims.test.ts
+++ b/test/resources/loader-claims.test.ts
@@ -136,16 +136,16 @@ describe('refcount / claims', () => {
     loader._getClaimed(scopeB, Asset.kind('sound', 'boom.ogg'));
     await handle.loaded;
 
-    loader._release(loader['_key'](Sound, 'boom.ogg'), scopeA);
+    loader._release(loader['_typeRegistry']['_key'](Sound, 'boom.ogg'), scopeA);
     expect(handle.audioBuffer).not.toBeNull(); // B still holds it
-    loader._release(loader['_key'](Sound, 'boom.ogg'), scopeB);
+    loader._release(loader['_typeRegistry']['_key'](Sound, 'boom.ogg'), scopeB);
     expect(handle.audioBuffer).toBeNull(); // both gone → evicted
   });
 
   test('release while the fetch is still in flight frees the handle on arrival (§4.7)', async () => {
     mockFetchAudio();
     const loader = createCoreLoader();
-    const key = loader['_key'](Sound, 'boom.ogg');
+    const key = loader['_typeRegistry']['_key'](Sound, 'boom.ogg');
 
     const handle = loader.get('boom.ogg');
     // Fetch is in flight: the handle is still deferred, not yet in _resources.
@@ -174,7 +174,7 @@ describe('refcount / claims', () => {
   test('a concurrent load in the reclaim window does not overwrite the healed handle (identity race)', async () => {
     mockFetchAudio();
     const loader = createCoreLoader();
-    const key = loader['_key'](Sound, 'boom.ogg');
+    const key = loader['_typeRegistry']['_key'](Sound, 'boom.ogg');
 
     const handle = loader.get('boom.ogg');
     await handle.loaded;

--- a/test/resources/loader-deferred-handles.test.ts
+++ b/test/resources/loader-deferred-handles.test.ts
@@ -37,7 +37,7 @@ function evictedHas(loader: Loader, key: string): boolean {
   return (loader as unknown as { _evicted: Set<string> })._evicted.has(key);
 }
 function keyOf(loader: Loader, source: string): string {
-  return (loader as unknown as { _key(t: unknown, s: string): string })._key(Texture, source);
+  return (loader as unknown as { _typeRegistry: { _key(t: unknown, s: string): string } })._typeRegistry._key(Texture, source);
 }
 
 /** Real major GC + macrotask hops so reclaimed WeakRefs settle. Needs `--expose-gc`. */

--- a/test/resources/loader-unload-claims.test.ts
+++ b/test/resources/loader-unload-claims.test.ts
@@ -35,7 +35,7 @@ function refSize(loader: Loader): number {
   return (loader as unknown as { _refs: Map<string, unknown> })._refs.size;
 }
 function keyOf(loader: Loader, type: unknown, source: string): string {
-  return (loader as unknown as { _key(t: unknown, s: string): string })._key(type, source);
+  return (loader as unknown as { _typeRegistry: { _key(t: unknown, s: string): string } })._typeRegistry._key(type, source);
 }
 
 describe('Loader unload()/unloadAll() claim consistency (A3)', () => {

--- a/test/resources/loader.test.ts
+++ b/test/resources/loader.test.ts
@@ -1496,6 +1496,20 @@ describe('destroy()', () => {
 
     expect(() => loader.destroy()).not.toThrow();
   });
+
+  test('destroys CacheStores before bound bindAsset handlers', () => {
+    class OrderAsset {}
+    const order: string[] = [];
+    const store = createCacheStoreMock({ destroy: vi.fn(() => order.push('store')) });
+    const handlerDestroy = vi.fn(() => order.push('handler'));
+    const loader = new Loader({ basePath: '/', cache: store });
+
+    loader.bindAsset({ type: OrderAsset }, { load: async () => 'x', destroy: handlerDestroy });
+
+    loader.destroy();
+
+    expect(order).toEqual(['store', 'handler']);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/resources/loader.test.ts
+++ b/test/resources/loader.test.ts
@@ -948,7 +948,7 @@ describe('unload(asset) + getIdentityKey — identity discrimination (Fix 2 regr
 
     await loader.load({ tmxA: tmxMap, tmxB: tmxMap, rpgA: rpgMap });
 
-    const ctor = loader['_assetTypeMap'].get('richAsset')!;
+    const ctor = loader['_typeRegistry']['resolveTypeName']('richAsset')!;
 
     expect(loader._peekResource(ctor, 'tmxA')).not.toBeNull();
     expect(loader._peekResource(ctor, 'tmxB')).not.toBeNull();
@@ -970,7 +970,7 @@ describe('unload(asset) + getIdentityKey — identity discrimination (Fix 2 regr
 
     await loader.load({ a: asset, b: asset });
 
-    const ctor = loader['_assetTypeMap'].get('richAsset')!;
+    const ctor = loader['_typeRegistry']['resolveTypeName']('richAsset')!;
 
     expect(loader._peekResource(ctor, 'a')).not.toBeNull();
     expect(loader._peekResource(ctor, 'b')).not.toBeNull();
@@ -997,7 +997,7 @@ describe('unload(asset) + getIdentityKey — identity discrimination (Fix 2 regr
 
     await loader.load({ tmxA: tmxMap, rpgA: rpgMap });
 
-    const ctor = loader['_assetTypeMap'].get('richAsset')!;
+    const ctor = loader['_typeRegistry']['resolveTypeName']('richAsset')!;
 
     loader.unload(rpgMap);
 
@@ -1206,7 +1206,7 @@ describe('hasLoadable() / hasAssetType() / hasExtension()', () => {
 
     expect(loader.hasLoadable(HandlerAsset)).toBe(false);
     loader.bindAsset<string>({ type: HandlerAsset, typeNames: ['handlerType'] }, { load: async () => 'ok' });
-    const ctor = loader['_assetTypeMap'].get('handlerType')!;
+    const ctor = loader['_typeRegistry']['resolveTypeName']('handlerType')!;
 
     expect(loader.hasLoadable(ctor)).toBe(true);
   });


### PR DESCRIPTION
## Summary

Slice 1 of 4 in the internal-only Loader-split refactor (`.workspace/specs/2026-07-25-loader-split-design.md`) — closing the second of 5 pre-1.0 architecture-audit findings (`src/resources/Loader.ts` flagged as the engine's single highest rewrite-risk system, 2640 lines / ~35 fields / ~70 methods).

This slice extracts the constructor-based type/extension/handler/seamless-adapter registry into a standalone `AssetTypeRegistry` class:

- `src/resources/AssetTypeRegistry.ts` (new) owns `register()`/`bindAsset()`/`registerSeamlessAdapter()` targets, extension mapping, per-instance type IDs, and key/identity-key derivation — proven correct standalone with its own unit test suite.
- `Loader` composes one `AssetTypeRegistry` instance and delegates all ~40+ call sites to it. Six public `Loader` methods (`register`/`registerSeamlessAdapter`/`bindAsset`/`hasLoadable`/`hasAssetType`/`hasExtension`) keep their exact original signatures and JSDoc as thin delegates.
- **Zero public API change** — verified structurally (nothing new exported from `src/resources/index.ts`/`src/index.ts`) and via `pnpm docs:api:check` (generated API docs unchanged in shape).

A real bug was caught and fixed during review: the initial migration reordered `Loader.destroy()`'s teardown (bound-`bindAsset`-handler destroy now ran before `CacheStore` destroy instead of after). Fixed by splitting `AssetTypeRegistry.destroy()` into `destroyFactories()`/`destroyHandlers()` so `Loader.destroy()` can interleave the store-teardown loop between them — now covered by a dedicated order-sensitive regression test.

Slices 2–4 (`AssetDecoder`, `AssetResidency`, final `Loader.ts` cleanup) are separate, later PRs per the spec.

## Test plan

- [x] `pnpm test:core` — 328 test files, 5302 tests passing, 0 failures (up from the 327/5290 baseline only by Task 1's new standalone tests — the pre-existing ~5000-line `test/resources/loader*.test.ts` suite is unmodified in its assertions, proving this refactor is behavior-preserving)
- [x] `pnpm typecheck` / `pnpm docs:api:check` — clean
- [x] Repo-wide grep confirms no file outside `AssetTypeRegistry.ts` (in `src/`, `packages/`, `examples/`, `site/`, `test/`) still references the removed fields/methods
- [x] `pnpm verify:quick` — all gates pass (pre-push hook)
- [x] Implemented via subagent-driven-development: 2 tasks, each independently reviewed; one mid-task scope correction (4 additional white-box test files using a different cast idiom the plan initially missed — found by the implementer, verified by the controller, fixed within the task); one final whole-branch review (3 Important + 2 Minor findings, all fixed and re-reviewed clean)

Design: `.workspace/specs/2026-07-25-loader-split-design.md`, Slice 1 plan: `.workspace/plans/2026-07-25-loader-split-slice1-type-registry.md` (both local, not part of this diff)