### PR TITLE
feat(input): validate ChordAction/SequenceAction patterns at compile time

### DIFF
--- a/site/src/content/api/chord-action.json
+++ b/site/src/content/api/chord-action.json
@@ -1,6 +1,6 @@
 {
   "title": "ChordAction",
-  "description": "Button-like action active while every channel in a chord is held at once — `Control+S`, a modifier held alongside a gamepad button, and so on. Exposes the same `active`/`pressed`/`released`/`value` quartet as ButtonAction, but the aggregate is the weakest of every bound channel instead of the strongest of a set of alternatives: `min(|v|) > threshold` for every bound channel holds if and only if every one of them individually exceeds threshold, so a chord is only ever as \"on\" as its least-engaged member. For an analog chord (a gamepad trigger held alongside a button, say), value reports the trigger's pull limited by whether the button is engaged at all — `0` the instant any member releases, never the button's own binary 0/1. `'|'` alternates between whole chords — `'Control+S|Meta+S'` is active while EITHER modifier is held alongside `S`. This composes the same strongest/weakest reduction one level deeper: each alternative reports its own weakest member as above, and the action reports the strongest of those alternatives, so an analog alternative's `value` still reflects its own least-engaged member rather than collapsing to a plain boolean. A string binding resolves `+`/`|`-joined tokens as case-insensitive Keyboard enum names (`'Control+S'`, `'control+s'`). This is a shortcut list syntax for enum lookups, not text or IME input — it never decodes typed characters, dead keys, or composed input, and rejects any token that is not a known `Keyboard` member. Use an array of InputChannels directly to include pointer or gamepad channels, or for a sequence with more than one step, use SequenceAction.",
+  "description": "Button-like action active while every channel in a chord is held at once — `Control+S`, a modifier held alongside a gamepad button, and so on. Exposes the same `active`/`pressed`/`released`/`value` quartet as ButtonAction, but the aggregate is the weakest of every bound channel instead of the strongest of a set of alternatives: `min(|v|) > threshold` for every bound channel holds if and only if every one of them individually exceeds threshold, so a chord is only ever as \"on\" as its least-engaged member. For an analog chord (a gamepad trigger held alongside a button, say), value reports the trigger's pull limited by whether the button is engaged at all — `0` the instant any member releases, never the button's own binary 0/1. `'|'` alternates between whole chords — `'Control+S|Meta+S'` is active while EITHER modifier is held alongside `S`. This composes the same strongest/weakest reduction one level deeper: each alternative reports its own weakest member as above, and the action reports the strongest of those alternatives, so an analog alternative's `value` still reflects its own least-engaged member rather than collapsing to a plain boolean. A string binding resolves `+`/`|`-joined tokens as case-insensitive Keyboard enum names (`'Control+S'`, `'control+s'`). This is a shortcut list syntax for enum lookups, not text or IME input — it never decodes typed characters, dead keys, or composed input, and rejects any token that is not a known `Keyboard` member. Use an array of InputChannels directly to include pointer or gamepad channels, or for a sequence with more than one step, use SequenceAction. A string LITERAL is additionally checked at compile time, so a typo (`'Ctrl+Sv'`), a stray separator (`'A++B'`) or a `'>'` that belongs to SequenceAction is a type error naming the reason rather than a throw on the first frame that constructs the action. A pattern that is only known at runtime — read from a config file, assembled from parts, or passed in from JavaScript — types as plain `string` and is checked by the parser alone, exactly as before.",
   "symbol": "ChordAction",
   "kind": "class",
   "subsystem": "input",
@@ -21,7 +21,8 @@
       "paragraphs": [
         "Button-like action active while every channel in a chord is held at once — `Control+S`, a modifier held alongside a gamepad button, and so on. Exposes the same `active`/`pressed`/`released`/`value` quartet as ButtonAction, but the aggregate is the weakest of every bound channel instead of the strongest of a set of alternatives: `min(|v|) > threshold` for every bound channel holds if and only if every one of them individually exceeds threshold, so a chord is only ever as \"on\" as its least-engaged member. For an analog chord (a gamepad trigger held alongside a button, say), value reports the trigger's pull limited by whether the button is engaged at all — `0` the instant any member releases, never the button's own binary 0/1.",
         "`'|'` alternates between whole chords — `'Control+S|Meta+S'` is active while EITHER modifier is held alongside `S`. This composes the same strongest/weakest reduction one level deeper: each alternative reports its own weakest member as above, and the action reports the strongest of those alternatives, so an analog alternative's `value` still reflects its own least-engaged member rather than collapsing to a plain boolean.",
-        "A string binding resolves `+`/`|`-joined tokens as case-insensitive Keyboard enum names (`'Control+S'`, `'control+s'`). This is a shortcut list syntax for enum lookups, not text or IME input — it never decodes typed characters, dead keys, or composed input, and rejects any token that is not a known `Keyboard` member. Use an array of InputChannels directly to include pointer or gamepad channels, or for a sequence with more than one step, use SequenceAction."
+        "A string binding resolves `+`/`|`-joined tokens as case-insensitive Keyboard enum names (`'Control+S'`, `'control+s'`). This is a shortcut list syntax for enum lookups, not text or IME input — it never decodes typed characters, dead keys, or composed input, and rejects any token that is not a known `Keyboard` member. Use an array of InputChannels directly to include pointer or gamepad channels, or for a sequence with more than one step, use SequenceAction.",
+        "A string LITERAL is additionally checked at compile time, so a typo (`'Ctrl+Sv'`), a stray separator (`'A++B'`) or a `'>'` that belongs to SequenceAction is a type error naming the reason rather than a throw on the first frame that constructs the action. A pattern that is only known at runtime — read from a config file, assembled from parts, or passed in from JavaScript — types as plain `string` and is checked by the parser alone, exactly as before."
       ],
       "importLine": "import { ChordAction } from '@codexo/exojs'",
       "sourceLink": null
@@ -32,7 +33,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(binding: ChordBinding, options: ActionOptions): ChordAction",
+          "signature": "new(binding: ValidatedChordBinding<Binding>, options: ActionOptions): ChordAction<Binding>",
           "signatureTokens": [
             {
               "text": "new",
@@ -51,8 +52,20 @@
               "kind": "punctuation"
             },
             {
-              "text": "ChordBinding",
+              "text": "ValidatedChordBinding",
               "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Binding",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
             },
             {
               "text": ", ",
@@ -81,12 +94,24 @@
             {
               "text": "ChordAction",
               "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Binding",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
             }
           ],
           "params": [
             {
               "name": "binding",
-              "type": "ChordBinding",
+              "type": "ValidatedChordBinding<Binding>",
               "optional": false
             },
             {
@@ -95,7 +120,7 @@
               "optional": false
             }
           ],
-          "returnType": "ChordAction",
+          "returnType": "ChordAction<Binding>",
           "description": ""
         }
       ],

