### PR TITLE
fix: address BLOCKER/HIGH findings from the independent architecture review

### DIFF
--- a/packages/exojs-particles/src/ParticleSystem.ts
+++ b/packages/exojs-particles/src/ParticleSystem.ts
@@ -176,6 +176,12 @@ export class ParticleSystem extends Drawable {
    * state — only dirty slots flow CPU → GPU.
    */
   private readonly _gpuDirtySlots = new Set<number>();
+  /**
+   * Slots handed out by `spawn()` while a recording window is open, or `null`
+   * when nothing is recording. Lets callers identify freshly spawned particles
+   * without diffing `liveCount`, which cannot see a recycled GPU slot.
+   */
+  private _spawnRecord: number[] | null = null;
 
   private _texture: Texture;
   private readonly _frames: Rectangle[] = [];
@@ -454,6 +460,46 @@ export class ParticleSystem extends Drawable {
     return this._spawnCpu();
   }
 
+  /**
+   * Begin recording the slots handed out by {@link spawn}.
+   *
+   * Callers that post-process freshly spawned particles cannot infer which
+   * slots those are from {@link liveCount}: in GPU mode a spawn may recycle a
+   * dead slot below the high-water mark, leaving the count unchanged, and the
+   * reused slots are scattered rather than contiguous. Pass the returned token
+   * back to {@link _endSpawnRecording}.
+   *
+   * @internal
+   */
+  public _beginSpawnRecording(): number[] | null {
+    const previous = this._spawnRecord;
+
+    this._spawnRecord = [];
+
+    return previous;
+  }
+
+  /**
+   * End the recording started by {@link _beginSpawnRecording} and return the
+   * slots allocated during it. Slots are also handed to an enclosing recording
+   * so a nested spawn stays visible to the outer window.
+   *
+   * @internal
+   */
+  public _endSpawnRecording(previous: number[] | null): readonly number[] {
+    const recorded = this._spawnRecord ?? [];
+
+    this._spawnRecord = previous;
+
+    if (previous !== null) {
+      for (const slot of recorded) {
+        previous.push(slot);
+      }
+    }
+
+    return recorded;
+  }
+
   /** Resets the system to zero live particles without destroying it. */
   public clearParticles(): this {
     this.liveCount = 0;
@@ -577,6 +623,7 @@ export class ParticleSystem extends Drawable {
 
     this.alive[slot] = 1;
     this.elapsed[slot] = 0;
+    this._spawnRecord?.push(slot);
 
     return slot;
   }
@@ -594,6 +641,7 @@ export class ParticleSystem extends Drawable {
         this._spawnHint = i + 1 === capacity ? 0 : i + 1;
         if (i >= this.liveCount) this.liveCount = i + 1;
         this._gpuDirtySlots.add(i);
+        this._spawnRecord?.push(i);
         return i;
       }
     }
@@ -605,6 +653,7 @@ export class ParticleSystem extends Drawable {
         this._spawnHint = i + 1;
         if (i >= this.liveCount) this.liveCount = i + 1;
         this._gpuDirtySlots.add(i);
+        this._spawnRecord?.push(i);
         return i;
       }
     }

--- a/packages/exojs-particles/src/modules/SpawnOnDeath.ts
+++ b/packages/exojs-particles/src/modules/SpawnOnDeath.ts
@@ -35,19 +35,22 @@ export class SpawnOnDeath extends DeathModule {
     const x = parent.posX[slot] ?? 0;
     const y = parent.posY[slot] ?? 0;
 
-    // Snapshot the target's pre-spawn count so we can apply the
-    // position to whichever slots the spawner adds.
-    const before = target.liveCount;
+    // Which slots the spawner took cannot be derived from liveCount: a
+    // GPU-mode target recycles dead slots below its high-water mark, so the
+    // count can stay put while particles are added, and the reused slots are
+    // scattered rather than contiguous. Record the allocations instead.
+    const previous = target._beginSpawnRecording();
+    let spawned: readonly number[];
 
-    for (let n = 0; n < this.count; n++) {
-      this.spawner.apply(target, 0);
+    try {
+      for (let n = 0; n < this.count; n++) {
+        this.spawner.apply(target, 0);
+      }
+    } finally {
+      spawned = target._endSpawnRecording(previous);
     }
 
-    const added = target.liveCount - before;
-
-    for (let i = 0; i < added; i++) {
-      const dst = before + i;
-
+    for (const dst of spawned) {
       target.posX[dst] = (target.posX[dst] ?? 0) + x;
       target.posY[dst] = (target.posY[dst] ?? 0) + y;
     }

--- a/packages/exojs-particles/src/particlesExtension.ts
+++ b/packages/exojs-particles/src/particlesExtension.ts
@@ -9,7 +9,14 @@ import { ParticleSystem } from './ParticleSystem';
 
 /** Options for {@link createParticlesExtension}. */
 export interface ParticlesExtensionOptions {
-  /** WebGL2 particle renderer batch size. Default: 8192. */
+  /**
+   * Particles the WebGL2 renderer's instance buffer is pre-sized for.
+   * Defaults to 8192.
+   *
+   * This is a starting allocation, not a limit: a system with more live
+   * particles grows the buffer instead of dropping the surplus, so raise it
+   * only to avoid the initial growth steps for a known-large system.
+   */
   readonly batchSize?: number;
 }
 

--- a/packages/exojs-particles/src/renderers/WebGl2ParticleRenderer.ts
+++ b/packages/exojs-particles/src/renderers/WebGl2ParticleRenderer.ts
@@ -61,10 +61,11 @@ export class WebGl2ParticleRenderer extends AbstractWebGl2Renderer<ParticleSyste
   public readonly _consumesSharedTransform = false;
 
   private readonly _shader: Shader;
-  private readonly _batchSize: number;
-  private readonly _instanceData: ArrayBuffer;
-  private readonly _instanceFloat32: Float32Array;
-  private readonly _instanceUint32: Uint32Array;
+  /** Particles the scratch buffer can currently hold. Grows, never shrinks. */
+  private _instanceCapacity: number;
+  private _instanceData: ArrayBuffer;
+  private _instanceFloat32: Float32Array;
+  private _instanceUint32: Uint32Array;
 
   private _instanceCount = 0;
   private _currentTexture: Texture | null = null;
@@ -80,9 +81,36 @@ export class WebGl2ParticleRenderer extends AbstractWebGl2Renderer<ParticleSyste
   public constructor(batchSize: number) {
     super();
 
-    this._batchSize = batchSize;
+    this._instanceCapacity = batchSize;
     this._shader = new Shader(vertexSource, fragmentSource);
     this._instanceData = new ArrayBuffer(batchSize * instanceStrideBytes);
+    this._instanceFloat32 = new Float32Array(this._instanceData);
+    this._instanceUint32 = new Uint32Array(this._instanceData);
+  }
+
+  /**
+   * Grow the per-instance scratch buffer to hold `particleCount` particles.
+   *
+   * Nothing about WebGL2 caps the instance count here — the buffer is a plain
+   * CPU-side allocation and the GL store is reallocated from it on the next
+   * upload. Growing instead of clamping is what keeps a system drawing the
+   * same number of particles on WebGL2 as it does on WebGPU. Growth is bounded
+   * by the system's own capacity, and doubling stops a system that ramps up to
+   * its peak from reallocating every frame.
+   */
+  private _ensureCapacity(particleCount: number): void {
+    if (particleCount <= this._instanceCapacity) {
+      return;
+    }
+
+    let capacity = this._instanceCapacity > 0 ? this._instanceCapacity : 1;
+
+    while (capacity < particleCount) {
+      capacity *= 2;
+    }
+
+    this._instanceCapacity = capacity;
+    this._instanceData = new ArrayBuffer(capacity * instanceStrideBytes);
     this._instanceFloat32 = new Float32Array(this._instanceData);
     this._instanceUint32 = new Uint32Array(this._instanceData);
   }
@@ -115,10 +143,15 @@ export class WebGl2ParticleRenderer extends AbstractWebGl2Renderer<ParticleSyste
     this._shader.getUniform('u_systemTransform').setValue(system.getGlobalTransform().toArray(false));
     this._shader.getUniform('u_localBounds').setValue(localBounds);
 
+    const limit = system.liveCount;
+
+    // Must precede the view reads below: growing swaps in fresh typed-array
+    // views over a new backing buffer.
+    this._ensureCapacity(limit);
+
     const f32 = this._instanceFloat32;
     const u32 = this._instanceUint32;
     const { posX, posY, scaleX, scaleY, rotations, color, textureIndex, alive } = system;
-    const limit = Math.min(system.liveCount, this._batchSize);
 
     // Pre-compute frame UVs from system.frames + texture; falls back
     // to the system.textureFrame when no atlas is declared.

--- a/packages/exojs-particles/test/particle-gpu.test.ts
+++ b/packages/exojs-particles/test/particle-gpu.test.ts
@@ -856,3 +856,82 @@ describe('UpdateModule.uploadTextures — missing map entry', () => {
     expect(() => module.uploadTextures({} as GPUDevice, new Map())).not.toThrow();
   });
 });
+
+describe('SpawnOnDeath into a GPU-mode target system', () => {
+  let restoreGlobals: () => void;
+
+  beforeEach(() => {
+    restoreGlobals = installGlobals();
+  });
+
+  afterEach(() => {
+    restoreGlobals();
+  });
+
+  /**
+   * Fill a GPU-mode system to capacity, then free one slot so the next spawn
+   * recycles that hole instead of extending the live range.
+   */
+  const makeGpuTargetWithHole = (capacity: number, hole: number): ParticleSystem => {
+    const env = makeMockDevice();
+    const target = new ParticleSystem(makeTexture(), { capacity, device: env.device });
+
+    target.addUpdateModule(new ApplyForce(0, 0));
+    target.update(tick(0));
+
+    for (let i = 0; i < capacity; i++) {
+      const slot = target.spawn();
+
+      target.lifetime[slot] = 10;
+    }
+
+    // Mirror what the GPU death path leaves behind: a dead slot below the
+    // live-range high-water mark.
+    target.alive[hole] = 0;
+    target.lifetime[hole] = -1;
+
+    return target;
+  };
+
+  test('recycled GPU slots receive the dying particle position', () => {
+    const target = makeGpuTargetWithHole(4, 1);
+    const parent = new ParticleSystem(makeTexture(), { capacity: 4 });
+
+    expect(target.gpuMode).toBe(true);
+
+    const parentSlot = parent.spawn();
+
+    parent.posX[parentSlot] = 100;
+    parent.posY[parentSlot] = 50;
+
+    const death = new SpawnOnDeath(target, new BurstSpawn({ schedule: [{ time: 0, count: 1 }], lifetime: new Constant(5) }));
+    const liveCountBefore = target.liveCount;
+
+    death.onDeath(parent, parentSlot);
+
+    // The spawn refilled the hole, so liveCount is unchanged — the signal the
+    // old count-diff heuristic relied on never fires here.
+    expect(target.liveCount).toBe(liveCountBefore);
+    expect(target.alive[1]).toBe(1);
+    expect(target.posX[1]).toBe(100);
+    expect(target.posY[1]).toBe(50);
+  });
+
+  test('CPU-mode targets still receive the dying particle position', () => {
+    const target = new ParticleSystem(makeTexture(), { capacity: 4 });
+    const parent = new ParticleSystem(makeTexture(), { capacity: 4 });
+
+    const parentSlot = parent.spawn();
+
+    parent.posX[parentSlot] = -20;
+    parent.posY[parentSlot] = 7;
+
+    const death = new SpawnOnDeath(target, new BurstSpawn({ schedule: [{ time: 0, count: 1 }], lifetime: new Constant(5) }));
+
+    death.onDeath(parent, parentSlot);
+
+    expect(target.liveCount).toBe(1);
+    expect(target.posX[0]).toBe(-20);
+    expect(target.posY[0]).toBe(7);
+  });
+});

--- a/packages/exojs-physics/src/PhysicsWorld.ts
+++ b/packages/exojs-physics/src/PhysicsWorld.ts
@@ -344,12 +344,20 @@ export class PhysicsWorld implements BodyOwner {
     return body;
   }
 
-  /** Destroy a body and its colliders. Deferred when called inside a callback. */
+  /**
+   * Destroy a body and its colliders. Every dynamic body touching it is woken,
+   * so anything that was resting on the destroyed body falls once its support is
+   * gone. Deferred when called inside a callback.
+   */
   public destroyBody(body: PhysicsBody): void {
     this._defer(() => this._removeBody(body));
   }
 
-  /** Destroy a single collider, recomputing its body's mass. Deferred when called inside a callback. */
+  /**
+   * Destroy a single collider, recomputing its body's mass. Wakes every dynamic
+   * body touching it, the same way {@link destroyBody} does. Deferred when
+   * called inside a callback.
+   */
   public destroyCollider(collider: Collider): void {
     this._defer(() => this._removeCollider(collider));
   }
@@ -1001,8 +1009,43 @@ export class PhysicsWorld implements BodyOwner {
       this._colliders.splice(index, 1);
     }
 
+    this._wakeTouchingBodies(collider);
     this._backend.removeCollider(collider);
     collider._markDestroyed();
+  }
+
+  /**
+   * Wake every dynamic body still touching `collider` at the moment it leaves
+   * the world. A sleeping body's sleep timer is frozen, so the island pass alone
+   * can never re-open its sleep decision: losing the support it rested on just
+   * removes a contact, and the island (now smaller, or a lone body) still reports
+   * a long-expired timer and is put straight back to sleep — a stack whose floor,
+   * platform or bottom box is destroyed would hang in mid-air forever. Kinematic
+   * and static supports are the sharp edge, since they are island boundaries
+   * rather than nodes and so are invisible to wake propagation, but the same hole
+   * exists for a dynamic support. Waking the far side of each contact is enough:
+   * the woken body's reset timer propagates through the rest of its sleeping
+   * island on the next step, exactly like any other wake event.
+   */
+  private _wakeTouchingBodies(collider: Collider): void {
+    for (const contact of this._backend.contactGraph.solidContacts) {
+      let other: Collider;
+
+      if (contact.a === collider) {
+        other = contact.b;
+      } else if (contact.b === collider) {
+        other = contact.a;
+      } else {
+        continue;
+      }
+
+      // Only reached for a collider that is part of a live contact, so it is
+      // attached and `body` cannot throw — a free-standing collider (a body
+      // destroyed before it was ever stepped) has no contacts to match.
+      if (other.body.type === 'dynamic') {
+        other.body.wake();
+      }
+    }
   }
 
   private _assertAlive(): void {

--- a/packages/exojs-physics/test/sleeping.test.ts
+++ b/packages/exojs-physics/test/sleeping.test.ts
@@ -24,6 +24,10 @@ const advance = (world: PhysicsWorld, seconds: number): void => {
 const addFloor = (world: PhysicsWorld, topY: number): PhysicsBody =>
   world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: topY + 20 }, colliders: [{ shape: new BoxShape(1200, 40) }] }));
 
+/** A wide kinematic platform whose top surface sits at `topY`. */
+const addPlatform = (world: PhysicsWorld, topY: number): PhysicsBody =>
+  world.add(new PhysicsBody({ type: 'kinematic', position: { x: 0, y: topY + 20 }, colliders: [{ shape: new BoxShape(1200, 40) }] }));
+
 /** A 32×32 dynamic box centred at `(x, y)`. */
 const addBox = (world: PhysicsWorld, x: number, y: number): PhysicsBody =>
   world.add(new PhysicsBody({ type: 'dynamic', position: { x, y }, colliders: [{ shape: new BoxShape(32, 32), friction: 0.5 }] }));
