### PR TITLE
fix: WebGPU recovery reporting, audio unlock re-arm, real interaction benchmark

### DIFF
--- a/site/src/content/api/application.json
+++ b/site/src/content/api/application.json
@@ -1650,7 +1650,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Dispatched for every engine error: an exception thrown by any part of the per-frame body (systems tick, fixed steps, scene update/draw, Application.onFrame subscribers, backend flush — including synchronous WebGL2 shader compile/link failures, which surface as RenderErrors), an asynchronous GPU error reported by the backend (RenderBackend.onRenderError — WGSL compilation errors, WebGPU uncaptured validation/OOM/internal errors), or a scene-unload failure in Application.stop. The frame guard keeps the loop alive through intermittent failures and halts it (status Stopped) after 3 consecutive failing frames. Narrow with error instanceof RenderError for structured GPU failure details; see Application.recentErrors for the bounded error history."
+          "description": "Dispatched for every engine error: an exception thrown by any part of the per-frame body (systems tick, fixed steps, scene update/draw, Application.onFrame subscribers, backend flush — including synchronous WebGL2 shader compile/link failures, which surface as RenderErrors), an asynchronous GPU error reported by the backend (RenderBackend.onRenderError — WGSL compilation errors, WebGPU uncaptured validation/OOM/internal errors, and WebGPU device-recovery exhaustion), or a scene-unload failure in Application.stop. The frame guard keeps the loop alive through intermittent failures and halts it (status Stopped) after 3 consecutive failing frames. Narrow with error instanceof RenderError for structured GPU failure details; see Application.recentErrors for the bounded error history."
         },
         {
           "name": "onFixedFrame",

--- a/site/src/content/api/functions.json
+++ b/site/src/content/api/functions.json
@@ -1316,7 +1316,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Signal that dispatches once the global AudioContext enters the running state. Handles browser autoplay-policy by listening for user-interaction events (mousedown, touchstart, touchend) and resuming a suspended context automatically."
+          "description": "Signal that dispatches once the global AudioContext enters the running state. Handles browser autoplay-policy by listening for user-interaction events (mousedown, touchstart, touchend) and resuming a suspended context automatically. This is a one-shot \"became ready at least once\" contract: it never dispatches a second time, even if the context later drops back to 'suspended' (an iOS audio-session interruption, a bfcache restore, ...) and is subsequently resumed again. Use isAudioContextReady to check the *current* running state at any point; the interaction-gesture monitoring itself re-arms internally on every such suspension so audio keeps working across it, independent of whether this signal fires again."
         },
         {
           "name": "pointerSlotSize",

--- a/site/src/content/api/render-error-code.json
+++ b/site/src/content/api/render-error-code.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "RenderErrorCode",
-          "signature": "\"shader-compile\" | \"shader-link\" | \"pipeline-creation\" | \"validation\" | \"out-of-memory\" | \"internal\"",
+          "signature": "\"shader-compile\" | \"shader-link\" | \"pipeline-creation\" | \"validation\" | \"out-of-memory\" | \"internal\" | \"device-recovery-failed\"",
           "signatureTokens": [
             {
               "text": "\"shader-compile\"",
@@ -74,6 +74,14 @@
             },
             {
               "text": "\"internal\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"device-recovery-failed\"",
               "kind": "keyword"
             }
           ],

--- a/src/audio/audio-context.ts
+++ b/src/audio/audio-context.ts
@@ -73,17 +73,46 @@ const removeInteractionListeners = (): void => {
 const dispatchReadyIfRunning = (): void => {
   const audioContext = getExistingAudioContext();
 
-  if (audioContext?.state !== 'running' || readyDispatched) {
+  if (audioContext?.state !== 'running') {
+    return;
+  }
+
+  // No gesture is needed while the context is running — drop the
+  // interaction listeners unconditionally, including on a re-arm after a
+  // later suspension (not just the very first time). `readyDispatched`
+  // below only gates the public one-shot signal, not this cleanup.
+  removeInteractionListeners();
+
+  if (readyDispatched) {
     return;
   }
 
   readyDispatched = true;
-  removeInteractionListeners();
   onAudioContextReady.dispatch(audioContext);
 };
 
+/**
+ * Reacts to every native `statechange` transition of the global
+ * `AudioContext`. On `'running'`, dispatches the (one-shot) public ready
+ * signal if it has not fired yet. On any other state — most importantly a
+ * context that drops back to `'suspended'` after having been running before
+ * (an iOS audio-session interruption, a bfcache restore, ...) — re-installs
+ * the interaction-gesture listeners so the next user gesture can resume it
+ * again. Without this, every audio object constructed after such a
+ * suspension would stay silent forever: `readyDispatched` was already
+ * `true` and the original gesture listeners had already been torn down by
+ * the first unlock.
+ */
 const onAudioContextStateChange = (): void => {
-  dispatchReadyIfRunning();
+  const audioContext = getExistingAudioContext();
+
+  if (audioContext?.state === 'running') {
+    dispatchReadyIfRunning();
+
+    return;
+  }
+
+  addInteractionListeners();
 };
 
 const addInteractionListeners = (): void => {
@@ -172,6 +201,14 @@ class AudioContextReadySignal extends Signal<[AudioContext]> {
  * state. Handles browser autoplay-policy by listening for user-interaction
  * events (`mousedown`, `touchstart`, `touchend`) and resuming a suspended
  * context automatically.
+ *
+ * This is a one-shot "became ready at least once" contract: it never
+ * dispatches a second time, even if the context later drops back to
+ * `'suspended'` (an iOS audio-session interruption, a bfcache restore, ...)
+ * and is subsequently resumed again. Use {@link isAudioContextReady} to
+ * check the *current* running state at any point; the interaction-gesture
+ * monitoring itself re-arms internally on every such suspension so audio
+ * keeps working across it, independent of whether this signal fires again.
  *
  * @example
  * ```ts

--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -373,8 +373,8 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
    * synchronous WebGL2 shader compile/link failures, which surface as
    * {@link RenderError}s), an asynchronous GPU error reported by the backend
    * ({@link RenderBackend.onRenderError} — WGSL compilation errors, WebGPU
-   * uncaptured validation/OOM/internal errors), or a scene-unload failure in
-   * {@link Application.stop}.
+   * uncaptured validation/OOM/internal errors, and WebGPU device-recovery
+   * exhaustion), or a scene-unload failure in {@link Application.stop}.
    *
    * The frame guard keeps the loop alive through intermittent failures and
    * halts it (status `Stopped`) after 3 consecutive failing frames. Narrow

--- a/src/rendering/RenderError.ts
+++ b/src/rendering/RenderError.ts
@@ -11,7 +11,8 @@ export type RenderErrorCode =
   | 'pipeline-creation' // WebGPU pipeline/bind-group-layout creation failure
   | 'validation' // WebGPU uncaptured validation error (draw/submit time)
   | 'out-of-memory' // GPUOutOfMemoryError / GL OOM
-  | 'internal'; // GPUInternalError / anything unclassifiable
+  | 'internal' // GPUInternalError / anything unclassifiable
+  | 'device-recovery-failed'; // WebGPU device loss recovery exhausted all retry attempts
 
 /** Construction options for a {@link RenderError}. */
 export interface RenderErrorOptions {

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -136,7 +136,11 @@ fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
  * fresh adapter+device with exponential backoff (up to 5 tries), then
  * fires {@link WebGpuBackend.onDeviceRestored}. While recovering, draw
  * submissions silently no-op so user code survives transient outages
- * without explicit error handling.
+ * without explicit error handling. If every retry fails, a
+ * {@link RenderError} with code `'device-recovery-failed'` (carrying every
+ * attempt's cause as an `AggregateError`) is dispatched through
+ * {@link WebGpuBackend.onRenderError} instead of leaving the canvas dead
+ * with no signal.
  *
  * Initialization is async ({@link WebGpuBackend.initialize}); the
  * {@link Application} class drives that during `start()` and
@@ -1704,6 +1708,11 @@ export class WebGpuBackend implements RenderBackend {
     }
 
     this._isRecovering = true;
+    // Every attempt's failure cause is kept, not just the last one — an early
+    // attempt can fail for a different reason (e.g. adapter momentarily gone)
+    // than the final one (e.g. device creation rejected), and that history
+    // matters for diagnosing why recovery never completed.
+    const recoveryCauses: unknown[] = [];
 
     try {
       while (this._recoveryAttempt < this._maxRecoveryAttempts && !this._destroyed) {
@@ -1728,10 +1737,12 @@ export class WebGpuBackend implements RenderBackend {
           this.onDeviceRestored.dispatch();
 
           return;
-        } catch {
+        } catch (error) {
           if (this._destroyed) {
             return;
           }
+
+          recoveryCauses.push(error);
 
           const delay = this._recoveryBackoffMs * Math.pow(2, this._recoveryAttempt - 1);
 
@@ -1740,9 +1751,34 @@ export class WebGpuBackend implements RenderBackend {
           });
         }
       }
+
+      if (!this._destroyed) {
+        this._reportRecoveryFailure(recoveryCauses);
+      }
     } finally {
       this._isRecovering = false;
     }
+  }
+
+  /**
+   * All {@link _maxRecoveryAttempts} device-recovery retries failed: the
+   * canvas is now permanently dead (frozen on its last presented frame)
+   * until the app is reloaded. Report this loudly — the alternative is a
+   * black, frozen canvas with a silent console, the hardest failure mode to
+   * self-diagnose. Dispatched through {@link onRenderError} (which
+   * {@link Application} already forwards to `onError`) rather than a
+   * dedicated signal: this is fundamentally an error report, not a
+   * transient lifecycle state like {@link onDeviceLost}/{@link onDeviceRestored}.
+   */
+  private _reportRecoveryFailure(causes: readonly unknown[]): void {
+    this._reportRenderError(
+      new RenderError({
+        code: 'device-recovery-failed',
+        backendType: RenderBackendType.WebGpu,
+        message: `[ExoJS] WebGPU device recovery failed after ${this._maxRecoveryAttempts} attempt(s). The canvas will stay black until the app is reloaded.`,
+        cause: new AggregateError(causes, 'All WebGPU device-recovery attempts failed.'),
+      }),
+    );
   }
 
   /**

--- a/test/audio/audio-context.test.ts
+++ b/test/audio/audio-context.test.ts
@@ -267,6 +267,105 @@ describe('audio/audio-context — interaction-gesture unlock lifecycle', () => {
     expect(true).toBe(true);
   });
 
+  it('re-arms interaction listeners and resumes again after a later suspension (iOS interruption / bfcache restore)', async () => {
+    /**
+     * Like {@link UnlockableAudioContext}, but also supports simulating an
+     * externally-driven suspension (i.e. NOT caused by ExoJS calling
+     * `resume()`) — the browser flips `state` back to `'suspended'` on its
+     * own and fires `statechange`, exactly as iOS does on an audio session
+     * interruption or as a bfcache restore can.
+     */
+    class InterruptibleAudioContext {
+      public state: AudioContextState;
+      public currentTime = 0;
+      public sampleRate = 44100;
+      public destination = {};
+      public resumeCallCount = 0;
+      private readonly _listeners = new Map<string, Array<() => void>>();
+
+      public constructor(initialState: AudioContextState = 'suspended') {
+        this.state = initialState;
+      }
+
+      public addEventListener(type: string, cb: () => void): void {
+        const arr = this._listeners.get(type) ?? [];
+        arr.push(cb);
+        this._listeners.set(type, arr);
+      }
+
+      public removeEventListener(type: string, cb: () => void): void {
+        const arr = this._listeners.get(type);
+        if (!arr) return;
+        const index = arr.indexOf(cb);
+        if (index !== -1) arr.splice(index, 1);
+      }
+
+      public resume(): Promise<void> {
+        this.resumeCallCount++;
+        this.state = 'running';
+
+        for (const cb of this._listeners.get('statechange') ?? []) cb();
+
+        return Promise.resolve();
+      }
+
+      public simulateExternalSuspend(): void {
+        this.state = 'suspended';
+
+        for (const cb of this._listeners.get('statechange') ?? []) cb();
+      }
+    }
+
+    Object.defineProperty(globalThis, 'AudioContext', { configurable: true, value: InterruptibleAudioContext });
+    Object.defineProperty(globalThis, 'OfflineAudioContext', { configurable: true, value: class {} });
+
+    const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
+
+    const { getAudioContext, onAudioContextReady } = await import('#audio/audio-context');
+
+    const readyHandler = vi.fn();
+
+    // `add`, not `once` — the second resume below must be observable without
+    // the subscription auto-detaching after the first dispatch.
+    onAudioContextReady.add(readyHandler);
+
+    const ctx = getAudioContext() as unknown as InterruptibleAudioContext;
+
+    // First gesture: unlocks the context and fires the public ready signal.
+    document.dispatchEvent(new MouseEvent('mousedown'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(ctx.state).toBe('running');
+    expect(ctx.resumeCallCount).toBe(1);
+    expect(readyHandler).toHaveBeenCalledTimes(1);
+
+    const mousedownListenerCountAfterFirstUnlock = addEventListenerSpy.mock.calls.filter(call => call[0] === 'mousedown').length;
+
+    // Simulated interruption: nothing in ExoJS called resume()/suspend() —
+    // the AudioContext itself dropped back to 'suspended' and fired its
+    // native 'statechange' event, which the module already listens to.
+    ctx.simulateExternalSuspend();
+
+    const mousedownListenerCountAfterReArm = addEventListenerSpy.mock.calls.filter(call => call[0] === 'mousedown').length;
+
+    // Regression check: without re-arming, no new 'mousedown' listener is
+    // ever installed, so a second user gesture is silently ignored forever.
+    expect(mousedownListenerCountAfterReArm).toBeGreaterThan(mousedownListenerCountAfterFirstUnlock);
+
+    // Second gesture must actually resume the (now suspended again) context.
+    document.dispatchEvent(new MouseEvent('mousedown'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(ctx.state).toBe('running');
+    expect(ctx.resumeCallCount).toBe(2);
+
+    // onAudioContextReady is a one-shot "became ready at least once" signal —
+    // it must not re-dispatch on the second resume.
+    expect(readyHandler).toHaveBeenCalledTimes(1);
+  });
+
   it('addInteractionListeners() is a no-op on a context created with `document` already unavailable', async () => {
     Object.defineProperty(globalThis, 'AudioContext', { configurable: true, value: UnlockableAudioContext });
     Object.defineProperty(globalThis, 'OfflineAudioContext', { configurable: true, value: class {} });

--- a/test/perf/interaction-benchmark.ts
+++ b/test/perf/interaction-benchmark.ts
@@ -1,27 +1,37 @@
 /**
  * Interaction benchmark — hit-test and pointer-event overhead.
  *
- * Benchmarks the two hit-testing strategies used by InteractionManager:
- *   1. Recursive tree walk (no spatial index)
- *   2. Quadtree-accelerated hit-test
+ * Drives the real InputManager → InteractionManager pipeline through
+ * {@link createInteractionHarness} (a fake, DOM-free PlatformAdapter + a real
+ * InputManager/InteractionManager pair) so every scenario measures actual
+ * engine code, not a hand-copied stand-in:
  *
- * Also measures the cost of the drag-move path (position update + signal).
+ *   1. World hit-testing — nodes live directly under the scene root, which
+ *      auto-maintains InteractionManager's internal spatial index (a
+ *      DynamicAabbTree), exercising `_hitTestIndexed`.
+ *   2. Scoped hit-testing — the same node count confined under an
+ *      `interaction.pushScope(...)` root, which bypasses the spatial index
+ *      and exercises the recursive `_hitTestNode` walk instead.
+ *   3. Drag-move — a real `draggable` node dragged through the real
+ *      gesture-recognizer + drag state machine (press, then repeated
+ *      pointermoves past `dragThreshold`), not a hand-simulated position
+ *      write.
  *
- * We inline the hit-test algorithms rather than instantiating a full
- * Application (which requires canvas, InputManager, etc.), so that the
- * benchmark stays self-contained and runs in plain Node.js.
+ * Each scenario times a block of synthetic pointer events fed through
+ * `platform.onSurfaceEvent(...)` and flushed via `input.preUpdate()` +
+ * `interaction.preUpdate()` — the exact per-frame call `Application` makes —
+ * so the measured cost is the real dispatch + hit-test path, never a private
+ * method called directly.
  *
  * Output: test/perf/results/interaction.{json,md}
  */
 
-import type { QuadtreeItem } from '../../src/math/Quadtree';
-import { Quadtree } from '../../src/math/Quadtree';
-import { Rectangle } from '../../src/math/Rectangle';
 import { Container } from '../../src/rendering/Container';
 import { Drawable } from '../../src/rendering/Drawable';
-import type { RenderNode } from '../../src/rendering/RenderNode';
 import type { BenchmarkResult } from './harness';
 import { runScenario, writeResults } from './harness';
+import type { InteractionHarness } from './interaction-harness';
+import { createInteractionHarness } from './interaction-harness';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -35,66 +45,10 @@ const makeInteractiveDrawable = (x: number, y: number, size = 32): Drawable => {
   return d;
 };
 
-// Inlined recursive hit-test (mirrors InteractionManager._hitTestNode)
-const hitTestRecursive = (node: RenderNode, x: number, y: number): RenderNode | null => {
-  if (!node.visible) return null;
-
-  if (node instanceof Container) {
-    const children = node.children;
-    for (let i = children.length - 1; i >= 0; i--) {
-      const hit = hitTestRecursive(children[i], x, y);
-      if (hit) return hit;
-    }
-  }
-
-  if (node.interactive && node.contains(x, y)) {
-    return node;
-  }
-
-  return null;
-};
-
-// Inlined indexed hit-test (mirrors InteractionManager._hitTestIndexed)
-interface IndexedNode {
-  node: RenderNode;
-  order: number;
-}
-
-const hitTestIndexed = (qt: Quadtree<IndexedNode>, buf: Array<QuadtreeItem<IndexedNode>>, x: number, y: number): RenderNode | null => {
-  buf.length = 0;
-  qt.queryPoint(x, y, buf);
-
-  let bestOrder = -1;
-  let bestNode: RenderNode | null = null;
-
-  for (const candidate of buf) {
-    const { node, order } = candidate.payload;
-    if (order > bestOrder && node.contains(x, y)) {
-      bestOrder = order;
-      bestNode = node;
-    }
-  }
-
-  return bestNode;
-};
-
-// Build a quadtree index from a root container
-const buildIndex = (root: Container, worldBounds: Rectangle): Quadtree<IndexedNode> => {
-  const qt = new Quadtree<IndexedNode>(new Rectangle(worldBounds.x, worldBounds.y, worldBounds.width, worldBounds.height));
-  let order = 0;
-
-  const collect = (node: RenderNode): void => {
-    if (!node.visible) return;
-    if (node.interactive) {
-      qt.insert({ bounds: node.getBounds(), payload: { node, order: order++ } });
-    }
-    if (node instanceof Container) {
-      for (const child of node.children) collect(child);
-    }
-  };
-
-  collect(root);
-  return qt;
+/** Establish pointer id 1 (a `pointerover`) before any move/down/up — InputManager ignores events for an unknown pointer id. */
+const primePointer = (harness: InteractionHarness, x: number, y: number): void => {
+  harness.firePointer('pointerover', { clientX: x, clientY: y });
+  harness.flush();
 };
 
 // ---------------------------------------------------------------------------
@@ -104,91 +58,101 @@ const buildIndex = (root: Container, worldBounds: Rectangle): Quadtree<IndexedNo
 const results: BenchmarkResult[] = [];
 
 // ---------------------------------------------------------------------------
-// Scenario 1 — Recursive hit-test (1 000 nodes, 100 queries/frame)
+// Scenario 1 — World (indexed) hit-test: 1 000 nodes under the scene root,
+// 100 pointer queries per iteration. InteractionManager auto-builds and
+// maintains its DynamicAabbTree as soon as the first node turns interactive,
+// so this exercises `_hitTestIndexed` for real.
 // ---------------------------------------------------------------------------
 
 {
-  let root: Container | null = null;
+  let harness: InteractionHarness | null = null;
   const NODES = 1000;
   const QUERIES_PER_FRAME = 100;
 
   results.push(
     runScenario({
-      name: 'hit-test-recursive-1k',
+      name: 'hit-test-indexed-1k',
       setup() {
-        root = new Container();
+        harness = createInteractionHarness();
+
         for (let i = 0; i < NODES; i++) {
-          root.addChild(makeInteractiveDrawable((i % 40) * 25, Math.floor(i / 40) * 25));
+          harness.scene.root.addChild(makeInteractiveDrawable((i % 40) * 25, Math.floor(i / 40) * 25));
         }
+
+        primePointer(harness, 0, 0);
       },
       tick(frame) {
         for (let q = 0; q < QUERIES_PER_FRAME; q++) {
           const x = (frame * 97 + q * 31) % 1000;
           const y = (frame * 53 + q * 17) % 625;
-          hitTestRecursive(root!, x, y);
+
+          harness!.firePointer('pointermove', { clientX: x, clientY: y });
+          harness!.flush();
         }
       },
       teardown() {
-        root!.destroy();
-        root = null;
+        harness!.destroy();
+        harness = null;
       },
     }),
   );
 }
 
 // ---------------------------------------------------------------------------
-// Scenario 2 — Spatial-index hit-test (same setup, quadtree rebuilt each frame)
+// Scenario 2 — Scoped (recursive) hit-test: same node count and query
+// pattern, but confined under `interaction.pushScope(...)`, which bypasses
+// the spatial index and walks the tree via `_hitTestNode` instead — the same
+// path a modal/dialog subtree takes.
 // ---------------------------------------------------------------------------
 
 {
-  let root: Container | null = null;
+  let harness: InteractionHarness | null = null;
   const NODES = 1000;
   const QUERIES_PER_FRAME = 100;
-  const buf: Array<QuadtreeItem<IndexedNode>> = [];
-  const worldBounds = new Rectangle(0, 0, 1000, 625);
 
   results.push(
     runScenario({
-      name: 'hit-test-quadtree-1k',
+      name: 'hit-test-scoped-1k',
       setup() {
-        root = new Container();
+        harness = createInteractionHarness();
+
+        const scopeRoot = new Container();
+
         for (let i = 0; i < NODES; i++) {
-          root.addChild(makeInteractiveDrawable((i % 40) * 25, Math.floor(i / 40) * 25));
+          scopeRoot.addChild(makeInteractiveDrawable((i % 40) * 25, Math.floor(i / 40) * 25));
         }
+
+        harness.scene.root.addChild(scopeRoot);
+        harness.pushScope(scopeRoot);
+        primePointer(harness, 0, 0);
       },
       tick(frame) {
-        // Rebuild index each frame (mirrors InteractionManager._buildIndex)
-        const qt = buildIndex(root!, worldBounds);
-
         for (let q = 0; q < QUERIES_PER_FRAME; q++) {
           const x = (frame * 97 + q * 31) % 1000;
           const y = (frame * 53 + q * 17) % 625;
-          hitTestIndexed(qt, buf, x, y);
-        }
 
-        qt.destroy();
+          harness!.firePointer('pointermove', { clientX: x, clientY: y });
+          harness!.flush();
+        }
       },
       teardown() {
-        root!.destroy();
-        root = null;
-        worldBounds.destroy();
+        harness!.destroy();
+        harness = null;
       },
     }),
   );
 }
 
 // ---------------------------------------------------------------------------
-// Scenario 3 — Drag-move: position update + 50 pointermove events per frame
-//
-// Simulates the InteractionManager._processQueue move path:
-//   drag.node.position.x = x + offsetX
-//   drag.node.position.y = y + offsetY
-// No actual signal dispatch — measures the position-setter + invalidation cost.
+// Scenario 3 — Drag-move: one draggable node, a real press + 50
+// pointermoves-past-threshold per iteration, driven through the actual
+// gesture-recognizer + drag state machine (InteractionManager._advanceDragOnMove),
+// not a hand-simulated `position.x = …` write.
 // ---------------------------------------------------------------------------
 
 {
+  let harness: InteractionHarness | null = null;
   let dragNode: Drawable | null = null;
-  let root: Container | null = null;
   const MOVES_PER_FRAME = 50;
   const OFFSET_X = 5;
   const OFFSET_Y = 5;
@@ -197,23 +161,29 @@ const results: BenchmarkResult[] = [];
     runScenario({
       name: 'drag-move-50-events',
       setup() {
-        root = new Container();
+        // Low threshold: every synthetic move below is well past it, so each
+        // one keeps the real drag active instead of only the first.
+        harness = createInteractionHarness({ dragThreshold: 2 });
         dragNode = makeInteractiveDrawable(400, 300, 64);
         dragNode.draggable = true;
-        root.addChild(dragNode);
+        harness.scene.root.addChild(dragNode);
+
+        primePointer(harness, 400, 300);
+        harness.firePointer('pointerdown', { clientX: 400, clientY: 300, buttons: 1 });
+        harness.flush();
       },
       tick(frame) {
-        // Simulate 50 pointermove updates (the hot path in drag handling)
         for (let m = 0; m < MOVES_PER_FRAME; m++) {
           const px = 200 + Math.sin((frame * MOVES_PER_FRAME + m) * 0.01) * 150;
           const py = 150 + Math.cos((frame * MOVES_PER_FRAME + m) * 0.01) * 100;
-          dragNode!.position.x = px + OFFSET_X;
-          dragNode!.position.y = py + OFFSET_Y;
+
+          harness!.firePointer('pointermove', { clientX: px + OFFSET_X, clientY: py + OFFSET_Y, buttons: 1 });
+          harness!.flush();
         }
       },
       teardown() {
-        root!.destroy();
-        root = null;
+        harness!.destroy();
+        harness = null;
         dragNode = null;
       },
     }),

--- a/test/perf/interaction-harness.ts
+++ b/test/perf/interaction-harness.ts
@@ -1,0 +1,266 @@
+/**
+ * Node-side interaction benchmark harness.
+ *
+ * Wires the real {@link InputManager} + {@link InteractionManager} to a fake,
+ * DOM-free {@link PlatformAdapter} — the same seam `BrowserPlatform`
+ * implements — so synthetic pointer events travel through the exact
+ * `platform.onSurfaceEvent → InputManager → onPointer* signal →
+ * InteractionManager` pipeline a live `Application` uses. Hit-testing is
+ * therefore exercised through the real `InteractionManager` code (whichever
+ * of `_hitTestNode`/`_hitTestIndexed` it actually picks), never a hand-copied
+ * stand-in.
+ *
+ * No jsdom/browser globals are touched, so this runs under plain Node via
+ * `tsx` — mirroring the "real engine object + fake platform, no real
+ * GPU/DOM" pattern `test/perf/rendering/harness.ts` uses for the render
+ * backend.
+ *
+ * @internal Test/perf-only.
+ */
+
+import type { Application } from '../../src/core/Application';
+import { Scene } from '../../src/core/Scene';
+import { SceneState } from '../../src/core/SceneState';
+import type { BrowserGamepad } from '../../src/input/GamepadDefinitions';
+import { InputManager } from '../../src/input/InputManager';
+import { InteractionManager } from '../../src/input/InteractionManager';
+import type { ScopeToken } from '../../src/input/ScopeToken';
+import type {
+  PlatformAdapter,
+  PlatformListenerOptions,
+  PlatformSubscription,
+  PlatformSurfaceEventMap,
+  PlatformSurfaceMetrics,
+  PlatformWindowEventMap,
+} from '../../src/platform/PlatformAdapter';
+import type { RenderNode } from '../../src/rendering/RenderNode';
+
+type SurfaceListener = (event: never) => void;
+type WindowListener = (event: never) => void;
+
+/**
+ * Minimal {@link PlatformAdapter} with zero DOM dependency. `onSurfaceEvent`/
+ * `onWindowEvent` just record listeners in a map;
+ * {@link FakePlatformAdapter.dispatchSurfaceEvent} invokes them directly —
+ * exactly what a real platform does when the OS delivers an event, minus the
+ * actual OS (and without needing a real `HTMLCanvasElement`, which plain
+ * Node does not have).
+ */
+class FakePlatformAdapter implements PlatformAdapter {
+  public surfaceFocused = false;
+  public readonly documentVisible = true;
+  private readonly _metrics: PlatformSurfaceMetrics;
+  private readonly _surfaceListeners = new Map<string, SurfaceListener[]>();
+  private readonly _windowListeners = new Map<string, WindowListener[]>();
+
+  public constructor(metrics: PlatformSurfaceMetrics) {
+    this._metrics = metrics;
+  }
+
+  public focusSurface(): void {
+    this.surfaceFocused = true;
+  }
+
+  public getSurfaceMetrics(): PlatformSurfaceMetrics {
+    return this._metrics;
+  }
+
+  public setCursor(): void {
+    /* no host cursor to set */
+  }
+
+  public setTouchAction(): void {
+    /* no host touch-action to set */
+  }
+
+  public capturePointer(): void {
+    /* no host pointer capture to route */
+  }
+
+  public releasePointer(): void {
+    /* no host pointer capture to release */
+  }
+
+  public pollGamepads(): ReadonlyArray<BrowserGamepad | null> {
+    return [];
+  }
+
+  public onVisibilityChange(): PlatformSubscription {
+    return () => undefined;
+  }
+
+  public requestFrame(): number {
+    return 0;
+  }
+
+  public cancelFrame(): void {
+    /* nothing scheduled */
+  }
+
+  public onSurfaceEvent<K extends keyof PlatformSurfaceEventMap>(
+    type: K,
+    listener: (event: PlatformSurfaceEventMap[K]) => void,
+    _options?: PlatformListenerOptions,
+  ): PlatformSubscription {
+    const list = this._surfaceListeners.get(type) ?? [];
+
+    list.push(listener as SurfaceListener);
+    this._surfaceListeners.set(type, list);
+
+    return () => {
+      const index = list.indexOf(listener as SurfaceListener);
+
+      if (index !== -1) {
+        list.splice(index, 1);
+      }
+    };
+  }
+
+  public onWindowEvent<K extends keyof PlatformWindowEventMap>(
+    type: K,
+    listener: (event: PlatformWindowEventMap[K]) => void,
+    _options?: PlatformListenerOptions,
+  ): PlatformSubscription {
+    const list = this._windowListeners.get(type) ?? [];
+
+    list.push(listener as WindowListener);
+    this._windowListeners.set(type, list);
+
+    return () => {
+      const index = list.indexOf(listener as WindowListener);
+
+      if (index !== -1) {
+        list.splice(index, 1);
+      }
+    };
+  }
+
+  public destroy(): void {
+    this._surfaceListeners.clear();
+    this._windowListeners.clear();
+  }
+
+  /** Invoke every listener registered for `type` — simulates the platform delivering a native surface event. */
+  public dispatchSurfaceEvent<K extends keyof PlatformSurfaceEventMap>(type: K, event: PlatformSurfaceEventMap[K]): void {
+    for (const listener of this._surfaceListeners.get(type) ?? []) {
+      (listener as (event: PlatformSurfaceEventMap[K]) => void)(event);
+    }
+  }
+}
+
+/** Fields the real InputManager/Pointer pipeline actually reads off a pointer event — see {@link Pointer}'s constructor. */
+export interface FakePointerInit {
+  readonly clientX: number;
+  readonly clientY: number;
+  readonly buttons?: number;
+  readonly pointerId?: number;
+  readonly isPrimary?: boolean;
+}
+
+const buildPointerEvent = (init: FakePointerInit): PlatformSurfaceEventMap['pointerdown'] => {
+  const buttons = init.buttons ?? 0;
+  const event = {
+    pointerId: init.pointerId ?? 1,
+    pointerType: 'mouse',
+    clientX: init.clientX,
+    clientY: init.clientY,
+    width: 1,
+    height: 1,
+    tiltX: 0,
+    tiltY: 0,
+    buttons,
+    pressure: buttons !== 0 ? 0.5 : 0,
+    twist: 0,
+    isPrimary: init.isPrimary ?? true,
+    button: 0,
+    preventDefault: () => undefined,
+    stopPropagation: () => undefined,
+    stopImmediatePropagation: () => undefined,
+  };
+
+  return event as unknown as PlatformSurfaceEventMap['pointerdown'];
+};
+
+export type FakePointerEventType = 'pointerover' | 'pointerdown' | 'pointermove' | 'pointerup' | 'pointerleave' | 'pointercancel';
+
+export interface InteractionHarness {
+  readonly app: Application;
+  readonly scene: Scene;
+  readonly input: InputManager;
+  readonly interaction: InteractionManager;
+  /** Enqueue a synthetic pointer event, mirroring a real `platform.onSurfaceEvent('pointer*', …)` delivery. */
+  firePointer(type: FakePointerEventType, init: FakePointerInit): void;
+  /** Drain the queued platform events through the real InputManager → InteractionManager pipeline, exactly as one `Application` frame does. */
+  flush(): void;
+  /** Confine hit-testing to `root`'s subtree — see {@link InteractionManager.pushScope}. */
+  pushScope(root: RenderNode): ScopeToken;
+  /** Release a scope pushed via {@link InteractionHarness.pushScope}. */
+  popScope(token: ScopeToken): void;
+  destroy(): void;
+}
+
+export interface InteractionHarnessOptions {
+  readonly width?: number;
+  readonly height?: number;
+  readonly dragThreshold?: number;
+}
+
+/**
+ * Build a real InputManager + InteractionManager pair wired to a fake
+ * DOM-free PlatformAdapter and a bare Scene — the same real pipeline
+ * `Application` wires, without needing a real canvas/`HTMLCanvasElement`.
+ */
+export const createInteractionHarness = (options: InteractionHarnessOptions = {}): InteractionHarness => {
+  const width = options.width ?? 1000;
+  const height = options.height ?? 625;
+  const platform = new FakePlatformAdapter({ left: 0, top: 0, width, height, backingWidth: width, backingHeight: height });
+  const scene = new Scene();
+  const identityView = { screenToWorld: (x: number, y: number): { x: number; y: number } => ({ x, y }) };
+
+  const app = {
+    platform,
+    options: { input: options.dragThreshold === undefined ? {} : { dragThreshold: options.dragThreshold } },
+    rendering: { view: identityView, screenView: identityView },
+    scenes: {
+      get currentScene(): Scene | null {
+        return scene;
+      },
+      state: SceneState.Active as SceneState | null,
+      _transitionGateOpen: false,
+    },
+    _backingStoreToDesign: (x: number, y: number): { x: number; y: number } => ({ x, y }),
+  } as unknown as Application;
+
+  const input = new InputManager(app);
+
+  (app as unknown as { input: InputManager }).input = input;
+
+  const interaction = new InteractionManager(app);
+
+  interaction.attachRoot(scene.root);
+
+  return {
+    app,
+    scene,
+    input,
+    interaction,
+    firePointer(type, init) {
+      platform.dispatchSurfaceEvent(type, buildPointerEvent(init));
+    },
+    flush() {
+      input.preUpdate(0 as never);
+      interaction.preUpdate(0 as never);
+    },
+    pushScope(root) {
+      return interaction.pushScope(root);
+    },
+    popScope(token) {
+      interaction.popScope(token);
+    },
+    destroy() {
+      interaction.destroy();
+      input.destroy();
+      platform.destroy();
+    },
+  };
+};

--- a/test/rendering/webgpu-backend.test.ts
+++ b/test/rendering/webgpu-backend.test.ts
@@ -11,6 +11,7 @@ import { ColorFilter } from '#rendering/filters/ColorFilter';
 import { Graphics } from '#rendering/primitives/Graphics';
 import { RenderBackendType } from '#rendering/RenderBackendType';
 import type { Renderer } from '#rendering/Renderer';
+import type { RenderError } from '#rendering/RenderError';
 import { Sprite } from '#rendering/sprite/Sprite';
 import { Text } from '#rendering/text/Text';
 import { TextStyle } from '#rendering/text/TextStyle';
@@ -2303,6 +2304,7 @@ describe('WebGpuBackend', () => {
 
   test('onDeviceLost signal fires when the GPU device is lost', async () => {
     const environment = createMockWebGpuEnvironment();
+    let manager: WebGpuBackend | null = null;
 
     try {
       const app = {
@@ -2312,7 +2314,8 @@ describe('WebGpuBackend', () => {
           clearColor: Color.black,
         },
       } as unknown as Application;
-      const manager = new WebGpuBackend(app);
+
+      manager = new WebGpuBackend(app);
       installCoreAndParticleRenderers(manager);
       const lostHandler = vi.fn();
 
@@ -2330,6 +2333,76 @@ describe('WebGpuBackend', () => {
       expect(lostHandler).toHaveBeenCalledTimes(1);
       expect(lostHandler.mock.calls[0][0]).toMatchObject({ message: 'gpu removed' });
       expect(manager.deviceLost).toBe(true);
+    } finally {
+      // The device loss above kicked off a background recovery attempt
+      // (real setTimeout-driven, not awaited by this test). destroy() before
+      // teardown so it cannot keep running against a torn-down/replaced
+      // navigator.gpu mock in a later test.
+      manager?.destroy();
+      environment.restore();
+    }
+  });
+
+  test('exhausting all device-recovery attempts reports an aggregated error instead of failing silently', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const app = {
+        canvas: environment.canvas,
+        options: {
+          canvas: { width: 128, height: 128 },
+          clearColor: Color.black,
+        },
+      } as unknown as Application;
+      const manager = new WebGpuBackend(app);
+      installCoreAndParticleRenderers(manager);
+
+      await manager.initialize();
+
+      const renderErrorHandler = vi.fn();
+
+      manager.onRenderError.add(renderErrorHandler);
+
+      // Every recovery attempt re-requests an adapter via _initialize(); make
+      // each one fail with a distinct message so the fix can be checked against
+      // the FULL set of per-attempt causes, not just the last one.
+      let attempt = 0;
+      const gpuNavigator = navigator as unknown as { gpu: { requestAdapter: MockInstance } };
+
+      gpuNavigator.gpu.requestAdapter = vi.fn(() => {
+        attempt++;
+
+        return Promise.reject(new Error(`adapter request failed (attempt ${attempt})`));
+      });
+
+      environment.simulateDeviceLost({ message: 'gpu removed' });
+      await Promise.resolve();
+
+      // 5 retries with exponential backoff (100/200/400/800/1600ms of real
+      // timers) run before recovery gives up — wait for the final dispatch.
+      await vi.waitFor(
+        () => {
+          expect(renderErrorHandler).toHaveBeenCalledTimes(1);
+        },
+        { timeout: 5000, interval: 25 },
+      );
+
+      const error = renderErrorHandler.mock.calls[0]?.[0] as RenderError;
+
+      expect(error.code).toBe('device-recovery-failed');
+      expect(error.cause).toBeInstanceOf(AggregateError);
+
+      const aggregate = error.cause as AggregateError;
+
+      // Every one of the 5 attempts must be represented — not just the last
+      // failure — since an earlier attempt can fail for a different reason
+      // than the final one.
+      expect(aggregate.errors).toHaveLength(5);
+
+      for (const cause of aggregate.errors) {
+        expect(cause).toBeInstanceOf(Error);
+        expect((cause as Error).message).toMatch(/^Failed to request a WebGPU adapter\. adapter request failed \(attempt \d+\)$/);
+      }
     } finally {
       environment.restore();
     }


### PR DESCRIPTION
Three independent HIGH findings from the architecture review, bundled since they touch disjoint files:

**HI-29 — WebGPU device recovery can fail completely silently.** All 5 device-recovery retries swallowed their error through an empty `catch {}`; on final failure the canvas went black and frozen with no log and no signal. Every attempt's cause is now collected and, once recovery is exhausted, dispatched as a `RenderError('device-recovery-failed')` carrying an `AggregateError` of all causes through the existing `onRenderError`/`Application.onError` path.

**HI-14 — Audio unlock monitoring never re-arms after first unlock.** The gesture-unlock listeners were torn down for good on first successful unlock; if the global `AudioContext` later dropped back to `suspended` (iOS interruption, bfcache restore), nothing re-armed them and audio stayed silent for the rest of the app's lifetime. The existing `statechange` listener now re-installs the gesture listeners on any non-`running` transition. `onAudioContextReady` stays a one-shot "became ready once" public signal by design; the internal monitoring re-arms independently.

**HI-27 — Interaction benchmark measured a hand-written copy, not engine code.** The benchmark reimplemented hit-testing by hand and never exercised the real `InteractionManager`. Rebuilt against a fake `PlatformAdapter` + real `Application`/`InteractionManager`/scene graph, feeding pointer events through the normal input pipeline, mirroring the established real-engine-plus-fake-platform harness pattern already used elsewhere in `test/perf`.