--- a/site/src/content/api/sequence-action.json
+++ b/site/src/content/api/sequence-action.json
@@ -1,6 +1,6 @@
 {
   "title": "SequenceAction",
-  "description": "Ordered input pattern — `+` joins a chord within one step, `|` alternates between whole alternatives within one step (any ONE of which satisfies it), `>` advances to the next step. `triggered` is `true` for the one frame the final step completes; see progress's own doc comment for how far a pattern has advanced. Precedence, loosest to tightest: `'>'` separates steps, `'|'` separates alternatives within one step, `'+'` joins channels required simultaneously within one alternative — `'A+B|C>D'` is \"(A and B) or C, then D\". A step with no `'|'` has exactly one alternative, so this is a strict superset of the pre-`'|'` grammar: nothing about a plain `'+'`/`'>'` pattern changes. A repeated single-channel step (`'A>A'`) requires a genuine release between the two presses: holding the channel down after the first accepted step never re-satisfies the second on its own, since a step only advances on a channel's rising (inactive-to-active) edge, not merely because it reads active — see `_update`'s implementation. A single atomic ChannelEventBatch never invents an order: two channels written together by the same real-world event (e.g. `A` and `B` both changing in one batch) can complete a chord STEP together, but can never be read as two sequential steps (`A` then `B`) within that same batch — see `_update`'s implementation comment. Switching from one alternative to another within the same step is never treated as an unrelated, mismatching entry — only a channel that belongs to NONE of the step's alternatives is. A string pattern resolves tokens as case-insensitive Keyboard enum names (`'Down>Down+Right>Right>A'`). This is a shortcut list syntax for enum lookups, not text or IME input — it never decodes typed characters, dead keys, or composed input, and rejects any token that is not a known `Keyboard` member. Use an InputSequence array of channels/chords/ alternations directly to include pointer or gamepad channels.",
+  "description": "Ordered input pattern — `+` joins a chord within one step, `|` alternates between whole alternatives within one step (any ONE of which satisfies it), `>` advances to the next step. `triggered` is `true` for the one frame the final step completes; see progress's own doc comment for how far a pattern has advanced. Precedence, loosest to tightest: `'>'` separates steps, `'|'` separates alternatives within one step, `'+'` joins channels required simultaneously within one alternative — `'A+B|C>D'` is \"(A and B) or C, then D\". A step with no `'|'` has exactly one alternative, so this is a strict superset of the pre-`'|'` grammar: nothing about a plain `'+'`/`'>'` pattern changes. A repeated single-channel step (`'A>A'`) requires a genuine release between the two presses: holding the channel down after the first accepted step never re-satisfies the second on its own, since a step only advances on a channel's rising (inactive-to-active) edge, not merely because it reads active — see `_update`'s implementation. A single atomic ChannelEventBatch never invents an order: two channels written together by the same real-world event (e.g. `A` and `B` both changing in one batch) can complete a chord STEP together, but can never be read as two sequential steps (`A` then `B`) within that same batch — see `_update`'s implementation comment. Switching from one alternative to another within the same step is never treated as an unrelated, mismatching entry — only a channel that belongs to NONE of the step's alternatives is. A string pattern resolves tokens as case-insensitive Keyboard enum names (`'Down>Down+Right>Right>A'`). This is a shortcut list syntax for enum lookups, not text or IME input — it never decodes typed characters, dead keys, or composed input, and rejects any token that is not a known `Keyboard` member. Use an InputSequence array of channels/chords/ alternations directly to include pointer or gamepad channels. A string LITERAL is additionally checked at compile time, so a typo (`'Up>Up>Dwon'`) or a stray separator (`'A>>B'`) is a type error naming the reason rather than a throw on the first frame that constructs the action. A pattern that is only known at runtime — read from a config file, assembled from parts, or passed in from JavaScript — types as plain `string` and is checked by the parser alone, exactly as before.",
   "symbol": "SequenceAction",
   "kind": "class",
   "subsystem": "input",
@@ -23,7 +23,8 @@
         "Precedence, loosest to tightest: `'>'` separates steps, `'|'` separates alternatives within one step, `'+'` joins channels required simultaneously within one alternative — `'A+B|C>D'` is \"(A and B) or C, then D\". A step with no `'|'` has exactly one alternative, so this is a strict superset of the pre-`'|'` grammar: nothing about a plain `'+'`/`'>'` pattern changes.",
         "A repeated single-channel step (`'A>A'`) requires a genuine release between the two presses: holding the channel down after the first accepted step never re-satisfies the second on its own, since a step only advances on a channel's rising (inactive-to-active) edge, not merely because it reads active — see `_update`'s implementation.",
         "A single atomic ChannelEventBatch never invents an order: two channels written together by the same real-world event (e.g. `A` and `B` both changing in one batch) can complete a chord STEP together, but can never be read as two sequential steps (`A` then `B`) within that same batch — see `_update`'s implementation comment. Switching from one alternative to another within the same step is never treated as an unrelated, mismatching entry — only a channel that belongs to NONE of the step's alternatives is.",
-        "A string pattern resolves tokens as case-insensitive Keyboard enum names (`'Down>Down+Right>Right>A'`). This is a shortcut list syntax for enum lookups, not text or IME input — it never decodes typed characters, dead keys, or composed input, and rejects any token that is not a known `Keyboard` member. Use an InputSequence array of channels/chords/ alternations directly to include pointer or gamepad channels."
+        "A string pattern resolves tokens as case-insensitive Keyboard enum names (`'Down>Down+Right>Right>A'`). This is a shortcut list syntax for enum lookups, not text or IME input — it never decodes typed characters, dead keys, or composed input, and rejects any token that is not a known `Keyboard` member. Use an InputSequence array of channels/chords/ alternations directly to include pointer or gamepad channels.",
+        "A string LITERAL is additionally checked at compile time, so a typo (`'Up>Up>Dwon'`) or a stray separator (`'A>>B'`) is a type error naming the reason rather than a throw on the first frame that constructs the action. A pattern that is only known at runtime — read from a config file, assembled from parts, or passed in from JavaScript — types as plain `string` and is checked by the parser alone, exactly as before."
       ],
       "importLine": "import { SequenceAction } from '@codexo/exojs'",
       "sourceLink": null
@@ -34,7 +35,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(pattern: SequenceBinding, options: SequenceActionOptions): SequenceAction",
+          "signature": "new(pattern: ValidatedSequenceBinding<Pattern>, options: SequenceActionOptions): SequenceAction<Pattern>",
           "signatureTokens": [
             {
               "text": "new",
@@ -53,8 +54,20 @@
               "kind": "punctuation"
             },
             {
-              "text": "SequenceBinding",
+              "text": "ValidatedSequenceBinding",
               "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Pattern",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
             },
             {
               "text": ", ",
@@ -83,12 +96,24 @@
             {
               "text": "SequenceAction",
               "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Pattern",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
             }
           ],
           "params": [
             {
               "name": "pattern",
-              "type": "SequenceBinding",
+              "type": "ValidatedSequenceBinding<Pattern>",
               "optional": false
             },
             {
@@ -97,7 +122,7 @@
               "optional": false
             }
           ],
-          "returnType": "SequenceAction",
+          "returnType": "SequenceAction<Pattern>",
           "description": ""
         }
       ],

