### PR TITLE
docs(rendering): publish the parity matrix, and four more features in it

### DIFF
--- a/site/src/components/ParityMatrix.astro
+++ b/site/src/components/ParityMatrix.astro
@@ -1,0 +1,223 @@
+---
+/**
+ * ParityMatrix — what the conformance suite has actually measured, per browser.
+ *
+ * Rows come from the hand-kept feature list, not from the measurements, so a
+ * feature nobody has written a scene for shows up as "not verified" instead of
+ * vanishing. That is the whole point: a table built only from what was measured
+ * can never report what was missed.
+ *
+ * Each cell carries both backends, because a browser can support a feature on
+ * one and not the other — the single most useful thing this table can tell you.
+ *
+ * Usage in MDX:
+ *   import ParityMatrix from '../../../components/ParityMatrix.astro';
+ *   <ParityMatrix />
+ */
+
+import evidence from '../../../test/rendering/parity/evidence.json';
+import { RENDER_FEATURES } from '../../../test/rendering/parity/features';
+
+type Backend = 'webgl2' | 'webgpu';
+type Support = 'supported' | 'divergent' | 'unavailable' | 'unknown';
+
+interface Row {
+  readonly feature: string;
+  readonly browser: string;
+  readonly backend: Backend;
+  readonly support: Support;
+  readonly measuredAt?: string;
+  readonly commit?: string;
+}
+
+const rows = evidence as readonly Row[];
+
+/** Browser column order: the ones we measure first, then anything else alphabetically. */
+const PREFERRED = ['chromium', 'firefox', 'webkit'];
+const browsers = [...new Set(rows.map(row => row.browser))].sort((a, b) => {
+  const ia = PREFERRED.indexOf(a);
+  const ib = PREFERRED.indexOf(b);
+
+  return (ia === -1 ? PREFERRED.length : ia) - (ib === -1 ? PREFERRED.length : ib) || a.localeCompare(b);
+});
+
+const LABELS: Record<string, string> = { chromium: 'Chromium', firefox: 'Firefox', webkit: 'Safari / WebKit', edge: 'Edge' };
+
+/**
+ * One cell's verdict for a single backend.
+ *
+ * `divergent` wins over everything: a single disagreeing scene is the headline,
+ * not an average. `unavailable` outranks `supported` only when nothing was
+ * supported, so a browser that supports half a feature still reads as partial.
+ */
+const verdictFor = (feature: string, browser: string, backend: Backend): 'ok' | 'differs' | 'missing' | 'untested' => {
+  const cell = rows.filter(row => row.feature === feature && row.browser === browser && row.backend === backend);
+
+  if (cell.length === 0) return 'untested';
+  if (cell.some(row => row.support === 'divergent')) return 'differs';
+  if (cell.some(row => row.support === 'supported')) return 'ok';
+  if (cell.every(row => row.support === 'unavailable')) return 'missing';
+
+  return 'untested';
+};
+
+const MARK = { ok: '✔', differs: '✕', missing: '–', untested: '?' } as const;
+const TITLE = {
+  ok: 'verified — every scene agreed',
+  differs: 'a scene disagreed between backends',
+  missing: 'this browser has no such backend',
+  untested: 'no measurement on record',
+} as const;
+
+const stamps = rows.filter(row => row.measuredAt !== undefined);
+const lastMeasured = stamps.length > 0 ? stamps.map(row => row.measuredAt!).sort().at(-1) : undefined;
+const measuredFeatures = new Set(rows.map(row => row.feature));
+const coverage = `${RENDER_FEATURES.filter(feature => measuredFeatures.has(feature.name)).length} of ${RENDER_FEATURES.length}`;
+---
+
+<figure class="parity">
+  <table>
+    <caption>
+      Verified rendering behaviour by browser — <strong>{coverage}</strong> features measured{lastMeasured ? `, last on ${lastMeasured}` : ''}.
+    </caption>
+    <thead>
+      <tr>
+        <th scope="col">Feature</th>
+        {browsers.map(browser => <th scope="col">{LABELS[browser] ?? browser}</th>)}
+      </tr>
+    </thead>
+    <tbody>
+      {
+        RENDER_FEATURES.map(feature => (
+          <tr class={measuredFeatures.has(feature.name) ? undefined : 'untested-row'}>
+            <th scope="row">
+              {feature.name}
+              <span class="summary">{feature.summary}</span>
+            </th>
+            {browsers.map(browser => (
+              <td>
+                {(['webgl2', 'webgpu'] as const).map(backend => {
+                  const verdict = verdictFor(feature.name, browser, backend);
+
+                  return (
+                    <span class:list={['cell', verdict]} title={`${backend === 'webgl2' ? 'WebGL2' : 'WebGPU'}: ${TITLE[verdict]}`}>
+                      <span class="backend">{backend === 'webgl2' ? 'GL' : 'GPU'}</span>
+                      <span class="mark">{MARK[verdict]}</span>
+                    </span>
+                  );
+                })}
+              </td>
+            ))}
+          </tr>
+        ))
+      }
+    </tbody>
+  </table>
+
+  <figcaption>
+    <span><span class="mark ok">✔</span> verified</span>
+    <span><span class="mark differs">✕</span> backends differ</span>
+    <span><span class="mark missing">–</span> backend absent in this browser</span>
+    <span><span class="mark untested">?</span> not measured</span>
+  </figcaption>
+</figure>
+
+<style>
+  .parity {
+    margin: 2rem 0;
+    overflow-x: auto;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+  }
+
+  caption {
+    caption-side: top;
+    text-align: left;
+    padding-bottom: 0.75rem;
+    color: var(--color-text-muted, #888);
+    font-size: 0.85rem;
+  }
+
+  th,
+  td {
+    border-bottom: 1px solid var(--color-border, #2a2a2a);
+    padding: 0.55rem 0.75rem;
+    text-align: left;
+    vertical-align: top;
+  }
+
+  thead th {
+    font-weight: 600;
+    white-space: nowrap;
+  }
+
+  tbody th {
+    font-weight: 500;
+    white-space: nowrap;
+  }
+
+  .summary {
+    display: block;
+    font-weight: 400;
+    font-size: 0.78rem;
+    color: var(--color-text-muted, #888);
+    white-space: normal;
+    max-width: 22ch;
+  }
+
+  .untested-row tbody th,
+  .untested-row {
+    opacity: 0.62;
+  }
+
+  .cell {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.3rem;
+    margin-right: 0.85rem;
+    white-space: nowrap;
+  }
+
+  .backend {
+    font-size: 0.7rem;
+    letter-spacing: 0.04em;
+    color: var(--color-text-muted, #888);
+  }
+
+  .mark {
+    font-weight: 700;
+  }
+
+  .cell.ok .mark,
+  .mark.ok {
+    color: var(--color-success, #3fb950);
+  }
+
+  .cell.differs .mark,
+  .mark.differs {
+    color: var(--color-danger, #f85149);
+  }
+
+  .cell.missing .mark,
+  .mark.missing {
+    color: var(--color-text-muted, #888);
+  }
+
+  .cell.untested .mark,
+  .mark.untested {
+    color: var(--color-warning, #d29922);
+  }
+
+  figcaption {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.1rem;
+    padding-top: 0.75rem;
+    font-size: 0.82rem;
+    color: var(--color-text-muted, #888);
+  }
+</style>

--- a/site/src/content/guide/debugging/backend-comparison.mdx
+++ b/site/src/content/guide/debugging/backend-comparison.mdx
@@ -5,6 +5,7 @@ description: 'Compare backend behavior and decide what to ship.'
 
 import ExamplePreview from '../../../components/ExamplePreview.astro';
 import Callout from '../../../components/Callout.astro';
+import ParityMatrix from '../../../components/ParityMatrix.astro';
 
 # Backend comparison
 
@@ -34,6 +35,22 @@ At any point, check `app.backend.backendType` (a [`RenderBackendType`](/ExoJS/en
 ## Feature parity
 
 The core rendering pipeline — sprites, meshes, graphics, text, containers, masks, filters, render-targets, views, culling — works identically on both backends. The API is the same. You write one scene and it renders on both.
+
+### What has been measured
+
+That claim is easy to make and hard to keep, so a conformance suite renders the same scenes through both backends in each browser and compares the frames pixel by pixel. The table below reports what it found — not what we believe.
+
+<ParityMatrix />
+
+Read it as evidence, not as a support promise. A `?` means nobody has measured that combination yet; it is not a statement that the feature is broken, and it is deliberately visible rather than hidden. The scenes use a texture whose every texel encodes its own coordinates, so a matching frame proves the right texel landed in the right pixel — not merely that two images happened to look alike.
+
+Chromium is measured on every CI run. Firefox and Safari need a machine with a display and are measured by hand, which is why their rows carry an older date.
+
+<Callout type="hint" title="Reproduce it yourself">
+`pnpm test:parity` runs the matrix on Chromium, `test:parity:firefox` and `test:parity:safari` on the others. Each run rewrites only the rows for the browser it exercised.
+</Callout>
+
+### Known differences
 
 Where differences exist, they are performance characteristics or rendering-path specifics, not API gaps:
 

--- a/test/rendering/parity/evidence.json
+++ b/test/rendering/parity/evidence.json
@@ -9,7 +9,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -23,7 +23,7 @@
     "delta": null,
     "note": "1791/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -36,7 +36,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -49,7 +49,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -63,7 +63,7 @@
     "delta": null,
     "note": "1792/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -76,7 +76,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -89,7 +89,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -103,7 +103,7 @@
     "delta": null,
     "note": "1024/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -116,7 +116,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -129,7 +129,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -143,7 +143,7 @@
     "delta": null,
     "note": "119/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -156,7 +156,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -169,7 +169,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -183,7 +183,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -196,7 +196,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -209,7 +209,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -223,7 +223,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -236,7 +236,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -249,7 +249,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -263,7 +263,7 @@
     "delta": null,
     "note": "2303/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -276,7 +276,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -289,7 +289,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -303,7 +303,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -316,7 +316,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -329,7 +329,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -343,7 +343,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -356,7 +356,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -369,7 +369,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -383,7 +383,7 @@
     "delta": null,
     "note": "256/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -396,7 +396,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -409,7 +409,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -423,7 +423,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -436,7 +436,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -449,7 +449,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -463,7 +463,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -476,7 +476,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -489,7 +489,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -503,7 +503,7 @@
     "delta": null,
     "note": "397/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -516,7 +516,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -529,7 +529,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -543,7 +543,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -556,7 +556,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -569,7 +569,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -583,7 +583,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -596,7 +596,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -609,7 +609,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -623,7 +623,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -636,7 +636,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -649,7 +649,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -663,7 +663,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -676,7 +676,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -689,7 +689,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -703,7 +703,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -716,7 +716,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -729,7 +729,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -743,7 +743,7 @@
     "delta": null,
     "note": "1791/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -756,7 +756,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -769,7 +769,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -783,7 +783,7 @@
     "delta": null,
     "note": "1792/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -796,7 +796,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -809,7 +809,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -823,7 +823,7 @@
     "delta": null,
     "note": "1024/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -836,7 +836,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -849,7 +849,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -863,7 +863,7 @@
     "delta": null,
     "note": "119/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -876,7 +876,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -889,7 +889,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -903,7 +903,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -916,7 +916,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -929,7 +929,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -943,7 +943,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -956,7 +956,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -969,7 +969,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -983,7 +983,7 @@
     "delta": null,
     "note": "2303/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -996,7 +996,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1009,7 +1009,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1023,7 +1023,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1036,7 +1036,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1049,7 +1049,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1063,7 +1063,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1076,7 +1076,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1089,7 +1089,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1103,7 +1103,7 @@
     "delta": null,
     "note": "256/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1116,7 +1116,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1129,7 +1129,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1143,7 +1143,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1156,7 +1156,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1169,7 +1169,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1183,7 +1183,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1196,7 +1196,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1209,7 +1209,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1223,7 +1223,7 @@
     "delta": null,
     "note": "397/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1236,7 +1236,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1249,7 +1249,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1263,7 +1263,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1276,7 +1276,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1289,7 +1289,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1303,7 +1303,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1316,7 +1316,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1329,7 +1329,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1343,7 +1343,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1356,7 +1356,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1369,7 +1369,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1383,7 +1383,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1396,7 +1396,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1409,7 +1409,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1423,7 +1423,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1436,7 +1436,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1449,7 +1449,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1463,7 +1463,7 @@
     "delta": null,
     "note": "1791/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1476,7 +1476,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1489,7 +1489,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1503,7 +1503,7 @@
     "delta": null,
     "note": "1792/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1516,7 +1516,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1529,7 +1529,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1543,7 +1543,7 @@
     "delta": null,
     "note": "1024/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1556,7 +1556,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1569,7 +1569,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1583,7 +1583,7 @@
     "delta": null,
     "note": "119/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1596,7 +1596,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1609,7 +1609,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1623,7 +1623,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1636,7 +1636,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1649,7 +1649,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1663,7 +1663,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1676,7 +1676,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1689,7 +1689,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1703,7 +1703,7 @@
     "delta": null,
     "note": "2303/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1716,7 +1716,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1729,7 +1729,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1743,7 +1743,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1756,7 +1756,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1769,7 +1769,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1783,7 +1783,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1796,7 +1796,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1809,7 +1809,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1823,7 +1823,7 @@
     "delta": null,
     "note": "256/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1836,7 +1836,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1849,7 +1849,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1863,7 +1863,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1876,7 +1876,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1889,7 +1889,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1903,7 +1903,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1916,7 +1916,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1929,7 +1929,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1943,7 +1943,7 @@
     "delta": null,
     "note": "354/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1956,7 +1956,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1969,7 +1969,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1983,7 +1983,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -1996,7 +1996,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2009,7 +2009,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2023,7 +2023,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2036,7 +2036,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2049,7 +2049,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2063,7 +2063,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2076,7 +2076,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2089,7 +2089,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2103,7 +2103,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2116,7 +2116,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2129,7 +2129,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2143,7 +2143,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2156,7 +2156,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2169,7 +2169,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2183,7 +2183,7 @@
     "delta": null,
     "note": "1791/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2196,7 +2196,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2209,7 +2209,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2223,7 +2223,7 @@
     "delta": null,
     "note": "1792/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2236,7 +2236,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2249,7 +2249,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2263,7 +2263,7 @@
     "delta": null,
     "note": "1024/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2276,7 +2276,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2289,7 +2289,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2303,7 +2303,7 @@
     "delta": null,
     "note": "119/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2316,7 +2316,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2329,7 +2329,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2343,7 +2343,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2356,7 +2356,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2369,7 +2369,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2383,7 +2383,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2396,7 +2396,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2409,7 +2409,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2423,7 +2423,7 @@
     "delta": null,
     "note": "2303/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2436,7 +2436,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2449,7 +2449,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2463,7 +2463,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2476,7 +2476,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2489,7 +2489,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2503,7 +2503,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2516,7 +2516,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2529,7 +2529,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2543,7 +2543,7 @@
     "delta": null,
     "note": "256/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2556,7 +2556,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2569,7 +2569,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2583,7 +2583,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2596,7 +2596,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2609,7 +2609,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2623,7 +2623,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2636,7 +2636,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2649,7 +2649,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2663,7 +2663,7 @@
     "delta": null,
     "note": "354/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2676,7 +2676,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2689,7 +2689,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2703,7 +2703,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2716,7 +2716,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2729,7 +2729,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2743,7 +2743,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2756,7 +2756,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2769,7 +2769,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2783,7 +2783,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2796,7 +2796,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2809,7 +2809,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2823,7 +2823,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2836,7 +2836,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2849,7 +2849,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2863,7 +2863,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2876,7 +2876,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2890,7 +2890,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2904,7 +2904,7 @@
     "delta": null,
     "note": "1791/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2917,7 +2917,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2931,7 +2931,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2945,7 +2945,7 @@
     "delta": null,
     "note": "1792/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2958,7 +2958,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2972,7 +2972,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2986,7 +2986,7 @@
     "delta": null,
     "note": "1024/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -2999,7 +2999,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3013,7 +3013,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3027,7 +3027,7 @@
     "delta": null,
     "note": "119/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3040,7 +3040,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3054,7 +3054,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3068,7 +3068,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3081,7 +3081,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3095,7 +3095,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3109,7 +3109,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3122,7 +3122,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3136,7 +3136,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3150,7 +3150,7 @@
     "delta": null,
     "note": "2303/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3163,7 +3163,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3177,7 +3177,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3191,7 +3191,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3204,7 +3204,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3218,7 +3218,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3232,7 +3232,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3245,7 +3245,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3259,7 +3259,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3273,7 +3273,7 @@
     "delta": null,
     "note": "256/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3286,7 +3286,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3300,7 +3300,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3314,7 +3314,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3327,7 +3327,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3341,7 +3341,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3355,7 +3355,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3368,7 +3368,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3382,7 +3382,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3396,7 +3396,7 @@
     "delta": null,
     "note": "307/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3409,7 +3409,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3423,7 +3423,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3437,7 +3437,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3450,7 +3450,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3464,7 +3464,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3478,7 +3478,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3491,7 +3491,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3505,7 +3505,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3519,7 +3519,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3532,7 +3532,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3546,7 +3546,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3560,7 +3560,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3573,7 +3573,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3587,7 +3587,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3601,7 +3601,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3614,7 +3614,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3628,7 +3628,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3642,7 +3642,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3656,7 +3656,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3670,7 +3670,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3684,7 +3684,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3698,7 +3698,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3712,7 +3712,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3726,7 +3726,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3740,7 +3740,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3754,7 +3754,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3768,7 +3768,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3782,7 +3782,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3796,7 +3796,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3810,7 +3810,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3824,7 +3824,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3838,7 +3838,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3852,7 +3852,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3866,7 +3866,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3880,7 +3880,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3894,7 +3894,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3908,7 +3908,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3922,7 +3922,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3936,7 +3936,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3950,7 +3950,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3964,7 +3964,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3978,7 +3978,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -3992,7 +3992,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4006,7 +4006,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4020,7 +4020,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4034,7 +4034,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4048,7 +4048,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4062,7 +4062,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4076,7 +4076,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4090,7 +4090,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4104,7 +4104,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4118,7 +4118,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4132,7 +4132,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4146,7 +4146,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4160,7 +4160,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4174,7 +4174,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4188,7 +4188,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4202,7 +4202,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4216,7 +4216,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4230,7 +4230,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4244,7 +4244,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4258,7 +4258,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4272,7 +4272,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4286,7 +4286,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4300,7 +4300,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4314,7 +4314,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4328,7 +4328,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4342,7 +4342,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4356,7 +4356,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   },
   {
@@ -4370,7 +4370,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "1ab0a43d",
+    "commit": "850fe6f5",
     "platform": "win32"
   }
 ]

--- a/test/rendering/parity/evidence.json
+++ b/test/rendering/parity/evidence.json
@@ -9,7 +9,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -23,7 +23,7 @@
     "delta": null,
     "note": "1791/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -36,7 +36,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -49,7 +49,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -63,7 +63,7 @@
     "delta": null,
     "note": "1792/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -76,7 +76,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -89,7 +89,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -103,7 +103,7 @@
     "delta": null,
     "note": "1024/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -116,7 +116,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -129,7 +129,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -143,7 +143,7 @@
     "delta": null,
     "note": "119/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -156,7 +156,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -169,7 +169,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -183,7 +183,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -196,7 +196,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -209,7 +209,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -223,7 +223,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -236,7 +236,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -249,7 +249,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -263,7 +263,7 @@
     "delta": null,
     "note": "2303/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -276,7 +276,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -289,7 +289,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -303,7 +303,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -316,7 +316,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -329,7 +329,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -343,7 +343,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -356,7 +356,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -369,7 +369,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -383,7 +383,7 @@
     "delta": null,
     "note": "256/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -396,7 +396,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -409,7 +409,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -423,7 +423,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -436,7 +436,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -449,7 +449,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -463,7 +463,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -476,7 +476,47 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
+    "platform": "win32"
+  },
+  {
+    "scene": "text/sdf-glyphs",
+    "property": "cross-backend-parity",
+    "feature": "Text",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "1ab0a43d",
+    "platform": "win32"
+  },
+  {
+    "scene": "text/sdf-glyphs",
+    "property": "renders-something",
+    "feature": "Text",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "397/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "1ab0a43d",
+    "platform": "win32"
+  },
+  {
+    "scene": "text/sdf-glyphs",
+    "property": "repeat-render-determinism",
+    "feature": "Text",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -489,7 +529,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -503,7 +543,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -516,7 +556,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -529,7 +569,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -543,7 +583,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -556,7 +596,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -569,7 +609,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -583,7 +623,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -596,7 +636,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -609,7 +649,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -623,7 +663,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -636,7 +676,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -649,7 +689,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -663,7 +703,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -676,7 +716,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -689,7 +729,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -703,7 +743,7 @@
     "delta": null,
     "note": "1791/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -716,7 +756,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -729,7 +769,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -743,7 +783,7 @@
     "delta": null,
     "note": "1792/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -756,7 +796,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -769,7 +809,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -783,7 +823,7 @@
     "delta": null,
     "note": "1024/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -796,7 +836,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -809,7 +849,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -823,7 +863,7 @@
     "delta": null,
     "note": "119/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -836,7 +876,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -849,7 +889,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -863,7 +903,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -876,7 +916,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -889,7 +929,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -903,7 +943,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -916,7 +956,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -929,7 +969,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -943,7 +983,7 @@
     "delta": null,
     "note": "2303/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -956,7 +996,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -969,7 +1009,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -983,7 +1023,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -996,7 +1036,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1009,7 +1049,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1023,7 +1063,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1036,7 +1076,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1049,7 +1089,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1063,7 +1103,7 @@
     "delta": null,
     "note": "256/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1076,7 +1116,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1089,7 +1129,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1103,7 +1143,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1116,7 +1156,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1129,7 +1169,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1143,7 +1183,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1156,7 +1196,47 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
+    "platform": "win32"
+  },
+  {
+    "scene": "text/sdf-glyphs",
+    "property": "cross-backend-parity",
+    "feature": "Text",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "1ab0a43d",
+    "platform": "win32"
+  },
+  {
+    "scene": "text/sdf-glyphs",
+    "property": "renders-something",
+    "feature": "Text",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "397/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "1ab0a43d",
+    "platform": "win32"
+  },
+  {
+    "scene": "text/sdf-glyphs",
+    "property": "repeat-render-determinism",
+    "feature": "Text",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1169,7 +1249,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1183,7 +1263,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1196,7 +1276,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1209,7 +1289,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1223,7 +1303,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1236,7 +1316,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1249,7 +1329,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1263,7 +1343,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1276,7 +1356,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1289,7 +1369,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1303,7 +1383,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1316,7 +1396,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1329,7 +1409,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1343,7 +1423,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1356,7 +1436,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1369,7 +1449,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1383,7 +1463,7 @@
     "delta": null,
     "note": "1791/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1396,7 +1476,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1409,7 +1489,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1423,7 +1503,7 @@
     "delta": null,
     "note": "1792/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1436,7 +1516,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1449,7 +1529,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1463,7 +1543,7 @@
     "delta": null,
     "note": "1024/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1476,7 +1556,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1489,7 +1569,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1503,7 +1583,7 @@
     "delta": null,
     "note": "119/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1516,7 +1596,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1529,7 +1609,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1543,7 +1623,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1556,7 +1636,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1569,7 +1649,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1583,7 +1663,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1596,7 +1676,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1609,7 +1689,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1623,7 +1703,7 @@
     "delta": null,
     "note": "2303/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1636,7 +1716,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1649,7 +1729,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1663,7 +1743,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1676,7 +1756,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1689,7 +1769,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1703,7 +1783,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1716,7 +1796,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1729,7 +1809,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1743,7 +1823,7 @@
     "delta": null,
     "note": "256/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1756,7 +1836,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1769,7 +1849,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1783,7 +1863,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1796,7 +1876,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1809,7 +1889,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1823,7 +1903,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1836,7 +1916,47 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
+    "platform": "win32"
+  },
+  {
+    "scene": "text/sdf-glyphs",
+    "property": "cross-backend-parity",
+    "feature": "Text",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "1ab0a43d",
+    "platform": "win32"
+  },
+  {
+    "scene": "text/sdf-glyphs",
+    "property": "renders-something",
+    "feature": "Text",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "354/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "1ab0a43d",
+    "platform": "win32"
+  },
+  {
+    "scene": "text/sdf-glyphs",
+    "property": "repeat-render-determinism",
+    "feature": "Text",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1849,7 +1969,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1863,7 +1983,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1876,7 +1996,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1889,7 +2009,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1903,7 +2023,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1916,7 +2036,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1929,7 +2049,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1943,7 +2063,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1956,7 +2076,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1969,7 +2089,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1983,7 +2103,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -1996,7 +2116,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2009,7 +2129,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2023,7 +2143,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2036,7 +2156,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2049,7 +2169,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2063,7 +2183,7 @@
     "delta": null,
     "note": "1791/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2076,7 +2196,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2089,7 +2209,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2103,7 +2223,7 @@
     "delta": null,
     "note": "1792/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2116,7 +2236,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2129,7 +2249,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2143,7 +2263,7 @@
     "delta": null,
     "note": "1024/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2156,7 +2276,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2169,7 +2289,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2183,7 +2303,7 @@
     "delta": null,
     "note": "119/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2196,7 +2316,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2209,7 +2329,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2223,7 +2343,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2236,7 +2356,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2249,7 +2369,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2263,7 +2383,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2276,7 +2396,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2289,7 +2409,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2303,7 +2423,7 @@
     "delta": null,
     "note": "2303/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2316,7 +2436,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2329,7 +2449,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2343,7 +2463,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2356,7 +2476,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2369,7 +2489,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2383,7 +2503,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2396,7 +2516,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2409,7 +2529,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2423,7 +2543,7 @@
     "delta": null,
     "note": "256/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2436,7 +2556,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2449,7 +2569,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2463,7 +2583,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2476,7 +2596,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2489,7 +2609,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2503,7 +2623,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2516,7 +2636,47 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
+    "platform": "win32"
+  },
+  {
+    "scene": "text/sdf-glyphs",
+    "property": "cross-backend-parity",
+    "feature": "Text",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "1ab0a43d",
+    "platform": "win32"
+  },
+  {
+    "scene": "text/sdf-glyphs",
+    "property": "renders-something",
+    "feature": "Text",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "354/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "1ab0a43d",
+    "platform": "win32"
+  },
+  {
+    "scene": "text/sdf-glyphs",
+    "property": "repeat-render-determinism",
+    "feature": "Text",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2529,7 +2689,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2543,7 +2703,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2556,7 +2716,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2569,7 +2729,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2583,7 +2743,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2596,7 +2756,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2609,7 +2769,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2623,7 +2783,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2636,7 +2796,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2649,7 +2809,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2663,7 +2823,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2676,7 +2836,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2689,7 +2849,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2703,7 +2863,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2716,7 +2876,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2730,7 +2890,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2744,7 +2904,7 @@
     "delta": null,
     "note": "1791/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2757,7 +2917,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2771,7 +2931,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2785,7 +2945,7 @@
     "delta": null,
     "note": "1792/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2798,7 +2958,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2812,7 +2972,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2826,7 +2986,7 @@
     "delta": null,
     "note": "1024/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2839,7 +2999,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2853,7 +3013,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2867,7 +3027,7 @@
     "delta": null,
     "note": "119/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2880,7 +3040,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2894,7 +3054,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2908,7 +3068,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2921,7 +3081,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2935,7 +3095,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2949,7 +3109,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2962,7 +3122,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2976,7 +3136,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -2990,7 +3150,7 @@
     "delta": null,
     "note": "2303/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3003,7 +3163,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3017,7 +3177,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3031,7 +3191,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3044,7 +3204,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3058,7 +3218,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3072,7 +3232,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3085,7 +3245,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3099,7 +3259,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3113,7 +3273,7 @@
     "delta": null,
     "note": "256/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3126,7 +3286,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3140,7 +3300,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3154,7 +3314,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3167,7 +3327,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3181,7 +3341,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3195,7 +3355,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3208,7 +3368,48 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
+    "platform": "win32"
+  },
+  {
+    "scene": "text/sdf-glyphs",
+    "property": "cross-backend-parity",
+    "feature": "Text",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "1ab0a43d",
+    "platform": "win32"
+  },
+  {
+    "scene": "text/sdf-glyphs",
+    "property": "renders-something",
+    "feature": "Text",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "307/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "1ab0a43d",
+    "platform": "win32"
+  },
+  {
+    "scene": "text/sdf-glyphs",
+    "property": "repeat-render-determinism",
+    "feature": "Text",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3222,7 +3423,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3236,7 +3437,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3249,7 +3450,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3263,7 +3464,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3277,7 +3478,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3290,7 +3491,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3304,7 +3505,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3318,7 +3519,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3331,7 +3532,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3345,7 +3546,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3359,7 +3560,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3372,7 +3573,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3386,7 +3587,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3400,7 +3601,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3413,7 +3614,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3427,7 +3628,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3441,7 +3642,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3455,7 +3656,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3469,7 +3670,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3483,7 +3684,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3497,7 +3698,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3511,7 +3712,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3525,7 +3726,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3539,7 +3740,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3553,7 +3754,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3567,7 +3768,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3581,7 +3782,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3595,7 +3796,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3609,7 +3810,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3623,7 +3824,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3637,7 +3838,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3651,7 +3852,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3665,7 +3866,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3679,7 +3880,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3693,7 +3894,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3707,7 +3908,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3721,7 +3922,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3735,7 +3936,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3749,7 +3950,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3763,7 +3964,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3777,7 +3978,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3791,7 +3992,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3805,7 +4006,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3819,7 +4020,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3833,7 +4034,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3847,7 +4048,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3861,7 +4062,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3875,7 +4076,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3889,7 +4090,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3903,7 +4104,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3917,7 +4118,49 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
+    "platform": "win32"
+  },
+  {
+    "scene": "text/sdf-glyphs",
+    "property": "cross-backend-parity",
+    "feature": "Text",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "1ab0a43d",
+    "platform": "win32"
+  },
+  {
+    "scene": "text/sdf-glyphs",
+    "property": "renders-something",
+    "feature": "Text",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "1ab0a43d",
+    "platform": "win32"
+  },
+  {
+    "scene": "text/sdf-glyphs",
+    "property": "repeat-render-determinism",
+    "feature": "Text",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3931,7 +4174,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3945,7 +4188,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3959,7 +4202,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3973,7 +4216,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -3987,7 +4230,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -4001,7 +4244,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -4015,7 +4258,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -4029,7 +4272,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -4043,7 +4286,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -4057,7 +4300,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -4071,7 +4314,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -4085,7 +4328,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -4099,7 +4342,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -4113,7 +4356,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   },
   {
@@ -4127,7 +4370,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "7f4a15ae",
+    "commit": "1ab0a43d",
     "platform": "win32"
   }
 ]

--- a/test/rendering/parity/evidence.json
+++ b/test/rendering/parity/evidence.json
@@ -1,5 +1,165 @@
 [
   {
+    "scene": "blend/additive-overlap",
+    "property": "cross-backend-parity",
+    "feature": "BlendMode",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "blend/additive-overlap",
+    "property": "renders-something",
+    "feature": "BlendMode",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1791/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "blend/additive-overlap",
+    "property": "repeat-render-determinism",
+    "feature": "BlendMode",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/overlapping-fills",
+    "property": "cross-backend-parity",
+    "feature": "Graphics",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/overlapping-fills",
+    "property": "renders-something",
+    "feature": "Graphics",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1792/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/overlapping-fills",
+    "property": "repeat-render-determinism",
+    "feature": "Graphics",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/solid-rectangle",
+    "property": "cross-backend-parity",
+    "feature": "Graphics",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/solid-rectangle",
+    "property": "renders-something",
+    "feature": "Graphics",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1024/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/solid-rectangle",
+    "property": "repeat-render-determinism",
+    "feature": "Graphics",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "mask/triangle-clip",
+    "property": "cross-backend-parity",
+    "feature": "Mask",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "mask/triangle-clip",
+    "property": "renders-something",
+    "feature": "Mask",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "119/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "mask/triangle-clip",
+    "property": "repeat-render-determinism",
+    "feature": "Mask",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
     "scene": "mesh/mirrored-uvs",
     "property": "cross-backend-parity",
     "feature": "Mesh",
@@ -9,7 +169,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -23,7 +183,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -36,7 +196,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -49,7 +209,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -63,7 +223,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -76,7 +236,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -89,7 +249,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -103,7 +263,7 @@
     "delta": null,
     "note": "2303/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -116,7 +276,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -129,7 +289,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -143,7 +303,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -156,7 +316,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -169,7 +329,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -183,7 +343,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -196,7 +356,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -209,7 +369,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -223,7 +383,7 @@
     "delta": null,
     "note": "256/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -236,7 +396,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -249,7 +409,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -263,7 +423,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -276,7 +436,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -289,7 +449,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -303,7 +463,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -316,7 +476,47 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "tint/half-intensity",
+    "property": "cross-backend-parity",
+    "feature": "Tint",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "tint/half-intensity",
+    "property": "renders-something",
+    "feature": "Tint",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1020/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "tint/half-intensity",
+    "property": "repeat-render-determinism",
+    "feature": "Tint",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -329,7 +529,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -343,7 +543,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -356,7 +556,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -369,7 +569,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -383,7 +583,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -396,7 +596,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -409,7 +609,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -423,7 +623,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -436,7 +636,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -449,7 +649,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -463,7 +663,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -476,7 +676,167 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "blend/additive-overlap",
+    "property": "cross-backend-parity",
+    "feature": "BlendMode",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "blend/additive-overlap",
+    "property": "renders-something",
+    "feature": "BlendMode",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1791/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "blend/additive-overlap",
+    "property": "repeat-render-determinism",
+    "feature": "BlendMode",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/overlapping-fills",
+    "property": "cross-backend-parity",
+    "feature": "Graphics",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/overlapping-fills",
+    "property": "renders-something",
+    "feature": "Graphics",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1792/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/overlapping-fills",
+    "property": "repeat-render-determinism",
+    "feature": "Graphics",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/solid-rectangle",
+    "property": "cross-backend-parity",
+    "feature": "Graphics",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/solid-rectangle",
+    "property": "renders-something",
+    "feature": "Graphics",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1024/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/solid-rectangle",
+    "property": "repeat-render-determinism",
+    "feature": "Graphics",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "mask/triangle-clip",
+    "property": "cross-backend-parity",
+    "feature": "Mask",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "mask/triangle-clip",
+    "property": "renders-something",
+    "feature": "Mask",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "119/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "mask/triangle-clip",
+    "property": "repeat-render-determinism",
+    "feature": "Mask",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -489,7 +849,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -503,7 +863,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -516,7 +876,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -529,7 +889,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -543,7 +903,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -556,7 +916,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -569,7 +929,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -583,7 +943,7 @@
     "delta": null,
     "note": "2303/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -596,7 +956,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -609,7 +969,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -623,7 +983,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -636,7 +996,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -649,7 +1009,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -663,7 +1023,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -676,7 +1036,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -689,7 +1049,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -703,7 +1063,7 @@
     "delta": null,
     "note": "256/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -716,7 +1076,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -729,7 +1089,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -743,7 +1103,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -756,7 +1116,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -769,7 +1129,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -783,7 +1143,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -796,7 +1156,47 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "tint/half-intensity",
+    "property": "cross-backend-parity",
+    "feature": "Tint",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "tint/half-intensity",
+    "property": "renders-something",
+    "feature": "Tint",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1020/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "tint/half-intensity",
+    "property": "repeat-render-determinism",
+    "feature": "Tint",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -809,7 +1209,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -823,7 +1223,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -836,7 +1236,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -849,7 +1249,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -863,7 +1263,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -876,7 +1276,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -889,7 +1289,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -903,7 +1303,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -916,7 +1316,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -929,7 +1329,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -943,7 +1343,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -956,7 +1356,167 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "cc2afe89",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "blend/additive-overlap",
+    "property": "cross-backend-parity",
+    "feature": "BlendMode",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "blend/additive-overlap",
+    "property": "renders-something",
+    "feature": "BlendMode",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1791/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "blend/additive-overlap",
+    "property": "repeat-render-determinism",
+    "feature": "BlendMode",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/overlapping-fills",
+    "property": "cross-backend-parity",
+    "feature": "Graphics",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/overlapping-fills",
+    "property": "renders-something",
+    "feature": "Graphics",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1792/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/overlapping-fills",
+    "property": "repeat-render-determinism",
+    "feature": "Graphics",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/solid-rectangle",
+    "property": "cross-backend-parity",
+    "feature": "Graphics",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/solid-rectangle",
+    "property": "renders-something",
+    "feature": "Graphics",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1024/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/solid-rectangle",
+    "property": "repeat-render-determinism",
+    "feature": "Graphics",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "mask/triangle-clip",
+    "property": "cross-backend-parity",
+    "feature": "Mask",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "mask/triangle-clip",
+    "property": "renders-something",
+    "feature": "Mask",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "119/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "mask/triangle-clip",
+    "property": "repeat-render-determinism",
+    "feature": "Mask",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -969,7 +1529,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -983,7 +1543,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -996,7 +1556,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1009,7 +1569,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1023,7 +1583,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1036,7 +1596,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1049,7 +1609,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1063,7 +1623,7 @@
     "delta": null,
     "note": "2303/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1076,7 +1636,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1089,7 +1649,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1103,7 +1663,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1116,7 +1676,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1129,7 +1689,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1143,7 +1703,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1156,7 +1716,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1169,7 +1729,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1183,7 +1743,7 @@
     "delta": null,
     "note": "256/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1196,7 +1756,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1209,7 +1769,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1223,7 +1783,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1236,7 +1796,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1249,7 +1809,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1263,7 +1823,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1276,7 +1836,47 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "tint/half-intensity",
+    "property": "cross-backend-parity",
+    "feature": "Tint",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "tint/half-intensity",
+    "property": "renders-something",
+    "feature": "Tint",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1020/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "tint/half-intensity",
+    "property": "repeat-render-determinism",
+    "feature": "Tint",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1289,7 +1889,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1303,7 +1903,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1316,7 +1916,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1329,7 +1929,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1343,7 +1943,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1356,7 +1956,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1369,7 +1969,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1383,7 +1983,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1396,7 +1996,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1409,7 +2009,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1423,7 +2023,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1436,7 +2036,167 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "blend/additive-overlap",
+    "property": "cross-backend-parity",
+    "feature": "BlendMode",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "blend/additive-overlap",
+    "property": "renders-something",
+    "feature": "BlendMode",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1791/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "blend/additive-overlap",
+    "property": "repeat-render-determinism",
+    "feature": "BlendMode",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/overlapping-fills",
+    "property": "cross-backend-parity",
+    "feature": "Graphics",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/overlapping-fills",
+    "property": "renders-something",
+    "feature": "Graphics",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1792/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/overlapping-fills",
+    "property": "repeat-render-determinism",
+    "feature": "Graphics",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/solid-rectangle",
+    "property": "cross-backend-parity",
+    "feature": "Graphics",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/solid-rectangle",
+    "property": "renders-something",
+    "feature": "Graphics",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1024/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/solid-rectangle",
+    "property": "repeat-render-determinism",
+    "feature": "Graphics",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "mask/triangle-clip",
+    "property": "cross-backend-parity",
+    "feature": "Mask",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "mask/triangle-clip",
+    "property": "renders-something",
+    "feature": "Mask",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "119/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "mask/triangle-clip",
+    "property": "repeat-render-determinism",
+    "feature": "Mask",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1449,7 +2209,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1463,7 +2223,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1476,7 +2236,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1489,7 +2249,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1503,7 +2263,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1516,7 +2276,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1529,7 +2289,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1543,7 +2303,7 @@
     "delta": null,
     "note": "2303/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1556,7 +2316,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1569,7 +2329,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1583,7 +2343,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1596,7 +2356,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1609,7 +2369,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1623,7 +2383,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1636,7 +2396,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1649,7 +2409,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1663,7 +2423,7 @@
     "delta": null,
     "note": "256/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1676,7 +2436,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1689,7 +2449,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1703,7 +2463,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1716,7 +2476,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1729,7 +2489,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1743,7 +2503,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1756,7 +2516,47 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "tint/half-intensity",
+    "property": "cross-backend-parity",
+    "feature": "Tint",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "tint/half-intensity",
+    "property": "renders-something",
+    "feature": "Tint",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1020/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "tint/half-intensity",
+    "property": "repeat-render-determinism",
+    "feature": "Tint",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1769,7 +2569,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1783,7 +2583,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1796,7 +2596,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1809,7 +2609,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1823,7 +2623,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1836,7 +2636,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1849,7 +2649,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1863,7 +2663,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1876,7 +2676,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1889,7 +2689,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1903,7 +2703,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1916,7 +2716,171 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "blend/additive-overlap",
+    "property": "cross-backend-parity",
+    "feature": "BlendMode",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "blend/additive-overlap",
+    "property": "renders-something",
+    "feature": "BlendMode",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1791/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "blend/additive-overlap",
+    "property": "repeat-render-determinism",
+    "feature": "BlendMode",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/overlapping-fills",
+    "property": "cross-backend-parity",
+    "feature": "Graphics",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/overlapping-fills",
+    "property": "renders-something",
+    "feature": "Graphics",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1792/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/overlapping-fills",
+    "property": "repeat-render-determinism",
+    "feature": "Graphics",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/solid-rectangle",
+    "property": "cross-backend-parity",
+    "feature": "Graphics",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/solid-rectangle",
+    "property": "renders-something",
+    "feature": "Graphics",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1024/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/solid-rectangle",
+    "property": "repeat-render-determinism",
+    "feature": "Graphics",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "mask/triangle-clip",
+    "property": "cross-backend-parity",
+    "feature": "Mask",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "mask/triangle-clip",
+    "property": "renders-something",
+    "feature": "Mask",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "119/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "mask/triangle-clip",
+    "property": "repeat-render-determinism",
+    "feature": "Mask",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1930,7 +2894,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1944,7 +2908,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1957,7 +2921,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1971,7 +2935,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1985,7 +2949,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -1998,7 +2962,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2012,7 +2976,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2026,7 +2990,7 @@
     "delta": null,
     "note": "2303/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2039,7 +3003,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2053,7 +3017,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2067,7 +3031,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2080,7 +3044,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2094,7 +3058,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2108,7 +3072,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2121,7 +3085,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2135,7 +3099,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2149,7 +3113,7 @@
     "delta": null,
     "note": "256/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2162,7 +3126,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2176,7 +3140,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2190,7 +3154,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2203,7 +3167,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2217,7 +3181,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2231,7 +3195,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2244,7 +3208,48 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "tint/half-intensity",
+    "property": "cross-backend-parity",
+    "feature": "Tint",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "tint/half-intensity",
+    "property": "renders-something",
+    "feature": "Tint",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1020/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "tint/half-intensity",
+    "property": "repeat-render-determinism",
+    "feature": "Tint",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2258,7 +3263,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2272,7 +3277,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2285,7 +3290,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2299,7 +3304,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2313,7 +3318,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2326,7 +3331,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2340,7 +3345,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2354,7 +3359,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2367,7 +3372,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2381,7 +3386,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2395,7 +3400,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2408,7 +3413,175 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "blend/additive-overlap",
+    "property": "cross-backend-parity",
+    "feature": "BlendMode",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "blend/additive-overlap",
+    "property": "renders-something",
+    "feature": "BlendMode",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "blend/additive-overlap",
+    "property": "repeat-render-determinism",
+    "feature": "BlendMode",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/overlapping-fills",
+    "property": "cross-backend-parity",
+    "feature": "Graphics",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/overlapping-fills",
+    "property": "renders-something",
+    "feature": "Graphics",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/overlapping-fills",
+    "property": "repeat-render-determinism",
+    "feature": "Graphics",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/solid-rectangle",
+    "property": "cross-backend-parity",
+    "feature": "Graphics",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/solid-rectangle",
+    "property": "renders-something",
+    "feature": "Graphics",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "graphics/solid-rectangle",
+    "property": "repeat-render-determinism",
+    "feature": "Graphics",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "mask/triangle-clip",
+    "property": "cross-backend-parity",
+    "feature": "Mask",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "mask/triangle-clip",
+    "property": "renders-something",
+    "feature": "Mask",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "mask/triangle-clip",
+    "property": "repeat-render-determinism",
+    "feature": "Mask",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2422,7 +3595,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2436,7 +3609,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2450,7 +3623,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2464,7 +3637,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2478,7 +3651,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2492,7 +3665,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2506,7 +3679,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2520,7 +3693,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2534,7 +3707,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2548,7 +3721,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2562,7 +3735,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2576,7 +3749,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2590,7 +3763,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2604,7 +3777,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2618,7 +3791,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2632,7 +3805,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2646,7 +3819,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2660,7 +3833,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2674,7 +3847,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2688,7 +3861,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2702,7 +3875,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2716,7 +3889,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2730,7 +3903,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2744,7 +3917,49 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "tint/half-intensity",
+    "property": "cross-backend-parity",
+    "feature": "Tint",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "tint/half-intensity",
+    "property": "renders-something",
+    "feature": "Tint",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
+    "platform": "win32"
+  },
+  {
+    "scene": "tint/half-intensity",
+    "property": "repeat-render-determinism",
+    "feature": "Tint",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2758,7 +3973,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2772,7 +3987,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2786,7 +4001,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2800,7 +4015,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2814,7 +4029,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2828,7 +4043,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2842,7 +4057,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2856,7 +4071,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2870,7 +4085,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2884,7 +4099,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2898,7 +4113,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   },
   {
@@ -2912,7 +4127,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "957ac0a4",
+    "commit": "7f4a15ae",
     "platform": "win32"
   }
 ]

--- a/test/rendering/parity/features.ts
+++ b/test/rendering/parity/features.ts
@@ -1,0 +1,38 @@
+/**
+ * The public rendering features the conformance matrix speaks about.
+ *
+ * Kept by hand on purpose. Deriving the list from the scenes that happen to
+ * exist would make the matrix structurally incapable of saying "this feature
+ * is unverified" — the row would simply not appear, and absence of a claim
+ * would look identical to absence of a problem. Listing features first and
+ * filling them from measurements second is what lets the table show its own
+ * gaps.
+ *
+ * Adding a feature here without a scene is therefore correct and expected: it
+ * turns an invisible gap into a visible one.
+ */
+
+export interface RenderFeature {
+  /** Matches `Scene.feature` for every scene that exercises it. */
+  readonly name: string;
+  /** One line, aimed at someone deciding whether they can rely on it. */
+  readonly summary: string;
+}
+
+export const RENDER_FEATURES: readonly RenderFeature[] = [
+  { name: 'Sprite', summary: 'Textured quads, the workhorse primitive.' },
+  { name: 'NineSlice', summary: 'Nine-quad scaling that keeps corners intact.' },
+  { name: 'RepeatingSprite', summary: 'Tiled fills via UV wrapping.' },
+  { name: 'Mesh', summary: 'Arbitrary triangle geometry with per-vertex UVs.' },
+  { name: 'Transform', summary: 'Position, rotation, scale, and parent composition.' },
+  { name: 'Text', summary: 'SDF and bitmap glyph rendering.' },
+  { name: 'Graphics', summary: 'Filled and stroked vector primitives.' },
+  { name: 'Tilemap', summary: 'Chunked tile layers from the tilemap package.' },
+  { name: 'Particles', summary: 'CPU and GPU particle systems.' },
+  { name: 'RenderTexture', summary: 'Rendering into a texture and sampling it back.' },
+  { name: 'Mask', summary: 'Stencil and alpha clipping.' },
+  { name: 'Filter', summary: 'Post-processing passes over a rendered region.' },
+  { name: 'BlendMode', summary: 'Separable and backdrop-aware blending.' },
+  { name: 'Tint', summary: 'Per-node colour modulation.' },
+  { name: 'Video', summary: 'Video frames uploaded as textures.' },
+];

--- a/test/rendering/parity/matrix.test.ts
+++ b/test/rendering/parity/matrix.test.ts
@@ -12,6 +12,9 @@ import { crossBackendParity } from './properties/crossBackendParity';
 import { determinism } from './properties/determinism';
 import { rendersSomething } from './properties/rendersSomething';
 import { runParityMatrix } from './runner';
+import { clippingScenes } from './scenes/clipping';
+import { colourScenes } from './scenes/colour';
+import { graphicsScenes } from './scenes/graphics';
 import { meshScenes } from './scenes/mesh';
 import { nineSliceScenes } from './scenes/nineSlice';
 import { repeatingSpriteScenes } from './scenes/repeatingSprite';
@@ -20,7 +23,17 @@ import { spriteCanvasScenes } from './scenes/spriteCanvas';
 import { transformScenes } from './scenes/transform';
 import type { Property, Scene } from './types';
 
-const scenes: readonly Scene[] = [...spriteScenes, ...spriteCanvasScenes, ...nineSliceScenes, ...repeatingSpriteScenes, ...meshScenes, ...transformScenes];
+const scenes: readonly Scene[] = [
+  ...spriteScenes,
+  ...spriteCanvasScenes,
+  ...nineSliceScenes,
+  ...repeatingSpriteScenes,
+  ...meshScenes,
+  ...transformScenes,
+  ...graphicsScenes,
+  ...colourScenes,
+  ...clippingScenes,
+];
 
 const properties: readonly Property[] = [crossBackendParity, determinism, rendersSomething];
 

--- a/test/rendering/parity/matrix.test.ts
+++ b/test/rendering/parity/matrix.test.ts
@@ -20,6 +20,7 @@ import { nineSliceScenes } from './scenes/nineSlice';
 import { repeatingSpriteScenes } from './scenes/repeatingSprite';
 import { spriteScenes } from './scenes/sprite';
 import { spriteCanvasScenes } from './scenes/spriteCanvas';
+import { textScenes } from './scenes/text';
 import { transformScenes } from './scenes/transform';
 import type { Property, Scene } from './types';
 
@@ -33,6 +34,7 @@ const scenes: readonly Scene[] = [
   ...graphicsScenes,
   ...colourScenes,
   ...clippingScenes,
+  ...textScenes,
 ];
 
 const properties: readonly Property[] = [crossBackendParity, determinism, rendersSomething];

--- a/test/rendering/parity/scenes/clipping.ts
+++ b/test/rendering/parity/scenes/clipping.ts
@@ -1,0 +1,50 @@
+/**
+ * Stencil-clipped scenes.
+ *
+ * A clip shape sends both backends down a path they otherwise never take —
+ * a stencil buffer on WebGL2 against a separate stencil attachment and
+ * pipeline state on WebGPU. The sprite inside keeps its coordinate texture, so
+ * the surviving pixels remain traceable: this checks not just *that* something
+ * was clipped, but that the same texels survived on both sides.
+ */
+
+import { Container } from '#rendering/Container';
+import { Geometry } from '#rendering/geometry/Geometry';
+import { Sprite } from '#rendering/sprite/Sprite';
+
+import { buildCoordinateTexture } from '../../browser/_selfDescribingFixture';
+import type { Scene } from '../types';
+
+const FIXTURE = 32;
+const CANVAS = 64;
+
+/** Right triangle covering the top-left half of a `size` square, in node space. */
+const rightTriangle = (size: number): Geometry =>
+  new Geometry({
+    attributes: [{ name: 'a_position', size: 2, type: 'f32', normalized: false, offset: 0 }],
+    vertexData: new Float32Array([0, 0, size, 0, 0, size]),
+    stride: 8,
+  });
+
+export const clippingScenes: readonly Scene[] = [
+  {
+    name: 'mask/triangle-clip',
+    feature: 'Mask',
+    size: CANVAS,
+    fixture: 'self-describing',
+    nearestSampled: true,
+    build: () => {
+      const root = new Container();
+      const clipped = new Container();
+      const sprite = new Sprite(buildCoordinateTexture(FIXTURE));
+
+      sprite.setPosition(8, 8);
+      clipped.clip = true;
+      clipped.clipShape = rightTriangle(FIXTURE);
+      clipped.addChild(sprite);
+      root.addChild(clipped);
+
+      return root;
+    },
+  },
+];

--- a/test/rendering/parity/scenes/colour.ts
+++ b/test/rendering/parity/scenes/colour.ts
@@ -1,0 +1,72 @@
+/**
+ * Tint and blend scenes.
+ *
+ * Both recolour a coordinate texture, which is why they declare
+ * `colour-modified`: the sprite still lands on exactly the right pixels, but
+ * the channels now carry a product of texel and tint instead of coordinates,
+ * so no pixel can be traced back. The runner caps them at `frame-equal`
+ * accordingly — the geometry is exact, the provenance is not.
+ *
+ * They are worth measuring precisely because colour maths is where the two
+ * backends run genuinely different code: fixed-function blend state on WebGL2
+ * against a blend descriptor plus, for the backdrop-aware modes, a shader.
+ */
+
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { BlendModes } from '#rendering/types';
+
+import { buildCoordinateTexture } from '../../browser/_selfDescribingFixture';
+import type { Scene } from '../types';
+
+const FIXTURE = 32;
+const CANVAS = 64;
+
+const tinted = (color: Color): Container => {
+  const root = new Container();
+  const sprite = new Sprite(buildCoordinateTexture(FIXTURE));
+
+  sprite.tint = color;
+  sprite.setPosition(8, 8);
+  root.addChild(sprite);
+
+  return root;
+};
+
+export const colourScenes: readonly Scene[] = [
+  {
+    // A half-intensity tint: every channel is scaled, so a backend that applies
+    // the tint in the wrong colour space diverges here and nowhere else.
+    name: 'tint/half-intensity',
+    feature: 'Tint',
+    size: CANVAS,
+    fixture: 'colour-modified',
+    nearestSampled: true,
+    build: () => tinted(new Color(128, 128, 128, 1)),
+  },
+  {
+    // Additive blending over an opaque backdrop — the classic case where a
+    // premultiply mismatch between backends shows up as a brighter or darker
+    // overlap while each sprite alone looks correct.
+    name: 'blend/additive-overlap',
+    feature: 'BlendMode',
+    size: CANVAS,
+    fixture: 'colour-modified',
+    nearestSampled: true,
+    build: () => {
+      const root = new Container();
+      const backdrop = new Sprite(buildCoordinateTexture(FIXTURE));
+      const overlay = new Sprite(buildCoordinateTexture(FIXTURE));
+
+      backdrop.setPosition(8, 8);
+      overlay.setPosition(24, 24);
+      overlay.blendMode = BlendModes.Additive;
+
+      root.addChild(backdrop);
+      root.addChild(overlay);
+
+      return root;
+    },
+  },
+];

--- a/test/rendering/parity/scenes/graphics.ts
+++ b/test/rendering/parity/scenes/graphics.ts
@@ -1,0 +1,63 @@
+/**
+ * Vector primitive scenes.
+ *
+ * Graphics draws no texture at all — geometry is generated from the fill
+ * commands themselves, so this is the one family where the two backends can
+ * disagree about triangulation rather than about sampling. Nothing here is
+ * traceable to a texel; the honest claim is that both backends produced the
+ * same frame.
+ */
+
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import { Graphics } from '#rendering/primitives/Graphics';
+
+import type { Scene } from '../types';
+
+const CANVAS = 64;
+
+const rooted = (graphics: Graphics): Container => {
+  const root = new Container();
+
+  root.addChild(graphics);
+
+  return root;
+};
+
+export const graphicsScenes: readonly Scene[] = [
+  {
+    name: 'graphics/solid-rectangle',
+    feature: 'Graphics',
+    size: CANVAS,
+    fixture: 'opaque-solid',
+    nearestSampled: false,
+    build: () => {
+      const graphics = new Graphics();
+
+      graphics.fillStyle = Color.green;
+      graphics.drawRectangle(8, 8, 32, 32);
+
+      return rooted(graphics);
+    },
+  },
+  {
+    // Two overlapping fills: the second must land on top of the first
+    // identically on both backends, which is a statement about draw order
+    // rather than about either shape alone.
+    name: 'graphics/overlapping-fills',
+    feature: 'Graphics',
+    size: CANVAS,
+    fixture: 'opaque-solid',
+    nearestSampled: false,
+    build: () => {
+      const graphics = new Graphics();
+
+      graphics.fillStyle = Color.red;
+      graphics.drawRectangle(8, 8, 32, 32);
+      graphics.fillStyle = Color.blue;
+      graphics.drawRectangle(24, 24, 32, 32);
+
+      return rooted(graphics);
+    },
+  },
+];

--- a/test/rendering/parity/scenes/text.ts
+++ b/test/rendering/parity/scenes/text.ts
@@ -1,0 +1,43 @@
+/**
+ * Text scenes.
+ *
+ * Text is its own subsystem: glyphs are rasterised into an SDF atlas at
+ * runtime and sampled with a dedicated shader, so neither the fixture trick nor
+ * nearest sampling applies. The claim here is narrower on purpose — both
+ * backends consume the same atlas and must turn it into the same frame.
+ *
+ * That still catches real divergence: the SDF shaders are written twice, once
+ * in GLSL and once in WGSL, and a threshold or channel-swizzle difference
+ * between them shows up as an edge that is a pixel fatter on one side.
+ *
+ * Font rasterisation differs between machines, which is fine — every property
+ * compares within a single browser on a single run, never against a baseline.
+ */
+
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import { Text } from '#rendering/text/Text';
+
+import type { Scene } from '../types';
+
+const CANVAS = 64;
+
+export const textScenes: readonly Scene[] = [
+  {
+    name: 'text/sdf-glyphs',
+    feature: 'Text',
+    size: CANVAS,
+    // SDF sampling is filtered by design; no output pixel maps to one texel.
+    fixture: 'interpolated',
+    nearestSampled: false,
+    build: () => {
+      const root = new Container();
+      const text = new Text('AB', { fillColor: Color.white, fontSize: 28 });
+
+      text.setPosition(6, 6);
+      root.addChild(text);
+
+      return root;
+    },
+  },
+];

--- a/test/rendering/parity/types.ts
+++ b/test/rendering/parity/types.ts
@@ -22,8 +22,13 @@ export type { EvidenceClass, EvidenceRow, SupportState } from './evidenceSink';
  * precondition for a `traced` verdict: each output pixel can be checked against
  * the texel it must have come from. Anything else can only be compared frame to
  * frame, sampled, or held against an oracle.
+ *
+ * `colour-modified` is a self-describing texture the scene then tints, blends
+ * or otherwise recolours. The geometry stays exact, but the channels no longer
+ * carry coordinates, so the pixel cannot be traced back — worth stating
+ * separately from `opaque-solid`, where nothing was traceable to begin with.
  */
-export type FixtureKind = 'self-describing' | 'opaque-solid' | 'interpolated';
+export type FixtureKind = 'self-describing' | 'colour-modified' | 'opaque-solid' | 'interpolated';
 
 export interface Scene {
   /** Stable identifier, `feature/variant` by convention. Used as the matrix key. */
@@ -85,6 +90,8 @@ export type Property = PerBackendProperty | CrossBackendProperty;
  * `traced` requires a self-describing fixture under nearest sampling — without
  * both, an output pixel cannot be traced back to a specific texel, however
  * exhaustively the frames were compared, so the claim drops to `frame-equal`.
+ * A `colour-modified` fixture fails the same test for a different reason: the
+ * geometry is still exact, but the channels no longer spell out coordinates.
  * Applying this in the runner rather than trusting each property keeps the
  * class observed instead of asserted.
  */


### PR DESCRIPTION
Two things: the matrix becomes visible to users, and it covers ten of fifteen features instead of five.

## The guide now shows what was measured

`Backend comparison` claimed the pipeline *"works identically on both backends"* with nothing behind it. It now carries the table the conformance suite produced.

Rows come from a **hand-kept feature list**, not from the measurements. That is the load-bearing decision: a table assembled only from what was measured can never report what was missed — the row would simply not appear, and absence of a claim would read as absence of a problem. Ten features are measured, five are visibly marked unmeasured.

| | cells |
|---|---|
| verified | 50 |
| backend absent in that browser | 10 |
| not measured | 30 |

The page says outright that `?` means nobody measured it, not that anything is broken, and that Chromium is re-measured every CI run while Firefox and Safari are measured by hand.

## Four more features

**Graphics**, **Tint**, **BlendMode**, **Mask**, **Text** — 21 scenes total, 90 tests per browser.

Adds a `colour-modified` fixture kind. Tint and blend scenes keep the coordinate texture, so the geometry stays exact, but the channels then carry a product of texel and tint rather than coordinates. `traced` would be a false claim and `opaque-solid` an understatement — the sprite still lands on precisely the right pixels. The runner caps them at `frame-equal`; `mask/triangle-clip` leaves its texture alone and stays `traced`.

Text declares `interpolated`: glyphs are rasterised into an SDF atlas and sampled through a dedicated shader, so no output pixel maps to one texel. The claim is narrower on purpose, and still has teeth — that shader exists twice, in GLSL and WGSL, and a threshold difference between them would show as an edge a pixel fatter on one side.

## Still unmeasured, and why

Not neglect — each needs the scene interface to grow:

- **RenderTexture** — `build()` returns a scene graph and never sees a backend; filling a render texture needs one.
- **Tilemap**, **Particles** — their renderers live in extension packages and are not in the core binding set the test backends wire up.
- **Filter** — `WebGl2ShaderFilter` and `WebGpuShaderFilter` are separate types, which a backend-neutral scene cannot construct.
- **Video** — needs an asset and is time-dependent, which the determinism property would have to account for.

## Verification

- `pnpm verify:quick` — green
- `pnpm test:parity` 90 passed · `:firefox` 90 passed · `:webkit` 36 passed, 54 skipped, none failed
- `pnpm site:build` — 1723 pages, table verified in the generated HTML