### PR TITLE
refactor(rendering,particles): generalize WebGPU compute SDK primitives, migrate ParticleGpuState onto them

### DIFF
--- a/packages/exojs-particles/src/gpu/ParticleGpuState.ts
+++ b/packages/exojs-particles/src/gpu/ParticleGpuState.ts
@@ -1,7 +1,9 @@
-﻿/// <reference types="@webgpu/types" />
+/// <reference types="@webgpu/types" />
 
 import type { Rectangle } from '@codexo/exojs';
 import type { Texture } from '@codexo/exojs';
+import type { ComputeBindGroupEntry } from '@codexo/exojs/renderer-sdk';
+import { reflectComputeBindings, WebGpuComputePipeline, WebGpuStorageBuffer, WebGpuUniformBuffer } from '@codexo/exojs/renderer-sdk';
 
 import type { UpdateModule } from "#modules/UpdateModule";
 import type { WgslContribution, WgslUniformField } from "#modules/WgslContribution";
@@ -14,17 +16,24 @@ import type { ParticleSystem } from "#ParticleSystem";
  * - **8 packed storage buffers** for the per-particle SoA data:
  *   positions/velocities/scales/rotInfo/timing as `vec2<f32>`, color and
  *   textureIndex as `u32`, plus the instance output buffer. Sits at the
- *   default WebGPU `maxStorageBuffersPerShaderStage = 8` limit.
- * - **One uniform buffer** for sim state (`dt`, `liveCount`).
- * - **One uniform buffer** for module configs (concatenated per-module
- *   structs with WGSL std140-ish alignment).
- * - **One uniform buffer** for frame UVs — `array<vec4<f32>, N>` where N
- *   is the system's frame count (or 1 when no atlas is declared). Each
- *   vec4 is `(uvMinX, uvMinY, uvMaxX, uvMaxY)` already flipY-adjusted.
+ *   default WebGPU `maxStorageBuffersPerShaderStage = 8` limit. Built on
+ *   the shared {@link WebGpuStorageBuffer} SDK primitive.
+ * - **Three uniform buffers** (sim state `dt`/`liveCount`, module configs —
+ *   concatenated per-module structs with WGSL std140-ish alignment — and
+ *   frame UVs, `array<vec4<f32>, N>` where N is the system's frame count or
+ *   1 when no atlas is declared, each vec4 `(uvMinX, uvMinY, uvMaxX, uvMaxY)`
+ *   already flipY-adjusted), built on the shared {@link WebGpuUniformBuffer}
+ *   SDK primitive.
  * - **N 1D textures** for modules that use lookup tables (Curve / ColorGradient).
  * - **Composite compute pipeline** built once at construction by
  *   concatenating the integration step + every registered module body +
- *   the pack-instances step into a single shader.
+ *   the pack-instances step into a single shader, via the shared
+ *   {@link WebGpuComputePipeline} SDK primitive (two bind groups: group 0
+ *   holds uniforms + module lookup textures/samplers, group 1 holds the
+ *   8 SoA storage buffers). The bind-group *layouts* are derived straight
+ *   from the shader's own `@group`/`@binding` declarations via
+ *   {@link reflectComputeBindings} — no hand-written binding list kept in
+ *   sync with the WGSL text by hand.
  *
  * The compute shader's pack-instances step reads `textureIndex[i]`, looks
  * up the matching frame UV, and writes a 40-byte interleaved record into
