### PR TITLE
docs(guide)!: make the guide snippets TypeScript and give the typecheck gate teeth

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "typecheck": "tsc --noEmit",
     "typecheck:examples": "tsc --noEmit -p tsconfig.examples.json",
     "typecheck:type-tests": "tsc --noEmit -p tsconfig.type-tests.json && tsc --noEmit -p tsconfig.type-tests-strict.json && tsc --noEmit -p tsconfig.type-tests-loose.json",
-    "typecheck:guides": "tsx scripts/extract-guide-snippets.ts && tsc --noEmit -p tsconfig.guides.json",
+    "typecheck:guides": "tsx scripts/extract-guide-snippets.ts && tsx scripts/typecheck-guides.ts",
     "typecheck:packages": "pnpm --filter \"@codexo/exojs-particles\" --filter \"@codexo/exojs-tilemap\" --filter \"@codexo/exojs-tiled\" --filter \"@codexo/exojs-physics\" --filter \"@codexo/exojs-audio-fx\" --filter \"@codexo/exojs-aseprite\" --filter \"@codexo/exojs-ldtk\" --filter \"@codexo/exojs-react\" typecheck",
     "typecheck:bench": "pnpm --filter @codexo/exojs-bench bench:setup && pnpm --filter @codexo/exojs-bench typecheck",
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\" \"examples/**/*.js\" \"site/src/**/*.{ts,tsx}\" \"scripts/**/*.ts\" \"*.config.ts\"",

--- a/scripts/extract-guide-snippets.ts
+++ b/scripts/extract-guide-snippets.ts
@@ -83,7 +83,14 @@ import ts from 'typescript';
 const REPO_ROOT = join(import.meta.dirname, '..');
 const GUIDE_DIR = join(REPO_ROOT, 'site', 'src', 'content', 'guide');
 const SRC_DIR = join(REPO_ROOT, 'src');
-const OUT_DIR = join(REPO_ROOT, '.workspace', 'generated', 'guide-typecheck');
+// Both overridable so several people (or agents) can iterate on disjoint guide
+// folders at once without racing each other's output directory, which this
+// script wipes on every run.
+const OUT_DIR = join(REPO_ROOT, process.env.GUIDE_SNIPPET_OUT ?? join('.workspace', 'generated', 'guide-typecheck'));
+const FOLDER_FILTER = (process.env.GUIDE_SNIPPET_FOLDERS ?? '')
+  .split(',')
+  .map(name => name.trim())
+  .filter(name => name.length > 0);
 
 const CHECKED_LANGS = new Set(['ts', 'tsx', 'typescript', 'js', 'javascript']);
 
