### PR TITLE
fix(assets): free value assets on refcount-0 eviction

### DIFF
--- a/site/src/content/api/asset-handler.json
+++ b/site/src/content/api/asset-handler.json
@@ -6,10 +6,10 @@
   "subsystem": "extensions",
   "importPath": "@codexo/exojs/extensions",
   "tier": "advanced",
-  "memberCount": 4,
+  "memberCount": 5,
   "counts": {
     "constructors": 0,
-    "methods": 4,
+    "methods": 5,
     "properties": 0,
     "events": 0
   },
@@ -148,6 +148,57 @@
           "params": [],
           "returnType": "void",
           "description": ""
+        },
+        {
+          "name": "dispose",
+          "signature": "dispose?(resource: Result): void",
+          "signatureTokens": [
+            {
+              "text": "dispose",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "resource",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Result",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "resource",
+              "type": "Result",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Releases the resources held by ONE loaded asset, called when the Loader evicts it at refcount 0 (its last claim was released). The handler stays alive; only that asset is torn down. A factory-backed handler forwards this to AssetFactory.dispose. Optional and safe to omit — implement it only when the produced asset owns something the garbage collector cannot reclaim on its own (a media element, a FontFace registered on document.fonts, a GPU buffer, a worker). Must be synchronous; use destroy for handler-wide teardown instead."
         },
         {
           "name": "getIdentityKey",

--- a/src/assets/AssetFactory.ts
+++ b/src/assets/AssetFactory.ts
@@ -28,8 +28,30 @@ export interface AssetFactory<T = unknown> {
   create(source: unknown, options?: unknown): Promise<T>;
 
   /**
-   * Releases all resources held by this factory, including any object URLs
-   * created during asset loading.
+   * Releases the resources held by ONE asset this factory produced — the
+   * per-resource counterpart of {@link destroy}. Called when the loader evicts
+   * that asset at refcount 0; the factory stays alive and keeps serving every
+   * other asset it created.
+   *
+   * Optional, and safe to omit: implement it only when a produced asset owns
+   * something the garbage collector cannot reclaim on its own (a media element
+   * to detach, a `FontFace` registered on `document.fonts`, a GPU buffer, a
+   * worker). A decoded `AudioBuffer`, a parsed JSON object or a compiled
+   * `WebAssembly.Module` needs nothing, so most factories do not implement it.
+   *
+   * Must be synchronous and must tolerate being called for a resource that was
+   * already released. `resource` is never handed back to a consumer afterwards:
+   * the loader drops it from the resident store and re-arms every live ref for
+   * the asset in the same step.
+   */
+  dispose?(resource: T): void;
+
+  /**
+   * Releases everything this factory owns ACROSS ALL the assets it ever
+   * produced — every object URL it created, every media element it still
+   * tracks — and leaves the factory unusable. Called once, when the owning
+   * loader/handler is destroyed, not per asset; use {@link dispose} for the
+   * teardown of a single evicted resource.
    */
   destroy(): void;
 }

--- a/src/assets/AssetResidency.ts
+++ b/src/assets/AssetResidency.ts
@@ -262,9 +262,13 @@ export class AssetResidency {
     if (this._evicted.has(key)) {
       this._evicted.delete(key);
 
-      // The handle was re-armed to 'loading' during eviction; just re-drive the fetch.
+      // The handle/ref was re-armed to 'loading' during eviction; just re-drive
+      // the fetch. A value key with no ref left (evicted after a bare `load()`)
+      // still refetches: nothing but this would restore its resident payload.
       if (this._typeRegistry.hasSeamlessAdapter(type)) {
         this._startSeamlessFetch(type, source, this._deferred.get(key)?.options);
+      } else {
+        this._startRefFetch(type, source, this._refs.get(key)?.options);
       }
     }
   }
@@ -314,12 +318,15 @@ export class AssetResidency {
    * live consumer handle for the key (drops payload + re-arms each to 'loading'),
    * remove the stored resource, and leave the handles registered in `_deferred`
    * so the next claim heals them all in place. Also drops a not-yet-started
-   * background-queue entry. Seamless payloads only — value-ref
-   * eviction is an accepted gap.
+   * background-queue entry. A value key (no seamless adapter for the type) takes
+   * the twin path in {@link _evictValueKey} instead.
    *
    * Only a payload that has already converged into `_resources` is dropped here.
    * A fetch still in flight (nothing stored yet) is left to the running fetch,
-   * which fills then frees on arrival — evicting mid-flight would race it.
+   * which fills then frees on arrival — evicting mid-flight would race it. The
+   * value path is gated identically: the same race exists there (a claim can be
+   * released while the key's single fetch is still running), and the same rule
+   * resolves it.
    */
   private _evictKey(key: string, type: AssetConstructor, source: string): void {
     const adapter = this._typeRegistry.getSeamlessAdapter(type);
@@ -365,12 +372,57 @@ export class AssetResidency {
       // self-entry identity guard in `_trackInFlight`.
       this._inFlight.delete(key);
     }
+    // A value payload may legitimately BE `null`/`undefined` (a JSON `null`, a
+    // nullish payload from a `bindAsset`-bound custom type), so this asks
+    // `_hasStored` where the seamless branch above can read the value itself —
+    // for a seamless type the stored resource is always the handle object.
+    else if (adapter === undefined && this._hasStored(type, source)) {
+      this._evictValueKey(key, type, source, stored);
+    }
 
     const queued = this._backgroundQueue.findIndex(entry => this._typeRegistry._key(entry.type, entry.alias) === key);
 
     if (queued !== -1) {
       this._backgroundQueue.splice(queued, 1);
     }
+  }
+
+  /**
+   * Value twin of the seamless eviction in {@link _evictKey}: hand the stored
+   * payload to the bound handler's per-resource `dispose` (a factory-backed
+   * handler forwards it to `AssetFactory.dispose`), drop it from `_resources`,
+   * and re-arm every live ref for the key in place — `AssetRef._begin()` is
+   * exactly what `adapter.evict(handle)` is for a seamless handle: payload
+   * dropped, state back to `'loading'`, identity kept, so the next claim heals
+   * every consumer that already holds the ref.
+   *
+   * Re-arming is not cosmetic bookkeeping. A ref left holding its `_value`
+   * would keep handing out the payload this method just disposed, and would pin
+   * it for as long as any consumer holds the ref — the eviction would free
+   * nothing at all.
+   *
+   * `dispose` is optional on the handler: most value types (parsed JSON, text,
+   * a compiled `WebAssembly.Module`) own nothing the garbage collector cannot
+   * reclaim once the last reference drops, so the delete below IS the whole
+   * teardown for them.
+   */
+  private _evictValueKey(key: string, type: AssetConstructor, source: string, stored: unknown): void {
+    this._typeRegistry.getHandler(type)?.dispose?.(stored);
+    this._resources.get(type)?.delete(source);
+
+    const entry = this._refs.get(key);
+
+    if (entry !== undefined) {
+      for (const ref of entry.refs) {
+        ref._begin();
+      }
+    }
+
+    this._evicted.add(key);
+    // Drop a resolved-but-not-yet-cleaned in-flight entry so the reclaim's
+    // re-fetch starts fresh instead of deduping onto it — see the seamless
+    // branch above for the full reasoning; it applies verbatim here.
+    this._inFlight.delete(key);
   }
 
   // -----------------------------------------------------------------------

--- a/src/assets/AssetTypeRegistry.ts
+++ b/src/assets/AssetTypeRegistry.ts
@@ -14,6 +14,8 @@ export interface HandlerEntry {
   getIdentityKey?: (config: unknown) => string;
   /** Optional byte-source constructor used by container loading (bypasses fetch). */
   createFromBytes?: (bytes: ArrayBuffer, options?: unknown) => Promise<unknown>;
+  /** Optional per-resource teardown, invoked by `AssetResidency` when a value asset of this type is evicted at refcount 0. */
+  dispose?: (resource: unknown) => void;
   /** Optional per-type IDB namespace for `context.fetchX()` calls made by this binding's handler. */
   storageName?: string;
 }
@@ -123,31 +125,7 @@ export class AssetTypeRegistry {
     // suffix is deliberately NOT a conflict — it simply outranks this binding.
 
     // All validation passed — install atomically.
-    // Localized type-erasure boundary: the internal registry uses a flat config
-    // `{ source, ...fields }`. The public AssetHandler<Result, Options> interface
-    // uses `AssetLoadRequest<Options> = { source, options? }`. This single `toRequest`
-    // helper is the only place where the erased flat config is cast to the typed
-    // request — justified by the `AssetBinding<Result, Options>` contract that
-    // associates this handler's Options with the registered constructor.
-    const toRequest = (config: unknown): AssetLoadRequest<Options> => {
-      const { source, ...rest } = config as { source: string } & Record<string, unknown>;
-
-      if (Object.keys(rest).length === 0) {
-        return { source };
-      }
-
-      return { source, options: rest as Options };
-    };
-
-    const boundIdentityKey = handler.getIdentityKey?.bind(handler);
-    const boundCreateFromBytes = handler.createFromBytes?.bind(handler);
-
-    this._handlerFunctions.set(keys.ctor, {
-      load: (config, ctx) => handler.load(toRequest(config), ctx),
-      ...(boundIdentityKey && { getIdentityKey: (config: unknown) => boundIdentityKey(toRequest(config)) }),
-      ...(boundCreateFromBytes && { createFromBytes: (bytes: ArrayBuffer, options?: unknown) => boundCreateFromBytes(bytes, options as Options) }),
-      ...(keys.storageName !== undefined && { storageName: keys.storageName }),
-    });
+    this._handlerFunctions.set(keys.ctor, this._createHandlerEntry<Result, Options>(handler, keys.storageName));
 
     for (const name of resolvedNames) {
       this._assetTypeMap.set(name, keys.ctor);
@@ -166,6 +144,45 @@ export class AssetTypeRegistry {
     if (keys.seamless !== undefined) {
       this.registerSeamlessAdapter(keys.ctor, keys.seamless);
     }
+  }
+
+  /**
+   * Erase one {@link AssetHandler}'s typed surface into the flat
+   * {@link HandlerEntry} every dispatch path reads. Each optional hook is
+   * carried over only when the handler actually implements it, so a missing
+   * `getIdentityKey`/`createFromBytes`/`dispose` stays `undefined` on the entry
+   * rather than becoming a wrapper that calls nothing.
+   *
+   * This is the single type-erasure boundary of the binding install: the
+   * internal registry uses a flat config `{ source, ...fields }`, while the
+   * public `AssetHandler<Result, Options>` interface uses
+   * `AssetLoadRequest<Options> = { source, options? }`. The `toRequest` helper
+   * below is the only place the erased flat config is cast back to the typed
+   * request — justified by the `AssetBinding<Result, Options>` contract that
+   * associates this handler's `Options` with the registered constructor.
+   */
+  private _createHandlerEntry<Result, Options>(handler: AssetHandler<Result, Options>, storageName: string | undefined): HandlerEntry {
+    const toRequest = (config: unknown): AssetLoadRequest<Options> => {
+      const { source, ...rest } = config as { source: string } & Record<string, unknown>;
+
+      if (Object.keys(rest).length === 0) {
+        return { source };
+      }
+
+      return { source, options: rest as Options };
+    };
+
+    const boundIdentityKey = handler.getIdentityKey?.bind(handler);
+    const boundCreateFromBytes = handler.createFromBytes?.bind(handler);
+    const boundDispose = handler.dispose?.bind(handler);
+
+    return {
+      load: (config, ctx) => handler.load(toRequest(config), ctx),
+      ...(boundIdentityKey && { getIdentityKey: (config: unknown) => boundIdentityKey(toRequest(config)) }),
+      ...(boundCreateFromBytes && { createFromBytes: (bytes: ArrayBuffer, options?: unknown) => boundCreateFromBytes(bytes, options as Options) }),
+      ...(boundDispose && { dispose: (resource: unknown) => boundDispose(resource as Result) }),
+      ...(storageName !== undefined && { storageName }),
+    };
   }
 
   /** Returns true if a handler is already registered for the given constructor. */

--- a/src/assets/coreAssetBindings.ts
+++ b/src/assets/coreAssetBindings.ts
@@ -31,10 +31,19 @@ import { BinaryAsset, CsvAsset, FontAsset, ImageAsset, Json, SubtitleAsset, SvgA
 // Adapter helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * The slice of `AssetFactory` the two generic handler adapters below drive:
+ * `create`, the optional per-resource `dispose` they forward when the loader
+ * evicts one asset, and the factory-wide `destroy` they forward on teardown.
+ */
+interface FactoryLike<Source, T> {
+  create(raw: Source, options?: unknown): Promise<T>;
+  dispose?(resource: T): void;
+  destroy(): void;
+}
+
 /** Create an AssetHandler backed by a factory that uses fetchArrayBuffer. */
-function binaryFactoryHandler<T>(
-  makeFactory: () => { create(raw: ArrayBuffer, options?: unknown): Promise<T>; destroy(): void },
-): (loader: Loader) => AssetHandler {
+function binaryFactoryHandler<T>(makeFactory: () => FactoryLike<ArrayBuffer, T>): (loader: Loader) => AssetHandler {
   return () => {
     const factory = makeFactory();
     return {
@@ -45,6 +54,9 @@ function binaryFactoryHandler<T>(
       createFromBytes(bytes: ArrayBuffer, options?: unknown): Promise<T> {
         return factory.create(bytes, options);
       },
+      dispose(resource: unknown): void {
+        factory.dispose?.(resource as T);
+      },
       destroy() {
         factory.destroy();
       },
@@ -53,7 +65,7 @@ function binaryFactoryHandler<T>(
 }
 
 /** Create an AssetHandler backed by a factory that uses fetchText. */
-function textFactoryHandler<T>(makeFactory: () => { create(raw: string, options?: unknown): Promise<T>; destroy(): void }): (loader: Loader) => AssetHandler {
+function textFactoryHandler<T>(makeFactory: () => FactoryLike<string, T>): (loader: Loader) => AssetHandler {
   return () => {
     const factory = makeFactory();
     return {
@@ -63,6 +75,9 @@ function textFactoryHandler<T>(makeFactory: () => { create(raw: string, options?
       },
       createFromBytes(bytes: ArrayBuffer, options?: unknown): Promise<T> {
         return factory.create(new TextDecoder().decode(bytes), options);
+      },
+      dispose(resource: unknown): void {
+        factory.dispose?.(resource as T);
       },
       destroy() {
         factory.destroy();

--- a/src/extensions/Extension.ts
+++ b/src/extensions/Extension.ts
@@ -65,6 +65,19 @@ export interface AssetHandler<Result = unknown, Options = undefined> {
    * @advanced
    */
   createFromBytes?(bytes: ArrayBuffer, options?: Options): Promise<Result>;
+  /**
+   * Releases the resources held by ONE loaded asset, called when the Loader
+   * evicts it at refcount 0 (its last claim was released). The handler stays
+   * alive; only that asset is torn down. A factory-backed handler forwards this
+   * to `AssetFactory.dispose`.
+   *
+   * Optional and safe to omit — implement it only when the produced asset owns
+   * something the garbage collector cannot reclaim on its own (a media element,
+   * a `FontFace` registered on `document.fonts`, a GPU buffer, a worker). Must
+   * be synchronous; use {@link destroy} for handler-wide teardown instead.
+   * @advanced
+   */
+  dispose?(resource: Result): void;
   destroy?(): void;
 }
 

--- a/test/assets/asset-residency.test.ts
+++ b/test/assets/asset-residency.test.ts
@@ -125,6 +125,72 @@ describe('AssetResidency', () => {
       expect(residency._peekResource(TypeA, 'a.png')).toBe(handle);
     });
 
+    test('claim then release at refcount 0 disposes and frees a stored value asset', () => {
+      const { residency, typeRegistry } = createResidency();
+      const dispose = vi.fn();
+      typeRegistry.bindAsset({ ctor: TypeA }, { load: async (request, ctx) => ctx.fetchText(request.source), dispose });
+
+      const scope = Symbol('scope');
+      const key = typeRegistry._key(TypeA, 'a.json');
+      const ref = residency._getRef(TypeA, 'a.json');
+      residency._claim(key, TypeA, 'a.json', scope);
+
+      const resource = { hp: 3 };
+      residency._storeResource(TypeA, 'a.json', resource);
+
+      expect(residency._peekResource(TypeA, 'a.json')).toBe(resource);
+      expect(ref.state).toBe('ready');
+
+      residency._release(key, scope);
+
+      // The bound handler's per-resource teardown ran on the exact payload...
+      expect(dispose).toHaveBeenCalledWith(resource);
+      // ...the payload left the resident store...
+      expect(residency._peekResource(TypeA, 'a.json')).toBeNull();
+      // ...and the ref was re-armed in place, so it neither hands out nor pins
+      // the value that was just disposed.
+      expect(ref.state).toBe('loading');
+      expect(() => ref.value).toThrow("'loading'");
+    });
+
+    test('a value asset whose handler implements no dispose is still freed at refcount 0', () => {
+      const { residency, typeRegistry } = createResidency();
+      typeRegistry.bindAsset({ ctor: TypeA }, { load: async (request, ctx) => ctx.fetchText(request.source) });
+
+      const scope = Symbol('scope');
+      const key = typeRegistry._key(TypeA, 'a.json');
+      residency._claim(key, TypeA, 'a.json', scope);
+      residency._storeResource(TypeA, 'a.json', { hp: 3 });
+
+      expect(() => residency._release(key, scope)).not.toThrow();
+      expect(residency._peekResource(TypeA, 'a.json')).toBeNull();
+    });
+
+    test('claim on an evicted value key re-drives the fetch and heals the same ref', async () => {
+      const { residency, typeRegistry } = createResidency({ cacheStrategy: createFakeStrategy(() => 'decoded') });
+      typeRegistry.bindAsset({ ctor: TypeA }, { load: async (request, ctx) => ctx.fetchText(request.source) });
+
+      const scope = Symbol('scope');
+      const key = typeRegistry._key(TypeA, 'a.json');
+      const ref = residency._getRef(TypeA, 'a.json');
+      residency._claim(key, TypeA, 'a.json', scope);
+
+      await new Promise(r => setTimeout(r, 0));
+      expect(ref.state).toBe('ready');
+
+      residency._release(key, scope);
+      expect(residency._peekResource(TypeA, 'a.json')).toBeNull();
+
+      residency._claim(key, TypeA, 'a.json', scope);
+      await new Promise(r => setTimeout(r, 0));
+
+      // Same ref identity, healed in place from a fresh fetch.
+      expect(residency._getRef(TypeA, 'a.json')).toBe(ref);
+      expect(ref.state).toBe('ready');
+      expect(ref.value).toBe('decoded');
+      expect(residency._peekResource(TypeA, 'a.json')).toBe('decoded');
+    });
+
     test('releaseScope releases every key held under that scope', () => {
       const { residency, typeRegistry } = createResidency();
       const adapter = createFakeSeamlessAdapter();


### PR DESCRIPTION
Fixes the remainder of BLK-2 (value/non-seamless asset eviction was an accepted gap). `AssetResidency._evictKey()` only freed GPU-adjacent state for seamless types (textures, part A, already merged); a value asset (json/text/binary/wasm/bmFont/music) sat in `_resources` forever after its last claim released, with no teardown ever running.

A value key now takes its own eviction path, mirroring the seamless one: the bound handler's optional per-resource `dispose` runs on the stored payload, the entry leaves `_resources`, and every live `AssetRef` is re-armed so no ref keeps handing out a disposed payload. `AssetFactory.dispose?(resource)` is the new per-resource counterpart to the existing factory-wide `destroy()`; no built-in factory implements it yet (a plain JSON object or a compiled WebAssembly module needs no teardown), and omitting it stays safe.

Deliberately out of scope (noted for a future item): ME-28/ME-30 (multi-consumer app-level claims, `.exoa` container-asset claims) — not touched.