### PR TITLE
feat(animation)!: schedule AnimatedSprite playback via a core AnimationManager

### DIFF
--- a/examples/tweens-animation/frame-animation.js
+++ b/examples/tweens-animation/frame-animation.js
@@ -24,14 +24,14 @@ class FrameAnimationScene extends Scene {
         });
         // The onFrame signal fires on every frame advance with the 0-based index.
         this.sprite.onFrame.add((_clip, frame) => this.hud.setStatus(`Frame: ${frame + 1}/${this.frameCount}`));
+        // In the scene tree, playback is advanced by the engine's
+        // AnimationManager once per frame -- no update() call of our own.
+        this.addChild(this.sprite);
         this.sprite.play('walk');
-    }
-    update(delta) {
-        this.sprite.update(delta);
     }
     draw(context) {
         context.backend.clear();
-        context.render(this.sprite);
+        context.render(this.root);
     }
 }
 const app = new Application({

--- a/examples/tweens-animation/frame-animation.ts
+++ b/examples/tweens-animation/frame-animation.ts
@@ -1,4 +1,4 @@
-import { AnimatedSprite, Application, Asset, Color, type RenderingContext, Scene, Spritesheet, type SpritesheetData, type Time } from '@codexo/exojs';
+import { AnimatedSprite, Application, Asset, Color, type RenderingContext, Scene, Spritesheet, type SpritesheetData } from '@codexo/exojs';
 import { mountControls } from '@examples/runtime';
 
 
@@ -33,16 +33,15 @@ class FrameAnimationScene extends Scene {
         // The onFrame signal fires on every frame advance with the 0-based index.
         this.sprite.onFrame.add((_clip, frame) => this.hud.setStatus(`Frame: ${frame + 1}/${this.frameCount}`));
 
+        // In the scene tree, playback is advanced by the engine's
+        // AnimationManager once per frame -- no update() call of our own.
+        this.addChild(this.sprite);
         this.sprite.play('walk');
-    }
-
-    override update(delta: Time): void {
-        this.sprite.update(delta);
     }
 
     override draw(context: RenderingContext): void {
         context.backend.clear();
-        context.render(this.sprite);
+        context.render(this.root);
     }
 }
 

--- a/site/src/content/api/action-options.json
+++ b/site/src/content/api/action-options.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "gamepadSlot",
-          "signature": "gamepadSlot?: 0 | 1 | 2 | 3",
+          "signature": "gamepadSlot?: 0 | 2 | 1 | 3",
           "signatureTokens": [
             {
               "text": "gamepadSlot",
@@ -53,7 +53,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "1",
+              "text": "2",
               "kind": "keyword"
             },
             {
@@ -61,7 +61,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "2",
+              "text": "1",
               "kind": "keyword"
             },
             {

--- a/site/src/content/api/animated-sprite.json
+++ b/site/src/content/api/animated-sprite.json
@@ -1,6 +1,6 @@
 {
   "title": "AnimatedSprite",
-  "description": "A Sprite that advances through a sequence of texture-frame Rectangles over time to produce frame-based animation. Multiple named clips can be registered via defineClip or the constructor. Call play to start a clip; call update each frame with the elapsed delta (seconds or a `Time` object) to advance playback. The `onFrame` signal fires on every frame advance and `onComplete` fires when a clip completes its final AnimatedSpriteClipDefinition.repeat cycle. Use AnimatedSprite.fromSpritesheet to create an instance directly from a Spritesheet's named animations.",
+  "description": "A Sprite that advances through a sequence of texture-frame Rectangles over time to produce frame-based animation. Multiple named clips can be registered via defineClip or the constructor. Call play to start a clip. Playback then advances by itself: a playing sprite attached to an Application's scene tree registers with that application's AnimationManager and is ticked once per frame, with no `update()` call of your own. A sprite that is never attached to a tree — one drawn immediate-mode via `context.render(sprite)`, say — has no owning application to reach, so drive it by calling update with the frame delta in **seconds** yourself. The `onFrame` signal fires on every frame advance and `onComplete` fires when a clip completes its final AnimatedSpriteClipDefinition.repeat cycle. Use AnimatedSprite.fromSpritesheet to create an instance directly from a Spritesheet's named animations.",
   "symbol": "AnimatedSprite",
   "kind": "class",
   "subsystem": "rendering",
@@ -20,7 +20,8 @@
       "members": [],
       "paragraphs": [
         "A Sprite that advances through a sequence of texture-frame Rectangles over time to produce frame-based animation.",
-        "Multiple named clips can be registered via defineClip or the constructor. Call play to start a clip; call update each frame with the elapsed delta (seconds or a `Time` object) to advance playback. The `onFrame` signal fires on every frame advance and `onComplete` fires when a clip completes its final AnimatedSpriteClipDefinition.repeat cycle.",
+        "Multiple named clips can be registered via defineClip or the constructor. Call play to start a clip. Playback then advances by itself: a playing sprite attached to an Application's scene tree registers with that application's AnimationManager and is ticked once per frame, with no `update()` call of your own. A sprite that is never attached to a tree — one drawn immediate-mode via `context.render(sprite)`, say — has no owning application to reach, so drive it by calling update with the frame delta in **seconds** yourself.",
+        "The `onFrame` signal fires on every frame advance and `onComplete` fires when a clip completes its final AnimatedSpriteClipDefinition.repeat cycle.",
         "Use AnimatedSprite.fromSpritesheet to create an instance directly from a Spritesheet's named animations."
       ],
       "importLine": "import { AnimatedSprite } from '@codexo/exojs'",
@@ -1035,7 +1036,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Start playing the named clip. By default restarts from frame 0; pass { restart: false } to resume from the current frame if the same clip is already active. Optionally overrides the clip's repeat setting."
+          "description": "Start playing the named clip. By default restarts from frame 0; pass { restart: false } to resume from the current frame if the same clip is already active. Optionally overrides the clip's repeat setting. Safe to call before the sprite is attached to a scene tree (in a constructor, ahead of addChild): the sprite simply has no owning AnimationManager to register with yet, and joins one the moment it is attached."
         },
         {
           "name": "project",
@@ -2073,7 +2074,7 @@
         },
         {
           "name": "update",
-          "signature": "update(delta: number | Time): this",
+          "signature": "update(deltaSeconds: number): this",
           "signatureTokens": [
             {
               "text": "update",
@@ -2084,7 +2085,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "delta",
+              "text": "deltaSeconds",
               "kind": "param"
             },
             {
@@ -2094,14 +2095,6 @@
             {
               "text": "number",
               "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Time",
-              "kind": "type"
             },
             {
               "text": ")",
@@ -2118,13 +2111,13 @@
           ],
           "params": [
             {
-              "name": "delta",
-              "type": "number | Time",
+              "name": "deltaSeconds",
+              "type": "number",
               "optional": false
             }
           ],
           "returnType": "this",
-          "description": "Advance playback by delta milliseconds (or a Time object). Call once per frame from the game loop. Dispatches onFrame for each frame boundary crossed and onComplete when the clip completes its final AnimatedSpriteClipDefinition.repeat cycle."
+          "description": "Advance playback by deltaSeconds — seconds, the same unit as Tween.update, and the unit a Time delta reports through delta.seconds. Clip authoring stays in its own units: AnimatedSpriteClipDefinition.frameDurations is still milliseconds per frame and fps is still frames per second; only this argument is seconds. Called automatically once per frame by the owning AnimationManager for a playing, attached sprite — call it yourself only for a sprite that is not part of an application's scene tree, or to step playback manually. Dispatches onFrame for each frame boundary crossed and onComplete when the clip completes its final AnimatedSpriteClipDefinition.repeat cycle."
         },
         {
           "name": "updateBounds",

--- a/site/src/content/api/animation-manager.json
+++ b/site/src/content/api/animation-manager.json
@@ -1,0 +1,366 @@
+{
+  "title": "AnimationManager",
+  "description": "Owns and advances the AnimatedSprites whose frame playback is currently running, driving them once per frame from Application.update — the SystemMethods.preUpdate phase, at SystemOrder.CoreAnimation. Registration is automatic and requires no user wiring: an AnimatedSprite registers itself here as soon as it is both *playing* and *attached* to a scene tree owned by an Application, and deregisters on `stop()`/`pause()`, on clip completion, on detach from the tree, and on `destroy()`. A sprite that is never attached to a tree (e.g. one drawn immediate-mode via `context.render(sprite)`) is never registered, and must be ticked by hand with AnimatedSprite.update — which stays public exactly for that case. Update iteration uses a snapshot so `onFrame`/`onComplete` handlers may freely play, stop, add or destroy sprites during the same frame without corrupting the loop.",
+  "symbol": "AnimationManager",
+  "kind": "class",
+  "subsystem": "animation",
+  "importPath": "@codexo/exojs",
+  "tier": "stable",
+  "memberCount": 8,
+  "counts": {
+    "constructors": 1,
+    "methods": 6,
+    "properties": 1,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Owns and advances the AnimatedSprites whose frame playback is currently running, driving them once per frame from Application.update — the SystemMethods.preUpdate phase, at SystemOrder.CoreAnimation.",
+        "Registration is automatic and requires no user wiring: an AnimatedSprite registers itself here as soon as it is both *playing* and *attached* to a scene tree owned by an Application, and deregisters on `stop()`/`pause()`, on clip completion, on detach from the tree, and on `destroy()`. A sprite that is never attached to a tree (e.g. one drawn immediate-mode via `context.render(sprite)`) is never registered, and must be ticked by hand with AnimatedSprite.update — which stays public exactly for that case.",
+        "Update iteration uses a snapshot so `onFrame`/`onComplete` handlers may freely play, stop, add or destroy sprites during the same frame without corrupting the loop."
+      ],
+      "importLine": "import { AnimationManager } from '@codexo/exojs'",
+      "sourceLink": null
+    },
+    {
+      "id": "constructors",
+      "title": "Constructors",
+      "members": [
+        {
+          "name": "new",
+          "signature": "new(): AnimationManager",
+          "signatureTokens": [
+            {
+              "text": "new",
+              "kind": "keyword"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "AnimationManager",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": "AnimationManager",
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "methods",
+      "title": "Methods",
+      "members": [
+        {
+          "name": "add",
+          "signature": "add(sprite: AnimatedSprite): this",
+          "signatureTokens": [
+            {
+              "text": "add",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "sprite",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "AnimatedSprite",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "sprite",
+              "type": "AnimatedSprite",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": "Register sprite so it is advanced once per frame. Idempotent, and a no-op for a destroyed sprite or a destroyed manager. Called automatically by AnimatedSprite; there is no need to call it by hand."
+        },
+        {
+          "name": "clear",
+          "signature": "clear(): this",
+          "signatureTokens": [
+            {
+              "text": "clear",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "this",
+          "description": "Deregister every sprite immediately. Playback state is left as-is — the sprites are simply no longer advanced by this manager."
+        },
+        {
+          "name": "destroy",
+          "signature": "destroy(): void",
+          "signatureTokens": [
+            {
+              "text": "destroy",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "void",
+          "description": "Tear down the manager. Deregisters every sprite and makes subsequent updates no-ops."
+        },
+        {
+          "name": "has",
+          "signature": "has(sprite: AnimatedSprite): boolean",
+          "signatureTokens": [
+            {
+              "text": "has",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "sprite",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "AnimatedSprite",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "sprite",
+              "type": "AnimatedSprite",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "description": "Whether sprite is currently registered for per-frame advancement."
+        },
+        {
+          "name": "preUpdate",
+          "signature": "preUpdate(delta: Time): void",
+          "signatureTokens": [
+            {
+              "text": "preUpdate",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "delta",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Time",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "delta",
+              "type": "Time",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Advance every registered sprite by the frame delta, converted to seconds at this single point of use. Sprites destroyed since the last frame are evicted rather than ticked, so a destroyed node can never be driven after teardown. Iterates a snapshot so playback callbacks that register or deregister sprites do not corrupt the loop."
+        },
+        {
+          "name": "remove",
+          "signature": "remove(sprite: AnimatedSprite): this",
+          "signatureTokens": [
+            {
+              "text": "remove",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "sprite",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "AnimatedSprite",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "sprite",
+              "type": "AnimatedSprite",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": "Remove sprite from the manager. Called automatically on stop/pause/complete/detach/destroy."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "size",
+          "signature": "size: number",
+          "signatureTokens": [
+            {
+              "text": "size",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Number of sprites currently registered for per-frame advancement."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/animation/AnimationManager.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/animation/AnimationManager.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/animation/AnimationManager.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/animation/AnimationManager.ts"
+}

--- a/site/src/content/api/application.json
+++ b/site/src/content/api/application.json
@@ -1,16 +1,16 @@
 {
   "title": "Application",
-  "description": "Top-level engine instance. Owns the canvas, render backend, scene-stack controller, the core managers (input, interaction, audio, tweens, rendering), the app-level SystemRegistry for user/extension systems, asset loader, and the per-frame loop. Lifecycle: construct with options → `await app.start(scene)` → engine runs the request-animation-frame loop until `app.stop()` or `app.destroy()`. The render backend is chosen and initialized during `start()`; query Application.backend or Application.capabilities after start has resolved. The class exposes Signals for the major state-change points (Application.onResize, Application.onFrame, Application.onCanvasFocusChange, Application.onVisibilityChange, Application.onBackendLost, Application.onBackendRestored) so subscribers can react without subclassing. `pauseOnHidden = true` short-circuits the per-frame work while `document.hidden` is true (still consumes RAF callbacks but skips scene update + render). Useful for games; leave off for tools and background-active simulations.",
+  "description": "Top-level engine instance. Owns the canvas, render backend, scene-stack controller, the core managers (input, interaction, audio, tweens, animations, rendering), the app-level SystemRegistry for user/extension systems, asset loader, and the per-frame loop. Lifecycle: construct with options → `await app.start(scene)` → engine runs the request-animation-frame loop until `app.stop()` or `app.destroy()`. The render backend is chosen and initialized during `start()`; query Application.backend or Application.capabilities after start has resolved. The class exposes Signals for the major state-change points (Application.onResize, Application.onFrame, Application.onCanvasFocusChange, Application.onVisibilityChange, Application.onBackendLost, Application.onBackendRestored) so subscribers can react without subclassing. `pauseOnHidden = true` short-circuits the per-frame work while `document.hidden` is true (still consumes RAF callbacks but skips scene update + render). Useful for games; leave off for tools and background-active simulations.",
   "symbol": "Application",
   "kind": "class",
   "subsystem": "core",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 51,
+  "memberCount": 52,
   "counts": {
     "constructors": 1,
     "methods": 10,
-    "properties": 32,
+    "properties": 33,
     "events": 8
   },
   "sections": [
@@ -19,7 +19,7 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "Top-level engine instance. Owns the canvas, render backend, scene-stack controller, the core managers (input, interaction, audio, tweens, rendering), the app-level SystemRegistry for user/extension systems, asset loader, and the per-frame loop.",
+        "Top-level engine instance. Owns the canvas, render backend, scene-stack controller, the core managers (input, interaction, audio, tweens, animations, rendering), the app-level SystemRegistry for user/extension systems, asset loader, and the per-frame loop.",
         "Lifecycle: construct with options → `await app.start(scene)` → engine runs the request-animation-frame loop until `app.stop()` or `app.destroy()`. The render backend is chosen and initialized during `start()`; query Application.backend or Application.capabilities after start has resolved.",
         "The class exposes Signals for the major state-change points (Application.onResize, Application.onFrame, Application.onCanvasFocusChange, Application.onVisibilityChange, Application.onBackendLost, Application.onBackendRestored) so subscribers can react without subclassing.",
         "`pauseOnHidden = true` short-circuits the per-frame work while `document.hidden` is true (still consumes RAF callbacks but skips scene update + render). Useful for games; leave off for tools and background-active simulations."
@@ -206,7 +206,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": "Tear down every owned subsystem (loader, the core managers — input, interaction, audio, tweens, rendering — the app system registry, backend, scene director, all clocks, all signals) and release event listeners. The application instance is unusable after this call. Fires the RAF halt synchronously (so no further frame runs after this call returns) but the rest of teardown runs as a background async chain, awaited internally: scenes — including every retained and preloaded scope, and any scene's own async unload() — is fully disposed FIRST, before the Loader, rendering context, audio manager, or backend are destroyed, so a scene's teardown code never touches an already-destroyed dependency. This intentionally does not route through the public Application.stop, which fire-and-forgets its own scene-clear — that would race against scenes._dispose()'s own active-scope teardown for ownership of the same scope. destroy() instead halts the frame loop directly and lets scenes._dispose() own scene teardown entirely."
+          "description": "Tear down every owned subsystem (loader, the core managers — input, interaction, audio, tweens, animations, rendering — the app system registry, backend, scene director, all clocks, all signals) and release event listeners. The application instance is unusable after this call. Fires the RAF halt synchronously (so no further frame runs after this call returns) but the rest of teardown runs as a background async chain, awaited internally: scenes — including every retained and preloaded scope, and any scene's own async unload() — is fully disposed FIRST, before the Loader, rendering context, audio manager, or backend are destroyed, so a scene's teardown code never touches an already-destroyed dependency. This intentionally does not route through the public Application.stop, which fire-and-forgets its own scene-clear — that would race against scenes._dispose()'s own active-scope teardown for ownership of the same scope. destroy() instead halts the frame loop directly and lets scenes._dispose() own scene teardown entirely."
         },
         {
           "name": "resize",
@@ -768,7 +768,7 @@
           ],
           "params": [],
           "returnType": "this",
-          "description": "One iteration of the per-frame loop. Invoked by requestAnimationFrame. When the document is hidden and pauseOnHidden is true, the frame clock is reset and the body is skipped — preventing a large delta spike on the first visible frame after resume. Each normal frame runs, in order: 1. **Pre-update** — app.systems pre-update phase, then the scene's preUpdate() hook and its own systems' pre-update phase. The engine's input, interaction, audio, tween and rendering managers are ordinary systems in this phase, pinned to the head of it by their SystemOrder Core* values, so this frame's input snapshot is current before anything simulates. An application system registered without an explicit order runs after all of them. 2. **Fixed steps** (zero or more) — app.systems fixed-update phase, scenes.fixedUpdate() + the scene's systems fixed-update phase, Application.onFixedFrame. 3. **Update** — app.systems update phase, then scenes.update() + the scene's systems update phase. 4. **Draw** — the scene draws (plus its systems and UI layer); an active transition session's own visual output composites either below or above the app.systems draw phase depending on the session's placement ('scene': below app overlays; 'screen': above them, matching the pre-transition-runtime default). 5. **Frame dispatch / flush** — Application.onFrame, backend GPU flush, frame-time stat write, RAF reschedule. The simulation delta forwarded to all update recipients is clamped to an internal maximum (100 ms) so that debugger pauses, device sleep/resume, or severe browser scheduling gaps cannot produce runaway animation advancement. Real wall-clock time and RAF cadence are unaffected; the raw elapsed delta is recorded separately in backend.stats.rawFrameDeltaMs."
+          "description": "One iteration of the per-frame loop. Invoked by requestAnimationFrame. When the document is hidden and pauseOnHidden is true, the frame clock is reset and the body is skipped — preventing a large delta spike on the first visible frame after resume. Each normal frame runs, in order: 1. **Pre-update** — app.systems pre-update phase, then the scene's preUpdate() hook and its own systems' pre-update phase. The engine's input, interaction, audio, tween, animation and rendering managers are ordinary systems in this phase, pinned to the head of it by their SystemOrder Core* values, so this frame's input snapshot is current before anything simulates. An application system registered without an explicit order runs after all of them. 2. **Fixed steps** (zero or more) — app.systems fixed-update phase, scenes.fixedUpdate() + the scene's systems fixed-update phase, Application.onFixedFrame. 3. **Update** — app.systems update phase, then scenes.update() + the scene's systems update phase. 4. **Draw** — the scene draws (plus its systems and UI layer); an active transition session's own visual output composites either below or above the app.systems draw phase depending on the session's placement ('scene': below app overlays; 'screen': above them, matching the pre-transition-runtime default). 5. **Frame dispatch / flush** — Application.onFrame, backend GPU flush, frame-time stat write, RAF reschedule. The simulation delta forwarded to all update recipients is clamped to an internal maximum (100 ms) so that debugger pauses, device sleep/resume, or severe browser scheduling gaps cannot produce runaway animation advancement. Real wall-clock time and RAF cadence are unaffected; the raw elapsed delta is recorded separately in backend.stats.rawFrameDeltaMs."
         }
       ],
       "paragraphs": [],
@@ -779,6 +779,27 @@
       "id": "properties",
       "title": "Properties",
       "members": [
+        {
+          "name": "animations",
+          "signature": "animations: AnimationManager",
+          "signatureTokens": [
+            {
+              "text": "animations",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "AnimationManager",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Drives frame playback for every AnimatedSprite that is playing and attached to this application's scene tree. Registration is automatic — see AnimationManager."
+        },
         {
           "name": "canvas",
           "signature": "canvas: HTMLCanvasElement",
@@ -1032,7 +1053,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "App-level system registry for user/extension systems — Application lifetime, independent of the active scene. The core managers (input, interaction, audio, tweens, rendering) are driven directly by the internal per-frame prepare stage and never occupy this registry, so any order is available; see SystemOrder for common reference points. Scene-scoped systems live on scenes.systems."
+          "description": "App-level system registry for user/extension systems — Application lifetime, independent of the active scene. The core managers (input, interaction, audio, tweens, animations, rendering) are driven directly by the internal per-frame prepare stage and never occupy this registry, so any order is available; see SystemOrder for common reference points. Scene-scoped systems live on scenes.systems."
         },
         {
           "name": "tweens",

--- a/site/src/content/api/input-binding-options.json
+++ b/site/src/content/api/input-binding-options.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "gamepadSlot",
-          "signature": "gamepadSlot?: 0 | 1 | 2 | 3",
+          "signature": "gamepadSlot?: 0 | 2 | 1 | 3",
           "signatureTokens": [
             {
               "text": "gamepadSlot",
@@ -53,7 +53,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "1",
+              "text": "2",
               "kind": "keyword"
             },
             {
@@ -61,7 +61,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "2",
+              "text": "1",
               "kind": "keyword"
             },
             {

--- a/site/src/content/api/scene-input-binding-options.json
+++ b/site/src/content/api/scene-input-binding-options.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "gamepadSlot",
-          "signature": "gamepadSlot?: 0 | 1 | 2 | 3",
+          "signature": "gamepadSlot?: 0 | 2 | 1 | 3",
           "signatureTokens": [
             {
               "text": "gamepadSlot",
@@ -53,7 +53,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "1",
+              "text": "2",
               "kind": "keyword"
             },
             {
@@ -61,7 +61,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "2",
+              "text": "1",
               "kind": "keyword"
             },
             {

--- a/site/src/content/api/sequence-action-options.json
+++ b/site/src/content/api/sequence-action-options.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "gamepadSlot",
-          "signature": "gamepadSlot?: 0 | 1 | 2 | 3",
+          "signature": "gamepadSlot?: 0 | 2 | 1 | 3",
           "signatureTokens": [
             {
               "text": "gamepadSlot",
@@ -53,7 +53,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "1",
+              "text": "2",
               "kind": "keyword"
             },
             {
@@ -61,7 +61,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "2",
+              "text": "1",
               "kind": "keyword"
             },
             {

--- a/site/src/content/api/system-order.json
+++ b/site/src/content/api/system-order.json
@@ -6,7 +6,7 @@
   "subsystem": "core",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 9,
+  "memberCount": 10,
   "counts": {
     "constructors": 0,
     "methods": 0,
@@ -28,6 +28,19 @@
       "id": "members",
       "title": "Members",
       "members": [
+        {
+          "name": "CoreAnimation",
+          "signature": "CoreAnimation",
+          "signatureTokens": [
+            {
+              "text": "CoreAnimation",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
         {
           "name": "CoreAudio",
           "signature": "CoreAudio",

--- a/site/src/content/guide/assets/aseprite.mdx
+++ b/site/src/content/guide/assets/aseprite.mdx
@@ -113,14 +113,11 @@ init() {
     this.player.play('walk');
     this.root.addChild(this.player);
 }
-
-update(delta: Time) {
-    this.player.update(delta); // advance the active clip
-}
 ```
 
-Like any `AnimatedSprite`, you must call `player.update(delta)` each frame to advance playback — see
-the [Animation](/ExoJS/en/guide/rendering/animation/) guide for the full clip/playback API.
+Like any `AnimatedSprite`, playback advances on its own once the sprite is in the scene tree — the
+engine's `AnimationManager` ticks it every frame. See the
+[Animation](/ExoJS/en/guide/rendering/animation/) guide for the full clip/playback API.
 
 The parsed clips are also exposed directly on `sheet.clips` — a read-only `Map` keyed by tag name —
 so you can inspect what was imported or build a sprite by hand:

--- a/site/src/content/guide/rendering/animation.mdx
+++ b/site/src/content/guide/rendering/animation.mdx
@@ -293,12 +293,34 @@ player.onComplete.add(clip => {
 });
 ```
 
-Call `player.update(delta)` each frame. The delta can be a `Time` object (from the scene's `update`) or a number in milliseconds:
+Playback advances by itself. Once the sprite is part of the scene tree, the engine's
+`AnimationManager` (`app.animations`) ticks every playing `AnimatedSprite` once per frame — there is
+nothing to call from your own `update`:
 
 ```ts
-update(delta: Time) {
-    this.player.update(delta);
+import { AnimatedSprite, Scene } from '@codexo/exojs';
+
+class Level extends Scene {
+    private player!: AnimatedSprite;
+
+    override init(): void {
+        this.addChild(this.player);
+        this.player.play('walk'); // advances automatically from here on
+    }
 }
+```
+
+A sprite you never add to the tree — one drawn immediate-mode via `context.render(sprite)` — has no
+owning application to reach, so drive it yourself with `update(deltaSeconds)`. The argument is
+**seconds**, the same unit as `Tween.update`:
+
+```ts
+import { AnimatedSprite } from '@codexo/exojs';
+
+declare const detached: AnimatedSprite;
+declare const frameSeconds: number;
+
+detached.update(frameSeconds);
 ```
 
 ### From a Spritesheet

--- a/src/animation/AnimationManager.ts
+++ b/src/animation/AnimationManager.ts
@@ -1,0 +1,99 @@
+import type { Time } from '#core/Time';
+import type { AnimatedSprite } from '#rendering/sprite/AnimatedSprite';
+
+/**
+ * Owns and advances the {@link AnimatedSprite}s whose frame playback is
+ * currently running, driving them once per frame from {@link Application.update}
+ * — the {@link SystemMethods.preUpdate} phase, at
+ * {@link SystemOrder.CoreAnimation}.
+ *
+ * Registration is automatic and requires no user wiring: an
+ * {@link AnimatedSprite} registers itself here as soon as it is both *playing*
+ * and *attached* to a scene tree owned by an {@link Application}, and
+ * deregisters on `stop()`/`pause()`, on clip completion, on detach from the
+ * tree, and on `destroy()`. A sprite that is never attached to a tree (e.g. one
+ * drawn immediate-mode via `context.render(sprite)`) is never registered, and
+ * must be ticked by hand with {@link AnimatedSprite.update} — which stays
+ * public exactly for that case.
+ *
+ * Update iteration uses a snapshot so `onFrame`/`onComplete` handlers may
+ * freely play, stop, add or destroy sprites during the same frame without
+ * corrupting the loop.
+ * @stable
+ */
+export class AnimationManager {
+  private _sprites = new Set<AnimatedSprite>();
+  private _destroyed = false;
+
+  /** Number of sprites currently registered for per-frame advancement. */
+  public get size(): number {
+    return this._sprites.size;
+  }
+
+  /**
+   * Register `sprite` so it is advanced once per frame. Idempotent, and a
+   * no-op for a destroyed sprite or a destroyed manager. Called automatically
+   * by {@link AnimatedSprite}; there is no need to call it by hand.
+   */
+  public add(sprite: AnimatedSprite): this {
+    if (this._destroyed || sprite.destroyed) {
+      return this;
+    }
+
+    this._sprites.add(sprite);
+
+    return this;
+  }
+
+  /** Remove `sprite` from the manager. Called automatically on stop/pause/complete/detach/destroy. */
+  public remove(sprite: AnimatedSprite): this {
+    this._sprites.delete(sprite);
+
+    return this;
+  }
+
+  /** Whether `sprite` is currently registered for per-frame advancement. */
+  public has(sprite: AnimatedSprite): boolean {
+    return this._sprites.has(sprite);
+  }
+
+  /**
+   * Advance every registered sprite by the frame `delta`, converted to seconds
+   * at this single point of use. Sprites destroyed since the last frame are
+   * evicted rather than ticked, so a destroyed node can never be driven after
+   * teardown. Iterates a snapshot so playback callbacks that register or
+   * deregister sprites do not corrupt the loop.
+   */
+  public preUpdate(delta: Time): void {
+    if (this._destroyed || this._sprites.size === 0) {
+      return;
+    }
+
+    const deltaSeconds = delta.seconds;
+
+    for (const sprite of [...this._sprites]) {
+      if (sprite.destroyed) {
+        this._sprites.delete(sprite);
+        continue;
+      }
+
+      sprite.update(deltaSeconds);
+    }
+  }
+
+  /**
+   * Deregister every sprite immediately. Playback state is left as-is — the
+   * sprites are simply no longer advanced by this manager.
+   */
+  public clear(): this {
+    this._sprites = new Set();
+
+    return this;
+  }
+
+  /** Tear down the manager. Deregisters every sprite and makes subsequent updates no-ops. */
+  public destroy(): void {
+    this.clear();
+    this._destroyed = true;
+  }
+}

--- a/src/animation/index.ts
+++ b/src/animation/index.ts
@@ -1,3 +1,4 @@
+export { AnimationManager } from './AnimationManager';
 export type { EasingFunction } from './Easing';
 export { Ease } from './Easing';
 export { Tween } from './Tween';

--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -1,3 +1,4 @@
+import { AnimationManager } from '#animation/AnimationManager';
 import { TweenManager } from '#animation/TweenManager';
 import { coreAssetBindings } from '#assets/coreAssetBindings';
 import { Loader, type LoaderOptions } from '#assets/Loader';
@@ -303,7 +304,7 @@ const defaultInputSettings: Required<InputApplicationOptions> = {
 /**
  * Top-level engine instance. Owns the canvas, render backend, scene-stack
  * controller, the core managers (input, interaction, audio, tweens,
- * rendering), the app-level {@link SystemRegistry} for user/extension
+ * animations, rendering), the app-level {@link SystemRegistry} for user/extension
  * systems, asset loader, and the per-frame loop.
  *
  * Lifecycle: construct with options → `await app.start(scene)` → engine
@@ -342,9 +343,15 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
   public readonly random: Random;
   public readonly tweens: TweenManager = new TweenManager();
   /**
+   * Drives frame playback for every {@link AnimatedSprite} that is playing and
+   * attached to this application's scene tree. Registration is automatic — see
+   * {@link AnimationManager}.
+   */
+  public readonly animations: AnimationManager = new AnimationManager();
+  /**
    * App-level system registry for user/extension systems — Application
    * lifetime, independent of the active scene. The core managers (input,
-   * interaction, audio, tweens, rendering) are driven directly by the
+   * interaction, audio, tweens, animations, rendering) are driven directly by the
    * internal per-frame prepare stage and never occupy this registry, so any
    * `order` is available; see {@link SystemOrder} for common reference
    * points. Scene-scoped systems live on `scenes.systems`.
@@ -567,9 +574,10 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
     this.systems._addCoreSystem(this.interaction, { order: SystemOrder.CoreInteraction });
     this.systems._addCoreSystem(this._audio, { order: SystemOrder.CoreAudio });
     this.systems._addCoreSystem(this.tweens, { order: SystemOrder.CoreTweens });
+    this.systems._addCoreSystem(this.animations, { order: SystemOrder.CoreAnimation });
     this.systems._addCoreSystem(this._rendering, { order: SystemOrder.CoreRendering });
 
-    this._coreSystems = [this.input, this.interaction, this._audio, this.tweens, this._rendering];
+    this._coreSystems = [this.input, this.interaction, this._audio, this.tweens, this.animations, this._rendering];
 
     // Every core manager exists by this point, so app-system bindings can capture references to them.
     materializeApplicationSystems(this, this._snapshot.systems);
@@ -934,8 +942,8 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
    *
    * 1. **Pre-update** — `app.systems` pre-update phase, then the scene's
    *    `preUpdate()` hook and its own systems' pre-update phase. The engine's
-   *    input, interaction, audio, tween and rendering managers are ordinary
-   *    systems in this phase, pinned to the head of it by their
+   *    input, interaction, audio, tween, animation and rendering managers are
+   *    ordinary systems in this phase, pinned to the head of it by their
    *    {@link SystemOrder} `Core*` values, so this frame's input snapshot is
    *    current before anything simulates. An application system registered
    *    without an explicit `order` runs after all of them.
@@ -994,8 +1002,9 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
         this.backend.stats.rawFrameDeltaMs = rawDeltaMs;
 
         // Bring per-frame state in sync before anything simulates: the engine's
-        // own input, interaction, audio, tween and rendering systems sit at the
-        // head of this phase (negative `order`), application systems follow.
+        // own input, interaction, audio, tween, animation and rendering systems
+        // sit at the head of this phase (negative `order`), application systems
+        // follow.
         this.systems._preUpdate(frameDelta);
         this.scenes.preUpdate(frameDelta);
 
@@ -1353,7 +1362,7 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
 
   /**
    * Tear down every owned subsystem (loader, the core managers — input,
-   * interaction, audio, tweens, rendering — the app system registry, backend,
+   * interaction, audio, tweens, animations, rendering — the app system registry, backend,
    * scene director, all clocks, all signals) and release event listeners. The
    * application instance is unusable after this call.
    *
@@ -1420,6 +1429,7 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
     this.systems.destroy();
 
     this._rendering.destroy();
+    this.animations.destroy();
     this.tweens.destroy();
     this._audio.destroy();
     this.interaction.destroy();

--- a/src/core/SystemOrder.ts
+++ b/src/core/SystemOrder.ts
@@ -20,6 +20,13 @@ export enum SystemOrder {
   CoreAudio = -300,
   /** Tween and sequencer advance. */
   CoreTweens = -200,
+  /**
+   * Sprite frame-animation advance. After {@link SystemOrder.CoreTweens} so a
+   * tween that drives playback (swapping clips, changing speed) has already
+   * applied this frame's value, and before {@link SystemOrder.CoreRendering}
+   * so the frame a sprite advances to is the one this frame renders.
+   */
+  CoreAnimation = -150,
   /** Renderer per-frame state reset and view update. Last of the engine's own pre-update systems. */
   CoreRendering = -100,
   /** The implicit order of a system that does not specify one. */

--- a/src/core/SystemRegistry.ts
+++ b/src/core/SystemRegistry.ts
@@ -250,7 +250,7 @@ export class SystemRegistry implements Destroyable {
   public remove(system: System): boolean {
     if (__DEV__ && this._coreSystems.has(system)) {
       logger.warn(
-        "SystemRegistry.remove(): removing one of the engine's own core systems stops that part of the engine for good — input, interaction, audio, tweens or rendering will no longer run. This is allowed on purpose, but it is almost never what you want; to reorder around one, use `before`/`after` against it instead.",
+        "SystemRegistry.remove(): removing one of the engine's own core systems stops that part of the engine for good — input, interaction, audio, tweens, animations or rendering will no longer run. This is allowed on purpose, but it is almost never what you want; to reorder around one, use `before`/`after` against it instead.",
         { source: 'SystemRegistry', once: 'systems:remove-core' },
       );
     }

--- a/src/rendering/sprite/AnimatedSprite.ts
+++ b/src/rendering/sprite/AnimatedSprite.ts
@@ -1,5 +1,6 @@
+import type { AnimationManager } from '#animation/AnimationManager';
 import { Signal } from '#core/Signal';
-import type { Time } from '#core/Time';
+import type { Stage } from '#core/Stage';
 import type { Rectangle } from '#math/Rectangle';
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { Texture } from '#rendering/texture/Texture';
@@ -75,10 +76,16 @@ function assertValidRepeat(context: string, repeat: number): void {
  * {@link Rectangle}s over time to produce frame-based animation.
  *
  * Multiple named clips can be registered via {@link defineClip} or the
- * constructor. Call {@link play} to start a clip; call {@link update} each
- * frame with the elapsed delta (seconds or a `Time` object) to advance
- * playback. The `onFrame` signal fires on every frame advance and
- * `onComplete` fires when a clip completes its final {@link AnimatedSpriteClipDefinition.repeat} cycle.
+ * constructor. Call {@link play} to start a clip. Playback then advances by
+ * itself: a playing sprite attached to an {@link Application}'s scene tree
+ * registers with that application's {@link AnimationManager} and is ticked
+ * once per frame, with no `update()` call of your own. A sprite that is never
+ * attached to a tree — one drawn immediate-mode via `context.render(sprite)`,
+ * say — has no owning application to reach, so drive it by calling
+ * {@link update} with the frame delta in **seconds** yourself.
+ *
+ * The `onFrame` signal fires on every frame advance and `onComplete` fires
+ * when a clip completes its final {@link AnimatedSpriteClipDefinition.repeat} cycle.
  *
  * Use {@link AnimatedSprite.fromSpritesheet} to create an instance directly
  * from a {@link Spritesheet}'s named animations.
@@ -92,6 +99,14 @@ export class AnimatedSprite extends Sprite {
   private _repeatOverride: number | null = null;
   private _elapsedFrameTimeMs = 0;
   private _completedCycles = 0;
+  /**
+   * The {@link AnimationManager} this sprite is currently registered with, or
+   * `null` when it is not being ticked by one (not playing, not attached to a
+   * tree, or destroyed). Kept as the single record of the registration so
+   * {@link _syncManagerRegistration} can always undo exactly what it did, even
+   * after the owning stage has already been swapped out.
+   */
+  private _manager: AnimationManager | null = null;
 
   public readonly onComplete = new Signal<[clip: string]>();
   public readonly onFrame = new Signal<[clip: string, frame: number]>();
@@ -256,6 +271,11 @@ export class AnimatedSprite extends Sprite {
    * Start playing the named clip. By default restarts from frame 0; pass
    * `{ restart: false }` to resume from the current frame if the same clip
    * is already active. Optionally overrides the clip's `repeat` setting.
+   *
+   * Safe to call before the sprite is attached to a scene tree (in a
+   * constructor, ahead of `addChild`): the sprite simply has no owning
+   * {@link AnimationManager} to register with yet, and joins one the moment it
+   * is attached.
    */
   public play(name: string, options: AnimatedSpritePlayOptions = {}): this {
     const clip = this._clips.get(name);
@@ -283,6 +303,7 @@ export class AnimatedSprite extends Sprite {
 
     this._repeatOverride = options.repeat ?? this._repeatOverride;
     this._playing = true;
+    this._syncManagerRegistration();
 
     return this;
   }
@@ -291,6 +312,7 @@ export class AnimatedSprite extends Sprite {
   public stop(): this {
     this._playing = false;
     this._elapsedFrameTimeMs = 0;
+    this._syncManagerRegistration();
 
     if (!this._currentClipName) {
       return this;
@@ -310,6 +332,7 @@ export class AnimatedSprite extends Sprite {
 
   public pause(): this {
     this._playing = false;
+    this._syncManagerRegistration();
 
     return this;
   }
@@ -317,18 +340,28 @@ export class AnimatedSprite extends Sprite {
   public resume(): this {
     if (this._currentClipName !== null) {
       this._playing = true;
+      this._syncManagerRegistration();
     }
 
     return this;
   }
 
   /**
-   * Advance playback by `delta` milliseconds (or a `Time` object). Call once
-   * per frame from the game loop. Dispatches `onFrame` for each frame
-   * boundary crossed and `onComplete` when the clip completes its final
-   * {@link AnimatedSpriteClipDefinition.repeat} cycle.
+   * Advance playback by `deltaSeconds` — seconds, the same unit as
+   * {@link Tween.update}, and the unit a `Time` delta reports through
+   * `delta.seconds`. Clip authoring stays in its own units:
+   * {@link AnimatedSpriteClipDefinition.frameDurations} is still milliseconds
+   * per frame and `fps` is still frames per second; only this argument is
+   * seconds.
+   *
+   * Called automatically once per frame by the owning {@link AnimationManager}
+   * for a playing, attached sprite — call it yourself only for a sprite that
+   * is not part of an application's scene tree, or to step playback manually.
+   * Dispatches `onFrame` for each frame boundary crossed and `onComplete` when
+   * the clip completes its final {@link AnimatedSpriteClipDefinition.repeat}
+   * cycle.
    */
-  public update(delta: Time | number): this {
+  public update(deltaSeconds: number): this {
     if (!this._playing || this._currentClipName === null) {
       return this;
     }
@@ -339,7 +372,10 @@ export class AnimatedSprite extends Sprite {
       return this;
     }
 
-    const deltaMs = typeof delta === 'number' ? delta : delta.milliseconds;
+    // Clip timing is authored in milliseconds (`frameDurations`, and `fps`
+    // normalized to `frameDurationMs`), so the seconds-based frame delta is
+    // converted once here and every threshold comparison below stays in ms.
+    const deltaMs = deltaSeconds * 1000;
 
     if (deltaMs <= 0) {
       return this;
@@ -386,6 +422,9 @@ export class AnimatedSprite extends Sprite {
         // In-bounds: last frame index.
         this._applyFrame(clip, this._currentFrameIndex);
         this._playing = false;
+        // Leave the manager before the signal, so a handler that calls play()
+        // again re-registers on top of a clean state rather than being undone.
+        this._syncManagerRegistration();
         this.onComplete.dispatch(this._currentClipName);
 
         break;
@@ -401,7 +440,25 @@ export class AnimatedSprite extends Sprite {
     return this;
   }
 
+  /**
+   * @internal — join or leave the owning application's {@link AnimationManager}
+   * as this sprite enters or leaves a scene tree. This is what makes
+   * `play()`-before-`addChild()` work: playback state is kept on the sprite,
+   * and the registration follows attachment.
+   */
+  public override _setStage(stage: Stage | null): void {
+    super._setStage(stage);
+
+    this._syncManagerRegistration();
+  }
+
   public override destroy(): void {
+    this._playing = false;
+    // Before `super.destroy()`, which detaches from the parent and would run
+    // the sync through `_setStage(null)` anyway — doing it here first also
+    // covers a sprite destroyed while already detached.
+    this._syncManagerRegistration();
+
     super.destroy();
 
     this.onComplete.destroy();
@@ -432,6 +489,26 @@ export class AnimatedSprite extends Sprite {
     }
 
     return new AnimatedSprite(spritesheet.texture, clips);
+  }
+
+  /**
+   * Reconcile this sprite's {@link AnimationManager} registration with the two
+   * facts that decide it: whether playback is running, and which application
+   * (if any) currently owns the tree this sprite is attached to. Called from
+   * every place either fact can change — `play`/`stop`/`pause`/`resume`, clip
+   * completion, attach/detach, and `destroy` — so there is exactly one rule
+   * rather than a registration and a deregistration to keep in step.
+   */
+  private _syncManagerRegistration(): void {
+    const target = this._playing && !this.destroyed ? (this._stage?.app?.animations ?? null) : null;
+
+    if (this._manager === target) {
+      return;
+    }
+
+    this._manager?.remove(this);
+    this._manager = target;
+    target?.add(this);
   }
 
   /**

--- a/test/animation/animation-manager.test.ts
+++ b/test/animation/animation-manager.test.ts
@@ -1,0 +1,104 @@
+import { AnimationManager } from '#animation/AnimationManager';
+import { Time } from '#core/Time';
+import { Rectangle } from '#math/Rectangle';
+import { AnimatedSprite } from '#rendering/sprite/AnimatedSprite';
+
+const createFrames = (): Rectangle[] => [new Rectangle(0, 0, 16, 16), new Rectangle(16, 0, 16, 16), new Rectangle(32, 0, 16, 16)];
+
+/** A three-frame clip at 10fps — one frame advance per 100ms. */
+const createSprite = (): AnimatedSprite => new AnimatedSprite(null, { walk: { frames: createFrames(), fps: 10 } });
+
+const frame = (milliseconds: number): Time => new Time(milliseconds);
+
+describe('AnimationManager', () => {
+  test('advances registered sprites by the frame delta converted to seconds', () => {
+    const manager = new AnimationManager();
+    const sprite = createSprite();
+
+    sprite.play('walk');
+    manager.add(sprite);
+
+    manager.preUpdate(frame(100));
+    expect(sprite.currentFrame).toBe(1);
+
+    manager.preUpdate(frame(100));
+    expect(sprite.currentFrame).toBe(2);
+  });
+
+  test('add() is idempotent and remove() drops the registration', () => {
+    const manager = new AnimationManager();
+    const sprite = createSprite();
+
+    manager.add(sprite).add(sprite);
+    expect(manager.size).toBe(1);
+    expect(manager.has(sprite)).toBe(true);
+
+    manager.remove(sprite);
+    expect(manager.size).toBe(0);
+    expect(manager.has(sprite)).toBe(false);
+  });
+
+  test('refuses to register a destroyed sprite', () => {
+    const manager = new AnimationManager();
+    const sprite = createSprite();
+
+    sprite.destroy();
+    manager.add(sprite);
+
+    expect(manager.size).toBe(0);
+  });
+
+  test('evicts a sprite destroyed between frames instead of ticking it', () => {
+    const manager = new AnimationManager();
+    const sprite = createSprite();
+
+    sprite.play('walk');
+    manager.add(sprite);
+    expect(manager.size).toBe(1);
+
+    sprite.destroy();
+
+    expect(() => {
+      manager.preUpdate(frame(100));
+    }).not.toThrow();
+    expect(manager.size).toBe(0);
+  });
+
+  test('a callback that registers or deregisters sprites mid-tick does not corrupt the loop', () => {
+    const manager = new AnimationManager();
+    const first = createSprite();
+    const second = createSprite();
+
+    first.play('walk');
+    second.play('walk');
+    manager.add(first);
+
+    first.onFrame.add(() => {
+      manager.add(second);
+      manager.remove(first);
+    });
+
+    manager.preUpdate(frame(100));
+
+    expect(first.currentFrame).toBe(1);
+    expect(manager.has(first)).toBe(false);
+    expect(manager.has(second)).toBe(true);
+  });
+
+  test('destroy() releases every sprite and makes later updates no-ops', () => {
+    const manager = new AnimationManager();
+    const sprite = createSprite();
+
+    sprite.play('walk');
+    manager.add(sprite);
+
+    manager.destroy();
+    expect(manager.size).toBe(0);
+
+    manager.add(sprite);
+    manager.preUpdate(frame(100));
+
+    expect(manager.size).toBe(0);
+    expect(sprite.currentFrame).toBe(0);
+  });
+});

--- a/test/core/__snapshots__/root-index-snapshot.test.ts.snap
+++ b/test/core/__snapshots__/root-index-snapshot.test.ts.snap
@@ -7,6 +7,7 @@ exports[`root index export surface snapshot > sorted runtime export names match 
   "ActionMap",
   "AmbiguousSceneInstanceError",
   "AnimatedSprite",
+  "AnimationManager",
   "Application",
   "ApplicationStatus",
   "ArcadeStickGamepadMapping",

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -13,6 +13,7 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "AnimatedSprite: class",
   "AnimatedSpriteClipDefinition: interface",
   "AnimatedSpritePlayOptions: interface",
+  "AnimationManager: class",
   "AnyAssetConfig: type alias",
   "AnyAssets: type alias",
   "AnySceneConstructor: type alias",

--- a/test/core/serialization.test.ts
+++ b/test/core/serialization.test.ts
@@ -548,12 +548,12 @@ describe('serialization — AnimatedSprite', () => {
     const restored = deserializeTree(data, loader) as AnimatedSprite;
 
     restored.play('idle');
-    restored.update(100);
+    restored.update(100 / 1000);
     expect(restored.currentFrame).toBe(1);
 
     // Frame 1 holds 300ms (frameDurations), not the 100ms it would hold at
     // the default 12fps if frameDurations had been lost in the round-trip.
-    restored.update(100);
+    restored.update(100 / 1000);
     expect(restored.currentFrame).toBe(1);
   });
 
@@ -576,7 +576,7 @@ describe('serialization — AnimatedSprite', () => {
     restored.play('punch');
     expect(restored.getLocalBounds().x).toBe(0);
 
-    restored.update(100);
+    restored.update(100 / 1000);
     expect(restored.currentFrame).toBe(1);
     expect(restored.getLocalBounds().x).toBe(4);
     expect(restored.getLocalBounds().y).toBe(-2);
@@ -601,11 +601,11 @@ describe('serialization — AnimatedSprite', () => {
     restored.play('triple');
 
     // 2 frames @ 10fps = 100ms/frame; one full cycle is 200ms.
-    restored.update(200);
+    restored.update(200 / 1000);
     expect(restored.playing).toBe(true);
     expect(completeSpy).not.toHaveBeenCalled();
 
-    restored.update(200);
+    restored.update(200 / 1000);
     expect(restored.playing).toBe(false);
     expect(completeSpy).toHaveBeenCalledWith('triple');
   });

--- a/test/rendering/animated-sprite-scheduling.test.ts
+++ b/test/rendering/animated-sprite-scheduling.test.ts
@@ -1,0 +1,227 @@
+/**
+ * AnimatedSprite frame playback is scheduled by the engine, not by hand:
+ * a playing sprite attached to an Application's scene tree registers with
+ * `app.animations` and is advanced once per frame from the core preUpdate
+ * phase — and deregisters again on stop, detach, completion and destroy.
+ */
+import { Application, ApplicationStatus } from '#core/Application';
+import { Time } from '#core/Time';
+import { Rectangle } from '#math/Rectangle';
+import { Container } from '#rendering/Container';
+import { AnimatedSprite } from '#rendering/sprite/AnimatedSprite';
+
+// ---------------------------------------------------------------------------
+// Backend stubs — keep WebGL2 / WebGPU out of jsdom. The factories must be
+// inline because vi.mock() is hoisted above any variable declaration.
+// ---------------------------------------------------------------------------
+
+const backendStub = (): Record<string, unknown> => ({
+  onContextLost: { add: vi.fn() },
+  onContextRestored: { add: vi.fn() },
+  onDeviceLost: { add: vi.fn() },
+  onDeviceRestored: { add: vi.fn() },
+  onRenderError: { add: vi.fn(), destroy: vi.fn() },
+  stats: {
+    frameTimeMs: 0,
+    drawCalls: 0,
+    culledNodes: 0,
+    submittedNodes: 0,
+    batches: 0,
+    renderPasses: 0,
+    renderTargetChanges: 0,
+    frame: 0,
+    rawFrameDeltaMs: 0,
+  },
+  resetStats: vi.fn().mockReturnThis(),
+  flush: vi.fn().mockReturnThis(),
+  initialize: vi.fn().mockResolvedValue(undefined),
+  destroy: vi.fn(),
+  resize: vi.fn().mockReturnThis(),
+  view: {},
+  renderTarget: {},
+  backendType: 'webgl2',
+  setView: vi.fn().mockReturnThis(),
+  draw: vi.fn().mockReturnThis(),
+  execute: vi.fn().mockReturnThis(),
+  clear: vi.fn().mockReturnThis(),
+  pushScissorRect: vi.fn().mockReturnThis(),
+  popScissorRect: vi.fn().mockReturnThis(),
+  acquireRenderTexture: vi.fn(),
+  releaseRenderTexture: vi.fn().mockReturnThis(),
+  composeWithAlphaMask: vi.fn().mockReturnThis(),
+});
+
+vi.mock('#rendering/webgl2/WebGl2Backend', () => ({
+  WebGl2Backend: vi.fn().mockImplementation(function () {
+    return backendStub();
+  }),
+}));
+
+vi.mock('#rendering/webgpu/WebGpuBackend', () => ({
+  WebGpuBackend: vi.fn().mockImplementation(function () {
+    return backendStub();
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Put the Application into the running state without going through start(). */
+const forceRunning = (app: Application): void => {
+  const record = app as unknown as Record<string, unknown>;
+
+  record['_status'] = ApplicationStatus.Running;
+  record['_frameLoopActive'] = true;
+};
+
+/** Run one frame of the real per-frame loop with a fixed `milliseconds` delta. */
+const advanceFrame = (app: Application, milliseconds: number): void => {
+  const clock = (app as unknown as Record<string, unknown>)['_frameClock'] as import('#core/Clock').Clock;
+
+  vi.spyOn(clock, 'elapsedTime', 'get').mockReturnValue(new Time(milliseconds));
+  app.update();
+};
+
+const createFrames = (): Rectangle[] => [new Rectangle(0, 0, 16, 16), new Rectangle(16, 0, 16, 16), new Rectangle(32, 0, 16, 16)];
+
+/** A three-frame clip at 10fps — one frame per 100ms of simulated time. */
+const createSprite = (): AnimatedSprite => new AnimatedSprite(null, { walk: { frames: createFrames(), fps: 10 } });
+
+describe('AnimatedSprite scheduling', () => {
+  let app: Application;
+  let root: Container;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(globalThis, 'requestAnimationFrame').mockReturnValue(1 as unknown as ReturnType<typeof requestAnimationFrame>);
+
+    app = new Application({ backend: { type: 'webgl2' } });
+    forceRunning(app);
+
+    // The input subsystem is not under test and jsdom has no gamepad API.
+    vi.spyOn(app.input, 'preUpdate').mockImplementation(() => undefined);
+    vi.spyOn(app.interaction, 'preUpdate').mockImplementation(() => undefined);
+
+    // A stage-attached root, the way a scene's structural root is bound.
+    root = new Container();
+    app.interaction.attachRoot(root);
+  });
+
+  afterEach(() => {
+    (app as unknown as Record<string, unknown>)['_status'] = ApplicationStatus.Stopped;
+    app.destroy();
+    vi.restoreAllMocks();
+  });
+
+  test('a playing sprite in the scene tree advances through the application frame loop', () => {
+    const sprite = createSprite();
+
+    root.addChild(sprite);
+    sprite.play('walk');
+
+    expect(sprite.currentFrame).toBe(0);
+
+    advanceFrame(app, 100);
+    expect(sprite.currentFrame).toBe(1);
+
+    advanceFrame(app, 100);
+    expect(sprite.currentFrame).toBe(2);
+  });
+
+  test('play() before the sprite is attached still starts ticking once it joins the tree', () => {
+    const sprite = createSprite();
+
+    // The common shape: build and start the sprite, then parent it.
+    sprite.play('walk');
+    expect(app.animations.size).toBe(0);
+
+    root.addChild(sprite);
+    expect(app.animations.has(sprite)).toBe(true);
+
+    advanceFrame(app, 100);
+    expect(sprite.currentFrame).toBe(1);
+  });
+
+  test('a paused or stopped sprite is not ticked and holds no registration', () => {
+    const sprite = createSprite();
+
+    root.addChild(sprite);
+    sprite.play('walk');
+    advanceFrame(app, 100);
+    expect(sprite.currentFrame).toBe(1);
+
+    sprite.pause();
+    expect(app.animations.has(sprite)).toBe(false);
+
+    advanceFrame(app, 200);
+    expect(sprite.currentFrame).toBe(1);
+
+    sprite.resume();
+    expect(app.animations.has(sprite)).toBe(true);
+
+    advanceFrame(app, 100);
+    expect(sprite.currentFrame).toBe(2);
+
+    sprite.stop();
+    expect(app.animations.has(sprite)).toBe(false);
+    expect(app.animations.size).toBe(0);
+  });
+
+  test('detaching a playing sprite from the tree stops it being ticked', () => {
+    const sprite = createSprite();
+
+    root.addChild(sprite);
+    sprite.play('walk');
+    expect(app.animations.size).toBe(1);
+
+    root.removeChild(sprite);
+
+    expect(app.animations.has(sprite)).toBe(false);
+    expect(app.animations.size).toBe(0);
+
+    advanceFrame(app, 100);
+    expect(sprite.currentFrame).toBe(0);
+
+    // Re-attaching a still-playing sprite resumes automatic advancement.
+    root.addChild(sprite);
+    expect(app.animations.size).toBe(1);
+
+    advanceFrame(app, 100);
+    expect(sprite.currentFrame).toBe(1);
+  });
+
+  test('destroying a playing sprite deregisters it, so no destroyed node is ticked afterwards', () => {
+    const sprite = createSprite();
+
+    root.addChild(sprite);
+    sprite.play('walk');
+    expect(app.animations.size).toBe(1);
+
+    sprite.destroy();
+
+    expect(app.animations.has(sprite)).toBe(false);
+    expect(app.animations.size).toBe(0);
+    expect(() => {
+      advanceFrame(app, 100);
+    }).not.toThrow();
+  });
+
+  test('a clip that completes deregisters itself instead of being ticked forever', () => {
+    const sprite = new AnimatedSprite(null, { burst: { frames: createFrames(), fps: 10, repeat: 1 } });
+
+    root.addChild(sprite);
+    sprite.play('burst');
+    expect(app.animations.size).toBe(1);
+
+    // 3 frames @ 10fps = one 300ms cycle; the frame delta is clamped to 100ms,
+    // so drive it with three real frames.
+    advanceFrame(app, 100);
+    advanceFrame(app, 100);
+    advanceFrame(app, 100);
+
+    expect(sprite.playing).toBe(false);
+    expect(sprite.currentFrame).toBe(2);
+    expect(app.animations.size).toBe(0);
+  });
+});

--- a/test/rendering/animated-sprite.test.ts
+++ b/test/rendering/animated-sprite.test.ts
@@ -11,9 +11,40 @@ const createTextureStub = (): Texture =>
     updateSource: () => undefined,
   }) as unknown as Texture;
 
+/**
+ * Frame delta helper. `AnimatedSprite.update()` takes SECONDS (matching
+ * `Tween.update`), while clips are authored in milliseconds (`fps`,
+ * `frameDurations`) — these specs are written against the clip's own ms
+ * timings, so they convert at the call site.
+ */
+const seconds = (milliseconds: number): number => milliseconds / 1000;
+
 const createFrames = (): Rectangle[] => [new Rectangle(0, 0, 16, 16), new Rectangle(16, 0, 16, 16), new Rectangle(32, 0, 16, 16)];
 
 describe('AnimatedSprite', () => {
+  test('update() reads its argument as seconds, not milliseconds', () => {
+    // Regression: `update()` used to take `Time | number`, where the plain
+    // number was MILLISECONDS — the opposite unit to `Tween.update`, which is
+    // always seconds. A caller who forwarded `delta.seconds` (or a manager
+    // that did) advanced playback 1000x too slowly. The signature is now
+    // seconds-only, matching Tween.
+    const sprite = new AnimatedSprite(null, {
+      // 4 frames at 10fps: one frame per 100ms, i.e. per 0.1 seconds.
+      walk: { frames: [...createFrames(), new Rectangle(48, 0, 16, 16)], fps: 10 },
+    });
+
+    sprite.play('walk');
+
+    // 0.25 seconds = 250ms = two whole 100ms frame holds, with 50ms left over.
+    // Read as milliseconds this would not advance a single frame.
+    sprite.update(0.25);
+    expect(sprite.currentFrame).toBe(2);
+
+    // The 50ms remainder carries: another 0.05s completes frame 2's hold.
+    sprite.update(0.05);
+    expect(sprite.currentFrame).toBe(3);
+  });
+
   test('play() snaps the sprite to the frame size while preserving user scale', () => {
     // Regression: the sprite starts out showing the full atlas texture
     // (128x64 stub). The first frame application used the keep-pixel-size
@@ -32,7 +63,7 @@ describe('AnimatedSprite', () => {
     expect(sprite.height).toBe(3 * 16);
 
     // Subsequent frame advances keep the pixel size stable.
-    sprite.update(100);
+    sprite.update(seconds(100));
     expect(sprite.currentFrame).toBe(1);
     expect(sprite.width).toBe(3 * 16);
   });
@@ -71,10 +102,10 @@ describe('AnimatedSprite', () => {
     expect(sprite.currentClip).toBe('walk');
     expect(sprite.currentFrame).toBe(0);
 
-    sprite.update(100);
+    sprite.update(seconds(100));
     expect(sprite.currentFrame).toBe(1);
 
-    sprite.update(100);
+    sprite.update(seconds(100));
     expect(sprite.currentFrame).toBe(2);
   });
 
@@ -89,7 +120,7 @@ describe('AnimatedSprite', () => {
     });
 
     sprite.play('looped');
-    sprite.update(300);
+    sprite.update(seconds(300));
 
     expect(sprite.currentFrame).toBe(0);
     expect(sprite.playing).toBe(true);
@@ -108,7 +139,7 @@ describe('AnimatedSprite', () => {
 
     sprite.onComplete.add(completeSpy);
     sprite.play('burst');
-    sprite.update(300);
+    sprite.update(seconds(300));
 
     expect(sprite.currentFrame).toBe(2);
     expect(sprite.playing).toBe(false);
@@ -125,15 +156,15 @@ describe('AnimatedSprite', () => {
     });
 
     sprite.play('move');
-    sprite.update(100);
+    sprite.update(seconds(100));
     expect(sprite.currentFrame).toBe(1);
 
     sprite.pause();
-    sprite.update(200);
+    sprite.update(seconds(200));
     expect(sprite.currentFrame).toBe(1);
 
     sprite.resume();
-    sprite.update(100);
+    sprite.update(seconds(100));
     expect(sprite.currentFrame).toBe(2);
 
     sprite.stop();
@@ -159,18 +190,18 @@ describe('AnimatedSprite', () => {
     sprite.play('idle');
 
     // Frame 0 holds 100ms.
-    sprite.update(100);
+    sprite.update(seconds(100));
     expect(sprite.currentFrame).toBe(1);
 
     // Frame 1 holds 100ms.
-    sprite.update(100);
+    sprite.update(seconds(100));
     expect(sprite.currentFrame).toBe(2);
 
     // Frame 2 holds 300ms; 100ms is not enough to advance yet.
-    sprite.update(100);
+    sprite.update(seconds(100));
     expect(sprite.currentFrame).toBe(2);
 
-    sprite.update(200);
+    sprite.update(seconds(200));
     expect(sprite.currentFrame).toBe(0);
   });
 
@@ -211,7 +242,7 @@ describe('AnimatedSprite', () => {
     const sprite = AnimatedSprite.fromSpritesheet(spritesheet);
 
     sprite.play('idle');
-    sprite.update(84);
+    sprite.update(seconds(84));
 
     expect(sprite.currentClip).toBe('idle');
     expect(sprite.currentFrame).toBe(1);
@@ -235,12 +266,12 @@ describe('AnimatedSprite', () => {
     expect(sprite.getLocalBounds().x).toBe(0);
     expect(sprite.getLocalBounds().y).toBe(0);
 
-    sprite.update(100);
+    sprite.update(seconds(100));
     expect(sprite.currentFrame).toBe(1);
     expect(sprite.getLocalBounds().x).toBe(4);
     expect(sprite.getLocalBounds().y).toBe(-2);
 
-    sprite.update(100);
+    sprite.update(seconds(100));
     expect(sprite.currentFrame).toBe(2);
     expect(sprite.getLocalBounds().x).toBe(0);
     expect(sprite.getLocalBounds().y).toBe(0);
@@ -256,7 +287,7 @@ describe('AnimatedSprite', () => {
     });
 
     sprite.play('walk');
-    sprite.update(100);
+    sprite.update(seconds(100));
 
     expect(sprite.getLocalBounds().x).toBe(0);
     expect(sprite.getLocalBounds().y).toBe(0);
@@ -309,23 +340,23 @@ describe('AnimatedSprite', () => {
 
       // Each cycle is 3 frames @ 10fps = 300ms. Advance through 2 full
       // cycles first — playback should still be running, no onComplete yet.
-      sprite.update(300);
+      sprite.update(seconds(300));
       expect(sprite.playing).toBe(true);
       expect(completeSpy).not.toHaveBeenCalled();
 
-      sprite.update(300);
+      sprite.update(seconds(300));
       expect(sprite.playing).toBe(true);
       expect(completeSpy).not.toHaveBeenCalled();
 
       // Third cycle: stops on the last frame and fires onComplete exactly once.
-      sprite.update(300);
+      sprite.update(seconds(300));
       expect(sprite.playing).toBe(false);
       expect(sprite.currentFrame).toBe(2);
       expect(completeSpy).toHaveBeenCalledTimes(1);
       expect(completeSpy).toHaveBeenCalledWith('triple');
 
       // Further updates are a no-op once stopped.
-      sprite.update(300);
+      sprite.update(seconds(300));
       expect(sprite.playing).toBe(false);
       expect(completeSpy).toHaveBeenCalledTimes(1);
     });
@@ -341,8 +372,8 @@ describe('AnimatedSprite', () => {
       });
 
       sprite.play('finite');
-      sprite.update(300);
-      sprite.update(300);
+      sprite.update(seconds(300));
+      sprite.update(seconds(300));
 
       expect(sprite.playing).toBe(false);
       expect(sprite.currentFrame).toBe(2);
@@ -361,8 +392,8 @@ describe('AnimatedSprite', () => {
 
       sprite.onComplete.add(completeSpy);
       sprite.play('twice');
-      sprite.update(300);
-      sprite.update(300);
+      sprite.update(seconds(300));
+      sprite.update(seconds(300));
 
       expect(sprite.playing).toBe(false);
       expect(completeSpy).toHaveBeenCalledTimes(1);
@@ -373,11 +404,11 @@ describe('AnimatedSprite', () => {
       sprite.play('twice');
       expect(sprite.playing).toBe(true);
 
-      sprite.update(300);
+      sprite.update(seconds(300));
       expect(sprite.playing).toBe(true);
       expect(completeSpy).toHaveBeenCalledTimes(1);
 
-      sprite.update(300);
+      sprite.update(seconds(300));
       expect(sprite.playing).toBe(false);
       expect(completeSpy).toHaveBeenCalledTimes(2);
     });
@@ -392,7 +423,7 @@ describe('AnimatedSprite', () => {
 
       sprite.onComplete.add(completeSpy);
       sprite.play('walk', { repeat: 1 });
-      sprite.update(300);
+      sprite.update(seconds(300));
 
       expect(sprite.playing).toBe(false);
       expect(completeSpy).toHaveBeenCalledWith('walk');
@@ -426,40 +457,40 @@ describe('AnimatedSprite', () => {
       sprite.play('combo');
 
       // ── Cycle 1 ──
-      sprite.update(100); // frame 0 -> 1
+      sprite.update(seconds(100)); // frame 0 -> 1
       expect(sprite.currentFrame).toBe(1);
 
-      sprite.update(100); // frame 1 -> 2
+      sprite.update(seconds(100)); // frame 1 -> 2
       expect(sprite.currentFrame).toBe(2);
 
       // Frame 2 holds 300ms; short of that must not wrap yet.
-      sprite.update(299);
+      sprite.update(seconds(299));
       expect(sprite.currentFrame).toBe(2);
       expect(sprite.playing).toBe(true);
       expect(completeSpy).not.toHaveBeenCalled();
 
       // The remaining 1ms completes frame 2's 300ms hold and wraps into cycle 2.
-      sprite.update(1);
+      sprite.update(seconds(1));
       expect(sprite.currentFrame).toBe(0);
       expect(sprite.playing).toBe(true);
       expect(completeSpy).not.toHaveBeenCalled();
 
       // ── Cycle 2 — same per-frame durations must apply again ──
-      sprite.update(100); // frame 0 -> 1
+      sprite.update(seconds(100)); // frame 0 -> 1
       expect(sprite.currentFrame).toBe(1);
 
-      sprite.update(100); // frame 1 -> 2
+      sprite.update(seconds(100)); // frame 1 -> 2
       expect(sprite.currentFrame).toBe(2);
 
       // Short of frame 2's 300ms hold on the final cycle: still not complete.
-      sprite.update(299);
+      sprite.update(seconds(299));
       expect(sprite.currentFrame).toBe(2);
       expect(sprite.playing).toBe(true);
       expect(completeSpy).not.toHaveBeenCalled();
 
       // The final 1ms genuinely completes the 2nd full cycle (500ms of real
       // per-frame hold time each, 1000ms total) and fires onComplete exactly once.
-      sprite.update(1);
+      sprite.update(seconds(1));
       expect(sprite.currentFrame).toBe(2);
       expect(sprite.playing).toBe(false);
       expect(completeSpy).toHaveBeenCalledTimes(1);
@@ -483,7 +514,7 @@ describe('AnimatedSprite', () => {
 
       sprite.onComplete.add(completeSpy);
       sprite.play('still');
-      sprite.update(1000);
+      sprite.update(seconds(1000));
 
       expect(sprite.currentFrame).toBe(0);
       expect(sprite.playing).toBe(true);

--- a/test/rendering/browser/webgl2-animated-sprite.test.ts
+++ b/test/rendering/browser/webgl2-animated-sprite.test.ts
@@ -142,7 +142,7 @@ describe('WebGL2 AnimatedSprite — frame-region UV swap', () => {
       expectPixelNear(readWebGl2Pixel(backend, 16, 16), [255, 0, 0, 255]);
 
       // Advance exactly one frame's worth of time (fps 10 → 100ms/frame)
-      sprite.update(100);
+      sprite.update(100 / 1000);
       expect(sprite.currentFrame).toBe(1);
 
       render(backend, root);
@@ -170,7 +170,7 @@ describe('WebGL2 AnimatedSprite — frame-region UV swap', () => {
       sprite.setPosition(8, 8);
       root.addChild(sprite);
 
-      sprite.update(100);
+      sprite.update(100 / 1000);
       expect(sprite.currentFrame).toBe(1);
 
       // Restart (the default) rewinds to frame 0

--- a/test/rendering/browser/webgpu-animated-sprite.test.ts
+++ b/test/rendering/browser/webgpu-animated-sprite.test.ts
@@ -168,7 +168,7 @@ describe('WebGPU AnimatedSprite — frame-region UV swap', () => {
       expectPixelNear(readPixel(16, 16), [255, 0, 0, 255]);
 
       // Advance exactly one frame's worth of time (fps 10 → 100ms/frame)
-      sprite.update(100);
+      sprite.update(100 / 1000);
       expect(sprite.currentFrame).toBe(1);
 
       if (!(await renderScene(ctx, backend, root))) {
@@ -201,7 +201,7 @@ describe('WebGPU AnimatedSprite — frame-region UV swap', () => {
       sprite.setPosition(8, 8);
       root.addChild(sprite);
 
-      sprite.update(100);
+      sprite.update(100 / 1000);
       expect(sprite.currentFrame).toBe(1);
 
       // Restart (the default) rewinds to frame 0


### PR DESCRIPTION
Fixes HI-15 from the independent architecture review: `AnimatedSprite` was the only timed subsystem outside the `SystemRegistry` model — nothing in the engine ticked it, so every playing sprite needed a hand-written `update()` call. It also accepted `update(delta: Time | number)` where the plain-number branch meant milliseconds, the opposite unit to `Tween.update(deltaSeconds)` — a 1000× error waiting to happen.

New `AnimationManager`, exposed as `app.animations` and wired exactly like `TweenManager` (a public field registered through `_addCoreSystem` at a new `SystemOrder.CoreAnimation`, after tweens and before rendering). `AnimatedSprite` joins and leaves it automatically: registration is the conjunction of "playback running" and "attached to an application-owned tree", reconciled from a single place so `play()` called before `addChild()` works correctly, and a stopped/detached/destroyed sprite is never ticked after teardown.

**BREAKING CHANGE:** `AnimatedSprite.update(deltaSeconds: number)` — seconds only, matching `Tween.update`. The `Time | number` union is gone. Clip authoring units are unchanged (`frameDurations` stays milliseconds, `fps` stays frames-per-second); only the incoming delta argument's unit changed. `update()` stays public for a sprite that never enters an application's scene tree (immediate-mode rendering) — it has no owning manager to reach and must still be driven by hand.