### PR TITLE
feat(release): make the parity matrix a per-release claim

### DIFF
--- a/scripts/release/cut.ts
+++ b/scripts/release/cut.ts
@@ -8,6 +8,8 @@
  *   - Working tree is clean.
  *   - CHANGELOG.md has a `## [VERSION] - YYYY-MM-DD` section for the target version.
  *   - No git tag vVERSION already exists.
+ *   - Parity evidence for Chromium and Firefox was measured on the current HEAD
+ *     (the published matrix claims the release, so it must describe it).
  *
  * What it does:
  *   1. Bumps `version` in all six lockstep package.json files.
@@ -30,6 +32,7 @@ import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { LOCKSTEP_PACKAGES } from './lockstep-packages.ts';
+import { EVIDENCE_PATH, type EvidenceRow, GUARANTEED_BROWSERS, readEvidence, staleEvidenceReasons, stampRelease, writeEvidence } from './parity-evidence.ts';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -95,6 +98,33 @@ function assertTagAbsent(version: string): void {
   }
 }
 
+/**
+ * The published parity matrix must describe the commit being released — it is
+ * linked from the deployment and troubleshooting guides, and the release states
+ * it holds as of this version.
+ *
+ * Compared against HEAD as it stands right now, before this script creates its
+ * own bump commit, because that is the tree the measurement ran against.
+ *
+ * Deliberately not a CI browser lane: the run is bound to the moment the claim
+ * gets published, not to every push.
+ */
+function assertEvidenceFresh(rows: readonly EvidenceRow[]): void {
+  const head = execSync('git rev-parse --short HEAD', { encoding: 'utf8', cwd: repoRoot }).trim();
+  const stale = staleEvidenceReasons(rows, head);
+
+  if (stale.length > 0) {
+    die(
+      `Parity evidence is not current for HEAD (${head}):\n` +
+        stale.map(line => `  - ${line}`).join('\n') +
+        `\n\nThe matrix is published from ${EVIDENCE_PATH} and the release claims it holds as of this version.\n` +
+        `Re-measure, commit the result, then re-run release:cut:\n` +
+        `  pnpm test:parity\n` +
+        `  pnpm test:parity:firefox`,
+    );
+  }
+}
+
 // ── Bump ───────────────────────────────────────────────────────────────────
 
 function bumpPackages(version: string): boolean {
@@ -144,7 +174,15 @@ log('  checking pre-conditions…');
 assertCleanTree();
 assertChangelogSection(version);
 assertTagAbsent(version);
-log('  ✓ tree clean, changelog section present, tag absent');
+
+const evidence = readEvidence(repoRoot);
+
+assertEvidenceFresh(evidence);
+log(`  ✓ tree clean, changelog section present, tag absent, parity evidence current (${GUARANTEED_BROWSERS.join(' + ')})`);
+
+log('\n→ stamping the release onto the parity evidence…');
+writeEvidence(repoRoot, stampRelease(evidence, version));
+log(`  ✓ ${EVIDENCE_PATH} now claims ${version}`);
 
 log('\n→ bumping lockstep packages…');
 const bumped = bumpPackages(version);
@@ -160,11 +198,16 @@ if (bumped) {
 
   log('\n→ committing version bump…');
   const packageJsonPaths = LOCKSTEP_DIRS.map(({ dir }) => resolve(dir, 'package.json')).join(' ');
-  run(`git add ${packageJsonPaths}`);
+  run(`git add ${packageJsonPaths} ${EVIDENCE_PATH}`);
   run(`git commit -m "chore(release): bump to ${version}"`);
   log(`  ✓ committed`);
 } else {
-  log('  all packages already at target version — skipping commit');
+  // The evidence stamp above already dirtied the tree, so it still needs a
+  // commit of its own — otherwise the tag would point at a tree whose matrix
+  // does not name the release it is published under.
+  log('  all packages already at target version — committing the evidence stamp only');
+  run(`git add ${EVIDENCE_PATH}`);
+  run(`git commit -m "chore(release): claim parity for ${version}"`);
 }
 
 log(`\n→ creating annotated tag ${tag}…`);

--- a/scripts/release/parity-evidence.ts
+++ b/scripts/release/parity-evidence.ts
@@ -1,0 +1,90 @@
+/**
+ * The parity matrix as a release claim.
+ *
+ * `test/rendering/parity/evidence.json` is measured by the browser suite and
+ * published on the site, linked from the deployment and troubleshooting guides.
+ * A release therefore states "as of this version, this parity holds" — a claim
+ * that is only honest if the evidence was measured on the commit being released.
+ *
+ * Kept apart from `cut.ts` so it can be tested without executing the release
+ * script, whose module body runs the whole cut on import.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+
+/**
+ * Browsers the published claim covers.
+ *
+ * Others may appear in the evidence and render in the table as data; they are
+ * simply not part of what a release guarantees, so a missing or stale row for
+ * them never blocks a cut.
+ */
+export const GUARANTEED_BROWSERS = ['chromium', 'firefox'] as const;
+
+export const EVIDENCE_PATH = 'test/rendering/parity/evidence.json';
+
+export interface EvidenceRow {
+  browser: string;
+  commit: string;
+  release?: string;
+  [key: string]: unknown;
+}
+
+export function parseEvidence(json: string): EvidenceRow[] {
+  const parsed: unknown = JSON.parse(json);
+
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${EVIDENCE_PATH} must contain an array of evidence rows.`);
+  }
+
+  return parsed as EvidenceRow[];
+}
+
+export function readEvidence(repoRoot: string): EvidenceRow[] {
+  return parseEvidence(readFileSync(`${repoRoot}/${EVIDENCE_PATH}`, 'utf8'));
+}
+
+/**
+ * Why the evidence cannot be claimed for `head`, one line per guaranteed
+ * browser. Empty means it is current and the cut may proceed.
+ *
+ * `head` is HEAD as it stands *before* the release script creates its bump
+ * commit — that is the tree the measurement ran against.
+ */
+export function staleEvidenceReasons(rows: readonly EvidenceRow[], head: string): string[] {
+  const reasons: string[] = [];
+
+  for (const browser of GUARANTEED_BROWSERS) {
+    const forBrowser = rows.filter(row => row.browser === browser);
+
+    if (forBrowser.length === 0) {
+      reasons.push(`${browser}: no rows at all`);
+      continue;
+    }
+
+    const mismatched = [...new Set(forBrowser.filter(row => row.commit !== head).map(row => row.commit))];
+
+    if (mismatched.length > 0) {
+      reasons.push(`${browser}: measured at ${mismatched.join(', ')}, HEAD is ${head}`);
+    }
+  }
+
+  return reasons;
+}
+
+/**
+ * Stamps the release onto every guaranteed-browser row, returning the new rows.
+ *
+ * The parity runner cannot do this: it executes before the release, when
+ * `package.json` still carries the previous version. It owns
+ * `measuredAt`/`commit`/`platform`; `release` is the release step's field.
+ *
+ * Non-guaranteed browsers are left untouched — stamping them would extend the
+ * claim to rows nobody promised to keep current.
+ */
+export function stampRelease(rows: readonly EvidenceRow[], version: string): EvidenceRow[] {
+  return rows.map(row => ((GUARANTEED_BROWSERS as readonly string[]).includes(row.browser) ? { ...row, release: version } : row));
+}
+
+export function writeEvidence(repoRoot: string, rows: readonly EvidenceRow[]): void {
+  writeFileSync(`${repoRoot}/${EVIDENCE_PATH}`, `${JSON.stringify(rows, null, 2)}\n`, 'utf8');
+}

--- a/site/src/components/ParityMatrix.astro
+++ b/site/src/components/ParityMatrix.astro
@@ -28,6 +28,8 @@ interface Row {
   readonly support: Support;
   readonly measuredAt?: string;
   readonly commit?: string;
+  /** Release this row is published under, stamped by `release:cut`. */
+  readonly release?: string;
 }
 
 const rows = evidence as readonly Row[];
@@ -73,12 +75,30 @@ const stamps = rows.filter(row => row.measuredAt !== undefined);
 const lastMeasured = stamps.length > 0 ? stamps.map(row => row.measuredAt!).sort().at(-1) : undefined;
 const measuredFeatures = new Set(rows.map(row => row.feature));
 const coverage = `${RENDER_FEATURES.filter(feature => measuredFeatures.has(feature.name)).length} of ${RENDER_FEATURES.length}`;
+
+/**
+ * The release this table is published as part of, written onto the rows by
+ * `release:cut`. Absent means measured since the last release and not yet
+ * claimed by one — current data, but no version stands behind it, and saying so
+ * is more useful than implying a guarantee that was never cut.
+ */
+const claimed = [...new Set(rows.map(row => row.release).filter((release): release is string => release !== undefined))].sort();
+const claimedIn = claimed.at(-1);
 ---
 
 <figure class="parity">
   <table>
     <caption>
       Verified rendering behaviour by browser — <strong>{coverage}</strong> features measured{lastMeasured ? `, last on ${lastMeasured}` : ''}.
+      {
+        claimedIn ? (
+          <span class="claim">
+            Guaranteed as of <strong>v{claimedIn}</strong>.
+          </span>
+        ) : (
+          <span class="claim">Measured after the last release — not yet part of a version's guarantee.</span>
+        )
+      }
     </caption>
     <thead>
       <tr>
@@ -140,6 +160,11 @@ const coverage = `${RENDER_FEATURES.filter(feature => measuredFeatures.has(featu
     padding-bottom: 0.75rem;
     color: var(--color-text-muted, #888);
     font-size: 0.85rem;
+  }
+
+  .claim {
+    display: block;
+    margin-top: 0.25rem;
   }
 
   th,

--- a/site/src/content/guide/debugging/backend-comparison.mdx
+++ b/site/src/content/guide/debugging/backend-comparison.mdx
@@ -44,6 +44,8 @@ That claim is easy to make and hard to keep, so a conformance suite renders the 
 
 Read it as evidence, not as a support promise. A `?` means nobody has measured that combination yet; it is not a statement that the feature is broken, and it is deliberately visible rather than hidden. The scenes use a texture whose every texel encodes its own coordinates, so a matching frame proves the right texel landed in the right pixel — not merely that two images happened to look alike.
 
+The table names the release it is guaranteed as of. `release:cut` refuses to cut a version until the evidence for Chromium and Firefox was measured on the commit being released, then stamps that version onto the rows — so the guarantee is tied to a version rather than to whenever someone last ran the suite. Rows measured after a release carry no version until the next one claims them.
+
 Chromium is measured on every CI run. Firefox and Safari need a machine with a display and are measured by hand, which is why their rows carry an older date.
 
 <Callout type="hint" title="Reproduce it yourself">

--- a/test/release/parity-evidence.test.ts
+++ b/test/release/parity-evidence.test.ts
@@ -1,0 +1,104 @@
+/**
+ * The release-time half of the parity matrix: whether the evidence may be
+ * claimed for a version, and what the claim looks like once stamped.
+ *
+ * The measurement half lives in `test/rendering/parity/` and runs in browsers.
+ * These are pure functions over already-recorded rows, so they run anywhere.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { type EvidenceRow, GUARANTEED_BROWSERS, parseEvidence, staleEvidenceReasons, stampRelease } from '../../scripts/release/parity-evidence';
+
+const row = (browser: string, commit: string, extra: Partial<EvidenceRow> = {}): EvidenceRow => ({
+  browser,
+  commit,
+  backend: 'webgl2',
+  support: 'supported',
+  ...extra,
+});
+
+describe('staleEvidenceReasons', () => {
+  it('accepts evidence measured on the released commit', () => {
+    const rows = [row('chromium', 'abc1234'), row('firefox', 'abc1234')];
+
+    expect(staleEvidenceReasons(rows, 'abc1234')).toEqual([]);
+  });
+
+  it('rejects a browser measured on an older commit, naming both commits', () => {
+    const rows = [row('chromium', 'abc1234'), row('firefox', 'old0000')];
+    const [reason, ...rest] = staleEvidenceReasons(rows, 'abc1234');
+
+    expect(rest).toEqual([]);
+    expect(reason).toContain('firefox');
+    expect(reason).toContain('old0000');
+    expect(reason).toContain('abc1234');
+  });
+
+  it('rejects a guaranteed browser with no rows at all', () => {
+    const rows = [row('chromium', 'abc1234')];
+
+    expect(staleEvidenceReasons(rows, 'abc1234')).toEqual(['firefox: no rows at all']);
+  });
+
+  it('reports every stale browser rather than stopping at the first', () => {
+    const rows = [row('chromium', 'old0000'), row('firefox', 'old0000')];
+
+    expect(staleEvidenceReasons(rows, 'abc1234')).toHaveLength(GUARANTEED_BROWSERS.length);
+  });
+
+  it('ignores browsers outside the guarantee, however stale', () => {
+    // They still render in the table as data — they are simply not something a
+    // release promises to keep current, so they must never block a cut.
+    const rows = [row('chromium', 'abc1234'), row('firefox', 'abc1234'), row('webkit', 'ancient')];
+
+    expect(staleEvidenceReasons(rows, 'abc1234')).toEqual([]);
+  });
+
+  it('collapses repeated stale commits instead of listing one per row', () => {
+    const rows = [row('chromium', 'abc1234'), row('firefox', 'old0000'), row('firefox', 'old0000'), row('firefox', 'old0000')];
+    const [reason] = staleEvidenceReasons(rows, 'abc1234');
+
+    expect(reason.match(/old0000/g)).toHaveLength(1);
+  });
+});
+
+describe('stampRelease', () => {
+  it('stamps the version onto guaranteed browsers only', () => {
+    const rows = [row('chromium', 'abc1234'), row('firefox', 'abc1234'), row('webkit', 'abc1234')];
+    const stamped = stampRelease(rows, '0.16.0');
+
+    expect(stamped.filter(r => r.release === '0.16.0').map(r => r.browser)).toEqual(['chromium', 'firefox']);
+    expect(stamped.find(r => r.browser === 'webkit')?.release).toBeUndefined();
+  });
+
+  it('overwrites a previous release rather than accumulating claims', () => {
+    const rows = [row('chromium', 'abc1234', { release: '0.15.2' })];
+
+    expect(stampRelease(rows, '0.16.0')[0]?.release).toBe('0.16.0');
+  });
+
+  it('does not mutate the rows it was given', () => {
+    const rows = [row('chromium', 'abc1234')];
+
+    stampRelease(rows, '0.16.0');
+
+    expect(rows[0]?.release).toBeUndefined();
+  });
+
+  it('leaves every other field untouched', () => {
+    const rows = [row('chromium', 'abc1234', { measuredAt: '2026-08-03', platform: 'win32' })];
+    const [stamped] = stampRelease(rows, '0.16.0');
+
+    expect(stamped).toMatchObject({ measuredAt: '2026-08-03', platform: 'win32', commit: 'abc1234' });
+  });
+});
+
+describe('parseEvidence', () => {
+  it('rejects a payload that is not an array', () => {
+    expect(() => parseEvidence('{"browser":"chromium"}')).toThrow(/must contain an array/i);
+  });
+
+  it('reads a well-formed array', () => {
+    expect(parseEvidence(JSON.stringify([row('chromium', 'abc1234')]))).toHaveLength(1);
+  });
+});

--- a/test/rendering/parity/evidenceSink.ts
+++ b/test/rendering/parity/evidenceSink.ts
@@ -78,6 +78,15 @@ export interface StampedEvidenceRow extends EvidenceRow {
    * about Safari.
    */
   readonly platform: string;
+  /**
+   * Release this row is published as part of, e.g. `0.16.0`.
+   *
+   * Written by `release:cut`, not by this sink — the runner executes before the
+   * release, when `package.json` still carries the previous version. Absent on
+   * rows measured since the last release, which is the honest reading: they are
+   * current data, but no release has claimed them yet.
+   */
+  readonly release?: string;
 }
 
 const OUTPUT = 'test/rendering/parity/evidence.json';


### PR DESCRIPTION
`evidence.json` is measured by the browser suite, checked into the repo, and published on the site — linked from the deployment, troubleshooting and performance guides, where users decide from it whether they can rely on a feature.

Nothing verified it still described the code. `git grep evidence -- .github/ scripts/` was empty and no workflow ran `test:parity`. Break text rendering on WebGPU tomorrow and the published table keeps its checkmark; nothing goes red. The only signal was the `measuredAt` stamp, which somebody had to think to read.

## What changes

`release:cut` gains a fourth pre-condition alongside clean tree / changelog section / free tag: **the evidence for Chromium and Firefox must have been measured on the commit being released.** On mismatch it aborts and names the commands to run.

The comparison is against `HEAD` *as it stands when the script starts* — before it creates its own bump commit — because that is the tree the measurement ran against.

It then stamps that version onto the guaranteed-browser rows and includes the file in the release commit. The runner cannot do this itself: it executes before the release, when `package.json` still carries the previous version. It keeps owning `measuredAt`/`commit`/`platform`; `release` is the release step's field.

Its **absence is meaningful**: rows measured since the last release are current data that no version yet stands behind, and the matrix caption says exactly that rather than implying a guarantee.

## What this deliberately is not

A CI browser lane. The run is bound to the moment the claim gets published, not to every push. Browsers outside the guarantee keep rendering as data and never block a cut — stamping them would extend a promise nobody made to keep them current.

## Structure

The logic lives in a new `scripts/release/parity-evidence.ts` rather than in `cut.ts`, whose module body runs the whole release on import and therefore cannot be tested. 12 new tests cover freshness (per-browser, multiple stale browsers, collapsed duplicate commits, non-guaranteed browsers ignored) and stamping (guaranteed-only, overwrite rather than accumulate, no mutation of the input).

Verified: `verify:quick` green, 12/12 new tests passing.

https://claude.ai/code/session_01XQYUhcmWjUM7uxiNBCbURX