### PR TITLE
fix(release): unblock the release dry run

### DIFF
--- a/scripts/release/external-consumers.ts
+++ b/scripts/release/external-consumers.ts
@@ -68,8 +68,10 @@ import { LdtkMap, ldtkExtension } from '@codexo/exojs-ldtk';
 export class DemoScene extends Scene {}
 
 export function verifyCoreProtocols(container: Container): void {
+    // ActionMap exposes its actions as named properties, not as an iterable —
+    // unlike Container below, which does implement Symbol.iterator.
     const actions = new ActionMap({ jump: new ButtonAction(Keyboard.Space) });
-    for (const action of actions) void action;
+    void actions.jump.active;
     for (const child of container) void child;
 
     // The binding is constructed (and therefore owned) right here, not


### PR DESCRIPTION
`pnpm release:prepare` failed at the external-consumer smoke test:

```
consumer.ts(15,26): error TS2488: Type 'ActionMapBase<{ jump: ButtonAction; }> & Readonly<{ jump: ButtonAction; }>'
must have a '[Symbol.iterator]()' method that returns an iterator.
```

The generated consumer iterated an `ActionMap`, which has never implemented `Symbol.iterator` — no commit under `src/input/` has ever added one. `Container`, iterated on the very next line, does implement it; `ActionMap` exposes its actions as named properties instead. The test now uses the API that exists.

**Why it surfaced only now.** The line arrived with #432 and had not run since. The release job is filtered on release-relevant paths, so it is skipped — and reported green — on most PRs. #456 changed `package.json`, which tripped the filter and gave this step its first real execution in months. Same shape as two other findings today: `lint:strict` red behind a laxer `lint:all` in CI, and the jsdom lane silently collecting a browser-only spec.

This blocks a real release: `verify:release` runs this smoke test.

Not changed here: whether `ActionMap` *should* be iterable. `Container` is, and the argument for consistency is real, but that is an API addition and belongs in its own decision rather than smuggled in as a test fix.

## Verification

`pnpm release:prepare --build --skip-zip` — completes, all four consumer checks pass:
- install (offline, 8 tarballs)
- Node ESM import
- TypeScript bundler-resolution type-check
- TypeScript subpath-entry (renderer-sdk) type-check