### PR TITLE
test(rendering): table-driven parity runner (matrix slice 3)

### DIFF
--- a/test/rendering/parity/evidence.json
+++ b/test/rendering/parity/evidence.json
@@ -6,7 +6,7 @@
     "browser": "chromium",
     "backend": "webgl2",
     "support": "supported",
-    "evidence": "sampled",
+    "evidence": "frame-equal",
     "delta": 0
   },
   {
@@ -16,7 +16,7 @@
     "browser": "chromium",
     "backend": "webgl2",
     "support": "supported",
-    "evidence": "sampled",
+    "evidence": "frame-equal",
     "delta": 0
   },
   {
@@ -26,7 +26,7 @@
     "browser": "chromium",
     "backend": "webgl2",
     "support": "supported",
-    "evidence": "exact",
+    "evidence": "traced",
     "delta": 0
   },
   {
@@ -36,7 +36,7 @@
     "browser": "chromium",
     "backend": "webgl2",
     "support": "supported",
-    "evidence": "exact",
+    "evidence": "traced",
     "delta": 0
   },
   {
@@ -46,7 +46,7 @@
     "browser": "chromium",
     "backend": "webgl2",
     "support": "supported",
-    "evidence": "exact",
+    "evidence": "traced",
     "delta": 0
   },
   {
@@ -56,7 +56,7 @@
     "browser": "chromium",
     "backend": "webgl2",
     "support": "supported",
-    "evidence": "exact",
+    "evidence": "traced",
     "delta": 0
   },
   {
@@ -66,7 +66,7 @@
     "browser": "chromium",
     "backend": "webgpu",
     "support": "supported",
-    "evidence": "sampled",
+    "evidence": "frame-equal",
     "delta": 0
   },
   {
@@ -76,7 +76,7 @@
     "browser": "chromium",
     "backend": "webgpu",
     "support": "supported",
-    "evidence": "sampled",
+    "evidence": "frame-equal",
     "delta": 0
   },
   {
@@ -86,7 +86,7 @@
     "browser": "chromium",
     "backend": "webgpu",
     "support": "supported",
-    "evidence": "exact",
+    "evidence": "traced",
     "delta": 0
   },
   {
@@ -96,7 +96,7 @@
     "browser": "chromium",
     "backend": "webgpu",
     "support": "supported",
-    "evidence": "exact",
+    "evidence": "traced",
     "delta": 0
   },
   {
@@ -106,7 +106,7 @@
     "browser": "chromium",
     "backend": "webgpu",
     "support": "supported",
-    "evidence": "exact",
+    "evidence": "traced",
     "delta": 0
   },
   {
@@ -116,7 +116,7 @@
     "browser": "chromium",
     "backend": "webgpu",
     "support": "supported",
-    "evidence": "exact",
+    "evidence": "traced",
     "delta": 0
   }
 ]

--- a/test/rendering/parity/evidence.json
+++ b/test/rendering/parity/evidence.json
@@ -1,0 +1,122 @@
+[
+  {
+    "scene": "sprite/canvas-texture",
+    "property": "cross-backend-parity",
+    "feature": "Sprite",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": 0
+  },
+  {
+    "scene": "sprite/canvas-texture",
+    "property": "repeat-render-determinism",
+    "feature": "Sprite",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": 0
+  },
+  {
+    "scene": "sprite/origin",
+    "property": "cross-backend-parity",
+    "feature": "Sprite",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "exact",
+    "delta": 0
+  },
+  {
+    "scene": "sprite/origin",
+    "property": "repeat-render-determinism",
+    "feature": "Sprite",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "exact",
+    "delta": 0
+  },
+  {
+    "scene": "sprite/translated",
+    "property": "cross-backend-parity",
+    "feature": "Sprite",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "exact",
+    "delta": 0
+  },
+  {
+    "scene": "sprite/translated",
+    "property": "repeat-render-determinism",
+    "feature": "Sprite",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "exact",
+    "delta": 0
+  },
+  {
+    "scene": "sprite/canvas-texture",
+    "property": "cross-backend-parity",
+    "feature": "Sprite",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": 0
+  },
+  {
+    "scene": "sprite/canvas-texture",
+    "property": "repeat-render-determinism",
+    "feature": "Sprite",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": 0
+  },
+  {
+    "scene": "sprite/origin",
+    "property": "cross-backend-parity",
+    "feature": "Sprite",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "exact",
+    "delta": 0
+  },
+  {
+    "scene": "sprite/origin",
+    "property": "repeat-render-determinism",
+    "feature": "Sprite",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "exact",
+    "delta": 0
+  },
+  {
+    "scene": "sprite/translated",
+    "property": "cross-backend-parity",
+    "feature": "Sprite",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "exact",
+    "delta": 0
+  },
+  {
+    "scene": "sprite/translated",
+    "property": "repeat-render-determinism",
+    "feature": "Sprite",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "exact",
+    "delta": 0
+  }
+]

