### PR TITLE
feat(input)!: key channels from KeyboardEvent.code instead of layout-dependent keyCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,6 +265,27 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
   order, instead of synchronously off the raw `pointermove`/timer callback.
   Handlers that relied on running mid-event now run on the next frame
   boundary, in order relative to the pointer phases that produced them.
+- **BREAKING — keyboard channels resolve from the physical key
+  (`KeyboardEvent.code`), fixing bindings on non-US layouts.**
+  `KeyboardEvent.keyCode` reports the layout's own character mapping, so the
+  physical key at the QWERTY "A" position reports the `Q` keyCode on a French
+  AZERTY keyboard and the `Y`/`Z` keys swap on a German QWERTZ one — a WASD
+  binding silently landed on the wrong physical keys for those players. A
+  `Keyboard` member now denotes a physical key POSITION, identical across
+  layouts; the member names and channel values are unchanged (they name the
+  key by its US-QWERTY legend, so `Keyboard.Colon` is the key a QWERTZ
+  keyboard prints "ö" on), and persisted numeric bindings keep working — but
+  the values are opaque slots now, not `keyCode`s. Also: a key ExoJS does not
+  track (media and IME/language keys, and the empty `code` a soft keyboard
+  reports) drives no channel at all instead of writing into whatever slot its
+  `keyCode` happened to fall on; each modifier stays ONE channel covering both
+  physical sides (`ShiftLeft`/`ShiftRight` → `Keyboard.Shift`);
+  `Keyboard.Clear` is removed (it has no `code` — that physical key is
+  `Keyboard.NumPad5`); and `Meta`, `ContextMenu`, `PrintScreen`,
+  `NumPadEqual`, `IntlBackslash`, `IntlRo`, `IntlYen` are added for physical
+  keys that previously had no name. New `keyboardChannelFromCode(code)`
+  resolves a raw DOM `code` to its channel for rebinding UIs that work off DOM
+  events.
 
 ### Removed
 

--- a/site/src/content/api/functions.json
+++ b/site/src/content/api/functions.json
@@ -6,10 +6,10 @@
   "subsystem": "core",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 24,
+  "memberCount": 25,
   "counts": {
     "constructors": 0,
-    "methods": 17,
+    "methods": 18,
     "properties": 7,
     "events": 0
   },
@@ -751,6 +751,61 @@
           ],
           "returnType": "boolean",
           "description": "Return true when value is a non-zero power of two."
