### PR TITLE
docs(resources): close out the Loader-split effort with final cleanup (Slice 4/4)

### DIFF
--- a/src/resources/AssetResidency.ts
+++ b/src/resources/AssetResidency.ts
@@ -453,9 +453,8 @@ export class AssetResidency {
    * Register a fresh deferred entry for `key` holding `handle` weakly, wire the
    * reverse `handle → key` lookup, and arm GC pruning. Returns the entry so the
    * caller can add further co-handles.
-   * @internal
    */
-  public _createDeferredEntry(key: string, handle: object, options?: unknown): { readonly handles: WeakHandleSet; readonly options: unknown } {
+  private _createDeferredEntry(key: string, handle: object, options?: unknown): { readonly handles: WeakHandleSet; readonly options: unknown } {
     const entry = { handles: new WeakHandleSet(handle), options };
 
     this._deferred.set(key, entry);
@@ -488,9 +487,8 @@ export class AssetResidency {
    * later one is silently dropped. Per-handle sampler / pre-size options never
    * conflict — each handle carries its own — so they are stripped before the
    * comparison and never warn. A `undefined` second option is a plain reuse.
-   * @internal
    */
-  public _warnOnFetchOptionConflict(type: AssetConstructor, source: string, key: string, existingOptions: unknown, newOptions: unknown): void {
+  private _warnOnFetchOptionConflict(type: AssetConstructor, source: string, key: string, existingOptions: unknown, newOptions: unknown): void {
     if (newOptions === undefined || this._fetchOptionsEquivalent(existingOptions, newOptions)) {
       return;
     }
@@ -605,7 +603,7 @@ export class AssetResidency {
 
   /** @internal */
   public async _loadSingle(type: AssetConstructor, alias: string, options?: unknown, explicitPath?: string): Promise<unknown> {
-    if (this._hasResource(type, alias)) {
+    if (this._hasStored(type, alias)) {
       const typeMap = this._resources.get(type);
       if (typeMap?.has(alias) === true) {
         return typeMap.get(alias);
@@ -639,7 +637,7 @@ export class AssetResidency {
    * @internal
    */
   public async _loadSingleAsset(type: AssetConstructor, alias: string, asset: Asset<unknown>): Promise<unknown> {
-    if (this._hasResource(type, alias)) {
+    if (this._hasStored(type, alias)) {
       return this._resources.get(type)?.get(alias);
     }
 
@@ -772,10 +770,6 @@ export class AssetResidency {
 
   private _normalizeError(error: unknown): Error {
     return error instanceof Error ? error : new Error(String(error));
-  }
-
-  private _hasResource(type: AssetConstructor, alias: string): boolean {
-    return this._resources.get(type)?.has(alias) ?? false;
   }
 
   // -----------------------------------------------------------------------
@@ -938,7 +932,7 @@ export class AssetResidency {
    * @internal
    */
   public _enqueueBackgroundFetch(type: AssetConstructor, source: string, options: unknown): void {
-    if (this._hasResource(type, source)) return;
+    if (this._hasStored(type, source)) return;
     if (this._inFlight.has(this._typeRegistry._key(type, source))) return;
     if (this._isQueuedInBackground(type, source)) return;
 
@@ -960,7 +954,7 @@ export class AssetResidency {
       }
       const key = this._typeRegistry._key(entry.type, entry.alias);
 
-      if (this._hasResource(entry.type, entry.alias) || this._inFlight.has(key)) {
+      if (this._hasStored(entry.type, entry.alias) || this._inFlight.has(key)) {
         this._backgroundLoaded++;
         this._onBackgroundItemDone();
         continue;
@@ -1271,6 +1265,18 @@ export class AssetResidency {
     // too is more correct for a full teardown; added during the Loader-split extraction.
     this._claims.clear();
     this._evicted.clear();
+
     this._backgroundQueue.length = 0;
+    this._backgroundActive = 0;
+    this._backgroundLoaded = 0;
+    this._backgroundTotal = 0;
+
+    // A pending awaitBackground() caller must not hang forever past destroy().
+    if (this._backgroundResolve) {
+      const resolve = this._backgroundResolve;
+
+      this._backgroundResolve = null;
+      resolve();
+    }
   }
 }

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -236,6 +236,14 @@ export interface LoadOptions {
  * const loader = new Loader({ basePath: '/assets/', cache: new IndexedDbStore('game') });
  * const { hero } = await loader.load(Assets.from({ hero: 'hero.png' }));
  * ```
+ *
+ * @remarks Internally, `Loader` is a thin orchestrator over three collaborators:
+ * `AssetTypeRegistry` (type/extension/handler registration), `AssetDecoder`
+ * (URL resolution, cache-strategy dispatch, `bindAsset` handler invocation),
+ * and `AssetResidency` (claims, in-flight dedup, the resident-resource store,
+ * deferred-handle healing, the background queue). `Loader` itself keeps the
+ * public call-shape dispatch (`load`/`get`/`unload` and their `@internal`
+ * scene-scope entry points) and the foreground-batch progress signals.
  */
 export class Loader {
   private readonly _typeRegistry = new AssetTypeRegistry();
@@ -290,6 +298,11 @@ export class Loader {
     const stores = options.cache ? (Array.isArray(options.cache) ? options.cache : [options.cache]) : [];
     const cacheStrategy = options.cacheStrategy ?? new CacheFirstStrategy();
 
+    // The callback below reads `this._residency` before it's assigned two
+    // statements down — safe only because AssetDecoder's constructor never
+    // invokes it synchronously (it fires later, on a real fetch resolving).
+    // If AssetDecoder's construction ever changes to eagerly call back into
+    // the loader, this ordering must change too.
     this._decoder = new AssetDecoder(this, this._typeRegistry, (type, alias, resource) => this._residency._storeResource(type, alias, resource), {
       basePath: options.basePath ?? '',
       fetchOptions: options.fetchOptions ?? {},
@@ -685,9 +698,9 @@ export class Loader {
    * Claimed variant of {@link get}: identical resolution, but each resolved key
    * is claimed under `claimer` (refcount). The public {@link get} delegates here
    * under the app-lifetime {@link _rootClaimer}; the scene-scoped loader proxy
-   * passes its own scope. `_claim` runs AFTER `_getSeamless`/`_getRef` so an
-   * evicted key's re-fetch is driven from here (the re-armed handle reads
-   * `'loading'`, which `_getSeamless` alone would not re-fetch).
+   * passes its own scope. `_claim` runs AFTER `AssetResidency._getSeamless`/
+   * `_getRef` so an evicted key's re-fetch is driven from here (the re-armed
+   * handle reads `'loading'`, which `_getSeamless` alone would not re-fetch).
    * @internal
    */
   public _getClaimed(claimer: symbol, typeOrPath: Loadable | string | object, source?: unknown): unknown {
@@ -1026,13 +1039,14 @@ export class Loader {
    * Adopt an externally-created handle-hybrid leaf (from `Assets.from()`) into
    * this loader: register it as the deferred/ref handle under its normalized
    * key, claim it under `claimer`, and drive the fetch. The existing fill site
-   * ({@link _storeResource}) transplants the fetched payload into this exact
-   * object, so every consumer that already holds the leaf pops in. Idempotent
-   * for a handle already adopted under the same key (no duplicate fetch).
+   * (`AssetResidency._storeResource`) transplants the fetched payload into this
+   * exact object, so every consumer that already holds the leaf pops in.
+   * Idempotent for a handle already adopted under the same key (no duplicate
+   * fetch).
    *
    * With `background`, the leaf is still registered + claimed + healed in place,
    * but its fetch is diverted into the low-priority background queue (see
-   * {@link _enqueueBackgroundFetch}) instead of started immediately —
+   * `AssetResidency._enqueueBackgroundFetch`) instead of started immediately —
    * `load(target, { background: true })`.
    * @internal
    */
@@ -1061,8 +1075,9 @@ export class Loader {
 
   /**
    * Release every claim held under a claim scope (a scene unloading its
-   * scene-private assets). Collect the held keys first, then release — `_release`
-   * mutates `_claims`, so we must not delete during iteration.
+   * scene-private assets). Collect the held keys first, then release —
+   * `AssetResidency._release` mutates its own claim map, so we must not
+   * delete during iteration.
    * @internal
    */
   public _releaseScope(claimer: symbol): void {


### PR DESCRIPTION
## Summary
- Final slice of the 4-slice internal Loader-split effort (Slices 1-3: AssetTypeRegistry #414, AssetDecoder #415, AssetResidency #416 — all merged). No new extraction, no new interfaces, no behavior change.
- Fixes documentation left stale by the earlier extractions: two dangling `{@link}` JSDoc references and two prose mentions of fields/methods that moved to `AssetResidency` in Slice 3.
- Documents the `Loader` constructor's `storeResource`-callback ordering dependency in code (previously only in the now-archived plan), and adds a brief `@remarks` architecture note to `Loader`'s class-level doc describing the three-collaborator composition (`AssetTypeRegistry` / `AssetDecoder` / `AssetResidency`).
- Collapses a verified byte-identical duplicate method pair (`_hasResource`/`_hasStored`) in `AssetResidency.ts`.
- Tightens visibility on 2 of 4 candidate methods with zero cross-class callers from `public @internal` to `private` (the other 2 candidates were correctly kept `public @internal` after review found real test-suite callers for them).
- Completes a previously half-applied `AssetResidency.destroy()` fix: the background-queue teardown now also resets the active/loaded/total counters and resolves a pending `awaitBackground()` promise, instead of leaving them stale after a full teardown.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test:core` — 330/330 files, 5344 passed, 15 skipped, 0 failed
- [x] `pnpm verify:quick` (typecheck + guides/examples/type-tests/packages typecheck + lint + format + docs:api:check) — clean, only pre-existing unrelated warnings
- [x] `pnpm docs:api:check` — confirms zero public API drift
- [x] Executed via subagent-driven-development; task-level review caught one real finding (2 of 4 visibility changes had been verified against `Loader.ts` only, missing real callers in `test/resources/asset-residency.test.ts`) — fixed and re-verified. Final whole-branch review: ready to merge, no blocking findings.