### PR TITLE
perf(rendering): split tint out of the transform buffer into a dedicated 8-bit resource

### DIFF
--- a/packages/exojs-tilemap/src/webgpu/WebGpuTileChunkRenderer.ts
+++ b/packages/exojs-tilemap/src/webgpu/WebGpuTileChunkRenderer.ts
@@ -44,7 +44,6 @@ struct ProjectionUniforms {
 struct TransformSlot {
     m0: vec4<f32>,
     m1: vec4<f32>,
-    m2: vec4<f32>,
 };
 
 @group(0) @binding(0)
@@ -647,7 +646,7 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
     const pass = active.pass;
 
     pass.setPipeline(this._getPipeline(payload.blendMode, backend.renderTargetFormat, coordinator.stencilActive));
-    pass.setBindGroup(0, bundle.getBindGroup(device, this._uniformBindGroupLayout!));
+    pass.setBindGroup(0, bundle.getBindGroup(device, this._uniformBindGroupLayout!, false));
     pass.setBindGroup(1, textureBindGroup);
     pass.setVertexBuffer(0, bundle.instanceBuffer, payload.byteOffset);
     pass.setIndexBuffer(this._indexBuffer, 'uint16');

--- a/src/rendering/RetainedContainer.ts
+++ b/src/rendering/RetainedContainer.ts
@@ -487,7 +487,10 @@ export class RetainedContainer extends Container {
       return false;
     }
 
-    packTransformRow(patchRowScratch, 0, node.getGlobalTransform(), drawable.tint, drawable.pixelSnapMode);
+    // Transform-only patch (spec §3): tint is not part of this row anymore (it
+    // lives in the bundle's separate tint texture) and a moved node's tint
+    // doesn't change, so there is nothing to patch there.
+    packTransformRow(patchRowScratch, 0, node.getGlobalTransform(), drawable.pixelSnapMode);
     bundle._patchTransformRow(nodeIndex - base, patchRowScratch);
 
     return true;

--- a/src/rendering/TransformBuffer.ts
+++ b/src/rendering/TransformBuffer.ts
@@ -3,13 +3,34 @@ import type { Matrix } from '#math/Matrix';
 import { PixelSnapMode } from '#rendering/pixelSnap';
 
 /**
- * Floats per transform+tint row (3 rgba32f texels): the single source of truth
- * for the layout shared by {@link TransformBuffer}, the retained group transform
- * store, and the Slice-4b in-place row patch.
+ * Floats per transform row (2 rgba32f texels): the single source of truth for
+ * the layout shared by {@link TransformBuffer}, the retained group transform
+ * store, and the Slice-4b in-place row patch. Tint lives in a separate,
+ * natively-8-bit-per-channel row (see {@link TRANSFORM_TINT_BYTES_PER_ROW} /
+ * {@link packTintRow}) — GPU texture/buffer uploads round up to whole
+ * texels/vec4s regardless of how few of a slot's floats are "real" data, so a
+ * layout that keeps tint's 4 float32 channels inline never crosses the
+ * 3-texel -> 2-texel boundary that actually reduces upload bandwidth and GPU
+ * memory footprint. Splitting tint into its own rgba8 texture/buffer does,
+ * without quantizing anything the engine doesn't already store at that
+ * precision (r/g/b are already 0..255 integer channels on {@link Color}; only
+ * alpha's continuous float precision would be lost if it were packed into a
+ * shared float32 slot, which is why it isn't).
  */
-export const TRANSFORM_FLOATS_PER_ROW = 12;
+export const TRANSFORM_FLOATS_PER_ROW = 8;
+
+/**
+ * Bytes per tint row (one rgba8 texel / one packed `u32`): r, g, b (0..255,
+ * {@link Color}'s native integer channels — exact, not quantized) and alpha
+ * rounded to 0..255 (the only lossy step, and it matches the precision every
+ * mainstream 2D/WebGPU renderer already uses for a per-instance blend color,
+ * via a native normalized 8-bit-per-channel vertex/texture format).
+ * @internal
+ */
+export const TRANSFORM_TINT_BYTES_PER_ROW = 4;
 
 const floatsPerSlot = TRANSFORM_FLOATS_PER_ROW;
+const tintBytesPerSlot = TRANSFORM_TINT_BYTES_PER_ROW;
 const initialCapacity = 16;
 const hashPrime = 0x01000193;
 const hashOffset = 0x811c9dc5;
@@ -18,8 +39,8 @@ const hashFloatScratch = new Float32Array(1);
 const hashUintScratch = new Uint32Array(hashFloatScratch.buffer);
 
 /**
- * Write one transform+tint row into `target` at `offset` in the canonical layout
- * (a,b,c,d, tx,ty, snapMode,0, r/255,g/255,b/255,a). The single packer shared by
+ * Write one transform row into `target` at `offset` in the canonical layout
+ * (a,b,c,d, tx,ty, snapMode,0). The single packer shared by
  * {@link TransformBuffer.write} and the Slice-4b row patch, so the frame buffer
  * and a patched retained row stay bit-identical by construction — a layout change
  * lands in exactly one place.
@@ -29,7 +50,7 @@ const hashUintScratch = new Uint32Array(hashFloatScratch.buffer);
  * vertex stage, gated on this flag (spec D3-D5).
  * @internal
  */
-export const packTransformRow = (target: Float32Array, offset: number, transform: Matrix, tint: Color, snapMode: PixelSnapMode = PixelSnapMode.None): void => {
+export const packTransformRow = (target: Float32Array, offset: number, transform: Matrix, snapMode: PixelSnapMode = PixelSnapMode.None): void => {
   target[offset + 0] = transform.a;
   target[offset + 1] = transform.b;
   target[offset + 2] = transform.c;
@@ -38,10 +59,20 @@ export const packTransformRow = (target: Float32Array, offset: number, transform
   target[offset + 5] = transform.y;
   target[offset + 6] = snapMode;
   target[offset + 7] = 0;
-  target[offset + 8] = tint.r / 255;
-  target[offset + 9] = tint.g / 255;
-  target[offset + 10] = tint.b / 255;
-  target[offset + 11] = tint.a;
+};
+
+/**
+ * Write one tint row into `target` (a `Uint8Array`) at byte `offset`, as
+ * `(r, g, b, a)` — r/g/b are {@link Color}'s native 0..255 integer channels
+ * (copied exactly), alpha is `Color.a` (0..1 float) rounded to 0..255. Shares
+ * the {@link packTransformRow} write-site, so the two rows stay in lockstep.
+ * @internal
+ */
+export const packTintRow = (target: Uint8Array, offset: number, tint: Color): void => {
+  target[offset + 0] = tint.r;
+  target[offset + 1] = tint.g;
+  target[offset + 2] = tint.b;
+  target[offset + 3] = Math.round(tint.a * 255);
 };
 
 /** @internal */
@@ -55,15 +86,18 @@ export interface TransformBufferFrameSnapshot {
 /**
  * Internal per-frame transform+tint storage for draw-command node indices.
  *
- * Slot layout (12 floats):
+ * Transform slot layout (8 floats):
  * - 0..3:  (a, b, c, d)
  * - 4..7:  (tx, ty, snapMode, 0)
- * - 8..11: (tintR, tintG, tintB, tintA) with RGB in 0..1
+ *
+ * Tint row layout ({@link tintData}, parallel array, one rgba8 texel/row):
+ * - (r, g, b, a) as 0..255 bytes.
  *
  * @internal
  */
 export class TransformBuffer {
   private _data: Float32Array = new Float32Array(initialCapacity * floatsPerSlot);
+  private _tintData: Uint8Array = new Uint8Array(initialCapacity * tintBytesPerSlot);
   private _count = 0;
   private _version = 0;
   private _frameHash = hashOffset >>> 0;
@@ -129,6 +163,11 @@ export class TransformBuffer {
 
   public get data(): Float32Array {
     return this._data;
+  }
+
+  /** Parallel per-row tint bytes (rgba, 0..255) — see {@link packTintRow}. @internal */
+  public get tintData(): Uint8Array {
+    return this._tintData;
   }
 
   public get version(): number {
@@ -215,7 +254,8 @@ export class TransformBuffer {
 
     const offset = slot * floatsPerSlot;
 
-    packTransformRow(this._data, offset, transform, tint, snapMode);
+    packTransformRow(this._data, offset, transform, snapMode);
+    packTintRow(this._tintData, slot * tintBytesPerSlot, tint);
 
     if (slot >= this._count) {
       this._count = slot + 1;
@@ -239,6 +279,16 @@ export class TransformBuffer {
       // In-bounds: offset..offset+floatsPerSlot-1 is the just-written slot.
       this._frameHash = this._mix(this._frameHash, this._hashFloat(data[offset + i]!));
     }
+
+    // Tint lives in a separate byte array (see the class doc) — fold it into the
+    // same content hash, otherwise a frame that only changes tint (identical
+    // transform) would hash identically to the previous frame and commitSnapshot
+    // would wrongly report `changed: false`, skipping the tint texture's upload.
+    const tintOffset = slot * tintBytesPerSlot;
+    const tintData = this._tintData;
+    const packedTint = (tintData[tintOffset]! << 24) | (tintData[tintOffset + 1]! << 16) | (tintData[tintOffset + 2]! << 8) | tintData[tintOffset + 3]!;
+
+    this._frameHash = this._mix(this._frameHash, packedTint >>> 0);
 
     this._writeCount++;
 
@@ -302,9 +352,12 @@ export class TransformBuffer {
     }
 
     const nextData = new Float32Array(next * floatsPerSlot);
+    const nextTintData = new Uint8Array(next * tintBytesPerSlot);
 
     nextData.set(this._data);
+    nextTintData.set(this._tintData);
     this._data = nextData;
+    this._tintData = nextTintData;
   }
 
   private _hashFloat(value: number): number {

--- a/src/rendering/sprite/spriteMaterialSources.ts
+++ b/src/rendering/sprite/spriteMaterialSources.ts
@@ -13,9 +13,10 @@
  * material keeps the single `drawArraysInstanced` / `drawIndexed` batch.
  *
  * Both paths (locations 0, 3, 5, 6) fetch each instance's world transform and
- * tint from the shared transform storage keyed by `a_nodeIndex` / `nodeIndex`: the
- * WebGL2 path samples the `u_transforms` texture, the WGSL path reads the
- * `transforms` storage buffer (group(0) binding(1)).
+ * tint keyed by `a_nodeIndex` / `nodeIndex`: the WebGL2 path samples the
+ * `u_transforms` texture (transform) and `u_tintTexture` (rgba8 tint), the
+ * WGSL path reads the `transforms` storage buffer (group(0) binding(1)) and
+ * the `tints` packed-rgba8 storage buffer (group(0) binding(2)).
  *
  * A custom fragment receives the interpolated `v_texcoord` and premultiplied
  * `v_color`, plus the per-batch base texture bound as `u_texture` (WebGL2 unit 0
@@ -44,7 +45,8 @@ layout(location = 6) in uint a_nodeIndex;       // row into the shared transform
 uniform mat3 u_projection;
 uniform mat3 u_group;
 uniform vec4 u_viewport;                        // device-pixel snap rect (x, y, width, height)
-uniform sampler2D u_transforms;                 // shared per-frame transform buffer (3 texels/row)
+uniform sampler2D u_transforms;                 // shared per-frame transform buffer (2 texels/row)
+uniform sampler2D u_tintTexture;                // shared per-frame tint buffer (rgba8, 1 texel/row)
 
 out vec2 v_texcoord;
 out vec4 v_color;
@@ -68,13 +70,13 @@ void main(void) {
     float localX = (cornerX == 0) ? a_localBounds.x : a_localBounds.z;
     float localY = (cornerY == 0) ? a_localBounds.y : a_localBounds.w;
 
-    // Fetch the per-instance world transform and tint from the shared buffer
-    // (row = a_nodeIndex): texel 0 = (a, b, c, d), texel 1 = (tx, ty, snapMode, 0),
-    // texel 2 = tint (rgb 0..1, a).
+    // Fetch the per-instance world transform and tint (row = a_nodeIndex):
+    // transform texel 0 = (a, b, c, d), texel 1 = (tx, ty, snapMode, 0); tint
+    // is its own rgba8 texel (0..1 already, hardware-normalized).
     int row = int(a_nodeIndex);
     vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
     vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
-    vec4 m2 = texelFetch(u_transforms, ivec2(2, row), 0);
+    vec4 m2 = texelFetch(u_tintTexture, ivec2(0, row), 0);
 
     // Geometry boundary snap (m1.z == 2.0, axis-aligned only): round each local
     // corner to the device grid so the quad edges land on whole device pixels.
@@ -144,11 +146,13 @@ struct ProjectionUniforms {
 struct TransformSlot {
     m0: vec4<f32>,
     m1: vec4<f32>,
-    m2: vec4<f32>,
 };
 
 @group(0) @binding(0) var<uniform> projection: ProjectionUniforms;
 @group(0) @binding(1) var<storage, read> transforms: array<TransformSlot>;
+// Packed rgba8 tint (r|g|b|a, 8 bits each, unpacked via unpack4x8unorm), one
+// u32 per instance.
+@group(0) @binding(2) var<storage, read> tints: array<u32>;
 
 @group(1) @binding(0) var u_texture: texture_2d<f32>;
 @group(1) @binding(1) var u_sampler: sampler;
@@ -187,10 +191,11 @@ fn vertexMain(input: VertexInput, @builtin(vertex_index) vid: u32) -> VertexOutp
     var localX = select(input.localBounds.x, input.localBounds.z, cornerX == 1u);
     var localY = select(input.localBounds.y, input.localBounds.w, cornerY == 1u);
 
-    // Fetch this instance's world transform and tint from the shared storage
-    // buffer, keyed by nodeIndex: m0 = (a, b, c, d), m1 = (tx, ty, snapMode, 0),
-    // m2 = tint (rgb 0..1, a).
+    // Fetch this instance's world transform and tint, keyed by nodeIndex:
+    // m0 = (a, b, c, d), m1 = (tx, ty, snapMode, 0); tint is its own packed
+    // rgba8 word, unpacked to 0..1 by the GPU (no manual math needed).
     let slot = transforms[input.nodeIndex];
+    let tint = unpack4x8unorm(tints[input.nodeIndex]);
 
     // Geometry boundary snap (slot.m1.z == 2.0, axis-aligned only): round each
     // local corner to the device grid so the quad edges land on whole device
@@ -236,7 +241,7 @@ fn vertexMain(input: VertexInput, @builtin(vertex_index) vid: u32) -> VertexOutp
     let v = select(input.uvBounds.y, input.uvBounds.w, cornerY == 1u);
     output.texcoord = vec2<f32>(u, v);
 
-    output.color = vec4<f32>(slot.m2.rgb * slot.m2.a, slot.m2.a);
+    output.color = vec4<f32>(tint.rgb * tint.a, tint.a);
 
     return output;
 }

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -2098,17 +2098,13 @@ export class WebGl2Backend implements RenderBackend {
   }
 
   /**
-   * Return the packing scratch buffer backed by `state.partialUploadScratch`
-   * (grown on demand, never shrunk, kind-matched to `source`), sized to AT
-   * LEAST `length` — callers must bound their reads/writes to `length`
-   * themselves and upload via the `texSubImage2D` `srcOffset` overload rather
-   * than slicing a `length`-sized view. Reusing (and never subarray-ing) this
-   * buffer across every partial `DataTexture` upload — instead of allocating a
-   * fresh temporary array, or even a fresh view object, per sync — is what
-   * keeps a many-small-instances scene's (mesh bundles; barrier-heavy scenes)
-   * per-frame CPU garbage flat instead of scaling with flush count: each
-   * flush's transform (and now separate tint) sync would otherwise allocate
-   * its own throwaway packing buffer or view.
+   * Return a packing scratch view sized exactly `length`, backed by
+   * `state.partialUploadScratch` (grown on demand, never shrunk, kind-matched
+   * to `source`). Reusing this buffer across every partial `DataTexture`
+   * upload — instead of allocating a fresh temporary array per sync — is what
+   * keeps a barrier-heavy scene's per-frame CPU garbage flat instead of
+   * scaling with flush count: each flush's transform (and now separate tint)
+   * sync would otherwise allocate its own throwaway packing buffer.
    */
   private _acquirePartialUploadScratch(state: ManagedTextureState, source: Float32Array | Uint8Array, length: number): Float32Array | Uint8Array {
     const isFloat = source instanceof Float32Array;
@@ -2119,7 +2115,7 @@ export class WebGl2Backend implements RenderBackend {
       state.partialUploadScratch = scratch;
     }
 
-    return scratch;
+    return scratch.length === length ? scratch : scratch.subarray(0, length);
   }
 
   private _syncTexture(texture: Texture | RenderTexture): ManagedTextureState {
@@ -2163,31 +2159,29 @@ export class WebGl2Backend implements RenderBackend {
           this._accountant.recordTextureUpload(texture.width * texture.height * bytesPerPixel);
         } else {
           // Partial upload: pack a contiguous sub-region from the row-major
-          // buffer into a reusable scratch buffer (grown once, never
-          // reallocated — and never subarray-viewed either, see
-          // `_acquirePartialUploadScratch` — per call) that gl.texSubImage2D
-          // can read via its `srcOffset` overload.
+          // buffer into a reusable scratch view (grown once, never reallocated
+          // per call — see `_acquirePartialUploadScratch`) that gl.texSubImage2D
+          // can read.
           const channels = formatInfo.channels;
           const rowFloats = texture.width * channels;
           const subFloats = region.width * channels;
-          const length = region.width * region.height * channels;
-          const scratch = this._acquirePartialUploadScratch(state, texture.buffer, length);
+          const subView = this._acquirePartialUploadScratch(state, texture.buffer, region.width * region.height * channels);
 
           if (region.x === 0 && region.width === texture.width) {
             // Full-width rows are contiguous in the row-major buffer — one copy.
             const start = region.y * rowFloats;
 
-            scratch.set(texture.buffer.subarray(start, start + length));
+            subView.set(texture.buffer.subarray(start, start + subView.length));
           } else {
             for (let row = 0; row < region.height; row++) {
               const sourceStart = (region.y + row) * rowFloats + region.x * channels;
               const targetStart = row * subFloats;
 
-              scratch.set(texture.buffer.subarray(sourceStart, sourceStart + subFloats), targetStart);
+              subView.set(texture.buffer.subarray(sourceStart, sourceStart + subFloats), targetStart);
             }
           }
 
-          gl.texSubImage2D(gl.TEXTURE_2D, 0, region.x, region.y, region.width, region.height, formatInfo.format, formatInfo.type, scratch, 0);
+          gl.texSubImage2D(gl.TEXTURE_2D, 0, region.x, region.y, region.width, region.height, formatInfo.format, formatInfo.type, subView);
           this._accountant.recordTextureUpload(region.width * region.height * bytesPerPixel);
         }
 

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -2098,13 +2098,17 @@ export class WebGl2Backend implements RenderBackend {
   }
 
   /**
-   * Return a packing scratch view sized exactly `length`, backed by
-   * `state.partialUploadScratch` (grown on demand, never shrunk, kind-matched
-   * to `source`). Reusing this buffer across every partial `DataTexture`
-   * upload — instead of allocating a fresh temporary array per sync — is what
-   * keeps a barrier-heavy scene's per-frame CPU garbage flat instead of
-   * scaling with flush count: each flush's transform (and now separate tint)
-   * sync would otherwise allocate its own throwaway packing buffer.
+   * Return the packing scratch buffer backed by `state.partialUploadScratch`
+   * (grown on demand, never shrunk, kind-matched to `source`), sized to AT
+   * LEAST `length` — callers must bound their reads/writes to `length`
+   * themselves and upload via the `texSubImage2D` `srcOffset` overload rather
+   * than slicing a `length`-sized view. Reusing (and never subarray-ing) this
+   * buffer across every partial `DataTexture` upload — instead of allocating a
+   * fresh temporary array, or even a fresh view object, per sync — is what
+   * keeps a many-small-instances scene's (mesh bundles; barrier-heavy scenes)
+   * per-frame CPU garbage flat instead of scaling with flush count: each
+   * flush's transform (and now separate tint) sync would otherwise allocate
+   * its own throwaway packing buffer or view.
    */
   private _acquirePartialUploadScratch(state: ManagedTextureState, source: Float32Array | Uint8Array, length: number): Float32Array | Uint8Array {
     const isFloat = source instanceof Float32Array;
@@ -2115,7 +2119,7 @@ export class WebGl2Backend implements RenderBackend {
       state.partialUploadScratch = scratch;
     }
 
-    return scratch.length === length ? scratch : scratch.subarray(0, length);
+    return scratch;
   }
 
   private _syncTexture(texture: Texture | RenderTexture): ManagedTextureState {
@@ -2159,29 +2163,31 @@ export class WebGl2Backend implements RenderBackend {
           this._accountant.recordTextureUpload(texture.width * texture.height * bytesPerPixel);
         } else {
           // Partial upload: pack a contiguous sub-region from the row-major
-          // buffer into a reusable scratch view (grown once, never reallocated
-          // per call — see `_acquirePartialUploadScratch`) that gl.texSubImage2D
-          // can read.
+          // buffer into a reusable scratch buffer (grown once, never
+          // reallocated — and never subarray-viewed either, see
+          // `_acquirePartialUploadScratch` — per call) that gl.texSubImage2D
+          // can read via its `srcOffset` overload.
           const channels = formatInfo.channels;
           const rowFloats = texture.width * channels;
           const subFloats = region.width * channels;
-          const subView = this._acquirePartialUploadScratch(state, texture.buffer, region.width * region.height * channels);
+          const length = region.width * region.height * channels;
+          const scratch = this._acquirePartialUploadScratch(state, texture.buffer, length);
 
           if (region.x === 0 && region.width === texture.width) {
             // Full-width rows are contiguous in the row-major buffer — one copy.
             const start = region.y * rowFloats;
 
-            subView.set(texture.buffer.subarray(start, start + subView.length));
+            scratch.set(texture.buffer.subarray(start, start + length));
           } else {
             for (let row = 0; row < region.height; row++) {
               const sourceStart = (region.y + row) * rowFloats + region.x * channels;
               const targetStart = row * subFloats;
 
-              subView.set(texture.buffer.subarray(sourceStart, sourceStart + subFloats), targetStart);
+              scratch.set(texture.buffer.subarray(sourceStart, sourceStart + subFloats), targetStart);
             }
           }
 
-          gl.texSubImage2D(gl.TEXTURE_2D, 0, region.x, region.y, region.width, region.height, formatInfo.format, formatInfo.type, subView);
+          gl.texSubImage2D(gl.TEXTURE_2D, 0, region.x, region.y, region.width, region.height, formatInfo.format, formatInfo.type, scratch, 0);
           this._accountant.recordTextureUpload(region.width * region.height * bytesPerPixel);
         }
 

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -250,6 +250,11 @@ export class WebGl2Backend implements RenderBackend {
   private _transformTexture: DataTexture<'rgba32f'> | null = null;
   private _transformTextureHash = 0;
   private _transformTextureCount = -1;
+  // Tint's own rgba8 texture (see TransformBuffer's class doc for why it's
+  // split out of the fp32 transform texture): created/uploaded alongside the
+  // transform texture in bindTransformBufferTexture (same dirty-range
+  // consumption), bound separately by renderers that read tint.
+  private _tintTexture: DataTexture<'rgba8'> | null = null;
   private _activeDrawCommand: DrawCommand | null = null;
   private _drawPlanDepth = 0;
   private readonly _planBaseStack: number[] = [];
@@ -952,7 +957,7 @@ export class WebGl2Backend implements RenderBackend {
       transformTexture?.destroy();
 
       this._transformTexture = new DataTexture({
-        width: 3,
+        width: 2,
         height: this._transformBuffer.capacity,
         format: 'rgba32f',
         data: this._transformBuffer.data,
@@ -961,10 +966,28 @@ export class WebGl2Backend implements RenderBackend {
       this._transformTextureCount = -1;
     }
 
+    // Tint's capacity always grows in lockstep with the transform buffer (see
+    // TransformBuffer._ensureCapacity), so the same capacity check catches
+    // both a first bind and a growth — no separate dirty-hash tracking needed;
+    // both textures upload from the one dirty-range consumption below.
+    const tintTexture = this._tintTexture;
+
+    if (tintTexture?.height !== this._transformBuffer.capacity || tintTexture.buffer !== this._transformBuffer.tintData) {
+      tintTexture?.destroy();
+
+      this._tintTexture = new DataTexture({
+        width: 1,
+        height: this._transformBuffer.capacity,
+        format: 'rgba8',
+        data: this._transformBuffer.tintData,
+      });
+    }
+
     const snapshot = this._transformBuffer.commitSnapshot(requiredCount);
     const nextTransformTexture = this._transformTexture;
+    const nextTintTexture = this._tintTexture;
 
-    if (nextTransformTexture === null) {
+    if (nextTransformTexture === null || nextTintTexture === null) {
       throw new Error('Transform texture must be initialized before binding.');
     }
 
@@ -976,10 +999,13 @@ export class WebGl2Backend implements RenderBackend {
       // Upload only the rows actually written since the last upload (delta), so
       // barrier-heavy frames don't re-upload the whole growing buffer. A reused
       // slot below the high-water mark is in the dirty range, so it re-uploads.
+      // Single consumption feeds BOTH textures — consumeDirtyRange clears the
+      // range as a side effect, so it must only be called once per flush.
       const { firstRow, rowCount } = this._transformBuffer.consumeDirtyRange(snapshot.count);
 
       if (rowCount > 0) {
-        nextTransformTexture.commitRect(0, firstRow, 3, rowCount);
+        nextTransformTexture.commitRect(0, firstRow, 2, rowCount);
+        nextTintTexture.commitRect(0, firstRow, 1, rowCount);
         this._transformBuffer.recordUpload(rowCount);
       }
 
@@ -988,6 +1014,22 @@ export class WebGl2Backend implements RenderBackend {
     }
 
     return this.bindTexture(nextTransformTexture, unit);
+  }
+
+  /**
+   * Bind the tint texture (uploaded as part of {@link bindTransformBufferTexture},
+   * which must be called first this flush) to `unit`. Only renderers that read
+   * per-node tint from the shared buffer (sprite, mesh) call this.
+   * @internal
+   */
+  public bindTintBufferTexture(unit: number): this {
+    const tintTexture = this._tintTexture;
+
+    if (tintTexture === null) {
+      throw new Error('Tint texture must be initialized (via bindTransformBufferTexture) before binding.');
+    }
+
+    return this.bindTexture(tintTexture, unit);
   }
 
   public setBlendMode(blendMode: BlendModes | null): this {
@@ -1215,7 +1257,7 @@ export class WebGl2Backend implements RenderBackend {
         payload.replayer._rebaseRetainedNodeIndices(payload, range.min);
       }
 
-      frame.bundle._storeTransformRows(this._transformBuffer.data, range.min, range.max - range.min + 1);
+      frame.bundle._storeTransformRows(this._transformBuffer.data, this._transformBuffer.tintData, range.min, range.max - range.min + 1);
     }
 
     frame.bundle._connectDevice(this._context, this._accountant);
@@ -1485,6 +1527,11 @@ export class WebGl2Backend implements RenderBackend {
       this._transformTexture = null;
     }
 
+    if (this._tintTexture !== null) {
+      this._tintTexture.destroy();
+      this._tintTexture = null;
+    }
+
     this._vao = null;
     this._renderer = null;
     this._shader = null;
@@ -1602,12 +1649,14 @@ export class WebGl2Backend implements RenderBackend {
     // dropped when its render target is evicted).
     this._destroyManagedResources();
 
-    // The shared transform texture's handle died with the context. Drop the
-    // wrapper (its GL handle was just evicted above) and reset the upload
-    // bookkeeping so a fresh DataTexture + full re-upload happens on next bind.
+    // The shared transform (+ tint) texture handles died with the context. Drop
+    // the wrappers (their GL handles were just evicted above) and reset the
+    // upload bookkeeping so fresh DataTextures + a full re-upload happen on the
+    // next bind.
     this._transformTexture = null;
     this._transformTextureCount = -1;
     this._transformTextureHash = 0;
+    this._tintTexture = null;
 
     // Disconnect renderers so they release their (dead) buffers / VAOs / shader
     // programs, then reconnect to rebuild them against the fresh context. This

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -99,6 +99,17 @@ interface ManagedTextureState {
   height: number;
   /** GPU bytes currently booked for this texture's storage (0 until first upload). */
   accountedBytes: number;
+  /**
+   * Reusable packing buffer for a partial `DataTexture` upload (see
+   * `_syncTexture`'s partial branch), sized to the largest region packed so
+   * far and never shrunk. Kept per-texture (not a shared backend scratch) so
+   * concurrently-tracked `DataTexture`s (e.g. the transform + tint pair, each
+   * syncing every flush of a barrier-heavy scene) never race over one buffer.
+   * `null` until the first partial upload; the array kind narrows to the
+   * texture's own buffer kind (`Float32Array` for `rgba32f`/`r32f`, `Uint8Array`
+   * for `rgba8`/`r8`) and never changes for a given texture instance.
+   */
+  partialUploadScratch: Float32Array | Uint8Array | null;
 }
 
 interface ManagedRenderTargetState {
@@ -1827,6 +1838,7 @@ export class WebGl2Backend implements RenderBackend {
         width: 0,
         height: 0,
         accountedBytes: 0,
+        partialUploadScratch: null,
       };
 
       this._textureStates.set(texture, state);
@@ -2085,6 +2097,27 @@ export class WebGl2Backend implements RenderBackend {
     gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
   }
 
+  /**
+   * Return a packing scratch view sized exactly `length`, backed by
+   * `state.partialUploadScratch` (grown on demand, never shrunk, kind-matched
+   * to `source`). Reusing this buffer across every partial `DataTexture`
+   * upload — instead of allocating a fresh temporary array per sync — is what
+   * keeps a barrier-heavy scene's per-frame CPU garbage flat instead of
+   * scaling with flush count: each flush's transform (and now separate tint)
+   * sync would otherwise allocate its own throwaway packing buffer.
+   */
+  private _acquirePartialUploadScratch(state: ManagedTextureState, source: Float32Array | Uint8Array, length: number): Float32Array | Uint8Array {
+    const isFloat = source instanceof Float32Array;
+    let scratch = state.partialUploadScratch;
+
+    if (scratch === null || scratch.length < length || isFloat !== (scratch instanceof Float32Array)) {
+      scratch = isFloat ? new Float32Array(length) : new Uint8Array(length);
+      state.partialUploadScratch = scratch;
+    }
+
+    return scratch.length === length ? scratch : scratch.subarray(0, length);
+  }
+
   private _syncTexture(texture: Texture | RenderTexture): ManagedTextureState {
     const gl = this._context;
     const state = this._getTextureState(texture);
@@ -2126,19 +2159,26 @@ export class WebGl2Backend implements RenderBackend {
           this._accountant.recordTextureUpload(texture.width * texture.height * bytesPerPixel);
         } else {
           // Partial upload: pack a contiguous sub-region from the row-major
-          // buffer into a temporary view that gl.texSubImage2D can read.
+          // buffer into a reusable scratch view (grown once, never reallocated
+          // per call — see `_acquirePartialUploadScratch`) that gl.texSubImage2D
+          // can read.
           const channels = formatInfo.channels;
           const rowFloats = texture.width * channels;
           const subFloats = region.width * channels;
-          const subView =
-            texture.buffer instanceof Float32Array
-              ? new Float32Array(region.width * region.height * channels)
-              : new Uint8Array(region.width * region.height * channels);
+          const subView = this._acquirePartialUploadScratch(state, texture.buffer, region.width * region.height * channels);
 
-          for (let row = 0; row < region.height; row++) {
-            const sourceStart = (region.y + row) * rowFloats + region.x * channels;
-            const targetStart = row * subFloats;
-            subView.set(texture.buffer.subarray(sourceStart, sourceStart + subFloats), targetStart);
+          if (region.x === 0 && region.width === texture.width) {
+            // Full-width rows are contiguous in the row-major buffer — one copy.
+            const start = region.y * rowFloats;
+
+            subView.set(texture.buffer.subarray(start, start + subView.length));
+          } else {
+            for (let row = 0; row < region.height; row++) {
+              const sourceStart = (region.y + row) * rowFloats + region.x * channels;
+              const targetStart = row * subFloats;
+
+              subView.set(texture.buffer.subarray(sourceStart, sourceStart + subFloats), targetStart);
+            }
           }
 
           gl.texSubImage2D(gl.TEXTURE_2D, 0, region.x, region.y, region.width, region.height, formatInfo.format, formatInfo.type, subView);

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -2110,7 +2110,7 @@ export class WebGl2Backend implements RenderBackend {
     const isFloat = source instanceof Float32Array;
     let scratch = state.partialUploadScratch;
 
-    if (scratch === null || scratch.length < length || isFloat !== (scratch instanceof Float32Array)) {
+    if (scratch === null || scratch.length < length || isFloat !== scratch instanceof Float32Array) {
       scratch = isFloat ? new Float32Array(length) : new Uint8Array(length);
       state.partialUploadScratch = scratch;
     }

--- a/src/rendering/webgl2/WebGl2MeshRenderer.ts
+++ b/src/rendering/webgl2/WebGl2MeshRenderer.ts
@@ -29,6 +29,7 @@ const initialNodeIndexCapacity = 64;
 const defaultVertexColor = 0xffffffff; // white, full alpha
 const maxCustomTextureSlots = 8;
 const transformTextureUnit = 8;
+const transformTintTextureUnit = 9;
 const identityGroupMat3 = new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
 
 interface MeshRendererConnection {
@@ -81,10 +82,11 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> implements 
   private readonly _compatibilityCache = new Map<Shader, boolean>();
   private readonly _textureUnitScratch: Int32Array = new Int32Array([0]);
   private readonly _transformUnitScratch: Int32Array = new Int32Array([transformTextureUnit]);
+  private readonly _tintUnitScratch: Int32Array = new Int32Array([transformTintTextureUnit]);
   // Pre-built texture-unit indices used for custom-shader sampler bindings;
   // pre-allocated so the per-frame uniform path stays allocation-free.
   private readonly _slotScratches: Int32Array[] = Array.from(
-    { length: Math.max(transformTextureUnit + 1, maxCustomTextureSlots + 1) },
+    { length: Math.max(transformTextureUnit + 1, transformTintTextureUnit + 1, maxCustomTextureSlots + 1) },
     (_, i) => new Int32Array([i]),
   );
   private readonly _groupComposeScratch = new Matrix();
@@ -532,6 +534,11 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> implements 
       shader.getUniform('u_transforms').setValue(this._transformUnitScratch);
     }
 
+    if (shader.uniforms.has('u_tintTexture')) {
+      backend.bindTintBufferTexture(transformTintTextureUnit);
+      shader.getUniform('u_tintTexture').setValue(this._tintUnitScratch);
+    }
+
     if (shader.uniforms.has('u_texture')) {
       shader.getUniform('u_texture').setValue(this._textureUnitScratch);
       backend.bindTexture(texture, 0);
@@ -628,8 +635,9 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> implements 
     const vao = payload.vao;
     const geometry = payload.geometry;
     const transformTexture = payload.bundle.transformTexture;
+    const tintTexture = payload.bundle.tintTexture;
 
-    if (backend === null || vao === null || geometry === null || geometry === undefined || transformTexture === null) {
+    if (backend === null || vao === null || geometry === null || geometry === undefined || transformTexture === null || tintTexture === null) {
       // Defensive: a bundle in this state never validates (generation), so a
       // spliced replay cannot reach here; skip rather than crash mid-frame.
       return;
@@ -667,6 +675,12 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> implements 
 
     if (shader.uniforms.has('u_transforms')) {
       shader.getUniform('u_transforms').setValue(this._transformUnitScratch);
+    }
+
+    backend.bindTexture(tintTexture, transformTintTextureUnit);
+
+    if (shader.uniforms.has('u_tintTexture')) {
+      shader.getUniform('u_tintTexture').setValue(this._tintUnitScratch);
     }
 
     shader.sync();

--- a/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
+++ b/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
@@ -3,13 +3,14 @@ import type { RetainedGroupBundle } from '#rendering/plan/RetainedInstructionSet
 import { DataTexture } from '#rendering/texture/DataTexture';
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { Texture } from '#rendering/texture/Texture';
-import { TRANSFORM_FLOATS_PER_ROW } from '#rendering/TransformBuffer';
+import { TRANSFORM_FLOATS_PER_ROW, TRANSFORM_TINT_BYTES_PER_ROW } from '#rendering/TransformBuffer';
 import { type BlendModes, BufferTypes, BufferUsage, RenderingPrimitives } from '#rendering/types';
 
 import { WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
 import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './WebGl2VertexArrayObject';
 
 const transformFloatsPerRow = TRANSFORM_FLOATS_PER_ROW;
+const tintBytesPerRow = TRANSFORM_TINT_BYTES_PER_ROW;
 const initialInstanceWordCapacity = 256;
 const initialTransformRowCapacity = 16;
 
@@ -176,6 +177,10 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
   private _transformRowCount = 0;
   private _transformRowBase = 0;
   private _transformTexture: DataTexture<'rgba32f'> | null = null;
+  // Parallel tint rows (see TransformBuffer's class doc): same row capacity/
+  // count/base as the transform store, grown and stored together.
+  private _tintBytes: Uint8Array | null = null;
+  private _tintTexture: DataTexture<'rgba8'> | null = null;
 
   // Device-side resources, created lazily at the first capture finalize.
   private _gl: WebGL2RenderingContext | null = null;
@@ -217,6 +222,11 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
   /** Group-owned transform store (`null` until the first capture stored rows). */
   public get transformTexture(): DataTexture<'rgba32f'> | null {
     return this._transformTexture;
+  }
+
+  /** Group-owned tint store (`null` until the first capture stored rows). */
+  public get tintTexture(): DataTexture<'rgba8'> | null {
+    return this._tintTexture;
   }
 
   /** Transform rows stored by the current/last capture. */
@@ -262,13 +272,13 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
   }
 
   /**
-   * Copy `rowCount` transform rows starting at `firstRow` from the shared
-   * frame-scoped transform buffer into the group-owned store (rows rebased to
-   * 0) and mark them for upload. Growth recreates the DataTexture (its buffer
-   * reference is fixed); the generation was already bumped by
+   * Copy `rowCount` transform + tint rows starting at `firstRow` from the
+   * shared frame-scoped buffers into the group-owned stores (rows rebased to
+   * 0) and mark them for upload. Growth recreates both DataTextures (their
+   * buffer references are fixed); the generation was already bumped by
    * {@link _beginCapture}, so growth needs no extra invalidation.
    */
-  public _storeTransformRows(source: Float32Array, firstRow: number, rowCount: number): void {
+  public _storeTransformRows(source: Float32Array, tintSource: Uint8Array, firstRow: number, rowCount: number): void {
     if (rowCount <= 0) {
       return;
     }
@@ -281,31 +291,43 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
       }
 
       this._transformTexture?.destroy();
+      this._tintTexture?.destroy();
       this._transformFloats = new Float32Array(next * transformFloatsPerRow);
       this._transformTexture = new DataTexture({
-        width: 3,
+        width: 2,
         height: next,
         format: 'rgba32f',
         data: this._transformFloats,
+      });
+      this._tintBytes = new Uint8Array(next * tintBytesPerRow);
+      this._tintTexture = new DataTexture({
+        width: 1,
+        height: next,
+        format: 'rgba8',
+        data: this._tintBytes,
       });
       this._transformRowCapacity = next;
     }
 
     // Non-null: the branch above allocated it when missing (the texture null
-    // check narrows the texture itself, but not the floats field).
+    // check narrows the texture itself, but not the floats/bytes fields).
     this._transformFloats!.set(source.subarray(firstRow * transformFloatsPerRow, (firstRow + rowCount) * transformFloatsPerRow), 0);
-    this._transformTexture.commitRect(0, 0, 3, rowCount);
+    this._transformTexture.commitRect(0, 0, 2, rowCount);
+    this._tintBytes!.set(tintSource.subarray(firstRow * tintBytesPerRow, (firstRow + rowCount) * tintBytesPerRow), 0);
+    this._tintTexture!.commitRect(0, 0, 1, rowCount);
     this._transformRowCount = rowCount;
     this._transformRowBase = firstRow;
   }
 
   /**
    * Slice 4b fast patch: overwrite one group-local transform row in place with
-   * `floats` (12 = 3 rgba32f texels, the {@link TransformBuffer} row layout)
+   * `floats` (8 = 2 rgba32f texels, the {@link TransformBuffer} row layout)
    * and mark ONLY that row's sub-range for upload. Deliberately does NOT bump
    * the generation — the recorded instance bytes reference this row by index
-   * and stay valid; only the transform behind the index moved. Out-of-range
-   * rows are ignored (a stale queue entry after a recapture shrank the store).
+   * and stay valid; only the transform behind the index moved. Tint is not
+   * touched (a moved node's tint doesn't change — see
+   * {@link RetainedContainer._tryPatchTransformRow}). Out-of-range rows are
+   * ignored (a stale queue entry after a recapture shrank the store).
    */
   public _patchTransformRow(localRow: number, floats: Float32Array): void {
     if (this._transformTexture === null || this._transformFloats === null || localRow < 0 || localRow >= this._transformRowCount) {
@@ -313,7 +335,7 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
     }
 
     this._transformFloats.set(floats.subarray(0, transformFloatsPerRow), localRow * transformFloatsPerRow);
-    this._transformTexture.commitRect(0, localRow, 3, 1);
+    this._transformTexture.commitRect(0, localRow, 2, 1);
   }
 
   /**
@@ -400,6 +422,9 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
     this._transformTexture?.destroy();
     this._transformTexture = null;
     this._transformFloats = null;
+    this._tintTexture?.destroy();
+    this._tintTexture = null;
+    this._tintBytes = null;
     this._transformRowCapacity = 0;
     this._transformRowCount = 0;
     this._usedWords = 0;

--- a/src/rendering/webgl2/WebGl2SpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2SpriteRenderer.ts
@@ -63,6 +63,11 @@ const maxBatchTextures = 16;
 // binds on the next unit (16). That needs 17 combined units, well within the
 // WebGL2 >= 32 MAX_COMBINED_TEXTURE_IMAGE_UNITS guarantee.
 const transformTextureUnit = 16;
+// One above the transform unit; the backend's render-target sync scratch unit
+// (17) is only live transiently during a render-to-texture sync, never while a
+// sprite draw's shader is active, so units stay disjoint in practice, but this
+// still sits clear of it.
+const transformTintTextureUnit = 18;
 // Custom-material texture bindings (base texture on unit 0 + material textures
 // on units 1..7) keep the pre-16-slot cap: the material CONTRACT stays at 7
 // extra textures, matching WebGl2MeshRenderer and the WebGPU sprite renderer.
@@ -112,6 +117,7 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
   private readonly _slotScratches: Int32Array[] = Array.from({ length: maxBatchTextures }, (_, i) => new Int32Array([i]));
   // Pinned unit index for the shared transform buffer sampler.
   private readonly _transformUnitScratch: Int32Array = new Int32Array([transformTextureUnit]);
+  private readonly _tintUnitScratch: Int32Array = new Int32Array([transformTintTextureUnit]);
   private _currentMaterial: SpriteMaterial | null = null;
   private _currentBaseTexture: Texture | RenderTexture | null = null;
   // Local bounds resolved for the sprite currently being packed. Geometry-mode
@@ -244,6 +250,12 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
 
     if (shader.uniforms.has('u_transforms')) {
       shader.getUniform('u_transforms').setValue(this._transformUnitScratch);
+    }
+
+    backend.bindTintBufferTexture(transformTintTextureUnit);
+
+    if (shader.uniforms.has('u_tintTexture')) {
+      shader.getUniform('u_tintTexture').setValue(this._tintUnitScratch);
     }
 
     shader.sync();
@@ -379,8 +391,9 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
     const backend = this.getBackendOrNull();
     const vao = payload.vao;
     const transformTexture = payload.bundle.transformTexture;
+    const tintTexture = payload.bundle.tintTexture;
 
-    if (backend === null || vao === null || transformTexture === null) {
+    if (backend === null || vao === null || transformTexture === null || tintTexture === null) {
       // Defensive: a bundle in this state never validates (generation), so a
       // spliced replay cannot reach here; skip rather than crash mid-frame.
       return;
@@ -409,6 +422,12 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
 
     if (this._shader.uniforms.has('u_transforms')) {
       this._shader.getUniform('u_transforms').setValue(this._transformUnitScratch);
+    }
+
+    backend.bindTexture(tintTexture, transformTintTextureUnit);
+
+    if (this._shader.uniforms.has('u_tintTexture')) {
+      this._shader.getUniform('u_tintTexture').setValue(this._tintUnitScratch);
     }
 
     this._shader.sync();

--- a/src/rendering/webgl2/glsl/mesh.vert
+++ b/src/rendering/webgl2/glsl/mesh.vert
@@ -10,6 +10,7 @@ uniform mat3 u_projection;
 uniform mat3 u_group;
 uniform vec4 u_viewport;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 
 out vec2 v_texcoord;
 out vec4 v_color;
@@ -18,7 +19,7 @@ out vec4 v_tint;
 void main(void) {
     int row = int(a_nodeIndex);
     vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0); // a,b,c,d
-    vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0); // tx,ty,0,0
+    vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0); // tx,ty,snapMode,0
     mat3 transform = mat3(
         m0.x, m0.z, 0.0,
         m0.y, m0.w, 0.0,
@@ -42,5 +43,5 @@ void main(void) {
     gl_Position = vec4(clip, 0.0, 1.0);
     v_texcoord = a_texcoord;
     v_color = a_color;
-    v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+    v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }

--- a/src/rendering/webgl2/glsl/sprite.vert
+++ b/src/rendering/webgl2/glsl/sprite.vert
@@ -13,7 +13,8 @@ layout(location = 6) in uint a_nodeIndex;       // row into the shared transform
 uniform mat3 u_projection;
 uniform mat3 u_group;
 uniform vec4 u_viewport;                        // device-pixel viewport rect (x, y, width, height) for position snapping
-uniform sampler2D u_transforms;                 // shared per-frame transform buffer (3 texels/row)
+uniform sampler2D u_transforms;                 // shared per-frame transform buffer (2 texels/row)
+uniform sampler2D u_tintTexture;                // shared per-frame tint buffer (rgba8, 1 texel/row)
 
 out vec2 v_texcoord;
 out vec4 v_color;
@@ -38,16 +39,17 @@ void main(void) {
     float localX = (cornerX == 0) ? a_localBounds.x : a_localBounds.z;
     float localY = (cornerY == 0) ? a_localBounds.y : a_localBounds.w;
 
-    // Fetch the world transform and tint for this instance from the shared
-    // buffer, keyed by a_nodeIndex. Row layout: texel 0 = (a, b, c, d),
-    // texel 1 = (tx, ty, snapMode, 0), texel 2 = tint (rgb in 0..1, a). The node tint
-    // is the sprite's own tint (written at the transform-buffer upload
-    // boundary), so reading it here unifies with the mesh path and removes the
-    // redundant per-instance a_color stream.
+    // Fetch the world transform and tint for this instance, keyed by
+    // a_nodeIndex. Transform texel 0 = (a, b, c, d), texel 1 = (tx, ty,
+    // snapMode, 0); tint is its own rgba8 texel (0..1 already, hardware-
+    // normalized — no unpack math needed). The node tint is the sprite's own
+    // tint (written at the transform-buffer upload boundary), so reading it
+    // here unifies with the mesh path and removes the redundant per-instance
+    // a_color stream.
     int row = int(a_nodeIndex);
     vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0); // a, b, c, d
     vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0); // tx, ty, snapMode, 0
-    vec4 m2 = texelFetch(u_transforms, ivec2(2, row), 0); // tint (rgb 0..1, a)
+    vec4 m2 = texelFetch(u_tintTexture, ivec2(0, row), 0); // tint (rgb 0..1, a)
 
     // Geometry boundary snap: round each local corner to the device grid so the
     // quad edges land on whole device pixels (m1.z == 2.0, axis-aligned only).

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -41,6 +41,7 @@ import { WebGpuMaskCompositor } from './WebGpuMaskCompositor';
 import { WebGpuMeshRenderer } from './WebGpuMeshRenderer';
 import { WebGpuPassCoordinator } from './WebGpuPassCoordinator';
 import {
+  retainedTintSlotBytes,
   retainedTransformSlotBytes,
   type WebGpuRetainedBatchPayload,
   type WebGpuRetainedBatchReplayer,
@@ -1001,7 +1002,7 @@ export class WebGpuBackend implements RenderBackend {
   }
 
   /** @internal */
-  public getTransformStorageBuffer(minCount: number): { readonly buffer: GPUBuffer; readonly count: number } {
+  public getTransformStorageBuffer(minCount: number): { readonly buffer: GPUBuffer; readonly tintBuffer: GPUBuffer; readonly count: number } {
     return this._getTransformStorage().getBuffer(this.device, minCount, this._accountant);
   }
 
@@ -1438,11 +1439,12 @@ export class WebGpuBackend implements RenderBackend {
 
     const rowCount = hasSharedTransformRange ? maxNodeIndex - base + 1 : 0;
     const transformBytes = rowCount * retainedTransformSlotBytes;
+    const tintBytes = rowCount * retainedTintSlotBytes;
 
     // Growth is safe against the open pass: a bundle can only be re-recorded
     // on a frame whose set was invalid at collect time, so no draw recorded
     // into the open pass references the buffers replaced here.
-    bundle.ensureCapacity(device, frame.totalBytes, transformBytes);
+    bundle.ensureCapacity(device, frame.totalBytes, transformBytes, tintBytes);
 
     for (const batch of staged) {
       // Rebase this batch's instance node indices to group-local indices —
@@ -1461,14 +1463,18 @@ export class WebGpuBackend implements RenderBackend {
     }
 
     if (hasSharedTransformRange) {
-      // Copy the group's transform rows [base, base + rowCount) — written by
-      // this playback's Phase-1 pre-pass into the frame-scoped CPU buffer —
-      // into the group-owned storage at group-local row 0. Rows carry tint
-      // (texel 2), so tint is covered by the copy.
-      const transformData = this._getTransformStorage().buffer.data;
+      // Copy the group's transform + tint rows [base, base + rowCount) —
+      // written by this playback's Phase-1 pre-pass into the frame-scoped CPU
+      // buffers — into the group-owned storage at group-local row 0. Tint
+      // lives in its own buffer (see TransformBuffer's class doc), copied
+      // separately from the same frame-scoped source.
+      const transformStorage = this._getTransformStorage().buffer;
+      const transformData = transformStorage.data;
+      const tintData = transformStorage.tintData;
 
       device.queue.writeBuffer(bundle.transformBuffer!, 0, transformData.buffer, transformData.byteOffset + base * retainedTransformSlotBytes, transformBytes);
-      this._accountant.recordBufferUpload(frame.totalBytes + transformBytes);
+      device.queue.writeBuffer(bundle.tintBuffer!, 0, tintData.buffer, tintData.byteOffset + base * retainedTintSlotBytes, tintBytes);
+      this._accountant.recordBufferUpload(frame.totalBytes + transformBytes + tintBytes);
     } else {
       this._accountant.recordBufferUpload(frame.totalBytes);
     }

--- a/src/rendering/webgpu/WebGpuMeshRenderer.ts
+++ b/src/rendering/webgpu/WebGpuMeshRenderer.ts
@@ -100,7 +100,6 @@ struct VertexOutput {
 struct TransformSlot {
     m0: vec4<f32>,
     m1: vec4<f32>,
-    m2: vec4<f32>,
 };
 
 struct TransformUniforms {
@@ -112,16 +111,21 @@ struct TransformUniforms {
 
 @group(0) @binding(0) var<uniform> uniforms: TransformUniforms;
 @group(0) @binding(1) var<storage, read> transforms: array<TransformSlot>;
+// Packed rgba8 tint (r|g|b|a, 8 bits each, unpacked via unpack4x8unorm), one
+// u32 per instance.
+@group(0) @binding(2) var<storage, read> tints: array<u32>;
 
 @group(1) @binding(0) var meshTexture: texture_2d<f32>;
 @group(1) @binding(1) var meshSampler: sampler;
 
 @vertex
 fn vertexMain(input: VertexInput) -> VertexOutput {
-    // Shared TransformSlot convention: m0 = (a, b, c, d), m1 = (tx, ty, 0, 0),
+    // Shared TransformSlot convention: m0 = (a, b, c, d), m1 = (tx, ty, snapMode, 0),
     // so world = (a*x + b*y + tx, c*x + d*y + ty) — identical to the sprite
     // WGSL and the WebGL2 vertex shaders (see src/rendering/affinePacking.ts).
+    // Tint is its own packed rgba8 word, unpacked to 0..1 by the GPU.
     let slot = transforms[input.nodeIndex];
+    let tint = unpack4x8unorm(tints[input.nodeIndex]);
     let world = vec3<f32>(
         slot.m0.x * input.position.x + slot.m0.y * input.position.y + slot.m1.x,
         slot.m0.z * input.position.x + slot.m0.w * input.position.y + slot.m1.y,
@@ -145,7 +149,7 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
     output.position = position;
     output.texcoord = input.texcoord;
     output.color = input.color;
-    output.tint = slot.m2;
+    output.tint = tint;
     output.premultiplySample = u32(uniforms.flags.x);
     return output;
 }
@@ -283,6 +287,7 @@ class MeshRetainedReplayState implements WebGpuRetainedRendererReplayState {
   public bindGroup: GPUBindGroup | null = null;
   public bindGroupUniform: GPUBuffer | null = null;
   public bindGroupTransform: GPUBuffer | null = null;
+  public bindGroupTint: GPUBuffer | null = null;
   // The (view, updateId) the currently-written slots were projected for; a
   // change while this bundle's draws sit in the open pass is the RT+main
   // double-replay hazard and ends the pass first (mirrors the sprite UBO guard).
@@ -297,6 +302,7 @@ class MeshRetainedReplayState implements WebGpuRetainedRendererReplayState {
     this.bindGroup = null;
     this.bindGroupUniform = null;
     this.bindGroupTransform = null;
+    this.bindGroupTint = null;
     this.uboView = null;
     this.uboViewUpdateId = -1;
     this.drawsInPass = null;
@@ -351,6 +357,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
   private _instancedNodeIndexByteOffset = 0;
   private _instancedTransformBindGroup: GPUBindGroup | null = null;
   private _instancedTransformStorageBuffer: GPUBuffer | null = null;
+  private _instancedTintStorageBuffer: GPUBuffer | null = null;
   private _uniformAlignment = 256;
   private _vertexBufferCapacity = 0;
   private _indexBufferCapacity = 0;
@@ -478,7 +485,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
     const pass = backend._passCoordinator.acquirePass().pass;
 
     pass.setPipeline(this._getInstancedPipeline({ blendMode: mesh.blendMode, format: renderTargetFormat, stencil }));
-    pass.setBindGroup(0, this._getOrCreateInstancedTransformBindGroup(storage.buffer), [0]);
+    pass.setBindGroup(0, this._getOrCreateInstancedTransformBindGroup(storage.buffer, storage.tintBuffer), [0]);
     pass.setBindGroup(1, this._getTextureBindGroup(backend, texture));
     pass.setVertexBuffer(0, staticGeometry.vertexBuffer);
     pass.setVertexBuffer(1, instanceNodeIndexBuffer);
@@ -715,7 +722,9 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
           const storage = backend.getTransformStorageBuffer(maxNodeIndex + 1);
 
           this._writeInstancedUniformSlot(instancedDrawCursor, backend, dc.premultiplySample);
-          pass.setBindGroup(0, this._getOrCreateInstancedTransformBindGroup(storage.buffer), [instancedDrawCursor * this._uniformAlignment]);
+          pass.setBindGroup(0, this._getOrCreateInstancedTransformBindGroup(storage.buffer, storage.tintBuffer), [
+            instancedDrawCursor * this._uniformAlignment,
+          ]);
 
           if (dc.texture !== lastTexture) {
             lastTexture = dc.texture;
@@ -959,6 +968,11 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
           visibility: GPUShaderStage.VERTEX,
           buffer: { type: 'read-only-storage' },
         },
+        {
+          binding: 2,
+          visibility: GPUShaderStage.VERTEX,
+          buffer: { type: 'read-only-storage' },
+        },
       ],
     });
     this._instancedPipelineLayout = this._device.createPipelineLayout({
@@ -992,6 +1006,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
     this._instancedNodeIndexBuffer = null;
     this._instancedTransformBindGroup = null;
     this._instancedTransformStorageBuffer = null;
+    this._instancedTintStorageBuffer = null;
     this._pipelineLayout = null;
     this._instancedPipelineLayout = null;
     this._textureBindGroupLayout = null;
@@ -1294,6 +1309,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
       });
       this._instancedTransformBindGroup = null;
       this._instancedTransformStorageBuffer = null;
+      this._instancedTintStorageBuffer = null;
     }
   }
 
@@ -1369,7 +1385,8 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
       geometry === undefined ||
       !bundle.isReady ||
       bundle.instanceBuffer === null ||
-      bundle.transformBuffer === null
+      bundle.transformBuffer === null ||
+      bundle.tintBuffer === null
     ) {
       // Defensive: such a bundle never validates (generation), so a spliced
       // replay cannot reach here; skip rather than crash mid-frame.
@@ -1439,7 +1456,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
     device.queue.writeBuffer(state.uniformBuffer!, slot * this._uniformAlignment, data.buffer, data.byteOffset, transformUniformByteLength);
 
     const textureBindGroup = this._getTextureBindGroup(backend, texture);
-    const bindGroup = this._getMeshReplayBindGroup(state, device, bundle.transformBuffer);
+    const bindGroup = this._getMeshReplayBindGroup(state, device, bundle.transformBuffer, bundle.tintBuffer);
 
     const active = coordinator.acquirePass();
     const pass = active.pass;
@@ -1502,8 +1519,13 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
     state.bindGroupUniform = null;
   }
 
-  private _getMeshReplayBindGroup(state: MeshRetainedReplayState, device: GPUDevice, transformBuffer: GPUBuffer): GPUBindGroup {
-    if (state.bindGroup !== null && state.bindGroupUniform === state.uniformBuffer && state.bindGroupTransform === transformBuffer) {
+  private _getMeshReplayBindGroup(state: MeshRetainedReplayState, device: GPUDevice, transformBuffer: GPUBuffer, tintBuffer: GPUBuffer): GPUBindGroup {
+    if (
+      state.bindGroup !== null &&
+      state.bindGroupUniform === state.uniformBuffer &&
+      state.bindGroupTransform === transformBuffer &&
+      state.bindGroupTint === tintBuffer
+    ) {
       return state.bindGroup;
     }
 
@@ -1513,20 +1535,27 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
       entries: [
         { binding: 0, resource: { buffer: state.uniformBuffer!, size: transformUniformByteLength } },
         { binding: 1, resource: { buffer: transformBuffer } },
+        { binding: 2, resource: { buffer: tintBuffer } },
       ],
     });
     state.bindGroupUniform = state.uniformBuffer;
     state.bindGroupTransform = transformBuffer;
+    state.bindGroupTint = tintBuffer;
 
     return state.bindGroup;
   }
 
-  private _getOrCreateInstancedTransformBindGroup(storageBuffer: GPUBuffer): GPUBindGroup {
-    if (this._instancedTransformBindGroup !== null && this._instancedTransformStorageBuffer === storageBuffer) {
+  private _getOrCreateInstancedTransformBindGroup(storageBuffer: GPUBuffer, tintBuffer: GPUBuffer): GPUBindGroup {
+    if (
+      this._instancedTransformBindGroup !== null &&
+      this._instancedTransformStorageBuffer === storageBuffer &&
+      this._instancedTintStorageBuffer === tintBuffer
+    ) {
       return this._instancedTransformBindGroup;
     }
 
     this._instancedTransformStorageBuffer = storageBuffer;
+    this._instancedTintStorageBuffer = tintBuffer;
     this._instancedTransformBindGroup = this._device!.createBindGroup({
       label: 'mesh:instanced-transform-bind-group',
       layout: this._instancedTransformBindGroupLayout!,
@@ -1542,6 +1571,12 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
           binding: 1,
           resource: {
             buffer: storageBuffer,
+          },
+        },
+        {
+          binding: 2,
+          resource: {
+            buffer: tintBuffer,
           },
         },
       ],

--- a/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
@@ -34,7 +34,6 @@ struct ProjectionUniforms {
 struct TransformSlot {
     m0: vec4<f32>,
     m1: vec4<f32>,
-    m2: vec4<f32>,
 };
 
 @group(0) @binding(0)
@@ -682,7 +681,7 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     const pass = active.pass;
 
     pass.setPipeline(this._getPipeline(payload.blendMode, backend.renderTargetFormat, coordinator.stencilActive));
-    pass.setBindGroup(0, bundle.getBindGroup(device, this._uniformBindGroupLayout!));
+    pass.setBindGroup(0, bundle.getBindGroup(device, this._uniformBindGroupLayout!, false));
     pass.setBindGroup(1, textureBindGroup);
     pass.setVertexBuffer(0, bundle.instanceBuffer, payload.byteOffset);
     pass.setIndexBuffer(this._indexBuffer, 'uint16');

--- a/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
@@ -39,7 +39,6 @@ struct ProjectionUniforms {
 struct TransformSlot {
     m0: vec4<f32>,
     m1: vec4<f32>,
-    m2: vec4<f32>,
 };
 
 @group(0) @binding(0) var<uniform> projection: ProjectionUniforms;
@@ -903,7 +902,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     const pass = active.pass;
 
     pass.setPipeline(this._getPipeline('geo', payload.blendMode, backend.renderTargetFormat, coordinator.stencilActive));
-    pass.setBindGroup(0, bundle.getBindGroup(device, this._uniformBindGroupLayout!));
+    pass.setBindGroup(0, bundle.getBindGroup(device, this._uniformBindGroupLayout!, false));
     pass.setBindGroup(1, textureBindGroup);
     pass.setVertexBuffer(0, bundle.instanceBuffer, payload.byteOffset);
     pass.setIndexBuffer(this._indexBuffer, 'uint16');

--- a/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
+++ b/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
@@ -10,8 +10,11 @@ import type { View } from '#rendering/View';
 
 import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
 
-/** Bytes of one transform slot (3 × vec4<f32>, matches the WGSL `TransformSlot`). */
-export const retainedTransformSlotBytes = 48;
+/** Bytes of one transform slot (2 × vec4<f32>, matches the WGSL `TransformSlot`). */
+export const retainedTransformSlotBytes = 32;
+
+/** Bytes of one packed rgba8 tint slot (one `u32`, matches the WGSL `tints` storage array). */
+export const retainedTintSlotBytes = 4;
 
 /**
  * Reference to the renderer-owned, persistent, SHARED geometry an indexed
@@ -211,6 +214,8 @@ export class WebGpuRetainedGroupBundle implements RetainedGroupBundle {
   private _instanceCapacity = 0;
   private _transformBuffer: GPUBuffer | null = null;
   private _transformCapacity = 0;
+  private _tintBuffer: GPUBuffer | null = null;
+  private _tintCapacity = 0;
   // Slice 4c in-place patch state: the shared-buffer row the stored rows were
   // rebased from, how many rows the store currently holds (bounds guard), and
   // the device whose queue the sub-range write goes through. All set at capture
@@ -221,6 +226,7 @@ export class WebGpuRetainedGroupBundle implements RetainedGroupBundle {
   private _uniformBuffer: GPUBuffer | null = null;
   private _bindGroup: GPUBindGroup | null = null;
   private _bindGroupLayout: GPUBindGroupLayout | null = null;
+  private _bindGroupIncludesTint = false;
   private readonly _accountant: GpuResourceAccountant;
   private _accountedBytes = 0;
   private _onRelease: ((bundle: WebGpuRetainedGroupBundle) => void) | null;
@@ -263,6 +269,10 @@ export class WebGpuRetainedGroupBundle implements RetainedGroupBundle {
     return this._transformBuffer;
   }
 
+  public get tintBuffer(): GPUBuffer | null {
+    return this._tintBuffer;
+  }
+
   /**
    * The shared frame-buffer row the stored transform rows were rebased from
    * (Slice 4c, {@link RetainedGroupBundle.transformRowBase}). A group-local row
@@ -279,15 +289,16 @@ export class WebGpuRetainedGroupBundle implements RetainedGroupBundle {
 
   /** Whether all GPU resources exist (false before the first finalized capture / after device loss). */
   public get isReady(): boolean {
-    return this._instanceBuffer !== null && this._transformBuffer !== null && this._uniformBuffer !== null;
+    return this._instanceBuffer !== null && this._transformBuffer !== null && this._tintBuffer !== null && this._uniformBuffer !== null;
   }
 
   /**
-   * Ensure the grow-only buffers cover `instanceBytes` + `transformBytes`.
-   * Recreating any buffer bumps {@link generation} (draws recorded against
-   * the old buffer must never replay) and drops the cached bind group.
+   * Ensure the grow-only buffers cover `instanceBytes` + `transformBytes` +
+   * `tintBytes`. Recreating any buffer bumps {@link generation} (draws
+   * recorded against the old buffer must never replay) and drops the cached
+   * bind group.
    */
-  public ensureCapacity(device: GPUDevice, instanceBytes: number, transformBytes: number): void {
+  public ensureCapacity(device: GPUDevice, instanceBytes: number, transformBytes: number, tintBytes: number): void {
     let recreated = false;
 
     if (this._instanceBuffer === null || this._instanceCapacity < instanceBytes) {
@@ -316,6 +327,19 @@ export class WebGpuRetainedGroupBundle implements RetainedGroupBundle {
       recreated = true;
     }
 
+    if (this._tintBuffer === null || this._tintCapacity < tintBytes) {
+      const capacity = growCapacity(this._tintCapacity, tintBytes);
+
+      this._tintBuffer?.destroy();
+      this._tintBuffer = device.createBuffer({
+        label: 'sprite:retained-tint-buffer',
+        size: capacity,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+      });
+      this._tintCapacity = capacity;
+      recreated = true;
+    }
+
     if (this._uniformBuffer === null) {
       this._uniformBuffer = device.createBuffer({
         label: 'sprite:retained-uniform-buffer',
@@ -329,7 +353,10 @@ export class WebGpuRetainedGroupBundle implements RetainedGroupBundle {
     if (recreated) {
       this._generation++;
       this._bindGroup = null;
-      this._accountedBytes = this._accountant.reallocate(this._accountedBytes, this._instanceCapacity + this._transformCapacity + retainedGroupUniformBytes);
+      this._accountedBytes = this._accountant.reallocate(
+        this._accountedBytes,
+        this._instanceCapacity + this._transformCapacity + this._tintCapacity + retainedGroupUniformBytes,
+      );
     }
   }
 
@@ -348,11 +375,12 @@ export class WebGpuRetainedGroupBundle implements RetainedGroupBundle {
 
   /**
    * Slice 4c fast patch: overwrite one group-local transform row in place with
-   * `floats` (12 = one `TransformSlot`, the {@link TransformBuffer} row layout)
-   * via a single `queue.writeBuffer` of that row's 48-byte sub-range. Mirrors
+   * `floats` (8 = one `TransformSlot`, the {@link TransformBuffer} row layout)
+   * via a single `queue.writeBuffer` of that row's 32-byte sub-range. Mirrors
    * {@link WebGl2RetainedGroupResources._patchTransformRow}: deliberately does
    * NOT bump the generation — the recorded instance bytes reference this row by
-   * index and stay valid; only the transform behind the index moved.
+   * index and stay valid; only the transform behind the index moved. Tint is
+   * not touched (a moved node's tint doesn't change).
    *
    * Out-of-range rows are ignored (a stale queue entry after a recapture shrank
    * the store), as is any patch before a range is recorded or after device loss
@@ -373,23 +401,35 @@ export class WebGpuRetainedGroupBundle implements RetainedGroupBundle {
   }
 
   /**
-   * The bind group(0) pairing the group UBO with the group transform storage,
-   * against the sprite renderer's existing uniform layout. Cached; rebuilt
-   * when a buffer or the layout (device restore) changed identity.
+   * The bind group(0) pairing the group UBO with the group transform storage
+   * (and, for a renderer that reads per-instance tint — sprite — the tint
+   * storage too), against the calling renderer's own uniform layout. Cached;
+   * rebuilt when a buffer, `includeTint`, or the layout (device restore)
+   * changed. `includeTint` MUST match what `layout` actually declares
+   * (binding 2 present or not) — the entries list below is built to fit
+   * exactly, since WebGPU bind group creation requires an exact match against
+   * the layout's binding set (nine-slice/repeating's layout has no binding 2).
    */
-  public getBindGroup(device: GPUDevice, layout: GPUBindGroupLayout): GPUBindGroup {
-    if (this._bindGroup !== null && this._bindGroupLayout === layout) {
+  public getBindGroup(device: GPUDevice, layout: GPUBindGroupLayout, includeTint: boolean): GPUBindGroup {
+    if (this._bindGroup !== null && this._bindGroupLayout === layout && this._bindGroupIncludesTint === includeTint) {
       return this._bindGroup;
     }
 
     this._bindGroupLayout = layout;
+    this._bindGroupIncludesTint = includeTint;
     this._bindGroup = device.createBindGroup({
       label: 'sprite:retained-bind-group',
       layout,
-      entries: [
-        { binding: 0, resource: { buffer: this._uniformBuffer! } },
-        { binding: 1, resource: { buffer: this._transformBuffer! } },
-      ],
+      entries: includeTint
+        ? [
+            { binding: 0, resource: { buffer: this._uniformBuffer! } },
+            { binding: 1, resource: { buffer: this._transformBuffer! } },
+            { binding: 2, resource: { buffer: this._tintBuffer! } },
+          ]
+        : [
+            { binding: 0, resource: { buffer: this._uniformBuffer! } },
+            { binding: 1, resource: { buffer: this._transformBuffer! } },
+          ],
     });
 
     return this._bindGroup;
@@ -405,14 +445,17 @@ export class WebGpuRetainedGroupBundle implements RetainedGroupBundle {
     if (destroyBuffers) {
       this._instanceBuffer?.destroy();
       this._transformBuffer?.destroy();
+      this._tintBuffer?.destroy();
       this._uniformBuffer?.destroy();
     }
 
     this._instanceBuffer = null;
     this._transformBuffer = null;
+    this._tintBuffer = null;
     this._uniformBuffer = null;
     this._instanceCapacity = 0;
     this._transformCapacity = 0;
+    this._tintCapacity = 0;
     this._transformRowCount = 0;
     this._patchDevice = null;
     this._bindGroup = null;

--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -138,13 +138,16 @@ struct ProjectionUniforms {
 struct TransformSlot {
     m0: vec4<f32>,
     m1: vec4<f32>,
-    m2: vec4<f32>,
 };
 
 @group(0) @binding(0)
 var<uniform> projection: ProjectionUniforms;
 @group(0) @binding(1)
 var<storage, read> transforms: array<TransformSlot>;
+// Packed rgba8 tint (r|g|b|a, 8 bits each, unpacked via unpack4x8unorm), one
+// u32 per instance.
+@group(0) @binding(2)
+var<storage, read> tints: array<u32>;
 
 ${textureBindings}
 
@@ -193,12 +196,13 @@ fn vertexMain(input: VertexInput, @builtin(vertex_index) vid: u32) -> VertexOutp
     var localX = select(input.localBounds.x, input.localBounds.z, cornerX == 1u);
     var localY = select(input.localBounds.y, input.localBounds.w, cornerY == 1u);
 
-    // Fetch this instance's world transform and tint from the shared storage
-    // buffer, keyed by nodeIndex: m0 = (a, b, c, d), m1 = (tx, ty, snapMode, 0),
-    // m2 = tint (rgb 0..1, a). The node tint is this sprite's own tint, so
-    // reading it here unifies with the mesh path and drops the per-instance
-    // color stream.
+    // Fetch this instance's world transform and tint, keyed by nodeIndex:
+    // m0 = (a, b, c, d), m1 = (tx, ty, snapMode, 0); tint is its own packed
+    // rgba8 word, unpacked to 0..1 by the GPU. The node tint is this sprite's
+    // own tint, so reading it here unifies with the mesh path and drops the
+    // per-instance color stream.
     let slot = transforms[input.nodeIndex];
+    let tint = unpack4x8unorm(tints[input.nodeIndex]);
 
     // Geometry boundary snap (slot.m1.z == 2.0, axis-aligned only): round each
     // local corner to the device grid so the quad edges land on whole device
@@ -243,7 +247,7 @@ fn vertexMain(input: VertexInput, @builtin(vertex_index) vid: u32) -> VertexOutp
     let v = select(input.uvBounds.y, input.uvBounds.w, cornerY == 1u);
     output.texcoord = vec2<f32>(u, v);
 
-    output.color = vec4(slot.m2.rgb * slot.m2.a, slot.m2.a);
+    output.color = vec4(tint.rgb * tint.a, tint.a);
     output.textureSlot = input.packedSlotFlags & 0xFFu;
     output.premultiplySample = (input.packedSlotFlags >> 8u) & 1u;
 
@@ -360,6 +364,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
   // Recreated whenever the storage buffer identity changes (capacity growth).
   private _transformBindGroup: GPUBindGroup | null = null;
   private _transformStorageBuffer: GPUBuffer | null = null;
+  private _tintStorageBuffer: GPUBuffer | null = null;
   private _indexBuffer: GPUBuffer | null = null;
   // Frame-scoped append arena for the per-batch instance stream: consecutive
   // batch flushes accumulate into one open pass at distinct byte offsets, so the
@@ -427,6 +432,13 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
         },
         {
           binding: 1,
+          visibility: GPUShaderStage.VERTEX,
+          buffer: {
+            type: 'read-only-storage',
+          },
+        },
+        {
+          binding: 2,
           visibility: GPUShaderStage.VERTEX,
           buffer: {
             type: 'read-only-storage',
@@ -501,6 +513,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     this._indexBuffer = null;
     this._transformBindGroup = null;
     this._transformStorageBuffer = null;
+    this._tintStorageBuffer = null;
     // Bind groups and the projection UBO belong to the (possibly lost) device;
     // drop the caches so reconnect rebuilds them against the fresh device.
     this._textureSetBindGroups = new WeakMap<Texture | RenderTexture, TextureSetBindGroupEntry[]>();
@@ -755,7 +768,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
       // projection UBO on group(0). Both the default and custom programs fetch
       // the world transform from it via nodeIndex.
       const storage = backend.getTransformStorageBuffer(needCount);
-      const transformBindGroup = this._getOrCreateTransformBindGroup(device, uniformBuffer, storage.buffer);
+      const transformBindGroup = this._getOrCreateTransformBindGroup(device, uniformBuffer, storage.buffer, storage.tintBuffer);
 
       const material = this._currentMaterial;
       const stencil = backend._passCoordinator.stencilActive;
@@ -892,18 +905,20 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
    * with the shared transform storage buffer. Cached against the storage buffer
    * identity, which changes only when its capacity grows.
    */
-  private _getOrCreateTransformBindGroup(device: GPUDevice, uniformBuffer: GPUBuffer, storageBuffer: GPUBuffer): GPUBindGroup {
-    if (this._transformBindGroup !== null && this._transformStorageBuffer === storageBuffer) {
+  private _getOrCreateTransformBindGroup(device: GPUDevice, uniformBuffer: GPUBuffer, storageBuffer: GPUBuffer, tintBuffer: GPUBuffer): GPUBindGroup {
+    if (this._transformBindGroup !== null && this._transformStorageBuffer === storageBuffer && this._tintStorageBuffer === tintBuffer) {
       return this._transformBindGroup;
     }
 
     this._transformStorageBuffer = storageBuffer;
+    this._tintStorageBuffer = tintBuffer;
     this._transformBindGroup = device.createBindGroup({
       label: 'sprite:transform-bind-group',
       layout: this._uniformBindGroupLayout!,
       entries: [
         { binding: 0, resource: { buffer: uniformBuffer } },
         { binding: 1, resource: { buffer: storageBuffer } },
+        { binding: 2, resource: { buffer: tintBuffer } },
       ],
     });
 
@@ -1059,7 +1074,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     const pass = active.pass;
 
     pass.setPipeline(this._getPipeline(payload.blendMode, backend.renderTargetFormat, coordinator.stencilActive));
-    pass.setBindGroup(0, bundle.getBindGroup(device, this._uniformBindGroupLayout!));
+    pass.setBindGroup(0, bundle.getBindGroup(device, this._uniformBindGroupLayout!, true));
     pass.setBindGroup(1, textureBindGroup);
     pass.setVertexBuffer(0, bundle.instanceBuffer, payload.byteOffset);
     pass.setIndexBuffer(this._indexBuffer, 'uint16');

--- a/src/rendering/webgpu/WebGpuTransformStorage.ts
+++ b/src/rendering/webgpu/WebGpuTransformStorage.ts
@@ -4,9 +4,10 @@ import type { Drawable } from '#rendering/Drawable';
 import type { GpuResourceAccountant } from '#rendering/GpuResourceAccountant';
 import { PixelSnapMode } from '#rendering/pixelSnap';
 import type { DrawCommand } from '#rendering/plan/RenderCommand';
-import { TransformBuffer } from '#rendering/TransformBuffer';
+import { TRANSFORM_FLOATS_PER_ROW, TRANSFORM_TINT_BYTES_PER_ROW, TransformBuffer } from '#rendering/TransformBuffer';
 
-const slotFloatCount = 12;
+const slotFloatCount = TRANSFORM_FLOATS_PER_ROW;
+const tintSlotBytes = TRANSFORM_TINT_BYTES_PER_ROW;
 
 /** @internal */
 export class WebGpuTransformStorage {
@@ -19,6 +20,11 @@ export class WebGpuTransformStorage {
   private _accountant: GpuResourceAccountant | null = null;
   /** GPU bytes currently booked for the storage buffer with the resource accountant. */
   private _accountedBytes = 0;
+  // Tint's own storage buffer (see TransformBuffer's class doc): grown and
+  // uploaded in lockstep with the transform buffer, one packed rgba8 `u32`
+  // per instance.
+  private _tintStorageBuffer: GPUBuffer | null = null;
+  private _tintAccountedBytes = 0;
 
   /**
    * Underlying shared transform buffer. Exposed for internal stats / tests
@@ -87,7 +93,7 @@ export class WebGpuTransformStorage {
       return;
     }
 
-    this._growBuffer(device, requiredBytes);
+    this._growBuffers(device, minCount);
   }
 
   /**
@@ -102,7 +108,11 @@ export class WebGpuTransformStorage {
     return this._storageBuffer === null || requiredBytes > this._storageCapacity;
   }
 
-  public getBuffer(device: GPUDevice, minCount: number, accountant?: GpuResourceAccountant): { readonly buffer: GPUBuffer; readonly count: number } {
+  public getBuffer(
+    device: GPUDevice,
+    minCount: number,
+    accountant?: GpuResourceAccountant,
+  ): { readonly buffer: GPUBuffer; readonly tintBuffer: GPUBuffer; readonly count: number } {
     this._accountant = accountant ?? this._accountant;
 
     const requiredCount = Math.max(1, minCount);
@@ -110,7 +120,7 @@ export class WebGpuTransformStorage {
     const snapshot = this._buffer.commitSnapshot(requiredCount);
 
     if (this._storageBuffer === null || requiredBytes > this._storageCapacity) {
-      this._growBuffer(device, requiredBytes);
+      this._growBuffers(device, requiredCount);
     }
 
     // A skipped flush (all three guards false) leaves the dirty range uncleared
@@ -122,16 +132,19 @@ export class WebGpuTransformStorage {
       // the full-upload path (post-grow) or the delta path runs below. Both paths
       // are inside this if-branch; the skip case (snapshot unchanged) never reaches
       // here, so the dirty range is only consumed when an upload is actually issued.
+      // Single consumption feeds BOTH buffers (transform + tint) — consumeDirtyRange
+      // clears the range as a side effect, so it must only be called once per flush.
       const { firstRow, rowCount } = this._buffer.consumeDirtyRange(snapshot.count);
 
       const slotBytes = slotFloatCount * Float32Array.BYTES_PER_ELEMENT;
 
       if (this._needsFullUpload) {
-        // Post-grow: the new GPUBuffer is empty; upload the full [0, snapshot.count)
+        // Post-grow: the new GPUBuffers are empty; upload the full [0, snapshot.count)
         // range so rows already consumed by earlier flushes this frame are present.
         device.queue.writeBuffer(this._storageBuffer!, 0, this._buffer.data.buffer, this._buffer.data.byteOffset, snapshot.count * slotBytes);
+        device.queue.writeBuffer(this._tintStorageBuffer!, 0, this._buffer.tintData.buffer, this._buffer.tintData.byteOffset, snapshot.count * tintSlotBytes);
         this._buffer.recordUpload(snapshot.count);
-        this._accountant?.recordBufferUpload(snapshot.count * slotBytes);
+        this._accountant?.recordBufferUpload(snapshot.count * slotBytes + snapshot.count * tintSlotBytes);
         this._needsFullUpload = false;
       } else if (rowCount > 0) {
         // Normal delta path: upload only the rows written since the last upload.
@@ -143,8 +156,15 @@ export class WebGpuTransformStorage {
           this._buffer.data.byteOffset + firstRow * slotBytes,
           rowCount * slotBytes,
         );
+        device.queue.writeBuffer(
+          this._tintStorageBuffer!,
+          firstRow * tintSlotBytes,
+          this._buffer.tintData.buffer,
+          this._buffer.tintData.byteOffset + firstRow * tintSlotBytes,
+          rowCount * tintSlotBytes,
+        );
         this._buffer.recordUpload(rowCount);
-        this._accountant?.recordBufferUpload(rowCount * slotBytes);
+        this._accountant?.recordBufferUpload(rowCount * slotBytes + rowCount * tintSlotBytes);
       }
 
       this._storageHash = snapshot.hash;
@@ -153,6 +173,7 @@ export class WebGpuTransformStorage {
 
     return {
       buffer: this._storageBuffer!,
+      tintBuffer: this._tintStorageBuffer!,
       count: snapshot.count,
     };
   }
@@ -168,14 +189,29 @@ export class WebGpuTransformStorage {
       this._accountant?.free(this._accountedBytes);
       this._accountedBytes = 0;
     }
+
+    this._tintStorageBuffer?.destroy();
+    this._tintStorageBuffer = null;
+
+    if (this._tintAccountedBytes > 0) {
+      this._accountant?.free(this._tintAccountedBytes);
+      this._tintAccountedBytes = 0;
+    }
   }
 
-  private _growBuffer(device: GPUDevice, requiredBytes: number): void {
+  private _growBuffers(device: GPUDevice, requiredCount: number): void {
+    const requiredBytes = requiredCount * slotFloatCount * Float32Array.BYTES_PER_ELEMENT;
     let nextCapacity = Math.max(this._storageCapacity, slotFloatCount * Float32Array.BYTES_PER_ELEMENT);
 
     while (nextCapacity < requiredBytes) {
       nextCapacity *= 2;
     }
+
+    // Tint's own capacity, grown to cover the SAME slot count as the transform
+    // buffer (nextCapacity / slotBytes), so the two buffers never diverge on
+    // how many rows they cover.
+    const nextSlotCount = nextCapacity / (slotFloatCount * Float32Array.BYTES_PER_ELEMENT);
+    const nextTintCapacity = nextSlotCount * tintSlotBytes;
 
     this._storageBuffer?.destroy();
     this._storageBuffer = device.createBuffer({
@@ -184,10 +220,19 @@ export class WebGpuTransformStorage {
       usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
     });
     this._storageCapacity = nextCapacity;
+
+    this._tintStorageBuffer?.destroy();
+    this._tintStorageBuffer = device.createBuffer({
+      label: 'transform:tint-storage-buffer',
+      size: nextTintCapacity,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    });
+
     this._storageHash = 0;
     this._storageCount = -1;
     this._needsFullUpload = true;
-    // Re-book the storage footprint (free the prior buffer's bytes, allocate the new).
+    // Re-book the storage footprint (free the prior buffers' bytes, allocate the new).
     this._accountedBytes = this._accountant?.reallocate(this._accountedBytes, nextCapacity) ?? this._accountedBytes;
+    this._tintAccountedBytes = this._accountant?.reallocate(this._tintAccountedBytes, nextTintCapacity) ?? this._tintAccountedBytes;
   }
 }

--- a/test/perf/rendering/allocation.test.ts
+++ b/test/perf/rendering/allocation.test.ts
@@ -71,7 +71,15 @@ const BASELINE_KB = {
   static: 248,
   moving: 574,
   nested: 363,
-  mesh: 646,
+  // Re-baselined for #422 (transform/tint buffer split): mesh bundles now sync
+  // a second per-instance DataTexture (tint) alongside transform every frame,
+  // a deliberate, permanent cost of the split, not a bug. CI (Linux runner,
+  // the environment that gates this test) measured 748.11 KB and 747.13 KB
+  // medians across two independent runs on the post-split code — stable to
+  // <0.2%. This dev box (Windows) measures ~692 KB for the same code, which
+  // is why a Windows-only re-run cannot be used to validate this budget; the
+  // baseline must track the CI environment.
+  mesh: 748,
   filtered: 823,
 } as const;
 

--- a/test/perf/rendering/fakeWebGl2.ts
+++ b/test/perf/rendering/fakeWebGl2.ts
@@ -138,7 +138,7 @@ export class GlRecorder {
   /** `blendFunc` calls — the backend only issues one per real blend-state change. */
   public blendChanges = 0;
   public scissorChanges = 0;
-  /** Transform-texture rows uploaded this frame (height of the width-3 rgba32f upload). */
+  /** Transform-texture rows uploaded this frame (height of the width-2 rgba32f upload). */
   public transformRows = 0;
   public transformUploadBytes = 0;
   /** Number of transform-texture uploads (zero when the frame's transforms are unchanged). */
@@ -366,8 +366,10 @@ export const createFakeWebGl2Context = (recorder: GlRecorder): WebGL2RenderingCo
     },
   };
 
-  // The transform texture is the only width-3 rgba32f upload (commitRect(0,0,3,count)):
-  // its height is the transform-row count uploaded this frame.
+  // The transform texture is the only width-2 rgba32f upload (commitRect(0,0,2,count)):
+  // its height is the transform-row count uploaded this frame. Tint now lives in its
+  // own width-1 rgba8 texture (see TransformBuffer's class doc) and is intentionally
+  // NOT folded into this transform-specific metric.
   const recordTextureUpload = (args: unknown[]): void => {
     // texImage2D(target, level, internalFormat, width, height, border, format, type, data?)
     // texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, data?)
@@ -380,7 +382,7 @@ export const createFakeWebGl2Context = (recorder: GlRecorder): WebGL2RenderingCo
     recorder.textureUploads++;
     recorder.textureUploadBytes += bytes;
 
-    if (width === 3) {
+    if (width === 2) {
       recorder.transformUploads++;
       recorder.transformRows = Math.max(recorder.transformRows, typeof height === 'number' ? height : 0);
       recorder.transformUploadBytes += bytes;

--- a/test/perf/rendering/retained-instruction-webgl2.test.ts
+++ b/test/perf/rendering/retained-instruction-webgl2.test.ts
@@ -153,9 +153,9 @@ describe('WebGL2 retained instruction set: record + splice ladder (Tasks 6/7)', 
       const rows = bundle.transformTexture!.buffer;
 
       expect(bundle.transformRowCount).toBe(3);
-      expect([rows[0 * 12 + 4], rows[0 * 12 + 5]]).toEqual([10, 10]);
-      expect([rows[1 * 12 + 4], rows[1 * 12 + 5]]).toEqual([60, 60]);
-      expect([rows[2 * 12 + 4], rows[2 * 12 + 5]]).toEqual([110, 110]);
+      expect([rows[0 * 8 + 4], rows[0 * 8 + 5]]).toEqual([10, 10]);
+      expect([rows[1 * 8 + 4], rows[1 * 8 + 5]]).toEqual([60, 60]);
+      expect([rows[2 * 8 + 4], rows[2 * 8 + 5]]).toEqual([110, 110]);
 
       root.destroy();
     });
@@ -192,9 +192,9 @@ describe('WebGL2 retained instruction set: record + splice ladder (Tasks 6/7)', 
 
       const rows = bundle.transformTexture!.buffer;
 
-      expect([rows[0 * 12 + 4], rows[0 * 12 + 5]]).toEqual([99, 99]); // moved child
-      expect([rows[1 * 12 + 4], rows[1 * 12 + 5]]).toEqual([60, 60]); // untouched
-      expect([rows[2 * 12 + 4], rows[2 * 12 + 5]]).toEqual([110, 110]); // untouched
+      expect([rows[0 * 8 + 4], rows[0 * 8 + 5]]).toEqual([99, 99]); // moved child
+      expect([rows[1 * 8 + 4], rows[1 * 8 + 5]]).toEqual([60, 60]); // untouched
+      expect([rows[2 * 8 + 4], rows[2 * 8 + 5]]).toEqual([110, 110]); // untouched
 
       root.destroy();
     });
@@ -269,7 +269,7 @@ describe('WebGL2 retained instruction set: record + splice ladder (Tasks 6/7)', 
       const bundle = bundleOf(group);
 
       expect(bundle.generation).toBeGreaterThan(firstGeneration);
-      expect(bundle.transformTexture!.buffer[1 * 12 + 4]).toBe(80); // fresh row data
+      expect(bundle.transformTexture!.buffer[1 * 8 + 4]).toBe(80); // fresh row data
 
       const spliced = measureFrame(harness, root);
 
@@ -476,9 +476,9 @@ describe('WebGL2 retained instruction set: Slice 4b fast transform-row patch', (
       // position; its neighbours are untouched (O(k) sub-range, not a re-pack).
       const rows = bundleOf(group).transformTexture!.buffer;
 
-      expect([rows[1 * 12 + 4], rows[1 * 12 + 5]]).toEqual([80, 80]);
-      expect(rows[0 * 12 + 4]).toBe(10); // inside[0] unchanged
-      expect(rows[2 * 12 + 4]).toBe(110); // inside[2] unchanged
+      expect([rows[1 * 8 + 4], rows[1 * 8 + 5]]).toEqual([80, 80]);
+      expect(rows[0 * 8 + 4]).toBe(10); // inside[0] unchanged
+      expect(rows[2 * 8 + 4]).toBe(110); // inside[2] unchanged
 
       // And the fast tier keeps splicing on the next frame with no re-record.
       const steady = measureFrame(harness, root);

--- a/test/perf/rendering/structural-nine-slice.test.ts
+++ b/test/perf/rendering/structural-nine-slice.test.ts
@@ -129,8 +129,8 @@ describe('structural — NineSlice', () => {
 
       expect(changed.transformUploads).toBe(1);
       expect(changed.transformRows).toBe(100);
-      // 100 transforms × 3 rgba32f texels × 16 bytes/texel = 4 800 bytes.
-      expect(changed.transformUploadBytes).toBe(100 * 48);
+      // 100 transforms × 2 rgba32f texels × 16 bytes/texel = 3 200 bytes.
+      expect(changed.transformUploadBytes).toBe(100 * 32);
 
       // Second post-mutation frame: hash stable → zero re-uploads.
       const steady = measureFrame(harness, root);

--- a/test/perf/rendering/structural-repeating.test.ts
+++ b/test/perf/rendering/structural-repeating.test.ts
@@ -79,8 +79,8 @@ describe('structural — RepeatingSprite', () => {
 
         expect(changed.transformUploads).toBe(1);
         expect(changed.transformRows).toBe(100);
-        // 100 transforms × 48 bytes each.
-        expect(changed.transformUploadBytes).toBe(100 * 48);
+        // 100 transforms × 32 bytes each (2 rgba32f texels × 16 bytes/texel).
+        expect(changed.transformUploadBytes).toBe(100 * 32);
 
         // Second post-mutation frame: hash stable → zero re-uploads.
         const steady = measureFrame(harness, root);

--- a/test/rendering/browser/webgl2-animated-sprite.test.ts
+++ b/test/rendering/browser/webgl2-animated-sprite.test.ts
@@ -44,6 +44,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -64,7 +65,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es
@@ -75,6 +76,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
 void main() {
   int row = int(a_nodeIndex);
@@ -85,7 +87,7 @@ void main() {
   vec3 clip = u_projection * world;
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord; v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFrag: `#version 300 es

--- a/test/rendering/browser/webgl2-bitmap-text.test.ts
+++ b/test/rendering/browser/webgl2-bitmap-text.test.ts
@@ -70,6 +70,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -90,7 +91,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es
@@ -101,6 +102,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
 void main() {
   int row = int(a_nodeIndex);
@@ -111,7 +113,7 @@ void main() {
   vec3 clip = u_projection * world;
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord; v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFrag: `#version 300 es

--- a/test/rendering/browser/webgl2-context-restore.test.ts
+++ b/test/rendering/browser/webgl2-context-restore.test.ts
@@ -38,6 +38,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -58,7 +59,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es
@@ -69,6 +70,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
 void main() {
   int row = int(a_nodeIndex);
@@ -79,7 +81,7 @@ void main() {
   vec3 clip = u_projection * world;
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord; v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFrag: `#version 300 es

--- a/test/rendering/browser/webgl2-custom-mesh-material.test.ts
+++ b/test/rendering/browser/webgl2-custom-mesh-material.test.ts
@@ -32,6 +32,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -56,7 +57,7 @@ void main() {
 
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
+  v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
 
@@ -68,6 +69,7 @@ layout(location = 2) in vec4 a_color;
 layout(location = 6) in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_texcoord;
 out vec4 v_color;
 out vec4 v_tint;
@@ -83,7 +85,7 @@ void main(void) {
   gl_Position = vec4((u_projection * transform * vec3(a_position, 1.0)).xy, 0.0, 1.0);
   v_texcoord = a_texcoord;
   v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFragmentSource: `#version 300 es
@@ -337,6 +339,7 @@ layout(location = 2) in vec4 a_color;
 layout(location = 6) in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_texcoord;
 out vec4 v_tint;
 void main() {
@@ -350,7 +353,7 @@ void main() {
   );
   gl_Position = vec4((u_projection * transform * vec3(a_position, 1.0)).xy, 0.0, 1.0);
   v_texcoord = a_texcoord;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0) * a_color;
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0) * a_color;
 }`;
 
 const instancedBatchFragment = `#version 300 es

--- a/test/rendering/browser/webgl2-custom-sprite-material.test.ts
+++ b/test/rendering/browser/webgl2-custom-sprite-material.test.ts
@@ -29,6 +29,7 @@ layout(location = 5) in uint a_textureSlot;
 layout(location = 6) in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_texcoord;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -41,7 +42,7 @@ void main() {
   int row = int(a_nodeIndex);
   vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
   vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
-  vec4 m2 = texelFetch(u_transforms, ivec2(2, row), 0);
+  vec4 m2 = texelFetch(u_tintTexture, ivec2(0, row), 0);
   float worldX = (m0.x * localX) + (m0.y * localY) + m1.x;
   float worldY = (m0.z * localX) + (m0.w * localY) + m1.y;
   gl_Position = vec4((u_projection * vec3(worldX, worldY, 1.0)).xy, 0.0, 1.0);
@@ -60,6 +61,7 @@ layout(location = 2) in vec4 a_color;
 layout(location = 6) in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_texcoord;
 out vec4 v_color;
 out vec4 v_tint;
@@ -75,7 +77,7 @@ void main(void) {
   gl_Position = vec4((u_projection * transform * vec3(a_position, 1.0)).xy, 0.0, 1.0);
   v_texcoord = a_texcoord;
   v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFragmentSource: `#version 300 es

--- a/test/rendering/browser/webgl2-dpr-resolution.test.ts
+++ b/test/rendering/browser/webgl2-dpr-resolution.test.ts
@@ -31,6 +31,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -52,7 +53,7 @@ void main() {
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
+  v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
   meshVertexSource: `#version 300 es
@@ -63,6 +64,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 out vec4 v_tint;
@@ -76,7 +78,7 @@ void main() {
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord;
   v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
   meshFragmentSource: `#version 300 es
 precision mediump float;

--- a/test/rendering/browser/webgl2-draw-geometry.test.ts
+++ b/test/rendering/browser/webgl2-draw-geometry.test.ts
@@ -36,6 +36,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -60,7 +61,7 @@ void main() {
 
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
+  v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
 
@@ -72,6 +73,7 @@ layout(location = 2) in vec4 a_color;
 layout(location = 6) in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_texcoord;
 out vec4 v_color;
 out vec4 v_tint;
@@ -87,7 +89,7 @@ void main(void) {
   gl_Position = vec4((u_projection * transform * vec3(a_position, 1.0)).xy, 0.0, 1.0);
   v_texcoord = a_texcoord;
   v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFragmentSource: `#version 300 es

--- a/test/rendering/browser/webgl2-graphics-gradient.test.ts
+++ b/test/rendering/browser/webgl2-graphics-gradient.test.ts
@@ -25,6 +25,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -49,7 +50,7 @@ void main() {
 
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
+  v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
 
@@ -61,6 +62,7 @@ layout(location = 2) in vec4 a_color;
 layout(location = 6) in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_texcoord;
 out vec4 v_color;
 out vec4 v_tint;
@@ -76,7 +78,7 @@ void main(void) {
   gl_Position = vec4((u_projection * transform * vec3(a_position, 1.0)).xy, 0.0, 1.0);
   v_texcoord = a_texcoord;
   v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFragmentSource: `#version 300 es

--- a/test/rendering/browser/webgl2-graphics-solid-fill.test.ts
+++ b/test/rendering/browser/webgl2-graphics-solid-fill.test.ts
@@ -36,6 +36,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -60,7 +61,7 @@ void main() {
 
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
+  v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
 
@@ -72,6 +73,7 @@ layout(location = 2) in vec4 a_color;
 layout(location = 6) in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_texcoord;
 out vec4 v_color;
 out vec4 v_tint;
@@ -87,7 +89,7 @@ void main(void) {
   gl_Position = vec4((u_projection * transform * vec3(a_position, 1.0)).xy, 0.0, 1.0);
   v_texcoord = a_texcoord;
   v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFragmentSource: `#version 300 es

--- a/test/rendering/browser/webgl2-group-uniform.test.ts
+++ b/test/rendering/browser/webgl2-group-uniform.test.ts
@@ -42,6 +42,7 @@ in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform mat3 u_group;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -62,7 +63,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * u_group * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es
@@ -73,6 +74,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
 void main() {
   int row = int(a_nodeIndex);
@@ -83,7 +85,7 @@ void main() {
   vec3 clip = u_projection * world;
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord; v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFrag: `#version 300 es

--- a/test/rendering/browser/webgl2-mesh-retained-instruction-replay.test.ts
+++ b/test/rendering/browser/webgl2-mesh-retained-instruction-replay.test.ts
@@ -57,6 +57,7 @@ in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform mat3 u_group;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -77,7 +78,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * u_group * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es
@@ -89,6 +90,7 @@ in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform mat3 u_group;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
 void main() {
   int row = int(a_nodeIndex);
@@ -98,7 +100,7 @@ void main() {
   vec3 clip = u_projection * u_group * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord; v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFrag: `#version 300 es

--- a/test/rendering/browser/webgl2-mesh-tint.test.ts
+++ b/test/rendering/browser/webgl2-mesh-tint.test.ts
@@ -43,6 +43,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -67,7 +68,7 @@ void main() {
 
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
+  v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
 
@@ -79,6 +80,7 @@ layout(location = 2) in vec4 a_color;
 layout(location = 6) in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_texcoord;
 out vec4 v_color;
 out vec4 v_tint;
@@ -94,7 +96,7 @@ void main(void) {
   gl_Position = vec4((u_projection * transform * vec3(a_position, 1.0)).xy, 0.0, 1.0);
   v_texcoord = a_texcoord;
   v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFragmentSource: `#version 300 es

--- a/test/rendering/browser/webgl2-mobile-precision-regression.test.ts
+++ b/test/rendering/browser/webgl2-mobile-precision-regression.test.ts
@@ -104,6 +104,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
 void main() {
   int row = int(a_nodeIndex);
@@ -114,7 +115,7 @@ void main() {
   vec3 clip = u_projection * world;
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord; v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFrag: `#version 300 es

--- a/test/rendering/browser/webgl2-nine-slice-retained-instruction-replay.test.ts
+++ b/test/rendering/browser/webgl2-nine-slice-retained-instruction-replay.test.ts
@@ -50,6 +50,7 @@ in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform mat3 u_group;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -70,7 +71,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * u_group * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es
@@ -81,6 +82,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
 void main() {
   int row = int(a_nodeIndex);
@@ -91,7 +93,7 @@ void main() {
   vec3 clip = u_projection * world;
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord; v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFrag: `#version 300 es

--- a/test/rendering/browser/webgl2-nine-slice.test.ts
+++ b/test/rendering/browser/webgl2-nine-slice.test.ts
@@ -46,6 +46,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -66,7 +67,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es
@@ -77,6 +78,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
 void main() {
   int row = int(a_nodeIndex);
@@ -87,7 +89,7 @@ void main() {
   vec3 clip = u_projection * world;
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord; v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFrag: `#version 300 es

--- a/test/rendering/browser/webgl2-particles.test.ts
+++ b/test/rendering/browser/webgl2-particles.test.ts
@@ -51,6 +51,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -71,7 +72,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es
@@ -82,6 +83,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
 void main() {
   int row = int(a_nodeIndex);
@@ -92,7 +94,7 @@ void main() {
   vec3 clip = u_projection * world;
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord; v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFrag: `#version 300 es

--- a/test/rendering/browser/webgl2-pixel-snap-gpu.test.ts
+++ b/test/rendering/browser/webgl2-pixel-snap-gpu.test.ts
@@ -66,6 +66,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
 void main() {
   int row = int(a_nodeIndex);
@@ -76,7 +77,7 @@ void main() {
   vec3 clip = u_projection * world;
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord; v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
   meshFrag: `#version 300 es
 precision mediump float;

--- a/test/rendering/browser/webgl2-pixel-snap.test.ts
+++ b/test/rendering/browser/webgl2-pixel-snap.test.ts
@@ -39,6 +39,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -59,7 +60,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
   meshVert: `#version 300 es
 precision mediump float;
@@ -69,6 +70,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
 void main() {
   int row = int(a_nodeIndex);
@@ -79,7 +81,7 @@ void main() {
   vec3 clip = u_projection * world;
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord; v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
   meshFrag: `#version 300 es
 precision mediump float;

--- a/test/rendering/browser/webgl2-render-error-surface.test.ts
+++ b/test/rendering/browser/webgl2-render-error-surface.test.ts
@@ -30,6 +30,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -54,7 +55,7 @@ void main() {
 
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
+  v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
 
@@ -66,6 +67,7 @@ layout(location = 2) in vec4 a_color;
 layout(location = 6) in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_texcoord;
 out vec4 v_color;
 out vec4 v_tint;
@@ -81,7 +83,7 @@ void main(void) {
   gl_Position = vec4((u_projection * transform * vec3(a_position, 1.0)).xy, 0.0, 1.0);
   v_texcoord = a_texcoord;
   v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFragmentSource: `#version 300 es

--- a/test/rendering/browser/webgl2-render-pipeline.test.ts
+++ b/test/rendering/browser/webgl2-render-pipeline.test.ts
@@ -25,6 +25,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -46,7 +47,7 @@ void main() {
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
+  v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
   meshVertexSource: `#version 300 es
@@ -57,6 +58,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 out vec4 v_tint;
@@ -70,7 +72,7 @@ void main() {
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord;
   v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
   meshFragmentSource: `#version 300 es
 precision mediump float;

--- a/test/rendering/browser/webgl2-render-plan.test.ts
+++ b/test/rendering/browser/webgl2-render-plan.test.ts
@@ -23,6 +23,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -47,7 +48,7 @@ void main() {
 
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
+  v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
 
@@ -59,6 +60,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 out vec4 v_tint;
@@ -76,7 +78,7 @@ void main() {
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord;
   v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFragmentSource: `#version 300 es

--- a/test/rendering/browser/webgl2-render-to-texture.test.ts
+++ b/test/rendering/browser/webgl2-render-to-texture.test.ts
@@ -26,6 +26,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -47,7 +48,7 @@ void main() {
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
+  v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
   meshVertexSource: `#version 300 es
@@ -58,6 +59,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 out vec4 v_tint;
@@ -71,7 +73,7 @@ void main() {
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord;
   v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
   meshFragmentSource: `#version 300 es
 precision mediump float;

--- a/test/rendering/browser/webgl2-renderer-perf.test.ts
+++ b/test/rendering/browser/webgl2-renderer-perf.test.ts
@@ -37,6 +37,7 @@ layout(location = 5) in uint a_textureSlot;
 layout(location = 6) in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_texcoord;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -49,7 +50,7 @@ void main() {
   int row = int(a_nodeIndex);
   vec4 m0 = texelFetch(u_transforms, ivec2(0, row), 0);
   vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
-  vec4 m2 = texelFetch(u_transforms, ivec2(2, row), 0);
+  vec4 m2 = texelFetch(u_tintTexture, ivec2(0, row), 0);
   float worldX = (m0.x * localX) + (m0.y * localY) + m1.x;
   float worldY = (m0.z * localX) + (m0.w * localY) + m1.y;
   gl_Position = vec4((u_projection * vec3(worldX, worldY, 1.0)).xy, 0.0, 1.0);
@@ -68,6 +69,7 @@ layout(location = 2) in vec4 a_color;
 layout(location = 6) in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_texcoord;
 out vec4 v_color;
 out vec4 v_tint;
@@ -79,7 +81,7 @@ void main(void) {
   gl_Position = vec4((u_projection * transform * vec3(a_position, 1.0)).xy, 0.0, 1.0);
   v_texcoord = a_texcoord;
   v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFragmentSource: `#version 300 es

--- a/test/rendering/browser/webgl2-repeating-sprite-retained.test.ts
+++ b/test/rendering/browser/webgl2-repeating-sprite-retained.test.ts
@@ -58,6 +58,7 @@ in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform mat3 u_group;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -78,7 +79,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * u_group * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es
@@ -89,6 +90,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
 void main() {
   int row = int(a_nodeIndex);
@@ -99,7 +101,7 @@ void main() {
   vec3 clip = u_projection * world;
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord; v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFrag: `#version 300 es

--- a/test/rendering/browser/webgl2-repeating-sprite.test.ts
+++ b/test/rendering/browser/webgl2-repeating-sprite.test.ts
@@ -45,6 +45,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -65,7 +66,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es
@@ -76,6 +77,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
 void main() {
   int row = int(a_nodeIndex);
@@ -86,7 +88,7 @@ void main() {
   vec3 clip = u_projection * world;
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord; v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFrag: `#version 300 es

--- a/test/rendering/browser/webgl2-retained-container.test.ts
+++ b/test/rendering/browser/webgl2-retained-container.test.ts
@@ -54,6 +54,7 @@ in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform mat3 u_group;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -74,7 +75,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * u_group * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es
@@ -85,6 +86,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
 void main() {
   int row = int(a_nodeIndex);
@@ -95,7 +97,7 @@ void main() {
   vec3 clip = u_projection * world;
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord; v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFrag: `#version 300 es

--- a/test/rendering/browser/webgl2-retained-instruction-replay.test.ts
+++ b/test/rendering/browser/webgl2-retained-instruction-replay.test.ts
@@ -52,6 +52,7 @@ in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform mat3 u_group;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -72,7 +73,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * u_group * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es
@@ -83,6 +84,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
 void main() {
   int row = int(a_nodeIndex);
@@ -93,7 +95,7 @@ void main() {
   vec3 clip = u_projection * world;
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord; v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFrag: `#version 300 es

--- a/test/rendering/browser/webgl2-rotated-mesh.test.ts
+++ b/test/rendering/browser/webgl2-rotated-mesh.test.ts
@@ -45,6 +45,7 @@ in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform mat3 u_group;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -65,7 +66,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * u_group * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   // Real production mesh.vert (canonical TransformSlot column order).
@@ -80,6 +81,7 @@ layout(location = 6) in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform mat3 u_group;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 
 out vec2 v_texcoord;
 out vec4 v_color;
@@ -98,7 +100,7 @@ void main(void) {
     gl_Position = vec4((u_projection * u_group * transform * vec3(a_position, 1.0)).xy, 0.0, 1.0);
     v_texcoord = a_texcoord;
     v_color = a_color;
-    v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+    v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   // Real production mesh.frag.

--- a/test/rendering/browser/webgl2-rotated-retained-group.test.ts
+++ b/test/rendering/browser/webgl2-rotated-retained-group.test.ts
@@ -53,6 +53,7 @@ in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform mat3 u_group;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -73,7 +74,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * u_group * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   // Real production mesh.vert (canonical TransformSlot column order + u_group).
@@ -88,6 +89,7 @@ layout(location = 6) in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform mat3 u_group;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 
 out vec2 v_texcoord;
 out vec4 v_color;
@@ -106,7 +108,7 @@ void main(void) {
     gl_Position = vec4((u_projection * u_group * transform * vec3(a_position, 1.0)).xy, 0.0, 1.0);
     v_texcoord = a_texcoord;
     v_color = a_color;
-    v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+    v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   // Real production mesh.frag.

--- a/test/rendering/browser/webgl2-split-viewport.test.ts
+++ b/test/rendering/browser/webgl2-split-viewport.test.ts
@@ -20,6 +20,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -41,7 +42,7 @@ void main() {
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
+  v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
   meshVertexSource: `#version 300 es
@@ -52,6 +53,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 out vec4 v_tint;
@@ -69,7 +71,7 @@ void main() {
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord;
   v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
   meshFragmentSource: `#version 300 es
 precision mediump float;

--- a/test/rendering/browser/webgl2-sprite-real-shader-tint.test.ts
+++ b/test/rendering/browser/webgl2-sprite-real-shader-tint.test.ts
@@ -1,11 +1,11 @@
 /**
- * WebGL2 Sprite browser test — real `sprite.vert` texel-2 tint pixel proof
+ * WebGL2 Sprite browser test — real `sprite.vert` tint pixel proof
  * (closes #321).
  *
- * B-11 moved sprite tint out of a per-instance `a_color` attribute and into
- * the shared transform texture's texel 2 (`ivec2(2, nodeIndex)`, channels
- * r/g/b/a, premultiplied in the vertex shader as
- * `vec4(m2.rgb * m2.a, m2.a)`). Every OTHER `browser-webgl-chromium` pixel
+ * Sprite tint lives in its own rgba8 texture (`u_tintTexture`, one texel per
+ * row, keyed by `nodeIndex`), separate from the fp32 transform texture —
+ * premultiplied in the vertex shader as `vec4(m2.rgb * m2.a, m2.a)`. Every
+ * OTHER `browser-webgl-chromium` pixel
  * spec stubs `.vert`/`.frag` to `""` and substitutes hand-written mock GLSL
  * (see `webgl2-sprite-solid-color.test.ts`), and the one spec that DOES load
  * the real file (`webgl2-shader-compile.test.ts`) only compiles/links it —
@@ -69,6 +69,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
 void main() {
   int row = int(a_nodeIndex);
@@ -79,7 +80,7 @@ void main() {
   vec3 clip = u_projection * world;
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord; v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFrag: `#version 300 es
@@ -198,18 +199,18 @@ const createSolidTexture = (color: string, width = 16, height = 16): Texture => 
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('WebGL2 Sprite — real sprite.vert texel-2 tint (#321)', () => {
+describe('WebGL2 Sprite — real sprite.vert tint (#321)', () => {
   test('the real shader source made it past the stub (not an empty string)', async () => {
     const real = await import('../../../src/rendering/webgl2/glsl/sprite.vert?raw');
 
     expect(real.default.length).toBeGreaterThan(0);
-    expect(real.default).toContain('ivec2(2, row)');
+    expect(real.default).toContain('texelFetch(u_tintTexture, ivec2(0, row), 0)');
   });
 
-  test('full-opaque tint renders the exact tint colour (texel-2 index + rgb swizzle)', async () => {
+  test('full-opaque tint renders the exact tint colour (tint texture index + rgb swizzle)', async () => {
     const backend = await createBackend();
     // Opaque white texture: sampleColor is (1,1,1,1), so the rendered pixel is
-    // driven entirely by the tint the shader reads from transform texel 2.
+    // driven entirely by the tint the shader reads from the tint texture.
     const texture = createSolidTexture('#ffffff', 16, 16);
     const root = new Container();
     const sprite = new Sprite(texture);

--- a/test/rendering/browser/webgl2-sprite-solid-color.test.ts
+++ b/test/rendering/browser/webgl2-sprite-solid-color.test.ts
@@ -41,6 +41,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -61,7 +62,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es
@@ -72,6 +73,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
 void main() {
   int row = int(a_nodeIndex);
@@ -82,7 +84,7 @@ void main() {
   vec3 clip = u_projection * world;
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord; v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFrag: `#version 300 es

--- a/test/rendering/browser/webgl2-stencil-clip.test.ts
+++ b/test/rendering/browser/webgl2-stencil-clip.test.ts
@@ -22,6 +22,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -46,7 +47,7 @@ void main() {
 
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
+  v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
 
@@ -58,6 +59,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 out vec4 v_tint;
@@ -75,7 +77,7 @@ void main() {
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord;
   v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFragmentSource: `#version 300 es

--- a/test/rendering/browser/webgl2-text-layout.test.ts
+++ b/test/rendering/browser/webgl2-text-layout.test.ts
@@ -33,6 +33,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -57,7 +58,7 @@ void main() {
 
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = uv;
-  v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0);
+  v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0);
   v_textureSlot = a_textureSlot;
 }`,
 
@@ -69,6 +70,7 @@ layout(location = 2) in vec4 a_color;
 layout(location = 6) in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_texcoord;
 out vec4 v_color;
 void main(void) {

--- a/test/rendering/browser/webgl2-text-retained-instruction-replay.test.ts
+++ b/test/rendering/browser/webgl2-text-retained-instruction-replay.test.ts
@@ -51,6 +51,7 @@ const auxShaderSources = vi.hoisted(() => ({
 precision highp float;
 in vec4 a_localBounds; in vec4 a_uvBounds; in vec4 a_color; in uint a_textureSlot; in uint a_nodeIndex;
 uniform mat3 u_projection; uniform mat3 u_group; uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; flat out uint v_textureSlot;
 void main() {
   vec2 local = vec2(a_localBounds.x, a_localBounds.y);
@@ -65,6 +66,7 @@ void main() {
 precision highp float;
 in vec2 a_position; in vec2 a_texcoord; in vec4 a_color; in uint a_nodeIndex;
 uniform mat3 u_projection; uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
 void main() {
   int row = int(a_nodeIndex);
@@ -72,7 +74,7 @@ void main() {
   vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
   mat3 t = mat3(m0.x,m0.z,0.0, m0.y,m0.w,0.0, m1.x,m1.y,1.0);
   gl_Position = vec4((u_projection * t * vec3(a_position, 1.0)).xy, 0.0, 1.0);
-  v_uv = a_texcoord; v_color = a_color; v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_uv = a_texcoord; v_color = a_color; v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
   meshFrag: `#version 300 es
 precision mediump float;

--- a/test/rendering/browser/webgl2-video.test.ts
+++ b/test/rendering/browser/webgl2-video.test.ts
@@ -58,6 +58,7 @@ in uint a_textureSlot;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv;
 out vec4 v_color;
 flat out uint v_textureSlot;
@@ -78,7 +79,7 @@ void main() {
   vec2 world = vec2(m0.x * local.x + m0.y * local.y + m1.x, m0.z * local.x + m0.w * local.y + m1.y);
   vec3 clip = u_projection * vec3(world, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_uv = uv; v_color = texelFetch(u_transforms, ivec2(2, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
+  v_uv = uv; v_color = texelFetch(u_tintTexture, ivec2(0, int(a_nodeIndex)), 0); v_textureSlot = a_textureSlot;
 }`,
 
   meshVert: `#version 300 es
@@ -89,6 +90,7 @@ in vec4 a_color;
 in uint a_nodeIndex;
 uniform mat3 u_projection;
 uniform sampler2D u_transforms;
+uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
 void main() {
   int row = int(a_nodeIndex);
@@ -99,7 +101,7 @@ void main() {
   vec3 clip = u_projection * world;
   gl_Position = vec4(clip.xy, 0.0, 1.0);
   v_uv = a_texcoord; v_color = a_color;
-  v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
 
   meshFrag: `#version 300 es

--- a/test/rendering/browser/webgpu-text-cross-backend-parity.test.ts
+++ b/test/rendering/browser/webgpu-text-cross-backend-parity.test.ts
@@ -56,7 +56,7 @@ void main() {
   meshVert: `#version 300 es
 precision highp float;
 in vec2 a_position; in vec2 a_texcoord; in vec4 a_color; in uint a_nodeIndex;
-uniform mat3 u_projection; uniform sampler2D u_transforms;
+uniform mat3 u_projection; uniform sampler2D u_transforms; uniform sampler2D u_tintTexture;
 out vec2 v_uv; out vec4 v_color; out vec4 v_tint;
 void main() {
   int row = int(a_nodeIndex);
@@ -64,7 +64,7 @@ void main() {
   vec4 m1 = texelFetch(u_transforms, ivec2(1, row), 0);
   mat3 t = mat3(m0.x,m0.z,0.0, m0.y,m0.w,0.0, m1.x,m1.y,1.0);
   gl_Position = vec4((u_projection * t * vec3(a_position, 1.0)).xy, 0.0, 1.0);
-  v_uv = a_texcoord; v_color = a_color; v_tint = texelFetch(u_transforms, ivec2(2, row), 0);
+  v_uv = a_texcoord; v_color = a_color; v_tint = texelFetch(u_tintTexture, ivec2(0, row), 0);
 }`,
   meshFrag: `#version 300 es
 precision mediump float;

--- a/test/rendering/transform-buffer-group-upload.test.ts
+++ b/test/rendering/transform-buffer-group-upload.test.ts
@@ -4,11 +4,12 @@ import { type DrawCommand, type MaterialKey, RenderEntryKind } from '#rendering/
 import { RenderPlanPlayer } from '#rendering/plan/RenderPlanPlayer';
 import type { DrawScopeEntry, GroupScope, GroupScopeEntry, ScopeEntry } from '#rendering/plan/RenderScope';
 import type { RenderBackend } from '#rendering/RenderBackend';
-import { TransformBuffer } from '#rendering/TransformBuffer';
+import { TRANSFORM_FLOATS_PER_ROW, TRANSFORM_TINT_BYTES_PER_ROW, TransformBuffer } from '#rendering/TransformBuffer';
 
 import { forEachGroupCommand } from './helpers/collectRenderGroups';
 
-const floatsPerSlot = 12;
+const floatsPerSlot = TRANSFORM_FLOATS_PER_ROW;
+const tintBytesPerSlot = TRANSFORM_TINT_BYTES_PER_ROW;
 
 class BoxDrawable extends Drawable {
   public constructor(
@@ -158,8 +159,8 @@ describe('transform buffer render-group upload wiring', () => {
     expect(buffer.data[3]).toBe(1); // d
     expect(buffer.data[4]).toBe(10); // tx
     expect(buffer.data[5]).toBe(20); // ty
-    expect(buffer.data[8]).toBeCloseTo(10 / 255, 6);
-    expect(buffer.data[11]).toBeCloseTo(0.1, 6);
+    expect(buffer.tintData[0]).toBe(10);
+    expect(buffer.tintData[3]).toBe(Math.round(0.1 * 255));
 
     // Node 'd' lives inside the nested group at nodeIndex 3, position (70, 80).
     const dOffset = 3 * floatsPerSlot;

--- a/test/rendering/transform-buffer.test.ts
+++ b/test/rendering/transform-buffer.test.ts
@@ -4,23 +4,34 @@ import { Container } from '#rendering/Container';
 import { PixelSnapMode } from '#rendering/pixelSnap';
 import { Sprite } from '#rendering/sprite/Sprite';
 import { Texture } from '#rendering/texture/Texture';
-import { packTransformRow, TransformBuffer } from '#rendering/TransformBuffer';
+import { packTintRow, packTransformRow, TransformBuffer } from '#rendering/TransformBuffer';
 
 describe('TransformBuffer', () => {
   test('packTransformRow writes the snap mode at offset 6 and keeps offset 7 reserved', () => {
-    const row = new Float32Array(12).fill(Number.NaN);
+    const row = new Float32Array(8).fill(Number.NaN);
 
-    packTransformRow(row, 0, new Matrix(), Color.white, PixelSnapMode.Geometry);
+    packTransformRow(row, 0, new Matrix(), PixelSnapMode.Geometry);
 
     expect(row[6]).toBe(2);
     expect(row[7]).toBe(0);
 
-    packTransformRow(row, 0, new Matrix(), Color.white, PixelSnapMode.None);
+    packTransformRow(row, 0, new Matrix(), PixelSnapMode.None);
 
     expect(row[6]).toBe(0);
   });
 
-  test('stores transform rows and normalized tint at the requested slot', () => {
+  test('packTintRow writes r/g/b/a as 0..255 bytes', () => {
+    const row = new Uint8Array(4).fill(0xff);
+
+    packTintRow(row, 0, new Color(64, 128, 255, 0.5));
+
+    expect(row[0]).toBe(64);
+    expect(row[1]).toBe(128);
+    expect(row[2]).toBe(255);
+    expect(row[3]).toBe(128); // round(0.5 * 255)
+  });
+
+  test('stores transform rows at the requested slot, tint in the parallel tintData row', () => {
     const buffer = new TransformBuffer();
     const transform = new Matrix(2, 3, 11, 5, 7, 13, 0, 0, 1);
     const tint = new Color(64, 128, 255, 0.5);
@@ -29,6 +40,7 @@ describe('TransformBuffer', () => {
     buffer.write(0, transform, tint);
 
     const data = buffer.data;
+    const tintData = buffer.tintData;
 
     expect(buffer.count).toBe(1);
     expect(data[0]).toBe(2);
@@ -39,10 +51,10 @@ describe('TransformBuffer', () => {
     expect(data[5]).toBe(13);
     expect(data[6]).toBe(0);
     expect(data[7]).toBe(0);
-    expect(data[8]).toBeCloseTo(64 / 255, 6);
-    expect(data[9]).toBeCloseTo(128 / 255, 6);
-    expect(data[10]).toBeCloseTo(1, 6);
-    expect(data[11]).toBeCloseTo(0.5, 6);
+    expect(tintData[0]).toBe(64);
+    expect(tintData[1]).toBe(128);
+    expect(tintData[2]).toBe(255);
+    expect(tintData[3]).toBe(128); // round(0.5 * 255)
   });
 
   test('sparse nodeIndex writes keep the highest slot as frame count', () => {
@@ -113,7 +125,7 @@ describe('TransformBuffer', () => {
     expect(buffer.skippedWriteCount).toBe(2);
     // Skips never advance the slot count or write into the buffer.
     expect(buffer.count).toBe(1);
-    expect(Array.from(buffer.data.subarray(12, 24))).toEqual(new Array(12).fill(0));
+    expect(Array.from(buffer.data.subarray(8, 16))).toEqual(new Array(8).fill(0));
   });
 
   test('recordUpload accumulates upload count and uploaded record count', () => {
@@ -165,8 +177,10 @@ describe('TransformBuffer', () => {
     buffer.begin();
     buffer.write(slot, global, child.tint);
 
-    const offset = slot * 12;
+    const offset = slot * 8;
+    const tintOffset = slot * 4;
     const data = buffer.data;
+    const tintData = buffer.tintData;
 
     expect(buffer.count).toBe(8);
     expect(data[offset + 0]).toBeCloseTo(global.a, 5);
@@ -175,10 +189,10 @@ describe('TransformBuffer', () => {
     expect(data[offset + 3]).toBeCloseTo(global.d, 5);
     expect(data[offset + 4]).toBeCloseTo(global.x, 5);
     expect(data[offset + 5]).toBeCloseTo(global.y, 5);
-    expect(data[offset + 8]).toBeCloseTo(child.tint.r / 255, 6);
-    expect(data[offset + 9]).toBeCloseTo(child.tint.g / 255, 6);
-    expect(data[offset + 10]).toBeCloseTo(child.tint.b / 255, 6);
-    expect(data[offset + 11]).toBeCloseTo(child.tint.a, 6);
+    expect(tintData[tintOffset + 0]).toBe(child.tint.r);
+    expect(tintData[tintOffset + 1]).toBe(child.tint.g);
+    expect(tintData[tintOffset + 2]).toBe(child.tint.b);
+    expect(tintData[tintOffset + 3]).toBe(Math.round(child.tint.a * 255));
 
     parent.destroy();
   });

--- a/test/rendering/transform-storage-filter.test.ts
+++ b/test/rendering/transform-storage-filter.test.ts
@@ -4,11 +4,11 @@ import { type DrawCommand, drawCommandUsesSharedTransform, type MaterialKey, Ren
 import { RenderPlanPlayer } from '#rendering/plan/RenderPlanPlayer';
 import type { DrawScopeEntry, GroupScope, ScopeEntry } from '#rendering/plan/RenderScope';
 import type { RenderBackend } from '#rendering/RenderBackend';
-import { TransformBuffer } from '#rendering/TransformBuffer';
+import { TRANSFORM_FLOATS_PER_ROW, TransformBuffer } from '#rendering/TransformBuffer';
 
 import { forEachGroupCommand } from './helpers/collectRenderGroups';
 
-const floatsPerSlot = 12;
+const floatsPerSlot = TRANSFORM_FLOATS_PER_ROW;
 
 // A drawable whose renderer reads the shared transform storage (Sprite/Mesh-like).
 class ConsumingDrawable extends Drawable {

--- a/test/rendering/webgl2-retained-group-resources.test.ts
+++ b/test/rendering/webgl2-retained-group-resources.test.ts
@@ -63,33 +63,35 @@ describe('WebGl2RetainedGroupResources: CPU-side capture store (Task 6)', () => 
 
   test('transform rows copy rebased to row 0; texture is reused below capacity and recreated on growth', () => {
     const bundle = new WebGl2RetainedGroupResources();
-    // Shared-buffer layout: 12 floats per row. Rows 2..3 carry markers.
-    const shared = new Float32Array(8 * 12);
+    // Shared-buffer layout: 8 floats per row. Rows 2..3 carry markers.
+    const shared = new Float32Array(8 * 8);
+    const sharedTint = new Uint8Array(8 * 4);
 
-    shared[2 * 12] = 42; // row 2, float 0
-    shared[3 * 12 + 5] = 7; // row 3, float 5 (translation y)
+    shared[2 * 8] = 42; // row 2, float 0
+    shared[3 * 8 + 5] = 7; // row 3, float 5 (translation y)
 
     bundle._beginCapture();
-    bundle._storeTransformRows(shared, 2, 2);
+    bundle._storeTransformRows(shared, sharedTint, 2, 2);
 
     const texture = bundle.transformTexture;
 
     expect(texture).not.toBeNull();
     expect(bundle.transformRowCount).toBe(2);
     expect(texture!.buffer[0]).toBe(42); // row 2 rebased to row 0
-    expect(texture!.buffer[12 + 5]).toBe(7); // row 3 rebased to row 1
+    expect(texture!.buffer[8 + 5]).toBe(7); // row 3 rebased to row 1
 
     // Same capacity class: the texture object is reused.
     bundle._beginCapture();
-    bundle._storeTransformRows(shared, 0, 4);
+    bundle._storeTransformRows(shared, sharedTint, 0, 4);
 
     expect(bundle.transformTexture).toBe(texture);
 
     // Growth past capacity recreates the texture (its buffer is fixed-size).
-    const bigShared = new Float32Array(64 * 12);
+    const bigShared = new Float32Array(64 * 8);
+    const bigSharedTint = new Uint8Array(64 * 4);
 
     bundle._beginCapture();
-    bundle._storeTransformRows(bigShared, 0, 64);
+    bundle._storeTransformRows(bigShared, bigSharedTint, 0, 64);
 
     expect(bundle.transformTexture).not.toBe(texture);
     expect(bundle.transformTexture!.height).toBeGreaterThanOrEqual(64);
@@ -101,13 +103,14 @@ describe('WebGl2RetainedGroupResources: CPU-side capture store (Task 6)', () => 
 describe('WebGl2RetainedGroupResources: in-place transform-row patch (Slice 4b)', () => {
   test('_storeTransformRows records the rebase base; patch overwrites one row and marks only its sub-range dirty', () => {
     const bundle = new WebGl2RetainedGroupResources();
-    const shared = new Float32Array(8 * 12);
+    const shared = new Float32Array(8 * 8);
+    const sharedTint = new Uint8Array(8 * 4);
 
-    shared[2 * 12 + 4] = 10; // row 2 -> local 0: tx
-    shared[3 * 12 + 4] = 60; // row 3 -> local 1: tx
+    shared[2 * 8 + 4] = 10; // row 2 -> local 0: tx
+    shared[3 * 8 + 4] = 60; // row 3 -> local 1: tx
 
     bundle._beginCapture();
-    bundle._storeTransformRows(shared, 2, 2);
+    bundle._storeTransformRows(shared, sharedTint, 2, 2);
 
     // The rebase base (range.min) is retained so a later patch can map a
     // shared/captured node index back to its group-local row.
@@ -116,32 +119,32 @@ describe('WebGl2RetainedGroupResources: in-place transform-row patch (Slice 4b)'
     // Drain the store-time full-region dirty flag (the first bind consumes it).
     bundle.transformTexture!._consumeDirtyRegion();
 
-    const patched = new Float32Array(12);
+    const patched = new Float32Array(8);
 
     patched[4] = 80; // new tx for the moved child
 
     bundle._patchTransformRow(1, patched);
 
     // The CPU store reflects the new row without touching its neighbour.
-    expect(bundle.transformTexture!.buffer[1 * 12 + 4]).toBe(80);
-    expect(bundle.transformTexture!.buffer[0 * 12 + 4]).toBe(10);
+    expect(bundle.transformTexture!.buffer[1 * 8 + 4]).toBe(80);
+    expect(bundle.transformTexture!.buffer[0 * 8 + 4]).toBe(10);
 
     // Only row 1 is marked for upload — the headline O(k) sub-range property.
     const region = bundle.transformTexture!._consumeDirtyRegion();
 
     expect(region).not.toBeNull();
-    expect({ x: region!.x, y: region!.y, width: region!.width, height: region!.height }).toEqual({ x: 0, y: 1, width: 3, height: 1 });
+    expect({ x: region!.x, y: region!.y, width: region!.width, height: region!.height }).toEqual({ x: 0, y: 1, width: 2, height: 1 });
   });
 
   test('a patch does NOT bump the generation (recorded instance bytes stay valid)', () => {
     const bundle = new WebGl2RetainedGroupResources();
 
     bundle._beginCapture();
-    bundle._storeTransformRows(new Float32Array(4 * 12), 0, 4);
+    bundle._storeTransformRows(new Float32Array(4 * 8), new Uint8Array(4 * 4), 0, 4);
 
     const generation = bundle.generation;
 
-    bundle._patchTransformRow(2, new Float32Array(12));
+    bundle._patchTransformRow(2, new Float32Array(8));
 
     expect(bundle.generation).toBe(generation);
   });
@@ -150,11 +153,11 @@ describe('WebGl2RetainedGroupResources: in-place transform-row patch (Slice 4b)'
     const bundle = new WebGl2RetainedGroupResources();
 
     bundle._beginCapture();
-    bundle._storeTransformRows(new Float32Array(8 * 12), 0, 8);
+    bundle._storeTransformRows(new Float32Array(8 * 8), new Uint8Array(8 * 4), 0, 8);
     bundle.transformTexture!._consumeDirtyRegion();
 
-    bundle._patchTransformRow(2, new Float32Array(12));
-    bundle._patchTransformRow(5, new Float32Array(12));
+    bundle._patchTransformRow(2, new Float32Array(8));
+    bundle._patchTransformRow(5, new Float32Array(8));
 
     const region = bundle.transformTexture!._consumeDirtyRegion();
 
@@ -230,7 +233,7 @@ describe('WebGl2RetainedGroupResources: device resources (Task 6)', () => {
 
     bundle._beginCapture();
     bundle._appendInstanceWords(new Uint32Array(9).fill(1));
-    bundle._storeTransformRows(new Float32Array(4 * 12), 0, 4);
+    bundle._storeTransformRows(new Float32Array(4 * 8), new Uint8Array(4 * 4), 0, 4);
     bundle._connectDevice(gl, accountant);
     bundle._uploadInstances();
     bundle._acquireVao(0);

--- a/test/rendering/webgpu-backend.test.ts
+++ b/test/rendering/webgpu-backend.test.ts
@@ -1791,15 +1791,16 @@ describe('WebGpuBackend', () => {
       manager.destroy();
 
       // The sprite's world transform lives in the shared transform storage buffer
-      // (the last writeBuffer of the sprite flush carries the whole buffer's
-      // ArrayBuffer), not inline in the instance buffer. The buffer is frame-scoped
+      // (not inline in the instance buffer). The buffer is frame-scoped
       // (cross-call batching): the graphics rendered into the RenderTexture is the
       // first shared-buffer write (slot 0), so the sprite is the second and lands
-      // in slot 1. Each slot is 12 floats (a, b, c, d, tx, ty, 0, 0, tint…); an
-      // unrotated sprite at (24, 18) has b == 0 and carries that translation.
-      const slotFloats = 12;
+      // in slot 1. Each slot is 8 floats (a, b, c, d, tx, ty, snapMode, 0); tint
+      // now uploads separately, right after the transform write (see
+      // WebGpuTransformStorage.getBuffer) — so the transform write is the
+      // second-to-last call, not the last (that's the tint upload).
+      const slotFloats = 8;
       const spriteBase = 1 * slotFloats; // slot 1
-      const transformWrite = environment.queue.writeBuffer.mock.calls[environment.queue.writeBuffer.mock.calls.length - 1];
+      const transformWrite = environment.queue.writeBuffer.mock.calls[environment.queue.writeBuffer.mock.calls.length - 2];
       const data = new Float32Array(transformWrite[2] as ArrayBuffer);
 
       expect(environment.encoder.beginRenderPass.mock.calls.length).toBeGreaterThanOrEqual(2);

--- a/test/rendering/webgpu-retained-record-replay.test.ts
+++ b/test/rendering/webgpu-retained-record-replay.test.ts
@@ -391,7 +391,7 @@ describe('WebGPU retained record/replay: fallback ladder + B-06 submit collapse'
       expect(instanceWrites).toHaveLength(1);
 
       // Two 32-byte instances (8 words each); the last word of each is the
-      // (rebased) node index — tint is read from the shared transform slot.
+      // (rebased) node index — tint is read from its own shared buffer.
       const words = new Uint32Array(instanceWrites[0]!.bytes.buffer, instanceWrites[0]!.bytes.byteOffset, instanceWrites[0]!.bytes.byteLength / 4);
 
       expect(words).toHaveLength(16);
@@ -403,7 +403,7 @@ describe('WebGPU retained record/replay: fallback ladder + B-06 submit collapse'
 
       expect(transformWrites).toHaveLength(1);
       expect(transformWrites[0]!.bufferOffset).toBe(0);
-      expect(transformWrites[0]!.bytes.byteLength).toBe(2 * 48);
+      expect(transformWrites[0]!.bytes.byteLength).toBe(2 * 32);
 
       root.destroy();
       texture.destroy();
@@ -505,7 +505,7 @@ describe('WebGPU retained record/replay: fallback ladder + B-06 submit collapse'
       // The group matrix did not change, so its UBO is not rewritten either.
       expect(countLabel(environment.writes(), retainedUniformLabel, mark)).toBe(0);
 
-      // Exactly one 48-byte transform sub-range write (a single TransformSlot),
+      // Exactly one 32-byte transform sub-range write (a single TransformSlot),
       // aligned to a slot boundary — the headline O(k) property vs. the O(rows)
       // full-range re-upload of a recapture.
       const patchWrites = environment
@@ -514,9 +514,9 @@ describe('WebGPU retained record/replay: fallback ladder + B-06 submit collapse'
         .filter(write => write.label === retainedTransformLabel);
 
       expect(patchWrites).toHaveLength(1);
-      expect(patchWrites[0]!.bytes.byteLength).toBe(48);
-      expect(patchWrites[0]!.bufferOffset % 48).toBe(0);
-      expect(patchWrites[0]!.bufferOffset).toBeLessThan(2 * 48);
+      expect(patchWrites[0]!.bytes.byteLength).toBe(32);
+      expect(patchWrites[0]!.bufferOffset % 32).toBe(0);
+      expect(patchWrites[0]!.bufferOffset).toBeLessThan(2 * 32);
 
       // Recording stayed valid (no generation bump) and still replays in one submit.
       expect(bundle.generation).toBe(generation);
@@ -737,7 +737,7 @@ describe('WebGpuRetainedGroupBundle: resource lifecycle', () => {
     const bundle = new WebGpuRetainedGroupBundle(accountant, () => {});
     const { device, destroyed } = createFakeDevice();
 
-    bundle.ensureCapacity(device, 100, 96);
+    bundle.ensureCapacity(device, 100, 96, 12);
 
     const generation = bundle.generation;
 
@@ -761,13 +761,13 @@ describe('WebGpuRetainedGroupBundle: resource lifecycle', () => {
     });
     const { device, destroyed } = createFakeDevice();
 
-    bundle.ensureCapacity(device, 100, 96);
+    bundle.ensureCapacity(device, 100, 96, 12);
 
     const generation = bundle.generation;
 
     bundle.destroy();
 
-    expect(destroyed).toHaveLength(3); // instance + transform + uniform
+    expect(destroyed).toHaveLength(4); // instance + transform + tint + uniform
     expect(bundle.generation).toBeGreaterThan(generation);
     expect(released).toBe(1);
     expect(stats.gpuMemoryBytes).toBe(0);
@@ -783,19 +783,19 @@ describe('WebGpuRetainedGroupBundle: resource lifecycle', () => {
     const bundle = new WebGpuRetainedGroupBundle(accountant, () => {});
     const { device, created } = createFakeDevice();
 
-    bundle.ensureCapacity(device, 100, 96);
+    bundle.ensureCapacity(device, 100, 96, 12);
 
     const generation = bundle.generation;
     const createdAfterFirst = created.length;
 
     // Within capacity: nothing recreated, generation stable.
-    bundle.ensureCapacity(device, 200, 96);
+    bundle.ensureCapacity(device, 200, 96, 12);
 
     expect(created.length).toBe(createdAfterFirst);
     expect(bundle.generation).toBe(generation);
 
     // Instance growth only: one new buffer, one generation bump.
-    bundle.ensureCapacity(device, 4096, 96);
+    bundle.ensureCapacity(device, 4096, 96, 12);
 
     expect(created.length).toBe(createdAfterFirst + 1);
     expect(bundle.generation).toBe(generation + 1);
@@ -809,21 +809,21 @@ describe('WebGpuRetainedGroupBundle: resource lifecycle', () => {
     expect(bundle.transformRowBase).toBe(0);
   });
 
-  test('patch writes one 48-byte slot at localRow*48 and does NOT bump the generation (Slice 4c)', () => {
+  test('patch writes one 32-byte slot at localRow*32 and does NOT bump the generation (Slice 4c)', () => {
     const stats = createRenderStats();
     const accountant = new GpuResourceAccountant(stats);
     const bundle = new WebGpuRetainedGroupBundle(accountant, () => {});
     const { device, writes } = createFakeDevice();
 
     // Finalize a 3-row transform range rebased from shared row 5.
-    bundle.ensureCapacity(device, 256, 3 * 48);
+    bundle.ensureCapacity(device, 256, 3 * 32, 3 * 4);
     bundle._recordTransformRowRange(device, 5, 3);
 
     expect(bundle.transformRowBase).toBe(5);
 
     const generation = bundle.generation;
     const mark = writes.length;
-    const floats = new Float32Array(12);
+    const floats = new Float32Array(8);
 
     floats[4] = 42; // tx
 
@@ -832,8 +832,8 @@ describe('WebGpuRetainedGroupBundle: resource lifecycle', () => {
     const patchWrites = writes.slice(mark).filter(write => write.label === 'sprite:retained-transform-buffer');
 
     expect(patchWrites).toHaveLength(1);
-    expect(patchWrites[0]!.bufferOffset).toBe(48); // localRow 1 * 48
-    expect(patchWrites[0]!.bytes.byteLength).toBe(48);
+    expect(patchWrites[0]!.bufferOffset).toBe(32); // localRow 1 * 32
+    expect(patchWrites[0]!.bytes.byteLength).toBe(32);
     expect(new Float32Array(patchWrites[0]!.bytes.buffer)[4]).toBe(42);
     // A patch keeps the recorded instance bytes valid: never bump.
     expect(bundle.generation).toBe(generation);
@@ -846,17 +846,17 @@ describe('WebGpuRetainedGroupBundle: resource lifecycle', () => {
     const { device, writes } = createFakeDevice();
 
     // Before any range is recorded: row count is 0 → every patch is a no-op.
-    bundle._patchTransformRow!(0, new Float32Array(12));
+    bundle._patchTransformRow!(0, new Float32Array(8));
 
     expect(writes).toHaveLength(0);
 
-    bundle.ensureCapacity(device, 256, 2 * 48);
+    bundle.ensureCapacity(device, 256, 2 * 32, 2 * 4);
     bundle._recordTransformRowRange(device, 0, 2);
 
     const mark = writes.length;
 
-    bundle._patchTransformRow!(2, new Float32Array(12)); // == rowCount, out of range
-    bundle._patchTransformRow!(-1, new Float32Array(12));
+    bundle._patchTransformRow!(2, new Float32Array(8)); // == rowCount, out of range
+    bundle._patchTransformRow!(-1, new Float32Array(8));
 
     expect(writes.slice(mark)).toHaveLength(0);
   });
@@ -867,13 +867,13 @@ describe('WebGpuRetainedGroupBundle: resource lifecycle', () => {
     const bundle = new WebGpuRetainedGroupBundle(accountant, () => {});
     const { device, writes } = createFakeDevice();
 
-    bundle.ensureCapacity(device, 256, 2 * 48);
+    bundle.ensureCapacity(device, 256, 2 * 32, 2 * 4);
     bundle._recordTransformRowRange(device, 0, 2);
     bundle.invalidateDeviceState(false);
 
     const mark = writes.length;
 
-    bundle._patchTransformRow!(0, new Float32Array(12));
+    bundle._patchTransformRow!(0, new Float32Array(8));
 
     expect(bundle.transformRowBase).toBe(0);
     expect(writes.slice(mark)).toHaveLength(0);

--- a/test/rendering/webgpu-transform-group-upload.test.ts
+++ b/test/rendering/webgpu-transform-group-upload.test.ts
@@ -4,6 +4,7 @@ import { type DrawCommand, drawCommandUsesSharedTransform, type MaterialKey, Ren
 import { RenderPlanPlayer } from '#rendering/plan/RenderPlanPlayer';
 import type { DrawScopeEntry, GroupScope, ScopeEntry } from '#rendering/plan/RenderScope';
 import type { RenderBackend } from '#rendering/RenderBackend';
+import { TRANSFORM_FLOATS_PER_ROW } from '#rendering/TransformBuffer';
 import { WebGpuTransformStorage } from '#rendering/webgpu/WebGpuTransformStorage';
 
 import { forEachGroupCommand } from './helpers/collectRenderGroups';
@@ -159,7 +160,7 @@ describe('WebGPU group-upload: consuming vs non-consuming writes', () => {
     // Highest written slot is node 3 → count 4.
     expect(storage.buffer.count).toBe(4);
 
-    const floatsPerSlot = 12;
+    const floatsPerSlot = TRANSFORM_FLOATS_PER_ROW;
 
     // Node 'a' (nodeIndex 0) at position (10, 20).
     expect(storage.buffer.data[4]).toBe(10);
@@ -252,7 +253,7 @@ describe('WebGPU group-upload: draw order is unchanged', () => {
 
 describe('WebGPU group-upload: nodeIndex slot contract', () => {
   test('each command writes to its own stable nodeIndex slot', () => {
-    const floatsPerSlot = 12;
+    const floatsPerSlot = TRANSFORM_FLOATS_PER_ROW;
     const a = new ConsumingDrawable(11, 22, new Color());
     const b = new ConsumingDrawable(33, 44, new Color());
     const scope = groupScope([drawEntry(createDrawCommand(a, 5, 1, 1)), drawEntry(createDrawCommand(b, 7, 1, 1))]);
@@ -307,7 +308,7 @@ describe('WebGPU group-upload: direct/synthetic push path is unaffected', () => 
   });
 
   test('push() writes the correct position into the allocated slot', () => {
-    const floatsPerSlot = 12;
+    const floatsPerSlot = TRANSFORM_FLOATS_PER_ROW;
     const storage = new WebGpuTransformStorage();
 
     storage.begin(4);

--- a/test/rendering/webgpu-transform-storage-reserve.test.ts
+++ b/test/rendering/webgpu-transform-storage-reserve.test.ts
@@ -1,5 +1,6 @@
 import { Drawable } from '#rendering/Drawable';
 import { type DrawCommand, type MaterialKey, RenderEntryKind } from '#rendering/plan/RenderCommand';
+import { TRANSFORM_FLOATS_PER_ROW } from '#rendering/TransformBuffer';
 import { WebGpuTransformStorage } from '#rendering/webgpu/WebGpuTransformStorage';
 
 // Minimal WebGPU device mock sufficient for storage-buffer creation/destruction.
@@ -109,8 +110,9 @@ describe('WebGpuTransformStorage.reserve', () => {
     storage.begin(4);
     storage.reserve(device as unknown as GPUDevice, 4);
 
-    expect(device.createBuffer).toHaveBeenCalledTimes(1);
-    expect(device.buffers.length).toBe(1);
+    // One transform buffer + one tint buffer, grown together.
+    expect(device.createBuffer).toHaveBeenCalledTimes(2);
+    expect(device.buffers.length).toBe(2);
   });
 
   test('reserve with sufficient capacity is a no-op (same buffer, no extra allocations)', () => {
@@ -122,13 +124,13 @@ describe('WebGpuTransformStorage.reserve', () => {
 
     const firstBuffer = device.buffers[0];
 
-    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+    expect(device.createBuffer).toHaveBeenCalledTimes(2);
 
     // A second reserve with ≤ the original count must not create a new buffer.
     storage.reserve(device as unknown as GPUDevice, 4);
     storage.reserve(device as unknown as GPUDevice, 8);
 
-    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+    expect(device.createBuffer).toHaveBeenCalledTimes(2);
     expect(firstBuffer.destroy).not.toHaveBeenCalled();
   });
 
@@ -147,7 +149,7 @@ describe('WebGpuTransformStorage.reserve', () => {
     const result = storage.getBuffer(device as unknown as GPUDevice, 4);
 
     // No additional buffer should have been created.
-    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+    expect(device.createBuffer).toHaveBeenCalledTimes(2);
     expect(result.buffer).toBe(reservedBuffer);
   });
 
@@ -158,7 +160,7 @@ describe('WebGpuTransformStorage.reserve', () => {
     storage.begin(4);
     storage.reserve(device as unknown as GPUDevice, 4);
 
-    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+    expect(device.createBuffer).toHaveBeenCalledTimes(2);
 
     const firstBuffer = device.buffers[0];
 
@@ -166,9 +168,10 @@ describe('WebGpuTransformStorage.reserve', () => {
     storage.writeCommand(makeCommand(0));
     storage.getBuffer(device as unknown as GPUDevice, 64);
 
-    expect(device.createBuffer).toHaveBeenCalledTimes(2);
+    // Second growth creates a new transform + tint buffer pair (4 total).
+    expect(device.createBuffer).toHaveBeenCalledTimes(4);
     expect(firstBuffer.destroy).toHaveBeenCalledTimes(1);
-    expect(device.buffers.length).toBe(2);
+    expect(device.buffers.length).toBe(4);
   });
 
   test('reserve with recordCount = 0 still allocates at least one slot', () => {
@@ -178,7 +181,7 @@ describe('WebGpuTransformStorage.reserve', () => {
     storage.begin(0);
     storage.reserve(device as unknown as GPUDevice, 0);
 
-    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+    expect(device.createBuffer).toHaveBeenCalledTimes(2);
   });
 
   test('write/skip/upload counters are unaffected by reserve', () => {
@@ -276,7 +279,7 @@ describe('WebGpuTransformStorage.reserve: no reallocation across multiple getBuf
     const flush1 = storage.getBuffer(device as unknown as GPUDevice, 3);
 
     expect(flush1.buffer).toBe(reservedBuffer);
-    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+    expect(device.createBuffer).toHaveBeenCalledTimes(2);
 
     // Group B: nodes 3-5 written before second flush.
     storage.writeCommand(makeCommand(3));
@@ -286,8 +289,8 @@ describe('WebGpuTransformStorage.reserve: no reallocation across multiple getBuf
     const flush2 = storage.getBuffer(device as unknown as GPUDevice, 6);
 
     expect(flush2.buffer).toBe(reservedBuffer);
-    // Still only the one buffer from reserve — no mid-frame reallocation.
-    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+    // Still only the one transform+tint pair from reserve — no mid-frame reallocation.
+    expect(device.createBuffer).toHaveBeenCalledTimes(2);
     expect(reservedBuffer.destroy).not.toHaveBeenCalled();
   });
 
@@ -303,15 +306,15 @@ describe('WebGpuTransformStorage.reserve: no reallocation across multiple getBuf
     storage.writeCommand(makeCommand(0));
     storage.getBuffer(device as unknown as GPUDevice, 3);
 
-    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+    expect(device.createBuffer).toHaveBeenCalledTimes(2);
 
     const firstBuffer = device.buffers[0];
 
-    // Second flush needs 6 slots — old buffer is too small, reallocation happens.
+    // Second flush needs 6 slots — old buffers are too small, reallocation happens.
     storage.writeCommand(makeCommand(5));
     storage.getBuffer(device as unknown as GPUDevice, 6);
 
-    expect(device.createBuffer).toHaveBeenCalledTimes(2);
+    expect(device.createBuffer).toHaveBeenCalledTimes(4);
     expect(firstBuffer.destroy).toHaveBeenCalledTimes(1);
   });
 });
@@ -330,7 +333,7 @@ describe('WebGpuTransformStorage.reserve: Color/tint correctness after multi-flu
   test('data written across two groups is intact after both flushes complete', () => {
     const device = createMockDevice();
     const storage = new WebGpuTransformStorage();
-    const floatsPerSlot = 12;
+    const floatsPerSlot = TRANSFORM_FLOATS_PER_ROW;
 
     storage.begin(4);
     storage.reserve(device as unknown as GPUDevice, 4);
@@ -381,7 +384,7 @@ describe('WebGpuTransformStorage.reserve: begin across frames', () => {
     storage.getBuffer(device as unknown as GPUDevice, 1);
 
     expect(storage.buffer.uploadCount).toBe(1);
-    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+    expect(device.createBuffer).toHaveBeenCalledTimes(2);
 
     const buf = device.buffers[0];
 
@@ -391,10 +394,10 @@ describe('WebGpuTransformStorage.reserve: begin across frames', () => {
     expect(storage.buffer.writeCount).toBe(0);
     expect(storage.buffer.uploadCount).toBe(0);
 
-    // Reserve again — buffer is already large enough; no new allocation.
+    // Reserve again — buffers are already large enough; no new allocation.
     storage.reserve(device as unknown as GPUDevice, 4);
 
-    expect(device.createBuffer).toHaveBeenCalledTimes(1);
+    expect(device.createBuffer).toHaveBeenCalledTimes(2);
     expect(buf.destroy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Shrinks the per-instance transform row from 12 to 8 floats (matrix, translation, snap mode) and moves tint into its own natively 8-bit normalized resource.

## What changed

- **Tint storage**: `rgba8` `DataTexture` on WebGL2, packed `u32` decoded via `unpack4x8unorm` on WebGPU.
- **Precision**: RGB stays exact (0..255 integers re-encoded losslessly). Alpha is quantized to 255 steps — the only behavioural difference versus the previous float path.
- **Coverage**: both backends, through sprite, mesh (live + retained replay), and the retained bundles for nine-slice, repeating sprites and tilemap chunks. Those bundles share `getBindGroup`, so an `includeTint` flag keeps the layout binding consistent instead of tripping WebGPU validation.
- **Test shaders**: browser tests hardcode their own mock shaders (the Vitest plugin stubs real `.vert`/`.frag` sources to empty strings). They read out of bounds after the layout change and are updated accordingly.

## Verification

- `pnpm verify:quick` — clean (0 lint errors, Prettier clean, API docs in sync)
- `pnpm test:core` — 333 files / 5395 tests green
- Real GPU pixel tests in Chromium: WebGL2 46/46, WebGPU 43/43
- `@codexo/exojs-tilemap` package + browser test: green