+        },
+        {
+          "name": "keyboardChannelFromCode",
+          "signature": "keyboardChannelFromCode(code: string): Keyboard | undefined",
+          "signatureTokens": [
+            {
+              "text": "keyboardChannelFromCode",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "code",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Keyboard",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "undefined",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "code",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Keyboard | undefined",
+          "description": "Resolve a KeyboardEvent.code to its Keyboard channel, or undefined for a key ExoJS does not track (media and IME/language keys, and the empty code a soft keyboard reports). This is the single seam between the platform's physical-key identity and the engine's channel model — see Keyboard for what \"physical\" means here and why keyCode is never used. Useful in a rebinding UI that has a raw DOM event rather than an engine channel; InputManager.onKeyDown already reports the resolved channel."
         },
         {
           "name": "lerp",

--- a/site/src/content/api/keyboard.json
+++ b/site/src/content/api/keyboard.json
@@ -1,12 +1,12 @@
 {
   "title": "Keyboard",
-  "description": "Channel indices for keyboard keys, derived from the legacy `KeyboardEvent.keyCode` map. Pass any value to the Input constructor to react to that key.",
+  "description": "Channel indices for keyboard keys, addressed by PHYSICAL key position. Pass any value to the Input constructor to react to that key. A key is identified by the Web platform's layout-independent `KeyboardEvent.code` (see keyboardChannelFromCode), not by the layout-dependent `keyCode`: Keyboard.A is the key at the QWERTY \"A\" position on every layout — the one an AZERTY keyboard prints \"Q\" on — so WASD-style bindings stay in the same place under the player's hand regardless of the player's layout. Every member therefore names a POSITION, described by the glyph a US-QWERTY keyboard prints there, and NOT the character the key actually produces: Keyboard.Z is the key a German QWERTZ keyboard prints \"Y\" on, and Keyboard.Colon the key it prints \"ö\" on. Use DOM text input for anything that needs the typed character, dead keys, or IME composition. The values are opaque channel indices inside the keyboard category — do not assume they equal any `keyCode`. Each modifier is ONE channel covering both physical sides: `ShiftLeft` and `ShiftRight` both drive Keyboard.Shift.",
   "symbol": "Keyboard",
   "kind": "enum",
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 99,
+  "memberCount": 105,
   "counts": {
     "constructors": 0,
     "methods": 0,
@@ -19,7 +19,11 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "Channel indices for keyboard keys, derived from the legacy `KeyboardEvent.keyCode` map. Pass any value to the Input constructor to react to that key."
+        "Channel indices for keyboard keys, addressed by PHYSICAL key position. Pass any value to the Input constructor to react to that key.",
+        "A key is identified by the Web platform's layout-independent `KeyboardEvent.code` (see keyboardChannelFromCode), not by the layout-dependent `keyCode`: Keyboard.A is the key at the QWERTY \"A\" position on every layout — the one an AZERTY keyboard prints \"Q\" on — so WASD-style bindings stay in the same place under the player's hand regardless of the player's layout.",
+        "Every member therefore names a POSITION, described by the glyph a US-QWERTY keyboard prints there, and NOT the character the key actually produces: Keyboard.Z is the key a German QWERTZ keyboard prints \"Y\" on, and Keyboard.Colon the key it prints \"ö\" on. Use DOM text input for anything that needs the typed character, dead keys, or IME composition.",
+        "The values are opaque channel indices inside the keyboard category — do not assume they equal any `keyCode`.",
+        "Each modifier is ONE channel covering both physical sides: `ShiftLeft` and `ShiftRight` both drive Keyboard.Shift."
       ],
       "importLine": "import { Keyboard } from '@codexo/exojs'",
       "sourceLink": null
@@ -120,19 +124,6 @@
           "description": ""
         },
         {
-          "name": "Clear",
-          "signature": "Clear",
-          "signatureTokens": [
-            {
-              "text": "Clear",
-              "kind": "name"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
           "name": "ClosedBracket",
           "signature": "ClosedBracket",
           "signatureTokens": [
@@ -164,6 +155,19 @@
           "signatureTokens": [
             {
               "text": "Comma",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "ContextMenu",
+          "signature": "ContextMenu",
+          "signatureTokens": [
+            {
+              "text": "ContextMenu",
               "kind": "name"
             }
           ],
@@ -588,6 +592,45 @@
           "description": ""
         },
         {
+          "name": "IntlBackslash",
+          "signature": "IntlBackslash",
+          "signatureTokens": [
+            {
+              "text": "IntlBackslash",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "IntlRo",
+          "signature": "IntlRo",
+          "signatureTokens": [
+            {
+              "text": "IntlRo",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "IntlYen",
+          "signature": "IntlYen",
+          "signatureTokens": [
+            {
+              "text": "IntlYen",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
           "name": "J",
           "signature": "J",
           "signatureTokens": [
@@ -645,6 +688,19 @@
           "signatureTokens": [
             {
               "text": "M",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "Meta",
+          "signature": "Meta",
+          "signatureTokens": [
+            {
+              "text": "Meta",
               "kind": "name"
             }
           ],
@@ -874,6 +930,19 @@
           "description": ""
         },
         {
+          "name": "NumPadEqual",
+          "signature": "NumPadEqual",
+          "signatureTokens": [
+            {
+              "text": "NumPadEqual",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
           "name": "NumPadMultiply",
           "signature": "NumPadMultiply",
           "signatureTokens": [
@@ -996,6 +1065,19 @@
           "signatureTokens": [
             {
               "text": "Period",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "PrintScreen",
+          "signature": "PrintScreen",
+          "signatureTokens": [
+            {
+              "text": "PrintScreen",
               "kind": "name"
             }
           ],

--- a/site/src/content/guide/input/keyboard-and-actions.mdx
+++ b/site/src/content/guide/input/keyboard-and-actions.mdx
@@ -9,7 +9,7 @@ import Callout from '../../../components/Callout.astro';
 
 # Keyboard & actions
 
-ExoJS maps keys to numeric channels via the [`Keyboard`](/ExoJS/en/api/keyboard/) enum. `Keyboard.Space` is channel 32, `Keyboard.A` is 65, `Keyboard.Left` is 37. Values follow the browser's legacy `KeyboardEvent.keyCode` mapping. Keys only fire while the canvas has focus; when focus leaves, all held keys are released automatically.
+ExoJS maps keys to numeric channels via the [`Keyboard`](/ExoJS/en/api/keyboard/) enum. A member names a **physical key position**, resolved from the browser's layout-independent `KeyboardEvent.code` — `Keyboard.A` is the key at the QWERTY "A" position on every layout, the one an AZERTY keyboard prints "Q" on, so a WASD binding stays the same physical square under the player's hand. The names describe the US-QWERTY legend, not the character the key produces; use DOM text input for typed characters, dead keys, and IME composition. The channel numbers themselves are opaque values — do not assume they equal any `keyCode`. Keys only fire while the canvas has focus; when focus leaves, all held keys are released automatically.
 
 ## Scene-scoped bindings
 
@@ -141,7 +141,7 @@ Keyboard.F1 .. Keyboard.F12
 Keyboard.NumPad0 .. Keyboard.NumPad9
 ```
 
-The full list includes punctuation, brackets, and navigation keys. All values match the browser's legacy `KeyboardEvent.keyCode` map used by ExoJS.
+The full list includes punctuation, brackets, and navigation keys. Punctuation members carry the glyph a US-QWERTY keyboard prints on that key (`Keyboard.Colon`, `Keyboard.Tilde`, `Keyboard.OpenBracket`, …) — the name is the US legend, the binding is the position, so on a QWERTZ keyboard `Keyboard.Colon` is the key printed "ö". A modifier is one channel per role, not per side: `ShiftLeft` and `ShiftRight` both drive `Keyboard.Shift`. Keys ExoJS does not track (media keys, IME/language keys) drive no channel at all. To resolve a raw DOM event yourself — in a rebinding UI, say — use `keyboardChannelFromCode(event.code)`.
 
 ## Canvas focus
 

--- a/site/src/content/guide/runtime/coordinates-and-views.mdx
+++ b/site/src/content/guide/runtime/coordinates-and-views.mdx
@@ -74,7 +74,7 @@ The `setZoom(z)` method scales how much world fits inside the view. `setZoom(2)`
 init() {
     this.zoom = 1;
 
-    this.inputs.onTrigger(Keyboard.Equals, () => { // the =/+ key
+    this.inputs.onTrigger(Keyboard.Equals, () => { // the key printed =/+ on US QWERTY
         this.zoom += 0.1;
     });
 }

--- a/site/src/content/guide/shipping/troubleshooting.mdx
+++ b/site/src/content/guide/shipping/troubleshooting.mdx
@@ -152,7 +152,9 @@ If you're using the `audio-reactive` template from `create-exo-app`, it already 
 
 **Canvas focus.** ExoJS keyboard and gamepad input requires the canvas to have focus. Click the canvas once to give it focus. If your page has other focusable elements that steal focus, keyboard input stops until the canvas is clicked again.
 
-**Key name mismatch.** ExoJS uses the `Keyboard` enum. `Keyboard.Space`, `Keyboard.A`, `Keyboard.ArrowLeft` — the names match the Web `KeyboardEvent.code` values but mapped to numeric channels. Check the [Keyboard guide](/ExoJS/en/guide/input/keyboard-and-actions/) for the full enum.
+**Key name mismatch.** ExoJS uses the `Keyboard` enum — `Keyboard.Space`, `Keyboard.A`, `Keyboard.Left`. Each member is a physical key position resolved from the Web `KeyboardEvent.code`, mapped to a numeric channel; the arrow keys are `Left`/`Up`/`Right`/`Down`, not `ArrowLeft`. Check the [Keyboard guide](/ExoJS/en/guide/input/keyboard-and-actions/) for the full enum.
+
+**A key produces a different character than its name.** That is intended: the enum names a *position* by its US-QWERTY legend, so `Keyboard.Z` is the key printed "Y" on a German QWERTZ keyboard and `Keyboard.Colon` the one printed "ö". Bindings stay physically where the player expects them. Never use the channel system to read typed text — use a DOM text input for characters, dead keys, and IME composition.
 
 **Input not polled in `update`.** Keyboard held-key state (`isActive`) and gamepad axis values are sampled per-frame inside `update`. Reading them in `init` or outside the frame loop gives stale results.
 

--- a/src/input/InputManager.ts
+++ b/src/input/InputManager.ts
@@ -17,6 +17,7 @@ import { builtInGamepadDefinitions, resolveGamepadDefinition } from './GamepadDe
 import { type GestureJournalEvent, GestureRecognizer } from './GestureRecognizer';
 import type { InputBindingOptions, InputChannel } from './InputBinding';
 import { InputBinding } from './InputBinding';
+import { keyboardChannelFromCode } from './keyboardCodes';
 import { computeDesignPoint, Pointer, PointerState, PointerStateFlag } from './Pointer';
 import { ChannelOffset, ChannelSize, maxPointers, pointerSlotSize, resolveGamepadSlotChannel } from './types';
 
@@ -758,12 +759,23 @@ export class InputManager {
     pointer.destroy();
   }
 
+  /**
+   * Keys are identified by PHYSICAL position (`KeyboardEvent.code`), never by
+   * the layout-dependent `keyCode` — see {@link keyboardChannelFromCode}. A
+   * key with no channel of its own (media and IME/language keys, and the empty
+   * `code` a soft keyboard reports) is ignored outright rather than writing
+   * into an arbitrary slot.
+   */
   private handleKeyDown(event: KeyboardEvent): void {
     if (!this.canvasFocusedValue) {
       return;
     }
 
-    const channel = ChannelOffset.Keyboard + event.keyCode;
+    const channel = keyboardChannelFromCode(event.code);
+
+    if (channel === undefined) {
+      return;
+    }
 
     this.channels[channel] = 1;
     this._recordChannelChanges(channel, 1);
@@ -775,12 +787,17 @@ export class InputManager {
     }
   }
 
+  /** Physical-key resolution and unmapped-key handling exactly as in {@link handleKeyDown}. */
   private handleKeyUp(event: KeyboardEvent): void {
     if (!this.canvasFocusedValue) {
       return;
     }
 
-    const channel = ChannelOffset.Keyboard + event.keyCode;
+    const channel = keyboardChannelFromCode(event.code);
+
+    if (channel === undefined) {
+      return;
+    }
 
     this.channels[channel] = 0;
     this._recordChannelChanges(channel, 1);

--- a/src/input/index.ts
+++ b/src/input/index.ts
@@ -17,6 +17,7 @@ export * from './InteractionEvent';
 export * from './InteractionManager';
 export * from './JoyConLeftGamepadMapping';
 export * from './JoyConRightGamepadMapping';
+export { keyboardChannelFromCode } from './keyboardCodes';
 export * from './KeyEvent';
 export * from './PlayStationGamepadMapping';
 export { Pointer, PointerState } from './Pointer';

--- a/src/input/keyboardCodes.ts
+++ b/src/input/keyboardCodes.ts
@@ -1,0 +1,177 @@
+import { Keyboard } from './types';
+
+/**
+ * Physical key (`KeyboardEvent.code`) → {@link Keyboard} channel.
+ *
+ * `code` names a key by its POSITION on a US-QWERTY reference keyboard and is
+ * identical across layouts, so the entry for `'KeyA'` is the key an AZERTY
+ * keyboard prints "Q" on and a QWERTZ keyboard prints "A" on. That is exactly
+ * what a game binding wants: WASD stays a physical square under the player's
+ * hand. `KeyboardEvent.keyCode` cannot express this — it reports the layout's
+ * own character mapping, so the same physical key yields a different number
+ * per layout.
+ *
+ * The `code` spelling lives in this table only. {@link Keyboard} member names
+ * stay as they are, so a punctuation key is listed under the glyph a US-QWERTY
+ * keyboard prints on it (`'Semicolon'` → {@link Keyboard.Colon}) rather than
+ * under a matching name.
+ *
+ * Both physical sides of a modifier deliberately share one channel
+ * (`ShiftLeft`/`ShiftRight` → {@link Keyboard.Shift}); the legacy `OSLeft`/
+ * `OSRight` spellings some browsers still emit alias onto
+ * {@link Keyboard.Meta}. Codes with no entry here (media keys, IME/language
+ * keys, and the empty `code` reported by soft keyboards) drive no channel.
+ */
+const channelsByCode = new Map<string, Keyboard>([
+  // Alphanumeric block.
+  ['KeyA', Keyboard.A],
+  ['KeyB', Keyboard.B],
+  ['KeyC', Keyboard.C],
+  ['KeyD', Keyboard.D],
+  ['KeyE', Keyboard.E],
+  ['KeyF', Keyboard.F],
+  ['KeyG', Keyboard.G],
+  ['KeyH', Keyboard.H],
+  ['KeyI', Keyboard.I],
+  ['KeyJ', Keyboard.J],
+  ['KeyK', Keyboard.K],
+  ['KeyL', Keyboard.L],
+  ['KeyM', Keyboard.M],
+  ['KeyN', Keyboard.N],
+  ['KeyO', Keyboard.O],
+  ['KeyP', Keyboard.P],
+  ['KeyQ', Keyboard.Q],
+  ['KeyR', Keyboard.R],
+  ['KeyS', Keyboard.S],
+  ['KeyT', Keyboard.T],
+  ['KeyU', Keyboard.U],
+  ['KeyV', Keyboard.V],
+  ['KeyW', Keyboard.W],
+  ['KeyX', Keyboard.X],
+  ['KeyY', Keyboard.Y],
+  ['KeyZ', Keyboard.Z],
+  ['Digit0', Keyboard.Zero],
+  ['Digit1', Keyboard.One],
+  ['Digit2', Keyboard.Two],
+  ['Digit3', Keyboard.Three],
+  ['Digit4', Keyboard.Four],
+  ['Digit5', Keyboard.Five],
+  ['Digit6', Keyboard.Six],
+  ['Digit7', Keyboard.Seven],
+  ['Digit8', Keyboard.Eight],
+  ['Digit9', Keyboard.Nine],
+
+  // Punctuation. The channel name is the US-QWERTY glyph; the key itself is
+  // the position, whatever the player's layout prints on it.
+  ['Backquote', Keyboard.Tilde],
+  ['Minus', Keyboard.Dash],
+  ['Equal', Keyboard.Equals],
+  ['BracketLeft', Keyboard.OpenBracket],
+  ['BracketRight', Keyboard.ClosedBracket],
+  ['Backslash', Keyboard.BackwardSlash],
+  ['Semicolon', Keyboard.Colon],
+  ['Quote', Keyboard.Quotes],
+  ['Comma', Keyboard.Comma],
+  ['Period', Keyboard.Period],
+  ['Slash', Keyboard.QuestionMark],
+  ['IntlBackslash', Keyboard.IntlBackslash],
+  ['IntlRo', Keyboard.IntlRo],
+  ['IntlYen', Keyboard.IntlYen],
+
+  // Control and whitespace.
+  ['Space', Keyboard.Space],
+  ['Enter', Keyboard.Enter],
+  ['Tab', Keyboard.Tab],
+  ['Backspace', Keyboard.Backspace],
+  ['Escape', Keyboard.Escape],
+  ['CapsLock', Keyboard.CapsLock],
+  ['ContextMenu', Keyboard.ContextMenu],
+
+  // Modifiers — both sides fold onto one channel.
+  ['ShiftLeft', Keyboard.Shift],
+  ['ShiftRight', Keyboard.Shift],
+  ['ControlLeft', Keyboard.Control],
+  ['ControlRight', Keyboard.Control],
+  ['AltLeft', Keyboard.Alt],
+  ['AltRight', Keyboard.Alt],
+  ['MetaLeft', Keyboard.Meta],
+  ['MetaRight', Keyboard.Meta],
+  ['OSLeft', Keyboard.Meta],
+  ['OSRight', Keyboard.Meta],
+
+  // Navigation and editing.
+  ['ArrowLeft', Keyboard.Left],
+  ['ArrowUp', Keyboard.Up],
+  ['ArrowRight', Keyboard.Right],
+  ['ArrowDown', Keyboard.Down],
+  ['Home', Keyboard.Home],
+  ['End', Keyboard.End],
+  ['PageUp', Keyboard.PageUp],
+  ['PageDown', Keyboard.PageDown],
+  ['Insert', Keyboard.Insert],
+  ['Delete', Keyboard.Delete],
+  ['Help', Keyboard.Help],
+
+  // System.
+  ['PrintScreen', Keyboard.PrintScreen],
+  ['ScrollLock', Keyboard.ScrollLock],
+  ['Pause', Keyboard.Pause],
+  ['NumLock', Keyboard.NumLock],
+
+  // Function row.
+  ['F1', Keyboard.F1],
+  ['F2', Keyboard.F2],
+  ['F3', Keyboard.F3],
+  ['F4', Keyboard.F4],
+  ['F5', Keyboard.F5],
+  ['F6', Keyboard.F6],
+  ['F7', Keyboard.F7],
+  ['F8', Keyboard.F8],
+  ['F9', Keyboard.F9],
+  ['F10', Keyboard.F10],
+  ['F11', Keyboard.F11],
+  ['F12', Keyboard.F12],
+
+  // Numeric keypad.
+  ['Numpad0', Keyboard.NumPad0],
+  ['Numpad1', Keyboard.NumPad1],
+  ['Numpad2', Keyboard.NumPad2],
+  ['Numpad3', Keyboard.NumPad3],
+  ['Numpad4', Keyboard.NumPad4],
+  ['Numpad5', Keyboard.NumPad5],
+  ['Numpad6', Keyboard.NumPad6],
+  ['Numpad7', Keyboard.NumPad7],
+  ['Numpad8', Keyboard.NumPad8],
+  ['Numpad9', Keyboard.NumPad9],
+  ['NumpadAdd', Keyboard.NumPadAdd],
+  ['NumpadSubtract', Keyboard.NumPadSubtract],
+  ['NumpadMultiply', Keyboard.NumPadMultiply],
+  ['NumpadDivide', Keyboard.NumPadDivide],
+  ['NumpadDecimal', Keyboard.NumPadDecimal],
+  ['NumpadEnter', Keyboard.NumPadEnter],
+  ['NumpadEqual', Keyboard.NumPadEqual],
+]);
+
+/**
+ * Resolve a `KeyboardEvent.code` to its {@link Keyboard} channel, or
+ * `undefined` for a key ExoJS does not track (media and IME/language keys, and
+ * the empty `code` a soft keyboard reports). This is the single seam between
+ * the platform's physical-key identity and the engine's channel model — see
+ * {@link Keyboard} for what "physical" means here and why `keyCode` is never
+ * used.
+ *
+ * Useful in a rebinding UI that has a raw DOM event rather than an engine
+ * channel; {@link InputManager.onKeyDown} already reports the resolved channel.
+ *
+ * @example
+ * ```ts
+ * const channel = keyboardChannelFromCode(event.code);
+ *
+ * if (channel !== undefined) {
+ *   profile.jump = channel;
+ * }
+ * ```
+ */
+export function keyboardChannelFromCode(code: string): Keyboard | undefined {
+  return channelsByCode.get(code);
+}

--- a/src/input/types.ts
+++ b/src/input/types.ts
@@ -58,8 +58,27 @@ export enum PointerButton {
 }
 
 /**
- * Channel indices for keyboard keys, derived from the legacy `KeyboardEvent.keyCode`
- * map. Pass any value to the {@link Input} constructor to react to that key.
+ * Channel indices for keyboard keys, addressed by PHYSICAL key position.
+ * Pass any value to the {@link Input} constructor to react to that key.
+ *
+ * A key is identified by the Web platform's layout-independent
+ * `KeyboardEvent.code` (see {@link keyboardChannelFromCode}), not by the
+ * layout-dependent `keyCode`: {@link Keyboard.A} is the key at the QWERTY "A"
+ * position on every layout — the one an AZERTY keyboard prints "Q" on — so
+ * WASD-style bindings stay in the same place under the player's hand
+ * regardless of the player's layout.
+ *
+ * Every member therefore names a POSITION, described by the glyph a US-QWERTY
+ * keyboard prints there, and NOT the character the key actually produces:
+ * {@link Keyboard.Z} is the key a German QWERTZ keyboard prints "Y" on, and
+ * {@link Keyboard.Colon} the key it prints "ö" on. Use DOM text input for
+ * anything that needs the typed character, dead keys, or IME composition.
+ *
+ * The values are opaque channel indices inside the keyboard category — do not
+ * assume they equal any `keyCode`.
+ *
+ * Each modifier is ONE channel covering both physical sides: `ShiftLeft` and
+ * `ShiftRight` both drive {@link Keyboard.Shift}.
  *
  * @example
  * ```ts
@@ -69,7 +88,6 @@ export enum PointerButton {
 export enum Keyboard {
   Backspace = ChannelOffset.Keyboard + 8,
   Tab = ChannelOffset.Keyboard + 9,
-  Clear = ChannelOffset.Keyboard + 12,
   Enter = ChannelOffset.Keyboard + 13,
   Shift = ChannelOffset.Keyboard + 16,
   Control = ChannelOffset.Keyboard + 17,
@@ -86,6 +104,7 @@ export enum Keyboard {
   Up = ChannelOffset.Keyboard + 38,
   Right = ChannelOffset.Keyboard + 39,
   Down = ChannelOffset.Keyboard + 40,
+  PrintScreen = ChannelOffset.Keyboard + 44,
   Insert = ChannelOffset.Keyboard + 45,
   Delete = ChannelOffset.Keyboard + 46,
   Help = ChannelOffset.Keyboard + 47,
@@ -125,6 +144,8 @@ export enum Keyboard {
   X = ChannelOffset.Keyboard + 88,
   Y = ChannelOffset.Keyboard + 89,
   Z = ChannelOffset.Keyboard + 90,
+  Meta = ChannelOffset.Keyboard + 91,
+  ContextMenu = ChannelOffset.Keyboard + 93,
   NumPad0 = ChannelOffset.Keyboard + 96,
   NumPad1 = ChannelOffset.Keyboard + 97,
   NumPad2 = ChannelOffset.Keyboard + 98,
@@ -155,6 +176,13 @@ export enum Keyboard {
   F12 = ChannelOffset.Keyboard + 123,
   NumLock = ChannelOffset.Keyboard + 144,
   ScrollLock = ChannelOffset.Keyboard + 145,
+  NumPadEqual = ChannelOffset.Keyboard + 146,
+  /** The extra key between left `Shift` and `Z` on ISO (non-US) keyboards. */
+  IntlBackslash = ChannelOffset.Keyboard + 147,
+  /** The extra key left of the right `Shift` on Japanese keyboards. */
+  IntlRo = ChannelOffset.Keyboard + 148,
+  /** The extra key right of `Backspace` on Japanese keyboards. */
+  IntlYen = ChannelOffset.Keyboard + 149,
   Colon = ChannelOffset.Keyboard + 186,
   Equals = ChannelOffset.Keyboard + 187,
   Comma = ChannelOffset.Keyboard + 188,

--- a/test/core/__snapshots__/root-index-snapshot.test.ts.snap
+++ b/test/core/__snapshots__/root-index-snapshot.test.ts.snap
@@ -240,6 +240,7 @@ exports[`root index export surface snapshot > sorted runtime export names match 
   "isAdvancedBlendMode",
   "isAudioContextReady",
   "isPowerOfTwo",
+  "keyboardChannelFromCode",
   "lerp",
   "logger",
   "maxPointers",

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -519,6 +519,7 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "isAdvancedBlendMode: variable",
   "isAudioContextReady: variable",
   "isPowerOfTwo: variable",
+  "keyboardChannelFromCode: function",
   "lerp: variable",
   "logger: variable",
   "maxPointers: variable",

--- a/test/input/actions.test.ts
+++ b/test/input/actions.test.ts
@@ -747,7 +747,7 @@ describe('ActionMap × InputManager lifecycle', () => {
     const imCanvas = (im as unknown as { platform: BrowserPlatform }).platform.surface;
 
     imCanvas.dispatchEvent(new FocusEvent('focus'));
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: Keyboard.Space } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space' }));
     im.update(0 as never);
 
     expect(map.jump.active).toBe(true);
@@ -785,7 +785,7 @@ describe('ActionMap × InputManager lifecycle', () => {
     const canvas = (im as unknown as { platform: BrowserPlatform }).platform.surface;
 
     canvas.dispatchEvent(new FocusEvent('focus'));
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: Keyboard.Space } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space' }));
     im.update(0 as never);
     expect(map.jump.pressed).toBe(true);
 
@@ -813,7 +813,7 @@ describe('ActionMap × InputManager lifecycle', () => {
     const canvas = (im as unknown as { platform: BrowserPlatform }).platform.surface;
 
     canvas.dispatchEvent(new FocusEvent('focus'));
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: Keyboard.Space } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space' }));
 
     im.attach(map);
 
@@ -823,7 +823,7 @@ describe('ActionMap × InputManager lifecycle', () => {
     // without the attach-moment snapshot supplying its true held value, so
     // the release would look like an already-0 channel instead of a real
     // 1 → 0 transition.
-    window.dispatchEvent(new KeyboardEvent('keyup', { keyCode: Keyboard.Space } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keyup', { code: 'Space' }));
     im.update(0 as never);
 
     expect(map.jump.active).toBe(false);
@@ -843,7 +843,7 @@ describe('ActionMap × InputManager lifecycle', () => {
     im.update(0 as never);
 
     map.detach();
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: Keyboard.Space } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space' }));
 
     // Reattaching to the SAME owner reuses the SAME long-lived ActionSample
     // object. Without `ActionOwnership.arm` forgetting the previously

--- a/test/input/focus-scope-integration.test.ts
+++ b/test/input/focus-scope-integration.test.ts
@@ -13,7 +13,6 @@ import { SceneState } from '#core/SceneState';
 import { InputManager } from '#input/InputManager';
 import { InteractionManager } from '#input/InteractionManager';
 import type { KeyEvent } from '#input/KeyEvent';
-import { Keyboard } from '#input/types';
 import { BrowserPlatform } from '#platform/BrowserPlatform';
 import { Container } from '#rendering/Container';
 
@@ -77,8 +76,8 @@ const createHarness = (): Harness => {
 };
 
 /** Dispatch a real keydown, then flush it through InputManager into FocusController. */
-const pressKey = (h: Harness, keyCode: number): void => {
-  window.dispatchEvent(new KeyboardEvent('keydown', { keyCode } as KeyboardEventInit));
+const pressKey = (h: Harness, code: string): void => {
+  window.dispatchEvent(new KeyboardEvent('keydown', { code }));
   h.input.update(0 as never);
 };
 
@@ -143,9 +142,9 @@ describe('active scopes as real focus traps', () => {
     h.scene.root.addChild(modal);
 
     h.im.pushScope(modal);
-    pressKey(h, 9); // Tab keyCode
-    pressKey(h, 9);
-    pressKey(h, 9);
+    pressKey(h, 'Tab');
+    pressKey(h, 'Tab');
+    pressKey(h, 'Tab');
 
     expect(h.im.focused).not.toBe(outside);
 
@@ -471,7 +470,7 @@ describe('KeyEvent bubbling', () => {
     grandparent.onKeyDown.add(() => seen.push('grandparent'));
 
     h.im.focus(child);
-    pressKey(h, Keyboard.A);
+    pressKey(h, 'KeyA');
 
     expect(seen).toEqual(['child', 'parent', 'grandparent']);
 
@@ -498,7 +497,7 @@ describe('KeyEvent bubbling', () => {
     });
 
     h.im.focus(child);
-    pressKey(h, Keyboard.A);
+    pressKey(h, 'KeyA');
 
     expect(seenCurrentTargets).toEqual([child, parent]);
     expect(seenTarget).toBe(child);
@@ -520,7 +519,7 @@ describe('KeyEvent bubbling', () => {
     parent.onKeyDown.add(parentHandler);
 
     h.im.focus(child);
-    pressKey(h, Keyboard.A);
+    pressKey(h, 'KeyA');
 
     expect(parentHandler).not.toHaveBeenCalled();
 
@@ -540,8 +539,8 @@ describe('KeyEvent bubbling', () => {
     parent.onKeyUp.add(parentHandler);
     h.im.focus(child);
 
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: Keyboard.A } as KeyboardEventInit));
-    window.dispatchEvent(new KeyboardEvent('keyup', { keyCode: Keyboard.A } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyA' }));
+    window.dispatchEvent(new KeyboardEvent('keyup', { code: 'KeyA' }));
     h.input.update(0 as never);
 
     expect(parentHandler).toHaveBeenCalledTimes(1);

--- a/test/input/input-manager-events.test.ts
+++ b/test/input/input-manager-events.test.ts
@@ -170,8 +170,8 @@ describe('InputManager — keyboard', () => {
 
     im.onKeyDown.add(onKeyDown);
     im.onKeyUp.add(onKeyUp);
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: Keyboard.Space } as KeyboardEventInit));
-    window.dispatchEvent(new KeyboardEvent('keyup', { keyCode: Keyboard.Space } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space' }));
+    window.dispatchEvent(new KeyboardEvent('keyup', { code: 'Space' }));
     im.update();
 
     expect(ch(im, Keyboard.Space)).toBe(0);
@@ -204,7 +204,7 @@ describe('InputManager — keyboard', () => {
     im.onKeyDown.add(onKeyDown);
     canvas.dispatchEvent(new FocusEvent('focus'));
 
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: Keyboard.Space } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space' }));
 
     expect(ch(im, Keyboard.Space)).toBe(1);
     expect(onKeyDown).not.toHaveBeenCalled(); // not flushed until update()
@@ -224,10 +224,10 @@ describe('InputManager — keyboard', () => {
     im.onKeyUp.add(onKeyUp);
     canvas.dispatchEvent(new FocusEvent('focus'));
 
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: Keyboard.A } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyA' }));
     im.update();
 
-    window.dispatchEvent(new KeyboardEvent('keyup', { keyCode: Keyboard.A } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keyup', { code: 'KeyA' }));
     expect(ch(im, Keyboard.A)).toBe(0);
 
     im.update();
@@ -247,8 +247,8 @@ describe('InputManager — keyboard', () => {
     im.onCanvasFocusChange.add(onFocusChange);
     canvas.dispatchEvent(new FocusEvent('focus'));
 
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: Keyboard.A } as KeyboardEventInit));
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: Keyboard.B } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyA' }));
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyB' }));
     im.update();
     onKeyUp.mockClear();
 
@@ -278,7 +278,7 @@ describe('InputManager — keyboard', () => {
     im.onCanvasFocusChange.add(onFocusChange);
     canvas.dispatchEvent(new FocusEvent('focus'));
 
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: Keyboard.Space } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space' }));
     im.update();
 
     window.dispatchEvent(new FocusEvent('blur'));
@@ -310,12 +310,12 @@ describe('InputManager — keyboard', () => {
     canvas.dispatchEvent(new FocusEvent('focus'));
     const binding = im.onStart(Keyboard.Space, () => {});
 
-    const downEvent = new KeyboardEvent('keydown', { keyCode: Keyboard.Space, cancelable: true } as KeyboardEventInit);
+    const downEvent = new KeyboardEvent('keydown', { code: 'Space', cancelable: true });
 
     window.dispatchEvent(downEvent);
     expect(downEvent.defaultPrevented).toBe(true);
 
-    const upEvent = new KeyboardEvent('keyup', { keyCode: Keyboard.Space, cancelable: true } as KeyboardEventInit);
+    const upEvent = new KeyboardEvent('keyup', { code: 'Space', cancelable: true });
 
     window.dispatchEvent(upEvent);
     expect(upEvent.defaultPrevented).toBe(true);
@@ -329,7 +329,7 @@ describe('InputManager — keyboard', () => {
 
     canvas.dispatchEvent(new FocusEvent('focus'));
 
-    const downEvent = new KeyboardEvent('keydown', { keyCode: Keyboard.Enter, cancelable: true } as KeyboardEventInit);
+    const downEvent = new KeyboardEvent('keydown', { code: 'Enter', cancelable: true });
 
     window.dispatchEvent(downEvent);
 
@@ -347,14 +347,14 @@ describe('InputManager — keyboard', () => {
 
     bindingA.unbind();
 
-    const stillCaptured = new KeyboardEvent('keydown', { keyCode: Keyboard.Space, cancelable: true } as KeyboardEventInit);
+    const stillCaptured = new KeyboardEvent('keydown', { code: 'Space', cancelable: true });
 
     window.dispatchEvent(stillCaptured);
     expect(stillCaptured.defaultPrevented).toBe(true);
 
     bindingB.unbind();
 
-    const noLongerCaptured = new KeyboardEvent('keydown', { keyCode: Keyboard.Space, cancelable: true } as KeyboardEventInit);
+    const noLongerCaptured = new KeyboardEvent('keydown', { code: 'Space', cancelable: true });
 
     window.dispatchEvent(noLongerCaptured);
     expect(noLongerCaptured.defaultPrevented).toBe(false);
@@ -373,7 +373,7 @@ describe('InputManager — keyboard', () => {
     // The physical press belongs to an earlier, already-closed frame. Its
     // batch is gone by the time this binding starts observing, while the live
     // channel correctly remains held.
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: Keyboard.Space } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space' }));
     im.update();
 
     const binding = im.onStart(Keyboard.Space, onStart, { threshold: 300 });
@@ -384,7 +384,7 @@ describe('InputManager — keyboard', () => {
     // The first post-construction batch is only the release. createBinding()
     // must have captured the held construction baseline so this is a real
     // stop, while the unknown pre-observation press time cannot become a tap.
-    window.dispatchEvent(new KeyboardEvent('keyup', { keyCode: Keyboard.Space } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keyup', { code: 'Space' }));
     im.update();
 
     expect(onStart).toHaveBeenCalledTimes(1);
@@ -817,7 +817,7 @@ describe('InputManager — binding factories', () => {
     im.onTrigger(Keyboard.Space, onTrigger);
 
     canvas.dispatchEvent(new FocusEvent('focus'));
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: Keyboard.Space } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space' }));
 
     im.update();
     expect(onStart).toHaveBeenCalledTimes(1);
@@ -828,7 +828,7 @@ describe('InputManager — binding factories', () => {
     expect(onStart).toHaveBeenCalledTimes(1);
     expect(onActive).toHaveBeenCalledTimes(2);
 
-    window.dispatchEvent(new KeyboardEvent('keyup', { keyCode: Keyboard.Space } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keyup', { code: 'Space' }));
     im.update();
 
     expect(onStop).toHaveBeenCalledTimes(1);
@@ -844,7 +844,7 @@ describe('InputManager — binding factories', () => {
     im.onStart([Keyboard.A, Keyboard.B], onStart);
     canvas.dispatchEvent(new FocusEvent('focus'));
 
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: Keyboard.B } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyB' }));
     im.update();
 
     expect(onStart).toHaveBeenCalledTimes(1);
@@ -883,7 +883,7 @@ describe('InputManager — binding factories', () => {
     canvas.dispatchEvent(new FocusEvent('focus'));
     binding.unbind();
 
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: Keyboard.Space } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space' }));
     im.update();
 
     expect(onActive).not.toHaveBeenCalled();
@@ -919,7 +919,7 @@ describe('InputManager — destroy', () => {
 
     im.destroy();
 
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: Keyboard.Space } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space' }));
     fire(canvas, 'pointerover', { pointerId: 1, pointerType: 'mouse', clientX: 1, clientY: 1, isPrimary: true });
     fire(canvas, 'pointerdown', { pointerId: 1, pointerType: 'mouse', clientX: 1, clientY: 1, isPrimary: true });
 

--- a/test/input/keyboard-codes.test.ts
+++ b/test/input/keyboard-codes.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for the layout-independent keyboard channel mapping: `KeyboardEvent.code`
+ * (physical key position) resolves to a `Keyboard` channel, and the
+ * layout-dependent `KeyboardEvent.keyCode` is never consulted.
+ */
+
+import type { Application } from '#core/Application';
+import { InputManager } from '#input/InputManager';
+import { keyboardChannelFromCode } from '#input/keyboardCodes';
+import { Keyboard } from '#input/types';
+import { BrowserPlatform } from '#platform/BrowserPlatform';
+
+const createCanvas = (width = 800, height = 600): HTMLCanvasElement => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = width;
+  canvas.height = height;
+
+  return canvas;
+};
+
+const createMockApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    platform: new BrowserPlatform(canvas),
+    width: canvas.width,
+    height: canvas.height,
+    pixelRatio: 1,
+    options: { input: {} },
+  }) as unknown as Application;
+
+const createFocusedInputManager = (): { im: InputManager; canvas: HTMLCanvasElement } => {
+  const canvas = createCanvas();
+  const im = new InputManager(createMockApp(canvas));
+
+  canvas.dispatchEvent(new FocusEvent('focus'));
+
+  return { im, canvas };
+};
+
+const ch = (im: InputManager, channel: number): number => (im as unknown as { channels: Float32Array }).channels[channel]!;
+
+const press = (init: KeyboardEventInit & { keyCode?: number }): void => {
+  window.dispatchEvent(new KeyboardEvent('keydown', init as KeyboardEventInit));
+};
+
+const release = (init: KeyboardEventInit & { keyCode?: number }): void => {
+  window.dispatchEvent(new KeyboardEvent('keyup', init as KeyboardEventInit));
+};
+
+describe('keyboardChannelFromCode', () => {
+  test('resolves physical key codes to their Keyboard channel', () => {
+    expect(keyboardChannelFromCode('KeyA')).toBe(Keyboard.A);
+    expect(keyboardChannelFromCode('Digit1')).toBe(Keyboard.One);
+    expect(keyboardChannelFromCode('ArrowLeft')).toBe(Keyboard.Left);
+    expect(keyboardChannelFromCode('Numpad5')).toBe(Keyboard.NumPad5);
+    expect(keyboardChannelFromCode('Semicolon')).toBe(Keyboard.Colon);
+    expect(keyboardChannelFromCode('Backquote')).toBe(Keyboard.Tilde);
+  });
+
+  test('a digit row key and its keypad twin stay separate channels', () => {
+    expect(keyboardChannelFromCode('Digit1')).not.toBe(keyboardChannelFromCode('Numpad1'));
+    expect(keyboardChannelFromCode('Enter')).not.toBe(keyboardChannelFromCode('NumpadEnter'));
+  });
+
+  test('folds both physical sides of a modifier onto one channel', () => {
+    expect(keyboardChannelFromCode('ShiftLeft')).toBe(Keyboard.Shift);
+    expect(keyboardChannelFromCode('ShiftRight')).toBe(Keyboard.Shift);
+    expect(keyboardChannelFromCode('ControlLeft')).toBe(Keyboard.Control);
+    expect(keyboardChannelFromCode('ControlRight')).toBe(Keyboard.Control);
+    expect(keyboardChannelFromCode('AltLeft')).toBe(Keyboard.Alt);
+    expect(keyboardChannelFromCode('AltRight')).toBe(Keyboard.Alt);
+    expect(keyboardChannelFromCode('MetaLeft')).toBe(Keyboard.Meta);
+    expect(keyboardChannelFromCode('MetaRight')).toBe(Keyboard.Meta);
+  });
+
+  test('returns undefined for an unmapped or absent code', () => {
+    expect(keyboardChannelFromCode('MediaPlayPause')).toBeUndefined();
+    expect(keyboardChannelFromCode('Unidentified')).toBeUndefined();
+    expect(keyboardChannelFromCode('')).toBeUndefined();
+  });
+
+  test('every mapped channel is inside the keyboard category', () => {
+    for (const code of ['KeyZ', 'Escape', 'F12', 'NumpadEnter', 'IntlBackslash']) {
+      const channel = keyboardChannelFromCode(code)!;
+
+      expect(channel).toBeGreaterThanOrEqual(0);
+      expect(channel).toBeLessThan(256);
+    }
+  });
+});
+
+describe('InputManager — layout-independent keyboard channels', () => {
+  test('a physical key maps to the same channel on AZERTY as on QWERTY', () => {
+    // The physical key at the QWERTY "A" position reports `code: 'KeyA'` on
+    // every layout; on a French AZERTY keyboard it produces the character "q"
+    // and the legacy keyCode 81 ("Q"), on US QWERTY the character "a" and
+    // keyCode 65. Only the physical position may decide the channel.
+    const { im } = createFocusedInputManager();
+
+    press({ code: 'KeyA', key: 'q', keyCode: 81 });
+
+    expect(ch(im, Keyboard.A)).toBe(1);
+    expect(ch(im, Keyboard.Q)).toBe(0);
+
+    release({ code: 'KeyA', key: 'q', keyCode: 81 });
+
+    expect(ch(im, Keyboard.A)).toBe(0);
+
+    im.destroy();
+  });
+
+  test('a physical key maps to the same channel on QWERTZ as on QWERTY', () => {
+    // German QWERTZ swaps Y and Z: the physical `KeyZ` key produces "y"
+    // (legacy keyCode 89) there and "z" (keyCode 90) on US QWERTY.
+    const { im } = createFocusedInputManager();
+
+    press({ code: 'KeyZ', key: 'y', keyCode: 89 });
+
+    expect(ch(im, Keyboard.Z)).toBe(1);
+    expect(ch(im, Keyboard.Y)).toBe(0);
+
+    im.destroy();
+  });
+
+  test('a punctuation key maps by position, not by the glyph the layout prints', () => {
+    // On QWERTZ the physical `Semicolon` key prints "ö"; on AZERTY it prints
+    // "m". Neither changes the channel — the member is named for the US-QWERTY
+    // legend of that position, not for the character produced.
+    const { im } = createFocusedInputManager();
+
+    press({ code: 'Semicolon', key: 'ö', keyCode: 192 });
+
+    expect(ch(im, Keyboard.Colon)).toBe(1);
+
+    im.destroy();
+  });
+
+  test('the legacy keyCode is never consulted', () => {
+    const { im } = createFocusedInputManager();
+
+    press({ code: 'Space', keyCode: 0 });
+
+    expect(ch(im, Keyboard.Space)).toBe(1);
+
+    im.destroy();
+  });
+
+  test('both shift keys drive the single Shift channel', () => {
+    const { im } = createFocusedInputManager();
+
+    press({ code: 'ShiftRight', key: 'Shift', keyCode: 16 });
+
+    expect(ch(im, Keyboard.Shift)).toBe(1);
+
+    release({ code: 'ShiftRight', key: 'Shift', keyCode: 16 });
+    press({ code: 'ShiftLeft', key: 'Shift', keyCode: 16 });
+
+    expect(ch(im, Keyboard.Shift)).toBe(1);
+
+    im.destroy();
+  });
+
+  test('an unmapped code writes no channel and dispatches no key signal', () => {
+    const { im } = createFocusedInputManager();
+    const onKeyDown = vi.fn();
+    const onKeyUp = vi.fn();
+
+    im.onKeyDown.add(onKeyDown);
+    im.onKeyUp.add(onKeyUp);
+
+    // A media key, and the empty `code` an Android soft keyboard reports.
+    press({ code: 'MediaPlayPause' });
+    press({ code: '', key: 'Unidentified', keyCode: 229 });
+    release({ code: 'MediaPlayPause' });
+    im.update();
+
+    expect(onKeyDown).not.toHaveBeenCalled();
+    expect(onKeyUp).not.toHaveBeenCalled();
+
+    im.destroy();
+  });
+
+  test('a mapped keydown still reaches the onKeyDown signal with its channel', () => {
+    const { im } = createFocusedInputManager();
+    const onKeyDown = vi.fn();
+
+    im.onKeyDown.add(onKeyDown);
+    press({ code: 'ArrowLeft', key: 'ArrowLeft', keyCode: 37 });
+    im.update();
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+    expect(onKeyDown).toHaveBeenCalledWith(Keyboard.Left);
+
+    im.destroy();
+  });
+});

--- a/test/input/pointer-frame-snapshot.test.ts
+++ b/test/input/pointer-frame-snapshot.test.ts
@@ -323,44 +323,44 @@ describe('ordered channel event log', () => {
       .filter(e => e.channel === (Keyboard.Space as number))
       .map(e => e.value);
 
-  const focusAndPress = (keyCode: number): void => {
+  const focusAndPress = (code: string): void => {
     canvas.dispatchEvent(new FocusEvent('focus'));
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keydown', { code }));
   };
 
   it('records a press then a release in that true order within one frame', () => {
-    focusAndPress(32);
-    window.dispatchEvent(new KeyboardEvent('keyup', { keyCode: 32 } as KeyboardEventInit));
+    focusAndPress('Space');
+    window.dispatchEvent(new KeyboardEvent('keyup', { code: 'Space' }));
 
     expect(forSpace(im)).toEqual([1, 0]);
   });
 
   it('records a release then a fresh press in that true order', () => {
-    focusAndPress(32);
+    focusAndPress('Space');
     im.update(0 as never);
 
-    window.dispatchEvent(new KeyboardEvent('keyup', { keyCode: 32 } as KeyboardEventInit));
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 32 } as KeyboardEventInit));
+    window.dispatchEvent(new KeyboardEvent('keyup', { code: 'Space' }));
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space' }));
 
     expect(forSpace(im)).toEqual([0, 1]);
   });
 
   it('does not consume the log when it is read mid-frame', () => {
-    focusAndPress(32);
+    focusAndPress('Space');
 
     expect(forSpace(im)).toEqual([1]);
     expect(forSpace(im)).toEqual([1]);
   });
 
   it('clears the log once the frame closes', () => {
-    focusAndPress(32);
+    focusAndPress('Space');
     im.update(0 as never);
 
     expect(forSpace(im)).toEqual([]);
   });
 
   it('does not log a repeat write of the same value', () => {
-    focusAndPress(32);
+    focusAndPress('Space');
     im.update(0 as never);
     im.update(0 as never); // still held, no new platform event
 
@@ -371,7 +371,7 @@ describe('ordered channel event log', () => {
 describe('keyboard dispatch order', () => {
   it('dispatches a Shift-up followed by a Tab-down in that true order, not grouped by type', () => {
     canvas.dispatchEvent(new FocusEvent('focus'));
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 16 } as KeyboardEventInit)); // Shift down
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'ShiftLeft' })); // Shift down
     im.update(0 as never);
 
     const seen: Array<{ channel: number; pressed: boolean }> = [];
@@ -383,8 +383,8 @@ describe('keyboard dispatch order', () => {
     // "all keydowns before all keyups" dispatch order would report Tab's
     // keydown before Shift's keyup, letting a Tab handler still see Shift
     // as held.
-    window.dispatchEvent(new KeyboardEvent('keyup', { keyCode: 16 } as KeyboardEventInit));
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 9 } as KeyboardEventInit)); // Tab down
+    window.dispatchEvent(new KeyboardEvent('keyup', { code: 'ShiftLeft' }));
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Tab' })); // Tab down
     im.update(0 as never);
 
     expect(seen).toEqual([


### PR DESCRIPTION
`InputManager` derived keyboard channels from `KeyboardEvent.keyCode`, which reports the **layout's character mapping**, not the physical key. On a French AZERTY keyboard the physical key at the QWERTY `Q` position reports the `A` keyCode, so a WASD binding silently lands on the wrong physical keys. That is the correctness bug this fixes — `keyCode` being deprecated is incidental.

## Approach: map at the boundary, keep the channel model

`Keyboard` members are `ChannelOffset.Keyboard + <legacy keyCode>` — only *derived from* keyCode, never required to *equal* one. So a `code` → channel lookup at the two dispatch sites is enough, and the dense numeric channel space is untouched.

Verified unaffected: the 768-slot `Float32Array` buffers, `channel < ChannelSize.Category` capture bookkeeping, `releaseAllKeyboardChannels()`, `pattern.ts`'s enum-name grammar (`'Up>Up>Down'`, `'Control+S'` still resolve), `resolveGamepadSlotChannel`, and channel numbers serialized to `localStorage` by `examples/input/key-rebinding.ts`.

The `code` spelling lives only in `src/input/keyboardCodes.ts`. **No enum member was renamed** — `Keyboard.A` stays `Keyboard.A`, so pattern strings stay readable.

## Decisions

- **Modifiers**: `ShiftLeft`/`ShiftRight` fold onto `Keyboard.Shift` (same for Control/Alt/Meta; legacy `OSLeft`/`OSRight` alias to `Meta`). Preserves today's semantics. Distinct per-side channels would make one key press write two channels, breaking the one-batch-per-real-event atomicity of `_recordChannelChanges` and double-dispatching into `FocusController`. Clean separate slice if ever wanted.
- **Digits vs numpad**: kept distinct (`Digit1`→`One`, `Numpad1`→`NumPad1`, `Enter`/`NumpadEnter` likewise), with a regression test.
- **Unmapped codes**: silently ignored, matching `Gamepad.ts`'s existing precedent for unmapped buttons/axes. Covers media keys, IME keys, and the empty `code` soft keyboards report.

## BREAKING

- `Keyboard.Clear` removed — no `code` maps to it (that physical key is `Numpad5`), so it would be permanently dead.
- Added into free slots so previously-reachable keys keep names: `Meta`, `ContextMenu`, `PrintScreen`, `NumPadEqual`, `IntlBackslash`, `IntlRo`, `IntlYen`.
- **No existing enum value changed**, so stored bindings stay valid.

Also exports `keyboardChannelFromCode` for rebinding UIs starting from a DOM event, and corrects `shipping/troubleshooting.mdx`, which claimed the enum names already matched `KeyboardEvent.code` and cited a nonexistent `Keyboard.ArrowLeft`.

## Verification

- `test/input`: 547 passed, incl. 11 new layout tests written failing-first (AZERTY `code:'KeyA', keyCode:81` → `Keyboard.A`; QWERTZ `code:'KeyZ', keyCode:89` → `Keyboard.Z`)
- full `pnpm test:core`: 5829 passed, 15 skipped
- all typecheck lanes, eslint, prettier, `docs:api:check` clean

## Open, deliberately left alone

Punctuation members are glyph-spelled (`Keyboard.Colon` is the key QWERTZ prints "ö" on) while the new members are `code`-spelled. JSDoc now states the name is the US-QWERTY legend of a *position*, not the character produced. Unifying that convention is a pure rename with zero behaviour change.