### PR TITLE
refactor(input)!: make the ActionMap action array internal

### DIFF
--- a/src/input/actions/ActionMap.ts
+++ b/src/input/actions/ActionMap.ts
@@ -103,8 +103,23 @@ function assertClaimable(action: Action, name: string, pending: ReadonlySet<Acti
  * ```
  */
 class ActionMapBase<T extends ActionRecord> {
-  /** The actions this map owns, in declaration order. */
-  public readonly actions: readonly Action[];
+  /**
+   * The actions this map owns, in declaration order — internal on purpose.
+   *
+   * The {@link Action} union has no public member common to all five variants:
+   * `ButtonAction`/`ChordAction` carry `value`/`active`/`pressed`/`released`,
+   * `AxisAction` a numeric `value`, `VectorAction` a `Vector` one, and
+   * `SequenceAction` neither — it reports `triggered`/`progress`. An array of
+   * that union is therefore unusable to a caller without narrowing every
+   * element, which is the same reason an `ActionMap` is not iterable. Exposing
+   * one and withholding the other would only be inconsistent.
+   *
+   * `_update`/`_reset` iterate it because those are internal and every variant
+   * implements them. If generic iteration ever becomes a goal — a remapping UI,
+   * an input-state serializer — it gets a designed public surface then, rather
+   * than this array reinstated as one.
+   */
+  private readonly _actions: readonly Action[];
 
   private _owner: ActionMapOwner | null = null;
   private readonly _ownership = new ActionOwnership();
@@ -113,7 +128,7 @@ class ActionMapBase<T extends ActionRecord> {
 
   public constructor(actions: T) {
     // Reads every enumerable getter on `actions` exactly once. Neither
-    // `this.actions` nor the instance assignment below may touch `actions`
+    // `this._actions` nor the instance assignment below may touch `actions`
     // again after this line — a getter that is not perfectly idempotent (or
     // that intentionally throws on a second read) would otherwise silently
     // observe a different value, or throw, purely as a side effect of how
@@ -140,7 +155,7 @@ class ActionMapBase<T extends ActionRecord> {
       claimedActions.add(action);
     }
 
-    this.actions = entries.map(([, action]) => action);
+    this._actions = entries.map(([, action]) => action);
     Object.assign(this, Object.fromEntries(entries));
   }
 
@@ -256,14 +271,14 @@ class ActionMapBase<T extends ActionRecord> {
       // its own very next _update call below, rather than trusting whatever
       // frame-to-frame state it carries from a previous, unrelated owner —
       // see ButtonLikeAction._reset's doc comment.
-      for (const action of this.actions) {
+      for (const action of this._actions) {
         action._reset();
       }
 
       const baselineSample = this._ownership.takeBaselineSample(sample);
 
       if (baselineSample !== null) {
-        for (const action of this.actions) {
+        for (const action of this._actions) {
           action._update(baselineSample);
         }
       }
@@ -271,14 +286,14 @@ class ActionMapBase<T extends ActionRecord> {
 
     const effectiveSample = resolution === 'baseline' ? this._ownership.filterBatches(sample) : sample;
 
-    for (const action of this.actions) {
+    for (const action of this._actions) {
       action._update(effectiveSample);
     }
   }
 
   /** Clear every action's state — used when an owner stops feeding the map. @internal */
   public _reset(): void {
-    for (const action of this.actions) {
+    for (const action of this._actions) {
       action._reset();
     }
 
@@ -314,7 +329,7 @@ class ActionMapBase<T extends ActionRecord> {
  * calls it.
  */
 const reservedActionMapNames: ReadonlySet<string> = new Set([
-  'actions',
+  '_actions',
   '_owner',
   '_ownership',
   '_availability',

--- a/test/core/js-protocols.test.ts
+++ b/test/core/js-protocols.test.ts
@@ -83,9 +83,10 @@ describe('JavaScript protocols', () => {
     expect(Symbol.iterator in container).toBe(true);
     expect(disposeKey in container).toBe(false);
 
-    // An ActionMap is deliberately NOT iterable: `map.actions` already exposes
-    // the same array in the same order, and an iterator yielding the `Action`
-    // union has no member a consumer could use without narrowing.
+    // An ActionMap is deliberately NOT iterable: an iterator yielding the
+    // `Action` union has no member a consumer could use without narrowing.
+    // The backing array is internal for exactly that reason — see
+    // `ActionMapBase._actions`. Actions are reached by name off the instance.
     expect(Symbol.iterator in map).toBe(false);
     expect(disposeKey in map).toBe(false);
   });

--- a/test/input/actions.test.ts
+++ b/test/input/actions.test.ts
@@ -470,7 +470,7 @@ describe('ActionMap', () => {
   });
 
   it.each([
-    'actions',
+    '_actions',
     'attached',
     'detach',
     '_owner',
@@ -489,6 +489,14 @@ describe('ActionMap', () => {
     '__defineGetter__',
   ])('rejects a reserved action name: "%s"', name => {
     expect(() => new ActionMap({ [name]: new ButtonAction(Keyboard.Space) })).toThrow(/reserved/i);
+  });
+
+  it('allows "actions" as an action name — the backing array is `_actions`', () => {
+    // Freed up when the array became internal. Nothing on the instance claims
+    // the bare name any more, so a control scheme may legitimately use it.
+    const map = new ActionMap({ actions: new ButtonAction(Keyboard.Space) });
+
+    expect(map.actions).toBeInstanceOf(ButtonAction);
   });
 
   it('rejects a `__proto__` action name (prototype-pollution vector via Object.assign)', () => {
@@ -522,7 +530,7 @@ describe('ActionMap', () => {
     // `crash` collides with a reserved name, so this whole construction
     // throws — `jump`, validated earlier in the same call, must NOT end up
     // permanently claimed by a map that was never actually built.
-    expect(() => new ActionMap({ jump, actions: crash })).toThrow(/reserved/i);
+    expect(() => new ActionMap({ jump, _actions: crash })).toThrow(/reserved/i);
 
     // `jump` must still be free to use in a real map.
     expect(() => new ActionMap({ jump })).not.toThrow();


### PR DESCRIPTION
`ActionMapBase.actions` was public and documented ("The actions this map owns, in declaration order"), but unusable from outside: the `Action` union has no member common to all five variants.

| Type | Public surface |
|---|---|
| `ButtonAction`, `ChordAction` | `value: number`, `active`, `pressed`, `released` |
| `AxisAction` | `value: number`, `active` |
| `VectorAction` | `value: Vector`, `active` |
| `SequenceAction` | `triggered`, `progress` — no `value`, no `active` |

A caller holding that array has to narrow every element before reading anything off it, and nothing in the repo ever did.

That is the same argument `js-protocols.test.ts` already makes for why an `ActionMap` is deliberately **not** iterable — "an iterator yielding the `Action` union has no member a consumer could use without narrowing". Exposing the array while withholding the iterator was inconsistent; this closes it on the side that costs nothing.

## What does not change

The real usage model, exactly as the guide teaches it:

```ts
if (controls.jump.pressed) player.jump();
```

Actions are reached by name off the instance, where the compiler knows the concrete type and no common member is needed. `_update`/`_reset` keep iterating the array internally — every variant implements them.

## Why not add a common base instead

A `BaseAction` or a `kind` discriminator would mean touching five classes, and in the wider variant a breaking change to `VectorAction.value` (a `Vector`, unlike everywhere else) — all to serve a caller that does not exist. If generic iteration ever becomes a goal (a remapping UI, an input-state serializer), it gets a designed public surface then, with knowledge of what it actually needs.

## Side effect

`actions` is now a legal action name. The reserved-name set holds `_actions` instead, and nothing on the instance claims the bare name. Covered by a new test.

https://claude.ai/code/session_01XQYUhcmWjUM7uxiNBCbURX