### PR TITLE
fix(rendering): reject attaching an already-destroyed child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,6 +349,14 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
   changes neither document order nor any child index, so the `children`
   snapshot keeps the reference stability its contract promises and the
   paint-order view alone is recomputed.
+- **`Container.addChild()`/`addChildAt()` reject an already-`destroy()`ed
+  child** instead of linking it into the tree anyway. The prior guard only
+  warned, and only under `__DEV__` — a production build attached the
+  destroyed node silently, where it either rendered nothing (skipped by the
+  render-plan collect step) or replayed freed transform/bounds state. The
+  check is now an always-on `invariant` throw, matching the existing
+  ancestor-cycle guard, so a use-after-destroy attach fails the same way in
+  every build instead of degrading quietly in production only.
 
 ### Docs
 

--- a/site/src/content/api/button.json
+++ b/site/src/content/api/button.json
@@ -473,7 +473,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds. Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/container.json
+++ b/site/src/content/api/container.json
@@ -314,7 +314,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds. Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/graphics.json
+++ b/site/src/content/api/graphics.json
@@ -311,7 +311,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds. Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/htmltext.json
+++ b/site/src/content/api/htmltext.json
@@ -354,7 +354,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds. Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/image-layer-node.json
+++ b/site/src/content/api/image-layer-node.json
@@ -333,7 +333,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds. Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/label.json
+++ b/site/src/content/api/label.json
@@ -494,7 +494,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds. Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/panel.json
+++ b/site/src/content/api/panel.json
@@ -473,7 +473,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds. Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/progress-bar.json
+++ b/site/src/content/api/progress-bar.json
@@ -473,7 +473,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds. Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/retained-container.json
+++ b/site/src/content/api/retained-container.json
@@ -390,7 +390,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds. Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/scroll-container.json
+++ b/site/src/content/api/scroll-container.json
@@ -475,7 +475,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds. Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/stack.json
+++ b/site/src/content/api/stack.json
@@ -473,7 +473,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds. Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/tile-layer-node.json
+++ b/site/src/content/api/tile-layer-node.json
@@ -358,7 +358,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds. Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/tile-map-band.json
+++ b/site/src/content/api/tile-map-band.json
@@ -279,7 +279,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds. Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/tile-map-node.json
+++ b/site/src/content/api/tile-map-node.json
@@ -357,7 +357,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds. Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/uiroot.json
+++ b/site/src/content/api/uiroot.json
@@ -313,7 +313,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds. Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/widget.json
+++ b/site/src/content/api/widget.json
@@ -456,7 +456,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds. Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
         },
         {
           "name": "addFilter",

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -1,5 +1,4 @@
 import { invariant } from '#core/dev';
-import { logger } from '#core/logging';
 import type { Stage } from '#core/Stage';
 import { removeArrayItems } from '#core/utils';
 import { RenderEntryKind } from '#rendering/plan/RenderCommand';
@@ -139,8 +138,9 @@ export class Container extends RenderNode {
 
   /**
    * Insert `child` at `index` in the child list. The child is detached
-   * from any previous parent first. Throws if `index` is out of bounds.
-   * Self-as-child is a no-op.
+   * from any previous parent first. Throws if `index` is out of bounds, if
+   * `child` has already been `destroy()`ed, or if `child` is an ancestor of
+   * this container (would create a cycle). Self-as-child is a no-op.
    */
   public addChildAt(child: RenderNode, index: number): this {
     if (index < 0 || index > this._children.length) {
@@ -151,15 +151,17 @@ export class Container extends RenderNode {
       return this;
     }
 
-    // Attaching an already-destroyed node is otherwise silent — it renders
-    // nothing (the collect dev-guard skips it) or replays freed state. Warn once
-    // in dev at the attach site, the earliest clear use-after-destroy signal.
-    if (__DEV__ && child.destroyed) {
-      logger.warn(
-        'Container.addChild(): the child has already been destroy()ed — using a destroyed node is a no-op at best and stale state at worst. Create a fresh node instead of re-adding a destroyed one.',
-        { source: 'rendering', once: 'container:add-destroyed-child' },
-      );
-    }
+    // Attaching an already-destroyed node used to be silent in production: it
+    // rendered nothing (the collect dev-guard skips it) or replayed freed
+    // state, and only a __DEV__-only warning ever fired — the check evaporated
+    // in production builds while the node was linked into the tree regardless.
+    // pre-1.0 favours a clean break over a use-after-destroy that half-works,
+    // so this is an always-on rejection (like the cycle guard below), not a
+    // dev diagnostic.
+    invariant(
+      !child.destroyed,
+      'Container.addChild(): cannot attach a child that has already been destroy()ed — its pooled state (transform/bounds) is gone, so reusing it renders nothing or replays stale state. Create a fresh node instead of re-adding a destroyed one.',
+    );
 
     // Reject reparenting an ancestor of this container as a child: it would
     // close a cycle in the scene graph, and every recursive walk over it

--- a/test/rendering/container.test.ts
+++ b/test/rendering/container.test.ts
@@ -1,5 +1,4 @@
 ﻿import type { Application } from '#core/Application';
-import { logger } from '#core/logging';
 import { SceneNode } from '#core/SceneNode';
 import type { InteractionHooks, Stage } from '#core/Stage';
 import { FocusController } from '#input/FocusController';
@@ -148,40 +147,35 @@ describe('Container', () => {
     expect(container.children).toEqual([third, first, second]);
   });
 
-  // Using a destroyed node is otherwise silent — warn once (dev only) at
-  // the attach site, the earliest clear signal of use-after-destroy. Asserted
-  // through a sink (which honours the logger's `once` dedup), not a warn spy
-  // (which would count calls before dedup).
+  // Attaching an already-destroyed node used to be silent in production — a
+  // __DEV__-only warning fired, then the node was linked into the tree anyway.
+  // The engine is pre-1.0 and favours clean breaks, so use-after-destroy is
+  // now rejected via `invariant`, which throws in EVERY build (unlike the
+  // __DEV__-stripped `assert`) — see `invariant`'s contract in `#core/dev`.
   describe('destroyed-child guard', () => {
-    let entries: string[];
-    let removeSink: () => void;
-
-    beforeEach(() => {
-      logger._resetOnce(); // fresh once-state per test (dedup is process-wide)
-      entries = [];
-      removeSink = logger.addSink(e => entries.push(e.message));
-    });
-
-    afterEach(() => removeSink());
-
-    const destroyedCount = (): number => entries.filter(m => m.includes('destroyed')).length;
-
-    test('warns exactly once even when multiple destroyed nodes are attached', () => {
+    test('addChild throws when the child was already destroy()ed', () => {
       const container = new Container();
+      const child = new DummyDrawable();
+      child.destroy();
 
-      for (let i = 0; i < 3; i++) {
-        const child = new DummyDrawable();
-        child.destroy();
-        container.addChild(child);
-      }
-
-      expect(destroyedCount()).toBe(1); // once, despite 3 destroyed attaches
+      expect(() => container.addChild(child)).toThrow(/destroy/i);
     });
 
-    test('does not warn when a live node is added', () => {
-      new Container().addChild(new DummyDrawable());
+    test('addChildAt throws and leaves the container and the destroyed node untouched', () => {
+      const container = new Container();
+      const survivor = new DummyDrawable();
+      container.addChild(survivor);
 
-      expect(destroyedCount()).toBe(0);
+      const destroyedChild = new DummyDrawable();
+      destroyedChild.destroy();
+
+      expect(() => container.addChildAt(destroyedChild, 0)).toThrow(/destroy/i);
+      expect(container.children).toEqual([survivor]);
+      expect(destroyedChild.parent).toBeNull();
+    });
+
+    test('does not throw when a live node is added', () => {
+      expect(() => new Container().addChild(new DummyDrawable())).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
`Container.addChildAt()` warned under `__DEV__` when the incoming child was already `destroy()`ed, then linked it into the tree regardless — in every build, because the warning was the only guard and it evaporates in a production bundle. The attached node then either rendered nothing or replayed freed transform/bounds state, silently.

Replaces the dev-only warn with `invariant` — the same always-on, never-`__DEV__`-gated mechanism the adjacent ancestor-cycle guard already uses two lines down.

**Reject over documented no-op**: every `addChild`/`addChildAt` call site in `src/` was checked, and no internal caller relies on attaching a destroyed node. Pre-1.0 favours clean breaks over shims, and a use-after-destroy that silently half-works is exactly the class of bug that policy targets.

**Sibling paths checked**: `addChildAt` is the only path that links an externally supplied node into a container (`child._setParent(this)` has exactly one call site). `swapChildren`/`setChildIndex` only reorder nodes already resolved via `getChildIndex()`, which throws for a non-child. `removeChildAt`/`removeChildren` only detach. No sibling defect.

Test-first: the new assertions fail against the old code with `expected [Function] to throw an error` — it only warned.

- `test/rendering`: 1532 passed
- `test/core test/ui test/input` sanity sweep: 1600 passed
- typecheck, eslint, `docs:api:check` clean

**Adjacent finding, deliberately not fixed here**: `Sprite.setTexture()` has the same shape — `__DEV__`-only warn, then assigns the destroyed texture anyway. Different class and resource kind; tracked separately.