### PR TITLE
feat(core)!: enforce synchronous lifecycle and frame hooks at type level and at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,6 +265,22 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
   order, instead of synchronously off the raw `pointermove`/timer callback.
   Handlers that relied on running mid-event now run on the next frame
   boundary, in order relative to the pointer phases that produced them.
+- **BREAKING — `Scene.init`, the frame hooks and the `System` phases must be
+  synchronous, enforced by the type system and by a hard failure in every
+  build.** `Scene.init`/`fixedUpdate`/`update`/`draw` and
+  `SystemMethods.fixedUpdate`/`update`/`draw` now return `Synchronous`
+  instead of `void`, so `override async update()` is a compile error — a bare
+  `void` return type could never reject it, because TypeScript accepts any
+  return type against a `void`-returning signature. Only thenables are
+  rejected; `void` and the engine's fluent `update(delta): this` convention
+  still compile unchanged. At runtime a hook that returns a thenable now
+  throws a lifecycle error naming the owner, the hook and the remedy, in
+  **production as well as development** — previously an async `init()` was a
+  dev-only activation failure and an async frame hook a dev-only warning, so
+  the same broken override silently dropped its timing and swallowed its
+  errors in a production build. Move asynchronous work into `Scene.load()`,
+  which the engine awaits once per activation. `Scene.load()`/`Scene.unload()`
+  are unchanged and stay asynchronous.
 
 ### Removed
 