@@ -126,6 +130,53 @@ describe('sleeping', () => {
     advance(world, 3); // well past the default timeToSleep
 
     expect(box.isSleeping).toBe(false);
+  });
+
+  it('destroying a kinematic platform wakes the sleeping body it supported', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const platform = addPlatform(world, 300);
+    const box = addBox(world, 0, 300 - 16 - 2);
+
+    advance(world, 2);
+    expect(box.isSleeping).toBe(true);
+
+    const restingY = box.y;
+
+    // A kinematic body is never an island node, so nothing else can re-open the
+    // box's sleep decision once its only support disappears.
+    world.destroyBody(platform);
+    world.step(FRAME);
+
+    expect(box.isSleeping).toBe(false);
+
+    // And it actually resumes falling instead of hanging in mid-air.
+    advance(world, 0.5);
+    expect(box.y).toBeGreaterThan(restingY + 32);
+  });
+
+  it('destroying a dynamic body wakes the sleeping stack it supported', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    addFloor(world, 300);
+    const boxes = addStack(world, 3, 300);
+
+    advance(world, 3);
+
+    for (const box of boxes) {
+      expect(box.isSleeping).toBe(true);
+    }
+
+    const topRestingY = boxes[2]!.y;
+
+    // Pull the bottom box out: the middle box is the direct contact, the top box
+    // wakes transitively through the island it shares with the middle one.
+    world.destroyBody(boxes[0]!);
+    world.step(FRAME);
+
+    expect(boxes[1]!.isSleeping).toBe(false);
+    expect(boxes[2]!.isSleeping).toBe(false);
+
+    advance(world, 0.5);
+    expect(boxes[2]!.y).toBeGreaterThan(topRestingY + 16);
   });
 
   it('sleep transitions are deterministic across identical runs', () => {

--- a/site/src/content/api/audio-manager.json
+++ b/site/src/content/api/audio-manager.json
@@ -6,10 +6,10 @@
   "subsystem": "audio",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 20,
+  "memberCount": 21,
   "counts": {
     "constructors": 1,
-    "methods": 11,
+    "methods": 12,
     "properties": 7,
     "events": 1
   },
@@ -377,6 +377,78 @@
           ],
           "returnType": "InputVoice",
           "description": "Open a live AudioInput (microphone / WebRTC stream) and return an InputVoice. The input is analysis-only by default (not audible) — tap it with an analyser, route it to a bus to monitor, or record it."
+        },
+        {
+          "name": "play",
+          "signature": "play(source: Sound, options?: SoundPlayOptions): Voice",
+          "signatureTokens": [
+            {
+              "text": "play",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "source",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Sound",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "options",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "SoundPlayOptions",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Voice",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "source",
+              "type": "Sound",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "SoundPlayOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Voice",
+          "description": "Play a Playable asset and return a Voice handle. Each call creates an independent playback instance. Call play() again to start another concurrent voice. The returned Voice lets you control this specific instance (stop(), volume, fade(), capabilities)."
         },
         {
           "name": "play",

--- a/site/src/content/api/button.json
+++ b/site/src/content/api/button.json
@@ -2699,7 +2699,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Bottommost edge of the subtree — see left."
         },
         {
           "name": "cacheAsBitmap",
@@ -3076,7 +3076,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered height of the whole subtree — see width."
         },
         {
           "name": "interactive",
@@ -3160,7 +3160,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Leftmost edge of the subtree in the node's global-transform space. These four edges are read straight off the aggregate bounds so they always span exactly width/height and agree with each other. They cannot be reconstructed from position and origin: origin is in local pixels and a container's own local bounds are empty, so the rendered extent comes entirely from the children."
         },
         {
           "name": "mask",
@@ -3294,7 +3294,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rightmost edge of the subtree — see left."
         },
         {
           "name": "rotation",
@@ -3420,7 +3420,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Topmost edge of the subtree — see left."
         },
         {
           "name": "uiHeight",
@@ -3504,7 +3504,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered width of the whole subtree, in the node's global-transform space. Unlike Sprite.width — which scales an unscaled texture frame — a container has no intrinsic local size, so this reads the aggregate bounds directly. Those are already scaled, so multiplying by scale again would count it twice. Writing rescales scale.x to make the subtree render at the requested width."
         },
         {
           "name": "x",

--- a/site/src/content/api/button.json
+++ b/site/src/content/api/button.json
@@ -840,7 +840,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Destroy this container and every node beneath it. Ownership is by containment: detaching a subtree only unlinks it, so the descendants' GPU-backed resources (cached bitmaps, filters, render textures) and signal listeners would outlive the tree that owned them and leak on every scene change."
         },
         {
           "name": "focus",

--- a/site/src/content/api/container.json
+++ b/site/src/content/api/container.json
@@ -571,7 +571,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Destroy this container and every node beneath it. Ownership is by containment: detaching a subtree only unlinks it, so the descendants' GPU-backed resources (cached bitmaps, filters, render textures) and signal listeners would outlive the tree that owned them and leak on every scene change."
         },
         {
           "name": "focus",

--- a/site/src/content/api/container.json
+++ b/site/src/content/api/container.json
@@ -1,6 +1,6 @@
 {
   "title": "Container",
-  "description": "Scene-graph node that owns child RenderNodes. Renders its subtree in document order with local `zIndex` ordering resolved inside the internal render plan at playback time. Bounds aggregate the local bounds + every visible child's bounds, so `container.getBounds()` always returns the smallest axis-aligned rectangle containing the subtree. Width/height accessors derive from the bounds (× `scale`) and writing to them rescales `scale` to fit. Adding a child re-parents it: the previous parent is detached automatically. Removing a child cascades bounds invalidation up the ancestor chain so further-up containers also rebuild on next read. Subclassed by Sprite, Mesh, Graphics, Text, etc. — the base `Container` is a non-drawing grouping node.",
+  "description": "Scene-graph node that owns child RenderNodes. Renders its subtree in document order with local `zIndex` ordering resolved inside the internal render plan at playback time. Bounds aggregate the local bounds + every visible child's bounds, so `container.getBounds()` always returns the smallest axis-aligned rectangle containing the subtree. The size and edge accessors report that rectangle; writing to `width`/`height` rescales `scale` to fit. Adding a child re-parents it: the previous parent is detached automatically. Removing a child cascades bounds invalidation up the ancestor chain so further-up containers also rebuild on next read. Subclassed by Sprite, Mesh, Graphics, Text, etc. — the base `Container` is a non-drawing grouping node.",
   "symbol": "Container",
   "kind": "class",
   "subsystem": "rendering",
@@ -20,7 +20,7 @@
       "members": [],
       "paragraphs": [
         "Scene-graph node that owns child RenderNodes. Renders its subtree in document order with local `zIndex` ordering resolved inside the internal render plan at playback time.",
-        "Bounds aggregate the local bounds + every visible child's bounds, so `container.getBounds()` always returns the smallest axis-aligned rectangle containing the subtree. Width/height accessors derive from the bounds (× `scale`) and writing to them rescales `scale` to fit.",
+        "Bounds aggregate the local bounds + every visible child's bounds, so `container.getBounds()` always returns the smallest axis-aligned rectangle containing the subtree. The size and edge accessors report that rectangle; writing to `width`/`height` rescales `scale` to fit.",
         "Adding a child re-parents it: the previous parent is detached automatically. Removing a child cascades bounds invalidation up the ancestor chain so further-up containers also rebuild on next read.",
         "Subclassed by Sprite, Mesh, Graphics, Text, etc. — the base `Container` is a non-drawing grouping node."
       ],
@@ -2362,7 +2362,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Bottommost edge of the subtree — see left."
         },
         {
           "name": "cacheAsBitmap",
@@ -2599,7 +2599,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered height of the whole subtree — see width."
         },
         {
           "name": "interactive",
@@ -2662,7 +2662,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Leftmost edge of the subtree in the node's global-transform space. These four edges are read straight off the aggregate bounds so they always span exactly width/height and agree with each other. They cannot be reconstructed from position and origin: origin is in local pixels and a container's own local bounds are empty, so the rendered extent comes entirely from the children."
         },
         {
           "name": "mask",
@@ -2796,7 +2796,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rightmost edge of the subtree — see left."
         },
         {
           "name": "rotation",
@@ -2901,7 +2901,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Topmost edge of the subtree — see left."
         },
         {
           "name": "visible",
@@ -2943,7 +2943,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered width of the whole subtree, in the node's global-transform space. Unlike Sprite.width — which scales an unscaled texture frame — a container has no intrinsic local size, so this reads the aggregate bounds directly. Those are already scaled, so multiplying by scale again would count it twice. Writing rescales scale.x to make the subtree render at the requested width."
         },
         {
           "name": "x",

--- a/site/src/content/api/gamepad-axis.json
+++ b/site/src/content/api/gamepad-axis.json
@@ -1,6 +1,6 @@
 {
   "title": "GamepadAxis",
-  "description": "Single mappable analog axis on a physical gamepad. Holds the raw browser `Gamepad.axes[]` index, the canonical channel the value is written to, and the transform pipeline applied each frame by transformValue. Direction-split axis channels (e.g. `LeftStickLeft`, `LeftStickRight`) live in the 0..1 range — set `invert: true` on the negative half so it reads positive when pushed in its direction. Aggregate channels (e.g. `LeftStickX`, `LeftStickY`) live in the full -1..1 range — set `bipolar: true` to preserve sign through the pipeline. The static namespace exports (`GamepadAxis.LeftStickLeft`, `.LeftStickX`, ...) carry the canonical channel offsets used to address each axis.",
+  "description": "Single mappable analog axis on a physical gamepad. Holds the raw browser `Gamepad.axes[]` index, the canonical channel the value is written to, and the transform pipeline applied each frame by transformValue. Direction-split axis channels (e.g. `LeftStickLeft`, `LeftStickRight`) live in the 0..1 range — set `invert: true` on the negative half so it reads positive when pushed in its direction. Aggregate channels (e.g. `LeftStickX`, `LeftStickY`) live in the full -1..1 range — set `bipolar: true` to preserve sign through the pipeline. The static namespace exports (`GamepadAxis.LeftStickLeft`, `.LeftStickX`, ...) carry the canonical channel offsets used to address each axis. `channel` can also target a GamepadButtonChannel — some devices report an inherently analog, button-shaped control (a trigger) through the raw `axes[]` array rather than `buttons[]`; routing such an axis at the canonical trigger channel keeps app code that binds `GamepadButton.LeftTrigger`/`RightTrigger` portable across devices regardless of which raw array the hardware happens to report through.",
   "symbol": "GamepadAxis",
   "kind": "class",
   "subsystem": "input",
@@ -22,7 +22,7 @@
         "Single mappable analog axis on a physical gamepad. Holds the raw browser `Gamepad.axes[]` index, the canonical channel the value is written to, and the transform pipeline applied each frame by transformValue.",
         "Direction-split axis channels (e.g. `LeftStickLeft`, `LeftStickRight`) live in the 0..1 range — set `invert: true` on the negative half so it reads positive when pushed in its direction.",
         "Aggregate channels (e.g. `LeftStickX`, `LeftStickY`) live in the full -1..1 range — set `bipolar: true` to preserve sign through the pipeline.",
-        "The static namespace exports (`GamepadAxis.LeftStickLeft`, `.LeftStickX`, ...) carry the canonical channel offsets used to address each axis."
+        "The static namespace exports (`GamepadAxis.LeftStickLeft`, `.LeftStickX`, ...) carry the canonical channel offsets used to address each axis. `channel` can also target a GamepadButtonChannel — some devices report an inherently analog, button-shaped control (a trigger) through the raw `axes[]` array rather than `buttons[]`; routing such an axis at the canonical trigger channel keeps app code that binds `GamepadButton.LeftTrigger`/`RightTrigger` portable across devices regardless of which raw array the hardware happens to report through."
       ],
       "importLine": "import { GamepadAxis } from '@codexo/exojs'",
       "sourceLink": null
@@ -33,7 +33,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(index: number, channel: GamepadAxisChannel, options: GamepadAxisOptions): GamepadAxis",
+          "signature": "new(index: number, channel: GamepadButtonChannel | GamepadAxisChannel, options: GamepadAxisOptions): GamepadAxis",
           "signatureTokens": [
             {
               "text": "new",
@@ -65,6 +65,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadButtonChannel",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
               "kind": "punctuation"
             },
             {
@@ -108,7 +116,7 @@
             },
             {
               "name": "channel",
-              "type": "GamepadAxisChannel",
+              "type": "GamepadButtonChannel | GamepadAxisChannel",
               "optional": false
             },
             {
@@ -208,7 +216,7 @@
         },
         {
           "name": "channel",
-          "signature": "channel: GamepadAxisChannel",
+          "signature": "channel: GamepadButtonChannel | GamepadAxisChannel",
           "signatureTokens": [
             {
               "text": "channel",
@@ -216,6 +224,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadButtonChannel",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
               "kind": "punctuation"
             },
             {

--- a/site/src/content/api/graphics.json
+++ b/site/src/content/api/graphics.json
@@ -3873,7 +3873,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Bottommost edge of the subtree — see left."
         },
         {
           "name": "cacheAsBitmap",
@@ -4181,7 +4181,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered height of the whole subtree — see width."
         },
         {
           "name": "interactive",
@@ -4244,7 +4244,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Leftmost edge of the subtree in the node's global-transform space. These four edges are read straight off the aggregate bounds so they always span exactly width/height and agree with each other. They cannot be reconstructed from position and origin: origin is in local pixels and a container's own local bounds are empty, so the rendered extent comes entirely from the children."
         },
         {
           "name": "lineColor",
@@ -4420,7 +4420,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rightmost edge of the subtree — see left."
         },
         {
           "name": "rotation",
@@ -4554,7 +4554,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Topmost edge of the subtree — see left."
         },
         {
           "name": "visible",
@@ -4596,7 +4596,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered width of the whole subtree, in the node's global-transform space. Unlike Sprite.width — which scales an unscaled texture frame — a container has no intrinsic local size, so this reads the aggregate bounds directly. Those are already scaled, so multiplying by scale again would count it twice. Writing rescales scale.x to make the subtree render at the requested width."
         },
         {
           "name": "x",

--- a/site/src/content/api/graphics.json
+++ b/site/src/content/api/graphics.json
@@ -880,7 +880,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Destroy this container and every node beneath it. Ownership is by containment: detaching a subtree only unlinks it, so the descendants' GPU-backed resources (cached bitmaps, filters, render textures) and signal listeners would outlive the tree that owned them and leak on every scene change."
         },
         {
           "name": "drawArc",

--- a/site/src/content/api/htmltext.json
+++ b/site/src/content/api/htmltext.json
@@ -700,7 +700,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Destroy this container and every node beneath it. Ownership is by containment: detaching a subtree only unlinks it, so the descendants' GPU-backed resources (cached bitmaps, filters, render textures) and signal listeners would outlive the tree that owned them and leak on every scene change."
         },
         {
           "name": "focus",

--- a/site/src/content/api/htmltext.json
+++ b/site/src/content/api/htmltext.json
@@ -2606,7 +2606,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Bottommost edge of the subtree — see left."
         },
         {
           "name": "cacheAsBitmap",
@@ -2864,7 +2864,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered height of the whole subtree — see width."
         },
         {
           "name": "html",
@@ -2948,7 +2948,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Leftmost edge of the subtree in the node's global-transform space. These four edges are read straight off the aggregate bounds so they always span exactly width/height and agree with each other. They cannot be reconstructed from position and origin: origin is in local pixels and a container's own local bounds are empty, so the rendered extent comes entirely from the children."
         },
         {
           "name": "mask",
@@ -3136,7 +3136,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rightmost edge of the subtree — see left."
         },
         {
           "name": "rotation",
@@ -3241,7 +3241,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Topmost edge of the subtree — see left."
         },
         {
           "name": "visible",
@@ -3283,7 +3283,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered width of the whole subtree, in the node's global-transform space. Unlike Sprite.width — which scales an unscaled texture frame — a container has no intrinsic local size, so this reads the aggregate bounds directly. Those are already scaled, so multiplying by scale again would count it twice. Writing rescales scale.x to make the subtree render at the requested width."
         },
         {
           "name": "x",

--- a/site/src/content/api/image-layer-node.json
+++ b/site/src/content/api/image-layer-node.json
@@ -2381,7 +2381,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Bottommost edge of the subtree — see left."
         },
         {
           "name": "cacheAsBitmap",
@@ -2618,7 +2618,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered height of the whole subtree — see width."
         },
         {
           "name": "interactive",
@@ -2702,7 +2702,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Leftmost edge of the subtree in the node's global-transform space. These four edges are read straight off the aggregate bounds so they always span exactly width/height and agree with each other. They cannot be reconstructed from position and origin: origin is in local pixels and a container's own local bounds are empty, so the rendered extent comes entirely from the children."
         },
         {
           "name": "mask",
@@ -2857,7 +2857,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rightmost edge of the subtree — see left."
         },
         {
           "name": "rotation",
@@ -2962,7 +2962,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Topmost edge of the subtree — see left."
         },
         {
           "name": "visible",
@@ -3004,7 +3004,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered width of the whole subtree, in the node's global-transform space. Unlike Sprite.width — which scales an unscaled texture frame — a container has no intrinsic local size, so this reads the aggregate bounds directly. Those are already scaled, so multiplying by scale again would count it twice. Writing rescales scale.x to make the subtree render at the requested width."
         },
         {
           "name": "x",

--- a/site/src/content/api/image-layer-node.json
+++ b/site/src/content/api/image-layer-node.json
@@ -590,7 +590,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Destroy this container and every node beneath it. Ownership is by containment: detaching a subtree only unlinks it, so the descendants' GPU-backed resources (cached bitmaps, filters, render textures) and signal listeners would outlive the tree that owned them and leak on every scene change."
         },
         {
           "name": "focus",

--- a/site/src/content/api/label.json
+++ b/site/src/content/api/label.json
@@ -861,7 +861,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Destroy this container and every node beneath it. Ownership is by containment: detaching a subtree only unlinks it, so the descendants' GPU-backed resources (cached bitmaps, filters, render textures) and signal listeners would outlive the tree that owned them and leak on every scene change."
         },
         {
           "name": "focus",

--- a/site/src/content/api/label.json
+++ b/site/src/content/api/label.json
@@ -2720,7 +2720,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Bottommost edge of the subtree — see left."
         },
         {
           "name": "cacheAsBitmap",
@@ -2978,7 +2978,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered height of the whole subtree — see width."
         },
         {
           "name": "interactive",
@@ -3041,7 +3041,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Leftmost edge of the subtree in the node's global-transform space. These four edges are read straight off the aggregate bounds so they always span exactly width/height and agree with each other. They cannot be reconstructed from position and origin: origin is in local pixels and a container's own local bounds are empty, so the rendered extent comes entirely from the children."
         },
         {
           "name": "mask",
@@ -3175,7 +3175,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rightmost edge of the subtree — see left."
         },
         {
           "name": "rotation",
@@ -3322,7 +3322,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Topmost edge of the subtree — see left."
         },
         {
           "name": "uiHeight",
@@ -3406,7 +3406,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered width of the whole subtree, in the node's global-transform space. Unlike Sprite.width — which scales an unscaled texture frame — a container has no intrinsic local size, so this reads the aggregate bounds directly. Those are already scaled, so multiplying by scale again would count it twice. Writing rescales scale.x to make the subtree render at the requested width."
         },
         {
           "name": "x",

--- a/site/src/content/api/layout-options.json
+++ b/site/src/content/api/layout-options.json
@@ -84,7 +84,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Text direction. Defaults to 'ltr'. RTL is not fully implemented."
+          "description": "Text direction. Defaults to 'ltr'. 'rtl' reverses each line's glyphs visually after wrapping, which is correct for uniformly right-to-left text. Full bidi (mixed LTR/RTL runs), Arabic contextual shaping, and direction-relative alignment are not implemented — align stays literal in both directions."
         },
         {
           "name": "letterSpacing",
@@ -134,7 +134,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Clip boundary in pixels. Text beyond this height is clipped or ellipsized."
+          "description": "Vertical boundary in pixels. Only whole lines that fit within it are kept. Has no effect on its own — pair it with an overflow policy."
         },
         {
           "name": "maxWidth",
@@ -200,7 +200,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "What to do when text overflows maxHeight. Defaults to 'visible'."
+          "description": "What to do with lines that do not fit maxHeight. Defaults to 'visible'. - 'visible' — Keep every line; maxHeight is ignored. - 'clip' — Drop the lines that do not fit. - 'ellipsis' — Drop them and mark the last visible line with …, shortening it so it still fits maxWidth when one is set."
         },
         {
           "name": "whiteSpace",

--- a/site/src/content/api/panel.json
+++ b/site/src/content/api/panel.json
@@ -2762,7 +2762,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Bottommost edge of the subtree — see left."
         },
         {
           "name": "cacheAsBitmap",
@@ -3062,7 +3062,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered height of the whole subtree — see width."
         },
         {
           "name": "interactive",
@@ -3125,7 +3125,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Leftmost edge of the subtree in the node's global-transform space. These four edges are read straight off the aggregate bounds so they always span exactly width/height and agree with each other. They cannot be reconstructed from position and origin: origin is in local pixels and a container's own local bounds are empty, so the rendered extent comes entirely from the children."
         },
         {
           "name": "mask",
@@ -3259,7 +3259,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rightmost edge of the subtree — see left."
         },
         {
           "name": "rotation",
@@ -3364,7 +3364,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Topmost edge of the subtree — see left."
         },
         {
           "name": "uiHeight",
@@ -3448,7 +3448,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered width of the whole subtree, in the node's global-transform space. Unlike Sprite.width — which scales an unscaled texture frame — a container has no intrinsic local size, so this reads the aggregate bounds directly. Those are already scaled, so multiplying by scale again would count it twice. Writing rescales scale.x to make the subtree render at the requested width."
         },
         {
           "name": "x",

--- a/site/src/content/api/panel.json
+++ b/site/src/content/api/panel.json
@@ -840,7 +840,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Destroy this container and every node beneath it. Ownership is by containment: detaching a subtree only unlinks it, so the descendants' GPU-backed resources (cached bitmaps, filters, render textures) and signal listeners would outlive the tree that owned them and leak on every scene change."
         },
         {
           "name": "focus",

--- a/site/src/content/api/particles-extension-options.json
+++ b/site/src/content/api/particles-extension-options.json
@@ -51,7 +51,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "WebGL2 particle renderer batch size. Default: 8192."
+          "description": "Particles the WebGL2 renderer's instance buffer is pre-sized for. Defaults to 8192. This is a starting allocation, not a limit: a system with more live particles grows the buffer instead of dropping the surplus, so raise it only to avoid the initial growth steps for a known-large system."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/physics-world.json
+++ b/site/src/content/api/physics-world.json
@@ -466,7 +466,7 @@
             }
           ],
           "returnType": "void",
-          "description": "Destroy a body and its colliders. Deferred when called inside a callback."
+          "description": "Destroy a body and its colliders. Every dynamic body touching it is woken, so anything that was resting on the destroyed body falls once its support is gone. Deferred when called inside a callback."
         },
         {
           "name": "destroyCollider",
@@ -513,7 +513,7 @@
             }
           ],
           "returnType": "void",
-          "description": "Destroy a single collider, recomputing its body's mass. Deferred when called inside a callback."
+          "description": "Destroy a single collider, recomputing its body's mass. Wakes every dynamic body touching it, the same way destroyBody does. Deferred when called inside a callback."
         },
         {
           "name": "fixedUpdate",

--- a/site/src/content/api/progress-bar.json
+++ b/site/src/content/api/progress-bar.json
@@ -840,7 +840,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Destroy this container and every node beneath it. Ownership is by containment: detaching a subtree only unlinks it, so the descendants' GPU-backed resources (cached bitmaps, filters, render textures) and signal listeners would outlive the tree that owned them and leak on every scene change."
         },
         {
           "name": "focus",

--- a/site/src/content/api/progress-bar.json
+++ b/site/src/content/api/progress-bar.json
@@ -2699,7 +2699,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Bottommost edge of the subtree — see left."
         },
         {
           "name": "cacheAsBitmap",
@@ -2999,7 +2999,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered height of the whole subtree — see width."
         },
         {
           "name": "interactive",
@@ -3062,7 +3062,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Leftmost edge of the subtree in the node's global-transform space. These four edges are read straight off the aggregate bounds so they always span exactly width/height and agree with each other. They cannot be reconstructed from position and origin: origin is in local pixels and a container's own local bounds are empty, so the rendered extent comes entirely from the children."
         },
         {
           "name": "mask",
@@ -3196,7 +3196,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rightmost edge of the subtree — see left."
         },
         {
           "name": "rotation",
@@ -3301,7 +3301,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Topmost edge of the subtree — see left."
         },
         {
           "name": "trackColor",
@@ -3427,7 +3427,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered width of the whole subtree, in the node's global-transform space. Unlike Sprite.width — which scales an unscaled texture frame — a container has no intrinsic local size, so this reads the aggregate bounds directly. Those are already scaled, so multiplying by scale again would count it twice. Writing rescales scale.x to make the subtree render at the requested width."
         },
         {
           "name": "x",

--- a/site/src/content/api/render-target.json
+++ b/site/src/content/api/render-target.json
@@ -1,6 +1,6 @@
 {
   "title": "RenderTarget",
-  "description": "Renderable destination — either the on-screen canvas (the `root` target owned by the backend) or an offscreen texture (a RenderTexture). Owns a View that controls the camera transform and viewport, and emits a destroy event so backends can release backing GPU resources. Set `view` to swap cameras for this target; call `resize(w, h)` when the underlying canvas / texture dimensions change.",
+  "description": "Renderable destination — either the on-screen canvas (the `root` target owned by the backend) or an offscreen texture (a RenderTexture). Owns a default View that controls the camera transform and viewport, and emits a destroy event so backends can release backing GPU resources. Set `view` to swap cameras for this target; call `resize(w, h)` when the underlying canvas / texture dimensions change. An assigned view is caller-owned: swapping it out or destroying the target leaves it alive, so destroy the views you create yourself.",
   "symbol": "RenderTarget",
   "kind": "class",
   "subsystem": "rendering",
@@ -19,8 +19,8 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "Renderable destination — either the on-screen canvas (the `root` target owned by the backend) or an offscreen texture (a RenderTexture). Owns a View that controls the camera transform and viewport, and emits a destroy event so backends can release backing GPU resources.",
-        "Set `view` to swap cameras for this target; call `resize(w, h)` when the underlying canvas / texture dimensions change."
+        "Renderable destination — either the on-screen canvas (the `root` target owned by the backend) or an offscreen texture (a RenderTexture). Owns a default View that controls the camera transform and viewport, and emits a destroy event so backends can release backing GPU resources.",
+        "Set `view` to swap cameras for this target; call `resize(w, h)` when the underlying canvas / texture dimensions change. An assigned view is caller-owned: swapping it out or destroying the target leaves it alive, so destroy the views you create yourself."
       ],
       "importLine": "import { RenderTarget } from '@codexo/exojs'",
       "sourceLink": null
@@ -599,7 +599,7 @@
             }
           ],
           "returnType": "this",
-          "description": ""
+          "description": "Point this target at view, or back at its own default view when passed null. The view is caller-owned — neither this call nor destroy releases it."
         },
         {
           "name": "updateViewport",

--- a/site/src/content/api/render-texture.json
+++ b/site/src/content/api/render-texture.json
@@ -833,7 +833,7 @@
             }
           ],
           "returnType": "this",
