### PR TITLE
refactor(core)!: hand out local bounds read-only, centralise the writes

### DIFF
--- a/packages/exojs-particles/src/ParticleSystem.ts
+++ b/packages/exojs-particles/src/ParticleSystem.ts
@@ -385,8 +385,7 @@ export class ParticleSystem extends Drawable {
     this._updateTexCoords = true;
     this._updateVertices = true;
 
-    this.getLocalBounds().set(0, 0, frame.width, frame.height);
-    this._invalidateBoundsCascade();
+    this._setLocalBounds(0, 0, frame.width, frame.height);
 
     return this;
   }

--- a/packages/exojs-tilemap/src/TileChunkNode.ts
+++ b/packages/exojs-tilemap/src/TileChunkNode.ts
@@ -1,4 +1,4 @@
-import type { Rectangle } from '@codexo/exojs';
+import type { ReadonlyRectangle } from '@codexo/exojs';
 import { Drawable } from '@codexo/exojs/renderer-sdk';
 
 import type { ChunkPage } from './chunkGeometry';
@@ -117,12 +117,13 @@ export class TileChunkNode extends Drawable {
     return this.pages.length === 0;
   }
 
-  public override getLocalBounds(): Rectangle {
-    const bounds = super.getLocalBounds();
-
-    bounds.set(0, 0, this._pixelWidth, this._pixelHeight);
-
-    return bounds;
+  /**
+   * Recomputed lazily on read, so it writes `_localBounds` directly rather than
+   * going through `_setLocalBounds`: an invalidating write inside a getter
+   * would re-dirty the node on every read.
+   */
+  public override getLocalBounds(): ReadonlyRectangle {
+    return this._localBounds.set(0, 0, this._pixelWidth, this._pixelHeight);
   }
 
   public override destroy(): void {

--- a/packages/exojs-tilemap/src/TileLayerNode.ts
+++ b/packages/exojs-tilemap/src/TileLayerNode.ts
@@ -1,4 +1,4 @@
-import type { Rectangle } from '@codexo/exojs';
+import type { ReadonlyRectangle } from '@codexo/exojs';
 import { Container } from '@codexo/exojs';
 import { PixelSnapMode, type RenderPlanBuilder } from '@codexo/exojs/renderer-sdk';
 
@@ -175,8 +175,13 @@ export class TileLayerNode extends Container {
     return this._chunkNodes;
   }
 
-  public override getLocalBounds(): Rectangle {
-    const bounds = super.getLocalBounds();
+  /**
+   * Recomputed lazily on read, so it writes `_localBounds` directly rather than
+   * going through `_setLocalBounds`: an invalidating write inside a getter
+   * would re-dirty the node on every read.
+   */
+  public override getLocalBounds(): ReadonlyRectangle {
+    const bounds = this._localBounds;
 
     // Reading the pixel extents directly (rather than gating on `bounded`)
     // is what narrows them to numbers — `bounded` is a plain boolean getter.

--- a/packages/exojs-tilemap/src/TileMapNode.ts
+++ b/packages/exojs-tilemap/src/TileMapNode.ts
@@ -1,4 +1,4 @@
-import type { Rectangle } from '@codexo/exojs';
+import type { ReadonlyRectangle } from '@codexo/exojs';
 import { Container } from '@codexo/exojs';
 import { PixelSnapMode } from '@codexo/exojs/renderer-sdk';
 
@@ -132,8 +132,13 @@ export class TileMapNode extends Container {
     return this;
   }
 
-  public override getLocalBounds(): Rectangle {
-    const bounds = super.getLocalBounds();
+  /**
+   * Recomputed lazily on read, so it writes `_localBounds` directly rather than
+   * going through `_setLocalBounds`: an invalidating write inside a getter
+   * would re-dirty the node on every read.
+   */
+  public override getLocalBounds(): ReadonlyRectangle {
+    const bounds = this._localBounds;
 
     // Reading the pixel extents directly (rather than gating on `bounded`)
     // is what narrows them to numbers — `bounded` is a plain boolean getter.

--- a/site/src/content/api/abstract-text.json
+++ b/site/src/content/api/abstract-text.json
@@ -518,7 +518,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -537,13 +537,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/animated-sprite.json
+++ b/site/src/content/api/animated-sprite.json
@@ -602,7 +602,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -621,13 +621,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/bitmap-text.json
+++ b/site/src/content/api/bitmap-text.json
@@ -563,7 +563,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -582,13 +582,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/bounds.json
+++ b/site/src/content/api/bounds.json
@@ -137,7 +137,7 @@
         },
         {
           "name": "addRect",
-          "signature": "addRect(rectangle: Rectangle, transform?: Matrix): this",
+          "signature": "addRect(rectangle: ReadonlyRectangle, transform?: Matrix): this",
           "signatureTokens": [
             {
               "text": "addRect",
@@ -156,7 +156,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             },
             {
@@ -195,7 +195,7 @@
           "params": [
             {
               "name": "rectangle",
-              "type": "Rectangle",
+              "type": "ReadonlyRectangle",
               "optional": false
             },
             {

--- a/site/src/content/api/button.json
+++ b/site/src/content/api/button.json
@@ -1025,7 +1025,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -1044,13 +1044,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/container.json
+++ b/site/src/content/api/container.json
@@ -756,7 +756,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -775,13 +775,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/drawable.json
+++ b/site/src/content/api/drawable.json
@@ -500,7 +500,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -519,13 +519,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/graphics.json
+++ b/site/src/content/api/graphics.json
@@ -2021,7 +2021,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -2040,13 +2040,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/htmltext.json
+++ b/site/src/content/api/htmltext.json
@@ -885,7 +885,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -904,13 +904,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/image-layer-node.json
+++ b/site/src/content/api/image-layer-node.json
@@ -775,7 +775,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -794,13 +794,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/label.json
+++ b/site/src/content/api/label.json
@@ -1046,7 +1046,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -1065,13 +1065,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/mesh.json
+++ b/site/src/content/api/mesh.json
@@ -521,7 +521,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -540,13 +540,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/nine-slice-sprite.json
+++ b/site/src/content/api/nine-slice-sprite.json
@@ -546,7 +546,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -565,13 +565,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "Recomputed lazily on read from the current logical size, so it writes _localBounds directly instead of going through _setLocalBounds: an invalidating write inside a getter would re-dirty the node on every read. The size setters own the invalidation for this node."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/panel.json
+++ b/site/src/content/api/panel.json
@@ -1025,7 +1025,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -1044,13 +1044,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/particle-system.json
+++ b/site/src/content/api/particle-system.json
@@ -1033,7 +1033,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -1052,13 +1052,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/progress-bar.json
+++ b/site/src/content/api/progress-bar.json
@@ -1025,7 +1025,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -1044,13 +1044,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/readonly-rectangle.json
+++ b/site/src/content/api/readonly-rectangle.json
@@ -1,16 +1,16 @@
 {
-  "title": "Rectangle",
-  "description": "Mutable axis-aligned rectangle defined by a top-left origin `(x, y)` and dimensions `(width, height)`. Implements ShapeLike with full SAT collision response for rectangles and polygons, and specialised algorithms for circle and ellipse intersections. `Rectangle.temp` is a shared scratch instance. Edge normals are lazily computed and cached; they are invalidated when position or size mutates. See ReadonlyRectangle for the read-only view engine APIs hand out when they return a live internal rectangle.",
-  "symbol": "Rectangle",
-  "kind": "class",
+  "title": "ReadonlyRectangle",
+  "description": "Read-only view of a Rectangle: every accessor and non-mutating query a rectangle offers, with none of its writers. Returned by APIs that hand out a LIVE internal rectangle for zero allocation cost — SceneNode.getLocalBounds being the canonical one. Those rectangles are read on hot per-frame paths, so cloning them defensively would add a per-frame allocation; the view costs nothing at runtime and removes the write at the type level instead. Owners keep a real Rectangle and expose a dedicated writer that also runs whatever invalidation the write implies. Same idea as a `readonly T[]`: the object underneath is still the mutable one, the view just does not offer a way to change it.",
+  "symbol": "ReadonlyRectangle",
+  "kind": "interface",
   "subsystem": "math",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 28,
+  "memberCount": 19,
   "counts": {
-    "constructors": 1,
-    "methods": 15,
-    "properties": 12,
+    "constructors": 0,
+    "methods": 10,
+    "properties": 9,
     "events": 0
   },
   "sections": [
@@ -19,130 +19,11 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "Mutable axis-aligned rectangle defined by a top-left origin `(x, y)` and dimensions `(width, height)`. Implements ShapeLike with full SAT collision response for rectangles and polygons, and specialised algorithms for circle and ellipse intersections.",
-        "`Rectangle.temp` is a shared scratch instance. Edge normals are lazily computed and cached; they are invalidated when position or size mutates.",
-        "See ReadonlyRectangle for the read-only view engine APIs hand out when they return a live internal rectangle."
+        "Read-only view of a Rectangle: every accessor and non-mutating query a rectangle offers, with none of its writers.",
+        "Returned by APIs that hand out a LIVE internal rectangle for zero allocation cost — SceneNode.getLocalBounds being the canonical one. Those rectangles are read on hot per-frame paths, so cloning them defensively would add a per-frame allocation; the view costs nothing at runtime and removes the write at the type level instead. Owners keep a real Rectangle and expose a dedicated writer that also runs whatever invalidation the write implies.",
+        "Same idea as a `readonly T[]`: the object underneath is still the mutable one, the view just does not offer a way to change it."
       ],
-      "importLine": "import { Rectangle } from '@codexo/exojs'",
-      "sourceLink": null
-    },
-    {
-      "id": "constructors",
-      "title": "Constructors",
-      "members": [
-        {
-          "name": "new",
-          "signature": "new(x: number, y: number, width: number, height: number): Rectangle",
-          "signatureTokens": [
-            {
-              "text": "new",
-              "kind": "keyword"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": "x",
-              "kind": "param"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "y",
-              "kind": "param"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "width",
-              "kind": "param"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "height",
-              "kind": "param"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            }
-          ],
-          "params": [
-            {
-              "name": "x",
-              "type": "number",
-              "optional": false
-            },
-            {
-              "name": "y",
-              "type": "number",
-              "optional": false
-            },
-            {
-              "name": "width",
-              "type": "number",
-              "optional": false
-            },
-            {
-              "name": "height",
-              "type": "number",
-              "optional": false
-            }
-          ],
-          "returnType": "Rectangle",
-          "description": ""
-        }
-      ],
-      "paragraphs": [],
-      "importLine": null,
+      "importLine": "import { ReadonlyRectangle } from '@codexo/exojs'",
       "sourceLink": null
     },
     {
@@ -151,7 +32,7 @@
       "members": [
         {
           "name": "clone",
-          "signature": "clone(): this",
+          "signature": "clone(): Rectangle",
           "signatureTokens": [
             {
               "text": "clone",
@@ -170,12 +51,12 @@
               "kind": "punctuation"
             },
             {
-              "text": "this",
-              "kind": "keyword"
+              "text": "Rectangle",
+              "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "this",
+          "returnType": "Rectangle",
           "description": ""
         },
         {
@@ -346,14 +227,14 @@
             }
           ],
           "returnType": "boolean",
-          "description": "Return true when rect is entirely within this rectangle (all four edges inside)."
+          "description": ""
         },
         {
-          "name": "copy",
-          "signature": "copy(rectangle: Rectangle): this",
+          "name": "equals",
+          "signature": "equals(rectangle?: Partial<RectangleLike>): boolean",
           "signatureTokens": [
             {
-              "text": "copy",
+              "text": "equals",
               "kind": "name"
             },
             {
@@ -365,80 +246,8 @@
               "kind": "param"
             },
             {
-              "text": ": ",
+              "text": "?",
               "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "this",
-              "kind": "keyword"
-            }
-          ],
-          "params": [
-            {
-              "name": "rectangle",
-              "type": "Rectangle",
-              "optional": false
-            }
-          ],
-          "returnType": "this",
-          "description": ""
-        },
-        {
-          "name": "destroy",
-          "signature": "destroy(): void",
-          "signatureTokens": [
-            {
-              "text": "destroy",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": ""
-        },
-        {
-          "name": "equals",
-          "signature": "equals(__namedParameters: Partial<Rectangle>): boolean",
-          "signatureTokens": [
-            {
-              "text": "equals",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": "__namedParameters",
-              "kind": "param"
             },
             {
               "text": ": ",
@@ -453,7 +262,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "RectangleLike",
               "kind": "type"
             },
             {
@@ -475,9 +284,9 @@
           ],
           "params": [
             {
-              "name": "__namedParameters",
-              "type": "Partial<Rectangle>",
-              "optional": false
+              "name": "rectangle",
+              "type": "Partial<RectangleLike>",
+              "optional": true
             }
           ],
           "returnType": "boolean",
@@ -594,7 +403,7 @@
         },
         {
           "name": "project",
-          "signature": "project(axis: Vector, result: Interval): Interval",
+          "signature": "project(axis: Vector, interval?: Interval): Interval",
           "signatureTokens": [
             {
               "text": "project",
@@ -621,8 +430,12 @@
               "kind": "punctuation"
             },
             {
-              "text": "result",
+              "text": "interval",
               "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
             },
             {
               "text": ": ",
@@ -652,259 +465,13 @@
               "optional": false
             },
             {
-              "name": "result",
+              "name": "interval",
               "type": "Interval",
-              "optional": false
+              "optional": true
             }
           ],
           "returnType": "Interval",
           "description": "Project this shape onto axis and write the scalar min/max into interval. Used internally by the SAT solver."
-        },
-        {
-          "name": "set",
-          "signature": "set(x: number, y: number, width: number, height: number): this",
-          "signatureTokens": [
-            {
-              "text": "set",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": "x",
-              "kind": "param"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "y",
-              "kind": "param"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "width",
-              "kind": "param"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "height",
-              "kind": "param"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "this",
-              "kind": "keyword"
-            }
-          ],
-          "params": [
-            {
-              "name": "x",
-              "type": "number",
-              "optional": false
-            },
-            {
-              "name": "y",
-              "type": "number",
-              "optional": false
-            },
-            {
-              "name": "width",
-              "type": "number",
-              "optional": false
-            },
-            {
-              "name": "height",
-              "type": "number",
-              "optional": false
-            }
-          ],
-          "returnType": "this",
-          "description": ""
-        },
-        {
-          "name": "setPosition",
-          "signature": "setPosition(x: number, y: number): this",
-          "signatureTokens": [
-            {
-              "text": "setPosition",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": "x",
-              "kind": "param"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "y",
-              "kind": "param"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "this",
-              "kind": "keyword"
-            }
-          ],
-          "params": [
-            {
-              "name": "x",
-              "type": "number",
-              "optional": false
-            },
-            {
-              "name": "y",
-              "type": "number",
-              "optional": false
-            }
-          ],
-          "returnType": "this",
-          "description": ""
-        },
-        {
-          "name": "setSize",
-          "signature": "setSize(width: number, height: number): this",
-          "signatureTokens": [
-            {
-              "text": "setSize",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": "width",
-              "kind": "param"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "height",
-              "kind": "param"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "this",
-              "kind": "keyword"
-            }
-          ],
-          "params": [
-            {
-              "name": "width",
-              "type": "number",
-              "optional": false
-            },
-            {
-              "name": "height",
-              "type": "number",
-              "optional": false
-            }
-          ],
-          "returnType": "this",
-          "description": ""
         },
         {
           "name": "transform",
@@ -972,7 +539,7 @@
             }
           ],
           "returnType": "Rectangle",
-          "description": "Apply a 3×3 affine matrix to all four corners of this rectangle, then return the axis-aligned bounding box of the transformed corners written into result. Defaults to mutating this in place. Returns result."
+          "description": "Unlike Rectangle.transform, result is REQUIRED here: the defaulted overload writes the transformed box back into the receiver, which a read-only view must not offer."
         }
       ],
       "paragraphs": [],
@@ -983,27 +550,6 @@
       "id": "properties",
       "title": "Properties",
       "members": [
-        {
-          "name": "collisionType",
-          "signature": "collisionType: CollisionType",
-          "signatureTokens": [
-            {
-              "text": "collisionType",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "CollisionType",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
         {
           "name": "bottom",
           "signature": "bottom: number",
@@ -1019,6 +565,27 @@
             {
               "text": "number",
               "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "collisionType",
+          "signature": "collisionType: CollisionType",
+          "signatureTokens": [
+            {
+              "text": "collisionType",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "CollisionType",
+              "kind": "type"
             }
           ],
           "params": [],
@@ -1068,27 +635,6 @@
           "description": ""
         },
         {
-          "name": "position",
-          "signature": "position: AbstractVector",
-          "signatureTokens": [
-            {
-              "text": "position",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "AbstractVector",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
           "name": "right",
           "signature": "right: number",
           "signatureTokens": [
@@ -1103,27 +649,6 @@
             {
               "text": "number",
               "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "size",
-          "signature": "size: Size",
-          "signatureTokens": [
-            {
-              "text": "size",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Size",
-              "kind": "type"
             }
           ],
           "params": [],
@@ -1208,27 +733,6 @@
             {
               "text": "number",
               "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "temp",
-          "signature": "temp: Rectangle",
-          "signatureTokens": [
-            {
-              "text": "temp",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Rectangle",
-              "kind": "type"
             }
           ],
           "params": [],

--- a/site/src/content/api/render-node.json
+++ b/site/src/content/api/render-node.json
@@ -501,7 +501,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -520,13 +520,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/repeating-sprite.json
+++ b/site/src/content/api/repeating-sprite.json
@@ -554,7 +554,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -573,13 +573,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "Recomputed lazily on read from the current logical size, so it writes _localBounds directly instead of going through _setLocalBounds: an invalidating write inside a getter would re-dirty the node on every read. The size setters own the invalidation for this node."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/retained-container.json
+++ b/site/src/content/api/retained-container.json
@@ -832,7 +832,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -851,13 +851,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/scene-node.json
+++ b/site/src/content/api/scene-node.json
@@ -369,7 +369,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -388,13 +388,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/scroll-container.json
+++ b/site/src/content/api/scroll-container.json
@@ -1027,7 +1027,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -1046,13 +1046,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/sprite.json
+++ b/site/src/content/api/sprite.json
@@ -477,7 +477,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -496,13 +496,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/stack.json
+++ b/site/src/content/api/stack.json
@@ -1072,7 +1072,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -1091,13 +1091,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/text.json
+++ b/site/src/content/api/text.json
@@ -544,7 +544,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -563,13 +563,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/tile-layer-node.json
+++ b/site/src/content/api/tile-layer-node.json
@@ -800,7 +800,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -819,13 +819,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "Recomputed lazily on read, so it writes _localBounds directly rather than going through _setLocalBounds: an invalidating write inside a getter would re-dirty the node on every read."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/tile-map-band.json
+++ b/site/src/content/api/tile-map-band.json
@@ -784,7 +784,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -803,13 +803,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/tile-map-node.json
+++ b/site/src/content/api/tile-map-node.json
@@ -862,7 +862,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -881,13 +881,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "Recomputed lazily on read, so it writes _localBounds directly rather than going through _setLocalBounds: an invalidating write inside a getter would re-dirty the node on every read."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/uiroot.json
+++ b/site/src/content/api/uiroot.json
@@ -755,7 +755,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -774,13 +774,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/video.json
+++ b/site/src/content/api/video.json
@@ -593,7 +593,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -612,13 +612,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/widget.json
+++ b/site/src/content/api/widget.json
@@ -1008,7 +1008,7 @@
         },
         {
           "name": "getLocalBounds",
-          "signature": "getLocalBounds(): Rectangle",
+          "signature": "getLocalBounds(): ReadonlyRectangle",
           "signatureTokens": [
             {
               "text": "getLocalBounds",
@@ -1027,13 +1027,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "ReadonlyRectangle",
               "kind": "type"
             }
           ],
           "params": [],
-          "returnType": "Rectangle",
-          "description": ""
+          "returnType": "ReadonlyRectangle",
+          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
         },
         {
           "name": "getNormals",

--- a/src/core/Bounds.ts
+++ b/src/core/Bounds.ts
@@ -1,4 +1,5 @@
 import type { Matrix } from '#math/Matrix';
+import type { ReadonlyRectangle } from '#math/Rectangle';
 import { Rectangle } from '#math/Rectangle';
 
 /**
@@ -53,7 +54,7 @@ export class Bounds {
    * the rectangle's corners are transformed into the bounds' coordinate
    * space first (via `Rectangle.temp` — does not mutate `rectangle`).
    */
-  public addRect(rectangle: Rectangle, transform?: Matrix): this {
+  public addRect(rectangle: ReadonlyRectangle, transform?: Matrix): this {
     if (transform) {
       rectangle = rectangle.transform(transform, Rectangle.temp);
     }

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -16,6 +16,7 @@ import type { Line } from '#math/Line';
 import { Matrix } from '#math/Matrix';
 import { ObservableVector, type ObservableVectorOwner } from '#math/ObservableVector';
 import { Polygon } from '#math/Polygon';
+import type { ReadonlyRectangle } from '#math/Rectangle';
 import { Rectangle } from '#math/Rectangle';
 import { degreesToRadians, trimRotation } from '#math/utils';
 import { Vector } from '#math/Vector';
@@ -211,7 +212,16 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
   protected _globalTransformVersion = 1;
   private _combinedParentVersion = -1;
   private _boundsBuiltAtVersion = -1;
-  private _localBounds = new Rectangle();
+  /**
+   * The node's local extent. `protected`, not `private`, for the ONE subclass
+   * pattern the invalidating writers below cannot serve: a subclass that
+   * recomputes its extent lazily from inside its own {@link getLocalBounds}
+   * override. Such an override must write this rectangle directly — routing it
+   * through {@link _setLocalBounds} would cascade an invalidation on every
+   * read, which re-dirties the node once per frame and defeats the retained
+   * static-subtree skip. Every other writer belongs in {@link _setLocalBounds}.
+   */
+  protected readonly _localBounds = new Rectangle();
   private _anchor = new ObservableVector(this, SceneNodeVectorChannel.Anchor, 0, 0);
   private _parentNode: Container | null = null;
   private _zIndex = 0;
@@ -511,8 +521,41 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
     return this;
   }
 
-  public getLocalBounds(): Rectangle {
+  /**
+   * This node's untransformed extent in its own local coordinate space.
+   *
+   * Returns the LIVE internal rectangle, not a copy: it is read on hot paths
+   * ({@link updateBounds} re-reads it on every transform-dirty recompute, i.e.
+   * potentially every frame for a moving node), so copying it here would add a
+   * per-frame allocation. It is therefore typed as a {@link ReadonlyRectangle}
+   * — reads are unchanged, writes are rejected at compile time.
+   *
+   * Writing to it directly would skip the bounds/content invalidation the
+   * engine needs, leaving culling, hit-testing and retained render fragments on
+   * a stale extent. A custom {@link Drawable} that owns its own size sets it
+   * through {@link _setLocalBounds}, which writes and invalidates in one step.
+   */
+  public getLocalBounds(): ReadonlyRectangle {
     return this._localBounds;
+  }
+
+  /**
+   * Write this node's local extent and run the bounds invalidation the change
+   * implies — the node's own bounds flag, the ancestor bounds cascade, and the
+   * content-dirty stamp that keeps retained fragments from replaying the old
+   * extent.
+   *
+   * This is the only supported way to resize a node from outside
+   * {@link getLocalBounds}; the rectangle itself is handed out read-only so the
+   * invalidation cannot be forgotten. Built-in drawables (Sprite, Text,
+   * BitmapText, Mesh, …) and custom ones alike go through here.
+   * @internal
+   */
+  public _setLocalBounds(x: number, y: number, width: number, height: number): this {
+    this._localBounds.set(x, y, width, height);
+    this._invalidateBoundsCascade();
+
+    return this;
   }
 
   /**

--- a/src/math/Rectangle.ts
+++ b/src/math/Rectangle.ts
@@ -20,6 +20,7 @@ import type { Line } from './Line';
 import type { Matrix } from './Matrix';
 import { ObservableVector, type ObservableVectorOwner } from './ObservableVector';
 import type { Polygon } from './Polygon';
+import type { RectangleLike } from './RectangleLike';
 import type { ShapeLike } from './ShapeLike';
 import { Size } from './Size';
 import { inRange } from './utils';
@@ -29,6 +30,42 @@ let temp: Rectangle | null = null;
 const tempPoint = new ObservableVector(null);
 
 /**
+ * Read-only view of a {@link Rectangle}: every accessor and non-mutating query
+ * a rectangle offers, with none of its writers.
+ *
+ * Returned by APIs that hand out a LIVE internal rectangle for zero allocation
+ * cost — {@link SceneNode.getLocalBounds} being the canonical one. Those
+ * rectangles are read on hot per-frame paths, so cloning them defensively would
+ * add a per-frame allocation; the view costs nothing at runtime and removes the
+ * write at the type level instead. Owners keep a real {@link Rectangle} and
+ * expose a dedicated writer that also runs whatever invalidation the write
+ * implies.
+ *
+ * Same idea as a `readonly T[]`: the object underneath is still the mutable
+ * one, the view just does not offer a way to change it.
+ */
+export interface ReadonlyRectangle extends Collidable {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+  readonly left: number;
+  readonly top: number;
+  readonly right: number;
+  readonly bottom: number;
+  equals(rectangle?: Partial<RectangleLike>): boolean;
+  clone(): Rectangle;
+  getBounds(): Rectangle;
+  containsRect(rect: Rectangle): boolean;
+  /**
+   * Unlike {@link Rectangle.transform}, `result` is REQUIRED here: the
+   * defaulted overload writes the transformed box back into the receiver, which
+   * a read-only view must not offer.
+   */
+  transform(matrix: Matrix, result: Rectangle): Rectangle;
+}
+
+/**
  * Mutable axis-aligned rectangle defined by a top-left origin `(x, y)` and
  * dimensions `(width, height)`. Implements {@link ShapeLike} with full SAT
  * collision response for rectangles and polygons, and specialised algorithms
@@ -36,8 +73,11 @@ const tempPoint = new ObservableVector(null);
  *
  * `Rectangle.temp` is a shared scratch instance. Edge normals are lazily
  * computed and cached; they are invalidated when position or size mutates.
+ *
+ * See {@link ReadonlyRectangle} for the read-only view engine APIs hand out
+ * when they return a live internal rectangle.
  */
-export class Rectangle implements ShapeLike, ObservableVectorOwner {
+export class Rectangle implements ShapeLike, ObservableVectorOwner, ReadonlyRectangle {
   public readonly collisionType: CollisionType = CollisionType.Rectangle;
 
   private readonly _position: ObservableVector;

--- a/src/rendering/mesh/Mesh.ts
+++ b/src/rendering/mesh/Mesh.ts
@@ -227,8 +227,7 @@ export class Mesh extends Drawable {
       if (y > maxY) maxY = y;
     }
 
-    this.getLocalBounds().set(minX, minY, maxX - minX, maxY - minY);
-    this._invalidateBoundsCascade();
+    this._setLocalBounds(minX, minY, maxX - minX, maxY - minY);
 
     return this;
   }

--- a/src/rendering/sprite/AnimatedSprite.ts
+++ b/src/rendering/sprite/AnimatedSprite.ts
@@ -464,8 +464,9 @@ export class AnimatedSprite extends Sprite {
     const offset = clip.frameOffsets?.[frameIndex];
 
     if (offset) {
-      this.getLocalBounds().setPosition(offset.x, offset.y);
-      this._invalidateBoundsCascade();
+      const { height, width } = this.getLocalBounds();
+
+      this._setLocalBounds(offset.x, offset.y, width, height);
     }
   }
 }

--- a/src/rendering/sprite/NineSliceSprite.ts
+++ b/src/rendering/sprite/NineSliceSprite.ts
@@ -1,4 +1,4 @@
-import type { Rectangle } from '#math/Rectangle';
+import type { ReadonlyRectangle } from '#math/Rectangle';
 import { Drawable } from '#rendering/Drawable';
 import type { Texture } from '#rendering/texture/Texture';
 import { TextureRegion } from '#rendering/texture/TextureRegion';
@@ -188,10 +188,14 @@ export class NineSliceSprite extends Drawable {
   // Bounds
   // -----------------------------------------------------------------------
 
-  public override getLocalBounds(): Rectangle {
-    const bounds = super.getLocalBounds();
-    bounds.set(0, 0, this._width, this._height);
-    return bounds;
+  /**
+   * Recomputed lazily on read from the current logical size, so it writes
+   * `_localBounds` directly instead of going through `_setLocalBounds`: an
+   * invalidating write inside a getter would re-dirty the node on every read.
+   * The size setters own the invalidation for this node.
+   */
+  public override getLocalBounds(): ReadonlyRectangle {
+    return this._localBounds.set(0, 0, this._width, this._height);
   }
 
   // -----------------------------------------------------------------------

--- a/src/rendering/sprite/RepeatingSprite.ts
+++ b/src/rendering/sprite/RepeatingSprite.ts
@@ -1,4 +1,4 @@
-import type { Rectangle } from '#math/Rectangle';
+import type { ReadonlyRectangle } from '#math/Rectangle';
 import { Drawable } from '#rendering/Drawable';
 import type { RepeatFit, RepeatMode } from '#rendering/texture/repeat';
 import type { Texture } from '#rendering/texture/Texture';
@@ -241,10 +241,14 @@ export class RepeatingSprite extends Drawable {
   // Bounds
   // -----------------------------------------------------------------------
 
-  public override getLocalBounds(): Rectangle {
-    const bounds = super.getLocalBounds();
-    bounds.set(0, 0, this._width, this._height);
-    return bounds;
+  /**
+   * Recomputed lazily on read from the current logical size, so it writes
+   * `_localBounds` directly instead of going through `_setLocalBounds`: an
+   * invalidating write inside a getter would re-dirty the node on every read.
+   * The size setters own the invalidation for this node.
+   */
+  public override getLocalBounds(): ReadonlyRectangle {
+    return this._localBounds.set(0, 0, this._width, this._height);
   }
 
   // -----------------------------------------------------------------------

--- a/src/rendering/sprite/Sprite.ts
+++ b/src/rendering/sprite/Sprite.ts
@@ -289,8 +289,7 @@ export class Sprite extends Drawable {
 
     this._textureFrame.copy(frame);
     this.flags.push(SpriteFlags.TextureCoords);
-    this.getLocalBounds().set(0, 0, frame.width, frame.height);
-    this._invalidateBoundsCascade();
+    this._setLocalBounds(0, 0, frame.width, frame.height);
 
     if (resetSize) {
       this.width = frame.width;

--- a/src/rendering/text/BitmapText.ts
+++ b/src/rendering/text/BitmapText.ts
@@ -293,8 +293,7 @@ export class BitmapText extends AbstractText {
       // contract like the non-empty path below, so a BitmapText going empty
       // does not leave a stale local bounds / un-dirtied revision behind for
       // culling, hit-testing, or an instruction-set cache of prior geometry.
-      this.getLocalBounds().set(0, 0, 0, 0);
-      this._invalidateBoundsCascade();
+      this._setLocalBounds(0, 0, 0, 0);
       this._updateOrigin();
       return;
     }
@@ -320,8 +319,7 @@ export class BitmapText extends AbstractText {
       if (py > maxY) maxY = py;
     }
     this._textBounds = { width: maxX, height: maxY };
-    this.getLocalBounds().set(0, 0, maxX, maxY);
-    this._invalidateBoundsCascade();
+    this._setLocalBounds(0, 0, maxX, maxY);
 
     // An anchor is a fraction of the bounds, so a node whose text just changed
     // width has to re-derive its origin — otherwise a centred label drifts left

--- a/src/rendering/text/Text.ts
+++ b/src/rendering/text/Text.ts
@@ -221,8 +221,7 @@ export class Text extends AbstractText {
       // going empty keeps its old local bounds and bumps no revision, so
       // culling / hit-testing / the retained group aggregate read a stale
       // extent, and any instruction-set cache of the prior geometry stays live.
-      this.getLocalBounds().set(0, 0, 0, 0);
-      this._invalidateBoundsCascade();
+      this._setLocalBounds(0, 0, 0, 0);
       this._updateOrigin();
       this._style.consumeDirty();
       return;
@@ -237,8 +236,7 @@ export class Text extends AbstractText {
     if (placements.length === 0) {
       // Same empty-transition contract as above: no glyphs placed, so reset the
       // extent and content-dirty rather than leaving a stale non-empty bounds.
-      this.getLocalBounds().set(0, 0, 0, 0);
-      this._invalidateBoundsCascade();
+      this._setLocalBounds(0, 0, 0, 0);
       this._updateOrigin();
       this._style.consumeDirty();
       return;
@@ -253,8 +251,7 @@ export class Text extends AbstractText {
       if (py > maxY) maxY = py;
     }
     this._textBounds = { width: maxX, height: maxY };
-    this.getLocalBounds().set(0, 0, maxX, maxY);
-    this._invalidateBoundsCascade();
+    this._setLocalBounds(0, 0, maxX, maxY);
 
     // An anchor is a fraction of the bounds, so a node whose text just changed
     // width has to re-derive its origin — otherwise a centred label drifts left

--- a/src/rendering/webgl2/WebGl2SpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2SpriteRenderer.ts
@@ -1,4 +1,4 @@
-import type { Rectangle } from '#math/Rectangle';
+import type { ReadonlyRectangle } from '#math/Rectangle';
 import type { UniformValue } from '#rendering/material/Material';
 import type { SpriteMaterial } from '#rendering/material/SpriteMaterial';
 import { Shader } from '#rendering/shader/Shader';
@@ -124,7 +124,7 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
   // boundary snapping now happens in the vertex shader, so this is always the
   // sprite's logical local bounds; the field lets _packInstance read the value
   // resolved once per render() call.
-  private _activeBounds: Rectangle | null = null;
+  private _activeBounds: ReadonlyRectangle | null = null;
 
   private _instanceCount = 0;
   // Highest transform-buffer row referenced by the pending batch; drives the
@@ -194,7 +194,7 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
    * bounds-snap happens here and logical state is never mutated. Consumed
    * synchronously by {@link _packInstance}.
    */
-  private _resolveBounds(sprite: Sprite): Rectangle {
+  private _resolveBounds(sprite: Sprite): ReadonlyRectangle {
     return sprite.getLocalBounds();
   }
 

--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -1,7 +1,7 @@
 /// <reference types="@webgpu/types" />
 
 import { Matrix } from '#math/Matrix';
-import type { Rectangle } from '#math/Rectangle';
+import type { ReadonlyRectangle } from '#math/Rectangle';
 import { packAffineMat4 } from '#rendering/affinePacking';
 import type { SpriteMaterial } from '#rendering/material/SpriteMaterial';
 import type { Sprite } from '#rendering/sprite/Sprite';
@@ -406,7 +406,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
   // boundary snapping now happens in the vertex shader, so this is always the
   // sprite's logical local bounds; the field lets _packInstance read the value
   // resolved once per render() call.
-  private _activeBounds: Rectangle | null = null;
+  private _activeBounds: ReadonlyRectangle | null = null;
 
   protected onConnect(backend: WebGpuBackend): void {
     if (this._device) {
@@ -584,7 +584,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
    * bounds-snap happens here and logical state is never mutated. Consumed
    * synchronously by {@link _packInstance}.
    */
-  private _resolveBounds(sprite: Sprite): Rectangle {
+  private _resolveBounds(sprite: Sprite): ReadonlyRectangle {
     return sprite.getLocalBounds();
   }
 

--- a/test/bench/interaction.bench.ts
+++ b/test/bench/interaction.bench.ts
@@ -9,7 +9,7 @@ import type { RenderNode } from '../../src/rendering/RenderNode';
 
 const makeInteractiveDrawable = (x: number, y: number, size = 32): Drawable => {
   const d = new Drawable();
-  d.getLocalBounds().set(0, 0, size, size);
+  d._setLocalBounds(0, 0, size, size);
   d.setPosition(x, y);
   d.interactive = true;
   return d;

--- a/test/bench/render-plan-play.bench.ts
+++ b/test/bench/render-plan-play.bench.ts
@@ -24,7 +24,7 @@ class TexturedDrawable extends Drawable {
 
   public constructor(x: number, y: number, texture: object) {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
     this.setPosition(x, y);
     this.texture = texture;
   }

--- a/test/bench/rendering.bench.ts
+++ b/test/bench/rendering.bench.ts
@@ -82,7 +82,7 @@ const createStubRuntime = (): RenderBackend => {
 
 const createNode = (x: number, y: number, size = 16): Drawable => {
   const node = new Drawable();
-  node.getLocalBounds().set(0, 0, size, size);
+  node._setLocalBounds(0, 0, size, size);
   node.setPosition(x, y);
   return node;
 };

--- a/test/bench/scene-graph.bench.ts
+++ b/test/bench/scene-graph.bench.ts
@@ -5,7 +5,7 @@ import { Drawable } from '../../src/rendering/Drawable';
 
 const makeDrawable = (x = 0, y = 0, size = 16): Drawable => {
   const d = new Drawable();
-  d.getLocalBounds().set(0, 0, size, size);
+  d._setLocalBounds(0, 0, size, size);
   d.setPosition(x, y);
   return d;
 };

--- a/test/bench/transform-upload.bench.ts
+++ b/test/bench/transform-upload.bench.ts
@@ -16,7 +16,7 @@ const FRAME_COUNT = 240;
 class ConsumingDrawable extends Drawable {
   public constructor(x: number, y: number) {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
     this.setPosition(x, y);
   }
 }
@@ -25,7 +25,7 @@ class ConsumingDrawable extends Drawable {
 class NonConsumingDrawable extends Drawable {
   public constructor(x: number, y: number) {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
     this.setPosition(x, y);
   }
 }

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -312,6 +312,7 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "RadialGradient: class",
   "Random: class",
   "RatePitched: interface",
+  "ReadonlyRectangle: interface",
   "RecentErrorEntry: interface",
   "Rectangle: class",
   "RectangleLike: interface",

--- a/test/core/oriented-bounds.test.ts
+++ b/test/core/oriented-bounds.test.ts
@@ -14,7 +14,7 @@ import { Drawable } from '#rendering/Drawable';
 describe('SceneNode oriented bounds (rotated SAT)', () => {
   it('getNormals() returns oriented (non-axis-aligned) axes for a rotated node', () => {
     const node = new SceneNode();
-    node.getLocalBounds().set(0, 0, 100, 40);
+    node._setLocalBounds(0, 0, 100, 40);
     node.setRotation(45);
     node.updateParentTransform();
 
@@ -30,7 +30,7 @@ describe('SceneNode oriented bounds (rotated SAT)', () => {
     // An 80×80 square rotated 45° about its centre at world (100, 100): its AABB is
     // ~[43, 157]² but the oriented diamond does not reach the AABB corners.
     const node = new SceneNode();
-    node.getLocalBounds().set(0, 0, 80, 80);
+    node._setLocalBounds(0, 0, 80, 80);
     node.setOrigin(40, 40);
     node.setPosition(100, 100);
     node.setRotation(45);
@@ -52,7 +52,7 @@ describe('SceneNode oriented bounds (rotated SAT)', () => {
     parent.setRotation(45);
 
     const child = new Drawable();
-    child.getLocalBounds().set(-40, -40, 80, 80); // centred on the parent's pivot
+    child._setLocalBounds(-40, -40, 80, 80); // centred on the parent's pivot
     parent.addChild(child);
     child.updateParentTransform();
 

--- a/test/core/scene-node-cache.test.ts
+++ b/test/core/scene-node-cache.test.ts
@@ -1,4 +1,4 @@
-﻿import { Container } from '#rendering/Container';
+import { Container } from '#rendering/Container';
 import { Drawable } from '#rendering/Drawable';
 import type { RenderBackend } from '#rendering/RenderBackend';
 
@@ -11,13 +11,13 @@ class TestDrawable extends Drawable {
     super();
     this._localWidth = w;
     this._localHeight = h;
-    this.getLocalBounds().set(0, 0, w, h);
+    this._setLocalBounds(0, 0, w, h);
   }
 
   public setLocalSize(w: number, h: number): void {
     this._localWidth = w;
     this._localHeight = h;
-    this.getLocalBounds().set(0, 0, w, h);
+    this._setLocalBounds(0, 0, w, h);
     this._invalidateBoundsCascade();
   }
 

--- a/test/core/scene-node-contains.test.ts
+++ b/test/core/scene-node-contains.test.ts
@@ -15,7 +15,7 @@ import { SceneNode } from '#core/SceneNode';
 class BoundedNode extends SceneNode {
   public constructor() {
     super();
-    this.getLocalBounds().set(0, 0, 100, 40);
+    this._setLocalBounds(0, 0, 100, 40);
   }
 }
 

--- a/test/core/scene-node-local-bounds.test.ts
+++ b/test/core/scene-node-local-bounds.test.ts
@@ -1,0 +1,60 @@
+import { Container } from '#rendering/Container';
+import { Drawable } from '#rendering/Drawable';
+
+describe('SceneNode._setLocalBounds', () => {
+  test('writes the local rectangle in place without reallocating it', () => {
+    const node = new Drawable();
+    const bounds = node.getLocalBounds();
+
+    node._setLocalBounds(2, 3, 16, 24);
+
+    expect(node.getLocalBounds()).toBe(bounds);
+    expect(node.getLocalBounds().x).toBe(2);
+    expect(node.getLocalBounds().y).toBe(3);
+    expect(node.getLocalBounds().width).toBe(16);
+    expect(node.getLocalBounds().height).toBe(24);
+  });
+
+  test('runs the bounds-invalidation cascade the manual write idiom used to require', () => {
+    const parent = new Container();
+    const node = new Drawable();
+
+    parent.addChild(node);
+
+    // Settle both nodes so a stale flag cannot mask the invalidation below.
+    parent.getBounds();
+    node.getBounds();
+
+    const nodeContentBefore = node._contentRevision;
+    const parentContentBefore = parent._contentRevision;
+
+    node._setLocalBounds(0, 0, 16, 24);
+
+    expect(node._contentRevision).toBeGreaterThan(nodeContentBefore);
+    expect(parent._contentRevision).toBeGreaterThan(parentContentBefore);
+
+    // The cascade must reach the node's OWN bounds and its ancestors', so a
+    // cull/hit-test reading either after the write sees the new extent.
+    expect(node.getBounds().width).toBe(16);
+    expect(node.getBounds().height).toBe(24);
+    expect(parent.getBounds().width).toBe(16);
+    expect(parent.getBounds().height).toBe(24);
+
+    parent.destroy();
+  });
+
+  test('feeds the local-space hit test of a rotated node', () => {
+    const node = new Drawable();
+
+    node._setLocalBounds(0, 0, 40, 20);
+    node.setRotation(45);
+
+    // Rotated off-axis: contains() maps the world point back through the
+    // inverse transform and tests it against the freshly written local
+    // rectangle, so a point in the empty AABB corner must miss.
+    expect(node.contains(21, -7)).toBe(true);
+    expect(node.contains(1, 13)).toBe(false);
+
+    node.destroy();
+  });
+});

--- a/test/core/scene-node-revision-invariants.test.ts
+++ b/test/core/scene-node-revision-invariants.test.ts
@@ -51,7 +51,7 @@ const containerCase = (name: string, expects: DirtyKind, mutate: (node: Containe
 // height) would be no-ops against the default fixture. Give those cases a
 // node with non-empty local bounds so the mutation actually changes a value.
 const withLocalBounds = <T extends Drawable | Container>(node: T): T => {
-  node.getLocalBounds().set(0, 0, 16, 16);
+  node._setLocalBounds(0, 0, 16, 16);
 
   return node;
 };

--- a/test/core/scene-node-transform-group.test.ts
+++ b/test/core/scene-node-transform-group.test.ts
@@ -119,7 +119,7 @@ describe('own-transform dirty seam (_markOwnTransformDirty)', () => {
     const parent = new Container();
     const node = new Drawable();
 
-    node.getLocalBounds().set(0, 0, 16, 16);
+    node._setLocalBounds(0, 0, 16, 16);
     parent.addChild(node);
     parent.getBounds(); // settle bounds flags
 

--- a/test/core/scene-node-transform.test.ts
+++ b/test/core/scene-node-transform.test.ts
@@ -20,10 +20,12 @@ import type { View } from '#rendering/View';
 class TestDrawable extends Drawable {
   public override updateBounds(): this {
     // Treat the drawable as a 100x100 unit-square in local space so bounds
-    // assertions have something nontrivial to verify.
-    const local = this.getLocalBounds();
-
-    local.set(0, 0, 100, 100);
+    // assertions have something nontrivial to verify. Written through the
+    // protected rectangle rather than `_setLocalBounds` because this runs
+    // inside a bounds recompute, where an invalidating write would re-dirty
+    // the node on every read (the same reason the lazy `getLocalBounds()`
+    // overrides in the engine write it directly).
+    this._localBounds.set(0, 0, 100, 100);
 
     return super.updateBounds();
   }

--- a/test/input/interaction-retained-group.test.ts
+++ b/test/input/interaction-retained-group.test.ts
@@ -105,7 +105,7 @@ const createApp = (): {
 const makeSprite = (): Drawable => {
   const sprite = new Drawable();
 
-  sprite.getLocalBounds().set(0, 0, 50, 50);
+  sprite._setLocalBounds(0, 0, 50, 50);
 
   return sprite;
 };

--- a/test/math/polygon.test.ts
+++ b/test/math/polygon.test.ts
@@ -423,7 +423,7 @@ describe('Polygon.intersectsWith()', () => {
   test('SceneNode target dispatches to intersectionRectPoly via getBounds()', () => {
     const node = new SceneNode();
 
-    node.getLocalBounds().set(0, 0, 10, 10);
+    node._setLocalBounds(0, 0, 10, 10);
     node.updateParentTransform();
 
     const polygon = square(5, 5, 10);
@@ -500,7 +500,7 @@ describe('Polygon.collidesWith()', () => {
   test('SceneNode target resolves via getCollisionSat', () => {
     const node = new SceneNode();
 
-    node.getLocalBounds().set(0, 0, 10, 10);
+    node._setLocalBounds(0, 0, 10, 10);
     node.updateParentTransform();
 
     const polygon = square(5, 5, 10);

--- a/test/math/rectangle.test.ts
+++ b/test/math/rectangle.test.ts
@@ -379,7 +379,7 @@ describe('Rectangle', () => {
     test('SceneNode target, axis-aligned: delegates to intersectionRectRect via getBounds()', () => {
       const node = new SceneNode();
 
-      node.getLocalBounds().set(0, 0, 10, 10);
+      node._setLocalBounds(0, 0, 10, 10);
       node.setPosition(5, 5);
       node.updateParentTransform();
 
@@ -390,7 +390,7 @@ describe('Rectangle', () => {
     test('SceneNode target, rotated: delegates to full SAT', () => {
       const node = new SceneNode();
 
-      node.getLocalBounds().set(0, 0, 10, 10);
+      node._setLocalBounds(0, 0, 10, 10);
       node.setPosition(5, 5);
       node.setRotation(45);
       node.updateParentTransform();
@@ -439,7 +439,7 @@ describe('Rectangle', () => {
     test('SceneNode target, axis-aligned: delegates to getCollisionRectangleRectangle', () => {
       const node = new SceneNode();
 
-      node.getLocalBounds().set(0, 0, 10, 10);
+      node._setLocalBounds(0, 0, 10, 10);
       node.setPosition(5, 5);
       node.updateParentTransform();
 
@@ -450,7 +450,7 @@ describe('Rectangle', () => {
     test('SceneNode target, rotated: delegates to getCollisionSat', () => {
       const node = new SceneNode();
 
-      node.getLocalBounds().set(0, 0, 10, 10);
+      node._setLocalBounds(0, 0, 10, 10);
       node.setPosition(5, 5);
       node.setRotation(45);
       node.updateParentTransform();

--- a/test/perf/collect-phase-benchmark.ts
+++ b/test/perf/collect-phase-benchmark.ts
@@ -125,7 +125,7 @@ const buildStressTree = (targetCount: number, seed: number): StressTree => {
 
     const leaf = new Drawable();
 
-    leaf.getLocalBounds().set(0, 0, 16, 16);
+    leaf._setLocalBounds(0, 0, 16, 16);
     leaf.setPosition(WORLD_OX + rng() * WORLD_W, WORLD_OY + rng() * WORLD_H);
     parent.addChild(leaf);
     leaves.push(leaf);

--- a/test/perf/interaction-benchmark.ts
+++ b/test/perf/interaction-benchmark.ts
@@ -39,7 +39,7 @@ import { createInteractionHarness } from './interaction-harness';
 
 const makeInteractiveDrawable = (x: number, y: number, size = 32): Drawable => {
   const d = new Drawable();
-  d.getLocalBounds().set(0, 0, size, size);
+  d._setLocalBounds(0, 0, size, size);
   d.setPosition(x, y);
   d.interactive = true;
   return d;

--- a/test/perf/profile-benchmark.ts
+++ b/test/perf/profile-benchmark.ts
@@ -219,7 +219,7 @@ const makeRegularPolygon = (cx: number, cy: number, radius: number, sides: numbe
 
 const makeInteractiveDrawable = (x: number, y: number, size = 32): Drawable => {
   const d = new Drawable();
-  d.getLocalBounds().set(0, 0, size, size);
+  d._setLocalBounds(0, 0, size, size);
   d.setPosition(x, y);
   d.interactive = true;
   return d;
@@ -489,7 +489,7 @@ const scenarioResults: ProfileScenarioResult[] = [];
               lvl2.addChild(lvl3);
               for (let d = 0; d < 10; d++) {
                 const leaf = new Drawable();
-                leaf.getLocalBounds().set(0, 0, 16, 16);
+                leaf._setLocalBounds(0, 0, 16, 16);
                 leaf.setPosition(d * 20, c * 20);
                 lvl3.addChild(leaf);
               }

--- a/test/perf/rendering-benchmark.ts
+++ b/test/perf/rendering-benchmark.ts
@@ -114,7 +114,7 @@ const createStubRuntime = (): RenderBackend => {
 
 const createNode = (x: number, y: number, size = 16): Drawable => {
   const node = new Drawable();
-  node.getLocalBounds().set(0, 0, size, size);
+  node._setLocalBounds(0, 0, size, size);
   node.setPosition(x, y);
   return node;
 };

--- a/test/perf/scene-graph-benchmark.ts
+++ b/test/perf/scene-graph-benchmark.ts
@@ -18,7 +18,7 @@ import { runScenario, writeResults } from './harness';
 
 const makeDrawable = (x = 0, y = 0, size = 16): Drawable => {
   const d = new Drawable();
-  d.getLocalBounds().set(0, 0, size, size);
+  d._setLocalBounds(0, 0, size, size);
   d.setPosition(x, y);
   return d;
 };

--- a/test/rendering/container.test.ts
+++ b/test/rendering/container.test.ts
@@ -1,4 +1,4 @@
-﻿import type { Application } from '#core/Application';
+import type { Application } from '#core/Application';
 import { SceneNode } from '#core/SceneNode';
 import type { InteractionHooks, Stage } from '#core/Stage';
 import { FocusController } from '#input/FocusController';
@@ -481,7 +481,7 @@ describe('Container paint-order cache', () => {
 // extent to aggregate.
 class SizedDrawable extends Drawable {
   public override updateBounds(): this {
-    this.getLocalBounds().set(0, 0, 100, 100);
+    this._setLocalBounds(0, 0, 100, 100);
 
     return super.updateBounds();
   }

--- a/test/rendering/destroyed-node-collect.test.ts
+++ b/test/rendering/destroyed-node-collect.test.ts
@@ -39,7 +39,7 @@ import type { View } from '#rendering/View';
 class LeafDrawable extends Drawable {
   public constructor(public readonly id: string) {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
   }
 }
 

--- a/test/rendering/mask-source.test.ts
+++ b/test/rendering/mask-source.test.ts
@@ -17,7 +17,7 @@ class TestDrawable extends Drawable {
   public override updateBounds(): this {
     // Give the drawable a non-zero local extent so getBounds() returns
     // a usable rectangle for the alpha-mask pipeline.
-    this.getLocalBounds().set(0, 0, 64, 48);
+    this._setLocalBounds(0, 0, 64, 48);
 
     return super.updateBounds();
   }

--- a/test/rendering/material-grouping.test.ts
+++ b/test/rendering/material-grouping.test.ts
@@ -12,7 +12,7 @@ import { RenderTexture } from '#rendering/texture/RenderTexture';
 class BoxDrawable extends Drawable {
   public constructor(public readonly id: string) {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
   }
 }
 

--- a/test/rendering/render-dispatch.test.ts
+++ b/test/rendering/render-dispatch.test.ts
@@ -1,4 +1,4 @@
-﻿import { Container } from '#rendering/Container';
+import { Container } from '#rendering/Container';
 import { Drawable } from '#rendering/Drawable';
 import { Mesh } from '#rendering/mesh/Mesh';
 import type { RenderBackend } from '#rendering/RenderBackend';
@@ -134,7 +134,7 @@ describe('render dispatch', () => {
     const { runtime, draw } = createRuntime();
     const drawable = new Drawable();
 
-    drawable.getLocalBounds().set(0, 0, 16, 16);
+    drawable._setLocalBounds(0, 0, 16, 16);
     drawable.setPosition(1000, 1000);
     drawable.render(runtime);
 
@@ -146,7 +146,7 @@ describe('render dispatch', () => {
     const { runtime, draw } = createRuntime();
     const drawable = new Drawable();
 
-    drawable.getLocalBounds().set(0, 0, 16, 16);
+    drawable._setLocalBounds(0, 0, 16, 16);
     drawable.setPosition(1000, 1000);
     drawable.cullable = false;
     drawable.render(runtime);
@@ -160,7 +160,7 @@ describe('render dispatch', () => {
     const container = new Container();
     const child = new Drawable();
 
-    child.getLocalBounds().set(0, 0, 16, 16);
+    child._setLocalBounds(0, 0, 16, 16);
     container.setPosition(500, 500);
     container.addChild(child);
     container.render(runtime);
@@ -173,7 +173,7 @@ describe('render dispatch', () => {
     const { runtime, draw } = createRuntime();
     const drawable = new Drawable();
 
-    drawable.getLocalBounds().set(0, 0, 16, 16);
+    drawable._setLocalBounds(0, 0, 16, 16);
     drawable.setPosition(260, 100);
     runtime.resetStats();
     drawable.render(runtime);

--- a/test/rendering/render-instructions.test.ts
+++ b/test/rendering/render-instructions.test.ts
@@ -14,14 +14,14 @@ import { collectRenderGroups } from './helpers/collectRenderGroups';
 class BoxDrawable extends Drawable {
   public constructor() {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
   }
 }
 
 class OtherDrawable extends Drawable {
   public constructor() {
     super();
-    this.getLocalBounds().set(0, 0, 20, 20);
+    this._setLocalBounds(0, 0, 20, 20);
   }
 }
 

--- a/test/rendering/render-plan-grouping-key-audit.test.ts
+++ b/test/rendering/render-plan-grouping-key-audit.test.ts
@@ -65,7 +65,7 @@ import { BlendModes } from '#rendering/types';
 class AuditDrawable extends Drawable {
   public constructor() {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
   }
 }
 

--- a/test/rendering/render-plan-player.test.ts
+++ b/test/rendering/render-plan-player.test.ts
@@ -9,7 +9,7 @@ import { renderGroupFromRange } from './helpers/collectRenderGroups';
 class BoxDrawable extends Drawable {
   public constructor(public readonly id: string) {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
   }
 }
 

--- a/test/rendering/render-plan.test.ts
+++ b/test/rendering/render-plan.test.ts
@@ -16,14 +16,14 @@ import { Texture } from '#rendering/texture/Texture';
 class BoxDrawable extends Drawable {
   public constructor(public readonly id: string) {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
   }
 }
 
 class CustomDrawable extends Drawable {
   public constructor() {
     super();
-    this.getLocalBounds().set(0, 0, 20, 20);
+    this._setLocalBounds(0, 0, 20, 20);
   }
 }
 

--- a/test/rendering/retained-container-reparent.test.ts
+++ b/test/rendering/retained-container-reparent.test.ts
@@ -21,7 +21,7 @@ import { RetainedContainer } from '#rendering/RetainedContainer';
 class LeafDrawable extends Drawable {
   public constructor(public readonly id: string) {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
   }
 }
 

--- a/test/rendering/retained-container.test.ts
+++ b/test/rendering/retained-container.test.ts
@@ -20,7 +20,7 @@ import { RetainedContainer } from '#rendering/RetainedContainer';
 class LeafDrawable extends Drawable {
   public constructor(public readonly id: string) {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
   }
 }
 

--- a/test/rendering/retained-group-fragment.test.ts
+++ b/test/rendering/retained-group-fragment.test.ts
@@ -309,7 +309,7 @@ class BoundaryContainer extends Container {
 class LeafDrawable extends Drawable {
   public constructor(public readonly id: string) {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
   }
 }
 

--- a/test/rendering/retained-instruction-equivalence.test.ts
+++ b/test/rendering/retained-instruction-equivalence.test.ts
@@ -45,7 +45,7 @@ const nodeIndexWord = 5;
 class ByteLeaf extends Drawable {
   public constructor(public readonly id = '') {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
   }
 }
 

--- a/test/rendering/retained-instruction-set.test.ts
+++ b/test/rendering/retained-instruction-set.test.ts
@@ -30,14 +30,14 @@ import { RetainedContainer } from '#rendering/RetainedContainer';
 class RecordableLeaf extends Drawable {
   public constructor(public readonly id = '') {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
   }
 }
 
 class UnflaggedLeaf extends Drawable {
   public constructor() {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
   }
 }
 
@@ -47,14 +47,14 @@ class MaterialLeaf extends Drawable {
 
   public constructor() {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
   }
 }
 
 class UnregisteredLeaf extends Drawable {
   public constructor() {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
   }
 }
 

--- a/test/rendering/retained-subtree-skip.test.ts
+++ b/test/rendering/retained-subtree-skip.test.ts
@@ -14,7 +14,7 @@ import { RenderTarget } from '#rendering/RenderTarget';
 class LeafDrawable extends Drawable {
   public constructor(public readonly id: string) {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
   }
 }
 

--- a/test/rendering/transform-buffer-group-upload.test.ts
+++ b/test/rendering/transform-buffer-group-upload.test.ts
@@ -19,7 +19,7 @@ class BoxDrawable extends Drawable {
     tint: Color,
   ) {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
     this.setPosition(x, y);
     this.setTint(tint);
   }

--- a/test/rendering/transform-buffer-upload-count.test.ts
+++ b/test/rendering/transform-buffer-upload-count.test.ts
@@ -13,7 +13,7 @@ import { forEachGroupCommand } from './helpers/collectRenderGroups';
 class ConsumingDrawable extends Drawable {
   public constructor(x: number, y: number, tint: Color) {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
     this.setPosition(x, y);
     this.setTint(tint);
   }
@@ -23,7 +23,7 @@ class ConsumingDrawable extends Drawable {
 class NonConsumingDrawable extends Drawable {
   public constructor(x: number, y: number, tint: Color) {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
     this.setPosition(x, y);
     this.setTint(tint);
   }

--- a/test/rendering/transform-storage-filter.test.ts
+++ b/test/rendering/transform-storage-filter.test.ts
@@ -14,7 +14,7 @@ const floatsPerSlot = TRANSFORM_FLOATS_PER_ROW;
 class ConsumingDrawable extends Drawable {
   public constructor(x: number, y: number, tint: Color) {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
     this.setPosition(x, y);
     this.setTint(tint);
   }
@@ -24,7 +24,7 @@ class ConsumingDrawable extends Drawable {
 class NonConsumingDrawable extends Drawable {
   public constructor(x: number, y: number, tint: Color) {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
     this.setPosition(x, y);
     this.setTint(tint);
   }

--- a/test/rendering/webgpu-transform-group-upload.test.ts
+++ b/test/rendering/webgpu-transform-group-upload.test.ts
@@ -13,7 +13,7 @@ import { forEachGroupCommand } from './helpers/collectRenderGroups';
 class ConsumingDrawable extends Drawable {
   public constructor(x: number, y: number, tint: Color) {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
     this.setPosition(x, y);
     this.setTint(tint);
   }
@@ -23,7 +23,7 @@ class ConsumingDrawable extends Drawable {
 class NonConsumingDrawable extends Drawable {
   public constructor(x: number, y: number, tint: Color) {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
     this.setPosition(x, y);
     this.setTint(tint);
   }

--- a/test/rendering/webgpu-transform-storage-reserve.test.ts
+++ b/test/rendering/webgpu-transform-storage-reserve.test.ts
@@ -75,7 +75,7 @@ const material = (): MaterialKey => ({
 class TestDrawable extends Drawable {
   public constructor() {
     super();
-    this.getLocalBounds().set(0, 0, 8, 8);
+    this._setLocalBounds(0, 0, 8, 8);
   }
 }
 

--- a/test/rendering/webgpu-transform-storage-stats.test.ts
+++ b/test/rendering/webgpu-transform-storage-stats.test.ts
@@ -8,7 +8,7 @@ import { WebGpuTransformStorage } from '#rendering/webgpu/WebGpuTransformStorage
 class ConsumingDrawable extends Drawable {
   public constructor(x: number, y: number, tint: Color) {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
     this.setPosition(x, y);
     this.setTint(tint);
   }
@@ -18,7 +18,7 @@ class ConsumingDrawable extends Drawable {
 class NonConsumingDrawable extends Drawable {
   public constructor(x: number, y: number, tint: Color) {
     super();
-    this.getLocalBounds().set(0, 0, 16, 16);
+    this._setLocalBounds(0, 0, 16, 16);
     this.setPosition(x, y);
     this.setTint(tint);
   }

--- a/test/type-tests/local-bounds-readonly.type-test.ts
+++ b/test/type-tests/local-bounds-readonly.type-test.ts
@@ -1,0 +1,49 @@
+import type { Matrix } from '#math/Matrix';
+import { Rectangle } from '#math/Rectangle';
+import type { Drawable } from '#rendering/Drawable';
+
+declare const node: Drawable;
+declare const matrix: Matrix;
+
+// `SceneNode.getLocalBounds()` hands out the LIVE internal rectangle for zero
+// allocation cost, so its return type is a read-only view: writing through it
+// would silently skip the bounds/content invalidation the engine needs.
+// Engine-internal writers go through `_setLocalBounds` instead.
+
+// @ts-expect-error — the read-only bounds view has no set()
+node.getLocalBounds().set(0, 0, 16, 16);
+// @ts-expect-error — the read-only bounds view has no setPosition()
+node.getLocalBounds().setPosition(1, 2);
+// @ts-expect-error — the read-only bounds view has no setSize()
+node.getLocalBounds().setSize(1, 2);
+// @ts-expect-error — the read-only bounds view has no copy()
+node.getLocalBounds().copy(new Rectangle(0, 0, 1, 1));
+// @ts-expect-error — the read-only bounds view has no destroy()
+node.getLocalBounds().destroy();
+// @ts-expect-error — x is read-only on the bounds view
+node.getLocalBounds().x = 4;
+// @ts-expect-error — width is read-only on the bounds view
+node.getLocalBounds().width = 4;
+// @ts-expect-error — transform() may not default to mutating the view in place
+node.getLocalBounds().transform(matrix);
+
+// Reads must keep working unchanged.
+const x: number = node.getLocalBounds().x;
+const y: number = node.getLocalBounds().y;
+const width: number = node.getLocalBounds().width;
+const height: number = node.getLocalBounds().height;
+const left: number = node.getLocalBounds().left;
+const top: number = node.getLocalBounds().top;
+const right: number = node.getLocalBounds().right;
+const bottom: number = node.getLocalBounds().bottom;
+const hit: boolean = node.getLocalBounds().contains(1, 2);
+const same: boolean = node.getLocalBounds().equals({ x: 0, y: 0, width: 1, height: 1 });
+const copied: Rectangle = node.getLocalBounds().clone();
+const boxed: Rectangle = node.getLocalBounds().getBounds();
+// An explicit `result` target keeps `transform()` non-mutating for the view.
+const mapped: Rectangle = node.getLocalBounds().transform(matrix, Rectangle.temp);
+
+// The engine-internal writer takes flat coordinates and owns the invalidation.
+node._setLocalBounds(0, 0, 16, 16);
+
+export { bottom, boxed, copied, height, hit, left, mapped, right, same, top, width, x, y };


### PR DESCRIPTION
Fixes HI-7 from the independent architecture review: `SceneNode.getLocalBounds()` returned the live internal `Rectangle`, so resizing a node meant mutating it directly and remembering to call `_invalidateBoundsCascade()` by hand — easy to forget in a custom `Drawable`, silently leaving culling, hit-testing and retained render fragments on a stale extent.

Writes now go through `SceneNode._setLocalBounds(x, y, width, height)`, which sets the rectangle and runs the invalidation in one step. Every built-in writer is migrated onto it (Sprite, AnimatedSprite, Text, BitmapText, Mesh, ParticleSystem).

`getLocalBounds()` returns the same live object as before — only the return *type* changes, to `ReadonlyRectangle`, a getters-only view. This is zero-cost at runtime (no clone, no freeze): the rectangle is re-read on every transform-dirty bounds recompute, a path that can run every frame for a moving node, so a defensive copy would add a per-frame allocation. The read-only view removes the footgun at the type level instead, mirroring the `readonly T[]` convention already used elsewhere in this codebase.

The one case the invalidating setter can't serve — a subclass that recomputes its extent lazily from inside its own `getLocalBounds()` override (`RepeatingSprite`, `NineSliceSprite`, and the tilemap package's `TileChunkNode`/`TileLayerNode`/`TileMapNode`) — keeps writing the now-`protected` `_localBounds` field directly, as before; routing those through the invalidating setter would re-dirty the node on every read and defeat the retained static-subtree skip.

**BREAKING CHANGE:** `SceneNode.getLocalBounds()` returns `ReadonlyRectangle` instead of `Rectangle`. Replace `node.getLocalBounds().set(x, y, w, h)` with `node._setLocalBounds(x, y, w, h)` and drop the manual `_invalidateBoundsCascade()` that followed it. Pre-1.0, no back-compat shim.