### PR TITLE
fix(resources): keep the catalog-leaf brand on Loader.get() results

### DIFF
--- a/site/src/content/api/loader.json
+++ b/site/src/content/api/loader.json
@@ -6,10 +6,10 @@
   "subsystem": "resources",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 35,
+  "memberCount": 34,
   "counts": {
     "constructors": 1,
-    "methods": 25,
+    "methods": 24,
     "properties": 2,
     "events": 7
   },
@@ -374,7 +374,7 @@
         },
         {
           "name": "get",
-          "signature": "get(asset: ValueAsset<T>): AssetRef<T>",
+          "signature": "get(asset: CatalogValueLeaf<T> | ValueAsset<T>): CatalogValueLeaf<T>",
           "signatureTokens": [
             {
               "text": "get",
@@ -390,6 +390,26 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "CatalogValueLeaf",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": " | ",
               "kind": "punctuation"
             },
             {
@@ -417,7 +437,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "AssetRef",
+              "text": "CatalogValueLeaf",
               "kind": "type"
             },
             {
@@ -436,16 +456,16 @@
           "params": [
             {
               "name": "asset",
-              "type": "ValueAsset<T>",
+              "type": "CatalogValueLeaf<T> | ValueAsset<T>",
               "optional": false
             }
           ],
-          "returnType": "AssetRef<T>",
-          "description": "Seamless/value access from an Asset.type(...) descriptor (asset-system v2 §4.2) — the replacement for the removed get(Type, dynamicSource) form. Builds and adopts the descriptor's handle-hybrid leaf: a resource type yields its heal-in-place handle, a value type a stable AssetRef. A type with neither a seamless adapter nor a value channel throws with guidance to use load(Asset.type(...)). The return type follows the ValueAsset brand (as InferCatalogLeaf does): a value-type descriptor (Asset.type<T>('json', …)) returns AssetRef<T> — even for an object payload — while a resource-type descriptor returns the resource itself, so the type always matches the runtime value. Unlike bare-path get('x.png'), this form is **not instance-deduped by source**: each call builds a fresh leaf, so repeated get(Asset.type(type, sameSrc)) accumulates distinct handles (all healing to the same deduped backend payload). It is the dynamic-source escape hatch — capture the handle once."
+          "returnType": "CatalogValueLeaf<T>",
+          "description": "Seamless/value access from an Asset.type(...) descriptor (asset-system v2 §4.2) — the replacement for the removed get(Type, dynamicSource) form. Builds and adopts the descriptor's handle-hybrid leaf: a resource type yields its heal-in-place handle, a value type a stable AssetRef. A type with neither a seamless adapter nor a value channel throws with guidance to use load(Asset.type(...)). The return type follows the ValueAsset brand (as InferCatalogLeaf does): a value-type descriptor (Asset.type<T>('json', …)) returns AssetRef<T> — even for an object payload — while a resource-type descriptor returns the resource itself, so the type always matches the runtime value. Both come back BRANDED, mirroring the _assetMeta stamp createLeaf applies, so the returned leaf can be fed straight back into a single-leaf load(…). Unlike bare-path get('x.png'), this form is **not instance-deduped by source**: each call builds a fresh leaf, so repeated get(Asset.type(type, sameSrc)) accumulates distinct handles (all healing to the same deduped backend payload). It is the dynamic-source escape hatch — capture the handle once."
         },
         {
           "name": "get",
-          "signature": "get(asset: Asset<T>): T",
+          "signature": "get(asset: Asset<T>): CatalogResourceLeaf<T>",
           "signatureTokens": [
             {
               "text": "get",
@@ -488,8 +508,20 @@
               "kind": "punctuation"
             },
             {
+              "text": "CatalogResourceLeaf",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
               "text": "T",
               "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
             }
           ],
           "params": [
@@ -499,12 +531,12 @@
               "optional": false
             }
           ],
-          "returnType": "T",
+          "returnType": "CatalogResourceLeaf<T>",
           "description": "Seamless deferred access by path (asset-system v2). Returns SYNCHRONOUSLY: an already-loaded source returns the stored resource; an unknown source returns a placeholder handle immediately, starts the fetch, and fills the handle in place when the payload arrives (track it via loadState / loaded). Failed loads switch the handle to its failed representation; calling get again for a 'failed' source retries and heals the same handle in place. Invalid inputs and missing bindings throw synchronously before a fetch starts. The path is normalized to an AssetDefinitions type by its suffix (basename-only, longest-suffix-first), consulting the app-local registerType override, then the binding-declared type, then the global defineAsset default. A resource suffix yields its heal-in-place handle; a value suffix (json, txt, csv, …) yields a stable AssetRef. Only leaf-capable suffixes are accepted at compile time (ExtensionKindMap); dynamic strings resolving to an unregistered suffix or a non-leaf type throw with guidance. The same source always yields the same instance — also across load — and options are first-wins: conflicting options on a later call are ignored with a one-time dev warning."
         },
         {
           "name": "get",
-          "signature": "get(leaf: CatalogResourceLeaf<T>): T",
+          "signature": "get(leaf: CatalogResourceLeaf<T>): CatalogResourceLeaf<T>",
           "signatureTokens": [
             {
               "text": "get",
@@ -547,8 +579,20 @@
               "kind": "punctuation"
             },
             {
+              "text": "CatalogResourceLeaf",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
               "text": "T",
               "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
             }
           ],
           "params": [
@@ -558,79 +602,8 @@
               "optional": false
             }
           ],
-          "returnType": "T",
-          "description": "Adopts a single handle-hybrid leaf (an Assets.from() property) and returns it — the same object, healing in place once its payload arrives. Matches on the catalog-leaf brand, so only a MATERIALIZED leaf is accepted; a raw resource instance has no _assetMeta stamp and is rejected here as it is at runtime."
-        },
-        {
-          "name": "get",
-          "signature": "get(leaf: CatalogValueLeaf<T>): AssetRef<T>",
-          "signatureTokens": [
-            {
-              "text": "get",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": "leaf",
-              "kind": "param"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "CatalogValueLeaf",
-              "kind": "type"
-            },
-            {
-              "text": "<",
-              "kind": "punctuation"
-            },
-            {
-              "text": "T",
-              "kind": "type"
-            },
-            {
-              "text": ">",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "AssetRef",
-              "kind": "type"
-            },
-            {
-              "text": "<",
-              "kind": "punctuation"
-            },
-            {
-              "text": "T",
-              "kind": "type"
-            },
-            {
-              "text": ">",
-              "kind": "punctuation"
-            }
-          ],
-          "params": [
-            {
-              "name": "leaf",
-              "type": "CatalogValueLeaf<T>",
-              "optional": false
-            }
-          ],
-          "returnType": "AssetRef<T>",
-          "description": "Adopts a single value leaf and returns the ref itself — its payload arrives on the ref."
+          "returnType": "CatalogResourceLeaf<T>",
+          "description": "Adopts a single handle-hybrid leaf (an Assets.from() property) and returns it — the same object, healing in place once its payload arrives. Matches on the catalog-leaf brand, so only a MATERIALIZED leaf is accepted; a raw resource instance has no _assetMeta stamp and is rejected here as it is at runtime. The brand rides along on the result: the returned leaf is the very object that was passed in, stamp included, so it stays re-loadable."
         },
         {
           "name": "hasAssetType",

--- a/src/core/scene/SceneLoader.ts
+++ b/src/core/scene/SceneLoader.ts
@@ -3,7 +3,6 @@ import type { Destroyable } from '#core/types';
 import type { Asset, ValueAsset } from '#resources/Asset';
 import type { CatalogEntry, KindByPath, LeafForPath, ResourceForKind } from '#resources/AssetDefinitions';
 import type { CatalogResourceLeaf, CatalogValueLeaf } from '#resources/assetMeta';
-import type { AssetRef } from '#resources/AssetRef';
 import type { Assets, InferAssetsProperties } from '#resources/Assets';
 import type { InferLoadedMap, Loader, LoadOptions } from '#resources/Loader';
 import type { LoadingQueue } from '#resources/LoadingQueue';
@@ -28,15 +27,15 @@ export class SceneLoader implements Destroyable {
   // handle, a value suffix a stable AssetRef. Leaf-capable suffixes only.
   public get<S extends string>(path: [KindByPath<S>] extends [never] ? never : S, options?: unknown): LeafForPath<S>;
   // Seamless/value access from an `Asset.type()` descriptor (mirrors Loader.get(asset)):
-  // a value-kind descriptor returns AssetRef<T>, a resource-kind descriptor the resource.
-  // A materialized VALUE LEAF resolves the same way, so both share one signature.
-  public get<T>(asset: ValueAsset<T> | CatalogValueLeaf<T>): AssetRef<T>;
-  public get<T>(asset: Asset<T>): T;
+  // a value-kind descriptor returns a value leaf, a resource-kind descriptor a resource
+  // leaf. A materialized VALUE LEAF resolves the same way, so both share one signature.
+  public get<T>(asset: ValueAsset<T> | CatalogValueLeaf<T>): CatalogValueLeaf<T>;
+  public get<T>(asset: Asset<T>): CatalogResourceLeaf<T>;
   // Adopts an Assets catalog under the scene scope (mirrors Loader.get(catalog)).
   public get<M extends Record<string, CatalogEntry>>(catalog: Assets<M>): InferAssetsProperties<M>;
   // Adopts a single handle-hybrid leaf under the scene scope (mirrors Loader.get(leaf)).
   // Brand-matched: only a materialized catalog leaf, never a raw resource.
-  public get<T extends object>(leaf: CatalogResourceLeaf<T>): T;
+  public get<T extends object>(leaf: CatalogResourceLeaf<T>): CatalogResourceLeaf<T>;
   public get(input: string | object, options?: unknown): unknown {
     return this._loader._getClaimed(this._scope, input, options);
   }

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -45,7 +45,7 @@ export class Container extends RenderNode {
    * and bounds invalidation stay consistent.
    */
   public get children(): readonly RenderNode[] {
-    return (this._childrenView ??= Object.freeze(this._children.slice()));
+    return (this._childrenView ??= Object.freeze([...this._children]));
   }
 
   public get width(): number {

--- a/src/resources/Loader.ts
+++ b/src/resources/Loader.ts
@@ -651,14 +651,18 @@ export class Loader {
    * does): a value-type descriptor (`Asset.type<T>('json', …)`) returns
    * `AssetRef<T>` — even for an object payload — while a resource-type descriptor
    * returns the resource itself, so the type always matches the runtime value.
+   * Both come back BRANDED, mirroring the `_assetMeta` stamp `createLeaf` applies,
+   * so the returned leaf can be fed straight back into a single-leaf `load(…)`.
    *
    * Unlike bare-path `get('x.png')`, this form is **not instance-deduped by
    * source**: each call builds a fresh leaf, so repeated `get(Asset.type(type, sameSrc))`
    * accumulates distinct handles (all healing to the same deduped backend
    * payload). It is the dynamic-source escape hatch — capture the handle once.
    */
-  public get<T>(asset: ValueAsset<T>): AssetRef<T>;
-  public get<T>(asset: Asset<T>): T;
+  // A materialized VALUE LEAF resolves exactly like a value descriptor — it is
+  // adopted and handed back unchanged — so both share one signature.
+  public get<T>(asset: ValueAsset<T> | CatalogValueLeaf<T>): CatalogValueLeaf<T>;
+  public get<T>(asset: Asset<T>): CatalogResourceLeaf<T>;
 
   /**
    * Adopts a single handle-hybrid leaf (an `Assets.from()` property) and returns
@@ -666,11 +670,10 @@ export class Loader {
    *
    * Matches on the catalog-leaf brand, so only a MATERIALIZED leaf is accepted;
    * a raw resource instance has no `_assetMeta` stamp and is rejected here as it
-   * is at runtime.
+   * is at runtime. The brand rides along on the result: the returned leaf is the
+   * very object that was passed in, stamp included, so it stays re-loadable.
    */
-  public get<T extends object>(leaf: CatalogResourceLeaf<T>): T;
-  /** Adopts a single value leaf and returns the ref itself — its payload arrives on the ref. */
-  public get<T>(leaf: CatalogValueLeaf<T>): AssetRef<T>;
+  public get<T extends object>(leaf: CatalogResourceLeaf<T>): CatalogResourceLeaf<T>;
   public get(input: string | object, options?: unknown): unknown {
     return this._getClaimed(this._rootClaimer, input, options);
   }

--- a/test/rendering/container.test.ts
+++ b/test/rendering/container.test.ts
@@ -211,6 +211,18 @@ describe('Container children view', () => {
     expect(container.children).not.toBe(before);
   });
 
+  test('a snapshot handed out earlier is independent of later child mutations', () => {
+    const container = new Container();
+    const first = new DummyDrawable();
+    container.addChild(first);
+    const before = container.children;
+
+    container.addChild(new DummyDrawable());
+    container.removeChild(first);
+
+    expect(before).toEqual([first]);
+  });
+
   test('is a real Array — Array.isArray, length, and indexed access all work like before', () => {
     const container = new Container();
     const first = new DummyDrawable();

--- a/test/type-tests/loader-catalog-leaf.type-test.ts
+++ b/test/type-tests/loader-catalog-leaf.type-test.ts
@@ -112,13 +112,31 @@ export async function leafLoads(): Promise<void> {
   const metricsQueue = loader.load(bag.metrics, { background: true });
   expectType<Equal<Awaited<typeof metricsQueue>, AtlasMetrics>>();
 
-  // `get(leaf)` adopts and returns the leaf: a resource leaf as its resource, a
-  // value leaf as the ref itself (its payload arrives on the ref).
-  expectType<Equal<ReturnType<typeof getTexture>, Texture>>();
-  expectType<Equal<ReturnType<typeof getSound>, Sound>>();
-  expectType<Equal<ReturnType<typeof getAtlas>, SpriteAtlas>>();
-  expectType<Equal<ReturnType<typeof getConfig>, AssetRef<unknown>>>();
-  expectType<Equal<ReturnType<typeof getMetrics>, AssetRef<AtlasMetrics>>>();
+  // `get(leaf)` adopts and returns THE SAME leaf — brand included, because the
+  // runtime hands back the very stamped object it was given. A resource leaf
+  // stays its resource, a value leaf the ref itself (its payload arrives on the
+  // ref); both keep the stamp that makes them re-loadable below.
+  expectType<Equal<ReturnType<typeof getTexture>, CatalogResourceLeaf<Texture>>>();
+  expectType<Equal<ReturnType<typeof getSound>, CatalogResourceLeaf<Sound>>>();
+  expectType<Equal<ReturnType<typeof getAtlas>, CatalogResourceLeaf<SpriteAtlas>>>();
+  expectType<Equal<ReturnType<typeof getConfig>, CatalogValueLeaf<unknown>>>();
+  expectType<Equal<ReturnType<typeof getMetrics>, CatalogValueLeaf<AtlasMetrics>>>();
+
+  // A branded `get()` result stays ordinarily usable…
+  const gotTexture: Texture = loader.get(bag.player);
+  const gotSound: Sound = loader.get(bag.jump);
+  const gotMetrics: AssetRef<AtlasMetrics> = loader.get(bag.metrics);
+  void [gotTexture, gotSound, gotMetrics];
+
+  // …and round-trips back into a single-leaf `load()` with exact inference.
+  const roundTripTexture = loader.load(loader.get(bag.player));
+  expectType<Equal<typeof roundTripTexture, LoadingQueue<Texture>>>();
+
+  const roundTripConfig = loader.load(loader.get(bag.config));
+  expectType<Equal<typeof roundTripConfig, LoadingQueue<unknown>>>();
+
+  const roundTripMetrics = loader.load(loader.get(bag.metrics));
+  expectType<Equal<typeof roundTripMetrics, LoadingQueue<AtlasMetrics>>>();
 }
 
 function getTexture() {
@@ -158,7 +176,7 @@ export async function derivedLeaves(): Promise<void> {
   expectType<Equal<typeof extendedLeaf, Texture>>();
 
   const extendedKept = loader.get(extended.player);
-  expectType<Equal<typeof extendedKept, Texture>>();
+  expectType<Equal<typeof extendedKept, CatalogResourceLeaf<Texture>>>();
 }
 
 // --- SceneLoader mirrors the same surface ----------------------------------
@@ -173,8 +191,14 @@ export async function sceneLeaves(): Promise<void> {
   const sceneAtlas = await scene.loader.load(bag.atlas);
   expectType<Equal<typeof sceneAtlas, SpriteAtlas>>();
 
-  expectType<Equal<ReturnType<typeof sceneGetTexture>, Texture>>();
-  expectType<Equal<ReturnType<typeof sceneGetMetrics>, AssetRef<AtlasMetrics>>>();
+  expectType<Equal<ReturnType<typeof sceneGetTexture>, CatalogResourceLeaf<Texture>>>();
+  expectType<Equal<ReturnType<typeof sceneGetMetrics>, CatalogValueLeaf<AtlasMetrics>>>();
+
+  const sceneRoundTrip = scene.loader.load(scene.loader.get(bag.player));
+  expectType<Equal<typeof sceneRoundTrip, LoadingQueue<Texture>>>();
+
+  const sceneValueRoundTrip = scene.loader.load(scene.loader.get(bag.metrics));
+  expectType<Equal<typeof sceneValueRoundTrip, LoadingQueue<AtlasMetrics>>>();
 }
 
 function sceneGetTexture() {
@@ -182,6 +206,47 @@ function sceneGetTexture() {
 }
 function sceneGetMetrics() {
   return scene.loader.get(bag.metrics);
+}
+
+// --- get(descriptor) is branded too, and round-trips ------------------------
+//
+// The `Asset.type(...)` branch mints its leaf through `createLeaf`, so the
+// returned handle carries the very same `_assetMeta` stamp a catalog leaf does.
+
+export function descriptorLeaves(): void {
+  const descriptorTexture = loader.get(Asset.type('texture', 'player.png'));
+  expectType<Equal<typeof descriptorTexture, CatalogResourceLeaf<Texture>>>();
+
+  const plainTexture: Texture = descriptorTexture;
+  void plainTexture;
+
+  const descriptorQueue = loader.load(descriptorTexture);
+  expectType<Equal<typeof descriptorQueue, LoadingQueue<Texture>>>();
+
+  const descriptorMetrics = loader.get(Asset.type('atlasMetrics', 'atlases/hero.meta'));
+  expectType<Equal<typeof descriptorMetrics, CatalogValueLeaf<AtlasMetrics>>>();
+
+  const plainRef: AssetRef<AtlasMetrics> = descriptorMetrics;
+  void plainRef;
+
+  const descriptorValueQueue = loader.load(descriptorMetrics);
+  expectType<Equal<typeof descriptorValueQueue, LoadingQueue<AtlasMetrics>>>();
+
+  // The scene-scoped mirror brands identically.
+  const sceneDescriptorTexture = scene.loader.get(Asset.type('texture', 'player.png'));
+  expectType<Equal<typeof sceneDescriptorTexture, CatalogResourceLeaf<Texture>>>();
+  expectType<Equal<ReturnType<typeof sceneLoadDescriptorTexture>, LoadingQueue<Texture>>>();
+
+  const sceneDescriptorMetrics = scene.loader.get(Asset.type('atlasMetrics', 'atlases/hero.meta'));
+  expectType<Equal<typeof sceneDescriptorMetrics, CatalogValueLeaf<AtlasMetrics>>>();
+  expectType<Equal<ReturnType<typeof sceneLoadDescriptorMetrics>, LoadingQueue<AtlasMetrics>>>();
+}
+
+function sceneLoadDescriptorTexture() {
+  return scene.loader.load(scene.loader.get(Asset.type('texture', 'player.png')));
+}
+function sceneLoadDescriptorMetrics() {
+  return scene.loader.load(scene.loader.get(Asset.type('atlasMetrics', 'atlases/hero.meta')));
 }
 
 // --- negative: only a MATERIALIZED leaf is a leaf ---------------------------
@@ -227,6 +292,32 @@ export function negatives(): void {
   scene.loader.load(rawTexture);
   // @ts-expect-error — raw resource, scene loader `get`.
   scene.loader.get(rawTexture);
+}
+
+// --- negative: bare-path `get()` stays UNBRANDED -----------------------------
+//
+// The deliberate asymmetry: a bare path resolves through the source-keyed dedup
+// rather than `createLeaf`, so the handle it returns carries no `_assetMeta`
+// stamp at runtime — and must therefore not be re-loadable as a single leaf.
+
+export function barePathStaysUnbranded(): void {
+  const bareTexture = loader.get('player.png');
+  expectType<Equal<typeof bareTexture, Texture>>();
+
+  const bareRef = loader.get('config.json');
+  expectType<Equal<typeof bareRef, AssetRef<unknown>>>();
+
+  // @ts-expect-error — an unstamped bare-path handle is not a single leaf.
+  loader.load(bareTexture);
+  // @ts-expect-error — …nor is the bare-path AssetRef.
+  loader.load(bareRef);
+  // @ts-expect-error — inline form, same contract.
+  loader.load(loader.get('player.png'));
+
+  const sceneBareTexture = scene.loader.get('player.png');
+  expectType<Equal<typeof sceneBareTexture, Texture>>();
+  // @ts-expect-error — the scene mirror keeps the asymmetry.
+  scene.loader.load(sceneBareTexture);
 }
 
 void [texture, sound, config, atlas, metrics, new AssetRef<unknown>()];

--- a/test/type-tests/package-bare-path-inference.type-test.ts
+++ b/test/type-tests/package-bare-path-inference.type-test.ts
@@ -64,11 +64,16 @@ type _LdtkGetIsRef = Expect<Equal<typeof ldtkLeaf, AssetRef<LdtkMap>>>;
 // The same contract on the descriptor path, which was already reachable before
 // bare paths were (`Asset.type(...)` brands a value kind as `ValueAsset<T>`, and
 // both `get(descriptor)` and a catalog leaf resolve it to `AssetRef<T>`).
+// Unlike the bare-path results above, a descriptor leaf is minted by `createLeaf`
+// and therefore comes back BRANDED — still an `AssetRef` for a value kind.
 const tiledFromDescriptor = loader.get(Asset.type('tiledMap', 'world.tmj'));
-type _TiledDescriptorIsRef = Expect<Equal<typeof tiledFromDescriptor, AssetRef<TiledMap>>>;
+type _TiledDescriptorIsRef = Expect<Equal<typeof tiledFromDescriptor, CatalogValueLeaf<TiledMap>>>;
+const tiledPlainRef: AssetRef<TiledMap> = tiledFromDescriptor;
 
 const asepriteFromDescriptor = loader.get(Asset.type('asepriteSheet', 'hero.aseprite.json'));
-type _AsepriteDescriptorIsRef = Expect<Equal<typeof asepriteFromDescriptor, AssetRef<AsepriteSheet>>>;
+type _AsepriteDescriptorIsRef = Expect<Equal<typeof asepriteFromDescriptor, CatalogValueLeaf<AsepriteSheet>>>;
+
+void tiledPlainRef;
 
 const catalog = Assets.from({ map: Asset.type('tileMap', 'world.tmj'), sheet: Asset.type('asepriteSheet', 'hero.aseprite.json') });
 type _CatalogLeavesAreRefs = Expect<Equal<(typeof catalog)['map'], CatalogValueLeaf<TileMap>>>;

--- a/test/type-tests/value-brand-catalog.type-test.ts
+++ b/test/type-tests/value-brand-catalog.type-test.ts
@@ -3,7 +3,7 @@
 // resolved map from `load(catalog)` unwraps it back to `Config`. Compiled by
 // `tsconfig.type-tests.json` via `pnpm typecheck:type-tests`.
 
-import { Asset, type AssetRef, Assets, type Loader, type Texture } from '@codexo/exojs';
+import { Asset, type AssetRef, Assets, type Loader, type LoadingQueue, type Texture } from '@codexo/exojs';
 
 import type { CatalogResourceLeaf, CatalogValueLeaf } from './helpers/catalog-leaf';
 
@@ -39,14 +39,32 @@ type _ShipResolved = Expect<Equal<LoadedMap['ship'], Texture>>;
 
 // direct get(asset) honors the same brand — value → AssetRef<T>, resource → T
 // (regression guard: the brand-blind `T extends object` overload typed object
-// value kinds as the resource while runtime returned an AssetRef).
+// value kinds as the resource while runtime returned an AssetRef). Both come
+// back as MATERIALIZED leaves: `get(Asset.type(...))` mints them via `createLeaf`,
+// so the `_assetMeta` stamp — and with it single-leaf re-loadability — survives.
 function getConfig() {
   return loader.get(Asset.type<Config>('json', 'config.json'));
 }
 function getShip() {
   return loader.get(Asset.type('texture', 'ship.png'));
 }
-type _GetConfigIsRef = Expect<Equal<ReturnType<typeof getConfig>, AssetRef<Config>>>;
-type _GetShipIsTexture = Expect<Equal<ReturnType<typeof getShip>, Texture>>;
+type _GetConfigIsRef = Expect<Equal<ReturnType<typeof getConfig>, CatalogValueLeaf<Config>>>;
+type _GetShipIsTexture = Expect<Equal<ReturnType<typeof getShip>, CatalogResourceLeaf<Texture>>>;
 
-export type { _ConfigIsRef, _ConfigResolved, _ConfigValue, _GetConfigIsRef, _GetShipIsTexture, _ShipIsTexture, _ShipResolved };
+// The brand rides ON the payload type, so ordinary annotations keep compiling…
+const configRef: AssetRef<Config> = getConfig();
+const shipTexture: Texture = getShip();
+
+// …and the leaf goes straight back into a single-leaf `load()`.
+function loadGotConfig() {
+  return loader.load(getConfig());
+}
+function loadGotShip() {
+  return loader.load(getShip());
+}
+type _GotConfigLoads = Expect<Equal<ReturnType<typeof loadGotConfig>, LoadingQueue<Config>>>;
+type _GotShipLoads = Expect<Equal<ReturnType<typeof loadGotShip>, LoadingQueue<Texture>>>;
+
+void [configRef, shipTexture];
+
+export type { _ConfigIsRef, _ConfigResolved, _ConfigValue, _GetConfigIsRef, _GetShipIsTexture, _GotConfigLoads, _GotShipLoads, _ShipIsTexture, _ShipResolved };


### PR DESCRIPTION
Follow-ups from #428, in two separate commits.

## 1. Leaf brand survives `Loader.get()`

Every `get()` form whose runtime result is `_assetMeta`-stamped now says so in its type:

```ts
get<T>(asset: ValueAsset<T> | CatalogValueLeaf<T>): CatalogValueLeaf<T>;
get<T>(asset: Asset<T>): CatalogResourceLeaf<T>;
get<T extends object>(leaf: CatalogResourceLeaf<T>): CatalogResourceLeaf<T>;
```

`SceneLoader` mirrors this. The value-descriptor and value-leaf overloads share one signature (as they already did on `SceneLoader`) — both resolve to the same branded ref.

A leaf obtained from `get()` is therefore re-loadable as a single leaf, which the runtime always accepted:

```ts
loader.load(loader.get(Asset.type('texture', 'player.png'))); // LoadingQueue<Texture>
loader.load(loader.get(assets.config));                       // LoadingQueue<Config>
```

Assignability to the plain `Texture` / `Sound` / `AssetRef<T>` is unchanged — the brand rides on the payload type.

**Deliberate asymmetry kept:** bare-path `get('player.png')` stays unbranded. That branch resolves through the source-keyed dedup rather than `createLeaf`, so its handle carries no stamp, and `load(loader.get('player.png'))` must keep failing to compile. `LeafForPath` is untouched; the negative contract is pinned in the type tests.

No runtime change: `_getClaimed`, `createLeaf`, `_stampMeta` and the stored meta are all as they were.

## 2. `Container.children` lint cleanup

`Object.freeze(this._children.slice())` → `Object.freeze([...this._children])`, clearing the standing `unicorn/prefer-spread` warning. Same semantics; the added test pins snapshot independence, which the existing cache/freeze tests did not cover.

## Verification

- all three type-test lanes (default / strict / loose), also with `dist/` moved aside — no source-resolution dependency left
- `pnpm verify:quick`, `pnpm test:core` (5442 passed), `pnpm build`