--- a/test/rendering/parity/evidenceSink.ts
+++ b/test/rendering/parity/evidenceSink.ts
@@ -1,0 +1,88 @@
+/**
+ * Node-side sink for the parity runner's evidence rows.
+ *
+ * The runner executes inside the browser and cannot write files, so it hands
+ * its rows to this vitest browser command, which runs in the node process.
+ * Registered in `vitest.config.ts` under the rendering projects' `browser.commands`.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+/** How thoroughly a (scene, property) pair was proven on one backend. */
+export type EvidenceClass = 'exact' | 'oracle' | 'tolerant' | 'sampled' | 'none';
+
+/** Whether the feature actually worked there — distinct from how well it was checked. */
+export type SupportState = 'supported' | 'divergent' | 'unknown';
+
+export interface EvidenceRow {
+  readonly scene: string;
+  readonly property: string;
+  readonly feature: string;
+  readonly browser: string;
+  readonly backend: 'webgl2' | 'webgpu';
+  readonly support: SupportState;
+  readonly evidence: EvidenceClass;
+  /** Largest per-channel deviation observed, when the property measured one. */
+  readonly delta: number | null;
+  /** Why the row is `unknown`/`none`, when it is. */
+  readonly note?: string;
+}
+
+const OUTPUT = 'test/rendering/parity/evidence.json';
+
+/**
+ * Rows accumulate across spec files within one vitest run: each browser spec
+ * calls this as it finishes, and the last write holds the full set.
+ */
+const collected = new Map<string, EvidenceRow>();
+
+const keyOf = (row: EvidenceRow): string => `${row.browser}|${row.backend}|${row.scene}|${row.property}`;
+
+/** Rows already on disk, minus every browser the current run is reporting on. */
+const carriedOverRows = (target: string, reportedBrowsers: ReadonlySet<string>): EvidenceRow[] => {
+  if (!existsSync(target)) return [];
+
+  try {
+    const previous = JSON.parse(readFileSync(target, 'utf8')) as EvidenceRow[];
+
+    return previous.filter(row => !reportedBrowsers.has(row.browser));
+  } catch {
+    // A corrupt or hand-edited artifact is replaced rather than merged into.
+    return [];
+  }
+};
+
+/**
+ * Merges rows into the run's collection and rewrites the artifact.
+ *
+ * A run only ever speaks for the browsers it actually exercised: rows for other
+ * browsers are carried over from the existing file, so running the Chromium
+ * lane does not erase what the Firefox lane recorded. Rows for a browser that
+ * *is* in this run are fully replaced, so stale combinations disappear when a
+ * scene or property is removed.
+ *
+ * Returns the row count so a spec can assert the handoff happened rather than
+ * trusting a silent void.
+ */
+export const writeParityEvidence = (_ctx: unknown, rows: readonly EvidenceRow[]): number => {
+  for (const row of rows) {
+    collected.set(keyOf(row), row);
+  }
+
+  const target = resolve(process.cwd(), OUTPUT);
+  const reportedBrowsers = new Set([...collected.values()].map(row => row.browser));
+  const merged = [...carriedOverRows(target, reportedBrowsers), ...collected.values()].sort((a, b) => keyOf(a).localeCompare(keyOf(b)));
+
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, `${JSON.stringify(merged, null, 2)}\n`, 'utf8');
+
+  return merged.length;
+};
+
+/** Drops everything collected so far; the runner calls this once per run. */
+export const resetParityEvidence = (): number => {
+  collected.clear();
+
+  return 0;
+};

