### PR TITLE
docs(guide): fix stale load(loader)/init(loader) scene-hook signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -359,6 +359,11 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
   game-starter template, and the `runtime`/`recipes`/`integrations` guides to
   the `change()`/`restore()`/`unload()`/`preload()` navigation API and the
   class-based `SceneTransition`/`PhasedSceneTransition` system.
+- Fixed a batch of guide chapters across `assets`/`audio`/`debugging`/`effects`/
+  `getting-started`/`input`/`recipes`/`rendering`/`runtime` that still taught
+  the removed `load(loader)`/`init(loader)` scene-hook signature; samples now
+  match `load(data)`/`init(data)` and reach the loader through `this.loader`
+  (scene-scoped) or `this.app.loader` (application-lifetime).
 
 ## [0.15.2] - 2026-07-04
 

--- a/site/src/content/guide/assets/aseprite.mdx
+++ b/site/src/content/guide/assets/aseprite.mdx
@@ -104,8 +104,8 @@ on a malformed document), resolves `meta.image` relative to the JSON source, sub
 playable clip. Call `play(tag)` with a tag name to start it:
 
 ```js
-async load(loader) {
-    this.sheet = await loader.load(Asset.type('asepriteSheet', 'sprites/hero.json'));
+async load() {
+    this.sheet = await this.loader.load(Asset.type('asepriteSheet', 'sprites/hero.json'));
 }
 
 init() {

--- a/site/src/content/guide/assets/loading-and-resources.mdx
+++ b/site/src/content/guide/assets/loading-and-resources.mdx
@@ -14,9 +14,9 @@ The contract is simple: declare what you need during `load`, await the loader, a
 
 ## The loader instance
 
-Every application owns one loader, available as `app.loader`. The same instance is passed into a scene's `load(loader)` and `init(loader)` hooks. You can also access it directly from any scene as `this.app.loader` once the scene has been registered.
+Every application owns one loader, available as `app.loader`. Inside a scene, reach it two ways: `this.loader` — a scene-scoped claim view whose assets release automatically when the scene ends — and `this.app.loader` — the same underlying application-lifetime instance, for assets that must outlive the scene.
 
-For most scenes you don't need to think about ownership — just use the `loader` argument in `load` and `init`.
+For most scenes you don't need to think about ownership — just use `this.loader` in `load` and `init`.
 
 ## Choose the form that fits
 
@@ -24,7 +24,7 @@ The loader offers several forms. Pick the smallest one that covers your case:
 
 | Form                                                                                        | Best for                                                                      |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `loader.load('hero.png')`                                                                   | One asset, path doubles as its identity — no alias needed                     |
+| `this.loader.load('hero.png')`                                                               | One asset, path doubles as its identity — no alias needed                     |
 | `Asset.type('texture', path)` / `Asset.type('sound', path)` / `Asset.type<T>('json', path)` | The path is computed at runtime (not a literal), or you want an explicit type |
 | `Assets.from({ hero: 'hero.png', … })`                                                      | A reusable, named group of assets shared across scenes                        |
 | `Assets.from({ hero: 'hero.png', music: Asset.type('music', path) })`                       | Mixed types and type-specific options in one catalog                          |
@@ -32,7 +32,7 @@ The loader offers several forms. Pick the smallest one that covers your case:
 When in doubt, start with a bare path string. Reach for `Assets.from` when assets belong together, and `Asset.type(...)` whenever the path isn't a string literal or the type should be explicit.
 
 <Callout type="hint" title="Load different types together, not one await at a time">
-  Awaiting loads sequentially makes each one wait for the previous download to finish. Group independent `loader.load(...)` calls in a single `Promise.all` so
+  Awaiting loads sequentially makes each one wait for the previous download to finish. Group independent `this.loader.load(...)` calls in a single `Promise.all` so
   unrelated resource types fetch concurrently.
 </Callout>
 
@@ -41,34 +41,34 @@ When in doubt, start with a bare path string. Reach for `Assets.from` when asset
 The path _is_ the identity — a bare string resolves directly to the finished asset, with its type inferred from the extension:
 
 ```js
