### PR TITLE
fix(resources): match single catalog leaves on a type-level meta brand

### DIFF
--- a/site/src/content/api/loader.json
+++ b/site/src/content/api/loader.json
@@ -6,10 +6,10 @@
   "subsystem": "resources",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 34,
+  "memberCount": 35,
   "counts": {
     "constructors": 1,
-    "methods": 24,
+    "methods": 25,
     "properties": 2,
     "events": 7
   },
@@ -504,7 +504,7 @@
         },
         {
           "name": "get",
-          "signature": "get(leaf: T): T",
+          "signature": "get(leaf: CatalogResourceLeaf<T>): T",
           "signatureTokens": [
             {
               "text": "get",
@@ -523,8 +523,20 @@
               "kind": "punctuation"
             },
             {
+              "text": "CatalogResourceLeaf",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
               "text": "T",
               "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
             },
             {
               "text": ")",
@@ -542,12 +554,83 @@
           "params": [
             {
               "name": "leaf",
-              "type": "T",
+              "type": "CatalogResourceLeaf<T>",
               "optional": false
             }
           ],
           "returnType": "T",
-          "description": "Adopts a single handle-hybrid leaf (an Assets.from() property) and returns it — the same object, healing in place once its payload arrives."
+          "description": "Adopts a single handle-hybrid leaf (an Assets.from() property) and returns it — the same object, healing in place once its payload arrives. Matches on the catalog-leaf brand, so only a MATERIALIZED leaf is accepted; a raw resource instance has no _assetMeta stamp and is rejected here as it is at runtime."
+        },
+        {
+          "name": "get",
+          "signature": "get(leaf: CatalogValueLeaf<T>): AssetRef<T>",
+          "signatureTokens": [
+            {
+              "text": "get",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "leaf",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "CatalogValueLeaf",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "AssetRef",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [
+            {
+              "name": "leaf",
+              "type": "CatalogValueLeaf<T>",
+              "optional": false
+            }
+          ],
+          "returnType": "AssetRef<T>",
+          "description": "Adopts a single value leaf and returns the ref itself — its payload arrives on the ref."
         },
         {
           "name": "hasAssetType",
@@ -958,7 +1041,7 @@
         },
         {
           "name": "load",
-          "signature": "load(leaf: AssetRef<T>, options?: LoadOptions): LoadingQueue<T>",
+          "signature": "load(leaf: CatalogValueLeaf<T>, options?: LoadOptions): LoadingQueue<T>",
           "signatureTokens": [
             {
               "text": "load",
@@ -977,7 +1060,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "AssetRef",
+              "text": "CatalogValueLeaf",
               "kind": "type"
             },
             {
@@ -1040,7 +1123,7 @@
           "params": [
             {
               "name": "leaf",
-              "type": "AssetRef<T>",
+              "type": "CatalogValueLeaf<T>",
               "optional": false
             },
             {
@@ -1054,7 +1137,7 @@
         },
         {
           "name": "load",
-          "signature": "load(leaf: T, options?: LoadOptions): LoadingQueue<T>",
+          "signature": "load(leaf: CatalogResourceLeaf<T>, options?: LoadOptions): LoadingQueue<T>",
           "signatureTokens": [
             {
               "text": "load",
@@ -1073,8 +1156,20 @@
               "kind": "punctuation"
             },
             {
+              "text": "CatalogResourceLeaf",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
               "text": "T",
               "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
             },
             {
               "text": ", ",
@@ -1124,7 +1219,7 @@
           "params": [
             {
               "name": "leaf",
-              "type": "T",
+              "type": "CatalogResourceLeaf<T>",
               "optional": false
             },
             {

--- a/src/core/scene/SceneLoader.ts
+++ b/src/core/scene/SceneLoader.ts
@@ -1,7 +1,8 @@
 import type { Application } from '#core/Application';
 import type { Destroyable } from '#core/types';
 import type { Asset, ValueAsset } from '#resources/Asset';
-import type { CatalogEntry, KindByPath, LeafForPath, ResourceAssetObject, ResourceForKind } from '#resources/AssetDefinitions';
+import type { CatalogEntry, KindByPath, LeafForPath, ResourceForKind } from '#resources/AssetDefinitions';
+import type { CatalogResourceLeaf, CatalogValueLeaf } from '#resources/assetMeta';
 import type { AssetRef } from '#resources/AssetRef';
 import type { Assets, InferAssetsProperties } from '#resources/Assets';
 import type { InferLoadedMap, Loader, LoadOptions } from '#resources/Loader';
@@ -28,12 +29,14 @@ export class SceneLoader implements Destroyable {
   public get<S extends string>(path: [KindByPath<S>] extends [never] ? never : S, options?: unknown): LeafForPath<S>;
   // Seamless/value access from an `Asset.type()` descriptor (mirrors Loader.get(asset)):
   // a value-kind descriptor returns AssetRef<T>, a resource-kind descriptor the resource.
-  public get<T>(asset: ValueAsset<T>): AssetRef<T>;
+  // A materialized VALUE LEAF resolves the same way, so both share one signature.
+  public get<T>(asset: ValueAsset<T> | CatalogValueLeaf<T>): AssetRef<T>;
   public get<T>(asset: Asset<T>): T;
   // Adopts an Assets catalog under the scene scope (mirrors Loader.get(catalog)).
   public get<M extends Record<string, CatalogEntry>>(catalog: Assets<M>): InferAssetsProperties<M>;
   // Adopts a single handle-hybrid leaf under the scene scope (mirrors Loader.get(leaf)).
-  public get<T extends ResourceAssetObject>(leaf: T): T;
+  // Brand-matched: only a materialized catalog leaf, never a raw resource.
+  public get<T extends object>(leaf: CatalogResourceLeaf<T>): T;
   public get(input: string | object, options?: unknown): unknown {
     return this._loader._getClaimed(this._scope, input, options);
   }
@@ -41,9 +44,9 @@ export class SceneLoader implements Destroyable {
   public load<T>(asset: Asset<T>): LoadingQueue<T>;
   public load<M extends Record<string, CatalogEntry>>(assets: Assets<M>, options?: LoadOptions): LoadingQueue<InferLoadedMap<M>>;
   // Single value-leaf (an `Assets.from()` AssetRef property): mirrors Loader.load(leaf).
-  public load<T>(leaf: AssetRef<T>, options?: LoadOptions): LoadingQueue<T>;
+  public load<T>(leaf: CatalogValueLeaf<T>, options?: LoadOptions): LoadingQueue<T>;
   // Single handle-hybrid leaf (an `Assets.from()` property): mirrors Loader.load(leaf).
-  public load<T extends ResourceAssetObject>(leaf: T, options?: LoadOptions): LoadingQueue<T>;
+  public load<T extends object>(leaf: CatalogResourceLeaf<T>, options?: LoadOptions): LoadingQueue<T>;
   // Bare path (mirrors Loader.load(path)): leaf-capable suffixes only.
   public load<S extends string>(path: [KindByPath<S>] extends [never] ? never : S): LoadingQueue<ResourceForKind<KindByPath<S>>>;
   public load(arg0: unknown, arg1?: unknown): LoadingQueue<unknown> {

--- a/src/resources/AssetDefinitions.ts
+++ b/src/resources/AssetDefinitions.ts
@@ -8,6 +8,7 @@ import type { Texture } from '#rendering/texture/Texture';
 import type { Video } from '#rendering/video/Video';
 
 import type { Asset, ValueAsset } from './Asset';
+import type { CatalogResourceLeaf, CatalogValueLeaf } from './assetMeta';
 import type { AssetRef } from './AssetRef';
 
 /**
@@ -175,16 +176,37 @@ export type KindByPath<S extends string> = MatchKind<KindBasename<KindStripQuery
 /** The resource type of an asset type. */
 export type ResourceForKind<K extends keyof AssetDefinitions> = AssetDefinitions[K]['resource'];
 
-/** Object-valued resource types that may appear as heal-in-place catalog leaves. @internal */
-export type ResourceAssetObject = Extract<AssetDefinitions[keyof AssetDefinitions]['resource'], object>;
+/**
+ * The leaf type an asset type materializes as inside a CATALOG: a value type
+ * yields a branded `AssetRef` over its resource, a resource type the branded
+ * placeholder resource itself.
+ *
+ * The brand is what the loader's single-leaf overloads match on — it mirrors the
+ * runtime `_assetMeta` stamp `createLeaf` applies, so a raw `new Texture()` (or
+ * an `AudioStream`, a `BmFont`, …) is correctly rejected where a materialized
+ * leaf is required.
+ *
+ * Deliberately NOT the type of a bare-path `loader.get(path)` result (that is
+ * {@link LeafForPath}): the bare-path branch resolves through the source-keyed
+ * dedup rather than `createLeaf`, so a freshly minted handle there carries no
+ * stamp — and claiming otherwise would let `load(loader.get('x.png'))` compile
+ * into the record fallback at runtime.
+ */
+export type CatalogLeafForKind<K extends keyof AssetDefinitions> = K extends ValueAssetKind
+  ? CatalogValueLeaf<ResourceForKind<K>>
+  : CatalogResourceLeaf<ResourceForKind<K>>;
 
 /** The per-type option bag: that type's config minus the `source` field. */
 export type OptionsForKind<K extends keyof AssetDefinitions> = Omit<AssetDefinitions[K]['config'], 'source'>;
 
 /**
- * The handle-hybrid leaf type a bare path string materializes as: a resource
- * type yields its resource (`Texture`/`Sound`), a {@link ValueAssetKind} yields
- * a deferred `AssetRef<resource>`. `unknown` when the suffix is unregistered.
+ * The handle-hybrid type a bare path resolves to through `loader.get(path)`: a
+ * resource type yields its resource (`Texture`/`Sound`), a
+ * {@link ValueAssetKind} a deferred `AssetRef<resource>`. `unknown` when the
+ * suffix is unregistered.
+ *
+ * Unbranded on purpose — see {@link CatalogLeafForKind}. The CATALOG twin (what
+ * `Assets.from({ ship: 'ship.png' }).ship` is) is {@link CatalogLeafForPath}.
  */
 export type LeafForPath<S extends string> = [KindByPath<S>] extends [never]
   ? unknown
@@ -192,31 +214,34 @@ export type LeafForPath<S extends string> = [KindByPath<S>] extends [never]
     ? AssetRef<ResourceForKind<KindByPath<S>>>
     : ResourceForKind<KindByPath<S>>;
 
+/** {@link LeafForPath}, branded — the leaf a bare path materializes as inside a catalog. */
+export type CatalogLeafForPath<S extends string> = [KindByPath<S>] extends [never] ? unknown : CatalogLeafForKind<KindByPath<S>>;
+
 /** A single catalog field input: a bare path string, an `Asset.type(...)` descriptor, or an explicit config. */
 export type CatalogEntry = string | Asset<unknown> | AnyAssetConfig;
 
 /**
- * The leaf type a {@link CatalogEntry} materializes as. A {@link ValueAsset}
+ * The leaf type a {@link CatalogEntry} materializes as — always BRANDED (see
+ * {@link LeafForKind}), because every one of these is produced by `createLeaf`
+ * and therefore carries the runtime `_assetMeta` stamp. A {@link ValueAsset}
  * brand (from `Asset.type<T>('json', …)`) classifies as `AssetRef<T>` FIRST,
  * before the `T extends object` heuristic that (only) the unbranded legacy
  * `Asset.type(...)` descriptors still rely on.
  */
 export type InferCatalogLeaf<E extends CatalogEntry> = E extends string
-  ? LeafForPath<E>
+  ? CatalogLeafForPath<E>
   : E extends ValueAsset<infer V>
-    ? AssetRef<V>
+    ? CatalogValueLeaf<V>
     : E extends Asset<infer T>
       ? T extends object
-        ? T
-        : AssetRef<T>
+        ? CatalogResourceLeaf<T>
+        : CatalogValueLeaf<T>
       : E extends { type: infer K extends keyof AssetDefinitions }
         ? E extends { parse: (raw: never) => infer R }
           ? K extends ValueAssetKind
-            ? AssetRef<R>
-            : AssetDefinitions[K]['resource']
-          : K extends ValueAssetKind
-            ? AssetRef<AssetDefinitions[K]['resource']>
-            : AssetDefinitions[K]['resource']
+            ? CatalogValueLeaf<R>
+            : CatalogResourceLeaf<AssetDefinitions[K]['resource']>
+          : CatalogLeafForKind<K>
         : never;
 
 /**

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -12,11 +12,10 @@ import type {
   InferLoadedEntry,
   KindByPath,
   LeafForPath,
-  ResourceAssetObject,
   ResourceForKind,
 } from './AssetDefinitions';
 import { createLeaf, getAssetKind } from './assetKindRegistry';
-import { _readMeta } from './assetMeta';
+import { _readMeta, type CatalogResourceLeaf, type CatalogValueLeaf } from './assetMeta';
 import type { AssetRef } from './AssetRef';
 import { AssetResidency, type AssetResidencySignals } from './AssetResidency';
 import { _normalizeEntry, type Assets, AssetsImpl, type InferAssetsProperties } from './Assets';
@@ -399,9 +398,16 @@ export class Loader {
   public load<M extends Record<string, CatalogEntry>>(assets: Assets<M>, options?: LoadOptions): LoadingQueue<InferLoadedMap<M>>;
   // Single value-leaf (an `Assets.from()` AssetRef property): `AssetRef.loaded` resolves
   // to the raw value, not the ref — this overload must win over the generic leaf one below.
-  public load<T>(leaf: AssetRef<T>, options?: LoadOptions): LoadingQueue<T>;
+  public load<T>(leaf: CatalogValueLeaf<T>, options?: LoadOptions): LoadingQueue<T>;
   // Single handle-hybrid leaf (an `Assets.from()` property): adopt + resolve its value.
-  public load<T extends ResourceAssetObject>(leaf: T, options?: LoadOptions): LoadingQueue<T>;
+  //
+  // Both leaf overloads match on the CATALOG-LEAF BRAND — the type-level mirror
+  // of the runtime `_assetMeta` stamp that `_loadClaimed` dispatches on — so a
+  // raw `new Texture()` / `new AssetRef()`, or a non-leaf resource like an
+  // `AudioStream`, is rejected here exactly as the runtime rejects it. `T` is
+  // recovered from the brand's phantom field, so the queue resolves to the plain
+  // resource rather than to the branded leaf type.
+  public load<T extends object>(leaf: CatalogResourceLeaf<T>, options?: LoadOptions): LoadingQueue<T>;
 
   // -----------------------------------------------------------------------
   // Loading — bare path (type normalized from the file suffix)
@@ -657,8 +663,14 @@ export class Loader {
   /**
    * Adopts a single handle-hybrid leaf (an `Assets.from()` property) and returns
    * it — the same object, healing in place once its payload arrives.
+   *
+   * Matches on the catalog-leaf brand, so only a MATERIALIZED leaf is accepted;
+   * a raw resource instance has no `_assetMeta` stamp and is rejected here as it
+   * is at runtime.
    */
-  public get<T extends ResourceAssetObject>(leaf: T): T;
+  public get<T extends object>(leaf: CatalogResourceLeaf<T>): T;
+  /** Adopts a single value leaf and returns the ref itself — its payload arrives on the ref. */
+  public get<T>(leaf: CatalogValueLeaf<T>): AssetRef<T>;
   public get(input: string | object, options?: unknown): unknown {
     return this._getClaimed(this._rootClaimer, input, options);
   }

--- a/src/resources/assetMeta.ts
+++ b/src/resources/assetMeta.ts
@@ -1,4 +1,5 @@
 import type { AssetDefinitions } from './AssetDefinitions';
+import type { AssetRef } from './AssetRef';
 
 /** Descriptor metadata stamped onto a handle-hybrid catalog leaf. */
 export interface AssetMeta {
@@ -11,16 +12,55 @@ export interface AssetMeta {
 export const _assetMeta: unique symbol = Symbol('exo.assetMeta');
 
 /**
- * Stamp {@link AssetMeta} onto a handle (non-enumerable); returns the handle.
+ * The type-level mirror of the runtime `_assetMeta` stamp: what makes an object
+ * a MATERIALIZED catalog leaf rather than a bare resource that happens to have
+ * the same shape.
+ *
+ * `_resolvedType` is a phantom — never written at runtime, and `AssetMeta`
+ * itself is unchanged. It exists so an overload can recover the payload a leaf
+ * resolves to: a naked type parameter inside an intersection is skipped for
+ * inference, so `T & CatalogLeafBrand<T>` infers `T` from THIS field alone and
+ * yields the plain resource (`Texture`), not the branded leaf type.
+ *
+ * @internal
+ */
+export interface CatalogLeafBrand<T> {
+  readonly [_assetMeta]: AssetMeta & { readonly _resolvedType?: T };
+}
+
+/**
+ * A resource type's catalog leaf: the heal-in-place placeholder resource itself
+ * (`Texture`, `Sound`, …), branded. Stays assignable to the bare resource, so
+ * `const texture: Texture = bag.player` keeps working.
+ * @internal
+ */
+export type CatalogResourceLeaf<T> = T & CatalogLeafBrand<T>;
+
+/**
+ * A value type's catalog leaf: a deferred {@link AssetRef}, branded with the
+ * DECODED payload type — which is what loading it resolves to.
+ * @internal
+ */
+export type CatalogValueLeaf<T> = AssetRef<T> & CatalogLeafBrand<T>;
+
+/** Any materialized catalog leaf, whatever it resolves to. @internal */
+export type AnyCatalogLeaf = CatalogLeafBrand<unknown>;
+
+/** What stamping `T` produces: an `AssetRef` leaf resolves to its payload, a resource leaf to itself. */
+type LeafPayloadOf<T> = T extends AssetRef<infer V> ? V : T;
+
+/**
+ * Stamp {@link AssetMeta} onto a handle (non-enumerable); returns the handle,
+ * typed as the branded leaf it has just become.
  *
  * The stamp is intentionally immutable (non-configurable, non-writable): a leaf's
  * asset meta never changes after creation, so no task re-stamps it.
  *
  * @internal
  */
-export function _stampMeta<T extends object>(target: T, meta: AssetMeta): T {
+export function _stampMeta<T extends object>(target: T, meta: AssetMeta): T & CatalogLeafBrand<LeafPayloadOf<T>> {
   Object.defineProperty(target, _assetMeta, { value: meta, enumerable: false, configurable: false, writable: false });
-  return target;
+  return target as T & CatalogLeafBrand<LeafPayloadOf<T>>;
 }
 
 /** Read the {@link AssetMeta} off a value, or `undefined` if not stamped. @internal */

--- a/test/resources/assetMeta.test.ts
+++ b/test/resources/assetMeta.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { _assetMeta, _readMeta, _stampMeta } from '#resources/assetMeta';
+import { AssetRef } from '#resources/AssetRef';
 
 describe('assetMeta', () => {
   it('stamps and reads back meta, non-enumerable', () => {
@@ -11,6 +12,17 @@ describe('assetMeta', () => {
     expect(_readMeta(target)).toEqual({ kind: 'texture', src: 'ship.png' });
     expect(Object.getOwnPropertyDescriptor(target, _assetMeta)?.enumerable).toBe(false); // non-enumerable
     expect((target as { [_assetMeta]?: unknown })[_assetMeta]).toBeDefined();
+  });
+
+  it('stamps an AssetRef the same way — the value-leaf half of the same contract', () => {
+    const ref = new AssetRef<{ hp: number }>();
+    const returned = _stampMeta(ref, { kind: 'json', src: 'config.json' });
+
+    expect(returned).toBe(ref);
+    expect(_readMeta(ref)).toEqual({ kind: 'json', src: 'config.json' });
+    // The stamp carries no `_resolvedType` — that field is a type-level phantom
+    // used to recover the payload type, never written at runtime.
+    expect(Object.hasOwn(_readMeta(ref) as object, '_resolvedType')).toBe(false);
   });
 
   it('readMeta returns undefined for unstamped and primitive values', () => {

--- a/test/resources/catalog-adopt.test.ts
+++ b/test/resources/catalog-adopt.test.ts
@@ -3,6 +3,7 @@ import { materializeAssetBindings } from '#extensions/materialize';
 import { Texture } from '#rendering/texture/Texture';
 import { ScaleModes } from '#rendering/types';
 import { createLeaf } from '#resources/assetKindRegistry';
+import { _readMeta } from '#resources/assetMeta';
 import { type AssetRef } from '#resources/AssetRef';
 import { Assets } from '#resources/Assets';
 import { coreAssetBindings } from '#resources/coreAssetBindings';
@@ -446,5 +447,26 @@ describe('Loader.get / load — Assets catalog adoption (end-to-end)', () => {
     expect(warnSpy).not.toHaveBeenCalled();
 
     warnSpy.mockRestore();
+  });
+
+  // The runtime contract the loader's single-leaf TYPE overloads mirror: a leaf
+  // is exactly an object carrying the `_assetMeta` stamp. A catalog property is
+  // stamped (it comes from `createLeaf`); a bare-path `get(path)` handle is NOT
+  // — that branch resolves through the source-keyed dedup instead. This is why
+  // `LeafForPath` (the `get(path)` result) stays unbranded while the catalog
+  // twin is branded: branding both would let `load(loader.get('x.png'))`
+  // compile into the record fallback.
+  test('catalog leaves carry the meta stamp; a bare-path get() handle does not', async () => {
+    mockFetchImage();
+    const loader = createCoreLoader();
+    const catalog = new Assets({ ship: 'ship.png' });
+
+    const catalogLeaf = loader.get(catalog).ship;
+    const barePathHandle = loader.get('other.png');
+
+    expect(_readMeta(catalogLeaf)).toEqual({ kind: 'texture', src: 'ship.png', opts: undefined });
+    expect(_readMeta(barePathHandle)).toBeUndefined();
+
+    await Promise.all([catalog.ship.loaded, (barePathHandle as Texture).loaded]);
   });
 });

--- a/test/type-tests/assets-compose.type-test.ts
+++ b/test/type-tests/assets-compose.type-test.ts
@@ -4,7 +4,9 @@
 // `never` — and, unlike a message string, matching no loader input.
 // Compiled by `tsconfig.type-tests.json` via `pnpm typecheck:type-tests`.
 
-import { type AnyAssets, type AssetRef, Assets, type Loader, type Texture } from '@codexo/exojs';
+import { type AnyAssets, Assets, type Loader, type Texture } from '@codexo/exojs';
+
+import type { CatalogResourceLeaf, CatalogValueLeaf } from './helpers/catalog-leaf';
 
 type Equal<A, B> = (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2 ? true : false;
 type Expect<T extends true> = T;
@@ -22,10 +24,10 @@ const forest = Assets.from({ tree: 'sprites/tree.png' });
 
 const composed = Assets.compose(shared, forest);
 
-type _ComposedLogo = Expect<Equal<typeof composed.logo, Texture>>;
-type _ComposedConfig = Expect<Equal<typeof composed.config, AssetRef<unknown>>>;
-type _ComposedTree = Expect<Equal<typeof composed.tree, Texture>>;
-type _ComposedEntries = Expect<Equal<(typeof composed.entries)['tree'], Texture>>;
+type _ComposedLogo = Expect<Equal<typeof composed.logo, CatalogResourceLeaf<Texture>>>;
+type _ComposedConfig = Expect<Equal<typeof composed.config, CatalogValueLeaf<unknown>>>;
+type _ComposedTree = Expect<Equal<typeof composed.tree, CatalogResourceLeaf<Texture>>>;
+type _ComposedEntries = Expect<Equal<(typeof composed.entries)['tree'], CatalogResourceLeaf<Texture>>>;
 
 declare const loader: Loader;
 
@@ -35,8 +37,8 @@ const left = Assets.compose(shared, forest);
 const right = Assets.compose(shared, Assets.from({ rock: 'sprites/rock.png' }));
 const diamond = Assets.compose(left, right);
 
-type _DiamondLogo = Expect<Equal<typeof diamond.logo, Texture>>;
-type _DiamondRock = Expect<Equal<typeof diamond.rock, Texture>>;
+type _DiamondLogo = Expect<Equal<typeof diamond.logo, CatalogResourceLeaf<Texture>>>;
+type _DiamondRock = Expect<Equal<typeof diamond.rock, CatalogResourceLeaf<Texture>>>;
 
 // --- conflicts --------------------------------------------------------------
 
@@ -73,10 +75,10 @@ loader.load(multiConflicted);
 
 const derived = Assets.extend(shared, { tree: 'sprites/tree.png', config: 'sprites/config.png' });
 
-type _DerivedKept = Expect<Equal<typeof derived.logo, Texture>>;
-type _DerivedAdded = Expect<Equal<typeof derived.tree, Texture>>;
+type _DerivedKept = Expect<Equal<typeof derived.logo, CatalogResourceLeaf<Texture>>>;
+type _DerivedAdded = Expect<Equal<typeof derived.tree, CatalogResourceLeaf<Texture>>>;
 // A deliberate override re-types the key: `config` was an AssetRef, now a Texture.
-type _DerivedOverridden = Expect<Equal<typeof derived.config, Texture>>;
+type _DerivedOverridden = Expect<Equal<typeof derived.config, CatalogResourceLeaf<Texture>>>;
 
 export type {
   _ComposedConfig,

--- a/test/type-tests/assets-group.type-test.ts
+++ b/test/type-tests/assets-group.type-test.ts
@@ -3,6 +3,8 @@
 
 import { Assets, type Texture } from '@codexo/exojs';
 
+import type { CatalogResourceLeaf } from './helpers/catalog-leaf';
+
 type Equal<A, B> = (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2 ? true : false;
 type Expect<T extends true> = T;
 
@@ -10,7 +12,7 @@ const assets = Assets.from({
   ...Assets.group('texture', { player: 'player.png', enemy: 'enemy.png' }, { mimeType: 'image/png' }),
 });
 
-type _PlayerIsTexture = Expect<Equal<typeof assets.player, Texture>>;
-type _EnemyIsTexture = Expect<Equal<typeof assets.enemy, Texture>>;
+type _PlayerIsTexture = Expect<Equal<typeof assets.player, CatalogResourceLeaf<Texture>>>;
+type _EnemyIsTexture = Expect<Equal<typeof assets.enemy, CatalogResourceLeaf<Texture>>>;
 
 export type { _EnemyIsTexture, _PlayerIsTexture };

--- a/test/type-tests/assets-one.type-test.ts
+++ b/test/type-tests/assets-one.type-test.ts
@@ -4,20 +4,22 @@
 
 import { Asset, AssetRef, Assets, type Texture } from '@codexo/exojs';
 
+import type { CatalogResourceLeaf, CatalogValueLeaf } from './helpers/catalog-leaf';
+
 type Equal<A, B> = (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2 ? true : false;
 type Expect<T extends true> = T;
 
 // bare path, resource kind → the resource leaf
 const ship = Assets.one('sprites/ship.png');
-type _ShipIsTexture = Expect<Equal<typeof ship, Texture>>;
+type _ShipIsTexture = Expect<Equal<typeof ship, CatalogResourceLeaf<Texture>>>;
 
 // bare path, value kind → deferred AssetRef
 const level = Assets.one('level.json');
-type _LevelIsRef = Expect<Equal<typeof level, AssetRef<unknown>>>;
+type _LevelIsRef = Expect<Equal<typeof level, CatalogValueLeaf<unknown>>>;
 
 // resource-kind descriptor → the resource leaf
 const tex = Assets.one(Asset.type('texture', 'x.png'));
-type _TexIsTexture = Expect<Equal<typeof tex, Texture>>;
+type _TexIsTexture = Expect<Equal<typeof tex, CatalogResourceLeaf<Texture>>>;
 
 export type { _LevelIsRef, _ShipIsTexture, _TexIsTexture };
 void AssetRef;

--- a/test/type-tests/assets-strict-false.type-test.ts
+++ b/test/type-tests/assets-strict-false.type-test.ts
@@ -10,6 +10,8 @@
 
 import { AssetRef, Assets, type Texture } from '@codexo/exojs';
 
+import type { CatalogResourceLeaf, CatalogValueLeaf } from './helpers/catalog-leaf';
+
 // Compile-time exact-type assertion, independent of vitest/expectTypeOf so it can
 // be validated by a bare `tsc --noEmit`.
 type Equal<A, B> = (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2 ? true : false;
@@ -22,8 +24,8 @@ const catalog = Assets.from({
 
 // Before the fix these both degraded to `{}` under strict:false. The literal path
 // strings must survive inference so their file suffix classifies the leaf.
-type _ShipIsTexture = Expect<Equal<typeof catalog.ship, Texture>>;
-type _LevelIsAssetRef = Expect<Equal<typeof catalog.level, AssetRef<unknown>>>;
+type _ShipIsTexture = Expect<Equal<typeof catalog.ship, CatalogResourceLeaf<Texture>>>;
+type _LevelIsAssetRef = Expect<Equal<typeof catalog.level, CatalogValueLeaf<unknown>>>;
 
 // Reference the aliases so `noUnusedLocals`-style checks and eslint stay quiet.
 export type { _LevelIsAssetRef, _ShipIsTexture };

--- a/test/type-tests/helpers/catalog-leaf.ts
+++ b/test/type-tests/helpers/catalog-leaf.ts
@@ -1,0 +1,10 @@
+// The catalog-leaf brand, for exact type assertions.
+//
+// `CatalogResourceLeaf` / `CatalogValueLeaf` are deliberately NOT part of the
+// root API — the brand mirrors the internal `_assetMeta` runtime stamp and is an
+// implementation detail of the loader's single-leaf overloads. The type tests
+// still need to NAME the leaf types to assert them exactly, so they reach the
+// internal module through the same `#`-subpath imports the other helpers here
+// use, rather than the brand being exported from `@codexo/exojs`.
+
+export type { CatalogResourceLeaf, CatalogValueLeaf } from '#resources/assetMeta';

--- a/test/type-tests/loader-catalog-input.type-test.ts
+++ b/test/type-tests/loader-catalog-input.type-test.ts
@@ -15,7 +15,9 @@
 // and `tsconfig.type-tests-loose.json` (`strictNullChecks: false`). Every
 // assertion below must hold identically in all three.
 
-import { Asset, type AssetRef, Assets, type Loader, type Scene, type Texture } from '@codexo/exojs';
+import { Asset, Assets, type Loader, type Scene, type Texture } from '@codexo/exojs';
+
+import type { CatalogResourceLeaf, CatalogValueLeaf } from './helpers/catalog-leaf';
 
 type Equal<A, B> = (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2 ? true : false;
 type Expect<T extends true> = T;
@@ -62,9 +64,9 @@ const extended = Assets.extend(bare, { enemy: 'sprites/enemy.png' });
 
 // The catalog LEAVES are unchanged by this fix — asserted so a regression in the
 // loaded-map inference can't be mistaken for a leaf-inference regression.
-type _BareLeafPlayer = Expect<Equal<typeof bare.player, Texture>>;
-type _BareLeafConfig = Expect<Equal<typeof bare.config, AssetRef<unknown>>>;
-type _ExplicitLeafConfig = Expect<Equal<typeof explicit.config, AssetRef<LevelData>>>;
+type _BareLeafPlayer = Expect<Equal<typeof bare.player, CatalogResourceLeaf<Texture>>>;
+type _BareLeafConfig = Expect<Equal<typeof bare.config, CatalogValueLeaf<unknown>>>;
+type _ExplicitLeafConfig = Expect<Equal<typeof explicit.config, CatalogValueLeaf<LevelData>>>;
 
 // --- loading them -----------------------------------------------------------
 
@@ -105,7 +107,7 @@ export async function loads(): Promise<void> {
 
   // `get()`/`release()` take the very same catalogs — same root cause, same fix.
   const held = loader.get(bare);
-  expectType<Equal<typeof held.player, Texture>>();
+  expectType<Equal<typeof held.player, CatalogResourceLeaf<Texture>>>();
   loader.release(bare);
   scene.loader.get(composed);
 }
@@ -121,14 +123,10 @@ export async function neighbours(): Promise<void> {
   const leafValue = await loader.load(mixed.level);
   expectType<Equal<typeof leafValue, LevelData>>();
 
-  // Single handle-hybrid leaf. PRE-EXISTING and untouched by this fix: that
-  // overload is keyed on `ResourceAssetObject`, which collapses to `never`
-  // because `json`'s `resource: unknown` swallows the resource union it is
-  // extracted from — so a resource leaf matches no overload today. The runtime
-  // accepts it (the meta-stamped-leaf branch of `_loadClaimed`). Asserted as-is
-  // so this file fails loudly the day the overload is repaired.
-  // @ts-expect-error — see above; tracked separately, not part of this change.
-  await loader.load(bare.player);
+  // Single handle-hybrid leaf. Full coverage of the brand-matched leaf overloads
+  // lives in `loader-catalog-leaf.type-test.ts`.
+  const leafHandle = await loader.load(bare.player);
+  expectType<Equal<typeof leafHandle, Texture>>();
 
   // Bare path.
   const path = await loader.load('sprites/solo.png');

--- a/test/type-tests/loader-catalog-leaf.type-test.ts
+++ b/test/type-tests/loader-catalog-leaf.type-test.ts
@@ -19,7 +19,19 @@
 // example project's settings, the engine's own strict profile and
 // `strictNullChecks: false`.
 
-import { Asset, AssetRef, Assets, type AudioStream, type BmFont, type Loader, type LoadingQueue, type Scene, type Sound, type Texture } from '@codexo/exojs';
+import {
+  Asset,
+  AssetRef,
+  Assets,
+  type AudioStream,
+  type BmFont,
+  type Loader,
+  type LoadingQueue,
+  type Scene,
+  type Sound,
+  type Texture,
+  type Video,
+} from '@codexo/exojs';
 
 import type { CatalogResourceLeaf, CatalogValueLeaf } from './helpers/catalog-leaf';
 
@@ -181,6 +193,7 @@ declare const rawAtlas: SpriteAtlas;
 // Non-leaf resource types: these have no seamless adapter, so the runtime never
 // hands them out as a catalog leaf either.
 declare const audioStream: AudioStream;
+declare const video: Video;
 declare const bmFont: BmFont;
 declare const image: HTMLImageElement;
 declare const fontFace: FontFace;
@@ -200,6 +213,8 @@ export function negatives(): void {
   // Non-leaf resource types must not sneak in through the leaf overloads.
   // @ts-expect-error — AudioStream is not a catalog leaf.
   loader.load(audioStream);
+  // @ts-expect-error — Video is not a catalog leaf.
+  loader.load(video);
   // @ts-expect-error — BmFont is not a catalog leaf.
   loader.load(bmFont);
   // @ts-expect-error — HTMLImageElement is not a catalog leaf.

--- a/test/type-tests/loader-catalog-leaf.type-test.ts
+++ b/test/type-tests/loader-catalog-leaf.type-test.ts
@@ -1,0 +1,217 @@
+// Type contract for the SINGLE-LEAF `Loader.load()` / `Loader.get()` overloads
+// (and their `SceneLoader` mirrors).
+//
+// Those overloads used to be keyed on `ResourceAssetObject`, i.e.
+// `Extract<AssetDefinitions[keyof AssetDefinitions]['resource'], object>` — but
+// `json`'s `resource: unknown` swallows the indexed union it is extracted from,
+// so the whole thing collapsed to `Extract<unknown, object>` = `never` and
+// `loader.load(bag.player)` matched no overload at all, while the runtime
+// accepted it happily.
+//
+// The replacement is not a hand-rolled union of object-ish resources: that would
+// wave through every raw `Texture`, plus non-leaf resources (`AudioStream`,
+// `Video`, `BmFont`, `FontFace`, `HTMLImageElement`) the runtime rejects. It
+// mirrors the runtime identity instead — the `_assetMeta` stamp `createLeaf`
+// puts on every materialized leaf — as a type-level brand, so the accepted set
+// is exactly the set `_loadClaimed`'s meta-stamped-leaf branch handles.
+//
+// `pnpm typecheck:type-tests` compiles this file under all three lanes: the
+// example project's settings, the engine's own strict profile and
+// `strictNullChecks: false`.
+
+import { Asset, AssetRef, Assets, type AudioStream, type BmFont, type Loader, type LoadingQueue, type Scene, type Sound, type Texture } from '@codexo/exojs';
+
+import type { CatalogResourceLeaf, CatalogValueLeaf } from './helpers/catalog-leaf';
+
+type Equal<A, B> = (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2 ? true : false;
+declare function expectType<_T extends true>(): void;
+
+declare const loader: Loader;
+declare const scene: Scene;
+
+// --- a custom seamless RESOURCE type and a custom VALUE type ----------------
+//
+// The brand must not lean on a hardcoded `'texture' | 'sound'` union, nor on
+// `ExtensionKindMap` alone: a seamless package type can be named explicitly in a
+// catalog config without ever claiming a file suffix. Both shapes are declared
+// here the way a package augments the engine.
+
+declare class SpriteAtlas {
+  public readonly frames: readonly string[];
+}
+
+interface AtlasMetrics {
+  readonly count: number;
+}
+
+declare module '@codexo/exojs' {
+  interface AssetDefinitions {
+    // A seamless resource type: no `isValue`, so its leaf heals in place.
+    spriteAtlas: { resource: SpriteAtlas; config: { source: string } };
+    // A value type: `isValue: true`, so its leaf is a deferred ref.
+    atlasMetrics: { resource: AtlasMetrics; config: { source: string }; isValue: true };
+  }
+}
+
+// --- the catalog ------------------------------------------------------------
+
+const bag = Assets.from({
+  player: 'player.png',
+  jump: 'jump.wav',
+  config: 'config.json',
+  // Explicit configs — no file suffix involved for the custom types.
+  atlas: Asset.type('spriteAtlas', 'atlases/hero'),
+  metrics: Asset.type('atlasMetrics', 'atlases/hero.meta'),
+});
+
+// A branded leaf stays ordinarily usable: the brand rides ON the resource, so
+// every existing annotation keeps compiling.
+const texture: Texture = bag.player;
+const sound: Sound = bag.jump;
+const config: AssetRef<unknown> = bag.config;
+const atlas: SpriteAtlas = bag.atlas;
+const metrics: AssetRef<AtlasMetrics> = bag.metrics;
+
+// …and it is exactly the branded leaf, not the bare resource.
+expectType<Equal<typeof bag.player, CatalogResourceLeaf<Texture>>>();
+expectType<Equal<typeof bag.jump, CatalogResourceLeaf<Sound>>>();
+expectType<Equal<typeof bag.config, CatalogValueLeaf<unknown>>>();
+expectType<Equal<typeof bag.atlas, CatalogResourceLeaf<SpriteAtlas>>>();
+expectType<Equal<typeof bag.metrics, CatalogValueLeaf<AtlasMetrics>>>();
+
+// --- load(leaf) / get(leaf) -------------------------------------------------
+
+export async function leafLoads(): Promise<void> {
+  const textureQueue = loader.load(bag.player);
+  expectType<Equal<typeof textureQueue, LoadingQueue<Texture>>>();
+  expectType<Equal<Awaited<typeof textureQueue>, Texture>>();
+
+  const soundQueue = loader.load(bag.jump, { background: true });
+  expectType<Equal<Awaited<typeof soundQueue>, Sound>>();
+
+  // A value leaf resolves to its DECODED payload, not to the ref.
+  const configQueue = loader.load(bag.config);
+  expectType<Equal<typeof configQueue, LoadingQueue<unknown>>>();
+  expectType<Equal<Awaited<typeof configQueue>, unknown>>();
+
+  const atlasQueue = loader.load(bag.atlas);
+  expectType<Equal<Awaited<typeof atlasQueue>, SpriteAtlas>>();
+
+  const metricsQueue = loader.load(bag.metrics, { background: true });
+  expectType<Equal<Awaited<typeof metricsQueue>, AtlasMetrics>>();
+
+  // `get(leaf)` adopts and returns the leaf: a resource leaf as its resource, a
+  // value leaf as the ref itself (its payload arrives on the ref).
+  expectType<Equal<ReturnType<typeof getTexture>, Texture>>();
+  expectType<Equal<ReturnType<typeof getSound>, Sound>>();
+  expectType<Equal<ReturnType<typeof getAtlas>, SpriteAtlas>>();
+  expectType<Equal<ReturnType<typeof getConfig>, AssetRef<unknown>>>();
+  expectType<Equal<ReturnType<typeof getMetrics>, AssetRef<AtlasMetrics>>>();
+}
+
+function getTexture() {
+  return loader.get(bag.player);
+}
+function getSound() {
+  return loader.get(bag.jump);
+}
+function getAtlas() {
+  return loader.get(bag.atlas);
+}
+function getConfig() {
+  return loader.get(bag.config);
+}
+function getMetrics() {
+  return loader.get(bag.metrics);
+}
+
+// --- composed / extended catalogs hand out the same branded leaves ----------
+
+const extra = Assets.from({ tree: 'tree.png', trees: 'trees.json' });
+const composed = Assets.compose(bag, extra);
+const extended = Assets.extend(bag, { enemy: 'enemy.png' });
+
+export async function derivedLeaves(): Promise<void> {
+  const composedLeaf = await loader.load(composed.tree);
+  expectType<Equal<typeof composedLeaf, Texture>>();
+
+  const composedValue = await loader.load(composed.trees);
+  expectType<Equal<typeof composedValue, unknown>>();
+
+  // A composition SHARES its inputs' leaves — the base key stays loadable too.
+  const composedBase = await loader.load(composed.player);
+  expectType<Equal<typeof composedBase, Texture>>();
+
+  const extendedLeaf = await loader.load(extended.enemy);
+  expectType<Equal<typeof extendedLeaf, Texture>>();
+
+  const extendedKept = loader.get(extended.player);
+  expectType<Equal<typeof extendedKept, Texture>>();
+}
+
+// --- SceneLoader mirrors the same surface ----------------------------------
+
+export async function sceneLeaves(): Promise<void> {
+  const sceneTexture = await scene.loader.load(bag.player);
+  expectType<Equal<typeof sceneTexture, Texture>>();
+
+  const sceneValue = await scene.loader.load(bag.config, { background: true });
+  expectType<Equal<typeof sceneValue, unknown>>();
+
+  const sceneAtlas = await scene.loader.load(bag.atlas);
+  expectType<Equal<typeof sceneAtlas, SpriteAtlas>>();
+
+  expectType<Equal<ReturnType<typeof sceneGetTexture>, Texture>>();
+  expectType<Equal<ReturnType<typeof sceneGetMetrics>, AssetRef<AtlasMetrics>>>();
+}
+
+function sceneGetTexture() {
+  return scene.loader.get(bag.player);
+}
+function sceneGetMetrics() {
+  return scene.loader.get(bag.metrics);
+}
+
+// --- negative: only a MATERIALIZED leaf is a leaf ---------------------------
+
+declare const rawTexture: Texture;
+declare const rawSound: Sound;
+declare const rawRef: AssetRef<unknown>;
+declare const rawAtlas: SpriteAtlas;
+// Non-leaf resource types: these have no seamless adapter, so the runtime never
+// hands them out as a catalog leaf either.
+declare const audioStream: AudioStream;
+declare const bmFont: BmFont;
+declare const image: HTMLImageElement;
+declare const fontFace: FontFace;
+
+export function negatives(): void {
+  // @ts-expect-error — a raw resource carries no `_assetMeta` stamp.
+  loader.load(rawTexture);
+  // @ts-expect-error — …and `get` rejects it for the same reason.
+  loader.get(rawTexture);
+  // @ts-expect-error — raw Sound is not a leaf either.
+  loader.load(rawSound);
+  // @ts-expect-error — a bare `AssetRef` is not a materialized value leaf.
+  loader.load(rawRef);
+  // @ts-expect-error — nor is a raw instance of a CUSTOM seamless resource.
+  loader.load(rawAtlas);
+
+  // Non-leaf resource types must not sneak in through the leaf overloads.
+  // @ts-expect-error — AudioStream is not a catalog leaf.
+  loader.load(audioStream);
+  // @ts-expect-error — BmFont is not a catalog leaf.
+  loader.load(bmFont);
+  // @ts-expect-error — HTMLImageElement is not a catalog leaf.
+  loader.load(image);
+  // @ts-expect-error — FontFace is not a catalog leaf.
+  loader.load(fontFace);
+
+  // The scene-scoped mirror enforces the same contract.
+  // @ts-expect-error — raw resource, scene loader.
+  scene.loader.load(rawTexture);
+  // @ts-expect-error — raw resource, scene loader `get`.
+  scene.loader.get(rawTexture);
+}
+
+void [texture, sound, config, atlas, metrics, new AssetRef<unknown>()];

--- a/test/type-tests/package-bare-path-inference.type-test.ts
+++ b/test/type-tests/package-bare-path-inference.type-test.ts
@@ -20,6 +20,8 @@ import type { LdtkMap } from '@codexo/exojs-ldtk';
 import type { TiledMap } from '@codexo/exojs-tiled';
 import type { TileMap } from '@codexo/exojs-tilemap';
 
+import type { CatalogValueLeaf } from './helpers/catalog-leaf';
+
 type Equal<A, B> = (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2 ? true : false;
 type Expect<T extends true> = T;
 
@@ -69,8 +71,8 @@ const asepriteFromDescriptor = loader.get(Asset.type('asepriteSheet', 'hero.asep
 type _AsepriteDescriptorIsRef = Expect<Equal<typeof asepriteFromDescriptor, AssetRef<AsepriteSheet>>>;
 
 const catalog = Assets.from({ map: Asset.type('tileMap', 'world.tmj'), sheet: Asset.type('asepriteSheet', 'hero.aseprite.json') });
-type _CatalogLeavesAreRefs = Expect<Equal<(typeof catalog)['map'], AssetRef<TileMap>>>;
-type _CatalogSheetIsRef = Expect<Equal<(typeof catalog)['sheet'], AssetRef<AsepriteSheet>>>;
+type _CatalogLeavesAreRefs = Expect<Equal<(typeof catalog)['map'], CatalogValueLeaf<TileMap>>>;
+type _CatalogSheetIsRef = Expect<Equal<(typeof catalog)['sheet'], CatalogValueLeaf<AsepriteSheet>>>;
 
 // A resource kind with a seamless adapter still resolves unwrapped — the marker
 // must not turn every package kind into a ref.

--- a/test/type-tests/parse.type-test.ts
+++ b/test/type-tests/parse.type-test.ts
@@ -3,7 +3,9 @@
 // catalog, and the resolved map from `load(catalog)` unwraps to R. Compiled by
 // `tsconfig.type-tests.json` via `pnpm typecheck:type-tests`.
 
-import { type AssetRef, Assets, type Loader } from '@codexo/exojs';
+import { Assets, type Loader } from '@codexo/exojs';
+
+import type { CatalogValueLeaf } from './helpers/catalog-leaf';
 
 type Equal<A, B> = (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2 ? true : false;
 type Expect<T extends true> = T;
@@ -17,7 +19,7 @@ const catalog = Assets.from({
 });
 
 // value config with `parse` → AssetRef<R>
-type _ConfigIsRef = Expect<Equal<typeof catalog.config, AssetRef<Config>>>;
+type _ConfigIsRef = Expect<Equal<typeof catalog.config, CatalogValueLeaf<Config>>>;
 type _ConfigValue = Expect<Equal<typeof catalog.config.value, Config>>;
 
 // resolved map from load(catalog) unwraps to the parsed value

--- a/test/type-tests/value-brand-catalog.type-test.ts
+++ b/test/type-tests/value-brand-catalog.type-test.ts
@@ -5,6 +5,8 @@
 
 import { Asset, type AssetRef, Assets, type Loader, type Texture } from '@codexo/exojs';
 
+import type { CatalogResourceLeaf, CatalogValueLeaf } from './helpers/catalog-leaf';
+
 type Equal<A, B> = (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2 ? true : false;
 type Expect<T extends true> = T;
 
@@ -18,10 +20,10 @@ const catalog = Assets.from({
 });
 
 // resource-kind descriptor → the resource leaf
-type _ShipIsTexture = Expect<Equal<typeof catalog.ship, Texture>>;
+type _ShipIsTexture = Expect<Equal<typeof catalog.ship, CatalogResourceLeaf<Texture>>>;
 
 // value-kind descriptor with object value → AssetRef<Config> (NOT Config)
-type _ConfigIsRef = Expect<Equal<typeof catalog.config, AssetRef<Config>>>;
+type _ConfigIsRef = Expect<Equal<typeof catalog.config, CatalogValueLeaf<Config>>>;
 
 // `.value` is well-typed on the ref leaf
 type _ConfigValue = Expect<Equal<typeof catalog.config.value, Config>>;

--- a/tsconfig.type-tests-loose.json
+++ b/tsconfig.type-tests-loose.json
@@ -14,5 +14,10 @@
     "strict": false,
     "strictNullChecks": false
   },
-  "include": ["test/type-tests/loader-catalog-input.type-test.ts", "test/type-tests/assets-strict-false.type-test.ts", "src/typings.d.ts"]
+  "include": [
+    "test/type-tests/loader-catalog-input.type-test.ts",
+    "test/type-tests/loader-catalog-leaf.type-test.ts",
+    "test/type-tests/assets-strict-false.type-test.ts",
+    "src/typings.d.ts"
+  ]
 }

--- a/tsconfig.type-tests-strict.json
+++ b/tsconfig.type-tests-strict.json
@@ -24,5 +24,5 @@
       "@codexo/exojs": ["./src/index.ts"]
     }
   },
-  "include": ["test/type-tests/loader-catalog-input.type-test.ts", "src/typings.d.ts"]
+  "include": ["test/type-tests/loader-catalog-input.type-test.ts", "test/type-tests/loader-catalog-leaf.type-test.ts", "src/typings.d.ts"]
 }


### PR DESCRIPTION
## Problem

The runtime accepts a single catalog leaf; the type surface did not:

```ts
const bag = Assets.from({ player: 'sprites/player.png', config: 'data/config.json' });

loader.load(bag.player); // TS2769 — no overload matches
loader.get(bag.player);  // TS2769
```

Both single-leaf overloads were keyed on

```ts
type ResourceAssetObject = Extract<AssetDefinitions[keyof AssetDefinitions]['resource'], object>;
```

and `json`'s `resource: unknown` collapses the indexed union to `unknown`, so `Extract<unknown, object>` is `never`. The overloads had been dead since that type was written.

## Why not a union of object-ish resources

It would accept far more than the runtime does: raw `new Texture()` / `new Sound()` instances, and the non-leaf resource types (`AudioStream`, `Video`, `BmFont`, `FontFace`, `HTMLImageElement`) that have no seamless adapter and are never handed out as a leaf. `_loadClaimed` dispatches on one thing only — the `_assetMeta` stamp `createLeaf` applies — so the type surface mirrors exactly that.

## The branded leaf model

```ts
interface CatalogLeafBrand<T> {
  readonly [_assetMeta]: AssetMeta & { readonly _resolvedType?: T };
}
type CatalogResourceLeaf<T> = T & CatalogLeafBrand<T>;
type CatalogValueLeaf<T>    = AssetRef<T> & CatalogLeafBrand<T>;
```

- `_resolvedType` is a **phantom** — never written at runtime, and the stored `AssetMeta` object is unchanged.
- A naked type parameter inside an intersection is skipped for inference, so `T & CatalogLeafBrand<T>` recovers `T` from that field alone: `load(bag.player)` is `LoadingQueue<Texture>`, not `LoadingQueue<Texture & brand>`.
- The brand rides **on** the resource, so `const t: Texture = bag.player` and `const c: AssetRef<unknown> = bag.config` keep compiling unchanged.
- `_stampMeta()` now returns the branded leaf it just produced.
- The brand stays internal — it is not exported from the root. The type tests name it through a `test/type-tests/helpers/catalog-leaf.ts` re-export, matching the existing `#`-subpath helper convention there.

`InferCatalogLeaf` brands through the new `CatalogLeafForKind` / `CatalogLeafForPath`. `InferLoadedMap` is untouched and still maps to raw loaded payloads.

### `LeafForPath` deliberately stays unbranded

`loader.get(path)` resolves through the source-keyed dedup, **not** through `createLeaf`, so a freshly minted bare-path handle carries no stamp. Branding `LeafForPath` too would have been a type lie, letting `load(loader.get('x.png'))` compile straight into the record fallback. A new runtime test in `catalog-adopt.test.ts` pins that asymmetry: a catalog leaf reads back its meta, a bare-path handle reads back `undefined`.

## Contracts

Positive — `Loader` and `SceneLoader` alike:

| Call | Type |
| --- | --- |
| `loader.load(bag.player)` | `LoadingQueue<Texture>` |
| `loader.load(bag.jump, { background: true })` | `LoadingQueue<Sound>` |
| `loader.load(bag.config)` | `LoadingQueue<unknown>` |
| `loader.get(bag.player)` | `Texture` |
| `loader.get(bag.config)` | `AssetRef<unknown>` |

…plus `compose()`/`extend()` leaves, and a declaration-merged **custom seamless resource** type and **custom `isValue`** type — both named explicitly via `Asset.type(...)` with no file suffix involved, so the brand demonstrably does not lean on `ExtensionKindMap` or a hardcoded `'texture' | 'sound'` union.

Negative — all rejected:

```ts
loader.load(new Texture());  loader.get(new Texture());
loader.load(new Sound());    loader.load(new AssetRef<unknown>());
loader.load(audioStream);    loader.load(bmFont);
loader.load(image);          loader.load(fontFace);
scene.loader.load(new Texture());
```

## Not changed

No runtime, residency, claim, composition/provenance or scene-lifecycle semantics. No public `AssetScope`, no public `evict()`, no new public seamless-kind registry.

## Tests and gates

New `test/type-tests/loader-catalog-leaf.type-test.ts`, compiled under all three lanes (example settings / engine-strict / `strictNullChecks: false`). Existing leaf assertions across seven type-test files moved to the branded types. Runtime: `assetMeta.test.ts` gains the `AssetRef` stamping case (and asserts `_resolvedType` is absent at runtime), `catalog-adopt.test.ts` the stamped-vs-unstamped contract.

`pnpm verify:quick` (0 errors), `pnpm test:core` (334 files, 5441 tests), `pnpm build` — green. Type-test lanes additionally re-verified with `dist/` removed, i.e. under clean-CI conditions.

The temporary `@ts-expect-error` #427 left on `loader.load(catalog.player)` is removed and replaced by a real assertion.