--- a/test/rendering/parity/evidenceSink.ts
+++ b/test/rendering/parity/evidenceSink.ts
@@ -9,8 +9,25 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
-/** How thoroughly a (scene, property) pair was proven on one backend. */
-export type EvidenceClass = 'exact' | 'oracle' | 'tolerant' | 'sampled' | 'none';
+/**
+ * How much a (scene, property) pair actually proves on one backend.
+ *
+ * This is the strength of the check, never its outcome — `delta` carries the
+ * outcome. A row can read `frame-equal` with `delta: 0` and still be weaker
+ * evidence than a `traced` row with the same delta, because a solid-colour
+ * texture renders identically whether or not the UVs were mirrored.
+ *
+ * - `traced` — every output pixel checked against the one texel it must have
+ *   come from. Needs a self-describing fixture under nearest sampling.
+ * - `frame-equal` — every pixel compared, but no pixel traceable to a source
+ *   texel: the frames match, which is weaker than each pixel being right.
+ * - `oracle` — compared against an expectation computed independently of the
+ *   renderer, so agreeing backends can still both be wrong and be caught.
+ * - `tolerant` — compared within a tolerance rather than for equality.
+ * - `sampled` — only some pixels looked at.
+ * - `none` — nothing established; see `note` for why.
+ */
+export type EvidenceClass = 'traced' | 'frame-equal' | 'oracle' | 'tolerant' | 'sampled' | 'none';
 
 /** Whether the feature actually worked there — distinct from how well it was checked. */
 export type SupportState = 'supported' | 'divergent' | 'unknown';
