### PR TITLE
test(assets): actually run the three GC-dependent specs

### DIFF
--- a/packages/exojs-config/vitest/index.js
+++ b/packages/exojs-config/vitest/index.js
@@ -36,6 +36,13 @@ export const workletTransformPlugin = createWorkletPlugin();
 
 /**
  * A jsdom unit/integration test project. Used for Core and each extension.
+ *
+ * `execArgv` passes `--expose-gc` to the worker so specs that assert weak-retention
+ * behaviour (`WeakRef`/`FinalizationRegistry` reclamation) can force a real major
+ * GC instead of self-skipping on a missing `globalThis.gc`. The flag only exposes
+ * the function; it does not otherwise change how V8 collects. Note this is a
+ * top-level test option in Vitest 4 — under `poolOptions.forks` it is silently
+ * ignored.
  * @param {{ name: string, include: string[], exclude?: string[], setupFiles?: string[], alias?: unknown }} opts
  */
 export function createJsdomTestProject(opts) {
@@ -53,6 +60,7 @@ export function createJsdomTestProject(opts) {
       include,
       ...(exclude ? { exclude } : {}),
       testTimeout: 15_000,
+      execArgv: ['--expose-gc'],
     },
   };
 }

--- a/test/assets/loader-deferred-handles.test.ts
+++ b/test/assets/loader-deferred-handles.test.ts
@@ -40,11 +40,18 @@ function keyOf(loader: Loader, source: string): string {
   return (loader as unknown as { _typeRegistry: { _key(t: unknown, s: string): string } })._typeRegistry._key(Texture, source);
 }
 
-/** Real major GC + macrotask hops so reclaimed WeakRefs settle. Needs `--expose-gc`. */
-const gc = (globalThis as { gc?: () => void }).gc;
+/**
+ * Real major GC + macrotask hops so reclaimed WeakRefs settle. `--expose-gc` comes
+ * from the shared vitest project factory, so an absent `gc` is a config regression
+ * to surface rather than a reason to skip.
+ */
 async function forceGc(): Promise<void> {
+  const gc = (globalThis as { gc?: () => void }).gc;
+
+  if (!gc) throw new Error('globalThis.gc is unavailable — the test project must pass --expose-gc to the fork pool');
+
   for (let i = 0; i < 10; i++) {
-    gc?.();
+    gc();
     await new Promise(resolve => setTimeout(resolve, 0));
   }
 }
@@ -100,9 +107,9 @@ describe('deferred handle bookkeeping (audit A4 / A5)', () => {
 
   // GC-dependent proof that the A4 leak is actually closed: once the game drops
   // its last reference to an evicted handle, the deferred entry (and its evicted
-  // marker) is reclaimed rather than accumulating forever. Runs only under
-  // `--expose-gc`; the structural test above is the deterministic CI guard.
-  test.runIf(typeof gc === 'function')('A4: a fully-released evicted handle is pruned from _deferred by the GC', async () => {
+  // marker) is reclaimed rather than accumulating forever. The structural test
+  // above covers the wiring; only this one proves the reclamation happens.
+  test('A4: a fully-released evicted handle is pruned from _deferred by the GC', async () => {
     const loader = createCoreLoader();
     const key = keyOf(loader, 'orphan.png');
 

--- a/test/assets/weak-handle-set.test.ts
+++ b/test/assets/weak-handle-set.test.ts
@@ -1,10 +1,17 @@
 import { WeakHandleSet } from '#assets/WeakHandleSet';
 
-/** Real major GC + a macrotask hop so reclaimed WeakRefs settle. Needs `--expose-gc`. */
-const gc = (globalThis as { gc?: () => void }).gc;
+/**
+ * Real major GC + a macrotask hop so reclaimed WeakRefs settle. `--expose-gc` comes
+ * from the shared vitest project factory, so an absent `gc` is a config regression
+ * to surface rather than a reason to skip.
+ */
 async function forceGc(): Promise<void> {
+  const gc = (globalThis as { gc?: () => void }).gc;
+
+  if (!gc) throw new Error('globalThis.gc is unavailable — the test project must pass --expose-gc to the fork pool');
+
   for (let i = 0; i < 10; i++) {
-    gc?.();
+    gc();
     await new Promise(resolve => setTimeout(resolve, 0));
   }
 }
@@ -68,9 +75,9 @@ describe('WeakHandleSet', () => {
   });
 
   // GC-dependent: proves the whole point of the class — a dropped handle is
-  // reclaimable and prune() compacts it out. Runs only under `--expose-gc`
-  // (`NODE_OPTIONS=--expose-gc`); the deterministic tests above are the CI guard.
-  test.runIf(typeof gc === 'function')('prune() drops the slot of a GC-reclaimed handle', async () => {
+  // reclaimable and prune() compacts it out. The deterministic tests above cover
+  // the bookkeeping; only these two prove the weakness is real.
+  test('prune() drops the slot of a GC-reclaimed handle', async () => {
     const survivor = { id: 'survivor' };
     const set = new WeakHandleSet(survivor);
     set.add({ id: 'ephemeral' }); // no strong reference kept — GC-eligible
@@ -81,7 +88,7 @@ describe('WeakHandleSet', () => {
     expect([...set]).toEqual([survivor]);
   });
 
-  test.runIf(typeof gc === 'function')('becomes empty once the last handle is reclaimed', async () => {
+  test('becomes empty once the last handle is reclaimed', async () => {
     const set = new WeakHandleSet({ id: 'only' }); // no strong reference kept
 
     await forceGc();


### PR DESCRIPTION
`test.runIf(typeof gc === 'function')` made three WeakRef-reclamation specs self-skip everywhere: nothing in the repo or CI ever passed `--expose-gc`, so they had never executed. Their deterministic siblings cover the bookkeeping, but not the reclamation itself — the property those specs exist for.

The shared jsdom project factory now passes `--expose-gc` via `execArgv`. Note this is a top-level test option in Vitest 4; under `poolOptions.forks` it is accepted and silently ignored. With `gc` guaranteed, the `runIf` guards are gone and `forceGc()` throws a named error if the flag ever disappears, so the failure mode is a loud config regression instead of a silent skip.

## Verification

- 0 flakes over 10 consecutive runs; the three add ~450ms.
- Teeth confirmed: without `execArgv` the three fail hard with the new message.
- Full suite: 8791 passed, 1 skipped (was 8788 / 4).
- `pnpm verify:quick` green.

The one remaining skip is the opt-in renderer benchmark sweep, which self-skips by design unless `EXOJS_PERF_PROFILE` is set.

https://claude.ai/code/session_01XQYUhcmWjUM7uxiNBCbURX