### PR TITLE
refactor(input): extract ButtonLikeAction base for ButtonAction/ChordAction

### DIFF
--- a/site/src/content/api/button-like-action.json
+++ b/site/src/content/api/button-like-action.json
@@ -1,7 +1,7 @@
 {
-  "title": "ButtonAction",
-  "description": "A named on/off input, fed by one source or by several interchangeable ones. Sources may be digital (a key) or analog (a trigger) — the action reports the strongest of them and compares it against its own threshold.",
-  "symbol": "ButtonAction",
+  "title": "ButtonLikeAction",
+  "description": "Shared mechanism behind every action that reduces a set of bound channels to a single on/off `active`/`pressed`/`released` (plus `value`) triad — ButtonAction (strongest of a set of alternative sources) and ChordAction (weakest of a set of required members). A subclass supplies only _aggregate; this base owns the batch-replay update loop, initial-baseline seeding, and reset.",
+  "symbol": "ButtonLikeAction",
   "kind": "class",
   "subsystem": "input",
   "importPath": "@codexo/exojs",
@@ -19,9 +19,9 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "A named on/off input, fed by one source or by several interchangeable ones. Sources may be digital (a key) or analog (a trigger) — the action reports the strongest of them and compares it against its own threshold."
+        "Shared mechanism behind every action that reduces a set of bound channels to a single on/off `active`/`pressed`/`released` (plus `value`) triad — ButtonAction (strongest of a set of alternative sources) and ChordAction (weakest of a set of required members). A subclass supplies only _aggregate; this base owns the batch-replay update loop, initial-baseline seeding, and reset."
       ],
-      "importLine": "import { ButtonAction } from '@codexo/exojs'",
+      "importLine": "import { ButtonLikeAction } from '@codexo/exojs'",
       "sourceLink": null
     },
     {
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(binding: OneOrMany<InputChannel>, options: ActionOptions): ButtonAction",
+          "signature": "new(channels: readonly number[], threshold: number): ButtonLikeAction",
           "signatureTokens": [
             {
               "text": "new",
@@ -41,7 +41,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "binding",
+              "text": "channels",
               "kind": "param"
             },
             {
@@ -49,19 +49,19 @@
               "kind": "punctuation"
             },
             {
-              "text": "OneOrMany",
-              "kind": "type"
+              "text": "readonly",
+              "kind": "keyword"
             },
             {
-              "text": "<",
+              "text": " ",
               "kind": "punctuation"
             },
             {
-              "text": "InputChannel",
-              "kind": "type"
+              "text": "number",
+              "kind": "keyword"
             },
             {
-              "text": ">",
+              "text": "[]",
               "kind": "punctuation"
             },
             {
@@ -69,7 +69,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "options",
+              "text": "threshold",
               "kind": "param"
             },
             {
@@ -77,8 +77,8 @@
               "kind": "punctuation"
             },
             {
-              "text": "ActionOptions",
-              "kind": "type"
+              "text": "number",
+              "kind": "keyword"
             },
             {
               "text": ")",
@@ -89,23 +89,23 @@
               "kind": "punctuation"
             },
             {
-              "text": "ButtonAction",
+              "text": "ButtonLikeAction",
               "kind": "type"
             }
           ],
           "params": [
             {
-              "name": "binding",
-              "type": "OneOrMany<InputChannel>",
+              "name": "channels",
+              "type": "readonly number[]",
               "optional": false
             },
             {
-              "name": "options",
-              "type": "ActionOptions",
+              "name": "threshold",
+              "type": "number",
               "optional": false
             }
           ],
-          "returnType": "ButtonAction",
+          "returnType": "ButtonLikeAction",
           "description": ""
         }
       ],
@@ -213,11 +213,11 @@
       "paragraphs": [],
       "importLine": null,
       "sourceLink": {
-        "label": "src/input/actions/ButtonAction.ts",
-        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/input/actions/ButtonAction.ts"
+        "label": "src/input/actions/ButtonLikeAction.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/input/actions/ButtonLikeAction.ts"
       }
     }
   ],
-  "sourcePath": "src/input/actions/ButtonAction.ts",
-  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/input/actions/ButtonAction.ts"
+  "sourcePath": "src/input/actions/ButtonLikeAction.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/input/actions/ButtonLikeAction.ts"
 }

