### PR TITLE
test(rendering): stop asserting the wording of a throw

### DIFF
--- a/test/perf/rendering/resource-lifetime.test.ts
+++ b/test/perf/rendering/resource-lifetime.test.ts
@@ -85,18 +85,6 @@ describe('GPU resource lifetime', () => {
       expect(() => measureSteadyFrame(harness, scene.root)).toThrow(/destroyed texture/i);
     });
 
-    test('the throw names the ownership rule, not just the symptom', () => {
-      const harness = createWebGl2Harness();
-      const texture = new DataTexture({ width: 16, height: 16, format: TextureFormat.Rgba8 });
-      const scene = buildSpriteScene({ count: 1, textures: [texture] });
-
-      texture.destroy();
-
-      // A bare "invalid texture" leaves the reader guessing which of the three
-      // ownership patterns they got wrong.
-      expect(() => measureSteadyFrame(harness, scene.root)).toThrow(/capture\(\)|releaseRenderTexture/i);
-    });
-
     test('rendering into a destroyed render target throws', () => {
       const harness = createWebGl2Harness();
       const target = new RenderTexture(32, 32);


### PR DESCRIPTION
`the throw names the ownership rule, not just the symptom` (added in #474) matched the error message against `/capture\(\)|releaseRenderTexture/`.

The throw itself is already covered by the test directly above it, which asserts a destroyed texture cannot be bound. All this one adds is that the message keeps mentioning two particular API names — so it fails when someone improves the wording, and passes when the guard is wrong as long as the string is unchanged.

Helpful error text is worth writing. Pinning it in a test makes it expensive to edit without making it more correct.

Verified: `rendering-perf` suite 9 passed.

https://claude.ai/code/session_01XQYUhcmWjUM7uxiNBCbURX