--- a/site/src/content/api/validated-chord-binding.json
+++ b/site/src/content/api/validated-chord-binding.json
@@ -1,0 +1,160 @@
+{
+  "title": "ValidatedChordBinding",
+  "description": "A ChordAction binding, checked at compile time when it is a string LITERAL. A valid pattern types as itself, an invalid one as the message explaining why — so `new ChordAction('Ctrl+Sv')` fails to compile with `Argument of type '\"Ctrl+Sv\"' is not assignable to parameter of type '\"ChordAction: unknown keyboard token \\\"Sv\\\" …\"'`. A plain `string` (a pattern read from a config file, built at runtime, or handed over from JavaScript) bails out and passes through untouched: only the parser above can judge it, and it still does. Array bindings pass through untouched as well, constrained by `ChordAction`'s own type parameter.",
+  "symbol": "ValidatedChordBinding",
+  "kind": "type",
+  "subsystem": "input",
+  "importPath": "@codexo/exojs",
+  "tier": "stable",
+  "memberCount": 0,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 0,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "A ChordAction binding, checked at compile time when it is a string LITERAL. A valid pattern types as itself, an invalid one as the message explaining why — so `new ChordAction('Ctrl+Sv')` fails to compile with `Argument of type '\"Ctrl+Sv\"' is not assignable to parameter of type '\"ChordAction: unknown keyboard token \\\"Sv\\\" …\"'`.",
+        "A plain `string` (a pattern read from a config file, built at runtime, or handed over from JavaScript) bails out and passes through untouched: only the parser above can judge it, and it still does. Array bindings pass through untouched as well, constrained by `ChordAction`'s own type parameter."
+      ],
+      "importLine": "import { ValidatedChordBinding } from '@codexo/exojs'",
+      "sourceLink": null
+    },
+    {
+      "id": "definition",
+      "title": "Definition",
+      "members": [
+        {
+          "name": "ValidatedChordBinding",
+          "signature": "P extends string ? string extends P ? P : OrPatternError<P, ChordTextError<P>> : P",
+          "signatureTokens": [
+            {
+              "text": "P",
+              "kind": "type"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "extends",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": " ? ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "extends",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "P",
+              "kind": "type"
+            },
+            {
+              "text": " ? ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "P",
+              "kind": "type"
+            },
+            {
+              "text": " : ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "OrPatternError",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "P",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ChordTextError",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "P",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": " : ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "P",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/input/actions/pattern.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/input/actions/pattern.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/input/actions/pattern.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/input/actions/pattern.ts"
+}

--- a/site/src/content/api/validated-sequence-binding.json
+++ b/site/src/content/api/validated-sequence-binding.json
@@ -1,0 +1,167 @@
+{
+  "title": "ValidatedSequenceBinding",
+  "description": "ValidatedChordBinding for SequenceAction, which allows `'>'` and therefore more than one step.",
+  "symbol": "ValidatedSequenceBinding",
+  "kind": "type",
+  "subsystem": "input",
+  "importPath": "@codexo/exojs",
+  "tier": "stable",
+  "memberCount": 0,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 0,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "ValidatedChordBinding for SequenceAction, which allows `'>'` and therefore more than one step."
+      ],
+      "importLine": "import { ValidatedSequenceBinding } from '@codexo/exojs'",
+      "sourceLink": null
+    },
+    {
+      "id": "definition",
+      "title": "Definition",
+      "members": [
+        {
+          "name": "ValidatedSequenceBinding",
+          "signature": "P extends string ? string extends P ? P : OrPatternError<P, PatternTextError<P, \"SequenceAction\">> : P",
+          "signatureTokens": [
+            {
+              "text": "P",
+              "kind": "type"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "extends",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": " ? ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "extends",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "P",
+              "kind": "type"
+            },
+            {
+              "text": " ? ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "P",
+              "kind": "type"
+            },
+            {
+              "text": " : ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "OrPatternError",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "P",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "PatternTextError",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "P",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"SequenceAction\"",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": " : ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "P",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/input/actions/pattern.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/input/actions/pattern.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/input/actions/pattern.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/input/actions/pattern.ts"
+}

--- a/src/input/actions/ChordAction.ts
+++ b/src/input/actions/ChordAction.ts
@@ -1,5 +1,5 @@
 import { ButtonLikeAction } from './ButtonLikeAction';
-import { type InputAlternation, type InputChord, normalizeSequence } from './pattern';
+import { type InputAlternation, type InputChord, normalizeSequence, type ValidatedChordBinding } from './pattern';
 import type { ActionOptions } from './types';
 
 /**
@@ -57,13 +57,21 @@ function weakestAt(values: Float32Array, indices: readonly number[]): number {
  * {@link InputChannel}s directly to include pointer or gamepad channels, or
  * for a sequence with more than one step, use {@link SequenceAction}.
  *
+ * A string LITERAL is additionally checked at compile time, so a typo
+ * (`'Ctrl+Sv'`), a stray separator (`'A++B'`) or a `'>'` that belongs to
+ * {@link SequenceAction} is a type error naming the reason rather than a throw
+ * on the first frame that constructs the action. A pattern that is only known
+ * at runtime — read from a config file, assembled from parts, or passed in
+ * from JavaScript — types as plain `string` and is checked by the parser
+ * alone, exactly as before.
+ *
  * @example
  * ```ts
  * const save = new ChordAction('Control+S|Meta+S');
  * const swap = new ChordAction([GamepadButton.LeftShoulder, GamepadButton.RightShoulder]);
  * ```
  */
-export class ChordAction extends ButtonLikeAction {
+export class ChordAction<const Binding extends ChordBinding = ChordBinding> extends ButtonLikeAction {
   /** One entry per alternative; each lists that alternative's channels as indices into {@link ButtonLikeAction._values}. */
   private readonly _alternativeIndices: ReadonlyArray<readonly number[]>;
 
@@ -71,9 +79,11 @@ export class ChordAction extends ButtonLikeAction {
    * @throws {Error} If a string binding contains a `>` step separator (use
    * {@link SequenceAction}), an unknown `Keyboard` token, an empty `+`/`|`
    * segment, a mix of a bare channel and a nested alternative within the
-   * same binding, or the same channel twice within one alternative.
+   * same binding, or the same channel twice within one alternative. A string
+   * literal is rejected at compile time for the same reasons — see
+   * {@link ValidatedChordBinding}.
    */
-  public constructor(binding: ChordBinding, options: ActionOptions = {}) {
+  public constructor(binding: ValidatedChordBinding<Binding>, options: ActionOptions = {}) {
     const steps = normalizeSequence(typeof binding === 'string' ? binding : [binding], options.gamepadSlot ?? 0, 'ChordAction');
 
     if (steps.length !== 1) {

--- a/src/input/actions/SequenceAction.ts
+++ b/src/input/actions/SequenceAction.ts
@@ -1,4 +1,4 @@
-import { type InputSequence, type NormalizedStep, normalizeSequence } from './pattern';
+import { type InputSequence, type NormalizedStep, normalizeSequence, type ValidatedSequenceBinding } from './pattern';
 import type { ActionOptions, ActionSample } from './types';
 
 /**
@@ -58,6 +58,13 @@ export interface SequenceActionOptions extends ActionOptions {
  * `Keyboard` member. Use an {@link InputSequence} array of channels/chords/
  * alternations directly to include pointer or gamepad channels.
  *
+ * A string LITERAL is additionally checked at compile time, so a typo
+ * (`'Up>Up>Dwon'`) or a stray separator (`'A>>B'`) is a type error naming the
+ * reason rather than a throw on the first frame that constructs the action. A
+ * pattern that is only known at runtime — read from a config file, assembled
+ * from parts, or passed in from JavaScript — types as plain `string` and is
+ * checked by the parser alone, exactly as before.
+ *
  * @example
  * ```ts
  * const konami = new SequenceAction('Up>Up>Down>Down>Left>Right>Left>Right>B>A', { maxGap: 800 });
@@ -68,7 +75,7 @@ export interface SequenceActionOptions extends ActionOptions {
  * const save = new SequenceAction('Control+K|Meta+K>S');
  * ```
  */
-export class SequenceAction {
+export class SequenceAction<const Pattern extends SequenceBinding = SequenceBinding> {
   /** One entry per step; each is one entry per alternative, each the channels that alternative requires together. */
   private readonly _steps: readonly NormalizedStep[];
   /** One entry per step — every channel across all of that step's alternatives, flattened and deduplicated, for "does this batch touch this step at all" checks. */
@@ -89,9 +96,11 @@ export class SequenceAction {
    * @throws {Error} If the pattern is empty, a string pattern contains an
    * unknown `Keyboard` token or an empty `+`/`>`/`|` segment, a mix of a bare
    * channel and a nested alternative within the same step, or any single
-   * alternative repeats the same channel twice.
+   * alternative repeats the same channel twice. A string literal is rejected
+   * at compile time for the same reasons — see
+   * {@link ValidatedSequenceBinding}.
    */
-  public constructor(pattern: SequenceBinding, options: SequenceActionOptions = {}) {
+  public constructor(pattern: ValidatedSequenceBinding<Pattern>, options: SequenceActionOptions = {}) {
     this._steps = normalizeSequence(pattern, options.gamepadSlot ?? 0, 'SequenceAction');
     this._stepChannels = this._steps.map(step => [...new Set(step.flat())]);
     this._channels = [...new Set(this._stepChannels.flat())];

--- a/src/input/actions/index.ts
+++ b/src/input/actions/index.ts
@@ -6,7 +6,7 @@ export { ButtonAction } from './ButtonAction';
 export { ButtonLikeAction } from './ButtonLikeAction';
 export type { ChordBinding } from './ChordAction';
 export { ChordAction } from './ChordAction';
-export type { InputAlternation, InputChord, InputSequence } from './pattern';
+export type { InputAlternation, InputChord, InputSequence, ValidatedChordBinding, ValidatedSequenceBinding } from './pattern';
 export type { SequenceActionOptions, SequenceBinding } from './SequenceAction';
 export { SequenceAction } from './SequenceAction';
 export type { ActionOptions, AtLeastOne, OneOrMany } from './types';

--- a/src/input/actions/pattern.ts
+++ b/src/input/actions/pattern.ts
@@ -59,14 +59,14 @@ const keyboardByName = new Map<string, number>(
  * `'Control+K'` are equivalent. Array bindings are unaffected: an alias is a
  * string-pattern-only convenience, never a second {@link Keyboard} member.
  */
-const keyboardAliases: ReadonlyArray<readonly [alias: string, canonical: keyof typeof Keyboard]> = [
+const keyboardAliases = [
   ['ctrl', 'Control'],
   ['cmd', 'Meta'],
   ['command', 'Meta'],
   ['super', 'Meta'],
   ['opt', 'Alt'],
   ['esc', 'Escape'],
-];
+] as const satisfies ReadonlyArray<readonly [alias: string, canonical: keyof typeof Keyboard]>;
 
 for (const [alias, canonical] of keyboardAliases) {
   keyboardByName.set(alias, Keyboard[canonical]);
@@ -203,3 +203,215 @@ export function normalizeSequence(input: string | InputSequence, gamepadSlot: 0 
 
   return rawSteps.map((step, index) => normalizeStep(step, index, chord, gamepadSlot, owner));
 }
+
+/*
+ * Type-level mirror of the string parser above.
+ *
+ * Everything below is a compile-time SECOND opinion, never a replacement: it
+ * only ever sees string LITERALS, so a pattern read from a config file, built
+ * at runtime, or passed from JavaScript still reaches the parser above and
+ * still throws the same errors. The two layers are kept in step by deriving
+ * from the same sources — the `Keyboard` enum itself and the one
+ * `keyboardAliases` table — and by wording each rejection like the runtime
+ * message it stands for, so a compile error and the throw it prevents read
+ * the same.
+ *
+ * The recursion is bounded by the pattern's `'>'` step count, not by its
+ * token count: forty steps of three tokens each still validate, while a
+ * pattern of roughly a hundred steps exhausts the compiler's instantiation
+ * depth (TS2589). A pattern that long is not a keyboard shortcut, and it is
+ * still parsed and validated at runtime — but if one is ever needed, widening
+ * it to `string` (or reaching for the array form) sidesteps this layer
+ * entirely.
+ */
+
+/** Whitespace `String.prototype.trim` strips, for {@link PatternTrim}. */
+type PatternWhitespace = ' ' | '\t' | '\n' | '\r' | '\f' | '\v';
+
+type PatternTrimStart<S extends string> = S extends `${PatternWhitespace}${infer Rest}` ? PatternTrimStart<Rest> : S;
+type PatternTrimEnd<S extends string> = S extends `${infer Rest}${PatternWhitespace}` ? PatternTrimEnd<Rest> : S;
+
+/**
+ * Type-level `String.prototype.trim`, mirroring the `.trim()` calls in
+ * `normalizeSequence`/`parseStepText`/`resolveToken` — `' Control + A '` must
+ * validate exactly like `'Control+A'`.
+ */
+type PatternTrim<S extends string> = PatternTrimEnd<PatternTrimStart<S>>;
+
+/**
+ * Alias name to the canonical lowercase {@link Keyboard} member name it stands
+ * for, derived from the one runtime {@link keyboardAliases} table so the two
+ * can never drift apart.
+ */
+type KeyboardAliasMap = { [Entry in (typeof keyboardAliases)[number] as Entry[0]]: Lowercase<Entry[1]> };
+
+/** Every lowercase name `resolveToken`'s lookup map holds: the reflexive {@link Keyboard} members plus the aliases. */
+type KeyboardTokenName = Lowercase<keyof typeof Keyboard> | keyof KeyboardAliasMap;
+
+/** One token reduced to `resolveToken`'s lookup key: trimmed, lowercased, optional `Keyboard.` prefix stripped. */
+type TokenLookupKey<S extends string> = Lowercase<PatternTrim<S>> extends `keyboard.${infer Rest}` ? Rest : Lowercase<PatternTrim<S>>;
+
+/**
+ * {@link TokenLookupKey} with an alias folded onto the member it resolves to,
+ * so `'ctrl'` and `'Control'` compare equal — the type-level stand-in for
+ * comparing the resolved channel NUMBERS, which is what `normalizeStep`'s
+ * duplicate check actually does. Sound because no two {@link Keyboard} members
+ * share a channel, so equal channels and equal canonical names coincide.
+ */
+type CanonicalToken<S extends string> = TokenLookupKey<S> extends infer Key extends keyof KeyboardAliasMap ? KeyboardAliasMap[Key] : TokenLookupKey<S>;
+
+/** The first of two checks that found something, or `never` when neither did. Encodes the runtime's left-to-right, throw-on-first-problem order. */
+type FirstPatternError<First, Second> = [First] extends [never] ? Second : First;
+
+/** `resolveToken`'s rejection. */
+type CheckToken<Token extends string, Pattern extends string, Owner extends PatternOwner> =
+  CanonicalToken<Token> extends KeyboardTokenName
+    ? never
+    : `${Owner}: unknown keyboard token "${PatternTrim<Token>}" in pattern "${Pattern}". Use a Keyboard enum name or pass numeric channels.`;
+
+/** `parseStepText`'s empty-`'+'`-segment rejection, for one token. */
+type CheckEmptyToken<Token extends string, Pattern extends string, Owner extends PatternOwner, Where extends string> =
+  PatternTrim<Token> extends '' ? `${Owner}: ${Where} of pattern "${Pattern}" contains an empty token.` : never;
+
+/** {@link CheckEmptyToken} across one alternative's `'+'`-joined tokens — a whole pass of its own, because the runtime checks every token for emptiness before resolving any of them. */
+type CheckEmptyTokens<
+  Rest extends string,
+  Pattern extends string,
+  Owner extends PatternOwner,
+  Where extends string,
+> = Rest extends `${infer Head}+${infer Tail}`
+  ? FirstPatternError<CheckEmptyToken<Head, Pattern, Owner, Where>, CheckEmptyTokens<Tail, Pattern, Owner, Where>>
+  : CheckEmptyToken<Rest, Pattern, Owner, Where>;
+
+/** {@link CheckToken} across one alternative's `'+'`-joined tokens. */
+type CheckTokens<Rest extends string, Pattern extends string, Owner extends PatternOwner> = Rest extends `${infer Head}+${infer Tail}`
+  ? FirstPatternError<CheckToken<Head, Pattern, Owner>, CheckTokens<Tail, Pattern, Owner>>
+  : CheckToken<Rest, Pattern, Owner>;
+
+/** One `'+'`-joined alternative: empty tokens first, then unknown ones, matching `parseStepText`. */
+type CheckAlternative<Text extends string, Pattern extends string, Owner extends PatternOwner, Where extends string> = FirstPatternError<
+  CheckEmptyTokens<Text, Pattern, Owner, Where>,
+  CheckTokens<Text, Pattern, Owner>
+>;
+
+/** One alternative of a step that DOES contain `'|'`, where an empty alternative is its own error rather than an empty token. */
+type CheckNamedAlternative<Text extends string, Pattern extends string, Owner extends PatternOwner, Where extends string> =
+  PatternTrim<Text> extends '' ? `${Owner}: ${Where} of pattern "${Pattern}" is empty — remove the stray '|'.` : CheckAlternative<Text, Pattern, Owner, Where>;
+
+/** Position label for the n-th `'|'`-separated alternative of a step, worded like `parseStepText`'s `location`. */
+type AlternativeWhere<Where extends string, Index extends readonly unknown[]> = `alternative ${[...Index, unknown]['length']} of ${Where}`;
+
+/** {@link CheckNamedAlternative} across a step's `'|'`-separated alternatives. */
+type CheckAlternatives<
+  Rest extends string,
+  Pattern extends string,
+  Owner extends PatternOwner,
+  Where extends string,
+  Index extends readonly unknown[],
+> = Rest extends `${infer Head}|${infer Tail}`
+  ? FirstPatternError<
+      CheckNamedAlternative<Head, Pattern, Owner, AlternativeWhere<Where, Index>>,
+      CheckAlternatives<Tail, Pattern, Owner, Where, [...Index, unknown]>
+    >
+  : CheckNamedAlternative<Rest, Pattern, Owner, AlternativeWhere<Where, Index>>;
+
+/** One `'>'`-separated step. A step with no `'|'` is one implicit alternative and is never described as one, exactly as `parseStepText` words it. */
+type CheckStep<Step extends string, Pattern extends string, Owner extends PatternOwner, Where extends string> = Step extends `${string}|${string}`
+  ? CheckAlternatives<Step, Pattern, Owner, Where, []>
+  : CheckAlternative<Step, Pattern, Owner, Where>;
+
+/** Position label for the n-th step — a {@link ChordAction} has no user-facing notion of "step N", only "the chord". */
+type StepWhere<Owner extends PatternOwner, Index extends readonly unknown[]> = Owner extends 'ChordAction'
+  ? 'the chord'
+  : `step ${[...Index, unknown]['length']}`;
+
+/** {@link CheckStep} across a pattern's `'>'`-separated steps. */
+type CheckSteps<
+  Rest extends string,
+  Pattern extends string,
+  Owner extends PatternOwner,
+  Index extends readonly unknown[],
+> = Rest extends `${infer Head}>${infer Tail}`
+  ? FirstPatternError<CheckStep<Head, Pattern, Owner, StepWhere<Owner, Index>>, CheckSteps<Tail, Pattern, Owner, [...Index, unknown]>>
+  : CheckStep<Rest, Pattern, Owner, StepWhere<Owner, Index>>;
+
+/** One alternative's tokens as canonical names, for {@link HasRepeatedToken}. */
+type TokenNames<Rest extends string> = Rest extends `${infer Head}+${infer Tail}` ? [CanonicalToken<Head>, ...TokenNames<Tail>] : [CanonicalToken<Rest>];
+
+type HasRepeatedToken<Names extends readonly string[]> = Names extends readonly [infer Head extends string, ...infer Tail extends string[]]
+  ? Head extends Tail[number]
+    ? true
+    : HasRepeatedToken<Tail>
+  : false;
+
+/** `normalizeStep`'s duplicate-channel rejection for one alternative. Unlike the parse errors above it does not quote the pattern, matching the runtime message. */
+type CheckDuplicates<Text extends string, Owner extends PatternOwner, Where extends string> =
+  HasRepeatedToken<TokenNames<Text>> extends true ? `${Owner}: ${Where} contains the same channel more than once.` : never;
+
+type CheckDuplicateAlternatives<
+  Rest extends string,
+  Owner extends PatternOwner,
+  Where extends string,
+  Index extends readonly unknown[],
+> = Rest extends `${infer Head}|${infer Tail}`
+  ? FirstPatternError<CheckDuplicates<Head, Owner, AlternativeWhere<Where, Index>>, CheckDuplicateAlternatives<Tail, Owner, Where, [...Index, unknown]>>
+  : CheckDuplicates<Rest, Owner, AlternativeWhere<Where, Index>>;
+
+type CheckDuplicateStep<Step extends string, Owner extends PatternOwner, Where extends string> = Step extends `${string}|${string}`
+  ? CheckDuplicateAlternatives<Step, Owner, Where, []>
+  : CheckDuplicates<Step, Owner, Where>;
+
+/** {@link CheckDuplicateStep} across every step — a pass of its own, because `normalizeSequence` parses every step before it normalizes any of them. */
+type CheckDuplicateSteps<Rest extends string, Owner extends PatternOwner, Index extends readonly unknown[]> = Rest extends `${infer Head}>${infer Tail}`
+  ? FirstPatternError<CheckDuplicateStep<Head, Owner, StepWhere<Owner, Index>>, CheckDuplicateSteps<Tail, Owner, [...Index, unknown]>>
+  : CheckDuplicateStep<Rest, Owner, StepWhere<Owner, Index>>;
+
+type CountSteps<Rest extends string, Counted extends readonly unknown[] = [unknown]> = Rest extends `${string}>${infer Tail}`
+  ? CountSteps<Tail, [...Counted, unknown]>
+  : Counted['length'];
+
+/** Every rejection `normalizeSequence` can reach for a string pattern, in the order it reaches them. */
+type PatternTextError<Pattern extends string, Owner extends PatternOwner> = FirstPatternError<
+  CheckSteps<PatternTrim<Pattern>, Pattern, Owner, []>,
+  CheckDuplicateSteps<PatternTrim<Pattern>, Owner, []>
+>;
+
+/** {@link PatternTextError} plus `ChordAction`'s own one-step rule, checked last because its constructor checks it only after `normalizeSequence` returns. */
+type ChordTextError<Pattern extends string> = FirstPatternError<
+  PatternTextError<Pattern, 'ChordAction'>,
+  PatternTrim<Pattern> extends `${string}>${string}`
+    ? `ChordAction: a chord binding ("${Pattern}") must resolve to exactly one simultaneous step, not ${CountSteps<PatternTrim<Pattern>>}. Use SequenceAction for '>' patterns.`
+    : never
+>;
+
+/** The binding itself when it passes, the rejection message when it does not. */
+type OrPatternError<Binding, Error> = [Error] extends [never] ? Binding : Error;
+
+/**
+ * A {@link ChordAction} binding, checked at compile time when it is a string
+ * LITERAL. A valid pattern types as itself, an invalid one as the message
+ * explaining why — so `new ChordAction('Ctrl+Sv')` fails to compile with
+ * `Argument of type '"Ctrl+Sv"' is not assignable to parameter of type
+ * '"ChordAction: unknown keyboard token \"Sv\" …"'`.
+ *
+ * A plain `string` (a pattern read from a config file, built at runtime, or
+ * handed over from JavaScript) bails out and passes through untouched: only
+ * the parser above can judge it, and it still does. Array bindings pass
+ * through untouched as well, constrained by `ChordAction`'s own type
+ * parameter.
+ */
+export type ValidatedChordBinding<P> = P extends string ? (string extends P ? P : OrPatternError<P, ChordTextError<P>>) : P;
+
+/** {@link ValidatedChordBinding} for {@link SequenceAction}, which allows `'>'` and therefore more than one step. */
+export type ValidatedSequenceBinding<P> = P extends string ? (string extends P ? P : OrPatternError<P, PatternTextError<P, 'SequenceAction'>>) : P;
+
+// Compile-time guard: every alias is lowercase and none shadows a real member,
+// so the lowercased key `resolveToken` builds reaches exactly one entry.
+type AssertAliasesAreUsableKeys =
+  keyof KeyboardAliasMap extends Lowercase<keyof KeyboardAliasMap>
+    ? [keyof KeyboardAliasMap & Lowercase<keyof typeof Keyboard>] extends [never]
+      ? true
+      : never
+    : never;
+const _keyboardAliasesAreUsableKeys: AssertAliasesAreUsableKeys = true;
+void _keyboardAliasesAreUsableKeys;

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -476,6 +476,8 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "UniformValue: type alias",
   "UnloadOptions: interface",
   "UnregisteredSceneError: class",
+  "ValidatedChordBinding: type alias",
+  "ValidatedSequenceBinding: type alias",
   "ValueAsset: type alias",
   "ValueOf: type alias",
   "Vector: class",

--- a/test/input/action-patterns.test.ts
+++ b/test/input/action-patterns.test.ts
@@ -36,6 +36,22 @@ function createSample(): SampleDriver {
   };
 }
 
+/**
+ * Presents a pattern the way a caller who assembled it at runtime does —
+ * read from a key-binding config, joined from parts, or handed over from
+ * JavaScript — by giving it the type such a caller has: plain `string`.
+ *
+ * The string parser is the ONLY guard those callers get, so the rejections
+ * asserted below are exactly the ones that matter for them. As a literal, a
+ * malformed pattern is rejected one layer earlier, by the compile-time check
+ * in `ValidatedChordBinding`/`ValidatedSequenceBinding` (covered in
+ * `test/type-tests/action-patterns.type-test.ts`), and would never reach the
+ * parser at all — which is why these cases have to arrive as non-literals to
+ * test anything. Keep this in place: without it the assertions still pass at
+ * runtime, but the file no longer type-checks.
+ */
+const runtimePattern = (pattern: string): string => pattern;
+
 describe('ChordAction', () => {
   test('presses only when every member is held and releases when one leaves', () => {
     const driver = createSample();
@@ -183,11 +199,11 @@ describe('ChordAction', () => {
   });
 
   test('rejects a `>` step separator, naming SequenceAction as the alternative', () => {
-    expect(() => new ChordAction('A>B')).toThrow(/ChordAction.*SequenceAction/);
+    expect(() => new ChordAction(runtimePattern('A>B'))).toThrow(/ChordAction.*SequenceAction/);
   });
 
   test('rejects an unknown keyboard token with a ChordAction-labeled message', () => {
-    expect(() => new ChordAction('Control+Nope')).toThrow(/ChordAction: unknown keyboard token/);
+    expect(() => new ChordAction(runtimePattern('Control+Nope'))).toThrow(/ChordAction: unknown keyboard token/);
   });
 
   test.each([
@@ -286,9 +302,9 @@ describe('ChordAction: `|` alternation', () => {
   });
 
   test('rejects an empty alternative in a string pattern', () => {
-    expect(() => new ChordAction('Control+S|')).toThrow(/ChordAction:.*alternative.*empty/);
-    expect(() => new ChordAction('|Control+S')).toThrow(/ChordAction:.*alternative.*empty/);
-    expect(() => new ChordAction('Control+S||Meta+S')).toThrow(/ChordAction:.*alternative.*empty/);
+    expect(() => new ChordAction(runtimePattern('Control+S|'))).toThrow(/ChordAction:.*alternative.*empty/);
+    expect(() => new ChordAction(runtimePattern('|Control+S'))).toThrow(/ChordAction:.*alternative.*empty/);
+    expect(() => new ChordAction(runtimePattern('Control+S||Meta+S'))).toThrow(/ChordAction:.*alternative.*empty/);
   });
 
   test('rejects a single empty alternative in an array pattern, distinct from an entirely empty chord', () => {
@@ -457,8 +473,8 @@ describe('SequenceAction', () => {
     // over the Keyboard enum, not a text-entry or IME surface: composed
     // characters and other non-enum tokens are always rejected, never
     // silently accepted as "whatever the user typed".
-    expect(() => new SequenceAction('é')).toThrow(/unknown keyboard token/);
-    expect(() => new SequenceAction('あ')).toThrow(/unknown keyboard token/);
+    expect(() => new SequenceAction(runtimePattern('é'))).toThrow(/unknown keyboard token/);
+    expect(() => new SequenceAction(runtimePattern('あ'))).toThrow(/unknown keyboard token/);
   });
 
   test('tolerates whitespace around every token and separator', () => {
@@ -609,7 +625,7 @@ describe('SequenceAction: `|` alternation', () => {
   });
 
   test('rejects an empty alternative in a string pattern, naming the correct step', () => {
-    expect(() => new SequenceAction('A>B|')).toThrow(/SequenceAction:.*alternative.*step 2.*empty/);
+    expect(() => new SequenceAction(runtimePattern('A>B|'))).toThrow(/SequenceAction:.*alternative.*step 2.*empty/);
   });
 
   test('rejects a single empty alternative in an array pattern step', () => {

--- a/test/type-tests/action-patterns.type-test.ts
+++ b/test/type-tests/action-patterns.type-test.ts
@@ -1,4 +1,35 @@
-import { ActionMap, ChordAction, type ChordBinding, type InputAlternation, type InputSequence, Keyboard, SequenceAction } from '../../src/index';
+// Type contract for `ChordAction`/`SequenceAction` pattern bindings.
+//
+// String LITERAL patterns are validated at compile time by the same grammar
+// the runtime parser implements: `>` separates sequence steps, `|` separates
+// alternatives within a step, `+` joins channels required together, and every
+// token must resolve to a `Keyboard` member (case-insensitively, whitespace
+// tolerated, with an optional `Keyboard.` prefix and the shorthand aliases).
+// Anything the compiler cannot see as a literal — a pattern read from a config
+// file, assembled at runtime, or handed over from JavaScript — must still
+// compile and is left to the runtime parser alone.
+//
+// `pnpm typecheck:type-tests` compiles this file under all three lanes, so
+// every assertion below must hold identically in all of them.
+
+import {
+  ActionMap,
+  ChordAction,
+  type ChordBinding,
+  type InputAlternation,
+  type InputSequence,
+  Keyboard,
+  SequenceAction,
+  type ValidatedChordBinding,
+  type ValidatedSequenceBinding,
+} from '../../src/index';
+
+type Equal<A, B> = (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+// ---------------------------------------------------------------------------
+// Array bindings — unchanged by the compile-time string validation
+// ---------------------------------------------------------------------------
 
 const chord: ChordBinding = [Keyboard.Control, Keyboard.K];
 const sequence: InputSequence = [Keyboard.A, [Keyboard.B, Keyboard.C]];
@@ -23,7 +54,211 @@ const comboTriggered: boolean = actions.combo.triggered;
 void shortcutPressed;
 void comboTriggered;
 
+// Array literals keep working in every shape the runtime accepts.
+void new ChordAction([Keyboard.Control, Keyboard.K]);
+void new ChordAction([
+  [Keyboard.Control, Keyboard.K],
+  [Keyboard.Meta, Keyboard.K],
+]);
+void new ChordAction(alternation);
+void new SequenceAction([Keyboard.A, [Keyboard.B, Keyboard.C]]);
+void new SequenceAction([alternation, Keyboard.Enter]);
+
 // @ts-expect-error ChordAction array bindings contain input channels, not arbitrary values.
 new ChordAction([{}]);
 // @ts-expect-error SequenceAction does not accept an arbitrary object pattern.
 new SequenceAction({});
+
+// ---------------------------------------------------------------------------
+// Non-literal patterns bail out — the runtime parser stays the only judge
+// ---------------------------------------------------------------------------
+
+declare function readPatternFromConfig(): string;
+
+const configuredChord = readPatternFromConfig();
+const configuredSequence = readPatternFromConfig();
+void new ChordAction(configuredChord);
+void new SequenceAction(configuredSequence);
+
+// A widened `string` passes through untouched rather than being rejected.
+type _PlainStringChordPasses = Expect<Equal<ValidatedChordBinding<string>, string>>;
+type _PlainStringSequencePasses = Expect<Equal<ValidatedSequenceBinding<string>, string>>;
+
+// The declared binding unions (which contain `string`) pass through too.
+const declaredChord: ChordBinding = 'Control+S';
+const declaredSequence: string | InputSequence = 'A>B';
+void new ChordAction(declaredChord);
+void new SequenceAction(declaredSequence);
+
+// A valid literal types as itself, so nothing about inference changes.
+type _ValidChordIsItself = Expect<Equal<ValidatedChordBinding<'Control+S'>, 'Control+S'>>;
+type _ValidSequenceIsItself = Expect<Equal<ValidatedSequenceBinding<'A>B'>, 'A>B'>>;
+
+// A union of literals is checked member by member — every member must hold.
+declare const platformIsApple: boolean;
+void new ChordAction(platformIsApple ? 'Meta+S' : 'Control+S');
+// @ts-expect-error only one member of the union is a valid pattern.
+new ChordAction(platformIsApple ? 'Meta+S' : 'Control+Sv');
+
+// ---------------------------------------------------------------------------
+// Valid string literals
+// ---------------------------------------------------------------------------
+
+void new ChordAction('Control+S');
+void new ChordAction('Ctrl+S');
+void new ChordAction('Control+S|Meta+S');
+void new ChordAction('Cmd+S|Ctrl+S');
+void new ChordAction('Ctrl+Alt+Shift+Meta+S');
+// Case-insensitive and whitespace tolerant, exactly like the runtime parser.
+void new ChordAction('ctrl+a');
+void new ChordAction('CTRL+A');
+void new ChordAction(' Control + A ');
+void new ChordAction('  ctrl  |  meta  ');
+// The optional `Keyboard.` prefix is stripped, case-insensitively.
+void new ChordAction('Keyboard.A');
+void new ChordAction('keyboard.control+Keyboard.S');
+// Every alias resolves.
+void new ChordAction('Cmd+K');
+void new ChordAction('Command+K');
+void new ChordAction('Super+K');
+void new ChordAction('Opt+K');
+void new ChordAction('Esc');
+// Non-alphabetic member names resolve too.
+void new ChordAction('NumPadAdd');
+void new ChordAction('IntlBackslash');
+void new ChordAction('F12');
+
+void new SequenceAction('A>B|C');
+void new SequenceAction('Down>Down+Right>Right');
+void new SequenceAction('Control+K|Meta+K>S');
+void new SequenceAction('Up>Up>Down>Down>Left>Right>Left>Right>B>A', { maxGap: 800 });
+// A realistically long pattern — eight steps of three tokens each — must stay
+// well inside the compiler's instantiation limits.
+void new SequenceAction('A+B+C>D+E+F>G+H+I>J+K+L>M+N+O>P+Q+R>S+T+U>V+W+X');
+void new SequenceAction('   Up  >  Down   >  Left + Right  |  Ctrl + Alt  >  A   ');
+
+// ---------------------------------------------------------------------------
+// Rejected string literals — unknown tokens
+// ---------------------------------------------------------------------------
+
+// @ts-expect-error 'Sv' is not a Keyboard member.
+new ChordAction('Ctrl+Sv');
+// @ts-expect-error 'KeyA' is not a Keyboard member — the member is named 'A'.
+new ChordAction('Keyboard.KeyA');
+// @ts-expect-error the alias table has no 'meta.' prefix, only 'Keyboard.'.
+new ChordAction('Meta.S');
+// @ts-expect-error a bare 'Keyboard.' prefix leaves nothing to resolve.
+new ChordAction('Keyboard.');
+// @ts-expect-error typo deep inside a long sequence.
+new SequenceAction('Up>Up>Down>Down>Left>Right>Left>Right>B>Av');
+// @ts-expect-error unknown token inside one alternative of a step.
+new SequenceAction('A>Ctrl+Sv|B');
+
+// The rejection message names the offending token and quotes the pattern.
+type _UnknownTokenMessage = Expect<
+  Equal<ValidatedChordBinding<'Ctrl+Sv'>, 'ChordAction: unknown keyboard token "Sv" in pattern "Ctrl+Sv". Use a Keyboard enum name or pass numeric channels.'>
+>;
+
+// ---------------------------------------------------------------------------
+// Rejected string literals — empty tokens, alternatives and patterns
+// ---------------------------------------------------------------------------
+
+// @ts-expect-error trailing '+' leaves an empty token.
+new ChordAction('A+');
+// @ts-expect-error leading '+' leaves an empty token.
+new ChordAction('+A');
+// @ts-expect-error doubled '+' leaves an empty token.
+new ChordAction('A++B');
+// @ts-expect-error whitespace is not a token.
+new ChordAction('A+ +B');
+// @ts-expect-error trailing '|' leaves an empty alternative.
+new ChordAction('A|');
+// @ts-expect-error leading '|' leaves an empty alternative.
+new ChordAction('|A');
+// @ts-expect-error doubled '|' leaves an empty alternative.
+new ChordAction('A||B');
+// @ts-expect-error an empty pattern has nothing to bind.
+new ChordAction('');
+// @ts-expect-error a whitespace-only pattern has nothing to bind.
+new ChordAction('   ');
+// @ts-expect-error an empty pattern has nothing to bind.
+new SequenceAction('');
+// @ts-expect-error doubled '>' leaves an empty step.
+new SequenceAction('A>>B');
+// @ts-expect-error a whitespace-only step has nothing to bind.
+new SequenceAction('A> >B');
+// @ts-expect-error a trailing '>' leaves an empty final step.
+new SequenceAction('A>B>');
+
+// An empty token is worded per position, like the runtime message.
+type _EmptyChordTokenMessage = Expect<Equal<ValidatedChordBinding<'A+'>, 'ChordAction: the chord of pattern "A+" contains an empty token.'>>;
+type _EmptySequenceTokenMessage = Expect<Equal<ValidatedSequenceBinding<'A>B+'>, 'SequenceAction: step 2 of pattern "A>B+" contains an empty token.'>>;
+type _EmptyAlternativeMessage = Expect<
+  Equal<ValidatedSequenceBinding<'A>B|'>, 'SequenceAction: alternative 2 of step 2 of pattern "A>B|" is empty — remove the stray \'|\'.'>
+>;
+
+// ---------------------------------------------------------------------------
+// Rejected string literals — repeated channels within one alternative
+// ---------------------------------------------------------------------------
+
+// @ts-expect-error the same channel twice within one chord.
+new ChordAction('A+A');
+// @ts-expect-error an alias and its canonical name are the same channel.
+new ChordAction('Ctrl+Control');
+// @ts-expect-error case and the 'Keyboard.' prefix do not make a second channel.
+new ChordAction('keyboard.a+A');
+// @ts-expect-error two aliases for Meta are still one channel.
+new ChordAction('Cmd+Super');
+// @ts-expect-error a repeat inside one alternative of a sequence step.
+new SequenceAction('A>Ctrl+Control|B');
+
+// A repeat across STEPS or across ALTERNATIVES is legitimate, not a duplicate.
+void new SequenceAction('A>A');
+void new ChordAction('Ctrl+S|Ctrl+K');
+
+type _RepeatedChannelMessage = Expect<Equal<ValidatedChordBinding<'Ctrl+Control'>, 'ChordAction: the chord contains the same channel more than once.'>>;
+
+// ---------------------------------------------------------------------------
+// Rejected string literals — ChordAction forbids '>'
+// ---------------------------------------------------------------------------
+
+// @ts-expect-error a chord is a single simultaneous step; use SequenceAction.
+new ChordAction('A>B');
+// @ts-expect-error even a valid multi-step pattern is not a chord.
+new ChordAction('Control+K>S');
+
+type _ChordRejectsStepsMessage = Expect<
+  Equal<
+    ValidatedChordBinding<'A>B'>,
+    'ChordAction: a chord binding ("A>B") must resolve to exactly one simultaneous step, not 2. Use SequenceAction for \'>\' patterns.'
+  >
+>;
+
+// An unknown token is reported before the step count, matching the order the
+// runtime reaches the two checks.
+type _ChordReportsTokenFirst = Expect<
+  Equal<ValidatedChordBinding<'A>Sv'>, 'ChordAction: unknown keyboard token "Sv" in pattern "A>Sv". Use a Keyboard enum name or pass numeric channels.'>
+>;
+
+// ---------------------------------------------------------------------------
+// Instances stay interchangeable regardless of the binding they were built from
+// ---------------------------------------------------------------------------
+
+declare function takesChord(action: ChordAction): void;
+declare function takesSequence(action: SequenceAction): void;
+
+takesChord(new ChordAction('Control+S'));
+takesChord(new ChordAction([Keyboard.Control, Keyboard.K]));
+takesChord(new ChordAction(configuredChord));
+takesSequence(new SequenceAction('A>B'));
+takesSequence(new SequenceAction([Keyboard.A, Keyboard.B]));
+
+const literalActions = new ActionMap({
+  save: new ChordAction('Control+S|Meta+S'),
+  konami: new SequenceAction('Up>Up>Down>Down>Left>Right>Left>Right>B>A'),
+});
+
+type _SaveIsChordAction = Expect<Equal<typeof literalActions.save, ChordAction>>;
+type _KonamiIsSequenceAction = Expect<Equal<typeof literalActions.konami, SequenceAction>>;
+type _SavePressed = Expect<Equal<typeof literalActions.save.pressed, boolean>>;
+type _KonamiTriggered = Expect<Equal<typeof literalActions.konami.triggered, boolean>>;


### PR DESCRIPTION
Pattern strings passed to `ChordAction` and `SequenceAction` are now checked by the compiler, not only by the runtime parser.

```ts
new ChordAction('Ctrl+S')    // ok
new ChordAction('Ctrl+Sv')   // error: unknown keyboard token "Sv"
new ChordAction('A>B')       // error: ChordAction rejects '>'
new ChordAction('Ctrl+Control') // error: duplicate channel
```

No new API surface — no template tag. The check rides on the existing constructors, so existing call sites benefit without changing.

## How it is built

Only `Keyboard` names are string-parsable (gamepad and pointer channels require the array form), so the validated namespace is `keyof typeof Keyboard` plus the six aliases, both derived from one `as const satisfies` table shared with the runtime. The type layer mirrors the parser's own precedence: `>` splits steps, `|` splits alternatives, `+` joins channels. It folds aliases, case, and the optional `Keyboard.` prefix to a canonical name before checking for duplicates. Modelled on `KindByPath` in `src/resources/AssetDefinitions.ts`.

Two constraints shaped the result:

- TypeScript forbids generic constructors (TS1092), so the type parameter sits on the class. It appears in no member, so every instantiation stays structurally identical and bare `ChordAction` still works everywhere — asserted with `Equal`.
- `P extends Validate<P>` is a circular constraint (TS2313) in every formulation. The diagnostic is delivered through the parameter type instead, which is what makes the message readable.

## Deliberately unchanged

The runtime parser keeps every validation and every message. Non-literal strings (`const p: string = fromConfig()`) bail out of the type check by design and remain the runtime's business — that is the path JavaScript and config-driven callers take, and `test/input/action-patterns.test.ts` now routes its malformed literals through a named helper to keep testing exactly that path.

## Limits

Recursion is bounded by step count, not token count: ~80 steps validate fine, ~100 hits TS2589. Documented in `pattern.ts`; the escape hatch is widening to `string` or using the array form.

## Verification

`tsc --noEmit` (src) and the type-tests lane both exit 0, independently re-run. `test/input` 579/579. `verify:quick` green.