### PR TITLE
chore(lint): replace inline disables with measured central rules

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -949,32 +949,6 @@ export default defineConfig([
   // for tightening once the underlying code is refactored.
   // ---------------------------------------------------------------------------
 
-  // WebGPU renderer lifecycle invariants: these classes rely on explicit init
-  // phases; forcing removal of `!` would add significant guard noise.
-  {
-    files: ['src/rendering/webgpu/WebGpuMeshRenderer.ts', 'src/rendering/webgpu/WebGpuMaskCompositor.ts'],
-    rules: {
-      '@typescript-eslint/no-non-null-assertion': 'off',
-    },
-  },
-
-  // Runtime capability/back-end probes intentionally keep defensive checks for
-  // browser/API variance, even when static types look stricter.
-  {
-    files: [
-      'src/core/capabilities.ts',
-      'src/rendering/webgl2/AbstractWebGl2Renderer.ts',
-      'src/rendering/webgl2/WebGl2Backend.ts',
-      'src/rendering/webgl2/WebGl2RenderBuffer.ts',
-      'src/rendering/webgpu/AbstractWebGpuRenderer.ts',
-      'src/rendering/webgpu/WebGpuBackend.ts',
-    ],
-    rules: {
-      '@typescript-eslint/no-unnecessary-condition': 'off',
-      '@typescript-eslint/strict-boolean-expressions': 'off',
-    },
-  },
-
   // Audio graph integration keeps defensive runtime checks against browser
   // API variance.
   {
@@ -984,26 +958,14 @@ export default defineConfig([
       '@typescript-eslint/strict-boolean-expressions': 'off',
       '@typescript-eslint/class-literal-property-style': 'off',
       '@typescript-eslint/prefer-nullish-coalescing': 'off',
-      '@typescript-eslint/no-floating-promises': 'off',
-      '@typescript-eslint/no-non-null-assertion': 'off',
-      complexity: 'off',
-    },
-  },
-
-  // Legacy WebGL2 backend/shader stack relies on dynamic browser APIs and
-  // typed-array plumbing that would otherwise create excessive false positives.
-  {
-    files: ['src/rendering/webgl2/**/*.ts'],
-    rules: {
-      '@typescript-eslint/no-unnecessary-condition': 'off',
-      '@typescript-eslint/strict-boolean-expressions': 'off',
-      '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-non-null-assertion': 'off',
     },
   },
 
   // Rendering hot paths rely on lifecycle invariants and a broad browser API
-  // surface; keep strict coverage elsewhere while reducing noise here.
+  // surface; keep strict coverage elsewhere while reducing noise here. Covers
+  // the whole subtree, WebGL2 and WebGPU alike — the backends, capability
+  // probes and renderer lifecycles all sit under it.
   {
     files: ['src/rendering/**/*.ts'],
     rules: {
@@ -1012,7 +974,6 @@ export default defineConfig([
       '@typescript-eslint/no-non-null-assertion': 'off',
       '@typescript-eslint/prefer-nullish-coalescing': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/no-unsafe-enum-comparison': 'off',
       '@typescript-eslint/switch-exhaustiveness-check': 'off',
       complexity: 'off',
     },
@@ -1036,19 +997,6 @@ export default defineConfig([
     },
   },
 
-  // Complex generic overload, internal queue logic, and cohesive single-file
-  // scope are intentional here. Splitting would degrade readability and release
-  // safety.
-  {
-    files: ['src/assets/Loader.ts'],
-    rules: {
-      'max-lines': 'off',
-      '@typescript-eslint/strict-boolean-expressions': 'off',
-      '@typescript-eslint/no-unsafe-assignment': 'off',
-      complexity: 'off',
-    },
-  },
-
   // Claim/refcount tracking, multi-handle fill, and options-equivalence
   // branching are inherently branchy state machines.
   {
@@ -1059,31 +1007,14 @@ export default defineConfig([
     },
   },
 
-  {
-    files: ['src/assets/factories/SubtitleFactory.ts'],
-    rules: {
-      '@typescript-eslint/no-unnecessary-condition': 'off',
-    },
-  },
-
   // Asset internals using browser/IDB APIs with weak runtime typings.
   {
-    files: ['src/assets/IndexedDbDatabase.ts', 'src/assets/IndexedDbStore.ts', 'src/assets/factories/**/*.ts'],
+    files: ['src/assets/IndexedDbDatabase.ts', 'src/assets/factories/**/*.ts'],
     rules: {
       '@typescript-eslint/no-non-null-assertion': 'off',
-      '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/require-await': 'off',
       '@typescript-eslint/strict-boolean-expressions': 'off',
       complexity: 'off',
-    },
-  },
-
-  // Intentional runtime plumbing / optional lifecycle guards.
-  {
-    files: ['src/core/Scene.ts', 'src/rendering/utils.ts'],
-    rules: {
-      '@typescript-eslint/no-non-null-assertion': 'off',
     },
   },
 
@@ -1103,6 +1034,9 @@ export default defineConfig([
       // instanced-draw support. Splitting would scatter tightly
       // coupled GL state. Known deviation, candidate for a later extraction.
       'max-lines': 'off',
+      // Context-loss and shader-compile diagnostics go straight to the console:
+      // by the time this backend reports, the routed logger may itself be gone.
+      'no-console': 'off',
     },
   },
 
@@ -1160,24 +1094,12 @@ export default defineConfig([
     },
   },
 
-  {
-    files: ['src/core/Application.ts', 'src/core/SceneDirector.ts', 'src/animation/Tween.ts', 'src/rendering/webgl2/WebGl2Backend.ts'],
-    rules: {
-      'no-console': 'off',
-    },
-  },
-
   // Extension renderer / GPU hot paths — same relaxed policy as core rendering.
   {
     files: ['packages/exojs-tilemap/src/webgl2/**/*.ts', 'packages/exojs-tilemap/src/webgpu/**/*.ts'],
     rules: {
       '@typescript-eslint/no-non-null-assertion': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'off',
-      '@typescript-eslint/strict-boolean-expressions': 'off',
-      '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/no-unsafe-argument': 'off',
-      '@typescript-eslint/no-unsafe-member-access': 'off',
-      '@typescript-eslint/prefer-nullish-coalescing': 'off',
       complexity: 'off',
     },
   },
@@ -1206,7 +1128,6 @@ export default defineConfig([
     rules: {
       '@typescript-eslint/no-non-null-assertion': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'off',
-      '@typescript-eslint/strict-boolean-expressions': 'off',
     },
   },
 
@@ -1241,18 +1162,13 @@ export default defineConfig([
   },
 
   // Extracted audio-effects/DSP package — same defensive audio regime as the
-  // core audio graph it was split from (bound methods, browser API variance).
-  // TODO: replace the BeatDetector relaxation by tightening its worklet payload
-  // types and normalizing input at the message boundary.
+  // core audio graph it was split from (browser API variance, DSP hot paths).
   {
     files: ['packages/exojs-audio-fx/src/**/*.ts'],
     rules: {
-      '@typescript-eslint/unbound-method': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'off',
       '@typescript-eslint/strict-boolean-expressions': 'off',
       '@typescript-eslint/class-literal-property-style': 'off',
-      '@typescript-eslint/prefer-nullish-coalescing': 'off',
-      '@typescript-eslint/no-floating-promises': 'off',
       '@typescript-eslint/no-non-null-assertion': 'off',
       complexity: 'off',
     },

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1403,9 +1403,26 @@ export default defineConfig([
       'simple-import-sort/imports': 'error',
       'simple-import-sort/exports': 'error',
       'unused-imports/no-unused-imports': 'error',
-      // Test files intentionally use jest mocks/spies and dynamic fixtures.
-      // Keep structural linting, but disable noisy type-aware false positives.
-      '@typescript-eslint/no-floating-promises': 'off',
+      // A promise dropped in a test is the failure mode this whole tree exists
+      // to prevent: the assertions after it run before the work does, so the
+      // test passes without proving anything. Measured across `test/**` it
+      // costs exactly one report, so it is on.
+      '@typescript-eslint/no-floating-promises': 'error',
+      // Equally quiet (two reports) and equally load-bearing: a value that
+      // stringifies to `[object Object]` makes the assertion compare noise.
+      '@typescript-eslint/no-base-to-string': 'error',
+      // The rules below stay off, but not for the reason that stood here
+      // before: it cited ts-jest, which this repo has not used since the
+      // Vitest migration. The real reason is the shape of test code and the
+      // measured cost of each rule across `test/**`:
+      //   no-unsafe-call 293, no-unsafe-member-access 279,
+      //   no-unsafe-assignment 241, no-unsafe-argument 89, no-unsafe-return 12
+      //     — the price of shape-only mocks; the type gate (`pnpm
+      //       typecheck:test`) is what actually holds these files honest.
+      //   require-await 395 — an `async` test body with no `await` is normal.
+      //   unbound-method 236 — `expect(obj.method)` reads the method by design.
+      // Revisit any of them by flipping it on and re-measuring, not by
+      // reasoning about it.
       '@typescript-eslint/no-misused-promises': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',
@@ -1417,14 +1434,15 @@ export default defineConfig([
       '@typescript-eslint/no-require-imports': 'off',
       '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/class-literal-property-style': 'off',
-      '@typescript-eslint/no-base-to-string': 'off',
       '@typescript-eslint/no-empty-function': 'off',
       '@typescript-eslint/no-redundant-type-constituents': 'off',
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/require-await': 'off',
-      // Test mocks intentionally use `as unknown as <RealType>` to satisfy
-      // jest's strict generic signatures with shape-only fakes. Auto-removing
-      // these casts breaks ts-jest type compilation.
+      // 235 reports, and autofixing them would be actively unsafe: ESLint types
+      // `test/**` through tsconfig.eslint.json while the gate gates it through
+      // tsconfig.test.json, and the two enable different options. A cast this
+      // rule calls unnecessary under one program can be load-bearing under the
+      // other, so `--fix` here can turn `pnpm typecheck:test` red.
       '@typescript-eslint/no-unnecessary-type-assertion': 'off',
       // Tests deliberately use bracket notation (`obj['_member']`) as a
       // project-wide friend-class convention to spy on protected/private

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -206,6 +206,18 @@ export default defineConfig([
           allow: ['private-constructors', 'protected-constructors', 'decoratedFunctions', 'overrideMethods'],
         },
       ],
+      // Two deliberate uses of `{}` run through the engine: an empty interface
+      // as the declaration-merging point consumers augment (FontRegistry,
+      // SceneRegistry), and `= {}` as the empty-registry default of a generic
+      // that is already fenced in by its `extends` constraint. Both were
+      // carrying inline disables saying so.
+      '@typescript-eslint/no-empty-object-type': ['error', { allowInterfaces: 'always', allowObjectTypes: 'always' }],
+      // `abstract new (...args: any[]) => T` is the only way to write "any
+      // constructor producing T": with `unknown[]`, parameter contravariance
+      // makes the type reject every constructor that declares real parameters,
+      // so `typeof Texture` would no longer match. Four type aliases carried an
+      // inline disable for exactly this; the rule ships an option for it.
+      '@typescript-eslint/no-explicit-any': ['error', { ignoreRestArgs: true }],
       '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/no-meaningless-void-operator': 'error',
       '@typescript-eslint/no-misused-promises': [
@@ -286,6 +298,49 @@ export default defineConfig([
         {
           selector: 'typeLike',
           format: ['StrictPascalCase'],
+          leadingUnderscore: 'forbid',
+          trailingUnderscore: 'forbid',
+        },
+        // Acronyms are the one place the Strict* formats get in the way: they
+        // reject consecutive capitals, so `UIRoot`, `HTMLText` and `_peekUI`
+        // each carried an inline disable repeating the same sentence. These
+        // two entries carry a `filter`, which outranks the generic selectors
+        // above, and relax only the capitalisation — a name without one of
+        // these acronyms stays strict.
+        {
+          selector: 'typeLike',
+          filter: { regex: '(HTML|UI|JSON)', match: true },
+          format: ['PascalCase'],
+          leadingUnderscore: 'forbid',
+          trailingUnderscore: 'forbid',
+        },
+        {
+          selector: ['variableLike', 'memberLike'],
+          filter: { regex: '(HTML|UI|JSON|DPad)', match: true },
+          format: ['camelCase', 'PascalCase'],
+          leadingUnderscore: 'allow',
+          trailingUnderscore: 'forbid',
+        },
+        // Same acronym exception, repeated for the `variable` + `const`
+        // selector above: that one is more specific than the grouped
+        // `variableLike` entry, so it would otherwise win and reject
+        // `GamepadButton.DPadUp`.
+        {
+          selector: 'variable',
+          modifiers: ['const'],
+          filter: { regex: '(HTML|UI|JSON|DPad)', match: true },
+          format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
+          leadingUnderscore: 'allow',
+          trailingUnderscore: 'forbid',
+        },
+        // A type property spelled in SCREAMING_CASE is a verbatim mirror of a
+        // constant some external API hands us under that exact name (WebGL
+        // extension constants, for one). Renaming it would break the lookup,
+        // so the shape declaration has to keep the foreign spelling.
+        {
+          selector: 'typeProperty',
+          filter: { regex: '^[A-Z][A-Z0-9_]*$', match: true },
+          format: ['UPPER_CASE'],
           leadingUnderscore: 'forbid',
           trailingUnderscore: 'forbid',
         },
@@ -449,6 +504,18 @@ export default defineConfig([
           allow: ['private-constructors', 'protected-constructors', 'decoratedFunctions', 'overrideMethods'],
         },
       ],
+      // Two deliberate uses of `{}` run through the engine: an empty interface
+      // as the declaration-merging point consumers augment (FontRegistry,
+      // SceneRegistry), and `= {}` as the empty-registry default of a generic
+      // that is already fenced in by its `extends` constraint. Both were
+      // carrying inline disables saying so.
+      '@typescript-eslint/no-empty-object-type': ['error', { allowInterfaces: 'always', allowObjectTypes: 'always' }],
+      // `abstract new (...args: any[]) => T` is the only way to write "any
+      // constructor producing T": with `unknown[]`, parameter contravariance
+      // makes the type reject every constructor that declares real parameters,
+      // so `typeof Texture` would no longer match. Four type aliases carried an
+      // inline disable for exactly this; the rule ships an option for it.
+      '@typescript-eslint/no-explicit-any': ['error', { ignoreRestArgs: true }],
       '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/no-meaningless-void-operator': 'error',
       '@typescript-eslint/no-misused-promises': [
@@ -528,6 +595,49 @@ export default defineConfig([
         {
           selector: 'typeLike',
           format: ['StrictPascalCase'],
+          leadingUnderscore: 'forbid',
+          trailingUnderscore: 'forbid',
+        },
+        // Acronyms are the one place the Strict* formats get in the way: they
+        // reject consecutive capitals, so `UIRoot`, `HTMLText` and `_peekUI`
+        // each carried an inline disable repeating the same sentence. These
+        // two entries carry a `filter`, which outranks the generic selectors
+        // above, and relax only the capitalisation — a name without one of
+        // these acronyms stays strict.
+        {
+          selector: 'typeLike',
+          filter: { regex: '(HTML|UI|JSON)', match: true },
+          format: ['PascalCase'],
+          leadingUnderscore: 'forbid',
+          trailingUnderscore: 'forbid',
+        },
+        {
+          selector: ['variableLike', 'memberLike'],
+          filter: { regex: '(HTML|UI|JSON|DPad)', match: true },
+          format: ['camelCase', 'PascalCase'],
+          leadingUnderscore: 'allow',
+          trailingUnderscore: 'forbid',
+        },
+        // Same acronym exception, repeated for the `variable` + `const`
+        // selector above: that one is more specific than the grouped
+        // `variableLike` entry, so it would otherwise win and reject
+        // `GamepadButton.DPadUp`.
+        {
+          selector: 'variable',
+          modifiers: ['const'],
+          filter: { regex: '(HTML|UI|JSON|DPad)', match: true },
+          format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
+          leadingUnderscore: 'allow',
+          trailingUnderscore: 'forbid',
+        },
+        // A type property spelled in SCREAMING_CASE is a verbatim mirror of a
+        // constant some external API hands us under that exact name (WebGL
+        // extension constants, for one). Renaming it would break the lookup,
+        // so the shape declaration has to keep the foreign spelling.
+        {
+          selector: 'typeProperty',
+          filter: { regex: '^[A-Z][A-Z0-9_]*$', match: true },
+          format: ['UPPER_CASE'],
           leadingUnderscore: 'forbid',
           trailingUnderscore: 'forbid',
         },
@@ -736,6 +846,18 @@ export default defineConfig([
       '@typescript-eslint/array-type': 'off',
       '@typescript-eslint/consistent-indexed-object-style': 'off',
       '@typescript-eslint/consistent-type-definitions': 'off',
+      // Two deliberate uses of `{}` run through the engine: an empty interface
+      // as the declaration-merging point consumers augment (FontRegistry,
+      // SceneRegistry), and `= {}` as the empty-registry default of a generic
+      // that is already fenced in by its `extends` constraint. Both were
+      // carrying inline disables saying so.
+      '@typescript-eslint/no-empty-object-type': ['error', { allowInterfaces: 'always', allowObjectTypes: 'always' }],
+      // `abstract new (...args: any[]) => T` is the only way to write "any
+      // constructor producing T": with `unknown[]`, parameter contravariance
+      // makes the type reject every constructor that declares real parameters,
+      // so `typeof Texture` would no longer match. Four type aliases carried an
+      // inline disable for exactly this; the rule ships an option for it.
+      '@typescript-eslint/no-explicit-any': ['error', { ignoreRestArgs: true }],
       '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/no-misused-promises': [
         'error',
@@ -1177,6 +1299,82 @@ export default defineConfig([
     files: ['packages/exojs-physics/src/**/*.ts'],
     rules: {
       '@typescript-eslint/no-non-null-assertion': 'off',
+    },
+  },
+
+  // `Map.forEach` is the allocation-free way to walk a Map: `for…of` builds a
+  // fresh iterator on every step, which these two per-frame paths cannot
+  // afford. Deleting the current entry mid-`forEach` is well-defined and both
+  // files rely on it. Scoped to the two files that actually run per frame
+  // rather than the whole package, so the rule keeps working everywhere else.
+  {
+    files: ['packages/exojs-physics/src/ContactGraph.ts', 'packages/exojs-physics/src/broadphase/AabbTreeBroadPhase.ts'],
+    rules: {
+      'unicorn/no-array-for-each': 'off',
+    },
+  },
+
+  // An AudioWorklet processor ships to the audio thread as one template
+  // literal, so its body cannot be split across imports the way `max-lines`
+  // assumes. The limit measures something these files cannot act on.
+  {
+    files: ['packages/exojs-audio-fx/src/worklets/*.worklet.ts'],
+    rules: {
+      'max-lines': 'off',
+    },
+  },
+
+  // LDtk marks its runtime-computed fields with a `__` prefix (`__identifier`,
+  // `__type`, …). These types mirror an external file format verbatim, so the
+  // prefix is data, not a naming choice we get to make.
+  {
+    files: ['packages/exojs-ldtk/src/**/*.ts'],
+    rules: {
+      '@typescript-eslint/naming-convention': [
+        'error',
+        {
+          selector: ['typeProperty', 'objectLiteralProperty'],
+          format: null,
+          leadingUnderscore: 'allowDouble',
+        },
+      ],
+    },
+  },
+
+  // React passes component and class references as PascalCase parameters
+  // (`SceneClass`), which is the ecosystem's spelling for "this argument is a
+  // constructor", not a naming slip.
+  {
+    files: ['packages/exojs-react/src/**/*.{ts,tsx}'],
+    rules: {
+      '@typescript-eslint/naming-convention': [
+        'error',
+        {
+          selector: 'parameter',
+          format: ['strictCamelCase', 'StrictPascalCase'],
+          leadingUnderscore: 'allow',
+        },
+      ],
+    },
+  },
+
+  // The input channel constants (`Pointer.X`, `GamepadButton.South`, …) are
+  // exposed as namespaces on purpose: it is the public spelling of the whole
+  // input API, and these three files are the only namespaces in the engine.
+  {
+    files: ['src/input/Pointer.ts', 'src/input/GamepadAxis.ts', 'src/input/GamepadButton.ts'],
+    rules: {
+      '@typescript-eslint/no-namespace': 'off',
+    },
+  },
+
+  // The one sanctioned console sink. Every routed DEV log and the one-time
+  // startup banner leave the engine through this file, so `no-console` is the
+  // wrong rule here rather than a violation to silence line by line.
+  {
+    files: ['src/core/logging.ts'],
+    rules: {
+      'no-console': 'off',
     },
   },
 

--- a/packages/exojs-audio-fx/src/worklets/beat-detector.worklet.ts
+++ b/packages/exojs-audio-fx/src/worklets/beat-detector.worklet.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */ // worklet body is a single template-literal string that cannot be import-split
 export const beatDetectorWorkletSource = `
 // ---- Hann window + FFT (radix-2 Cooley-Tukey) ----
 function applyHannWindow(real, imag) {

--- a/packages/exojs-ldtk/src/LdtkData.ts
+++ b/packages/exojs-ldtk/src/LdtkData.ts
@@ -8,7 +8,6 @@
  * @see https://ldtk.io/json/
  */
 
-/* eslint-disable @typescript-eslint/naming-convention -- LDtk uses __ prefix for runtime fields */
 
 import type { TilePropertyPoint, TilePropertyTileRef } from '@codexo/exojs-tilemap';
 

--- a/packages/exojs-ldtk/src/ldtkToTileMap.ts
+++ b/packages/exojs-ldtk/src/ldtkToTileMap.ts
@@ -437,7 +437,6 @@ function convertFieldInstances(fields: readonly LdtkFieldInstance[]): TileProper
  */
 function isLdtkArrayField(
   field: LdtkFieldInstance,
-  // eslint-disable-next-line @typescript-eslint/naming-convention -- LDtk uses __ prefix for runtime fields
 ): field is Extract<LdtkFieldInstance, { readonly __type: `Array<${string}>` }> {
   return field.__type.startsWith('Array<');
 }

--- a/packages/exojs-physics/src/ContactGraph.ts
+++ b/packages/exojs-physics/src/ContactGraph.ts
@@ -67,7 +67,6 @@ export class ContactGraph {
     this.sensorExit.length = 0;
     this.solidContacts.length = 0;
 
-    // eslint-disable-next-line unicorn/no-array-for-each -- forEach is the allocation-free path; for…of over a Map allocates an iterator every step.
     this._records.forEach(resetSeen);
 
     for (const pair of pairs) {
@@ -113,7 +112,7 @@ export class ContactGraph {
     // + thisArg is the allocation-free iteration (for…of allocates an entry tuple
     // per record each step); the thisArg binds `this`, so unbound-method is a
     // false positive here.
-    // eslint-disable-next-line unicorn/no-array-for-each, @typescript-eslint/unbound-method
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- the thisArg above binds it
     this._records.forEach(this._removeIfUnseen, this);
 
     sortInPlace(this.collisionStart, byColliderPair);

--- a/packages/exojs-physics/src/broadphase/AabbTreeBroadPhase.ts
+++ b/packages/exojs-physics/src/broadphase/AabbTreeBroadPhase.ts
@@ -96,12 +96,10 @@ export class AabbTreeBroadPhase implements BroadPhase, SpatialIndex {
   public computePairs(colliders: readonly Collider[], out: CandidatePair[]): CandidatePair[] {
     this.sync(colliders);
 
-    // eslint-disable-next-line unicorn/no-array-for-each -- allocation-free forEach over the Map (see ContactGraph's resetSeen/_removeIfUnseen for the same idiom); deleting the current entry during forEach is safe.
     this._pairs.forEach(this._dropIfStale);
 
     out.length = 0;
     this._collectTarget = out;
-    // eslint-disable-next-line unicorn/no-array-for-each -- allocation-free forEach over the Map, same idiom as above.
     this._pairs.forEach(this._collectPair);
     sortInPlace(out, byPairId);
 

--- a/packages/exojs-react/src/useScene.ts
+++ b/packages/exojs-react/src/useScene.ts
@@ -36,7 +36,6 @@ import { useExoApp } from './useExoApp';
  * }
  * ```
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function useScene<T extends Scene>(SceneClass: new () => T, deps: DependencyList = []): T | null {
   const app = useExoApp();
   const [scene, setScene] = useState<T | null>(null);

--- a/packages/exojs-react/src/useSignal.ts
+++ b/packages/exojs-react/src/useSignal.ts
@@ -32,8 +32,9 @@ export function useSignal<Args extends unknown[], T>(signal: Signal<Args> | null
     (onStoreChange: () => void): (() => void) => {
       if (!signal) {
         // No signal to subscribe to (e.g. before an Application exists) — nothing to unsubscribe either.
-        // eslint-disable-next-line @typescript-eslint/no-empty-function -- intentional no-op unsubscribe
-        return () => {};
+        return () => {
+          // Nothing was subscribed, so there is nothing to unsubscribe.
+        };
       }
 
       signal.add(onStoreChange);

--- a/src/assets/AssetDecoder.ts
+++ b/src/assets/AssetDecoder.ts
@@ -115,8 +115,9 @@ export class AssetDecoder {
       storageName,
       process,
       create: data => Promise.resolve(data as T),
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      destroy() {},
+      destroy() {
+        // Nothing to release: this strategy hands back the decoded value as-is.
+      },
     };
     return this._cacheStrategy.resolve(
       { storageName, key: source, url, requestOptions: this._fetchOptions, factory, options: undefined },

--- a/src/assets/FactoryRegistry.ts
+++ b/src/assets/FactoryRegistry.ts
@@ -6,7 +6,6 @@ import type { AssetFactory } from './AssetFactory';
  * Any abstract or concrete constructor whose instances are the asset type
  * produced by a factory (e.g. `typeof Texture`, `typeof Sound`).
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AssetConstructor<T = unknown> = abstract new (...args: any[]) => T;
 
 /** Climbs one step up the prototype chain, returning the parent constructor. */

--- a/src/assets/Loader.ts
+++ b/src/assets/Loader.ts
@@ -45,7 +45,6 @@ function toStoreList(cache: CacheStore | readonly CacheStore[]): readonly CacheS
  * Any abstract or concrete constructor that can be used as an asset type token
  * with {@link Loader.load} and related methods.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Loadable = abstract new (...args: any[]) => unknown;
 
 /**

--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -138,7 +138,6 @@ export interface InputApplicationOptions {
   allowTextSelection?: boolean;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- empty registry is a valid default
 export interface ApplicationOptions<Registry extends SceneRegistryShape<Registry> = {}> {
   clearColor?: Color;
   backend?: BackendConfig;
@@ -325,7 +324,6 @@ const defaultInputSettings: Required<InputApplicationOptions> = {
  * scene update + render). Useful for games; leave off for tools and
  * background-active simulations.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- empty registry is a valid default
 export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
   public readonly options: ApplicationOptions<Registry>;
   public readonly canvas: HTMLCanvasElement;

--- a/src/core/PhasedSceneTransition.ts
+++ b/src/core/PhasedSceneTransition.ts
@@ -204,10 +204,8 @@ export class PhasedSceneTransitionSession implements SceneTransitionSession {
   private readonly _enterPhaseState: unknown;
 
   public constructor(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exit and enter may be different PhasedSceneTransition<PhaseState> instantiations (composition); the session itself is untyped over PhaseState, matching its @internal status.
-    private readonly _exitPhase: PhasedSceneTransition<any>,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- same as above: a different PhaseState instantiation than the exit phase.
-    private readonly _enterPhase: PhasedSceneTransition<any>,
+    private readonly _exitPhase: PhasedSceneTransition<unknown>,
+    private readonly _enterPhase: PhasedSceneTransition<unknown>,
     private readonly _environment: SceneTransitionEnvironment,
   ) {
     this._exitPhaseState = this._exitPhase._createPhaseStateForSession();

--- a/src/core/PhasedSceneTransition.ts
+++ b/src/core/PhasedSceneTransition.ts
@@ -206,7 +206,7 @@ export class PhasedSceneTransitionSession implements SceneTransitionSession {
   public constructor(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exit and enter may be different PhasedSceneTransition<PhaseState> instantiations (composition); the session itself is untyped over PhaseState, matching its @internal status.
     private readonly _exitPhase: PhasedSceneTransition<any>,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- same as above: a different PhaseState instantiation than the exit phase.
     private readonly _enterPhase: PhasedSceneTransition<any>,
     private readonly _environment: SceneTransitionEnvironment,
   ) {

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -265,7 +265,6 @@ export class Scene<Data = void, AppLike extends ApplicationLike = Application> {
   }
 
   /** @internal — the UI layer if materialized, else `null` (no lazy allocation). */
-  // eslint-disable-next-line @typescript-eslint/naming-convention -- UI is an acronym (cf. HTMLText)
   public _peekUI(): UIRoot | null {
     return this._ui;
   }

--- a/src/core/SceneDirector.ts
+++ b/src/core/SceneDirector.ts
@@ -145,7 +145,6 @@ class DirectorTransitionEnvironment implements SceneTransitionEnvironment {
  * and {@link SceneDirector._renderTransition}, composited above or below the
  * app draw systems depending on the session's `placement`.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- empty registry is a valid default
 export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
   private readonly _app: Application;
   private readonly _registry: SceneRegistryIndex;

--- a/src/core/SceneTypes.ts
+++ b/src/core/SceneTypes.ts
@@ -123,7 +123,7 @@ export type NavigableSceneConstructor<Registry> = keyof Registry extends never
   ? AnySceneConstructor
   : { [K in keyof Registry]: Registry[K] extends { scene: infer C } ? C : Registry[K] }[keyof Registry];
 
-/* eslint-disable @typescript-eslint/no-explicit-any -- ApplicationLike/ApplicationOf must accept `Application<any>` and an abstract constructor's erased argument list. */
+/* eslint-disable @typescript-eslint/no-explicit-any -- `Application<any>` in type-argument position: `unknown` is not assignable to a concretely-typed Application, so the wildcard is what makes ApplicationLike accept every instantiation. */
 /**
  * Anything that resolves to a concrete {@link Application} instance type: the
  * instance itself, its constructor, or `typeof` an already-typed instance.

--- a/src/core/logging.ts
+++ b/src/core/logging.ts
@@ -121,7 +121,6 @@ export function createConsoleSink(): LogSink {
     if (entry.severity >= LogSeverity.Error) method = 'error';
     else if (entry.severity >= LogSeverity.Warning) method = 'warn';
 
-    /* eslint-disable no-console -- the single sanctioned console sink that default DEV logging routes through. */
     if (entry.error) {
       console[method](prefix, consolePrefixStyle, entry.message, entry.error);
     } else if (entry.data) {
@@ -129,7 +128,6 @@ export function createConsoleSink(): LogSink {
     } else {
       console[method](prefix, consolePrefixStyle, entry.message);
     }
-    /* eslint-enable no-console */
   };
 }
 
@@ -155,7 +153,6 @@ export function hello(info?: { backend?: string }): void {
 
   const suffix = info?.backend !== undefined ? ` (${info.backend})` : '';
 
-  /* eslint-disable-next-line no-console -- one-time DEV startup banner, not a routed log entry. */
   console.log(`%cExoJS v${__VERSION__}${suffix}`, consolePrefixStyle);
 }
 

--- a/src/core/serialization/Prefab.ts
+++ b/src/core/serialization/Prefab.ts
@@ -41,7 +41,6 @@ export class Prefab {
    * Build a prefab from a previously serialized descriptor — e.g. one produced
    * by {@link toJSON} and persisted to disk or fetched over the network.
    */
-  // eslint-disable-next-line @typescript-eslint/naming-convention -- mirrors the standard `toJSON` JSON convention
   public static fromJSON(descriptor: SerializedNode): Prefab {
     return new Prefab(descriptor);
   }
@@ -57,7 +56,6 @@ export class Prefab {
   }
 
   /** The underlying JSON descriptor (JSON-serialisable). Treat as read-only. The standard `JSON.stringify(prefab)` hook. */
-  // eslint-disable-next-line @typescript-eslint/naming-convention -- `toJSON` is the standard JSON.stringify hook name
   public toJSON(): SerializedNode {
     return this._descriptor;
   }

--- a/src/core/serialization/SerializationRegistry.ts
+++ b/src/core/serialization/SerializationRegistry.ts
@@ -7,7 +7,6 @@ import type { NodeSerializer } from './NodeSerializer';
  * Any abstract or concrete {@link SceneNode} constructor usable as a
  * serialization key.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type SceneNodeConstructor<T extends SceneNode = SceneNode> = abstract new (...args: any[]) => T;
 
 /**

--- a/src/input/GamepadAxis.ts
+++ b/src/input/GamepadAxis.ts
@@ -144,7 +144,6 @@ export class GamepadAxis {
 
 const axis = (offset: number): GamepadAxisChannel => (ChannelOffset.Gamepads + offset) as GamepadAxisChannel;
 
-/* eslint-disable @typescript-eslint/no-namespace */
 /**
  * Channel-identifier constants. The axis section starts after the 32-slot
  * button block: 24 named axes (offsets 32..55) plus 8 reserved slots
@@ -192,4 +191,3 @@ export namespace GamepadAxis {
   export const AuxiliaryAxis3Positive = axis(55);
   // Offsets 56..63 reserved for future named axes / custom mapping use.
 }
-/* eslint-enable @typescript-eslint/no-namespace */

--- a/src/input/GamepadButton.ts
+++ b/src/input/GamepadButton.ts
@@ -114,7 +114,6 @@ export class GamepadButton {
 
 const button = (offset: number): GamepadButtonChannel => (ChannelOffset.Gamepads + offset) as GamepadButtonChannel;
 
-/* eslint-disable @typescript-eslint/no-namespace, @typescript-eslint/naming-convention */
 /**
  * Channel-identifier constants — same convention as `Pointer.X` /
  * `Keyboard.Space`. The first 32 slots of each gamepad sub-buffer are
@@ -165,4 +164,3 @@ export namespace GamepadButton {
   export const Paddle4 = button(23);
   // Offsets 24..31 reserved for future named buttons / custom mapping use.
 }
-/* eslint-enable @typescript-eslint/no-namespace, @typescript-eslint/naming-convention */

--- a/src/input/InputManager.ts
+++ b/src/input/InputManager.ts
@@ -474,10 +474,10 @@ export class InputManager {
    * @internal
    */
   public _snapshotActionChannels(): Float32Array {
-    // `.slice()` (not a spread) deliberately — a spread of a typed array
-    // yields a plain `number[]`, not a `Float32Array`.
-    // eslint-disable-next-line unicorn/prefer-spread
-    return this.channels.slice();
+    // Constructing from the source copies it and states the result type in the
+    // code. A spread would yield a plain `number[]`, which is why the rule's
+    // suggestion does not apply to a typed array.
+    return new Float32Array(this.channels);
   }
 
   /**

--- a/src/input/InteractionManager.ts
+++ b/src/input/InteractionManager.ts
@@ -607,7 +607,6 @@ export class InteractionManager implements InteractionHooks {
    * call its trap would only engage on the next unrelated focus change.
    * @internal
    */
-  // eslint-disable-next-line @typescript-eslint/naming-convention -- UI is an acronym (cf. HTMLText)
   public attachUIRoot(root: Container): void {
     root._setStage(this._uiStage);
     this._focus._enforceActiveScopeTrap();
@@ -620,7 +619,6 @@ export class InteractionManager implements InteractionHooks {
    * here — UI nodes were never registered through that path.
    * @internal
    */
-  // eslint-disable-next-line @typescript-eslint/naming-convention -- UI is an acronym (cf. HTMLText)
   public detachUIRoot(root: Container): void {
     this._removeScopesInSubtree(root);
     this._focus._notifyNodeRemoved(root);
@@ -1449,7 +1447,6 @@ export class InteractionManager implements InteractionHooks {
   }
 
   /** Whether `node` lives inside the active scene's UI layer. */
-  // eslint-disable-next-line @typescript-eslint/naming-convention -- UI is an acronym (cf. HTMLText)
   private _isUINode(node: RenderNode): boolean {
     const uiRoot = this._app.scenes.currentScene?._peekUI() ?? null;
 

--- a/src/input/Pointer.ts
+++ b/src/input/Pointer.ts
@@ -584,7 +584,6 @@ export class Pointer {
  * pointer). For multi-touch access use `Pointer.Slot{N}Active /
  * Slot{N}X / Slot{N}Y`.
  */
-// eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace Pointer {
   // --- Primary-pointer convenience aliases (slot 0) ---
   export const Active = pointerCh(0);

--- a/src/rendering/text/AbstractText.ts
+++ b/src/rendering/text/AbstractText.ts
@@ -38,8 +38,9 @@ export abstract class AbstractText extends Drawable {
    * calls are only needed when you require up-to-date geometry outside
    * of a render pass (e.g. to measure bounds right after a style change).
    */
-  // eslint-disable-next-line @typescript-eslint/no-empty-function -- intentional no-op; subclasses override
-  public syncDirty(): void {}
+  public syncDirty(): void {
+    // Intentional no-op; subclasses override.
+  }
 
   /**
    * Advance the node by `dt` milliseconds.

--- a/src/rendering/text/HTMLText.ts
+++ b/src/rendering/text/HTMLText.ts
@@ -12,7 +12,6 @@ const fontMime: Record<FontFormat, string> = {
   otf: 'font/otf',
 };
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export interface HTMLTextOptions {
   /** CSS injected inside a &lt;style&gt; tag within the SVG foreignObject. */
   css?: string;
@@ -58,7 +57,6 @@ export interface HTMLTextOptions {
  * ```
  * @stable
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export class HTMLText extends Container {
   private _html: string;
   private _css: string;

--- a/src/rendering/text/TextStyle.ts
+++ b/src/rendering/text/TextStyle.ts
@@ -36,7 +36,6 @@ export type FontWeight = 'normal' | 'bold' | '100' | '200' | '300' | '400' | '50
  * }
  * ```
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface FontRegistry {}
 
 /**

--- a/src/rendering/webgl2/WebGl2ShaderProgram.ts
+++ b/src/rendering/webgl2/WebGl2ShaderProgram.ts
@@ -20,7 +20,6 @@ interface ManagedUniform {
 interface ParallelCompileExtension {
   // Naming-convention exception: this is a verbatim WebGL extension constant
   // exposed by the driver under its spec-defined uppercase name.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   readonly COMPLETION_STATUS_KHR: number;
 }
 

--- a/src/ui/Button.ts
+++ b/src/ui/Button.ts
@@ -133,7 +133,7 @@ export class Button extends Widget {
 
     // `channel` is a generic numeric input channel (KeyEvent.channel is `number`),
     // intentionally compared against the Keyboard enum constants — see KeyEvent docs.
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- widening casts are redundant here, so the suppression is the only honest option
     if (this.enabled && (channel === Keyboard.Enter || channel === Keyboard.Space)) {
       event.preventDefault();
       this.onClick.dispatch(this);

--- a/src/ui/Tooltip.ts
+++ b/src/ui/Tooltip.ts
@@ -170,7 +170,6 @@ export class Tooltip {
    * Walk up the target's parent chain to find the nearest {@link UIRoot}.
    * Returns `null` when the target is not attached to a UI layer.
    */
-  // eslint-disable-next-line @typescript-eslint/naming-convention -- UI is an acronym (cf. HTMLText)
   private _findUIRoot(): UIRoot | null {
     let current = this._target.parent;
 

--- a/src/ui/UIRoot.ts
+++ b/src/ui/UIRoot.ts
@@ -16,7 +16,6 @@ import type { RenderingContext } from '#rendering/RenderingContext';
  * Add widgets with `scene.ui.addChild(...)`. The {@link UIRoot.onResize} signal
  * fires whenever the screen size changes, so anchored widgets can re-layout.
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention -- UI is an acronym (cf. HTMLText)
 export class UIRoot extends Container {
   /** Fires with `(width, height)` whenever the screen size changes. */
   public readonly onResize = new Signal<[width: number, height: number]>();

--- a/test/assets/loader-extension-matching.test.ts
+++ b/test/assets/loader-extension-matching.test.ts
@@ -94,7 +94,7 @@ describe('compound extension matching', () => {
 
     registerExtensionKind('mock.json', 'json'); // compound suffix → the json value kind (bound via coreAssetBindings)
     global.fetch = vi.fn(async (url: string | URL | Request): Promise<Response> => {
-      seen.push(String(url));
+      seen.push(url instanceof Request ? url.url : String(url));
       return {
         ok: true,
         status: 200,

--- a/test/core/scene/scene-navigation-transaction.test.ts
+++ b/test/core/scene/scene-navigation-transaction.test.ts
@@ -94,7 +94,7 @@ describe('SceneNavigationTransaction', () => {
       expect(reportError).toHaveBeenCalledWith(failure);
     });
 
-    test('does not start teardown until beginOutgoingTeardown is called', () => {
+    test('does not start teardown until beginOutgoingTeardown is called', async () => {
       const onStopScene = new Signal<[Scene]>();
       const onStateChange = new Signal<[SceneState, SceneState, Scene]>();
       const reportError = vi.fn();
@@ -106,7 +106,7 @@ describe('SceneNavigationTransaction', () => {
       expect(scope.destroy).not.toHaveBeenCalled();
 
       transaction.dispatchStopScene(pendingStopScene);
-      transaction.beginOutgoingTeardown(pendingStopScene);
+      await transaction.beginOutgoingTeardown(pendingStopScene);
 
       expect(scope.destroy).toHaveBeenCalledTimes(1);
     });

--- a/test/perf/harness.ts
+++ b/test/perf/harness.ts
@@ -95,7 +95,11 @@ const DEFAULT_COLUMNS: ColumnDef[] = [
 
 const getCellValue = (result: BenchmarkResult, key: string): string => {
   if (key in result) {
-    return String(result[key as keyof BenchmarkResult] ?? '');
+    // `extra` is a record, not a cell — its columns are resolved below by name.
+    // Stringifying it here would print `[object Object]` into the table.
+    const value = key === 'extra' ? undefined : result[key as Exclude<keyof BenchmarkResult, 'extra'>];
+
+    return String(value ?? '');
   }
 
   // Peek into extra fields


### PR DESCRIPTION
Four commits that work through the repo's ESLint suppressions, each step measured rather than reasoned about.

## 1. `src/**` inline disables: 46 → 15

Almost none of them were rule violations — they were mis-scoped rules. `strictCamelCase` rejects consecutive capitals, so `UIRoot`, `HTMLText`, `fromJSON` and `DPadUp` each carried their own exception for the same cause; those now live in the naming-convention config as acronym filters. `abstract new (...args: any[]) => T` needs `any` because `unknown[]` makes parameter contravariance reject every real constructor — the rule ships `ignoreRestArgs` for exactly that. An empty `{}` as a declaration-merging point is an architectural pattern, not an oversight.

Worth knowing for later: a `variable` + `const` selector outranks the grouped `variableLike` entry, so acronym exceptions need both or they silently fail to apply.

## 2. Type-aware linting for `test/**`

The test tree has been parsed with type information for a while, but every type-aware rule was off under a comment citing ts-jest — which this repo has not used since the Vitest migration. Measured instead of assumed: `no-floating-promises` costs one report, `no-base-to-string` two. All three were real bugs:

- `scene-navigation-transaction` dropped the promise from `beginOutgoingTeardown()` and asserted immediately after. Green only because `destroy` happens to run synchronously; the moment it doesn't, the test proves nothing and still passes.
- `loader-extension-matching` stringified `string | URL | Request` — a `Request` would have written `[object Object]` into the assertion.
- The benchmark table stringified `BenchmarkResult.extra`, a record, into a single cell.

Both rules are now on. The rest stay off, but with measured numbers in the comment instead of a legend: `no-unsafe-*` 914, `require-await` 395, `unbound-method` 236.

## 3. Remaining suppressions evaluated

Three more resolved, one deliberately rolled back. `AnySceneConstructor`'s `SceneConstructor<any>` passes typecheck, type tests, examples, guides and the ratchet as `<unknown>` — and is back on `any` anyway: the comment there documents a case that actually happened ("silently rejects the single most common case"), and the gates only prove today's tree compiles, not that a future consumer with a data-carrying scene gets through. `PhasedSceneTransition` keeps `unknown`: internal fields, the state is never inspected.

## 4. Rule disables that no longer suppress anything

Every per-subsystem override was measured by running its own rules at error level across the scope it covers. Entries reporting zero were removed — two whole blocks (`Loader.ts`, `SubtitleFactory.ts`) plus 15 individual rules. Four further blocks turned out to restate what a later, broader block already sets and are gone as well.

The `no-console` allowlist named four files; only `WebGl2Backend.ts` still logs, so three files return to the default.

Net: config from 1672 to 1580 lines, 183 to 156 `off` entries, 52 to 45 scopes.

Verified by snapshotting the effective config (`eslint --print-config`) for 24 representative files before and after — the only differences are the removed dead entries flipping from `off` to their configured level.

## Known gap

`packages/*/test/**` has no type-aware linting at all (`projectService: false`); the rules crash there. 46 preset rules are dark as a result, including `await-thenable`, `no-floating-promises` and `only-throw-error`. Wiring that up is separate work — noted in the commit and in memory.

`pnpm verify:quick` green.

https://claude.ai/code/session_01XQYUhcmWjUM7uxiNBCbURX