### PR TITLE
fix(resources): decide a value-ref adopt retry from the key, not the leaf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -341,7 +341,10 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
   failed handed the loader a brand-new `'idle'` leaf, which joined the failed
   key, flipped to `'loading'`, and hung there because nothing restarted the
   fetch. Whether an adoption is a retry is now decided by the source's own
-  failed handles, not by the state of whichever leaf asked.
+  failed handles, not by the state of whichever leaf asked — and that holds for
+  seamless handles and value refs (`AssetRef`) alike, so a second scene
+  re-claiming a previously-failed JSON/text/binary asset recovers instead of
+  hanging.
 - **`Loader.inspect()` reports `'failed'`, not `'ready'`,** for a value key
   whose fetch succeeded but whose own `parse()` failed: the raw payload is
   stored either way, so a resident payload alone never means "readable".

--- a/src/resources/AssetResidency.ts
+++ b/src/resources/AssetResidency.ts
@@ -458,7 +458,24 @@ export class AssetResidency {
       // `existingRef === undefined` branch above already fetched (or filled)
       // for a brand-new entry, and its guard makes it mutually exclusive with
       // this block, so no key is ever fetched twice in one adopt.
-      if (retryingFailedLeaf && existingRef !== undefined) {
+      //
+      // Like the seamless path below, the retry is decided from the KEY, not
+      // from the adopted ref: a brand-new ref is 'idle' (re-armed to 'loading'
+      // above), never 'failed', yet joining a key whose earlier load failed is
+      // every bit as much a retry request. Without the sibling check such a ref
+      // would join the set, find no stored payload, and sit in 'loading'
+      // forever — its fetch already settled into failure, so `_storeResource`
+      // never runs for the key and nothing else would ever restart it.
+      // Reading the siblings after the join above is equivalent to reading them
+      // before it: the adopted ref is 'loading' by now either way, so its own
+      // failure only ever surfaces through `retryingFailedLeaf`.
+      //
+      // Gated on `stored === undefined` so this only ever ADDS the missing
+      // refetch. A key whose payload is resident takes the re-fill branch below
+      // solely on the adopted ref's own retry, unchanged: a ref's `parse()` can
+      // reject a payload that fetched fine, and re-running it for every joining
+      // ref would turn an unrelated adopt into a silent re-parse of the set.
+      if (existingRef !== undefined && (retryingFailedLeaf || (stored === undefined && this._hasFailedRef(existingRef)))) {
         if (stored === undefined) {
           for (const ref of existingRef.refs) if (ref.state === 'failed') ref._begin();
           if (background) this._enqueueBackgroundFetch(ctor, meta.src, existingRef.options);
@@ -728,6 +745,22 @@ export class AssetResidency {
   private _hasFailedHandle(entry: { readonly handles: WeakHandleSet }, adapter: SeamlessAdapter<unknown>): boolean {
     for (const handle of entry.handles) {
       if (adapter.stateOf(handle) === 'failed') {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Value-ref twin of {@link _hasFailedHandle}: does any ref registered for a
+   * value key sit in `'failed'`? Then the key's last attempt ended in failure
+   * and an adoption joining it is a retry, whatever state the adopted ref
+   * itself was in.
+   */
+  private _hasFailedRef(entry: { readonly refs: ReadonlySet<AssetRef<unknown>> }): boolean {
+    for (const ref of entry.refs) {
+      if (ref.state === 'failed') {
         return true;
       }
     }

--- a/test/resources/catalog-adopt.test.ts
+++ b/test/resources/catalog-adopt.test.ts
@@ -659,6 +659,67 @@ describe('Loader._adopt — retrying a failed catalog leaf (hardening)', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  test('adopting a BRAND-NEW value ref for a key whose earlier load FAILED retries the key instead of stranding the new ref', async () => {
+    const { fetchMock, succeed } = togglableJsonFetch({ hp: 7 });
+    const loader = createCoreLoader();
+
+    const first = createLeaf('json', 'scene-handoff.json') as AssetRef<unknown>;
+
+    loader._adopt(first, Symbol('scene-a'));
+    await expect(first.loaded).rejects.toThrow();
+    expect(first.loadState).toBe('failed');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Value twin of the seamless case: a second scene hands over a ref that was
+    // never adopted before — 'idle', never 'failed'. What failed is the KEY, so
+    // the joining ref must drive the retry off its FAILED SIBLING, not off its
+    // own prior state. Nothing else would restart the key: its fetch already
+    // settled into failure, so `_storeResource` never runs for it.
+    succeed();
+
+    const fresh = createLeaf('json', 'scene-handoff.json') as AssetRef<unknown>;
+
+    loader._adopt(fresh, Symbol('scene-b'));
+
+    expect(fresh.loadState).toBe('loading');
+    expect(fetchMock).toHaveBeenCalledTimes(2); // re-armed AND refetched — never 'loading' with nothing in flight
+    expect(loader.inspect().find(r => r.source === 'scene-handoff.json')).toMatchObject({ state: 'loading', inFlight: true });
+
+    // A THIRD brand-new ref joining in the SAME tick must not fetch again: the
+    // adopt above already re-armed every sibling, so none reads 'failed'.
+    const alsoFresh = createLeaf('json', 'scene-handoff.json') as AssetRef<unknown>;
+
+    loader._adopt(alsoFresh, Symbol('scene-c'));
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    await expect(fresh.loaded).resolves.toEqual({ hp: 7 });
+    expect(fresh.loadState).toBe('ready');
+    expect(alsoFresh.loadState).toBe('ready');
+    expect(first.loadState).toBe('ready'); // the originally-failed ref heals in place too
+    expect(fetchMock).toHaveBeenCalledTimes(2); // exactly ONE retry fetch served all three
+    expect(loader.inspect().find(r => r.source === 'scene-handoff.json')).toMatchObject({ state: 'ready', inFlight: false });
+  });
+
+  test('a BRAND-NEW value ref adopted onto a still-broken failed key fails honestly again instead of hanging in loading', async () => {
+    const { fetchMock } = togglableJsonFetch({ hp: 0 });
+    const loader = createCoreLoader();
+
+    const first = createLeaf('json', 'still-down.json') as AssetRef<unknown>;
+
+    loader._adopt(first, Symbol('scene-a'));
+    await expect(first.loaded).rejects.toThrow();
+
+    const fresh = createLeaf('json', 'still-down.json') as AssetRef<unknown>;
+
+    loader._adopt(fresh, Symbol('scene-b')); // source is still down
+
+    await expect(fresh.loaded).rejects.toThrow();
+    expect(fresh.loadState).toBe('failed'); // an honest re-failure, not a silent hang
+    expect(first.loadState).toBe('failed');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(loader.inspect().find(r => r.source === 'still-down.json')).toMatchObject({ state: 'failed', inFlight: false });
+  });
+
   test('re-adopting a failed value ref with { background: true } queues the retry instead of fetching immediately', async () => {
     const { fetchMock, succeed } = togglableJsonFetch({ ready: true });
     const loader = createCoreLoader();


### PR DESCRIPTION
## What

`af09a7c2` moved the **seamless** adopt path off the adopted leaf's own state and onto the key's failed siblings, but left the `AssetRef` branch keyed on `retryingFailedLeaf` alone.

A brand-new value ref is always `'idle'`, never `'failed'`. Joining a key whose earlier load failed, it found no stored payload, started no fetch, and sat in `'loading'` forever — `.value` threw, `.loaded` never settled, and no later `get()` healed it, because `_getRef` returns the existing stuck ref rather than creating a fresh one.

Reproducible whenever a second scene re-claims a previously-failed JSON/text/binary asset.

## How

Mirrors `_hasFailedHandle` as `_hasFailedRef` and widens the retry guard to it.

The new clause is gated on `stored === undefined`, so it only ever **adds** the missing refetch. A key whose payload is already resident still takes the re-fill branch on the adopted ref's own retry alone: a ref's `parse()` can reject a payload that fetched fine, and re-running it for every joining ref would turn an unrelated adopt into a silent re-parse of the whole set.

## Tests

Adds the value twins of the two existing seamless regression tests. Without the fix, the still-broken-key test does not fail an assertion — it **times out**, which is the hang itself.

- `test/resources/catalog-adopt.test.ts`: 35/35
- `test/resources`: 741 passed, 3 skipped
- `pnpm verify:quick`: green

## Note

The CHANGELOG already claimed retries were decided by the source's failed handles rather than by whichever leaf asked. That was only ever true of the seamless path; it is now true of both, and the entry says so.

Found during a full roadmap-vs-code audit, not by a bug report.