@@ -22,6 +39,7 @@ export interface EvidenceRow {
   readonly browser: string;
   readonly backend: 'webgl2' | 'webgpu';
   readonly support: SupportState;
+  /** How strong the check was — not what it found. */
   readonly evidence: EvidenceClass;
   /** Largest per-channel deviation observed, when the property measured one. */
   readonly delta: number | null;

--- a/test/rendering/parity/frames.ts
+++ b/test/rendering/parity/frames.ts
@@ -1,0 +1,23 @@
+/** Frame comparison shared by the properties. */
+
+/**
+ * Largest per-channel difference between two frames.
+ *
+ * Whole-frame rather than sampled: the point of a self-describing fixture is
+ * that every pixel is predictable, so every pixel is worth comparing.
+ */
+export const maxChannelDelta = (a: ArrayLike<number>, b: ArrayLike<number>): number => {
+  if (a.length !== b.length) {
+    throw new Error(`Frames differ in size (${a.length} vs ${b.length}); they are not comparable.`);
+  }
+
+  let worst = 0;
+
+  for (let i = 0; i < a.length; i++) {
+    const delta = Math.abs(a[i]! - b[i]!);
+
+    if (delta > worst) worst = delta;
+  }
+
+  return worst;
+};

--- a/test/rendering/parity/matrix.test.ts
+++ b/test/rendering/parity/matrix.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Entry point for the table-driven conformance matrix.
+ *
+ * Adding a feature means adding a scene to a catalog; adding a correctness
+ * check means adding a property, which then applies to every existing scene.
+ * Neither requires touching this file.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import { crossBackendParity } from './properties/crossBackendParity';
+import { determinism } from './properties/determinism';
+import { runParityMatrix } from './runner';
+import { spriteScenes } from './scenes/sprite';
+import { spriteCanvasScenes } from './scenes/spriteCanvas';
+import type { Property, Scene } from './types';
+
+const scenes: readonly Scene[] = [...spriteScenes, ...spriteCanvasScenes];
+const properties: readonly Property[] = [crossBackendParity, determinism];
+
+runParityMatrix(scenes, properties);

--- a/test/rendering/parity/properties/crossBackendParity.ts
+++ b/test/rendering/parity/properties/crossBackendParity.ts
@@ -1,0 +1,57 @@
+/**
+ * The same scene, rendered by both backends, must produce the same frame.
+ *
+ * This is the parity claim the whole matrix exists to make explicit. Note what
+ * it does *not* catch: if both backends are wrong in the same way, they still
+ * agree. Correctness against an independent expectation is the oracle
+ * property's job.
+ */
+
+import { Color } from '#core/Color';
+
+import {
+  createWebGl2TestBackend,
+  createWebGpuTestBackend,
+  readWebGl2Frame,
+  readWebGpuFrame,
+  renderWebGl2Once,
+  renderWebGpuOnce,
+} from '../../browser/_backendSetup';
+import { maxChannelDelta } from '../frames';
+import type { CrossBackendProperty, PropertyResult } from '../types';
+
+export const crossBackendParity: CrossBackendProperty = {
+  name: 'cross-backend-parity',
+  scope: 'cross-backend',
+  appliesTo: () => true,
+
+  run: async ({ scene, skip }): Promise<PropertyResult> => {
+    const gl = await createWebGl2TestBackend(scene.size);
+    const gpu = await createWebGpuTestBackend(scene.size);
+
+    try {
+      renderWebGl2Once(gl, scene.build(), Color.black);
+
+      // A dropped device is missing evidence, never satisfied evidence.
+      const rendered = await renderWebGpuOnce({ skip }, gpu, scene.build(), Color.black);
+
+      if (!rendered) {
+        return { support: 'unknown', evidence: 'none', delta: null, note: 'WebGPU device lost mid-run' };
+      }
+
+      const glFrame = readWebGl2Frame(gl, scene.size);
+      const gpuFrame = readWebGpuFrame(gpu, scene.size);
+      const delta = maxChannelDelta(glFrame, gpuFrame);
+
+      return {
+        support: delta === 0 ? 'supported' : 'divergent',
+        evidence: 'exact',
+        delta,
+        ...(delta === 0 ? {} : { note: `backends differ by ${delta} on at least one channel` }),
+      };
+    } finally {
+      gl.destroy();
+      gpu.destroy();
+    }
+  },
+};

--- a/test/rendering/parity/properties/crossBackendParity.ts
+++ b/test/rendering/parity/properties/crossBackendParity.ts
@@ -45,7 +45,9 @@ export const crossBackendParity: CrossBackendProperty = {
 
       return {
         support: delta === 0 ? 'supported' : 'divergent',
-        evidence: 'exact',
+        // Whole-frame comparison; the runner decides whether the scene lets it
+        // count as `traced` rather than merely `frame-equal`.
+        evidence: 'traced',
         delta,
         ...(delta === 0 ? {} : { note: `backends differ by ${delta} on at least one channel` }),
       };

--- a/test/rendering/parity/properties/determinism.ts
+++ b/test/rendering/parity/properties/determinism.ts
@@ -1,0 +1,72 @@
+/**
+ * Rendering the same scene twice must produce the same frame.
+ *
+ * Cheap, and it holds for every scene regardless of fixture kind — which makes
+ * it the property that proves the runner itself works. A failure here means
+ * frame-to-frame state leaks (a retained cache serving a stale batch, an
+ * uncleared buffer), not a backend difference.
+ */
+
+import { Color } from '#core/Color';
+
+import {
+  createWebGl2TestBackend,
+  createWebGpuTestBackend,
+  readWebGl2Frame,
+  readWebGpuFrame,
+  renderWebGl2Once,
+  renderWebGpuOnce,
+} from '../../browser/_backendSetup';
+import { maxChannelDelta } from '../frames';
+import type { PerBackendProperty, PropertyResult } from '../types';
+
+const verdict = (delta: number): PropertyResult => ({
+  support: delta === 0 ? 'supported' : 'divergent',
+  evidence: 'exact',
+  delta,
+  ...(delta === 0 ? {} : { note: `frame 2 differs from frame 1 by ${delta}` }),
+});
+
+export const determinism: PerBackendProperty = {
+  name: 'repeat-render-determinism',
+  scope: 'per-backend',
+  appliesTo: () => true,
+
+  run: async ({ scene, skip }, backend): Promise<PropertyResult> => {
+    // A fresh graph per frame: reusing one would let retained state make the
+    // second frame identical for the wrong reason.
+    if (backend === 'webgl2') {
+      const gl = await createWebGl2TestBackend(scene.size);
+
+      try {
+        renderWebGl2Once(gl, scene.build(), Color.black);
+
+        const first = readWebGl2Frame(gl, scene.size);
+
+        renderWebGl2Once(gl, scene.build(), Color.black);
+
+        return verdict(maxChannelDelta(first, readWebGl2Frame(gl, scene.size)));
+      } finally {
+        gl.destroy();
+      }
+    }
+
+    const gpu = await createWebGpuTestBackend(scene.size);
+
+    try {
+      if (!(await renderWebGpuOnce({ skip }, gpu, scene.build(), Color.black))) {
+        return { support: 'unknown', evidence: 'none', delta: null, note: 'WebGPU device lost mid-run' };
+      }
+
+      const first = readWebGpuFrame(gpu, scene.size);
+
+      if (!(await renderWebGpuOnce({ skip }, gpu, scene.build(), Color.black))) {
+        return { support: 'unknown', evidence: 'none', delta: null, note: 'WebGPU device lost mid-run' };
+      }
+
+      return verdict(maxChannelDelta(first, readWebGpuFrame(gpu, scene.size)));
+    } finally {
+      gpu.destroy();
+    }
+  },
+};

--- a/test/rendering/parity/properties/determinism.ts
+++ b/test/rendering/parity/properties/determinism.ts
@@ -22,7 +22,9 @@ import type { PerBackendProperty, PropertyResult } from '../types';
 
 const verdict = (delta: number): PropertyResult => ({
   support: delta === 0 ? 'supported' : 'divergent',
-  evidence: 'exact',
+  // Whole-frame comparison; the runner decides whether the scene lets it count
+  // as `traced` rather than merely `frame-equal`.
+  evidence: 'traced',
   delta,
   ...(delta === 0 ? {} : { note: `frame 2 differs from frame 1 by ${delta}` }),
 });

--- a/test/rendering/parity/runner.ts
+++ b/test/rendering/parity/runner.ts
@@ -1,0 +1,117 @@
+/**
+ * Walks the scene × property cross product and emits one test per applicable
+ * combination, recording what each one actually proved.
+ *
+ * The evidence rows are the point: a passing test proves something, and the
+ * matrix is the record of *which* something. A combination that never runs
+ * leaves a row saying so, which is how the matrix can show absence of
+ * verification — the thing a suite of green tests structurally cannot.
+ */
+
+import { commands } from '@vitest/browser/context';
+import { afterAll, describe, expect, test } from 'vitest';
+
+import type { EvidenceRow } from './evidenceSink';
+import { cappedEvidence, type Property, type Scene } from './types';
+
+interface ParityCommands {
+  writeParityEvidence: (rows: readonly EvidenceRow[]) => Promise<number>;
+}
+
+const sink = commands as unknown as ParityCommands;
+
+/** Which engine the run is executing in; the matrix is per browser, not just per backend. */
+export const currentBrowser = (): string => {
+  const ua = navigator.userAgent;
+
+  if (ua.includes('Firefox/')) return 'firefox';
+  if (ua.includes('Edg/')) return 'edge';
+  if (ua.includes('Chrome/') || ua.includes('Chromium/')) return 'chromium';
+  if (ua.includes('Safari/')) return 'webkit';
+
+  return 'unknown';
+};
+
+const BACKENDS = ['webgl2', 'webgpu'] as const;
+
+/**
+ * Registers the tests for one catalog.
+ *
+ * Call at module top level from a spec file — the `describe`/`test` calls have
+ * to happen during collection, so scenes and properties must be known
+ * statically rather than discovered mid-run.
+ */
+export const runParityMatrix = (scenes: readonly Scene[], properties: readonly Property[]): void => {
+  const browser = currentBrowser();
+  const rows: EvidenceRow[] = [];
+
+  const record = (scene: Scene, property: Property, backend: 'webgl2' | 'webgpu', result: Awaited<ReturnType<Property['run']>>): void => {
+    rows.push({
+      scene: scene.name,
+      property: property.name,
+      feature: scene.feature,
+      browser,
+      backend,
+      support: result.support,
+      evidence: cappedEvidence(scene, result.evidence),
+      delta: result.delta,
+      ...(result.note === undefined ? {} : { note: result.note }),
+    });
+  };
+
+  for (const scene of scenes) {
+    describe(scene.name, () => {
+      for (const property of properties) {
+        if (!property.appliesTo(scene)) {
+          // Not applicable is still information: it is why the matrix cell is
+          // empty, as opposed to the check having failed or been skipped.
+          for (const backend of BACKENDS) {
+            rows.push({
+              scene: scene.name,
+              property: property.name,
+              feature: scene.feature,
+              browser,
+              backend,
+              support: 'unknown',
+              evidence: 'none',
+              delta: null,
+              note: 'property does not apply to this scene',
+            });
+          }
+
+          continue;
+        }
+
+        if (property.scope === 'cross-backend') {
+          test(`${property.name}`, async ctx => {
+            // Runtime skip for a lost device, not a disabled test.
+            // eslint-disable-next-line vitest/no-disabled-tests
+            const result = await property.run({ scene, skip: reason => ctx.skip(reason) });
+
+            for (const backend of BACKENDS) record(scene, property, backend, result);
+
+            if (result.support === 'divergent') expect.fail(result.note ?? `${scene.name} diverges between backends`);
+          });
+
+          continue;
+        }
+
+        for (const backend of BACKENDS) {
+          test(`${property.name} [${backend}]`, async ctx => {
+            // Runtime skip for a lost device, not a disabled test.
+            // eslint-disable-next-line vitest/no-disabled-tests
+            const result = await property.run({ scene, skip: reason => ctx.skip(reason) }, backend);
+
+            record(scene, property, backend, result);
+
+            if (result.support === 'divergent') expect.fail(result.note ?? `${property.name} fails for ${scene.name} on ${backend}`);
+          });
+        }
+      }
+    });
+  }
+
+  afterAll(async () => {
+    if (rows.length > 0) await sink.writeParityEvidence(rows);
+  });
+};

--- a/test/rendering/parity/scenes/sprite.ts
+++ b/test/rendering/parity/scenes/sprite.ts
@@ -1,0 +1,47 @@
+/**
+ * Sprite scenes over a coordinate-encoding texture.
+ *
+ * Each is drawn 1:1 — one screen pixel per texel — so a sample point never
+ * lands on a texel boundary and every output pixel has exactly one correct
+ * source texel.
+ */
+
+import { Container } from '#rendering/Container';
+import { Sprite } from '#rendering/sprite/Sprite';
+
+import { buildCoordinateTexture } from '../../browser/_selfDescribingFixture';
+import type { Scene } from '../types';
+
+const FIXTURE = 32;
+const CANVAS = 64;
+
+const spriteAt = (x: number, y: number): Container => {
+  const root = new Container();
+  const sprite = new Sprite(buildCoordinateTexture(FIXTURE));
+
+  sprite.setPosition(x, y);
+  root.addChild(sprite);
+
+  return root;
+};
+
+export const spriteScenes: readonly Scene[] = [
+  {
+    name: 'sprite/origin',
+    feature: 'Sprite',
+    size: CANVAS,
+    fixture: 'self-describing',
+    nearestSampled: true,
+    build: () => spriteAt(0, 0),
+  },
+  {
+    // Same sprite at a whole-pixel offset: a translation must move the image
+    // without altering which texel any given output pixel came from.
+    name: 'sprite/translated',
+    feature: 'Sprite',
+    size: CANVAS,
+    fixture: 'self-describing',
+    nearestSampled: true,
+    build: () => spriteAt(16, 8),
+  },
+];

--- a/test/rendering/parity/scenes/spriteCanvas.ts
+++ b/test/rendering/parity/scenes/spriteCanvas.ts
@@ -1,0 +1,52 @@
+/**
+ * A sprite over an ordinary canvas-sourced texture.
+ *
+ * Deliberately not self-describing: an output pixel here carries a colour, not
+ * the identity of the texel it came from, so a matching frame proves the two
+ * backends agree but not that either placed the right texel. The runner caps
+ * this at `sampled` however exact the comparison happens to be — which is the
+ * point of capping it there rather than trusting the property's claim.
+ */
+
+import { Container } from '#rendering/Container';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+
+import type { Scene } from '../types';
+
+const CANVAS = 64;
+
+const solidTexture = (color: string, edge: number): Texture => {
+  const source = document.createElement('canvas');
+
+  source.width = edge;
+  source.height = edge;
+
+  const ctx = source.getContext('2d');
+
+  if (ctx === null) throw new Error('A 2D context is required to build the fixture.');
+
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, edge, edge);
+
+  return new Texture(source);
+};
+
+export const spriteCanvasScenes: readonly Scene[] = [
+  {
+    name: 'sprite/canvas-texture',
+    feature: 'Sprite',
+    size: CANVAS,
+    fixture: 'opaque-solid',
+    nearestSampled: false,
+    build: () => {
+      const root = new Container();
+      const sprite = new Sprite(solidTexture('#ff0000', 16));
+
+      sprite.setPosition(8, 8);
+      root.addChild(sprite);
+
+      return root;
+    },
+  },
+];

--- a/test/rendering/parity/scenes/spriteCanvas.ts
+++ b/test/rendering/parity/scenes/spriteCanvas.ts
@@ -3,8 +3,9 @@
  *
  * Deliberately not self-describing: an output pixel here carries a colour, not
  * the identity of the texel it came from, so a matching frame proves the two
- * backends agree but not that either placed the right texel. The runner caps
- * this at `sampled` however exact the comparison happens to be — which is the
+ * backends agree but not that either placed the right texel. Mirror the UVs and
+ * this scene still renders byte-identical frames. The runner therefore caps it
+ * at `frame-equal` however exhaustively the frames were compared — which is the
  * point of capping it there rather than trusting the property's claim.
  */
 

--- a/test/rendering/parity/types.ts
+++ b/test/rendering/parity/types.ts
@@ -1,0 +1,94 @@
+/**
+ * The vocabulary the parity runner walks: scenes describe *what* to render,
+ * properties describe *what must hold* about a rendering, and the runner emits
+ * one test per applicable combination.
+ *
+ * A scene knows nothing about backends or assertions, and a property knows
+ * nothing about any particular feature. That split is what lets a new feature
+ * cost one scene entry, and a new correctness check one property entry that
+ * applies to every existing scene at once.
+ */
+
+import type { Container } from '#rendering/Container';
+
+import type { EvidenceClass, SupportState } from './evidenceSink';
+
+export type { EvidenceClass, EvidenceRow, SupportState } from './evidenceSink';
+
+/**
+ * How a scene's texture data is built.
+ *
+ * `self-describing` means every texel encodes its own coordinates, which is the
+ * precondition for an `exact` verdict: each output pixel can be checked against
+ * the texel it must have come from. Anything else can only be sampled or
+ * compared against an oracle.
+ */
+export type FixtureKind = 'self-describing' | 'opaque-solid' | 'interpolated';
+
+export interface Scene {
+  /** Stable identifier, `feature/variant` by convention. Used as the matrix key. */
+  readonly name: string;
+  /** The public feature this scene exercises, as it should appear in the matrix. */
+  readonly feature: string;
+  /** Edge length of the square canvas this scene expects. */
+  readonly size: number;
+  readonly fixture: FixtureKind;
+  /** Nearest sampling is the other half of the `exact` precondition. */
+  readonly nearestSampled: boolean;
+  /** Builds a fresh scene graph. Called once per backend — never share nodes across backends. */
+  readonly build: () => Container;
+}
+
+/** What a property observed. `support` and `evidence` are deliberately separate axes. */
+export interface PropertyResult {
+  readonly support: SupportState;
+  /** The strongest class this property could justify. The runner may downgrade it. */
+  readonly evidence: EvidenceClass;
+  readonly delta: number | null;
+  readonly note?: string;
+}
+
+/**
+ * Whether a property needs one backend or both.
+ *
+ * `per-backend` properties run once per backend and say something about that
+ * backend alone (determinism, oracle agreement). `cross-backend` properties
+ * compare the two and produce a single row per backend pair.
+ */
+export type PropertyScope = 'per-backend' | 'cross-backend';
+
+export interface PropertyContext {
+  readonly scene: Scene;
+  /** Skips the run when the software adapter drops the device mid-test. */
+  readonly skip: (reason: string) => void;
+}
+
+export interface PerBackendProperty {
+  readonly name: string;
+  readonly scope: 'per-backend';
+  readonly appliesTo: (scene: Scene) => boolean;
+  readonly run: (ctx: PropertyContext, backend: 'webgl2' | 'webgpu') => Promise<PropertyResult>;
+}
+
+export interface CrossBackendProperty {
+  readonly name: string;
+  readonly scope: 'cross-backend';
+  readonly appliesTo: (scene: Scene) => boolean;
+  readonly run: (ctx: PropertyContext) => Promise<PropertyResult>;
+}
+
+export type Property = PerBackendProperty | CrossBackendProperty;
+
+/**
+ * Caps a property's claim at what the scene can actually support.
+ *
+ * `exact` requires a self-describing fixture under nearest sampling — without
+ * both, an output pixel cannot be traced back to a specific texel, so the
+ * verdict is at best `sampled`. Applying this in the runner rather than
+ * trusting each property keeps the class observed instead of asserted.
+ */
+export const cappedEvidence = (scene: Scene, claimed: EvidenceClass): EvidenceClass => {
+  if (claimed !== 'exact') return claimed;
+
+  return scene.fixture === 'self-describing' && scene.nearestSampled ? 'exact' : 'sampled';
+};

--- a/test/rendering/parity/types.ts
+++ b/test/rendering/parity/types.ts
@@ -19,9 +19,9 @@ export type { EvidenceClass, EvidenceRow, SupportState } from './evidenceSink';
  * How a scene's texture data is built.
  *
  * `self-describing` means every texel encodes its own coordinates, which is the
- * precondition for an `exact` verdict: each output pixel can be checked against
- * the texel it must have come from. Anything else can only be sampled or
- * compared against an oracle.
+ * precondition for a `traced` verdict: each output pixel can be checked against
+ * the texel it must have come from. Anything else can only be compared frame to
+ * frame, sampled, or held against an oracle.
  */
 export type FixtureKind = 'self-describing' | 'opaque-solid' | 'interpolated';
 
@@ -33,7 +33,7 @@ export interface Scene {
   /** Edge length of the square canvas this scene expects. */
   readonly size: number;
   readonly fixture: FixtureKind;
-  /** Nearest sampling is the other half of the `exact` precondition. */
+  /** Nearest sampling is the other half of the `traced` precondition. */
   readonly nearestSampled: boolean;
   /** Builds a fresh scene graph. Called once per backend — never share nodes across backends. */
   readonly build: () => Container;
@@ -82,13 +82,14 @@ export type Property = PerBackendProperty | CrossBackendProperty;
 /**
  * Caps a property's claim at what the scene can actually support.
  *
- * `exact` requires a self-describing fixture under nearest sampling — without
- * both, an output pixel cannot be traced back to a specific texel, so the
- * verdict is at best `sampled`. Applying this in the runner rather than
- * trusting each property keeps the class observed instead of asserted.
+ * `traced` requires a self-describing fixture under nearest sampling — without
+ * both, an output pixel cannot be traced back to a specific texel, however
+ * exhaustively the frames were compared, so the claim drops to `frame-equal`.
+ * Applying this in the runner rather than trusting each property keeps the
+ * class observed instead of asserted.
  */
 export const cappedEvidence = (scene: Scene, claimed: EvidenceClass): EvidenceClass => {
-  if (claimed !== 'exact') return claimed;
+  if (claimed !== 'traced') return claimed;
 
-  return scene.fixture === 'self-describing' && scene.nearestSampled ? 'exact' : 'sampled';
+  return scene.fixture === 'self-describing' && scene.nearestSampled ? 'traced' : 'frame-equal';
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,8 @@ import { createJsdomTestProject, shaderStubPlugin, srcConditions, workletTransfo
 import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vitest/config';
 
+import { resetParityEvidence, writeParityEvidence } from './test/rendering/parity/evidenceSink';
+
 // Note: Vite alias matching uses longest-first order. Subpath aliases must come
 // before the root alias so '@codexo/exojs/renderer-sdk' resolves before '@codexo/exojs'.
 // These map the PUBLIC cross-package specifiers to source for in-repo tests.
@@ -88,6 +90,10 @@ const browserSetupFiles = ['./test/rendering/browser/_setup-dev-global.ts'];
 // a probe shader instead of the shipped one still declares its own `vi.mock`,
 // which takes precedence over these.
 const renderingBrowserSetupFiles = [...browserSetupFiles, './test/rendering/browser/_glslMocks.ts'];
+
+// The parity runner executes in the browser and cannot write files, so it hands
+// its evidence rows to these node-side commands.
+const parityCommands = { writeParityEvidence, resetParityEvidence };
 
 export default defineConfig({
   test: {
@@ -280,9 +286,10 @@ export default defineConfig({
           name: 'browser-webgpu',
           globals: true,
           setupFiles: renderingBrowserSetupFiles,
-          include: ['test/rendering/browser/webgpu-*.test.ts'],
+          include: ['test/rendering/browser/webgpu-*.test.ts', 'test/rendering/parity/**/*.test.ts'],
           browser: {
             enabled: true,
+            commands: parityCommands,
             headless: !webgpuCiHeaded,
             provider: playwright({
               launchOptions: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -143,7 +143,9 @@ export default defineConfig({
         name: 'exojs',
         alias: aliasConfig,
         include: ['test/**/*.test.ts'],
-        exclude: ['test/rendering/browser/**/*.test.ts', 'test/perf/rendering/**/*.test.ts'],
+        // The parity matrix runs in `browser-webgpu`: its runner imports the
+        // browser context module, which throws on import under jsdom.
+        exclude: ['test/rendering/browser/**/*.test.ts', 'test/rendering/parity/**/*.test.ts', 'test/perf/rendering/**/*.test.ts'],
       }),
       createJsdomTestProject({
         name: 'exojs-particles',


### PR DESCRIPTION
First vertical slice of the conformance matrix: scene catalog, property
catalog, and a runner that walks the cross product.

## What it produces

`test/rendering/parity/evidence.json` — one row per (scene, property, browser,
backend), each carrying two independent axes:

- **`support`** — did it work there (`supported` / `divergent` / `unknown`)
- **`evidence`** — how well was that shown (`exact` / `oracle` / `tolerant` /
  `sampled` / `none`)

Keeping them apart is the point. A green test suite can say "passing" but not
"unverified", which is precisely how a WebGPU sprite path stayed broken while
every test passed — no test covered it, and a missing test never turns red.

## Observed, not claimed

`exact` requires a self-describing fixture under nearest sampling. The runner
caps each property's claim at what the scene can actually back up, so the class
cannot be asserted by a property that has not earned it.
`sprite/canvas-texture` exists to exercise that downgrade: the comparison is
byte-exact, but the scene cannot trace a pixel to a texel, so it records as
`sampled`.

## Getting the rows out

The runner executes in the browser and cannot write files, so it hands rows to
a vitest browser command running in node. A run only speaks for the browsers it
exercised — rows for other browsers are carried over rather than clobbered, so
the Chromium lane will not erase what a Firefox lane recorded.

## Verification

Both failure modes were checked by deliberate sabotage rather than assumed:
injecting a frame difference fails the test with the delta in the message, and
a non-self-describing scene is recorded as `sampled` rather than `exact`.

webgpu lane 192 → 201 tests, `verify:quick` green.

## Not in this slice

Oracle and translation-invariance properties, the remaining scene catalogs
(nine-slice, repeating sprite, tilemap), matrix rendering for the docs site,
and the sync gate. The evidence artifact is checked in but nothing enforces it
yet.