### PR TITLE
feat(input): side-specific modifier channels alongside the aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,20 @@ state, claims, inFlight, background }` — for diagnostics and support bundles.
   `using` type-checks under `es2022` without consumers bumping `lib`/`target`.
 - **`FadeSceneTransitionOptions`** is exported from the root and
   `core/transitions` barrels (previously unnameable by consumers).
+- **Side-specific keyboard modifier channels.** `Keyboard` gains
+  `ShiftLeft`/`ShiftRight`, `ControlLeft`/`ControlRight`, `AltLeft`/`AltRight`,
+  and `MetaLeft`/`MetaRight`, each occupying a previously-unused channel slot
+  — no existing `Keyboard` member's numeric value changes. `Shift`/`Control`/
+  `Alt`/`Meta` remain as aggregate OR-channels, active whenever either
+  physical side is held; releasing one side while the other stays down keeps
+  the aggregate active instead of clearing it. `keyboardChannelFromCode`
+  now resolves a modifier `code` to its side-specific channel rather than
+  the aggregate. `onKeyDown`/`onKeyUp` keep dispatching exactly once per
+  physical key event, carrying the side-specific channel — the aggregate is
+  buffer state an action reads, not a signal of its own. `ChordAction`/
+  `SequenceAction` string patterns gain shorthand aliases: `Ctrl` for
+  `Control`, `Cmd`/`Command`/`Super` for `Meta`, `Opt` for `Alt`, `Esc` for
+  `Escape`.
 
 ### Changed
 

--- a/site/src/content/api/functions.json
+++ b/site/src/content/api/functions.json
@@ -805,7 +805,7 @@
             }
           ],
           "returnType": "Keyboard | undefined",
-          "description": "Resolve a KeyboardEvent.code to its Keyboard channel, or undefined for a key ExoJS does not track (media and IME/language keys, and the empty code a soft keyboard reports). This is the single seam between the platform's physical-key identity and the engine's channel model — see Keyboard for what \"physical\" means here and why keyCode is never used. Useful in a rebinding UI that has a raw DOM event rather than an engine channel; InputManager.onKeyDown already reports the resolved channel."
+          "description": "Resolve a KeyboardEvent.code to its Keyboard channel, or undefined for a key ExoJS does not track (media and IME/language keys, and the empty code a soft keyboard reports). This is the single seam between the platform's physical-key identity and the engine's channel model — see Keyboard for what \"physical\" means here and why keyCode is never used. For a modifier this returns the SIDE-SPECIFIC channel ('ShiftLeft' → Keyboard.ShiftLeft), never the aggregate — InputManager writes the aggregate channel alongside it on every keydown/keyup. Useful in a rebinding UI that has a raw DOM event rather than an engine channel; InputManager.onKeyDown already reports the resolved channel."
         },
         {
           "name": "lerp",

--- a/site/src/content/api/keyboard.json
+++ b/site/src/content/api/keyboard.json
@@ -1,12 +1,12 @@
 {
   "title": "Keyboard",
-  "description": "Channel indices for keyboard keys, addressed by PHYSICAL key position. Pass any value to the Input constructor to react to that key. A key is identified by the Web platform's layout-independent `KeyboardEvent.code` (see keyboardChannelFromCode), not by the layout-dependent `keyCode`: Keyboard.A is the key at the QWERTY \"A\" position on every layout — the one an AZERTY keyboard prints \"Q\" on — so WASD-style bindings stay in the same place under the player's hand regardless of the player's layout. Every member therefore names a POSITION, described by the glyph a US-QWERTY keyboard prints there, and NOT the character the key actually produces: Keyboard.Z is the key a German QWERTZ keyboard prints \"Y\" on, and Keyboard.Colon the key it prints \"ö\" on. Use DOM text input for anything that needs the typed character, dead keys, or IME composition. The values are opaque channel indices inside the keyboard category — do not assume they equal any `keyCode`. Each modifier is ONE channel covering both physical sides: `ShiftLeft` and `ShiftRight` both drive Keyboard.Shift.",
+  "description": "Channel indices for keyboard keys, addressed by PHYSICAL key position. Pass any value to the Input constructor to react to that key. A key is identified by the Web platform's layout-independent `KeyboardEvent.code` (see keyboardChannelFromCode), not by the layout-dependent `keyCode`: Keyboard.A is the key at the QWERTY \"A\" position on every layout — the one an AZERTY keyboard prints \"Q\" on — so WASD-style bindings stay in the same place under the player's hand regardless of the player's layout. Every member therefore names a POSITION, described by the glyph a US-QWERTY keyboard prints there, and NOT the character the key actually produces: Keyboard.Z is the key a German QWERTZ keyboard prints \"Y\" on, and Keyboard.Colon the key it prints \"ö\" on. Use DOM text input for anything that needs the typed character, dead keys, or IME composition. The values are opaque channel indices inside the keyboard category — do not assume they equal any `keyCode`. Each modifier has both a side-specific channel (`ShiftLeft`, `ShiftRight`, `ControlLeft`, `ControlRight`, `AltLeft`, `AltRight`, `MetaLeft`, `MetaRight`) and an aggregate one (`Shift`, `Control`, `Alt`, `Meta`) that is active whenever either side is held — the aggregate is what a game binding wants (\"was Control held\", regardless of which hand), while the side-specific channels exist for a key-press visualizer or a rebinding UI that needs to tell the two physical keys apart. Releasing one side while the other stays held keeps the aggregate active.",
   "symbol": "Keyboard",
   "kind": "enum",
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 105,
+  "memberCount": 113,
   "counts": {
     "constructors": 0,
     "methods": 0,
@@ -23,7 +23,7 @@
         "A key is identified by the Web platform's layout-independent `KeyboardEvent.code` (see keyboardChannelFromCode), not by the layout-dependent `keyCode`: Keyboard.A is the key at the QWERTY \"A\" position on every layout — the one an AZERTY keyboard prints \"Q\" on — so WASD-style bindings stay in the same place under the player's hand regardless of the player's layout.",
         "Every member therefore names a POSITION, described by the glyph a US-QWERTY keyboard prints there, and NOT the character the key actually produces: Keyboard.Z is the key a German QWERTZ keyboard prints \"Y\" on, and Keyboard.Colon the key it prints \"ö\" on. Use DOM text input for anything that needs the typed character, dead keys, or IME composition.",
         "The values are opaque channel indices inside the keyboard category — do not assume they equal any `keyCode`.",
-        "Each modifier is ONE channel covering both physical sides: `ShiftLeft` and `ShiftRight` both drive Keyboard.Shift."
+        "Each modifier has both a side-specific channel (`ShiftLeft`, `ShiftRight`, `ControlLeft`, `ControlRight`, `AltLeft`, `AltRight`, `MetaLeft`, `MetaRight`) and an aggregate one (`Shift`, `Control`, `Alt`, `Meta`) that is active whenever either side is held — the aggregate is what a game binding wants (\"was Control held\", regardless of which hand), while the side-specific channels exist for a key-press visualizer or a rebinding UI that needs to tell the two physical keys apart. Releasing one side while the other stays held keeps the aggregate active."
       ],
       "importLine": "import { Keyboard } from '@codexo/exojs'",
       "sourceLink": null
@@ -51,6 +51,32 @@
           "signatureTokens": [
             {
               "text": "Alt",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "AltLeft",
+          "signature": "AltLeft",
+          "signatureTokens": [
+            {
+              "text": "AltLeft",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "AltRight",
+          "signature": "AltRight",
+          "signatureTokens": [
+            {
+              "text": "AltRight",
               "kind": "name"
             }
           ],
@@ -181,6 +207,32 @@
           "signatureTokens": [
             {
               "text": "Control",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "ControlLeft",
+          "signature": "ControlLeft",
+          "signatureTokens": [
+            {
+              "text": "ControlLeft",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "ControlRight",
+          "signature": "ControlRight",
+          "signatureTokens": [
+            {
+              "text": "ControlRight",
               "kind": "name"
             }
           ],
@@ -709,6 +761,32 @@
           "description": ""
         },
         {
+          "name": "MetaLeft",
+          "signature": "MetaLeft",
+          "signatureTokens": [
+            {
+              "text": "MetaLeft",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "MetaRight",
+          "signature": "MetaRight",
+          "signatureTokens": [
+            {
+              "text": "MetaRight",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
           "name": "N",
           "signature": "N",
           "signatureTokens": [
@@ -1195,6 +1273,32 @@
           "signatureTokens": [
             {
               "text": "Shift",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "ShiftLeft",
+          "signature": "ShiftLeft",
+          "signatureTokens": [
+            {
+              "text": "ShiftLeft",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "ShiftRight",
+          "signature": "ShiftRight",
+          "signatureTokens": [
+            {
+              "text": "ShiftRight",
               "kind": "name"
             }
           ],

--- a/site/src/content/guide/input/chords-and-sequences.mdx
+++ b/site/src/content/guide/input/chords-and-sequences.mdx
@@ -45,7 +45,7 @@ class GameScene extends Scene {
 
 ## Not text or IME input
 
-String patterns resolve case-insensitive `Keyboard` enum names only (`'Control+S'`, `'control+s'`). They are not a text or IME API: they never decode typed characters, dead keys, or composed input, and reject any token that is not a known `Keyboard` member. Use DOM text input outside the game channel system for localized characters, composition, and editable text.
+String patterns resolve case-insensitive `Keyboard` enum names only (`'Control+S'`, `'control+s'`), plus a handful of shorthand aliases (`Ctrl` for `Control`, `Cmd`/`Command`/`Super` for `Meta`, `Opt` for `Alt`, `Esc` for `Escape`) — see [Modifier sides](/ExoJS/en/guide/input/keyboard-and-actions/#modifier-sides). They are not a text or IME API: they never decode typed characters, dead keys, or composed input, and reject any token that is not a known `Keyboard` member or alias. Use DOM text input outside the game channel system for localized characters, composition, and editable text.
 
 Array patterns accept keyboard, pointer, gamepad-button, and gamepad-axis channels directly — mix a chord step of several channels as a nested array: `new SequenceAction([Keyboard.J, Keyboard.J, [Keyboard.Control, Keyboard.K]])`. A repeated single-channel step like the two `Keyboard.J` entries above requires a genuine release between them: holding `J` down after the first step is accepted does not also satisfy the second, since a step only advances on a fresh press (an inactive-to-active transition), never merely because a channel already reads as held. `gamepadSlot` remaps gamepad channels exactly as it does for other actions.
 

--- a/site/src/content/guide/input/keyboard-and-actions.mdx
+++ b/site/src/content/guide/input/keyboard-and-actions.mdx
@@ -141,7 +141,34 @@ Keyboard.F1 .. Keyboard.F12
 Keyboard.NumPad0 .. Keyboard.NumPad9
 ```
 