-async load(loader) {
-    const texture = await loader.load('image/hero.png');
+async load() {
+    const texture = await this.loader.load('image/hero.png');
     this.hero = new Sprite(texture);
 }
 ```
 
-There's no separate alias step: call `loader.get('image/hero.png')` again anywhere later — same string, same `Texture` instance. Leaf-capable types such as `texture`, `sound`, `json`, and `text` resolve this way from their file extension. Types that can't be inferred from a path (`music`, `video`, `bmFont`, `font`, …) need an explicit descriptor — see [`Asset.type(...)`](#dynamic-paths-and-non-seamless-types) below.
+There's no separate alias step: call `this.loader.get('image/hero.png')` again anywhere later — same string, same `Texture` instance. Leaf-capable types such as `texture`, `sound`, `json`, and `text` resolve this way from their file extension. Types that can't be inferred from a path (`music`, `video`, `bmFont`, `font`, …) need an explicit descriptor — see [`Asset.type(...)`](#dynamic-paths-and-non-seamless-types) below.
 
 ## Homogeneous batch
 
 When you need several assets of the same type, load them in parallel and keep the returned instances:
 
 ```js
-async load(loader) {
+async load() {
     [this.hero, this.ground, this.coin] = await Promise.all([
-        loader.load('image/hero.png'),
-        loader.load('image/ground.png'),
-        loader.load('image/coin.png'),
+        this.loader.load('image/hero.png'),
+        this.loader.load('image/ground.png'),
+        this.loader.load('image/coin.png'),
     ]);
 }
 ```
 
 The `loader.basePath` option in `ApplicationOptions` prepends a base prefix to all relative paths, so these resolve to e.g. `assets/image/hero.png`.
 
-Because the path is the identity, `loader.get('image/hero.png')` returns the very same `Texture` instance from anywhere else in your code — `init`, a later scene, a system — as long as the string matches.
+Because the path is the identity, the same source path returns the very same `Texture` instance from anywhere else in your code — `this.loader.get('image/hero.png')` from `init`, a later scene, or `app.loader.get(...)` from a system — as long as the string matches.
 
 <Callout type="hint" title="get() returns synchronously for a valid leaf type">
-  For a registered seamless or value suffix, `loader.get(...)` returns synchronously — even before the fetch finishes. Ask for a valid path you haven't loaded
+  For a registered seamless or value suffix, `this.loader.get(...)` returns synchronously — even before the fetch finishes. Ask for a valid path you haven't loaded
   yet and you get a placeholder handle/ref immediately, which then heals once the network request resolves. Invalid input or a missing type/handler still throws
   synchronously. Check `.ready` / `.state` for asynchronous fetch outcomes (see [Status channel](#status-channel-instead-of-throwing) below).
 </Callout>
@@ -87,13 +87,13 @@ async _changeLevel(levelName: string) {
 }
 
 // Non-leaf types do not have a bare-path form, even for a literal path
-const music = await loader.load(Asset.type('music', 'audio/theme.ogg'));
+const music = await this.app.loader.load(Asset.type('music', 'audio/theme.ogg'));
 ```
 
 <Callout type="hint" title="get(Asset.type(...)) is the dynamic-path escape hatch">
-  For seamless and value types, `loader.get(Asset.type(type, dynamicPath))` returns a handle or `AssetRef` immediately and starts the asynchronous load. Capture
+  For seamless and value types, `this.loader.get(Asset.type(type, dynamicPath))` returns a handle or `AssetRef` immediately and starts the asynchronous load. Capture
   that returned object: each descriptor call creates a fresh leaf, although the backend fetch is still deduplicated. Non-leaf types have no synchronous handle
-  and must use `await loader.load(Asset.type(...))`.
+  and must use `await this.loader.load(Asset.type(...))`.
 </Callout>
 
 ## Multiple resource types in parallel
@@ -101,17 +101,17 @@ const music = await loader.load(Asset.type('music', 'audio/theme.ogg'));
 When a scene needs different asset types, load them in parallel with `Promise.all`:
 
 ```js
-async load(loader) {
+async load() {
     [this.sky, this.ambient, this.coin, this.jump, this.levels] = await Promise.all([
-        loader.load('image/sky.png'),
-        loader.load(Asset.type('music', 'audio/ambient.ogg')),
-        loader.load('audio/coin.wav'),
-        loader.load('audio/jump.wav'),
-        loader.load('data/levels.json'),
+        this.loader.load('image/sky.png'),
+        this.loader.load(Asset.type('music', 'audio/ambient.ogg')),
+        this.loader.load('audio/coin.wav'),
+        this.loader.load('audio/jump.wav'),
+        this.loader.load('data/levels.json'),
     ]);
 }
 
-init(loader) {
+init() {
     this.sky = new Sprite(this.sky);
 }
 ```
@@ -130,15 +130,15 @@ const SceneAssets = Assets.from({
     click: Asset.type('sound', 'audio/click.ogg'),
 });
 
-async load(loader) {
-    const { hero, click } = await loader.load(SceneAssets);
+async load() {
+    const { hero, click } = await this.loader.load(SceneAssets);
 
     this.hero  = new Sprite(hero);
     this.click = click;
 }
 ```
 
-The result is an object whose keys match the input and whose values are the resolved resource instances directly — no separate `get()` step needed, though `loader.get('image/hero.png')` / `loader.get('audio/click.ogg')` still work afterward since the source path remains the identity.
+The result is an object whose keys match the input and whose values are the resolved resource instances directly — no separate `get()` step needed, though `this.loader.get('image/hero.png')` / `this.loader.get('audio/click.ogg')` still work afterward since the source path remains the identity.
 
 ## Reusable asset references
 
@@ -158,7 +158,7 @@ Every property is a real, usable handle _before_ any loader touches it — `Titl
 
 ```js
 // Fetches every entry and heals each handle in place
-await loader.load(TitleAssets);
+await this.loader.load(TitleAssets);
 
 // Same objects as before load() — now populated
 this.logo = new Sprite(TitleAssets.logo);
@@ -176,7 +176,7 @@ TitleAssets.config; // AssetRef<{ startLevel: string }>
 `Assets` also exposes an `.entries` record for iteration and inspection. To load several existing catalogs concurrently, keep their types intact and start both queues:
 
 ```js
-await Promise.all([loader.load(CommonAssets), loader.load(TitleAssets)]);
+await Promise.all([this.loader.load(CommonAssets), this.loader.load(TitleAssets)]);
 ```
 
 The key `'entries'` is reserved and will throw if you try to use it as an asset name inside an `Assets` container.
@@ -232,7 +232,7 @@ An override is a new declaration, so composing a derived catalog back together w
 Every `loader.load(...)` call returns a `LoadingQueue<T>`. It implements `PromiseLike<T>`, so `await` and `Promise.all` both work. It also exposes per-queue progress via `onProgress`:
 
 ```js
-const loading = loader.load(TitleAssets);
+const loading = this.loader.load(TitleAssets);
 
 loading.onProgress.add(progress => {
   bar.value = progress.loaded / progress.total;
@@ -253,7 +253,7 @@ const title = await loading;
 Start two queues simultaneously and wait for both:
 
 ```js
-const [title, game] = await Promise.all([loader.load(TitleAssets), loader.load(GameAssets)]);
+const [title, game] = await Promise.all([this.loader.load(TitleAssets), this.loader.load(GameAssets)]);
 ```
 
 Each queue tracks its own progress independently. The result tuple is typed: `title` has the shape of `TitleAssets`, `game` has the shape of `GameAssets`.
@@ -261,9 +261,9 @@ Each queue tracks its own progress independently. The result tuple is typed: `ti
 A practical startup pattern — show the title screen as soon as title assets are ready, while game assets continue loading in the background:
 
 ```js
-async load(loader) {
-    const titleQueue = loader.load(TitleAssets);
-    const gameQueue  = loader.load(GameAssets);
+async load() {
+    const titleQueue = this.loader.load(TitleAssets);
+    const gameQueue  = this.loader.load(GameAssets);
 
     titleQueue.onProgress.add((p) => {
         this._titleProgress = p.loaded / p.total;
@@ -295,27 +295,27 @@ Because the batch is shared, `total` can grow mid-flight: if a new `loader.load(
 
 ```js
 class BootScene extends Scene {
-  init(loader) {
-    loader.onLoadStart.add((key, url) => {
+  init() {
+    this.app.loader.onLoadStart.add((key, url) => {
       this.progressBar.visible = true;
     });
 
-    loader.onLoadProgress.add((loaded, total, key) => {
+    this.app.loader.onLoadProgress.add((loaded, total, key) => {
       this.progressBar.value = loaded / total;
     });
 
-    loader.onLoadError.add((key, error) => {
+    this.app.loader.onLoadError.add((key, error) => {
       console.warn(`Failed to load "${key}":`, error);
       // onLoadComplete still fires once the rest of the batch settles
     });
 
-    loader.onLoadComplete.add(() => {
+    this.app.loader.onLoadComplete.add(() => {
       this.progressBar.visible = false;
       this._enterGame();
     });
 
     // Trigger loads from anywhere — the signals above see all of them
-    loader.load(TitleAssets);
+    this.loader.load(TitleAssets);
   }
 }
 ```
@@ -333,24 +333,24 @@ signals in `unload()` so a listener from a torn-down scene never fires
 
 ```js
 class BootScene extends Scene {
-  init(loader) {
+  init() {
     this._onLoadComplete = () => {
       this.progressBar.visible = false;
       this._enterGame();
     };
 
-    loader.onLoadStart.add((key, url) => {
+    this.app.loader.onLoadStart.add((key, url) => {
       this.progressBar.visible = true;
     });
-    loader.onLoadProgress.add((loaded, total, key) => {
+    this.app.loader.onLoadProgress.add((loaded, total, key) => {
       this.progressBar.value = loaded / total;
     });
-    loader.onLoadError.add((key, error) => {
+    this.app.loader.onLoadError.add((key, error) => {
       console.warn(`Failed to load "${key}":`, error);
     });
-    loader.onLoadComplete.add(this._onLoadComplete);
+    this.app.loader.onLoadComplete.add(this._onLoadComplete);
 
-    loader.load(TitleAssets);
+    this.loader.load(TitleAssets);
   }
 
   unload() {
@@ -387,7 +387,7 @@ interface AssetStatus {
 ```
 
 ```js
-const tex = loader.get('hero.png'); // synchronous for a valid, registered suffix
+const tex = this.loader.get('hero.png'); // synchronous for a valid, registered suffix
 
 if (tex.ready) {
   // draw it
@@ -401,18 +401,18 @@ await tex.loaded; // Promise<this> — resolves once ready, rejects on failure
 The same `.state` / `.ready` / `.error` / `.loaded` contract applies to `AssetRef` values such as JSON or text — read `.value` once `.ready` is `true`:
 
 ```js
-const config = loader.get('data/config.json'); // AssetRef<unknown>
+const config = this.loader.get('data/config.json'); // AssetRef<unknown>
 await config.loaded;
 console.log(config.value.startLevel);
 ```
 
-`get()` returns before network work settles. A later load failure moves the handle/ref to `'failed'`, rejects its `.loaded` promise, and is reported through `loader.onError`; calling `get()` again retries and can heal that same source-keyed handle. By contrast, the awaitable returned by `load()` rejects at the call site on failure and reports the same `Error` through `loader.onError`. Invalid input or a missing type/handler is a synchronous configuration error for either API. A catalog entry's optional `parse` transform must be synchronous — if it returns a Promise (or anything else thenable), the ref it belongs to fails with an explicit error instead of silently awaiting it; do any asynchronous decoding inside the asset handler's load phase instead.
+`get()` returns before network work settles. A later load failure moves the handle/ref to `'failed'`, rejects its `.loaded` promise, and is reported through `this.app.loader.onError`; calling `get()` again retries and can heal that same source-keyed handle. By contrast, the awaitable returned by `load()` rejects at the call site on failure and reports the same `Error` through `this.app.loader.onError`. Invalid input or a missing type/handler is a synchronous configuration error for either API. A catalog entry's optional `parse` transform must be synchronous — if it returns a Promise (or anything else thenable), the ref it belongs to fails with an explicit error instead of silently awaiting it; do any asynchronous decoding inside the asset handler's load phase instead.
 
-`loader.release(...)` drops your claim on an asset; the object itself keeps its identity and heals back to `'loading'` if you `get()` the same source again. It accepts a handle, an `Asset` descriptor, a whole catalog, or a `(type, source)` pair. Releasing a valid form that was never claimed — a descriptor you never loaded, a catalog leaf you never adopted — is a harmless no-op, and releasing twice is always idempotent:
+`this.app.loader.release(...)` drops your claim on an asset; the object itself keeps its identity and heals back to `'loading'` if you `get()` the same source again. It accepts a handle, an `Asset` descriptor, a whole catalog, or a `(type, source)` pair. Releasing a valid form that was never claimed — a descriptor you never loaded, a catalog leaf you never adopted — is a harmless no-op, and releasing twice is always idempotent:
 
 ```js
-loader.release(TitleAssets); // releases every leaf in the catalog
-loader.release(logo); // a single handle from get()
+this.app.loader.release(TitleAssets); // releases every leaf in the catalog
+this.app.loader.release(logo); // a single handle from get()
 ```
 
 Releasing only ever drops _your_ claim. Assets loaded through `scene.loader` belong to that scene and are released when it ends, so releasing at app level can never pull an asset out from under a scene that still needs it. The payload is evicted once the last owner lets go.
@@ -425,13 +425,13 @@ Releasing only ever drops _your_ claim. Assets loaded through `scene.loader` bel
 
 <Callout type="hint" title="Non-seamless types have no placeholder">
   Types that aren't seamless — `AudioStream`, `Video`, `BmFont`, `FontAsset`, and custom types — have no placeholder to hand back, so there's nothing to `get()`
-  speculatively. Load them by reference and hold onto the resolved value: `const music = await loader.load(Asset.type('music', 'audio/theme.ogg'))`. There is no
+  speculatively. Load them by reference and hold onto the resolved value: `const music = await this.loader.load(Asset.type('music', 'audio/theme.ogg'))`. There is no
   `has()`/`peek()` guard — for a seamless handle read `.ready` / `.state`; for a non-seamless resource, `await` the load (or its returned handle's `.loaded`
   promise) before you use it.
 </Callout>
 
 <Callout type="hint" title="Inspecting what's currently loaded">
-  `loader.inspect()` returns a frozen, sorted snapshot — one row per claimed asset, with its state, claim count, and whether it's in flight or still queued in
+  `this.app.loader.inspect()` returns a frozen, sorted snapshot — one row per claimed asset, with its state, claim count, and whether it's in flight or still queued in
   the background — for debugging or a support bundle. It's read-only: nothing you do with the returned array changes what's actually loaded.
 </Callout>
 
@@ -439,14 +439,14 @@ Releasing only ever drops _your_ claim. Assets loaded through `scene.loader` bel
 
 The lifecycle guarantees that:
 
-- Inside `load`, you can `await loader.load(...)` to fetch assets.
+- Inside `load`, you can `await this.loader.load(...)` to fetch assets.
 - `init` runs once `load` is complete — it is safe to read assets there, and every seamless handle you loaded is already `.ready`.
-- After `init`, the same `loader` is still available. Subsequent calls to `loader.get('same/path.png')` from `update`, `draw`, or other places return the same instance.
-- Calling `loader.get('a/path/you-never-loaded.png')` from anywhere kicks off the fetch itself and hands back a `'loading'` placeholder — check `.ready` before relying on the payload being present.
+- After `init`, `this.loader` is still available. Subsequent calls to `this.loader.get('same/path.png')` from `update`, `draw`, or other places return the same instance.
+- Calling `this.loader.get('a/path/you-never-loaded.png')` from anywhere kicks off the fetch itself and hands back a `'loading'` placeholder — check `.ready` before relying on the payload being present.
 
 ## Loading on demand
 
-`loader.load(...)` works any time, not just inside the `load` hook. A computed path isn't a string literal, so use `Asset.type('texture', ...)`:
+`this.loader.load(...)` (or `this.app.loader.load(...)` for an app-lifetime claim) works any time, not just inside the `load` hook. A computed path isn't a string literal, so use `Asset.type('texture', ...)`:
 
 ```js
 async _changeLevel(levelName) {
@@ -481,8 +481,8 @@ Load the menu catalog once and keep it resident, then load level catalogs as the
 
 ```js
 // In the menu scene
-async load(loader) {
-    await loader.load(MenuAssets);
+async load() {
+    await this.loader.load(MenuAssets);
 }
 
 // Later, when entering gameplay
@@ -493,14 +493,14 @@ async _enterLevel1() {
 }
 ```
 
-Loading is idempotent: a catalog whose leaves are already resident resolves immediately without re-fetching, so you can call `loader.load(Level1Assets)` again from anywhere without a guard. Treat catalog names and their keys as part of your project's asset contract.
+Loading is idempotent: a catalog whose leaves are already resident resolves immediately without re-fetching, so you can call `this.app.loader.load(Level1Assets)` again from anywhere without a guard. Treat catalog names and their keys as part of your project's asset contract.
 
 ### Progress for a loading screen
 
 `loader.load(catalog)` returns a `LoadingQueue` — attach `onProgress` for a per-catalog bar, exactly as in [Progress and parallel loading](#progress-and-parallel-loading):
 
 ```js
-const loading = loader.load(Level1Assets);
+const loading = this.app.loader.load(Level1Assets);
 
 loading.onProgress.add(p => {
   this.bar.value = p.loaded / p.total;
@@ -517,7 +517,7 @@ Awaiting a catalog rejects if any leaf fails. Wrap the await and read each leaf'
 
 ```js
 try {
-  await loader.load(Level1Assets);
+  await this.app.loader.load(Level1Assets);
 } catch {
   if (Level1Assets.tiles.state === 'failed') {
     console.warn('tiles failed:', Level1Assets.tiles.error);
@@ -534,10 +534,10 @@ To fetch a catalog ahead of time without blocking the current scene, pass `{ bac
 
 ```js
 // Kick off the next level while the player is still in this one
-loader.load(Level2Assets, { background: true });
+this.app.loader.load(Level2Assets, { background: true });
 ```
 
-A backgrounded leaf is boosted to fetch immediately if something `get()`s or foreground-`load()`s it before the queue reaches it — so there's nothing to guard against. Request it in the background early, then `await loader.load(Level2Assets)` when you actually need it and it resolves as soon as the in-flight fetch finishes. `loader.awaitBackground()` resolves once the background queue has fully drained.
+A backgrounded leaf is boosted to fetch immediately if something `get()`s or foreground-`load()`s it before the queue reaches it — so there's nothing to guard against. Request it in the background early, then `await this.app.loader.load(Level2Assets)` when you actually need it and it resolves as soon as the in-flight fetch finishes. `this.app.loader.awaitBackground()` resolves once the background queue has fully drained.
 
 ## Caching and IndexedDB
 
@@ -649,14 +649,14 @@ Install the binding by passing it on an [`Extension`](/ExoJS/en/api/extension/) 
 
 ```js
 // Dynamic path or explicit reference
-const field = await loader.load(Asset.type('heightField', 'maps/level-1.hf'));
+const field = await this.loader.load(Asset.type('heightField', 'maps/level-1.hf'));
 
 // Or grouped in a catalog
 const World = Assets.from({ level1: Asset.type('heightField', 'maps/level-1.hf') });
 ```
 
 <Callout type="hint" title="Bare-path inference is opt-in">
-`Asset.type('heightField', ...)` always works. To *also* allow a bare `loader.load('maps/level-1.hf')` (extension-inferred), the type must be **leaf-capable** — either a value type (`isValue: true`) or a resource with a `seamless` adapter that heals in place — and it must declare its file suffixes. Register them on the descriptor and mirror the suffix→type mapping in the type system:
+`Asset.type('heightField', ...)` always works. To *also* allow a bare `this.loader.load('maps/level-1.hf')` (extension-inferred), the type must be **leaf-capable** — either a value type (`isValue: true`) or a resource with a `seamless` adapter that heals in place — and it must declare its file suffixes. Register them on the descriptor and mirror the suffix→type mapping in the type system:
 
 ```ts no-check
 export const heightFieldBinding = defineAsset({

--- a/site/src/content/guide/audio/audio-basics.mdx
+++ b/site/src/content/guide/audio/audio-basics.mdx
@@ -31,10 +31,10 @@ Both types are loaded through the `Loader`, like textures, then played through `
 import { Asset, AudioStream, Scene } from '@codexo/exojs';
 
 class AudioScene extends Scene {
-    async load(loader) {
+    async load() {
         const [laser, theme] = await Promise.all([
-            loader.load('audio/laser.ogg'),
-            loader.load(Asset.type('music', 'audio/theme.ogg')),
+            this.loader.load('audio/laser.ogg'),
+            this.loader.load(Asset.type('music', 'audio/theme.ogg')),
         ]);
         this.laser = laser;
         this.theme = theme;
@@ -140,7 +140,7 @@ Pass `{ toVolume }` to fade the incoming voice to something other than full, and
 For rapid-fire SFX (gunshots, footsteps, UI clicks), set `poolSize` higher and use the default FIFO strategy:
 
 ```js
-const gunshot = loader.get('audio/gunshot.ogg');
+const gunshot = this.loader.get('audio/gunshot.ogg');
 gunshot.poolSize = 24;
 
 // ... hold spacebar to fire rapidly ...

--- a/site/src/content/guide/audio/audio-reactive-visualization.mdx
+++ b/site/src/content/guide/audio/audio-reactive-visualization.mdx
@@ -29,8 +29,8 @@ import { Asset, AudioStream, Scene } from '@codexo/exojs';
 import { AudioAnalyser } from '@codexo/exojs-audio-fx';
 
 class VisualizerScene extends Scene {
-    async load(loader) {
-        this.music = await loader.load(Asset.type('music', 'audio/track.ogg'));
+    async load() {
+        this.music = await this.loader.load(Asset.type('music', 'audio/track.ogg'));
     }
 
     init() {
@@ -153,7 +153,7 @@ A simple scrolling spectrogram:
 ```js
 import { DataTexture, Sprite } from '@codexo/exojs';
 
-init(loader) {
+init() {
     this.analyser = new AudioAnalyser({ fftSize: 512 });
     this.analyser.source = this.app.audio.music;
 
@@ -196,8 +196,8 @@ import { Asset, Application, AudioStream,
 import { AudioAnalyser, BeatDetector } from '@codexo/exojs-audio-fx';
 
 class AudioReactiveScene extends Scene {
-    async load(loader) {
-        this.music = await loader.load(Asset.type('music', 'audio/track.ogg'));
+    async load() {
+        this.music = await this.loader.load(Asset.type('music', 'audio/track.ogg'));
     }
 
     init() {

--- a/site/src/content/guide/audio/spatial-audio.mdx
+++ b/site/src/content/guide/audio/spatial-audio.mdx
@@ -43,7 +43,7 @@ Valid target types are:
 `Sound` itself carries no spatial state — position and distance model live on the `Voice` that `app.audio.play()` returns. Seed the initial position via `PlayOptions`:
 
 ```js
-const pickup = loader.get('audio/pickup.wav');
+const pickup = this.loader.get('audio/pickup.wav');
 const voice = this.app.audio.play(pickup, { position: { x: 320, y: 180 } });
 ```
 
@@ -180,11 +180,11 @@ The same explicit-or-derived rule applies symmetrically to the listener: set `ap
 The most common pattern is to set the listener's target to the camera or player once in `init`, then pass a `position` in `PlayOptions` right before each one-shot play:
 
 ```js
-init(loader) {
-    this.pickupSfx = loader.get('audio/pickup.wav');
+init() {
+    this.pickupSfx = this.loader.get('audio/pickup.wav');
     this.pickupSfx.volume = 0.6;
 
-    app.audio.listener.target = this.player;
+    this.app.audio.listener.target = this.player;
 }
 
 update(delta) {
@@ -203,7 +203,7 @@ A voice played without a `position` plays non-spatially — full volume in both 
 For ambient sounds that should follow the listener's general area but not overlap, set a large `refDistance`:
 
 ```js
-const waterfall = loader.get('audio/waterfall.ogg');
+const waterfall = this.loader.get('audio/waterfall.ogg');
 const voice = this.app.audio.play(waterfall, {
     loop: true,
     position: { x: 600, y: 200 },

--- a/site/src/content/guide/debugging/custom-renderers.mdx
+++ b/site/src/content/guide/debugging/custom-renderers.mdx
@@ -30,9 +30,9 @@ class CustomPassScene extends Scene {
     private pipeline!: RenderPipeline;
     private angle = 0;
 
-    override init(loader): void {
-        this.back = new Sprite(loader.get('image/hero.png')).setAnchor(0.5).setPosition(280, 300);
-        this.front = new Sprite(loader.get('image/hero.png')).setAnchor(0.5).setPosition(520, 300);
+    override init(): void {
+        this.back = new Sprite(this.loader.get('image/hero.png')).setAnchor(0.5).setPosition(280, 300);
+        this.front = new Sprite(this.loader.get('image/hero.png')).setAnchor(0.5).setPosition(520, 300);
         this.between = new Graphics();
 
         this.pipeline = new RenderPipeline()

--- a/site/src/content/guide/debugging/debugging-and-inspection.mdx
+++ b/site/src/content/guide/debugging/debugging-and-inspection.mdx
@@ -155,7 +155,7 @@ import { Scene, View } from '@codexo/exojs';
 import { RenderPassInspectorLayer } from '@codexo/exojs/debug';
 
 class GameScene extends Scene {
-    init(loader) {
+    init() {
         // ... normal scene setup with filters, sprites, etc. ...
 
         this.inspector = new RenderPassInspectorLayer(this.app);

--- a/site/src/content/guide/effects/post-processing.mdx
+++ b/site/src/content/guide/effects/post-processing.mdx
@@ -72,12 +72,12 @@ class BloomScene extends Scene {
     private blur!: BlurFilter;
     private pipeline!: RenderPipeline;
 
-    override init(loader): void {
+    override init(): void {
         this.baseRt = new RenderTexture(800, 600);
         this.glowRt = new RenderTexture(800, 600);
         this.blurredRt = new RenderTexture(800, 600);
 
-        this.bunny = new Sprite(loader.get('image/bunny.png')).setAnchor(0.5);
+        this.bunny = new Sprite(this.loader.get('image/bunny.png')).setAnchor(0.5);
         this.baseSprite = new Sprite(this.baseRt);
         this.glowSprite = new Sprite(this.blurredRt)
             .setTint(new Color(255, 255, 255, 0.8))
@@ -180,11 +180,11 @@ class TrailScene extends Scene {
     private final!: Sprite;
     private pipeline!: RenderPipeline;
 
-    override init(loader): void {
+    override init(): void {
         this.feedbackRt = new RenderTexture(800, 600);
         this.decay = new Sprite(this.feedbackRt)
             .setTint(new Color(255, 255, 255, 0.93)); // 93% opaque = 7% fade per frame
-        this.hero = new Sprite(loader.get('image/hero.png')).setAnchor(0.5);
+        this.hero = new Sprite(this.loader.get('image/hero.png')).setAnchor(0.5);
         this.final = new Sprite(this.feedbackRt);
 
         this.pipeline = new RenderPipeline()

--- a/site/src/content/guide/getting-started/your-first-scene.mdx
+++ b/site/src/content/guide/getting-started/your-first-scene.mdx
@@ -40,12 +40,12 @@ There's nothing visible yet because the scene doesn't render anything beyond the
 
 Scenes have four lifecycle hooks. You override the ones you need:
 
-- `async load(loader)` — declare assets upfront. Resolves before `init` runs.
-- `init(loader)` — set up state. Assets are available via `loader.get(...)`.
+- `async load()` — declare assets upfront. Resolves before `init` runs.
+- `init()` — set up state. Assets are available via `this.loader.get(...)`.
 - `update(delta)` — per-frame logic.
 - `draw(context)` — per-frame rendering.
 
-This scene skips `load` entirely. `Texture` is a *seamless* asset type: `loader.get(...)` never throws, even for a path nothing has fetched yet — it hands back a placeholder immediately and heals it in place once the network request resolves. That's enough to build and position a sprite directly in `init`:
+This scene skips `load` entirely. `Texture` is a *seamless* asset type: `this.loader.get(...)` never throws, even for a path nothing has fetched yet — it hands back a placeholder immediately and heals it in place once the network request resolves. That's enough to build and position a sprite directly in `init`:
 
 <SourceSnippet
   source="examples/getting-started/hello-world.ts"
@@ -61,7 +61,7 @@ A few things worth pointing out:
 - The default sprite anchor is `(0, 0)` — the top-left. With `setAnchor(0.5)`, the sprite's center becomes its pivot point, so `setPosition(width / 2, height / 2)` places the sprite at the canvas center rather than offset to one corner.
 
 <Callout type="hint" title="Prefer load() once a scene has more than a placeholder">
-Getting away without `load` works because `Texture` heals in place — fine for a one-sprite demo. Once a scene has several assets, or you don't want a visible pop-in while the texture arrives, declare them upfront with `async load(loader) { await loader.load(...); }` instead — see [Loading and resources](/ExoJS/en/guide/assets/loading-and-resources/).
+Getting away without `load` works because `Texture` heals in place — fine for a one-sprite demo. Once a scene has several assets, or you don't want a visible pop-in while the texture arrives, declare them upfront with `async load() { await this.loader.load(...); }` instead — see [Loading and resources](/ExoJS/en/guide/assets/loading-and-resources/).
 </Callout>
 
 <Callout type="pitfall" title="A sprite that won't center">

--- a/site/src/content/guide/input/gamepad.mdx
+++ b/site/src/content/guide/input/gamepad.mdx
@@ -216,7 +216,7 @@ Per-pad bindings are the typical choice for game logic — the player number map
 The `gamepads` array is populated before `init` runs, but the browser's gamepad API only reports connected pads after a button press on some platforms (a browser security restriction). In `init`, check `app.input.connectedGamepads`; if empty, wait for the `onGamepadConnected` signal:
 
 ```js
-init(loader) {
+init() {
     const pad = app.input.firstConnectedGamepad;
 
     if (pad) {

--- a/site/src/content/guide/input/keyboard-and-actions.mdx
+++ b/site/src/content/guide/input/keyboard-and-actions.mdx
@@ -28,7 +28,7 @@ Each returns an `InputBinding` you can call `.unbind()` on to detach early. The 
 import { Keyboard, Scene } from '@codexo/exojs';
 
 class GameScene extends Scene {
-    init(loader) {
+    init() {
         this.inputs.onTrigger(Keyboard.Space, () => {
             this.player.jump();
         });
@@ -43,7 +43,7 @@ class GameScene extends Scene {
 For held-key patterns — movement, continuous actions — use `onActive`/`onStop` to track a boolean flag, then consume it in `update`:
 
 ```js
-init(loader) {
+init() {
     this.move = { left: 0, right: 0, up: 0, down: 0 };
 
     this.inputs.onActive(Keyboard.A, () => { this.move.left  = 1; });
@@ -89,7 +89,7 @@ These are raw — no threshold, no auto-disposal. Use them for global shortcuts 
 The `onKeyDown` signal accepts a callback that receives the raw channel number. This is the mechanism for letting the player remap controls at runtime:
 
 ```js
-init(loader) {
+init() {
     this.jumpChannel = Keyboard.Space;
     this.rebindRequested = false;
     this.jumpDirty = true;
@@ -194,12 +194,12 @@ Scene-scoped bindings from `this.inputs` are cleaned up when the scene unloads, 
 import { GamepadAxis, GamepadButton, Keyboard, Scene, Sprite } from '@codexo/exojs';
 
 class PlayerScene extends Scene {
-    async load(loader) {
-        await loader.load('image/hero.png');
+    async load() {
+        await this.loader.load('image/hero.png');
     }
 
-    init(loader) {
-        this.sprite = new Sprite(loader.get('image/hero.png'))
+    init() {
+        this.sprite = new Sprite(this.loader.get('image/hero.png'))
             .setAnchor(0.5)
             .setPosition(400, 300);
 
@@ -277,7 +277,7 @@ The "best input wins" logic — `Math.abs(this.stick.x) > Math.abs(keyX)` — pi
 A clean pattern for larger projects is to centralise input state in a small plain object and let each device category write into it:
 
 ```js
-init(loader) {
+init() {
     // One source of truth for movement intent
     this.move = { x: 0, y: 0 };
     this.actions = { jump: 0, interact: 0, pause: 0 };
@@ -326,7 +326,7 @@ This keeps input handling in one location, makes it easy to add a third device (
 Scene-scoped bindings (`this.inputs.onTrigger(...)`) are automatically disposed when the scene's `destroy` runs. Per-pad bindings (`pad.onTrigger(...)`) are not — they live on the `Gamepad` instance, which outlives any single scene. Store per-pad bindings in an array and unbind them in `destroy`:
 
 ```js
-init(loader) {
+init() {
     this._padBindings = [];
     const pad = this.app.input.getGamepad(0);
 

--- a/site/src/content/guide/input/mouse-and-pointer.mdx
+++ b/site/src/content/guide/input/mouse-and-pointer.mdx
@@ -74,7 +74,7 @@ this.inputs.onActive(Pointer.Slot1X, value => {
 For most multi-touch use cases, tracking pointer instances by ID via the signal API is simpler:
 
 ```js
-init(loader) {
+init() {
     this.pointers = new Map();
 
     this.app.input.onPointerDown.add(p => {
@@ -138,8 +138,8 @@ For raw canvas backing-store pixels — e.g. an off-screen render target at a di
 A `Sprite` (or any `RenderNode`) can be made interactive and draggable directly:
 
 ```js
-init(loader) {
-    this.sprite = new Sprite(loader.get('image/hero.png'));
+init() {
+    this.sprite = new Sprite(this.loader.get('image/hero.png'));
     this.sprite.setAnchor(0.5);
     this.sprite.setPosition(400, 300);
 

--- a/site/src/content/guide/recipes/audio-reactive-scene.mdx
+++ b/site/src/content/guide/recipes/audio-reactive-scene.mdx
@@ -33,10 +33,10 @@ import {
 const app = new Application({ extensions: [particlesExtension] });
 
 class AudioReactiveScene extends Scene {
-    async load(loader) {
+    async load() {
         const [music, particleTexture] = await Promise.all([
-            loader.load(Asset.type('music', 'audio/track.ogg')),
-            loader.load('image/particle.png'),
+            this.loader.load(Asset.type('music', 'audio/track.ogg')),
+            this.loader.load('image/particle.png'),
         ]);
         this.music = music;
         this.particleTexture = particleTexture;

--- a/site/src/content/guide/recipes/camera-follow-and-parallax.mdx
+++ b/site/src/content/guide/recipes/camera-follow-and-parallax.mdx
@@ -19,9 +19,9 @@ Snapping `view.setCenter` onto the player every frame feels rigid. Ease it inste
 </Callout>
 
 ```js
-init(loader) {
+init() {
     this._view = new View(400, 300, 800, 600);
-    this.player = new Sprite(loader.get('image/hero.png'));
+    this.player = new Sprite(this.loader.get('image/hero.png'));
 }
 
 update(delta) {
@@ -52,7 +52,7 @@ The multiplier controls how quickly the camera catches up. Higher values = snapp
 For menu screens, background effects, or mouse-driven depth, offset layers proportionally to the pointer position relative to the screen center:
 
 ```js
-init(loader) {
+init() {
     // Three layers at different depths
     this._layers = [0.15, 0.35, 0.6].map(speed => {
         const g = new Graphics();

--- a/site/src/content/guide/recipes/game-feel.mdx
+++ b/site/src/content/guide/recipes/game-feel.mdx
@@ -21,8 +21,8 @@ When the player takes damage, flash the sprite red for a fraction of a second an
 ```js
 import { ColorFilter, Signal } from '@codexo/exojs';
 
-init(loader) {
-    this.player = new Sprite(loader.get('image/hero.png'));
+init() {
+    this.player = new Sprite(this.loader.get('image/hero.png'));
     this.flash = new ColorFilter(new Color(255, 255, 255, 1));
     this.player.filters = [this.flash];
 

--- a/site/src/content/guide/recipes/split-screen.mdx
+++ b/site/src/content/guide/recipes/split-screen.mdx
@@ -15,7 +15,7 @@ Split screen renders the same scene from two (or more) camera viewpoints into se
 Create two `View` objects. Each gets its own viewport rectangle — the left view covers the left half of the canvas, the right view covers the right half. In `draw`, set the backend's active view, render the shared world, swap views, render again:
 
 ```js
-init(loader) {
+init() {
     const { width, height } = this.app.canvas;
 
     // Left player view — left half of screen
@@ -32,10 +32,10 @@ init(loader) {
     this._divider.drawRectangle(width / 2 - 1, 0, 2, height);
 
     // Shared world objects — both views see these
-    this._leftPlayer = new Sprite(loader.get('image/hero.png'))
+    this._leftPlayer = new Sprite(this.loader.get('image/hero.png'))
         .setAnchor(0.5)
         .setTint(new Color(120, 190, 255));
-    this._rightPlayer = new Sprite(loader.get('image/hero.png'))
+    this._rightPlayer = new Sprite(this.loader.get('image/hero.png'))
         .setAnchor(0.5)
         .setTint(new Color(255, 180, 120));
 }

--- a/site/src/content/guide/recipes/ui-patterns.mdx
+++ b/site/src/content/guide/recipes/ui-patterns.mdx
@@ -14,13 +14,13 @@ In-canvas UI means text boxes, dialog panels, progress indicators, and interacti
 A dialog system shows text one character at a time, accompanied by a subtle sound. It's built from three primitives: a `Text` node for the dialog text, a `Sound` for the character tick, and a timer (or tween) to drive the reveal:
 
 ```js
-init(loader) {
+init() {
     this.lines = [
         'Commander, the anomaly has entered low orbit.',
         'All wings hold formation and await my signal.',
     ];
 
-    this.portrait = new Sprite(loader.get('image/portrait.png'))
+    this.portrait = new Sprite(this.loader.get('image/portrait.png'))
         .setAnchor(0.5).setScale(1.7).setPosition(170, 420);
 
     this.box = new Text('', {
@@ -30,7 +30,7 @@ init(loader) {
     });
     this.box.setPosition(270, 360);
 
-    this.beep = loader.get('audio/beep.ogg');
+    this.beep = this.loader.get('audio/beep.ogg');
 
     this.lineIndex = 0;
     this.chars = 0;
@@ -85,12 +85,12 @@ The pattern is self-contained: the scene owns the dialog state, `update` drives 
 A radial progress ring using a custom shader filter and a tween. The shader draws a circular arc — a `uProgress` uniform controls how much of the circle is filled. A tween drives `uProgress` from 0 to 1:
 
 ```js
-init(loader) {
+init() {
     this.progress = { v: 0 };
     this.label = new Text('0%', { fillColor: Color.white, fontSize: 42 });
     this.label.setPosition(360, 410);
 
-    this.ring = new Sprite(loader.get('image/uv.png')).setScale(2.2);
+    this.ring = new Sprite(this.loader.get('image/uv.png')).setScale(2.2);
     this.filter = new WebGl2ShaderFilter({
         fragmentSource: progressGlsl,
         uniforms: { uProgress: 0 },

--- a/site/src/content/guide/rendering/animation.mdx
+++ b/site/src/content/guide/rendering/animation.mdx
@@ -20,8 +20,8 @@ All three can coexist in one scene. Use tweens for UI transitions and canned mot
 A [`Tween`](/ExoJS/en/api/tween/) interpolates numeric properties on any target object from their current value to configured end values over a duration in seconds. Create one through `app.tweens.create(target)`, configure it fluently, and call `start()`:
 
 ```js
-init(loader) {
-    this.sprite = new Sprite(loader.get('image/hero.png'));
+init() {
+    this.sprite = new Sprite(this.loader.get('image/hero.png'));
     this.sprite.setAnchor(0.5);
     this.sprite.setPosition(100, 300);
 

--- a/site/src/content/guide/rendering/graphics.mdx
+++ b/site/src/content/guide/rendering/graphics.mdx
@@ -125,7 +125,7 @@ For shapes that do not change, create the `Graphics` once in `init` and never ca
 Because `Graphics` extends `Container`, it inherits position, rotation, scale, and origin. A single `Graphics` object with several drawn shapes behaves as a group — rotating the `Graphics` rotates all its shape children together:
 
 ```js
-init(loader) {
+init() {
     this.group = new Graphics();
     this.group.fillColor = Color.goldenrod;
     this.group.drawCircle(-40, 0, 20);

--- a/site/src/content/guide/rendering/render-targets.mdx
+++ b/site/src/content/guide/rendering/render-targets.mdx
@@ -39,7 +39,7 @@ Default sampler settings — linear filtering, clamp-to-edge wrapping, premultip
 Set the render target on the backend, draw normally, then restore the canvas:
 
 ```js
-init(loader) {
+init() {
     const backend = this.app.backend;
 
     this.offscreen = new RenderTexture(256, 256);
@@ -113,7 +113,7 @@ The `setSize()` method changes the texture dimensions. `powerOfTwo` reports whet
 **Cached layers.** Render a complex, static container once into a `RenderTexture`, then display the result as a sprite. Subsequent frames skip the container's render tree entirely — one texture draw instead of N child draws:
 
 ```js
-init(loader) {
+init() {
     this.buildComplexScene(); // builds this.staticLayer
 
     this.cache = new RenderTexture(

--- a/site/src/content/guide/rendering/sprites.mdx
+++ b/site/src/content/guide/rendering/sprites.mdx
@@ -18,12 +18,12 @@ A sprite needs a texture. The shortest path from file to visible quad:
 import { Scene, Sprite } from '@codexo/exojs';
 
 class MyScene extends Scene {
-    async load(loader) {
-        await loader.load('image/hero.png');
+    async load() {
+        await this.loader.load('image/hero.png');
     }
 
-    init(loader) {
-        this.hero = new Sprite(loader.get('image/hero.png'));
+    init() {
+        this.hero = new Sprite(this.loader.get('image/hero.png'));
         this.addChild(this.hero);
     }
 
@@ -43,10 +43,10 @@ A sprite's position places its anchor point in the parent's coordinate space. By
 `setAnchor(0.5)` centers the anchor at the sprite's middle, making `setPosition(400, 300)` place the sprite's center at `(400, 300)`:
 
 ```js
-init(loader) {
+init() {
     const { width, height } = this.app.canvas;
 
-    this.hero = new Sprite(loader.get('image/hero.png'));
+    this.hero = new Sprite(this.loader.get('image/hero.png'));
     this.hero.setAnchor(0.5);
     this.hero.setPosition(width / 2, height / 2);
     this.addChild(this.hero);
@@ -169,7 +169,7 @@ The `animations` map feeds into `AnimatedSprite.fromSpritesheet()`, covered in t
 // Video as a sprite texture
 import { Asset, RenderTexture, Sprite, Video } from '@codexo/exojs';
 
-const video = await loader.load(Asset.type('video', 'intro.mp4'));
+const video = await this.loader.load(Asset.type('video', 'intro.mp4'));
 const sprite = new Sprite(video.texture);
 
 // A RenderTexture (offscreen render) as a sprite texture

--- a/site/src/content/guide/rendering/text.mdx
+++ b/site/src/content/guide/rendering/text.mdx
@@ -35,11 +35,11 @@ label.style.fillColor = Color.tomato; // updates only the mesh tint — no atlas
 System fonts (Arial, Times New Roman, etc.) work immediately. For custom web fonts, load one via `Asset.type('font', ...)` in the scene's `load` hook — fonts aren't a seamless type, so a bare path isn't enough; an explicit descriptor is required even for a literal path, and `family` is a required option:
 
 ```js
-async load(loader) {
-    await loader.load(Asset.type('font', 'font/MyFont.woff2', { family: 'MyFont' }));
+async load() {
+    await this.loader.load(Asset.type('font', 'font/MyFont.woff2', { family: 'MyFont' }));
 }
 
-init(loader) {
+init() {
     this.title = new Text('Custom Font', {
         fontFamily: 'MyFont',
         fontSize: 48,

--- a/site/src/content/guide/runtime/scene-graph.mdx
+++ b/site/src/content/guide/runtime/scene-graph.mdx
@@ -17,9 +17,9 @@ Two key types: [`RenderNode`](/ExoJS/en/api/render-node/) is the abstract base f
 Every scene starts with one container already in place — `this.root`. Adding a node via `this.addChild(...)` is shorthand for `this.root.addChild(...)`:
 
 ```js
-init(loader) {
-    this.hero = new Sprite(loader.get('hero.png'));
-    this.coin = new Sprite(loader.get('coin.png'));
+init() {
+    this.hero = new Sprite(this.loader.get('hero.png'));
+    this.coin = new Sprite(this.loader.get('coin.png'));
 
     this.addChild(this.hero);
     this.addChild(this.coin);
@@ -29,12 +29,12 @@ init(loader) {
 For larger scenes, build sub-containers and add nodes to them instead:
 
 ```js
-init(loader) {
+init() {
     this.world = new Container();
     this.hud = new Container();
 
-    this.world.addChild(new Sprite(loader.get('level.png')));
-    this.hud.addChild(new Sprite(loader.get('health-bar.png')));
+    this.world.addChild(new Sprite(this.loader.get('level.png')));
+    this.hud.addChild(new Sprite(this.loader.get('health-bar.png')));
 
     this.addChild(this.world);
     this.addChild(this.hud);
@@ -51,8 +51,8 @@ When a parent transforms, its children move with it. If you set the parent's pos
 this.player = new Container();
 this.player.setPosition(100, 0);
 
-const body = new Sprite(loader.get('body.png'));
-const head = new Sprite(loader.get('head.png'));
+const body = new Sprite(this.loader.get('body.png'));
+const head = new Sprite(this.loader.get('head.png'));
 head.setPosition(0, -32);
 
 this.player.addChild(body);


### PR DESCRIPTION
23 guide files still taught `init(loader)` / `load(loader)` / bare `loader.…` in their code samples. That signature does not exist: the current hooks are `load(_data)` and `init(_data)` with no loader parameter (`src/core/Scene.ts:340,352`); the loader is reached via `this.loader` (scene-scoped) or `this.app.loader` (full surface).

All 20 known-affected files needed changes; three more had the identical drift and are included. `examples/**` was swept too and was already correct.

`assets/loading-and-resources.mdx` got the deepest rework — its prose already said `this.app.loader` while nearly every sample contradicted it. `release()`, `inspect()`, `awaitBackground()` and the `onLoad*`/`onError` signals are routed through `this.app.loader` specifically, since `SceneLoader` genuinely lacks those members.

`pnpm typecheck:guides` passes.

## Known gap this PR does NOT close

The guide gate is toothless for exactly this class of error, so it will drift back without a follow-up.

Verified empirically: re-introducing `init(loader)` into `rendering/sprites.mdx` still leaves `pnpm typecheck:guides` at exit 0. The cause is not `no-check` — the 12 markers in the tree sit on unrelated blocks — but the fence language. The samples are ```js, and `scripts/extract-guide-snippets.ts:718` extracts `js` blocks as `.js` under `allowJs`, where TypeScript does not check override signatures at all; a surplus hook parameter is simply not an error in JS.

Converting the samples to ```ts fences is the fix. Tracked separately so this PR stays a content fix.