### PR TITLE
ci(test): run the Firefox WebGL2 lane headed under xvfb

### DIFF
--- a/.github/workflows/_ci-checks.yml
+++ b/.github/workflows/_ci-checks.yml
@@ -462,9 +462,22 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps firefox
 
-      - name: Browser tests (Firefox WebGL2, headless)
+      - name: Install xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
+      # Firefox disables WebGL outright in headless mode — no preference changes
+      # that, it is a browser-level limitation (playwright#1032, #21783, still
+      # current). A window is the only configuration where a context exists, so
+      # this runs headed against the virtual display xvfb supplies, the same
+      # recipe as the Chromium WebGPU lane above. LIBGL_ALWAYS_SOFTWARE points
+      # Mesa at llvmpipe so there is something to rasterise on.
+      - name: Browser tests (Firefox WebGL2, headed via xvfb)
         continue-on-error: true
-        run: pnpm test:browser:webgl:firefox
+        env:
+          EXOJS_FIREFOX_CI_HEADED: '1'
+          LIBGL_ALWAYS_SOFTWARE: '1'
+          GALLIUM_DRIVER: llvmpipe
+        run: xvfb-run -a pnpm test:browser:webgl:firefox
 
       - name: Browser tests (Firefox WebGPU, headed)
         continue-on-error: true

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -67,7 +67,9 @@ const realShaderPlugin = {
 
 // Per-project browser headedness:
 //  - WebGL2 Chromium: new headless. EXOJS_BROWSER_HEADED=1 only for local headed debug.
-//  - WebGL2 Firefox:  headless.
+//  - WebGL2 Firefox:  headless locally (Windows/macOS need no X server and give a
+//    context either way); headed under xvfb in CI via EXOJS_FIREFOX_CI_HEADED=1,
+//    because Firefox on Linux disables WebGL entirely in headless mode.
 //  - WebGPU Chromium: headless by default (safe for local dev with no display server).
 //    CI opts into headed mode via EXOJS_WEBGPU_CI_HEADED=1 — Mesa lavapipe needs a
 //    real display to report a real Vulkan adapter instead of falling back to
@@ -78,6 +80,7 @@ const realShaderPlugin = {
 const headed = process.env['EXOJS_BROWSER_HEADED'] === '1';
 const webgl2Headless = !headed;
 const webgpuCiHeaded = process.env['EXOJS_WEBGPU_CI_HEADED'] === '1';
+const firefoxCiHeaded = process.env['EXOJS_FIREFOX_CI_HEADED'] === '1';
 
 // Setup run in every browser project to install the `__DEV__` global (see the
 // browserBase note) before any engine module evaluates.
@@ -255,6 +258,22 @@ export default defineConfig({
       },
 
       // ── browser-webgl-firefox — WebGL2 via Firefox headless ──────────────
+      // On Linux this lane failed every file on `getContext('webgl2') === null`
+      // — "This browser or hardware does not support WebGL" — while
+      // `continue-on-error` kept the check green. The cause is not configuration
+      // but Firefox itself: it disables WebGL in headless mode, and no
+      // preference overrides that (playwright#1032, #21783 — still current). A
+      // window is the only configuration with a context, so CI runs this headed
+      // against xvfb's virtual display, the same recipe the Chromium WebGPU lane
+      // uses. Locally it stays headless: Windows and macOS need no X server and
+      // hand out a context either way, which is exactly why the CI gap went
+      // unnoticed for so long.
+      //
+      // The prefs are belt-and-braces for the runner: `webgl.force-enabled`
+      // overrides the driver blocklist that rejects unknown CI hardware, and
+      // `gfx.webrender.software` selects the software backend — the counterpart
+      // to Chromium's `--use-angle=swiftshader`. (`webgl.out-of-process: false`
+      // was tried and rejected: it kills the browser connection mid-run.)
       {
         ...browserBase,
         test: {
@@ -262,7 +281,20 @@ export default defineConfig({
           globals: true,
           setupFiles: renderingBrowserSetupFiles,
           include: ['test/rendering/browser/webgl2-*.test.ts'],
-          browser: { enabled: true, headless: true, provider: playwright(), instances: [{ browser: 'firefox' }] },
+          browser: {
+            enabled: true,
+            headless: !firefoxCiHeaded,
+            provider: playwright({
+              launchOptions: {
+                firefoxUserPrefs: {
+                  'webgl.force-enabled': true,
+                  'webgl.disabled': false,
+                  'gfx.webrender.software': true,
+                },
+              },
+            }),
+            instances: [{ browser: 'firefox' }],
+          },
         },
       },
 


### PR DESCRIPTION
**Experiment — no auto-merge.** Whether this works can only be answered by CI, so please look at the Firefox lane result before merging.

## The problem

The Firefox WebGL2 lane failed **45 of its 46 files** in the last run on main, every one on the same error:

```
Error: This browser or hardware does not support WebGL.
× canvas.getContext("webgl2") returns a real WebGL2RenderingContext
```

`continue-on-error: true` reports the check green regardless, so the lane spends runner time on every engine PR while covering nothing. The workflow comment already recorded the symptom; what was missing is that it is fixable.

## The cause

Not our configuration — Firefox disables WebGL in headless mode as a browser-level limitation, and no preference overrides it ([playwright#1032](https://github.com/microsoft/playwright/issues/1032), [playwright#21783](https://github.com/microsoft/playwright/issues/21783); [still current in 2025](https://adequatica.github.io/2025/05/08/overcoming-bugs-in-testing-infrastructure-with-playwright.html)). A window is the only configuration where a context exists.

This is Linux-only, which is exactly why it went unnoticed: on Windows and macOS Firefox needs no X server and hands out a context headless. Local runs pass, CI silently does not.

## The change

CI runs the lane headed against xvfb's virtual display — the same recipe `browser-tests-webgpu-chromium` already uses successfully. `EXOJS_FIREFOX_CI_HEADED=1` gates it so local runs stay headless and never pop a window.

The prefs are belt-and-braces for unknown runner hardware: `webgl.force-enabled` overrides the driver blocklist, `gfx.webrender.software` selects the software backend (the counterpart to Chromium's `--use-angle=swiftshader`), and `LIBGL_ALWAYS_SOFTWARE`/`GALLIUM_DRIVER` point Mesa at llvmpipe.

`webgl.out-of-process: false` was tried and dropped — it closes the browser connection mid-run (locally 28/28 → dead session).

## What to expect

Best case the lane gets a context and we find out how much of the suite Firefox actually passes — screenshot comparisons may well differ from the Chromium references, which would be a real finding rather than the current blank. Worst case it still reports no context, and then the honest move is to delete the lane instead of paying for it.

Either way it stays `continue-on-error` and blocks nothing.

https://claude.ai/code/session_01XQYUhcmWjUM7uxiNBCbURX