-The full list includes punctuation, brackets, and navigation keys. Punctuation members carry the glyph a US-QWERTY keyboard prints on that key (`Keyboard.Colon`, `Keyboard.Tilde`, `Keyboard.OpenBracket`, …) — the name is the US legend, the binding is the position, so on a QWERTZ keyboard `Keyboard.Colon` is the key printed "ö". A modifier is one channel per role, not per side: `ShiftLeft` and `ShiftRight` both drive `Keyboard.Shift`. Keys ExoJS does not track (media keys, IME/language keys) drive no channel at all. To resolve a raw DOM event yourself — in a rebinding UI, say — use `keyboardChannelFromCode(event.code)`.
+The full list includes punctuation, brackets, and navigation keys. Punctuation members carry the glyph a US-QWERTY keyboard prints on that key (`Keyboard.Colon`, `Keyboard.Tilde`, `Keyboard.OpenBracket`, …) — the name is the US legend, the binding is the position, so on a QWERTZ keyboard `Keyboard.Colon` is the key printed "ö". Keys ExoJS does not track (media keys, IME/language keys) drive no channel at all. To resolve a raw DOM event yourself — in a rebinding UI, say — use `keyboardChannelFromCode(event.code)`; for a modifier this returns the side-specific channel (see below), never the aggregate.
+
+### Modifier sides
+
+Every modifier exposes both a side-specific channel and an aggregate one:
+
+```
+Keyboard.ShiftLeft    Keyboard.ShiftRight    Keyboard.Shift    (aggregate)
+Keyboard.ControlLeft  Keyboard.ControlRight  Keyboard.Control  (aggregate)
+Keyboard.AltLeft      Keyboard.AltRight      Keyboard.Alt      (aggregate)
+Keyboard.MetaLeft     Keyboard.MetaRight     Keyboard.Meta     (aggregate)
+```
+
+Bind to the aggregate (`Keyboard.Control`) for a normal game binding — it is
+active whenever either physical key is held, and releasing one side while the
+other stays down keeps it active. Bind to a side-specific channel
+(`Keyboard.ControlLeft`) only when you genuinely need to tell the two keys
+apart, such as a key-press visualizer or a rebinding UI. `onKeyDown`/`onKeyUp`
+always report the side-specific channel that was actually pressed — the
+aggregate is buffer state an action reads, not something that fires its own
+signal, so one physical key press is still exactly one `onKeyDown` dispatch.
+
+`ChordAction`/`SequenceAction` string patterns also accept a few shorthand
+aliases for the modifier and `Escape` tokens: `Ctrl` for `Control`, `Cmd` /
+`Command` / `Super` for `Meta`, `Opt` for `Alt`, and `Esc` for `Escape` — so
+`'Ctrl+K'` and `'Control+K'` are equivalent. Aliases are a string-pattern
+convenience only; array bindings always use the `Keyboard` enum member
+directly.
 
 ## Canvas focus
 

