### PR TITLE
refactor(resources): extract AssetDecoder from Loader (Loader split, Slice 2/4)

### DIFF
--- a/src/resources/AssetDecoder.ts
+++ b/src/resources/AssetDecoder.ts
@@ -1,0 +1,238 @@
+import type { AssetTypeRegistry } from './AssetTypeRegistry';
+import type { AssetFactory } from './AssetFactory';
+import type { CacheStore } from './CacheStore';
+import type { CacheStrategy } from './CacheStrategy';
+import type { AssetConstructor } from './FactoryRegistry';
+import type { AssetLoaderContext, Loader } from './Loader';
+
+/** Construction options for {@link AssetDecoder}. Values are already resolved by `Loader` — see `Loader`'s constructor. */
+export interface AssetDecoderOptions {
+  basePath: string;
+  fetchOptions: RequestInit;
+  stores: readonly CacheStore[];
+  cacheStrategy: CacheStrategy;
+}
+
+/**
+ * Turns "a type + a path, or a `bindAsset` handler" into a decoded resource:
+ * URL resolution, cache-strategy dispatch, `bindAsset` handler invocation
+ * (including the {@link AssetLoaderContext} handlers receive), and the
+ * container byte-injection path. Extracted from `Loader` (Loader split,
+ * Slice 2) — every method here is a direct, behavior-preserving relocation.
+ *
+ * Deliberately does not know about claims, deferred handles, or the
+ * resident-resource map: every method that resolves a resource hands it to
+ * the `storeResource` callback supplied at construction instead of storing
+ * it directly, so this class stays "identity + bytes/handler in, resource
+ * out."
+ */
+export class AssetDecoder {
+  private readonly _loader: Loader;
+  private readonly _typeRegistry: AssetTypeRegistry;
+  private readonly _storeResource: (type: AssetConstructor, alias: string, resource: unknown) => unknown;
+  private readonly _stores: readonly CacheStore[];
+  private readonly _cacheStrategy: CacheStrategy;
+  private _basePath: string;
+  private _fetchOptions: RequestInit;
+
+  public constructor(
+    loader: Loader,
+    typeRegistry: AssetTypeRegistry,
+    storeResource: (type: AssetConstructor, alias: string, resource: unknown) => unknown,
+    options: AssetDecoderOptions,
+  ) {
+    this._loader = loader;
+    this._typeRegistry = typeRegistry;
+    this._storeResource = storeResource;
+    this._stores = options.stores;
+    this._cacheStrategy = options.cacheStrategy;
+    this._basePath = options.basePath;
+    this._fetchOptions = options.fetchOptions;
+  }
+
+  /**
+   * Base path prepended to every relative asset URL at fetch time.
+   * Absolute URLs (starting with `http://`, `https://`, or `//`) are
+   * passed through unchanged.
+   */
+  public get basePath(): string {
+    return this._basePath;
+  }
+
+  public set basePath(value: string) {
+    this._basePath = value;
+  }
+
+  /** Default `RequestInit` options merged into every `fetch` call. */
+  public get fetchOptions(): RequestInit {
+    return this._fetchOptions;
+  }
+
+  public set fetchOptions(value: RequestInit) {
+    this._fetchOptions = value;
+  }
+
+  private _resolveUrl(path: string): string {
+    if (path.startsWith('http://') || path.startsWith('https://') || path.startsWith('//') || path.startsWith('/')) {
+      return path;
+    }
+
+    return `${this._basePath}${path}`;
+  }
+
+  /**
+   * Fetches `source` through the loader's cache strategy with an inline
+   * pass-through factory, using `source` as the IDB key.
+   *
+   * `process` converts the raw `Response` to the storable intermediate form
+   * (e.g. `r.text()`, `r.arrayBuffer()`, `r.json()`).  `create` is always the
+   * identity function — the cached value is returned unchanged.
+   * @internal
+   */
+  public _contextFetch<T>(source: string, storageName: string, process: (response: Response) => Promise<T>): Promise<T> {
+    const url = this._resolveUrl(source);
+    const factory: AssetFactory<T> = {
+      storageName,
+      process,
+      create: data => Promise.resolve(data as T),
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      destroy() {},
+    };
+    return this._cacheStrategy.resolve(
+      { storageName, key: source, url, requestOptions: this._fetchOptions, factory, options: undefined },
+      this._stores,
+    ) as Promise<T>;
+  }
+
+  /**
+   * Builds an {@link AssetLoaderContext} for a handler invocation.
+   *
+   * The `fetch*` helpers on the returned context route through the loader's
+   * configured cache strategy and IDB stores, using `source` as the IDB key
+   * (so the same URL is never fetched twice regardless of the asset alias).
+   * @internal
+   */
+  public _buildHandlerContext(identityKey: string): AssetLoaderContext {
+    const ctx: AssetLoaderContext = {
+      loader: this._loader,
+      identityKey,
+      fetchText: (source: string) => this._contextFetch<string>(source, '__ctx_text', r => r.text()),
+      fetchArrayBuffer: (source: string) => this._contextFetch<ArrayBuffer>(source, '__ctx_binary', r => r.arrayBuffer()),
+      fetchJson: <T = unknown>(source: string) => this._contextFetch<T>(source, '__ctx_json', r => r.json() as Promise<T>),
+    };
+    return ctx;
+  }
+
+  /**
+   * Calls a handler-based custom asset loader and hands the result to the
+   * `storeResource` callback.
+   *
+   * Unlike {@link _fetch}, this does NOT automatically bypass caching — the
+   * handler controls caching by calling `context.fetchText` /
+   * `context.fetchArrayBuffer` / `context.fetchJson`, which route through
+   * the loader's cache strategy.
+   * @internal
+   */
+  public async _fetchWithHandler(
+    type: AssetConstructor,
+    alias: string,
+    source: string,
+    fullConfig: unknown,
+    handler: (config: unknown, ctx: AssetLoaderContext) => Promise<unknown>,
+    context: AssetLoaderContext,
+  ): Promise<unknown> {
+    const url = this._resolveUrl(source);
+    try {
+      const resource = await handler(fullConfig, context);
+
+      return this._storeResource(type, alias, resource);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to load "${alias}" from "${url}": ${message}`, { cause: error });
+    }
+  }
+
+  /** @internal */
+  public async _fetch(type: AssetConstructor, alias: string, path: string, options?: unknown): Promise<unknown> {
+    const factory = this._typeRegistry.resolveFactory(type);
+    const url = this._resolveUrl(path);
+
+    try {
+      const resource = await this._cacheStrategy.resolve(
+        {
+          storageName: factory.storageName,
+          key: path, // source-path as IDB key so same resource is not cached multiple times under different aliases
+          url,
+          requestOptions: this._fetchOptions,
+          factory,
+          options,
+        },
+        this._stores,
+      );
+
+      return this._storeResource(type, alias, resource);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      throw new Error(`Failed to load "${alias}" from "${url}": ${message}`, {
+        cause: error,
+      });
+    }
+  }
+
+  /**
+   * Dispatches a load through the `bindAsset` handler path if one is
+   * registered for `type`, otherwise through the plain `register()`-based
+   * {@link _fetch}. Shared by the foreground and background fetch
+   * dispatchers on `Loader` so both honor `bindAsset` handlers identically.
+   * @internal
+   */
+  public _dispatchFetch(type: AssetConstructor, alias: string, path: string, options?: unknown): Promise<unknown> {
+    const handlerEntry = this._typeRegistry.getHandler(type);
+
+    if (!handlerEntry) {
+      return this._fetch(type, alias, path, options);
+    }
+
+    const identityKey = this._typeRegistry._identityKey(type, path);
+    const config: Record<string, unknown> = { source: path };
+
+    if (options !== null && options !== undefined && typeof options === 'object') {
+      Object.assign(config, options as Record<string, unknown>);
+    }
+
+    const context = this._buildHandlerContext(identityKey);
+
+    return this._fetchWithHandler(type, alias, path, config, handlerEntry.load, context);
+  }
+
+  /**
+   * Construct an asset from in-memory `bytes` (no fetch) and hand it to the
+   * `storeResource` callback under `alias`. Uses the type's
+   * {@link AssetHandler.createFromBytes} when present, otherwise a
+   * `register()`-style factory; throws if neither can build from bytes. The
+   * backing path for `Loader.loadContainer`.
+   * @internal
+   */
+  public async _injectSource(type: AssetConstructor, alias: string, bytes: ArrayBuffer, options?: unknown): Promise<void> {
+    const handlerEntry = this._typeRegistry.getHandler(type);
+    let resource: unknown;
+
+    if (handlerEntry?.createFromBytes) {
+      resource = await handlerEntry.createFromBytes(bytes, options);
+    } else if (this._typeRegistry.hasFactory(type)) {
+      resource = await this._typeRegistry.resolveFactory(type).create(bytes, options);
+    } else {
+      throw new Error(`Asset type "${type.name}" cannot be built from container bytes (no createFromBytes handler).`);
+    }
+
+    this._storeResource(type, alias, resource);
+  }
+
+  /** Destroys every configured cache store. */
+  public destroy(): void {
+    for (const store of this._stores) {
+      store.destroy();
+    }
+  }
+}

--- a/src/resources/AssetDecoder.ts
+++ b/src/resources/AssetDecoder.ts
@@ -1,5 +1,7 @@
-import type { AssetTypeRegistry } from './AssetTypeRegistry';
+import type { AssetHandler } from '#extensions/Extension';
+
 import type { AssetFactory } from './AssetFactory';
+import type { AssetTypeRegistry } from './AssetTypeRegistry';
 import type { CacheStore } from './CacheStore';
 import type { CacheStrategy } from './CacheStrategy';
 import type { AssetConstructor } from './FactoryRegistry';
@@ -50,11 +52,7 @@ export class AssetDecoder {
     this._fetchOptions = options.fetchOptions;
   }
 
-  /**
-   * Base path prepended to every relative asset URL at fetch time.
-   * Absolute URLs (starting with `http://`, `https://`, or `//`) are
-   * passed through unchanged.
-   */
+  /** Base path prepended to relative asset URLs at fetch time. @see Loader.basePath for the full contract. */
   public get basePath(): string {
     return this._basePath;
   }

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -7,6 +7,7 @@ import type { Texture } from '#rendering/texture/Texture';
 
 import { type Asset, AssetImpl, type ValueAsset } from './Asset';
 import { parseContainer } from './AssetContainer';
+import { AssetDecoder } from './AssetDecoder';
 import type {
   AssetDefinitions,
   AssetInput,
@@ -250,6 +251,7 @@ interface QueueEntry {
  */
 export class Loader {
   private readonly _typeRegistry = new AssetTypeRegistry();
+  private readonly _decoder: AssetDecoder;
   private readonly _resources = new Map<AssetConstructor, Map<string, unknown>>();
   // Reverse lookup: loaded resource object → the (type, source) it was first
   // stored under. Backs {@link Loader.keyFor} for scene serialization. A
@@ -258,8 +260,6 @@ export class Loader {
   private readonly _resourceKeys = new WeakMap<object, { type: AssetConstructor; source: string }>();
   private readonly _inFlight = new Map<string, Promise<unknown>>();
   private readonly _preventStoreKeys = new Set<string>();
-  private readonly _stores: readonly CacheStore[];
-  private readonly _cacheStrategy: CacheStrategy;
 
   // ── Identity / alias tracking for the new Asset API ───────────────────────
   // Maps alias key (`${typeId}:${alias}`) to an identity key (`id:${typeId}:${source}`)
@@ -338,8 +338,6 @@ export class Loader {
   /** Deferred handle / value-ref → its resource key, for `release(handle)`. @internal */
   private readonly _handleKeys = new WeakMap<object, string>();
 
-  private _basePath: string;
-  private _fetchOptions: RequestInit;
   private _concurrency: number;
 
   private _fgBatchActive = 0;
@@ -369,11 +367,17 @@ export class Loader {
   public readonly onLoadError = new Signal<[key: string, error: Error]>();
 
   public constructor(options: LoaderOptions = {}) {
-    this._basePath = options.basePath ?? '';
-    this._fetchOptions = options.fetchOptions ?? {};
     this._concurrency = options.concurrency ?? 6;
-    this._stores = options.cache ? (Array.isArray(options.cache) ? options.cache : [options.cache]) : [];
-    this._cacheStrategy = options.cacheStrategy ?? new CacheFirstStrategy();
+
+    const stores = options.cache ? (Array.isArray(options.cache) ? options.cache : [options.cache]) : [];
+    const cacheStrategy = options.cacheStrategy ?? new CacheFirstStrategy();
+
+    this._decoder = new AssetDecoder(this, this._typeRegistry, (type, alias, resource) => this._storeResource(type, alias, resource), {
+      basePath: options.basePath ?? '',
+      fetchOptions: options.fetchOptions ?? {},
+      stores,
+      cacheStrategy,
+    });
   }
 
   // -----------------------------------------------------------------------
@@ -421,7 +425,7 @@ export class Loader {
    * @param url Path to the container file, resolved against the loader base path.
    */
   public async loadContainer(url: string): Promise<void> {
-    const buffer = await this._contextFetch<ArrayBuffer>(url, '__ctx_binary', response => response.arrayBuffer());
+    const buffer = await this._decoder._contextFetch<ArrayBuffer>(url, '__ctx_binary', response => response.arrayBuffer());
     const { entries, dataStart } = parseContainer(buffer);
 
     // Resolve every type up front so an unknown type fails before any asset is stored.
@@ -440,7 +444,7 @@ export class Loader {
         const start = dataStart + entry.offset;
         const slice = buffer.slice(start, start + entry.length);
 
-        return this._injectSource(type, entry.alias, slice, entry.options);
+        return this._decoder._injectSource(type, entry.alias, slice, entry.options);
       }),
     );
   }
@@ -1146,11 +1150,11 @@ export class Loader {
    * passed through unchanged.
    */
   public get basePath(): string {
-    return this._basePath;
+    return this._decoder.basePath;
   }
 
   public set basePath(value: string) {
-    this._basePath = value;
+    this._decoder.basePath = value;
   }
 
   /**
@@ -1158,11 +1162,11 @@ export class Loader {
    * Override per-load with the `options` argument of {@link load}.
    */
   public get fetchOptions(): RequestInit {
-    return this._fetchOptions;
+    return this._decoder.fetchOptions;
   }
 
   public set fetchOptions(value: RequestInit) {
-    this._fetchOptions = value;
+    this._decoder.fetchOptions = value;
   }
 
   // -----------------------------------------------------------------------
@@ -1227,11 +1231,7 @@ export class Loader {
     // Order matters: bound-handler destroy must run after store destroy (mirrors
     // the original inline teardown order) — see the regression test in loader.test.ts.
     this._typeRegistry.destroyFactories();
-
-    for (const store of this._stores) {
-      store.destroy();
-    }
-
+    this._decoder.destroy();
     this._typeRegistry.destroyHandlers();
 
     this._resources.clear();
@@ -1670,7 +1670,7 @@ export class Loader {
 
     const path = explicitPath ?? alias;
 
-    return this._trackInFlight(type, alias, this._dispatchFetch(type, alias, path, options));
+    return this._trackInFlight(type, alias, this._decoder._dispatchFetch(type, alias, path, options));
   }
 
   private _createLoadingQueue<T>(
@@ -1808,11 +1808,11 @@ export class Loader {
     let fetchPromise: Promise<unknown>;
     if (handlerEntry) {
       const fullConfig = { source, ...extraOnly };
-      const context = this._buildHandlerContext(identityKey);
-      fetchPromise = this._fetchWithHandler(type, alias, source, fullConfig, handlerEntry.load, context);
+      const context = this._decoder._buildHandlerContext(identityKey);
+      fetchPromise = this._decoder._fetchWithHandler(type, alias, source, fullConfig, handlerEntry.load, context);
     } else {
       const options = Object.keys(extraOnly).length > 0 ? extraOnly : undefined;
-      fetchPromise = this._fetch(type, alias, source, options);
+      fetchPromise = this._decoder._fetch(type, alias, source, options);
     }
 
     const tracked: Promise<unknown> = fetchPromise
@@ -1839,147 +1839,6 @@ export class Loader {
 
     this._inFlightByIdentity.set(identityKey, tracked);
     return tracked;
-  }
-
-  /**
-   * Calls a handler-based custom asset loader and stores the result.
-   *
-   * Unlike `_fetch`, this does NOT automatically bypass caching — the handler
-   * controls caching by calling `context.fetchText` / `context.fetchArrayBuffer`
-   * / `context.fetchJson`, which route through the loader's cache strategy.
-   */
-  private async _fetchWithHandler(
-    type: AssetConstructor,
-    alias: string,
-    source: string,
-    fullConfig: unknown,
-    handler: (config: unknown, ctx: AssetLoaderContext) => Promise<unknown>,
-    context: AssetLoaderContext,
-  ): Promise<unknown> {
-    const url = this._resolveUrl(source);
-    try {
-      const resource = await handler(fullConfig, context);
-
-      return this._storeResource(type, alias, resource);
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`Failed to load "${alias}" from "${url}": ${message}`, { cause: error });
-    }
-  }
-
-  /**
-   * Builds an {@link AssetLoaderContext} for a handler invocation.
-   *
-   * The `fetch*` helpers on the returned context route through the loader's
-   * configured cache strategy and IDB stores, using `source` as the IDB key
-   * (so the same URL is never fetched twice regardless of the asset alias).
-   */
-  private _buildHandlerContext(identityKey: string): AssetLoaderContext {
-    const ctx: AssetLoaderContext = {
-      loader: this,
-      identityKey,
-      fetchText: (source: string) => this._contextFetch<string>(source, '__ctx_text', r => r.text()),
-      fetchArrayBuffer: (source: string) => this._contextFetch<ArrayBuffer>(source, '__ctx_binary', r => r.arrayBuffer()),
-      fetchJson: <T = unknown>(source: string) => this._contextFetch<T>(source, '__ctx_json', r => r.json() as Promise<T>),
-    };
-    return ctx;
-  }
-
-  /**
-   * Fetches `source` through the loader's cache strategy with an inline
-   * pass-through factory, using `source` as the IDB key.
-   *
-   * `process` converts the raw `Response` to the storable intermediate form
-   * (e.g. `r.text()`, `r.arrayBuffer()`, `r.json()`).  `create` is always the
-   * identity function — the cached value is returned unchanged.
-   */
-  private _contextFetch<T>(source: string, storageName: string, process: (response: Response) => Promise<T>): Promise<T> {
-    const url = this._resolveUrl(source);
-    const factory: AssetFactory<T> = {
-      storageName,
-      process,
-      create: data => Promise.resolve(data as T),
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      destroy() {},
-    };
-    return this._cacheStrategy.resolve(
-      { storageName, key: source, url, requestOptions: this._fetchOptions, factory, options: undefined },
-      this._stores,
-    ) as Promise<T>;
-  }
-
-  /**
-   * Construct an asset from in-memory `bytes` (no fetch) and store it under
-   * `alias`. Uses the type's {@link AssetHandler.createFromBytes} when present,
-   * otherwise a `register()`-style factory; throws if neither can build from
-   * bytes. The backing path for {@link loadContainer}.
-   */
-  private async _injectSource(type: AssetConstructor, alias: string, bytes: ArrayBuffer, options?: unknown): Promise<void> {
-    const handlerEntry = this._typeRegistry.getHandler(type);
-    let resource: unknown;
-
-    if (handlerEntry?.createFromBytes) {
-      resource = await handlerEntry.createFromBytes(bytes, options);
-    } else if (this._typeRegistry.hasFactory(type)) {
-      resource = await this._typeRegistry.resolveFactory(type).create(bytes, options);
-    } else {
-      throw new Error(`Asset type "${type.name}" cannot be built from container bytes (no createFromBytes handler).`);
-    }
-
-    this._storeResource(type, alias, resource);
-  }
-
-  /**
-   * Dispatches a load through the `bindAsset` handler path if one is
-   * registered for `type`, otherwise through the plain `register()`-based
-   * {@link _fetch}. Shared by the foreground ({@link _loadSingle}) and
-   * background ({@link _startBackgroundEntry}) fetch dispatchers so both
-   * honor `bindAsset` handlers identically.
-   */
-  private _dispatchFetch(type: AssetConstructor, alias: string, path: string, options?: unknown): Promise<unknown> {
-    const handlerEntry = this._typeRegistry.getHandler(type);
-
-    if (!handlerEntry) {
-      return this._fetch(type, alias, path, options);
-    }
-
-    const identityKey = this._typeRegistry._identityKey(type, path);
-    const config: Record<string, unknown> = { source: path };
-
-    if (options !== null && options !== undefined && typeof options === 'object') {
-      Object.assign(config, options as Record<string, unknown>);
-    }
-
-    const context = this._buildHandlerContext(identityKey);
-
-    return this._fetchWithHandler(type, alias, path, config, handlerEntry.load, context);
-  }
-
-  private async _fetch(type: AssetConstructor, alias: string, path: string, options?: unknown): Promise<unknown> {
-    const factory = this._typeRegistry.resolveFactory(type);
-    const url = this._resolveUrl(path);
-
-    try {
-      const resource = await this._cacheStrategy.resolve(
-        {
-          storageName: factory.storageName,
-          key: path, // source-path as IDB key so same resource is not cached multiple times under different aliases
-          url,
-          requestOptions: this._fetchOptions,
-          factory,
-          options,
-        },
-        this._stores,
-      );
-
-      return this._storeResource(type, alias, resource);
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-
-      throw new Error(`Failed to load "${alias}" from "${url}": ${message}`, {
-        cause: error,
-      });
-    }
   }
 
   // -----------------------------------------------------------------------
@@ -2066,7 +1925,7 @@ export class Loader {
   private _startBackgroundEntry(entry: QueueEntry): void {
     this._backgroundActive++;
 
-    this._trackInFlight(entry.type, entry.alias, this._dispatchFetch(entry.type, entry.alias, entry.path, entry.options))
+    this._trackInFlight(entry.type, entry.alias, this._decoder._dispatchFetch(entry.type, entry.alias, entry.path, entry.options))
       .catch(error => {
         const err = this._normalizeError(error);
         const key2 = this._typeRegistry._key(entry.type, entry.alias);
@@ -2454,13 +2313,5 @@ export class Loader {
     }
 
     return resource;
-  }
-
-  private _resolveUrl(path: string): string {
-    if (path.startsWith('http://') || path.startsWith('https://') || path.startsWith('//') || path.startsWith('/')) {
-      return path;
-    }
-
-    return `${this._basePath}${path}`;
   }
 }

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -1228,8 +1228,9 @@ export class Loader {
    * registered via `bindAsset`.
    */
   public destroy(): void {
-    // Order matters: bound-handler destroy must run after store destroy (mirrors
-    // the original inline teardown order) — see the regression test in loader.test.ts.
+    // Order matters: bound-handler destroy must run after store destroy (via
+    // this._decoder.destroy(), which mirrors the original inline teardown
+    // order) — see the regression test in loader.test.ts.
     this._typeRegistry.destroyFactories();
     this._decoder.destroy();
     this._typeRegistry.destroyHandlers();

--- a/test/resources/asset-decoder.test.ts
+++ b/test/resources/asset-decoder.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import type { AssetFactory } from '#resources/AssetFactory';
+import { AssetDecoder } from '#resources/AssetDecoder';
+import { AssetTypeRegistry } from '#resources/AssetTypeRegistry';
+import type { CacheRequest, CacheStrategy } from '#resources/CacheStrategy';
+import type { CacheStore } from '#resources/CacheStore';
+import type { Loader } from '#resources/Loader';
+
+class TypeA {}
+
+const fakeLoader = {} as Loader;
+
+function fakeFactory<T>(create: (data: unknown, options?: unknown) => T): AssetFactory<T> {
+  return {
+    storageName: 'test',
+    process: async (r: Response) => r,
+    create: async (data: unknown, options?: unknown) => create(data, options),
+    destroy: vi.fn(),
+  };
+}
+
+const createCacheStoreMock = (overrides: Partial<CacheStore> = {}): CacheStore => ({
+  load: vi.fn(async (): Promise<unknown | null> => null),
+  save: vi.fn(async (): Promise<void> => undefined),
+  delete: vi.fn(async (): Promise<boolean> => true),
+  clear: vi.fn(async (): Promise<boolean> => true),
+  destroy: vi.fn(),
+  ...overrides,
+});
+
+/** Fake strategy that resolves to a canned value and records the request it received. */
+function createFakeStrategy(resolveTo: (request: CacheRequest) => unknown = () => 'resolved'): {
+  strategy: CacheStrategy;
+  requests: CacheRequest[];
+} {
+  const requests: CacheRequest[] = [];
+  const strategy: CacheStrategy = {
+    resolve: vi.fn(async (request: CacheRequest) => {
+      requests.push(request);
+      return resolveTo(request);
+    }),
+  };
+  return { strategy, requests };
+}
+
+function createDecoder(overrides: { cacheStrategy?: CacheStrategy; stores?: CacheStore[]; basePath?: string } = {}) {
+  const typeRegistry = new AssetTypeRegistry();
+  const stores = overrides.stores ?? [];
+  const { strategy } = overrides.cacheStrategy ? { strategy: overrides.cacheStrategy } : createFakeStrategy();
+  const storeResource = vi.fn((_type: unknown, _alias: string, resource: unknown) => resource);
+
+  const decoder = new AssetDecoder(fakeLoader, typeRegistry, storeResource, {
+    basePath: overrides.basePath ?? '',
+    fetchOptions: {},
+    stores,
+    cacheStrategy: strategy,
+  });
+
+  return { decoder, typeRegistry, storeResource, strategy };
+}
+
+describe('AssetDecoder', () => {
+  test('basePath/fetchOptions round-trip', () => {
+    const { decoder } = createDecoder();
+
+    decoder.basePath = 'assets/';
+    expect(decoder.basePath).toBe('assets/');
+
+    decoder.fetchOptions = { credentials: 'include' };
+    expect(decoder.fetchOptions).toEqual({ credentials: 'include' });
+  });
+
+  test('_fetch resolves through the cache strategy with the base-path-prefixed URL and stores via the callback', async () => {
+    const { strategy, requests } = createFakeStrategy(() => 'decoded-value');
+    const { decoder, typeRegistry, storeResource } = createDecoder({ cacheStrategy: strategy, basePath: 'assets/' });
+
+    typeRegistry.register(TypeA, fakeFactory(() => new TypeA()));
+
+    const result = await decoder._fetch(TypeA, 'hero', 'hero.png');
+
+    expect(requests[0]?.url).toBe('assets/hero.png');
+    expect(requests[0]?.key).toBe('hero.png');
+    expect(storeResource).toHaveBeenCalledWith(TypeA, 'hero', 'decoded-value');
+    expect(result).toBe('decoded-value');
+  });
+
+  test('_fetch wraps a rejected cache-strategy resolve in a "Failed to load" error and never stores', async () => {
+    const { strategy } = createFakeStrategy();
+    (strategy.resolve as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('network down'));
+    const { decoder, typeRegistry, storeResource } = createDecoder({ cacheStrategy: strategy });
+
+    typeRegistry.register(TypeA, fakeFactory(() => new TypeA()));
+
+    await expect(decoder._fetch(TypeA, 'hero', 'hero.png')).rejects.toThrow(/Failed to load "hero" from "hero.png": network down/);
+    expect(storeResource).not.toHaveBeenCalled();
+  });
+
+  test('_fetchWithHandler invokes the handler with the built context and stores the result', async () => {
+    const { decoder, storeResource } = createDecoder();
+    const handler = vi.fn(async () => 'handler-result');
+    const context = decoder._buildHandlerContext('id:1:hero.png');
+
+    const result = await decoder._fetchWithHandler(TypeA, 'hero', 'hero.png', { source: 'hero.png' }, handler, context);
+
+    expect(handler).toHaveBeenCalledWith({ source: 'hero.png' }, context);
+    expect(storeResource).toHaveBeenCalledWith(TypeA, 'hero', 'handler-result');
+    expect(result).toBe('handler-result');
+  });
+
+  test('_fetchWithHandler wraps a handler rejection and never stores', async () => {
+    const { decoder, storeResource } = createDecoder();
+    const handler = vi.fn(async () => {
+      throw new Error('bad payload');
+    });
+    const context = decoder._buildHandlerContext('id:1:hero.png');
+
+    await expect(decoder._fetchWithHandler(TypeA, 'hero', 'hero.png', {}, handler, context)).rejects.toThrow(
+      /Failed to load "hero" from "hero.png": bad payload/,
+    );
+    expect(storeResource).not.toHaveBeenCalled();
+  });
+
+  test('_dispatchFetch routes through _fetch when no bindAsset handler is registered', async () => {
+    const { strategy, requests } = createFakeStrategy(() => 'plain-fetch-value');
+    const { decoder, typeRegistry, storeResource } = createDecoder({ cacheStrategy: strategy });
+
+    typeRegistry.register(TypeA, fakeFactory(() => new TypeA()));
+
+    await decoder._dispatchFetch(TypeA, 'hero', 'hero.png');
+
+    expect(requests).toHaveLength(1);
+    expect(storeResource).toHaveBeenCalledWith(TypeA, 'hero', 'plain-fetch-value');
+  });
+
+  test('_dispatchFetch routes through the bindAsset handler when one is registered, merging options into the config', async () => {
+    const { decoder, typeRegistry, storeResource } = createDecoder();
+    const load = vi.fn(async (config: unknown) => ({ config }));
+
+    typeRegistry.bindAsset({ type: TypeA }, { load });
+
+    await decoder._dispatchFetch(TypeA, 'hero', 'hero.png', { scale: 2 });
+
+    expect(load).toHaveBeenCalledTimes(1);
+    const [configArg, contextArg] = load.mock.calls[0] as [unknown, unknown];
+
+    // Config should have source and include scale (either merged at top level or in options)
+    expect(configArg).toMatchObject({ source: 'hero.png' });
+    expect(contextArg).toMatchObject({ identityKey: expect.any(String) });
+    expect(storeResource).toHaveBeenCalledWith(TypeA, 'hero', expect.any(Object));
+  });
+
+  test('_injectSource uses createFromBytes when the handler provides it, and stores via the callback', async () => {
+    const { decoder, typeRegistry, storeResource } = createDecoder();
+    const createFromBytes = vi.fn(async (bytes: ArrayBuffer) => `from-bytes:${bytes.byteLength}`);
+
+    typeRegistry.bindAsset({ type: TypeA }, { load: vi.fn(), createFromBytes });
+
+    await decoder._injectSource(TypeA, 'hero', new ArrayBuffer(4));
+
+    expect(createFromBytes).toHaveBeenCalled();
+    expect(storeResource).toHaveBeenCalledWith(TypeA, 'hero', 'from-bytes:4');
+  });
+
+  test('_injectSource falls back to a register()-based factory when no createFromBytes handler exists', async () => {
+    const { decoder, typeRegistry, storeResource } = createDecoder();
+
+    typeRegistry.register(TypeA, fakeFactory((bytes: unknown) => `from-factory:${(bytes as ArrayBuffer).byteLength}`));
+
+    await decoder._injectSource(TypeA, 'hero', new ArrayBuffer(8));
+
+    expect(storeResource).toHaveBeenCalledWith(TypeA, 'hero', 'from-factory:8');
+  });
+
+  test('_injectSource throws when the type has neither createFromBytes nor a factory, and never stores', async () => {
+    const { decoder, storeResource } = createDecoder();
+
+    await expect(decoder._injectSource(TypeA, 'hero', new ArrayBuffer(4))).rejects.toThrow(/cannot be built from container bytes/);
+    expect(storeResource).not.toHaveBeenCalled();
+  });
+
+  test('_buildHandlerContext exposes the owning loader and routes fetch* through _contextFetch', async () => {
+    const { strategy, requests } = createFakeStrategy(() => 'ctx-text-value');
+    const { decoder } = createDecoder({ cacheStrategy: strategy });
+
+    const context = decoder._buildHandlerContext('id:1:hero.txt');
+
+    expect(context.loader).toBe(fakeLoader);
+    expect(context.identityKey).toBe('id:1:hero.txt');
+
+    const value = await context.fetchText('hero.txt');
+
+    expect(value).toBe('ctx-text-value');
+    expect(requests[0]?.storageName).toBe('__ctx_text');
+    expect(requests[0]?.key).toBe('hero.txt');
+  });
+
+  test('destroy() destroys every configured cache store', () => {
+    const storeA = createCacheStoreMock();
+    const storeB = createCacheStoreMock();
+    const { decoder } = createDecoder({ stores: [storeA, storeB] });
+
+    decoder.destroy();
+
+    expect(storeA.destroy).toHaveBeenCalledTimes(1);
+    expect(storeB.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/resources/asset-decoder.test.ts
+++ b/test/resources/asset-decoder.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test, vi } from 'vitest';
 
-import type { AssetFactory } from '#resources/AssetFactory';
 import { AssetDecoder } from '#resources/AssetDecoder';
+import type { AssetFactory } from '#resources/AssetFactory';
 import { AssetTypeRegistry } from '#resources/AssetTypeRegistry';
-import type { CacheRequest, CacheStrategy } from '#resources/CacheStrategy';
 import type { CacheStore } from '#resources/CacheStore';
+import type { CacheRequest, CacheStrategy } from '#resources/CacheStrategy';
 import type { Loader } from '#resources/Loader';
 
 class TypeA {}
@@ -75,7 +75,10 @@ describe('AssetDecoder', () => {
     const { strategy, requests } = createFakeStrategy(() => 'decoded-value');
     const { decoder, typeRegistry, storeResource } = createDecoder({ cacheStrategy: strategy, basePath: 'assets/' });
 
-    typeRegistry.register(TypeA, fakeFactory(() => new TypeA()));
+    typeRegistry.register(
+      TypeA,
+      fakeFactory(() => new TypeA()),
+    );
 
     const result = await decoder._fetch(TypeA, 'hero', 'hero.png');
 
@@ -90,7 +93,10 @@ describe('AssetDecoder', () => {
     (strategy.resolve as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('network down'));
     const { decoder, typeRegistry, storeResource } = createDecoder({ cacheStrategy: strategy });
 
-    typeRegistry.register(TypeA, fakeFactory(() => new TypeA()));
+    typeRegistry.register(
+      TypeA,
+      fakeFactory(() => new TypeA()),
+    );
 
     await expect(decoder._fetch(TypeA, 'hero', 'hero.png')).rejects.toThrow(/Failed to load "hero" from "hero.png": network down/);
     expect(storeResource).not.toHaveBeenCalled();
@@ -125,7 +131,10 @@ describe('AssetDecoder', () => {
     const { strategy, requests } = createFakeStrategy(() => 'plain-fetch-value');
     const { decoder, typeRegistry, storeResource } = createDecoder({ cacheStrategy: strategy });
 
-    typeRegistry.register(TypeA, fakeFactory(() => new TypeA()));
+    typeRegistry.register(
+      TypeA,
+      fakeFactory(() => new TypeA()),
+    );
 
     await decoder._dispatchFetch(TypeA, 'hero', 'hero.png');
 
@@ -160,7 +169,10 @@ describe('AssetDecoder', () => {
   test('_injectSource falls back to a register()-based factory when no createFromBytes handler exists', async () => {
     const { decoder, typeRegistry, storeResource } = createDecoder();
 
-    typeRegistry.register(TypeA, fakeFactory((bytes: unknown) => `from-factory:${(bytes as ArrayBuffer).byteLength}`));
+    typeRegistry.register(
+      TypeA,
+      fakeFactory((bytes: unknown) => `from-factory:${(bytes as ArrayBuffer).byteLength}`),
+    );
 
     await decoder._injectSource(TypeA, 'hero', new ArrayBuffer(8));
 

--- a/test/resources/asset-decoder.test.ts
+++ b/test/resources/asset-decoder.test.ts
@@ -141,13 +141,8 @@ describe('AssetDecoder', () => {
 
     await decoder._dispatchFetch(TypeA, 'hero', 'hero.png', { scale: 2 });
 
-    expect(load).toHaveBeenCalledTimes(1);
-    const [configArg, contextArg] = load.mock.calls[0] as [unknown, unknown];
-
-    // Config should have source and include scale (either merged at top level or in options)
-    expect(configArg).toMatchObject({ source: 'hero.png' });
-    expect(contextArg).toMatchObject({ identityKey: expect.any(String) });
-    expect(storeResource).toHaveBeenCalledWith(TypeA, 'hero', expect.any(Object));
+    expect(load).toHaveBeenCalledWith({ source: 'hero.png', options: { scale: 2 } }, expect.objectContaining({ identityKey: expect.any(String) }));
+    expect(storeResource).toHaveBeenCalledWith(TypeA, 'hero', { config: { source: 'hero.png', options: { scale: 2 } } });
   });
 
   test('_injectSource uses createFromBytes when the handler provides it, and stores via the callback', async () => {


### PR DESCRIPTION
## Summary
- Extracts the fetch/handler-dispatch/cache-strategy plumbing from `Loader` into a standalone `AssetDecoder` class (`src/resources/AssetDecoder.ts`), continuing the internal Loader-split effort started in Slice 1 (#414, `AssetTypeRegistry`).
- `AssetDecoder` deliberately never touches the resident-resource map: every resolved value is handed to a constructor-injected `storeResource` callback (currently wired to `Loader._storeResource`), so Slice 3 (`AssetResidency`) can repoint that one callback without redesigning this class.
- Pure internal refactor — no public API change. `Loader`'s public methods keep their exact signatures/JSDoc; `basePath`/`fetchOptions` become thin delegates. `docs:api:check` confirms zero drift in the generated API docs.
- `destroy()` teardown order (factories → stores → handlers) is preserved, including the regression coverage added after the Slice 1 review found a real ordering bug.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test:core` — 329/329 files, 5326 passed, 15 skipped, 0 failed
- [x] `pnpm verify:quick` (typecheck + guides/examples/type-tests/packages typecheck + lint + format + docs:api:check) — clean, only pre-existing unrelated warnings
- [x] New `test/resources/asset-decoder.test.ts` (12 tests) exercises `AssetDecoder` standalone against a real `AssetTypeRegistry` and faked I/O boundary (`CacheStrategy`/`CacheStore`)
- [x] Task-level and final whole-branch review both completed via subagent-driven-development (one fix round each: a loosened test assertion in Task 1, and lint/format/doc findings in the final review) — all findings verified addressed