--- a/site/src/content/api/chord-action.json
+++ b/site/src/content/api/chord-action.json
@@ -1,16 +1,16 @@
 {
   "title": "ChordAction",
-  "description": "Button-like action active while every channel in a chord is held at once — `Control+S`, a modifier held alongside a gamepad button, and so on. Exposes the same `active`/`pressed`/`released` triad as ButtonAction, but the aggregate is the AND of every bound channel instead of the strongest of a set of alternatives. A string binding resolves `+`-joined tokens as case-insensitive Keyboard enum names (`'Control+S'`, `'control+s'`). This is a shortcut list syntax for enum lookups, not text or IME input — it never decodes typed characters, dead keys, or composed input, and rejects any token that is not a known `Keyboard` member. Use an array of InputChannels directly to include pointer or gamepad channels, or for a sequence with more than one step, use SequenceAction.",
+  "description": "Button-like action active while every channel in a chord is held at once — `Control+S`, a modifier held alongside a gamepad button, and so on. Exposes the same `active`/`pressed`/`released`/`value` quartet as ButtonAction, but the aggregate is the weakest of every bound channel instead of the strongest of a set of alternatives: `min(|v|) > threshold` for every bound channel holds if and only if every one of them individually exceeds threshold, so a chord is only ever as \"on\" as its least-engaged member. For an analog chord (a gamepad trigger held alongside a button, say), value reports the trigger's pull limited by whether the button is engaged at all — `0` the instant any member releases, never the button's own binary 0/1. A string binding resolves `+`-joined tokens as case-insensitive Keyboard enum names (`'Control+S'`, `'control+s'`). This is a shortcut list syntax for enum lookups, not text or IME input — it never decodes typed characters, dead keys, or composed input, and rejects any token that is not a known `Keyboard` member. Use an array of InputChannels directly to include pointer or gamepad channels, or for a sequence with more than one step, use SequenceAction.",
   "symbol": "ChordAction",
   "kind": "class",
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 6,
+  "memberCount": 5,
   "counts": {
     "constructors": 1,
-    "methods": 2,
-    "properties": 3,
+    "methods": 0,
+    "properties": 4,
     "events": 0
   },
   "sections": [
@@ -19,7 +19,7 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "Button-like action active while every channel in a chord is held at once — `Control+S`, a modifier held alongside a gamepad button, and so on. Exposes the same `active`/`pressed`/`released` triad as ButtonAction, but the aggregate is the AND of every bound channel instead of the strongest of a set of alternatives.",
+        "Button-like action active while every channel in a chord is held at once — `Control+S`, a modifier held alongside a gamepad button, and so on. Exposes the same `active`/`pressed`/`released`/`value` quartet as ButtonAction, but the aggregate is the weakest of every bound channel instead of the strongest of a set of alternatives: `min(|v|) > threshold` for every bound channel holds if and only if every one of them individually exceeds threshold, so a chord is only ever as \"on\" as its least-engaged member. For an analog chord (a gamepad trigger held alongside a button, say), value reports the trigger's pull limited by whether the button is engaged at all — `0` the instant any member releases, never the button's own binary 0/1.",
         "A string binding resolves `+`-joined tokens as case-insensitive Keyboard enum names (`'Control+S'`, `'control+s'`). This is a shortcut list syntax for enum lookups, not text or IME input — it never decodes typed characters, dead keys, or composed input, and rejects any token that is not a known `Keyboard` member. Use an array of InputChannels directly to include pointer or gamepad channels, or for a sequence with more than one step, use SequenceAction."
       ],
       "importLine": "import { ChordAction } from '@codexo/exojs'",
@@ -103,91 +103,6 @@
       "sourceLink": null
     },
     {
-      "id": "methods",
-      "title": "Methods",
-      "members": [
-        {
-          "name": "_reset",
-          "signature": "_reset(): void",
-          "signatureTokens": [
-            {
-              "text": "_reset",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": ""
-        },
-        {
-          "name": "_update",
-          "signature": "_update(sample: ActionSample): void",
-          "signatureTokens": [
-            {
-              "text": "_update",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": "sample",
-              "kind": "param"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "ActionSample",
-              "kind": "type"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [
-            {
-              "name": "sample",
-              "type": "ActionSample",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "description": ""
-        }
-      ],
-      "paragraphs": [],
-      "importLine": null,
-      "sourceLink": null
-    },
-    {
       "id": "properties",
       "title": "Properties",
       "members": [
@@ -210,7 +125,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "true while the aggregate value exceeds the action's threshold."
         },
         {
           "name": "pressed",
@@ -231,7 +146,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "true on the frame the AGGREGATE value crossed above the action's own threshold. Bound sources are replayed in the true order their channels changed, batch by whole batch (see ChannelEventBatch's doc comment — every channel a single real-world event wrote together is applied before the aggregate is evaluated even once), so a value that crosses the threshold twice within one frame (0.4 → 0.7 → 0.4 at threshold 0.5) sets both pressed and released on that same frame, while a source that never actually reaches the threshold (0 → 0.1 → 0 at threshold 0.5) sets neither. A second, alternative source tapping while a first stays continuously active never manufactures an edge either, because the aggregate itself never drops below threshold."
         },
         {
           "name": "released",
@@ -252,7 +167,28 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "true on the frame the aggregate value crossed back below the threshold. See pressed."
+        },
+        {
+          "name": "value",
+          "signature": "value: number",
+          "signatureTokens": [
+            {
+              "text": "value",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Aggregate source value this frame, in 0..1. Reads 0 on a frame where the source was pressed and released again between two frame boundaries — check pressed for that case rather than the value."
         }
       ],
       "paragraphs": [],

--- a/src/input/InputManager.ts
+++ b/src/input/InputManager.ts
@@ -488,7 +488,7 @@ export class InputManager {
    * the correct state. `_update` forwards straight through here: with the
    * map's ownership tracker already reset, it resolves to the SAME baseline
    * path a fresh attach or a genuine handoff would (see
-   * {@link ButtonAction._update}'s doc comment). Re-arms the watermark first
+   * {@link ButtonLikeAction._update}'s doc comment). Re-arms the watermark first
    * (see {@link ActionMapBase._armBaseline}) since this map stays with the
    * SAME owner across the suspend/resume cycle and so never goes through
    * `_attach` again — without this, a resume triggered partway through the

--- a/src/input/actions/ActionMap.ts
+++ b/src/input/actions/ActionMap.ts
@@ -255,7 +255,7 @@ class ActionMapBase<T extends ActionRecord> {
       // Force every action to re-baseline against the live channel state on
       // its own very next _update call below, rather than trusting whatever
       // frame-to-frame state it carries from a previous, unrelated owner —
-      // see ButtonAction._reset's doc comment.
+      // see ButtonLikeAction._reset's doc comment.
       for (const action of this.actions) {
         action._reset();
       }

--- a/src/input/actions/ButtonAction.ts
+++ b/src/input/actions/ButtonAction.ts
@@ -1,7 +1,8 @@
 import type { InputChannel } from '#input/InputBinding';
 import { resolveGamepadSlotChannel } from '#input/types';
 
-import type { ActionOptions, ActionSample, OneOrMany } from './types';
+import { ButtonLikeAction } from './ButtonLikeAction';
+import type { ActionOptions, OneOrMany } from './types';
 import { toChannels } from './types';
 
 /** Strongest absolute value across every entry, sign-preserving. */
@@ -30,167 +31,15 @@ function strongestOf(values: Float32Array): number {
  * const accelerate = new ButtonAction(GamepadButton.RightTrigger, { threshold: 0.5 });
  * ```
  */
-export class ButtonAction {
-  private readonly _channels: readonly number[];
-  private readonly _threshold: number;
-  /** Last known value of each bound channel, in `_channels` order — the replay baseline `_update` advances. */
-  private readonly _channelValues: Float32Array;
-  /**
-   * `false` until this action has established an initial baseline for every
-   * bound channel — see `_update`'s doc comment. Reset by `_reset()`, and
-   * implicitly by the owning {@link ActionMap} on a legitimate ownership
-   * handoff (a fresh reset forces the next `_update` to re-baseline against
-   * the new owner's live state).
-   */
-  private _seeded = false;
-  private _value = 0;
-  private _active = false;
-  private _pressedThisFrame = false;
-  private _releasedThisFrame = false;
-
+export class ButtonAction extends ButtonLikeAction {
   public constructor(binding: OneOrMany<InputChannel>, options: ActionOptions = {}) {
     const slot = options.gamepadSlot ?? 0;
+    const channels = toChannels(binding).map(channel => resolveGamepadSlotChannel(channel, slot));
 
-    this._channels = toChannels(binding).map(channel => resolveGamepadSlotChannel(channel, slot));
-    this._threshold = options.threshold ?? 0;
-    this._channelValues = new Float32Array(this._channels.length);
+    super(channels, options.threshold ?? 0);
   }
 
-  /**
-   * Strongest source value this frame, in 0..1. Reads `0` on a frame where the
-   * source was pressed and released again between two frame boundaries — check
-   * {@link pressed} for that case rather than the value.
-   */
-  public get value(): number {
-    return Math.abs(this._value);
-  }
-
-  /** `true` while the value exceeds the action's threshold. */
-  public get active(): boolean {
-    return this._active;
-  }
-
-  /**
-   * `true` on the frame the AGGREGATE value — the strongest of every bound
-   * source — crossed above the action's own threshold. Bound sources are
-   * replayed in the true order their channels changed, batch by whole batch
-   * (see {@link ChannelEventBatch}'s doc comment — every channel a single
-   * real-world event wrote together is applied before the aggregate is
-   * evaluated even once), so a value that crosses the threshold twice within
-   * one frame (0.4 → 0.7 → 0.4 at threshold 0.5) sets both {@link pressed}
-   * and {@link released} on that same frame, while a source that never
-   * actually reaches the threshold (0 → 0.1 → 0 at threshold 0.5) sets
-   * neither. A second, alternative source tapping while a first stays
-   * continuously active never manufactures an edge either, because the
-   * aggregate itself never drops below threshold.
-   */
-  public get pressed(): boolean {
-    return this._pressedThisFrame;
-  }
-
-  /** `true` on the frame the aggregate value crossed back below the threshold. See {@link pressed}. */
-  public get released(): boolean {
-    return this._releasedThisFrame;
-  }
-
-  /**
-   * Replay this frame's ordered batches, evaluating the aggregate state once
-   * per batch rather than once per individual channel within it.
-   *
-   * The very first call ever (or the first call after `_reset()` — see that
-   * method's doc comment) additionally seeds every bound channel that has NO
-   * batch entry THIS SAME call directly from `sample.values`, with no edge —
-   * a channel already active before this action started watching correctly
-   * contributes to the aggregate without a synthetic press. A channel that
-   * DOES have a batch entry this call is deliberately left unseeded: it was
-   * necessarily `0` a moment ago (a batch entry only exists where the value
-   * actually changed), so replaying it below detects a real, legitimate edge
-   * instead of being masked by a seed that jumped straight to the final
-   * value — seeding every bound channel unconditionally from `sample.values`
-   * (the frame's FINAL state) and then still replaying the very batches that
-   * led there would silently erase whatever edge those batches represent.
-   *
-   * @internal
-   */
-  public _update(sample: ActionSample): void {
-    if (!this._seeded) {
-      this._seeded = true;
-      this._seedUntouchedChannels(sample);
-      this._active = Math.abs(strongestOf(this._channelValues)) > this._threshold;
-    }
-
-    this._pressedThisFrame = false;
-    this._releasedThisFrame = false;
-
-    let wasActive = this._active;
-
-    for (const batch of sample.batches) {
-      let touchedBoundChannel = false;
-
-      for (const event of batch.channels) {
-        const index = this._channels.indexOf(event.channel);
-
-        if (index === -1) {
-          continue;
-        }
-
-        this._channelValues[index] = event.value;
-        touchedBoundChannel = true;
-      }
-
-      if (!touchedBoundChannel) {
-        continue;
-      }
-
-      const isActive = Math.abs(strongestOf(this._channelValues)) > this._threshold;
-
-      if (!wasActive && isActive) {
-        this._pressedThisFrame = true;
-      } else if (wasActive && !isActive) {
-        this._releasedThisFrame = true;
-      }
-
-      wasActive = isActive;
-    }
-
-    this._value = strongestOf(this._channelValues);
-    this._active = wasActive;
-  }
-
-  /** Seed every bound channel with no batch entry this call directly from `sample.values` — see `_update`'s doc comment. */
-  private _seedUntouchedChannels(sample: ActionSample): void {
-    const touched = new Set<number>();
-
-    for (const batch of sample.batches) {
-      for (const event of batch.channels) {
-        touched.add(event.channel);
-      }
-    }
-
-    for (let i = 0; i < this._channels.length; i++) {
-      const channel = this._channels[i]!;
-
-      if (!touched.has(channel)) {
-        this._channelValues[i] = sample.values[channel] ?? 0;
-      }
-    }
-  }
-
-  /**
-   * Clear all state, as if no source had ever been touched — used when an
-   * owner stops feeding this action (a scene suspend), and by the owning
-   * {@link ActionMap} to force a fresh baseline on a legitimate ownership
-   * handoff, since the new owner's channel buffer is unrelated to the old
-   * one's.
-   *
-   * @internal
-   */
-  public _reset(): void {
-    this._channelValues.fill(0);
-    this._value = 0;
-    this._active = false;
-    this._pressedThisFrame = false;
-    this._releasedThisFrame = false;
-    this._seeded = false;
+  protected override _aggregate(values: Float32Array): number {
+    return strongestOf(values);
   }
 }

--- a/src/input/actions/ButtonLikeAction.ts
+++ b/src/input/actions/ButtonLikeAction.ts
@@ -1,0 +1,186 @@
+import type { ActionSample } from './types';
+
+/**
+ * Shared mechanism behind every action that reduces a set of bound channels
+ * to a single on/off `active`/`pressed`/`released` (plus `value`) triad —
+ * {@link ButtonAction} (strongest of a set of alternative sources) and
+ * {@link ChordAction} (weakest of a set of required members). A subclass
+ * supplies only {@link _aggregate}; this base owns the batch-replay update
+ * loop, initial-baseline seeding, and reset.
+ */
+export abstract class ButtonLikeAction {
+  protected readonly _channels: readonly number[];
+  protected readonly _threshold: number;
+  /** Last known value of each bound channel, in `_channels` order — the replay baseline `_update` advances. */
+  protected readonly _values: Float32Array;
+  /**
+   * `false` until this action has established an initial baseline for every
+   * bound channel — see `_update`'s doc comment. Reset by `_reset()`, and
+   * implicitly by the owning {@link ActionMap} on a legitimate ownership
+   * handoff (a fresh reset forces the next `_update` to re-baseline against
+   * the new owner's live state).
+   */
+  protected _seeded = false;
+  protected _value = 0;
+  protected _active = false;
+  protected _pressedThisFrame = false;
+  protected _releasedThisFrame = false;
+
+  protected constructor(channels: readonly number[], threshold: number) {
+    this._channels = channels;
+    this._threshold = threshold;
+    this._values = new Float32Array(channels.length);
+  }
+
+  /**
+   * Reduce every bound channel's current value to the single, sign-preserving
+   * number `_update` compares against `_threshold`. {@link ButtonAction}
+   * reports the strongest entry (the loudest of a set of interchangeable
+   * sources wins); {@link ChordAction} reports the weakest (a chord is only
+   * as strong as its least-engaged member) — `min(|v|) > threshold` for every
+   * bound channel is equivalent to requiring every one of them individually
+   * past threshold, so `ChordAction`'s AND-of-all semantics fall out of this
+   * same comparison without a separate code path.
+   *
+   * @internal
+   */
+  protected abstract _aggregate(values: Float32Array): number;
+
+  /**
+   * Aggregate source value this frame, in 0..1. Reads `0` on a frame where the
+   * source was pressed and released again between two frame boundaries — check
+   * {@link pressed} for that case rather than the value.
+   */
+  public get value(): number {
+    return Math.abs(this._value);
+  }
+
+  /** `true` while the aggregate value exceeds the action's threshold. */
+  public get active(): boolean {
+    return this._active;
+  }
+
+  /**
+   * `true` on the frame the AGGREGATE value crossed above the action's own
+   * threshold. Bound sources are replayed in the true order their channels
+   * changed, batch by whole batch (see {@link ChannelEventBatch}'s doc
+   * comment — every channel a single real-world event wrote together is
+   * applied before the aggregate is evaluated even once), so a value that
+   * crosses the threshold twice within one frame (0.4 → 0.7 → 0.4 at
+   * threshold 0.5) sets both {@link pressed} and {@link released} on that
+   * same frame, while a source that never actually reaches the threshold
+   * (0 → 0.1 → 0 at threshold 0.5) sets neither. A second, alternative
+   * source tapping while a first stays continuously active never
+   * manufactures an edge either, because the aggregate itself never drops
+   * below threshold.
+   */
+  public get pressed(): boolean {
+    return this._pressedThisFrame;
+  }
+
+  /** `true` on the frame the aggregate value crossed back below the threshold. See {@link pressed}. */
+  public get released(): boolean {
+    return this._releasedThisFrame;
+  }
+
+  /**
+   * Replay this frame's ordered batches, evaluating the aggregate state once
+   * per batch rather than once per individual channel within it.
+   *
+   * The very first call ever (or the first call after `_reset()` — see that
+   * method's doc comment) additionally seeds every bound channel that has NO
+   * batch entry THIS SAME call directly from `sample.values`, with no edge —
+   * a channel already active before this action started watching correctly
+   * contributes to the aggregate without a synthetic press. A channel that
+   * DOES have a batch entry this call is deliberately left unseeded: it was
+   * necessarily `0` a moment ago (a batch entry only exists where the value
+   * actually changed), so replaying it below detects a real, legitimate edge
+   * instead of being masked by a seed that jumped straight to the final
+   * value — seeding every bound channel unconditionally from `sample.values`
+   * (the frame's FINAL state) and then still replaying the very batches that
+   * led there would silently erase whatever edge those batches represent.
+   *
+   * @internal
+   */
+  public _update(sample: ActionSample): void {
+    if (!this._seeded) {
+      this._seeded = true;
+      this._seedUntouchedChannels(sample);
+      this._active = Math.abs(this._aggregate(this._values)) > this._threshold;
+    }
+
+    this._pressedThisFrame = false;
+    this._releasedThisFrame = false;
+
+    let wasActive = this._active;
+
+    for (const batch of sample.batches) {
+      let touchedBoundChannel = false;
+
+      for (const event of batch.channels) {
+        const index = this._channels.indexOf(event.channel);
+
+        if (index === -1) {
+          continue;
+        }
+
+        this._values[index] = event.value;
+        touchedBoundChannel = true;
+      }
+
+      if (!touchedBoundChannel) {
+        continue;
+      }
+
+      const isActive = Math.abs(this._aggregate(this._values)) > this._threshold;
+
+      if (!wasActive && isActive) {
+        this._pressedThisFrame = true;
+      } else if (wasActive && !isActive) {
+        this._releasedThisFrame = true;
+      }
+
+      wasActive = isActive;
+    }
+
+    this._value = this._aggregate(this._values);
+    this._active = wasActive;
+  }
+
+  /** Seed every bound channel with no batch entry this call directly from `sample.values` — see `_update`'s doc comment. */
+  private _seedUntouchedChannels(sample: ActionSample): void {
+    const touched = new Set<number>();
+
+    for (const batch of sample.batches) {
+      for (const event of batch.channels) {
+        touched.add(event.channel);
+      }
+    }
+
+    for (let i = 0; i < this._channels.length; i++) {
+      const channel = this._channels[i]!;
+
+      if (!touched.has(channel)) {
+        this._values[i] = sample.values[channel] ?? 0;
+      }
+    }
+  }
+
+  /**
+   * Clear all state, as if no source had ever been touched — used when an
+   * owner stops feeding this action (a scene suspend), and by the owning
+   * {@link ActionMap} to force a fresh baseline on a legitimate ownership
+   * handoff, since the new owner's channel buffer is unrelated to the old
+   * one's.
+   *
+   * @internal
+   */
+  public _reset(): void {
+    this._values.fill(0);
+    this._value = 0;
+    this._active = false;
+    this._pressedThisFrame = false;
+    this._releasedThisFrame = false;
+    this._seeded = false;
+  }
+}

--- a/src/input/actions/ChordAction.ts
+++ b/src/input/actions/ChordAction.ts
@@ -1,5 +1,6 @@
+import { ButtonLikeAction } from './ButtonLikeAction';
 import { type InputChord, normalizeSequence } from './pattern';
-import type { ActionOptions, ActionSample } from './types';
+import type { ActionOptions } from './types';
 
 /**
  * A binding accepted by {@link ChordAction}: a `'+'`-joined string of
@@ -8,12 +9,36 @@ import type { ActionOptions, ActionSample } from './types';
  */
 export type ChordBinding = string | InputChord;
 
+/** Weakest absolute value across every entry, sign-preserving. */
+function weakestOf(values: Float32Array): number {
+  if (values.length === 0) {
+    return 0;
+  }
+
+  let weakest = values[0] ?? 0;
+
+  for (let i = 1; i < values.length; i++) {
+    const value = values[i] ?? 0;
+
+    if (Math.abs(value) < Math.abs(weakest)) {
+      weakest = value;
+    }
+  }
+
+  return weakest;
+}
+
 /**
  * Button-like action active while every channel in a chord is held at once —
  * `Control+S`, a modifier held alongside a gamepad button, and so on. Exposes
- * the same `active`/`pressed`/`released` triad as {@link ButtonAction}, but
- * the aggregate is the AND of every bound channel instead of the strongest of
- * a set of alternatives.
+ * the same `active`/`pressed`/`released`/`value` quartet as {@link ButtonAction},
+ * but the aggregate is the weakest of every bound channel instead of the
+ * strongest of a set of alternatives: `min(|v|) > threshold` for every bound
+ * channel holds if and only if every one of them individually exceeds
+ * threshold, so a chord is only ever as "on" as its least-engaged member. For
+ * an analog chord (a gamepad trigger held alongside a button, say), {@link value}
+ * reports the trigger's pull limited by whether the button is engaged at all —
+ * `0` the instant any member releases, never the button's own binary 0/1.
  *
  * A string binding resolves `+`-joined tokens as case-insensitive
  * {@link Keyboard} enum names (`'Control+S'`, `'control+s'`). This is a
@@ -29,15 +54,7 @@ export type ChordBinding = string | InputChord;
  * const swap = new ChordAction([GamepadButton.LeftShoulder, GamepadButton.RightShoulder]);
  * ```
  */
-export class ChordAction {
-  private readonly _channels: readonly number[];
-  private readonly _threshold: number;
-  private readonly _values: Float32Array;
-  private _seeded = false;
-  private _active = false;
-  private _pressed = false;
-  private _released = false;
-
+export class ChordAction extends ButtonLikeAction {
   /**
    * @throws {Error} If a string binding contains a `>` step separator (use
    * {@link SequenceAction}), an unknown `Keyboard` token, an empty `+`
@@ -53,77 +70,10 @@ export class ChordAction {
       );
     }
 
-    this._channels = steps[0]!;
-    this._threshold = options.threshold ?? 0;
-    this._values = new Float32Array(this._channels.length);
+    super(steps[0]!, options.threshold ?? 0);
   }
 
-  public get active(): boolean {
-    return this._active;
-  }
-
-  public get pressed(): boolean {
-    return this._pressed;
-  }
-
-  public get released(): boolean {
-    return this._released;
-  }
-
-  public _update(sample: ActionSample): void {
-    if (!this._seeded) {
-      this._seeded = true;
-      this._seed(sample);
-      this._active = this._isActive();
-    }
-
-    this._pressed = false;
-    this._released = false;
-    let wasActive = this._active;
-
-    for (const batch of sample.batches) {
-      let touched = false;
-
-      for (const event of batch.channels) {
-        const index = this._channels.indexOf(event.channel);
-        if (index === -1) continue;
-        this._values[index] = event.value;
-        touched = true;
-      }
-
-      if (!touched) continue;
-
-      const active = this._isActive();
-      this._pressed ||= !wasActive && active;
-      this._released ||= wasActive && !active;
-      wasActive = active;
-    }
-
-    this._active = wasActive;
-  }
-
-  public _reset(): void {
-    this._values.fill(0);
-    this._seeded = false;
-    this._active = false;
-    this._pressed = false;
-    this._released = false;
-  }
-
-  private _isActive(): boolean {
-    return this._channels.length > 0 && this._values.every(value => Math.abs(value) > this._threshold);
-  }
-
-  private _seed(sample: ActionSample): void {
-    const touched = new Set<number>();
-
-    for (const batch of sample.batches) {
-      for (const event of batch.channels) touched.add(event.channel);
-    }
-
-    for (let i = 0; i < this._channels.length; i++) {
-      const channel = this._channels[i]!;
-      if (!touched.has(channel)) this._values[i] = sample.values[channel] ?? 0;
-    }
+  protected override _aggregate(values: Float32Array): number {
+    return weakestOf(values);
   }
 }

--- a/src/input/actions/index.ts
+++ b/src/input/actions/index.ts
@@ -3,6 +3,7 @@ export { ActionMap } from './ActionMap';
 export type { AxisBinding, AxisCompositeBinding } from './AxisAction';
 export { AxisAction } from './AxisAction';
 export { ButtonAction } from './ButtonAction';
+export { ButtonLikeAction } from './ButtonLikeAction';
 export type { ChordBinding } from './ChordAction';
 export { ChordAction } from './ChordAction';
 export type { InputChord, InputSequence } from './pattern';

--- a/src/input/actions/types.ts
+++ b/src/input/actions/types.ts
@@ -168,8 +168,8 @@ export class ActionOwnership {
    * true attach-moment state BEFORE those filtered batches are replayed on
    * top of it: a watermark alone tells an action which batches to skip, but
    * a channel a skipped batch touches is thereby excluded from that action's
-   * own live-value seed too (see `ButtonAction._seedUntouchedChannels`'s doc
-   * comment), so without this snapshot a channel held before attach and
+   * own live-value seed too (see `ButtonLikeAction._seedUntouchedChannels`'s
+   * doc comment), so without this snapshot a channel held before attach and
    * released by the very next real batch would seed from a synthetic zero
    * instead of its true held value, silently swallowing the release.
    *

--- a/test/core/__snapshots__/root-index-snapshot.test.ts.snap
+++ b/test/core/__snapshots__/root-index-snapshot.test.ts.snap
@@ -36,6 +36,7 @@ exports[`root index export surface snapshot > sorted runtime export names match 
   "BufferUsage",
   "Button",
   "ButtonAction",
+  "ButtonLikeAction",
   "CacheFirstStrategy",
   "CallbackRenderPass",
   "Capabilities",

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -75,6 +75,7 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "BuildInfo: interface",
   "Button: class",
   "ButtonAction: class",
+  "ButtonLikeAction: class",
   "ButtonOptions: interface",
   "CacheFirstStrategy: class",
   "CacheRequest: interface",

--- a/test/input/action-patterns.test.ts
+++ b/test/input/action-patterns.test.ts
@@ -128,6 +128,47 @@ describe('ChordAction', () => {
     expect(action.active).toBe(true);
   });
 
+  test('value reports the weakest member for an analog chord, and 0 when any member is released', () => {
+    const driver = createSample();
+    const action = new ChordAction([GamepadButton.South, GamepadButton.RightTrigger]);
+
+    // South is fully engaged (1); the trigger's own pull (0.6) is the
+    // least-engaged member, so it — not South's binary 1 — is what value
+    // reports for the chord as a whole.
+    driver.batch(10, [
+      [GamepadButton.South, 1],
+      [GamepadButton.RightTrigger, 0.6],
+    ]);
+    action._update(driver.sample);
+    expect(action.value).toBeCloseTo(0.6);
+
+    driver.frame();
+    driver.batch(20, [[GamepadButton.RightTrigger, 0]]);
+    action._update(driver.sample);
+    expect(action.value).toBe(0);
+  });
+
+  test('a member crossing threshold twice within one frame still sets pressed and released together', () => {
+    const driver = createSample();
+    const action = new ChordAction([GamepadButton.South, GamepadButton.RightTrigger], { threshold: 0.5 });
+
+    driver.batch(10, [
+      [GamepadButton.South, 1],
+      [GamepadButton.RightTrigger, 0.4],
+    ]);
+    action._update(driver.sample);
+    expect(action.active).toBe(false);
+
+    driver.frame();
+    driver.batch(20, [[GamepadButton.RightTrigger, 0.7]]);
+    driver.batch(30, [[GamepadButton.RightTrigger, 0.4]]);
+    action._update(driver.sample);
+
+    expect(action.pressed).toBe(true);
+    expect(action.released).toBe(true);
+    expect(action.active).toBe(false);
+  });
+
   test('tolerates whitespace around tokens (Control + Shift + A)', () => {
     const driver = createSample();
     const action = new ChordAction('Control + Shift + A');


### PR DESCRIPTION
## Summary
- `ButtonAction` and `ChordAction` duplicated their entire batch-replay update loop, seeding, reset, and `active`/`pressed`/`released` triad, differing in exactly one expression deciding activity.
- Extract that mechanism into an exported abstract `ButtonLikeAction` base with a single hook, `_aggregate(values)`: `ButtonAction` reports the strongest bound channel (loudest of a set of alternatives), `ChordAction` the weakest (a chord is only as strong as its least-engaged member).
- The base computes activity uniformly as `Math.abs(aggregate(values)) > threshold`. `min(|v|) > threshold` holds iff `every(|v| > threshold)`, so `ChordAction`'s AND-of-all semantics fall out of the same comparison already used for `ButtonAction` — behaviour-preserving by construction, not by test luck.
- `ChordAction` now also gets a `value` getter for free: an analog chord's weakest member (e.g. a trigger's pull limited by whether a held button is engaged), `0` the instant any member releases.
- Out of scope, untouched: `SequenceAction`, `AxisAction`/`VectorAction`, and the pre-existing `strongestOf`/`sampleStrongest` duplication.

## Test plan
- [x] Every pre-existing `ButtonAction` and `ChordAction` test passes unchanged (94/94 in `test/input/actions.test.ts` + `test/input/action-patterns.test.ts`), no existing test edited.
- [x] Added: `ChordAction.value` reports the weakest member for an analog chord, and `0` when any member is released.
- [x] Added: a member crossing threshold twice within one real frame still sets `pressed` and `released` together for `ChordAction` (mirrors the existing `ButtonAction` batch-replay test).
- [x] `pnpm test:core` — 348 files / 5844 tests passed (15 pre-existing skips), 0 failures.
- [x] `pnpm verify:quick` — clean (0 errors; only pre-existing unrelated warnings).
- [x] `pnpm docs:api:generate` run and regenerated docs committed (`button-action.json`, `chord-action.json`, new `button-like-action.json`); `docs:api:check` in sync.