-          "description": ""
+          "description": "Point this target at view, or back at its own default view when passed null. The view is caller-owned — neither this call nor destroy releases it."
         },
         {
           "name": "setWrapMode",

--- a/site/src/content/api/rendering-context.json
+++ b/site/src/content/api/rendering-context.json
@@ -840,7 +840,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "The active world View — the default for render. Defaults to a view matching the initial backend view. Replace with a custom View for follow, zoom, bounds, or split-screen viewport behavior."
+          "description": "The active world View — the default for render. Defaults to a view matching the initial backend view. Replace with a custom View for follow, zoom, bounds, or split-screen viewport behavior. An assigned view is caller-owned, the same contract as trackView: assigning a replacement never destroys the outgoing one, so a view can be swapped out and back (per scene, per split-screen mode) and stays valid in between. Destroy the views you create once you are done with them; the context only releases the default camera it created for itself and screenView."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/retained-container.json
+++ b/site/src/content/api/retained-container.json
@@ -2438,7 +2438,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Bottommost edge of the subtree — see left."
         },
         {
           "name": "cacheAsBitmap",
@@ -2675,7 +2675,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered height of the whole subtree — see width."
         },
         {
           "name": "interactive",
@@ -2738,7 +2738,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Leftmost edge of the subtree in the node's global-transform space. These four edges are read straight off the aggregate bounds so they always span exactly width/height and agree with each other. They cannot be reconstructed from position and origin: origin is in local pixels and a container's own local bounds are empty, so the rendered extent comes entirely from the children."
         },
         {
           "name": "mask",
@@ -2872,7 +2872,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rightmost edge of the subtree — see left."
         },
         {
           "name": "rotation",
@@ -2977,7 +2977,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Topmost edge of the subtree — see left."
         },
         {
           "name": "visible",
@@ -3019,7 +3019,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered width of the whole subtree, in the node's global-transform space. Unlike Sprite.width — which scales an unscaled texture frame — a container has no intrinsic local size, so this reads the aggregate bounds directly. Those are already scaled, so multiplying by scale again would count it twice. Writing rescales scale.x to make the subtree render at the requested width."
         },
         {
           "name": "x",

--- a/site/src/content/api/scroll-container.json
+++ b/site/src/content/api/scroll-container.json
@@ -842,7 +842,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Destroy this container and every node beneath it. Ownership is by containment: detaching a subtree only unlinks it, so the descendants' GPU-backed resources (cached bitmaps, filters, render textures) and signal listeners would outlive the tree that owned them and leak on every scene change."
         },
         {
           "name": "focus",

--- a/site/src/content/api/scroll-container.json
+++ b/site/src/content/api/scroll-container.json
@@ -2858,7 +2858,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Bottommost edge of the subtree — see left."
         },
         {
           "name": "cacheAsBitmap",
@@ -3116,7 +3116,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered height of the whole subtree — see width."
         },
         {
           "name": "interactive",
@@ -3179,7 +3179,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Leftmost edge of the subtree in the node's global-transform space. These four edges are read straight off the aggregate bounds so they always span exactly width/height and agree with each other. They cannot be reconstructed from position and origin: origin is in local pixels and a container's own local bounds are empty, so the rendered extent comes entirely from the children."
         },
         {
           "name": "mask",
@@ -3313,7 +3313,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rightmost edge of the subtree — see left."
         },
         {
           "name": "rotation",
@@ -3460,7 +3460,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Topmost edge of the subtree — see left."
         },
         {
           "name": "uiHeight",
@@ -3544,7 +3544,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered width of the whole subtree, in the node's global-transform space. Unlike Sprite.width — which scales an unscaled texture frame — a container has no intrinsic local size, so this reads the aggregate bounds directly. Those are already scaled, so multiplying by scale again would count it twice. Writing rescales scale.x to make the subtree render at the requested width."
         },
         {
           "name": "x",

--- a/site/src/content/api/sound.json
+++ b/site/src/content/api/sound.json
@@ -118,7 +118,7 @@
       "members": [
         {
           "name": "_createVoice",
-          "signature": "_createVoice(manager: AudioManager, options: PlayOptions): Voice",
+          "signature": "_createVoice(manager: AudioManager, options: SoundPlayOptions): Voice",
           "signatureTokens": [
             {
               "text": "_createVoice",
@@ -153,7 +153,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "PlayOptions",
+              "text": "SoundPlayOptions",
               "kind": "type"
             },
             {
@@ -177,7 +177,7 @@
             },
             {
               "name": "options",
-              "type": "PlayOptions",
+              "type": "SoundPlayOptions",
               "optional": false
             }
           ],

--- a/site/src/content/api/stack.json
+++ b/site/src/content/api/stack.json
@@ -887,7 +887,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Destroy this container and every node beneath it. Ownership is by containment: detaching a subtree only unlinks it, so the descendants' GPU-backed resources (cached bitmaps, filters, render textures) and signal listeners would outlive the tree that owned them and leak on every scene change."
         },
         {
           "name": "focus",

--- a/site/src/content/api/stack.json
+++ b/site/src/content/api/stack.json
@@ -2775,7 +2775,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Bottommost edge of the subtree — see left."
         },
         {
           "name": "cacheAsBitmap",
@@ -3054,7 +3054,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered height of the whole subtree — see width."
         },
         {
           "name": "interactive",
@@ -3117,7 +3117,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Leftmost edge of the subtree in the node's global-transform space. These four edges are read straight off the aggregate bounds so they always span exactly width/height and agree with each other. They cannot be reconstructed from position and origin: origin is in local pixels and a container's own local bounds are empty, so the rendered extent comes entirely from the children."
         },
         {
           "name": "mask",
@@ -3272,7 +3272,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rightmost edge of the subtree — see left."
         },
         {
           "name": "rotation",
@@ -3398,7 +3398,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Topmost edge of the subtree — see left."
         },
         {
           "name": "uiHeight",
@@ -3482,7 +3482,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered width of the whole subtree, in the node's global-transform space. Unlike Sprite.width — which scales an unscaled texture frame — a container has no intrinsic local size, so this reads the aggregate bounds directly. Those are already scaled, so multiplying by scale again would count it twice. Writing rescales scale.x to make the subtree render at the requested width."
         },
         {
           "name": "x",

--- a/site/src/content/api/text-options.json
+++ b/site/src/content/api/text-options.json
@@ -135,7 +135,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Text direction. Defaults to 'ltr'. RTL is not fully implemented."
+          "description": "Text direction. Defaults to 'ltr'. 'rtl' reverses each line's glyphs visually after wrapping, which is correct for uniformly right-to-left text. Full bidi (mixed LTR/RTL runs), Arabic contextual shaping, and direction-relative alignment are not implemented — align stays literal in both directions."
         },
         {
           "name": "fillColor",
@@ -467,7 +467,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Clip boundary in pixels. Text beyond this height is clipped or ellipsized."
+          "description": "Vertical boundary in pixels. Only whole lines that fit within it are kept. Has no effect on its own — pair it with an overflow policy."
         },
         {
           "name": "maxWidth",
@@ -583,7 +583,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "What to do when text overflows maxHeight. Defaults to 'visible'."
+          "description": "What to do with lines that do not fit maxHeight. Defaults to 'visible'. - 'visible' — Keep every line; maxHeight is ignored. - 'clip' — Drop the lines that do not fit. - 'ellipsis' — Drop them and mark the last visible line with …, shortening it so it still fits maxWidth when one is set."
         },
         {
           "name": "sdfRadius",

--- a/site/src/content/api/tile-layer-node.json
+++ b/site/src/content/api/tile-layer-node.json
@@ -615,7 +615,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Destroy this container and every node beneath it. Ownership is by containment: detaching a subtree only unlinks it, so the descendants' GPU-backed resources (cached bitmaps, filters, render textures) and signal listeners would outlive the tree that owned them and leak on every scene change."
         },
         {
           "name": "focus",

--- a/site/src/content/api/tile-layer-node.json
+++ b/site/src/content/api/tile-layer-node.json
@@ -2435,7 +2435,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Bottommost edge of the subtree — see left."
         },
         {
           "name": "cacheAsBitmap",
@@ -2672,7 +2672,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered height of the whole subtree — see width."
         },
         {
           "name": "interactive",
@@ -2756,7 +2756,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Leftmost edge of the subtree in the node's global-transform space. These four edges are read straight off the aggregate bounds so they always span exactly width/height and agree with each other. They cannot be reconstructed from position and origin: origin is in local pixels and a container's own local bounds are empty, so the rendered extent comes entirely from the children."
         },
         {
           "name": "mask",
@@ -2911,7 +2911,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rightmost edge of the subtree — see left."
         },
         {
           "name": "rotation",
@@ -3016,7 +3016,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Topmost edge of the subtree — see left."
         },
         {
           "name": "visible",
@@ -3058,7 +3058,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered width of the whole subtree, in the node's global-transform space. Unlike Sprite.width — which scales an unscaled texture frame — a container has no intrinsic local size, so this reads the aggregate bounds directly. Those are already scaled, so multiplying by scale again would count it twice. Writing rescales scale.x to make the subtree render at the requested width."
         },
         {
           "name": "x",

--- a/site/src/content/api/tile-map-band.json
+++ b/site/src/content/api/tile-map-band.json
@@ -2382,7 +2382,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Bottommost edge of the subtree — see left."
         },
         {
           "name": "cacheAsBitmap",
@@ -2619,7 +2619,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered height of the whole subtree — see width."
         },
         {
           "name": "interactive",
@@ -2744,7 +2744,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Leftmost edge of the subtree in the node's global-transform space. These four edges are read straight off the aggregate bounds so they always span exactly width/height and agree with each other. They cannot be reconstructed from position and origin: origin is in local pixels and a container's own local bounds are empty, so the rendered extent comes entirely from the children."
         },
         {
           "name": "mask",
@@ -2878,7 +2878,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rightmost edge of the subtree — see left."
         },
         {
           "name": "rotation",
@@ -2983,7 +2983,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Topmost edge of the subtree — see left."
         },
         {
           "name": "visible",
@@ -3025,7 +3025,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered width of the whole subtree, in the node's global-transform space. Unlike Sprite.width — which scales an unscaled texture frame — a container has no intrinsic local size, so this reads the aggregate bounds directly. Those are already scaled, so multiplying by scale again would count it twice. Writing rescales scale.x to make the subtree render at the requested width."
         },
         {
           "name": "x",

--- a/site/src/content/api/tile-map-node.json
+++ b/site/src/content/api/tile-map-node.json
@@ -2497,7 +2497,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Bottommost edge of the subtree — see left."
         },
         {
           "name": "cacheAsBitmap",
@@ -2734,7 +2734,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered height of the whole subtree — see width."
         },
         {
           "name": "interactive",
@@ -2838,7 +2838,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Leftmost edge of the subtree in the node's global-transform space. These four edges are read straight off the aggregate bounds so they always span exactly width/height and agree with each other. They cannot be reconstructed from position and origin: origin is in local pixels and a container's own local bounds are empty, so the rendered extent comes entirely from the children."
         },
         {
           "name": "map",
@@ -3014,7 +3014,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rightmost edge of the subtree — see left."
         },
         {
           "name": "rotation",
@@ -3119,7 +3119,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Topmost edge of the subtree — see left."
         },
         {
           "name": "visible",
@@ -3161,7 +3161,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered width of the whole subtree, in the node's global-transform space. Unlike Sprite.width — which scales an unscaled texture frame — a container has no intrinsic local size, so this reads the aggregate bounds directly. Those are already scaled, so multiplying by scale again would count it twice. Writing rescales scale.x to make the subtree render at the requested width."
         },
         {
           "name": "x",

--- a/site/src/content/api/tile-map-node.json
+++ b/site/src/content/api/tile-map-node.json
@@ -614,7 +614,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Destroy this container and every node beneath it. Ownership is by containment: detaching a subtree only unlinks it, so the descendants' GPU-backed resources (cached bitmaps, filters, render textures) and signal listeners would outlive the tree that owned them and leak on every scene change."
         },
         {
           "name": "focus",

--- a/site/src/content/api/uiroot.json
+++ b/site/src/content/api/uiroot.json
@@ -570,7 +570,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Destroy this container and every node beneath it. Ownership is by containment: detaching a subtree only unlinks it, so the descendants' GPU-backed resources (cached bitmaps, filters, render textures) and signal listeners would outlive the tree that owned them and leak on every scene change."
         },
         {
           "name": "focus",

--- a/site/src/content/api/uiroot.json
+++ b/site/src/content/api/uiroot.json
@@ -2361,7 +2361,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Bottommost edge of the subtree — see left."
         },
         {
           "name": "cacheAsBitmap",
@@ -2598,7 +2598,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered height of the whole subtree — see width."
         },
         {
           "name": "interactive",
@@ -2661,7 +2661,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Leftmost edge of the subtree in the node's global-transform space. These four edges are read straight off the aggregate bounds so they always span exactly width/height and agree with each other. They cannot be reconstructed from position and origin: origin is in local pixels and a container's own local bounds are empty, so the rendered extent comes entirely from the children."
         },
         {
           "name": "mask",
@@ -2795,7 +2795,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rightmost edge of the subtree — see left."
         },
         {
           "name": "rotation",
@@ -2942,7 +2942,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Topmost edge of the subtree — see left."
         },
         {
           "name": "visible",
@@ -2984,7 +2984,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered width of the whole subtree, in the node's global-transform space. Unlike Sprite.width — which scales an unscaled texture frame — a container has no intrinsic local size, so this reads the aggregate bounds directly. Those are already scaled, so multiplying by scale again would count it twice. Writing rescales scale.x to make the subtree render at the requested width."
         },
         {
           "name": "x",

--- a/site/src/content/api/view.json
+++ b/site/src/content/api/view.json
@@ -6,11 +6,11 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 38,
+  "memberCount": 39,
   "counts": {
     "constructors": 1,
     "methods": 29,
-    "properties": 8,
+    "properties": 9,
     "events": 0
   },
   "sections": [
@@ -233,7 +233,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Release the math objects this view owns. Idempotent — the same view can be reachable from more than one owner (a RenderTarget it was assigned to as well as the code that created it), so a second call must not take _center, _size, _viewport and the cached matrices through a second teardown."
         },
         {
           "name": "follow",
@@ -1806,6 +1806,27 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once destroy has run. A destroyed view keeps its last computed transform but no longer reacts to mutations — its center stops marking the transform stale — so it must not be put back into use."
         },
         {
           "name": "height",

--- a/site/src/content/api/widget.json
+++ b/site/src/content/api/widget.json
@@ -823,7 +823,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Destroy this container and every node beneath it. Ownership is by containment: detaching a subtree only unlinks it, so the descendants' GPU-backed resources (cached bitmaps, filters, render textures) and signal listeners would outlive the tree that owned them and leak on every scene change."
         },
         {
           "name": "focus",

--- a/site/src/content/api/widget.json
+++ b/site/src/content/api/widget.json
@@ -2682,7 +2682,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Bottommost edge of the subtree — see left."
         },
         {
           "name": "cacheAsBitmap",
@@ -2940,7 +2940,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered height of the whole subtree — see width."
         },
         {
           "name": "interactive",
@@ -3003,7 +3003,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Leftmost edge of the subtree in the node's global-transform space. These four edges are read straight off the aggregate bounds so they always span exactly width/height and agree with each other. They cannot be reconstructed from position and origin: origin is in local pixels and a container's own local bounds are empty, so the rendered extent comes entirely from the children."
         },
         {
           "name": "mask",
@@ -3137,7 +3137,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rightmost edge of the subtree — see left."
         },
         {
           "name": "rotation",
@@ -3242,7 +3242,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Topmost edge of the subtree — see left."
         },
         {
           "name": "uiHeight",
@@ -3326,7 +3326,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Rendered width of the whole subtree, in the node's global-transform space. Unlike Sprite.width — which scales an unscaled texture frame — a container has no intrinsic local size, so this reads the aggregate bounds directly. Those are already scaled, so multiplying by scale again would count it twice. Writing rescales scale.x to make the subtree render at the requested width."
         },
         {
           "name": "x",

--- a/site/src/content/guide/debugging/backend-comparison.mdx
+++ b/site/src/content/guide/debugging/backend-comparison.mdx
@@ -52,6 +52,10 @@ Chromium is measured on every CI run. Firefox and Safari need a machine with a d
 `pnpm test:parity` runs the matrix on Chromium, `test:parity:firefox` and `test:parity:safari` on the others. Each run rewrites only the rows for the browser it exercised.
 </Callout>
 
+<Callout type="broken" title="WebGPU isn't reliable on Safari yet">
+The Safari column above shows it — `auto` already keeps Safari on WebGL2 for this reason. Stick with WebGL2 there rather than pinning `backend: { type: 'webgpu' }` for production use.
+</Callout>
+
 ### Known differences
 
 Where differences exist, they are performance characteristics or rendering-path specifics, not API gaps:

--- a/src/assets/seamless.ts
+++ b/src/assets/seamless.ts
@@ -108,7 +108,11 @@ export const textureSeamlessAdapter: SeamlessAdapter<Texture> = {
 
   evict(handle: Texture): void {
     presizes.delete(handle);
-    handle.setSource(null); // frees the GPU upload via the version bump in updateSource()
+    // setSource(null) alone only bumps the version — a backend only notices
+    // on its next bind, which may never come for a handle nothing is
+    // currently drawing. releaseGpu() frees the backend's GPU texture now.
+    handle.setSource(null);
+    handle.releaseGpu();
     handle._loadState.begin();
   },
 

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -8,6 +8,7 @@ import { AudioListener } from './AudioListener';
 import type { SpatialVoice } from './BaseVoice';
 import { InputVoice } from './InputVoice';
 import type { Playable, PlayOptions, Voice } from './Playable';
+import type { Sound, SoundPlayOptions } from './Sound';
 import { createSpatialSmoothingSettings, type SpatialSmoothingSettings } from './spatial-smoothing';
 
 /**
@@ -116,6 +117,8 @@ export class AudioManager {
    * @param options - Per-play overrides (bus, volume, loop, playbackRate, detune, time, muted).
    * @returns A {@link Voice} handle for the new instance.
    */
+  public play(source: Sound, options?: SoundPlayOptions): Voice;
+  public play(source: Playable, options?: PlayOptions): Voice;
   public play(source: Playable, options?: PlayOptions): Voice {
     return source._createVoice(this, options ?? {});
   }

--- a/src/audio/Sound.ts
+++ b/src/audio/Sound.ts
@@ -351,7 +351,7 @@ export class Sound implements Playable {
    * Pool limits are enforced: if the pool is full the configured eviction
    * strategy picks a victim to stop before the new voice starts.
    */
-  public _createVoice(manager: AudioManager, options: PlayOptions): Voice {
+  public _createVoice(manager: AudioManager, options: SoundPlayOptions): Voice {
     const bus = options.bus ?? manager.sound;
     const notLoaded = this._notLoadedVoice(bus);
 
@@ -377,7 +377,7 @@ export class Sound implements Playable {
    * Create a voice for a named sprite clip.
    * @internal Used by managers that want sprite-level playback.
    */
-  public _createSpriteVoice(manager: AudioManager, name: string, options: PlayOptions = {}): Voice {
+  public _createSpriteVoice(manager: AudioManager, name: string, options: SoundPlayOptions = {}): Voice {
     const clip = this._sprites.get(name);
 
     if (!clip) {
@@ -436,7 +436,7 @@ export class Sound implements Playable {
    * pool limit, builds the {@link SoundVoice}, seeds spatialization from the
    * play-time options, and tracks the voice for eviction.
    */
-  private _buildVoice(manager: AudioManager, options: PlayOptions, offset: number, window: SoundVoiceWindow): Voice {
+  private _buildVoice(manager: AudioManager, options: SoundPlayOptions, offset: number, window: SoundVoiceWindow): Voice {
     // @internal invariant: the buffer is non-null here. Both `_createVoice` and
     // `_createSpriteVoice` route through `_notLoadedVoice` before reaching this
     // method, so a null buffer can no longer arrive through any real caller.
@@ -452,15 +452,22 @@ export class Sound implements Playable {
     const volume = clamp(options.muted ? 0 : (options.volume ?? (this.muted ? 0 : this.volume)), 0, 1);
     const bus = options.bus ?? manager.sound;
 
-    // Pool eviction: stop the victim voice if we're at capacity.
-    this._pruneEndedVoices();
+    if (options.replace === true) {
+      // Singleton-replace mode: every other active voice of this sound is
+      // stopped so the new one plays alone, bypassing pool eviction policy
+      // entirely (there is nothing left in the pool to evict against).
+      this._stopAllVoices();
+    } else {
+      // Pool eviction: stop the victim voice if we're at capacity.
+      this._pruneEndedVoices();
 
-    if (this._activeVoices.length >= this._poolSize) {
-      const victimIndex = this._pickEvictionVictim();
-      const victim = this._activeVoices[victimIndex];
-      if (victim) {
-        this._activeVoices.splice(victimIndex, 1);
-        victim.voice.stop();
+      if (this._activeVoices.length >= this._poolSize) {
+        const victimIndex = this._pickEvictionVictim();
+        const victim = this._activeVoices[victimIndex];
+        if (victim) {
+          this._activeVoices.splice(victimIndex, 1);
+          victim.voice.stop();
+        }
       }
     }
 

--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -384,8 +384,12 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
   public readonly onError = new Signal<[error: Error]>();
   public pauseOnHidden = false;
 
-  /** The engine's own `preUpdate` systems, owned here rather than by the registry. */
-  private readonly _coreSystems: readonly System[];
+  /**
+   * The engine's own `preUpdate` systems, owned here rather than by the
+   * registry. Reassigned when the backend fallback rebuilds one of them, so
+   * that teardown unregisters the instances that are actually registered.
+   */
+  private _coreSystems: readonly System[];
 
   private readonly _updateHandler: () => void;
   private readonly _startupClock: Clock = new Clock();
@@ -1495,13 +1499,18 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
       this._backendType = 'webgl2';
       this._backend = this.createBackend(this._backendType, this._snapshot);
 
-      // Swap in a rendering context bound to the rebuilt backend. The internal
-      // prepare stage reads `this._rendering` fresh every frame, so no
-      // registry bookkeeping is needed here.
+      // Swap in a rendering context bound to the rebuilt backend. Everything
+      // holding the outgoing context has to be repointed, not just the field:
+      // the registry drives the systems it was handed at registration time,
+      // so leaving the old entry in place would tick a destroyed context every
+      // frame and never the live one.
       const previousRendering = this._rendering;
 
+      this.systems._removeCoreSystem(previousRendering);
       previousRendering.destroy();
       this._rendering = new RenderingContext(this._backend);
+      this.systems._addCoreSystem(this._rendering, { order: SystemOrder.CoreRendering });
+      this._coreSystems = this._coreSystems.map(system => (system === previousRendering ? this._rendering : system));
 
       await this._backend.initialize();
     }

--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -935,6 +935,14 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
       // halts only after `maxConsecutiveFrameErrors` consecutive failures.
       try {
         const rawDeltaMs = this._frameClock.elapsedTime.milliseconds;
+
+        // Restart the moment the delta is read, not at the end of the frame:
+        // the clock has to span frame start to frame start. Restarting after
+        // the frame's own work would leave that work out of the next delta,
+        // so a frame that runs long would report the gap it caused as
+        // *shorter*, slowing the simulation exactly when it is already behind.
+        this._frameClock.restart();
+
         const clampedDeltaMs = Math.min(rawDeltaMs, maxDeltaMs);
         const frameDelta = Time.temp.set(clampedDeltaMs);
         const frameStart = performance.now();
@@ -1002,7 +1010,6 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
         // this is what keeps the canvas alive through a throwing frame.
         if (this._frameLoopActive) {
           this._frameRequest = this.platform.requestFrame(this._updateHandler);
-          this._frameClock.restart();
           this._frameCount++;
         }
       }

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -324,6 +324,12 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
     if (this._visible !== visible) {
       this._visible = visible;
       this._markStructureDirty();
+      // A container folds in only its VISIBLE children, so flipping this bit
+      // changes every ancestor's aggregate extent. Without the bounds cascade
+      // the cached ancestor rect survives the change: a re-shown subtree keeps
+      // the shrunken rect, the container fails the viewport intersection, and
+      // the whole subtree stops rendering even though it is visible again.
+      this._invalidateBoundsFlags();
     }
   }
 

--- a/src/input/GamepadAxis.ts
+++ b/src/input/GamepadAxis.ts
@@ -1,5 +1,6 @@
 import { clamp } from '#math/utils';
 
+import type { GamepadButtonChannel } from './GamepadButton';
 import { ChannelOffset } from './types';
 
 declare const gamepadAxisChannelBrand: unique symbol;
@@ -96,17 +97,22 @@ export interface GamepadAxisOptions {
  *
  * The static namespace exports (`GamepadAxis.LeftStickLeft`,
  * `.LeftStickX`, ...) carry the canonical channel offsets used to address
- * each axis.
+ * each axis. `channel` can also target a {@link GamepadButtonChannel} —
+ * some devices report an inherently analog, button-shaped control (a
+ * trigger) through the raw `axes[]` array rather than `buttons[]`; routing
+ * such an axis at the canonical trigger channel keeps app code that binds
+ * `GamepadButton.LeftTrigger`/`RightTrigger` portable across devices
+ * regardless of which raw array the hardware happens to report through.
  */
 export class GamepadAxis {
   public readonly index: number;
-  public readonly channel: GamepadAxisChannel;
+  public readonly channel: GamepadAxisChannel | GamepadButtonChannel;
   public readonly invert: boolean;
   public readonly normalize: boolean;
   public readonly threshold: number;
   public readonly bipolar: boolean;
 
-  public constructor(index: number, channel: GamepadAxisChannel, options: GamepadAxisOptions = {}) {
+  public constructor(index: number, channel: GamepadAxisChannel | GamepadButtonChannel, options: GamepadAxisOptions = {}) {
     this.index = index;
     this.channel = channel;
     this.invert = options.invert ?? false;

--- a/src/input/InputManager.ts
+++ b/src/input/InputManager.ts
@@ -23,6 +23,28 @@ import { ChannelOffset, ChannelSize, maxPointers, pointerSlotSize, resolveGamepa
 
 const gamepadSlots = 4;
 
+// Approximate pixel-equivalents for `WheelEvent.deltaMode` units other than
+// `DOM_DELTA_PIXEL`. Firefox defaults to `DOM_DELTA_LINE` while most other
+// browsers default to `DOM_DELTA_PIXEL`, so without this conversion the
+// same physical scroll gesture reports wildly different raw magnitudes
+// depending on the browser. Values are round approximations (a typical line
+// height / viewport size) rather than device-exact figures — the Gamepad
+// API and DOM wheel spec don't expose a precise conversion factor.
+const wheelLineHeightPx = 16;
+const wheelPageSizePx = 800;
+
+/** Convert a raw `WheelEvent` delta component to an approximate pixel-equivalent, based on its `deltaMode`. */
+function normalizeWheelDelta(delta: number, deltaMode: number): number {
+  switch (deltaMode) {
+    case 1: // WheelEvent.DOM_DELTA_LINE
+      return delta * wheelLineHeightPx;
+    case 2: // WheelEvent.DOM_DELTA_PAGE
+      return delta * wheelPageSizePx;
+    default: // WheelEvent.DOM_DELTA_PIXEL
+      return delta;
+  }
+}
+
 /**
  * Strategy used by {@link InputManager} when assigning physical gamepads to
  * slot indices in {@link InputManager.gamepads}.
@@ -1059,7 +1081,13 @@ export class InputManager {
       return;
     }
 
-    this.wheelOffset.set(event.deltaX, event.deltaY);
+    // Fast/high-precision scrolling routinely fires several `wheel` events
+    // within one engine frame — accumulate them here (mirroring the
+    // journal's accumulate-then-flush-per-frame pattern for other input
+    // signals) rather than overwriting, or all but the last sub-frame event
+    // would be silently lost. `updateEvents` resets this to zero once the
+    // accumulated total has been dispatched for the frame.
+    this.wheelOffset.add(normalizeWheelDelta(event.deltaX, event.deltaMode), normalizeWheelDelta(event.deltaY, event.deltaMode));
     this.flags.push(InputManagerFlag.MouseWheel);
 
     stopEvent(event);

--- a/src/input/SteamDeckGamepadMapping.ts
+++ b/src/input/SteamDeckGamepadMapping.ts
@@ -68,11 +68,18 @@ export class SteamDeckGamepadMapping extends GamepadMapping {
         new GamepadAxis(2, GamepadAxis.RightStickX, { bipolar: true }),
         new GamepadAxis(3, GamepadAxis.RightStickY, { bipolar: true }),
 
-        // Triggers as analog axes (Steam Deck reports them as a8/a9,
-        // not buttons). Browsers expose -1..+1; normalize to 0..1
-        // for the canonical trigger channels.
-        new GamepadAxis(8, GamepadAxis.AuxiliaryAxis0Positive, { normalize: true }),
-        new GamepadAxis(9, GamepadAxis.AuxiliaryAxis1Positive, { normalize: true }),
+        // Triggers as analog axes (Steam Deck reports them as a8/a9, not
+        // buttons 6/7 the way a W3C-standard-mapped device would — raw
+        // button index 8 is already claimed by RightShoulder above, so the
+        // pull amount can only arrive via axes[]). They still route to the
+        // SAME canonical GamepadButton.LeftTrigger/RightTrigger channels
+        // every other family's triggers use, so `new
+        // ButtonAction(GamepadButton.RightTrigger)` works uniformly
+        // regardless of which raw array a given controller reports
+        // through. Raw axes report -1..+1; normalize to 0..1 to match the
+        // other families' 0..1 trigger pull range.
+        new GamepadAxis(8, GamepadButton.RightTrigger, { normalize: true }),
+        new GamepadAxis(9, GamepadButton.LeftTrigger, { normalize: true }),
       ],
     );
   }

--- a/src/math/collision-detection.ts
+++ b/src/math/collision-detection.ts
@@ -765,6 +765,10 @@ const getCollisionEllipseEllipse = (ellipseA: Ellipse, ellipseB: Ellipse): Colli
  * Full SAT collision response for any two {@link Collidable} shapes. Tests all
  * edge normals from both shapes and computes the minimum-translation axis.
  * Returns `null` when they do not overlap.
+ *
+ * `projectionN` points from `shapeA` toward `shapeB` — the same orientation the
+ * shape-specific responses use — so moving `shapeB` by `projectionV`, or
+ * `shapeA` by its negation, pulls the pair apart.
  */
 const getCollisionSat = (shapeA: Collidable, shapeB: Collidable): CollisionResponse | null => {
   const normalsA = shapeA.getNormals();
@@ -776,6 +780,13 @@ const getCollisionSat = (shapeA: Collidable, shapeB: Collidable): CollisionRespo
   const projB = new Interval();
 
   let overlap = Infinity;
+  // Edge normals only describe an axis orientation, never a side: a shape hands
+  // out both `n` and `-n`, so the winning axis on its own cannot tell where
+  // shapeB sits and mirrored layouts collapse onto one direction — pushing one
+  // of the two pairs deeper instead of apart. Record whether the chosen axis has
+  // to be flipped to keep pointing from shapeA toward shapeB, deciding by
+  // projection midpoint (kept doubled as `min + max` to skip the halving).
+  let flipProjection = false;
   let shapeAinB = true;
   let shapeBinA = true;
   let containsA: boolean;
@@ -810,6 +821,7 @@ const getCollisionSat = (shapeA: Collidable, shapeB: Collidable): CollisionRespo
     if (distance < overlap) {
       overlap = distance;
       projection.copy(normal);
+      flipProjection = projA.min + projA.max > projB.min + projB.max;
     }
   }
 
@@ -841,7 +853,12 @@ const getCollisionSat = (shapeA: Collidable, shapeB: Collidable): CollisionRespo
     if (distance < overlap) {
       overlap = distance;
       projection.copy(normal);
+      flipProjection = projA.min + projA.max > projB.min + projB.max;
     }
+  }
+
+  if (flipProjection) {
+    projection.multiply(-1, -1);
   }
 
   const projectionV = projection.clone().multiply(overlap, overlap);

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -14,8 +14,8 @@ import { RenderNode } from './RenderNode';
  *
  * Bounds aggregate the local bounds + every visible child's bounds, so
  * `container.getBounds()` always returns the smallest axis-aligned rectangle
- * containing the subtree. Width/height accessors derive from the bounds
- * (× `scale`) and writing to them rescales `scale` to fit.
+ * containing the subtree. The size and edge accessors report that rectangle;
+ * writing to `width`/`height` rescales `scale` to fit.
  *
  * Adding a child re-parents it: the previous parent is detached
  * automatically. Removing a child cascades bounds invalidation up the
@@ -103,36 +103,79 @@ export class Container extends RenderNode {
     return this.children[Symbol.iterator]();
   }
 
+  /**
+   * Rendered width of the whole subtree, in the node's global-transform space.
+   *
+   * Unlike {@link Sprite.width} — which scales an unscaled texture frame — a
+   * container has no intrinsic local size, so this reads the aggregate bounds
+   * directly. Those are already scaled, so multiplying by `scale` again would
+   * count it twice. Writing rescales `scale.x` to make the subtree render at
+   * the requested width.
+   */
   public get width(): number {
-    return Math.abs(this.scale.x) * this.getBounds().width;
+    return this.getBounds().width;
   }
 
   public set width(value: number) {
-    this.scale.x = value / this.getBounds().width;
+    this._rescaleToFit('x', value, this.getBounds().width);
   }
 
+  /** Rendered height of the whole subtree — see {@link width}. */
   public get height(): number {
-    return Math.abs(this.scale.y) * this.getBounds().height;
+    return this.getBounds().height;
   }
 
   public set height(value: number) {
-    this.scale.y = value / this.getBounds().height;
+    this._rescaleToFit('y', value, this.getBounds().height);
   }
 
+  /**
+   * Rescale one axis so the subtree's rendered extent along it becomes
+   * `target`.
+   *
+   * `current` is a world-space measurement and therefore already linear in
+   * `scale[axis]`, so the new scale is the old one times the ratio. Dividing
+   * `target` by `current` instead — as if `current` were an unscaled local
+   * size — makes the assigned value relate quadratically to the rendered
+   * result. Going through the ratio also preserves a negative (mirrored)
+   * scale, which an absolute division would silently flip.
+   */
+  private _rescaleToFit(axis: 'x' | 'y', target: number, current: number): void {
+    // An empty container (or one collapsed to zero by a zero scale) has no
+    // extent to scale from; dividing by it would poison scale with NaN or
+    // Infinity, and being NaN it would never recover. Keep the current scale
+    // until the subtree has a real extent.
+    if (current !== 0) {
+      this.scale[axis] = (this.scale[axis] * target) / current;
+    }
+  }
+
+  /**
+   * Leftmost edge of the subtree in the node's global-transform space.
+   *
+   * These four edges are read straight off the aggregate bounds so they always
+   * span exactly {@link width}/{@link height} and agree with each other. They
+   * cannot be reconstructed from `position` and `origin`: `origin` is in local
+   * pixels and a container's own local bounds are empty, so the rendered
+   * extent comes entirely from the children.
+   */
   public get left(): number {
-    return this.x - this.width * this.origin.x;
+    return this.getBounds().left;
   }
 
+  /** Topmost edge of the subtree — see {@link left}. */
   public get top(): number {
-    return this.y - this.height * this.origin.y;
+    return this.getBounds().top;
   }
 
+  /** Rightmost edge of the subtree — see {@link left}. */
   public get right(): number {
-    return this.x + this.width - this.origin.x;
+    return this.getBounds().right;
   }
 
+  /** Bottommost edge of the subtree — see {@link left}. */
   public get bottom(): number {
-    return this.y + this.height - this.origin.y;
+    return this.getBounds().bottom;
   }
 
   /**

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -540,8 +540,38 @@ export class Container extends RenderNode {
     return this;
   }
 
+  /**
+   * Destroy this container and every node beneath it.
+   *
+   * Ownership is by containment: detaching a subtree only unlinks it, so the
+   * descendants' GPU-backed resources (cached bitmaps, filters, render
+   * textures) and signal listeners would outlive the tree that owned them and
+   * leak on every scene change.
+   */
   public override destroy(): void {
+    // Idempotent by contract, matching Texture.destroy(): re-entry would take
+    // already-released pooled state through a second teardown.
+    if (this.destroyed) {
+      return;
+    }
+
+    // Snapshot before detaching: removeChildren() empties the live array, and a
+    // child's own destroy() walks its subtree, so iterating the live list while
+    // it is being mutated would skip entries.
+    const children = [...this._childList];
+
+    // Detach first, so every child leaves the interaction/focus registries and
+    // drops its stage while it is still a valid node; only then tear it down.
     this.removeChildren();
+
+    for (const child of children) {
+      // A child the caller already destroyed stays destroyed — re-entering its
+      // teardown would double-release resources it no longer owns.
+      if (!child.destroyed) {
+        child.destroy();
+      }
+    }
+
     this._retainedPlan?.invalidate();
 
     super.destroy();

--- a/src/rendering/RenderBackend.ts
+++ b/src/rendering/RenderBackend.ts
@@ -98,7 +98,21 @@ export interface RenderBackend {
    */
   supportsColorFormat(format: ColorTextureFormat): boolean;
 
+  /**
+   * Borrow a temporary {@link RenderTexture} of exactly `width × height` from
+   * the backend's pool, allocating one if no pooled entry matches. Hand it back
+   * with {@link releaseRenderTexture} — destroying a borrowed texture instead
+   * corrupts the pool.
+   */
   acquireRenderTexture(width: number, height: number): RenderTexture;
+
+  /**
+   * Return a borrowed render texture for reuse. The pool is bounded in both
+   * entry count and total bytes, so a workflow whose intermediates resize every
+   * frame retires dead size classes instead of hoarding them: the least recently
+   * released entries are destroyed once either cap is exceeded. Never touch the
+   * texture again after releasing it.
+   */
   releaseRenderTexture(texture: RenderTexture): this;
 
   /**

--- a/src/rendering/RenderNode.ts
+++ b/src/rendering/RenderNode.ts
@@ -394,12 +394,17 @@ export abstract class RenderNode extends SceneNode {
 
   /** @internal */
   public _collect(builder: RenderPlanBuilder, seq?: number): void {
-    if (__DEV__ && this.destroyed) {
+    if (this.destroyed) {
       // A node destroy()ed but left attached to the tree (the documented
       // footgun) has released its pooled transform/bounds; collecting it would
       // read freed state and re-pin it. Skip it — the diagnostic is emitted
       // once by the nearest RetainedContainer; the plain path degrades
       // silently to "renders nothing", which is the correct result.
+      //
+      // Unconditional, NOT __DEV__-gated: the skip is the behaviour, not a
+      // diagnostic. Gating it would let production keep replaying a destroyed
+      // node's last visual state while dev renders nothing — a dev/prod
+      // divergence in what ends up on screen.
       return;
     }
 

--- a/src/rendering/RenderTarget.ts
+++ b/src/rendering/RenderTarget.ts
@@ -7,12 +7,14 @@ import { View } from './View';
 /**
  * Renderable destination — either the on-screen canvas (the `root`
  * target owned by the backend) or an offscreen texture (a
- * {@link RenderTexture}). Owns a {@link View} that controls the
+ * {@link RenderTexture}). Owns a default {@link View} that controls the
  * camera transform and viewport, and emits a destroy event so backends
  * can release backing GPU resources.
  *
  * Set `view` to swap cameras for this target; call `resize(w, h)` when
- * the underlying canvas / texture dimensions change.
+ * the underlying canvas / texture dimensions change. An assigned view is
+ * caller-owned: swapping it out or destroying the target leaves it alive,
+ * so destroy the views you create yourself.
  */
 export class RenderTarget {
   /**
@@ -113,6 +115,11 @@ export class RenderTarget {
     return this;
   }
 
+  /**
+   * Point this target at `view`, or back at its own default view when passed
+   * `null`. The view is caller-owned — neither this call nor {@link destroy}
+   * releases it.
+   */
   public setView(view: View | null): this {
     const nextView = view || this._defaultView;
 
@@ -176,10 +183,10 @@ export class RenderTarget {
 
     this._destroyListeners.clear();
 
-    if (this._view !== this._defaultView) {
-      this._view.destroy();
-    }
-
+    // Only the default view is ours. A view handed to `setView` stays
+    // caller-owned — the backend assigns the application's active camera to its
+    // root target on every `setView`, so releasing it here would take that
+    // camera down with the target.
     this._defaultView.destroy();
     this._viewport.destroy();
     this._size.destroy();

--- a/src/rendering/RenderTexturePool.ts
+++ b/src/rendering/RenderTexturePool.ts
@@ -1,0 +1,138 @@
+import { RenderTexture } from '#rendering/texture/RenderTexture';
+import { type ColorTextureFormat, TextureFormat } from '#rendering/types';
+
+import { estimateTextureBytes } from './GpuResourceAccountant';
+
+/**
+ * Largest number of render textures kept for reuse. Filter and mask
+ * intermediates come in a handful of sizes per frame, so a few dozen entries
+ * cover every realistic working set; beyond that the pool is hoarding, not
+ * recycling.
+ * @internal
+ */
+export const MAX_POOLED_RENDER_TEXTURES = 32;
+
+/**
+ * Largest total VRAM the pool may hold, in bytes. The count cap alone is no
+ * protection — 32 full-screen 4K targets would be well over a gigabyte — so
+ * whichever limit binds first wins.
+ * @internal
+ */
+export const MAX_POOLED_RENDER_TEXTURE_BYTES = 64 * 1024 * 1024;
+
+/** Bytes per pixel of a color attachment format. */
+const colorFormatBytesPerPixel = (format: ColorTextureFormat): number => {
+  switch (format) {
+    case TextureFormat.Rgba8:
+      return 4;
+    case TextureFormat.Rgba16F:
+      return 8;
+    case TextureFormat.Rgba32F:
+      return 16;
+  }
+};
+
+/**
+ * Recycles the short-lived {@link RenderTexture}s that filters, masks and
+ * backdrop blends allocate every frame, keyed by exact `width × height` match.
+ *
+ * Bounded on purpose. Any workflow whose intermediates resize as they animate
+ * retires one size class per frame and never asks for it again, so an unbounded
+ * pool would grow forever, each dead entry still holding real VRAM. Past either
+ * cap the least recently released entries are destroyed, which runs the
+ * backend's own destroy-listener teardown and frees the GPU objects rather than
+ * merely dropping the reference.
+ *
+ * One pool per backend instance — the textures it holds belong to that
+ * backend's device/context.
+ * @internal
+ */
+export class RenderTexturePool {
+  /** Least recently released first, so eviction pops from the front. */
+  private readonly _textures: RenderTexture[] = [];
+  private _bytes = 0;
+
+  /** Number of textures currently held for reuse. */
+  public get size(): number {
+    return this._textures.length;
+  }
+
+  /** Estimated VRAM held by the pooled textures, in bytes. */
+  public get bytes(): number {
+    return this._bytes;
+  }
+
+  /**
+   * Take a pooled texture of exactly `width × height`, or allocate a fresh one.
+   * The result is borrowed: hand it back with {@link release} rather than
+   * destroying it.
+   */
+  public acquire(width: number, height: number): RenderTexture {
+    for (let index = 0; index < this._textures.length; index++) {
+      // In-bounds: `index` ranges over `0..length-1`.
+      const texture = this._textures[index]!;
+
+      if (texture.width === width && texture.height === height) {
+        this._textures.splice(index, 1);
+        this._bytes -= this._estimateBytes(texture);
+
+        return texture;
+      }
+    }
+
+    return new RenderTexture(width, height);
+  }
+
+  /**
+   * Hand a borrowed texture back for reuse, evicting older entries if that puts
+   * the pool over either cap. Releasing a texture twice, or releasing one that
+   * has already been destroyed, is a no-op — both would otherwise seed the pool
+   * with an entry that throws the moment it is bound.
+   */
+  public release(texture: RenderTexture): void {
+    if (texture.destroyed || this._textures.includes(texture)) {
+      return;
+    }
+
+    texture.setView(null);
+    this._textures.push(texture);
+    this._bytes += this._estimateBytes(texture);
+    this._evictToCapacity();
+  }
+
+  /** Destroy every pooled texture and empty the pool. */
+  public destroy(): void {
+    for (const texture of this._textures) {
+      texture.destroy();
+    }
+
+    this._textures.length = 0;
+    this._bytes = 0;
+  }
+
+  /**
+   * Empty the pool without destroying anything. For device loss only: the
+   * backing GPU textures died with the device, so calling `destroy()` on them
+   * would target a dead device instead of releasing anything.
+   */
+  public forget(): void {
+    this._textures.length = 0;
+    this._bytes = 0;
+  }
+
+  private _evictToCapacity(): void {
+    while (this._textures.length > 0 && (this._textures.length > MAX_POOLED_RENDER_TEXTURES || this._bytes > MAX_POOLED_RENDER_TEXTURE_BYTES)) {
+      // Non-empty per the loop guard.
+      const evicted = this._textures.shift()!;
+
+      this._bytes -= this._estimateBytes(evicted);
+      // Destroying runs the backend's destroy listener, which deletes the GPU
+      // texture and framebuffer and books the bytes back off the accountant.
+      evicted.destroy();
+    }
+  }
+
+  private _estimateBytes(texture: RenderTexture): number {
+    return estimateTextureBytes(texture.width, texture.height, colorFormatBytesPerPixel(texture.format));
+  }
+}

--- a/src/rendering/RenderingContext.ts
+++ b/src/rendering/RenderingContext.ts
@@ -71,6 +71,8 @@ export interface DrawBatchOptions {
  */
 export class RenderingContext implements DrawContext {
   private readonly _backend: RenderBackend;
+  /** The camera this context creates for itself, and the only view it may release. */
+  private readonly _defaultView: View;
   private _view: View;
   private readonly _screenView: View;
   /** Lazily-created pooled drawable reused by every {@link drawGeometry} call. */
@@ -90,10 +92,11 @@ export class RenderingContext implements DrawContext {
     const viewCenterX = backend.view?.center?.x ?? viewWidth / 2;
     const viewCenterY = backend.view?.center?.y ?? viewHeight / 2;
 
-    this._view = View.from({
+    this._defaultView = View.from({
       center: { x: viewCenterX, y: viewCenterY },
       size: { width: viewWidth, height: viewHeight },
     });
+    this._view = this._defaultView;
     this._screenView = new View(viewCenterX, viewCenterY, viewWidth, viewHeight);
   }
 
@@ -101,19 +104,20 @@ export class RenderingContext implements DrawContext {
    * The active world {@link View} — the default for {@link render}. Defaults to
    * a view matching the initial backend view. Replace with a custom `View` for
    * follow, zoom, bounds, or split-screen viewport behavior.
+   *
+   * An assigned view is caller-owned, the same contract as {@link trackView}:
+   * assigning a replacement never destroys the outgoing one, so a view can be
+   * swapped out and back (per scene, per split-screen mode) and stays valid in
+   * between. Destroy the views you create once you are done with them; the
+   * context only releases the default camera it created for itself and
+   * {@link screenView}.
    */
   public get view(): View {
     return this._view;
   }
 
   public set view(view: View) {
-    const previousView = this._view;
-
     this._view = view;
-
-    if (previousView !== view) {
-      previousView.destroy();
-    }
   }
 
   /**
@@ -176,13 +180,14 @@ export class RenderingContext implements DrawContext {
   }
 
   /**
-   * Destroy the resources this context owns — the active {@link View} and the
-   * screen-space {@link View}. The {@link RenderBackend} is owned by the
+   * Destroy the resources this context owns — its own default camera and the
+   * screen-space {@link View}. A {@link View} assigned through {@link view} is
+   * caller-owned and left alone. The {@link RenderBackend} is owned by the
    * Application and destroyed separately.
    * @internal — invoked directly by {@link Application.destroy}.
    */
   public destroy(): void {
-    this._view.destroy();
+    this._defaultView.destroy();
     this._screenView.destroy();
     this._trackedViews.clear();
     this._renderedViews.clear();

--- a/src/rendering/View.ts
+++ b/src/rendering/View.ts
@@ -98,6 +98,7 @@ export class View implements ObservableVectorOwner {
   private _shakeOffsetX = 0;
   private _shakeOffsetY = 0;
   private _updateId = 0;
+  private _isDestroyed = false;
 
   public constructor(centerX: number, centerY: number, width: number, height: number) {
     this._center = new ObservableVector(this, 0, centerX, centerY);
@@ -201,6 +202,15 @@ export class View implements ObservableVectorOwner {
 
   public get zoomLevel(): number {
     return this._zoomLevel;
+  }
+
+  /**
+   * `true` once {@link destroy} has run. A destroyed view keeps its last
+   * computed transform but no longer reacts to mutations — its center stops
+   * marking the transform stale — so it must not be put back into use.
+   */
+  public get destroyed(): boolean {
+    return this._isDestroyed;
   }
 
   public setCenter(x: number, y: number): this {
@@ -594,7 +604,19 @@ export class View implements ObservableVectorOwner {
     return this;
   }
 
+  /**
+   * Release the math objects this view owns. Idempotent — the same view can be
+   * reachable from more than one owner (a {@link RenderTarget} it was assigned
+   * to as well as the code that created it), so a second call must not take
+   * `_center`, `_size`, `_viewport` and the cached matrices through a second
+   * teardown.
+   */
   public destroy(): void {
+    if (this._isDestroyed) {
+      return;
+    }
+
+    this._isDestroyed = true;
     this.stopShake();
     this.clearFollow();
 

--- a/src/rendering/text/BitmapText.ts
+++ b/src/rendering/text/BitmapText.ts
@@ -161,6 +161,19 @@ export class BitmapText extends AbstractText {
   private _textBounds: TextSize = { width: 0, height: 0 };
   private _adapter: BmFontAdapter;
 
+  /**
+   * Rebuilds on any style mutation. Bound once so it can be detached again
+   * when the style is replaced or the node is destroyed.
+   */
+  private readonly _onStyleChange = (): void => {
+    // TextStyle latches its dirty flag until something consumes it, and only
+    // dispatches onChange on the clean-to-dirty edge. Draining it here is what
+    // keeps the second and every later mutation notifying instead of just the
+    // first. BitmapText rebuilds eagerly, so there is no deferred hint to keep.
+    this._style.consumeDirty();
+    this._rebuild();
+  };
+
   public constructor(text: string, font: BmFont, options: BitmapTextOptions = {}) {
     super(text);
     this._font = font;
@@ -169,6 +182,7 @@ export class BitmapText extends AbstractText {
     this._style = new TextStyle(options);
     this._layout = options.layout ?? {};
     this._adapter = new BmFontAdapter(font.fontData, font.textures, this._fontScale);
+    this._attachStyle();
     this._rebuild();
   }
 
@@ -192,7 +206,9 @@ export class BitmapText extends AbstractText {
   }
 
   public set style(v: TextStyle | TextStyleOptions) {
+    this._style.onChange.remove(this._onStyleChange);
     this._style = v instanceof TextStyle ? v : new TextStyle(v);
+    this._attachStyle();
     this._rebuild();
   }
 
@@ -254,11 +270,20 @@ export class BitmapText extends AbstractText {
   }
 
   public override destroy(): void {
+    this._style.onChange.remove(this._onStyleChange);
     this._pageQuads = [];
     super.destroy();
   }
 
   // ── Private ──────────────────────────────────────────────────────────────
+
+  private _attachStyle(): void {
+    // A freshly constructed style starts dirty. The caller rebuilds right
+    // after attaching, so drain that initial flag — otherwise the style never
+    // reaches the clean state its next mutation needs in order to dispatch.
+    this._style.consumeDirty();
+    this._style.onChange.add(this._onStyleChange);
+  }
 
   private _rebuild(): void {
     this._pageQuads = [];

--- a/src/rendering/text/LayoutOptions.ts
+++ b/src/rendering/text/LayoutOptions.ts
@@ -5,13 +5,30 @@
 export interface LayoutOptions {
   /** Word-wrap boundary in pixels. Lines exceeding this width are broken at word boundaries. */
   maxWidth?: number;
-  /** Clip boundary in pixels. Text beyond this height is clipped or ellipsized. */
+  /**
+   * Vertical boundary in pixels. Only whole lines that fit within it are kept.
+   * Has no effect on its own — pair it with an `overflow` policy.
+   */
   maxHeight?: number;
-  /** What to do when text overflows `maxHeight`. Defaults to `'visible'`. */
+  /**
+   * What to do with lines that do not fit `maxHeight`. Defaults to `'visible'`.
+   *
+   * - `'visible'`  — Keep every line; `maxHeight` is ignored.
+   * - `'clip'`     — Drop the lines that do not fit.
+   * - `'ellipsis'` — Drop them and mark the last visible line with `…`,
+   *   shortening it so it still fits `maxWidth` when one is set.
+   */
   overflow?: 'visible' | 'clip' | 'ellipsis';
   /** Additional gap in pixels between glyphs (on top of the font's advance). */
   letterSpacing?: number;
-  /** Text direction. Defaults to `'ltr'`. RTL is not fully implemented. */
+  /**
+   * Text direction. Defaults to `'ltr'`.
+   *
+   * `'rtl'` reverses each line's glyphs visually after wrapping, which is
+   * correct for uniformly right-to-left text. Full bidi (mixed LTR/RTL runs),
+   * Arabic contextual shaping, and direction-relative alignment are not
+   * implemented — `align` stays literal in both directions.
+   */
   direction?: 'ltr' | 'rtl';
   /**
    * Break individual words that are wider than `maxWidth` at character boundaries.

--- a/src/rendering/text/TextLayout.ts
+++ b/src/rendering/text/TextLayout.ts
@@ -35,9 +35,14 @@ export function measureText(text: string, style: TextLayoutStyle, provider: Glyp
  * options.
  *
  * Handles `\n` line breaks, left/center/right/justify alignment, `letterSpacing`,
- * `leading`, `breakWords`, `whiteSpace` preprocessing, and optional kerning
- * (if the provider implements `getKerning`). RTL and ligature shaping are out
- * of scope; Unicode/diacritics are delegated to the browser's canvas engine.
+ * `leading`, `breakWords`, `whiteSpace` preprocessing, `maxHeight` overflow
+ * (`clip` / `ellipsis`), right-to-left flow, and optional kerning (if the
+ * provider implements `getKerning`).
+ *
+ * `direction: 'rtl'` reverses each line visually once wrapping is done, so
+ * uniformly right-to-left text reads correctly. Full bidi, Arabic contextual
+ * shaping, and ligature shaping are out of scope; Unicode/diacritics are
+ * delegated to the browser's canvas engine.
  *
  * Returns an empty array for empty text.
  */
@@ -48,6 +53,9 @@ export function layoutText(text: string, style: TextLayoutStyle, layout: LayoutO
   const computedLineHeight = fontSize * lineHeight + leading;
   const letterSpacing = layout.letterSpacing ?? 0;
   const maxWidth = layout.maxWidth;
+  const maxHeight = layout.maxHeight;
+  const overflow = layout.overflow ?? 'visible';
+  const rtl = layout.direction === 'rtl';
   const breakWords = layout.breakWords ?? false;
   const whiteSpace = layout.whiteSpace ?? 'pre-line';
 
@@ -66,13 +74,32 @@ export function layoutText(text: string, style: TextLayoutStyle, layout: LayoutO
     }
   }
 
+  // ── Vertical overflow ─────────────────────────────────────────────────────
+  // Only whole line boxes count as fitting: a line whose baseline row would
+  // extend past maxHeight is dropped rather than rendered half-cut.
+  if (maxHeight !== undefined && overflow !== 'visible' && computedLineHeight > 0) {
+    const maxLines = Math.max(0, Math.floor(maxHeight / computedLineHeight));
+
+    if (allLines.length > maxLines) {
+      allLines.length = maxLines;
+
+      if (overflow === 'ellipsis' && maxLines > 0) {
+        // In-bounds: maxLines > 0 and allLines.length === maxLines.
+        allLines[maxLines - 1] = _ellipsize(allLines[maxLines - 1]!, fontSize, provider, maxWidth, letterSpacing);
+      }
+    }
+  }
+
   // Pass 1: gather glyph info per line, track widths and word counts.
   const linePlacements: LinePlacement[] = [];
   let maxLineWidth = 0;
 
   for (let lineIndex = 0; lineIndex < allLines.length; lineIndex++) {
     // In-bounds: lineIndex < allLines.length.
-    const line = allLines[lineIndex]!;
+    // RTL reorders each line visually before placement, so the cursor can keep
+    // advancing left-to-right and every downstream step (alignment, justify,
+    // quad building) stays direction-agnostic.
+    const line = rtl ? _reverseGraphemes(allLines[lineIndex]!) : allLines[lineIndex]!;
     const lineY = lineIndex * computedLineHeight;
     let cursorX = 0;
     let wordCount = 0;
@@ -228,6 +255,43 @@ export function buildTextPageQuads(placements: readonly GlyphPlacement[]): TextP
 }
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
+
+/** Character appended to the last visible line under `overflow: 'ellipsis'`. */
+const ELLIPSIS = '…';
+
+/**
+ * Reverse a line by code point, so astral characters survive the round trip.
+ * Combining marks and bidi runs are not reordered — see `layoutText`.
+ */
+function _reverseGraphemes(line: string): string {
+  return [...line].reverse().join('');
+}
+
+function _measureChars(chars: readonly string[], fontSize: number, provider: GlyphProvider, letterSpacing: number): number {
+  if (chars.length === 0) return 0;
+  let width = 0;
+  for (const char of chars) {
+    width += provider.getGlyph(char, fontSize).advance + letterSpacing;
+  }
+  // The gap after the final glyph is not part of the line's ink extent.
+  return width - letterSpacing;
+}
+
+/**
+ * Append an ellipsis to `line`, dropping trailing characters until the result
+ * fits `maxWidth`. Without a `maxWidth` there is nothing to fit against, so the
+ * ellipsis is simply appended.
+ */
+function _ellipsize(line: string, fontSize: number, provider: GlyphProvider, maxWidth: number | undefined, letterSpacing: number): string {
+  if (maxWidth === undefined) return line + ELLIPSIS;
+
+  const chars = [...line];
+  while (chars.length > 0 && _measureChars([...chars, ELLIPSIS], fontSize, provider, letterSpacing) > maxWidth) {
+    chars.pop();
+  }
+
+  return chars.join('') + ELLIPSIS;
+}
 
 function _applyWhiteSpace(text: string, mode: 'normal' | 'pre' | 'pre-line'): string {
   if (mode === 'pre') return text;

--- a/src/rendering/texture/Texture.ts
+++ b/src/rendering/texture/Texture.ts
@@ -90,6 +90,7 @@ export class Texture {
   private _size: Size = new Size(0, 0);
   private _isDestroyed = false;
   private readonly _destroyListeners: Set<() => void> = new Set<() => void>();
+  private readonly _releaseListeners: Set<() => void> = new Set<() => void>();
   /** @internal — load lifecycle, driven by the Loader's seamless pipeline. */
   public readonly _loadState = new LoadState<Texture>();
   private _scaleMode: ScaleModes;
@@ -266,6 +267,27 @@ export class Texture {
     return this;
   }
 
+  /**
+   * Register a callback fired when {@link releaseGpu} runs. Distinct from
+   * {@link addDestroyListener}: the handle stays alive and bindable
+   * afterwards, ready for a later {@link setSource} to re-upload — used by
+   * seamless asset eviction, which drops the payload but keeps the handle's
+   * identity so a later fill can heal every consumer in place.
+   * @internal
+   */
+  public addReleaseListener(listener: () => void): this {
+    this._releaseListeners.add(listener);
+
+    return this;
+  }
+
+  /** @internal */
+  public removeReleaseListener(listener: () => void): this {
+    this._releaseListeners.delete(listener);
+
+    return this;
+  }
+
   public setScaleMode(scaleMode: ScaleModes): this {
     if (this._scaleMode !== scaleMode) {
       this._scaleMode = scaleMode;
@@ -345,8 +367,26 @@ export class Texture {
     }
 
     this._destroyListeners.clear();
+    this._releaseListeners.clear();
     this._size.destroy();
     this._source = null;
+  }
+
+  /**
+   * Free this texture's GPU-side payload right now instead of waiting for a
+   * backend to notice on its next bind. `setSource(null)` alone only bumps
+   * {@link version} — a backend re-uploads (and so frees the old payload)
+   * only when it next binds this exact handle, which may never happen for a
+   * texture nothing is currently drawing. Call this immediately after
+   * dropping the source to reclaim the memory without depending on a future
+   * bind. The handle itself is unaffected: it stays bindable, and a later
+   * {@link setSource} re-uploads normally.
+   * @internal
+   */
+  public releaseGpu(): void {
+    for (const listener of [...this._releaseListeners]) {
+      listener();
+    }
   }
 
   private _touch(): void {

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -28,6 +28,7 @@ import type { RenderError } from '#rendering/RenderError';
 import type { RenderStats } from '#rendering/RenderStats';
 import { createRenderStats, resetRenderStats } from '#rendering/RenderStats';
 import { RenderTarget } from '#rendering/RenderTarget';
+import { RenderTexturePool } from '#rendering/RenderTexturePool';
 import type { Shader } from '#rendering/shader/Shader';
 import { DataTexture, type DataTextureFormat } from '#rendering/texture/DataTexture';
 import { RenderTexture } from '#rendering/texture/RenderTexture';
@@ -215,7 +216,7 @@ export class WebGl2Backend implements RenderBackend {
   private readonly _renderTargetStates: Map<RenderTarget, ManagedRenderTargetState> = new Map<RenderTarget, ManagedRenderTargetState>();
   private readonly _textureDestroyHandlers: Map<Texture | RenderTexture, () => void> = new Map<Texture | RenderTexture, () => void>();
   private readonly _renderTargetDestroyHandlers: Map<RenderTarget, () => void> = new Map<RenderTarget, () => void>();
-  private readonly _temporaryRenderTextures: RenderTexture[] = [];
+  private readonly _renderTexturePool: RenderTexturePool = new RenderTexturePool();
   private readonly _clipBoundsStack: Rectangle[] = [];
   private readonly _clipPixelStack: PixelClipBoundsState[] = [];
   private readonly _clipPointA: Vector = new Vector();
@@ -851,27 +852,11 @@ export class WebGl2Backend implements RenderBackend {
   }
 
   public acquireRenderTexture(width: number, height: number): RenderTexture {
-    for (let index = 0; index < this._temporaryRenderTextures.length; index++) {
-      // In-bounds: `index` ranges over `0..length-1`.
-      const texture = this._temporaryRenderTextures[index]!;
-
-      if (texture.width === width && texture.height === height) {
-        this._temporaryRenderTextures.splice(index, 1);
-
-        return texture;
-      }
-    }
-
-    return new RenderTexture(width, height);
+    return this._renderTexturePool.acquire(width, height);
   }
 
   public releaseRenderTexture(texture: RenderTexture): this {
-    if (this._temporaryRenderTextures.includes(texture)) {
-      return this;
-    }
-
-    texture.setView(null);
-    this._temporaryRenderTextures.push(texture);
+    this._renderTexturePool.release(texture);
 
     return this;
   }
@@ -1507,7 +1492,7 @@ export class WebGl2Backend implements RenderBackend {
     this.rendererRegistry.destroy();
     this._clearColor.destroy();
     this._destroyManagedResources();
-    this._destroyTemporaryRenderTextures();
+    this._renderTexturePool.destroy();
 
     for (const clipBounds of this._clipBoundsStack) {
       clipBounds.destroy();
@@ -1795,14 +1780,6 @@ export class WebGl2Backend implements RenderBackend {
     for (const texture of [...this._textureStates.keys()]) {
       this._evictTexture(texture, false);
     }
-  }
-
-  private _destroyTemporaryRenderTextures(): void {
-    for (const texture of this._temporaryRenderTextures) {
-      texture.destroy();
-    }
-
-    this._temporaryRenderTextures.length = 0;
   }
 
   private _getRenderTargetState(target: RenderTarget): ManagedRenderTargetState {

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -31,7 +31,7 @@ import { RenderTarget } from '#rendering/RenderTarget';
 import type { Shader } from '#rendering/shader/Shader';
 import { DataTexture, type DataTextureFormat } from '#rendering/texture/DataTexture';
 import { RenderTexture } from '#rendering/texture/RenderTexture';
-import type { Texture } from '#rendering/texture/Texture';
+import { Texture } from '#rendering/texture/Texture';
 import { TransformBuffer } from '#rendering/TransformBuffer';
 import { BlendModes, type ColorTextureFormat, TextureFormat } from '#rendering/types';
 import type { View } from '#rendering/View';
@@ -148,6 +148,11 @@ interface DestroyListenable {
   removeDestroyListener(listener: () => void): unknown;
 }
 
+interface ReleaseListenable {
+  addReleaseListener(listener: () => void): unknown;
+  removeReleaseListener(listener: () => void): unknown;
+}
+
 // One open retained-capture window. Frames stack for nested
 // recording groups: a flushed batch's bytes are stored once in the
 // INNERMOST frame's bundle, while its instruction is appended to every open
@@ -214,6 +219,7 @@ export class WebGl2Backend implements RenderBackend {
   private readonly _textureStates: Map<Texture | RenderTexture, ManagedTextureState> = new Map<Texture | RenderTexture, ManagedTextureState>();
   private readonly _renderTargetStates: Map<RenderTarget, ManagedRenderTargetState> = new Map<RenderTarget, ManagedRenderTargetState>();
   private readonly _textureDestroyHandlers: Map<Texture | RenderTexture, () => void> = new Map<Texture | RenderTexture, () => void>();
+  private readonly _textureReleaseHandlers: Map<Texture, () => void> = new Map<Texture, () => void>();
   private readonly _renderTargetDestroyHandlers: Map<RenderTarget, () => void> = new Map<RenderTarget, () => void>();
   private readonly _temporaryRenderTextures: RenderTexture[] = [];
   private readonly _clipBoundsStack: Rectangle[] = [];
@@ -1836,6 +1842,12 @@ export class WebGl2Backend implements RenderBackend {
         this._evictTexture(texture, true);
       });
 
+      if (texture instanceof Texture) {
+        this._subscribeToRelease(texture, this._textureReleaseHandlers, () => {
+          this._evictTexture(texture, true, false);
+        });
+      }
+
       state = {
         handle: this._createTextureHandle(),
         version: -1,
@@ -1855,6 +1867,22 @@ export class WebGl2Backend implements RenderBackend {
     if (!handlers.has(descriptor)) {
       descriptor.addDestroyListener(handler);
       handlers.set(descriptor, handler);
+    }
+  }
+
+  private _subscribeToRelease<T extends ReleaseListenable>(descriptor: T, handlers: Map<T, () => void>, handler: () => void): void {
+    if (!handlers.has(descriptor)) {
+      descriptor.addReleaseListener(handler);
+      handlers.set(descriptor, handler);
+    }
+  }
+
+  private _unsubscribeFromRelease<T extends ReleaseListenable>(descriptor: T, handlers: Map<T, () => void>): void {
+    const handler = handlers.get(descriptor);
+
+    if (handler) {
+      descriptor.removeReleaseListener(handler);
+      handlers.delete(descriptor);
     }
   }
 
@@ -1905,10 +1933,23 @@ export class WebGl2Backend implements RenderBackend {
     }
   }
 
-  private _evictTexture(texture: Texture | RenderTexture, rebind: boolean): void {
+  /**
+   * Free a texture's GPU-side state. `unsubscribeDestroy` is `false` only
+   * when called from a {@link Texture.releaseGpu} listener: the handle isn't
+   * actually destroyed there, so the destroy subscription must survive for a
+   * real, later `destroy()`. The release subscription is always dropped —
+   * `_getTextureState` re-subscribes it fresh if the handle is bound again.
+   */
+  private _evictTexture(texture: Texture | RenderTexture, rebind: boolean, unsubscribeDestroy = true): void {
     const state = this._textureStates.get(texture);
 
-    this._unsubscribeFromDestroy(texture, this._textureDestroyHandlers);
+    if (unsubscribeDestroy) {
+      this._unsubscribeFromDestroy(texture, this._textureDestroyHandlers);
+    }
+
+    if (texture instanceof Texture) {
+      this._unsubscribeFromRelease(texture, this._textureReleaseHandlers);
+    }
 
     if (state) {
       if (this._texture === texture) {

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -32,7 +32,7 @@ import { createRenderStats, resetRenderStats } from '#rendering/RenderStats';
 import { RenderTarget } from '#rendering/RenderTarget';
 import { DataTexture, type DataTextureFormat } from '#rendering/texture/DataTexture';
 import { RenderTexture } from '#rendering/texture/RenderTexture';
-import type { Texture } from '#rendering/texture/Texture';
+import { Texture } from '#rendering/texture/Texture';
 import type { BlendModes, ColorTextureFormat } from '#rendering/types';
 import { ScaleModes, TextureFormat, WrapModes } from '#rendering/types';
 import type { View } from '#rendering/View';
@@ -166,6 +166,7 @@ export class WebGpuBackend implements RenderBackend {
   private _recoveryBackoffMs = 100;
   private readonly _textureStates: Map<Texture | RenderTexture, ManagedWebGpuTextureState> = new Map<Texture | RenderTexture, ManagedWebGpuTextureState>();
   private readonly _textureDestroyHandlers: Map<Texture | RenderTexture, () => void> = new Map<Texture | RenderTexture, () => void>();
+  private readonly _textureReleaseHandlers: Map<Texture, () => void> = new Map<Texture, () => void>();
   private readonly _renderTargetDestroyHandlers: Map<RenderTarget, () => void> = new Map<RenderTarget, () => void>();
   private readonly _temporaryRenderTextures: RenderTexture[] = [];
   private readonly _clipBoundsStack: Rectangle[] = [];
@@ -1778,7 +1779,12 @@ export class WebGpuBackend implements RenderBackend {
       texture.removeDestroyListener(handler);
     }
 
+    for (const [texture, handler] of this._textureReleaseHandlers) {
+      texture.removeReleaseListener(handler);
+    }
+
     this._textureDestroyHandlers.clear();
+    this._textureReleaseHandlers.clear();
     this._textureStates.clear();
 
     // Recycled RenderTexture pool: drop entries — their backing GPUTexture
@@ -2009,6 +2015,16 @@ export class WebGpuBackend implements RenderBackend {
 
       texture.addDestroyListener(destroyHandler);
       this._textureDestroyHandlers.set(texture, destroyHandler);
+
+      if (texture instanceof Texture) {
+        const releaseHandler = (): void => {
+          this._evictTexture(texture, false);
+        };
+
+        texture.addReleaseListener(releaseHandler);
+        this._textureReleaseHandlers.set(texture, releaseHandler);
+      }
+
       this._textureStates.set(texture, state);
     }
 
@@ -2251,13 +2267,32 @@ export class WebGpuBackend implements RenderBackend {
     return state;
   }
 
-  private _evictTexture(texture: Texture | RenderTexture): void {
+  /**
+   * Free a texture's GPU-side state. `unsubscribeDestroy` is `false` only
+   * when called from a {@link Texture.releaseGpu} listener: the handle isn't
+   * actually destroyed there, so the destroy subscription must survive for a
+   * real, later `destroy()`. The release subscription is always dropped —
+   * `_getTextureState` re-subscribes it fresh if the handle is bound again.
+   */
+  private _evictTexture(texture: Texture | RenderTexture, unsubscribeDestroy = true): void {
     const state = this._textureStates.get(texture);
-    const destroyHandler = this._textureDestroyHandlers.get(texture);
 
-    if (destroyHandler) {
-      texture.removeDestroyListener(destroyHandler);
-      this._textureDestroyHandlers.delete(texture);
+    if (unsubscribeDestroy) {
+      const destroyHandler = this._textureDestroyHandlers.get(texture);
+
+      if (destroyHandler) {
+        texture.removeDestroyListener(destroyHandler);
+        this._textureDestroyHandlers.delete(texture);
+      }
+    }
+
+    if (texture instanceof Texture) {
+      const releaseHandler = this._textureReleaseHandlers.get(texture);
+
+      if (releaseHandler) {
+        texture.removeReleaseListener(releaseHandler);
+        this._textureReleaseHandlers.delete(texture);
+      }
     }
 
     if (state) {

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -30,6 +30,7 @@ import { formatShaderError, RenderError, type RenderErrorCode } from '#rendering
 import type { RenderStats } from '#rendering/RenderStats';
 import { createRenderStats, resetRenderStats } from '#rendering/RenderStats';
 import { RenderTarget } from '#rendering/RenderTarget';
+import { RenderTexturePool } from '#rendering/RenderTexturePool';
 import { DataTexture, type DataTextureFormat } from '#rendering/texture/DataTexture';
 import { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { Texture } from '#rendering/texture/Texture';
@@ -167,7 +168,7 @@ export class WebGpuBackend implements RenderBackend {
   private readonly _textureStates: Map<Texture | RenderTexture, ManagedWebGpuTextureState> = new Map<Texture | RenderTexture, ManagedWebGpuTextureState>();
   private readonly _textureDestroyHandlers: Map<Texture | RenderTexture, () => void> = new Map<Texture | RenderTexture, () => void>();
   private readonly _renderTargetDestroyHandlers: Map<RenderTarget, () => void> = new Map<RenderTarget, () => void>();
-  private readonly _temporaryRenderTextures: RenderTexture[] = [];
+  private readonly _renderTexturePool: RenderTexturePool = new RenderTexturePool();
   private readonly _clipBoundsStack: Rectangle[] = [];
   private readonly _clipPixelStack: PixelClipBoundsState[] = [];
   private readonly _clipPointA: Vector = new Vector();
@@ -750,27 +751,11 @@ export class WebGpuBackend implements RenderBackend {
   }
 
   public acquireRenderTexture(width: number, height: number): RenderTexture {
-    for (let index = 0; index < this._temporaryRenderTextures.length; index++) {
-      // index is bounded by the array length via the for-loop guard.
-      const texture = this._temporaryRenderTextures[index]!;
-
-      if (texture.width === width && texture.height === height) {
-        this._temporaryRenderTextures.splice(index, 1);
-
-        return texture;
-      }
-    }
-
-    return new RenderTexture(width, height);
+    return this._renderTexturePool.acquire(width, height);
   }
 
   public releaseRenderTexture(texture: RenderTexture): this {
-    if (this._temporaryRenderTextures.includes(texture)) {
-      return this;
-    }
-
-    texture.setView(null);
-    this._temporaryRenderTextures.push(texture);
+    this._renderTexturePool.release(texture);
 
     return this;
   }
@@ -843,7 +828,7 @@ export class WebGpuBackend implements RenderBackend {
     this._setActiveRenderer(null);
     this.rendererRegistry.destroy();
     this._destroyManagedTextures();
-    this._destroyTemporaryRenderTextures();
+    this._renderTexturePool.destroy();
 
     for (const clipBounds of this._clipBoundsStack) {
       clipBounds.destroy();
@@ -1783,7 +1768,7 @@ export class WebGpuBackend implements RenderBackend {
 
     // Recycled RenderTexture pool: drop entries — their backing GPUTexture
     // is gone with the dead device.
-    this._temporaryRenderTextures.length = 0;
+    this._renderTexturePool.forget();
 
     // Disconnect renderers so they release pipelines / buffers / bind
     // groups tied to the dead device. They reconnect during _initialize().
@@ -1962,14 +1947,6 @@ export class WebGpuBackend implements RenderBackend {
     for (const texture of [...this._textureStates.keys()]) {
       this._evictTexture(texture);
     }
-  }
-
-  private _destroyTemporaryRenderTextures(): void {
-    for (const texture of this._temporaryRenderTextures) {
-      texture.destroy();
-    }
-
-    this._temporaryRenderTextures.length = 0;
   }
 
   private _getTextureState(texture: Texture | RenderTexture): ManagedWebGpuTextureState {

--- a/test/audio/sound.test.ts
+++ b/test/audio/sound.test.ts
@@ -65,17 +65,33 @@ describe('Sound', () => {
     vi.restoreAllMocks();
   });
 
-  // manager.play({ replace: true }) stops prior instance before starting a new one.
-  test('manager.play(sound) with replace: true stops prior instance before starting a new one', () => {
+  // Default (and explicit replace: false): concurrent instances layer, nothing is stopped.
+  test('manager.play(sound, { replace: false }) called twice keeps both instances playing concurrently', () => {
     const factory = setupSourceFactorySpy();
     const manager = new AudioManager();
     const sound = new Sound(createAudioBufferStub());
 
-    manager.play(sound);
-    sound._stopAllVoices(); // simulate replace: stop old voices
-    manager.play(sound);
+    manager.play(sound, { replace: false });
+    manager.play(sound, { replace: false });
 
-    // Two sources created; first was stopped
+    expect(factory.sources.length).toBe(2);
+    expect(factory.sources[0].stop).not.toHaveBeenCalled();
+    expect(factory.sources[1].stop).not.toHaveBeenCalled();
+
+    factory.restore();
+    sound.destroy();
+  });
+
+  // manager.play(sound, { replace: true }) stops the prior instance before starting a new one.
+  test('manager.play(sound, { replace: true }) stops prior instance before starting a new one', () => {
+    const factory = setupSourceFactorySpy();
+    const manager = new AudioManager();
+    const sound = new Sound(createAudioBufferStub());
+
+    manager.play(sound, { replace: true });
+    manager.play(sound, { replace: true });
+
+    // Two sources created; the first was stopped when the second started.
     expect(factory.sources.length).toBe(2);
     expect(factory.sources[0].stop).toHaveBeenCalledTimes(1);
     expect(factory.sources[1].stop).toHaveBeenCalledTimes(0);

--- a/test/core/application-lifecycle.test.ts
+++ b/test/core/application-lifecycle.test.ts
@@ -1277,5 +1277,44 @@ describe('Application lifecycle / getters / sizing', () => {
         rafSpy.mockRestore();
       }
     });
+
+    test('teardown after the fallback destroys the surviving rendering context exactly once', async () => {
+      const restoreGpu = setNavigatorGpu({});
+      const webgpuInitialize = vi.fn().mockRejectedValue(new Error('webgpu init failed'));
+      const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1);
+
+      try {
+        const { Application } = await loadHarness({ webgpuInitialize });
+        const { RenderingContext } = await import('#rendering/RenderingContext');
+        const destroyedContexts: unknown[] = [];
+
+        vi.spyOn(RenderingContext.prototype, 'destroy').mockImplementation(function (this: unknown) {
+          destroyedContexts.push(this);
+        });
+
+        const app = new Application({ canvas: { element: document.createElement('canvas') } });
+
+        await app.start();
+
+        const survivingRendering = app.rendering;
+
+        // Ignore the fallback's own teardown of the context it discarded.
+        destroyedContexts.length = 0;
+
+        app.destroy();
+
+        // destroy() halts the frame loop synchronously and finishes the rest
+        // of teardown on an async chain it awaits internally.
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        // The application unregisters its own core systems so that it, and
+        // not the registry, destroys them — a stale entry in that list would
+        // leave the live context to be destroyed from both sides.
+        expect(destroyedContexts.filter(context => context === survivingRendering)).toHaveLength(1);
+      } finally {
+        restoreGpu();
+        rafSpy.mockRestore();
+      }
+    });
   });
 });

--- a/test/core/application-loop.test.ts
+++ b/test/core/application-loop.test.ts
@@ -321,6 +321,92 @@ describe('Application.update() — loop timing', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Frame delta measures the wall-clock gap between frames
+  // -------------------------------------------------------------------------
+
+  describe('frame delta spans the full gap between frames', () => {
+    /**
+     * Replace `_frameClock` with a clock driven by an explicit virtual
+     * timeline, so a frame's own processing cost can be injected at a chosen
+     * point without depending on real wall-clock timing. Returns a handle that
+     * advances the timeline.
+     */
+    function installVirtualFrameClock(target: Application): { advance: (ms: number) => void } {
+      let nowMs = 0;
+      let startedAtMs = 0;
+
+      const virtualClock = {
+        get elapsedTime(): Time {
+          return new Time(nowMs - startedAtMs);
+        },
+        restart(): void {
+          startedAtMs = nowMs;
+        },
+        start(): void {
+          startedAtMs = nowMs;
+        },
+        stop(): void {
+          /* the virtual timeline only moves when a test advances it */
+        },
+        destroy(): void {
+          /* nothing to release */
+        },
+      };
+
+      (target as unknown as Record<string, unknown>)['_frameClock'] = virtualClock;
+
+      return {
+        advance: (ms: number): void => {
+          nowMs += ms;
+        },
+      };
+    }
+
+    test('a frame that spends CPU time still reports the full frame-to-frame gap on the next frame', () => {
+      const timeline = installVirtualFrameClock(app);
+      const frameProcessingMs = 12;
+      const framePeriodMs = 16;
+      const observedDeltas: number[] = [];
+
+      vi.spyOn(app.tweens, 'preUpdate').mockImplementation((delta: Time) => {
+        observedDeltas.push(delta.milliseconds);
+      });
+
+      // Charge the frame's own processing cost to the timeline from inside the
+      // frame body, after the delta has been read — this is the cost that must
+      // not be subtracted from the next frame's delta.
+      app.onFrame.add(() => {
+        timeline.advance(frameProcessingMs);
+      });
+
+      app.update();
+
+      // The next frame callback lands one frame period after the previous one
+      // began, so the remaining wait is the period minus the work already done.
+      timeline.advance(framePeriodMs - frameProcessingMs);
+
+      app.update();
+
+      expect(observedDeltas).toHaveLength(2);
+      expect(observedDeltas[1]).toBe(framePeriodMs);
+    });
+
+    test('rawFrameDeltaMs reports elapsed wall time, not wall time minus the previous frame cost', () => {
+      const timeline = installVirtualFrameClock(app);
+
+      app.onFrame.add(() => {
+        timeline.advance(12);
+      });
+
+      app.update();
+      timeline.advance(4);
+      app.update();
+
+      expect(app.backend.stats.rawFrameDeltaMs).toBe(16);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Regression — existing behavior unaffected
   // -------------------------------------------------------------------------
 

--- a/test/core/application.test.ts
+++ b/test/core/application.test.ts
@@ -356,6 +356,34 @@ describe('Application', () => {
     }
   });
 
+  test('the WebGL2 fallback registers the rebuilt rendering context in place of the discarded one', async () => {
+    const restoreGpu = setNavigatorGpu({});
+    const webgpuInitialize = vi.fn().mockRejectedValue(new Error('webgpu failed'));
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1);
+
+    try {
+      const { Application } = await loadApplicationHarness({ webgpuInitialize });
+      const app = new Application({
+        canvas: { element: document.createElement('canvas') },
+      });
+      const discardedRendering = app.rendering;
+      const registeredCount = app.systems.size;
+
+      await app.start(DummyScene);
+
+      // The registry holds the system objects handed to it at registration
+      // time, so swapping `app.rendering` alone would leave it ticking the
+      // destroyed context and never the live one.
+      expect(app.rendering).not.toBe(discardedRendering);
+      expect(app.systems.has(discardedRendering)).toBe(false);
+      expect(app.systems.has(app.rendering)).toBe(true);
+      expect(app.systems.size).toBe(registeredCount);
+    } finally {
+      restoreGpu();
+      rafSpy.mockRestore();
+    }
+  });
+
   test('explicit webgpu selection still fails instead of falling back', async () => {
     const restoreGpu = setNavigatorGpu({});
     const webgpuError = new Error('webgpu failed');

--- a/test/core/scene-node-transform.test.ts
+++ b/test/core/scene-node-transform.test.ts
@@ -1,8 +1,9 @@
 ﻿import { SceneNode } from '#core/SceneNode';
 import { Matrix } from '#math/Matrix';
-import type { Rectangle } from '#math/Rectangle';
+import { Rectangle } from '#math/Rectangle';
 import { Container } from '#rendering/Container';
 import { Drawable } from '#rendering/Drawable';
+import type { View } from '#rendering/View';
 
 // Regression suite for the SceneNode transform cache after the 0.5.0 inline
 // of `Transformable`. These tests assert behavior that was previously implicit
@@ -315,6 +316,58 @@ describe('SceneNode bounds after transform changes', () => {
     expect(bounds.y).toBe(0);
     expect(bounds.width).toBe(300);
     expect(bounds.height).toBe(300);
+
+    container.destroy();
+  });
+
+  test('toggling a child visible refreshes the cached ancestor bounds', () => {
+    const container = new Container();
+    const childA = new TestDrawable();
+    const childB = new TestDrawable();
+
+    childA.setPosition(0, 0);
+    childB.setPosition(200, 200);
+    container.addChild(childA, childB);
+
+    // Warm the cache: the aggregate spans (0,0)-(300,300) while both are visible.
+    expect(container.getBounds().width).toBe(300);
+
+    // Hiding a child shrinks the aggregate — Container.updateBounds() only folds
+    // in visible children — so the cached rect must be rebuilt, not replayed.
+    childB.visible = false;
+
+    expect(container.getBounds().width).toBe(100);
+    expect(container.getBounds().height).toBe(100);
+
+    // Re-showing must grow it back. A stale cache here culls the container away
+    // and the re-shown subtree silently stops rendering.
+    childB.visible = true;
+
+    expect(container.getBounds().width).toBe(300);
+    expect(container.getBounds().height).toBe(300);
+
+    container.destroy();
+  });
+
+  test('a re-shown subtree makes an out-of-view container test in-view again', () => {
+    const container = new Container();
+    const child = new TestDrawable();
+
+    child.setPosition(500, 0);
+    container.addChild(child);
+
+    const view = { getBounds: () => new Rectangle(400, 0, 300, 300) } as unknown as View;
+
+    expect(container.getBounds().width).toBe(600);
+    expect(container.inView(view)).toBe(true);
+
+    child.visible = false;
+
+    expect(container.inView(view)).toBe(false);
+
+    child.visible = true;
+
+    expect(container.inView(view)).toBe(true);
 
     container.destroy();
   });

--- a/test/core/scene.test.ts
+++ b/test/core/scene.test.ts
@@ -129,6 +129,24 @@ describe('Scene', () => {
     expect(child.parent).toBeNull();
   });
 
+  test('_teardownInternals destroys the whole scene subtree, not just the root', () => {
+    const scene = new Scene();
+    const branch = new Container();
+    const leaf = new DummyDrawable();
+
+    branch.addChild(leaf);
+    scene.addChild(branch);
+
+    // Scene owns no separate child walk — it delegates to the root container's
+    // recursive destroy, so every node a scene held is released on teardown
+    // instead of leaking its resources across the scene change.
+    scene._teardownInternals();
+
+    expect(scene.root.destroyed).toBe(true);
+    expect(branch.destroyed).toBe(true);
+    expect(leaf.destroyed).toBe(true);
+  });
+
   // CONTRACT — do not weaken without an explicit identity decision.
   //
   // Scene.root is a structural ownership/traversal anchor. The

--- a/test/input/input-manager-events.test.ts
+++ b/test/input/input-manager-events.test.ts
@@ -478,7 +478,7 @@ describe('InputManager — mouse wheel', () => {
     canvas.dispatchEvent(new WheelEvent('wheel', { deltaX: 1, deltaY: -1, deltaMode: WheelEvent.DOM_DELTA_LINE }));
     canvas.dispatchEvent(new WheelEvent('wheel', { deltaX: 3, deltaY: 4, deltaMode: WheelEvent.DOM_DELTA_PIXEL }));
 
-    im.preUpdate();
+    im.preUpdate(0 as never);
 
     // Only one flush per frame, carrying the SUM of all three events, not
     // just the last one — and the line-mode event converted to its

--- a/test/input/input-manager-events.test.ts
+++ b/test/input/input-manager-events.test.ts
@@ -460,6 +460,34 @@ describe('InputManager — mouse wheel', () => {
 
     im.destroy();
   });
+
+  test('multiple wheel events within one frame accumulate instead of overwriting, normalized across deltaModes', () => {
+    const { im, canvas } = createInputManager();
+    const seen: Array<{ x: number; y: number }> = [];
+    const onWheel = vi.fn((vector: { x: number; y: number }) => {
+      seen.push({ x: vector.x, y: vector.y });
+    });
+
+    im.onMouseWheel.add(onWheel);
+    canvas.dispatchEvent(new FocusEvent('focus'));
+
+    // Three sub-frame events, as fast/high-precision scrolling routinely
+    // produces. Mixed deltaMode: DOM_DELTA_PIXEL passes through unchanged,
+    // DOM_DELTA_LINE is Firefox's default and reports in line units.
+    canvas.dispatchEvent(new WheelEvent('wheel', { deltaX: 5, deltaY: 2, deltaMode: WheelEvent.DOM_DELTA_PIXEL }));
+    canvas.dispatchEvent(new WheelEvent('wheel', { deltaX: 1, deltaY: -1, deltaMode: WheelEvent.DOM_DELTA_LINE }));
+    canvas.dispatchEvent(new WheelEvent('wheel', { deltaX: 3, deltaY: 4, deltaMode: WheelEvent.DOM_DELTA_PIXEL }));
+
+    im.preUpdate();
+
+    // Only one flush per frame, carrying the SUM of all three events, not
+    // just the last one — and the line-mode event converted to its
+    // pixel-equivalent (16px/line) before being summed in.
+    expect(onWheel).toHaveBeenCalledTimes(1);
+    expect(seen).toEqual([{ x: 5 + 16 + 3, y: 2 - 16 + 4 }]);
+
+    im.destroy();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/input/specialized-gamepad-mapping.test.ts
+++ b/test/input/specialized-gamepad-mapping.test.ts
@@ -1,9 +1,38 @@
 import { ArcadeStickGamepadMapping } from '#input/ArcadeStickGamepadMapping';
-import { GamepadAxis } from '#input/GamepadAxis';
+import { Gamepad } from '#input/Gamepad';
 import { GamepadButton } from '#input/GamepadButton';
 import { parseGamepadDescriptor, resolveGamepadDefinition } from '#input/GamepadDefinitions';
 import { GamepadMappingFamily } from '#input/GamepadMapping';
 import { SteamDeckGamepadMapping } from '#input/SteamDeckGamepadMapping';
+import { ChannelSize } from '#input/types';
+
+type BrowserGamepad = NonNullable<ReturnType<Navigator['getGamepads']>[number]>;
+
+const createSteamDeckNativeGamepad = (axesValues: number[]): BrowserGamepad =>
+  ({
+    id: 'Valve Steam Deck (Vendor: 28de Product: 1205)',
+    index: 0,
+    connected: true,
+    mapping: '',
+    timestamp: 0,
+    axes: axesValues,
+    buttons: [],
+    vibrationActuator: null,
+  }) as unknown as BrowserGamepad;
+
+const steamDeckDefinition = () => ({
+  name: 'Steam Deck',
+  descriptor: {
+    id: 'Valve Steam Deck',
+    index: 0,
+    name: 'Steam Deck',
+    label: 'Steam Deck',
+    vendorId: '28de',
+    productId: '1205',
+    productKey: '28de:1205',
+  },
+  mapping: new SteamDeckGamepadMapping(),
+});
 
 describe('specialized gamepad mappings', () => {
   test('arcade stick mapping keeps the fight-stick surface explicit and axis-free', () => {
@@ -37,14 +66,39 @@ describe('specialized gamepad mappings', () => {
     expect(buttonsByIndex.get(2)).toBe(GamepadButton.Capture);
   });
 
-  test('Steam Deck triggers report through analog axes, not buttons', () => {
+  test('Steam Deck triggers read through the raw axes array but route to the canonical trigger button channels', () => {
     const mapping = new SteamDeckGamepadMapping();
     const triggerAxes = mapping.axes.filter(a => a.index === 8 || a.index === 9);
 
-    // Triggers come via a8/a9 — left at a9, right at a8 per SDL.
+    // Triggers come via a8/a9 (not raw buttons 6/7) — left at a9, right at
+    // a8 per SDL — but must still land on the SAME canonical channels every
+    // other family's triggers use, or `new ButtonAction(GamepadButton.RightTrigger)`
+    // (the canonical, device-agnostic way to bind a trigger) silently reads
+    // nothing on Steam Deck.
     expect(triggerAxes).toHaveLength(2);
-    expect(triggerAxes.find(a => a.index === 8)?.channel).toBe(GamepadAxis.AuxiliaryAxis0Positive);
-    expect(triggerAxes.find(a => a.index === 9)?.channel).toBe(GamepadAxis.AuxiliaryAxis1Positive);
+    expect(triggerAxes.find(a => a.index === 8)?.channel).toBe(GamepadButton.RightTrigger);
+    expect(triggerAxes.find(a => a.index === 9)?.channel).toBe(GamepadButton.LeftTrigger);
+    expect(mapping.hasChannel(GamepadButton.RightTrigger)).toBe(true);
+    expect(mapping.hasChannel(GamepadButton.LeftTrigger)).toBe(true);
+  });
+
+  test('Steam Deck raw trigger axis values reach GamepadButton.RightTrigger/LeftTrigger through Gamepad.update()', () => {
+    const channels = new Float32Array(ChannelSize.Container);
+    const pad = new Gamepad(0, channels);
+
+    // Raw axes array: only indices 8 (right trigger) and 9 (left trigger)
+    // matter here; everything else is left at rest.
+    const axes = [0, 0, 0, 0, 0, 0, 0, 0, 0.6, -0.2];
+
+    pad._bind(createSteamDeckNativeGamepad(axes), steamDeckDefinition());
+    pad.update();
+
+    const rightTriggerOffset = Gamepad.resolveChannelOffset(0, GamepadButton.RightTrigger);
+    const leftTriggerOffset = Gamepad.resolveChannelOffset(0, GamepadButton.LeftTrigger);
+
+    // normalize: true maps raw -1..1 to 0..1, so 0.6 -> 0.8 and -0.2 -> 0.4.
+    expect(channels[rightTriggerOffset]).toBeCloseTo(0.8);
+    expect(channels[leftTriggerOffset]).toBeCloseTo(0.4);
   });
 
   test('resolves Steam Deck PID 28de:1205 to SteamDeckGamepadMapping', () => {

--- a/test/math/collision-detection.test.ts
+++ b/test/math/collision-detection.test.ts
@@ -1030,4 +1030,75 @@ describe('getCollisionSat', () => {
 
     expect(getCollisionSat(empty, square(0, 0, 10))).toBeNull();
   });
+
+  // The MTV direction must follow the same convention as the non-SAT
+  // responses (see getCollisionRectangleRectangle / getCollisionCircleCircle):
+  // projectionN points from shapeA toward shapeB. Deriving it from the raw
+  // edge normal instead makes mirrored placements collapse onto the same
+  // direction, which pushes one of the two pairs deeper instead of apart.
+
+  test('mirrored horizontal placements produce opposite MTV directions', () => {
+    const toTheRight = getCollisionSat(square(0, 0, 10), square(5, 0, 10));
+    const toTheLeft = getCollisionSat(square(0, 0, 10), square(-5, 0, 10));
+
+    expect(toTheRight).not.toBeNull();
+    expect(toTheLeft).not.toBeNull();
+
+    expect(toTheRight!.projectionN.x).toBeCloseTo(1);
+    expect(toTheRight!.projectionN.y).toBeCloseTo(0);
+    expect(toTheLeft!.projectionN.x).toBeCloseTo(-1);
+    expect(toTheLeft!.projectionN.y).toBeCloseTo(0);
+  });
+
+  test('mirrored vertical placements produce opposite MTV directions', () => {
+    const below = getCollisionSat(square(0, 0, 10), rect(0, 5, 10, 10));
+    const above = getCollisionSat(square(0, 0, 10), rect(0, -5, 10, 10));
+
+    expect(below).not.toBeNull();
+    expect(above).not.toBeNull();
+
+    expect(below!.projectionN.x).toBeCloseTo(0);
+    expect(below!.projectionN.y).toBeCloseTo(1);
+    expect(above!.projectionN.x).toBeCloseTo(0);
+    expect(above!.projectionN.y).toBeCloseTo(-1);
+  });
+
+  test('mirrored diagonal placements produce opposite MTV directions', () => {
+    // The diamond's normals are diagonal, so the winning axis here comes from
+    // the second shape rather than the axis-aligned square.
+    // Both diamonds sit mirrored through the square's centre (5, 5), each
+    // overlapping one of its diagonal corners.
+    const upperRight = getCollisionSat(square(0, 0, 10), diamond(14, -4, 10));
+    const lowerLeft = getCollisionSat(square(0, 0, 10), diamond(-4, 14, 10));
+
+    expect(upperRight).not.toBeNull();
+    expect(lowerLeft).not.toBeNull();
+
+    expect(upperRight!.projectionN.x).toBeCloseTo(-lowerLeft!.projectionN.x);
+    expect(upperRight!.projectionN.y).toBeCloseTo(-lowerLeft!.projectionN.y);
+    expect(upperRight!.projectionN.x).toBeGreaterThan(0);
+    expect(upperRight!.projectionN.y).toBeLessThan(0);
+  });
+
+  test('applying the MTV to shapeA separates both mirrored placements', () => {
+    // projectionN points from shapeA toward shapeB, so shapeA has to move
+    // along its negation to come apart.
+    for (const offset of [5, -5]) {
+      const shapeA = square(0, 0, 10);
+      const shapeB = square(offset, 0, 10);
+      const response = getCollisionSat(shapeA, shapeB);
+
+      expect(response).not.toBeNull();
+      expect(response!.overlap).toBeGreaterThan(0);
+
+      shapeA.x -= response!.projectionV.x;
+      shapeA.y -= response!.projectionV.y;
+
+      const resolved = getCollisionSat(shapeA, shapeB);
+
+      // Touching shapes still report a response, but with zero penetration.
+      expect(resolved?.overlap ?? 0).toBeLessThan(response!.overlap);
+      expect(resolved?.overlap ?? 0).toBeCloseTo(0);
+    }
+  });
 });

--- a/test/perf/rendering/resource-lifetime.test.ts
+++ b/test/perf/rendering/resource-lifetime.test.ts
@@ -17,6 +17,7 @@
 // scene transition and never releasing it loses VRAM slowly enough that no
 // single-frame assertion would catch it.
 // ---------------------------------------------------------------------------
+import { textureSeamlessAdapter } from '#assets/seamless';
 import { RenderTarget } from '#rendering/RenderTarget';
 import { DataTexture } from '#rendering/texture/DataTexture';
 import { RenderTexture } from '#rendering/texture/RenderTexture';
@@ -150,6 +151,47 @@ describe('GPU resource lifetime', () => {
       for (const texture of held) {
         texture.destroy();
       }
+    });
+  });
+
+  describe('seamless texture eviction frees GPU memory immediately', () => {
+    test('textureSeamlessAdapter.evict() drops gpuMemoryBytes without waiting for a rebind', () => {
+      const harness = createWebGl2Harness();
+      const texture = new DataTexture({ width: 32, height: 32, format: TextureFormat.Rgba8 });
+
+      measureSteadyFrame(harness, buildSpriteScene({ count: 1, textures: [texture] }).root);
+
+      const beforeEvict = harness.backend.stats.gpuMemoryBytes;
+
+      // Nothing renders this handle again afterwards — the point is that
+      // eviction must not depend on a future bind to notice the drop.
+      textureSeamlessAdapter.evict(texture);
+
+      expect(harness.backend.stats.gpuMemoryBytes).toBeLessThan(beforeEvict);
+    });
+
+    test('an evicted handle stays alive and reusable, unlike destroy()', () => {
+      const harness = createWebGl2Harness();
+      const texture = new DataTexture({ width: 16, height: 16, format: TextureFormat.Rgba8 });
+
+      measureSteadyFrame(harness, buildSpriteScene({ count: 1, textures: [texture] }).root);
+      textureSeamlessAdapter.evict(texture);
+
+      expect(texture.destroyed).toBe(false);
+      expect(() => measureSteadyFrame(harness, buildSpriteScene({ count: 1, textures: [texture] }).root)).not.toThrow();
+    });
+
+    test('a real destroy() after eviction still frees the destroy subscription exactly once', () => {
+      const harness = createWebGl2Harness();
+      const texture = new DataTexture({ width: 16, height: 16, format: TextureFormat.Rgba8 });
+
+      measureSteadyFrame(harness, buildSpriteScene({ count: 1, textures: [texture] }).root);
+      textureSeamlessAdapter.evict(texture);
+
+      // Eviction must not have dropped the destroy subscription — it exists
+      // precisely so a later real destroy() is still observed by the backend.
+      expect(() => texture.destroy()).not.toThrow();
+      expect(texture.destroyed).toBe(true);
     });
   });
 });

--- a/test/perf/rendering/structural-particles.test.ts
+++ b/test/perf/rendering/structural-particles.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tier-A structural regression tests for the WebGL2 particle renderer.
+ *
+ * Key measured fact: the renderer's per-instance buffer is a CPU-side scratch
+ * allocation that the GL buffer is re-sized from on upload — not a hardware
+ * limit. A system holding more live particles than the configured batch size
+ * must therefore still draw every one of them, matching the WebGPU renderer
+ * which grows its instance buffer on demand. Anything less means the same
+ * scene renders a different particle count per backend.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { materializeRendererBindings } from '#extensions/materialize';
+import { Container } from '#rendering/Container';
+
+import { createParticlesExtension } from '../../../packages/exojs-particles/src/particlesExtension';
+import { ParticleSystem } from '../../../packages/exojs-particles/src/ParticleSystem';
+import { makeTextures } from './fixtures';
+import { createWebGl2Harness, measureFrame, type WebGl2Harness } from './harness';
+
+const withParticleHarness = (batchSize: number, fn: (harness: WebGl2Harness) => void): void => {
+  const harness = createWebGl2Harness();
+
+  materializeRendererBindings(harness.backend, createParticlesExtension({ batchSize }).renderers!);
+
+  try {
+    fn(harness);
+  } finally {
+    harness.destroy();
+  }
+};
+
+/**
+ * Build a system with `count` live particles at the view centre. Slots are
+ * written directly and `update()` is never called, so nothing expires and the
+ * live count is exactly `count`.
+ */
+const buildParticleScene = (count: number): { root: Container; system: ParticleSystem } => {
+  const texture = makeTextures(1)[0]!;
+  const system = new ParticleSystem(texture, { capacity: count });
+  const root = new Container();
+
+  for (let i = 0; i < count; i++) {
+    const slot = system.spawn();
+
+    system.posX[slot] = 0;
+    system.posY[slot] = 0;
+    system.scaleX[slot] = 1;
+    system.scaleY[slot] = 1;
+    system.rotations[slot] = 0;
+    system.color[slot] = 0xffffffff;
+    system.lifetime[slot] = 1;
+  }
+
+  system.setPosition(640, 360);
+  root.addChild(system);
+
+  return { root, system };
+};
+
+describe('structural — WebGL2 particles', () => {
+  it('draws every live particle when the count is below the batch size', () => {
+    withParticleHarness(256, harness => {
+      const { root, system } = buildParticleScene(100);
+
+      expect(system.liveCount).toBe(100);
+      expect(measureFrame(harness, root).instances).toBe(100);
+
+      root.destroy();
+    });
+  });
+
+  it('draws every live particle when the count exceeds the batch size', () => {
+    withParticleHarness(64, harness => {
+      const { root, system } = buildParticleScene(500);
+
+      expect(system.liveCount).toBe(500);
+      // Previously clamped to the batch size, silently dropping 436 particles.
+      expect(measureFrame(harness, root).instances).toBe(500);
+
+      root.destroy();
+    });
+  });
+
+  it('keeps the grown capacity across frames instead of reallocating every frame', () => {
+    withParticleHarness(64, harness => {
+      const { root } = buildParticleScene(500);
+
+      measureFrame(harness, root);
+      const second = measureFrame(harness, root);
+
+      expect(second.instances).toBe(500);
+      // The scratch buffer already covers 500 instances, so the second frame
+      // must not orphan-reallocate the instance store again.
+      expect(second.bufferReallocations).toBe(0);
+
+      root.destroy();
+    });
+  });
+});

--- a/test/rendering/container.test.ts
+++ b/test/rendering/container.test.ts
@@ -4,6 +4,7 @@ import type { InteractionHooks, Stage } from '#core/Stage';
 import { FocusController } from '#input/FocusController';
 import { Container } from '#rendering/Container';
 import { Drawable } from '#rendering/Drawable';
+import { ColorFilter } from '#rendering/filters/ColorFilter';
 import { Graphics } from '#rendering/primitives/Graphics';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import type { RenderNode } from '#rendering/RenderNode';
@@ -618,5 +619,114 @@ describe('Container geometry accessors', () => {
     expect(container.width).toBe(300);
 
     container.destroy();
+  });
+});
+
+describe('Container.destroy() tears down the whole subtree', () => {
+  test('every descendant is destroyed, not merely detached', () => {
+    const root = new Container();
+    const branch = new Container();
+    const leaf = new DummyDrawable();
+    const sibling = new DummyDrawable();
+
+    branch.addChild(leaf);
+    root.addChild(branch, sibling);
+
+    const branchSpy = vi.spyOn(branch, 'destroy');
+    const leafSpy = vi.spyOn(leaf, 'destroy');
+    const siblingSpy = vi.spyOn(sibling, 'destroy');
+
+    root.destroy();
+
+    expect(branchSpy).toHaveBeenCalledTimes(1);
+    expect(leafSpy).toHaveBeenCalledTimes(1);
+    expect(siblingSpy).toHaveBeenCalledTimes(1);
+
+    expect(root.destroyed).toBe(true);
+    expect(branch.destroyed).toBe(true);
+    expect(leaf.destroyed).toBe(true);
+    expect(sibling.destroyed).toBe(true);
+  });
+
+  test('a grandchild-held disposable resource is released', () => {
+    const root = new Container();
+    const branch = new Container();
+    const leaf = new DummyDrawable();
+    const filter = new ColorFilter();
+    const filterSpy = vi.spyOn(filter, 'destroy');
+
+    leaf.filters = [filter];
+    branch.addChild(leaf);
+    root.addChild(branch);
+
+    root.destroy();
+
+    // RenderNode.destroy() releases a node's own filters, so this only fires
+    // if the grandchild was genuinely destroyed rather than just unlinked.
+    expect(filterSpy).toHaveBeenCalled();
+  });
+
+  test('descendants are detached as well as destroyed', () => {
+    const root = new Container();
+    const branch = new Container();
+    const leaf = new DummyDrawable();
+
+    branch.addChild(leaf);
+    root.addChild(branch);
+
+    root.destroy();
+
+    expect(root.children).toHaveLength(0);
+    expect(branch.parent).toBeNull();
+  });
+
+  test('an already-destroyed child is not destroyed a second time', () => {
+    const root = new Container();
+    const leaf = new DummyDrawable();
+
+    root.addChild(leaf);
+    leaf.destroy();
+
+    const leafSpy = vi.spyOn(leaf, 'destroy');
+
+    expect(() => root.destroy()).not.toThrow();
+    expect(leafSpy).not.toHaveBeenCalled();
+  });
+
+  test('destroying an already-destroyed container is a no-op', () => {
+    const root = new Container();
+    const leaf = new DummyDrawable();
+
+    root.addChild(leaf);
+    root.destroy();
+
+    const leafSpy = vi.spyOn(leaf, 'destroy');
+
+    expect(() => root.destroy()).not.toThrow();
+    expect(leafSpy).not.toHaveBeenCalled();
+  });
+
+  test('a deep chain is destroyed all the way down', () => {
+    const root = new Container();
+    const nodes: Container[] = [root];
+
+    for (let depth = 0; depth < 5; depth++) {
+      const next = new Container();
+
+      nodes[nodes.length - 1]!.addChild(next);
+      nodes.push(next);
+    }
+
+    const leaf = new DummyDrawable();
+
+    nodes[nodes.length - 1]!.addChild(leaf);
+
+    root.destroy();
+
+    for (const node of nodes) {
+      expect(node.destroyed).toBe(true);
+    }
+
+    expect(leaf.destroyed).toBe(true);
   });
 });

--- a/test/rendering/container.test.ts
+++ b/test/rendering/container.test.ts
@@ -475,3 +475,148 @@ describe('Container paint-order cache', () => {
     expect(container.getChildIndex(c)).toBe(1);
   });
 });
+
+// A 100x100 local-space box, so the geometry accessors below have a nontrivial
+// extent to aggregate.
+class SizedDrawable extends Drawable {
+  public override updateBounds(): this {
+    this.getLocalBounds().set(0, 0, 100, 100);
+
+    return super.updateBounds();
+  }
+
+  public override render(_backend: RenderBackend): this {
+    return this;
+  }
+}
+
+describe('Container geometry accessors', () => {
+  test('width/height report the rendered world extent, not the extent times scale', () => {
+    const container = new Container();
+
+    container.addChild(new SizedDrawable());
+    container.setScale(2, 3);
+
+    // The subtree aggregate is already world-space: a 100x100 child under a
+    // 2x/3x container renders 200x300. Multiplying by scale a second time
+    // would report 400x900.
+    expect(container.width).toBe(200);
+    expect(container.height).toBe(300);
+    expect(container.width).toBe(container.getBounds().width);
+    expect(container.height).toBe(container.getBounds().height);
+
+    container.destroy();
+  });
+
+  test('assigning width/height relates linearly to the resulting rendered size', () => {
+    const container = new Container();
+
+    container.addChild(new SizedDrawable());
+
+    expect(container.width).toBe(100);
+
+    container.width = 200;
+
+    expect(container.width).toBe(200);
+    expect(container.getBounds().width).toBe(200);
+
+    // Doubling the CURRENT width must double the rendered size. Dividing the
+    // target by an already-scaled measurement instead squares the factor, so
+    // this second round trip is where the quadratic relationship shows up.
+    container.width = container.width * 2;
+
+    expect(container.width).toBe(400);
+    expect(container.getBounds().width).toBe(400);
+
+    container.height = 50;
+
+    expect(container.height).toBe(50);
+    expect(container.getBounds().height).toBe(50);
+
+    container.destroy();
+  });
+
+  test('assigning width preserves a mirrored scale sign', () => {
+    const container = new Container();
+
+    container.addChild(new SizedDrawable());
+    container.setScale(-1, 1);
+
+    expect(container.width).toBe(100);
+
+    container.width = 250;
+
+    expect(container.scale.x).toBe(-2.5);
+    expect(container.width).toBe(250);
+
+    container.destroy();
+  });
+
+  test('assigning width to an empty container is a no-op instead of poisoning scale with NaN', () => {
+    const container = new Container();
+
+    container.width = 200;
+    container.height = 200;
+
+    expect(container.scale.x).toBe(1);
+    expect(container.scale.y).toBe(1);
+
+    container.destroy();
+  });
+
+  test('left/top/right/bottom are the world bounds edges for a non-zero origin', () => {
+    const container = new Container();
+
+    container.addChild(new SizedDrawable());
+    // `origin` is in LOCAL pixels: the transform translates by
+    // `position - origin * scale`, so the subtree shifts to (-25,-40)-(75,60).
+    container.setOrigin(25, 40);
+
+    expect(container.left).toBe(-25);
+    expect(container.top).toBe(-40);
+    expect(container.right).toBe(75);
+    expect(container.bottom).toBe(60);
+
+    container.destroy();
+  });
+
+  test('left/top/right/bottom stay mutually consistent under origin, scale and position', () => {
+    const container = new Container();
+
+    container.addChild(new SizedDrawable());
+    container.setOrigin(25, 40);
+    container.setScale(2, 3);
+    container.setPosition(10, 20);
+
+    const bounds = container.getBounds();
+
+    expect(container.left).toBe(bounds.x);
+    expect(container.top).toBe(bounds.y);
+    expect(container.right).toBe(bounds.x + bounds.width);
+    expect(container.bottom).toBe(bounds.y + bounds.height);
+
+    // The edges must span exactly the reported size — the invariant the
+    // mismatched origin terms used to break.
+    expect(container.right - container.left).toBe(container.width);
+    expect(container.bottom - container.top).toBe(container.height);
+
+    container.destroy();
+  });
+
+  test('edges follow a child that moves the aggregate', () => {
+    const container = new Container();
+    const near = new SizedDrawable();
+    const far = new SizedDrawable();
+
+    far.setPosition(200, 200);
+    container.addChild(near, far);
+
+    expect(container.left).toBe(0);
+    expect(container.top).toBe(0);
+    expect(container.right).toBe(300);
+    expect(container.bottom).toBe(300);
+    expect(container.width).toBe(300);
+
+    container.destroy();
+  });
+});

--- a/test/rendering/destroyed-node-collect.test.ts
+++ b/test/rendering/destroyed-node-collect.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Collect-time contract for a node that was `destroy()`ed but left attached to
+ * the tree.
+ *
+ * Two halves:
+ *
+ *   1. Behaviour — the node contributes nothing to the render plan. A destroyed
+ *      node has released its pooled transform/bounds, so collecting it reads
+ *      freed state and re-pins it; "renders nothing" is the only correct result.
+ *
+ *   2. Production parity — the skip is never `__DEV__`-gated, so dev and
+ *      production behave identically. Vitest always compiles `__DEV__` to
+ *      `true`, which makes a dev-only skip indistinguishable from an
+ *      unconditional one at runtime, so this half is verified structurally: the
+ *      early return must not sit inside anything `__DEV__` can switch off.
+ *      Gating it would leave production replaying a destroyed node's last
+ *      visual state — a behavioural divergence, not a missing diagnostic.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import ts from 'typescript';
+
+import { Container } from '#rendering/Container';
+import { Drawable } from '#rendering/Drawable';
+import { type DrawCommand, RenderEntryKind } from '#rendering/plan/RenderCommand';
+import { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
+import { RenderPlanOptimizer } from '#rendering/plan/RenderPlanOptimizer';
+import type { GroupScope } from '#rendering/plan/RenderScope';
+import type { RenderBackend } from '#rendering/RenderBackend';
+import { RenderBackendType } from '#rendering/RenderBackendType';
+import { createRenderStats } from '#rendering/RenderStats';
+import { RenderTarget } from '#rendering/RenderTarget';
+
+class LeafDrawable extends Drawable {
+  public constructor(public readonly id: string) {
+    super();
+    this.getLocalBounds().set(0, 0, 16, 16);
+  }
+}
+
+// File-local fake backend (repo convention keeps test harnesses file-local
+// rather than importing them across test files).
+const createTestBackend = (): RenderBackend => {
+  const renderTarget = new RenderTarget(800, 600, true);
+
+  return {
+    backendType: RenderBackendType.WebGl2,
+    stats: createRenderStats(),
+    renderTarget,
+    get view() {
+      return renderTarget.view;
+    },
+    async initialize() {
+      return this;
+    },
+    resetStats() {
+      return this;
+    },
+    clear() {
+      return this;
+    },
+    resize() {
+      return this;
+    },
+    setView(v) {
+      renderTarget.setView(v);
+      return this;
+    },
+    setRenderTarget() {
+      return this;
+    },
+    pushScissorRect() {
+      return this;
+    },
+    popScissorRect() {
+      return this;
+    },
+    composeWithAlphaMask() {
+      return this;
+    },
+    acquireRenderTexture() {
+      throw new Error('not used in this test');
+    },
+    releaseRenderTexture() {
+      return this;
+    },
+    draw() {
+      return this;
+    },
+    execute() {
+      return this;
+    },
+    flush() {
+      return this;
+    },
+    destroy() {
+      renderTarget.destroy();
+    },
+  } as unknown as RenderBackend;
+};
+
+const gatherScopeDraws = (scope: GroupScope, out: DrawCommand[]): void => {
+  for (const entry of scope.entries) {
+    if (entry.kind === RenderEntryKind.Draw) {
+      out.push(entry.command);
+    } else if (entry.kind === RenderEntryKind.Group) {
+      gatherScopeDraws(entry.scope, out);
+    } else if (entry.kind === RenderEntryKind.Barrier && entry.scope.childPlan !== null) {
+      gatherScopeDraws(entry.scope.childPlan, out);
+    }
+  }
+};
+
+const collectIds = (root: Container, backend: RenderBackend): string[] => {
+  const builder = RenderPlanBuilder.acquire();
+  const plan = builder.build(root, backend);
+
+  RenderPlanOptimizer.optimize(plan);
+
+  const draws: DrawCommand[] = [];
+  for (const pass of plan.passes) {
+    gatherScopeDraws(pass.root, draws);
+  }
+
+  RenderPlanBuilder.release(builder);
+
+  return draws.map(d => (d.drawable as LeafDrawable).id);
+};
+
+describe('destroyed-but-attached node: collect behaviour', () => {
+  test('a destroyed direct child is excluded from the collected draws', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const leafA = new LeafDrawable('a');
+    const leafB = new LeafDrawable('b');
+
+    root.addChild(leafA, leafB);
+
+    expect(collectIds(root, backend)).toEqual(['a', 'b']);
+
+    // The footgun: destroy WITHOUT removeChild, so the node stays linked in.
+    leafA.destroy();
+
+    expect(collectIds(root, backend)).toEqual(['b']);
+
+    backend.destroy();
+  });
+
+  test('a destroyed child nested in a sub-container is excluded too', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const mid = new Container();
+    const leafA = new LeafDrawable('a');
+    const leafB = new LeafDrawable('b');
+
+    mid.addChild(leafA);
+    root.addChild(mid, leafB);
+
+    expect(collectIds(root, backend).sort()).toEqual(['a', 'b']);
+
+    leafA.destroy();
+
+    expect(collectIds(root, backend)).toEqual(['b']);
+
+    backend.destroy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Production parity: the skip must survive `__DEV__ === false`.
+// ---------------------------------------------------------------------------
+
+const rootDir = resolve(import.meta.dirname!, '..', '..');
+
+const devToken = /(?<![a-zA-Z0-9_$])__DEV__(?![a-zA-Z0-9_$])/;
+
+const parseSource = (rel: string): ts.SourceFile =>
+  ts.createSourceFile(rel, readFileSync(resolve(rootDir, rel), 'utf8'), ts.ScriptTarget.ES2022, true);
+
+/**
+ * Whether `node` sits inside anything `__DEV__` can switch off — an
+ * `if (__DEV__)` branch, a `__DEV__ && …` short-circuit, or a `__DEV__ ? …`
+ * conditional. A neighbouring `if (__DEV__) logger.warn(…)` statement is
+ * correctly *not* a gate, which is why this walks the AST instead of nearby
+ * source lines.
+ */
+const isDevGated = (node: ts.Node, source: ts.SourceFile): boolean => {
+  for (let current: ts.Node = node; current.parent !== undefined; current = current.parent) {
+    const parent = current.parent;
+
+    if (
+      ts.isIfStatement(parent) &&
+      (parent.thenStatement === current || parent.elseStatement === current) &&
+      devToken.test(parent.expression.getText(source))
+    ) {
+      return true;
+    }
+
+    if (
+      ts.isConditionalExpression(parent) &&
+      (parent.whenTrue === current || parent.whenFalse === current) &&
+      devToken.test(parent.condition.getText(source))
+    ) {
+      return true;
+    }
+
+    if (ts.isBinaryExpression(parent) && parent.right === current && devToken.test(parent.left.getText(source))) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+/** The body of `RenderNode._collect`, located structurally rather than by line number. */
+const findCollectBody = (source: ts.SourceFile): ts.Block => {
+  let found: ts.Block | undefined;
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isMethodDeclaration(node) && node.name.getText(source) === '_collect' && node.body !== undefined) {
+      found = node.body;
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(source);
+
+  if (found === undefined) {
+    throw new Error('Could not locate RenderNode._collect — update this structural check.');
+  }
+
+  return found;
+};
+
+/** Every `if` inside `_collect` whose condition tests `this.destroyed`. */
+const destroyedGuards = (body: ts.Block, source: ts.SourceFile): ts.IfStatement[] => {
+  const guards: ts.IfStatement[] = [];
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isIfStatement(node) && /(?<![a-zA-Z0-9_$])this\.destroyed(?![a-zA-Z0-9_$])/.test(node.expression.getText(source))) {
+      guards.push(node);
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(body);
+
+  return guards;
+};
+
+describe('destroyed-but-attached node: production parity', () => {
+  test('the destroyed-node skip in RenderNode._collect is not __DEV__-gated', () => {
+    const rel = 'src/rendering/RenderNode.ts';
+    const source = parseSource(rel);
+    const guards = destroyedGuards(findCollectBody(source), source);
+
+    expect(guards.length).toBeGreaterThan(0);
+
+    for (const guard of guards) {
+      // The condition itself must not carry `__DEV__ && …`, and the guard must
+      // not be nested inside a dev-only branch. Either form would strip the
+      // skip from production and leave a destroyed node rendering its last
+      // visual state.
+      expect(devToken.test(guard.expression.getText(source))).toBe(false);
+      expect(isDevGated(guard, source)).toBe(false);
+    }
+  });
+});

--- a/test/rendering/destroyed-node-collect.test.ts
+++ b/test/rendering/destroyed-node-collect.test.ts
@@ -32,6 +32,7 @@ import type { RenderBackend } from '#rendering/RenderBackend';
 import { RenderBackendType } from '#rendering/RenderBackendType';
 import { createRenderStats } from '#rendering/RenderStats';
 import { RenderTarget } from '#rendering/RenderTarget';
+import type { View } from '#rendering/View';
 
 class LeafDrawable extends Drawable {
   public constructor(public readonly id: string) {
@@ -64,7 +65,7 @@ const createTestBackend = (): RenderBackend => {
     resize() {
       return this;
     },
-    setView(v) {
+    setView(v: View | null) {
       renderTarget.setView(v);
       return this;
     },

--- a/test/rendering/destroyed-node-collect.test.ts
+++ b/test/rendering/destroyed-node-collect.test.ts
@@ -177,8 +177,7 @@ const rootDir = resolve(import.meta.dirname!, '..', '..');
 
 const devToken = /(?<![a-zA-Z0-9_$])__DEV__(?![a-zA-Z0-9_$])/;
 
-const parseSource = (rel: string): ts.SourceFile =>
-  ts.createSourceFile(rel, readFileSync(resolve(rootDir, rel), 'utf8'), ts.ScriptTarget.ES2022, true);
+const parseSource = (rel: string): ts.SourceFile => ts.createSourceFile(rel, readFileSync(resolve(rootDir, rel), 'utf8'), ts.ScriptTarget.ES2022, true);
 
 /**
  * Whether `node` sits inside anything `__DEV__` can switch off — an

--- a/test/rendering/render-target.test.ts
+++ b/test/rendering/render-target.test.ts
@@ -1,0 +1,50 @@
+import { RenderTarget } from '#rendering/RenderTarget';
+import { View } from '#rendering/View';
+
+describe('RenderTarget view ownership', () => {
+  test('setView does not destroy the view it replaces', () => {
+    const target = new RenderTarget(320, 200);
+    const first = new View(0, 0, 320, 200);
+    const second = new View(0, 0, 320, 200);
+
+    target.setView(first);
+    target.setView(second);
+
+    expect(first.destroyed).toBe(false);
+    expect(target.view).toBe(second);
+
+    first.destroy();
+    second.destroy();
+    target.destroy();
+  });
+
+  test('destroy releases the default view but leaves an assigned view alive', () => {
+    const target = new RenderTarget(320, 200);
+    const custom = new View(0, 0, 320, 200);
+
+    target.setView(custom);
+    target.destroy();
+
+    // The backend assigns the application's active camera to its root target on
+    // every setView, so destroying the target must not take that camera with it.
+    expect(custom.destroyed).toBe(false);
+
+    custom.setCenter(40, 60);
+
+    expect(custom.getBounds().left).toBe(-120);
+
+    custom.destroy();
+  });
+
+  test('destroy is idempotent and fires destroy listeners exactly once', () => {
+    const target = new RenderTarget(320, 200);
+    const listener = vi.fn();
+
+    target.addDestroyListener(listener);
+    target.destroy();
+    target.destroy();
+
+    expect(target.destroyed).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/rendering/render-texture-pool.test.ts
+++ b/test/rendering/render-texture-pool.test.ts
@@ -1,0 +1,175 @@
+import { MAX_POOLED_RENDER_TEXTURE_BYTES, MAX_POOLED_RENDER_TEXTURES, RenderTexturePool } from '#rendering/RenderTexturePool';
+import { RenderTexture } from '#rendering/texture/RenderTexture';
+import { TextureFormat } from '#rendering/types';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import { createFakeCanvas, createFakeWebGl2Context, GlRecorder, installFakeWebGl2Globals } from '../perf/rendering/fakeWebGl2';
+import { createMockBackend, createMockWebGpuEnvironment } from './webgpuMockEnvironment';
+
+/** A backend wired to the recording fake GL context — enough for pool bookkeeping, no renderers needed. */
+const createFakeWebGl2Backend = (): WebGl2Backend => {
+  installFakeWebGl2Globals();
+
+  const context = createFakeWebGl2Context(new GlRecorder());
+  const canvas = createFakeCanvas(256, 256, context);
+
+  return new WebGl2Backend({
+    canvas,
+    options: { canvas: { width: 256, height: 256 }, rendering: { debug: false }, clearColor: undefined },
+  } as unknown as ConstructorParameters<typeof WebGl2Backend>[0]);
+};
+
+describe('RenderTexturePool', () => {
+  test('hands back an exact size match and allocates for anything else', () => {
+    const pool = new RenderTexturePool();
+    const released = new RenderTexture(64, 32);
+
+    pool.release(released);
+
+    expect(pool.acquire(48, 48)).not.toBe(released);
+    expect(pool.acquire(64, 32)).toBe(released);
+    expect(pool.size).toBe(0);
+  });
+
+  test('releasing the same texture twice pools it once', () => {
+    const pool = new RenderTexturePool();
+    const texture = new RenderTexture(64, 64);
+
+    pool.release(texture);
+    pool.release(texture);
+
+    expect(pool.size).toBe(1);
+  });
+
+  test('caps the entry count and destroys the least recently released entries', () => {
+    const pool = new RenderTexturePool();
+    const released: RenderTexture[] = [];
+
+    for (let index = 0; index < MAX_POOLED_RENDER_TEXTURES * 4; index++) {
+      const texture = new RenderTexture(16, 16);
+
+      released.push(texture);
+      pool.release(texture);
+    }
+
+    const live = released.filter(texture => !texture.destroyed);
+
+    expect(pool.size).toBe(MAX_POOLED_RENDER_TEXTURES);
+    expect(live).toHaveLength(MAX_POOLED_RENDER_TEXTURES);
+    // Least recently released go first, so the survivors are the newest entries.
+    expect(live).toEqual(released.slice(-MAX_POOLED_RENDER_TEXTURES));
+  });
+
+  test('caps the pooled byte budget when the entries are large', () => {
+    const pool = new RenderTexturePool();
+    // 1024×1024 rgba8 = 4 MiB each, so the byte budget bites well before the count cap.
+    const perTextureBytes = 1024 * 1024 * 4;
+    const expectedSurvivors = Math.floor(MAX_POOLED_RENDER_TEXTURE_BYTES / perTextureBytes);
+
+    expect(expectedSurvivors).toBeLessThan(MAX_POOLED_RENDER_TEXTURES);
+
+    for (let index = 0; index < MAX_POOLED_RENDER_TEXTURES; index++) {
+      pool.release(new RenderTexture(1024, 1024));
+    }
+
+    expect(pool.size).toBe(expectedSurvivors);
+    expect(pool.bytes).toBeLessThanOrEqual(MAX_POOLED_RENDER_TEXTURE_BYTES);
+  });
+
+  test('accounts float formats at their real cost', () => {
+    const pool = new RenderTexturePool();
+
+    pool.release(new RenderTexture(256, 256, { format: TextureFormat.Rgba32F }));
+
+    expect(pool.bytes).toBe(256 * 256 * 16);
+  });
+
+  test('never pools an already destroyed texture', () => {
+    const pool = new RenderTexturePool();
+    const texture = new RenderTexture(64, 64);
+
+    texture.destroy();
+    pool.release(texture);
+
+    expect(pool.size).toBe(0);
+    expect(pool.acquire(64, 64)).not.toBe(texture);
+  });
+
+  test('destroy releases every pooled texture; forget drops them untouched', () => {
+    const destroyed = new RenderTexturePool();
+    const forgotten = new RenderTexturePool();
+    const owned = new RenderTexture(64, 64);
+    const orphaned = new RenderTexture(64, 64);
+
+    destroyed.release(owned);
+    forgotten.release(orphaned);
+
+    destroyed.destroy();
+    forgotten.forget();
+
+    expect(destroyed.size).toBe(0);
+    expect(owned.destroyed).toBe(true);
+    expect(forgotten.size).toBe(0);
+    expect(orphaned.destroyed).toBe(false);
+
+    orphaned.destroy();
+  });
+});
+
+describe('WebGl2Backend render texture pool', () => {
+  test('stays bounded when many same-size textures are released', () => {
+    const backend = createFakeWebGl2Backend();
+    const released: RenderTexture[] = [];
+
+    // Hold them all at once — an animated filter whose bounds resize every frame
+    // hands back far more textures than it ever re-acquires at a given size.
+    for (let index = 0; index < MAX_POOLED_RENDER_TEXTURES * 8; index++) {
+      released.push(backend.acquireRenderTexture(32, 32));
+    }
+
+    for (const texture of released) {
+      backend.releaseRenderTexture(texture);
+    }
+
+    const live = released.filter(texture => !texture.destroyed);
+
+    expect(live).toHaveLength(MAX_POOLED_RENDER_TEXTURES);
+    // Eviction must free GPU state, not just drop the reference.
+    expect(released.filter(texture => texture.destroyed)).toHaveLength(MAX_POOLED_RENDER_TEXTURES * 7);
+
+    // A pooled texture is still reused, and an evicted one is never handed back.
+    const reacquired = backend.acquireRenderTexture(32, 32);
+
+    expect(reacquired.destroyed).toBe(false);
+    expect(live).toContain(reacquired);
+
+    backend.destroy();
+  });
+});
+
+describe('WebGpuBackend render texture pool', () => {
+  test('stays bounded when many same-size textures are released', async () => {
+    const backend = await createMockBackend(createMockWebGpuEnvironment());
+    const released: RenderTexture[] = [];
+
+    for (let index = 0; index < MAX_POOLED_RENDER_TEXTURES * 8; index++) {
+      released.push(backend.acquireRenderTexture(32, 32));
+    }
+
+    for (const texture of released) {
+      backend.releaseRenderTexture(texture);
+    }
+
+    const live = released.filter(texture => !texture.destroyed);
+
+    expect(live).toHaveLength(MAX_POOLED_RENDER_TEXTURES);
+    expect(released.filter(texture => texture.destroyed)).toHaveLength(MAX_POOLED_RENDER_TEXTURES * 7);
+
+    const reacquired = backend.acquireRenderTexture(32, 32);
+
+    expect(reacquired.destroyed).toBe(false);
+    expect(live).toContain(reacquired);
+
+    backend.destroy();
+  });
+});

--- a/test/rendering/rendering-context.test.ts
+++ b/test/rendering/rendering-context.test.ts
@@ -396,6 +396,71 @@ describe('RenderingContext', () => {
     node.destroy();
     context.destroy();
   });
+
+  test('swapping the active view leaves the replaced view usable', () => {
+    const { backend } = createMockBackend();
+    const context = new RenderingContext(backend);
+    const first = new View(0, 0, 100, 100);
+    const second = new View(0, 0, 100, 100);
+
+    context.view = first;
+    context.view = second;
+
+    expect(first.destroyed).toBe(false);
+    expect(context.view).toBe(second);
+
+    // A silently destroyed view stops reacting to mutations: its center no
+    // longer marks the transform stale, so the camera freezes without an error.
+    const updateId = first.updateId;
+
+    first.setCenter(25, 50);
+
+    expect(first.updateId).toBeGreaterThan(updateId);
+    expect(first.getBounds().left).toBe(-25);
+
+    first.destroy();
+    second.destroy();
+    context.destroy();
+  });
+
+  test('swapping away and back to a fresh view keeps the active view live', () => {
+    const { backend, setViewSpy } = createMockBackend();
+    const context = new RenderingContext(backend);
+    const node = new Container();
+    const first = new View(0, 0, 100, 100);
+    const second = new View(0, 0, 100, 100);
+    const third = new View(10, 20, 100, 100);
+
+    context.view = first;
+    context.view = second;
+    context.view = third;
+    context.render(node);
+
+    expect(third.destroyed).toBe(false);
+    expect(setViewSpy).toHaveBeenLastCalledWith(third);
+    expect(backend.view).toBe(third);
+
+    first.destroy();
+    second.destroy();
+    third.destroy();
+    node.destroy();
+    context.destroy();
+  });
+
+  test('destroy releases the context-owned views but not a caller-assigned one', () => {
+    const { backend } = createMockBackend();
+    const context = new RenderingContext(backend);
+    const custom = new View(0, 0, 100, 100);
+    const screenView = context.screenView;
+
+    context.view = custom;
+    context.destroy();
+
+    expect(custom.destroyed).toBe(false);
+    expect(screenView.destroyed).toBe(true);
+
+    custom.destroy();
+  });
 });
 
 // Standard interleaved mesh layout: position f32x2 @0, texcoord f32x2 @8,

--- a/test/rendering/text/bitmap-text.test.ts
+++ b/test/rendering/text/bitmap-text.test.ts
@@ -138,6 +138,46 @@ describe('BitmapText', () => {
     expect(text.pageQuads[0]).not.toBe(first);
   });
 
+  test('mutating a style property in place triggers an immediate rebuild', () => {
+    // Line 0 ("A") is narrower than line 1 ("AB"), so right-alignment has to
+    // shift line 0's glyph to the right — a rebuild that skipped would leave
+    // it at x = 0.
+    const text = new BitmapText('A\nAB', makeFont());
+    const first = text.pageQuads[0];
+    const firstX = first.vertices[0];
+
+    text.style.align = 'right';
+
+    expect(text.pageQuads[0]).not.toBe(first);
+    expect(text.pageQuads[0].vertices[0]).toBeGreaterThan(firstX);
+  });
+
+  test('consecutive in-place style mutations each trigger a rebuild', () => {
+    // Guards the dirty-latch failure mode: a style that stays dirty after the
+    // first notification would silently swallow every later mutation.
+    const text = new BitmapText('AB', makeFont());
+
+    text.style.leading = 4;
+    const afterFirst = text.pageQuads[0];
+    text.style.leading = 8;
+
+    expect(text.pageQuads[0]).not.toBe(afterFirst);
+  });
+
+  test('replacing the style detaches the previous one from rebuilds', () => {
+    const text = new BitmapText('AB', makeFont());
+    const previous = text.style;
+    text.style = { align: 'left' };
+
+    const afterSwap = text.pageQuads[0];
+    previous.leading = 12;
+
+    expect(text.pageQuads[0]).toBe(afterSwap);
+
+    text.style.leading = 12;
+    expect(text.pageQuads[0]).not.toBe(afterSwap);
+  });
+
   test('layout setter (maxWidth) triggers rebuild', () => {
     const text = new BitmapText('AB', makeFont());
     const first = text.pageQuads[0];

--- a/test/rendering/text/text-layout.test.ts
+++ b/test/rendering/text/text-layout.test.ts
@@ -387,6 +387,130 @@ describe('layoutText', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Vertical overflow — maxHeight + overflow
+// ---------------------------------------------------------------------------
+
+describe('layoutText vertical overflow', () => {
+  // fontSize 16 * lineHeight 1.2 = 19.2px per line, so maxHeight 40 fits two.
+  const twoLineMaxHeight = 40;
+
+  function overflowStyle(): TextStyle {
+    return new TextStyle({ fontSize: 16, lineHeight: 1.2, align: 'left' });
+  }
+
+  test('maxHeight without overflow keeps every line visible', () => {
+    const placements = layoutText('A\nB\nC', overflowStyle(), { maxHeight: twoLineMaxHeight }, makeAtlas());
+
+    expect(placements).toHaveLength(3);
+    expect(placements[2].y).toBeCloseTo(38.4);
+  });
+
+  test('overflow "clip" drops lines that do not fit maxHeight', () => {
+    const placements = layoutText('A\nB\nC', overflowStyle(), { maxHeight: twoLineMaxHeight, overflow: 'clip' }, makeAtlas());
+
+    expect(placements).toHaveLength(2);
+    expect(placements[0].y).toBe(0);
+    expect(placements[1].y).toBeCloseTo(19.2);
+  });
+
+  test('overflow "ellipsis" clips and appends an ellipsis to the last visible line', () => {
+    const placements = layoutText('A\nB\nC', overflowStyle(), { maxHeight: twoLineMaxHeight, overflow: 'ellipsis' }, makeAtlas());
+
+    // 'A' on line 0, then 'B' + the ellipsis glyph on line 1.
+    expect(placements).toHaveLength(3);
+    expect(placements[0].y).toBe(0);
+    expect(placements[1].y).toBeCloseTo(19.2);
+    expect(placements[2].y).toBeCloseTo(19.2);
+  });
+
+  test('overflow without maxHeight leaves the text untouched', () => {
+    const placements = layoutText('A\nB\nC', overflowStyle(), { overflow: 'clip' }, makeAtlas());
+
+    expect(placements).toHaveLength(3);
+  });
+
+  test('maxHeight smaller than a single line clips everything away', () => {
+    const placements = layoutText('A\nB', overflowStyle(), { maxHeight: 5, overflow: 'clip' }, makeAtlas());
+
+    expect(placements).toHaveLength(0);
+  });
+
+  test('overflow "ellipsis" drops trailing characters so the line still fits maxWidth', () => {
+    // advance 10, maxWidth 30 → three glyph slots. 'ABC' already fills them,
+    // so the ellipsis has to displace a character rather than overflow.
+    const placements = layoutText('ABC\nD', overflowStyle(), { maxWidth: 30, maxHeight: 19.2, overflow: 'ellipsis' }, makeAtlas());
+
+    expect(placements).toHaveLength(3);
+    for (const p of placements) expect(p.y).toBe(0);
+    expect(placements[2].x).toBe(20);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Text direction
+// ---------------------------------------------------------------------------
+
+describe('layoutText direction', () => {
+  /** Provider whose per-character advance doubles as an identity marker. */
+  function makeCharProvider(advances: Record<string, number>): GlyphProvider {
+    return {
+      getGlyph: (char: string, fontSize: number): GlyphInfo => {
+        const advance = advances[char] ?? 10;
+        return {
+          x: 0,
+          y: 0,
+          width: advance,
+          height: fontSize,
+          advance,
+          ascent: fontSize,
+          page: 0,
+          uvLeft: 0,
+          uvTop: 0,
+          uvRight: 1,
+          uvBottom: 1,
+        };
+      },
+    };
+  }
+
+  test('direction "ltr" places glyphs in logical order', () => {
+    const provider = makeCharProvider({ A: 10, B: 20 });
+    const style = new TextStyle({ fontSize: 16, align: 'left' });
+
+    const placements = layoutText('AB', style, { direction: 'ltr' }, provider);
+
+    expect(placements[0].width).toBe(10); // 'A' first
+    expect(placements[0].x).toBe(0);
+    expect(placements[1].width).toBe(20); // 'B' second
+    expect(placements[1].x).toBe(10);
+  });
+
+  test('direction "rtl" reverses the visual glyph order within a line', () => {
+    const provider = makeCharProvider({ A: 10, B: 20 });
+    const style = new TextStyle({ fontSize: 16, align: 'left' });
+
+    const placements = layoutText('AB', style, { direction: 'rtl' }, provider);
+
+    expect(placements[0].width).toBe(20); // 'B' now leads visually
+    expect(placements[0].x).toBe(0);
+    expect(placements[1].width).toBe(10); // 'A' trails
+    expect(placements[1].x).toBe(20);
+  });
+
+  test('direction "rtl" reverses each line independently', () => {
+    const provider = makeCharProvider({ A: 10, B: 20, C: 30, D: 40 });
+    const style = new TextStyle({ fontSize: 16, lineHeight: 1.2, align: 'left' });
+
+    const placements = layoutText('AB\nCD', style, { direction: 'rtl' }, provider);
+
+    expect(placements[0].width).toBe(20); // line 0 → 'B', 'A'
+    expect(placements[1].width).toBe(10);
+    expect(placements[2].width).toBe(40); // line 1 → 'D', 'C'
+    expect(placements[3].width).toBe(30);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // measureText()
 // ---------------------------------------------------------------------------
 

--- a/test/rendering/view.test.ts
+++ b/test/rendering/view.test.ts
@@ -182,3 +182,33 @@ describe('View — coordinate conversion', () => {
     expect(highDpr.y).toBeCloseTo(300, 2);
   });
 });
+
+describe('View.destroy', () => {
+  test('reports destroyed only after destroy has run', () => {
+    const view = new View(0, 0, 100, 100);
+
+    expect(view.destroyed).toBe(false);
+
+    view.destroy();
+
+    expect(view.destroyed).toBe(true);
+  });
+
+  test('is idempotent — a second call is a no-op and never re-releases owned state', () => {
+    const view = new View(0, 0, 100, 100);
+    const centerDestroy = vi.spyOn(view.center, 'destroy');
+    const sizeDestroy = vi.spyOn(view.size, 'destroy');
+    const viewportDestroy = vi.spyOn(view.viewport, 'destroy');
+
+    view.destroy();
+
+    expect(() => {
+      view.destroy();
+    }).not.toThrow();
+
+    expect(view.destroyed).toBe(true);
+    expect(centerDestroy).toHaveBeenCalledTimes(1);
+    expect(sizeDestroy).toHaveBeenCalledTimes(1);
+    expect(viewportDestroy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Fixes 19 confirmed BLOCKER/HIGH findings from an independent architecture review, cross-checked against a second independent evaluation pass. Each fix ships with a regression test that was verified to fail against the pre-fix code first.

## Core / Runtime
- Frame delta now measures true wall-clock time between frames instead of frame-period-minus-processing-time, which was making the simulation run in slow motion under load.
- The WebGPU→WebGL2 auto-fallback now re-registers the rebuilt `RenderingContext` with the `SystemRegistry` and the core-system teardown list — previously the destroyed instance kept ticking and got double-destroyed on teardown.

## Scene Graph
- `visible` setter now invalidates ancestor bounds, fixing wrongly-culled subtrees after a re-show.
- `Container.width`/`height`/`left`/`top`/`right`/`bottom` now use correct, mutually consistent geometry (previously quadratic instead of linear scaling, and dimensionally wrong edges under a non-zero origin).
- `RenderNode._collect` now skips destroyed-but-attached nodes unconditionally, not only under `__DEV__`.
- `Container.destroy()` now recursively destroys the whole subtree instead of only detaching children, closing a GPU/signal-listener leak on every scene change.

## Math
- `getCollisionSat`'s MTV direction is now stable and oriented consistently with the rest of the collision module (previously mirrored shape layouts could yield identical, wrong-direction normals).

## Rendering
- `View.destroy()` is now idempotent; view ownership on `RenderingContext.view`/`RenderTarget` is now caller-owned, matching `trackView`'s documented model (same leak also found and fixed on `RenderTarget.destroy()`).
- The shared render-texture pool is now bounded by entry count and byte budget with LRU eviction, instead of growing without limit.
- GPU memory for a seamlessly-evicted texture is now actually released immediately via a new release-listener mechanism, instead of only bumping a version counter that a backend might never notice.

## Audio
- `SoundPlayOptions.replace` is now implemented (previously documented but a no-op).

## Physics
- Destroying a body or collider now wakes every sleeping body it was touching, so a stack resting on a destroyed support falls instead of staying frozen (affects both kinematic and dynamic supports).

## Particles / Text
- `BitmapText.style.*` mutation now triggers a rebuild, matching its documented "immediate rebuild" contract.
- `LayoutOptions.maxHeight`/`overflow`/`direction` are now implemented in text layout (RTL as visual line reversal; full bidi is out of scope and documented as such).
- The WebGL2 particle instance buffer now grows to fit the live count instead of silently dropping particles above a fixed cap.
- `SpawnOnDeath` now spawns at the correct death position in GPU simulation mode.

## Input
- Mouse wheel deltas now accumulate across multiple events per frame and normalize `deltaMode`, instead of the last event silently overwriting the rest.
- Steam Deck trigger axes now route to the canonical `GamepadButton` trigger channel.

## Docs
- The backend-comparison guide notes that WebGPU isn't reliable on Safari yet, next to the parity matrix that already shows it.

## Verification
- `pnpm verify:quick` and the full multi-project test suite (8891 passed) both green.
- No public API export drift (root-index snapshot unchanged).