### PR TITLE
fix: useScene survives React StrictMode, Application.start() joins in-flight startup

### DIFF
--- a/packages/exojs-react/src/useScene.ts
+++ b/packages/exojs-react/src/useScene.ts
@@ -1,5 +1,5 @@
 import { ApplicationStatus, type Scene, type SceneConstructor } from '@codexo/exojs';
-import { type DependencyList, useEffect, useState } from 'react';
+import { type DependencyList, useEffect, useRef, useState } from 'react';
 
 import { useExoApp } from './useExoApp';
 
@@ -13,8 +13,13 @@ import { useExoApp } from './useExoApp';
  * On first call (engine not yet started) this hook calls `app.start(SceneClass)`,
  * which initializes the render backend and begins the per-frame loop. On
  * subsequent dep-change remounts it calls `app.scenes.change(SceneClass)` to
- * switch scenes without restarting the engine. Each activation constructs a
- * fresh instance — this hook never reuses one across calls.
+ * switch scenes without restarting the engine, constructing a fresh instance.
+ *
+ * Effects that run while startup is still in flight — React StrictMode
+ * double-mounts every effect in development — join that `app.start()` call
+ * instead of racing a second navigation against it, and only activate
+ * `SceneClass` afterwards if startup did not already leave it active. A
+ * StrictMode double mount therefore activates the scene exactly once.
  *
  * A failure in `app.start()`/`app.scenes.change()` (e.g. a scene's `load()`
  * rejects) is caught and routed to {@link Application.onError} rather than