@@ -617,7 +624,7 @@ const FREE_IDENTIFIER_RE = /(?<![.\w$])([A-Za-z_$][\w$]*)/g;
  * PascalCase names may be used in type position too (`orb: OrbData`), so
  * they get a merging `type X = any;` alongside the value declaration. */
 function anyFallbackDecl(name: string): string[] {
-  return /^[A-Z]/.test(name) ? [`var ${name};`, `type ${name} = any;`] : [`var ${name};`];
+  return /^[A-Z]/.test(name) ? [`var ${name}: any;`, `type ${name} = any;`] : [`var ${name}: any;`];
 }
 
 function collectFreeIdentifiers(memberTexts: string[]): Set<string> {
@@ -677,7 +684,15 @@ mkdirSync(OUT_DIR, { recursive: true });
 
 const coreExportNames = computeCoreExportNames();
 
-const files = walkMdx(GUIDE_DIR);
+const files = walkMdx(GUIDE_DIR).filter(file => {
+  if (FOLDER_FILTER.length === 0) {
+    return true;
+  }
+
+  const folder = relative(GUIDE_DIR, file).replaceAll('\\', '/').split('/')[0];
+
+  return folder !== undefined && FOLDER_FILTER.includes(folder);
+});
 let extracted = 0;
 let skippedMeta = 0;
 let skippedPartial = 0;

--- a/scripts/typecheck-guides.ts
+++ b/scripts/typecheck-guides.ts
@@ -1,0 +1,66 @@
+/**
+ * Typechecks the guide snippets extracted by extract-guide-snippets.ts.
+ *
+ * This exists instead of a plain `tsc -p tsconfig.guides.json` because that
+ * config maps `@codexo/exojs` onto `src/index.ts`, which pulls the whole engine
+ * into the program. `tsc` reports diagnostics for those dependency files too,
+ * under a compiler configuration the engine and the packages never build with
+ * — they have their own, stricter gate. Acting on such a diagnostic means
+ * editing library source to satisfy a documentation check, which is backwards,
+ * so this reports only diagnostics that belong to a generated snippet.
+ *
+ * Diagnostics with no file at all (bad config, missing lib) are always
+ * reported: those are failures of the gate itself, not of a dependency.
+ */
+import { relative, resolve } from 'node:path';
+
+import ts from 'typescript';
+
+const REPO_ROOT = resolve(import.meta.dirname, '..');
+const CONFIG_PATH = resolve(REPO_ROOT, 'tsconfig.guides.json');
+const SNIPPET_DIR = resolve(REPO_ROOT, process.env.GUIDE_SNIPPET_OUT ?? '.workspace/generated/guide-typecheck');
+
+const FORMAT_HOST: ts.FormatDiagnosticsHost = {
+  getCanonicalFileName: fileName => fileName,
+  getCurrentDirectory: () => REPO_ROOT,
+  getNewLine: () => ts.sys.newLine,
+};
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+const configFile = ts.readConfigFile(CONFIG_PATH, ts.sys.readFile);
+
+if (configFile.error) {
+  fail(ts.formatDiagnosticsWithColorAndContext([configFile.error], FORMAT_HOST));
+}
+
+const parsed = ts.parseJsonConfigFileContent(configFile.config, ts.sys, REPO_ROOT, undefined, CONFIG_PATH);
+
+if (parsed.errors.length > 0) {
+  fail(ts.formatDiagnosticsWithColorAndContext(parsed.errors, FORMAT_HOST));
+}
+
+const program = ts.createProgram({ rootNames: parsed.fileNames, options: parsed.options });
+
+const isSnippetDiagnostic = (diagnostic: ts.Diagnostic): boolean => {
+  if (diagnostic.file === undefined) {
+    return true;
+  }
+
+  const relativePath = relative(SNIPPET_DIR, resolve(diagnostic.file.fileName));
+
+  return relativePath.length > 0 && !relativePath.startsWith('..');
+};
+
+const diagnostics = ts.getPreEmitDiagnostics(program).filter(isSnippetDiagnostic);
+
+if (diagnostics.length > 0) {
+  console.error(ts.formatDiagnosticsWithColorAndContext(diagnostics, FORMAT_HOST));
+  console.error(`typecheck:guides: ${diagnostics.length} error(s) in extracted guide snippets.`);
+  process.exit(1);
+}
+
+console.log(`typecheck:guides: ${parsed.fileNames.length} snippet file(s) checked, no errors.`);

--- a/site/src/content/guide/assets/aseprite.mdx
+++ b/site/src/content/guide/assets/aseprite.mdx
@@ -114,7 +114,7 @@ init() {
     this.root.addChild(this.player);
 }
 
-update(delta) {
+update(delta: Time) {
     this.player.update(delta); // advance the active clip
 }
 ```

--- a/site/src/content/guide/assets/aseprite.mdx
+++ b/site/src/content/guide/assets/aseprite.mdx
@@ -37,7 +37,7 @@ With `/register`, the import must run before `new Application()` — it seeds th
 Pass `asepriteExtension` to `ApplicationOptions.extensions`. This is explicit, tree-shakeable, and
 order-independent — the extension is bound to exactly this `Application`:
 
-```js
+```ts
 import { Application } from '@codexo/exojs';
 import { asepriteExtension } from '@codexo/exojs-aseprite';
 
@@ -52,7 +52,7 @@ globally. You decide which `Application` gets the extension.
 For an app that always wants Aseprite support, import the `/register` entry once at startup. It
 registers `asepriteExtension` in the global `ExtensionRegistry` and re-exports the same public API:
 
-```js
+```ts
 import '@codexo/exojs-aseprite/register';
 import { Application } from '@codexo/exojs';
 
@@ -68,7 +68,7 @@ order.
 An `Application` constructed with an explicit empty list takes **no** extensions — not even
 globally registered ones — and will not recognise the `asepriteSheet` type:
 
-```js
+```ts
 import { Application } from '@codexo/exojs';
 
 const app = new Application({ extensions: [] }); // core only; no AsepriteSheet
@@ -103,7 +103,7 @@ on a malformed document), resolves `meta.image` relative to the JSON source, sub
 [`AnimatedSprite`](/ExoJS/en/api/animated-sprite/) with every Aseprite tag pre-defined as a named,
 playable clip. Call `play(tag)` with a tag name to start it:
 
-```js
+```ts
 async load() {
     this.sheet = await this.loader.load(Asset.type('asepriteSheet', 'sprites/hero.json'));
 }
@@ -125,7 +125,7 @@ the [Animation](/ExoJS/en/guide/rendering/animation/) guide for the full clip/pl
 The parsed clips are also exposed directly on `sheet.clips` — a read-only `Map` keyed by tag name —
 so you can inspect what was imported or build a sprite by hand:
 
-```js no-check
+```ts no-check
 sheet.clips.size;          // number of tags
 sheet.clips.has('walk');   // true when the 'walk' tag exists
 sheet.clips.keys();        // iterate tag names

--- a/site/src/content/guide/assets/ldtk.mdx
+++ b/site/src/content/guide/assets/ldtk.mdx
@@ -33,7 +33,7 @@ Like all extensions, the core ships nothing LDtk-specific — an `Application` o
 Pass `ldtkExtension` to `ApplicationOptions.extensions`. This is explicit, tree-shakeable, and
 order-independent — the extension is bound to exactly this `Application`:
 
-```js
+```ts
 import { Application } from '@codexo/exojs';
 import { ldtkExtension } from '@codexo/exojs-ldtk';
 
@@ -50,7 +50,7 @@ For an app that always wants LDtk support, import the `/register` entry once at 
 registers `ldtkExtension` (and its `tilemapExtension` dependency) in the global `ExtensionRegistry`
 and re-exports the same public API:
 
-```js
+```ts
 import '@codexo/exojs-ldtk/register';
 import { Application } from '@codexo/exojs';
 
@@ -65,7 +65,7 @@ from the global registry. The explicit `extensions: [...]` form works regardless
 An `Application` constructed with an explicit empty list takes **no** extensions — not even
 globally registered ones — and will not recognise `.ldtk` files:
 
-```js
+```ts
 import { Application } from '@codexo/exojs';
 
 const app = new Application({ extensions: [] }); // core only; no LdtkMap
@@ -100,7 +100,7 @@ With "Save levels to separate files" enabled, each level lives in a sibling `<id
 
 A loaded `LdtkMap` exposes one runtime `TileMap` per LDtk level, plus the raw parsed document:
 
-```js no-check
+```ts no-check
 world.levels;                      // readonly TileMap[] — one per level, in document order
 world.getLevelByName('Level_0');   // TileMap | undefined — lookup by LDtk identifier
 world.data;                        // the raw parsed LdtkData document
@@ -117,7 +117,7 @@ World-space placement is stored in `TileMap.properties` (`worldX` / `worldY`), a
 level's own "Custom fields" tab — distinct from fields on the entities placed inside it), merged in
 under their own field identifier:
 
-```js no-check
+```ts no-check
 level.properties.worldX;       // number — level's world-space X position in pixels
 level.properties.musicTrack;   // whatever value the level's own custom field carries
 ```
@@ -135,7 +135,7 @@ levels into the same single ordered list, so the rest of this guide's API is unc
 The only difference is that each converted level's `TileMap.properties` additionally carries the
 owning world's id under the reserved `ldtkWorldIid` key:
 
-```js no-check
+```ts no-check
 level.properties.ldtkWorldIid; // string | undefined — set only for multi-world projects
 ```
 
@@ -153,7 +153,7 @@ scene.root.addChild(new TileMapNode(level));
 
 To stream a multi-level world, add a node per level — each level is its own `TileMap`:
 
-```js no-check
+```ts no-check
 for (const level of world.levels) {
     scene.root.addChild(new TileMapNode(level));
 }

--- a/site/src/content/guide/assets/loading-and-resources.mdx
+++ b/site/src/content/guide/assets/loading-and-resources.mdx
@@ -40,7 +40,7 @@ When in doubt, start with a bare path string. Reach for `Assets.from` when asset
 
 The path _is_ the identity — a bare string resolves directly to the finished asset, with its type inferred from the extension:
 
-```js
+```ts
 async load() {
     const texture = await this.loader.load('image/hero.png');
     this.hero = new Sprite(texture);
@@ -53,7 +53,7 @@ There's no separate alias step: call `this.loader.get('image/hero.png')` again a
 
 When you need several assets of the same type, load them in parallel and keep the returned instances:
 
-```js
+```ts
 async load() {
     [this.hero, this.ground, this.coin] = await Promise.all([
         this.loader.load('image/hero.png'),
@@ -100,7 +100,7 @@ const music = await this.app.loader.load(Asset.type('music', 'audio/theme.ogg'))
 
 When a scene needs different asset types, load them in parallel with `Promise.all`:
 
-```js
+```ts
 async load() {
     [this.sky, this.ambient, this.coin, this.jump, this.levels] = await Promise.all([
         this.loader.load('image/sky.png'),
@@ -124,7 +124,7 @@ For value assets such as `Json` (and `TextAsset`, `CsvAsset`, and the other data
 
 Build mixed groups with `Assets.from(...)`. This is the canonical catalog API; the old inline-record `loader.load({ alias: config })` call shape has been removed.
 
-```js
+```ts
 const SceneAssets = Assets.from({
     hero: 'image/hero.png',
     click: Asset.type('sound', 'audio/click.ogg'),
@@ -156,7 +156,7 @@ export const TitleAssets = Assets.from({
 
 Every property is a real, usable handle _before_ any loader touches it — `TitleAssets.logo` is already a `Texture` (in the `'loading'` state), and `TitleAssets.config` is already an `AssetRef`. Load the whole catalog, then read the same properties:
 
-```js
+```ts
 // Fetches every entry and heals each handle in place
 await this.loader.load(TitleAssets);
 
@@ -175,7 +175,7 @@ TitleAssets.config; // AssetRef<{ startLevel: string }>
 
 `Assets` also exposes an `.entries` record for iteration and inspection. To load several existing catalogs concurrently, keep their types intact and start both queues:
 
-```js
+```ts
 await Promise.all([this.loader.load(CommonAssets), this.loader.load(TitleAssets)]);
 ```
 
@@ -231,7 +231,7 @@ An override is a new declaration, so composing a derived catalog back together w
 
 Every `loader.load(...)` call returns a `LoadingQueue<T>`. It implements `PromiseLike<T>`, so `await` and `Promise.all` both work. It also exposes per-queue progress via `onProgress`:
 
-```js
+```ts
 const loading = this.loader.load(TitleAssets);
 
 loading.onProgress.add(progress => {
@@ -252,7 +252,7 @@ const title = await loading;
 
 Start two queues simultaneously and wait for both:
 
-```js
+```ts
 const [title, game] = await Promise.all([this.loader.load(TitleAssets), this.loader.load(GameAssets)]);
 ```
 
@@ -260,7 +260,7 @@ Each queue tracks its own progress independently. The result tuple is typed: `ti
 
 A practical startup pattern — show the title screen as soon as title assets are ready, while game assets continue loading in the background:
 
-```js
+```ts
 async load() {
     const titleQueue = this.loader.load(TitleAssets);
     const gameQueue  = this.loader.load(GameAssets);
@@ -293,7 +293,7 @@ async load() {
 
 Because the batch is shared, `total` can grow mid-flight: if a new `loader.load(...)` call starts while others are still pending, its assets are added to the same running total rather than starting a fresh count at 0. That is exactly what you want for a boot screen — one progress bar that stays accurate no matter how many scenes or systems kick off loads concurrently.
 
-```js
+```ts
 class BootScene extends Scene {
   init() {
     this.app.loader.onLoadStart.add((key, url) => {
@@ -331,7 +331,7 @@ app-level `stop()`/`destroy()` mid-load, are both real cases. Check
 signals in `unload()` so a listener from a torn-down scene never fires
 `change()` against a Director that has since moved on:
 
-```js
+```ts
 class BootScene extends Scene {
   init() {
     this._onLoadComplete = () => {
@@ -386,7 +386,7 @@ interface AssetStatus {
 }
 ```
 
-```js
+```ts
 const tex = this.loader.get('hero.png'); // synchronous for a valid, registered suffix
 
 if (tex.ready) {
@@ -400,7 +400,7 @@ await tex.loaded; // Promise<this> — resolves once ready, rejects on failure
 
 The same `.state` / `.ready` / `.error` / `.loaded` contract applies to `AssetRef` values such as JSON or text — read `.value` once `.ready` is `true`:
 
-```js
+```ts
 const config = this.loader.get('data/config.json'); // AssetRef<unknown>
 await config.loaded;
 console.log(config.value.startLevel);
@@ -410,7 +410,7 @@ console.log(config.value.startLevel);
 
 `this.app.loader.release(...)` drops your claim on an asset; the object itself keeps its identity and heals back to `'loading'` if you `get()` the same source again. It accepts a handle, an `Asset` descriptor, a whole catalog, or a `(type, source)` pair. Releasing a valid form that was never claimed — a descriptor you never loaded, a catalog leaf you never adopted — is a harmless no-op, and releasing twice is always idempotent:
 
-```js
+```ts
 this.app.loader.release(TitleAssets); // releases every leaf in the catalog
 this.app.loader.release(logo); // a single handle from get()
 ```
@@ -448,7 +448,7 @@ The lifecycle guarantees that:
 
 `this.loader.load(...)` (or `this.app.loader.load(...)` for an app-lifetime claim) works any time, not just inside the `load` hook. A computed path isn't a string literal, so use `Asset.type('texture', ...)`:
 
-```js
+```ts
 async _changeLevel(levelName) {
     const bg = await this.app.loader.load(
         Asset.type('texture', `image/levels/${levelName}.png`)
@@ -479,7 +479,7 @@ export const Level1Assets = Assets.from({
 
 Load the menu catalog once and keep it resident, then load level catalogs as the player progresses:
 
-```js
+```ts
 // In the menu scene
 async load() {
     await this.loader.load(MenuAssets);
@@ -499,7 +499,7 @@ Loading is idempotent: a catalog whose leaves are already resident resolves imme
 
 `loader.load(catalog)` returns a `LoadingQueue` — attach `onProgress` for a per-catalog bar, exactly as in [Progress and parallel loading](#progress-and-parallel-loading):
 
-```js
+```ts
 const loading = this.app.loader.load(Level1Assets);
 
 loading.onProgress.add(p => {
@@ -515,7 +515,7 @@ For one screen that reflects every load regardless of how many catalogs are in f
 
 Awaiting a catalog rejects if any leaf fails. Wrap the await and read each leaf's status channel to find which one — a failed seamless handle still renders a visible "missing" fallback, so the scene keeps running:
 
-```js
+```ts
 try {
   await this.app.loader.load(Level1Assets);
 } catch {
@@ -532,7 +532,7 @@ There is no separate bundle error type — every leaf carries its own `.state` /
 
 To fetch a catalog ahead of time without blocking the current scene, pass `{ background: true }`. Every leaf is still claimed and heals in place, but its fetch is routed through a low-priority queue while the frame loop keeps running:
 
-```js
+```ts
 // Kick off the next level while the player is still in this one
 this.app.loader.load(Level2Assets, { background: true });
 ```
@@ -543,7 +543,7 @@ A backgrounded leaf is boosted to fetch immediately if something `get()`s or for
 
 By default the loader fetches from the network every session. To persist processed assets across sessions, pass an `IndexedDbStore`:
 
-```js
+```ts
 import { Loader, IndexedDbStore } from '@codexo/exojs';
 
 const loader = new Loader({
@@ -554,7 +554,7 @@ const loader = new Loader({
 
 When constructing the loader through `Application`, pass `LoaderOptions` under the `loader` key:
 
-```js
+```ts
 const app = new Application({
   loader: {
     basePath: '/assets/',
@@ -575,7 +575,7 @@ The cache above persists _loaded assets_. For **user save data** (settings, prof
 - [`IndexedDbKeyValueStore`](/ExoJS/en/api/indexed-db-key-value-store/) — IndexedDB via structured clone: large, async, stores `Blob`s and `ArrayBuffer`s natively.
 - [`MemoryStore`](/ExoJS/en/api/memory-store/) — in-memory and ephemeral, for tests and throwaway data.
 
-```js
+```ts
 import { WebStorageStore } from '@codexo/exojs';
 
 const saves = new WebStorageStore(localStorage, { prefix: 'my-game:' });
@@ -647,7 +647,7 @@ Supply an optional `getIdentityKey(req)` on the handler to control in-flight ded
 
 Install the binding by passing it on an [`Extension`](/ExoJS/en/api/extension/) to `ApplicationOptions.extensions`. Once installed, the type works everywhere the built-ins do:
 
-```js
+```ts
 // Dynamic path or explicit reference
 const field = await this.loader.load(Asset.type('heightField', 'maps/level-1.hf'));
 

--- a/site/src/content/guide/assets/loading-and-resources.mdx
+++ b/site/src/content/guide/assets/loading-and-resources.mdx
@@ -449,7 +449,7 @@ The lifecycle guarantees that:
 `this.loader.load(...)` (or `this.app.loader.load(...)` for an app-lifetime claim) works any time, not just inside the `load` hook. A computed path isn't a string literal, so use `Asset.type('texture', ...)`:
 
 ```ts
-async _changeLevel(levelName) {
+async _changeLevel(levelName: string) {
     const bg = await this.app.loader.load(
         Asset.type('texture', `image/levels/${levelName}.png`)
     );

--- a/site/src/content/guide/assets/tiled-maps.mdx
+++ b/site/src/content/guide/assets/tiled-maps.mdx
@@ -33,7 +33,7 @@ Like all extensions, the core ships nothing Tiled-specific — an `Application` 
 Pass `tiledExtension` to `ApplicationOptions.extensions`. This is explicit, tree-shakeable, and
 order-independent — the extension is bound to exactly this `Application`:
 
-```js
+```ts
 import { Application } from '@codexo/exojs';
 import { tiledExtension } from '@codexo/exojs-tiled';
 
@@ -48,7 +48,7 @@ globally. You decide which `Application` gets the extension.
 For an app that always wants Tiled support, import the `/register` entry once at startup. It
 registers `tiledExtension` in the global `ExtensionRegistry` and re-exports the same public API:
 
-```js
+```ts
 import '@codexo/exojs-tiled/register';
 import { Application } from '@codexo/exojs';
 
@@ -64,7 +64,7 @@ order.
 An `Application` constructed with an explicit empty list takes **no** extensions — not even
 globally registered ones — and will not recognise `.tmj` files:
 
-```js
+```ts
 import { Application } from '@codexo/exojs';
 
 const app = new Application({ extensions: [] }); // core only; no TiledMap
@@ -83,7 +83,7 @@ resolve to the same handler.
 XML (`.tmx`/`.tsx`), isometric or hexagonal orientations, collection-of-images tilesets, and `zstd` compression each raise a clear error rather than loading. Export an orthogonal JSON map (`.tmj`) with CSV, gzip, or zlib data. Infinite (chunked) maps **are** supported: `toTileMap()` converts each chunked layer to an unbounded runtime layer whose data streams in on demand via `getChunkSource()` — see the [Infinite maps](/ExoJS/en/guide/rendering/infinite-maps/) chapter.
 </Callout>
 
-```js no-check
+```ts no-check
 import { Asset } from '@codexo/exojs';
 
 // Explicit type
@@ -100,7 +100,7 @@ references as a `Texture` through the same loader, returning a fully-resolved `T
 
 `TiledMap` exposes the parsed metadata, layers, and the resolved tileset textures:
 
-```js no-check
+```ts no-check
 map.width;            // map width in tiles
 map.height;           // map height in tiles
 map.tileWidth;        // tile width in pixels
@@ -123,7 +123,7 @@ Tiled's custom properties (on maps, layers, tiles, and objects) survive the trip
 map's Tiled property list. Plain-scalar Tiled types (`string`, `int`, `float`, `bool`, `color`,
 `file`) come through as their equivalent JS value:
 
-```js no-check
+```ts no-check
 const tileMap = map.toTileMap();
 const [spawnLayer] = tileMap.objectLayers;
 const spawn = spawnLayer.objects.find(object => object.name === 'PlayerSpawn');
@@ -169,7 +169,7 @@ a plain number or silently dropped; both are now tagged (`TilePropertyObjectRef`
 An object drawn with Tiled's text tool converts to a `TextObject` — a `TileMapObject` whose
 `kind` is `'text'` and whose `text` field carries the styled content:
 
-```js no-check
+```ts no-check
 import { ObjectKind } from '@codexo/exojs-tilemap';
 
 const tileMap = map.toTileMap();
@@ -198,7 +198,7 @@ A Tiled image layer converts to an `ImageLayer` — a data-only layer holding a 
 image, alongside the same offset/parallax/tint/opacity/`properties` fields tile and object layers
 carry:
 
-```js no-check
+```ts no-check
 const tileMap = map.toTileMap();
 const [background] = tileMap.imageLayers;
 
@@ -219,7 +219,7 @@ Shapes drawn in Tiled's tile collision editor (the `objectgroup` on an individua
 tileset) survive the trip through `toTileMap()` as `TileDefinition.collision` — a list of
 `TileMapObject`s in tile-local pixel space (origin at the top-left of the cell):
 
-```js no-check
+```ts no-check
 const tileMap = map.toTileMap();
 const [ground] = tileMap.layers;
 const tile = ground.getTileAt(3, 5);
@@ -258,7 +258,7 @@ Wang sets — Tiled's terrain/auto-tile definitions — parse onto `TiledTileset
 it to a layer with `autoTile` (a full-layer pass) or `refreshCell` (an incremental, single-cell
 update) from `@codexo/exojs-tilemap`:
 
-```js no-check
+```ts no-check
 import { tiledWangSetToWangSet } from '@codexo/exojs-tiled';
 import { autoTile, refreshCell } from '@codexo/exojs-tilemap';
 
@@ -292,7 +292,7 @@ different local tile ID for a set duration. `toTileMap()` carries these frames i
 `TileDefinition.animation`; `@codexo/exojs-tilemap` ships `TileAnimator` to drive them at runtime,
 RPG-Maker style — advancing every animated cell across one or more layers on a shared clock:
 
-```js no-check
+```ts no-check
 import { TileAnimator } from '@codexo/exojs-tilemap';
 
 const tileMap = map.toTileMap();
@@ -313,7 +313,7 @@ animated tiles.
 The tileset textures a `TiledMap` exposes are loaded through the `Loader` and owned by the
 **loader cache** — not by the `TiledMap`. This matters for teardown:
 
-```js no-check
+```ts no-check
 map.destroy(); // releases the TiledMap; does NOT destroy tileset textures
 ```
 

--- a/site/src/content/guide/audio/audio-basics.mdx
+++ b/site/src/content/guide/audio/audio-basics.mdx
@@ -27,7 +27,7 @@ Use `Sound` when you need many overlapping instances of the same short clip. Use
 
 Both types are loaded through the `Loader`, like textures, then played through `app.audio`:
 
-```js
+```ts
 import { Asset, AudioStream, Scene } from '@codexo/exojs';
 
 class AudioScene extends Scene {
@@ -55,7 +55,7 @@ Browsers require a user gesture before Web Audio starts. ExoJS handles this auto
 
 `app.audio.play(asset, ...)` always returns a `Voice` immediately, even while audio is still locked. Stream and sound playback is deferred and starts automatically on that first gesture, so you can call `play()` in `init` and keep the returned voice — there is no separate "start on click" step beyond the gesture the browser already requires. Check `app.audio.locked` to know whether the gesture has happened yet; `app.audio.onUnlock` fires once when it does.
 
-```js
+```ts
 if (this.app.audio.locked) {
     // still waiting for the first user gesture; the queued voice will auto-start
 }
@@ -69,7 +69,7 @@ Browsers won't start audio until the user interacts with the page. Trigger the f
 
 Per-play overrides are passed to `play()`; everything afterwards is controlled on the returned `Voice`:
 
-```js
+```ts
 // Per-play overrides (bus, volume, loop, playbackRate, detune, time, muted)
 const voice = this.app.audio.play(sound, { volume: 0.5, loop: true, playbackRate: 1.2 });
 
@@ -81,7 +81,7 @@ voice.stop(800);        // fade out over 800ms, then stop
 
 Every `Voice` carries `volume` (get/set), `fade(to, ms)`, `stop(fadeMs?)`, an `ended` flag, an `onEnd` signal, the bus it routes through (`voice.bus`), and an `output` node you can tap for analysis. Beyond that base, a voice mixes in only the capabilities its backing node actually supports — narrow with a cast or an `'x' in voice` check:
 
-```js
+```ts
 import { Pausable, Seekable } from '@codexo/exojs';
 
 // A SoundVoice is Seekable + Loopable + RatePitched + Spatializable.
@@ -107,7 +107,7 @@ Voice volume is linear gain in the range `[0, 1]`, where 1 is "as authored". The
 
 `fade(to, ms)` ramps a voice's volume without stopping it; `stop(fadeMs)` ramps to zero and then releases the voice:
 
-```js
+```ts
 // Fade out over 800ms, then stop
 voice.stop(800);
 
@@ -117,7 +117,7 @@ voice.fade(0.7, 500);
 
 The `crossFade` utility fades one playing voice down while fading another up, in parallel:
 
-```js no-check
+```ts no-check
 import { crossFade } from '@codexo/exojs';
 
 const current = this.app.audio.play(this.trackA, { volume: 0.7 });
@@ -139,7 +139,7 @@ Pass `{ toVolume }` to fade the incoming voice to something other than full, and
 
 For rapid-fire SFX (gunshots, footsteps, UI clicks), set `poolSize` higher and use the default FIFO strategy:
 
-```js
+```ts
 const gunshot = this.loader.get('audio/gunshot.ogg');
 gunshot.poolSize = 24;
 
@@ -149,7 +149,7 @@ this.app.audio.play(gunshot); // oldest voice gets evicted when the pool is full
 
 Pitch variation for a richer sound is one line — randomise `playbackRate` per play:
 
-```js
+```ts
 const cents = Math.random() * 300 - 150; // -150 to +150 cents
 this.app.audio.play(sound, { playbackRate: Math.pow(2, cents / 1200) });
 ```
@@ -160,7 +160,7 @@ The audio manager exposes three built-in buses: `app.audio.master`, `app.audio.m
 
 Route a play through a specific bus with the `bus` option, or reassign a live voice's `bus`:
 
-```js
+```ts
 import { AudioBus } from '@codexo/exojs';
 
 const voiceBus = new AudioBus('voice-over', { parent: app.audio.master });
@@ -178,7 +178,7 @@ Buses have independent `volume` (0..2), `muted`, and `pan` controls, plus a filt
 
 A `Sound` can define named sub-regions ("sprites") on the descriptor — useful when you bake several effects into a single file and want to address them by name rather than by offset:
 
-```js
+```ts
 sound.defineSprite('impact', { start: 0.5, end: 0.8 });
 sound.defineSprite('whoosh', { start: 1.2, end: 1.6 });
 ```

--- a/site/src/content/guide/audio/audio-basics.mdx
+++ b/site/src/content/guide/audio/audio-basics.mdx
@@ -28,9 +28,14 @@ Use `Sound` when you need many overlapping instances of the same short clip. Use
 Both types are loaded through the `Loader`, like textures, then played through `app.audio`:
 
 ```ts
-import { Asset, AudioStream, Scene } from '@codexo/exojs';
+import { Asset, AudioStream, Scene, Sound } from '@codexo/exojs';
+import type { Voice } from '@codexo/exojs';
 
 class AudioScene extends Scene {
+    private laser!: Sound;
+    private theme!: AudioStream;
+    private themeVoice!: Voice;
+
     async load() {
         const [laser, theme] = await Promise.all([
             this.loader.load('audio/laser.ogg'),

--- a/site/src/content/guide/audio/audio-effects.mdx
+++ b/site/src/content/guide/audio/audio-effects.mdx
@@ -57,8 +57,6 @@ app.audio.master.addEffect(compressor);
 All properties are live get/set. The `compressor.reduction` getter returns the current gain reduction in dB (always ≤ 0) — useful for live level metering:
 
 ```ts
-import { Time } from '@codexo/exojs';
-
 update(delta: Time) {
     const gr = this.compressor.reduction;
     this.meterBar.height = Math.abs(gr) * 10; // scale to pixels

--- a/site/src/content/guide/audio/audio-effects.mdx
+++ b/site/src/content/guide/audio/audio-effects.mdx
@@ -57,7 +57,9 @@ app.audio.master.addEffect(compressor);
 All properties are live get/set. The `compressor.reduction` getter returns the current gain reduction in dB (always ≤ 0) — useful for live level metering:
 
 ```ts
-update(delta) {
+import { Time } from '@codexo/exojs';
+
+update(delta: Time) {
     const gr = this.compressor.reduction;
     this.meterBar.height = Math.abs(gr) * 10; // scale to pixels
 }

--- a/site/src/content/guide/audio/audio-effects.mdx
+++ b/site/src/content/guide/audio/audio-effects.mdx
@@ -14,7 +14,7 @@ Every bus in ExoJS carries a filter chain — an ordered list of [`AudioEffect`]
 
 A bus's filter chain is `inputNode → [filter₁ → filter₂ → ...] → panNode → outputNode`. Adding a filter appends it to the end of the chain. Order matters — a compressor before reverb sounds different from a compressor after reverb.
 
-```js
+```ts
 import { CompressorEffect, DelayEffect, ReverbEffect } from '@codexo/exojs-audio-fx';
 
 const compressor = new CompressorEffect({ threshold: -20, ratio: 8 });
@@ -28,7 +28,7 @@ app.audio.sound.addEffect(delay);
 
 Remove a filter to take it out of the chain without destroying it:
 
-```js
+```ts
 app.audio.master.removeEffect(reverb);
 ```
 
@@ -42,7 +42,7 @@ Filters are reusable — move one from bus to bus by removing it from the old bu
 
 A dynamics compressor that clamps the dynamic range of audio passing through it. Useful for evening out volume, adding punch to SFX, and preventing clipping when many sounds play simultaneously:
 
-```js
+```ts
 const compressor = new CompressorEffect({
     threshold: -24,   // dBFS — signals above this get compressed
     ratio: 12,        // 1:1 = no compression, 20:1 = near-limiting
@@ -56,7 +56,7 @@ app.audio.master.addEffect(compressor);
 
 All properties are live get/set. The `compressor.reduction` getter returns the current gain reduction in dB (always ≤ 0) — useful for live level metering:
 
-```js
+```ts
 update(delta) {
     const gr = this.compressor.reduction;
     this.meterBar.height = Math.abs(gr) * 10; // scale to pixels
@@ -67,7 +67,7 @@ update(delta) {
 
 `ReverbEffect` simulates acoustic space by convolving audio through a procedurally-generated impulse response:
 
-```js
+```ts
 const reverb = new ReverbEffect({
     durationSeconds: 2,   // IR length — longer = bigger space
     decay: 2,             // exponential decay factor
@@ -81,7 +81,7 @@ Changing `durationSeconds` or `decay` on a live `ReverbEffect` rebuilds its impu
 
 `DelayEffect` creates an echo with configurable feedback:
 
-```js
+```ts
 const delay = new DelayEffect({
     delaySeconds: 0.3,    // echo interval
     feedback: 0.45,       // 0 = one echo, 0.95 = long tail
@@ -95,7 +95,7 @@ Both expose live `wet`, `delaySeconds`, `feedback`, `decay`, and `durationSecond
 
 A sidechain compressor — when the sidechain bus exceeds a threshold, the main signal is attenuated. Common use case: automatically lower music volume when voice-over plays:
 
-```js
+```ts
 import { AudioBus } from '@codexo/exojs';
 import { DuckingEffect } from '@codexo/exojs-audio-fx';
 
@@ -119,7 +119,7 @@ app.audio.music.addEffect(ducker);
 
 Several filters cover tone shaping and modulation effects:
 
-```js
+```ts
 import { HighpassFilter, LowpassFilter } from '@codexo/exojs';
 import { ChorusEffect, EqualizerEffect } from '@codexo/exojs-audio-fx';
 
@@ -144,7 +144,7 @@ Like `ChorusEffect`, the six filters below are built from native Web Audio nodes
 
 Soft-clip saturation through a tanh-based `WaveShaperNode` curve, followed by a tone-control lowpass on the wet path. `drive` (0..1) controls clip intensity and `tone` (0..1) sweeps the wet-path cutoff logarithmically from 100 Hz to 20 kHz:
 
-```js
+```ts
 import { DistortionEffect } from '@codexo/exojs-audio-fx';
 
 const dist = new DistortionEffect({ drive: 0.6, tone: 0.7, wet: 0.8 });
@@ -155,7 +155,7 @@ app.audio.sound.addEffect(dist);
 
 Sweeps a cascade of allpass filters with a sine LFO, producing moving notches in the spectrum. `stages` (an even number, 2..12) sets the notch count and `feedback` (0..0.9) sharpens the resonance:
 
-```js
+```ts
 import { PhaserEffect } from '@codexo/exojs-audio-fx';
 
 const phaser = new PhaserEffect({ stages: 6, rateHz: 0.3, depth: 0.8, feedback: 0.4, wet: 0.6 });
@@ -166,7 +166,7 @@ app.audio.music.addEffect(phaser);
 
 A short (0.5–20 ms) LFO-modulated delay with a feedback loop, producing the classic sweeping "jet-plane" comb-filter sound. Unlike `ChorusEffect` — a longer, feedback-free delay used for thickening — the feedback here reinforces phase cancellation:
 
-```js
+```ts
 import { FlangerEffect } from '@codexo/exojs-audio-fx';
 
 const flanger = new FlangerEffect({ delayMs: 3, depthMs: 2, rateHz: 0.25, feedback: 0.5, wet: 0.5 });
@@ -177,7 +177,7 @@ app.audio.sound.addEffect(flanger);
 
 Amplitude-modulates the signal with a sine LFO for classic volume pulsing. Set `autoPan: true` to have the same LFO drive stereo panning in sync with the pulse:
 
-```js
+```ts
 import { TremoloEffect } from '@codexo/exojs-audio-fx';
 
 const tremolo = new TremoloEffect({ rateHz: 5, depth: 0.7, autoPan: true });
@@ -188,7 +188,7 @@ app.audio.music.addEffect(tremolo);
 
 Multiplies the input by a carrier oscillator, producing sum/difference sidebands while suppressing the fundamental. Mid-range carrier frequencies (100–1000 Hz) give the classic robotic ring-mod timbre; sub-audio rates (< 20 Hz) sound like tremolo:
 
-```js
+```ts
 import { RingModulatorEffect } from '@codexo/exojs-audio-fx';
 
 const ringMod = new RingModulatorEffect({ frequency: 220, waveform: 'sine', wet: 0.8 });
@@ -199,7 +199,7 @@ app.audio.sound.addEffect(ringMod);
 
 An envelope-driven wah: a rectifier and smoothing filter track input loudness and sweep a resonant bandpass filter upward from `baseFrequency`. `sensitivity` sets the maximum sweep in Hz and `responseMs` controls how snappy or legato the response feels:
 
-```js
+```ts
 import { AutoWahEffect } from '@codexo/exojs-audio-fx';
 
 const wah = new AutoWahEffect({ baseFrequency: 300, sensitivity: 2500, q: 5, wet: 0.8 });
@@ -212,7 +212,7 @@ app.audio.sound.addEffect(wah);
 
 A stereo delay whose taps cross-feed between channels, bouncing echoes hard-left/hard-right. `delayTime` sets the per-tap interval in seconds and `feedback` (0..0.9) controls how long the bounce sustains:
 
-```js
+```ts
 import { PingPongDelayEffect } from '@codexo/exojs-audio-fx';
 
 const pingPong = new PingPongDelayEffect({ delayTime: 0.3, feedback: 0.5, wet: 0.5 });
@@ -223,7 +223,7 @@ app.audio.music.addEffect(pingPong);
 
 A brick-wall limiter — a `DynamicsCompressorNode` fixed at a high ratio and hard knee — meant as a safety net at the end of a chain to catch peaks before they clip:
 
-```js
+```ts
 import { LimiterEffect } from '@codexo/exojs-audio-fx';
 
 const limiter = new LimiterEffect({ threshold: -3, release: 0.1 });
@@ -234,7 +234,7 @@ app.audio.master.addEffect(limiter);
 
 Convolves the signal with a real impulse response instead of `ReverbEffect`'s procedurally generated one — useful for captured spaces, cabinet/speaker simulation, or telephone-style filtering. Pass a decoded `AudioBuffer` or a loaded `Sound`; call `setImpulse()` to swap the IR later:
 
-```js
+```ts
 import { ConvolutionEffect } from '@codexo/exojs-audio-fx';
 
 const hall = await loader.load('hall.wav');
@@ -250,7 +250,7 @@ Four filters use `AudioWorkletProcessor` and load asynchronously. They extend `W
 A `WorkletEffect` loads its processor asynchronously — the bus rewires itself once it's ready, but until then the effect passes audio through untouched. `await effect.ready` before you rely on its output or read state from it.
 </Callout>
 
-```js no-check
+```ts no-check
 import { BitCrusherEffect, GranularEffect, PitchShiftEffect, VocoderEffect } from '@codexo/exojs-audio-fx';
 
 // Granular pitch shifting (0.25x to 4x)
@@ -272,7 +272,7 @@ All four have live `wet` controls. `PitchShiftEffect` exposes `pitch`; `Granular
 
 Bus-level filters affect everything on that bus. Create isolated chains for specific sound categories:
 
-```js
+```ts
 const ambientBus = new AudioBus('ambient', { parent: app.audio.master });
 app.audio.registerBus(ambientBus);
 

--- a/site/src/content/guide/audio/audio-reactive-visualization.mdx
+++ b/site/src/content/guide/audio/audio-reactive-visualization.mdx
@@ -24,7 +24,7 @@ Both the analyser and the beat detector connect as parallel taps. They never aff
 
 An `AudioAnalyser` wraps a Web Audio `AnalyserNode` and exposes frequency and time-domain data. You point it at a source, then call its getters each frame:
 
-```js
+```ts
 import { Asset, AudioStream, Scene } from '@codexo/exojs';
 import { AudioAnalyser } from '@codexo/exojs-audio-fx';
 
@@ -64,7 +64,7 @@ The raw FFT returns N bins linearly spaced from 0 Hz to the Nyquist frequency (h
 
 The mel and log methods accept an optional `bands` parameter (default 32) and frequency range (`fMin`/`fMax`, default 20 Hz to 20 kHz, clamped to Nyquist). The filterbanks are built once per `(bands, fMin, fMax, fftSize)` combination and cached on the analyser instance — subsequent calls at the same parameters are just a weighted sum.
 
-```js
+```ts
 update(delta) {
     const mel32 = this.analyser.getSpectrumMel(null, { bands: 32 });
     // mel32[0] is the lowest mel band, mel32[31] is the highest
@@ -85,7 +85,7 @@ update(delta) {
 
 The event signals — `onBeat`, `onDownbeat`, `onBarStart`, `onTempoChange` — fire when the worklet processor detects a beat and dispatches a message to the main thread. Use them for one-shot side effects: spawning a particle burst, triggering a screen flash, advancing a sequencer:
 
-```js
+```ts
 this.detector = new BeatDetector();
 this.detector.source = this.app.audio.music;
 
@@ -107,7 +107,7 @@ For continuous animation — something that smoothly decays between beats rather
 
 These are all pure derivations from the detector's internal state — they do not allocate, do not fire events, and are safe to call every frame:
 
-```js
+```ts
 import { Color } from '@codexo/exojs';
 
 update(delta) {
@@ -150,7 +150,7 @@ A scrolling spectrogram rewrites just one column per frame. `commitRect(x, y, wi
 
 A simple scrolling spectrogram:
 
-```js
+```ts
 import { DataTexture, Sprite } from '@codexo/exojs';
 
 init() {
@@ -190,7 +190,7 @@ For ring-buffer patterns where only the newest column changes, `commitRect(col, 
 
 Here is a complete scene that combines an analyser-driven bar graph with beat-triggered background color changes:
 
-```js
+```ts
 import { Asset, Application, AudioStream,
     Color, Graphics, Scene } from '@codexo/exojs';
 import { AudioAnalyser, BeatDetector } from '@codexo/exojs-audio-fx';

--- a/site/src/content/guide/audio/audio-reactive-visualization.mdx
+++ b/site/src/content/guide/audio/audio-reactive-visualization.mdx
@@ -26,9 +26,14 @@ An `AudioAnalyser` wraps a Web Audio `AnalyserNode` and exposes frequency and ti
 
 ```ts
 import { Asset, AudioStream, Scene } from '@codexo/exojs';
+import type { Time } from '@codexo/exojs';
 import { AudioAnalyser } from '@codexo/exojs-audio-fx';
 
 class VisualizerScene extends Scene {
+    private music!: AudioStream;
+    private analyser!: AudioAnalyser;
+    private spectrum!: Uint8Array;
+
     async load() {
         this.music = await this.loader.load(Asset.type('music', 'audio/track.ogg'));
     }
@@ -41,7 +46,7 @@ class VisualizerScene extends Scene {
         this.analyser.source = this.app.audio.music;
     }
 
-    update(delta) {
+    update(delta: Time) {
         this.spectrum = this.analyser.getSpectrum();
     }
 }
@@ -65,7 +70,9 @@ The raw FFT returns N bins linearly spaced from 0 Hz to the Nyquist frequency (h
 The mel and log methods accept an optional `bands` parameter (default 32) and frequency range (`fMin`/`fMax`, default 20 Hz to 20 kHz, clamped to Nyquist). The filterbanks are built once per `(bands, fMin, fMax, fftSize)` combination and cached on the analyser instance — subsequent calls at the same parameters are just a weighted sum.
 
 ```ts
-update(delta) {
+import { Time } from '@codexo/exojs';
+
+update(delta: Time) {
     const mel32 = this.analyser.getSpectrumMel(null, { bands: 32 });
     // mel32[0] is the lowest mel band, mel32[31] is the highest
 
@@ -86,6 +93,8 @@ update(delta) {
 The event signals — `onBeat`, `onDownbeat`, `onBarStart`, `onTempoChange` — fire when the worklet processor detects a beat and dispatches a message to the main thread. Use them for one-shot side effects: spawning a particle burst, triggering a screen flash, advancing a sequencer:
 
 ```ts
+import { BeatDetector } from '@codexo/exojs-audio-fx';
+
 this.detector = new BeatDetector();
 this.detector.source = this.app.audio.music;
 
@@ -193,9 +202,16 @@ Here is a complete scene that combines an analyser-driven bar graph with beat-tr
 ```ts
 import { Asset, Application, AudioStream,
     Color, Graphics, Scene } from '@codexo/exojs';
+import type { RenderingContext, Time } from '@codexo/exojs';
 import { AudioAnalyser, BeatDetector } from '@codexo/exojs-audio-fx';
 
 class AudioReactiveScene extends Scene {
+    private music!: AudioStream;
+    private analyser!: AudioAnalyser;
+    private detector!: BeatDetector;
+    private bars!: Graphics;
+    private _bg!: Color;
+
     async load() {
         this.music = await this.loader.load(Asset.type('music', 'audio/track.ogg'));
     }
@@ -214,7 +230,7 @@ class AudioReactiveScene extends Scene {
         this._bg = new Color(20, 24, 30, 1);
     }
 
-    update(delta) {
+    update(delta: Time) {
         const bands = this.analyser.getSpectrumMel(null, { bands: 32 });
         const { width, height } = this.app.canvas;
         const barW = width / bands.length;
@@ -239,7 +255,7 @@ class AudioReactiveScene extends Scene {
         this._bg = new Color(20, 24, Math.round(30 + this.detector.pulse * 60), 1);
     }
 
-    draw(context) {
+    draw(context: RenderingContext) {
         context.backend.clear(this._bg);
         context.render(this.bars);
     }

--- a/site/src/content/guide/audio/audio-reactive-visualization.mdx
+++ b/site/src/content/guide/audio/audio-reactive-visualization.mdx
@@ -70,8 +70,6 @@ The raw FFT returns N bins linearly spaced from 0 Hz to the Nyquist frequency (h
 The mel and log methods accept an optional `bands` parameter (default 32) and frequency range (`fMin`/`fMax`, default 20 Hz to 20 kHz, clamped to Nyquist). The filterbanks are built once per `(bands, fMin, fMax, fftSize)` combination and cached on the analyser instance — subsequent calls at the same parameters are just a weighted sum.
 
 ```ts
-import { Time } from '@codexo/exojs';
-
 update(delta: Time) {
     const mel32 = this.analyser.getSpectrumMel(null, { bands: 32 });
     // mel32[0] is the lowest mel band, mel32[31] is the highest
@@ -117,9 +115,7 @@ For continuous animation — something that smoothly decays between beats rather
 These are all pure derivations from the detector's internal state — they do not allocate, do not fire events, and are safe to call every frame:
 
 ```ts
-import { Color } from '@codexo/exojs';
-
-update(delta) {
+update(delta: Time) {
     const beat = this.detector.pulse;
     const downbeat = this.detector.barPulse;
 
@@ -160,8 +156,6 @@ A scrolling spectrogram rewrites just one column per frame. `commitRect(x, y, wi
 A simple scrolling spectrogram:
 
 ```ts
-import { DataTexture, Sprite } from '@codexo/exojs';
-
 init() {
     this.analyser = new AudioAnalyser({ fftSize: 512 });
     this.analyser.source = this.app.audio.music;
@@ -179,7 +173,7 @@ init() {
     this.col = 0;
 }
 
-update(delta) {
+update(delta: Time) {
     const bands = this.analyser.getSpectrumMel(null, { bands: 64 });
     const buf = this.specTex.buffer;
 

--- a/site/src/content/guide/audio/beat-detection.mdx
+++ b/site/src/content/guide/audio/beat-detection.mdx
@@ -16,7 +16,7 @@ This chapter covers what the detector does and the events it fires. The next cha
 
 The detector taps a live audio source — an `AudioBus`, a `Voice`, an `AudioNode`, or a `MediaStream` — as a parallel branch that does not affect the source's main signal chain. It does not accept a `Sound`/`AudioStream` descriptor; tap the bus the audio plays through (e.g. `app.audio.music`) or the individual `Voice` you got back from `play()`:
 
-```js
+```ts
 import { Asset, AudioStream } from '@codexo/exojs';
 import { BeatDetector } from '@codexo/exojs-audio-fx';
 
@@ -29,7 +29,7 @@ detector.source = this.app.audio.music; // the bus the track plays through
 
 You can also pass the source as a constructor option, or point it at a single voice:
 
-```js
+```ts
 const voice = this.app.audio.play(track, { loop: true });
 const detector = new BeatDetector({ source: voice });
 ```
@@ -40,7 +40,7 @@ The detector runs its own FFT inside the worklet processor. No `AudioAnalyser` i
 
 Two read-only getters give you the detector's current tempo estimate:
 
-```js
+```ts
 update(delta) {
     const bpm = this.detector.tempo;           // 0 before lock-in
     const confidence = this.detector.confidence; // 0..1
@@ -49,7 +49,7 @@ update(delta) {
 
 `tempo` returns 0 until the detector has enough data to lock onto a stable beat. `confidence` rises as the beat grid stabilises. The `onTempoChange` signal fires when the detector settles on a new tempo:
 
-```js
+```ts
 detector.onTempoChange.add((newBpm, oldBpm) => {
     console.log(`Tempo changed from ${oldBpm} to ${newBpm} BPM`);
 });
@@ -70,7 +70,7 @@ Four signals fire at discrete moments in the music:
 
 Use `onBeat` for things that should happen on every beat — a sprite pulses, a particle burst fires, a UI element flashes:
 
-```js
+```ts
 detector.onBeat.add(info => {
     this.pulse = 0.3;
     this.particleBurst.reset();
@@ -83,7 +83,7 @@ detector.onBeat.add(info => {
 
 Use `onDownbeat` for events that should only fire on the "one" — a brighter flash, a bar-level visual change, a camera shake:
 
-```js
+```ts
 detector.onDownbeat.add(info => {
     this.barFlash = 0.5;
 });
@@ -91,7 +91,7 @@ detector.onDownbeat.add(info => {
 
 `BeatInfo` carries `isDownbeat` and `beatInBar` so you can use the general `onBeat` signal and filter inside the callback:
 
-```js
+```ts
 detector.onBeat.add(info => {
     if (info.isDownbeat) {
         // big effect on beat 1
@@ -105,7 +105,7 @@ detector.onBeat.add(info => {
 
 The detector exposes read-only state you can poll every frame:
 
-```js
+```ts
 detector.tempo              // BPM, or 0 before lock
 detector.confidence         // 0..1 locking quality
 detector.beatPhase          // 0..1 phase within current beat
@@ -129,7 +129,7 @@ Beats arrive `'provisional'` first — low-latency and ideal for snappy visual r
 
 The detector attempts 4/4 vs. 3/4 time-signature detection when `enableTimeSignatureDetection` is `true` (the default). Set it `false` in the constructor to lock to 4/4:
 
-```js
+```ts
 const detector = new BeatDetector({
     enableTimeSignatureDetection: false,
 });
@@ -147,7 +147,7 @@ Beat/state messages are posted from the worklet and handled asynchronously on th
 
 Construction options with their defaults:
 
-```js
+```ts
 const detector = new BeatDetector({
     minBpm: 50,                            // minimum detectable tempo
     maxBpm: 300,                           // maximum detectable tempo
@@ -170,7 +170,7 @@ const detector = new BeatDetector({
 
 Create one detector per scene (or share across scenes if the same source persists). Destroy it when you're done:
 
-```js
+```ts
 destroy() {
     this.detector.destroy();
 }

--- a/site/src/content/guide/audio/beat-detection.mdx
+++ b/site/src/content/guide/audio/beat-detection.mdx
@@ -41,7 +41,9 @@ The detector runs its own FFT inside the worklet processor. No `AudioAnalyser` i
 Two read-only getters give you the detector's current tempo estimate:
 
 ```ts
-update(delta) {
+import { Time } from '@codexo/exojs';
+
+update(delta: Time) {
     const bpm = this.detector.tempo;           // 0 before lock-in
     const confidence = this.detector.confidence; // 0..1
 }

--- a/site/src/content/guide/audio/beat-detection.mdx
+++ b/site/src/content/guide/audio/beat-detection.mdx
@@ -41,8 +41,6 @@ The detector runs its own FFT inside the worklet processor. No `AudioAnalyser` i
 Two read-only getters give you the detector's current tempo estimate:
 
 ```ts
-import { Time } from '@codexo/exojs';
-
 update(delta: Time) {
     const bpm = this.detector.tempo;           // 0 before lock-in
     const confidence = this.detector.confidence; // 0..1

--- a/site/src/content/guide/audio/spatial-audio.mdx
+++ b/site/src/content/guide/audio/spatial-audio.mdx
@@ -144,9 +144,9 @@ const alarm = app.audio.play(alarmLoop, {
 `voice.follow(node)` keeps `position` in sync with a tracked node every frame, but it does **not** touch `orientation` — a rotating emitter's facing direction has no single obvious source (a turret's barrel and its base may rotate independently, for instance), so this stays an explicit, per-frame assignment you own:
 
 ```ts
-update(delta) {
-    voice.follow(this.turret);          // position tracks automatically...
-    voice.orientation = this.turret.rotation; // ...orientation does not
+update(delta: Time) {
+    this.voice.follow(this.turret);          // position tracks automatically...
+    this.voice.orientation = this.turret.rotation; // ...orientation does not
 }
 ```
 </Callout>
@@ -187,11 +187,11 @@ init() {
     this.app.audio.listener.target = this.player;
 }
 
-update(delta) {
+update(delta: Time) {
     // ... game logic ...
 
-    if (pickupCollected) {
-        this.app.audio.play(this.pickupSfx, { position: { x: item.x, y: item.y } });
+    if (this.pickupCollected) {
+        this.app.audio.play(this.pickupSfx, { position: { x: this.item.x, y: this.item.y } });
     }
 }
 ```

--- a/site/src/content/guide/audio/spatial-audio.mdx
+++ b/site/src/content/guide/audio/spatial-audio.mdx
@@ -18,7 +18,7 @@ The listener and every source sit on one plane (Z=0), panned with the Web Audio 
 
 The [`AudioListener`](/ExoJS/en/api/audio-listener/) is a singleton at `app.audio.listener`. Set its position directly or point it at a target that updates every frame:
 
-```js
+```ts
 // Static listener — audio doesn't move
 app.audio.listener.position.set(400, 300);
 
@@ -42,7 +42,7 @@ Valid target types are:
 
 `Sound` itself carries no spatial state — position and distance model live on the `Voice` that `app.audio.play()` returns. Seed the initial position via `PlayOptions`:
 
-```js
+```ts
 const pickup = this.loader.get('audio/pickup.wav');
 const voice = this.app.audio.play(pickup, { position: { x: 320, y: 180 } });
 ```
@@ -51,7 +51,7 @@ The audio pans left when the source is left of the listener, right when to the r
 
 To move a source *while it plays*, drive the live `Voice` — spatial voices are `Spatializable`, exposing `position` and `follow()`:
 
-```js
+```ts
 // Move the live source each frame...
 voice.position = { x: item.x, y: item.y };
 
@@ -74,7 +74,7 @@ Three attenuation curves control how volume drops with distance:
 
 Configure per-voice via `PlayOptions` at play time, or live on the returned `Voice`:
 
-```js no-check
+```ts no-check
 import { Sound } from '@codexo/exojs';
 
 const ambient = new Sound(audioBuffer);
@@ -92,7 +92,7 @@ const voice = this.app.audio.play(ambient, {
 
 All four attenuation properties are also live setters on the `Voice` — reassign them to change the model or falloff of a sound that's already playing:
 
-```js
+```ts
 voice.distanceModel = 'inverse';
 voice.refDistance = 80;
 voice.rolloffFactor = 2;
@@ -104,13 +104,13 @@ The `PannerNode` behind every spatial voice supports two panning algorithms. `'e
 
 Switch the app-wide default once:
 
-```js
+```ts
 app.audio.spatial.panningModel = 'HRTF';
 ```
 
 Or override it per source, leaving the app-wide default untouched for everything else:
 
-```js
+```ts
 const voice = app.audio.play(footsteps, {
     position: { x: npc.x, y: npc.y },
     panningModel: 'HRTF',
@@ -119,7 +119,7 @@ const voice = app.audio.play(footsteps, {
 
 A voice's `panningModel` is also a live setter — set it back to `null` to drop the override and re-inherit `app.audio.spatial.panningModel`:
 
-```js
+```ts
 voice.panningModel = null;
 ```
 
@@ -129,7 +129,7 @@ A spatial voice can face a direction and attenuate sound outside a cone in front
 
 `orientation` alone has no audible effect — a source is omnidirectional until you narrow `coneInnerAngle`/`coneOuterAngle` below the default `360°`. Inside `coneInnerAngle` the source plays at full volume; between `coneInnerAngle` and `coneOuterAngle` it fades toward `coneOuterGain`; beyond `coneOuterAngle` it plays at `coneOuterGain`.
 
-```js
+```ts
 const alarm = app.audio.play(alarmLoop, {
     loop: true,
     position: { x: turret.x, y: turret.y },
@@ -143,7 +143,7 @@ const alarm = app.audio.play(alarmLoop, {
 <Callout type="warning" title="orientation is not auto-synced with follow()">
 `voice.follow(node)` keeps `position` in sync with a tracked node every frame, but it does **not** touch `orientation` — a rotating emitter's facing direction has no single obvious source (a turret's barrel and its base may rotate independently, for instance), so this stays an explicit, per-frame assignment you own:
 
-```js
+```ts
 update(delta) {
     voice.follow(this.turret);          // position tracks automatically...
     voice.orientation = this.turret.rotation; // ...orientation does not
@@ -155,7 +155,7 @@ update(delta) {
 
 Doppler pitch-shifting is off by default (`app.audio.spatial.dopplerFactor` is `0`) — enabling it costs nothing extra when unused, since the engine skips the calculation entirely while the factor is zero. Turn it on app-wide with:
 
-```js
+```ts
 app.audio.spatial.dopplerFactor = 1;
 ```
 
@@ -163,13 +163,13 @@ app.audio.spatial.dopplerFactor = 1;
 
 The effect needs a velocity to work with. Set it explicitly on a voice:
 
-```js
+```ts
 voice.velocity = { x: 120, y: 0 };
 ```
 
 Or omit it entirely and let the engine derive it automatically each frame from the position deltas of a followed node:
 
-```js
+```ts
 voice.follow(car); // no explicit velocity — derived from car's frame-to-frame position
 ```
 
@@ -179,7 +179,7 @@ The same explicit-or-derived rule applies symmetrically to the listener: set `ap
 
 The most common pattern is to set the listener's target to the camera or player once in `init`, then pass a `position` in `PlayOptions` right before each one-shot play:
 
-```js
+```ts
 init() {
     this.pickupSfx = this.loader.get('audio/pickup.wav');
     this.pickupSfx.volume = 0.6;
@@ -202,7 +202,7 @@ A voice played without a `position` plays non-spatially — full volume in both 
 
 For ambient sounds that should follow the listener's general area but not overlap, set a large `refDistance`:
 
-```js
+```ts
 const waterfall = this.loader.get('audio/waterfall.ogg');
 const voice = this.app.audio.play(waterfall, {
     loop: true,

--- a/site/src/content/guide/debugging/backend-comparison.mdx
+++ b/site/src/content/guide/debugging/backend-comparison.mdx
@@ -12,7 +12,7 @@ ExoJS renders through one of two backends: WebGL2 or WebGPU. The choice is autom
 
 ## Selection
 
-```js
+```ts
 import { Application } from '@codexo/exojs';
 
 // Auto-select (prefers WebGPU, falls back to WebGL2)

--- a/site/src/content/guide/debugging/custom-renderers.mdx
+++ b/site/src/content/guide/debugging/custom-renderers.mdx
@@ -90,7 +90,7 @@ A `RenderPipeline` composes high-level `RenderPass` objects (`RenderNodePass`, `
 
 When you need full GPU control — raw pipeline creation, custom vertex buffers, compute dispatches — access `WebGpuBackend` directly through `app.backend`. This is the escape hatch: you bypass ExoJS drawable types and renderer pipelines entirely, working at the WebGPU API level:
 
-```js no-check
+```ts no-check
 import { WebGpuBackend } from '@codexo/exojs';
 
 class CustomTriangleRenderer {

--- a/site/src/content/guide/debugging/custom-renderers.mdx
+++ b/site/src/content/guide/debugging/custom-renderers.mdx
@@ -21,7 +21,7 @@ Reach for `CallbackRenderPass` for almost all custom draw work — it slots into
 </Callout>
 
 ```ts
-import { CallbackRenderPass, Color, Graphics, RenderNodePass, RenderPipeline, Scene, Sprite } from '@codexo/exojs';
+import { CallbackRenderPass, Color, Graphics, RenderingContext, RenderNodePass, RenderPipeline, Scene, Sprite, Time } from '@codexo/exojs';
 
 class CustomPassScene extends Scene {
     private back!: Sprite;
@@ -49,11 +49,11 @@ class CustomPassScene extends Scene {
             .addPass(new RenderNodePass(this.front)); // draws on top
     }
 
-    override update(delta): void {
+    override update(delta: Time): void {
         this.angle += delta.seconds * 2.2;
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         this.pipeline.execute(context);
     }
 }

--- a/site/src/content/guide/debugging/debugging-and-inspection.mdx
+++ b/site/src/content/guide/debugging/debugging-and-inspection.mdx
@@ -15,7 +15,7 @@ ExoJS ships five diagnostic layers in the `@codexo/exojs/debug` optional entrypo
 
 The [`DebugOverlay`](/ExoJS/en/api/debug-overlay/) is the entry point. Create one against your application, toggle individual layers by setting their `visible` flag:
 
-```js
+```ts
 import { DebugOverlay } from '@codexo/exojs/debug';
 
 const debug = new DebugOverlay(app);
@@ -48,7 +48,7 @@ Press F1 or set `debug.layers.performance.visible = true` to enable it.
 
 The [`BoundingBoxesLayer`](/ExoJS/en/api/bounding-boxes-layer/) draws colored rectangle outlines around every visible `RenderNode` with non-zero bounds. Each node's outline hue cycles by its `zIndex` — adjacent z-indices get visually distinct colors. This layer renders in world space, so boxes move and rotate with the scene:
 
-```js
+```ts
 debug.layers.boundingBoxes.visible = true;  // or F2
 ```
 
@@ -68,7 +68,7 @@ The [`HitTestLayer`](/ExoJS/en/api/hit-test-layer/) color-codes interactive node
 
 This layer renders in world space. Combined with `debug.layers.pointerStack.visible` (F4), which lists which nodes are under the cursor in a screen-space panel, you can trace the full hit-test path from pointer position to interactive node:
 
-```js
+```ts
 debug.layers.hitTest.visible = true;       // or F3
 debug.layers.pointerStack.visible = true;  // or F4
 ```
@@ -85,7 +85,7 @@ Debug layers have zero overhead when their `visible` flag is `false` — `DebugO
 
 Separately from the visual overlays above, ExoJS ships a message-first [`Logger`](/ExoJS/en/api/logger/) in the core module — no special entrypoint required. The engine uses it internally (for example, `Application` logs unexpected failures with `source: 'Application'`), and it's available for your own code too. A ready-to-use default instance, `logger`, is exported alongside the class:
 
-```js
+```ts
 import { logger } from '@codexo/exojs';
 
 logger.debug('Bundle "level-1" queued', { source: 'assets' });
@@ -104,7 +104,7 @@ Only `Error` survives a production build — `Debug`, `Info` and `Warning` are s
 
 To capture log entries yourself — for an in-game console, telemetry, or a custom debug panel — register a sink with `addSink`. It returns an unsubscribe function:
 
-```js
+```ts
 import { logger, LogSeverity } from '@codexo/exojs';
 
 const unsubscribe = logger.addSink((entry) => {
@@ -119,7 +119,7 @@ unsubscribe();
 
 For warnings that could otherwise repeat every frame (a stale asset reference checked in `update`, say), pass `once` — the entry is dropped after the first call for a given key, at any severity:
 
-```js
+```ts
 update(delta) {
     if (this.texture.width > 4096) {
         logger.warn('Texture exceeds 4096px — this may hurt performance on mobile GPUs.', { source: 'rendering', once: 'huge-texture' });
@@ -150,7 +150,7 @@ The panel does not show drawables with zero filters — they are invisible to th
 
 Import from the debug entrypoint, construct against the application, subscribe to `app.onFrame`, and toggle visibility:
 
-```js
+```ts
 import { Scene, View } from '@codexo/exojs';
 import { RenderPassInspectorLayer } from '@codexo/exojs/debug';
 
@@ -192,7 +192,7 @@ The screen-space view swap is necessary because `RenderPassInspectorLayer` retur
 
 If you only need the data and not the built-in panel, read `inspector.entries` and `inspector.totalPasses` directly — the `update` call is still required to populate the entry snapshot:
 
-```js
+```ts
 update(delta) {
     // ... game logic ...
 

--- a/site/src/content/guide/debugging/debugging-and-inspection.mdx
+++ b/site/src/content/guide/debugging/debugging-and-inspection.mdx
@@ -120,7 +120,7 @@ unsubscribe();
 For warnings that could otherwise repeat every frame (a stale asset reference checked in `update`, say), pass `once` — the entry is dropped after the first call for a given key, at any severity:
 
 ```ts
-update(delta) {
+update(delta: Time) {
     if (this.texture.width > 4096) {
         logger.warn('Texture exceeds 4096px — this may hurt performance on mobile GPUs.', { source: 'rendering', once: 'huge-texture' });
     }
@@ -155,6 +155,9 @@ import { Scene, View } from '@codexo/exojs';
 import { RenderPassInspectorLayer } from '@codexo/exojs/debug';
 
 class GameScene extends Scene {
+    private inspector!: RenderPassInspectorLayer;
+    private _screenView!: View;
+
     init() {
         // ... normal scene setup with filters, sprites, etc. ...
 
@@ -193,14 +196,15 @@ The screen-space view swap is necessary because `RenderPassInspectorLayer` retur
 If you only need the data and not the built-in panel, read `inspector.entries` and `inspector.totalPasses` directly — the `update` call is still required to populate the entry snapshot:
 
 ```ts
-update(delta) {
+update(delta: Time) {
     // ... game logic ...
 
     console.log(`Passes this frame: ${this.inspector.totalPasses}`);
     for (const entry of this.inspector.entries) {
+        const filterNames = entry.filters.map((f: Filter) => f.constructor.name).join(', ');
         console.log(
             `${entry.drawableLabel} ${entry.width}x${entry.height}` +
-            ` filters=[${entry.filters.map(f => f.constructor.name).join(', ')}]` +
+            ` filters=[${filterNames}]` +
             (entry.hasMask ? ' mask' : '') +
             (entry.cachedAsBitmap ? ' cached' : ''),
         );

--- a/site/src/content/guide/debugging/performance.mdx
+++ b/site/src/content/guide/debugging/performance.mdx
@@ -15,7 +15,7 @@ Performance in ExoJS is about three things: how many drawables you push per fram
 
 Before making changes, measure. The [`PerformanceLayer`](/ExoJS/en/api/performance-layer/) from `@codexo/exojs/debug` gives you FPS, frame time, draw-call count, and node count in real time:
 
-```js
+```ts
 import { DebugOverlay } from '@codexo/exojs/debug';
 
 const debug = new DebugOverlay(app);
@@ -42,7 +42,7 @@ Every filter on a drawable adds one render pass for that drawable. A container w
 
 The [`RenderPassInspectorLayer`](/ExoJS/en/api/render-pass-inspector-layer/) shows exactly who is adding passes. Enable it during development when frame time rises and you suspect filter overhead:
 
-```js
+```ts
 import { RenderPassInspectorLayer } from '@codexo/exojs/debug';
 // See 7.6 Render pipeline debugging for setup
 ```
@@ -89,7 +89,7 @@ Nodes that fall entirely outside the current `View`'s viewport are skipped by th
 
 The automatic check calls `getBounds()`, which for a `Container` walks every visible child and unions their bounds — for a complex `Graphics` node or a container with hundreds of children, that walk runs every frame even when the node's on-screen footprint is trivial to reason about. Set `cullArea` to a `Rectangle` and the cull check uses it directly instead of computing bounds:
 
-```js
+```ts
 import { Color, Container, Graphics, Rectangle } from '@codexo/exojs';
 
 // A debris field built from hundreds of small Graphics children — walking

--- a/site/src/content/guide/effects/custom-mesh-shaders.mdx
+++ b/site/src/content/guide/effects/custom-mesh-shaders.mdx
@@ -28,7 +28,7 @@ A custom shader filter ([`WebGl2ShaderFilter`](/ExoJS/en/api/web-gl2-shader-filt
 
 Build a `ShaderSource` from the shader text, then wrap it in a `MeshMaterial` with the initial uniform values. At least one language source is required on the `ShaderSource`. Pass `glsl` for WebGL2, `wgsl` for WebGPU, or both for cross-backend meshes:
 
-```js
+```ts
 import { MeshMaterial, ShaderSource } from '@codexo/exojs';
 
 const waveMaterial = new MeshMaterial({
@@ -167,7 +167,7 @@ You can omit any of them. If your fragment shader ignores the texture and sample
 
 Anything you put in `MeshMaterial.uniforms` is set after the auto-binds. Mutate the `uniforms` map between frames to drive animated effects:
 
-```js
+```ts
 update(delta) {
     this.waveMaterial.uniforms.u_time = this.clock.elapsedSeconds;
     this.waveMaterial.uniforms.u_waveAmp = 10 + this.detector.pulse * 15;
@@ -191,7 +191,7 @@ When a uniform is spelled differently across your two shader sources it silently
 
 Pass a `MeshMaterial` in the mesh constructor's `material` option:
 
-```js
+```ts
 import { Mesh, MeshMaterial, ShaderSource } from '@codexo/exojs';
 
 // A minimal stand-in material — see the Construction section for the full
@@ -249,7 +249,7 @@ When a mesh is destroyed, its `MeshMaterial` is left untouched. The material out
 
 When you write shaders for both GLSL and WGSL, keeping uniform names synchronized across languages becomes a manual task. The reflection helpers live on the `ShaderSource`, reachable through `material.shader`. `getDeclaredUniforms()` reflects uniform declarations from each language's source via lightweight regex parsing. Companion method `detectUniformDrift()` compares the two and reports names that appear in only one language:
 
-```js
+```ts
 const drift = waveMaterial.shader.detectUniformDrift();
 // drift.onlyInGlsl → ['u_waveAmp']
 // drift.onlyInWgsl → ['u_displacement']
@@ -257,7 +257,7 @@ const drift = waveMaterial.shader.detectUniformDrift();
 
 Auto-bound uniforms (`u_projection`, `u_translation`, `u_tint`, `u_texture`, `u_mesh`) are excluded from the comparison — they are intentionally declared differently across languages. Use `detectUniformDrift` in a CI check to catch typos and mismatches:
 
-```js no-check
+```ts no-check
 import assert from 'node:assert';
 
 const drift = waveMaterial.shader.detectUniformDrift();

--- a/site/src/content/guide/effects/custom-mesh-shaders.mdx
+++ b/site/src/content/guide/effects/custom-mesh-shaders.mdx
@@ -168,7 +168,7 @@ You can omit any of them. If your fragment shader ignores the texture and sample
 Anything you put in `MeshMaterial.uniforms` is set after the auto-binds. Mutate the `uniforms` map between frames to drive animated effects:
 
 ```ts
-update(delta) {
+update(delta: Time) {
     this.waveMaterial.uniforms.u_time = this.clock.elapsedSeconds;
     this.waveMaterial.uniforms.u_waveAmp = 10 + this.detector.pulse * 15;
 }

--- a/site/src/content/guide/effects/filters.mdx
+++ b/site/src/content/guide/effects/filters.mdx
@@ -20,7 +20,7 @@ Each filter you attach re-renders that node's output once more per frame — a t
 
 Filters go on the drawable. The array is processed in order — filter 0 receives the node's raw render, filter 1 receives filter 0's output, and so on:
 
-```js
+```ts
 import { BlurFilter, Color, ColorFilter } from '@codexo/exojs';
 
 const blur = new BlurFilter({ radius: 3, quality: 2 });
@@ -45,7 +45,7 @@ Set `cacheAsBitmap = true` on a filtered subtree that doesn't change each frame:
 
 A box blur, not a shader — it works by rendering the input texture multiple times at symmetric pixel offsets with additive blending. Higher quality produces more offset samples per axis and a smoother result at the cost of more draw calls:
 
-```js
+```ts
 const blur = new BlurFilter({ radius: 4, quality: 2 });
 sprite.filters = [blur];
 
@@ -60,7 +60,7 @@ blur.quality = 3;
 
 Multiplies the rendered output by a tint color. The simplest filter — one multiplicative blend:
 
-```js
+```ts
 const color = new ColorFilter(new Color(255, 160, 120));
 sprite.filters = [color];
 
@@ -77,7 +77,7 @@ Maps every pixel through a Look-Up Table texture. Two modes:
 - **1D LUT** (palette): `N×1` texture, indexed by a single channel. Palette cycling, posterisation, indexed-color effects.
 - **3D LUT** (color grading): `N²×N` unwrapped cube texture with trilinear interpolation. Cinematic color grading, film stock emulation, tone mapping.
 
-```js no-check
+```ts no-check
 import { LutFilter } from '@codexo/exojs';
 
 // From a DaVinci/OBS/Photoshop-exported PNG strip
@@ -95,7 +95,7 @@ filter.setLut(differentLutTexture);
 
 `WebGl2ShaderFilter` and `WebGpuShaderFilter` accept a fragment shader source and an optional uniforms map. They render a fullscreen quad and execute the shader against the filter input texture:
 
-```js no-check
+```ts no-check
 import { WebGl2ShaderFilter } from '@codexo/exojs';
 
 const waveFilter = new WebGl2ShaderFilter({
@@ -133,7 +133,7 @@ Both auto-bind `uTexture` (the filter input) and `uResolution` (output dimension
 
 Filters on a `Container` apply to the container's entire rendered subtree — every child is drawn into an off-screen target first, then the filter chain processes that target. A blur on a container blurs all children together, not individually:
 
-```js
+```ts
 const world = new Container();
 world.filters = [new BlurFilter({ radius: 2 })];
 world.addChild(hero);   // hero is drawn into container's RT, then blurred

--- a/site/src/content/guide/effects/filters.mdx
+++ b/site/src/content/guide/effects/filters.mdx
@@ -21,7 +21,9 @@ Each filter you attach re-renders that node's output once more per frame — a t
 Filters go on the drawable. The array is processed in order — filter 0 receives the node's raw render, filter 1 receives filter 0's output, and so on:
 
 ```ts
-import { BlurFilter, Color, ColorFilter } from '@codexo/exojs';
+import { BlurFilter, Color, ColorFilter, Sprite } from '@codexo/exojs';
+
+let sprite: Sprite;
 
 const blur = new BlurFilter({ radius: 3, quality: 2 });
 const tint = new ColorFilter(new Color(140, 210, 255));

--- a/site/src/content/guide/effects/particles.mdx
+++ b/site/src/content/guide/effects/particles.mdx
@@ -22,7 +22,7 @@ The mental model: you register modules that describe how particles *spawn*, what
 
 Register the extension when creating your Application:
 
-```js
+```ts
 import { Application } from '@codexo/exojs';
 import { particlesExtension } from '@codexo/exojs-particles';
 
@@ -31,7 +31,7 @@ const app = new Application({ extensions: [particlesExtension] });
 
 Or use the `/register` convenience import for global registration:
 
-```js
+```ts
 import '@codexo/exojs-particles/register';
 import { Application } from '@codexo/exojs';
 
@@ -42,7 +42,7 @@ const app = new Application(); // picks up particlesExtension automatically
 
 A particle system needs a texture and a capacity:
 
-```js
+```ts
 import { BlendModes } from '@codexo/exojs';
 import { ParticleSystem } from '@codexo/exojs-particles';
 
@@ -55,7 +55,7 @@ const system = new ParticleSystem(loader.get('image/spark.png'), {
 
 The system is a `Drawable`, so it has a position, rotation, scale, tint, blend mode, and participates in the scene graph like any sprite:
 
-```js
+```ts
 system.setPosition(400, 500);
 system.setBlendMode(BlendModes.Additive);
 ```
@@ -68,7 +68,7 @@ A spawn module creates new particles each frame. Two built-in spawners cover the
 
 **`RateSpawn`** — continuous emission at a configurable rate (particles per second):
 
-```js no-check
+```ts no-check
 import { ConeDirection, Constant, RateSpawn, Range, Vector } from '@codexo/exojs-particles';
 
 system.addSpawnModule(new RateSpawn({
@@ -81,7 +81,7 @@ system.addSpawnModule(new RateSpawn({
 
 **`BurstSpawn`** — named bursts at scheduled times, with optional looping:
 
-```js no-check
+```ts no-check
 import { BurstSpawn, ConeDirection, Constant, Range, Vector } from '@codexo/exojs-particles';
 
 const burst = new BurstSpawn({
@@ -131,7 +131,7 @@ A system takes the WGSL compute path when the backend is WebGPU and every update
 
 The frequently-used update modules:
 
-```js no-check
+```ts no-check
 import { Color } from '@codexo/exojs';
 import {
     AlphaFadeOverLifetime,
@@ -180,7 +180,7 @@ Other available update modules: `RotateOverLifetime`, `VelocityOverLifetime`, `A
 
 A death module fires once per particle when its lifetime expires. The only built-in death module is `SpawnOnDeath`:
 
-```js no-check
+```ts no-check
 import { SpawnOnDeath } from '@codexo/exojs-particles';
 
 system.addDeathModule(new SpawnOnDeath(
@@ -196,7 +196,7 @@ system.addDeathModule(new SpawnOnDeath(
 
 `ParticleSystem` is a `Drawable` — it renders itself when you call `context.render(system)` in `draw`. Call `system.update(delta)` in your scene's `update`:
 
-```js
+```ts
 update(delta) {
     this.system.update(delta);
 }
@@ -213,7 +213,7 @@ The update loop runs spawn modules, advances particle state (velocity integratio
 
 For manual spawning or custom logic, the system exposes its internal arrays as public `readonly` references:
 
-```js
+```ts
 system.posX[i]         // X position of particle i
 system.posY[i]         // Y position
 system.velX[i]         // X velocity

--- a/site/src/content/guide/effects/particles.mdx
+++ b/site/src/content/guide/effects/particles.mdx
@@ -197,11 +197,11 @@ system.addDeathModule(new SpawnOnDeath(
 `ParticleSystem` is a `Drawable` — it renders itself when you call `context.render(system)` in `draw`. Call `system.update(delta)` in your scene's `update`:
 
 ```ts
-update(delta) {
+update(delta: Time) {
     this.system.update(delta);
 }
 
-draw(context) {
+draw(context: RenderingContext) {
     context.backend.clear();
     context.render(this.system);
 }

--- a/site/src/content/guide/effects/post-processing.mdx
+++ b/site/src/content/guide/effects/post-processing.mdx
@@ -17,7 +17,7 @@ The building blocks — `RenderTexture` and `Filter` — are covered in their ow
 The minimal pattern: render your scene into a `RenderTexture`, apply a filter, display the result. Build the pipeline once in `init`, then run it each frame with `pipeline.execute(context)`:
 
 ```ts
-import { BlurFilter, CallbackRenderPass, Color, Container, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite } from '@codexo/exojs';
+import { BlurFilter, CallbackRenderPass, Color, Container, RenderNodePass, RenderingContext, RenderPipeline, RenderTexture, Scene, Sprite } from '@codexo/exojs';
 
 class PostProcessScene extends Scene {
     private sceneRt!: RenderTexture;
@@ -43,7 +43,7 @@ class PostProcessScene extends Scene {
             .addPass(new RenderNodePass(this.final, { clear: Color.black }));
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         this.pipeline.execute(context);
     }
 }
@@ -60,7 +60,7 @@ That pipeline is already three passes — scene render, blur, composite. Post-pr
 Bloom requires two renderings of the same scene: one at normal brightness (the base), one with only the bright parts tinted and blurred (the glow). The glow is composited additively over the base. Because the same sprite is drawn twice with different tints, each off-screen step is a `CallbackRenderPass` that sets the tint before rendering:
 
 ```ts
-import { BlendModes, BlurFilter, CallbackRenderPass, Color, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite } from '@codexo/exojs';
+import { BlendModes, BlurFilter, CallbackRenderPass, Color, RenderingContext, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite } from '@codexo/exojs';
 
 class BloomScene extends Scene {
     private baseRt!: RenderTexture;
@@ -113,7 +113,7 @@ class BloomScene extends Scene {
             .addPass(new RenderNodePass(this.glowSprite));
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         this.pipeline.execute(context);
     }
 }
@@ -126,7 +126,7 @@ The two glow/base passes each set a tint on the shared `bunny` sprite, then rend
 Instead of a single filter, pass the output through a chain — one `CallbackRenderPass` per filter step, bracketed by a scene render and a composite:
 
 ```ts
-import { BlurFilter, CallbackRenderPass, Color, ColorFilter, Graphics, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite } from '@codexo/exojs';
+import { BlurFilter, CallbackRenderPass, Color, ColorFilter, Graphics, RenderingContext, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite } from '@codexo/exojs';
 
 class FilterChainScene extends Scene {
     private scene!: Graphics;
@@ -158,7 +158,7 @@ class FilterChainScene extends Scene {
             .addPass(new RenderNodePass(this.final, { clear: Color.black }));
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         this.pipeline.execute(context);
     }
 }
@@ -171,7 +171,7 @@ Each `filter.apply()` call is one additional render pass. For a chain of N filte
 Reuse a render target as its own input to create motion trails. The feedback pass deliberately omits `clear`, so the decayed previous frame accumulates instead of being wiped:
 
 ```ts
-import { CallbackRenderPass, Color, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite } from '@codexo/exojs';
+import { CallbackRenderPass, Color, RenderingContext, RenderNodePass, RenderPipeline, RenderTexture, Scene, Sprite } from '@codexo/exojs';
 
 class TrailScene extends Scene {
     private feedbackRt!: RenderTexture;
@@ -202,7 +202,7 @@ class TrailScene extends Scene {
             .addPass(new RenderNodePass(this.final, { clear: Color.black }));
     }
 
-    override draw(context): void {
+    override draw(context: RenderingContext): void {
         this.pipeline.execute(context);
     }
 }

--- a/site/src/content/guide/getting-started/resize-dpr-and-canvas.mdx
+++ b/site/src/content/guide/getting-started/resize-dpr-and-canvas.mdx
@@ -58,7 +58,7 @@ Resizing the surface does not move what you already positioned. A sprite centere
 
 The example calls `layout()` every frame from `update`, which is simple and always correct. For heavier layouts, subscribe to `app.onResize` instead and recompute only when the size actually changes:
 
-```js no-check
+```ts no-check
 init() {
     this.layout();
     app.onResize.add(() => this.layout());
@@ -71,7 +71,7 @@ Either approach works — poll in `update` for small scenes, react to `onResize`
 
 The manual `app.resize` + `onResize` pattern above works well when you compute the size yourself. For the common cases — filling a container, scaling a fixed-resolution canvas to fit, or letterboxing — pass `canvas.sizingMode` instead and let the application manage the CSS and `ResizeObserver` for you:
 
-```js
+```ts
 import { Application } from '@codexo/exojs';
 
 const app = new Application({
@@ -90,7 +90,7 @@ Assign `app.sizingMode` at any time to switch strategies on the fly — swap to 
 
 `sizingMode` is also a live, runtime-settable property — not just a constructor option. Assigning `app.sizingMode` re-applies the strategy immediately: it disconnects any previous `ResizeObserver` and installs the new mode's CSS/observer. That makes it easy to switch strategies in response to user actions, for example filling the screen on fullscreen entry and returning to a fixed size on exit:
 
-```js
+```ts
 import { Application } from '@codexo/exojs';
 
 const app = new Application({

--- a/site/src/content/guide/getting-started/what-is-exojs.mdx
+++ b/site/src/content/guide/getting-started/what-is-exojs.mdx
@@ -25,10 +25,10 @@ A typical ExoJS project starts with two pieces: an [`Application`](/ExoJS/en/api
 The application owns the runtime configuration — render backend, canvas size, asset path, frame loop. The scene loads resources, updates state, and draws each frame.
 
 ```ts
-import { Application, Scene } from '@codexo/exojs';
+import { Application, type RenderingContext, Scene } from '@codexo/exojs';
 
 class MyScene extends Scene {
-    draw(context) {
+    draw(context: RenderingContext) {
         context.backend.clear();
     }
 }

--- a/site/src/content/guide/getting-started/what-is-exojs.mdx
+++ b/site/src/content/guide/getting-started/what-is-exojs.mdx
@@ -24,7 +24,7 @@ A typical ExoJS project starts with two pieces: an [`Application`](/ExoJS/en/api
 
 The application owns the runtime configuration — render backend, canvas size, asset path, frame loop. The scene loads resources, updates state, and draws each frame.
 
-```js
+```ts
 import { Application, Scene } from '@codexo/exojs';
 
 class MyScene extends Scene {

--- a/site/src/content/guide/getting-started/your-first-scene.mdx
+++ b/site/src/content/guide/getting-started/your-first-scene.mdx
@@ -19,7 +19,7 @@ This chapter builds one from scratch: a single sprite, centered on the canvas, r
 
 The smallest viable scene has just a `draw` method. The application calls it every frame; the scene tells the backend what to put on screen:
 
-```js
+```ts
 import { Application, Scene } from '@codexo/exojs';
 
 class HelloScene extends Scene {
@@ -72,7 +72,7 @@ A sprite's default anchor is its top-left corner. `setPosition(width / 2, height
 
 Override `update` to advance state once per frame. The `delta` argument carries the elapsed time since the previous frame; multiplying transforms by `delta.seconds` makes motion frame-rate independent:
 
-```js
+```ts
 update(delta) {
     this.sprite.rotate(120 * delta.seconds);
 }
@@ -84,7 +84,7 @@ This rotates the sprite at 120 degrees per second regardless of whether the brow
 
 The `app.canvas` property is a regular `HTMLCanvasElement`. In a real page, you place it wherever your layout needs it:
 
-```js
+```ts
 document.getElementById('scene').append(app.canvas);
 ```
 

--- a/site/src/content/guide/getting-started/your-first-scene.mdx
+++ b/site/src/content/guide/getting-started/your-first-scene.mdx
@@ -20,10 +20,10 @@ This chapter builds one from scratch: a single sprite, centered on the canvas, r
 The smallest viable scene has just a `draw` method. The application calls it every frame; the scene tells the backend what to put on screen:
 
 ```ts
-import { Application, Scene } from '@codexo/exojs';
+import { Application, type RenderingContext, Scene } from '@codexo/exojs';
 
 class HelloScene extends Scene {
-    draw(context) {
+    draw(context: RenderingContext) {
         context.backend.clear();
     }
 }
@@ -73,7 +73,7 @@ A sprite's default anchor is its top-left corner. `setPosition(width / 2, height
 Override `update` to advance state once per frame. The `delta` argument carries the elapsed time since the previous frame; multiplying transforms by `delta.seconds` makes motion frame-rate independent:
 
 ```ts
-update(delta) {
+update(delta: Time) {
     this.sprite.rotate(120 * delta.seconds);
 }
 ```

--- a/site/src/content/guide/input/gamepad.mdx
+++ b/site/src/content/guide/input/gamepad.mdx
@@ -164,16 +164,19 @@ Aggregate channels are bipolar — they preserve the full signed range and apply
 Not every controller has every button or axis. A detached Joy-Con has no right stick; a basic pad has no paddles. Use `hasChannel()` to gate optional bindings:
 
 ```ts
-if (pad.hasChannel(GamepadAxis.RightStickX)) {
-    pad.onActive(GamepadAxis.RightStickX, value => {
-        this.camera.rotate(value * 2);
-    });
-}
+init() {
+    const pad = this.app.input.getGamepad(0);
+    if (pad.hasChannel(GamepadAxis.RightStickX)) {
+        pad.onActive(GamepadAxis.RightStickX, value => {
+            this.camera.rotate(value * 2);
+        });
+    }
 
-if (pad.hasChannel(GamepadButton.Paddle1)) {
-    pad.onActive(GamepadButton.Paddle1, value => {
-        this.player.dash();
-    });
+    if (pad.hasChannel(GamepadButton.Paddle1)) {
+        pad.onActive(GamepadButton.Paddle1, value => {
+            this.player.dash();
+        });
+    }
 }
 ```
 
@@ -184,17 +187,20 @@ Binding to a channel the pad doesn't declare is harmless — the listener simply
 The Web Gamepad API exposes dual-rumble actuators on most modern controllers. Check support and trigger effects:
 
 ```ts
-if (pad.canVibrate) {
-    pad.vibrate({
-        duration: 200,           // ms
-        weakMagnitude: 0.5,     // low-frequency rumble 0..1
-        strongMagnitude: 0.8,   // high-frequency rumble 0..1
-        startDelay: 0,
-    });
-}
+init() {
+    const pad = this.app.input.getGamepad(0);
+    if (pad.canVibrate) {
+        pad.vibrate({
+            duration: 200,           // ms
+            weakMagnitude: 0.5,     // low-frequency rumble 0..1
+            strongMagnitude: 0.8,   // high-frequency rumble 0..1
+            startDelay: 0,
+        });
+    }
 
-// Stop rumble early
-pad.stopVibration();
+    // Stop rumble early
+    pad.stopVibration();
+}
 ```
 
 `vibrate()` is async and resolves when the effect finishes or is cancelled. Call `stopVibration()` to cut a running effect short (e.g. when the player releases a trigger). Both methods are silent no-ops on unsupported hardware.
@@ -217,13 +223,13 @@ The `gamepads` array is populated before `init` runs, but the browser's gamepad 
 
 ```ts
 init() {
-    const pad = app.input.firstConnectedGamepad;
+    const pad = this.app.input.firstConnectedGamepad;
 
     if (pad) {
         this.bindPad(pad);
     }
 
-    app.input.onGamepadConnected.add(p => {
+    this.app.input.onGamepadConnected.add(p => {
         if (!this._activePad) this.bindPad(p);
     });
 }

--- a/site/src/content/guide/input/gamepad.mdx
+++ b/site/src/content/guide/input/gamepad.mdx
@@ -13,7 +13,7 @@ ExoJS manages gamepads through four stable slot mailboxes. Each slot is a [`Game
 
 ## The four-slot model
 
-```js
+```ts
 const pad0 = app.input.gamepads[0];  // always exists, may be disconnected
 const pad1 = app.input.getGamepad(1); // same thing, reads more clearly
 
@@ -24,7 +24,7 @@ if (pad0.connected) {
 
 The `gamepads` array is always length 4. Check `pad.connected` before reading pad state. Convenience accessors on the input manager:
 
-```js
+```ts
 app.input.hasGamepad               // true when at least one pad is connected
 app.input.connectedGamepadCount    // how many slots are occupied
 app.input.firstConnectedGamepad    // first in slot order, or null
@@ -39,7 +39,7 @@ On most browsers a connected controller isn't reported until the user presses a 
 
 Subscribe to lifecycle signals at either level:
 
-```js
+```ts
 // Per-slot — fires only for that specific slot
 pad0.onConnect.add(() => {
     console.log('Controller connected to slot 0');
@@ -72,7 +72,7 @@ When a compact shift occurs, `pad.onPadReassigned` fires on the receiving slot w
 
 The [`GamepadButton`](/ExoJS/en/api/gamepad-button/) namespace provides 24 named button channels. Buttons use cross-platform semantic names rather than per-console labels:
 
-```js
+```ts
 import { GamepadButton } from '@codexo/exojs';
 
 const pad = app.input.getGamepad(0);
@@ -140,7 +140,7 @@ GamepadAxis.RightStickX     GamepadAxis.RightStickY
 
 A single signed value per axis — negative is left/up, positive is right/down. The callback receives the full -1..1 range, making a single line of code drive 2D movement:
 
-```js
+```ts
 pad.onActive(GamepadAxis.LeftStickX, value => {
     this.move.x = value;  // -1..1, already deadzoned
 });
@@ -163,7 +163,7 @@ Aggregate channels are bipolar — they preserve the full signed range and apply
 
 Not every controller has every button or axis. A detached Joy-Con has no right stick; a basic pad has no paddles. Use `hasChannel()` to gate optional bindings:
 
-```js
+```ts
 if (pad.hasChannel(GamepadAxis.RightStickX)) {
     pad.onActive(GamepadAxis.RightStickX, value => {
         this.camera.rotate(value * 2);
@@ -183,7 +183,7 @@ Binding to a channel the pad doesn't declare is harmless — the listener simply
 
 The Web Gamepad API exposes dual-rumble actuators on most modern controllers. Check support and trigger effects:
 
-```js
+```ts
 if (pad.canVibrate) {
     pad.vibrate({
         duration: 200,           // ms
@@ -215,7 +215,7 @@ Per-pad bindings are the typical choice for game logic — the player number map
 
 The `gamepads` array is populated before `init` runs, but the browser's gamepad API only reports connected pads after a button press on some platforms (a browser security restriction). In `init`, check `app.input.connectedGamepads`; if empty, wait for the `onGamepadConnected` signal:
 
-```js
+```ts
 init() {
     const pad = app.input.firstConnectedGamepad;
 

--- a/site/src/content/guide/input/keyboard-and-actions.mdx
+++ b/site/src/content/guide/input/keyboard-and-actions.mdx
@@ -56,7 +56,7 @@ init() {
     this.inputs.onStop(Keyboard.S,    () => { this.move.down  = 0; });
 }
 
-update(delta) {
+update(delta: Time) {
     const speed = 280 * delta.seconds;
     const dx = (this.move.right - this.move.left) * speed;
     const dy = (this.move.down - this.move.up) * speed;
@@ -119,7 +119,7 @@ _rebindJump() {
     this.jumpDirty = false;
 }
 
-update(delta) {
+update(delta: Time) {
     this._rebindJump();
     // ... apply jumpVelocity ...
 }
@@ -191,9 +191,14 @@ Scene-scoped bindings from `this.inputs` are cleaned up when the scene unloads, 
 </Callout>
 
 ```ts
-import { GamepadAxis, GamepadButton, Keyboard, Scene, Sprite } from '@codexo/exojs';
+import { GamepadAxis, GamepadButton, Keyboard, type RenderingContext, Scene, Sprite, type Time } from '@codexo/exojs';
 
 class PlayerScene extends Scene {
+    private sprite!: Sprite;
+    private keys!: { left: number; right: number; up: number; down: number };
+    private stick!: { x: number; y: number };
+    private jumpImpulse!: number;
+
     async load() {
         await this.loader.load('image/hero.png');
     }
@@ -248,7 +253,7 @@ class PlayerScene extends Scene {
         });
     }
 
-    update(delta) {
+    update(delta: Time) {
         // Best input wins: prefer the device with the larger magnitude
         const keyX = this.keys.right - this.keys.left;
         const keyY = this.keys.down - this.keys.up;
@@ -263,7 +268,7 @@ class PlayerScene extends Scene {
         this.jumpImpulse = Math.min(0, this.jumpImpulse + 800 * delta.seconds);
     }
 
-    draw(context) {
+    draw(context: RenderingContext) {
         context.backend.clear();
         context.render(this.sprite);
     }
@@ -304,7 +309,7 @@ init() {
     // Consume actions once in update, then reset
 }
 
-update(delta) {
+update(delta: Time) {
     if (this.actions.pause) {
         this.togglePause();       // pauses/resumes via app.scenes + shows/hides the pause overlay on scene.ui
         this.actions.pause = 0;

--- a/site/src/content/guide/input/keyboard-and-actions.mdx
+++ b/site/src/content/guide/input/keyboard-and-actions.mdx
@@ -24,7 +24,7 @@ The scene's `this.inputs` registry creates bindings that are automatically dispo
 
 Each returns an `InputBinding` you can call `.unbind()` on to detach early. The `threshold` option (in ms) overrides the 300 ms default for `onTrigger`:
 
-```js no-check
+```ts no-check
 import { Keyboard, Scene } from '@codexo/exojs';
 
 class GameScene extends Scene {
@@ -42,7 +42,7 @@ class GameScene extends Scene {
 
 For held-key patterns — movement, continuous actions — use `onActive`/`onStop` to track a boolean flag, then consume it in `update`:
 
-```js
+```ts
 init() {
     this.move = { left: 0, right: 0, up: 0, down: 0 };
 
@@ -68,7 +68,7 @@ update(delta) {
 
 `app.input` exposes two lower-level signals that fire on raw keydown/keyup events, regardless of the current scene:
 
-```js
+```ts
 app.input.onKeyDown.add(channel => {
     console.log('Key pressed:', channel);
 });
@@ -88,7 +88,7 @@ These are raw — no threshold, no auto-disposal. Use them for global shortcuts 
 
 The `onKeyDown` signal accepts a callback that receives the raw channel number. This is the mechanism for letting the player remap controls at runtime:
 
-```js
+```ts
 init() {
     this.jumpChannel = Keyboard.Space;
     this.rebindRequested = false;
@@ -147,7 +147,7 @@ The full list includes punctuation, brackets, and navigation keys. All values ma
 
 Keyboard input is gated on canvas focus. When the user tabs away or clicks outside the canvas, all held keys are released automatically and no further key events fire until focus returns. The `app.input.onCanvasFocusChange` signal notifies you of transitions:
 
-```js
+```ts
 app.input.onCanvasFocusChange.add(focused => {
     if (!focused) this.pause();
 });
@@ -174,7 +174,7 @@ ExoJS does not ship a dedicated action-map abstraction layer. Instead, the exist
 
 Every binding factory — `onTrigger`, `onStart`, `onActive`, `onStop` — accepts an array of channels. The callback fires when any channel in the array activates:
 
-```js
+```ts
 this.inputs.onTrigger([Keyboard.Space, Keyboard.J], () => {
     this.player.jump();
 });
@@ -190,7 +190,7 @@ Per-pad bindings on `Gamepad` (`pad.onTrigger`, `pad.onActive`, etc.) coexist wi
 Scene-scoped bindings from `this.inputs` are cleaned up when the scene unloads, but `pad.onTrigger`/`pad.onActive` bindings live on the long-lived `Gamepad` and are not. Keep their `InputBinding` handles and call `unbind()` in `destroy`, or they stack up across scene changes.
 </Callout>
 
-```js
+```ts
 import { GamepadAxis, GamepadButton, Keyboard, Scene, Sprite } from '@codexo/exojs';
 
 class PlayerScene extends Scene {
@@ -276,7 +276,7 @@ The "best input wins" logic — `Math.abs(this.stick.x) > Math.abs(keyX)` — pi
 
 A clean pattern for larger projects is to centralise input state in a small plain object and let each device category write into it:
 
-```js
+```ts
 init() {
     // One source of truth for movement intent
     this.move = { x: 0, y: 0 };
@@ -325,7 +325,7 @@ This keeps input handling in one location, makes it easy to add a third device (
 
 Scene-scoped bindings (`this.inputs.onTrigger(...)`) are automatically disposed when the scene's `destroy` runs. Per-pad bindings (`pad.onTrigger(...)`) are not — they live on the `Gamepad` instance, which outlives any single scene. Store per-pad bindings in an array and unbind them in `destroy`:
 
-```js
+```ts
 init() {
     this._padBindings = [];
     const pad = this.app.input.getGamepad(0);

--- a/site/src/content/guide/input/mouse-and-pointer.mdx
+++ b/site/src/content/guide/input/mouse-and-pointer.mdx
@@ -27,7 +27,7 @@ The application's input manager emits these pointer signals:
 
 Each signal's callback receives the `Pointer` instance:
 
-```js
+```ts
 app.input.onPointerMove.add(pointer => {
     this.crosshair.position.set(pointer.x, pointer.y);
 });
@@ -47,7 +47,7 @@ The pointer's `position` is in canvas-local pixel space — `(0, 0)` is the top-
 
 `Pointer.X`, `Pointer.Y`, and `Pointer.Active` are channel constants that always reference the primary pointer (normally the mouse, or the first finger to touch). These can be used with the binding API just like keyboard channels:
 
-```js
+```ts
 this.inputs.onActive(Pointer.Active, () => {
     this.isPointing = true;
 });
@@ -62,7 +62,7 @@ The signal-style API (`app.input.onPointerMove`) is typically more ergonomic for
 
 Each pointer gets a slot index (0–15). Per-slot channel constants let you track individual fingers for multi-touch:
 
-```js
+```ts
 import { Pointer } from '@codexo/exojs';
 
 // Slot 1 (second finger)
@@ -73,7 +73,7 @@ this.inputs.onActive(Pointer.Slot1X, value => {
 
 For most multi-touch use cases, tracking pointer instances by ID via the signal API is simpler:
 
-```js
+```ts
 init() {
     this.pointers = new Map();
 
@@ -101,7 +101,7 @@ init() {
 
 The input manager includes built-in gesture recognizers for common multi-touch patterns:
 
-```js
+```ts
 app.input.onPinch.add((scale, center) => {
     // scale > 1 = spreading fingers, scale < 1 = pinching
     this.camera.zoom *= scale;
@@ -124,7 +124,7 @@ These are high-level events built on top of the raw pointer signals. They track 
 
 Pointer positions are in **design space** (`0..app.width` × `0..app.height`), independent of device pixel ratio or how the canvas is displayed. To map them into scene world coordinates — for placing objects, selecting units, or aiming — pass them through the active view's `screenToWorld`, which undoes the camera's pan / zoom / rotation:
 
-```js
+```ts
 const world = this._view.screenToWorld(pointer.x, pointer.y);
 // world.x, world.y are now in scene world space
 ```
@@ -137,7 +137,7 @@ For raw canvas backing-store pixels — e.g. an off-screen render target at a di
 
 A `Sprite` (or any `RenderNode`) can be made interactive and draggable directly:
 
-```js
+```ts
 init() {
     this.sprite = new Sprite(this.loader.get('image/hero.png'));
     this.sprite.setAnchor(0.5);
@@ -154,7 +154,7 @@ Setting `interactive = true` makes the sprite participate in hit testing. Settin
 
 The `Pointer` instance passed to every signal callback carries the properties you typically need:
 
-```js
+```ts
 pointer.x, pointer.y   // design-space pixel position (0..app.width, 0..app.height)
 pointer.position       // Vector with current x and y
 pointer.buttons        // bitmask: 1=left, 2=right, 4=middle

--- a/site/src/content/guide/recipes/audio-reactive-scene.mdx
+++ b/site/src/content/guide/recipes/audio-reactive-scene.mdx
@@ -23,16 +23,25 @@ One analyser for frequency data, one beat detector for rhythm, one particle syst
 
 ```ts
 import { Asset, Application, AudioStream,
-    Scene, View, Vector, Color, Ease } from '@codexo/exojs';
-import { AudioAnalyser, BeatDetector } from '@codexo/exojs-audio-fx';
+    Scene, Texture, Time, RenderingContext, View, Vector, Color, Ease } from '@codexo/exojs';
+
+import { AudioAnalyser, BeatDetector, BeatInfo } from '@codexo/exojs-audio-fx';
 import {
     AlphaFadeOverLifetime, BurstSpawn, ConeDirection, Constant,
     particlesExtension, ParticleSystem,
 } from '@codexo/exojs-particles';
-
 const app = new Application({ extensions: [particlesExtension] });
 
 class AudioReactiveScene extends Scene {
+    private music!: AudioStream;
+    private particleTexture!: Texture;
+    private analyser!: AudioAnalyser;
+    private detector!: BeatDetector;
+    private _bg!: Color;
+    private particles!: ParticleSystem;
+    private burst!: BurstSpawn;
+    private view!: View;
+
     async load() {
         const [music, particleTexture] = await Promise.all([
             this.loader.load(Asset.type('music', 'audio/track.ogg')),
@@ -71,7 +80,7 @@ class AudioReactiveScene extends Scene {
         });
     }
 
-    update(delta) {
+    update(delta: Time) {
         this.view.update(delta.milliseconds);
         this.particles.update(delta);
 
@@ -85,7 +94,7 @@ class AudioReactiveScene extends Scene {
         );
     }
 
-    draw(context) {
+    draw(context: RenderingContext) {
         context.backend.clear(this._bg);
         context.render(this.particles, { view: this.view });
     }
@@ -108,7 +117,7 @@ this.detector.onBarStart.add(() => {
 });
 
 // Mid-band → particle tint cycling
-this.detector.onBeat.add(info => {
+this.detector.onBeat.add((info: BeatInfo) => {
     if (info.beatInBar === 2 || info.beatInBar === 4) {
         this.burst.config.tint = new Constant(
             info.beatInBar === 2 ? Color.orange : Color.skyBlue
@@ -125,7 +134,7 @@ this.detector.onBeat.add(info => {
 For frequency-driven shake (low-end rumble instead of discrete hits), lerp the view center by the low-band energy in `update`:
 
 ```ts
-update(delta) {
+update(delta: Time) {
     const { low } = this.analyser.getLowMidHigh();
     const shakeX = (Math.random() - 0.5) * low * 20;
     const shakeY = (Math.random() - 0.5) * low * 20;

--- a/site/src/content/guide/recipes/audio-reactive-scene.mdx
+++ b/site/src/content/guide/recipes/audio-reactive-scene.mdx
@@ -21,7 +21,7 @@ Three systems run in parallel, each driven by a different facet of the audio ana
 
 One analyser for frequency data, one beat detector for rhythm, one particle system for visual feedback:
 
-```js
+```ts
 import { Asset, Application, AudioStream,
     Scene, View, Vector, Color, Ease } from '@codexo/exojs';
 import { AudioAnalyser, BeatDetector } from '@codexo/exojs-audio-fx';
@@ -96,7 +96,7 @@ class AudioReactiveScene extends Scene {
 
 The pattern scales by adding more independent listeners, each reacting to a different audio facet:
 
-```js
+```ts
 // Bar start → tween chain on a central logo
 this.detector.onBarStart.add(() => {
     this.app.tweens.create(this.logo.scale)
@@ -124,7 +124,7 @@ this.detector.onBeat.add(info => {
 
 For frequency-driven shake (low-end rumble instead of discrete hits), lerp the view center by the low-band energy in `update`:
 
-```js
+```ts
 update(delta) {
     const { low } = this.analyser.getLowMidHigh();
     const shakeX = (Math.random() - 0.5) * low * 20;

--- a/site/src/content/guide/recipes/build-orb-dodge.mdx
+++ b/site/src/content/guide/recipes/build-orb-dodge.mdx
@@ -64,7 +64,7 @@ A scene has four lifecycle hooks — override the ones you need:
 
 The player is a filled circle drawn with `Graphics`. Keyboard movement uses `this.inputs.onActive` (fires every frame while the key is held) and `this.inputs.onStop` (fires when the key is released) to track a directional velocity:
 
-```js
+```ts
 init() {
     this.world = new Container();
 
@@ -88,7 +88,7 @@ Bindings registered through `this.inputs` auto-dispose when the scene is destroy
 
 In `update`, normalize the direction vector so diagonal movement is not faster than cardinal movement, then clamp the position inside the canvas:
 
-```js
+```ts
 update(delta) {
     const mag = Math.hypot(this.dx, this.dy) || 1;
     if (this.dx !== 0 || this.dy !== 0) {
@@ -107,7 +107,7 @@ update(delta) {
 
 Orbs are created dynamically during `update` on a timer. Each orb spawns just outside one of the four edges and moves toward the center area with a small random offset:
 
-```js
+```ts
 spawnOrb() {
     const danger = Math.random() < 0.4;
     // pick a random edge (0=top, 1=right, 2=bottom, 3=left)
@@ -140,7 +140,7 @@ Orbs are stored in an array of `{ gfx, vx, vy, danger }` objects. Danger orbs ar
 
 Each frame, move every orb and check its distance to the player. Distance collision is reliable for circles because it captures overlap without axis-aligned assumptions:
 
-```js
+```ts
 const dist = Math.hypot(ox - this.px, oy - this.py);
 if (dist < PLAYER_RADIUS + ORB_RADIUS) {
     this.world.removeChild(orb.gfx);
@@ -166,7 +166,7 @@ Orbs that leave the canvas are also removed. After the loop, if `gameEnded` is t
 
 Score and elapsed time sit on top of the world as plain `Text` nodes — rendered after `context.render(this.world)` so they always appear in front:
 
-```js
+```ts
 draw(context) {
     context.backend.clear();
     context.render(this.world);
@@ -177,7 +177,7 @@ draw(context) {
 
 `Text` content is updated by assigning to `.text`:
 
-```js
+```ts
 this.scoreText.text = `Score: ${this.score}`;
 this.timeText.text  = `${this.elapsed.toFixed(1)} s`;
 ```
@@ -199,7 +199,7 @@ When the player restarts, `change(PlayScene)` switches back. `SceneDirector` alw
 
 Both scenes are registered by constructor in `ApplicationOptions.scenes`, and navigate to each other by constructor — never by a pre-built instance:
 
-```js
+```ts
 const app = new Application({
     scenes: { PlayScene, GameOverScene },
     // ...
@@ -214,7 +214,7 @@ app.start(PlayScene);
 
 When `SceneDirector` switches scenes it calls `destroy()` on the outgoing scene. For `PlayScene`, override it to release orb graphics that were created dynamically:
 
-```js
+```ts
 override destroy() {
     for (const orb of this.orbs) {
         orb.gfx.destroy();

--- a/site/src/content/guide/recipes/build-orb-dodge.mdx
+++ b/site/src/content/guide/recipes/build-orb-dodge.mdx
@@ -46,12 +46,12 @@ The game uses two scenes: `PlayScene` drives the active game loop, `GameOverScen
 Define a constant set for canvas dimensions and game parameters at the top so both scenes can reference them:
 
 ```ts no-check
-const CANVAS_WIDTH = 800;
-const CANVAS_HEIGHT = 600;
-const PLAYER_RADIUS = 18;
-const PLAYER_SPEED = 260;
-const ORB_RADIUS = 14;
-const SPAWN_INTERVAL = 1.2;
+const CANVAS_WIDTH: number = 800;
+const CANVAS_HEIGHT: number = 600;
+const PLAYER_RADIUS: number = 18;
+const PLAYER_SPEED: number = 260;
+const ORB_RADIUS: number = 14;
+const SPAWN_INTERVAL: number = 1.2;
 ```
 
 A scene has four lifecycle hooks — override the ones you need:
@@ -66,6 +66,15 @@ The player is a filled circle drawn with `Graphics`. Keyboard movement uses `thi
 
 ```ts
 init() {
+    const CANVAS_WIDTH: number = 800;
+    const CANVAS_HEIGHT: number = 600;
+    const PLAYER_RADIUS: number = 18;
+    const PLAYER_SPEED: number = 260;
+    const ORB_RADIUS: number = 14;
+    const ORB_SPEED_MIN: number = 80;
+    const ORB_SPEED_MAX: number = 200;
+    const SPAWN_INTERVAL: number = 1.2;
+
     this.world = new Container();
 
     this.player = new Graphics();
@@ -89,7 +98,12 @@ Bindings registered through `this.inputs` auto-dispose when the scene is destroy
 In `update`, normalize the direction vector so diagonal movement is not faster than cardinal movement, then clamp the position inside the canvas:
 
 ```ts
-update(delta) {
+update(delta: Time) {
+    const CANVAS_WIDTH: number = 800;
+    const CANVAS_HEIGHT: number = 600;
+    const PLAYER_RADIUS: number = 18;
+    const PLAYER_SPEED: number = 260;
+
     const mag = Math.hypot(this.dx, this.dy) || 1;
     if (this.dx !== 0 || this.dy !== 0) {
         this.px += (this.dx / mag) * PLAYER_SPEED * delta.seconds;
@@ -109,6 +123,12 @@ Orbs are created dynamically during `update` on a timer. Each orb spawns just ou
 
 ```ts
 spawnOrb() {
+    const CANVAS_WIDTH: number = 800;
+    const CANVAS_HEIGHT: number = 600;
+    const ORB_RADIUS: number = 14;
+    const ORB_SPEED_MIN: number = 80;
+    const ORB_SPEED_MAX: number = 200;
+
     const danger = Math.random() < 0.4;
     // pick a random edge (0=top, 1=right, 2=bottom, 3=left)
     const side = Math.floor(Math.random() * 4);
@@ -167,7 +187,7 @@ Orbs that leave the canvas are also removed. After the loop, if `gameEnded` is t
 Score and elapsed time sit on top of the world as plain `Text` nodes — rendered after `context.render(this.world)` so they always appear in front:
 
 ```ts
-draw(context) {
+draw(context: RenderingContext) {
     context.backend.clear();
     context.render(this.world);
     context.render(this.scoreText);

--- a/site/src/content/guide/recipes/camera-follow-and-parallax.mdx
+++ b/site/src/content/guide/recipes/camera-follow-and-parallax.mdx
@@ -24,14 +24,14 @@ init() {
     this.player = new Sprite(this.loader.get('image/hero.png'));
 }
 
-update(delta) {
+update(delta: Time) {
     // ... move player based on input ...
 
     // Camera follows player
     this._view.setCenter(this.player.position.x, this.player.position.y);
 }
 
-draw(context) {
+draw(context: RenderingContext) {
     context.backend.clear();
     context.render(this.worldLayer, { view: this._view });
 }
@@ -40,9 +40,11 @@ draw(context) {
 For smooth following, lerp the camera center instead of snapping:
 
 ```ts
-this._cameraX += (this.player.x - this._cameraX) * 5 * delta.seconds;
-this._cameraY += (this.player.y - this._cameraY) * 5 * delta.seconds;
-this._view.setCenter(this._cameraX, this._cameraY);
+update(delta: Time) {
+    this._cameraX += (this.player.x - this._cameraX) * 5 * delta.seconds;
+    this._cameraY += (this.player.y - this._cameraY) * 5 * delta.seconds;
+    this._view.setCenter(this._cameraX, this._cameraY);
+}
 ```
 
 The multiplier controls how quickly the camera catches up. Higher values = snappier. This is a simple exponential ease — no tween needed.
@@ -66,7 +68,7 @@ init() {
     });
 }
 
-draw(context) {
+draw(context: RenderingContext) {
     context.backend.clear();
     for (const layer of this._layers) {
         const offsetX = (400 - this._pointer.x) * layer.speed;
@@ -88,7 +90,7 @@ A layer that only fills the viewport shows its edge the moment parallax shifts i
 For side-scrolling games, offset background layers relative to the camera position rather than the pointer:
 
 ```ts
-draw(context) {
+draw(context: RenderingContext) {
     context.backend.clear();
 
     // Background — moves at 30% of camera speed

--- a/site/src/content/guide/recipes/camera-follow-and-parallax.mdx
+++ b/site/src/content/guide/recipes/camera-follow-and-parallax.mdx
@@ -18,7 +18,7 @@ A `View` controls what portion of the world is visible. To make the camera follo
 Snapping `view.setCenter` onto the player every frame feels rigid. Ease it instead — `cur += (target - cur) * k * dt` — so the camera trails slightly and catches up smoothly, no tween needed.
 </Callout>
 
-```js
+```ts
 init() {
     this._view = new View(400, 300, 800, 600);
     this.player = new Sprite(this.loader.get('image/hero.png'));
@@ -39,7 +39,7 @@ draw(context) {
 
 For smooth following, lerp the camera center instead of snapping:
 
-```js
+```ts
 this._cameraX += (this.player.x - this._cameraX) * 5 * delta.seconds;
 this._cameraY += (this.player.y - this._cameraY) * 5 * delta.seconds;
 this._view.setCenter(this._cameraX, this._cameraY);
@@ -51,7 +51,7 @@ The multiplier controls how quickly the camera catches up. Higher values = snapp
 
 For menu screens, background effects, or mouse-driven depth, offset layers proportionally to the pointer position relative to the screen center:
 
-```js
+```ts
 init() {
     // Three layers at different depths
     this._layers = [0.15, 0.35, 0.6].map(speed => {
@@ -87,7 +87,7 @@ A layer that only fills the viewport shows its edge the moment parallax shifts i
 
 For side-scrolling games, offset background layers relative to the camera position rather than the pointer:
 
-```js
+```ts
 draw(context) {
     context.backend.clear();
 
@@ -116,7 +116,7 @@ The layer position is set relative to the camera center *before* rendering. Sinc
 
 Parallax layers need to be wider than the viewport, or you see edges when the camera shifts. For tiled backgrounds, draw the tile pattern across a range that extends beyond the viewport boundaries by at least the maximum parallax offset:
 
-```js
+```ts
 const viewW = 800;
 const maxOffset = viewW * 0.3; // 30% for the slowest layer
 const totalW = viewW + maxOffset * 2;

--- a/site/src/content/guide/recipes/cinematics.mdx
+++ b/site/src/content/guide/recipes/cinematics.mdx
@@ -16,7 +16,7 @@ A cinematic is a scene. It owns the sequence. Tweens drive every timed element �
 
 The key technique: **tween chains and delays**. Each tween starts at a specific time offset. Together they form a timeline:
 
-```js
+```ts
 class CinematicScene extends Scene {
     async load() {
         // AudioStream has no bare-path form, so use `Asset.type(...)` — and since
@@ -111,14 +111,14 @@ Each tween operates independently — they don't need to know about each other. 
 
 Navigate to the cinematic scene from the game to fully replace the active scene while the cutscene plays:
 
-```js no-check
+```ts no-check
 // From the game scene — switch to the cinematic:
 this.app.scenes.change(CinematicScene);
 ```
 
 Because the cinematic is now the only active scene, the game scene neither renders nor updates for the duration. When the cinematic ends, switch back:
 
-```js no-check
+```ts no-check
 // At the end of the sequence — chain a tween to transition back to the game:
 this.app.tweens.create(this.barSize)
     .to({ v: 70 }, 0.6)
@@ -135,7 +135,7 @@ The closing shutter bars animate over the scene, then `change(...)` transitions 
 
 If you want the shutter bars or subtitle text to stay in screen space and be immune to camera transforms, put them on `scene.ui` instead of rendering them in `draw`:
 
-```js
+```ts
 init() {
     // ... main cinematic setup ...
 
@@ -163,7 +163,7 @@ Add a skip mechanism — press any confirm key (Space, Enter, gamepad Start) to 
 Staggering tweens with `Tween.delay()` is what turns independent animations into a timeline — no sequencer needed. To skip the whole cutscene, `app.tweens.clear()` stops every active tween at once so you can snap straight to the end state.
 </Callout>
 
-```js no-check
+```ts no-check
 init() {
     // ... cinematic setup ...
 
@@ -180,7 +180,7 @@ init() {
 
 For a smoother skip, fast-forward remaining tweens to completion rather than cutting hard:
 
-```js no-check
+```ts no-check
 this.inputs.onTrigger(Keyboard.Space, () => {
     // Jump all tweens to their end state
     this.app.tweens.clear(); // stops all active tweens

--- a/site/src/content/guide/recipes/game-feel.mdx
+++ b/site/src/content/guide/recipes/game-feel.mdx
@@ -18,7 +18,7 @@ When the player takes damage, flash the sprite red for a fraction of a second an
 `ColorFilter.color` is the filter's live `Color`, not a constructor snapshot. Mutate or tween it in place for a damage flash — set it red, tween back to white — with no filter rebuild.
 </Callout>
 
-```js
+```ts
 import { ColorFilter, Signal } from '@codexo/exojs';
 
 init() {
@@ -44,7 +44,7 @@ The key insight: the `ColorFilter` multiplies the sprite's rendered output by th
 
 `View.shake(intensity, durationMs, { frequency, decay })` is the simplest feedback effect in ExoJS. Fire it on any dramatic event:
 
-```js
+```ts
 this.app.input.onPointerTap.add(pointer => {
     // Position the burst at the click location (relative to system position)
     this.burstPos.set(pointer.x - this.particles.position.x, pointer.y - this.particles.position.y);
@@ -60,7 +60,7 @@ Combine it with a particle burst for a complete explosion feel — particles pro
 
 Tweens are the workhorse of game feel. A few reusable patterns:
 
-```js
+```ts
 // Scale punch — grow on hit, settle back
 this.app.tweens.create(this.sprite.scale)
     .to({ x: 1.4, y: 1.4 }, 0.08)
@@ -90,7 +90,7 @@ Each pattern is fire-and-forget — call `.start()` inside an event handler and 
 
 For held actions — thrust, charging, spinning up — continuous feedback creates presence:
 
-```js
+```ts
 update(delta) {
     const thrustMag = Math.hypot(this.thrust.x, this.thrust.y);
 

--- a/site/src/content/guide/recipes/game-feel.mdx
+++ b/site/src/content/guide/recipes/game-feel.mdx
@@ -91,7 +91,7 @@ Each pattern is fire-and-forget — call `.start()` inside an event handler and 
 For held actions — thrust, charging, spinning up — continuous feedback creates presence:
 
 ```ts
-update(delta) {
+update(delta: Time) {
     const thrustMag = Math.hypot(this.thrust.x, this.thrust.y);
 
     if (thrustMag > 0.05) {

--- a/site/src/content/guide/recipes/game-feel.mdx
+++ b/site/src/content/guide/recipes/game-feel.mdx
@@ -19,8 +19,6 @@ When the player takes damage, flash the sprite red for a fraction of a second an
 </Callout>
 
 ```ts
-import { ColorFilter, Signal } from '@codexo/exojs';
-
 init() {
     this.player = new Sprite(this.loader.get('image/hero.png'));
     this.flash = new ColorFilter(new Color(255, 255, 255, 1));

--- a/site/src/content/guide/recipes/gameplay-collision.mdx
+++ b/site/src/content/guide/recipes/gameplay-collision.mdx
@@ -134,6 +134,12 @@ The sign convention: `projectionN` points **from shapeB toward shapeA** (away fr
 `shape.contains(x, y)` returns `true` if the world-space point is inside the shape. Every shape implements it:
 
 ```ts
+import { Rectangle, Vector } from '@codexo/exojs';
+
+const enemyHitbox: Rectangle = new Rectangle(0, 0, 100, 100);
+const pointer: Vector = new Vector(0, 0);
+function selectEnemy(): void {}
+
 if (enemyHitbox.contains(pointer.x, pointer.y)) {
     selectEnemy();
 }

--- a/site/src/content/guide/recipes/gameplay-collision.mdx
+++ b/site/src/content/guide/recipes/gameplay-collision.mdx
@@ -34,7 +34,7 @@ All shapes carry a `position` (`Vector`) and expose `collisionType` for dispatch
 
 `shapeA.intersectsWith(shapeB)` returns `true` if the shapes overlap. This is the cheapest query — no penetration depth, no contact normal, just a boolean:
 
-```js
+```ts
 import { Circle, Rectangle } from '@codexo/exojs';
 
 const player = new Circle(400, 300, 20);
@@ -77,7 +77,7 @@ Supported response pairs in the current implementation:
 
 `projectionV` is the minimum-translation vector (MTV): the smallest displacement that separates the two shapes. Move the caller by `projectionV` and the shapes no longer overlap.
 
-```js
+```ts
 // Top-down wall blocking — push the player out of the wall
 const response = player.collidesWith(wall);
 
@@ -90,7 +90,7 @@ if (response) {
 
 For two-way separation (two dynamic objects), split the MTV:
 
-```js
+```ts
 const response = a.collidesWith(b);
 
 if (response) {
@@ -106,7 +106,7 @@ if (response) {
 
 `projectionN` is the unit normal of the contact surface. Use it to classify which side was hit — without it you cannot distinguish "landed on the floor" from "hit a wall":
 
-```js
+```ts
 const response = player.collidesWith(surface);
 
 if (response) {
@@ -133,7 +133,7 @@ The sign convention: `projectionN` points **from shapeB toward shapeA** (away fr
 
 `shape.contains(x, y)` returns `true` if the world-space point is inside the shape. Every shape implements it:
 
-```js
+```ts
 if (enemyHitbox.contains(pointer.x, pointer.y)) {
     selectEnemy();
 }
@@ -145,7 +145,7 @@ A `Sprite`'s `contains()` works on the rotated quad — fast AABB check when rot
 
 Every `SceneNode` (Sprites, Containers, etc.) implements `Collidable` with `CollisionType.SceneNode`. This means you can collision-test drawables directly without wrapping them in shape primitives:
 
-```js
+```ts
 const hero = new Sprite(texture);
 hero.setPosition(400, 300);
 
@@ -168,7 +168,7 @@ if (hero.intersectsWith(box)) {
 
 For scenes with many objects, pair-wise collision checks against every other object are O(n²). A [`Quadtree`](/ExoJS/en/api/quadtree/) reduces the search space:
 
-```js no-check
+```ts no-check
 import { Quadtree } from '@codexo/exojs';
 
 const tree = new Quadtree(new Rectangle(0, 0, 800, 600), 8, 5);
@@ -209,7 +209,7 @@ interface SweptHit {
 
 ### Available sweep functions
 
-```js
+```ts
 import { Sweep } from '@codexo/exojs';
 ```
 
@@ -224,7 +224,7 @@ import { Sweep } from '@codexo/exojs';
 
 ### Tunneling-safe movement
 
-```js
+```ts
 import { Sweep } from '@codexo/exojs';
 
 // In your update loop:
@@ -253,7 +253,7 @@ The batch helpers (`Sweep.rectangleAgainst`, `Sweep.circleAgainst`) include a sw
 
 `Sweep.substep` is a fallback generator for shape pairs that lack a closed-form swept test. It yields evenly-spaced snapshots along the move path so you can run your own `intersectsWith` check at each step:
 
-```js
+```ts
 import { Sweep } from '@codexo/exojs';
 
 for (const snapshot of Sweep.substep(fromX, fromY, dx, dy, maxStepSize)) {

--- a/site/src/content/guide/recipes/hud-overlay.mdx
+++ b/site/src/content/guide/recipes/hud-overlay.mdx
@@ -14,7 +14,7 @@ A HUD (heads-up display) renders UI elements on top of the game world — health
 
 Add HUD elements directly to `scene.ui` instead of creating a separate overlay scene. The world (game nodes, sprites, graphics) lives under `scene.root`; the HUD (labels, progress bars, panels) lives on `scene.ui` and is composited on top automatically — no extra scene or stack needed.
 
-```js
+```ts
 class GameScene extends Scene {
     init() {
         this._angle = 0;
@@ -42,7 +42,7 @@ class GameScene extends Scene {
 
 Start the scene as normal — `scene.ui` is rendered automatically:
 
-```js
+```ts
 const game = new GameScene();
 await app.start(game);
 ```
@@ -62,7 +62,7 @@ A mini-map is a special HUD element: it needs a second `View` to render the worl
 Inside a `{ target }` render redirect, issue your draws through `context.backend` directly. A `context.render(node)` call there resets the active view back to the camera, so the off-screen capture would render from the wrong viewpoint.
 </Callout>
 
-```js
+```ts
 // In GameScene.init: build the capture pass once.
 const miniRt = new RenderTexture(260, 260);
 const capturePass = new CallbackRenderPass(

--- a/site/src/content/guide/recipes/pause-menu.mdx
+++ b/site/src/content/guide/recipes/pause-menu.mdx
@@ -18,7 +18,7 @@ One scene, one UI layer. The pause overlay (a `Panel` + `Label`) lives on `scene
 `app.tweens` keeps advancing even while the scene is paused — only `update()` and scene-level systems freeze. That is what lets a blur ramp or menu transition animate smoothly over the frozen world.
 </Callout>
 
-```js
+```ts
 class GameScene extends Scene {
     init() {
         this.player = new Sprite(this.loader.get('image/hero.png'));
@@ -112,7 +112,7 @@ The `destroy` hook clears the blur filter from `scene.root`. Without this, the f
 
 If the pause menu offers options like "Return to main menu" or "Quit", use `app.scenes.change(...)` to navigate away — it unloads the current scene and loads the next one, optionally with a fade transition:
 
-```js
+```ts
 // Inside a resume button's onClick handler:
 resumeButton.onClick.add(() => {
     this.togglePause(); // unpause first

--- a/site/src/content/guide/recipes/split-screen.mdx
+++ b/site/src/content/guide/recipes/split-screen.mdx
@@ -14,7 +14,7 @@ Split screen renders the same scene from two (or more) camera viewpoints into se
 
 Create two `View` objects. Each gets its own viewport rectangle — the left view covers the left half of the canvas, the right view covers the right half. In `draw`, set the backend's active view, render the shared world, swap views, render again:
 
-```js
+```ts
 init() {
     const { width, height } = this.app.canvas;
 
@@ -84,7 +84,7 @@ This means you can have objects visible in both views (a shared flag, a power-up
 
 Two players on one keyboard means binding different key sets to each player — WASD for player 1, arrow keys for player 2 — both registered via the same scene's `this.inputs`. For gamepad co-op, bind each pad slot to a different player:
 
-```js
+```ts
 const pad0 = this.app.input.getGamepad(0);
 pad0.onActive(GamepadAxis.LeftStickX, v => { this._player1.move.x = v; });
 

--- a/site/src/content/guide/recipes/split-screen.mdx
+++ b/site/src/content/guide/recipes/split-screen.mdx
@@ -40,7 +40,7 @@ init() {
         .setTint(new Color(255, 180, 120));
 }
 
-update(delta) {
+update(delta: Time) {
     // Move players independently...
     this._leftPlayer.move(/* WASD */);
     this._rightPlayer.move(/* Arrows */);
@@ -50,7 +50,7 @@ update(delta) {
     this._rightView.setCenter(this._rightPlayer.position.x, this._rightPlayer.position.y);
 }
 
-draw(context) {
+draw(context: RenderingContext) {
     context.backend.clear();
 
     // Render left view

--- a/site/src/content/guide/recipes/ui-patterns.mdx
+++ b/site/src/content/guide/recipes/ui-patterns.mdx
@@ -13,7 +13,7 @@ In-canvas UI means text boxes, dialog panels, progress indicators, and interacti
 
 A dialog system shows text one character at a time, accompanied by a subtle sound. It's built from three primitives: a `Text` node for the dialog text, a `Sound` for the character tick, and a timer (or tween) to drive the reveal:
 
-```js
+```ts
 init() {
     this.lines = [
         'Commander, the anomaly has entered low orbit.',
@@ -60,7 +60,7 @@ update(delta) {
 
 A click advances to the next line or skips the current reveal to show the full line immediately:
 
-```js
+```ts
 this.app.input.onPointerTap.add(() => {
     const line = this.lines[this.lineIndex];
 
@@ -84,7 +84,7 @@ The pattern is self-contained: the scene owns the dialog state, `update` drives 
 
 A radial progress ring using a custom shader filter and a tween. The shader draws a circular arc — a `uProgress` uniform controls how much of the circle is filled. A tween drives `uProgress` from 0 to 1:
 
-```js
+```ts
 init() {
     this.progress = { v: 0 };
     this.label = new Text('0%', { fillColor: Color.white, fontSize: 42 });

--- a/site/src/content/guide/recipes/ui-patterns.mdx
+++ b/site/src/content/guide/recipes/ui-patterns.mdx
@@ -38,7 +38,7 @@ init() {
     this.done = false;
 }
 
-update(delta) {
+update(delta: Time) {
     if (this.done) return;
 
     this.timer += delta.seconds;
@@ -86,15 +86,16 @@ A radial progress ring using a custom shader filter and a tween. The shader draw
 
 ```ts
 init() {
+    const progressGlsl: string = '';
     this.progress = { v: 0 };
-    this.label = new Text('0%', { fillColor: Color.white, fontSize: 42 });
-    this.label.setPosition(360, 410);
+this.label = new Text('0%', { fillColor: Color.white, fontSize: 42 });
+this.label.setPosition(360, 410);
 
-    this.ring = new Sprite(this.loader.get('image/uv.png')).setScale(2.2);
-    this.filter = new WebGl2ShaderFilter({
-        fragmentSource: progressGlsl,
-        uniforms: { uProgress: 0 },
-    });
+this.ring = new Sprite(this.loader.get('image/uv.png')).setScale(2.2);
+this.filter = new WebGl2ShaderFilter({
+    fragmentSource: progressGlsl as string,
+    uniforms: { uProgress: 0 },
+});
     this.ring.filters = [this.filter];
 
     this.app.tweens.create(this.progress)

--- a/site/src/content/guide/rendering/animation.mdx
+++ b/site/src/content/guide/rendering/animation.mdx
@@ -19,7 +19,7 @@ All three can coexist in one scene. Use tweens for UI transitions and canned mot
 
 A [`Tween`](/ExoJS/en/api/tween/) interpolates numeric properties on any target object from their current value to configured end values over a duration in seconds. Create one through `app.tweens.create(target)`, configure it fluently, and call `start()`:
 
-```js
+```ts
 init() {
     this.sprite = new Sprite(this.loader.get('image/hero.png'));
     this.sprite.setAnchor(0.5);
@@ -53,7 +53,7 @@ State is readable at `tween.state`: `'idle'`, `'active'`, `'paused'`, `'stopped'
 
 ### Callbacks
 
-```js
+```ts
 this.app.tweens.create(sprite)
     .to({ rotation: 360 }, 2)
     .onStart(() => console.log('started'))
@@ -73,7 +73,7 @@ this.app.tweens.create(sprite)
 
 `Ease` provides 31 standard Penner easing functions (including `linear`). All accept normalized time `t` in [0, 1] and return an eased value that starts at 0 and ends at 1:
 
-```js no-check
+```ts no-check
 import { Ease } from '@codexo/exojs';
 
 Ease.linear
@@ -95,7 +95,7 @@ Ease.elasticIn  Ease.elasticOut  Ease.elasticInOut
 
 Chain tweens to build sequenced motion without nesting callbacks:
 
-```js
+```ts
 const moveRight = this.app.tweens.create(sprite.position)
     .to({ x: 700 }, 1.0)
     .easing(Ease.cubicInOut);
@@ -114,7 +114,7 @@ moveRight.start();
 
 Because `chain()` returns the next tween, keep a reference to the first tween and start that first tween:
 
-```js
+```ts
 const first = this.app.tweens.create(sprite.position)
     .to({ x: 700 }, 1.0)
 
@@ -135,7 +135,7 @@ Only the first tween in the chain needs a `start()` call — each chained tween 
 
 `chain()` links exactly one tween to exactly one successor — fine for a short relay, but it can't express "run these two tweens together, then move on" or "pause for a beat between steps" without extra bookkeeping. [`TweenSequencer`](/ExoJS/en/api/tween-sequencer/) covers those cases. Create one with `app.tweens.createSequencer()` and build it up with `.then()` and `.wait()`:
 
-```js
+```ts
 const fadeIn = this.app.tweens.create(sprite)
     .to({ alpha: 1 }, 0.4);
 
@@ -169,7 +169,7 @@ Reach for `.chain()` when you already have two tween references and just need on
 
 Calling `start()` on an active tween restarts it from zero. To replace a running animation cleanly, stop the old tween and start a new one on the same target:
 
-```js
+```ts
 // Interrupt the current move and slide to a new position
 this._activeTween?.stop();
 this._activeTween = this.app.tweens.create(sprite.position)
@@ -188,7 +188,7 @@ Tween interpolation is purely numeric. Attempting to tween a non-number property
 
 ### Defining clips
 
-```js
+```ts
 import { AnimatedSprite, Rectangle } from '@codexo/exojs';
 
 const player = new AnimatedSprite(texture);
@@ -209,7 +209,7 @@ player.defineClip('walk', {
 
 Multiple clips can be registered on the same `AnimatedSprite`:
 
-```js
+```ts
 player.defineClip('idle', { frames: [new Rectangle(0, 32, 32, 32)], fps: 1 });              // repeat: -1 (default) — loops forever
 player.defineClip('jump', { frames: [new Rectangle(128, 0, 32, 32)], fps: 1, repeat: 1 });  // plays once
 ```
@@ -223,7 +223,7 @@ Two optional clip fields cover cases a single `fps` value can't express:
 - **`frameDurations`** — a per-frame hold time in milliseconds, parallel to `frames`. When present it drives playback timing directly and `fps` is ignored while advancing frames (still accepted as a display-only average). Use it for clips with intentionally uneven pacing, such as an impact frame that lingers longer than the rest.
 - **`frameOffsets`** — a per-frame local draw offset (`{ x, y }` in local pixels), parallel to `frames`. Use it to keep frames anchored to a stable point when the source frames are trimmed to different sizes — without it, differently-trimmed frames jitter around their own top-left corner.
 
-```js
+```ts
 player.defineClip('hit', {
     frames: [frame0, frame1, frame2],
     frameDurations: [80, 40, 200],                                    // ms per frame — frame1 is a quick flash, frame2 lingers
@@ -235,7 +235,7 @@ Both arrays are usually populated automatically rather than written by hand: the
 
 ### Playback control
 
-```js
+```ts
 player.play('walk');                        // start from frame 0
 player.play('walk', { restart: false });    // resume if same clip
 player.play('walk', { repeat: 1 });         // override repeat count for this play
@@ -247,7 +247,7 @@ player.stop();     // stop and rewind to frame 0
 
 The `onFrame` signal fires on every frame advance; `onComplete` fires when the clip completes its final `repeat` cycle:
 
-```js
+```ts
 player.onFrame.add((clip, frame) => {
     console.log(`Frame ${frame} of clip "${clip}"`);
 });
@@ -259,7 +259,7 @@ player.onComplete.add(clip => {
 
 Call `player.update(delta)` each frame. The delta can be a `Time` object (from the scene's `update`) or a number in milliseconds:
 
-```js
+```ts
 update(delta) {
     this.player.update(delta);
 }
@@ -269,7 +269,7 @@ update(delta) {
 
 If a `Spritesheet` has animation data, `AnimatedSprite.fromSpritesheet()` creates a configured instance directly:
 
-```js
+```ts
 import { AnimatedSprite, Spritesheet } from '@codexo/exojs';
 
 const sheet = new Spritesheet(texture, spritesheetJson);

--- a/site/src/content/guide/rendering/animation.mdx
+++ b/site/src/content/guide/rendering/animation.mdx
@@ -54,7 +54,7 @@ State is readable at `tween.state`: `'idle'`, `'active'`, `'paused'`, `'stopped'
 ### Callbacks
 
 ```ts
-this.app.tweens.create(sprite)
+this.app.tweens.create(this.sprite)
     .to({ rotation: 360 }, 2)
     .onStart(() => console.log('started'))
     .onUpdate(t => console.log(`progress: ${t}`))
@@ -172,8 +172,8 @@ Calling `start()` on an active tween restarts it from zero. To replace a running
 ```ts
 // Interrupt the current move and slide to a new position
 this._activeTween?.stop();
-this._activeTween = this.app.tweens.create(sprite.position)
-    .to({ x: newTarget }, 0.3)
+this._activeTween = this.app.tweens.create(this.sprite.position)
+    .to({ x: this._newTarget }, 0.3)
     .easing(Ease.cubicOut)
     .start();
 ```
@@ -260,7 +260,7 @@ player.onComplete.add(clip => {
 Call `player.update(delta)` each frame. The delta can be a `Time` object (from the scene's `update`) or a number in milliseconds:
 
 ```ts
-update(delta) {
+update(delta: Time) {
     this.player.update(delta);
 }
 ```

--- a/site/src/content/guide/rendering/graphics.mdx
+++ b/site/src/content/guide/rendering/graphics.mdx
@@ -107,7 +107,9 @@ Each of these emits a `drawPath` call behind the scenes. The `currentPoint` prop
 `clear()` removes all child meshes and resets the pen state (position, colors, line width). The `Graphics` object itself stays alive. This is the right pattern for per-frame redrawing:
 
 ```ts
-update(delta) {
+import { Time } from '@codexo/exojs';
+
+update(delta: Time) {
     this.g.clear();
 
     this.g.fillColor = Color.tomato;
@@ -136,7 +138,7 @@ init() {
     this.addChild(this.group);
 }
 
-update(delta) {
+update(delta: Time) {
     this.group.rotate(60 * delta.seconds);
 }
 ```

--- a/site/src/content/guide/rendering/graphics.mdx
+++ b/site/src/content/guide/rendering/graphics.mdx
@@ -107,8 +107,6 @@ Each of these emits a `drawPath` call behind the scenes. The `currentPoint` prop
 `clear()` removes all child meshes and resets the pen state (position, colors, line width). The `Graphics` object itself stays alive. This is the right pattern for per-frame redrawing:
 
 ```ts
-import { Time } from '@codexo/exojs';
-
 update(delta: Time) {
     this.g.clear();
 

--- a/site/src/content/guide/rendering/graphics.mdx
+++ b/site/src/content/guide/rendering/graphics.mdx
@@ -16,7 +16,7 @@ Use `Graphics` when you need shapes that are defined in code rather than loaded 
 
 `Graphics` holds a `fillColor` and a `lineColor`, both `Color` instances. When you call a fill shape method (`drawRectangle`, `drawCircle`, `drawPolygon`, `drawStar`, `drawEllipse`), the shape is filled with the current `fillColor`. When `lineWidth` is greater than zero, the shape is also outlined with the current `lineColor`.
 
-```js
+```ts
 import { Color, Graphics } from '@codexo/exojs';
 
 const g = new Graphics();
@@ -30,7 +30,7 @@ g.drawCircle(200, 40, 40);
 
 Each draw call creates a separate `Mesh`. Changing `fillColor` between calls produces multi-colored output without creating a new `Graphics` instance:
 
-```js
+```ts
 g.fillColor = Color.tomato;
 g.drawCircle(0, 0, 30);
 
@@ -43,37 +43,37 @@ g.drawRectangle(40, -20, 60, 40);
 Seven shape methods cover the common cases. All coordinates are in the `Graphics` object's local space and participate in its transform.
 
 **Rectangles:**
-```js
+```ts
 g.drawRectangle(x, y, width, height);
 ```
 
 **Circles:**
-```js
+```ts
 g.drawCircle(centerX, centerY, radius);
 ```
 
 **Ellipses:**
-```js
+```ts
 g.drawEllipse(centerX, centerY, radiusX, radiusY);
 ```
 
 **Polygons** from a flat `[x0, y0, x1, y1, ...]` array:
-```js
+```ts
 g.drawPolygon([0, -30, 30, 30, -30, 30]); // triangle
 ```
 
 **Stars** with configurable points, inner radius, and rotation in radians (default inner radius is half the outer radius):
-```js
+```ts
 g.drawStar(centerX, centerY, points, radius, innerRadius, rotationRadians);
 ```
 
 **Lines** between two explicit points (does not use or affect the pen position):
-```js
+```ts
 g.drawLine(startX, startY, endX, endY);
 ```
 
 **Paths** from a flat point array, drawn as a stroked polyline:
-```js
+```ts
 g.drawPath([x0, y0, x1, y1, x2, y2, ...]);
 ```
 
@@ -81,7 +81,7 @@ g.drawPath([x0, y0, x1, y1, x2, y2, ...]);
 
 `Graphics` tracks a cursor position. Path commands move the cursor and emit stroked line segments:
 
-```js
+```ts
 g.moveTo(50, 50);
 g.lineTo(150, 100);
 g.lineTo(100, 200);
@@ -106,7 +106,7 @@ Each of these emits a `drawPath` call behind the scenes. The `currentPoint` prop
 
 `clear()` removes all child meshes and resets the pen state (position, colors, line width). The `Graphics` object itself stays alive. This is the right pattern for per-frame redrawing:
 
-```js
+```ts
 update(delta) {
     this.g.clear();
 
@@ -124,7 +124,7 @@ For shapes that do not change, create the `Graphics` once in `init` and never ca
 
 Because `Graphics` extends `Container`, it inherits position, rotation, scale, and origin. A single `Graphics` object with several drawn shapes behaves as a group — rotating the `Graphics` rotates all its shape children together:
 
-```js
+```ts
 init() {
     this.group = new Graphics();
     this.group.fillColor = Color.goldenrod;

--- a/site/src/content/guide/rendering/immediate-mode.mdx
+++ b/site/src/content/guide/rendering/immediate-mode.mdx
@@ -70,7 +70,9 @@ Build the geometry once in `Scene.init` and keep it — it carries no transform,
 `drawGeometry(geometry, transform, options?)` draws the geometry with `transform` as its raw world matrix. The matrix is taken verbatim as `a, b, c, d, tx, ty` — there is no position / rotation / scale / origin composition the way a node would apply. You build the world matrix yourself, which is the point: full control, zero overhead.
 
 ```ts
-draw(context) {
+import type { RenderingContext } from '@codexo/exojs';
+
+draw(context: RenderingContext) {
     context.backend.clear();
 
     // A row of the same triangle, each at a different position, rotation,
@@ -112,7 +114,9 @@ const batch = new RenderBatch(sparkGeometry);
 Each frame, rebuild the instances and submit the batch. `clear` resets the instance count but **keeps** the pooled per-instance storage, so a steady-state batch allocates nothing across frames. `add` **copies** the transform and tint, so you can reuse one scratch `Matrix` for every instance:
 
 ```ts
-draw(context) {
+import type { RenderingContext } from '@codexo/exojs';
+
+draw(context: RenderingContext) {
     context.backend.clear();
 
     this.batch.clear();

--- a/site/src/content/guide/rendering/immediate-mode.mdx
+++ b/site/src/content/guide/rendering/immediate-mode.mdx
@@ -69,7 +69,7 @@ Build the geometry once in `Scene.init` and keep it — it carries no transform,
 
 `drawGeometry(geometry, transform, options?)` draws the geometry with `transform` as its raw world matrix. The matrix is taken verbatim as `a, b, c, d, tx, ty` — there is no position / rotation / scale / origin composition the way a node would apply. You build the world matrix yourself, which is the point: full control, zero overhead.
 
-```js
+```ts
 draw(context) {
     context.backend.clear();
 
@@ -94,7 +94,7 @@ The optional third argument carries a `tint` ([`Color`](/ExoJS/en/api/color/)) m
 
 A [`RenderBatch`](/ExoJS/en/api/render-batch/) is one geometry plus one material drawn once with N per-instance `(transform, tint)` pairs — the instanced form of the immediate path. It collapses thousands of like items into a single draw call.
 
-```js
+```ts
 import { Geometry, RenderBatch } from '@codexo/exojs';
 
 // In Scene.init — the geometry must be 'static' (the default); the batch
@@ -111,7 +111,7 @@ const batch = new RenderBatch(sparkGeometry);
 
 Each frame, rebuild the instances and submit the batch. `clear` resets the instance count but **keeps** the pooled per-instance storage, so a steady-state batch allocates nothing across frames. `add` **copies** the transform and tint, so you can reuse one scratch `Matrix` for every instance:
 
-```js
+```ts
 draw(context) {
     context.backend.clear();
 
@@ -142,7 +142,7 @@ Call `batch.destroy()` in `Scene.unload`/`destroy` to release the pooled storage
 
 The payoff is visible in the per-frame counters. `context.stats.drawCalls` reports the number of GPU draw calls issued this frame. A batched field of 2,400 sparks adds exactly **one** to that count; drawing the same 2,400 sparks with one `drawGeometry` each adds 2,400. Read it at the end of `draw` to surface it in a HUD or the debug overlay:
 
-```js no-check
+```ts no-check
 const drawCalls = context.stats.drawCalls;
 hud.setStatus(`sparks via RenderBatch · drawCalls: ${drawCalls}`);
 ```

--- a/site/src/content/guide/rendering/immediate-mode.mdx
+++ b/site/src/content/guide/rendering/immediate-mode.mdx
@@ -70,8 +70,6 @@ Build the geometry once in `Scene.init` and keep it — it carries no transform,
 `drawGeometry(geometry, transform, options?)` draws the geometry with `transform` as its raw world matrix. The matrix is taken verbatim as `a, b, c, d, tx, ty` — there is no position / rotation / scale / origin composition the way a node would apply. You build the world matrix yourself, which is the point: full control, zero overhead.
 
 ```ts
-import type { RenderingContext } from '@codexo/exojs';
-
 draw(context: RenderingContext) {
     context.backend.clear();
 
@@ -114,8 +112,6 @@ const batch = new RenderBatch(sparkGeometry);
 Each frame, rebuild the instances and submit the batch. `clear` resets the instance count but **keeps** the pooled per-instance storage, so a steady-state batch allocates nothing across frames. `add` **copies** the transform and tint, so you can reuse one scratch `Matrix` for every instance:
 
 ```ts
-import type { RenderingContext } from '@codexo/exojs';
-
 draw(context: RenderingContext) {
     context.backend.clear();
 

--- a/site/src/content/guide/rendering/render-targets.mdx
+++ b/site/src/content/guide/rendering/render-targets.mdx
@@ -76,8 +76,6 @@ The sprite displays the off-screen render as its texture. You can position, scal
 The render-to-texture step typically happens once during `init` for static content, or inside `draw` for content that changes per frame:
 
 ```ts
-import type { RenderingContext } from '@codexo/exojs';
-
 draw(context: RenderingContext) {
     // 1. Draw game world into the off-screen target
     context.backend.setRenderTarget(this.offscreen);

--- a/site/src/content/guide/rendering/render-targets.mdx
+++ b/site/src/content/guide/rendering/render-targets.mdx
@@ -15,7 +15,7 @@ This is the foundation of multi-pass rendering in ExoJS: render-to-texture for c
 
 A `RenderTexture` has pixel dimensions and optional sampler parameters:
 
-```js
+```ts
 import { RenderTexture } from '@codexo/exojs';
 
 const rt = new RenderTexture(256, 256);
@@ -23,7 +23,7 @@ const rt = new RenderTexture(256, 256);
 
 The constructor accepts an optional `SamplerOptions` object to control how the texture is sampled when used on a sprite:
 
-```js
+```ts
 import { RenderTexture, ScaleModes, WrapModes } from '@codexo/exojs';
 
 const rt = new RenderTexture(512, 512, {
@@ -38,7 +38,7 @@ Default sampler settings — linear filtering, clamp-to-edge wrapping, premultip
 
 Set the render target on the backend, draw normally, then restore the canvas:
 
-```js
+```ts
 init() {
     const backend = this.app.backend;
 
@@ -62,7 +62,7 @@ Everything between `setRenderTarget(rt)` and `setRenderTarget(null)` draws into 
 
 Once drawn, a `RenderTexture` can be assigned to any `Sprite`:
 
-```js
+```ts
 this.display = new Sprite(this.offscreen);
 this.display.setPosition(400, 300);
 this.display.setAnchor(0.5);
@@ -75,7 +75,7 @@ The sprite displays the off-screen render as its texture. You can position, scal
 
 The render-to-texture step typically happens once during `init` for static content, or inside `draw` for content that changes per frame:
 
-```js
+```ts
 draw(context) {
     // 1. Draw game world into the off-screen target
     context.backend.setRenderTarget(this.offscreen);
@@ -96,7 +96,7 @@ When a `RenderTexture` is used as the active render target, draw calls write int
 
 `RenderTexture` extends [`RenderTarget`](/ExoJS/en/api/render-target/), which carries a `View` for camera control, size management, and viewport configuration. When drawing into a `RenderTexture`, the render target's view determines the coordinate system. By default it uses a pixel-aligned view matching the texture dimensions:
 
-```js
+```ts
 import { RenderTexture, View } from '@codexo/exojs';
 
 const rt = new RenderTexture(400, 300);
@@ -112,7 +112,7 @@ The `setSize()` method changes the texture dimensions. `powerOfTwo` reports whet
 
 **Cached layers.** Render a complex, static container once into a `RenderTexture`, then display the result as a sprite. Subsequent frames skip the container's render tree entirely — one texture draw instead of N child draws:
 
-```js
+```ts
 init() {
     this.buildComplexScene(); // builds this.staticLayer
 

--- a/site/src/content/guide/rendering/render-targets.mdx
+++ b/site/src/content/guide/rendering/render-targets.mdx
@@ -76,7 +76,9 @@ The sprite displays the off-screen render as its texture. You can position, scal
 The render-to-texture step typically happens once during `init` for static content, or inside `draw` for content that changes per frame:
 
 ```ts
-draw(context) {
+import type { RenderingContext } from '@codexo/exojs';
+
+draw(context: RenderingContext) {
     // 1. Draw game world into the off-screen target
     context.backend.setRenderTarget(this.offscreen);
     context.backend.clear();
@@ -131,7 +133,7 @@ init() {
     this.staticLayer.visible = false;
 }
 
-draw(context) {
+draw(context: RenderingContext) {
     context.backend.clear();
     context.render(this.cachedSprite);
     // ... dynamic content on top ...

--- a/site/src/content/guide/rendering/retained-containers.mdx
+++ b/site/src/content/guide/rendering/retained-containers.mdx
@@ -45,7 +45,7 @@ const decor = new RetainedContainer();
 
 Fill it once with static children, add it to your scene, and move only the group:
 
-```js
+```ts
 init() {
     this.decor = new RetainedContainer();
 
@@ -76,7 +76,7 @@ The speed comes from a deliberate trade: descendants of an engaged group resolve
 
 For a true world-space position or orientation of a node inside the group — picking, spatial audio, physics, any math against nodes outside the group — use [`getWorldTransform()`](/ExoJS/en/api/scene-node/), which composes through the group boundary and returns the real world matrix:
 
-```js
+```ts
 update() {
     // getBounds() here is group-local. For a real world position, compose
     // through the boundary:

--- a/site/src/content/guide/rendering/retained-containers.mdx
+++ b/site/src/content/guide/rendering/retained-containers.mdx
@@ -46,6 +46,8 @@ const decor = new RetainedContainer();
 Fill it once with static children, add it to your scene, and move only the group:
 
 ```ts
+import type { RenderingContext } from '@codexo/exojs';
+
 init() {
     this.decor = new RetainedContainer();
 
@@ -56,7 +58,7 @@ init() {
     }
 }
 
-draw(context) {
+draw(context: RenderingContext) {
     context.backend.clear();
 
     // Panning the camera over the world is ONE group-matrix update — no

--- a/site/src/content/guide/rendering/retained-containers.mdx
+++ b/site/src/content/guide/rendering/retained-containers.mdx
@@ -46,8 +46,6 @@ const decor = new RetainedContainer();
 Fill it once with static children, add it to your scene, and move only the group:
 
 ```ts
-import type { RenderingContext } from '@codexo/exojs';
-
 init() {
     this.decor = new RetainedContainer();
 

--- a/site/src/content/guide/rendering/sprites.mdx
+++ b/site/src/content/guide/rendering/sprites.mdx
@@ -16,8 +16,11 @@ A sprite needs a texture. The shortest path from file to visible quad:
 
 ```ts
 import { Scene, Sprite } from '@codexo/exojs';
+import type { RenderingContext } from '@codexo/exojs';
 
 class MyScene extends Scene {
+    private hero!: Sprite;
+
     async load() {
         await this.loader.load('image/hero.png');
     }
@@ -27,7 +30,7 @@ class MyScene extends Scene {
         this.addChild(this.hero);
     }
 
-    draw(context) {
+    draw(context: RenderingContext) {
         context.backend.clear();
         context.render(this.root);
     }

--- a/site/src/content/guide/rendering/sprites.mdx
+++ b/site/src/content/guide/rendering/sprites.mdx
@@ -14,7 +14,7 @@ A [`Sprite`](/ExoJS/en/api/sprite/) is the primary drawable for textured quads �
 
 A sprite needs a texture. The shortest path from file to visible quad:
 
-```js
+```ts
 import { Scene, Sprite } from '@codexo/exojs';
 
 class MyScene extends Scene {
@@ -42,7 +42,7 @@ A sprite's position places its anchor point in the parent's coordinate space. By
 
 `setAnchor(0.5)` centers the anchor at the sprite's middle, making `setPosition(400, 300)` place the sprite's center at `(400, 300)`:
 
-```js
+```ts
 init() {
     const { width, height } = this.app.canvas;
 
@@ -59,7 +59,7 @@ init() {
 
 `sprite.width` and `sprite.height` report the rendered pixel dimensions (texture frame size multiplied by absolute scale). Setting them adjusts the scale to match:
 
-```js
+```ts
 this.hero.width = 64;  // scale.x becomes 64 / textureFrame.width
 this.hero.height = 64; // scale.y becomes 64 / textureFrame.height
 ```
@@ -70,7 +70,7 @@ this.hero.height = 64; // scale.y becomes 64 / textureFrame.height
 
 `sprite.tint` is a `Color` that multiplies the sprite's pixel colors at draw time. White tint (`Color.white`) leaves the texture unchanged. A red tint mutes green and blue channels. Tinting does not allocate or create new textures:
 
-```js
+```ts
 import { Color } from '@codexo/exojs';
 
 this.hero.tint = new Color(255, 128, 128, 1); // reddish tint
@@ -81,7 +81,7 @@ this.hero.tint = new Color(128, 128, 255, 0.8); // blue tint, 80% opacity
 
 A sprite can display a sub-region of its texture through `textureFrame`. This is the mechanism behind spritesheet frame selection:
 
-```js
+```ts
 import { Rectangle } from '@codexo/exojs';
 
 // Show only the top-left 32x32 pixels of a 128x128 texture
@@ -90,7 +90,7 @@ this.sprite.setTextureFrame(new Rectangle(0, 0, 32, 32));
 
 By default `setTextureFrame` resets the sprite's width and height to the frame's dimensions. Pass `false` as the second argument to keep the current display size — useful for animation where frame dimensions vary but the on-screen size should stay constant:
 
-```js
+```ts
 this.sprite.setTextureFrame(new Rectangle(32, 0, 32, 32), false);
 ```
 
@@ -100,7 +100,7 @@ Call `resetTextureFrame()` to restore the full texture.
 
 `sprite.blendMode` controls how the sprite composites with pixels already in the framebuffer. The default is `BlendModes.Normal` (standard alpha blending):
 
-```js
+```ts
 import { BlendModes } from '@codexo/exojs';
 
 this.glow.blendMode = BlendModes.Additive;
@@ -137,7 +137,7 @@ Blend modes are per-sprite. Combined with tinting they cover common glow, shadow
 
 A [`Spritesheet`](/ExoJS/en/api/spritesheet/) slices a single texture atlas into named frames and optional animation sequences. It accepts a JSON descriptor in the Aseprite / TexturePacker format:
 
-```js
+```ts
 import { Spritesheet } from '@codexo/exojs';
 
 const sheet = new Spritesheet(texture, {
@@ -165,7 +165,7 @@ The `animations` map feeds into `AnimatedSprite.fromSpritesheet()`, covered in t
 
 `Sprite` accepts any `Texture` or `RenderTexture`. This means sprites can display video frames, SVG rasterizations, off-screen renders, or `DataTexture` pixel buffers — any source the engine can wrap as a `Texture`:
 
-```js
+```ts
 // Video as a sprite texture
 import { Asset, RenderTexture, Sprite, Video } from '@codexo/exojs';
 

--- a/site/src/content/guide/rendering/text.mdx
+++ b/site/src/content/guide/rendering/text.mdx
@@ -11,7 +11,7 @@ import ExamplePreview from '../../../components/ExamplePreview.astro';
 
 ## A minimal text node
 
-```js
+```ts
 import { Color, Text } from '@codexo/exojs';
 
 const label = new Text('Hello', {
@@ -23,7 +23,7 @@ const label = new Text('Hello', {
 
 The second argument is a `TextOptions` object — a flat merge of [`TextStyleOptions`](/ExoJS/en/api/text-style/) (visual appearance) and `LayoutOptions` (flow and overflow). All properties are optional and have defaults. The live `TextStyle` is stored as `text.style`; mutating its fields is cheap and is applied automatically before the next render pass — no manual rebuild call is needed:
 
-```js
+```ts
 import { Color } from '@codexo/exojs';
 
 label.style.fontSize = 32;            // rebuilds the glyph mesh on the next draw
@@ -34,7 +34,7 @@ label.style.fillColor = Color.tomato; // updates only the mesh tint — no atlas
 
 System fonts (Arial, Times New Roman, etc.) work immediately. For custom web fonts, load one via `Asset.type('font', ...)` in the scene's `load` hook — fonts aren't a seamless type, so a bare path isn't enough; an explicit descriptor is required even for a literal path, and `family` is a required option:
 
-```js
+```ts
 async load() {
     await this.loader.load(Asset.type('font', 'font/MyFont.woff2', { family: 'MyFont' }));
 }
@@ -91,7 +91,7 @@ Glyphs are rasterized into the shared SDF atlas; the mesh tint is initialized fr
 
 Multiline text works by embedding `\n` characters in the string:
 
-```js
+```ts
 import { Color, Text } from '@codexo/exojs';
 
 const dialog = new Text('Line one\nLine two\nLine three', {
@@ -103,7 +103,7 @@ const dialog = new Text('Line one\nLine two\nLine three', {
 
 To wrap long runs automatically, set `maxWidth` (in pixels) — lines that exceed it break at word boundaries. Add `breakWords: true` to also split individual words that are wider than `maxWidth`:
 
-```js
+```ts
 import { Color, Text } from '@codexo/exojs';
 
 const longString = 'A long run of text that wraps automatically once it exceeds the layout width.';
@@ -120,7 +120,7 @@ const wrapped = new Text(longString, {
 
 The `align` property controls horizontal positioning relative to the `Text` node's local origin:
 
-```js
+```ts
 import { Color, Text } from '@codexo/exojs';
 
 const centered = new Text('Centered Title', {
@@ -137,7 +137,7 @@ A center-aligned text node at `(400, 20)` centers its glyphs horizontally around
 
 `Text` extends `Container`, so it carries position, rotation, scale, origin, and anchor. You can rotate text, tint the whole node, apply filters, and nest it inside other containers:
 
-```js
+```ts
 this.hud = new Container();
 this.scoreLabel = new Text('Score: 0', { fillColor: Color.white, fontSize: 24 });
 this.scoreLabel.setPosition(10, 10);

--- a/site/src/content/guide/rendering/text.mdx
+++ b/site/src/content/guide/rendering/text.mdx
@@ -24,7 +24,9 @@ const label = new Text('Hello', {
 The second argument is a `TextOptions` object — a flat merge of [`TextStyleOptions`](/ExoJS/en/api/text-style/) (visual appearance) and `LayoutOptions` (flow and overflow). All properties are optional and have defaults. The live `TextStyle` is stored as `text.style`; mutating its fields is cheap and is applied automatically before the next render pass — no manual rebuild call is needed:
 
 ```ts
-import { Color } from '@codexo/exojs';
+import { Color, Text } from '@codexo/exojs';
+
+const label = new Text('Hello', { fillColor: Color.black, fontSize: 24 });
 
 label.style.fontSize = 32;            // rebuilds the glyph mesh on the next draw
 label.style.fillColor = Color.tomato; // updates only the mesh tint — no atlas work

--- a/site/src/content/guide/runtime/application.mdx
+++ b/site/src/content/guide/runtime/application.mdx
@@ -14,7 +14,7 @@ The [`Application`](/ExoJS/en/api/application/) is the runtime host. One instanc
 
 Every option is optional. If you pass nothing, ExoJS picks reasonable defaults — an 800×600 canvas it created itself, a `cornflowerBlue` clear color, and an auto-selected render backend (WebGPU when available, WebGL2 otherwise).
 
-```js
+```ts
 import { Application } from '@codexo/exojs';
 
 const app = new Application();
@@ -22,7 +22,7 @@ const app = new Application();
 
 When you need to control the configuration, pass a grouped options object:
 
-```js
+```ts
 import { Application, Color } from '@codexo/exojs';
 
 const app = new Application({
@@ -52,7 +52,7 @@ whole life of the application. Assigning a new `Color` copies its channels into 
 (effective from the next frame), which makes it a convenient way to react to game state without
 touching draw code:
 
-```js
+```ts
 import { Application, Color } from '@codexo/exojs';
 
 const app = new Application();
@@ -64,7 +64,7 @@ function onLowHealth(isLow) {
 
 You can also mutate the existing instance in place instead of allocating a new `Color` each time:
 
-```js
+```ts
 app.clearColor.set(20, 20, 40, 1); // dusk
 ```
 
@@ -76,7 +76,7 @@ app.clearColor.set(20, 20, 40, 1); // dusk
 
 By default the application creates its own canvas. Read it from `app.canvas` and place it in your page wherever your layout needs it:
 
-```js
+```ts
 const app = new Application({
     canvas: { width: 800, height: 600 },
 });
@@ -85,7 +85,7 @@ document.body.append(app.canvas);
 
 If your page already has a canvas — for example because the layout is owned by a framework that renders the element for you — pass it in via `canvas.element`:
 
-```js
+```ts
 const canvas = document.querySelector('canvas');
 const app = new Application({
     canvas: { element: canvas, width: 800, height: 600 },
@@ -98,7 +98,7 @@ Either way, `app.canvas` is the active `HTMLCanvasElement`. CSS rules, ResizeObs
 
 `canvas.pixelRatio` scales the backing buffer relative to logical CSS pixels. By default it is the host's `window.devicePixelRatio` **clamped to `2`**, so rendering is crisp on Retina/HiDPI screens out of the box. Pass an explicit value to override:
 
-```js
+```ts
 const app = new Application({
     canvas: {
         width: 1280,
@@ -117,7 +117,7 @@ Pass `pixelRatio: 1` to force logical-pixel rendering, or `window.devicePixelRat
 
 For pixel-art games where you want crisp upscaling without browser blurring, combine `pixelRatio` with the `imageRendering` hint:
 
-```js
+```ts
 const app = new Application({
     canvas: {
         width: 320,
@@ -133,7 +133,7 @@ const app = new Application({
 
 The frame loop only runs once you give the application a scene to run:
 
-```js
+```ts
 import { Application, Scene } from '@codexo/exojs';
 
 class HelloScene extends Scene {
@@ -168,7 +168,7 @@ Most code reaches these through the active scene (`this.app.input`, `this.app.tw
 
 The application emits a small set of signals you can subscribe to without subclassing:
 
-```js
+```ts
 app.onFrame.add(time => {
     console.log(`Frame at ${time.seconds.toFixed(3)}s`);
 });
@@ -184,7 +184,7 @@ For most projects the scene's `update` and `draw` hooks are enough; reach for th
 
 Browsers throttle background tabs to roughly 1 fps. For games this usually shows up as motion artifacts when the user comes back. Toggle `pauseOnHidden` to skip update + render entirely while the tab is hidden:
 
-```js
+```ts
 app.pauseOnHidden = true;
 ```
 

--- a/site/src/content/guide/runtime/application.mdx
+++ b/site/src/content/guide/runtime/application.mdx
@@ -57,7 +57,7 @@ import { Application, Color } from '@codexo/exojs';
 
 const app = new Application();
 
-function onLowHealth(isLow) {
+function onLowHealth(isLow: boolean) {
     app.clearColor = isLow ? Color.darkRed : Color.cornflowerBlue;
 }
 ```
@@ -134,10 +134,10 @@ const app = new Application({
 The frame loop only runs once you give the application a scene to run:
 
 ```ts
-import { Application, Scene } from '@codexo/exojs';
+import { Application, RenderingContext, Scene } from '@codexo/exojs';
 
 class HelloScene extends Scene {
-    draw(context) {
+    draw(context: RenderingContext) {
         context.backend.clear();
     }
 }

--- a/site/src/content/guide/runtime/coordinates-and-views.mdx
+++ b/site/src/content/guide/runtime/coordinates-and-views.mdx
@@ -39,7 +39,7 @@ Every render backend exposes a `view` property. The view defines how world space
 
 Set the center to `(400, 300)` and the size to `(800, 600)`, and the canvas shows the world from `(0, 0)` to `(800, 600)`. Move the center to `(400, 600)` and the camera scrolls down by 300 pixels' worth of world.
 
-```js
+```ts
 draw(context) {
     context.view.setCenter(400, 300);
     context.view.resize(800, 600);
@@ -55,7 +55,7 @@ You don't usually configure the view by hand — it tracks the canvas size autom
 
 The view supports following a target. The target can be any object with `x` and `y` properties — typically a scene node, but a plain `{x, y}` object works too:
 
-```js
+```ts
 draw(context) {
     context.view.follow(this.player);
 
@@ -70,7 +70,7 @@ Following keeps the view centered on the target while the scene renders. Call `c
 
 The `setZoom(z)` method scales how much world fits inside the view. `setZoom(2)` means the view shows half as much world as it normally would (everything looks twice as big). `setZoom(0.5)` does the opposite (everything looks zoomed out). The `zoomIn(amount)` and `zoomOut(amount)` helpers adjust relative to the current zoom.
 
-```js
+```ts
 init() {
     this.zoom = 1;
 
@@ -100,7 +100,7 @@ A handful of misalignments come up regularly:
 
 The active view can be swapped on every frame. Used together with viewports, this gives you split-screen, picture-in-picture, and minimap rendering — render the world once with one view configuration into one viewport, then again with a different configuration into another:
 
-```js
+```ts
 draw(context) {
     context.backend.clear();
 

--- a/site/src/content/guide/runtime/coordinates-and-views.mdx
+++ b/site/src/content/guide/runtime/coordinates-and-views.mdx
@@ -40,7 +40,7 @@ Every render backend exposes a `view` property. The view defines how world space
 Set the center to `(400, 300)` and the size to `(800, 600)`, and the canvas shows the world from `(0, 0)` to `(800, 600)`. Move the center to `(400, 600)` and the camera scrolls down by 300 pixels' worth of world.
 
 ```ts
-draw(context) {
+draw(context: RenderingContext) {
     context.view.setCenter(400, 300);
     context.view.resize(800, 600);
 
@@ -56,7 +56,7 @@ You don't usually configure the view by hand — it tracks the canvas size autom
 The view supports following a target. The target can be any object with `x` and `y` properties — typically a scene node, but a plain `{x, y}` object works too:
 
 ```ts
-draw(context) {
+draw(context: RenderingContext) {
     context.view.follow(this.player);
 
     context.backend.clear();
@@ -79,7 +79,7 @@ init() {
     });
 }
 
-draw(context) {
+draw(context: RenderingContext) {
     context.view.setZoom(this.zoom);
 
     context.backend.clear();
@@ -101,7 +101,7 @@ A handful of misalignments come up regularly:
 The active view can be swapped on every frame. Used together with viewports, this gives you split-screen, picture-in-picture, and minimap rendering — render the world once with one view configuration into one viewport, then again with a different configuration into another:
 
 ```ts
-draw(context) {
+draw(context: RenderingContext) {
     context.backend.clear();
 
     context.view.setViewport(0, 0, 0.5, 1);

--- a/site/src/content/guide/runtime/scene-graph.mdx
+++ b/site/src/content/guide/runtime/scene-graph.mdx
@@ -16,7 +16,7 @@ Two key types: [`RenderNode`](/ExoJS/en/api/render-node/) is the abstract base f
 
 Every scene starts with one container already in place — `this.root`. Adding a node via `this.addChild(...)` is shorthand for `this.root.addChild(...)`:
 
-```js
+```ts
 init() {
     this.hero = new Sprite(this.loader.get('hero.png'));
     this.coin = new Sprite(this.loader.get('coin.png'));
@@ -28,7 +28,7 @@ init() {
 
 For larger scenes, build sub-containers and add nodes to them instead:
 
-```js
+```ts
 init() {
     this.world = new Container();
     this.hud = new Container();
@@ -47,7 +47,7 @@ Containers can be added, removed, and moved between parents at any time. The hie
 
 When a parent transforms, its children move with it. If you set the parent's position to `(100, 0)` and a child's position to `(20, 0)`, the child renders at world position `(120, 0)`:
 
-```js
+```ts
 this.player = new Container();
 this.player.setPosition(100, 0);
 
@@ -73,7 +73,7 @@ Skew (shear) slants the local shape along one or both axes without scaling or ro
 
 Both are in degrees, consistent with `rotation`. Use the compound setter when setting both at once:
 
-```js
+```ts
 hero.skewX = 15;           // lean right 15°
 hero.skewY = -5;           // tilt top-left slightly
 
@@ -93,7 +93,7 @@ Common uses:
 
 Children render in the order they were added. The first child drawn ends up at the back; the last child drawn ends up on top. To put a sprite in front of another, add it later — or change its position in the parent's child list:
 
-```js
+```ts
 this.world.addChild(this.background);
 this.world.addChild(this.player);    // drawn over background
 this.world.addChild(this.foreground); // drawn over player
@@ -109,7 +109,7 @@ Children paint in the order you add them — last added sits on top. For depth t
 
 The container API covers the common cases:
 
-```js
+```ts
 parent.addChild(child);              // append (variadic — pass multiple)
 parent.addChildAt(child, index);     // insert at a specific index
 parent.removeChild(child);           // remove by reference
@@ -135,7 +135,7 @@ Each level is independent: rotating the player rotates everything inside it with
 
 Each render node has a `mask` property that clips its rendering to a shape. The mask source can be a `Rectangle`, a `Texture`, another `RenderNode`, or `null` (no mask). Masks are applied during render, not during transform — children of a masked container are still positioned normally, but only the visible region is drawn.
 
-```js
+```ts
 import { Rectangle } from '@codexo/exojs';
 
 this.viewport = new Container();

--- a/site/src/content/guide/runtime/scenes-and-lifecycle.mdx
+++ b/site/src/content/guide/runtime/scenes-and-lifecycle.mdx
@@ -17,7 +17,7 @@ The split between application and scene matters: the application is the long-liv
 
 A scene is a class that extends `Scene`. Override the hooks you need; leave the rest at their defaults:
 
-```js
+```ts
 import { Scene } from '@codexo/exojs';
 
 class TitleScene extends Scene {
@@ -44,7 +44,7 @@ Scene structure stays in your code. State lives on `this`, organized however you
 
 Register the scene's constructor and hand it to `app.start`; the application takes over:
 
-```js
+```ts
 const app = new Application({ scenes: { TitleScene } });
 app.start(TitleScene);
 ```
@@ -55,7 +55,7 @@ From this point on, the application runs the scene's `update` and `draw` once pe
 
 Most non-trivial projects have more than one scene. The application owns a scene director (`app.scenes`) that drives the active scene. Use `change` to swap in a new scene, and register scene constructors up front so `change` knows which classes are valid targets:
 
-```js
+```ts
 const app = new Application({ scenes: { GameScene } });
 
 // Replace the active scene with a fresh instance
@@ -73,7 +73,7 @@ For a typical app: a `MenuScene` calls `this.app.scenes.change(GameScene)` when 
 
 Every scene has a built-in `scene.ui` layer that sits screen-fixed above the scene's world content. Nodes added to `scene.ui` are always rendered on top — no explicit render call in `draw` required — and they are anchored relative to the canvas, not the world.
 
-```js
+```ts
 import { Label, ProgressBar, Scene } from '@codexo/exojs';
 
 class GameScene extends Scene {
@@ -99,7 +99,7 @@ To freeze a scene without leaving it — the canonical pause menu — call `app.
 
 A pause overlay is just nodes on `scene.ui` that you show and hide in response to the state change:
 
-```js
+```ts
 import { Keyboard, Label, Panel, Scene } from '@codexo/exojs';
 
 class GameScene extends Scene {
@@ -162,7 +162,7 @@ You override the hooks you need. Empty hooks like `update` and `draw` do nothing
 
 The `load` hook is the async setup hook. Use it to register everything the scene needs and await the loader:
 
-```js
+```ts
 import { Scene } from '@codexo/exojs';
 
 class GameScene extends Scene {
@@ -181,7 +181,7 @@ The application doesn't call `init` until this promise resolves, so by the time 
 
 The `init` hook is where you create the scene's actual objects. Read a previously-loaded asset via `this.loader`:
 
-```js
+```ts
 init() {
     this.hero = new Sprite(this.loader.get('image/hero.png'));
     this.hero.setAnchor(0.5);
@@ -196,7 +196,7 @@ The `init` hook runs once per scene-start. If you start the scene again later it
 
 `update` runs once per real frame, so its `delta` varies with the display's refresh rate and any hitches. `fixedUpdate` is the other logic hook: the engine runs it a constant number of times per second — independent of frame rate — before `update`:
 
-```js
+```ts
 fixedUpdate(delta) {
     this.world.step(delta.seconds);
 }
@@ -204,7 +204,7 @@ fixedUpdate(delta) {
 
 Behind the scenes, the application accumulates each frame's elapsed time and drains it in fixed-size chunks — `1 / 60` s by default, configurable via `fixedTimeStep` (seconds) on the `Application` constructor options:
 
-```js
+```ts
 const app = new Application({ fixedTimeStep: 1 / 30 });
 ```
 
@@ -222,7 +222,7 @@ Because `fixedUpdate` calls don't line up one-to-one with rendered frames, there
 
 **`frameAlpha` is not applied automatically** — the scene graph never interpolates itself. It exists for you to read and use if you want smooth visual motion between fixed steps: keep the previous and current fixed-step positions and lerp between them by `frameAlpha` when you draw.
 
-```js
+```ts
 fixedUpdate() {
     this.hero.prevX = this.hero.x;
     this.world.step(1 / 60); // moves the body; the binding updates this.hero.x
@@ -243,7 +243,7 @@ If you don't need buttery-smooth motion, ignore `frameAlpha` — most scenes nev
 
 The `update` hook runs once per frame, before `draw`. The argument carries the elapsed time since the previous frame:
 
-```js
+```ts
 update(delta) {
     this.hero.rotate(120 * delta.seconds);
 }
@@ -255,7 +255,7 @@ Multiplying by `delta.seconds` keeps motion frame-rate independent. The same cod
 
 This is the hook with the most surprising default: **`draw` does nothing if you don't override it.** The engine never auto-traverses the scene graph for you.
 
-```js
+```ts
 draw(context) {
     context.backend.clear();
     context.render(this.root);
@@ -270,7 +270,7 @@ ExoJS never auto-renders the tree. If `draw` is missing or omits `context.render
 
 The trade-off is that you can render selectively when you need to:
 
-```js
+```ts
 draw(context) {
     context.backend.clear();
     context.render(this.world);
@@ -289,7 +289,7 @@ When a frame grows into a sequence of distinct phases — render the world, capt
 
 Scenes receive input through `this.inputs`, which proxies to the application's input manager. Register bindings in `init`:
 
-```js
+```ts
 init() {
     this.inputs.onTrigger(Keyboard.Space, () => {
         this.player.jump();

--- a/site/src/content/guide/runtime/scenes-and-lifecycle.mdx
+++ b/site/src/content/guide/runtime/scenes-and-lifecycle.mdx
@@ -18,18 +18,18 @@ The split between application and scene matters: the application is the long-liv
 A scene is a class that extends `Scene`. Override the hooks you need; leave the rest at their defaults:
 
 ```ts
-import { Scene } from '@codexo/exojs';
+import { RenderingContext, Scene, Time } from '@codexo/exojs';
 
 class TitleScene extends Scene {
     init() {
         // build state
     }
 
-    update(delta) {
+    update(delta: Time) {
         // per-frame logic
     }
 
-    draw(context) {
+    draw(context: RenderingContext) {
         // per-frame rendering
         context.backend.clear();
     }
@@ -77,6 +77,8 @@ Every scene has a built-in `scene.ui` layer that sits screen-fixed above the sce
 import { Label, ProgressBar, Scene } from '@codexo/exojs';
 
 class GameScene extends Scene {
+    private healthBar!: ProgressBar;
+
     init() {
         const title = new Label('Score: 0', { fontSize: 22 });
         title.anchorIn(this.ui, 'top-left', 18, 14);
@@ -103,6 +105,9 @@ A pause overlay is just nodes on `scene.ui` that you show and hide in response t
 import { Keyboard, Label, Panel, Scene } from '@codexo/exojs';
 
 class GameScene extends Scene {
+    private pausePanel!: Panel;
+    private pauseLabel!: Label;
+
     init() {
         // Pause overlay — hidden until paused
         this.pausePanel = new Panel({ width: 360, height: 120, cornerRadius: 12 });
@@ -197,7 +202,7 @@ The `init` hook runs once per scene-start. If you start the scene again later it
 `update` runs once per real frame, so its `delta` varies with the display's refresh rate and any hitches. `fixedUpdate` is the other logic hook: the engine runs it a constant number of times per second — independent of frame rate — before `update`:
 
 ```ts
-fixedUpdate(delta) {
+fixedUpdate(delta: Time) {
     this.world.step(delta.seconds);
 }
 ```
@@ -228,7 +233,7 @@ fixedUpdate() {
     this.world.step(1 / 60); // moves the body; the binding updates this.hero.x
 }
 
-draw(context) {
+draw(context: RenderingContext) {
     const alpha = this.app.frameAlpha;
     const renderX = this.hero.prevX + (this.hero.x - this.hero.prevX) * alpha;
     this.hero.setPosition(renderX, this.hero.y);
@@ -244,7 +249,7 @@ If you don't need buttery-smooth motion, ignore `frameAlpha` — most scenes nev
 The `update` hook runs once per frame, before `draw`. The argument carries the elapsed time since the previous frame:
 
 ```ts
-update(delta) {
+update(delta: Time) {
     this.hero.rotate(120 * delta.seconds);
 }
 ```
@@ -256,7 +261,7 @@ Multiplying by `delta.seconds` keeps motion frame-rate independent. The same cod
 This is the hook with the most surprising default: **`draw` does nothing if you don't override it.** The engine never auto-traverses the scene graph for you.
 
 ```ts
-draw(context) {
+draw(context: RenderingContext) {
     context.backend.clear();
     context.render(this.root);
 }
@@ -271,7 +276,7 @@ ExoJS never auto-renders the tree. If `draw` is missing or omits `context.render
 The trade-off is that you can render selectively when you need to:
 
 ```ts
-draw(context) {
+draw(context: RenderingContext) {
     context.backend.clear();
     context.render(this.world);
 

--- a/site/src/content/guide/runtime/ui-and-widgets.mdx
+++ b/site/src/content/guide/runtime/ui-and-widgets.mdx
@@ -17,7 +17,7 @@ On top of that layer, ExoJS ships a small set of widgets — [`Panel`](/ExoJS/en
 
 Each widget takes an options object and exposes the handful of properties you tend to change at runtime:
 
-```js
+```ts
 import { Button, Label, Panel, ProgressBar } from '@codexo/exojs';
 
 const score = new Label('Score: 0', { fontSize: 24 });
@@ -38,7 +38,7 @@ A `Label` wraps a runtime [`Text`](/ExoJS/en/api/text/), so it accepts the same 
 
 Widgets extend [`Widget`](/ExoJS/en/api/widget/), which adds an explicit layout size and screen-edge anchoring. `widget.anchorIn(scene.ui, anchor, offsetX, offsetY)` pins a widget to a corner or edge and re-applies the position whenever the canvas resizes:
 
-```js
+```ts
 import { Label, ProgressBar, Scene } from '@codexo/exojs';
 
 class HudScene extends Scene {
@@ -64,7 +64,7 @@ The anchor accepts `'top-left'`, `'top'`, `'top-right'`, `'left'`, `'center'`, `
 
 A `Stack` flows its children in a row or column with even spacing and sizes itself to fit. Use it for menus and button groups:
 
-```js
+```ts
 import { Button, Panel, Scene, Stack } from '@codexo/exojs';
 
 class MenuScene extends Scene {
@@ -87,7 +87,7 @@ class MenuScene extends Scene {
 
 A `ScrollContainer` clips its content to a fixed `width` × `height` and scrolls it with the mouse wheel — useful for inventories, logs, or any list longer than its box. Add children to `scroll.content`, not to the container itself:
 
-```js
+```ts
 import { Label, Scene, ScrollContainer } from '@codexo/exojs';
 
 class InventoryScene extends Scene {
@@ -116,7 +116,7 @@ Parent scrollable items to `scroll.content`, never to the `ScrollContainer` itse
 
 UI nodes are hit-tested in screen space *before* the world, so a `Button` on `scene.ui` is clickable even under a panned or zoomed camera. Listen to `button.onClick`:
 
-```js
+```ts
 import { Button, Scene } from '@codexo/exojs';
 
 class GameScene extends Scene {
@@ -133,7 +133,7 @@ class GameScene extends Scene {
 
 Widgets are also keyboard-focusable. Mark any node `focusable` and give it a `tabIndex`; it then receives focus and routed key events:
 
-```js
+```ts
 import { Button, Keyboard } from '@codexo/exojs';
 
 const field = new Button({ label: 'Name' });
@@ -155,7 +155,7 @@ Do not confuse this with canvas focus — whether the browser is sending the pag
 
 A `Tooltip` attaches to any `interactive` node and shows a small text label near the pointer after a short delay, hiding again as soon as the pointer leaves. It parents itself to the nearest `UIRoot` ancestor of its target, so it always renders above other content — the target just needs to already be in the scene tree:
 
-```js
+```ts
 import { Button, Scene, Tooltip } from '@codexo/exojs';
 
 class ShopScene extends Scene {
@@ -176,7 +176,7 @@ Options cover the delay before showing (`delay`, in seconds), the offset from th
 
 A pause menu is the canonical combination: freeze the world with `app.scenes.pause()` — which stops `update` and the scene's systems while it keeps drawing — and show an overlay built from widgets on `scene.ui`. Call `app.scenes.resume()` to unfreeze:
 
-```js
+```ts
 import { Keyboard, Label, Panel, Scene } from '@codexo/exojs';
 
 class GameScene extends Scene {

--- a/site/src/content/guide/runtime/ui-and-widgets.mdx
+++ b/site/src/content/guide/runtime/ui-and-widgets.mdx
@@ -159,6 +159,8 @@ A `Tooltip` attaches to any `interactive` node and shows a small text label near
 import { Button, Scene, Tooltip } from '@codexo/exojs';
 
 class ShopScene extends Scene {
+    private tooltip!: Tooltip;
+
     init() {
         const upgrade = new Button({ label: 'Upgrade', width: 160, height: 44 });
         upgrade.interactive = true;
@@ -180,6 +182,9 @@ A pause menu is the canonical combination: freeze the world with `app.scenes.pau
 import { Keyboard, Label, Panel, Scene } from '@codexo/exojs';
 
 class GameScene extends Scene {
+    private pausePanel!: Panel;
+    private pauseLabel!: Label;
+
     init() {
         this.pausePanel = new Panel({ width: 420, height: 140, cornerRadius: 18 });
         this.pausePanel.anchorIn(this.ui, 'center');

--- a/site/src/content/guide/shipping/deployment.mdx
+++ b/site/src/content/guide/shipping/deployment.mdx
@@ -118,7 +118,7 @@ Files placed in `public/` are copied verbatim to `dist/` during the build. A fil
 
 Reference assets without the `public/` prefix:
 
-```js no-check
+```ts no-check
 await loader.load('assets/bunny.png'); // correct
 ```
 

--- a/site/src/content/guide/shipping/troubleshooting.mdx
+++ b/site/src/content/guide/shipping/troubleshooting.mdx
@@ -41,7 +41,7 @@ A blank or black canvas usually means one of the following:
 
 **`context.render()` is missing from `draw`.** Every frame you need to both clear the backend and explicitly render your scene graph root:
 
-```js
+```ts
 draw(context) {
     context.backend.clear();
     context.render(this.root);
@@ -60,7 +60,7 @@ See [Your first scene](/ExoJS/en/guide/getting-started/your-first-scene/) for a 
 
 Pre-0.9 ExoJS snippets commonly use an older draw signature. If you copied code from an older tutorial or GitHub issue, it may look like this:
 
-```js no-check
+```ts no-check
 // old (0.8.x and earlier) — do not use
 draw(backend) {
     backend.clear();
@@ -70,7 +70,7 @@ draw(backend) {
 
 The current API passes a render context, not a bare backend, and renders nodes through the context rather than calling `render` on the node itself:
 
-```js
+```ts
 draw(context) {
     context.backend.clear();
     context.render(sprite);
@@ -115,7 +115,7 @@ Asset load failures typically produce network errors in the browser's developer 
 
 **Vite `public/` path confusion.** Files in `public/` are served from the site root. A file at `public/assets/bunny.png` is available at `/assets/bunny.png`, not `public/assets/bunny.png`. Reference it without the `public/` prefix:
 
-```js no-check
+```ts no-check
 await loader.load('assets/bunny.png'); // correct
 await loader.load('public/assets/bunny.png'); // wrong
 ```
@@ -138,7 +138,7 @@ The symptom: audio code runs without errors, but nothing is audible. Often the b
 
 The fix: start audio in response to a click, tap, or keypress:
 
-```js no-check
+```ts no-check
 button.addEventListener('click', () => {
     mySound.play(); // the engine resumes the AudioContext on the first user gesture
 });
@@ -179,7 +179,7 @@ Using an old property name silently produces no error but the style is ignored. 
 
 If your scene runs slowly, measure first before guessing. The [`DebugOverlay`](/ExoJS/en/api/debug-overlay/) from `@codexo/exojs/debug` shows FPS, frame time, and draw-call count in real time:
 
-```js
+```ts
 import { DebugOverlay } from '@codexo/exojs/debug';
 
 const debug = new DebugOverlay(app);

--- a/site/src/content/guide/shipping/troubleshooting.mdx
+++ b/site/src/content/guide/shipping/troubleshooting.mdx
@@ -42,7 +42,7 @@ A blank or black canvas usually means one of the following:
 **`context.render()` is missing from `draw`.** Every frame you need to both clear the backend and explicitly render your scene graph root:
 
 ```ts
-draw(context) {
+draw(context: RenderingContext) {
     context.backend.clear();
     context.render(this.root);
 }
@@ -71,9 +71,9 @@ draw(backend) {
 The current API passes a render context, not a bare backend, and renders nodes through the context rather than calling `render` on the node itself:
 
 ```ts
-draw(context) {
+draw(context: RenderingContext) {
     context.backend.clear();
-    context.render(sprite);
+    context.render(this.root);
 }
 ```
 

--- a/tsconfig.guides.json
+++ b/tsconfig.guides.json
@@ -5,8 +5,20 @@
   // fenced blocks into .workspace/generated/guide-typecheck/ and this config
   // type-checks them against the engine source (no build required).
   //
-  // `strict` is off so untyped guide parameters (draw(context), update(delta))
-  // do not add noise. The gate reliably catches:
+  // `strict` is off so a guide snippet is not buried under null-checking noise
+  // that has nothing to do with drift, but `noImplicitAny` is ON: TypeScript
+  // never infers an override's parameter types from the base class, so an
+  // unannotated parameter is invisible to every other setting. That one flag is
+  // what gives this gate teeth.
+  //
+  // Note this combination is deliberately NOT a subset of the library's own
+  // config — under it, `[]` and a bare `undefined` become implicit `any`, which
+  // full `strict` does not. Since the paths below map the engine onto its
+  // sources, a plain `tsc -p` would report those in engine and package files.
+  // scripts/typecheck-guides.ts therefore reports only snippet diagnostics; the
+  // library has its own, stricter gate.
+  //
+  // The gate reliably catches:
   //   - removed/renamed exports:  import { MeshShader } → module error
   //   - stale constructor options: new Application({ width }) → excess-property error
   //   - stale TextStyle keys:  { fill: 'white' } → excess-property error
@@ -27,6 +39,7 @@
     "checkJs": true,
     "noEmit": true,
     "strict": false,
+    "noImplicitAny": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
The guide typecheck gate could not catch API drift. Reintroducing a stale `init(loader)` override left `pnpm typecheck:guides` green.

## Why it was toothless

Measured rather than assumed:

- **The fence language was not the cause.** Renaming the extracted snippets from `.js` to `.ts` produced 116 errors, all of them the JavaScript-infers-class-fields-from-`this.x` difference. Zero were engine drift.
- **A `.ts` file does not catch it either.** `class ProbeScene extends Scene { init(loader) { loader.add('x'); } }` compiles clean either way: `Scene.init(_data)` still exists, only the parameter's meaning changed, and an unannotated parameter accepts anything.
- **TypeScript never infers an override's parameter types from the base class.** An untyped parameter is unreachable by any compiler setting.

The operative cause was `noImplicitAny` being off. Annotations are the only thing that can be wrong, and annotations require TypeScript.

## What changed

1. All 326 `js` fences become `ts` — mechanical, no snippet content touched.
2. Parameter annotations and class field declarations across all 12 guide folders, working off a 321-error list.
3. `noImplicitAny: true`, plus a small `scripts/typecheck-guides.ts` that reports only diagnostics inside the extracted snippets.
4. Bare method-body blocks stay inside the gate.

## On scoping the gate

`noImplicitAny` with `strict` off is deliberately **not** a subset of the library's own config — under it a bare `[]` and a bare `undefined` become implicit `any`, which full `strict` does not. Since `tsconfig.guides.json` maps the engine onto its sources, a plain `tsc -p` reported diagnostics in `src/` and `packages/` that build clean under their real config. Acting on those means editing library source to satisfy a documentation check. The gate now reports snippet diagnostics only; the library keeps its own stricter gate.

## Verified by mutation, not by a green run

- Dropping a parameter annotation fails with `TS7006`.
- Reintroducing the original `init(loader)` fails with an override mismatch **and** `TS2339` on `loader.add` — that API is itself long gone.

## Coverage

198 blocks checked, against 196 before this work. Along the way it briefly regressed: four guide pages lost their `this.*` checking because annotating tempted an `import` line above a class-method body, which cannot appear inside a class and made those blocks match neither extraction strategy. Caught by diffing the extraction statistics before and after; invisible in the gate itself.

The 152 context-free excerpts remain unchecked. Closing that means cutting them from real compiled sources via `<SourceSnippet region>`, which is a separate track.