### PR TITLE
fix(webgpu): make Safari usable — canvas uploads, and auto keeps WebKit on WebGL2

### DIFF
--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -49,7 +49,7 @@ import type { System } from './System';
 import { SystemOrder } from './SystemOrder';
 import { SystemRegistry } from './SystemRegistry';
 import { Time } from './Time';
-import { canvasSourceToDataUrl } from './utils';
+import { canvasSourceToDataUrl, isWebKitUserAgent } from './utils';
 
 export enum ApplicationStatus {
   Loading = 1,
@@ -1500,10 +1500,23 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
     }
   }
 
+  /**
+   * Whether `backend: 'auto'` should pick WebGPU. Presence of `navigator.gpu`
+   * is necessary but not sufficient: WebKit ships a WebGPU implementation that
+   * renders this engine incorrectly — SDF text draws as an empty frame, and
+   * repeated runs of the parity matrix fail a different set of scenes each
+   * time, which points at the driver rather than at engine code. Neither has a
+   * feature flag to test, and both produce a broken picture with no error, so
+   * `auto` keeps WebKit on WebGL2, where the same scenes render correctly.
+   *
+   * This is not a permanent verdict. `backend: 'webgpu'` still selects it
+   * explicitly for anyone testing WebKit's implementation, and the check should
+   * go once the parity matrix comes back clean there.
+   */
   private canUseWebGpu(): boolean {
     const gpuNavigator = navigator as Navigator & Partial<{ gpu: GPU }>;
 
-    return !!gpuNavigator.gpu;
+    return !!gpuNavigator.gpu && !isWebKitUserAgent(navigator.userAgent);
   }
 
   private _applyCanvasSize(width: number, height: number): void {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -78,6 +78,27 @@ export const supportsTouchEvents: boolean = canUseWindow() && 'ontouchstart' in 
 export const supportsPointerEvents: boolean = typeof PointerEvent !== 'undefined';
 
 /**
+ * Whether a user-agent string identifies a browser running on WebKit: Safari,
+ * and every iOS browser regardless of brand — Chrome, Firefox and Edge on iOS
+ * are all WebKit underneath and inherit its rendering defects, so they belong
+ * on the same side of this test as Safari does.
+ *
+ * Blink and Gecko carry `AppleWebKit` in their UA for historical reasons, so
+ * that token alone decides nothing. `Chrome`/`Chromium`/`Edg/` mark real Blink
+ * (their iOS builds say `CriOS`/`EdgiOS` instead and are correctly left in).
+ * Requiring `Safari/` additionally excludes non-browser consumers of the same
+ * string — jsdom, for one, reports `AppleWebKit` with no `Safari/` token.
+ *
+ * A UA test rather than a capability probe, used only where a defect has no
+ * feature to detect — see `Application.canUseWebGpu`, which keeps WebKit off a
+ * WebGPU implementation that renders incorrectly without reporting an error.
+ *
+ * @param userAgent - The UA string to classify.
+ */
+export const isWebKitUserAgent = (userAgent: string): boolean =>
+  userAgent.includes('AppleWebKit') && userAgent.includes('Safari/') && !['Chrome', 'Chromium', 'Edg/'].some(token => userAgent.includes(token));
+
+/**
  * Lazy-cached probe for the third `EventListenerOptions` argument to
  * `addEventListener` (passive/capture object). Older browsers ignore the
  * object and treat it as the boolean `useCapture`. Probed once on first call.

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -2029,6 +2029,12 @@ export class WebGpuBackend implements RenderBackend {
    * future Safari that fixes it, with no version sniffing.
    */
   private async _probeCanvasExternalImageCopy(): Promise<boolean> {
+    // Held outside the try so the finally can release them whatever happens:
+    // the readback maps asynchronously, and a device lost (or destroyed) in
+    // that window rejects mid-probe, which would otherwise strand both.
+    let probeTexture: GPUTexture | null = null;
+    let readback: GPUBuffer | null = null;
+
     try {
       const canvas = document.createElement('canvas');
 
@@ -2042,7 +2048,7 @@ export class WebGpuBackend implements RenderBackend {
       ctx.fillStyle = '#ff0000';
       ctx.fillRect(0, 0, 2, 2);
 
-      const probeTexture = this.device.createTexture({
+      probeTexture = this.device.createTexture({
         label: 'backend:probe:canvas-external-image-copy',
         size: { width: 2, height: 2 },
         format: managedTextureFormat,
@@ -2059,7 +2065,8 @@ export class WebGpuBackend implements RenderBackend {
       // `copyTextureToBuffer` requires `bytesPerRow` aligned to 256 bytes,
       // unlike `writeTexture` (see the managed-texture upload above).
       const bytesPerRow = 256;
-      const readback = this.device.createBuffer({
+
+      readback = this.device.createBuffer({
         label: 'backend:probe:canvas-external-image-copy-readback',
         size: bytesPerRow * 2,
         usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
@@ -2075,14 +2082,15 @@ export class WebGpuBackend implements RenderBackend {
       const pixel = new Uint8Array(readback.getMappedRange().slice(0, 4));
 
       readback.unmap();
-      readback.destroy();
-      probeTexture.destroy();
 
       return pixel[0] === 255 && pixel[1] === 0 && pixel[2] === 0 && pixel[3] === 255;
     } catch {
       // An unexpected failure here says nothing about the real browser
       // behaviour — stay on the always-correct fallback rather than guess.
       return false;
+    } finally {
+      readback?.destroy();
+      probeTexture?.destroy();
     }
   }
 

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -183,6 +183,12 @@ export class WebGpuBackend implements RenderBackend {
   private _context: GPUCanvasContext | null = null;
   private _device: GPUDevice | null = null;
   private _format: GPUTextureFormat | null = null;
+  // `copyExternalImageToTexture` from a <canvas> source: `null` while unknown
+  // (never probed yet), `true`/`false` once the one-off probe below resolves.
+  // See `_probeCanvasExternalImageCopy` for why this is measured instead of
+  // assumed.
+  private _canvasExternalImageCopySupported: boolean | null = null;
+  private _canvasExternalImageCopyProbeStarted = false;
   private _initializePromise: Promise<this> | null = null;
   private _renderTarget: RenderTarget;
   // Reused scratch for the device-pixel snap viewport rect (see _snapViewport).
@@ -2006,6 +2012,80 @@ export class WebGpuBackend implements RenderBackend {
     return state;
   }
 
+  /**
+   * Whether `copyExternalImageToTexture` actually writes pixels when its
+   * source is a 2D `<canvas>`. Safari's WebGPU accepts the call and reports
+   * no validation error, but the destination texture is left at its cleared
+   * contents — a correctness bug with no capability or feature flag to read
+   * it off, so this uploads a known pixel and reads it back for real.
+   *
+   * Runs once per backend instance, kicked off lazily on the first canvas-
+   * sourced texture upload rather than during `initialize()` — an app that
+   * never uses one (no `Graphics`, no gradients, no `HTMLText`) shouldn't pay
+   * for it. Until it resolves, uploads fall back to the always-correct
+   * `getImageData` path; this promotes them to the cheaper direct copy only
+   * once actually confirmed, and stays on the fallback forever on a browser
+   * where the probe reports `false` — including transparently picking up a
+   * future Safari that fixes it, with no version sniffing.
+   */
+  private async _probeCanvasExternalImageCopy(): Promise<boolean> {
+    try {
+      const canvas = document.createElement('canvas');
+
+      canvas.width = 2;
+      canvas.height = 2;
+
+      const ctx = canvas.getContext('2d');
+
+      if (ctx === null) return false;
+
+      ctx.fillStyle = '#ff0000';
+      ctx.fillRect(0, 0, 2, 2);
+
+      const probeTexture = this.device.createTexture({
+        label: 'backend:probe:canvas-external-image-copy',
+        size: { width: 2, height: 2 },
+        format: managedTextureFormat,
+        // `copyExternalImageToTexture` requires RENDER_ATTACHMENT on its
+        // destination, not just COPY_DST — the managed-texture path above
+        // gets this for free through `_getTextureUsage`'s mipmap usage
+        // (mipmapping defaults on), but this standalone probe texture has to
+        // ask for it explicitly.
+        usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.RENDER_ATTACHMENT,
+      });
+
+      this.device.queue.copyExternalImageToTexture({ source: canvas, flipY: false }, { texture: probeTexture }, { width: 2, height: 2 });
+
+      // `copyTextureToBuffer` requires `bytesPerRow` aligned to 256 bytes,
+      // unlike `writeTexture` (see the managed-texture upload above).
+      const bytesPerRow = 256;
+      const readback = this.device.createBuffer({
+        label: 'backend:probe:canvas-external-image-copy-readback',
+        size: bytesPerRow * 2,
+        usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+      });
+
+      const encoder = this.device.createCommandEncoder({ label: 'backend:probe:canvas-external-image-copy-encoder' });
+
+      encoder.copyTextureToBuffer({ texture: probeTexture }, { buffer: readback, bytesPerRow, rowsPerImage: 2 }, { width: 2, height: 2 });
+      this.device.queue.submit([encoder.finish()]);
+
+      await readback.mapAsync(GPUMapMode.READ);
+
+      const pixel = new Uint8Array(readback.getMappedRange().slice(0, 4));
+
+      readback.unmap();
+      readback.destroy();
+      probeTexture.destroy();
+
+      return pixel[0] === 255 && pixel[1] === 0 && pixel[2] === 0 && pixel[3] === 255;
+    } catch {
+      // An unexpected failure here says nothing about the real browser
+      // behaviour — stay on the always-correct fallback rather than guess.
+      return false;
+    }
+  }
+
   private _syncTexture(texture: Texture | RenderTexture): ManagedWebGpuTextureState {
     if (!(texture instanceof RenderTexture) && !(texture instanceof DataTexture) && (texture.source === null || texture.width === 0 || texture.height === 0)) {
       throw new Error('WebGPU sprite rendering requires a texture with a valid source and non-zero dimensions.');
@@ -2090,19 +2170,53 @@ export class WebGpuBackend implements RenderBackend {
       } else if (!(texture instanceof RenderTexture)) {
         const source = texture.source!;
 
-        this.device.queue.copyExternalImageToTexture(
-          {
-            source,
-            flipY: false,
-          },
-          {
-            texture: state.texture,
-          },
-          {
-            width: texture.width,
-            height: texture.height,
-          },
-        );
+        if (source instanceof HTMLCanvasElement && this._canvasExternalImageCopySupported !== true) {
+          // `copyExternalImageToTexture` from a 2D <canvas> silently uploads
+          // nothing on Safari's WebGPU — the destination texture stays at its
+          // cleared contents and no validation error surfaces to catch it.
+          // `getImageData` + `writeTexture` reads the same unpremultiplied
+          // bytes `rgba8unorm` (this backend's managed texture format)
+          // expects, so it produces an identical upload on browsers where the
+          // external-image path already works — but it forces a GPU→CPU→GPU
+          // round trip that `copyExternalImageToTexture` normally avoids, so
+          // it only runs while `_canvasExternalImageCopySupported` isn't
+          // confirmed `true` (unknown, still probing, or confirmed broken).
+          // See `_probeCanvasExternalImageCopy`.
+          if (!this._canvasExternalImageCopyProbeStarted) {
+            this._canvasExternalImageCopyProbeStarted = true;
+            void this._probeCanvasExternalImageCopy().then(supported => {
+              this._canvasExternalImageCopySupported = supported;
+            });
+          }
+
+          const ctx = source.getContext('2d');
+
+          if (ctx === null) throw new Error('A 2D context is required to upload a canvas-sourced texture.');
+
+          const { data } = ctx.getImageData(0, 0, texture.width, texture.height);
+
+          this.device.queue.writeTexture(
+            { texture: state.texture },
+            data,
+            { bytesPerRow: texture.width * MANAGED_TEXTURE_BYTES_PER_PIXEL, rowsPerImage: texture.height },
+            { width: texture.width, height: texture.height },
+          );
+        } else {
+          this.device.queue.copyExternalImageToTexture(
+            {
+              source,
+              flipY: false,
+            },
+            {
+              texture: state.texture,
+            },
+            {
+              width: texture.width,
+              height: texture.height,
+            },
+          );
+        }
+
         this._accountant.recordTextureUpload(texture.width * texture.height * MANAGED_TEXTURE_BYTES_PER_PIXEL);
 
         if (state.mipLevelCount > 1) {

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -2170,30 +2170,38 @@ export class WebGpuBackend implements RenderBackend {
       } else if (!(texture instanceof RenderTexture)) {
         const source = texture.source!;
 
+        // `copyExternalImageToTexture` from a <canvas> silently uploads nothing
+        // on Safari's WebGPU — the destination texture stays at its cleared
+        // contents and no validation error surfaces to catch it. `getImageData`
+        // + `writeTexture` reads the same unpremultiplied bytes `rgba8unorm`
+        // (this backend's managed texture format) expects, so it produces an
+        // identical upload on browsers where the external-image path already
+        // works — but it forces a GPU→CPU→GPU round trip that
+        // `copyExternalImageToTexture` normally avoids, so it only runs while
+        // `_canvasExternalImageCopySupported` isn't confirmed `true` (unknown,
+        // still probing, or confirmed broken). See
+        // `_probeCanvasExternalImageCopy`.
+        //
+        // The fallback needs a 2D context, and `getContext('2d')` returns null
+        // on a canvas already bound to another context type — a WebGL minimap,
+        // a `bitmaprenderer` target. `TextureSource` accepts those, and
+        // `copyExternalImageToTexture` handles them, so they take the direct
+        // path rather than failing the upload. On Safari that leaves them
+        // subject to the very bug worked around here, but no fallback exists:
+        // their pixels are not readable from the CPU side.
         if (source instanceof HTMLCanvasElement && this._canvasExternalImageCopySupported !== true) {
-          // `copyExternalImageToTexture` from a 2D <canvas> silently uploads
-          // nothing on Safari's WebGPU — the destination texture stays at its
-          // cleared contents and no validation error surfaces to catch it.
-          // `getImageData` + `writeTexture` reads the same unpremultiplied
-          // bytes `rgba8unorm` (this backend's managed texture format)
-          // expects, so it produces an identical upload on browsers where the
-          // external-image path already works — but it forces a GPU→CPU→GPU
-          // round trip that `copyExternalImageToTexture` normally avoids, so
-          // it only runs while `_canvasExternalImageCopySupported` isn't
-          // confirmed `true` (unknown, still probing, or confirmed broken).
-          // See `_probeCanvasExternalImageCopy`.
           if (!this._canvasExternalImageCopyProbeStarted) {
             this._canvasExternalImageCopyProbeStarted = true;
             void this._probeCanvasExternalImageCopy().then(supported => {
               this._canvasExternalImageCopySupported = supported;
             });
           }
+        }
 
-          const ctx = source.getContext('2d');
+        const canvasReadbackContext = source instanceof HTMLCanvasElement && this._canvasExternalImageCopySupported !== true ? source.getContext('2d') : null;
 
-          if (ctx === null) throw new Error('A 2D context is required to upload a canvas-sourced texture.');
-
-          const { data } = ctx.getImageData(0, 0, texture.width, texture.height);
+        if (canvasReadbackContext !== null) {
+          const { data } = canvasReadbackContext.getImageData(0, 0, texture.width, texture.height);
 
           this.device.queue.writeTexture(
             { texture: state.texture },

--- a/test/rendering/browser/webgpu-canvas-source-texture.test.ts
+++ b/test/rendering/browser/webgpu-canvas-source-texture.test.ts
@@ -1,0 +1,72 @@
+/**
+ * A canvas-sourced `Texture` must upload regardless of which context the canvas
+ * already holds.
+ *
+ * `TextureSource` accepts any `HTMLCanvasElement`, and a caller may well hand
+ * over one that is already driven by WebGL or `bitmaprenderer` — a minimap, an
+ * offscreen effect, another engine's output. `copyExternalImageToTexture` takes
+ * such a canvas happily; `getImageData` cannot, because `getContext('2d')`
+ * returns null once a canvas is bound to a different context type. The
+ * Safari-workaround upload path therefore has to fall back rather than assume a
+ * 2D context exists.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+
+import { createWebGpuTestBackend, readWebGpuFrame, renderWebGpuOnce } from './_backendSetup';
+
+const SIZE = 64;
+
+const pixelAt = (frame: ArrayLike<number>, x: number, y: number): readonly [number, number, number, number] => {
+  const i = (y * SIZE + x) * 4;
+
+  return [frame[i]!, frame[i + 1]!, frame[i + 2]!, frame[i + 3]!];
+};
+
+/** A 16×16 canvas filled opaque red through a WebGL2 context, so no 2D context can be obtained from it. */
+const webglBackedCanvas = (edge = 16): HTMLCanvasElement => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = edge;
+  canvas.height = edge;
+
+  const gl = canvas.getContext('webgl2');
+
+  if (gl === null) throw new Error('This suite needs a WebGL2 context to claim the canvas.');
+
+  gl.clearColor(1, 0, 0, 1);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  gl.finish();
+
+  return canvas;
+};
+
+describe('WebGPU uploads a canvas-sourced texture whose canvas is not 2D', () => {
+  test('getContext("2d") returning null does not fail the upload', async ctx => {
+    const backend = await createWebGpuTestBackend(SIZE);
+    const root = new Container();
+    const canvas = webglBackedCanvas();
+
+    // Precondition of the whole test: this canvas genuinely has no 2D context.
+    expect(canvas.getContext('2d')).toBeNull();
+
+    const sprite = new Sprite(new Texture(canvas));
+
+    sprite.setPosition(8, 8);
+    root.addChild(sprite);
+
+    try {
+      if (!(await renderWebGpuOnce(ctx, backend, root, Color.black))) return;
+
+      expect(pixelAt(readWebGpuFrame(backend, SIZE), 16, 16)).toEqual([255, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/parity/evidence.json
+++ b/test/rendering/parity/evidence.json
@@ -8,9 +8,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "blend/additive-overlap",
@@ -22,9 +22,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1791/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "blend/additive-overlap",
@@ -35,9 +35,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/overlapping-fills",
@@ -48,9 +48,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/overlapping-fills",
@@ -62,9 +62,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1792/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/overlapping-fills",
@@ -75,9 +75,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/solid-rectangle",
@@ -88,9 +88,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/solid-rectangle",
@@ -102,9 +102,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1024/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/solid-rectangle",
@@ -115,9 +115,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mask/triangle-clip",
@@ -128,9 +128,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mask/triangle-clip",
@@ -142,9 +142,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "119/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mask/triangle-clip",
@@ -155,9 +155,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/mirrored-uvs",
@@ -168,9 +168,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/mirrored-uvs",
@@ -182,9 +182,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1023/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/mirrored-uvs",
@@ -195,9 +195,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/textured-quad",
@@ -208,9 +208,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/textured-quad",
@@ -222,9 +222,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1023/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/textured-quad",
@@ -235,9 +235,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/stretched",
@@ -248,9 +248,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/stretched",
@@ -262,9 +262,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "2303/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/stretched",
@@ -275,9 +275,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/unstretched",
@@ -288,9 +288,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/unstretched",
@@ -302,9 +302,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1023/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/unstretched",
@@ -315,9 +315,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "particles/static-quad",
@@ -328,9 +328,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "particles/static-quad",
@@ -342,9 +342,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "255/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "particles/static-quad",
@@ -355,9 +355,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "repeating/tiled",
@@ -366,11 +366,12 @@
     "browser": "chromium",
     "backend": "webgl2",
     "support": "supported",
-    "evidence": "traced",
-    "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "evidence": "tolerant",
+    "delta": 1,
+    "note": "backends agree within 1 of one channel step",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "repeating/tiled",
@@ -382,9 +383,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1020/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "repeating/tiled",
@@ -395,9 +396,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/canvas-texture",
@@ -408,9 +409,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/canvas-texture",
@@ -422,9 +423,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "256/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/canvas-texture",
@@ -435,9 +436,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/origin",
@@ -448,9 +449,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/origin",
@@ -462,9 +463,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1023/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/origin",
@@ -475,9 +476,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/translated",
@@ -488,9 +489,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/translated",
@@ -502,9 +503,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1023/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/translated",
@@ -515,9 +516,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "text/sdf-glyphs",
@@ -528,9 +529,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "text/sdf-glyphs",
@@ -541,10 +542,10 @@
     "support": "supported",
     "evidence": "sampled",
     "delta": null,
-    "note": "397/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "377/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "text/sdf-glyphs",
@@ -555,9 +556,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tilemap/two-by-two",
@@ -568,9 +569,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tilemap/two-by-two",
@@ -582,9 +583,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1020/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tilemap/two-by-two",
@@ -595,9 +596,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tint/half-intensity",
@@ -608,9 +609,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tint/half-intensity",
@@ -621,10 +622,10 @@
     "support": "supported",
     "evidence": "sampled",
     "delta": null,
-    "note": "1020/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "1023/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tint/half-intensity",
@@ -635,9 +636,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/flipped-x",
@@ -648,9 +649,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/flipped-x",
@@ -662,9 +663,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "255/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/flipped-x",
@@ -675,9 +676,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/nested-parent-offset",
@@ -688,9 +689,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/nested-parent-offset",
@@ -702,9 +703,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "255/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/nested-parent-offset",
@@ -715,9 +716,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/rotated-quarter-turn",
@@ -728,9 +729,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/rotated-quarter-turn",
@@ -742,9 +743,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "255/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/rotated-quarter-turn",
@@ -755,9 +756,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/scaled-2x",
@@ -768,9 +769,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/scaled-2x",
@@ -782,9 +783,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1020/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/scaled-2x",
@@ -795,9 +796,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "blend/additive-overlap",
@@ -808,9 +809,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "blend/additive-overlap",
@@ -822,9 +823,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1791/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "blend/additive-overlap",
@@ -835,9 +836,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/overlapping-fills",
@@ -848,9 +849,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/overlapping-fills",
@@ -862,9 +863,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1792/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/overlapping-fills",
@@ -875,9 +876,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/solid-rectangle",
@@ -888,9 +889,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/solid-rectangle",
@@ -902,9 +903,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1024/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/solid-rectangle",
@@ -915,9 +916,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mask/triangle-clip",
@@ -928,9 +929,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mask/triangle-clip",
@@ -942,9 +943,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "119/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mask/triangle-clip",
@@ -955,9 +956,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/mirrored-uvs",
@@ -968,9 +969,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/mirrored-uvs",
@@ -982,9 +983,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1023/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/mirrored-uvs",
@@ -995,9 +996,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/textured-quad",
@@ -1008,9 +1009,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/textured-quad",
@@ -1022,9 +1023,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1023/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/textured-quad",
@@ -1035,9 +1036,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/stretched",
@@ -1048,9 +1049,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/stretched",
@@ -1062,9 +1063,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "2303/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/stretched",
@@ -1075,9 +1076,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/unstretched",
@@ -1088,9 +1089,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/unstretched",
@@ -1102,9 +1103,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1023/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/unstretched",
@@ -1115,9 +1116,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "particles/static-quad",
@@ -1128,9 +1129,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "particles/static-quad",
@@ -1142,9 +1143,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "255/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "particles/static-quad",
@@ -1155,9 +1156,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "repeating/tiled",
@@ -1166,11 +1167,12 @@
     "browser": "chromium",
     "backend": "webgpu",
     "support": "supported",
-    "evidence": "traced",
-    "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "evidence": "tolerant",
+    "delta": 1,
+    "note": "backends agree within 1 of one channel step",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "repeating/tiled",
@@ -1181,10 +1183,10 @@
     "support": "supported",
     "evidence": "sampled",
     "delta": null,
-    "note": "1020/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "1024/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "repeating/tiled",
@@ -1195,9 +1197,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/canvas-texture",
@@ -1208,9 +1210,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/canvas-texture",
@@ -1222,9 +1224,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "256/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/canvas-texture",
@@ -1235,9 +1237,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/origin",
@@ -1248,9 +1250,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/origin",
@@ -1262,9 +1264,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1023/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/origin",
@@ -1275,9 +1277,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/translated",
@@ -1288,9 +1290,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/translated",
@@ -1302,9 +1304,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1023/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/translated",
@@ -1315,9 +1317,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "text/sdf-glyphs",
@@ -1328,9 +1330,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "text/sdf-glyphs",
@@ -1341,10 +1343,10 @@
     "support": "supported",
     "evidence": "sampled",
     "delta": null,
-    "note": "397/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "377/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "text/sdf-glyphs",
@@ -1355,9 +1357,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tilemap/two-by-two",
@@ -1368,9 +1370,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tilemap/two-by-two",
@@ -1382,9 +1384,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1020/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tilemap/two-by-two",
@@ -1395,9 +1397,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tint/half-intensity",
@@ -1408,9 +1410,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tint/half-intensity",
@@ -1421,10 +1423,10 @@
     "support": "supported",
     "evidence": "sampled",
     "delta": null,
-    "note": "1020/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "1023/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tint/half-intensity",
@@ -1435,9 +1437,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/flipped-x",
@@ -1448,9 +1450,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/flipped-x",
@@ -1462,9 +1464,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "255/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/flipped-x",
@@ -1475,9 +1477,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/nested-parent-offset",
@@ -1488,9 +1490,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/nested-parent-offset",
@@ -1502,9 +1504,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "255/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/nested-parent-offset",
@@ -1515,9 +1517,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/rotated-quarter-turn",
@@ -1528,9 +1530,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/rotated-quarter-turn",
@@ -1542,9 +1544,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "255/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/rotated-quarter-turn",
@@ -1555,9 +1557,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/scaled-2x",
@@ -1568,9 +1570,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/scaled-2x",
@@ -1582,9 +1584,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1020/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/scaled-2x",
@@ -1595,9 +1597,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "blend/additive-overlap",
@@ -3205,13 +3207,12 @@
     "feature": "BlendMode",
     "browser": "webkit",
     "backend": "webgl2",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "blend/additive-overlap",
@@ -3223,9 +3224,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1791/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "blend/additive-overlap",
@@ -3236,9 +3237,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/overlapping-fills",
@@ -3246,13 +3247,12 @@
     "feature": "Graphics",
     "browser": "webkit",
     "backend": "webgl2",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/overlapping-fills",
@@ -3264,9 +3264,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1792/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/overlapping-fills",
@@ -3277,9 +3277,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/solid-rectangle",
@@ -3287,13 +3287,12 @@
     "feature": "Graphics",
     "browser": "webkit",
     "backend": "webgl2",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/solid-rectangle",
@@ -3305,9 +3304,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1024/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/solid-rectangle",
@@ -3318,9 +3317,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mask/triangle-clip",
@@ -3328,13 +3327,12 @@
     "feature": "Mask",
     "browser": "webkit",
     "backend": "webgl2",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mask/triangle-clip",
@@ -3346,9 +3344,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "119/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mask/triangle-clip",
@@ -3359,9 +3357,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/mirrored-uvs",
@@ -3369,13 +3367,12 @@
     "feature": "Mesh",
     "browser": "webkit",
     "backend": "webgl2",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/mirrored-uvs",
@@ -3387,9 +3384,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1023/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/mirrored-uvs",
@@ -3400,9 +3397,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/textured-quad",
@@ -3410,13 +3407,12 @@
     "feature": "Mesh",
     "browser": "webkit",
     "backend": "webgl2",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/textured-quad",
@@ -3428,9 +3424,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1023/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/textured-quad",
@@ -3441,9 +3437,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/stretched",
@@ -3451,13 +3447,12 @@
     "feature": "NineSlice",
     "browser": "webkit",
     "backend": "webgl2",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/stretched",
@@ -3469,9 +3464,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "2303/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/stretched",
@@ -3482,9 +3477,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/unstretched",
@@ -3492,13 +3487,12 @@
     "feature": "NineSlice",
     "browser": "webkit",
     "backend": "webgl2",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/unstretched",
@@ -3510,9 +3504,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1023/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/unstretched",
@@ -3523,9 +3517,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "particles/static-quad",
@@ -3533,13 +3527,13 @@
     "feature": "Particles",
     "browser": "webkit",
     "backend": "webgl2",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "divergent",
+    "evidence": "traced",
+    "delta": 15,
+    "note": "backends differ by 15 on at least one channel",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "particles/static-quad",
@@ -3551,9 +3545,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "255/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "particles/static-quad",
@@ -3564,9 +3558,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "repeating/tiled",
@@ -3574,13 +3568,13 @@
     "feature": "RepeatingSprite",
     "browser": "webkit",
     "backend": "webgl2",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "tolerant",
+    "delta": 1,
+    "note": "backends agree within 1 of one channel step",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "repeating/tiled",
@@ -3592,9 +3586,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1020/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "repeating/tiled",
@@ -3605,9 +3599,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/canvas-texture",
@@ -3615,13 +3609,12 @@
     "feature": "Sprite",
     "browser": "webkit",
     "backend": "webgl2",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/canvas-texture",
@@ -3633,9 +3626,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "256/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/canvas-texture",
@@ -3646,9 +3639,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/origin",
@@ -3656,13 +3649,12 @@
     "feature": "Sprite",
     "browser": "webkit",
     "backend": "webgl2",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/origin",
@@ -3674,9 +3666,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1023/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/origin",
@@ -3687,9 +3679,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/translated",
@@ -3697,13 +3689,12 @@
     "feature": "Sprite",
     "browser": "webkit",
     "backend": "webgl2",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/translated",
@@ -3715,9 +3706,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1023/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/translated",
@@ -3728,9 +3719,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "text/sdf-glyphs",
@@ -3738,13 +3729,12 @@
     "feature": "Text",
     "browser": "webkit",
     "backend": "webgl2",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "text/sdf-glyphs",
@@ -3755,10 +3745,10 @@
     "support": "supported",
     "evidence": "sampled",
     "delta": null,
-    "note": "307/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "390/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "text/sdf-glyphs",
@@ -3769,9 +3759,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tilemap/two-by-two",
@@ -3779,13 +3769,13 @@
     "feature": "Tilemap",
     "browser": "webkit",
     "backend": "webgl2",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "divergent",
+    "evidence": "traced",
+    "delta": 15,
+    "note": "backends differ by 15 on at least one channel",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tilemap/two-by-two",
@@ -3797,9 +3787,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1020/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tilemap/two-by-two",
@@ -3810,9 +3800,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tint/half-intensity",
@@ -3820,13 +3810,12 @@
     "feature": "Tint",
     "browser": "webkit",
     "backend": "webgl2",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tint/half-intensity",
@@ -3837,10 +3826,10 @@
     "support": "supported",
     "evidence": "sampled",
     "delta": null,
-    "note": "1020/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "1023/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tint/half-intensity",
@@ -3851,9 +3840,9 @@
     "support": "supported",
     "evidence": "frame-equal",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/flipped-x",
@@ -3861,13 +3850,12 @@
     "feature": "Transform",
     "browser": "webkit",
     "backend": "webgl2",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/flipped-x",
@@ -3879,9 +3867,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "255/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/flipped-x",
@@ -3892,9 +3880,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/nested-parent-offset",
@@ -3902,13 +3890,12 @@
     "feature": "Transform",
     "browser": "webkit",
     "backend": "webgl2",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/nested-parent-offset",
@@ -3920,9 +3907,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "255/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/nested-parent-offset",
@@ -3933,9 +3920,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/rotated-quarter-turn",
@@ -3943,13 +3930,12 @@
     "feature": "Transform",
     "browser": "webkit",
     "backend": "webgl2",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/rotated-quarter-turn",
@@ -3961,9 +3947,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "255/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/rotated-quarter-turn",
@@ -3974,9 +3960,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/scaled-2x",
@@ -3984,13 +3970,13 @@
     "feature": "Transform",
     "browser": "webkit",
     "backend": "webgl2",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "divergent",
+    "evidence": "traced",
+    "delta": 15,
+    "note": "backends differ by 15 on at least one channel",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/scaled-2x",
@@ -4002,9 +3988,9 @@
     "evidence": "sampled",
     "delta": null,
     "note": "1020/4096 pixels drawn",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/scaled-2x",
@@ -4015,9 +4001,9 @@
     "support": "supported",
     "evidence": "traced",
     "delta": 0,
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "blend/additive-overlap",
@@ -4025,13 +4011,12 @@
     "feature": "BlendMode",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "blend/additive-overlap",
@@ -4039,13 +4024,13 @@
     "feature": "BlendMode",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
+    "support": "supported",
+    "evidence": "sampled",
     "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "1791/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "blend/additive-overlap",
@@ -4053,13 +4038,12 @@
     "feature": "BlendMode",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/overlapping-fills",
@@ -4067,13 +4051,12 @@
     "feature": "Graphics",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/overlapping-fills",
@@ -4081,13 +4064,13 @@
     "feature": "Graphics",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
+    "support": "supported",
+    "evidence": "sampled",
     "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "1792/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/overlapping-fills",
@@ -4095,13 +4078,13 @@
     "feature": "Graphics",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "divergent",
+    "evidence": "frame-equal",
+    "delta": 255,
+    "note": "frame 2 differs from frame 1 by 255",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/solid-rectangle",
@@ -4109,13 +4092,12 @@
     "feature": "Graphics",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/solid-rectangle",
@@ -4123,13 +4105,13 @@
     "feature": "Graphics",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
+    "support": "divergent",
+    "evidence": "sampled",
     "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "scene rendered an empty frame",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "graphics/solid-rectangle",
@@ -4137,13 +4119,13 @@
     "feature": "Graphics",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "divergent",
+    "evidence": "frame-equal",
+    "delta": 128,
+    "note": "frame 2 differs from frame 1 by 128",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mask/triangle-clip",
@@ -4151,13 +4133,12 @@
     "feature": "Mask",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mask/triangle-clip",
@@ -4165,13 +4146,13 @@
     "feature": "Mask",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
+    "support": "supported",
+    "evidence": "sampled",
     "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "119/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mask/triangle-clip",
@@ -4179,13 +4160,12 @@
     "feature": "Mask",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/mirrored-uvs",
@@ -4193,13 +4173,12 @@
     "feature": "Mesh",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/mirrored-uvs",
@@ -4207,13 +4186,13 @@
     "feature": "Mesh",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
+    "support": "supported",
+    "evidence": "sampled",
     "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "1023/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/mirrored-uvs",
@@ -4221,13 +4200,13 @@
     "feature": "Mesh",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "divergent",
+    "evidence": "traced",
+    "delta": 31,
+    "note": "frame 2 differs from frame 1 by 31",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/textured-quad",
@@ -4235,13 +4214,12 @@
     "feature": "Mesh",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/textured-quad",
@@ -4249,13 +4227,13 @@
     "feature": "Mesh",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
+    "support": "divergent",
+    "evidence": "sampled",
     "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "scene rendered an empty frame",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "mesh/textured-quad",
@@ -4263,13 +4241,12 @@
     "feature": "Mesh",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/stretched",
@@ -4277,13 +4254,12 @@
     "feature": "NineSlice",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/stretched",
@@ -4291,13 +4267,13 @@
     "feature": "NineSlice",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
+    "support": "supported",
+    "evidence": "sampled",
     "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "2303/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/stretched",
@@ -4305,13 +4281,12 @@
     "feature": "NineSlice",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/unstretched",
@@ -4319,13 +4294,12 @@
     "feature": "NineSlice",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/unstretched",
@@ -4333,13 +4307,13 @@
     "feature": "NineSlice",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
+    "support": "supported",
+    "evidence": "sampled",
     "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "1023/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "nine-slice/unstretched",
@@ -4347,13 +4321,13 @@
     "feature": "NineSlice",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "divergent",
+    "evidence": "traced",
+    "delta": 31,
+    "note": "frame 2 differs from frame 1 by 31",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "particles/static-quad",
@@ -4361,13 +4335,13 @@
     "feature": "Particles",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "divergent",
+    "evidence": "traced",
+    "delta": 15,
+    "note": "backends differ by 15 on at least one channel",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "particles/static-quad",
@@ -4375,13 +4349,13 @@
     "feature": "Particles",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
+    "support": "supported",
+    "evidence": "sampled",
     "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "255/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "particles/static-quad",
@@ -4389,13 +4363,13 @@
     "feature": "Particles",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "divergent",
+    "evidence": "traced",
+    "delta": 15,
+    "note": "frame 2 differs from frame 1 by 15",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "repeating/tiled",
@@ -4403,13 +4377,13 @@
     "feature": "RepeatingSprite",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "tolerant",
+    "delta": 1,
+    "note": "backends agree within 1 of one channel step",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "repeating/tiled",
@@ -4417,13 +4391,13 @@
     "feature": "RepeatingSprite",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
+    "support": "divergent",
+    "evidence": "sampled",
     "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "scene rendered an empty frame",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "repeating/tiled",
@@ -4431,13 +4405,12 @@
     "feature": "RepeatingSprite",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/canvas-texture",
@@ -4445,13 +4418,12 @@
     "feature": "Sprite",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/canvas-texture",
@@ -4459,13 +4431,13 @@
     "feature": "Sprite",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
+    "support": "supported",
+    "evidence": "sampled",
     "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "256/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/canvas-texture",
@@ -4473,13 +4445,12 @@
     "feature": "Sprite",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/origin",
@@ -4487,13 +4458,12 @@
     "feature": "Sprite",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/origin",
@@ -4501,13 +4471,13 @@
     "feature": "Sprite",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
+    "support": "supported",
+    "evidence": "sampled",
     "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "1023/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/origin",
@@ -4515,13 +4485,12 @@
     "feature": "Sprite",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/translated",
@@ -4529,13 +4498,12 @@
     "feature": "Sprite",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/translated",
@@ -4543,13 +4511,13 @@
     "feature": "Sprite",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
+    "support": "supported",
+    "evidence": "sampled",
     "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "1023/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "sprite/translated",
@@ -4557,13 +4525,13 @@
     "feature": "Sprite",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "divergent",
+    "evidence": "traced",
+    "delta": 31,
+    "note": "frame 2 differs from frame 1 by 31",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "text/sdf-glyphs",
@@ -4571,13 +4539,12 @@
     "feature": "Text",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "text/sdf-glyphs",
@@ -4585,13 +4552,13 @@
     "feature": "Text",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
+    "support": "supported",
+    "evidence": "sampled",
     "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "390/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "text/sdf-glyphs",
@@ -4599,13 +4566,12 @@
     "feature": "Text",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tilemap/two-by-two",
@@ -4613,13 +4579,13 @@
     "feature": "Tilemap",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "divergent",
+    "evidence": "traced",
+    "delta": 15,
+    "note": "backends differ by 15 on at least one channel",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tilemap/two-by-two",
@@ -4627,13 +4593,13 @@
     "feature": "Tilemap",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
+    "support": "supported",
+    "evidence": "sampled",
     "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "1020/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tilemap/two-by-two",
@@ -4641,13 +4607,12 @@
     "feature": "Tilemap",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tint/half-intensity",
@@ -4655,13 +4620,12 @@
     "feature": "Tint",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tint/half-intensity",
@@ -4669,13 +4633,13 @@
     "feature": "Tint",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
+    "support": "supported",
+    "evidence": "sampled",
     "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "1023/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "tint/half-intensity",
@@ -4683,13 +4647,12 @@
     "feature": "Tint",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "frame-equal",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/flipped-x",
@@ -4697,13 +4660,12 @@
     "feature": "Transform",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/flipped-x",
@@ -4711,13 +4673,13 @@
     "feature": "Transform",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
+    "support": "supported",
+    "evidence": "sampled",
     "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "255/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/flipped-x",
@@ -4725,13 +4687,12 @@
     "feature": "Transform",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/nested-parent-offset",
@@ -4739,13 +4700,12 @@
     "feature": "Transform",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/nested-parent-offset",
@@ -4753,13 +4713,13 @@
     "feature": "Transform",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
+    "support": "supported",
+    "evidence": "sampled",
     "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "255/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/nested-parent-offset",
@@ -4767,13 +4727,12 @@
     "feature": "Transform",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/rotated-quarter-turn",
@@ -4781,13 +4740,12 @@
     "feature": "Transform",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/rotated-quarter-turn",
@@ -4795,13 +4753,13 @@
     "feature": "Transform",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
+    "support": "supported",
+    "evidence": "sampled",
     "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "255/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/rotated-quarter-turn",
@@ -4809,13 +4767,12 @@
     "feature": "Transform",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/scaled-2x",
@@ -4823,13 +4780,13 @@
     "feature": "Transform",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "divergent",
+    "evidence": "traced",
+    "delta": 15,
+    "note": "backends differ by 15 on at least one channel",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/scaled-2x",
@@ -4837,13 +4794,13 @@
     "feature": "Transform",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
+    "support": "supported",
+    "evidence": "sampled",
     "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "note": "1020/4096 pixels drawn",
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   },
   {
     "scene": "transform/scaled-2x",
@@ -4851,12 +4808,11 @@
     "feature": "Transform",
     "browser": "webkit",
     "backend": "webgpu",
-    "support": "unavailable",
-    "evidence": "none",
-    "delta": null,
-    "note": "no WebGPU adapter in this browser",
-    "measuredAt": "2026-08-03",
-    "commit": "eeda88de",
-    "platform": "win32"
+    "support": "supported",
+    "evidence": "traced",
+    "delta": 0,
+    "measuredAt": "2026-08-05",
+    "commit": "daddd77d",
+    "platform": "darwin"
   }
 ]

--- a/test/rendering/webgpu-backend.test.ts
+++ b/test/rendering/webgpu-backend.test.ts
@@ -22,6 +22,20 @@ import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { particlesExtension, ParticleSystem } from '../../packages/exojs-particles/src/index';
 
+/**
+ * The 2D-context stub `test/setup-env.vitest.ts` installs globally. Tests that
+ * swap in a richer context for glyph rasterisation restore this one afterwards,
+ * so it has to carry `getImageData` too — the backend reads canvas-sourced
+ * textures back through it, and a stub without it fails every later test in the
+ * file with a TypeError rather than an assertion.
+ */
+const defaultContext2dStub = (): unknown => ({
+  fillStyle: '',
+  fillRect: () => undefined,
+  drawImage: () => undefined,
+  getImageData: (_x: number, _y: number, width: number, height: number) => ({ data: new Uint8ClampedArray(width * height * 4), width, height }),
+});
+
 interface MockWebGpuEnvironment {
   readonly canvas: HTMLCanvasElement;
   readonly context: GPUCanvasContext;
@@ -41,6 +55,7 @@ interface MockWebGpuEnvironment {
   };
   readonly queue: {
     writeBuffer: MockInstance;
+    writeTexture: MockInstance;
     submit: MockInstance;
     copyExternalImageToTexture: MockInstance;
   };
@@ -709,7 +724,12 @@ describe('WebGpuBackend', () => {
       manager.destroy();
 
       expect(environment.pass.drawIndexed).toHaveBeenCalledWith(6, 1, 0, 0, 0);
-      expect(environment.queue.copyExternalImageToTexture).toHaveBeenCalledTimes(1);
+      // Canvas-sourced textures upload through `writeTexture`, not
+      // `copyExternalImageToTexture`: the backend routes them via `getImageData`
+      // until its one-off probe confirms the direct copy actually writes pixels,
+      // and that probe needs a real device, so it never resolves under these
+      // mocks. Every canvas-upload assertion in this file counts the same call.
+      expect(environment.queue.writeTexture).toHaveBeenCalledTimes(1);
       expect(environment.textures.length).toBeGreaterThan(0);
       expect(environment.textures.every(gpuTexture => gpuTexture.destroy.mock.calls.length > 0)).toBe(true);
     } finally {
@@ -796,7 +816,7 @@ describe('WebGpuBackend', () => {
 
       expect(environment.pass.drawIndexed).toHaveBeenCalledTimes(1);
       expect(environment.pass.drawIndexed).toHaveBeenCalledWith(6, 2, 0, 0, 0);
-      expect(environment.queue.copyExternalImageToTexture).toHaveBeenCalledTimes(1);
+      expect(environment.queue.writeTexture).toHaveBeenCalledTimes(1);
     } finally {
       environment.restore();
     }
@@ -838,7 +858,7 @@ describe('WebGpuBackend', () => {
 
       expect(environment.pass.drawIndexed).toHaveBeenCalledTimes(1);
       expect(environment.pass.drawIndexed).toHaveBeenCalledWith(6, 2, 0, 0, 0);
-      expect(environment.queue.copyExternalImageToTexture).toHaveBeenCalledTimes(2);
+      expect(environment.queue.writeTexture).toHaveBeenCalledTimes(2);
     } finally {
       environment.restore();
     }
@@ -1237,7 +1257,7 @@ describe('WebGpuBackend', () => {
     } finally {
       Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
         configurable: true,
-        value: () => ({ fillStyle: '', fillRect: () => undefined, drawImage: () => undefined }),
+        value: defaultContext2dStub,
       });
       environment.restore();
     }
@@ -1299,7 +1319,7 @@ describe('WebGpuBackend', () => {
     } finally {
       Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
         configurable: true,
-        value: () => ({ fillStyle: '', fillRect: () => undefined, drawImage: () => undefined }),
+        value: defaultContext2dStub,
       });
       environment.restore();
     }
@@ -1363,7 +1383,7 @@ describe('WebGpuBackend', () => {
     } finally {
       Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
         configurable: true,
-        value: () => ({ fillStyle: '', fillRect: () => undefined, drawImage: () => undefined }),
+        value: defaultContext2dStub,
       });
       environment.restore();
     }
@@ -1393,7 +1413,7 @@ describe('WebGpuBackend', () => {
       video.destroy();
       manager.destroy();
 
-      expect(environment.queue.copyExternalImageToTexture).not.toHaveBeenCalled();
+      expect(environment.queue.writeTexture).not.toHaveBeenCalled();
       expect(environment.pass.drawIndexed).not.toHaveBeenCalled();
     } finally {
       environment.restore();
@@ -1549,7 +1569,7 @@ describe('WebGpuBackend', () => {
       manager.destroy();
 
       expect(environment.pass.drawIndexed).toHaveBeenCalledWith(6, 1, 0, 0, 0);
-      expect(environment.queue.copyExternalImageToTexture).toHaveBeenCalledTimes(1);
+      expect(environment.queue.writeTexture).toHaveBeenCalledTimes(1);
       expect(environment.queue.submit).toHaveBeenCalled();
     } finally {
       environment.restore();

--- a/test/setup-env.vitest.ts
+++ b/test/setup-env.vitest.ts
@@ -42,6 +42,17 @@ const mockContext2d = {
   fillStyle: '',
   fillRect: () => undefined,
   drawImage: () => undefined,
+  // The WebGPU backend reads canvas-sourced textures back through
+  // `getImageData` (see its Safari canvas-upload workaround), so a stub without
+  // it turns every such upload into a TypeError rather than a test failure that
+  // says what is missing. Transparent black of the requested size is enough:
+  // these suites assert upload calls and batching, never pixel values.
+  getImageData: (_x: number, _y: number, width: number, height: number) => ({
+    data: new Uint8ClampedArray(Math.max(width, 0) * Math.max(height, 0) * 4),
+    width,
+    height,
+    colorSpace: 'srgb' as PredefinedColorSpace,
+  }),
 };
 
 // Guarded on `HTMLCanvasElement` so the file is inert under the `node`

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -37,4 +37,50 @@ describe('utils/core', () => {
     expect(supportsEventOptions()).toBe(true);
     expect(addEventListenerSpy).toHaveBeenCalled();
   });
+
+  // Gates the `auto` backend choice away from WebKit's WebGPU, so a
+  // misclassification either strands Safari on WebGL2 or hands Chrome a broken
+  // picture. Real UA strings, since that is what the regexes actually meet.
+  describe('isWebKitUserAgent', () => {
+    const webkit = [
+      ['Safari 18, macOS', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3 Safari/605.1.15'],
+      [
+        'Safari, iPhone',
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 18_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3 Mobile/15E148 Safari/604.1',
+      ],
+      ['iPad', 'Mozilla/5.0 (iPad; CPU OS 18_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3 Mobile/15E148 Safari/604.1'],
+      // Brand-name browsers on iOS are WebKit underneath and inherit the same
+      // rendering defects, so they belong on this side of the test.
+      [
+        'Chrome, iOS',
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 18_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/133.0.0.0 Mobile/15E148 Safari/604.1',
+      ],
+      [
+        'Firefox, iOS',
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 18_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/133.0 Mobile/15E148 Safari/605.1.15',
+      ],
+    ] as const;
+
+    const notWebKit = [
+      ['Chrome, macOS', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36'],
+      ['Edge, Windows', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36 Edg/133.0.0.0'],
+      ['Firefox, desktop', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:135.0) Gecko/20100101 Firefox/135.0'],
+      // Carries AppleWebKit with no Safari token. The unit suite runs under it,
+      // so misreading this as WebKit would silently steer every `auto` backend
+      // test to WebGL2.
+      ['jsdom', 'Mozilla/5.0 (win32) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/29.1.1'],
+    ] as const;
+
+    it.each(webkit)('detects %s', async (_label, userAgent) => {
+      const { isWebKitUserAgent } = await import('#core/utils');
+
+      expect(isWebKitUserAgent(userAgent)).toBe(true);
+    });
+
+    it.each(notWebKit)('does not flag %s', async (_label, userAgent) => {
+      const { isWebKitUserAgent } = await import('#core/utils');
+
+      expect(isWebKitUserAgent(userAgent)).toBe(false);
+    });
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -372,12 +372,21 @@ export default defineConfig({
       //
       // Prerequisites on the Mac, once: `safaridriver --enable`, plus
       // Develop ▸ Allow Remote Automation in Safari's menu.
+      //
+      // Uses `realShaderPlugin` instead of `browserBase.plugins` (which carries
+      // `shaderStubPlugin`) and skips `_glslMocks.ts`: that setup file
+      // un-stubs GLSL via `vi.mock`, but `@vitest/browser-webdriverio` has no
+      // CDP-equivalent hook for Vitest's module-mock interception, so the mock
+      // silently no-ops and every shader compiles from an empty string. Serving
+      // real GLSL straight from the transform sidesteps the gap instead of
+      // depending on a mock that cannot fire under plain WebDriver.
       {
         ...browserBase,
+        plugins: [realShaderPlugin, workletTransformPlugin],
         test: {
           name: 'browser-parity-safari',
           globals: true,
-          setupFiles: renderingBrowserSetupFiles,
+          setupFiles: browserSetupFiles,
           include: ['test/rendering/parity/**/*.test.ts'],
           browser: {
             enabled: true,


### PR DESCRIPTION
Safari renders this engine wrongly under WebGPU, and `backend: 'auto'` sends every Safari user there. This makes Safari usable again.

## Safari's canvas uploads are a silent no-op

`copyExternalImageToTexture()` from an `HTMLCanvasElement` is accepted with no validation error, but the destination texture keeps its cleared contents. Every untextured `Graphics` fill (which falls back to the canvas-backed `Texture.white`/gradient textures) and every canvas-sourced `Sprite` rendered as nothing. Confirmed with a bare-metal upload+readback outside the renderer; the same bytes round-trip correctly through `writeTexture`.

Canvas sources are read back via `getImageData` and uploaded with `writeTexture` instead — the path `DataTexture` already uses. Applying that unconditionally would cost every browser a GPU→CPU→GPU round trip, so it is gated behind a one-off runtime probe that uploads a known pixel and reads it back for real. Chrome and Firefox keep the fast path once confirmed, Safari stays on the correct-but-slower one, and a future Safari that fixes the bug is picked up automatically — no version sniffing.

## `auto` no longer picks WebGPU on WebKit

The canvas fix is not enough to make Safari's WebGPU trustworthy:

- `text/sdf-glyphs` renders as a fully empty frame, no validation error. Ruled out by bare-metal probes against real Safari: canvas-texture upload, the `r8unorm` format, the storage-buffer read-after-write pattern, and the `fragmentSdf` shader itself all work in isolation. The fault is somewhere in `WebGpuTextRenderer`'s own batching/bind-group orchestration, not yet isolated.
- Repeated parity runs fail a *different* set of scenes each time, including previously-clean ones unrelated to canvas textures. That looks like non-determinism in Safari's WebGPU driver, not something engine code can fix.

Neither has a capability to probe, and both produce a broken picture without an error, so `auto` keeps WebKit on WebGL2 — where the same scenes render correctly. `backend: 'webgpu'` still selects it explicitly for anyone testing WebKit's implementation, and the check should go once the parity matrix comes back clean there.

`isWebKitUserAgent` counts every iOS browser as WebKit (Chrome/Firefox/Edge on iOS are WebKit underneath) and excludes jsdom, which reports `AppleWebKit` with no `Safari/` token. Covered by a table of real UA strings.

## Two defects found while reviewing the workaround

- **Canvases without a 2D context failed the upload.** `TextureSource` accepts any `HTMLCanvasElement`, including one bound to WebGL or `bitmaprenderer`; `getContext('2d')` returns null for those and the new path threw. Since the fallback runs on every browser until the probe resolves, this would have broken Chrome and Firefox too. They take the direct path now. Regression test included — it claims a canvas with a WebGL2 context and asserts the sprite still draws.
- **The probe leaked on failure.** Its texture and readback buffer were released only on the success path, so a device lost while the readback mapped stranded both. Moved to `finally`.

## The unit suite was red

The workaround broke 27 tests in `webgpu-backend.test.ts`, unnoticed because only the browser suite was run against it: the shared 2D-context stub has no `getImageData`, three text tests restored a stub without it, and eight assertions still expected `copyExternalImageToTexture` where canvas sources now use `writeTexture`. Video sources keep the direct path and their original assertion.

## Verification

- Full unit suite: 8797 passed.
- WebGPU browser suite (Chromium): 293 passed, 47 files.
- `pnpm verify:quick` green.
- Safari evidence in `evidence.json` is from real Safari runs on macOS and left untouched by the Windows runs here.

## Still open

`text/sdf-glyphs` in Safari's WebGPU, narrowed to `WebGpuTextRenderer.flush()`/`_getTexBindGroup()`. Not blocking: with this PR, Safari users get WebGL2 and a correct picture.

https://claude.ai/code/session_01XQYUhcmWjUM7uxiNBCbURX