### PR TITLE
fix(webgpu): tilemaps and particles backed by a DataTexture rendered nothing

### DIFF
--- a/packages/exojs-particles/src/renderers/WebGpuParticleRenderer.ts
+++ b/packages/exojs-particles/src/renderers/WebGpuParticleRenderer.ts
@@ -2,6 +2,7 @@
 
 import type { BlendModes } from '@codexo/exojs/renderer-sdk';
 import type { WebGpuBackend } from '@codexo/exojs/renderer-sdk';
+import { DataTexture } from '@codexo/exojs/renderer-sdk';
 import { Texture } from '@codexo/exojs/renderer-sdk';
 import { AbstractWebGpuRenderer } from '@codexo/exojs/renderer-sdk';
 import { getWebGpuBlendState } from '@codexo/exojs/renderer-sdk';
@@ -124,7 +125,14 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
     const backend = this._backend;
     const texture = system.texture;
 
-    if (backend === null || !(texture instanceof Texture) || texture.source === null || texture.width === 0 || texture.height === 0 || system.liveCount === 0) {
+    // A null `source` means a Texture still waiting on its image — but
+    // DataTexture extends Texture and keeps its pixels in a CPU buffer, so it
+    // has none by design. Without the exemption every procedurally-generated
+    // particle texture renders as nothing here while WebGL2, which has no such
+    // guard, draws it.
+    const awaitingImage = texture instanceof Texture && !(texture instanceof DataTexture) && texture.source === null;
+
+    if (backend === null || !(texture instanceof Texture) || awaitingImage || texture.width === 0 || texture.height === 0 || system.liveCount === 0) {
       return;
     }
 

--- a/packages/exojs-tilemap/src/webgpu/WebGpuTileChunkRenderer.ts
+++ b/packages/exojs-tilemap/src/webgpu/WebGpuTileChunkRenderer.ts
@@ -12,6 +12,7 @@ import type { View, WebGpuBackend } from '@codexo/exojs/renderer-sdk';
 import {
   AbstractWebGpuRenderer,
   type BlendModes,
+  DataTexture,
   getWebGpuBlendState,
   packAffineMat4,
   packSnapViewport,
@@ -299,7 +300,12 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
       return;
     }
 
-    if (texture instanceof Texture && texture.source === null) {
+    // A null `source` means a Texture still waiting on its image — but
+    // DataTexture extends Texture and keeps its pixels in a CPU buffer, so it
+    // has none by design. Without the exemption a procedurally-generated
+    // tileset renders as nothing here while WebGL2, which has no such guard,
+    // draws it.
+    if (texture instanceof Texture && !(texture instanceof DataTexture) && texture.source === null) {
       return;
     }
 

--- a/src/renderer-sdk.ts
+++ b/src/renderer-sdk.ts
@@ -23,6 +23,10 @@ export { RendererRegistry } from '#rendering/RendererRegistry';
 export type { ShaderProgram } from '#rendering/shader/Shader';
 export { Shader } from '#rendering/shader/Shader';
 export { Spritesheet } from '#rendering/sprite/Spritesheet';
+// Renderers that guard on `Texture.source === null` need this to tell "still
+// waiting on an image" from "holds its pixels in a CPU buffer" — without it an
+// extension renderer silently drops every procedurally-generated texture.
+export { DataTexture } from '#rendering/texture/DataTexture';
 export { RenderTexture } from '#rendering/texture/RenderTexture';
 export { Texture } from '#rendering/texture/Texture';
 export { BlendModes, BufferTypes, BufferUsage, RenderingPrimitives } from '#rendering/types';

--- a/test/rendering/browser/_glslMocks.ts
+++ b/test/rendering/browser/_glslMocks.ts
@@ -43,3 +43,14 @@ vi.mock('#rendering/webgl2/glsl/text-color.frag', async () => ({ default: (await
 vi.mock('#rendering/webgl2/glsl/text-msdf.frag', async () => ({ default: (await import('../../../src/rendering/webgl2/glsl/text-msdf.frag?raw')).default }));
 vi.mock('#rendering/webgl2/glsl/text-sdf.frag', async () => ({ default: (await import('../../../src/rendering/webgl2/glsl/text-sdf.frag?raw')).default }));
 vi.mock('#rendering/webgl2/glsl/text.vert', async () => ({ default: (await import('../../../src/rendering/webgl2/glsl/text.vert?raw')).default }));
+
+// Extension-package shaders. The stub plugin blanks these the same way it
+// blanks core ones, but they live outside `src/`, so they need their own
+// entries — without them a particle scene compiles an empty vertex shader and
+// draws nothing.
+vi.mock('../../../packages/exojs-particles/src/renderers/glsl/particle.frag', async () => ({
+  default: (await import('../../../packages/exojs-particles/src/renderers/glsl/particle.frag?raw')).default,
+}));
+vi.mock('../../../packages/exojs-particles/src/renderers/glsl/particle.vert', async () => ({
+  default: (await import('../../../packages/exojs-particles/src/renderers/glsl/particle.vert?raw')).default,
+}));

--- a/test/rendering/parity/backends.ts
+++ b/test/rendering/parity/backends.ts
@@ -1,0 +1,31 @@
+/**
+ * Backend construction for the parity properties.
+ *
+ * Wraps the shared test-backend helpers with the one thing a scene may need on
+ * top of them: registering renderers that live outside the core binding set.
+ * Every property goes through here, so a scene declaring `wireRenderers` is
+ * honoured identically in all of them — putting that call in each property
+ * instead would mean three places to forget it in.
+ */
+
+import type { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+import type { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { createWebGl2TestBackend, createWebGpuTestBackend } from '../browser/_backendSetup';
+import type { Scene } from './types';
+
+export const openWebGl2 = async (scene: Scene): Promise<WebGl2Backend> => {
+  const backend = await createWebGl2TestBackend(scene.size);
+
+  scene.wireRenderers?.(backend);
+
+  return backend;
+};
+
+export const openWebGpu = async (scene: Scene): Promise<WebGpuBackend> => {
+  const backend = await createWebGpuTestBackend(scene.size);
+
+  scene.wireRenderers?.(backend);
+
+  return backend;
+};

--- a/test/rendering/parity/evidence.json
+++ b/test/rendering/parity/evidence.json
@@ -9,7 +9,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -23,7 +23,7 @@
     "delta": null,
     "note": "1791/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -36,7 +36,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -49,7 +49,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -63,7 +63,7 @@
     "delta": null,
     "note": "1792/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -76,7 +76,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -89,7 +89,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -103,7 +103,7 @@
     "delta": null,
     "note": "1024/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -116,7 +116,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -129,7 +129,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -143,7 +143,7 @@
     "delta": null,
     "note": "119/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -156,7 +156,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -169,7 +169,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -183,7 +183,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -196,7 +196,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -209,7 +209,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -223,7 +223,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -236,7 +236,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -249,7 +249,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -263,7 +263,7 @@
     "delta": null,
     "note": "2303/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -276,7 +276,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -289,7 +289,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -303,7 +303,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -316,7 +316,47 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "particles/static-quad",
+    "property": "cross-backend-parity",
+    "feature": "Particles",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "particles/static-quad",
+    "property": "renders-something",
+    "feature": "Particles",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "255/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "particles/static-quad",
+    "property": "repeat-render-determinism",
+    "feature": "Particles",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -329,7 +369,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -343,7 +383,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -356,7 +396,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -369,7 +409,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -383,7 +423,7 @@
     "delta": null,
     "note": "256/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -396,7 +436,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -409,7 +449,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -423,7 +463,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -436,7 +476,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -449,7 +489,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -463,7 +503,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -476,7 +516,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -489,7 +529,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -503,7 +543,7 @@
     "delta": null,
     "note": "397/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -516,7 +556,47 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "tilemap/two-by-two",
+    "property": "cross-backend-parity",
+    "feature": "Tilemap",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "tilemap/two-by-two",
+    "property": "renders-something",
+    "feature": "Tilemap",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1020/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "tilemap/two-by-two",
+    "property": "repeat-render-determinism",
+    "feature": "Tilemap",
+    "browser": "chromium",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -529,7 +609,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -543,7 +623,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -556,7 +636,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -569,7 +649,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -583,7 +663,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -596,7 +676,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -609,7 +689,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -623,7 +703,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -636,7 +716,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -649,7 +729,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -663,7 +743,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -676,7 +756,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -689,7 +769,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -703,7 +783,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -716,7 +796,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -729,7 +809,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -743,7 +823,7 @@
     "delta": null,
     "note": "1791/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -756,7 +836,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -769,7 +849,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -783,7 +863,7 @@
     "delta": null,
     "note": "1792/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -796,7 +876,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -809,7 +889,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -823,7 +903,7 @@
     "delta": null,
     "note": "1024/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -836,7 +916,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -849,7 +929,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -863,7 +943,7 @@
     "delta": null,
     "note": "119/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -876,7 +956,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -889,7 +969,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -903,7 +983,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -916,7 +996,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -929,7 +1009,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -943,7 +1023,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -956,7 +1036,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -969,7 +1049,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -983,7 +1063,7 @@
     "delta": null,
     "note": "2303/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -996,7 +1076,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1009,7 +1089,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1023,7 +1103,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1036,7 +1116,47 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "particles/static-quad",
+    "property": "cross-backend-parity",
+    "feature": "Particles",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "particles/static-quad",
+    "property": "renders-something",
+    "feature": "Particles",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "255/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "particles/static-quad",
+    "property": "repeat-render-determinism",
+    "feature": "Particles",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1049,7 +1169,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1063,7 +1183,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1076,7 +1196,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1089,7 +1209,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1103,7 +1223,7 @@
     "delta": null,
     "note": "256/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1116,7 +1236,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1129,7 +1249,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1143,7 +1263,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1156,7 +1276,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1169,7 +1289,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1183,7 +1303,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1196,7 +1316,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1209,7 +1329,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1223,7 +1343,7 @@
     "delta": null,
     "note": "397/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1236,7 +1356,47 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "tilemap/two-by-two",
+    "property": "cross-backend-parity",
+    "feature": "Tilemap",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "tilemap/two-by-two",
+    "property": "renders-something",
+    "feature": "Tilemap",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1020/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "tilemap/two-by-two",
+    "property": "repeat-render-determinism",
+    "feature": "Tilemap",
+    "browser": "chromium",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1249,7 +1409,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1263,7 +1423,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1276,7 +1436,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1289,7 +1449,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1303,7 +1463,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1316,7 +1476,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1329,7 +1489,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1343,7 +1503,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1356,7 +1516,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1369,7 +1529,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1383,7 +1543,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1396,7 +1556,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1409,7 +1569,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1423,7 +1583,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1436,7 +1596,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1449,7 +1609,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1463,7 +1623,7 @@
     "delta": null,
     "note": "1791/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1476,7 +1636,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1489,7 +1649,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1503,7 +1663,7 @@
     "delta": null,
     "note": "1792/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1516,7 +1676,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1529,7 +1689,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1543,7 +1703,7 @@
     "delta": null,
     "note": "1024/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1556,7 +1716,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1569,7 +1729,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1583,7 +1743,7 @@
     "delta": null,
     "note": "119/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1596,7 +1756,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1609,7 +1769,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1623,7 +1783,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1636,7 +1796,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1649,7 +1809,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1663,7 +1823,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1676,7 +1836,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1689,7 +1849,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1703,7 +1863,7 @@
     "delta": null,
     "note": "2303/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1716,7 +1876,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1729,7 +1889,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1743,7 +1903,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1756,7 +1916,47 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "particles/static-quad",
+    "property": "cross-backend-parity",
+    "feature": "Particles",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "particles/static-quad",
+    "property": "renders-something",
+    "feature": "Particles",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "255/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "particles/static-quad",
+    "property": "repeat-render-determinism",
+    "feature": "Particles",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1769,7 +1969,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1783,7 +1983,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1796,7 +1996,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1809,7 +2009,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1823,7 +2023,7 @@
     "delta": null,
     "note": "256/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1836,7 +2036,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1849,7 +2049,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1863,7 +2063,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1876,7 +2076,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1889,7 +2089,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1903,7 +2103,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1916,7 +2116,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1929,7 +2129,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1943,7 +2143,7 @@
     "delta": null,
     "note": "354/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1956,7 +2156,47 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "tilemap/two-by-two",
+    "property": "cross-backend-parity",
+    "feature": "Tilemap",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "tilemap/two-by-two",
+    "property": "renders-something",
+    "feature": "Tilemap",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1020/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "tilemap/two-by-two",
+    "property": "repeat-render-determinism",
+    "feature": "Tilemap",
+    "browser": "firefox",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1969,7 +2209,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1983,7 +2223,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -1996,7 +2236,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2009,7 +2249,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2023,7 +2263,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2036,7 +2276,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2049,7 +2289,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2063,7 +2303,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2076,7 +2316,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2089,7 +2329,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2103,7 +2343,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2116,7 +2356,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2129,7 +2369,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2143,7 +2383,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2156,7 +2396,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2169,7 +2409,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2183,7 +2423,7 @@
     "delta": null,
     "note": "1791/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2196,7 +2436,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2209,7 +2449,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2223,7 +2463,7 @@
     "delta": null,
     "note": "1792/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2236,7 +2476,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2249,7 +2489,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2263,7 +2503,7 @@
     "delta": null,
     "note": "1024/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2276,7 +2516,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2289,7 +2529,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2303,7 +2543,7 @@
     "delta": null,
     "note": "119/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2316,7 +2556,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2329,7 +2569,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2343,7 +2583,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2356,7 +2596,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2369,7 +2609,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2383,7 +2623,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2396,7 +2636,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2409,7 +2649,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2423,7 +2663,7 @@
     "delta": null,
     "note": "2303/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2436,7 +2676,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2449,7 +2689,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2463,7 +2703,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2476,7 +2716,47 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "particles/static-quad",
+    "property": "cross-backend-parity",
+    "feature": "Particles",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "particles/static-quad",
+    "property": "renders-something",
+    "feature": "Particles",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "255/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "particles/static-quad",
+    "property": "repeat-render-determinism",
+    "feature": "Particles",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2489,7 +2769,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2503,7 +2783,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2516,7 +2796,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2529,7 +2809,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2543,7 +2823,7 @@
     "delta": null,
     "note": "256/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2556,7 +2836,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2569,7 +2849,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2583,7 +2863,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2596,7 +2876,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2609,7 +2889,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2623,7 +2903,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2636,7 +2916,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2649,7 +2929,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2663,7 +2943,7 @@
     "delta": null,
     "note": "354/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2676,7 +2956,47 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "tilemap/two-by-two",
+    "property": "cross-backend-parity",
+    "feature": "Tilemap",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "tilemap/two-by-two",
+    "property": "renders-something",
+    "feature": "Tilemap",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1020/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "tilemap/two-by-two",
+    "property": "repeat-render-determinism",
+    "feature": "Tilemap",
+    "browser": "firefox",
+    "backend": "webgpu",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2689,7 +3009,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2703,7 +3023,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2716,7 +3036,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2729,7 +3049,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2743,7 +3063,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2756,7 +3076,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2769,7 +3089,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2783,7 +3103,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2796,7 +3116,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2809,7 +3129,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2823,7 +3143,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2836,7 +3156,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2849,7 +3169,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2863,7 +3183,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2876,7 +3196,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2890,7 +3210,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2904,7 +3224,7 @@
     "delta": null,
     "note": "1791/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2917,7 +3237,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2931,7 +3251,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2945,7 +3265,7 @@
     "delta": null,
     "note": "1792/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2958,7 +3278,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2972,7 +3292,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2986,7 +3306,7 @@
     "delta": null,
     "note": "1024/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -2999,7 +3319,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3013,7 +3333,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3027,7 +3347,7 @@
     "delta": null,
     "note": "119/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3040,7 +3360,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3054,7 +3374,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3068,7 +3388,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3081,7 +3401,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3095,7 +3415,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3109,7 +3429,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3122,7 +3442,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3136,7 +3456,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3150,7 +3470,7 @@
     "delta": null,
     "note": "2303/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3163,7 +3483,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3177,7 +3497,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3191,7 +3511,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3204,7 +3524,48 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "particles/static-quad",
+    "property": "cross-backend-parity",
+    "feature": "Particles",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "particles/static-quad",
+    "property": "renders-something",
+    "feature": "Particles",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "255/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "particles/static-quad",
+    "property": "repeat-render-determinism",
+    "feature": "Particles",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3218,7 +3579,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3232,7 +3593,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3245,7 +3606,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3259,7 +3620,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3273,7 +3634,7 @@
     "delta": null,
     "note": "256/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3286,7 +3647,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3300,7 +3661,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3314,7 +3675,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3327,7 +3688,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3341,7 +3702,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3355,7 +3716,7 @@
     "delta": null,
     "note": "1023/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3368,7 +3729,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3382,7 +3743,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3396,7 +3757,7 @@
     "delta": null,
     "note": "307/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3409,7 +3770,48 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "tilemap/two-by-two",
+    "property": "cross-backend-parity",
+    "feature": "Tilemap",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "tilemap/two-by-two",
+    "property": "renders-something",
+    "feature": "Tilemap",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "sampled",
+    "delta": null,
+    "note": "1020/4096 pixels drawn",
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "tilemap/two-by-two",
+    "property": "repeat-render-determinism",
+    "feature": "Tilemap",
+    "browser": "webkit",
+    "backend": "webgl2",
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3423,7 +3825,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3437,7 +3839,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3450,7 +3852,7 @@
     "evidence": "frame-equal",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3464,7 +3866,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3478,7 +3880,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3491,7 +3893,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3505,7 +3907,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3519,7 +3921,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3532,7 +3934,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3546,7 +3948,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3560,7 +3962,7 @@
     "delta": null,
     "note": "255/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3573,7 +3975,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3587,7 +3989,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3601,7 +4003,7 @@
     "delta": null,
     "note": "1020/4096 pixels drawn",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3614,7 +4016,7 @@
     "evidence": "traced",
     "delta": 0,
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3628,7 +4030,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3642,7 +4044,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3656,7 +4058,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3670,7 +4072,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3684,7 +4086,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3698,7 +4100,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3712,7 +4114,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3726,7 +4128,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3740,7 +4142,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3754,7 +4156,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3768,7 +4170,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3782,7 +4184,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3796,7 +4198,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3810,7 +4212,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3824,7 +4226,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3838,7 +4240,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3852,7 +4254,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3866,7 +4268,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3880,7 +4282,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3894,7 +4296,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3908,7 +4310,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3922,7 +4324,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3936,7 +4338,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3950,7 +4352,49 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "particles/static-quad",
+    "property": "cross-backend-parity",
+    "feature": "Particles",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "particles/static-quad",
+    "property": "renders-something",
+    "feature": "Particles",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "particles/static-quad",
+    "property": "repeat-render-determinism",
+    "feature": "Particles",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3964,7 +4408,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3978,7 +4422,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -3992,7 +4436,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4006,7 +4450,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4020,7 +4464,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4034,7 +4478,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4048,7 +4492,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4062,7 +4506,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4076,7 +4520,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4090,7 +4534,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4104,7 +4548,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4118,7 +4562,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4132,7 +4576,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4146,7 +4590,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4160,7 +4604,49 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "tilemap/two-by-two",
+    "property": "cross-backend-parity",
+    "feature": "Tilemap",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "tilemap/two-by-two",
+    "property": "renders-something",
+    "feature": "Tilemap",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
+    "platform": "win32"
+  },
+  {
+    "scene": "tilemap/two-by-two",
+    "property": "repeat-render-determinism",
+    "feature": "Tilemap",
+    "browser": "webkit",
+    "backend": "webgpu",
+    "support": "unavailable",
+    "evidence": "none",
+    "delta": null,
+    "note": "no WebGPU adapter in this browser",
+    "measuredAt": "2026-08-03",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4174,7 +4660,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4188,7 +4674,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4202,7 +4688,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4216,7 +4702,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4230,7 +4716,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4244,7 +4730,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4258,7 +4744,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4272,7 +4758,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4286,7 +4772,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4300,7 +4786,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4314,7 +4800,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4328,7 +4814,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4342,7 +4828,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4356,7 +4842,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   },
   {
@@ -4370,7 +4856,7 @@
     "delta": null,
     "note": "no WebGPU adapter in this browser",
     "measuredAt": "2026-08-03",
-    "commit": "850fe6f5",
+    "commit": "eeda88de",
     "platform": "win32"
   }
 ]

--- a/test/rendering/parity/matrix.test.ts
+++ b/test/rendering/parity/matrix.test.ts
@@ -17,10 +17,12 @@ import { colourScenes } from './scenes/colour';
 import { graphicsScenes } from './scenes/graphics';
 import { meshScenes } from './scenes/mesh';
 import { nineSliceScenes } from './scenes/nineSlice';
+import { particleScenes } from './scenes/particles';
 import { repeatingSpriteScenes } from './scenes/repeatingSprite';
 import { spriteScenes } from './scenes/sprite';
 import { spriteCanvasScenes } from './scenes/spriteCanvas';
 import { textScenes } from './scenes/text';
+import { tilemapScenes } from './scenes/tilemap';
 import { transformScenes } from './scenes/transform';
 import type { Property, Scene } from './types';
 
@@ -35,6 +37,8 @@ const scenes: readonly Scene[] = [
   ...colourScenes,
   ...clippingScenes,
   ...textScenes,
+  ...tilemapScenes,
+  ...particleScenes,
 ];
 
 const properties: readonly Property[] = [crossBackendParity, determinism, rendersSomething];

--- a/test/rendering/parity/properties/crossBackendParity.ts
+++ b/test/rendering/parity/properties/crossBackendParity.ts
@@ -9,16 +9,8 @@
 
 import { Color } from '#core/Color';
 
-import {
-  createWebGl2TestBackend,
-  createWebGpuTestBackend,
-  readWebGl2Frame,
-  readWebGpuFrame,
-  renderWebGl2Once,
-  renderWebGpuOnce,
-  webGl2Available,
-  webGpuAvailable,
-} from '../../browser/_backendSetup';
+import { readWebGl2Frame, readWebGpuFrame, renderWebGl2Once, renderWebGpuOnce, webGl2Available, webGpuAvailable } from '../../browser/_backendSetup';
+import { openWebGl2, openWebGpu } from '../backends';
 import { maxChannelDelta } from '../frames';
 import type { CrossBackendProperty, PropertyResult } from '../types';
 
@@ -49,8 +41,8 @@ export const crossBackendParity: CrossBackendProperty = {
       return { support: 'unavailable', evidence: 'none', delta: null, note: 'no WebGPU adapter in this browser' };
     }
 
-    const gl = await createWebGl2TestBackend(scene.size);
-    const gpu = await createWebGpuTestBackend(scene.size);
+    const gl = await openWebGl2(scene);
+    const gpu = await openWebGpu(scene);
 
     try {
       renderWebGl2Once(gl, scene.build(), Color.black);

--- a/test/rendering/parity/properties/determinism.ts
+++ b/test/rendering/parity/properties/determinism.ts
@@ -9,16 +9,8 @@
 
 import { Color } from '#core/Color';
 
-import {
-  createWebGl2TestBackend,
-  createWebGpuTestBackend,
-  readWebGl2Frame,
-  readWebGpuFrame,
-  renderWebGl2Once,
-  renderWebGpuOnce,
-  webGl2Available,
-  webGpuAvailable,
-} from '../../browser/_backendSetup';
+import { readWebGl2Frame, readWebGpuFrame, renderWebGl2Once, renderWebGpuOnce, webGl2Available, webGpuAvailable } from '../../browser/_backendSetup';
+import { openWebGl2, openWebGpu } from '../backends';
 import { maxChannelDelta } from '../frames';
 import type { PerBackendProperty, PropertyResult } from '../types';
 
@@ -44,7 +36,7 @@ export const determinism: PerBackendProperty = {
         return { support: 'unavailable', evidence: 'none', delta: null, note: 'no WebGL2 context in this browser' };
       }
 
-      const gl = await createWebGl2TestBackend(scene.size);
+      const gl = await openWebGl2(scene);
 
       try {
         renderWebGl2Once(gl, scene.build(), Color.black);
@@ -63,7 +55,7 @@ export const determinism: PerBackendProperty = {
       return { support: 'unavailable', evidence: 'none', delta: null, note: 'no WebGPU adapter in this browser' };
     }
 
-    const gpu = await createWebGpuTestBackend(scene.size);
+    const gpu = await openWebGpu(scene);
 
     try {
       if (!(await renderWebGpuOnce({ skip }, gpu, scene.build(), Color.black))) {

--- a/test/rendering/parity/properties/rendersSomething.ts
+++ b/test/rendering/parity/properties/rendersSomething.ts
@@ -13,16 +13,8 @@
 
 import { Color } from '#core/Color';
 
-import {
-  createWebGl2TestBackend,
-  createWebGpuTestBackend,
-  readWebGl2Frame,
-  readWebGpuFrame,
-  renderWebGl2Once,
-  renderWebGpuOnce,
-  webGl2Available,
-  webGpuAvailable,
-} from '../../browser/_backendSetup';
+import { readWebGl2Frame, readWebGpuFrame, renderWebGl2Once, renderWebGpuOnce, webGl2Available, webGpuAvailable } from '../../browser/_backendSetup';
+import { openWebGl2, openWebGpu } from '../backends';
 import { drawnPixelCount } from '../frames';
 import type { PerBackendProperty, PropertyResult } from '../types';
 
@@ -48,7 +40,7 @@ export const rendersSomething: PerBackendProperty = {
         return { support: 'unavailable', evidence: 'none', delta: null, note: 'no WebGL2 context in this browser' };
       }
 
-      const gl = await createWebGl2TestBackend(scene.size);
+      const gl = await openWebGl2(scene);
 
       try {
         renderWebGl2Once(gl, scene.build(), Color.black);
@@ -63,7 +55,7 @@ export const rendersSomething: PerBackendProperty = {
       return { support: 'unavailable', evidence: 'none', delta: null, note: 'no WebGPU adapter in this browser' };
     }
 
-    const gpu = await createWebGpuTestBackend(scene.size);
+    const gpu = await openWebGpu(scene);
 
     try {
       if (!(await renderWebGpuOnce({ skip }, gpu, scene.build(), Color.black))) {

--- a/test/rendering/parity/scenes/particles.ts
+++ b/test/rendering/parity/scenes/particles.ts
@@ -1,0 +1,60 @@
+/**
+ * Particle scenes.
+ *
+ * Particles render as instanced quads driven by a struct-of-arrays buffer, so
+ * this measures a path no other scene touches: per-instance position, scale and
+ * colour read straight from typed arrays on WebGL2, from a storage buffer on
+ * WebGPU.
+ *
+ * Placement bypasses spawn and update modules and writes the SoA slot directly.
+ * That is deliberate — the simulation is time- and RNG-driven, and a scene the
+ * determinism property cannot trust would report noise as divergence. What is
+ * under test here is the rendering of a known particle state, not the
+ * simulation that would normally produce it.
+ */
+
+import { materializeRendererBindings } from '#extensions/materialize';
+import { Container } from '#rendering/Container';
+
+// Package path rather than the alias: `@codexo/exojs-particles` has no vite
+// alias in the browser projects, which is why every particle browser test
+// reaches into the source directly.
+import { particlesExtension, ParticleSystem } from '../../../../packages/exojs-particles/src/index';
+import { buildCoordinateTexture } from '../../browser/_selfDescribingFixture';
+import type { Scene } from '../types';
+
+const FIXTURE = 16;
+const CANVAS = 64;
+
+export const particleScenes: readonly Scene[] = [
+  {
+    name: 'particles/static-quad',
+    feature: 'Particles',
+    size: CANVAS,
+    fixture: 'self-describing',
+    nearestSampled: true,
+    wireRenderers: backend => materializeRendererBindings(backend, particlesExtension.renderers ?? []),
+    build: () => {
+      const root = new Container();
+      const system = new ParticleSystem(buildCoordinateTexture(FIXTURE), { capacity: 4 });
+      const slot = system.spawn();
+
+      system.posX[slot] = 0;
+      system.posY[slot] = 0;
+      system.scaleX[slot] = 1;
+      system.scaleY[slot] = 1;
+      system.rotations[slot] = 0;
+      // Opaque white: no tint, so the coordinate texture reaches the frame intact.
+      system.color[slot] = 0xffffffff;
+      // Only consulted by update(), which this scene never calls.
+      system.lifetime[slot] = 1;
+
+      // The quad is system-local and centred on the origin, so this puts it in
+      // the middle of the canvas, clear of every edge.
+      system.setPosition(CANVAS / 2, CANVAS / 2);
+      root.addChild(system);
+
+      return root;
+    },
+  },
+];

--- a/test/rendering/parity/scenes/tilemap.ts
+++ b/test/rendering/parity/scenes/tilemap.ts
@@ -1,0 +1,55 @@
+/**
+ * Tilemap scenes.
+ *
+ * The tilemap renderer lives in an extension package, so this is the first
+ * scene family that has to register anything: without `wireRenderers` the node
+ * draws nothing at all, and every comparison would pass on two empty frames.
+ *
+ * A tile layer is an instanced draw with per-tile UV offsets, which is a
+ * different code path from a plain sprite on both backends — and the one place
+ * a half-texel offset shows up as visible seams between tiles.
+ */
+
+import { TILE_TRANSFORM_IDENTITY, TileLayer, TileMap, TileMapNode } from '@codexo/exojs-tilemap';
+
+import { Container } from '#rendering/Container';
+
+import { buildCoordinateTexture } from '../../browser/_selfDescribingFixture';
+import { makeTileset, wireTilemapRenderers } from '../../browser/_tilemapScene';
+import type { Scene } from '../types';
+
+const TILE = 16;
+const CANVAS = 64;
+
+/** A 2×2 layer of the same tile: adjacent tiles must not bleed into each other. */
+const tiledLayer = (): Container => {
+  const root = new Container();
+  const tileset = makeTileset(buildCoordinateTexture(TILE));
+  const layer = new TileLayer({ id: 1, name: 'ground', width: 2, height: 2, tileWidth: TILE, tileHeight: TILE, tilesets: [tileset] });
+
+  for (let y = 0; y < 2; y++) {
+    for (let x = 0; x < 2; x++) {
+      layer.setTileAt(x, y, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+    }
+  }
+
+  const map = new TileMap({ name: 'm', width: 2, height: 2, tileWidth: TILE, tileHeight: TILE, tilesets: [tileset], layers: [layer] });
+  const node = new TileMapNode(map);
+
+  node.setPosition(8, 8);
+  root.addChild(node);
+
+  return root;
+};
+
+export const tilemapScenes: readonly Scene[] = [
+  {
+    name: 'tilemap/two-by-two',
+    feature: 'Tilemap',
+    size: CANVAS,
+    fixture: 'self-describing',
+    nearestSampled: true,
+    wireRenderers: wireTilemapRenderers,
+    build: tiledLayer,
+  },
+];

--- a/test/rendering/parity/types.ts
+++ b/test/rendering/parity/types.ts
@@ -10,6 +10,7 @@
  */
 
 import type { Container } from '#rendering/Container';
+import type { RenderBackend } from '#rendering/RenderBackend';
 
 import type { EvidenceClass, SupportState } from './evidenceSink';
 
@@ -42,6 +43,17 @@ export interface Scene {
   readonly nearestSampled: boolean;
   /** Builds a fresh scene graph. Called once per backend — never share nodes across backends. */
   readonly build: () => Container;
+  /**
+   * Registers renderers this scene needs beyond the core set, called once on a
+   * freshly initialised backend before anything is drawn.
+   *
+   * Features living in extension packages — tilemaps, particles — have no
+   * binding in `wireCoreRenderers`, so without this their nodes would silently
+   * draw nothing. Which is precisely the failure `renders-something` was added
+   * to catch, and a matrix row claiming verification of an unregistered
+   * renderer would be worse than no row at all.
+   */
+  readonly wireRenderers?: (backend: RenderBackend) => void;
 }
 
 /** What a property observed. `support` and `evidence` are deliberately separate axes. */


### PR DESCRIPTION
The conformance matrix found a second shipped bug of the same class as #453 — this time in both extension packages.

## The defect

`WebGpuTileChunkRenderer` and `WebGpuParticleRenderer` both skip any texture reporting a null `source`:

```ts
if (texture instanceof Texture && texture.source === null) return;
```

That guard means *"a `Texture` still waiting on its image"*. But `DataTexture` extends `Texture` and holds its pixels in a CPU buffer, so it has no source **by design**. Every procedurally-generated tileset and particle texture therefore rendered as nothing on WebGPU, while WebGL2 — which has no such guard — drew it correctly.

#453 fixed exactly this in the core sprite, nine-slice and repeating renderers. These two live in packages and were missed, because nothing exercised them from both backends at once. Adding Tilemap and Particles scenes to the matrix surfaced them within minutes: full frame on WebGL2, empty frame on WebGPU, both scenes, both properties.

## `DataTexture` joins the renderer SDK

Without it an extension renderer cannot make the distinction the core renderers make. Guarding on `source === null` is a reasonable thing for a renderer author to write — and until now the SDK gave them no way to write it correctly.

## Test-side work that found it

- **`Scene.wireRenderers`** — extension renderers are outside the core binding set, so a scene can now register its own. All three properties call it through a single helper. Forgetting it would not fail loudly: the node would draw nothing and both comparisons would pass on two empty frames. `renders-something` is what turns that into a failure.
- **Particle placement writes the SoA slot directly** instead of spawning through update modules. The simulation is time- and RNG-driven, and a scene the determinism property cannot trust would report noise as divergence. What is measured is the rendering of a known particle state.
- **Package GLSL joins the setup-file mock list.** Those shaders live outside `src/`, so the stub plugin blanked them with nothing restoring them, and a particle scene compiled an empty vertex shader.

## Results

23 scenes, 12 of 15 features, 100 tests per browser. After the fix, both new scenes draw identical pixel counts on both backends — 1020 for the tilemap, 255 for the particle quad — at delta 0.

Still unmeasured: RenderTexture (needs a live backend at scene-build time), Filter (backend-specific types a neutral scene cannot construct), Video (asset plus time dependence).

## Verification

- `pnpm verify:quick` — green
- particles + tilemap unit suites: 29 files, 660 tests passed
- `pnpm test:parity` 100 passed · `:firefox` 100 passed · `:webkit` 40 passed, 60 skipped, none failed