### PR TITLE
fix(core): detach a node from its parent when it is destroyed

### DIFF
--- a/packages/exojs-bench/src/rendering/driver.ts
+++ b/packages/exojs-bench/src/rendering/driver.ts
@@ -230,11 +230,11 @@ const realShaderPlugin = {
  * MUST be `false`: the competitor arms are pre-bundled from their published npm
  * dist (`optimizeDeps.include`), i.e. their PRODUCTION builds with dev-only
  * guards already stripped. Measuring exojs source with `__DEV__=true` therefore
- * pits an unshipped dev build (per-frame dev diagnostics — e.g.
- * `RetainedGroupFragment._devHasDestroyedDrawable`, a full O(captured-drawables)
- * scan every clean retained frame) against competitors' prod builds. That
- * asymmetry inflated the exojs numbers by 20-30x on the static-heavy retained
- * arm alone (2.3 ms vs the real ~0.1 ms prod floor). `false` compiles the same
+ * pits an unshipped dev build — carrying per-frame dev diagnostics that can scan
+ * the whole captured set on a clean retained frame — against competitors' prod
+ * builds. That asymmetry inflated the exojs numbers by 20-30x on the
+ * static-heavy retained arm alone (2.3 ms vs the real ~0.1 ms prod floor).
+ * `false` compiles the same
  * path a shipped exojs game runs, making the cross-arm comparison apples-to-apples.
  */
 const ENGINE_DEV_BUILD = false;

--- a/site/src/content/api/abstract-text.json
+++ b/site/src/content/api/abstract-text.json
@@ -427,7 +427,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Release this node's pooled state (transform, bounds, flags) and unlink it from its parent. The unlink comes first and is what makes a bare destroy() safe. A node left in its parent's child list bumps no revision, so every cache keyed on that revision — a Container's retained draw slots, a RetainedContainer's recorded GPU instruction set — would keep replaying the dead node's last captured frame. Removing it stamps the parent structure-dirty, which drops those captures, and runs the node's regular detach cleanup (bounds cascade, interaction/focus deregistration, stage clearing) while this node's own state is still intact. Container.removeChild is a no-op for a node it does not hold, so the already-correct removeChild()-then-destroy() order costs nothing more than the null check here. The destroyed flag is raised before the unlink so detach-time observers (e.g. focus, which suppresses onBlur on a destroyed node) see a node that is going away rather than one merely being reparented."
         },
         {
           "name": "focus",
@@ -2146,7 +2146,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "filters",

--- a/site/src/content/api/animated-sprite.json
+++ b/site/src/content/api/animated-sprite.json
@@ -511,7 +511,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Release this node's pooled state (transform, bounds, flags) and unlink it from its parent. The unlink comes first and is what makes a bare destroy() safe. A node left in its parent's child list bumps no revision, so every cache keyed on that revision — a Container's retained draw slots, a RetainedContainer's recorded GPU instruction set — would keep replaying the dead node's last captured frame. Removing it stamps the parent structure-dirty, which drops those captures, and runs the node's regular detach cleanup (bounds cascade, interaction/focus deregistration, stage clearing) while this node's own state is still intact. Container.removeChild is a no-op for a node it does not hold, so the already-correct removeChild()-then-destroy() order costs nothing more than the null check here. The destroyed flag is raised before the unlink so detach-time observers (e.g. focus, which suppresses onBlur on a destroyed node) see a node that is going away rather than one merely being reparented."
         },
         {
           "name": "focus",
@@ -2776,7 +2776,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "filters",

--- a/site/src/content/api/bitmap-text.json
+++ b/site/src/content/api/bitmap-text.json
@@ -472,7 +472,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Release this node's pooled state (transform, bounds, flags) and unlink it from its parent. The unlink comes first and is what makes a bare destroy() safe. A node left in its parent's child list bumps no revision, so every cache keyed on that revision — a Container's retained draw slots, a RetainedContainer's recorded GPU instruction set — would keep replaying the dead node's last captured frame. Removing it stamps the parent structure-dirty, which drops those captures, and runs the node's regular detach cleanup (bounds cascade, interaction/focus deregistration, stage clearing) while this node's own state is still intact. Container.removeChild is a no-op for a node it does not hold, so the already-correct removeChild()-then-destroy() order costs nothing more than the null check here. The destroyed flag is raised before the unlink so detach-time observers (e.g. focus, which suppresses onBlur on a destroyed node) see a node that is going away rather than one merely being reparented."
         },
         {
           "name": "focus",
@@ -2238,7 +2238,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "filters",

--- a/site/src/content/api/button.json
+++ b/site/src/content/api/button.json
@@ -2980,7 +2980,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "enabled",

--- a/site/src/content/api/container.json
+++ b/site/src/content/api/container.json
@@ -2545,7 +2545,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "filters",

--- a/site/src/content/api/drawable.json
+++ b/site/src/content/api/drawable.json
@@ -409,7 +409,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Release this node's pooled state (transform, bounds, flags) and unlink it from its parent. The unlink comes first and is what makes a bare destroy() safe. A node left in its parent's child list bumps no revision, so every cache keyed on that revision — a Container's retained draw slots, a RetainedContainer's recorded GPU instruction set — would keep replaying the dead node's last captured frame. Removing it stamps the parent structure-dirty, which drops those captures, and runs the node's regular detach cleanup (bounds cascade, interaction/focus deregistration, stage clearing) while this node's own state is still intact. Container.removeChild is a no-op for a node it does not hold, so the already-correct removeChild()-then-destroy() order costs nothing more than the null check here. The destroyed flag is raised before the unlink so detach-time observers (e.g. focus, which suppresses onBlur on a destroyed node) see a node that is going away rather than one merely being reparented."
         },
         {
           "name": "focus",
@@ -2052,7 +2052,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "filters",

--- a/site/src/content/api/graphics.json
+++ b/site/src/content/api/graphics.json
@@ -4077,7 +4077,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "fillColor",

--- a/site/src/content/api/htmltext.json
+++ b/site/src/content/api/htmltext.json
@@ -2810,7 +2810,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "filters",

--- a/site/src/content/api/image-layer-node.json
+++ b/site/src/content/api/image-layer-node.json
@@ -2564,7 +2564,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "filters",

--- a/site/src/content/api/label.json
+++ b/site/src/content/api/label.json
@@ -2903,7 +2903,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "enabled",

--- a/site/src/content/api/mesh.json
+++ b/site/src/content/api/mesh.json
@@ -430,7 +430,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Release this node's pooled state (transform, bounds, flags) and unlink it from its parent. The unlink comes first and is what makes a bare destroy() safe. A node left in its parent's child list bumps no revision, so every cache keyed on that revision — a Container's retained draw slots, a RetainedContainer's recorded GPU instruction set — would keep replaying the dead node's last captured frame. Removing it stamps the parent structure-dirty, which drops those captures, and runs the node's regular detach cleanup (bounds cascade, interaction/focus deregistration, stage clearing) while this node's own state is still intact. Container.removeChild is a no-op for a node it does not hold, so the already-correct removeChild()-then-destroy() order costs nothing more than the null check here. The destroyed flag is raised before the unlink so detach-time observers (e.g. focus, which suppresses onBlur on a destroyed node) see a node that is going away rather than one merely being reparented."
         },
         {
           "name": "focus",
@@ -2143,7 +2143,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "filters",

--- a/site/src/content/api/nine-slice-sprite.json
+++ b/site/src/content/api/nine-slice-sprite.json
@@ -455,7 +455,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Release this node's pooled state (transform, bounds, flags) and unlink it from its parent. The unlink comes first and is what makes a bare destroy() safe. A node left in its parent's child list bumps no revision, so every cache keyed on that revision — a Container's retained draw slots, a RetainedContainer's recorded GPU instruction set — would keep replaying the dead node's last captured frame. Removing it stamps the parent structure-dirty, which drops those captures, and runs the node's regular detach cleanup (bounds cascade, interaction/focus deregistration, stage clearing) while this node's own state is still intact. Container.removeChild is a no-op for a node it does not hold, so the already-correct removeChild()-then-destroy() order costs nothing more than the null check here. The destroyed flag is raised before the unlink so detach-time observers (e.g. focus, which suppresses onBlur on a destroyed node) see a node that is going away rather than one merely being reparented."
         },
         {
           "name": "focus",
@@ -2380,7 +2380,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "filters",

--- a/site/src/content/api/panel.json
+++ b/site/src/content/api/panel.json
@@ -2987,7 +2987,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "enabled",

--- a/site/src/content/api/particle-system.json
+++ b/site/src/content/api/particle-system.json
@@ -3153,7 +3153,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "filters",

--- a/site/src/content/api/progress-bar.json
+++ b/site/src/content/api/progress-bar.json
@@ -2903,7 +2903,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "enabled",

--- a/site/src/content/api/render-node.json
+++ b/site/src/content/api/render-node.json
@@ -410,7 +410,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Release this node's pooled state (transform, bounds, flags) and unlink it from its parent. The unlink comes first and is what makes a bare destroy() safe. A node left in its parent's child list bumps no revision, so every cache keyed on that revision — a Container's retained draw slots, a RetainedContainer's recorded GPU instruction set — would keep replaying the dead node's last captured frame. Removing it stamps the parent structure-dirty, which drops those captures, and runs the node's regular detach cleanup (bounds cascade, interaction/focus deregistration, stage clearing) while this node's own state is still intact. Container.removeChild is a no-op for a node it does not hold, so the already-correct removeChild()-then-destroy() order costs nothing more than the null check here. The destroyed flag is raised before the unlink so detach-time observers (e.g. focus, which suppresses onBlur on a destroyed node) see a node that is going away rather than one merely being reparented."
         },
         {
           "name": "focus",
@@ -1938,7 +1938,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "filters",

--- a/site/src/content/api/repeating-sprite.json
+++ b/site/src/content/api/repeating-sprite.json
@@ -463,7 +463,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Release this node's pooled state (transform, bounds, flags) and unlink it from its parent. The unlink comes first and is what makes a bare destroy() safe. A node left in its parent's child list bumps no revision, so every cache keyed on that revision — a Container's retained draw slots, a RetainedContainer's recorded GPU instruction set — would keep replaying the dead node's last captured frame. Removing it stamps the parent structure-dirty, which drops those captures, and runs the node's regular detach cleanup (bounds cascade, interaction/focus deregistration, stage clearing) while this node's own state is still intact. Container.removeChild is a no-op for a node it does not hold, so the already-correct removeChild()-then-destroy() order costs nothing more than the null check here. The destroyed flag is raised before the unlink so detach-time observers (e.g. focus, which suppresses onBlur on a destroyed node) see a node that is going away rather than one merely being reparented."
         },
         {
           "name": "focus",
@@ -2242,7 +2242,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "filters",

--- a/site/src/content/api/retained-container.json
+++ b/site/src/content/api/retained-container.json
@@ -647,7 +647,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": "Release the retained GPU instruction set and fragment cache, then destroy this container and its subtree. Beware the in-place-destroy footgun: SceneNode.destroy does not detach a node from its parent, and the retained fragment keeps the whole previously-collected command range — including a child's resources — until a structural change drops it. Destroying a child directly leaves the fragment replaying freed resources, because nothing invalidated it. Call Container.removeChild first (removal bumps the structure revision and drops the fragment), or destroy the whole group at once."
+          "description": "Release the retained GPU instruction set and fragment cache, then destroy this container and its subtree. A retained fragment keeps the whole previously-collected command range — including a child's resources — until a structural change drops it. Destroying a descendant on its own is safe regardless of call order: SceneNode.destroy unlinks the node from its parent, and that removal bumps the structure revision up to this boundary, which drops the fragment instead of replaying freed resources."
         },
         {
           "name": "focus",
@@ -2621,7 +2621,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "filters",

--- a/site/src/content/api/scene-node.json
+++ b/site/src/content/api/scene-node.json
@@ -307,7 +307,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Release this node's pooled state (transform, bounds, flags) and unlink it from its parent. The unlink comes first and is what makes a bare destroy() safe. A node left in its parent's child list bumps no revision, so every cache keyed on that revision — a Container's retained draw slots, a RetainedContainer's recorded GPU instruction set — would keep replaying the dead node's last captured frame. Removing it stamps the parent structure-dirty, which drops those captures, and runs the node's regular detach cleanup (bounds cascade, interaction/focus deregistration, stage clearing) while this node's own state is still intact. Container.removeChild is a no-op for a node it does not hold, so the already-correct removeChild()-then-destroy() order costs nothing more than the null check here. The destroyed flag is raised before the unlink so detach-time observers (e.g. focus, which suppresses onBlur on a destroyed node) see a node that is going away rather than one merely being reparented."
         },
         {
           "name": "getBounds",
@@ -1420,7 +1420,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "isAlignedBox",

--- a/site/src/content/api/scroll-container.json
+++ b/site/src/content/api/scroll-container.json
@@ -3041,7 +3041,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "enabled",

--- a/site/src/content/api/sprite.json
+++ b/site/src/content/api/sprite.json
@@ -386,7 +386,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Release this node's pooled state (transform, bounds, flags) and unlink it from its parent. The unlink comes first and is what makes a bare destroy() safe. A node left in its parent's child list bumps no revision, so every cache keyed on that revision — a Container's retained draw slots, a RetainedContainer's recorded GPU instruction set — would keep replaying the dead node's last captured frame. Removing it stamps the parent structure-dirty, which drops those captures, and runs the node's regular detach cleanup (bounds cascade, interaction/focus deregistration, stage clearing) while this node's own state is still intact. Container.removeChild is a no-op for a node it does not hold, so the already-correct removeChild()-then-destroy() order costs nothing more than the null check here. The destroyed flag is raised before the unlink so detach-time observers (e.g. focus, which suppresses onBlur on a destroyed node) see a node that is going away rather than one merely being reparented."
         },
         {
           "name": "focus",
@@ -2218,7 +2218,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "filters",

--- a/site/src/content/api/stack.json
+++ b/site/src/content/api/stack.json
@@ -2958,7 +2958,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "direction",

--- a/site/src/content/api/text.json
+++ b/site/src/content/api/text.json
@@ -453,7 +453,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Release this node's pooled state (transform, bounds, flags) and unlink it from its parent. The unlink comes first and is what makes a bare destroy() safe. A node left in its parent's child list bumps no revision, so every cache keyed on that revision — a Container's retained draw slots, a RetainedContainer's recorded GPU instruction set — would keep replaying the dead node's last captured frame. Removing it stamps the parent structure-dirty, which drops those captures, and runs the node's regular detach cleanup (bounds cascade, interaction/focus deregistration, stage clearing) while this node's own state is still intact. Container.removeChild is a no-op for a node it does not hold, so the already-correct removeChild()-then-destroy() order costs nothing more than the null check here. The destroyed flag is raised before the unlink so detach-time observers (e.g. focus, which suppresses onBlur on a destroyed node) see a node that is going away rather than one merely being reparented."
         },
         {
           "name": "focus",
@@ -2243,7 +2243,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "filters",

--- a/site/src/content/api/tile-layer-node.json
+++ b/site/src/content/api/tile-layer-node.json
@@ -2618,7 +2618,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "filters",

--- a/site/src/content/api/tile-map-band.json
+++ b/site/src/content/api/tile-map-band.json
@@ -2565,7 +2565,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "filters",

--- a/site/src/content/api/tile-map-node.json
+++ b/site/src/content/api/tile-map-node.json
@@ -2680,7 +2680,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "filters",

--- a/site/src/content/api/uiroot.json
+++ b/site/src/content/api/uiroot.json
@@ -2544,7 +2544,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "filters",

--- a/site/src/content/api/video.json
+++ b/site/src/content/api/video.json
@@ -502,7 +502,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Release this node's pooled state (transform, bounds, flags) and unlink it from its parent. The unlink comes first and is what makes a bare destroy() safe. A node left in its parent's child list bumps no revision, so every cache keyed on that revision — a Container's retained draw slots, a RetainedContainer's recorded GPU instruction set — would keep replaying the dead node's last captured frame. Removing it stamps the parent structure-dirty, which drops those captures, and runs the node's regular detach cleanup (bounds cascade, interaction/focus deregistration, stage clearing) while this node's own state is still intact. Container.removeChild is a no-op for a node it does not hold, so the already-correct removeChild()-then-destroy() order costs nothing more than the null check here. The destroyed flag is raised before the unlink so detach-time observers (e.g. focus, which suppresses onBlur on a destroyed node) see a node that is going away rather than one merely being reparented."
         },
         {
           "name": "focus",
@@ -2929,7 +2929,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "duration",

--- a/site/src/content/api/widget.json
+++ b/site/src/content/api/widget.json
@@ -2865,7 +2865,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node and — for a RetainedContainer — evicts it from any cached fragment so a child destroyed without removeChild cannot be replayed stale."
+          "description": "true once destroy has run on this node. A destroyed node has released its pooled resources (transform/bounds), has been unlinked from its parent, renders nothing, and must not be reused or re-attached. The render plan skips a destroyed node, so even one handed straight to a renderer as a detached root contributes nothing."
         },
         {
           "name": "enabled",

--- a/site/src/content/guide/rendering/retained-containers.mdx
+++ b/site/src/content/guide/rendering/retained-containers.mdx
@@ -113,15 +113,11 @@ That is what makes the cost **O(batches)** rather than O(nodes) in the group. It
 On a real-GPU run (WebGL2 and WebGPU, both backends), a 100k-sprite retained `static-heavy` scene costs 0.215 ms (WebGL2) and 0.252 ms (WebGPU) per frame — the two backends within ~1.17× of each other, both near the CPU-timer floor. On `batch-breaking` (a scene deliberately designed to defeat sprite-batching with many distinct textures) at 25k retained nodes, WebGL2 costs 23.7 ms and WebGPU 4.6 ms — WebGPU is the faster backend on this workload. Both are the recorded-batch tier at work: cost tracks batch count, not node count.
 </Callout>
 
-## Lifecycle and the in-place-destroy footgun
+## Lifecycle
 
-Adding and removing children works exactly as on a plain container, and both correctly invalidate the fragment. Destroying is where the retained tier has a sharp edge.
+Adding, removing and destroying children all work exactly as on a plain container, and all three correctly invalidate the fragment.
 
-Because the fragment holds the whole previously-collected command range, it keeps references to the resources of every child — and [`destroy()`](/ExoJS/en/api/scene-node/) does **not** detach a node from its parent. So calling `child.destroy()` on a child that is still in the group leaves the child in the child list, does not bump the structure revision, and the fragment keeps replaying the freed resources until some _other_ change happens to invalidate it.
-
-<Callout type="pitfall" title="Remove before you destroy a child">
-`retained.removeChild(child)` first, then `child.destroy()`. Removal bumps the structure revision, which drops the fragment, so the next frame re-collects without the departed child. Destroying a child in place skips that step. Destroying the whole `RetainedContainer` is always safe — it tears down its subtree and releases the retained GPU bundle together.
-</Callout>
+The fragment holds the whole previously-collected command range, so it keeps references to the resources of every child until something drops it. That something is the structure revision: [`destroy()`](/ExoJS/en/api/scene-node/) unlinks the node from its parent as its first step, and that removal bumps the revision up to the group boundary. Whether you call `retained.removeChild(child)` first or destroy the child in place, the next frame re-collects without it — no stale replay of freed resources either way. Destroying the whole `RetainedContainer` tears down its subtree and releases the retained GPU bundle together.
 
 ## Effects on children: supported, with one depth rule
 

--- a/site/src/content/guide/runtime/scene-graph.mdx
+++ b/site/src/content/guide/runtime/scene-graph.mdx
@@ -137,6 +137,8 @@ Removing a child doesn't destroy it — you can keep the reference and re-add it
 `removeChild` only detaches — the node keeps its textures, listeners and children in memory, ready to re-add. When you're done with it for good, call `destroy()` too, or it lingers as a leak.
 </Callout>
 
+The reverse direction needs no bookkeeping: `destroy()` unlinks the node from its parent for you, so `child.destroy()` on its own leaves no dangling entry in the child list. A destroyed node is permanently spent, though — re-adding one throws rather than silently rendering nothing.
+
 ## Why this stays composable
 
 Because transforms cascade and children render in order, large scenes are built by nesting smaller scenes. A `Player` container groups body, weapon, hat, and effects. A `World` container groups player, enemies, and tiles. A `Game` scene groups world and HUD.

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -307,10 +307,10 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
 
   /**
    * `true` once {@link destroy} has run on this node. A destroyed node has
-   * released its pooled resources (transform/bounds), renders nothing, and
-   * must not be reused or re-attached. The render plan skips a destroyed node
-   * and — for a {@link RetainedContainer} — evicts it from any cached fragment
-   * so a child destroyed without `removeChild` cannot be replayed stale.
+   * released its pooled resources (transform/bounds), has been unlinked from
+   * its parent, renders nothing, and must not be reused or re-attached. The
+   * render plan skips a destroyed node, so even one handed straight to a
+   * renderer as a detached root contributes nothing.
    */
   public get destroyed(): boolean {
     return this._isDestroyed;
@@ -839,8 +839,30 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
     return view.getBounds().intersectsWith(bounds);
   }
 
+  /**
+   * Release this node's pooled state (transform, bounds, flags) and unlink it
+   * from its parent.
+   *
+   * The unlink comes first and is what makes a bare `destroy()` safe. A node
+   * left in its parent's child list bumps no revision, so every cache keyed on
+   * that revision — a {@link Container}'s retained draw slots, a
+   * `RetainedContainer`'s recorded GPU instruction set — would keep replaying
+   * the dead node's last captured frame. Removing it stamps the parent
+   * structure-dirty, which drops those captures, and runs the node's regular
+   * detach cleanup (bounds cascade, interaction/focus deregistration, stage
+   * clearing) while this node's own state is still intact.
+   *
+   * `Container.removeChild` is a no-op for a node it does not hold, so the
+   * already-correct `removeChild()`-then-`destroy()` order costs nothing more
+   * than the null check here.
+   *
+   * The destroyed flag is raised before the unlink so detach-time observers
+   * (e.g. focus, which suppresses `onBlur` on a destroyed node) see a node that
+   * is going away rather than one merely being reparented.
+   */
   public destroy(): void {
     this._isDestroyed = true;
+    this._parentNode?.removeChild(this as unknown as RenderNode);
     this._transform.destroy();
     this._position.destroy();
     this._scale.destroy();

--- a/src/input/FocusController.ts
+++ b/src/input/FocusController.ts
@@ -89,10 +89,11 @@ export class FocusController implements FocusHooks {
 
   /**
    * Clear focus, or only clear it when `node` currently holds it. Fires
-   * `onBlur` — unless the previously focused node is already destroyed (a
-   * bare `destroy()` with no prior `removeChild()` never reaches
-   * {@link _notifyNodeRemoved}, so this can be the first place that notices),
-   * in which case no event is dispatched on it.
+   * `onBlur` — unless the previously focused node is already destroyed, in
+   * which case no event is dispatched on it. `destroy()` unlinks the node and
+   * so routes through {@link _notifyNodeRemoved} here, but it raises the
+   * destroyed flag first precisely so a teardown drops focus without calling
+   * back into user code on a node that is going away.
    */
   public blur(node?: RenderNode): void {
     const previous = this._focused;

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -410,20 +410,14 @@ export class Container extends RenderNode {
 
     const viewUpdateId = builder.view.updateId;
 
+    // A captured slot can no longer outlive its drawable: `SceneNode.destroy`
+    // unlinks the node, and the removal stamps this container structure-dirty,
+    // so a destroyed direct child always fails the key check above rather than
+    // being replayed from a stale slot.
     if (this._retainedPlan?.isClean(this._contentRevision, this._structureRevision, this._transformRevision, viewUpdateId, builder.backend)) {
-      if (__DEV__ && this._retainedPlan._devHasDestroyedDrawable()) {
-        // A direct drawable child was destroy()ed but left attached, so
-        // no revision bumped and the slot cache still looks clean. Drop the
-        // stale capture (releasing the strong refs) and fall through to a full
-        // collect, which skips the destroyed child (RenderNode._collect dev
-        // guard) and recaptures without it. Silent here — the loud diagnostic
-        // is owned by the nearest RetainedContainer.
-        this._retainedPlan.invalidate();
-      } else {
-        this._replayRetainedChildren(builder);
+      this._replayRetainedChildren(builder);
 
-        return;
-      }
+      return;
     }
 
     this._collectAndCaptureChildren(builder, viewUpdateId);

--- a/src/rendering/RenderNode.ts
+++ b/src/rendering/RenderNode.ts
@@ -395,11 +395,11 @@ export abstract class RenderNode extends SceneNode {
   /** @internal */
   public _collect(builder: RenderPlanBuilder, seq?: number): void {
     if (this.destroyed) {
-      // A node destroy()ed but left attached to the tree (the documented
-      // footgun) has released its pooled transform/bounds; collecting it would
-      // read freed state and re-pin it. Skip it — the diagnostic is emitted
-      // once by the nearest RetainedContainer; the plain path degrades
-      // silently to "renders nothing", which is the correct result.
+      // A destroyed node has released its pooled transform/bounds; collecting
+      // it would read freed state and re-pin it. `destroy()` unlinks the node,
+      // so this normally cannot be reached through a parent's child list — but
+      // a destroyed node handed straight to the renderer as a detached root
+      // still lands here. Skip it: "renders nothing" is the correct result.
       //
       // Unconditional, NOT __DEV__-gated: the skip is the behaviour, not a
       // diagnostic. Gating it would let production keep replaying a destroyed

--- a/src/rendering/RetainedContainer.ts
+++ b/src/rendering/RetainedContainer.ts
@@ -123,7 +123,6 @@ export class RetainedContainer extends Container {
   private _devFragmentBuilds = 0;
   private _devFragmentInvalidations = 0;
   private _devRetentionWarned = false;
-  private _devDestroyedWarned = false;
 
   public constructor() {
     super();
@@ -303,18 +302,11 @@ export class RetainedContainer extends Container {
       return;
     }
 
-    const fragmentClean = this._fragment.isClean(this._contentRevision, this._structureRevision, builder.backend);
-
-    if (fragmentClean && __DEV__ && this._fragment._devHasDestroyedDrawable()) {
-      // P3f: a descendant was destroy()ed but left attached, so no revision
-      // bumped and the capture still looks clean. Replaying it would splice a
-      // dead drawable for a whole frame and pin it against GC. Drop the capture
-      // (releasing the strong refs), warn once, and fall through to a full
-      // collect — which skips the destroyed child (RenderNode._collect dev
-      // guard) and recaptures a clean fragment.
-      this._fragment.invalidate();
-      this._warnReplayedDestroyed();
-    } else if (fragmentClean) {
+    // A recorded draw can no longer outlive its drawable: `SceneNode.destroy`
+    // unlinks the node, and that removal stamps every ancestor up to this
+    // boundary structure-dirty, so a destroyed descendant always fails the key
+    // check below instead of being replayed out of the recorded bundle.
+    if (this._fragment.isClean(this._contentRevision, this._structureRevision, builder.backend)) {
       // A content/structure-clean frame may still carry transform-only
       // descendant moves, since an own-transform move no longer content-
       // dirties. The recorded instruction set's baked transform rows are stale
@@ -499,13 +491,12 @@ export class RetainedContainer extends Container {
    * Release the retained GPU instruction set and fragment cache, then destroy
    * this container and its subtree.
    *
-   * Beware the in-place-destroy footgun: {@link SceneNode.destroy} does not
-   * detach a node from its parent, and the retained fragment keeps the whole
-   * previously-collected command range — including a child's resources — until
-   * a structural change drops it. Destroying a child directly leaves the
-   * fragment replaying freed resources, because nothing invalidated it. Call
-   * {@link Container.removeChild} first (removal bumps the structure revision
-   * and drops the fragment), or destroy the whole group at once.
+   * A retained fragment keeps the whole previously-collected command range —
+   * including a child's resources — until a structural change drops it.
+   * Destroying a descendant on its own is safe regardless of call order:
+   * {@link SceneNode.destroy} unlinks the node from its parent, and that
+   * removal bumps the structure revision up to this boundary, which drops the
+   * fragment instead of replaying freed resources.
    */
   public override destroy(): void {
     // Balance the constructor's boundary registration exactly once (destroy may
@@ -563,26 +554,6 @@ export class RetainedContainer extends Container {
   private _escapeCheckContent = -1;
   private _escapeCheckStructure = -1;
 
-  /**
-   * P3f dev diagnostic: warn ONCE when the retained fragment was found holding
-   * a child that was `destroy()`ed without `removeChild()` (so it stayed
-   * attached and the capture still looked clean). Dev builds only; the call
-   * site is `__DEV__`-guarded and stripped from production.
-   */
-  private _warnReplayedDestroyed(): void {
-    if (this._devDestroyedWarned) {
-      return;
-    }
-
-    this._devDestroyedWarned = true;
-    logger.warn(
-      `RetainedContainer${this.name ? ` '${this.name}'` : ''} held a child that was destroy()ed without ` +
-        'removeChild() — it stayed attached to the subtree, so no revision change dropped the retained fragment. ' +
-        'The stale capture has been evicted and the destroyed child skipped; detach children (removeChild) before ' +
-        'or instead of destroying them.',
-      { source: 'rendering' },
-    );
-  }
   private _deepBarrierWarned = false;
   /**
    * Direct children whose subtrees contain a deep barrier: they

--- a/src/rendering/plan/RetainedGroupFragment.ts
+++ b/src/rendering/plan/RetainedGroupFragment.ts
@@ -382,25 +382,6 @@ export class RetainedGroupFragment {
   }
 
   /**
-   * @internal — dev-only P3f probe: `true` when any captured draw still
-   * references a destroyed {@link Drawable} (a child destroy()ed without
-   * `removeChild`, so no revision bump dropped the capture). Scans only the
-   * live prefix of the grow-only draw pool — the same O(draws) the replay
-   * already walks — so it adds no allocation and is stripped from production
-   * via the `__DEV__` guard at the call site.
-   */
-  public _devHasDestroyedDrawable(): boolean {
-    for (let index = 0; index < this._drawCursor; index++) {
-      // `?.`: released pool records (post-invalidate) hold no drawable.
-      if (this._drawPool[index]!.drawable?.destroyed) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  /**
    * Drop the grow-only draw pool's strong references to their drawables so an
    * evicted/destroyed drawable can be garbage-collected. The pooled
    * record objects survive and their `drawable` is rewritten in place on the

--- a/src/rendering/plan/RetainedPlanCache.ts
+++ b/src/rendering/plan/RetainedPlanCache.ts
@@ -161,25 +161,6 @@ export class RetainedPlanCache {
   }
 
   /**
-   * @internal — dev-only P3f probe: `true` when any captured slot still
-   * references a destroyed {@link Drawable} (a direct drawable child
-   * destroy()ed without `removeChild`, so no revision bump dropped the
-   * capture). Scans only the active slot list — the same O(slots) the replay
-   * already walks — and is stripped from production via the `__DEV__` guard at
-   * the call site.
-   */
-  public _devHasDestroyedDrawable(): boolean {
-    for (let index = 0; index < this._slots.length; index++) {
-      // `?.`: released pool records (post-invalidate) hold no drawable.
-      if (this._slots[index]!.drawable?.destroyed) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  /**
    * Drop the grow-only slot pool's strong references to their drawables so an
    * evicted/destroyed drawable can be garbage-collected. The pooled slot
    * objects survive and their `drawable` is rewritten in place on the next

--- a/test/rendering/container.test.ts
+++ b/test/rendering/container.test.ts
@@ -730,3 +730,98 @@ describe('Container.destroy() tears down the whole subtree', () => {
     expect(leaf.destroyed).toBe(true);
   });
 });
+
+// A node that stays linked into its parent's child list after `destroy()` is
+// the root of a whole family of stale-state bugs: nothing bumps the parent's
+// structure revision, so every cache keyed on it (a container's retained draw
+// slots, a RetainedContainer's recorded instruction set) keeps replaying the
+// dead node. `destroy()` therefore unlinks first, which makes the misuse
+// self-correcting instead of silently wrong.
+describe('SceneNode.destroy() detaches the node from its parent', () => {
+  test('destroying a still-attached drawable clears its parent and drops it from the child list', () => {
+    const container = new Container();
+    const child = new DummyDrawable();
+    const sibling = new DummyDrawable();
+
+    container.addChild(child, sibling);
+
+    child.destroy();
+
+    expect(child.parent).toBeNull();
+    expect(container.children).toEqual([sibling]);
+    expect(sibling.destroyed).toBe(false);
+  });
+
+  test('destroying a still-attached container clears its parent and drops it from the child list', () => {
+    const root = new Container();
+    const branch = new Container();
+
+    branch.addChild(new DummyDrawable());
+    root.addChild(branch);
+
+    branch.destroy();
+
+    expect(branch.parent).toBeNull();
+    expect(root.children).toEqual([]);
+  });
+
+  test('the detach bumps the parent structure revision, so caches keyed on it are dropped', () => {
+    const container = new Container();
+    const child = new DummyDrawable();
+
+    container.addChild(child);
+
+    const before = container._structureRevision;
+
+    child.destroy();
+
+    expect(container._structureRevision).not.toBe(before);
+  });
+
+  test('detaching first keeps the removal side effects — the node leaves the interaction and focus registries', () => {
+    const container = new Container();
+    const child = new DummyDrawable();
+    const removed: RenderNode[] = [];
+    const focus = new FocusController({ input: { onKeyDown: { add() {}, remove() {} }, onKeyUp: { add() {}, remove() {} } } } as unknown as Application);
+    const interaction = {
+      _notifyNodeAdded() {},
+      _notifyNodeRemoved(node: RenderNode) {
+        removed.push(node);
+      },
+      _notifyInteractiveChanged() {},
+      _notifyBoundsInvalidated() {},
+      _notifyTransformGroupMoved() {},
+    } as unknown as InteractionHooks;
+    const stage = { interaction, focus } as unknown as Stage;
+
+    container._setStage(stage);
+    container.addChild(child);
+
+    child.destroy();
+
+    expect(removed).toContain(child);
+    expect(child._getStage()).toBeNull();
+  });
+
+  test('the already-correct removeChild()-then-destroy() order is unaffected', () => {
+    const container = new Container();
+    const child = new DummyDrawable();
+
+    container.addChild(child);
+    container.removeChild(child);
+
+    const revisionAfterRemoval = container._structureRevision;
+
+    expect(() => child.destroy()).not.toThrow();
+    expect(child.parent).toBeNull();
+    // Nothing left to unlink, so the second pass must not dirty the container.
+    expect(container._structureRevision).toBe(revisionAfterRemoval);
+  });
+
+  test('destroying an unparented node is a no-op for parent linkage', () => {
+    const orphan = new DummyDrawable();
+
+    expect(() => orphan.destroy()).not.toThrow();
+    expect(orphan.parent).toBeNull();
+  });
+});

--- a/test/rendering/destroyed-node-collect.test.ts
+++ b/test/rendering/destroyed-node-collect.test.ts
@@ -1,12 +1,14 @@
 /**
- * Collect-time contract for a node that was `destroy()`ed but left attached to
- * the tree.
+ * Collect-time contract for a `destroy()`ed node.
  *
  * Two halves:
  *
  *   1. Behaviour — the node contributes nothing to the render plan. A destroyed
  *      node has released its pooled transform/bounds, so collecting it reads
  *      freed state and re-pins it; "renders nothing" is the only correct result.
+ *      `destroy()` unlinks the node from its parent, so the ordinary route into
+ *      the collector is already closed; the remaining one is a destroyed node
+ *      handed to the renderer as a detached root, which the guard still covers.
  *
  *   2. Production parity — the skip is never `__DEV__`-gated, so dev and
  *      production behave identically. Vitest always compiles `__DEV__` to
@@ -130,8 +132,8 @@ const collectIds = (root: Container, backend: RenderBackend): string[] => {
   return draws.map(d => (d.drawable as LeafDrawable).id);
 };
 
-describe('destroyed-but-attached node: collect behaviour', () => {
-  test('a destroyed direct child is excluded from the collected draws', () => {
+describe('destroyed node: collect behaviour', () => {
+  test('a destroyed direct child is unlinked and excluded from the collected draws', () => {
     const backend = createTestBackend();
     const root = new Container();
     const leafA = new LeafDrawable('a');
@@ -141,9 +143,10 @@ describe('destroyed-but-attached node: collect behaviour', () => {
 
     expect(collectIds(root, backend)).toEqual(['a', 'b']);
 
-    // The footgun: destroy WITHOUT removeChild, so the node stays linked in.
+    // The misuse this covers: destroy WITHOUT a preceding removeChild.
     leafA.destroy();
 
+    expect(leafA.parent).toBeNull();
     expect(collectIds(root, backend)).toEqual(['b']);
 
     backend.destroy();
@@ -163,7 +166,24 @@ describe('destroyed-but-attached node: collect behaviour', () => {
 
     leafA.destroy();
 
+    expect(leafA.parent).toBeNull();
     expect(collectIds(root, backend)).toEqual(['b']);
+
+    backend.destroy();
+  });
+
+  test('a destroyed node collected as a detached root contributes nothing', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const leaf = new LeafDrawable('a');
+
+    root.addChild(leaf);
+
+    expect(collectIds(root, backend)).toEqual(['a']);
+
+    root.destroy();
+
+    expect(collectIds(root, backend)).toEqual([]);
 
     backend.destroy();
   });

--- a/test/rendering/retained-container.test.ts
+++ b/test/rendering/retained-container.test.ts
@@ -1730,9 +1730,8 @@ describe('RetainedContainer: deep-barrier escape scoped to the offending sub-bra
 });
 
 describe('RetainedContainer: destroyed-child eviction', () => {
-  test('a child destroy()ed without removeChild is evicted from the replay next frame and warns once', () => {
+  test('a child destroy()ed without removeChild drops the fragment key itself, so the replay cannot resurrect it', () => {
     const backend = createTestBackend();
-    const warnSpy = vi.spyOn(logger, 'warn');
     const root = new Container();
     const group = new RetainedContainer();
     const leafA = new LeafDrawable('a');
@@ -1745,26 +1744,27 @@ describe('RetainedContainer: destroyed-child eviction', () => {
 
     // Frame 1: full collect + capture (both children present).
     expect(collectDraws(root, backend).map(d => (d.drawable as LeafDrawable).id)).toEqual(['a', 'b']);
+    expect(fragmentOf(group).isClean(group._contentRevision, group._structureRevision, backend)).toBe(true);
 
-    // The footgun: destroy WITHOUT removeChild — the child stays attached, so
-    // no revision bump and the fragment is still "clean".
+    // The misuse: destroy WITHOUT removeChild. `destroy()` unlinks the child
+    // itself, which stamps the group structure-dirty — asserted on the fragment
+    // key rather than on the draws, because that is the part production runs
+    // (Vitest always compiles __DEV__ to `true`, so draw-level assertions alone
+    // could not distinguish a real invalidation from a dev-only rescue).
     leafA.destroy();
+
+    expect(leafA.parent).toBeNull();
+    expect(fragmentOf(group).isClean(group._contentRevision, group._structureRevision, backend)).toBe(false);
 
     // Frame 2: the retained fragment must NOT replay the destroyed drawable.
     const frame2 = collectDraws(root, backend).map(d => (d.drawable as LeafDrawable).id);
     expect(frame2).toEqual(['b']);
     expect(frame2).not.toContain('a');
 
-    // Frame 3: still evicted, and no per-frame warning storm.
+    // Frame 3: still gone once the fragment has recaptured without it.
     const frame3 = collectDraws(root, backend).map(d => (d.drawable as LeafDrawable).id);
     expect(frame3).toEqual(['b']);
 
-    const destroyedWarnings = warnSpy.mock.calls.filter(call => String(call[0]).includes('destroy'));
-
-    expect(destroyedWarnings).toHaveLength(1);
-    expect(String(destroyedWarnings[0]![0])).toContain('decor');
-
-    warnSpy.mockRestore();
     root.destroy();
     backend.destroy();
   });

--- a/test/rendering/retained-group-fragment.test.ts
+++ b/test/rendering/retained-group-fragment.test.ts
@@ -35,6 +35,18 @@ const makeScopeDrawEntry = (drawable: Drawable, nodeIndex = 0): DrawScopeEntry =
   },
 });
 
+interface DrawPoolCarrier {
+  _drawPool: Array<{ drawable: Drawable | undefined }>;
+  _drawCursor: number;
+}
+
+/** The live prefix of the fragment's grow-only draw pool, as raw references. */
+const pooledDrawables = (fragment: RetainedGroupFragment): Array<Drawable | undefined> => {
+  const carrier = fragment as unknown as DrawPoolCarrier;
+
+  return carrier._drawPool.slice(0, carrier._drawCursor).map(record => record.drawable);
+};
+
 describe('RetainedGroupFragment', () => {
   test('isClean is false before any capture; hasCapture reflects lifecycle', () => {
     const fragment = new RetainedGroupFragment();
@@ -139,31 +151,21 @@ describe('RetainedGroupFragment', () => {
     drawable.destroy();
   });
 
-  test('_devHasDestroyedDrawable reports a destroyed captured drawable', () => {
-    const fragment = new RetainedGroupFragment();
-    const drawable = new Drawable();
-
-    fragment.capture(1, 1, fakeBackendA, [makeScopeDrawEntry(drawable)]);
-
-    expect(fragment._devHasDestroyedDrawable()).toBe(false);
-
-    drawable.destroy();
-
-    expect(fragment._devHasDestroyedDrawable()).toBe(true);
-  });
-
   test('invalidate() releases the pooled strong reference to drawables so they can GC', () => {
     const fragment = new RetainedGroupFragment();
     const drawable = new Drawable();
 
     fragment.capture(1, 1, fakeBackendA, [makeScopeDrawEntry(drawable)]);
+
+    expect(pooledDrawables(fragment)).toContain(drawable);
+
     drawable.destroy();
 
-    // Before the fix the grow-only draw pool still pins the destroyed drawable
-    // even after the entries array is emptied.
+    // Emptying the entries array is not enough: the grow-only draw pool holds
+    // its own strong reference and would keep pinning the destroyed drawable.
     fragment.invalidate();
 
-    expect(fragment._devHasDestroyedDrawable()).toBe(false);
+    expect(pooledDrawables(fragment)).not.toContain(drawable);
     expect(fragment.entries).toEqual([]);
   });
 });

--- a/test/rendering/retained-subtree-skip.test.ts
+++ b/test/rendering/retained-subtree-skip.test.ts
@@ -112,6 +112,12 @@ const collectDraws = (root: Container, backend: RenderBackend): DrawCommand[] =>
   return draws;
 };
 
+interface RetainedPlanCarrier {
+  _retainedPlan: RetainedPlanCache | null;
+}
+
+const retainedPlanOf = (container: Container): RetainedPlanCache | null => (container as unknown as RetainedPlanCarrier)._retainedPlan;
+
 const snapshot = (draws: readonly DrawCommand[]) =>
   draws.map(d => ({
     id: (d.drawable as LeafDrawable).id,
@@ -220,6 +226,42 @@ describe('static-subtree skip: invalidation gates', () => {
     const draws = collectDraws(root, backend);
 
     expect(draws.map(d => (d.drawable as LeafDrawable).id)).toEqual(['a', 'b']);
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  // The stale-replay bug this guards: a captured direct drawable child that is
+  // `destroy()`ed WITHOUT a preceding `removeChild()`. `destroy()` now unlinks
+  // the node itself, so the capture key changes and the fast path is gone —
+  // asserted on the cache key rather than on the collected draws, because the
+  // draw-level symptom used to be papered over by a __DEV__-only slot scan that
+  // production builds strip out (and Vitest always compiles __DEV__ to `true`,
+  // so the draws alone cannot tell the two apart).
+  test('destroying a captured direct drawable child invalidates the capture key itself, not only via a dev-only scan', () => {
+    const backend = createTestBackend();
+    const root = new Container();
+    const doomed = new LeafDrawable('doomed');
+    const survivor = new LeafDrawable('survivor');
+
+    root.addChild(doomed, survivor);
+
+    expect(collectDraws(root, backend).map(d => (d.drawable as LeafDrawable).id)).toEqual(['doomed', 'survivor']);
+
+    const cache = retainedPlanOf(root);
+
+    expect(cache).not.toBeNull();
+
+    const isCaptureClean = (): boolean =>
+      cache!.isClean(root._contentRevision, root._structureRevision, root._transformRevision, backend.view.updateId, backend);
+
+    expect(isCaptureClean()).toBe(true);
+
+    doomed.destroy();
+
+    expect(isCaptureClean()).toBe(false);
+    expect(root.children).toEqual([survivor]);
+    expect(collectDraws(root, backend).map(d => (d.drawable as LeafDrawable).id)).toEqual(['survivor']);
 
     root.destroy();
     backend.destroy();


### PR DESCRIPTION
Fixes the remainder of HI-5 from the independent architecture review: `SceneNode.destroy()` raised the destroyed flag but left the node linked into its parent's child list. Nothing bumped the parent's structure revision, so `Container`'s retained-plan fast path (and `RetainedContainer`'s fragment cache) kept replaying a destroyed direct child's last captured frame — silently, in every build, since the only prior detection was a `__DEV__`-only scan compiled out of production.

`destroy()` now unlinks the node from its parent first (before releasing pooled state), so both retained caches see the resulting structure-dirty stamp on their next `isClean()` check and correctly recapture instead of replaying stale state. `Container.removeChild` is already a no-op for a node it doesn't hold, so the already-correct `removeChild()`-then-`destroy()` order costs nothing beyond a null check.

Both now-unreachable `__DEV__` destroyed-drawable scans (plain retained-plan cache and `RetainedContainer`'s fragment) are removed as dead code.