--- a/src/input/FocusController.ts
+++ b/src/input/FocusController.ts
@@ -277,7 +277,7 @@ export class FocusController implements FocusHooks {
   }
 
   private _handleKeyDown(channel: number): void {
-    if (channel === Keyboard.Shift) {
+    if (channel === Keyboard.ShiftLeft || channel === Keyboard.ShiftRight) {
       this._shiftDown = true;
     }
 
@@ -301,7 +301,7 @@ export class FocusController implements FocusHooks {
   }
 
   private _handleKeyUp(channel: number): void {
-    if (channel === Keyboard.Shift) {
+    if (channel === Keyboard.ShiftLeft || channel === Keyboard.ShiftRight) {
       this._shiftDown = false;
     }
 

--- a/src/input/InputManager.ts
+++ b/src/input/InputManager.ts
@@ -17,7 +17,7 @@ import { builtInGamepadDefinitions, resolveGamepadDefinition } from './GamepadDe
 import { type GestureJournalEvent, GestureRecognizer } from './GestureRecognizer';
 import type { InputBindingOptions, InputChannel } from './InputBinding';
 import { InputBinding } from './InputBinding';
-import { keyboardChannelFromCode } from './keyboardCodes';
+import { keyboardChannelFromCode, keyboardModifierChannelInfo } from './keyboardCodes';
 import { computeDesignPoint, Pointer, PointerState, PointerStateFlag } from './Pointer';
 import { ChannelOffset, ChannelSize, maxPointers, pointerSlotSize, resolveGamepadSlotChannel } from './types';
 
@@ -765,6 +765,12 @@ export class InputManager {
    * key with no channel of its own (media and IME/language keys, and the empty
    * `code` a soft keyboard reports) is ignored outright rather than writing
    * into an arbitrary slot.
+   *
+   * For a modifier, `channel` is the SIDE-SPECIFIC channel and this also
+   * writes the aggregate channel (`ShiftLeft` -> also sets `Shift`) — see
+   * {@link keyboardModifierChannelInfo}. `keyEvents`/`onKeyDown` only ever see
+   * the side channel: the aggregate is buffer state an action reads, not a
+   * signal of its own, keeping one physical event equal to one dispatch.
    */
   private handleKeyDown(event: KeyboardEvent): void {
     if (!this.canvasFocusedValue) {
@@ -779,15 +785,31 @@ export class InputManager {
 
     this.channels[channel] = 1;
     this._recordChannelChanges(channel, 1);
+
+    const modifier = keyboardModifierChannelInfo(channel);
+    let capturedByAggregate = false;
+
+    if (modifier !== undefined) {
+      this.channels[modifier.aggregate] = 1;
+      this._recordChannelChanges(modifier.aggregate, 1);
+      capturedByAggregate = this.capturedKeyChannels.has(modifier.aggregate);
+    }
+
     this.keyEvents.push({ channel, pressed: true });
     this.flags.push(InputManagerFlag.KeyChange);
 
-    if (this.capturedKeyChannels.has(channel)) {
+    if (capturedByAggregate || this.capturedKeyChannels.has(channel)) {
       stopEvent(event);
     }
   }
 
-  /** Physical-key resolution and unmapped-key handling exactly as in {@link handleKeyDown}. */
+  /**
+   * Physical-key resolution and unmapped-key handling exactly as in
+   * {@link handleKeyDown}. For a modifier, the aggregate channel is set to
+   * the SIBLING side's current value rather than unconditionally cleared —
+   * releasing left `Control` while right `Control` is still held must not
+   * clear {@link Keyboard.Control} — see {@link keyboardModifierChannelInfo}.
+   */
   private handleKeyUp(event: KeyboardEvent): void {
     if (!this.canvasFocusedValue) {
       return;
@@ -801,10 +823,20 @@ export class InputManager {
 
     this.channels[channel] = 0;
     this._recordChannelChanges(channel, 1);
+
+    const modifier = keyboardModifierChannelInfo(channel);
+    let capturedByAggregate = false;
+
+    if (modifier !== undefined) {
+      this.channels[modifier.aggregate] = this.channels[modifier.sibling] ?? 0;
+      this._recordChannelChanges(modifier.aggregate, 1);
+      capturedByAggregate = this.capturedKeyChannels.has(modifier.aggregate);
+    }
+
     this.keyEvents.push({ channel, pressed: false });
     this.flags.push(InputManagerFlag.KeyChange);
 
-    if (this.capturedKeyChannels.has(channel)) {
+    if (capturedByAggregate || this.capturedKeyChannels.has(channel)) {
       stopEvent(event);
     }
   }

--- a/src/input/actions/pattern.ts
+++ b/src/input/actions/pattern.ts
@@ -26,6 +26,25 @@ const keyboardByName = new Map<string, number>(
     .map(([name, value]) => [name.toLowerCase(), value]),
 );
 
+/**
+ * Shorthand aliases for a string pattern token, resolved on top of the
+ * reflexive {@link Keyboard} member table above — `'Ctrl+K'` and
+ * `'Control+K'` are equivalent. Array bindings are unaffected: an alias is a
+ * string-pattern-only convenience, never a second {@link Keyboard} member.
+ */
+const keyboardAliases: ReadonlyArray<readonly [alias: string, canonical: keyof typeof Keyboard]> = [
+  ['ctrl', 'Control'],
+  ['cmd', 'Meta'],
+  ['command', 'Meta'],
+  ['super', 'Meta'],
+  ['opt', 'Alt'],
+  ['esc', 'Escape'],
+];
+
+for (const [alias, canonical] of keyboardAliases) {
+  keyboardByName.set(alias, Keyboard[canonical]);
+}
+
 function resolveToken(token: string, owner: PatternOwner, patternText: string): number {
   const normalized = token
     .trim()

--- a/src/input/keyboardCodes.ts
+++ b/src/input/keyboardCodes.ts
@@ -16,11 +16,14 @@ import { Keyboard } from './types';
  * keyboard prints on it (`'Semicolon'` → {@link Keyboard.Colon}) rather than
  * under a matching name.
  *
- * Both physical sides of a modifier deliberately share one channel
- * (`ShiftLeft`/`ShiftRight` → {@link Keyboard.Shift}); the legacy `OSLeft`/
- * `OSRight` spellings some browsers still emit alias onto
- * {@link Keyboard.Meta}. Codes with no entry here (media keys, IME/language
- * keys, and the empty `code` reported by soft keyboards) drive no channel.
+ * A modifier resolves to its SIDE-SPECIFIC channel here (`'ShiftLeft'` →
+ * {@link Keyboard.ShiftLeft}, not the aggregate {@link Keyboard.Shift}) —
+ * {@link InputManager} derives the aggregate from it via
+ * {@link modifierChannelInfo}. The legacy `OSLeft`/`OSRight` spellings some
+ * browsers still emit alias onto {@link Keyboard.MetaLeft}/
+ * {@link Keyboard.MetaRight}. Codes with no entry here (media keys,
+ * IME/language keys, and the empty `code` reported by soft keyboards) drive
+ * no channel.
  */
 const channelsByCode = new Map<string, Keyboard>([
   // Alphanumeric block.
@@ -87,17 +90,19 @@ const channelsByCode = new Map<string, Keyboard>([
   ['CapsLock', Keyboard.CapsLock],
   ['ContextMenu', Keyboard.ContextMenu],
 
-  // Modifiers — both sides fold onto one channel.
-  ['ShiftLeft', Keyboard.Shift],
-  ['ShiftRight', Keyboard.Shift],
-  ['ControlLeft', Keyboard.Control],
-  ['ControlRight', Keyboard.Control],
-  ['AltLeft', Keyboard.Alt],
-  ['AltRight', Keyboard.Alt],
-  ['MetaLeft', Keyboard.Meta],
-  ['MetaRight', Keyboard.Meta],
-  ['OSLeft', Keyboard.Meta],
-  ['OSRight', Keyboard.Meta],
+  // Modifiers — each side resolves to its own channel; see
+  // `modifierChannelInfo` for how the aggregate channel is derived from it.
+  ['ShiftLeft', Keyboard.ShiftLeft],
+  ['ShiftRight', Keyboard.ShiftRight],
+  ['ControlLeft', Keyboard.ControlLeft],
+  ['ControlRight', Keyboard.ControlRight],
+  ['AltLeft', Keyboard.AltLeft],
+  ['AltRight', Keyboard.AltRight],
+  ['MetaLeft', Keyboard.MetaLeft],
+  ['MetaRight', Keyboard.MetaRight],
+  // Legacy spellings some browsers still emit for the Meta key.
+  ['OSLeft', Keyboard.MetaLeft],
+  ['OSRight', Keyboard.MetaRight],
 
   // Navigation and editing.
   ['ArrowLeft', Keyboard.Left],
@@ -160,6 +165,10 @@ const channelsByCode = new Map<string, Keyboard>([
  * {@link Keyboard} for what "physical" means here and why `keyCode` is never
  * used.
  *
+ * For a modifier this returns the SIDE-SPECIFIC channel (`'ShiftLeft'` →
+ * {@link Keyboard.ShiftLeft}), never the aggregate — {@link InputManager}
+ * writes the aggregate channel alongside it on every keydown/keyup.
+ *
  * Useful in a rebinding UI that has a raw DOM event rather than an engine
  * channel; {@link InputManager.onKeyDown} already reports the resolved channel.
  *
@@ -174,4 +183,46 @@ const channelsByCode = new Map<string, Keyboard>([
  */
 export function keyboardChannelFromCode(code: string): Keyboard | undefined {
   return channelsByCode.get(code);
+}
+
+/**
+ * A modifier's side-specific channel's aggregate and sibling — the two facts
+ * {@link InputManager} needs to keep both channel kinds in sync. `aggregate`
+ * is the OR-channel written alongside a side channel (`ShiftLeft` ->
+ * `Shift`). `sibling` is the other physical side of the same modifier,
+ * consulted on release: the aggregate is set to the sibling's CURRENT value
+ * rather than unconditionally cleared, so releasing left `Control` while
+ * right `Control` is still held leaves {@link Keyboard.Control} active.
+ *
+ * @internal
+ */
+interface ModifierChannelInfo {
+  readonly aggregate: Keyboard;
+  readonly sibling: Keyboard;
+}
+
+/**
+ * Side-specific modifier channel → {@link ModifierChannelInfo}. Every
+ * modifier side channel from {@link channelsByCode} has an entry; every other
+ * channel (non-modifier keys) has none, which is how {@link InputManager}
+ * tells a plain key apart from a modifier side.
+ */
+const modifierChannelInfo = new Map<Keyboard, ModifierChannelInfo>([
+  [Keyboard.ShiftLeft, { aggregate: Keyboard.Shift, sibling: Keyboard.ShiftRight }],
+  [Keyboard.ShiftRight, { aggregate: Keyboard.Shift, sibling: Keyboard.ShiftLeft }],
+  [Keyboard.ControlLeft, { aggregate: Keyboard.Control, sibling: Keyboard.ControlRight }],
+  [Keyboard.ControlRight, { aggregate: Keyboard.Control, sibling: Keyboard.ControlLeft }],
+  [Keyboard.AltLeft, { aggregate: Keyboard.Alt, sibling: Keyboard.AltRight }],
+  [Keyboard.AltRight, { aggregate: Keyboard.Alt, sibling: Keyboard.AltLeft }],
+  [Keyboard.MetaLeft, { aggregate: Keyboard.Meta, sibling: Keyboard.MetaRight }],
+  [Keyboard.MetaRight, { aggregate: Keyboard.Meta, sibling: Keyboard.MetaLeft }],
+]);
+
+/**
+ * Look up `channel`'s {@link ModifierChannelInfo}, or `undefined` when
+ * `channel` is not a side-specific modifier channel (every non-modifier key,
+ * and the aggregate channels themselves). @internal
+ */
+export function keyboardModifierChannelInfo(channel: Keyboard): ModifierChannelInfo | undefined {
+  return modifierChannelInfo.get(channel);
 }

--- a/src/input/types.ts
+++ b/src/input/types.ts
@@ -77,8 +77,14 @@ export enum PointerButton {
  * The values are opaque channel indices inside the keyboard category — do not
  * assume they equal any `keyCode`.
  *
- * Each modifier is ONE channel covering both physical sides: `ShiftLeft` and
- * `ShiftRight` both drive {@link Keyboard.Shift}.
+ * Each modifier has both a side-specific channel (`ShiftLeft`, `ShiftRight`,
+ * `ControlLeft`, `ControlRight`, `AltLeft`, `AltRight`, `MetaLeft`,
+ * `MetaRight`) and an aggregate one (`Shift`, `Control`, `Alt`, `Meta`) that
+ * is active whenever either side is held — the aggregate is what a game
+ * binding wants ("was Control held", regardless of which hand), while the
+ * side-specific channels exist for a key-press visualizer or a rebinding UI
+ * that needs to tell the two physical keys apart. Releasing one side while
+ * the other stays held keeps the aggregate active.
  *
  * @example
  * ```ts
@@ -89,11 +95,26 @@ export enum Keyboard {
   Backspace = ChannelOffset.Keyboard + 8,
   Tab = ChannelOffset.Keyboard + 9,
   Enter = ChannelOffset.Keyboard + 13,
+  /** Aggregate: active while either {@link ShiftLeft} or {@link ShiftRight} is held. */
   Shift = ChannelOffset.Keyboard + 16,
+  /** Aggregate: active while either {@link ControlLeft} or {@link ControlRight} is held. */
   Control = ChannelOffset.Keyboard + 17,
+  /** Aggregate: active while either {@link AltLeft} or {@link AltRight} is held. */
   Alt = ChannelOffset.Keyboard + 18,
   Pause = ChannelOffset.Keyboard + 19,
   CapsLock = ChannelOffset.Keyboard + 20,
+  /** Physical left `Shift` key. Also drives the aggregate {@link Shift} channel. */
+  ShiftLeft = ChannelOffset.Keyboard + 21,
+  /** Physical right `Shift` key. Also drives the aggregate {@link Shift} channel. */
+  ShiftRight = ChannelOffset.Keyboard + 22,
+  /** Physical left `Control` key. Also drives the aggregate {@link Control} channel. */
+  ControlLeft = ChannelOffset.Keyboard + 23,
+  /** Physical right `Control` key. Also drives the aggregate {@link Control} channel. */
+  ControlRight = ChannelOffset.Keyboard + 24,
+  /** Physical left `Alt` key. Also drives the aggregate {@link Alt} channel. */
+  AltLeft = ChannelOffset.Keyboard + 25,
+  /** Physical right `Alt` key. Also drives the aggregate {@link Alt} channel. */
+  AltRight = ChannelOffset.Keyboard + 26,
   Escape = ChannelOffset.Keyboard + 27,
   Space = ChannelOffset.Keyboard + 32,
   PageUp = ChannelOffset.Keyboard + 33,
@@ -144,8 +165,13 @@ export enum Keyboard {
   X = ChannelOffset.Keyboard + 88,
   Y = ChannelOffset.Keyboard + 89,
   Z = ChannelOffset.Keyboard + 90,
+  /** Aggregate: active while either {@link MetaLeft} or {@link MetaRight} is held. */
   Meta = ChannelOffset.Keyboard + 91,
   ContextMenu = ChannelOffset.Keyboard + 93,
+  /** Physical left `Meta`/`Cmd`/`Windows` key. Also drives the aggregate {@link Meta} channel. */
+  MetaLeft = ChannelOffset.Keyboard + 94,
+  /** Physical right `Meta`/`Cmd`/`Windows` key. Also drives the aggregate {@link Meta} channel. */
+  MetaRight = ChannelOffset.Keyboard + 95,
   NumPad0 = ChannelOffset.Keyboard + 96,
   NumPad1 = ChannelOffset.Keyboard + 97,
   NumPad2 = ChannelOffset.Keyboard + 98,

--- a/test/input/action-patterns.test.ts
+++ b/test/input/action-patterns.test.ts
@@ -189,6 +189,23 @@ describe('ChordAction', () => {
   test('rejects an unknown keyboard token with a ChordAction-labeled message', () => {
     expect(() => new ChordAction('Control+Nope')).toThrow(/ChordAction: unknown keyboard token/);
   });
+
+  test.each([
+    ['Ctrl', Keyboard.Control],
+    ['Cmd', Keyboard.Meta],
+    ['Command', Keyboard.Meta],
+    ['Super', Keyboard.Meta],
+    ['Opt', Keyboard.Alt],
+    ['Esc', Keyboard.Escape],
+  ])('alias token %s resolves to the same channel as its canonical spelling', (alias, canonical) => {
+    const driver = createSample();
+    const action = new ChordAction(alias);
+
+    driver.batch(10, [[canonical, 1]]);
+    action._update(driver.sample);
+
+    expect(action.active).toBe(true);
+  });
 });
 
 describe('SequenceAction', () => {

--- a/test/input/focus-controller.test.ts
+++ b/test/input/focus-controller.test.ts
@@ -191,13 +191,32 @@ describe('FocusController', () => {
     onKeyDown.dispatch(Keyboard.Tab);
     expect(focus.focused).toBe(c);
 
-    onKeyDown.dispatch(Keyboard.Shift);
+    // The real InputManager dispatches onKeyDown/onKeyUp with the
+    // side-specific channel only (see Keyboard's own doc comment) — never
+    // the aggregate Shift channel directly — so either physical Shift key
+    // must be recognized here.
+    onKeyDown.dispatch(Keyboard.ShiftRight);
     onKeyDown.dispatch(Keyboard.Tab);
     expect(focus.focused).toBe(b);
 
-    onKeyUp.dispatch(Keyboard.Shift);
+    onKeyUp.dispatch(Keyboard.ShiftRight);
     onKeyDown.dispatch(Keyboard.Tab);
     expect(focus.focused).toBe(c);
+  });
+
+  test('either physical Shift key (left or right) triggers Shift+Tab reverse navigation', () => {
+    const { scene, focus, onKeyDown, onKeyUp } = createFocusApp();
+    const a = focusable();
+    const b = focusable();
+
+    scene.root.addChild(a).addChild(b);
+    focus.focus(b);
+
+    onKeyDown.dispatch(Keyboard.ShiftLeft);
+    onKeyDown.dispatch(Keyboard.Tab);
+    expect(focus.focused).toBe(a);
+
+    onKeyUp.dispatch(Keyboard.ShiftLeft);
   });
 
   test('Tab wraps around the scope', () => {

--- a/test/input/input-manager-events.test.ts
+++ b/test/input/input-manager-events.test.ts
@@ -338,6 +338,26 @@ describe('InputManager — keyboard', () => {
     im.destroy();
   });
 
+  test('a binding captured on the aggregate modifier channel still suppresses the default for a side-key event', () => {
+    const { im, canvas } = createInputManager();
+
+    canvas.dispatchEvent(new FocusEvent('focus'));
+    const binding = im.onStart(Keyboard.Control, () => {});
+
+    const downEvent = new KeyboardEvent('keydown', { code: 'ControlLeft', cancelable: true });
+
+    window.dispatchEvent(downEvent);
+    expect(downEvent.defaultPrevented).toBe(true);
+
+    const upEvent = new KeyboardEvent('keyup', { code: 'ControlLeft', cancelable: true });
+
+    window.dispatchEvent(upEvent);
+    expect(upEvent.defaultPrevented).toBe(true);
+
+    binding.unbind();
+    im.destroy();
+  });
+
   test('ref-counts captured channels: unbinding one of two bindings on the same channel keeps it captured', () => {
     const { im, canvas } = createInputManager();
 

--- a/test/input/keyboard-codes.test.ts
+++ b/test/input/keyboard-codes.test.ts
@@ -63,15 +63,24 @@ describe('keyboardChannelFromCode', () => {
     expect(keyboardChannelFromCode('Enter')).not.toBe(keyboardChannelFromCode('NumpadEnter'));
   });
 
-  test('folds both physical sides of a modifier onto one channel', () => {
-    expect(keyboardChannelFromCode('ShiftLeft')).toBe(Keyboard.Shift);
-    expect(keyboardChannelFromCode('ShiftRight')).toBe(Keyboard.Shift);
-    expect(keyboardChannelFromCode('ControlLeft')).toBe(Keyboard.Control);
-    expect(keyboardChannelFromCode('ControlRight')).toBe(Keyboard.Control);
-    expect(keyboardChannelFromCode('AltLeft')).toBe(Keyboard.Alt);
-    expect(keyboardChannelFromCode('AltRight')).toBe(Keyboard.Alt);
-    expect(keyboardChannelFromCode('MetaLeft')).toBe(Keyboard.Meta);
-    expect(keyboardChannelFromCode('MetaRight')).toBe(Keyboard.Meta);
+  test('resolves each physical side of a modifier to its own side-specific channel', () => {
+    expect(keyboardChannelFromCode('ShiftLeft')).toBe(Keyboard.ShiftLeft);
+    expect(keyboardChannelFromCode('ShiftRight')).toBe(Keyboard.ShiftRight);
+    expect(keyboardChannelFromCode('ControlLeft')).toBe(Keyboard.ControlLeft);
+    expect(keyboardChannelFromCode('ControlRight')).toBe(Keyboard.ControlRight);
+    expect(keyboardChannelFromCode('AltLeft')).toBe(Keyboard.AltLeft);
+    expect(keyboardChannelFromCode('AltRight')).toBe(Keyboard.AltRight);
+    expect(keyboardChannelFromCode('MetaLeft')).toBe(Keyboard.MetaLeft);
+    expect(keyboardChannelFromCode('MetaRight')).toBe(Keyboard.MetaRight);
+
+    // Every side channel is distinct from its aggregate and from its sibling.
+    expect(keyboardChannelFromCode('ShiftLeft')).not.toBe(Keyboard.Shift);
+    expect(keyboardChannelFromCode('ShiftLeft')).not.toBe(keyboardChannelFromCode('ShiftRight'));
+  });
+
+  test('the legacy OSLeft/OSRight spellings alias onto the Meta side channels', () => {
+    expect(keyboardChannelFromCode('OSLeft')).toBe(Keyboard.MetaLeft);
+    expect(keyboardChannelFromCode('OSRight')).toBe(Keyboard.MetaRight);
   });
 
   test('returns undefined for an unmapped or absent code', () => {
@@ -146,7 +155,7 @@ describe('InputManager — layout-independent keyboard channels', () => {
     im.destroy();
   });
 
-  test('both shift keys drive the single Shift channel', () => {
+  test('either shift key drives the aggregate Shift channel', () => {
     const { im } = createFocusedInputManager();
 
     press({ code: 'ShiftRight', key: 'Shift', keyCode: 16 });
@@ -193,5 +202,252 @@ describe('InputManager — layout-independent keyboard channels', () => {
     expect(onKeyDown).toHaveBeenCalledWith(Keyboard.Left);
 
     im.destroy();
+  });
+});
+
+describe('InputManager — modifier side and aggregate channels', () => {
+  test('a modifier keydown writes both its side channel and the aggregate channel', () => {
+    const { im } = createFocusedInputManager();
+
+    press({ code: 'ControlLeft', key: 'Control', keyCode: 17 });
+
+    expect(ch(im, Keyboard.ControlLeft)).toBe(1);
+    expect(ch(im, Keyboard.ControlRight)).toBe(0);
+    expect(ch(im, Keyboard.Control)).toBe(1);
+
+    im.destroy();
+  });
+
+  test('both sides held, one released: the aggregate stays active until the second release', () => {
+    const { im } = createFocusedInputManager();
+
+    press({ code: 'ControlLeft', key: 'Control', keyCode: 17 });
+    press({ code: 'ControlRight', key: 'Control', keyCode: 17 });
+
+    expect(ch(im, Keyboard.Control)).toBe(1);
+
+    release({ code: 'ControlLeft', key: 'Control', keyCode: 17 });
+
+    // Right Control is still held — the aggregate must stay active.
+    expect(ch(im, Keyboard.ControlLeft)).toBe(0);
+    expect(ch(im, Keyboard.ControlRight)).toBe(1);
+    expect(ch(im, Keyboard.Control)).toBe(1);
+
+    release({ code: 'ControlRight', key: 'Control', keyCode: 17 });
+
+    expect(ch(im, Keyboard.Control)).toBe(0);
+
+    im.destroy();
+  });
+
+  test('one physical modifier press produces exactly one onKeyDown dispatch, carrying the side channel', () => {
+    const { im } = createFocusedInputManager();
+    const onKeyDown = vi.fn();
+
+    im.onKeyDown.add(onKeyDown);
+    press({ code: 'AltLeft', key: 'Alt', keyCode: 18 });
+    im.update();
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+    expect(onKeyDown).toHaveBeenCalledWith(Keyboard.AltLeft);
+
+    im.destroy();
+  });
+
+  test('a binding on the aggregate channel activates from either physical side', () => {
+    const { im } = createFocusedInputManager();
+    const onStart = vi.fn();
+
+    im.onStart(Keyboard.Control, onStart);
+
+    press({ code: 'ControlRight', key: 'Control', keyCode: 17 });
+    im.update();
+
+    expect(onStart).toHaveBeenCalledTimes(1);
+
+    im.destroy();
+  });
+
+  test('a binding on one side channel does not activate from the other side', () => {
+    const { im } = createFocusedInputManager();
+    const onStart = vi.fn();
+
+    im.onStart(Keyboard.ControlLeft, onStart);
+
+    press({ code: 'ControlRight', key: 'Control', keyCode: 17 });
+    im.update();
+
+    expect(onStart).not.toHaveBeenCalled();
+
+    im.destroy();
+  });
+
+  test('canvas blur releases both side and aggregate channels together', () => {
+    const { im, canvas } = createFocusedInputManager();
+
+    press({ code: 'ShiftLeft', key: 'Shift', keyCode: 16 });
+
+    expect(ch(im, Keyboard.ShiftLeft)).toBe(1);
+    expect(ch(im, Keyboard.Shift)).toBe(1);
+
+    canvas.dispatchEvent(new FocusEvent('blur'));
+
+    expect(ch(im, Keyboard.ShiftLeft)).toBe(0);
+    expect(ch(im, Keyboard.Shift)).toBe(0);
+
+    im.destroy();
+  });
+});
+
+describe('Keyboard enum stability', () => {
+  // The exact pre-existing member -> value mapping, frozen here as a
+  // regression guard: a serialized numeric binding (a persisted rebinding
+  // profile, say) must keep resolving to the exact same Keyboard member it
+  // always did. New side-specific channels occupy previously-unused slots
+  // only — no existing member's value may ever move.
+  const preexisting: Record<string, number> = {
+    Backspace: 8,
+    Tab: 9,
+    Enter: 13,
+    Shift: 16,
+    Control: 17,
+    Alt: 18,
+    Pause: 19,
+    CapsLock: 20,
+    Escape: 27,
+    Space: 32,
+    PageUp: 33,
+    PageDown: 34,
+    End: 35,
+    Home: 36,
+    Left: 37,
+    Up: 38,
+    Right: 39,
+    Down: 40,
+    PrintScreen: 44,
+    Insert: 45,
+    Delete: 46,
+    Help: 47,
+    Zero: 48,
+    One: 49,
+    Two: 50,
+    Three: 51,
+    Four: 52,
+    Five: 53,
+    Six: 54,
+    Seven: 55,
+    Eight: 56,
+    Nine: 57,
+    A: 65,
+    B: 66,
+    C: 67,
+    D: 68,
+    E: 69,
+    F: 70,
+    G: 71,
+    H: 72,
+    I: 73,
+    J: 74,
+    K: 75,
+    L: 76,
+    M: 77,
+    N: 78,
+    O: 79,
+    P: 80,
+    Q: 81,
+    R: 82,
+    S: 83,
+    T: 84,
+    U: 85,
+    V: 86,
+    W: 87,
+    X: 88,
+    Y: 89,
+    Z: 90,
+    Meta: 91,
+    ContextMenu: 93,
+    NumPad0: 96,
+    NumPad1: 97,
+    NumPad2: 98,
+    NumPad3: 99,
+    NumPad4: 100,
+    NumPad5: 101,
+    NumPad6: 102,
+    NumPad7: 103,
+    NumPad8: 104,
+    NumPad9: 105,
+    NumPadMultiply: 106,
+    NumPadAdd: 107,
+    NumPadEnter: 108,
+    NumPadSubtract: 109,
+    NumPadDecimal: 110,
+    NumPadDivide: 111,
+    F1: 112,
+    F2: 113,
+    F3: 114,
+    F4: 115,
+    F5: 116,
+    F6: 117,
+    F7: 118,
+    F8: 119,
+    F9: 120,
+    F10: 121,
+    F11: 122,
+    F12: 123,
+    NumLock: 144,
+    ScrollLock: 145,
+    NumPadEqual: 146,
+    IntlBackslash: 147,
+    IntlRo: 148,
+    IntlYen: 149,
+    Colon: 186,
+    Equals: 187,
+    Comma: 188,
+    Dash: 189,
+    Period: 190,
+    QuestionMark: 191,
+    Tilde: 192,
+    OpenBracket: 219,
+    BackwardSlash: 220,
+    ClosedBracket: 221,
+    Quotes: 222,
+  };
+
+  test('every pre-existing member still resolves to its exact original numeric channel value', () => {
+    expect(Object.keys(preexisting)).toHaveLength(105);
+
+    for (const [name, value] of Object.entries(preexisting)) {
+      expect((Keyboard as unknown as Record<string, number>)[name]).toBe(value);
+    }
+  });
+
+  test('the new side-specific channels occupy only slots that were unused before this change', () => {
+    const newChannels = {
+      ShiftLeft: Keyboard.ShiftLeft,
+      ShiftRight: Keyboard.ShiftRight,
+      ControlLeft: Keyboard.ControlLeft,
+      ControlRight: Keyboard.ControlRight,
+      AltLeft: Keyboard.AltLeft,
+      AltRight: Keyboard.AltRight,
+      MetaLeft: Keyboard.MetaLeft,
+      MetaRight: Keyboard.MetaRight,
+    };
+    const newValues = Object.values(newChannels);
+    const preexistingValues = new Set(Object.values(preexisting));
+
+    // Every new channel is distinct from every other new channel...
+    expect(new Set(newValues).size).toBe(newValues.length);
+
+    // ...and from every pre-existing channel.
+    for (const value of newValues) {
+      expect(preexistingValues.has(value)).toBe(false);
+    }
+  });
+
+  test('the full enum has exactly 113 members, each with a unique numeric value', () => {
+    const forwardEntries = Object.entries(Keyboard).filter((entry): entry is [string, number] => typeof entry[1] === 'number');
+
+    expect(forwardEntries).toHaveLength(113);
+    expect(new Set(forwardEntries.map(([, value]) => value)).size).toBe(113);
   });
 });

--- a/test/input/pointer-frame-snapshot.test.ts
+++ b/test/input/pointer-frame-snapshot.test.ts
@@ -388,7 +388,7 @@ describe('keyboard dispatch order', () => {
     im.update(0 as never);
 
     expect(seen).toEqual([
-      { channel: Keyboard.Shift, pressed: false },
+      { channel: Keyboard.ShiftLeft, pressed: false },
       { channel: Keyboard.Tab, pressed: true },
     ]);
   });


### PR DESCRIPTION
Both physical sides of a modifier folded onto one channel. That is the right default for a binding — a game wants "Control held", not "the left Control key" — but it left left/right unobservable, which a key-press visualizer or a rebinding UI legitimately needs.

## What changed

Each modifier now has both. `ShiftLeft`, `ShiftRight`, `ControlLeft`, `ControlRight`, `AltLeft`, `AltRight`, `MetaLeft` and `MetaRight` are real channels; `Shift`, `Control`, `Alt` and `Meta` remain as derived OR-channels over their two sides.

`'Control+S'` still binds side-independently. `'ControlLeft+S'` binds one side. Nothing in the existing API changes meaning.

## Purely additive

The eight new members occupy previously unused slots in the keyboard category (21–26, 94–95). **No pre-existing enum value moved**, so serialized numeric bindings stay valid. This is asserted by a test that hardcodes all 105 pre-existing member→value pairs, checks the new values collide with none of them, and pins the enum at 113 uniquely-valued members.

## The subtle parts

**Release.** `handleKeyUp` sets the aggregate to the *other* side's current value rather than a hard `0` — letting go of left Control while right Control is still held must not drop `Keyboard.Control`.

**Signals.** `onKeyDown`/`onKeyUp` dispatch the side channel only, so one physical event stays one signal and the one-batch-per-event atomicity is untouched. The aggregate is buffer state that actions read, mirroring how aggregate gamepad axes already work — they exist as channel state and never as events. `FocusController`'s Shift+Tab detection matches either side accordingly.

**Capture.** `capturedKeyChannels` is tested against the side channel *and* its aggregate, or a binding on `Keyboard.Control` would stop swallowing the browser default.

## Cost

None at runtime. The keyboard category has 256 fixed slots regardless of how many members exist, blur-release already iterates all of them, and the snapshot always copies the full buffer.

## Also

String aliases layered over the reflexive enum token table: `Ctrl`, `Cmd`, `Command`, `Super`, `Opt`, `Esc`. String path only; array bindings unchanged.

## Deliberately not done

Two pre-existing tests changed, both because they encoded the old fold-at-resolution behaviour that this change deliberately alters: `keyboard-codes.test.ts`'s "folds both physical sides onto one channel" and `pointer-frame-snapshot.test.ts`'s Shift/Tab dispatch-order assertion. Aggregate coverage is replaced, not dropped.