### PR TITLE
feat(rendering)!: give GPU resources an ownership contract

### DIFF
--- a/site/src/content/api/render-target.json
+++ b/site/src/content/api/render-target.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 18,
+  "memberCount": 19,
   "counts": {
     "constructors": 1,
     "methods": 10,
-    "properties": 7,
+    "properties": 8,
     "events": 0
   },
   "sections": [
@@ -659,6 +659,27 @@
           "params": [],
           "returnType": null,
           "description": "Whether this target needs a stencil attachment for geometric stencil clipping (RenderNode.clip with a Geometry clipShape). Set by the WebGL2 backend when such a clip is rendered into an offscreen RenderTexture, so its framebuffer gets a depth/stencil renderbuffer; the WebGL2 on-screen root uses the default framebuffer's stencil (requested at context creation), so the flag only affects offscreen WebGL2 targets. The WebGPU backend does not consult this flag: it allocates a separate depth24plus-stencil8 attachment per clipped target (root included) on demand, sized to the colour attachment's physical pixels."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run. A destroyed target must not be rendered into — the backend throws rather than drawing into released GPU state."
         },
         {
           "name": "height",

--- a/site/src/content/api/render-texture.json
+++ b/site/src/content/api/render-texture.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 34,
+  "memberCount": 35,
   "counts": {
     "constructors": 1,
     "methods": 16,
-    "properties": 17,
+    "properties": 18,
     "events": 0
   },
   "sections": [
@@ -990,6 +990,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run. A destroyed target must not be rendered into — the backend throws rather than drawing into released GPU state."
         },
         {
           "name": "flipY",

--- a/site/src/content/api/rendering-context.json
+++ b/site/src/content/api/rendering-context.json
@@ -151,7 +151,7 @@
             }
           ],
           "returnType": "RenderTexture",