@@ -49,24 +58,25 @@ export class ParticleGpuState {
   /** GPU buffer holding interleaved per-instance vertex data, written by compute, read as VERTEX by the renderer. */
   public readonly instanceBuffer: GPUBuffer;
 
-  private readonly _positions: GPUBuffer;
-  private readonly _velocities: GPUBuffer;
-  private readonly _scales: GPUBuffer;
-  private readonly _rotInfo: GPUBuffer;
-  private readonly _timing: GPUBuffer;
-  private readonly _color: GPUBuffer;
-  private readonly _textureIndex: GPUBuffer;
+  private readonly _positions: WebGpuStorageBuffer;
+  private readonly _velocities: WebGpuStorageBuffer;
+  private readonly _scales: WebGpuStorageBuffer;
+  private readonly _rotInfo: WebGpuStorageBuffer;
+  private readonly _timing: WebGpuStorageBuffer;
+  private readonly _color: WebGpuStorageBuffer;
+  private readonly _textureIndex: WebGpuStorageBuffer;
+  private readonly _instanceStorageBuffer: WebGpuStorageBuffer;
 
-  private readonly _simUniformBuffer: GPUBuffer;
+  private readonly _simUniformBuffer: WebGpuUniformBuffer;
   private readonly _simUniformData: ArrayBuffer = new ArrayBuffer(16);
   private readonly _simUniformView: DataView;
 
-  private readonly _moduleUniformBuffer: GPUBuffer | null;
+  private readonly _moduleUniformBuffer: WebGpuUniformBuffer | null;
   private readonly _moduleUniformData: ArrayBuffer | null;
   private readonly _moduleUniformView: DataView | null;
   private readonly _moduleSlots: readonly ModuleSlot[];
 
-  private readonly _framesUniformBuffer: GPUBuffer;
+  private readonly _framesUniformBuffer: WebGpuUniformBuffer;
   private readonly _framesUniformData: ArrayBuffer;
   private readonly _framesUniformView: Float32Array;
   private readonly _frameCount: number;
@@ -75,7 +85,7 @@ export class ParticleGpuState {
   private readonly _samplerFiltering: GPUSampler;
   private readonly _samplerNonFiltering: GPUSampler;
 
-  private readonly _pipeline: GPUComputePipeline;
+  private readonly _pipelineWrapper: WebGpuComputePipeline;
   private readonly _bindGroup0: GPUBindGroup;
   private readonly _bindGroup1: GPUBindGroup;
 
@@ -117,11 +127,7 @@ export class ParticleGpuState {
     if (uniformOffset > 0) {
       this._moduleUniformData = new ArrayBuffer(totalUniformBytes);
       this._moduleUniformView = new DataView(this._moduleUniformData);
-      this._moduleUniformBuffer = device.createBuffer({
-        label: 'particle-module-uniforms',
-        size: totalUniformBytes,
-        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
-      });
+      this._moduleUniformBuffer = new WebGpuUniformBuffer(device, totalUniformBytes, 'particle-module-uniforms');
     } else {
       this._moduleUniformData = null;
       this._moduleUniformView = null;
@@ -132,64 +138,25 @@ export class ParticleGpuState {
     this._frameCount = Math.max(1, frames.length);
     this._framesUniformData = new ArrayBuffer(this._frameCount * 16);
     this._framesUniformView = new Float32Array(this._framesUniformData);
-    this._framesUniformBuffer = device.createBuffer({
-      label: 'particle-frames-uniforms',
-      size: this._framesUniformData.byteLength,
-      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
-    });
+    this._framesUniformBuffer = new WebGpuUniformBuffer(device, this._framesUniformData.byteLength, 'particle-frames-uniforms');
     this._writeFrames(frames, texture);
 
     const vec2Bytes = capacity * 8;
     const u32Bytes = capacity * 4;
 
-    this._positions = device.createBuffer({
-      label: 'particle-positions',
-      size: vec2Bytes,
-      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
-    });
-    this._velocities = device.createBuffer({
-      label: 'particle-velocities',
-      size: vec2Bytes,
-      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
-    });
-    this._scales = device.createBuffer({
-      label: 'particle-scales',
-      size: vec2Bytes,
-      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
-    });
-    this._rotInfo = device.createBuffer({
-      label: 'particle-rotInfo',
-      size: vec2Bytes,
-      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
-    });
-    this._timing = device.createBuffer({
-      label: 'particle-timing',
-      size: vec2Bytes,
-      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
-    });
-    this._color = device.createBuffer({
-      label: 'particle-color',
-      size: u32Bytes,
-      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
-    });
-    this._textureIndex = device.createBuffer({
-      label: 'particle-textureIndex',
-      size: u32Bytes,
-      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
-    });
+    this._positions = new WebGpuStorageBuffer(device, vec2Bytes, 'particle-positions');
+    this._velocities = new WebGpuStorageBuffer(device, vec2Bytes, 'particle-velocities');
+    this._scales = new WebGpuStorageBuffer(device, vec2Bytes, 'particle-scales');
+    this._rotInfo = new WebGpuStorageBuffer(device, vec2Bytes, 'particle-rotInfo');
+    this._timing = new WebGpuStorageBuffer(device, vec2Bytes, 'particle-timing');
+    this._color = new WebGpuStorageBuffer(device, u32Bytes, 'particle-color');
+    this._textureIndex = new WebGpuStorageBuffer(device, u32Bytes, 'particle-textureIndex');
 
-    this.instanceBuffer = device.createBuffer({
-      label: 'particle-instance-output',
-      size: capacity * instanceBytes,
-      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
-    });
+    this._instanceStorageBuffer = new WebGpuStorageBuffer(device, capacity * instanceBytes, 'particle-instance-output', GPUBufferUsage.VERTEX);
+    this.instanceBuffer = this._instanceStorageBuffer.buffer;
 
     this._simUniformView = new DataView(this._simUniformData);
-    this._simUniformBuffer = device.createBuffer({
-      label: 'particle-sim-uniforms',
-      size: 16,
-      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
-    });
+    this._simUniformBuffer = new WebGpuUniformBuffer(device, 16, 'particle-sim-uniforms');
 
     // r32float textures aren't filterable in core WebGPU (would require
     // the optional `float32-filterable` feature). Use `nearest` for
@@ -229,55 +196,15 @@ export class ParticleGpuState {
 
     const wgsl = this._buildShader(slots);
 
-    const bindGroup0Layout = this._buildBindGroup0Layout(slots);
-    const bindGroup1Layout = device.createBindGroupLayout({
-      label: 'particle-soa-bgl',
-      entries: [
-        { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
-        { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
-        { binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
-        { binding: 3, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
-        { binding: 4, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
-        { binding: 5, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
-        { binding: 6, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } }, // textureIndex (matches WGSL `var<storage, read>`)
-        { binding: 7, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
-      ],
+    this._pipelineWrapper = WebGpuComputePipeline.create(device, {
+      wgsl,
+      workgroupSize,
+      bindingGroups: reflectComputeBindings(wgsl, { nonFilteringResources: this._nonFilteringResourceNames(slots) }),
+      label: 'particle-compute',
     });
 
-    const pipelineLayout = device.createPipelineLayout({
-      label: 'particle-compute-layout',
-      bindGroupLayouts: [bindGroup0Layout, bindGroup1Layout],
-    });
-
-    const shaderModule = device.createShaderModule({
-      label: 'particle-compute-shader',
-      code: wgsl,
-    });
-
-    this._pipeline = device.createComputePipeline({
-      label: 'particle-compute-pipeline',
-      layout: pipelineLayout,
-      compute: {
-        module: shaderModule,
-        entryPoint: 'main',
-      },
-    });
-
-    this._bindGroup0 = this._buildBindGroup0(bindGroup0Layout, slots);
-    this._bindGroup1 = device.createBindGroup({
-      label: 'particle-soa-bg',
-      layout: bindGroup1Layout,
-      entries: [
-        { binding: 0, resource: { buffer: this._positions } },
-        { binding: 1, resource: { buffer: this._velocities } },
-        { binding: 2, resource: { buffer: this._scales } },
-        { binding: 3, resource: { buffer: this._rotInfo } },
-        { binding: 4, resource: { buffer: this._timing } },
-        { binding: 5, resource: { buffer: this._color } },
-        { binding: 6, resource: { buffer: this._textureIndex } },
-        { binding: 7, resource: { buffer: this.instanceBuffer } },
-      ],
-    });
+    this._bindGroup0 = this._pipelineWrapper.createBindGroup(0, this._buildBindGroup0Entries(slots), 'particle-uniforms-bg');
+    this._bindGroup1 = this._pipelineWrapper.createBindGroup(1, this._buildSoaBindGroupEntries(), 'particle-soa-bg');
 
     // Modules upload their lookup textures.
     for (const slot of slots) {
@@ -310,10 +237,8 @@ export class ParticleGpuState {
     const encoder = this.device.createCommandEncoder({ label: 'particle-compute' });
     const pass = encoder.beginComputePass({ label: 'particle-compute-pass' });
 
-    pass.setPipeline(this._pipeline);
-    pass.setBindGroup(0, this._bindGroup0);
-    pass.setBindGroup(1, this._bindGroup1);
-    pass.dispatchWorkgroups(Math.ceil(liveCount / workgroupSize));
+    this._pipelineWrapper.dispatch(pass, liveCount, [this._bindGroup0, this._bindGroup1]);
+
     pass.end();
 
     this.device.queue.submit([encoder.finish()]);
@@ -327,7 +252,7 @@ export class ParticleGpuState {
     this._timing.destroy();
     this._color.destroy();
     this._textureIndex.destroy();
-    this.instanceBuffer.destroy();
+    this._instanceStorageBuffer.destroy();
     this._simUniformBuffer.destroy();
     this._framesUniformBuffer.destroy();
     this._moduleUniformBuffer?.destroy();
@@ -367,7 +292,7 @@ export class ParticleGpuState {
       }
     }
 
-    this.device.queue.writeBuffer(this._framesUniformBuffer, 0, this._framesUniformData);
+    this._framesUniformBuffer.write(this._framesUniformView);
   }
 
   /**
@@ -376,12 +301,12 @@ export class ParticleGpuState {
    * Slots not in the dirty set are left alone — GPU keeps the integrated
    * state from previous compute dispatches.
    *
-   * Each dirty slot triggers 7 small `queue.writeBuffer` calls (one per
-   * SoA channel). For typical spawn rates (≤200/s) this is negligible
-   * (≤1400 calls/s); contiguous-range batching is a future optimisation.
+   * Each dirty slot triggers 7 small writes (one per SoA channel, via
+   * {@link WebGpuStorageBuffer.write}). For typical spawn rates (≤200/s)
+   * this is negligible (≤1400 calls/s); contiguous-range batching is a
+   * future optimisation.
    */
   public uploadDirty(system: ParticleSystem, slots: Iterable<number>): void {
-    const queue = this.device.queue;
     const scratch2 = this._dirtyScratchVec2;
     const scratch1 = this._dirtyScratchU32;
 
@@ -391,29 +316,29 @@ export class ParticleGpuState {
 
       scratch2[0] = system.posX[slot]!;
       scratch2[1] = system.posY[slot]!;
-      queue.writeBuffer(this._positions, byteOffset2, scratch2.buffer, 0, 8);
+      this._positions.write(scratch2, byteOffset2);
 
       scratch2[0] = system.velX[slot]!;
       scratch2[1] = system.velY[slot]!;
-      queue.writeBuffer(this._velocities, byteOffset2, scratch2.buffer, 0, 8);
+      this._velocities.write(scratch2, byteOffset2);
 
       scratch2[0] = system.scaleX[slot]!;
       scratch2[1] = system.scaleY[slot]!;
-      queue.writeBuffer(this._scales, byteOffset2, scratch2.buffer, 0, 8);
+      this._scales.write(scratch2, byteOffset2);
 
       scratch2[0] = system.rotations[slot]!;
       scratch2[1] = system.rotationSpeeds[slot]!;
-      queue.writeBuffer(this._rotInfo, byteOffset2, scratch2.buffer, 0, 8);
+      this._rotInfo.write(scratch2, byteOffset2);
 
       scratch2[0] = system.elapsed[slot]!;
       scratch2[1] = system.lifetime[slot]!;
-      queue.writeBuffer(this._timing, byteOffset2, scratch2.buffer, 0, 8);
+      this._timing.write(scratch2, byteOffset2);
 
       scratch1[0] = system.color[slot]!;
-      queue.writeBuffer(this._color, byteOffset1, scratch1.buffer, 0, 4);
+      this._color.write(scratch1, byteOffset1);
 
       scratch1[0] = system.textureIndex[slot]!;
-      queue.writeBuffer(this._textureIndex, byteOffset1, scratch1.buffer, 0, 4);
+      this._textureIndex.write(scratch1, byteOffset1);
     }
   }
 
@@ -423,7 +348,7 @@ export class ParticleGpuState {
   private _writeSimUniforms(dt: number, liveCount: number): void {
     this._simUniformView.setFloat32(0, dt, true);
     this._simUniformView.setUint32(4, liveCount, true);
-    this.device.queue.writeBuffer(this._simUniformBuffer, 0, this._simUniformData);
+    this._simUniformBuffer.write(this._simUniformView);
   }
 
   private _writeModuleUniforms(dt: number): void {
@@ -435,52 +360,40 @@ export class ParticleGpuState {
       slot.module.writeUniforms?.(this._moduleUniformView, slot.uniformByteOffset, dt);
     }
 
-    this.device.queue.writeBuffer(this._moduleUniformBuffer, 0, this._moduleUniformData);
+    this._moduleUniformBuffer.write(this._moduleUniformView);
   }
 
-  private _buildBindGroup0Layout(slots: readonly ModuleSlot[]): GPUBindGroupLayout {
-    const entries: GPUBindGroupLayoutEntry[] = [
-      { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
-      { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
-    ];
-
-    if (this._moduleUniformBuffer !== null) {
-      entries.push({ binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } });
-    }
-
-    let textureBindingIndex = this._moduleUniformBuffer !== null ? 3 : 2;
+  /**
+   * WGSL variable names of module lookup textures/samplers whose format isn't natively
+   * filterable (`r32float` Curve LUTs) — fed to {@link reflectComputeBindings} so it declares
+   * `'unfilterable-float'`/`'non-filtering'` for those specific bindings instead of the default
+   * `'float'`/`'filtering'`, an ambiguity the WGSL text itself can't resolve (see that
+   * function's doc comment).
+   */
+  private _nonFilteringResourceNames(slots: readonly ModuleSlot[]): Set<string> {
+    const names = new Set<string>();
 
     for (const slot of slots) {
       for (const t of slot.contribution.textures ?? []) {
-        const filterable = t.format !== 'r32float';
-
-        entries.push({
-          binding: textureBindingIndex++,
-          visibility: GPUShaderStage.COMPUTE,
-          texture: {
-            viewDimension: '1d',
-            sampleType: filterable ? 'float' : 'unfilterable-float',
-          },
-        });
-        entries.push({
-          binding: textureBindingIndex++,
-          visibility: GPUShaderStage.COMPUTE,
-          sampler: { type: filterable ? 'filtering' : 'non-filtering' },
-        });
+        if (t.format === 'r32float') {
+          names.add(`u_${slot.contribution.key}_${t.name}`);
+          names.add(`u_${slot.contribution.key}_${t.name}_sampler`);
+        }
       }
     }
 
-    return this.device.createBindGroupLayout({ label: 'particle-uniforms-bgl', entries });
+    return names;
   }
 
-  private _buildBindGroup0(layout: GPUBindGroupLayout, slots: readonly ModuleSlot[]): GPUBindGroup {
-    const entries: GPUBindGroupEntry[] = [
-      { binding: 0, resource: { buffer: this._simUniformBuffer } },
-      { binding: 1, resource: { buffer: this._framesUniformBuffer } },
+  /** Group-0 bind-group entries, matching group 0's bindings (reflected from the shader text) one-to-one. */
+  private _buildBindGroup0Entries(slots: readonly ModuleSlot[]): ComputeBindGroupEntry[] {
+    const entries: ComputeBindGroupEntry[] = [
+      { binding: 0, buffer: this._simUniformBuffer.buffer },
+      { binding: 1, buffer: this._framesUniformBuffer.buffer },
     ];
 
     if (this._moduleUniformBuffer !== null) {
-      entries.push({ binding: 2, resource: { buffer: this._moduleUniformBuffer } });
+      entries.push({ binding: 2, buffer: this._moduleUniformBuffer.buffer });
     }
 
     let textureBindingIndex = this._moduleUniformBuffer !== null ? 3 : 2;
@@ -491,12 +404,26 @@ export class ParticleGpuState {
         const filterable = t.format !== 'r32float';
         const sampler = filterable ? this._samplerFiltering : this._samplerNonFiltering;
 
-        entries.push({ binding: textureBindingIndex++, resource: tex.createView({ dimension: '1d' }) });
-        entries.push({ binding: textureBindingIndex++, resource: sampler });
+        entries.push({ binding: textureBindingIndex++, textureView: tex.createView({ dimension: '1d' }) });
+        entries.push({ binding: textureBindingIndex++, sampler });
       }
     }
 
-    return this.device.createBindGroup({ label: 'particle-uniforms-bg', layout, entries });
+    return entries;
+  }
+
+  /** Group-1 bind-group entries: the 8 SoA storage buffers, matching group 1's bindings (reflected from the shader text) one-to-one. */
+  private _buildSoaBindGroupEntries(): ComputeBindGroupEntry[] {
+    return [
+      { binding: 0, buffer: this._positions.buffer },
+      { binding: 1, buffer: this._velocities.buffer },
+      { binding: 2, buffer: this._scales.buffer },
+      { binding: 3, buffer: this._rotInfo.buffer },
+      { binding: 4, buffer: this._timing.buffer },
+      { binding: 5, buffer: this._color.buffer },
+      { binding: 6, buffer: this._textureIndex.buffer },
+      { binding: 7, buffer: this._instanceStorageBuffer.buffer },
+    ];
   }
 
   private _buildShader(slots: readonly ModuleSlot[]): string {

--- a/src/renderer-sdk.ts
+++ b/src/renderer-sdk.ts
@@ -44,7 +44,7 @@ export type { WebGl2VertexArrayObjectRuntime } from '#rendering/webgl2/WebGl2Ver
 export { WebGl2VertexArrayObject } from '#rendering/webgl2/WebGl2VertexArrayObject';
 export { AbstractWebGpuRenderer } from '#rendering/webgpu/AbstractWebGpuRenderer';
 export type { ComputeBindGroupEntry, ComputeBinding } from '#rendering/webgpu/compute/index';
-export { reflectComputeBindings,WebGpuComputePipeline, WebGpuStorageBuffer, WebGpuUniformBuffer } from '#rendering/webgpu/compute/index';
+export { reflectComputeBindings, WebGpuComputePipeline, WebGpuStorageBuffer, WebGpuUniformBuffer } from '#rendering/webgpu/compute/index';
 export { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 export { getWebGpuBlendState } from '#rendering/webgpu/WebGpuBlendState';
 export type { WebGpuActiveRenderPass } from '#rendering/webgpu/WebGpuPassCoordinator';

--- a/src/renderer-sdk.ts
+++ b/src/renderer-sdk.ts
@@ -43,8 +43,8 @@ export { createWebGl2ShaderProgram } from '#rendering/webgl2/WebGl2ShaderProgram
 export type { WebGl2VertexArrayObjectRuntime } from '#rendering/webgl2/WebGl2VertexArrayObject';
 export { WebGl2VertexArrayObject } from '#rendering/webgl2/WebGl2VertexArrayObject';
 export { AbstractWebGpuRenderer } from '#rendering/webgpu/AbstractWebGpuRenderer';
-export type { ComputeBinding } from '#rendering/webgpu/compute/index';
-export { WebGpuComputePipeline, WebGpuStorageBuffer } from '#rendering/webgpu/compute/index';
+export type { ComputeBindGroupEntry, ComputeBinding } from '#rendering/webgpu/compute/index';
+export { reflectComputeBindings,WebGpuComputePipeline, WebGpuStorageBuffer, WebGpuUniformBuffer } from '#rendering/webgpu/compute/index';
 export { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 export { getWebGpuBlendState } from '#rendering/webgpu/WebGpuBlendState';
 export type { WebGpuActiveRenderPass } from '#rendering/webgpu/WebGpuPassCoordinator';

--- a/src/rendering/webgpu/compute/WebGpuComputePipeline.ts
+++ b/src/rendering/webgpu/compute/WebGpuComputePipeline.ts
@@ -2,22 +2,108 @@
 
 /**
  * Description of a single buffer binding for a compute pipeline. Mirrors
- * the WGSL `@group(0) @binding(N)` declaration.
+ * the WGSL `@group(N) @binding(M)` declaration.
  *
  * `binding` matches the WGSL binding number; `type` chooses the storage
  * mode. `'storage'` is read-write (`var<storage, read_write>` in WGSL),
  * `'storage-read'` is read-only (`var<storage, read>`), `'uniform'` is
  * read-only and aligned to 16 bytes (`var<uniform>`).
  */
-export interface ComputeBinding {
-  binding: number;
-  type: 'storage' | 'storage-read' | 'uniform';
+export interface ComputeBufferBinding {
+  readonly kind: 'buffer';
+  readonly binding: number;
+  readonly type: 'storage' | 'storage-read' | 'uniform';
+}
+
+/** Compute-visible sampled-texture binding (e.g. a 1D lookup table). */
+export interface ComputeTextureBinding {
+  readonly kind: 'texture';
+  readonly binding: number;
+  readonly viewDimension: GPUTextureViewDimension;
+  readonly sampleType: GPUTextureSampleType;
+}
+
+/** Compute-visible sampler binding, paired with a {@link ComputeTextureBinding}. */
+export interface ComputeSamplerBinding {
+  readonly kind: 'sampler';
+  readonly binding: number;
+  readonly type: GPUSamplerBindingType;
 }
 
 /**
- * Owning wrapper around a `GPUComputePipeline` plus its bind-group layout.
- * Created once per shader; multiple bind groups can be bound per dispatch
- * to render different particle systems with the same pipeline.
+ * Compute-visible storage-texture binding (a shader writes into it directly,
+ * unlike {@link ComputeTextureBinding} which is sampled/read-only).
+ *
+ * `'write-only'` is broadly supported in core WebGPU. `'read-only'` and
+ * `'read-write'` access are a newer core-feature addition and NOT
+ * guaranteed available on every backend/browser — check
+ * `device.features.has(...)`/the relevant capability before requesting
+ * anything other than `'write-only'`, and prefer it unless the shader
+ * genuinely needs to read back what it wrote within the same dispatch.
+ */
+export interface ComputeStorageTextureBinding {
+  readonly kind: 'storageTexture';
+  readonly binding: number;
+  readonly access: GPUStorageTextureAccess;
+  readonly format: GPUTextureFormat;
+  readonly viewDimension?: GPUTextureViewDimension;
+}
+
+/** One binding within a compute pipeline's bind-group layout. */
+export type ComputeBinding = ComputeBufferBinding | ComputeTextureBinding | ComputeSamplerBinding | ComputeStorageTextureBinding;
+
+/** Resource to bind at `binding` when building a bind group via {@link WebGpuComputePipeline.createBindGroup}. */
+export type ComputeBindGroupEntry =
+  | { readonly binding: number; readonly buffer: GPUBuffer; readonly offset?: number; readonly size?: number }
+  | { readonly binding: number; readonly textureView: GPUTextureView }
+  | { readonly binding: number; readonly sampler: GPUSampler };
+
+const toLayoutEntry = (b: ComputeBinding): GPUBindGroupLayoutEntry => {
+  if (b.kind === 'texture') {
+    return { binding: b.binding, visibility: GPUShaderStage.COMPUTE, texture: { viewDimension: b.viewDimension, sampleType: b.sampleType } };
+  }
+
+  if (b.kind === 'sampler') {
+    return { binding: b.binding, visibility: GPUShaderStage.COMPUTE, sampler: { type: b.type } };
+  }
+
+  if (b.kind === 'storageTexture') {
+    return {
+      binding: b.binding,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { access: b.access, format: b.format, ...(b.viewDimension !== undefined && { viewDimension: b.viewDimension }) },
+    };
+  }
+
+  let bufferType: GPUBufferBindingType = 'read-only-storage';
+
+  if (b.type === 'uniform') {
+    bufferType = 'uniform';
+  } else if (b.type === 'storage') {
+    bufferType = 'storage';
+  }
+
+  return { binding: b.binding, visibility: GPUShaderStage.COMPUTE, buffer: { type: bufferType } };
+};
+
+const toGroupEntry = (e: ComputeBindGroupEntry): GPUBindGroupEntry => {
+  if ('textureView' in e) {
+    return { binding: e.binding, resource: e.textureView };
+  }
+
+  if ('sampler' in e) {
+    return { binding: e.binding, resource: e.sampler };
+  }
+
+  return { binding: e.binding, resource: { buffer: e.buffer, offset: e.offset ?? 0, ...(e.size !== undefined && { size: e.size }) } };
+};
+
+/**
+ * Owning wrapper around a `GPUComputePipeline` plus its bind-group layouts —
+ * one layout per declared group (`@group(0)`, `@group(1)`, ... in
+ * declaration order). Created once per shader; multiple bind groups can be
+ * built per layout and swapped across dispatches (e.g. to run the same
+ * pipeline against different data sets).
  *
  * Construct via {@link create}; do not call `new GPUComputePipeline`
  * directly elsewhere.
@@ -25,13 +111,13 @@ export interface ComputeBinding {
 export class WebGpuComputePipeline {
   public readonly device: GPUDevice;
   public readonly pipeline: GPUComputePipeline;
-  public readonly bindGroupLayout: GPUBindGroupLayout;
+  public readonly bindGroupLayouts: readonly GPUBindGroupLayout[];
   public readonly workgroupSize: number;
 
-  public constructor(device: GPUDevice, pipeline: GPUComputePipeline, bindGroupLayout: GPUBindGroupLayout, workgroupSize: number) {
+  public constructor(device: GPUDevice, pipeline: GPUComputePipeline, bindGroupLayouts: readonly GPUBindGroupLayout[], workgroupSize: number) {
     this.device = device;
     this.pipeline = pipeline;
-    this.bindGroupLayout = bindGroupLayout;
+    this.bindGroupLayouts = bindGroupLayouts;
     this.workgroupSize = workgroupSize;
   }
 
@@ -41,7 +127,7 @@ export class WebGpuComputePipeline {
       wgsl: string;
       entryPoint?: string;
       workgroupSize?: number;
-      bindings: readonly ComputeBinding[];
+      bindingGroups: ReadonlyArray<readonly ComputeBinding[]>;
       label?: string;
     },
   ): WebGpuComputePipeline {
@@ -49,28 +135,16 @@ export class WebGpuComputePipeline {
     const entryPoint = opts.entryPoint ?? 'main';
     const label = opts.label ?? 'compute';
 
-    const bindGroupLayout = device.createBindGroupLayout({
-      label: `${label}-bgl`,
-      entries: opts.bindings.map(b => {
-        let bufferType: GPUBufferBindingType = 'read-only-storage';
-        if (b.type === 'uniform') {
-          bufferType = 'uniform';
-        } else if (b.type === 'storage') {
-          bufferType = 'storage';
-        }
-        return {
-          binding: b.binding,
-          visibility: GPUShaderStage.COMPUTE,
-          buffer: {
-            type: bufferType,
-          },
-        };
+    const bindGroupLayouts = opts.bindingGroups.map((bindings, groupIndex) =>
+      device.createBindGroupLayout({
+        label: `${label}-bgl${groupIndex}`,
+        entries: bindings.map(toLayoutEntry),
       }),
-    });
+    );
 
     const pipelineLayout = device.createPipelineLayout({
       label: `${label}-layout`,
-      bindGroupLayouts: [bindGroupLayout],
+      bindGroupLayouts,
     });
 
     const module = device.createShaderModule({
@@ -87,41 +161,71 @@ export class WebGpuComputePipeline {
       },
     });
 
-    return new WebGpuComputePipeline(device, pipeline, bindGroupLayout, workgroupSize);
+    return new WebGpuComputePipeline(device, pipeline, bindGroupLayouts, workgroupSize);
   }
 
   /**
-   * Construct a bind group from `entries` in the order matching the
-   * binding indices declared at pipeline creation. The caller is
-   * responsible for the buffers' lifecycle.
+   * Build a bind group for group `groupIndex` (matching its position in
+   * {@link create}'s `bindingGroups`) from `entries`. The caller is
+   * responsible for the bound resources' lifecycle.
    */
-  public createBindGroup(entries: ReadonlyArray<{ binding: number; buffer: GPUBuffer; offset?: number; size?: number }>, label?: string): GPUBindGroup {
+  public createBindGroup(groupIndex: number, entries: readonly ComputeBindGroupEntry[], label?: string): GPUBindGroup {
     return this.device.createBindGroup({
-      label: label ?? 'compute-bg',
-      layout: this.bindGroupLayout,
-      entries: entries.map(e => ({
-        binding: e.binding,
-        resource: {
-          buffer: e.buffer,
-          offset: e.offset ?? 0,
-          ...(e.size !== undefined && { size: e.size }),
-        },
-      })),
+      label: label ?? `compute-bg${groupIndex}`,
+      layout: this.bindGroupLayouts[groupIndex]!,
+      entries: entries.map(toGroupEntry),
     });
   }
 
+  private _bind(passEncoder: GPUComputePassEncoder, bindGroups: readonly GPUBindGroup[]): void {
+    passEncoder.setPipeline(this.pipeline);
+
+    for (let i = 0; i < bindGroups.length; i++) {
+      passEncoder.setBindGroup(i, bindGroups[i]);
+    }
+  }
+
   /**
-   * Dispatch this pipeline over `itemCount` items. Workgroups dispatched
-   * = `ceil(itemCount / workgroupSize)`. Caller must have set the bind
-   * group on the pass already.
+   * Set this pipeline, bind `bindGroups` at their array index, and dispatch
+   * a 1D workgroup grid sized for `itemCount` independent items — workgroups
+   * dispatched = `ceil(itemCount / workgroupSize)`. No-ops when `itemCount
+   * <= 0`. The common case for "N independent items, one thread per item".
    */
-  public dispatch(passEncoder: GPUComputePassEncoder, itemCount: number): void {
+  public dispatch(passEncoder: GPUComputePassEncoder, itemCount: number, bindGroups: readonly GPUBindGroup[] = []): void {
     if (itemCount <= 0) {
       return;
     }
 
+    this._bind(passEncoder, bindGroups);
+
     const workgroups = Math.ceil(itemCount / this.workgroupSize);
 
     passEncoder.dispatchWorkgroups(workgroups);
+  }
+
+  /**
+   * Set this pipeline, bind `bindGroups`, and dispatch `x`×`y`×`z` workgroups
+   * directly — no item-count derivation. Use for 2D/3D compute problems (e.g.
+   * per-texel image processing); use {@link dispatch} for the 1D
+   * "N independent items" case instead, since the two take different units
+   * (workgroup counts here vs. item counts there).
+   */
+  public dispatchWorkgroups(passEncoder: GPUComputePassEncoder, x: number, y = 1, z = 1, bindGroups: readonly GPUBindGroup[] = []): void {
+    this._bind(passEncoder, bindGroups);
+    passEncoder.dispatchWorkgroups(x, y, z);
+  }
+
+  /**
+   * Set this pipeline, bind `bindGroups`, and dispatch indirectly: workgroup
+   * counts are read from `indirectBuffer` at `indirectOffset` (3× `u32`,
+   * x/y/z) instead of being supplied by the caller. Use when the dispatch
+   * size is only known GPU-side — e.g. a prior compute pass writes a
+   * survivor count after culling/compaction. `indirectBuffer` must have been
+   * created with `GPUBufferUsage.INDIRECT` (plus `STORAGE` if a compute
+   * shader is what writes the counts into it).
+   */
+  public dispatchIndirect(passEncoder: GPUComputePassEncoder, indirectBuffer: GPUBuffer, indirectOffset: number, bindGroups: readonly GPUBindGroup[] = []): void {
+    this._bind(passEncoder, bindGroups);
+    passEncoder.dispatchWorkgroupsIndirect(indirectBuffer, indirectOffset);
   }
 }

--- a/src/rendering/webgpu/compute/WebGpuComputePipeline.ts
+++ b/src/rendering/webgpu/compute/WebGpuComputePipeline.ts
@@ -224,7 +224,12 @@ export class WebGpuComputePipeline {
    * created with `GPUBufferUsage.INDIRECT` (plus `STORAGE` if a compute
    * shader is what writes the counts into it).
    */
-  public dispatchIndirect(passEncoder: GPUComputePassEncoder, indirectBuffer: GPUBuffer, indirectOffset: number, bindGroups: readonly GPUBindGroup[] = []): void {
+  public dispatchIndirect(
+    passEncoder: GPUComputePassEncoder,
+    indirectBuffer: GPUBuffer,
+    indirectOffset: number,
+    bindGroups: readonly GPUBindGroup[] = [],
+  ): void {
     this._bind(passEncoder, bindGroups);
     passEncoder.dispatchWorkgroupsIndirect(indirectBuffer, indirectOffset);
   }

--- a/src/rendering/webgpu/compute/WebGpuStorageBuffer.ts
+++ b/src/rendering/webgpu/compute/WebGpuStorageBuffer.ts
@@ -1,9 +1,11 @@
 /// <reference types="@webgpu/types" />
 
 /**
- * Owning wrapper around a `GPUBuffer` allocated with `STORAGE | COPY_DST | COPY_SRC`.
- * Designed for the data-oriented ParticleSystem GPU path: one storage
- * buffer per SoA channel, written to from CPU each spawn frame, read by
+ * Owning wrapper around a `GPUBuffer` allocated with `STORAGE | COPY_DST | COPY_SRC`,
+ * plus any `extraUsage` flags passed at construction (e.g. `GPUBufferUsage.VERTEX`
+ * for a buffer a compute shader writes and a render pass then reads as instanced
+ * vertex input). Designed for the data-oriented ParticleSystem GPU path: one
+ * storage buffer per SoA channel, written to from CPU each spawn frame, read by
  * compute shaders, and (optionally) read back to CPU for expire detection.
  *
  * Lifetime: the caller (typically `ParticleGpuState`) owns the buffer and
@@ -17,14 +19,14 @@ export class WebGpuStorageBuffer {
 
   private _readbackBuffer: GPUBuffer | null = null;
 
-  public constructor(device: GPUDevice, byteLength: number, label = 'storage') {
+  public constructor(device: GPUDevice, byteLength: number, label = 'storage', extraUsage: GPUBufferUsageFlags = 0) {
     this.device = device;
     this.byteLength = byteLength;
     this.label = label;
     this.buffer = device.createBuffer({
       label,
       size: byteLength,
-      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | extraUsage,
     });
   }
 

--- a/src/rendering/webgpu/compute/WebGpuUniformBuffer.ts
+++ b/src/rendering/webgpu/compute/WebGpuUniformBuffer.ts
@@ -1,0 +1,38 @@
+/// <reference types="@webgpu/types" />
+
+/**
+ * Owning wrapper around a `GPUBuffer` allocated with `UNIFORM | COPY_DST`,
+ * plus any `extraUsage` flags passed at construction. Counterpart to
+ * {@link WebGpuStorageBuffer} for the uniform-buffer case — deliberately
+ * simpler (no readback support): uniform buffers are CPU→GPU config data,
+ * written every frame and read by shaders, essentially never read back.
+ *
+ * Lifetime: the caller owns the buffer and must call {@link destroy} when
+ * the system is torn down.
+ */
+export class WebGpuUniformBuffer {
+  public readonly device: GPUDevice;
+  public readonly buffer: GPUBuffer;
+  public readonly byteLength: number;
+  public readonly label: string;
+
+  public constructor(device: GPUDevice, byteLength: number, label = 'uniform', extraUsage: GPUBufferUsageFlags = 0) {
+    this.device = device;
+    this.byteLength = byteLength;
+    this.label = label;
+    this.buffer = device.createBuffer({
+      label,
+      size: byteLength,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST | extraUsage,
+    });
+  }
+
+  /** Upload the contents of `data` to this buffer at `byteOffset`. */
+  public write(data: ArrayBufferView, byteOffset = 0, byteSize?: number): void {
+    this.device.queue.writeBuffer(this.buffer, byteOffset, data.buffer, data.byteOffset, byteSize ?? data.byteLength);
+  }
+
+  public destroy(): void {
+    this.buffer.destroy();
+  }
+}

--- a/src/rendering/webgpu/compute/index.ts
+++ b/src/rendering/webgpu/compute/index.ts
@@ -1,3 +1,5 @@
-export type { ComputeBinding } from './WebGpuComputePipeline';
+export { reflectComputeBindings } from './reflectComputeBindings';
+export type { ComputeBindGroupEntry, ComputeBinding } from './WebGpuComputePipeline';
 export { WebGpuComputePipeline } from './WebGpuComputePipeline';
 export { WebGpuStorageBuffer } from './WebGpuStorageBuffer';
+export { WebGpuUniformBuffer } from './WebGpuUniformBuffer';

--- a/src/rendering/webgpu/compute/reflectComputeBindings.ts
+++ b/src/rendering/webgpu/compute/reflectComputeBindings.ts
@@ -98,7 +98,8 @@ const stripComments = (source: string): string => source.replaceAll(/\/\/.*$/gm,
 const uniformBufferDecl = /@group\((\d+)\)\s*@binding\((\d+)\)\s*var\s*<uniform>\s*(\w+)\s*:/g;
 const storageBufferDecl = /@group\((\d+)\)\s*@binding\((\d+)\)\s*var\s*<storage\s*,\s*(read_write|read)\s*>\s*(\w+)\s*:/g;
 const samplerDecl = /@group\((\d+)\)\s*@binding\((\d+)\)\s*var\s+(\w+)\s*:\s*(sampler_comparison|sampler)\s*;/g;
-const textureDecl = /@group\((\d+)\)\s*@binding\((\d+)\)\s*var\s+(\w+)\s*:\s*(texture_1d|texture_2d|texture_2d_array|texture_3d|texture_cube|texture_cube_array)<(f32|i32|u32)>\s*;/g;
+const textureDecl =
+  /@group\((\d+)\)\s*@binding\((\d+)\)\s*var\s+(\w+)\s*:\s*(texture_1d|texture_2d|texture_2d_array|texture_3d|texture_cube|texture_cube_array)<(f32|i32|u32)>\s*;/g;
 const storageTextureDecl =
   /@group\((\d+)\)\s*@binding\((\d+)\)\s*var\s+(\w+)\s*:\s*(texture_storage_1d|texture_storage_2d|texture_storage_2d_array|texture_storage_3d)<([\w-]+)\s*,\s*(read_write|read|write)\s*>\s*;/g;
 

--- a/src/rendering/webgpu/compute/reflectComputeBindings.ts
+++ b/src/rendering/webgpu/compute/reflectComputeBindings.ts
@@ -1,0 +1,119 @@
+/// <reference types="@webgpu/types" />
+
+import type { ComputeBinding } from './WebGpuComputePipeline';
+
+/**
+ * Derives the `bindingGroups` shape {@link WebGpuComputePipeline.create} expects directly from
+ * a WGSL compute shader's own `@group(N) @binding(M)` declarations, instead of hand-writing a
+ * parallel `ComputeBinding[][]` that has to be kept in sync with the shader text by hand.
+ *
+ * Deliberately narrow — this is NOT a general WGSL parser. No expression/statement parsing, no
+ * auto-assignment of group/binding numbers (unlike e.g. PlayCanvas's WGSL processor, which lets
+ * shaders omit `@group`/`@binding` entirely and assigns them itself), no uniform-buffer member
+ * byte-offset computation (that stays a JS-side concern — see `WgslContribution`/
+ * `wgslUniformByteSize` in `@codexo/exojs-particles`). It only reads resource declarations that
+ * already carry explicit `@group`/`@binding` attributes, the convention every ExoJS-authored
+ * compute shader already follows.
+ *
+ * `f32`-sampled textures (`texture_1d<f32>`, `texture_2d<f32>`, ...) and plain `sampler`
+ * bindings are ambiguous between WebGPU's filterable and non-filterable variants — that
+ * distinction depends on the actual `GPUTextureFormat` bound at runtime (e.g. `r32float` is
+ * unfilterable, `rgba8unorm` is not), which isn't expressible in the WGSL declaration itself.
+ * Defaults to filterable (`'float'` / `'filtering'`); pass `nonFilteringResources` (a set of the
+ * WGSL variable names involved) to override per-resource.
+ *
+ * Comments are stripped before matching. Block-comment stripping is NOT nesting-aware (WGSL
+ * technically permits nested `/*` `*` `/` comments) — fine for engine-generated shader text,
+ * which never nests comments; a hand-authored shader that does would need manual
+ * `ComputeBinding[][]` instead.
+ */
+export function reflectComputeBindings(wgsl: string, options?: { nonFilteringResources?: ReadonlySet<string> }): ComputeBinding[][] {
+  const nonFiltering = options?.nonFilteringResources ?? new Set<string>();
+  const source = stripComments(wgsl);
+  const groups: ComputeBinding[][] = [];
+
+  const push = (groupIndex: number, binding: ComputeBinding): void => {
+    (groups[groupIndex] ??= []).push(binding);
+  };
+
+  for (const m of source.matchAll(uniformBufferDecl)) {
+    push(Number(m[1]), { kind: 'buffer', binding: Number(m[2]), type: 'uniform' });
+  }
+
+  for (const m of source.matchAll(storageBufferDecl)) {
+    const readOnly = m[3] === 'read';
+
+    push(Number(m[1]), { kind: 'buffer', binding: Number(m[2]), type: readOnly ? 'storage-read' : 'storage' });
+  }
+
+  for (const m of source.matchAll(samplerDecl)) {
+    const name = m[3]!;
+    const comparison = m[4] === 'sampler_comparison';
+
+    push(Number(m[1]), { kind: 'sampler', binding: Number(m[2]), type: samplerTypeFor(comparison, nonFiltering.has(name)) });
+  }
+
+  for (const m of source.matchAll(textureDecl)) {
+    const name = m[3]!;
+    const viewDimension = textureViewDimensions.get(m[4]!)!;
+    const component = m[5]!;
+
+    push(Number(m[1]), { kind: 'texture', binding: Number(m[2]), viewDimension, sampleType: sampleTypeFor(component, nonFiltering.has(name)) });
+  }
+
+  for (const m of source.matchAll(storageTextureDecl)) {
+    const viewDimension = storageTextureViewDimensions.get(m[4]!)!;
+    const format = m[5] as GPUTextureFormat;
+
+    push(Number(m[1]), { kind: 'storageTexture', binding: Number(m[2]), access: storageAccessFor(m[6]!), format, viewDimension });
+  }
+
+  return Array.from({ length: groups.length }, (_, i) => [...(groups[i] ?? [])].sort((a, b) => a.binding - b.binding));
+}
+
+const samplerTypeFor = (comparison: boolean, nonFiltering: boolean): GPUSamplerBindingType => {
+  if (comparison) return 'comparison';
+
+  return nonFiltering ? 'non-filtering' : 'filtering';
+};
+
+const sampleTypeFor = (component: string, nonFiltering: boolean): GPUTextureSampleType => {
+  if (component === 'i32') return 'sint';
+  if (component === 'u32') return 'uint';
+
+  return nonFiltering ? 'unfilterable-float' : 'float';
+};
+
+const storageAccessFor = (accessToken: string): GPUStorageTextureAccess => {
+  if (accessToken === 'write') return 'write-only';
+  if (accessToken === 'read') return 'read-only';
+
+  return 'read-write';
+};
+
+const stripComments = (source: string): string => source.replaceAll(/\/\/.*$/gm, '').replaceAll(/\/\*[\s\S]*?\*\//g, '');
+
+// Buffer declarations never need their WGSL type text — only the storage class matters for a
+// `ComputeBinding`, so these stop at `:` rather than chasing the type through to `;`.
+const uniformBufferDecl = /@group\((\d+)\)\s*@binding\((\d+)\)\s*var\s*<uniform>\s*(\w+)\s*:/g;
+const storageBufferDecl = /@group\((\d+)\)\s*@binding\((\d+)\)\s*var\s*<storage\s*,\s*(read_write|read)\s*>\s*(\w+)\s*:/g;
+const samplerDecl = /@group\((\d+)\)\s*@binding\((\d+)\)\s*var\s+(\w+)\s*:\s*(sampler_comparison|sampler)\s*;/g;
+const textureDecl = /@group\((\d+)\)\s*@binding\((\d+)\)\s*var\s+(\w+)\s*:\s*(texture_1d|texture_2d|texture_2d_array|texture_3d|texture_cube|texture_cube_array)<(f32|i32|u32)>\s*;/g;
+const storageTextureDecl =
+  /@group\((\d+)\)\s*@binding\((\d+)\)\s*var\s+(\w+)\s*:\s*(texture_storage_1d|texture_storage_2d|texture_storage_2d_array|texture_storage_3d)<([\w-]+)\s*,\s*(read_write|read|write)\s*>\s*;/g;
+
+const textureViewDimensions = new Map<string, GPUTextureViewDimension>([
+  ['texture_1d', '1d'],
+  ['texture_2d', '2d'],
+  ['texture_2d_array', '2d-array'],
+  ['texture_3d', '3d'],
+  ['texture_cube', 'cube'],
+  ['texture_cube_array', 'cube-array'],
+]);
+
+const storageTextureViewDimensions = new Map<string, GPUTextureViewDimension>([
+  ['texture_storage_1d', '1d'],
+  ['texture_storage_2d', '2d'],
+  ['texture_storage_2d_array', '2d-array'],
+  ['texture_storage_3d', '3d'],
+]);


### PR DESCRIPTION
## Summary

- `WebGpuComputePipeline` gains multi-group bind groups, texture/sampler/storage-texture bindings, and dedicated `dispatchWorkgroups` (2D/3D) and `dispatchIndirect` methods alongside the existing item-count `dispatch`.
- New `WebGpuUniformBuffer` mirrors `WebGpuStorageBuffer` for the uniform-buffer case (kept as a separate class rather than merged — different real-world usage shape: storage buffers get read back, uniform buffers essentially never do).
- New `reflectComputeBindings(wgsl, options?)` derives `bindingGroups` directly from a compute shader's own `@group`/`@binding` declarations via a small set of targeted regexes, instead of a hand-written parallel binding list that has to be kept in sync with the shader text by hand.
- `ParticleGpuState` (exojs-particles) is migrated fully onto these primitives — all 8 storage buffers, all 3 uniform buffers, the compute pipeline, and both bind-group layouts (the second one now reflected, not hand-written). ~50 lines of binding-list bookkeeping removed.

No public API change to `ParticleSystem` or any engine-facing surface — internal-only, plus new SDK-only exports on `@codexo/exojs/renderer-sdk` (`WebGpuUniformBuffer`, `reflectComputeBindings`, extended `WebGpuComputePipeline`/`ComputeBinding`).

## Test plan

- [x] `pnpm typecheck` (root) clean
- [x] `pnpm --filter @codexo/exojs-particles typecheck` clean
- [x] `eslint` clean on all touched files
- [x] `packages/exojs-particles/test/particle-gpu.test.ts` — all 27 tests pass **unmodified**, proving the reflected bind-group layout matches the previously hand-written one bit-for-bit (including the module-uniforms-present/absent branch and the `r32float` non-filtering texture/sampler case)
- [x] `pnpm verify:quick` (full local pre-push gate: typecheck across all projects, guides, examples, type-tests, packages, lint, format, API-doc sync) — all green