@@ -39,9 +44,18 @@ import { useExoApp } from './useExoApp';
 export function useScene<T extends Scene>(SceneClass: new () => T, deps: DependencyList = []): T | null {
   const app = useExoApp();
   const [scene, setScene] = useState<T | null>(null);
+  // Bumped on every effect run so an async `apply()` can tell whether a newer
+  // run has since taken over — the flag below only covers a run whose own
+  // cleanup has fired.
+  const generationRef = useRef(0);
 
   useEffect(() => {
     let cancelled = false;
+    const generation = ++generationRef.current;
+    // Only the newest, still-mounted run may touch component/app state: an
+    // earlier one's activation result is no longer what the component asked
+    // for, and neither is its failure.
+    const isStale = (): boolean => cancelled || generationRef.current !== generation;
     // This hook's contract has always been zero-arg activation only (no data
     // parameter) — `T extends Scene` (Data defaults to void), but that generic
     // `T` can't be distributed through the navigation call's conditional types
@@ -51,19 +65,43 @@ export function useScene<T extends Scene>(SceneClass: new () => T, deps: Depende
 
     const apply = async (): Promise<void> => {
       try {
-        // Stopped: first activation, which initializes the backend and starts
-        // the frame loop. Otherwise the engine is already running and this is a
-        // scene switch without a restart.
-        await (app.status === ApplicationStatus.Stopped ? app.start(target) : app.scenes.change(target));
+        if (app.status === ApplicationStatus.Stopped || app.status === ApplicationStatus.Loading) {
+          // Stopped: first activation, which initializes the backend and starts
+          // the frame loop. Loading: an earlier effect's `start()` is still in
+          // flight — including its own initial scene navigation, which
+          // `scenes.change()` would collide with (navigation never queues, it
+          // rejects). `start()` joins that in-flight run instead, ignoring the
+          // target passed here.
+          await app.start(target);
 
-        if (!cancelled) {
+          if (isStale()) {
+            return;
+          }
+
+          // Startup activates its own target, which is this one whenever the
+          // joined `start()` came from an effect for the same scene (the
+          // StrictMode double-mount case) — activating again would needlessly
+          // tear the scene down and rebuild it. A `start()` that targeted a
+          // different scene, or none at all, still needs the switch.
+          if (!(app.scenes.currentScene instanceof SceneClass)) {
+            await app.scenes.change(target);
+          }
+        } else {
+          // The engine is already running: a scene switch without a restart.
+          await app.scenes.change(target);
+        }
+
+        if (!isStale()) {
           setScene(app.scenes.currentScene as T);
         }
       } catch (error) {
         // Route to Application.onError instead of leaving an unhandled
         // rejection — app.start()/change() reject rather than dispatching
-        // onError themselves.
-        app.onError.dispatch(error instanceof Error ? error : new Error(String(error)));
+        // onError themselves. A superseded run stays silent: its failure is no
+        // longer this component's state, exactly like its success.
+        if (!isStale()) {
+          app.onError.dispatch(error instanceof Error ? error : new Error(String(error)));
+        }
       }
     };
 

--- a/packages/exojs-react/test/support/mock-application.ts
+++ b/packages/exojs-react/test/support/mock-application.ts
@@ -4,12 +4,33 @@ import { vi } from 'vitest';
 // each test file's `vi.mock('@codexo/exojs', …)` factory via
 // `configureApplicationStatus(actual.ApplicationStatus)` so the mock never
 // hard-codes the enum's numeric members (and can't drift from the real engine).
-const status = { stopped: 4, running: 2 };
+const status = { stopped: 4, running: 2, loading: 1 };
 
 /** Inject the real enum values so the mock's status matches what the hooks compare against. */
-export function configureApplicationStatus(applicationStatus: { Stopped: number; Running: number }): void {
+export function configureApplicationStatus(applicationStatus: { Stopped: number; Running: number; Loading: number }): void {
   status.stopped = applicationStatus.Stopped;
   status.running = applicationStatus.Running;
+  status.loading = applicationStatus.Loading;
+}
+
+/**
+ * Stand-in for the engine's `ConcurrentSceneNavigationError`, used until a test
+ * file injects the real class via {@link configureConcurrentNavigationError}.
+ * It cannot be imported at module scope here for the same reason `MockSignal`
+ * exists (see below).
+ */
+class MockConcurrentSceneNavigationError extends Error {
+  public constructor() {
+    super('A Scene switch or transition is already in progress.');
+    this.name = 'ConcurrentSceneNavigationError';
+  }
+}
+
+let concurrentNavigationError: new () => Error = MockConcurrentSceneNavigationError;
+
+/** Inject the real error class so tests can assert on its identity, not just its name. */
+export function configureConcurrentNavigationError(errorClass: new () => Error): void {
+  concurrentNavigationError = errorClass;
 }
 
 interface MockSceneDirector {
@@ -102,6 +123,21 @@ export class MockApplication {
     this.destroyed = true;
   });
 
+  /** Every scene instance activated through `start()`/`scenes.change()`, in activation order. */
+  public readonly activations: unknown[] = [];
+
+  /**
+   * True while `start()`'s initial navigation is running. The real
+   * SceneDirector never queues navigation: an overlapping `change()` rejects
+   * with `ConcurrentSceneNavigationError` — including against the navigation
+   * `Application.start()` performs internally, which is the window a React
+   * StrictMode double-mount lands in.
+   */
+  private _navigationInFlight = false;
+
+  /** The in-flight `start()` run, mirroring `Application._startPromise`. */
+  private _startPromise: Promise<MockApplication> | null = null;
+
   public readonly scenes: MockSceneDirector = {
     currentScene: null,
     // The real SceneDirector.change() takes a constructor and constructs a
@@ -110,17 +146,56 @@ export class MockApplication {
     // exposes, while `change.mock.calls` still records the raw constructor
     // argument tests assert against.
     change: vi.fn(async (SceneClass: new () => unknown): Promise<MockSceneDirector> => {
-      this.scenes.currentScene = new SceneClass();
+      if (this._navigationInFlight) {
+        throw new concurrentNavigationError();
+      }
+
+      this._activate(SceneClass);
+
       return this.scenes;
     }),
   };
 
   public readonly start = vi.fn(async (SceneClass?: new () => unknown): Promise<MockApplication> => {
-    this.status = status.running;
-    if (SceneClass !== undefined) {
-      this.scenes.currentScene = new SceneClass();
+    // Mirrors the real Application.start(): a call made while an earlier one is
+    // still in flight joins it (and ignores its own target) instead of
+    // returning a resolved promise mid-startup; a call on an already-running
+    // application is a no-op.
+    if (this._startPromise !== null) {
+      return this._startPromise;
     }
-    return this;
+
+    if (this.status !== status.stopped) {
+      return this;
+    }
+
+    // `Loading` is entered synchronously, before the first await, so a caller
+    // in the same tick observes a startup that is genuinely still running.
+    this.status = status.loading;
+    this._navigationInFlight = SceneClass !== undefined;
+
+    const startPromise = (async (): Promise<MockApplication> => {
+      try {
+        // Stands in for backend init / capability detection — the async window
+        // during which the initial navigation has not completed yet.
+        await Promise.resolve();
+
+        if (SceneClass !== undefined) {
+          this._activate(SceneClass);
+        }
+
+        this.status = status.running;
+
+        return this;
+      } finally {
+        this._navigationInFlight = false;
+        this._startPromise = null;
+      }
+    })();
+
+    this._startPromise = startPromise;
+
+    return startPromise;
   });
 
   public constructor(options: MockApplicationOptions = {}) {
@@ -130,6 +205,14 @@ export class MockApplication {
     // captures the later live-sync writes the hook performs.
     this._sizingMode = options.canvas?.sizingMode ?? 'fixed';
     MockApplication.instances.push(this);
+  }
+
+  /** Construct and install a scene instance, recording the activation. */
+  private _activate(SceneClass: new () => unknown): void {
+    const scene = new SceneClass();
+
+    this.scenes.currentScene = scene;
+    this.activations.push(scene);
   }
 
   public get sizingMode(): string {

--- a/packages/exojs-react/test/useScene.test.tsx
+++ b/packages/exojs-react/test/useScene.test.tsx
@@ -1,6 +1,6 @@
-import { Application, Scene as ExoScene } from '@codexo/exojs';
+import { Application, ApplicationStatus, Scene as ExoScene } from '@codexo/exojs';
 import { render, waitFor } from '@testing-library/react';
-import { type DependencyList, type ReactElement, type ReactNode } from 'react';
+import { type DependencyList, type ReactElement, type ReactNode, StrictMode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ExoContext } from '../src/ExoContext';
@@ -11,12 +11,14 @@ import { MockApplication } from './support/mock-application';
 // above this file's imports (top-level bindings are not initialised yet).
 vi.mock('@codexo/exojs', async importActual => {
   const actual = await importActual<typeof import('@codexo/exojs')>();
-  const { MockApplication: MockApp, configureApplicationStatus } = await import('./support/mock-application');
+  const { MockApplication: MockApp, configureApplicationStatus, configureConcurrentNavigationError } = await import('./support/mock-application');
   configureApplicationStatus(actual.ApplicationStatus);
+  configureConcurrentNavigationError(actual.ConcurrentSceneNavigationError);
   return { ...actual, Application: MockApp };
 });
 
 class LevelScene extends ExoScene {}
+class MenuScene extends ExoScene {}
 
 function SceneProbe({ sceneClass, deps }: { sceneClass: new () => ExoScene; deps?: DependencyList }): ReactElement {
   const scene = useScene(sceneClass, deps);
@@ -112,6 +114,74 @@ describe('useScene', () => {
     render(provide(app, <SceneProbe sceneClass={LevelScene} />));
 
     await waitFor(() => expect(onError).toHaveBeenCalledWith(new Error('start failed as a plain string')));
+  });
+
+  it('survives the StrictMode double effect mount without a concurrent-navigation error', async () => {
+    const app = makeApp();
+    const errors: Error[] = [];
+    app.onError.add(error => errors.push(error));
+
+    // StrictMode double-invokes effects in development: mount, cleanup, mount
+    // again — synchronously, within the same commit. The second mount runs
+    // while the first mount's app.start() is still mid-navigation.
+    const { findByText } = render(
+      <StrictMode>
+        <ExoContext.Provider value={app as unknown as Application}>
+          <SceneProbe sceneClass={LevelScene} />
+        </ExoContext.Provider>
+      </StrictMode>,
+    );
+
+    await waitFor(() => expect(app.status).toBe(ApplicationStatus.Running));
+
+    // The second mount must join the in-flight start() rather than racing a
+    // scenes.change() against its navigation.
+    expect(errors).toEqual([]);
+    expect(app.scenes.change).not.toHaveBeenCalled();
+    expect(app.start).toHaveBeenCalledTimes(2);
+
+    // Activated exactly once, and the surviving effect reports the live scene.
+    expect(app.activations).toHaveLength(1);
+    expect(await findByText('LevelScene')).toBeTruthy();
+  });
+
+  it('activates its own target after joining a start() that was already loading another scene', async () => {
+    const app = makeApp();
+    const onError = vi.fn();
+    app.onError.add(onError);
+
+    // Startup is already in flight for a different scene when the hook mounts.
+    const starting = app.start(MenuScene);
+    const { findByText } = render(provide(app, <SceneProbe sceneClass={LevelScene} />));
+
+    await starting;
+
+    expect(await findByText('LevelScene')).toBeTruthy();
+    expect(app.scenes.change).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('does not report a rejected activation from an effect that was already superseded', async () => {
+    const app = makeApp();
+    const onError = vi.fn();
+    app.onError.add(onError);
+    let rejectStart!: (error: Error) => void;
+    app.start.mockImplementationOnce(
+      () =>
+        new Promise<MockApplication>((_resolve, reject) => {
+          rejectStart = reject;
+        }),
+    );
+
+    const view = render(provide(app, <SceneProbe sceneClass={LevelScene} />));
+
+    // Cleanup has run by the time the pending start() rejects — the failure
+    // belongs to a run nothing is listening to any more.
+    view.unmount();
+    rejectStart(new Error('start failed after unmount'));
+
+    await Promise.resolve().then(() => Promise.resolve());
+    expect(onError).not.toHaveBeenCalled();
   });
 
   it('does not install the scene when the component unmounts before app.start() resolves', async () => {

--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -400,6 +400,13 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
   private _frameAlpha = 0;
 
   private _status: ApplicationStatus = ApplicationStatus.Stopped;
+  /**
+   * The startup run that is currently in flight, or `null` while none is.
+   * Held so a second {@link Application.start} call made during the `Loading`
+   * window can await the same run instead of returning a resolved promise
+   * while startup — including its initial scene navigation — is still going.
+   */
+  private _startPromise: Promise<this> | null = null;
   private _frameLoopActive = false;
   private _destroyed = false;
   private _pixelRatio: number = defaultCanvasSettings.pixelRatio;
@@ -772,66 +779,96 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
    */
   public async start<K extends RegistryKeyOf<Registry>>(target: K, ...args: ChangeSceneArgs<InferSceneData<Registry[K]>>): Promise<this>;
   public async start<C extends NavigableSceneConstructor<Registry>>(target: C, ...args: ChangeSceneArgs<InferSceneData<C>>): Promise<this>;
+  /**
+   * Concurrency: a call made while an earlier `start()` is still in flight
+   * (status `Loading`) joins that run — it resolves when startup actually
+   * completes, or rejects with its failure, and its own `target`/`args` are
+   * ignored rather than driving a second, overlapping scene navigation
+   * ({@link SceneDirector.change} rejects on overlapping navigation). Check
+   * {@link SceneDirector.currentScene} after such a call if the second
+   * caller's target may differ from the one already starting.
+   */
   public async start(target?: AnySceneConstructor | string, ...args: readonly unknown[]): Promise<this> {
     invariant(!this._destroyed, 'Application.start() was called after destroy(). Construct a new Application instead of reusing a destroyed one.');
 
-    if (this._status === ApplicationStatus.Stopped) {
-      this._status = ApplicationStatus.Loading;
+    if (this._startPromise !== null) {
+      return this._startPromise;
+    }
 
-      // Kick off capability detection in parallel with renderer init — both
-      // are mostly-async startup work, no point serializing them.
-      const capabilitiesPromise = Capabilities.ready;
+    if (this._status !== ApplicationStatus.Stopped) {
+      return this;
+    }
 
-      try {
-        await this.initializeBackend();
+    this._status = ApplicationStatus.Loading;
 
-        if (this.options.hello) {
-          hello({ backend: this._backendType });
-        }
+    // Published before the first await so a `start()` call made from the same
+    // synchronous tick — or any point in the `Loading` window — finds it. The
+    // reset runs in the chained `finally`, i.e. once the run has fully settled
+    // (success or failure), leaving a failed application restartable.
+    const startPromise = this._runStartup(target, args).finally(() => {
+      this._startPromise = null;
+    });
 
-        // The frame loop must be live BEFORE the initial navigation runs —
-        // a frame-driven SceneTransitionSession needs update()/render()
-        // calls to progress, and update()'s gate no longer waits for
-        // `_status === Running`. Started as early as
-        // possible (ahead of the capabilities await, not just the scene
-        // nav) so nothing downstream can observe the loop live and
-        // `_status` already `Running` in the same synchronous tick — a real
-        // RAF callback never fires synchronously anyway, so capabilities
-        // (documented as available only once `start()` resolves) is always
-        // settled well before any frame body actually runs.
-        this._startFrameLoop();
+    this._startPromise = startPromise;
 
-        // Guarantee at least one full microtask turn between the loop going
-        // live and `_status` flipping to `Running` — otherwise, when
-        // `capabilitiesPromise` is already settled (e.g. a later `start()`
-        // call on a second Application reusing the memoized
-        // `Capabilities.ready`), the two awaits below could resolve in the
-        // same synchronous continuation as `_startFrameLoop()`, collapsing
-        // the "loop active, not yet Running" window race-callers (a
-        // frame-driven transition, tests) rely on being able to observe.
-        await Promise.resolve();
+    return startPromise;
+  }
 
-        this._capabilities = await capabilitiesPromise;
+  /** The actual startup work behind {@link Application.start}, run at most once at a time. */
+  private async _runStartup(target: AnySceneConstructor | string | undefined, args: readonly unknown[]): Promise<this> {
+    // Kick off capability detection in parallel with renderer init — both
+    // are mostly-async startup work, no point serializing them.
+    const capabilitiesPromise = Capabilities.ready;
 
-        if (target !== undefined) {
-          // `target`'s implementation-level type is a union (registered key
-          // OR constructor) — TS overload resolution does not distribute
-          // over a union-typed argument, so the cast picks the constructor
-          // overload purely for compile-time dispatch; SceneDirector.change()'s
-          // own single implementation signature already accepts both shapes
-          // and forwards whichever one was actually passed at runtime.
-          await this.scenes.change(
-            target as NavigableSceneConstructor<Registry>,
-            ...(args as ChangeSceneArgs<InferSceneData<NavigableSceneConstructor<Registry>>>),
-          );
-        }
+    try {
+      await this.initializeBackend();
 
-        this._status = ApplicationStatus.Running;
-      } catch (error) {
-        this._stopFrameLoop();
-        this._status = ApplicationStatus.Stopped;
-        throw error;
+      if (this.options.hello) {
+        hello({ backend: this._backendType });
       }
+
+      // The frame loop must be live BEFORE the initial navigation runs —
+      // a frame-driven SceneTransitionSession needs update()/render()
+      // calls to progress, and update()'s gate no longer waits for
+      // `_status === Running`. Started as early as
+      // possible (ahead of the capabilities await, not just the scene
+      // nav) so nothing downstream can observe the loop live and
+      // `_status` already `Running` in the same synchronous tick — a real
+      // RAF callback never fires synchronously anyway, so capabilities
+      // (documented as available only once `start()` resolves) is always
+      // settled well before any frame body actually runs.
+      this._startFrameLoop();
+
+      // Guarantee at least one full microtask turn between the loop going
+      // live and `_status` flipping to `Running` — otherwise, when
+      // `capabilitiesPromise` is already settled (e.g. a later `start()`
+      // call on a second Application reusing the memoized
+      // `Capabilities.ready`), the two awaits below could resolve in the
+      // same synchronous continuation as `_startFrameLoop()`, collapsing
+      // the "loop active, not yet Running" window race-callers (a
+      // frame-driven transition, tests) rely on being able to observe.
+      await Promise.resolve();
+
+      this._capabilities = await capabilitiesPromise;
+
+      if (target !== undefined) {
+        // `target`'s implementation-level type is a union (registered key
+        // OR constructor) — TS overload resolution does not distribute
+        // over a union-typed argument, so the cast picks the constructor
+        // overload purely for compile-time dispatch; SceneDirector.change()'s
+        // own single implementation signature already accepts both shapes
+        // and forwards whichever one was actually passed at runtime.
+        await this.scenes.change(
+          target as NavigableSceneConstructor<Registry>,
+          ...(args as ChangeSceneArgs<InferSceneData<NavigableSceneConstructor<Registry>>>),
+        );
+      }
+
+      this._status = ApplicationStatus.Running;
+    } catch (error) {
+      this._stopFrameLoop();
+      this._status = ApplicationStatus.Stopped;
+      throw error;
     }
 
     return this;

--- a/test/core/application-start.test.ts
+++ b/test/core/application-start.test.ts
@@ -6,7 +6,7 @@ import type { MockInstance } from 'vitest';
  * WebGL2/WebGPU backends are mocked (kept out of jsdom) — SceneDirector,
  * the scene registry, and scene activation all run for real.
  */
-import { Application } from '#core/Application';
+import { Application, ApplicationStatus } from '#core/Application';
 import { Scene } from '#core/Scene';
 
 // ---------------------------------------------------------------------------
@@ -127,6 +127,58 @@ describe('Application.start() — scene-less and constructor overloads', () => {
     await expect(app.start(FailingLoadScene)).rejects.toThrow('load failed');
 
     expect((app as unknown as { _frameLoopActive: boolean })._frameLoopActive).toBe(false);
+
+    app.destroy();
+  });
+
+  test('a second start() while startup is in flight joins it instead of resolving early', async () => {
+    class ConcurrentStartScene extends Scene {}
+    const app = new Application({ backend: { type: 'webgl2' }, scenes: { concurrent: ConcurrentStartScene } });
+
+    const first = app.start(ConcurrentStartScene);
+
+    // start() flips to Loading synchronously, before its first await — so the
+    // second caller below observes a startup that is genuinely still running.
+    expect(app.status).toBe(ApplicationStatus.Loading);
+
+    const second = app.start(ConcurrentStartScene);
+
+    await expect(second).resolves.toBe(app);
+
+    // Awaiting the second call must mean startup is done — not merely that the
+    // call returned early while the first one is still mid-navigation.
+    expect(app.status).toBe(ApplicationStatus.Running);
+    expect(app.scenes.currentScene).toBeInstanceOf(ConcurrentStartScene);
+
+    await first;
+    app.destroy();
+  });
+
+  test('a concurrent start() rejects with the in-flight startup failure and leaves the app restartable', async () => {
+    let failNextLoad = true;
+
+    class FlakyStartScene extends Scene {
+      public override load(): void {
+        if (failNextLoad) {
+          failNextLoad = false;
+          throw new Error('load failed');
+        }
+      }
+    }
+
+    const app = new Application({ backend: { type: 'webgl2' }, scenes: { flaky: FlakyStartScene } });
+
+    const first = app.start(FlakyStartScene);
+    const second = app.start(FlakyStartScene);
+
+    await expect(first).rejects.toThrow('load failed');
+    await expect(second).rejects.toThrow('load failed');
+
+    expect(app.status).toBe(ApplicationStatus.Stopped);
+
+    // The failed attempt must not leave a stale in-flight promise behind.
+    await expect(app.start(FlakyStartScene)).resolves.toBe(app);
+    expect(app.scenes.currentScene).toBeInstanceOf(FlakyStartScene);
 
     app.destroy();
   });


### PR DESCRIPTION
Fixes HI-28 together with its hard prerequisite ME-2, per the architecture review.

**ME-2 — `Application.start()` resolved early on re-entrant calls.** A second `start()` call made while status was `Loading` fell straight through the guarding `if`, returning a resolved `this` while backend init/capability detection/initial navigation were all still running — a failed startup could even be reported as a success. `start()` now tracks the in-flight run in `_startPromise` and returns it to any caller made while `Loading`, so every concurrent caller settles with the real result.

**HI-28 — `useScene` collided with React StrictMode.** StrictMode's double effect-mount meant the second mount saw `app.status === Loading` (not `Stopped`) and took the scene-switch branch, firing `app.scenes.change()` straight into the first mount's still-in-flight navigation — which never queues and rejects with `ConcurrentSceneNavigationError`, hitting essentially every `exojs-react` user's first test run. `useScene` now joins the in-flight `start()` (made possible by the ME-2 fix above) and only performs an additional scene switch if startup didn't already leave the right scene active. An effect-generation counter and a matching staleness guard on the `onError` dispatch stop a superseded effect run from reporting a stale result or error.