-          "description": ""
+          "description": "Renders node into a freshly allocated RenderTexture and returns it. **The returned texture belongs to the caller**, destroy() included. This is one of three ownership patterns for GPU-backed render resources, and the only one that hands ownership across the API boundary: - **Caller-owned** — this method. Nothing releases the result for you; hold it as long as you need it and destroy it when you are done. Capturing per frame without destroying leaks VRAM steadily. - **Backend-pooled, borrowed** — acquireRenderTexture() / releaseRenderTexture() on the backend, used for filter intermediates. Whoever acquires returns it; destroying a pooled texture instead of releasing it corrupts the pool. - **Node-owned** — RenderNode's cacheAsBitmap texture. Entirely internal; the node allocates, resizes and frees it. Using any of them after destroy() throws — see assertLiveResource."
         },
         {
           "name": "clear",

--- a/src/rendering/RenderTarget.ts
+++ b/src/rendering/RenderTarget.ts
@@ -31,6 +31,7 @@ export class RenderTarget {
 
   private readonly _root: boolean;
   private readonly _destroyListeners: Set<() => void> = new Set<() => void>();
+  private _isDestroyed = false;
   private _version = 0;
   protected _size: Size;
   protected _viewport: Rectangle = new Rectangle();
@@ -82,6 +83,15 @@ export class RenderTarget {
 
   public get version(): number {
     return this._version;
+  }
+
+  /**
+   * `true` once {@link destroy} has run. A destroyed target must not be
+   * rendered into — the backend throws rather than drawing into released
+   * GPU state.
+   */
+  public get destroyed(): boolean {
+    return this._isDestroyed;
   }
 
   /**
@@ -150,6 +160,16 @@ export class RenderTarget {
   }
 
   public destroy(): void {
+    // Idempotent by contract. Without this guard a second call would run the
+    // whole teardown again — `_defaultView`, `_viewport` and `_size` would each
+    // take a second `destroy()`, and a listener re-registered after the first
+    // call would fire against already-released GPU state.
+    if (this._isDestroyed) {
+      return;
+    }
+
+    this._isDestroyed = true;
+
     for (const listener of [...this._destroyListeners]) {
       listener();
     }

--- a/src/rendering/RenderingContext.ts
+++ b/src/rendering/RenderingContext.ts
@@ -238,6 +238,25 @@ export class RenderingContext implements DrawContext {
     return this._backend.supportsColorFormat(format);
   }
 
+  /**
+   * Renders `node` into a freshly allocated {@link RenderTexture} and returns it.
+   *
+   * **The returned texture belongs to the caller**, `destroy()` included. This
+   * is one of three ownership patterns for GPU-backed render resources, and the
+   * only one that hands ownership across the API boundary:
+   *
+   * - **Caller-owned** — this method. Nothing releases the result for you; hold
+   *   it as long as you need it and destroy it when you are done. Capturing per
+   *   frame without destroying leaks VRAM steadily.
+   * - **Backend-pooled, borrowed** — `acquireRenderTexture()` /
+   *   `releaseRenderTexture()` on the backend, used for filter intermediates.
+   *   Whoever acquires returns it; destroying a pooled texture instead of
+   *   releasing it corrupts the pool.
+   * - **Node-owned** — {@link RenderNode}'s `cacheAsBitmap` texture. Entirely
+   *   internal; the node allocates, resizes and frees it.
+   *
+   * Using any of them after `destroy()` throws — see `assertLiveResource`.
+   */
   public capture(node: RenderNode, options: CaptureOptions): RenderTexture {
     const target = new RenderTexture(options.width, options.height, options.format !== undefined ? { format: options.format } : undefined);
     const view = new View(options.width / 2, options.height / 2, options.width, options.height);

--- a/src/rendering/assertLiveResource.ts
+++ b/src/rendering/assertLiveResource.ts
@@ -1,0 +1,45 @@
+/**
+ * Anything carrying the destroyed flag. Structural on purpose: `RenderTexture`
+ * descends from `RenderTarget`, not from `Texture`, yet both reach the backend
+ * through the same texture-binding entry point.
+ */
+interface Destroyable {
+  readonly destroyed: boolean;
+}
+
+/**
+ * Guards against handing a destroyed GPU resource back to a backend.
+ *
+ * Both assertions throw in **every** build, not just under `__DEV__`. Using a
+ * released resource is undefined behaviour at the driver level: WebGL2 silently
+ * renders nothing or samples garbage, WebGPU raises a validation error on a
+ * later frame, and either way the symptom surfaces far from the call that
+ * caused it. Stripping the check in production would remove it from exactly the
+ * builds where the resulting bug is hardest to trace.
+ *
+ * This matches what the rest of the engine already does — `Sprite.setTexture()`
+ * and `Container.addChildAt()` both throw unconditionally on a destroyed input.
+ *
+ * Cost is a single branch on a path that already binds GPU state, so it does
+ * not register against the surrounding work.
+ */
+
+export function assertLiveTexture(texture: Destroyable): void {
+  if (texture.destroyed) {
+    throw new Error(
+      'Cannot bind a destroyed texture. It was passed to a renderer after `destroy()` had already run — ' +
+        'check whether something released it while a node still referenced it. ' +
+        'A RenderTexture returned by `RenderingContext.capture()` belongs to the caller; one obtained from ' +
+        "the backend's temporary pool must be handed back with `releaseRenderTexture()` rather than destroyed.",
+    );
+  }
+}
+
+export function assertLiveRenderTarget(target: Destroyable): void {
+  if (target.destroyed) {
+    throw new Error(
+      'Cannot render into a destroyed render target. It was activated after `destroy()` had already run — ' +
+        'check whether something released it while a render pass still referenced it.',
+    );
+  }
+}

--- a/src/rendering/texture/Texture.ts
+++ b/src/rendering/texture/Texture.ts
@@ -331,6 +331,15 @@ export class Texture {
   }
 
   public destroy(): void {
+    // Idempotent by contract. Without this guard a second call would take
+    // `_size` through a second `destroy()` and re-fire any listener registered
+    // after the first call, against GPU state that is already released.
+    if (this._isDestroyed) {
+      return;
+    }
+
+    this._isDestroyed = true;
+
     for (const listener of [...this._destroyListeners]) {
       listener();
     }
@@ -338,7 +347,6 @@ export class Texture {
     this._destroyListeners.clear();
     this._size.destroy();
     this._source = null;
-    this._isDestroyed = true;
   }
 
   private _touch(): void {

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -4,6 +4,7 @@ import { Signal } from '#core/Signal';
 import { Matrix } from '#math/Matrix';
 import type { Rectangle } from '#math/Rectangle';
 import { Vector } from '#math/Vector';
+import { assertLiveRenderTarget, assertLiveTexture } from '#rendering/assertLiveResource';
 import type { BackendRenderPass } from '#rendering/BackendRenderPass';
 import type { Drawable } from '#rendering/Drawable';
 import type { Geometry } from '#rendering/geometry/Geometry';
@@ -636,6 +637,9 @@ export class WebGl2Backend implements RenderBackend {
 
   public setRenderTarget(target: RenderTarget | null): this {
     const renderTarget = target || this._rootRenderTarget;
+
+    assertLiveRenderTarget(renderTarget);
+
     const changed = this._renderTarget !== renderTarget;
 
     if (changed) {
@@ -2119,6 +2123,8 @@ export class WebGl2Backend implements RenderBackend {
   }
 
   private _syncTexture(texture: Texture | RenderTexture): ManagedTextureState {
+    assertLiveTexture(texture);
+
     const gl = this._context;
     const state = this._getTextureState(texture);
     const version = texture instanceof RenderTexture ? texture.textureVersion : texture.version;

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -7,6 +7,7 @@ import { Signal } from '#core/Signal';
 import { type Matrix } from '#math/Matrix';
 import type { Rectangle } from '#math/Rectangle';
 import { Vector } from '#math/Vector';
+import { assertLiveRenderTarget, assertLiveTexture } from '#rendering/assertLiveResource';
 import type { BackendRenderPass } from '#rendering/BackendRenderPass';
 import type { Drawable } from '#rendering/Drawable';
 import type { Geometry } from '#rendering/geometry/Geometry';
@@ -561,6 +562,8 @@ export class WebGpuBackend implements RenderBackend {
 
   public setRenderTarget(target: RenderTarget | null): this {
     const nextRenderTarget = target ?? this._rootRenderTarget;
+
+    assertLiveRenderTarget(nextRenderTarget);
 
     if (this._renderTarget !== nextRenderTarget) {
       this._flushActiveRenderer();
@@ -2095,6 +2098,8 @@ export class WebGpuBackend implements RenderBackend {
   }
 
   private _syncTexture(texture: Texture | RenderTexture): ManagedWebGpuTextureState {
+    assertLiveTexture(texture);
+
     if (!(texture instanceof RenderTexture) && !(texture instanceof DataTexture) && (texture.source === null || texture.width === 0 || texture.height === 0)) {
       throw new Error('WebGPU sprite rendering requires a texture with a valid source and non-zero dimensions.');
     }

--- a/test/perf/rendering/resource-lifetime.test.ts
+++ b/test/perf/rendering/resource-lifetime.test.ts
@@ -1,0 +1,167 @@
+// ---------------------------------------------------------------------------
+// GPU resource lifetime: the ownership contract's edge cases.
+//
+// The sibling `resource-accounting.test.ts` proves the *bookkeeping* is exact —
+// adding a texture raises `gpuMemoryBytes` by precisely its footprint, freeing
+// it lowers it by the same. What it never asks is who is supposed to do the
+// freeing, or what happens when a resource is used after it has been released.
+// Those are the two ways a real game leaks or corrupts state, and neither was
+// covered.
+//
+// Three things are asserted here:
+//   - `destroy()` is idempotent, on both `Texture` and `RenderTarget`
+//   - binding/activating a destroyed resource throws, in every build
+//   - repeated allocate/free cycles reach a VRAM plateau rather than growing
+//
+// The plateau test is the one with teeth: a game allocating a render target per
+// scene transition and never releasing it loses VRAM slowly enough that no
+// single-frame assertion would catch it.
+// ---------------------------------------------------------------------------
+import { RenderTarget } from '#rendering/RenderTarget';
+import { DataTexture } from '#rendering/texture/DataTexture';
+import { RenderTexture } from '#rendering/texture/RenderTexture';
+import { TextureFormat } from '#rendering/types';
+
+import { buildSpriteScene } from './fixtures';
+import { createWebGl2Harness, measureSteadyFrame } from './harness';
+
+describe('GPU resource lifetime', () => {
+  describe('destroy() is idempotent', () => {
+    test('a second Texture.destroy() is a no-op and does not throw', () => {
+      const texture = new DataTexture({ width: 16, height: 16, format: TextureFormat.Rgba8 });
+
+      texture.destroy();
+
+      expect(texture.destroyed).toBe(true);
+      expect(() => texture.destroy()).not.toThrow();
+      expect(texture.destroyed).toBe(true);
+    });
+
+    test('a second RenderTarget.destroy() is a no-op and does not throw', () => {
+      const target = new RenderTarget(64, 64);
+
+      target.destroy();
+
+      expect(target.destroyed).toBe(true);
+      expect(() => target.destroy()).not.toThrow();
+      expect(target.destroyed).toBe(true);
+    });
+
+    test('destroy listeners fire exactly once across repeated destroy() calls', () => {
+      const target = new RenderTarget(64, 64);
+      const listener = vi.fn();
+
+      target.addDestroyListener(listener);
+
+      target.destroy();
+      target.destroy();
+      target.destroy();
+
+      // Backends release framebuffers here. Firing twice would double-free.
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    test('a RenderTexture destroyed twice reports destroyed on both the texture and target halves', () => {
+      const renderTexture = new RenderTexture(32, 32);
+
+      renderTexture.destroy();
+      expect(() => renderTexture.destroy()).not.toThrow();
+
+      expect(renderTexture.destroyed).toBe(true);
+    });
+  });
+
+  describe('use-after-destroy throws', () => {
+    test('binding a destroyed texture throws', () => {
+      const harness = createWebGl2Harness();
+      const texture = new DataTexture({ width: 16, height: 16, format: TextureFormat.Rgba8 });
+      const scene = buildSpriteScene({ count: 1, textures: [texture] });
+
+      // Warm it so the failure cannot be blamed on a cold path.
+      measureSteadyFrame(harness, scene.root);
+
+      texture.destroy();
+
+      expect(() => measureSteadyFrame(harness, scene.root)).toThrow(/destroyed texture/i);
+    });
+
+    test('the throw names the ownership rule, not just the symptom', () => {
+      const harness = createWebGl2Harness();
+      const texture = new DataTexture({ width: 16, height: 16, format: TextureFormat.Rgba8 });
+      const scene = buildSpriteScene({ count: 1, textures: [texture] });
+
+      texture.destroy();
+
+      // A bare "invalid texture" leaves the reader guessing which of the three
+      // ownership patterns they got wrong.
+      expect(() => measureSteadyFrame(harness, scene.root)).toThrow(/capture\(\)|releaseRenderTexture/i);
+    });
+
+    test('rendering into a destroyed render target throws', () => {
+      const harness = createWebGl2Harness();
+      const target = new RenderTexture(32, 32);
+
+      target.destroy();
+
+      expect(() => harness.backend.setRenderTarget(target)).toThrow(/destroyed render target/i);
+    });
+
+    test('a live target still activates normally', () => {
+      const harness = createWebGl2Harness();
+      const target = new RenderTexture(32, 32);
+
+      expect(() => harness.backend.setRenderTarget(target)).not.toThrow();
+
+      harness.backend.setRenderTarget(null);
+      target.destroy();
+    });
+  });
+
+  describe('VRAM reaches a plateau across allocate/free cycles', () => {
+    test('repeatedly creating and destroying textures does not grow gpuMemoryBytes', () => {
+      const harness = createWebGl2Harness();
+      const readings: number[] = [];
+
+      // Each cycle stands in for one scene transition: allocate, draw with it,
+      // release. A backend that forgets a texture on free grows monotonically.
+      for (let cycle = 0; cycle < 8; cycle++) {
+        const texture = new DataTexture({ width: 32, height: 32, format: TextureFormat.Rgba8 });
+
+        measureSteadyFrame(harness, buildSpriteScene({ count: 1, textures: [texture] }).root);
+        texture.destroy();
+
+        readings.push(harness.backend.stats.gpuMemoryBytes);
+      }
+
+      // Cycle 0 also allocates the renderers' own buffers, so compare from 1 on:
+      // every later cycle must land on exactly the same total.
+      const [, ...settled] = readings;
+
+      expect(new Set(settled).size).toBe(1);
+    });
+
+    test('a texture left undestroyed does grow VRAM — the plateau test can fail', () => {
+      const harness = createWebGl2Harness();
+      const held: DataTexture[] = [];
+      const readings: number[] = [];
+
+      for (let cycle = 0; cycle < 4; cycle++) {
+        const texture = new DataTexture({ width: 32, height: 32, format: TextureFormat.Rgba8 });
+
+        held.push(texture);
+        measureSteadyFrame(harness, buildSpriteScene({ count: 1, textures: [texture] }).root);
+        readings.push(harness.backend.stats.gpuMemoryBytes);
+      }
+
+      // Proves the assertion above has teeth rather than passing vacuously:
+      // the same loop without `destroy()` is strictly increasing.
+      const [, ...settled] = readings;
+
+      expect(new Set(settled).size).toBeGreaterThan(1);
+
+      for (const texture of held) {
+        texture.destroy();
+      }
+    });
+  });
+});


### PR DESCRIPTION
The accounting side was already exact — `resource-accounting.test.ts` proves adding a texture raises `gpuMemoryBytes` by precisely its footprint and freeing it lowers it by the same. What was never stated is **who does the freeing**, and what happens when a released resource is used anyway. Those are the two ways a game actually leaks or corrupts GPU state.

## The three ownership patterns

All three already existed in the code; none was ever named. `RenderingContext.capture()` now documents them, since it is the only one that hands ownership across the API boundary:

| Pattern | Who releases |
|---|---|
| **Caller-owned** — `capture()` | You. Nothing releases the result; capturing per frame without destroying leaks steadily. |
| **Backend-pooled** — `acquireRenderTexture()`/`releaseRenderTexture()` | Whoever acquires. Destroying a pooled texture instead of releasing corrupts the pool. |
| **Node-owned** — `cacheAsBitmap` | The node, internally. |

## `destroy()` is now idempotent

Previously a second call ran the whole teardown again: `_size`/`_viewport`/`_defaultView` each took a second `destroy()`, and destroy listeners — which is where backends release framebuffers — fired again against already-released state. `RenderTarget` also gains the `destroyed` flag it lacked entirely (`Texture` already had one).

## Use-after-destroy throws, in every build

Not `__DEV__`-only. A released resource is undefined behaviour at the driver level: WebGL2 silently draws nothing or samples garbage, WebGPU raises a validation error a frame later, and the symptom surfaces far from its cause. Stripping the check in production would remove it from exactly the builds where the bug is hardest to trace.

This matches `Sprite.setTexture()` and `Container.addChildAt()`, which have thrown unconditionally since the hardening batch. The guard sits at **one entry per backend** (`_syncTexture`, `setRenderTarget`), so it costs a single branch on a path that already binds GPU state.

## Tests

New `resource-lifetime.test.ts` (10 tests): idempotent destroy on both types, listeners firing exactly once across repeated calls, use-after-destroy throwing on both halves, and a **VRAM plateau test** across repeated allocate/free cycles — the case a game hits by allocating a render target per scene transition, which no single-frame assertion would catch.

Its companion deliberately omits `destroy()` and asserts VRAM *does* grow, so the plateau assertion cannot pass vacuously.

Verified: `rendering-perf` 89 passed, `test/rendering` 1538 passed, `verify:quick` green.

https://claude.ai/code/session_01XQYUhcmWjUM7uxiNBCbURX