### PR TITLE
chore: clear the avoidable build and lint warnings

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1291,7 +1291,9 @@ export default defineConfig([
     rules: {
       'no-console': 'warn',
       '@typescript-eslint/no-require-imports': 'warn',
-      '@typescript-eslint/no-unused-vars': 'warn',
+      // Base no-unused-vars handled by `unused-imports/no-unused-vars`, which
+      // honours the `_` prefix this repo uses for deliberately unused bindings.
+      '@typescript-eslint/no-unused-vars': 'off',
       'unicorn/prefer-node-protocol': 'warn',
       'security/detect-non-literal-fs-filename': 'off',
     },
@@ -1376,7 +1378,9 @@ export default defineConfig([
       'simple-import-sort/exports': 'error',
       'unused-imports/no-unused-imports': 'error',
       '@typescript-eslint/no-empty-function': 'warn',
-      '@typescript-eslint/no-unused-vars': 'warn',
+      // Base no-unused-vars handled by `unused-imports/no-unused-vars` below,
+      // which honours the `_` prefix; leaving both on double-reports.
+      '@typescript-eslint/no-unused-vars': 'off',
       'unused-imports/no-unused-vars': [
         'error',
         {

--- a/packages/exojs-tilemap/src/ChunkStreamer.ts
+++ b/packages/exojs-tilemap/src/ChunkStreamer.ts
@@ -1,4 +1,4 @@
-import type { View } from '@codexo/exojs';
+import { logger, type View } from '@codexo/exojs';
 
 import type { ChunkPayload, ChunkSource } from './ChunkSource';
 import type { ChunkRange, TileLayer } from './TileLayer';
@@ -219,9 +219,11 @@ export class ChunkStreamer {
       result = this._source.getChunk(cx, cy);
     } catch (error) {
       this._inFlight.delete(key);
-      if (__DEV__) {
-        console.warn(`[ChunkStreamer] source.getChunk(${cx}, ${cy}) threw synchronously:`, error);
-      }
+      logger.warn(`ChunkStreamer: source.getChunk(${cx}, ${cy}) threw synchronously.`, {
+        source: 'ChunkStreamer',
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
+
       return;
     }
 
@@ -230,9 +232,10 @@ export class ChunkStreamer {
         payload => { this._onResolved(key, cx, cy, token, payload); },
         (error: unknown) => {
           this._inFlight.delete(key);
-          if (__DEV__) {
-            console.warn(`[ChunkStreamer] source.getChunk(${cx}, ${cy}) rejected:`, error);
-          }
+          logger.warn(`ChunkStreamer: source.getChunk(${cx}, ${cy}) rejected.`, {
+            source: 'ChunkStreamer',
+            error: error instanceof Error ? error : new Error(String(error)),
+          });
         },
       );
       return;

--- a/scripts/release/cut.ts
+++ b/scripts/release/cut.ts
@@ -66,10 +66,6 @@ function run(cmd: string, opts: { cwd?: string } = {}): void {
   execSync(cmd, { stdio: 'inherit', cwd: opts.cwd ?? repoRoot });
 }
 
-function runCapture(cmd: string): string {
-  return execSync(cmd, { cwd: repoRoot, encoding: 'utf8' }).trim();
-}
-
 // ── Pre-flight checks ──────────────────────────────────────────────────────
 
 function assertCleanTree(): void {

--- a/src/input/FocusController.ts
+++ b/src/input/FocusController.ts
@@ -375,7 +375,10 @@ export class FocusController implements FocusHooks {
     }
 
     const currentIndex = this._focused === null ? -1 : focusables.indexOf(this._focused);
-    let nextIndex = currentIndex === -1 ? (direction === 1 ? 0 : count - 1) : currentIndex;
+    // With nothing focused yet, entering forwards starts at the first candidate
+    // and entering backwards at the last.
+    const entryIndex = direction === 1 ? 0 : count - 1;
+    let nextIndex = currentIndex === -1 ? entryIndex : currentIndex;
 
     for (let attempt = 0; attempt < count; attempt++) {
       if (currentIndex !== -1 || attempt > 0) {

--- a/test/core/focus-visibility.test.ts
+++ b/test/core/focus-visibility.test.ts
@@ -78,7 +78,6 @@ const loadHarness = async (): Promise<FocusVisibilityHarness> => {
     onRenderError: { add: vi.fn(), destroy: vi.fn() },
     onDeviceLost: { add: vi.fn(), destroy: vi.fn() },
     onDeviceRestored: { add: vi.fn(), destroy: vi.fn() },
-    onRenderError: { add: vi.fn(), destroy: vi.fn() },
   };
 
   vi.resetModules();

--- a/test/rendering/browser/webgpu-split-viewport.test.ts
+++ b/test/rendering/browser/webgpu-split-viewport.test.ts
@@ -114,6 +114,8 @@ describe('WebGPU split-screen viewport', () => {
         validationError = await device.popErrorScope();
       } catch (error) {
         if (isDeviceLoss(error)) {
+          // Runtime skip for a lost device, not a disabled test.
+          // eslint-disable-next-line vitest/no-disabled-tests
           ctx.skip('WebGPU device lost mid-test — unstable software adapter');
 
           return;
@@ -173,6 +175,8 @@ describe('WebGPU split-screen viewport', () => {
         validationError = await device.popErrorScope();
       } catch (error) {
         if (isDeviceLoss(error)) {
+          // Runtime skip for a lost device, not a disabled test.
+          // eslint-disable-next-line vitest/no-disabled-tests
           ctx.skip('WebGPU device lost mid-test — unstable software adapter');
 
           return;
@@ -228,6 +232,8 @@ describe('WebGPU split-screen viewport', () => {
         validationError = await device.popErrorScope();
       } catch (error) {
         if (isDeviceLoss(error)) {
+          // Runtime skip for a lost device, not a disabled test.
+          // eslint-disable-next-line vitest/no-disabled-tests
           ctx.skip('WebGPU device lost mid-test — unstable software adapter');
 
           return;
@@ -285,6 +291,8 @@ describe('WebGPU split-screen viewport', () => {
         validationError = await device.popErrorScope();
       } catch (error) {
         if (isDeviceLoss(error)) {
+          // Runtime skip for a lost device, not a disabled test.
+          // eslint-disable-next-line vitest/no-disabled-tests
           ctx.skip('WebGPU device lost mid-test — unstable software adapter');
 
           return;

--- a/test/rendering/parity/runner.ts
+++ b/test/rendering/parity/runner.ts
@@ -8,8 +8,8 @@
  * verification — the thing a suite of green tests structurally cannot.
  */
 
-import { commands } from '@vitest/browser/context';
 import { afterAll, describe, expect, test } from 'vitest';
+import { commands } from 'vitest/browser';
 
 import type { EvidenceRow } from './evidenceSink';
 import { cappedEvidence, type Property, type Scene } from './types';


### PR DESCRIPTION
Sweeps the warnings that every local run and CI job printed, keeping the ones that carry real information.

**The one that mattered:** `pnpm lint:strict` exited 1 on a single `no-nested-ternary` warning in `FocusController`, and `lint:strict` sits inside `verify:release`. CI only runs `lint:all`, which has no `--max-warnings`, so nothing ever reported the release path as blocked.

**ESLint config fix.** The `scripts/` and `examples/` blocks left `@typescript-eslint/no-unused-vars` enabled next to `unused-imports/no-unused-vars`. Only the latter is configured with `argsIgnorePattern: '^_'`, so every deliberately unused binding warned anyway — and in `examples/` the same line was reported twice. `src/` and `packages/` already switch the base rule off for exactly this reason. Drops 7 warnings without touching a line of example code.

**Real defect found on the way:** `ChunkStreamer` logged with bare `console.warn` and its own prefix, bypassing the engine logger every other subsystem reports through. Those two warnings reached no sink.

**Also:** the deprecated `@vitest/browser/context` import (the new `vitest/browser` path re-exports it verbatim), a duplicate `onRenderError` key that vite flagged and nothing failed on, one dead release-script function, and four device-loss `ctx.skip` calls now annotated as runtime skips the way the parity runner already annotates them.

Warning count: 51 → 36, errors 0. What remains is `site/`+React (20) and non-null assertions in `packages/` (13) — both need judgement per case, not a sweep.

## Verification

- `pnpm lint:strict` — exit 0 (was 1)
- `pnpm lint:all` — 36 warnings, 0 errors
- `pnpm verify:quick` — green
- unit + tilemap: 6440 passed, browser WebGPU parity: 9 passed, no deprecation line