--- a/examples/audio-basics/audio-buses.ts
+++ b/examples/audio-basics/audio-buses.ts
@@ -27,7 +27,7 @@ class AudioBusesScene extends Scene {
     private sfxButton = { x: 0, y: 0, w: 0, h: 0 };
     private hud!: ReturnType<typeof mountControls>;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;

--- a/examples/audio-basics/crossfade-tracks.ts
+++ b/examples/audio-basics/crossfade-tracks.ts
@@ -30,7 +30,7 @@ class CrossfadeTracksScene extends Scene {
     private meterBaseY = 0;
     private hud!: ReturnType<typeof mountControls>;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;

--- a/examples/audio-basics/music-loop.ts
+++ b/examples/audio-basics/music-loop.ts
@@ -14,7 +14,7 @@ class MusicLoopScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
     private panel!: ReturnType<typeof mountControlPanel>;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;

--- a/examples/audio-fx/compressor.ts
+++ b/examples/audio-fx/compressor.ts
@@ -35,7 +35,7 @@ class CompressorScene extends Scene {
     private meterY = 0;
     private hud!: ReturnType<typeof mountControls>;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;

--- a/examples/audio-fx/ducking.ts
+++ b/examples/audio-fx/ducking.ts
@@ -25,7 +25,7 @@ class DuckingScene extends Scene {
     private voiceBarY = 0;
     private hud!: ReturnType<typeof mountControls>;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;

--- a/examples/beat-detection/beat-sync-pulse.ts
+++ b/examples/beat-detection/beat-sync-pulse.ts
@@ -24,7 +24,7 @@ class BeatSyncPulseScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
     private tapPrompt!: Text;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;

--- a/examples/beat-detection/frequency-bands.ts
+++ b/examples/beat-detection/frequency-bands.ts
@@ -34,7 +34,7 @@ class FrequencyBandsScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
     private tapPrompt!: Text;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         // AudioStream has no seamless adapter — await it explicitly.

--- a/examples/beat-detection/tempo-tracking.ts
+++ b/examples/beat-detection/tempo-tracking.ts
@@ -18,7 +18,7 @@ class TempoTrackingScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
     private tapPrompt!: Text;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;

--- a/examples/debug-layer/asset-browser.ts
+++ b/examples/debug-layer/asset-browser.ts
@@ -184,7 +184,7 @@ class AssetBrowserScene extends Scene {
     loadedCats  = new Set<string>();
     loadingCats = new Set<string>();
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.assetLoader = this.loader;

--- a/examples/input/gamepad.ts
+++ b/examples/input/gamepad.ts
@@ -13,7 +13,7 @@ class GamepadScene extends Scene {
     private status!: Sprite;
     private container!: Container;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const buttonsData = (await this.loader.load(Asset.type('json', 'json/buttons.json'))) as SpritesheetData;

--- a/examples/showcase/audio-reactive-particles.ts
+++ b/examples/showcase/audio-reactive-particles.ts
@@ -26,7 +26,7 @@ class AudioReactiveParticlesScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
     private tapPrompt!: Text;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;

--- a/examples/showcase/audio-visualisation.ts
+++ b/examples/showcase/audio-visualisation.ts
@@ -18,7 +18,7 @@ class AudioVisualisationScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
     private tapPrompt!: Text;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;

--- a/examples/showcase/boss-intro-cinematic.ts
+++ b/examples/showcase/boss-intro-cinematic.ts
@@ -20,7 +20,7 @@ class BossIntroCinematicScene extends Scene {
     private width = 0;
     private height = 0;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;

--- a/examples/showcase/low-band-camera-shake.ts
+++ b/examples/showcase/low-band-camera-shake.ts
@@ -13,7 +13,7 @@ class LowBandCameraShakeScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
     private tapPrompt!: Text;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;

--- a/examples/showcase/vinyl-record.ts
+++ b/examples/showcase/vinyl-record.ts
@@ -15,7 +15,7 @@ class VinylRecordScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
     private tapPrompt!: Text;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;

--- a/examples/spatial-audio/falloff-curves.ts
+++ b/examples/spatial-audio/falloff-curves.ts
@@ -49,7 +49,7 @@ class FalloffCurvesScene extends Scene {
     private plot = { x: 0, y: 0, w: 0, h: 0 };
     private hud!: ReturnType<typeof mountControls>;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;

--- a/examples/spatial-audio/listener-and-source.ts
+++ b/examples/spatial-audio/listener-and-source.ts
@@ -29,7 +29,7 @@ class ListenerAndSourceScene extends Scene {
     private tapPrompt!: Text;
     private hud!: ReturnType<typeof mountControls>;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;

--- a/examples/spatial-audio/moving-source.ts
+++ b/examples/spatial-audio/moving-source.ts
@@ -27,7 +27,7 @@ class MovingSourceScene extends Scene {
     private tapPrompt!: Text;
     private hud!: ReturnType<typeof mountControls>;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;

--- a/examples/sprites-textures/blendmodes.ts
+++ b/examples/sprites-textures/blendmodes.ts
@@ -44,7 +44,7 @@ class BlendmodesScene extends Scene {
     // is awaited here purely to seed the fetch with `scaleMode: Nearest`; its
     // return value is intentionally unused. The subsequent 2-argument `get()`
     // calls for the same sources are unaffected and stay seamless.
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;

--- a/examples/sprites-textures/spritesheet-frames.ts
+++ b/examples/sprites-textures/spritesheet-frames.ts
@@ -14,7 +14,7 @@ class SpritesheetFramesScene extends Scene {
     private playing = true;
     private hud!: ReturnType<typeof mountControls>;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;

--- a/examples/sprites-textures/svg-drawable.ts
+++ b/examples/sprites-textures/svg-drawable.ts
@@ -6,7 +6,7 @@ class SvgDrawableScene extends Scene {
     private texture!: Texture;
     private sprite!: Sprite;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;

--- a/examples/sprites-textures/video-drawable.ts
+++ b/examples/sprites-textures/video-drawable.ts
@@ -22,7 +22,7 @@ class VideoDrawableScene extends Scene {
     private readonly loadedVideos = new Set<string>();
     private switching = false;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;

--- a/examples/text-fonts/basic-text.ts
+++ b/examples/text-fonts/basic-text.ts
@@ -6,7 +6,7 @@ class BasicTextScene extends Scene {
     private time!: Time;
     private text!: Text;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         await this.loader.load(Asset.type('font', 'font/Kenney Future.ttf', { family: 'Kenney Future' }));

--- a/examples/text-fonts/bitmap-text-basic.ts
+++ b/examples/text-fonts/bitmap-text-basic.ts
@@ -10,7 +10,7 @@ class BitmapTextBasicScene extends Scene {
     private counter!: BitmapText;
     private frame = 0;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         this.font = await this.loader.load(Asset.type('bmFont', assets.demo.fonts.kenneyBlocksFnt));

--- a/examples/text-fonts/web-fonts.ts
+++ b/examples/text-fonts/web-fonts.ts
@@ -6,7 +6,7 @@ class WebFontsScene extends Scene {
     private default!: Text;
     private loaded!: Text;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         await this.loader.load(Asset.type('font', 'font/Kenney Future.ttf', { family: 'Kenney Future' }));

--- a/examples/tilemap/infinite-terrain.ts
+++ b/examples/tilemap/infinite-terrain.ts
@@ -85,7 +85,7 @@ class InfiniteTerrainScene extends Scene {
     private hudTimer = 0;
     private hud!: ReturnType<typeof mountControls>;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const tilesTexture = await this.loader.load(Asset.type('texture', assets.demo.tilesets.map.image));
         this.tileset = new TileSet({
             name: 'biomes',

--- a/examples/tilemap/ldtk-world-import.ts
+++ b/examples/tilemap/ldtk-world-import.ts
@@ -31,7 +31,7 @@ class LdtkWorldImportScene extends Scene {
     private hud!: ReturnType<typeof mountControls>;
     private showIntGrid = true;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         // The .ldtk source must be an absolute URL: @codexo/exojs-ldtk resolves
         // tileset relPaths with `new URL(relPath, source)`, which throws for a
         // relative `source` (unlike the Tiled adapter's relative-base-aware

--- a/examples/tilemap/tile-chunks-and-bands.ts
+++ b/examples/tilemap/tile-chunks-and-bands.ts
@@ -37,7 +37,7 @@ class TileChunksAndBandsScene extends Scene {
     private moveY = 0;
     private hud!: ReturnType<typeof mountControls>;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         // ── Tileset + two layers, built entirely in code ──────────────────
         // Await the atlas load: TileSet needs a TextureRegion with real
         // dimensions, so a not-yet-hydrated `loader.get()` handle is not enough.

--- a/examples/tilemap/tiled-infinite-map.ts
+++ b/examples/tilemap/tiled-infinite-map.ts
@@ -33,7 +33,7 @@ class TiledInfiniteMapScene extends Scene {
     private hudTimer = 0;
     private hud!: ReturnType<typeof mountControls>;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const source = await this.loader.load(Asset.type('tiledMap', 'json/maps/drift-fields.tmj'));
         const runtimeMap = source.toTileMap();
 

--- a/examples/tilemap/tiled-map-import.ts
+++ b/examples/tilemap/tiled-map-import.ts
@@ -44,7 +44,7 @@ class TiledMapImportScene extends Scene {
     private filterIndex = 0;
     private hud!: ReturnType<typeof mountControls>;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         // Advanced path: parsed TiledMap -> map property lookup -> manual
         // toTileMap() conversion (the common-case Asset.type('tileMap', ...)
         // binding does the same conversion internally).

--- a/examples/tilemap/worker-streamed-terrain.ts
+++ b/examples/tilemap/worker-streamed-terrain.ts
@@ -174,7 +174,7 @@ class WorkerStreamedTerrainScene extends Scene {
     private frameMs = 0;
     private hud!: ReturnType<typeof mountControls>;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const tilesTexture = await this.loader.load(Asset.type('texture', assets.demo.tilesets.map.image));
         this.tileset = new TileSet({
             name: 'biomes',

--- a/examples/tweens-animation/frame-animation.ts
+++ b/examples/tweens-animation/frame-animation.ts
@@ -10,7 +10,7 @@ class FrameAnimationScene extends Scene {
     private frameCount = 0;
     private hud!: ReturnType<typeof mountControls>;
 
-    override async init(): Promise<void> {
+    override async load(): Promise<void> {
         const app = this.app;
         if (app === null) throw new Error('Scene.app is unavailable before the scene is attached to an Application.');
         const { width, height } = app.canvas;

--- a/site/src/content/api/scene.json
+++ b/site/src/content/api/scene.json
@@ -220,7 +220,7 @@
         },
         {
           "name": "draw",
-          "signature": "draw(_context: RenderingContext): void",
+          "signature": "draw(_context: RenderingContext): Synchronous",
           "signatureTokens": [
             {
               "text": "draw",
@@ -251,8 +251,8 @@
               "kind": "punctuation"
             },
             {
-              "text": "void",
-              "kind": "keyword"
+              "text": "Synchronous",
+              "kind": "type"
             }
           ],
           "params": [
@@ -262,12 +262,12 @@
               "optional": false
             }
           ],
-          "returnType": "void",
-          "description": "Explicit per-frame rendering entry point. Override to choose what gets rendered. The default body is intentionally empty: Scene does not automatically traverse Scene.root. Auto-rendering the full hierarchy would conflict with ExoJS's \"explicit instead of implicit\" identity. Users decide which subtree(s) render each frame — context.render(this.root) is the recommended high-level path, but selective rendering (e.g. context.render(world) while skipping ui for a given frame) is equally valid and intentionally supported."
+          "returnType": "Synchronous",
+          "description": "Explicit per-frame rendering entry point. Override to choose what gets rendered. The default body is intentionally empty: Scene does not automatically traverse Scene.root. Auto-rendering the full hierarchy would conflict with ExoJS's \"explicit instead of implicit\" identity. Users decide which subtree(s) render each frame — context.render(this.root) is the recommended high-level path, but selective rendering (e.g. context.render(world) while skipping ui for a given frame) is equally valid and intentionally supported. Must be synchronous — see Scene.update. An async draw() would present incomplete frames."
         },
         {
           "name": "fixedUpdate",
-          "signature": "fixedUpdate(_step: Time): void",
+          "signature": "fixedUpdate(_step: Time): Synchronous",
           "signatureTokens": [
             {
               "text": "fixedUpdate",
@@ -298,8 +298,8 @@
               "kind": "punctuation"
             },
             {
-              "text": "void",
-              "kind": "keyword"
+              "text": "Synchronous",
+              "kind": "type"
             }
           ],
           "params": [
@@ -309,12 +309,12 @@
               "optional": false
             }
           ],
-          "returnType": "void",
-          "description": "Fixed-timestep logic hook. Called zero or more times per frame with a constant delta (Application.fixedTimeStep) before Scene.update, so physics and deterministic gameplay advance at a frame-rate-independent rate. Put physicsWorld.step(delta) and movement here; leave camera, UI and purely visual work in Scene.update. Default is a no-op. Override in subclass."
+          "returnType": "Synchronous",
+          "description": "Fixed-timestep logic hook. Called zero or more times per frame with a constant delta (Application.fixedTimeStep) before Scene.update, so physics and deterministic gameplay advance at a frame-rate-independent rate. Put physicsWorld.step(delta) and movement here; leave camera, UI and purely visual work in Scene.update. Default is a no-op. Override in subclass. Must be synchronous — see Scene.update."
         },
         {
           "name": "init",
-          "signature": "init(_data: Readonly<Data>): void",
+          "signature": "init(_data: Readonly<Data>): Synchronous",
           "signatureTokens": [
             {
               "text": "init",
@@ -357,8 +357,8 @@
               "kind": "punctuation"
             },
             {
-              "text": "void",
-              "kind": "keyword"
+              "text": "Synchronous",
+              "kind": "type"
             }
           ],
           "params": [
@@ -368,8 +368,8 @@
               "optional": false
             }
           ],
-          "returnType": "void",
-          "description": "Optional synchronous setup hook. Runs once per activation, after the Promise returned by Scene.load has fulfilled and before the scene becomes active: register scene systems, connect stable scene objects, bind input, register interaction roots, start scene audio. Must remain synchronous — development builds detect a returned thenable and fail activation with a lifecycle error. Override in subclass."
+          "returnType": "Synchronous",
+          "description": "Optional synchronous setup hook. Runs once per activation, after the Promise returned by Scene.load has fulfilled and before the scene becomes active: register scene systems, connect stable scene objects, bind input, register interaction roots, start scene audio. Override in subclass. Must be synchronous: async init() is a compile error (see Synchronous) and, for callers the type system cannot reach, a thrown lifecycle error that fails activation in **every** build. Put asynchronous setup in Scene.load, which the engine awaits before init() runs."
         },
         {
           "name": "load",
@@ -624,7 +624,7 @@
         },
         {
           "name": "update",
-          "signature": "update(_delta: Time): void",
+          "signature": "update(_delta: Time): Synchronous",
           "signatureTokens": [
             {
               "text": "update",
@@ -655,8 +655,8 @@
               "kind": "punctuation"
             },
             {
-              "text": "void",
-              "kind": "keyword"
+              "text": "Synchronous",
+              "kind": "type"
             }
           ],
           "params": [
@@ -666,8 +666,8 @@
               "optional": false
             }
           ],
-          "returnType": "void",
-          "description": "Per-frame logic hook. Receives the time elapsed since the previous frame. The scene-graph transforms are still authoritative — mutate positions, advance timers, drive AI here. Override in subclass."
+          "returnType": "Synchronous",
+          "description": "Per-frame logic hook. Receives the time elapsed since the previous frame. The scene-graph transforms are still authoritative — mutate positions, advance timers, drive AI here. Override in subclass. Must be synchronous — see Scene.init for the contract and Synchronous for why. The frame path never awaits a hook result, so an async override would drop its timing and swallow its errors."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/synchronous.json
+++ b/site/src/content/api/synchronous.json
@@ -1,0 +1,102 @@
+{
+  "title": "Synchronous",
+  "description": "Return type of the engine hooks that must not be asynchronous: Scene.init, the frame hooks Scene.fixedUpdate / Scene.update / Scene.draw, and the SystemMethods phases. Write these overrides exactly as before — a body that returns nothing satisfies `Synchronous`, `override update(delta: Time): void` remains the idiomatic annotation, and the engine's fluent `update(delta): this` convention still fits. It is deliberately *not* a bare `void`. TypeScript makes a `void`-returning signature assignable from a signature returning **anything at all**, so `override async update()` compiles clean against a `void` base — the exact mistake this contract exists to prevent. The union above keeps `void`, keeps every ordinary object return, and rejects only thenables: `then` is pinned to `never`, so any type carrying a callable `then` (a `Promise`, or a hand-rolled thenable) fails to match. `object &` is what makes the remaining constituent non-weak, so a return type with no `then` property at all is still accepted rather than tripping TypeScript's weak-type check. Nothing here exists at runtime; no engine code reads `then` off a hook result to decide anything (the always-on runtime guard does its own check). Hooks the engine genuinely awaits — Scene.load and Scene.unload — are typed `Promise<void> | void` instead and stay asynchronous.",
+  "symbol": "Synchronous",
+  "kind": "type",
+  "subsystem": "core",
+  "importPath": "@codexo/exojs",
+  "tier": "stable",
+  "memberCount": 0,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 0,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Return type of the engine hooks that must not be asynchronous: Scene.init, the frame hooks Scene.fixedUpdate / Scene.update / Scene.draw, and the SystemMethods phases. Write these overrides exactly as before — a body that returns nothing satisfies `Synchronous`, `override update(delta: Time): void` remains the idiomatic annotation, and the engine's fluent `update(delta): this` convention still fits.",
+        "It is deliberately *not* a bare `void`. TypeScript makes a `void`-returning signature assignable from a signature returning **anything at all**, so `override async update()` compiles clean against a `void` base — the exact mistake this contract exists to prevent. The union above keeps `void`, keeps every ordinary object return, and rejects only thenables: `then` is pinned to `never`, so any type carrying a callable `then` (a `Promise`, or a hand-rolled thenable) fails to match. `object &` is what makes the remaining constituent non-weak, so a return type with no `then` property at all is still accepted rather than tripping TypeScript's weak-type check.",
+        "Nothing here exists at runtime; no engine code reads `then` off a hook result to decide anything (the always-on runtime guard does its own check).",
+        "Hooks the engine genuinely awaits — Scene.load and Scene.unload — are typed `Promise<void> | void` instead and stay asynchronous."
+      ],
+      "importLine": "import { Synchronous } from '@codexo/exojs'",
+      "sourceLink": null
+    },
+    {
+      "id": "definition",
+      "title": "Definition",
+      "members": [
+        {
+          "name": "Synchronous",
+          "signature": "void | object & { then?: never }",
+          "signatureTokens": [
+            {
+              "text": "void",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "object",
+              "kind": "keyword"
+            },
+            {
+              "text": " & ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "{ ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "then",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "never",
+              "kind": "keyword"
+            },
+            {
+              "text": " }",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/core/types.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/core/types.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/core/types.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/core/types.ts"
+}

--- a/site/src/content/api/system-methods.json
+++ b/site/src/content/api/system-methods.json
@@ -1,6 +1,6 @@
 {
   "title": "SystemMethods",
-  "description": "The three scheduler phases a System may participate in, one per dispatch stage of the Application frame loop: fixed-timestep simulation, variable-rate update, and rendering.",
+  "description": "The three scheduler phases a System may participate in, one per dispatch stage of the Application frame loop: fixed-timestep simulation, variable-rate update, and rendering. Every phase must be synchronous. The registry dispatches them on the frame path and never awaits a result, so an `async` phase is a compile error (see Synchronous) and, for callers the type system cannot reach, a thrown error in every build. Asynchronous work belongs in the owning scene's Scene.load.",
   "symbol": "SystemMethods",
   "kind": "interface",
   "subsystem": "core",
@@ -19,7 +19,8 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "The three scheduler phases a System may participate in, one per dispatch stage of the Application frame loop: fixed-timestep simulation, variable-rate update, and rendering."
+        "The three scheduler phases a System may participate in, one per dispatch stage of the Application frame loop: fixed-timestep simulation, variable-rate update, and rendering.",
+        "Every phase must be synchronous. The registry dispatches them on the frame path and never awaits a result, so an `async` phase is a compile error (see Synchronous) and, for callers the type system cannot reach, a thrown error in every build. Asynchronous work belongs in the owning scene's Scene.load."
       ],
       "importLine": "import { SystemMethods } from '@codexo/exojs'",
       "sourceLink": null
@@ -30,7 +31,7 @@
       "members": [
         {
           "name": "draw",
-          "signature": "draw?(context: RenderingContext): void",
+          "signature": "draw?(context: RenderingContext): Synchronous",
           "signatureTokens": [
             {
               "text": "draw",
@@ -65,8 +66,8 @@
               "kind": "punctuation"
             },
             {
-              "text": "void",
-              "kind": "keyword"
+              "text": "Synchronous",
+              "kind": "type"
             }
           ],
           "params": [
@@ -76,12 +77,12 @@
               "optional": false
             }
           ],
-          "returnType": "void",
+          "returnType": "Synchronous",
           "description": "Render into context. Called once per frame, after SystemMethods.update."
         },
         {
           "name": "fixedUpdate",
-          "signature": "fixedUpdate?(step: Time): void",
+          "signature": "fixedUpdate?(step: Time): Synchronous",
           "signatureTokens": [
             {
               "text": "fixedUpdate",
@@ -116,8 +117,8 @@
               "kind": "punctuation"
             },
             {
-              "text": "void",
-              "kind": "keyword"
+              "text": "Synchronous",
+              "kind": "type"
             }
           ],
           "params": [
@@ -127,12 +128,12 @@
               "optional": false
             }
           ],
-          "returnType": "void",
+          "returnType": "Synchronous",
           "description": "Advance by one fixed-timestep step (Application.fixedTimeStep). Called zero or more times per frame, before SystemMethods.update."
         },
         {
           "name": "update",
-          "signature": "update?(delta: Time): void",
+          "signature": "update?(delta: Time): Synchronous",
           "signatureTokens": [
             {
               "text": "update",
@@ -167,8 +168,8 @@
               "kind": "punctuation"
             },
             {
-              "text": "void",
-              "kind": "keyword"
+              "text": "Synchronous",
+              "kind": "type"
             }
           ],
           "params": [
@@ -178,7 +179,7 @@
               "optional": false
             }
           ],
-          "returnType": "void",
+          "returnType": "Synchronous",
           "description": "Advance by the variable frame delta. Called once per frame, after fixed steps."
         }
       ],

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -18,7 +18,7 @@ import { SERIALIZATION_VERSION, type SerializedScene } from './serialization/typ
 import { Signal } from './Signal';
 import type { SystemRegistry } from './SystemRegistry';
 import type { Time } from './Time';
-import type { Destroyable } from './types';
+import type { Destroyable, Synchronous } from './types';
 
 /**
  * A scene's lifecycle host. Subclass to define scene behavior:
@@ -346,10 +346,15 @@ export class Scene<Data = void, AppLike extends ApplicationLike = Application> {
    * Promise returned by {@link Scene.load} has fulfilled and before the
    * scene becomes active: register scene systems, connect stable scene
    * objects, bind input, register interaction roots, start scene audio.
-   * Must remain synchronous — development builds detect a returned thenable
-   * and fail activation with a lifecycle error. Override in subclass.
+   * Override in subclass.
+   *
+   * Must be synchronous: `async init()` is a compile error (see
+   * {@link Synchronous}) and, for callers the type system cannot reach, a
+   * thrown lifecycle error that fails activation in **every** build. Put
+   * asynchronous setup in {@link Scene.load}, which the engine awaits before
+   * `init()` runs.
    */
-  public init(_data: Readonly<Data>): void {
+  public init(_data: Readonly<Data>): Synchronous {
     // override in subclass
   }
 
@@ -357,8 +362,12 @@ export class Scene<Data = void, AppLike extends ApplicationLike = Application> {
    * Per-frame logic hook. Receives the time elapsed since the previous
    * frame. The scene-graph transforms are still authoritative — mutate
    * positions, advance timers, drive AI here. Override in subclass.
+   *
+   * Must be synchronous — see {@link Scene.init} for the contract and
+   * {@link Synchronous} for why. The frame path never awaits a hook result,
+   * so an `async` override would drop its timing and swallow its errors.
    */
-  public update(_delta: Time): void {
+  public update(_delta: Time): Synchronous {
     // override in subclass
   }
 
@@ -369,8 +378,10 @@ export class Scene<Data = void, AppLike extends ApplicationLike = Application> {
    * rate. Put `physicsWorld.step(delta)` and movement here; leave camera, UI and
    * purely visual work in {@link Scene.update}. Default is a no-op. Override in
    * subclass.
+   *
+   * Must be synchronous — see {@link Scene.update}.
    */
-  public fixedUpdate(_step: Time): void {
+  public fixedUpdate(_step: Time): Synchronous {
     // override in subclass
   }
 
@@ -387,9 +398,12 @@ export class Scene<Data = void, AppLike extends ApplicationLike = Application> {
    * skipping `ui` for a given frame) is equally valid and intentionally
    * supported.
    *
+   * Must be synchronous — see {@link Scene.update}. An `async` draw() would
+   * present incomplete frames.
+   *
    * @see Scene.root for why root is structural, not render-authoritative.
    */
-  public draw(_context: RenderingContext): void {
+  public draw(_context: RenderingContext): Synchronous {
     // override in subclass
   }
 

--- a/src/core/SceneScope.ts
+++ b/src/core/SceneScope.ts
@@ -10,6 +10,7 @@ import { SceneInteraction } from './scene/SceneInteraction';
 import { SceneLoader } from './scene/SceneLoader';
 import { SceneTweens } from './scene/SceneTweens';
 import { canDestroy, canRestore, canSuspend, SceneState } from './SceneState';
+import { hookOwnerName, requireSynchronousHook } from './syncHooks';
 import { SystemRegistry } from './SystemRegistry';
 import type { Time } from './Time';
 
@@ -23,7 +24,8 @@ const updateMeasure = 'exojs:scene-update';
 const drawStartMark = 'exojs:scene-draw:start';
 const drawMeasure = 'exojs:scene-draw';
 
-const isThenable = (value: unknown): boolean => value instanceof Promise;
+const frameHookRemedy =
+  'The frame path never awaits a hook result, so an async override loses its timing and swallows its errors. Move the asynchronous work into load(), which the engine awaits once per activation.';
 
 /**
  * Internal owner of one {@link Scene} activation: constructs and attaches the
@@ -88,29 +90,20 @@ export class SceneScope<Data = unknown> {
    * application-wide effect yet (definition §4.1/§4.2). The caller commits
    * the switch and calls {@link SceneScope.activate} once the previous scene
    * has been disposed. Throws the original `load()`/`init()` error, or a
-   * dev-only lifecycle error when `init()` returns a thenable (it must be
-   * synchronous).
+   * lifecycle error when `init()` returns a thenable — in every build, not
+   * only in development (it must be synchronous).
    */
   public async prepare(data: Data): Promise<void> {
     await this.scene.load(data);
 
-    // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- init() is declared void; capturing the raw return is exactly how a broken async override is detected below.
     const result = this.scene.init(data) as unknown;
 
-    if (isThenable(result)) {
-      // Detach any rejection from the abandoned thenable — an async init()
-      // is a dev-mode activation error below, so the original async result
-      // is intentionally discarded and must never surface as an unhandled
-      // rejection on top of that error.
-      (result as Promise<unknown>).catch(() => {
-        /* discarded: see the thenable-detection error thrown below */
-      });
-
-      if (__DEV__) {
-        throw new Error(
-          'Scene.init() must be synchronous, but it returned a thenable (e.g. an async function). init() runs only after load() has completed — move asynchronous setup into load() instead.',
-        );
-      }
+    if (result !== undefined) {
+      requireSynchronousHook(
+        result,
+        `${hookOwnerName(this.scene, 'Scene')}.init()`,
+        'init() runs only after load() has completed — move the asynchronous setup into load() instead.',
+      );
     }
 
     const previous = this._state;
@@ -275,8 +268,8 @@ export class SceneScope<Data = unknown> {
   /**
    * Forward one fixed step to the scene and its systems, gated to `Active`
    * and unpaused (§3 state table — `fixedUpdate` never runs while paused,
-   * unlike {@link SceneScope.draw}). Warns (dev-only) if `Scene.fixedUpdate`
-   * returns a thenable — the hook must be synchronous.
+   * unlike {@link SceneScope.draw}). Throws in every build if
+   * `Scene.fixedUpdate` returns a thenable — the hook must be synchronous.
    */
   public fixedUpdate(step: Time): void {
     if (this._state !== SceneState.Active || this._paused) {
@@ -284,19 +277,10 @@ export class SceneScope<Data = unknown> {
     }
 
     if (__DEV__) Perf.mark(fixedUpdateStartMark);
-    // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
-    const result = this.scene.fixedUpdate(step);
+    const result = this.scene.fixedUpdate(step) as unknown;
     if (__DEV__) Perf.measure(fixedUpdateMeasure, fixedUpdateStartMark);
 
-    if (__DEV__ && isThenable(result)) {
-      logger.warn(
-        'Scene.fixedUpdate() returned a Promise. fixedUpdate() must be synchronous — async logic here breaks frame timing and silently drops errors. Move async work into load() or init() instead.',
-        {
-          source: 'SceneScope',
-          once: 'scene-scope:async-fixed-update',
-        },
-      );
-    }
+    if (result !== undefined) this._requireSynchronousFrameHook(result, 'fixedUpdate');
 
     this.systems._fixedUpdate(step);
 
@@ -308,7 +292,7 @@ export class SceneScope<Data = unknown> {
 
   /**
    * Forward one frame's update to the scene and its systems, gated to
-   * `Active` and unpaused. Warns (dev-only) if `Scene.update` returns a
+   * `Active` and unpaused. Throws in every build if `Scene.update` returns a
    * thenable — the hook must be synchronous.
    */
   public update(delta: Time): void {
@@ -317,19 +301,10 @@ export class SceneScope<Data = unknown> {
     }
 
     if (__DEV__) Perf.mark(updateStartMark);
-    // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
-    const result = this.scene.update(delta);
+    const result = this.scene.update(delta) as unknown;
     if (__DEV__) Perf.measure(updateMeasure, updateStartMark);
 
-    if (__DEV__ && isThenable(result)) {
-      logger.warn(
-        'Scene.update() returned a Promise. update() must be synchronous — async logic here breaks frame timing and silently drops errors. Move async work into load() or init() instead.',
-        {
-          source: 'SceneScope',
-          once: 'scene-scope:async-update',
-        },
-      );
-    }
+    if (result !== undefined) this._requireSynchronousFrameHook(result, 'update');
 
     this.systems._update(delta);
 
@@ -342,8 +317,8 @@ export class SceneScope<Data = unknown> {
   /**
    * Forward one frame's draw to the scene, its systems, then the UI layer —
    * gated to `Active` regardless of `paused` (a paused scene keeps rendering
-   * while simulation is frozen). Warns (dev-only) if `Scene.draw` returns a
-   * thenable — the hook must be synchronous.
+   * while simulation is frozen). Throws in every build if `Scene.draw`
+   * returns a thenable — the hook must be synchronous.
    */
   public draw(context: RenderingContext): void {
     if (this._state !== SceneState.Active) {
@@ -351,16 +326,10 @@ export class SceneScope<Data = unknown> {
     }
 
     if (__DEV__) Perf.mark(drawStartMark);
-    // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
-    const result = this.scene.draw(context);
+    const result = this.scene.draw(context) as unknown;
     if (__DEV__) Perf.measure(drawMeasure, drawStartMark);
 
-    if (__DEV__ && isThenable(result)) {
-      logger.warn('Scene.draw() returned a Promise. draw() must be synchronous — an async draw() produces incomplete frames and silently drops errors.', {
-        source: 'SceneScope',
-        once: 'scene-scope:async-draw',
-      });
-    }
+    if (result !== undefined) this._requireSynchronousFrameHook(result, 'draw');
 
     this.systems._draw(context);
     this.scene._peekUI()?._render(context);
@@ -495,6 +464,16 @@ export class SceneScope<Data = unknown> {
     }
 
     this._app.interaction.detachRoot(this.scene.root);
+  }
+
+  /**
+   * Cold half of the frame-hook synchrony contract. The dispatchers keep the
+   * hot path to a single `result !== undefined` comparison and only call this
+   * once a hook has actually returned something, so building the message here
+   * costs nothing per frame.
+   */
+  private _requireSynchronousFrameHook(result: unknown, hook: string): void {
+    requireSynchronousHook(result, `${hookOwnerName(this.scene, 'Scene')}.${hook}()`, frameHookRemedy);
   }
 
   private _guard(errors: unknown[], fn: () => void): void {

--- a/src/core/System.ts
+++ b/src/core/System.ts
@@ -1,20 +1,26 @@
 import type { RenderingContext } from '#rendering/RenderingContext';
 
 import type { Time } from './Time';
-import type { Destroyable } from './types';
+import type { Destroyable, Synchronous } from './types';
 
 /**
  * The three scheduler phases a {@link System} may participate in, one per
  * dispatch stage of the {@link Application} frame loop: fixed-timestep
  * simulation, variable-rate update, and rendering.
+ *
+ * Every phase must be synchronous. The registry dispatches them on the frame
+ * path and never awaits a result, so an `async` phase is a compile error (see
+ * {@link Synchronous}) and, for callers the type system cannot reach, a thrown
+ * error in every build. Asynchronous work belongs in the owning scene's
+ * {@link Scene.load}.
  */
 export interface SystemMethods {
   /** Advance by one fixed-timestep `step` ({@link Application.fixedTimeStep}). Called zero or more times per frame, before {@link SystemMethods.update}. */
-  fixedUpdate?(step: Time): void;
+  fixedUpdate?(step: Time): Synchronous;
   /** Advance by the variable frame `delta`. Called once per frame, after fixed steps. */
-  update?(delta: Time): void;
+  update?(delta: Time): Synchronous;
   /** Render into `context`. Called once per frame, after {@link SystemMethods.update}. */
-  draw?(context: RenderingContext): void;
+  draw?(context: RenderingContext): Synchronous;
 }
 
 /**

--- a/src/core/SystemRegistry.ts
+++ b/src/core/SystemRegistry.ts
@@ -1,6 +1,7 @@
 import type { RenderingContext } from '#rendering/RenderingContext';
 
 import { Signal } from './Signal';
+import { hookOwnerName, requireSynchronousHook } from './syncHooks';
 import type { System } from './System';
 import type { Time } from './Time';
 import type { Destroyable } from './types';
@@ -49,6 +50,20 @@ type PendingMutation = PendingAdd | PendingRemove;
 const isPendingAdd = (mutation: PendingMutation): mutation is PendingAdd => mutation.add;
 
 const tieBreak = (a: SystemRegistration, b: SystemRegistration): number => a.order - b.order || a.sequence - b.sequence;
+
+/**
+ * Cold half of the system-phase synchrony contract. The phase loops keep the
+ * hot path to a single `result !== undefined` comparison and only call this
+ * once a phase has actually returned something, so building the message here
+ * costs nothing per frame.
+ */
+const requireSynchronousPhase = (result: unknown, system: System, phase: string): void => {
+  requireSynchronousHook(
+    result,
+    `${hookOwnerName(system, 'System')}.${phase}()`,
+    'The frame path never awaits a phase result, so an async phase loses its timing and swallows its errors. Move the asynchronous work into the owning scene’s load(), which the engine awaits once per activation.',
+  );
+};
 
 /**
  * Sorts `list` in place. Pure `order`/`sequence` comparison when no
@@ -291,7 +306,9 @@ export class SystemRegistry implements Destroyable {
 
     for (const registration of this._fixedList) {
       if (registration.active) {
-        registration.system.fixedUpdate!(step);
+        const result = registration.system.fixedUpdate!(step) as unknown;
+
+        if (result !== undefined) requireSynchronousPhase(result, registration.system, 'fixedUpdate');
       }
     }
   }
@@ -309,7 +326,9 @@ export class SystemRegistry implements Destroyable {
 
     for (const registration of this._updateList) {
       if (registration.active) {
-        registration.system.update!(delta);
+        const result = registration.system.update!(delta) as unknown;
+
+        if (result !== undefined) requireSynchronousPhase(result, registration.system, 'update');
       }
     }
   }
@@ -327,7 +346,9 @@ export class SystemRegistry implements Destroyable {
 
     for (const registration of this._drawList) {
       if (registration.active) {
-        registration.system.draw!(context);
+        const result = registration.system.draw!(context) as unknown;
+
+        if (result !== undefined) requireSynchronousPhase(result, registration.system, 'draw');
       }
     }
   }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -95,6 +95,7 @@ export type {
   Mutable,
   PlaybackOptions,
   StreamingLoadEvent,
+  Synchronous,
   TextureSource,
   TimeInterval,
   TypedArray,

--- a/src/core/syncHooks.ts
+++ b/src/core/syncHooks.ts
@@ -1,0 +1,50 @@
+// Always-on guard for the engine's synchronous lifecycle hooks.
+//
+// Nothing in this module is `__DEV__`-gated. An `async` override of a hook the
+// engine never awaits drops that hook's timing and swallows every error it
+// throws, so the failure has to look the same in a production build as it does
+// in development — a dev-only warning would hide the exact defect it is meant
+// to surface. This is the {@link invariant} category from `./dev`, not the
+// {@link assert} one: it throws in every build and is never stripped.
+//
+// The type system rejects an async override ahead of this guard (see
+// {@link Synchronous}); the guard covers what types cannot reach — plain
+// JavaScript consumers, `any`, `Object.assign`ed methods, and anything crossing
+// a module boundary untyped.
+
+const swallow = (): void => {
+  // Intentionally empty — see requireSynchronousHook's detach comment.
+};
+
+/**
+ * Class name of `owner`, or `fallback` when it has none worth reporting — a
+ * plain object literal, a null-prototype object, or an anonymous class
+ * expression.
+ */
+export function hookOwnerName(owner: object, fallback: string): string {
+  const name = (owner as { constructor?: { name?: string } }).constructor?.name;
+
+  return name === undefined || name === '' || name === 'Object' ? fallback : name;
+}
+
+/**
+ * Throw when a hook that must be synchronous returned a thenable. `subject` is
+ * the fully qualified hook (`'GameScene.update()'`) and `remedy` the sentence
+ * telling the caller where the asynchronous work belongs instead.
+ *
+ * Callers keep the check off the hot path with a `result !== undefined` test,
+ * so a well-behaved hook costs one comparison per dispatch and never reaches
+ * this function.
+ */
+export function requireSynchronousHook(result: unknown, subject: string, remedy: string): void {
+  if (result === null || typeof result !== 'object' || typeof (result as PromiseLike<unknown>).then !== 'function') {
+    return;
+  }
+
+  // Detach the abandoned thenable's rejection. The engine drops this result by
+  // design, so its eventual rejection must never surface as an unhandled
+  // rejection stacked on top of the lifecycle error thrown below.
+  void Promise.resolve(result as PromiseLike<unknown>).catch(swallow);
+
+  throw new Error(`[ExoJS] ${subject} returned a Promise, but it must be synchronous. ${remedy}`);
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -20,6 +20,34 @@ export type TypedEnum<Enum, Type> = { [Key in keyof Enum]: Type };
 /** Type-level extractor of an object's value type, equivalent to `T[keyof T]`. */
 export type ValueOf<T> = T[keyof T];
 
+/**
+ * Return type of the engine hooks that must not be asynchronous:
+ * {@link Scene.init}, the frame hooks {@link Scene.fixedUpdate} /
+ * {@link Scene.update} / {@link Scene.draw}, and the {@link SystemMethods}
+ * phases. Write these overrides exactly as before — a body that returns
+ * nothing satisfies `Synchronous`, `override update(delta: Time): void`
+ * remains the idiomatic annotation, and the engine's fluent
+ * `update(delta): this` convention still fits.
+ *
+ * It is deliberately *not* a bare `void`. TypeScript makes a `void`-returning
+ * signature assignable from a signature returning **anything at all**, so
+ * `override async update()` compiles clean against a `void` base — the exact
+ * mistake this contract exists to prevent. The union above keeps `void`,
+ * keeps every ordinary object return, and rejects only thenables: `then` is
+ * pinned to `never`, so any type carrying a callable `then` (a `Promise`, or
+ * a hand-rolled thenable) fails to match. `object &` is what makes the
+ * remaining constituent non-weak, so a return type with no `then` property at
+ * all is still accepted rather than tripping TypeScript's weak-type check.
+ *
+ * Nothing here exists at runtime; no engine code reads `then` off a hook
+ * result to decide anything (the always-on runtime guard does its own check).
+ *
+ * Hooks the engine genuinely awaits — {@link Scene.load} and
+ * {@link Scene.unload} — are typed `Promise<void> | void` instead and stay
+ * asynchronous.
+ */
+export type Synchronous = void | (object & { then?: never });
+
 /** Strips `readonly` modifiers from every property of `T`. */
 export type Mutable<T> = {
   -readonly [P in keyof T]: T[P];

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -431,6 +431,7 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "Sweep: variable",
   "SweptHit: interface",
   "SwitchProGamepadMapping: class",
+  "Synchronous: type alias",
   "System: type alias",
   "SystemMethods: interface",
   "SystemOrder: enum",

--- a/test/core/scene-scope-sync-hooks.test.ts
+++ b/test/core/scene-scope-sync-hooks.test.ts
@@ -1,0 +1,500 @@
+/**
+ * Synchronous-hook contract for `Scene.init` and the frame hooks
+ * (`fixedUpdate`/`update`/`draw`), plus the `System` phases dispatched by
+ * `SystemRegistry`.
+ *
+ * Two halves:
+ *
+ *   1. Behaviour — an `async` override is a hard failure, not a warning: it
+ *      throws, names the owner and the hook, and points at `load()`. The
+ *      abandoned thenable's rejection is detached so it never surfaces as an
+ *      unhandled rejection on top of the lifecycle error. `load()`/`unload()`
+ *      stay legitimately asynchronous.
+ *
+ *   2. Production parity — the guard is never `__DEV__`-gated, so dev and
+ *      production behave identically. Vitest always compiles `__DEV__` to
+ *      `true`, so production is verified two ways: structurally (no `__DEV__`
+ *      anywhere near the guard or inside it) and empirically, by running the
+ *      guard module through the REAL production pipeline
+ *      (`@rollup/plugin-replace` with `__DEV__ → false`, then `terser` with the
+ *      repo's `pure_funcs`) and executing the minified output.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { runInNewContext } from 'node:vm';
+
+import replace from '@rollup/plugin-replace';
+import terser from '@rollup/plugin-terser';
+import { type Plugin, rollup } from 'rollup';
+import ts from 'typescript';
+
+import type { Application } from '#core/Application';
+import { Scene } from '#core/Scene';
+import { SceneScope } from '#core/SceneScope';
+import { Signal } from '#core/Signal';
+import { SystemRegistry } from '#core/SystemRegistry';
+import { Time } from '#core/Time';
+
+import { createBuildDefines, resolveVersion } from '../../packages/exojs-config/build-defines/index.js';
+
+const rootDir = resolve(import.meta.dirname!, '..', '..');
+
+const readSource = (rel: string): string => readFileSync(resolve(rootDir, rel), 'utf8');
+
+/**
+ * Blanks out block and line comments, preserving line structure. The
+ * production-parity checks below are about executable code — prose that
+ * *mentions* `__DEV__` (this contract's documentation does, at length) must not
+ * read as a guard.
+ */
+const stripComments = (source: string): string =>
+  source.replace(/\/\*[\s\S]*?\*\//g, block => block.replace(/[^\n]/g, ' ')).replace(/\/\/[^\n]*/g, line => ' '.repeat(line.length));
+
+const devToken = /(?<![a-zA-Z0-9_$])__DEV__(?![a-zA-Z0-9_$])/;
+
+/** Parses `rel` into a TypeScript AST with parent pointers, for the structural checks below. */
+const parseSource = (rel: string): ts.SourceFile => ts.createSourceFile(rel, readSource(rel), ts.ScriptTarget.ES2022, true);
+
+/** Every call to a `requireSynchronous…` guard. AST-based, so comments and strings never count. */
+const guardCallSites = (source: ts.SourceFile): ts.CallExpression[] => {
+  const calls: ts.CallExpression[] = [];
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && /(?:^|\.)_?requireSynchronous\w*$/.test(node.expression.getText(source))) {
+      calls.push(node);
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(source);
+
+  return calls;
+};
+
+/**
+ * Whether `node` sits inside anything `__DEV__` can switch off — an
+ * `if (__DEV__)` branch, a `__DEV__ && …` short-circuit, or a `__DEV__ ? …`
+ * conditional. A neighbouring `if (__DEV__) Perf.mark(…)` statement is
+ * correctly *not* a gate, which is why this walks the AST instead of nearby
+ * source lines.
+ */
+const isDevGated = (node: ts.Node, source: ts.SourceFile): boolean => {
+  for (let current: ts.Node = node; current.parent !== undefined; current = current.parent) {
+    const parent = current.parent;
+
+    if (
+      ts.isIfStatement(parent) &&
+      (parent.thenStatement === current || parent.elseStatement === current) &&
+      devToken.test(parent.expression.getText(source))
+    ) {
+      return true;
+    }
+
+    if (
+      ts.isConditionalExpression(parent) &&
+      (parent.whenTrue === current || parent.whenFalse === current) &&
+      devToken.test(parent.condition.getText(source))
+    ) {
+      return true;
+    }
+
+    if (ts.isBinaryExpression(parent) && parent.right === current && devToken.test(parent.left.getText(source))) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+/** Minimal Application stand-in covering every touchpoint SceneScope activation reaches. */
+const createAppStub = (): Application =>
+  ({
+    loader: { _releaseScope: vi.fn() },
+    interaction: {
+      attachRoot: vi.fn(),
+      detachRoot: vi.fn(),
+      attachUIRoot: vi.fn(),
+      detachUIRoot: vi.fn(),
+    },
+    onError: new Signal<[Error]>(),
+  }) as unknown as Application;
+
+/** Prepares and activates `scene`, so the frame hooks actually dispatch. */
+const activate = async (scene: Scene): Promise<SceneScope> => {
+  const scope = new SceneScope(createAppStub(), scene);
+
+  await scope.prepare(undefined);
+  scope.activate();
+
+  return scope;
+};
+
+/** Lets any queued microtask-level unhandled rejection surface before the test ends. */
+const flushMicrotasks = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe('synchronous hook contract', () => {
+  describe('Scene.init()', () => {
+    test('an async override fails activation, naming the scene, the hook and load()', async () => {
+      class AsyncInitScene extends Scene {}
+
+      const scene = Object.assign(new AsyncInitScene(), {
+        async init(): Promise<void> {
+          /* never awaited by the engine */
+        },
+      });
+      const scope = new SceneScope(createAppStub(), scene);
+
+      await expect(scope.prepare(undefined)).rejects.toThrow(/AsyncInitScene\.init\(\)/);
+      await expect(new SceneScope(createAppStub(), scene).prepare(undefined)).rejects.toThrow(/must be synchronous/);
+      await expect(new SceneScope(createAppStub(), scene).prepare(undefined)).rejects.toThrow(/load\(\)/);
+    });
+
+    test('the abandoned init() rejection is detached, not left unhandled', async () => {
+      const scene = Object.assign(new Scene(), {
+        init(): unknown {
+          return Promise.reject(new Error('rejected inside the abandoned init() promise'));
+        },
+      });
+      const scope = new SceneScope(createAppStub(), scene);
+
+      await expect(scope.prepare(undefined)).rejects.toThrow(/must be synchronous/);
+      await flushMicrotasks();
+    });
+
+    test('a synchronous init() is unaffected', async () => {
+      const scope = new SceneScope(createAppStub(), new Scene());
+
+      await expect(scope.prepare(undefined)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('Scene frame hooks', () => {
+    test('an async fixedUpdate() override throws, naming the scene, the hook and load()', async () => {
+      class AsyncFixedScene extends Scene {}
+
+      const scene = Object.assign(new AsyncFixedScene(), {
+        async fixedUpdate(): Promise<void> {
+          /* never awaited by the engine */
+        },
+      });
+      const scope = await activate(scene);
+
+      expect(() => scope.fixedUpdate(new Time(16))).toThrow(/AsyncFixedScene\.fixedUpdate\(\) returned a Promise/);
+      expect(() => scope.fixedUpdate(new Time(16))).toThrow(/must be synchronous/);
+      expect(() => scope.fixedUpdate(new Time(16))).toThrow(/load\(\)/);
+    });
+
+    test('an async update() override throws, naming the scene and the hook', async () => {
+      class AsyncUpdateScene extends Scene {}
+
+      const scene = Object.assign(new AsyncUpdateScene(), {
+        async update(): Promise<void> {
+          /* never awaited by the engine */
+        },
+      });
+      const scope = await activate(scene);
+
+      expect(() => scope.update(new Time(16))).toThrow(/AsyncUpdateScene\.update\(\) returned a Promise/);
+    });
+
+    test('an async draw() override throws, naming the scene and the hook', async () => {
+      class AsyncDrawScene extends Scene {}
+
+      const scene = Object.assign(new AsyncDrawScene(), {
+        async draw(): Promise<void> {
+          /* never awaited by the engine */
+        },
+      });
+      const scope = await activate(scene);
+
+      expect(() => scope.draw({} as never)).toThrow(/AsyncDrawScene\.draw\(\) returned a Promise/);
+    });
+
+    test('the abandoned frame-hook rejection is detached, not left unhandled', async () => {
+      const scene = Object.assign(new Scene(), {
+        update(): unknown {
+          return Promise.reject(new Error('rejected inside the abandoned update() promise'));
+        },
+      });
+      const scope = await activate(scene);
+
+      expect(() => scope.update(new Time(16))).toThrow(/must be synchronous/);
+      await flushMicrotasks();
+    });
+
+    test('synchronous frame hooks still dispatch to the scene and its systems', async () => {
+      const fixedUpdate = vi.fn();
+      const update = vi.fn();
+      const draw = vi.fn();
+      const scene = Object.assign(new Scene(), { fixedUpdate, update, draw });
+      const scope = await activate(scene);
+
+      const system = { fixedUpdate: vi.fn(), update: vi.fn(), draw: vi.fn() };
+
+      scope.systems.add(system);
+
+      scope.fixedUpdate(new Time(16));
+      scope.update(new Time(16));
+      scope.draw({} as never);
+
+      expect(fixedUpdate).toHaveBeenCalledTimes(1);
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(draw).toHaveBeenCalledTimes(1);
+      expect(system.fixedUpdate).toHaveBeenCalledTimes(1);
+      expect(system.update).toHaveBeenCalledTimes(1);
+      expect(system.draw).toHaveBeenCalledTimes(1);
+    });
+
+    test('a hook returning a plain non-thenable value is not a synchrony violation', async () => {
+      const scene = Object.assign(new Scene(), {
+        update(): unknown {
+          return 42;
+        },
+      });
+      const scope = await activate(scene);
+
+      expect(() => scope.update(new Time(16))).not.toThrow();
+    });
+  });
+
+  describe('System phases', () => {
+    test('an async update() phase throws, naming the system and the phase', () => {
+      class AsyncSystem {
+        public async update(): Promise<void> {
+          /* never awaited by the engine */
+        }
+      }
+
+      const registry = new SystemRegistry();
+
+      registry.add(new AsyncSystem() as never);
+
+      expect(() => registry._update(new Time(16))).toThrow(/AsyncSystem\.update\(\) returned a Promise/);
+      expect(() => registry._update(new Time(16))).toThrow(/must be synchronous/);
+    });
+
+    test('an async fixedUpdate() phase throws', () => {
+      class AsyncFixedSystem {
+        public async fixedUpdate(): Promise<void> {
+          /* never awaited by the engine */
+        }
+      }
+
+      const registry = new SystemRegistry();
+
+      registry.add(new AsyncFixedSystem() as never);
+
+      expect(() => registry._fixedUpdate(new Time(16))).toThrow(/AsyncFixedSystem\.fixedUpdate\(\) returned a Promise/);
+    });
+
+    test('an async draw() phase throws', () => {
+      class AsyncDrawSystem {
+        public async draw(): Promise<void> {
+          /* never awaited by the engine */
+        }
+      }
+
+      const registry = new SystemRegistry();
+
+      registry.add(new AsyncDrawSystem() as never);
+
+      expect(() => registry._draw({} as never)).toThrow(/AsyncDrawSystem\.draw\(\) returned a Promise/);
+    });
+
+    test('an async phase on a plain object literal falls back to a generic owner label', () => {
+      const registry = new SystemRegistry();
+
+      registry.add({
+        async update(): Promise<void> {
+          /* never awaited by the engine */
+        },
+      } as never);
+
+      expect(() => registry._update(new Time(16))).toThrow(/System\.update\(\) returned a Promise/);
+    });
+
+    test('synchronous system phases are unaffected', () => {
+      const registry = new SystemRegistry();
+      const system = { update: vi.fn() };
+
+      registry.add(system);
+
+      expect(() => registry._update(new Time(16))).not.toThrow();
+      expect(system.update).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('load()/unload() stay asynchronous', () => {
+    test('an async load() override is awaited before init() and never rejected as a synchrony violation', async () => {
+      const events: string[] = [];
+
+      class AsyncLoadScene extends Scene {
+        public override async load(): Promise<void> {
+          events.push('load:start');
+          await Promise.resolve();
+          events.push('load:end');
+        }
+
+        public override init(): void {
+          events.push('init');
+        }
+      }
+
+      const scope = new SceneScope(createAppStub(), new AsyncLoadScene());
+
+      await expect(scope.prepare(undefined)).resolves.toBeUndefined();
+      expect(events).toEqual(['load:start', 'load:end', 'init']);
+    });
+
+    test('an async unload() override is awaited during teardown', async () => {
+      const events: string[] = [];
+
+      class AsyncUnloadScene extends Scene {
+        public override async unload(): Promise<void> {
+          events.push('unload:start');
+          await Promise.resolve();
+          events.push('unload:end');
+        }
+      }
+
+      const scope = await activate(new AsyncUnloadScene());
+
+      await scope.destroy();
+
+      expect(events).toEqual(['unload:start', 'unload:end']);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Production parity.
+// ---------------------------------------------------------------------------
+
+/** Extracts the `pure_funcs` list from `rollup.config.ts` — never hard-coded here. */
+const extractPureFuncs = (): string[] => {
+  const config = readSource('rollup.config.ts');
+  const match = /pure_funcs:\s*\[([^\]]*)\]/.exec(config);
+
+  expect(match).not.toBeNull();
+
+  return [...match![1]!.matchAll(/'([^']+)'/g)].map(m => m[1]!);
+};
+
+/**
+ * Bundles `src/core/syncHooks.ts` through the EXACT transform chain
+ * `rollup.config.ts` uses for production (`__DEV__ → false`, then `terser` with
+ * the repo's `pure_funcs`) and returns the minified IIFE. The module imports
+ * nothing, so this bundles one small file and stays fast.
+ */
+const buildProductionSyncHooks = async (pureFuncs: string[]): Promise<string> => {
+  const virtualId = '\0virtual-sync-hooks.js';
+  const code = ts.transpileModule(readSource('src/core/syncHooks.ts'), {
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
+  }).outputText;
+
+  const virtualPlugin: Plugin = {
+    name: 'virtual-sync-hooks',
+    resolveId: id => (id === virtualId ? id : null),
+    load: id => (id === virtualId ? code : null),
+  };
+
+  // Same define values production uses (mode: 'production' → __DEV__: 'false').
+  const defines = createBuildDefines({ mode: 'production', version: resolveVersion(rootDir), revision: 'test' });
+
+  const bundle = await rollup({
+    input: virtualId,
+    plugins: [virtualPlugin, replace({ preventAssignment: true, values: defines }), terser({ compress: { pure_funcs: pureFuncs } })],
+    onwarn: () => {
+      // Silence rollup's treeshaking noise for this tiny synthetic entry.
+    },
+  });
+
+  try {
+    const { output } = await bundle.generate({ format: 'iife', name: 'syncHooks' });
+
+    return output[0]!.code;
+  } finally {
+    await bundle.close();
+  }
+};
+
+describe('production parity of the synchronous-hook guard', () => {
+  test('the guard module has no executable __DEV__ reference, so nothing in it can be stripped', () => {
+    expect(stripComments(readSource('src/core/syncHooks.ts'))).not.toMatch(devToken);
+  });
+
+  test.each([
+    // SceneScope: init() plus the three frame hooks, and the shared cold-path helper.
+    { file: 'src/core/SceneScope.ts', minimumCallSites: 5 },
+    // SystemRegistry: the three phase loops, and the shared cold-path helper.
+    { file: 'src/core/SystemRegistry.ts', minimumCallSites: 4 },
+  ])('$file invokes the guard outside every __DEV__ branch', ({ file, minimumCallSites }) => {
+    const source = parseSource(file);
+    const callSites = guardCallSites(source);
+
+    expect(callSites.length).toBeGreaterThanOrEqual(minimumCallSites);
+
+    for (const call of callSites) {
+      const { line } = source.getLineAndCharacterOfPosition(call.getStart(source));
+
+      expect(isDevGated(call, source), `${file}:${line + 1} must not sit inside a __DEV__ branch`).toBe(false);
+    }
+  });
+
+  test('the __DEV__-gate detector actually detects a gate', () => {
+    // Guards the guard: without this, a broken `isDevGated` would silently pass
+    // the assertions above no matter how the call sites were written.
+    const probe = ts.createSourceFile(
+      'probe.ts',
+      'if (__DEV__) { requireSynchronousHook(x, y, z); }\nif (__DEV__ && x) requireSynchronousHook(x, y, z);\n',
+      ts.ScriptTarget.ES2022,
+      true,
+    );
+    const calls = guardCallSites(probe);
+
+    expect(calls).toHaveLength(2);
+    expect(calls.map(call => isDevGated(call, probe))).toEqual([true, true]);
+  });
+
+  test('the guard is absent from every rollup pure_funcs list, so terser never drops its callsites', () => {
+    const config = readSource('rollup.config.ts');
+    const blocks = [...config.matchAll(/pure_funcs:\s*\[([^\]]*)\]/g)].map(m => m[1]!);
+
+    expect(blocks.length).toBeGreaterThan(0);
+
+    for (const block of blocks) {
+      expect(block).not.toContain("'requireSynchronousHook'");
+    }
+  });
+
+  test('still throws after the real production pipeline (__DEV__ → false + terser)', async () => {
+    const output = await buildProductionSyncHooks(extractPureFuncs());
+    const sandbox: { syncHooks?: { requireSynchronousHook: (result: unknown, subject: string, remedy: string) => void } } = {};
+
+    runInNewContext(output, sandbox);
+
+    const guard = sandbox.syncHooks!.requireSynchronousHook;
+
+    expect(typeof guard).toBe('function');
+
+    let message = '';
+
+    try {
+      guard(Promise.resolve(), 'ProdScene.update()', 'Move asynchronous work into load().');
+    } catch (error) {
+      message = (error as Error).message;
+    }
+
+    expect(message).toContain('ProdScene.update()');
+    expect(message).toContain('must be synchronous');
+    expect(message).toContain('Move asynchronous work into load().');
+
+    // A synchronous result stays a no-op in production, exactly as in dev.
+    expect(() => guard(undefined, 'ProdScene.update()', 'irrelevant')).not.toThrow();
+  }, 20_000);
+});

--- a/test/type-tests/synchronous-hooks.type-test.ts
+++ b/test/type-tests/synchronous-hooks.type-test.ts
@@ -1,0 +1,198 @@
+// Type contract for the synchronous engine hooks: `Scene.init` and the frame
+// hooks (`fixedUpdate`/`update`/`draw`), plus the three `SystemMethods`
+// phases, reject an `async` override at compile time — a plain `void` return
+// type does NOT, because TypeScript makes a `void`-returning signature
+// assignable from a signature returning anything at all.
+//
+// `Scene.load`/`Scene.unload` are the hooks the engine genuinely awaits and
+// must stay asynchronous; the bottom half pins that down so the prohibition
+// can never be widened onto them by accident.
+//
+// Compiled by `tsconfig.type-tests.json` and `tsconfig.type-tests-loose.json`
+// (`strictNullChecks: false`) via `pnpm typecheck:type-tests`.
+
+import { type RenderingContext, Scene, type Synchronous, type System, type Time } from '@codexo/exojs';
+
+// ── Scene: synchronous overrides are accepted, exactly as before ────────────
+
+class SyncScene extends Scene {
+  public override init(): void {
+    // noop
+  }
+
+  public override fixedUpdate(_step: Time): void {
+    // noop
+  }
+
+  public override update(_delta: Time): void {
+    // noop
+  }
+
+  public override draw(_context: RenderingContext): void {
+    // noop
+  }
+}
+void SyncScene;
+
+// An unannotated override infers `void` and is accepted too.
+class InferredSyncScene extends Scene {
+  public override update(_delta: Time) {
+    // noop
+  }
+}
+void InferredSyncScene;
+
+// The hook return type is nameable, for code that wants to be explicit.
+class ExplicitSyncScene extends Scene {
+  public override update(_delta: Time): Synchronous {
+    // noop
+  }
+}
+void ExplicitSyncScene;
+
+// Only thenables are banned — the engine's fluent `update(delta): this`
+// convention (Application, SceneDirector, AnimatedSprite, ParticleSystem, …)
+// must keep compiling, so a non-thenable return stays legal.
+class FluentScene extends Scene {
+  public override update(_delta: Time): this {
+    return this;
+  }
+}
+void FluentScene;
+
+// ── Scene: async overrides are rejected ────────────────────────────────────
+
+class AsyncInitScene extends Scene {
+  // @ts-expect-error — init() must be synchronous; move async setup into load().
+  public override async init(): Promise<void> {
+    await Promise.resolve();
+  }
+}
+void AsyncInitScene;
+
+class AsyncFixedUpdateScene extends Scene {
+  // @ts-expect-error — fixedUpdate() must be synchronous.
+  public override async fixedUpdate(_step: Time): Promise<void> {
+    await Promise.resolve();
+  }
+}
+void AsyncFixedUpdateScene;
+
+class AsyncUpdateScene extends Scene {
+  // @ts-expect-error — update() must be synchronous.
+  public override async update(_delta: Time): Promise<void> {
+    await Promise.resolve();
+  }
+}
+void AsyncUpdateScene;
+
+class AsyncDrawScene extends Scene {
+  // @ts-expect-error — draw() must be synchronous.
+  public override async draw(_context: RenderingContext): Promise<void> {
+    await Promise.resolve();
+  }
+}
+void AsyncDrawScene;
+
+// An `async` override with an inferred return type is rejected as well — the
+// mistake is almost always written without the explicit `Promise<void>`.
+class InferredAsyncUpdateScene extends Scene {
+  // @ts-expect-error — update() must be synchronous.
+  public override async update(_delta: Time) {
+    await Promise.resolve();
+  }
+}
+void InferredAsyncUpdateScene;
+
+// Returning a Promise without `async` is the same violation.
+class ThenableUpdateScene extends Scene {
+  // @ts-expect-error — update() must not return a Promise.
+  public override update(_delta: Time): Promise<void> {
+    return Promise.resolve();
+  }
+}
+void ThenableUpdateScene;
+
+// A hand-rolled thenable is rejected too — the ban is on the `then` protocol,
+// not on the `Promise` class, which matches what the runtime guard detects.
+class CustomThenable {
+  public then(_onFulfilled: () => void): void {
+    // noop
+  }
+}
+
+class CustomThenableScene extends Scene {
+  // @ts-expect-error — update() must not return a thenable of any kind.
+  public override update(_delta: Time): CustomThenable {
+    return new CustomThenable();
+  }
+}
+void CustomThenableScene;
+
+// ── System phases ──────────────────────────────────────────────────────────
+
+const syncSystem: System = {
+  update(_delta) {
+    // noop
+  },
+};
+void syncSystem;
+
+const asyncUpdateSystem: System = {
+  // @ts-expect-error — a System's update() phase must be synchronous.
+  async update(_delta) {
+    await Promise.resolve();
+  },
+};
+void asyncUpdateSystem;
+
+const asyncFixedUpdateSystem: System = {
+  // @ts-expect-error — a System's fixedUpdate() phase must be synchronous.
+  async fixedUpdate(_step) {
+    await Promise.resolve();
+  },
+};
+void asyncFixedUpdateSystem;
+
+const asyncDrawSystem: System = {
+  // @ts-expect-error — a System's draw() phase must be synchronous.
+  async draw(_context) {
+    await Promise.resolve();
+  },
+};
+void asyncDrawSystem;
+
+class AsyncSystemClass {
+  public async update(_delta: Time): Promise<void> {
+    await Promise.resolve();
+  }
+}
+
+// @ts-expect-error — a class-based System's phase must be synchronous too.
+const asyncSystemInstance: System = new AsyncSystemClass();
+void asyncSystemInstance;
+
+// ── load()/unload() stay asynchronous ──────────────────────────────────────
+
+class AsyncLoadScene extends Scene<{ readonly level: number }> {
+  public override async load(data: Readonly<{ readonly level: number }>): Promise<void> {
+    await Promise.resolve(data.level);
+  }
+
+  public override async unload(): Promise<void> {
+    await Promise.resolve();
+  }
+}
+void AsyncLoadScene;
+
+// A synchronous load()/unload() remains valid — the hooks are `Promise<void> | void`.
+class SyncLoadScene extends Scene {
+  public override load(): void {
+    // noop
+  }
+
+  public override unload(): void {
+    // noop
+  }
+}
+void SyncLoadScene;

--- a/tsconfig.type-tests-loose.json
+++ b/tsconfig.type-tests-loose.json
@@ -18,6 +18,10 @@
     "test/type-tests/loader-catalog-input.type-test.ts",
     "test/type-tests/loader-catalog-leaf.type-test.ts",
     "test/type-tests/assets-strict-false.type-test.ts",
+    // The synchronous-hook prohibition leans on a union with `void`, whose
+    // assignability differs under `strictNullChecks: false` — it has to hold
+    // for a non-strict consumer too, not just the strict lane.
+    "test/type-tests/synchronous-hooks.type-test.ts",
     "src/typings.d.ts"
   ]
 }


### PR DESCRIPTION
An `async init()` override had its rejection detached and was only rejected under `__DEV__`; `fixedUpdate`/`update`/`draw` returning a Promise were only dev-warned. In production the thenable was silently discarded — the same invalid override behaved differently per build. System frame hooks had no guard at all, not even a warning.

## Scope check first

`Scene.load()` and `Scene.unload()` are the only genuinely awaited hooks and **stay `Promise<void> | void`**. No other lifecycle hook is awaited anywhere. `SystemMethods.fixedUpdate/update/draw` share the frame-hook contract and had the same defect, so they are included.

## Type level

`void` alone is **not** enough — verified, not assumed: TypeScript accepts an `async` override against a `void`-returning signature in every configuration tried. The hooks now return a new exported `Synchronous`:

```ts
export type Synchronous = void | (object & { then?: never });
```

An earlier unconstructible-brand attempt worked but banned all non-void returns and broke `ParticleSystem.update(delta): this` — the engine's fluent convention. This form pins `then` to `never` and uses `object &` to defeat the weak-type check, rejecting **only thenables** (`Promise` and hand-rolled alike). Confirmed across all three type-test lanes.

## Runtime

`src/core/syncHooks.ts` throws in every build, naming owner and hook and pointing at `load()`. It also detaches the abandoned thenable's rejection so it cannot stack an unhandled rejection on top of the lifecycle error.

Vitest hard-compiles `__DEV__` to `true`, so production was proven three ways: the module contains no executable `__DEV__` token; an AST walk proves no guard call site sits inside a `__DEV__` branch (with a probe test proving the detector has teeth); and the module is bundled through the real rollup pipeline with production defines plus terser, then executed via `node:vm` and asserted to still throw. Mutation-tested — wrapping the throw in `if (__DEV__)` fails two of the three.

## Frame-path cost

One `result !== undefined` compare per dispatch; message construction is in cold helpers. Measured at 100 systems/frame: ≤0.7 ns per phase call, below run-to-run noise, ~0.0004% of a 16.67 ms budget.

## Collateral

Closing the type hole exposed **32 examples** with illegal `override async init()` — a known-but-invisible bug, since a `void`-returning signature structurally accepted a `Promise<void>` override. All were uniform with no `this.init()` callers; renamed to `load()`, bodies unchanged, since `load()` runs in the same `Preparing` state with the same facilities.

## Verification

- `test/core`: 997 passed · full `pnpm test:core`: 5839 passed, 15 skipped
- typecheck, all 3 type-test lanes, `typecheck:examples`/`:guides`/`:packages`, eslint `--max-warnings=0`, prettier, `docs:api:check` all clean