### PR TITLE
feat(assets): cancel in-flight asset loads nobody is waiting for any more

### DIFF
--- a/site/src/content/api/asset-loader-context.json
+++ b/site/src/content/api/asset-loader-context.json
@@ -6,11 +6,11 @@
   "subsystem": "assets",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 5,
+  "memberCount": 6,
   "counts": {
     "constructors": 0,
     "methods": 3,
-    "properties": 2,
+    "properties": 3,
     "events": 0
   },
   "sections": [
@@ -256,6 +256,31 @@
           "params": [],
           "returnType": null,
           "description": "The owning Loader instance."
+        },
+        {
+          "name": "signal",
+          "signature": "signal?: AbortSignal",
+          "signatureTokens": [
+            {
+              "text": "signal",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "AbortSignal",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Cancellation signal for the load this handler invocation belongs to. It aborts once no claim scope needs the result any more — a scene torn down mid-navigation, or a LoadingQueue.cancel call. The fetch* helpers below already forward it, so a handler built out of them needs no extra work. Forward it explicitly to any fetching or decoding the handler performs itself; undefined means the caller started this load without a cancellation channel."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/loading-queue.json
+++ b/site/src/content/api/loading-queue.json
@@ -1,16 +1,16 @@
 {
   "title": "LoadingQueue",
-  "description": "An awaitable, progress-aware load operation. Implements `PromiseLike<T>` so it can be `await`ed directly and composed with `Promise.all([queue1, queue2])` without wrapping. Progress is updated as individual items complete via _notifyItem.",
+  "description": "An awaitable, progress-aware load operation. Implements `PromiseLike<T>` so it can be `await`ed directly and composed with `Promise.all([queue1, queue2])` without wrapping. Progress is updated as individual items complete via _notifyItem. A load that is no longer wanted can be dropped with cancel.",
   "symbol": "LoadingQueue",
   "kind": "class",
   "subsystem": "assets",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 5,
+  "memberCount": 7,
   "counts": {
     "constructors": 0,
-    "methods": 3,
-    "properties": 1,
+    "methods": 4,
+    "properties": 2,
     "events": 1
   },
   "sections": [
@@ -21,7 +21,7 @@
       "paragraphs": [
         "An awaitable, progress-aware load operation.",
         "Implements `PromiseLike<T>` so it can be `await`ed directly and composed with `Promise.all([queue1, queue2])` without wrapping.",
-        "Progress is updated as individual items complete via _notifyItem."
+        "Progress is updated as individual items complete via _notifyItem. A load that is no longer wanted can be dropped with cancel."
       ],
       "importLine": "import { LoadingQueue } from '@codexo/exojs'",
       "sourceLink": null
@@ -30,6 +30,35 @@
       "id": "methods",
       "title": "Methods",
       "members": [
+        {
+          "name": "cancel",
+          "signature": "cancel(): void",
+          "signatureTokens": [
+            {
+              "text": "cancel",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "void",
+          "description": "Gives up on this load: drops the claims it registered and, once no other claim scope still wants the same asset, aborts the in-flight network request behind it. Idempotent. This is a claim-level operation, so the underlying fetch survives as long as anyone else needs it — a second scene loading the same texture keeps it downloading, and only the last cancellation actually stops the request. The queue then rejects with the platform's AbortError; a cancelled load is deliberately NOT reported through Loader.onError, since nothing failed. Cancelling a load whose assets are already resident behaves like Loader.release(...) for the keys this call claimed: the result is no longer wanted, so it is freed at refcount 0."
+        },
         {
           "name": "catch",
           "signature": "catch(onrejected?: (reason: unknown) => Caught | PromiseLike<Caught> | null): Promise<T | Caught>",
@@ -429,6 +458,27 @@
       "id": "properties",
       "title": "Properties",
       "members": [
+        {
+          "name": "cancelled",
+          "signature": "cancelled: boolean",
+          "signatureTokens": [
+            {
+              "text": "cancelled",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Whether cancel has been called on this queue."
+        },
         {
           "name": "progress",
           "signature": "progress: LoadingProgress",

--- a/src/assets/AssetDecoder.ts
+++ b/src/assets/AssetDecoder.ts
@@ -6,6 +6,7 @@ import type { CacheStore } from './CacheStore';
 import type { CacheStrategy } from './CacheStrategy';
 import type { AssetConstructor } from './FactoryRegistry';
 import type { AssetLoaderContext, Loader } from './Loader';
+import { isAbortError } from './SharedAbort';
 
 /** Sink a decoded resource is handed to, returning the value callers should see for it. */
 export type ResourceStore = (type: AssetConstructor, alias: string, resource: unknown) => unknown;
@@ -109,7 +110,7 @@ export class AssetDecoder {
    * identity function — the cached value is returned unchanged.
    * @internal
    */
-  public _contextFetch<T>(source: string, storageName: string, process: (response: Response) => Promise<T>): Promise<T> {
+  public _contextFetch<T>(source: string, storageName: string, process: (response: Response) => Promise<T>, signal?: AbortSignal): Promise<T> {
     const url = this._resolveUrl(source);
     const factory: AssetFactory<T> = {
       storageName,
@@ -119,10 +120,11 @@ export class AssetDecoder {
         // Nothing to release: this strategy hands back the decoded value as-is.
       },
     };
-    return this._cacheStrategy.resolve(
-      { storageName, key: source, url, requestOptions: this._fetchOptions, factory, options: undefined },
-      this._stores,
-    ) as Promise<T>;
+    // Spread only when a signal is actually threaded through, so a plain fetch
+    // keeps handing the strategy the very `fetchOptions` object it always did.
+    const requestOptions = signal === undefined ? this._fetchOptions : { ...this._fetchOptions, signal };
+
+    return this._cacheStrategy.resolve({ storageName, key: source, url, requestOptions, factory, options: undefined }, this._stores) as Promise<T>;
   }
 
   /**
@@ -137,15 +139,21 @@ export class AssetDecoder {
    * namespace for every `fetch*` call made through this context, giving the
    * binding its own IDB namespace instead of sharing one with every other
    * handler.
+   *
+   * `signal` is the cancellation signal of the load this handler invocation
+   * belongs to. Every `fetch*` helper forwards it automatically; it is also
+   * exposed on the context so a handler doing its own fetching or decoding can
+   * honor it.
    * @internal
    */
-  public _buildHandlerContext(identityKey: string, storageName?: string): AssetLoaderContext {
+  public _buildHandlerContext(identityKey: string, storageName?: string, signal?: AbortSignal): AssetLoaderContext {
     const ctx: AssetLoaderContext = {
       loader: this._loader,
       identityKey,
-      fetchText: (source: string) => this._contextFetch<string>(source, storageName ?? '__ctx_text', r => r.text()),
-      fetchArrayBuffer: (source: string) => this._contextFetch<ArrayBuffer>(source, storageName ?? '__ctx_binary', r => r.arrayBuffer()),
-      fetchJson: <T = unknown>(source: string) => this._contextFetch<T>(source, storageName ?? '__ctx_json', r => r.json() as Promise<T>),
+      signal,
+      fetchText: (source: string) => this._contextFetch<string>(source, storageName ?? '__ctx_text', r => r.text(), signal),
+      fetchArrayBuffer: (source: string) => this._contextFetch<ArrayBuffer>(source, storageName ?? '__ctx_binary', r => r.arrayBuffer(), signal),
+      fetchJson: <T = unknown>(source: string) => this._contextFetch<T>(source, storageName ?? '__ctx_json', r => r.json() as Promise<T>, signal),
     };
     return ctx;
   }
@@ -158,6 +166,10 @@ export class AssetDecoder {
    * by calling `context.fetchText` /
    * `context.fetchArrayBuffer` / `context.fetchJson`, which route through
    * the loader's cache strategy.
+   *
+   * A cancellation rejection is rethrown unwrapped: the "Failed to load … from
+   * …" envelope would hide the `AbortError` name the residency dispatches on to
+   * tell a deliberate cancel apart from a genuine load failure.
    * @internal
    */
   public async _fetchWithHandler(
@@ -174,6 +186,10 @@ export class AssetDecoder {
 
       return this._storeResource(type, alias, resource);
     } catch (error: unknown) {
+      if (isAbortError(error)) {
+        throw error;
+      }
+
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to load "${alias}" from "${url}": ${message}`, { cause: error });
     }
@@ -183,9 +199,12 @@ export class AssetDecoder {
    * Dispatches a load through the `bindAsset` handler bound for `type`.
    * Shared by the foreground and background fetch dispatchers on `Loader` so
    * both honor `bindAsset` handlers identically.
+   *
+   * `signal` cancels the dispatched work — it reaches the network through the
+   * handler context's `fetch*` helpers.
    * @internal
    */
-  public _dispatchFetch(type: AssetConstructor, alias: string, path: string, options?: unknown): Promise<unknown> {
+  public _dispatchFetch(type: AssetConstructor, alias: string, path: string, options?: unknown, signal?: AbortSignal): Promise<unknown> {
     const handlerEntry = this._typeRegistry.getHandler(type);
 
     if (!handlerEntry) {
@@ -199,7 +218,7 @@ export class AssetDecoder {
       Object.assign(config, options as Record<string, unknown>);
     }
 
-    const context = this._buildHandlerContext(identityKey, handlerEntry.storageName);
+    const context = this._buildHandlerContext(identityKey, handlerEntry.storageName, signal);
 
     return this._fetchWithHandler(type, alias, path, config, handlerEntry.load, context);
   }

--- a/src/assets/AssetResidency.ts
+++ b/src/assets/AssetResidency.ts
@@ -9,6 +9,7 @@ import { AssetRef } from './AssetRef';
 import type { AssetTypeRegistry } from './AssetTypeRegistry';
 import type { AssetConstructor } from './FactoryRegistry';
 import type { SeamlessAdapter } from './seamless';
+import { isAbortError, SharedAbort } from './SharedAbort';
 import { WeakHandleSet } from './WeakHandleSet';
 
 interface QueueEntry {
@@ -101,6 +102,15 @@ export class AssetResidency {
   private readonly _resourceKeys = new WeakMap<object, { type: AssetConstructor; source: string }>();
   private readonly _inFlight = new Map<string, Promise<unknown>>();
   private readonly _preventStoreKeys = new Set<string>();
+
+  // ── Cancellation ──────────────────────────────────────────────────────────
+  // One {@link SharedAbort} per in-flight fetch, mirroring the two dedup
+  // keyspaces below it: `_abortByKey` for an alias-keyed fetch (one holder —
+  // the key itself), `_abortByIdentity` for an identity-deduped fetch whose
+  // holders are every alias key riding it. Aborting is therefore never a
+  // property of one consumer's cancel, but of the LAST holder leaving.
+  private readonly _abortByKey = new Map<string, SharedAbort>();
+  private readonly _abortByIdentity = new Map<string, SharedAbort>();
 
   // ── Identity / alias tracking for the Asset API ───────────────────────────
   private readonly _aliasKeyToIdentityKey = new Map<string, string>();
@@ -322,11 +332,12 @@ export class AssetResidency {
    * the twin path in {@link _evictValueKey} instead.
    *
    * Only a payload that has already converged into `_resources` is dropped here.
-   * A fetch still in flight (nothing stored yet) is left to the running fetch,
-   * which fills then frees on arrival — evicting mid-flight would race it. The
-   * value path is gated identically: the same race exists there (a claim can be
-   * released while the key's single fetch is still running), and the same rule
-   * resolves it.
+   * A fetch still in flight (nothing stored yet) has nothing to evict — it is
+   * CANCELLED instead: reaching refcount 0 means no claim scope is waiting for
+   * its result any more, which is exactly the condition the key's
+   * {@link SharedAbort} arms on. A fetch other holders still ride (a second
+   * alias on the same identity-deduped request) is left running; only the last
+   * departure aborts it. The value path is gated identically.
    */
   private _evictKey(key: string, type: AssetConstructor, source: string): void {
     const adapter = this._typeRegistry.getSeamlessAdapter(type);
@@ -378,6 +389,12 @@ export class AssetResidency {
     // for a seamless type the stored resource is always the handle object.
     else if (adapter === undefined && this._hasStored(type, source)) {
       this._evictValueKey(key, type, source, stored);
+    }
+    // Nothing resident: whatever fetch is running for this key (if any) has no
+    // claimer left waiting on it. Cancel it, and mark the key evicted so a later
+    // claim re-drives the fetch into the handles this abort leaves behind.
+    else if (this._abortInFlight(key)) {
+      this._evicted.add(key);
     }
 
     const queued = this._backgroundQueue.findIndex(entry => this._typeRegistry._key(entry.type, entry.alias) === key);
@@ -983,15 +1000,48 @@ export class AssetResidency {
    * never released and the queue wedges.
    */
   private _dispatchTracked(type: AssetConstructor, alias: string, path: string, options: unknown): Promise<unknown> {
+    const key = this._typeRegistry._key(type, alias);
+    const abort = new SharedAbort(key);
+
+    this._abortByKey.set(key, abort);
+
     let fetch: Promise<unknown>;
 
     try {
-      fetch = this._decoder._dispatchFetch(type, alias, path, options);
+      fetch = this._decoder._dispatchFetch(type, alias, path, options, abort.signal);
     } catch (error: unknown) {
       fetch = Promise.reject(this._normalizeError(error));
     }
 
-    return this._trackInFlight(type, alias, fetch);
+    return this._trackInFlight(type, alias, fetch, abort);
+  }
+
+  /**
+   * Drop `key`'s interest in whatever fetch is running for it, in BOTH dedup
+   * keyspaces: its own alias-keyed request, and the identity-deduped request it
+   * may share with sibling aliases. Returns whether either was actually
+   * aborted — a fetch a sibling holder still needs stays running.
+   */
+  private _abortInFlight(key: string): boolean {
+    let aborted = this._releaseAbort(this._abortByKey, key, key);
+    const identityKey = this._aliasKeyToIdentityKey.get(key);
+
+    if (identityKey !== undefined) {
+      aborted = this._releaseAbort(this._abortByIdentity, identityKey, key) || aborted;
+    }
+
+    return aborted;
+  }
+
+  /** Release one holder from a tracked {@link SharedAbort}, forgetting the handle if that aborted it. */
+  private _releaseAbort(handles: Map<string, SharedAbort>, handleKey: string, holder: string): boolean {
+    if (handles.get(handleKey)?.release(holder) !== true) {
+      return false;
+    }
+
+    handles.delete(handleKey);
+
+    return true;
   }
 
   /**
@@ -1026,13 +1076,20 @@ export class AssetResidency {
 
     const existing = this._inFlightByIdentity.get(identityKey);
     if (existing) {
+      // Join the shared request as an extra holder: this alias's own release
+      // must not cancel a fetch the alias that started it is still waiting on.
+      this._abortByIdentity.get(identityKey)?.retain(aliasKey);
+
       return existing.then(resource => this._storeResource(type, alias, resource));
     }
+
+    const abort = new SharedAbort(aliasKey);
+    this._abortByIdentity.set(identityKey, abort);
 
     let fetchPromise: Promise<unknown>;
     if (handlerEntry) {
       const fullConfig = { source, ...extraOnly };
-      const context = this._decoder._buildHandlerContext(identityKey, handlerEntry.storageName);
+      const context = this._decoder._buildHandlerContext(identityKey, handlerEntry.storageName, abort.signal);
       fetchPromise = this._decoder._fetchWithHandler(type, alias, source, fullConfig, handlerEntry.load, context);
     } else {
       fetchPromise = Promise.reject(this._typeRegistry._missingHandlerError(type));
@@ -1040,6 +1097,12 @@ export class AssetResidency {
 
     const tracked: Promise<unknown> = fetchPromise
       .finally(() => {
+        abort.settle();
+
+        if (this._abortByIdentity.get(identityKey) === abort) {
+          this._abortByIdentity.delete(identityKey);
+        }
+
         this._inFlightByIdentity.delete(identityKey);
       })
       .then(
@@ -1065,7 +1128,7 @@ export class AssetResidency {
     return tracked;
   }
 
-  private _trackInFlight(type: AssetConstructor, alias: string, promise: Promise<unknown>): Promise<unknown> {
+  private _trackInFlight(type: AssetConstructor, alias: string, promise: Promise<unknown>, abort?: SharedAbort): Promise<unknown> {
     const key = this._typeRegistry._key(type, alias);
     const trackedPromise = promise.finally(() => {
       // Clear only our OWN entry: a superseding load (e.g. a reclaim re-fetch
@@ -1077,6 +1140,15 @@ export class AssetResidency {
       }
 
       this._preventStoreKeys.delete(key);
+
+      // Disarm cancellation in the same tick the fetch settles: a release
+      // arriving afterwards must not abort a request whose result already
+      // landed. Same self-entry identity guard as the in-flight slot above.
+      abort?.settle();
+
+      if (abort !== undefined && this._abortByKey.get(key) === abort) {
+        this._abortByKey.delete(key);
+      }
     });
 
     // Non-swallowing observer: fails deferred handles / value refs (fresh
@@ -1088,8 +1160,21 @@ export class AssetResidency {
     return trackedPromise;
   }
 
+  /**
+   * Central failure sink for a tracked fetch.
+   *
+   * A CANCELLED fetch takes the same handle bookkeeping but none of the
+   * reporting: every handle/ref still has to settle — leaving them `'loading'`
+   * would strand `.loaded` and the load queues awaiting it forever — while
+   * `onError` and the missing-source diagnostic stay silent, because nothing
+   * failed. A cancel only ever happens once the key's last claim is gone, so
+   * there is no consumer left to surprise with someone else's cancellation, and
+   * the `'failed'` state it leaves behind is the same retry request a later
+   * `get()`/`_adopt`/claim already knows how to heal.
+   */
   private _onTrackedFailure(type: AssetConstructor, alias: string, key: string, error: unknown): void {
     const err = this._normalizeError(error);
+    const cancelled = isAbortError(error);
     const deferredEntry = this._deferred.get(key);
 
     if (deferredEntry !== undefined) {
@@ -1099,7 +1184,9 @@ export class AssetResidency {
         adapter?.fail(handle, err);
       }
 
-      this._warnMissingSource(alias, key, err);
+      if (!cancelled) {
+        this._warnMissingSource(alias, key, err);
+      }
     } else {
       const refEntry = this._refs.get(key);
 
@@ -1108,11 +1195,15 @@ export class AssetResidency {
           ref._fail(err);
         }
 
-        this._warnMissingSource(alias, key, err);
+        if (!cancelled) {
+          this._warnMissingSource(alias, key, err);
+        }
       }
     }
 
-    this._signals.onError.dispatch(type, alias, err);
+    if (!cancelled) {
+      this._signals.onError.dispatch(type, alias, err);
+    }
   }
 
   /**
@@ -1619,8 +1710,25 @@ export class AssetResidency {
   // Lifecycle
   // -----------------------------------------------------------------------
 
-  /** Clears all resident-resource, in-flight, claim, and background-queue state. Called from `Loader.destroy()`. */
+  /**
+   * Clears all resident-resource, in-flight, claim, and background-queue state,
+   * cancelling every fetch still running. Called from `Loader.destroy()` — the
+   * loader is going away, so no holder can possibly still want a result, and a
+   * download left running would only compete for bandwidth with whatever
+   * replaces it.
+   */
   public destroy(): void {
+    for (const abort of this._abortByKey.values()) {
+      abort.abort();
+    }
+
+    for (const abort of this._abortByIdentity.values()) {
+      abort.abort();
+    }
+
+    this._abortByKey.clear();
+    this._abortByIdentity.clear();
+
     this._resources.clear();
     this._inFlight.clear();
     this._preventStoreKeys.clear();

--- a/src/assets/Loader.ts
+++ b/src/assets/Loader.ts
@@ -26,6 +26,7 @@ import type { CacheStrategy } from './CacheStrategy';
 import type { AssetConstructor } from './FactoryRegistry';
 import { LoadingQueue } from './LoadingQueue';
 import type { SeamlessAdapter } from './seamless';
+import { isAbortError } from './SharedAbort';
 import { BinaryAsset, CsvAsset, Json, SubtitleAsset, TextAsset, WasmAsset, XmlAsset } from './tokens';
 
 /** Normalize the single-or-many `cache` option into the list the decoder takes. */
@@ -76,6 +77,17 @@ export interface AssetLoaderContext {
    * Useful for diagnostics; also equals the key used for in-flight dedup.
    */
   readonly identityKey: string;
+  /**
+   * Cancellation signal for the load this handler invocation belongs to. It
+   * aborts once no claim scope needs the result any more — a scene torn down
+   * mid-navigation, or a {@link LoadingQueue.cancel} call.
+   *
+   * The `fetch*` helpers below already forward it, so a handler built out of
+   * them needs no extra work. Forward it explicitly to any fetching or decoding
+   * the handler performs itself; `undefined` means the caller started this load
+   * without a cancellation channel.
+   */
+  readonly signal?: AbortSignal | undefined;
   /** Fetches `source` as UTF-8 text, routing through the loader's cache/IDB. */
   fetchText(source: string): Promise<string>;
   /** Fetches `source` as an `ArrayBuffer`, routing through the loader's cache/IDB. */
@@ -504,7 +516,7 @@ export class Loader {
         this._adopt(leaf, claimer, background);
       }
 
-      return this._createAdoptedQueue(entries, results => {
+      return this._createAdoptedQueue(claimer, entries, results => {
         const out: Record<string, unknown> = {};
 
         for (const [alias] of entries) {
@@ -522,7 +534,7 @@ export class Loader {
       const background = (arg1 as LoadOptions | undefined)?.priority === LoadPriority.Background;
       this._adopt(leaf, claimer, background);
 
-      return this._createAdoptedQueue([['value', leaf]], results => results.get('value'));
+      return this._createAdoptedQueue(claimer, [['value', leaf]], results => results.get('value'));
     }
 
     // 2b. Bare path string — normalize it to a `{ type, source }` descriptor and
@@ -540,7 +552,9 @@ export class Loader {
       // The font type requires a family option — infer it from the filename when not provided
       const options: unknown = type === 'font' ? { family: (path.split('/').pop()?.split(/[?#]/)[0] ?? '').replace(/\.[^.]+$/, '') } : undefined;
 
-      this._claim(this._typeRegistry._key(ctor, path), ctor, path, claimer);
+      const key = this._typeRegistry._key(ctor, path);
+
+      this._claim(key, ctor, path, claimer);
       this._onFgBatchStart(path, path);
       let notifyFn: ((success: boolean) => void) | null = null;
       const promise = this._residency._loadSingle(ctor, path, options).then(
@@ -551,11 +565,11 @@ export class Loader {
         },
         e => {
           notifyFn?.(false);
-          this._onFgBatchSettled(path, false, this._normalizeError(e));
+          this._onFgBatchSettled(path, false, this._settleError(e));
           throw e;
         },
       );
-      const queue = new LoadingQueue(promise, 1);
+      const queue = new LoadingQueue(promise, 1, () => this._cancelClaims(claimer, [key]));
       notifyFn = queue._notifyItem.bind(queue);
       return queue;
     }
@@ -1091,6 +1105,7 @@ export class Loader {
     buildResult: (results: Map<string, unknown>) => T,
   ): LoadingQueue<T> {
     const results = new Map<string, unknown>();
+    const claimedKeys: string[] = [];
     let notifyFn: ((success: boolean) => void) | null = null;
 
     const itemPromises = items.map(({ alias, asset }) => {
@@ -1107,13 +1122,16 @@ export class Loader {
           },
           error => {
             notifyFn?.(false);
-            this._onFgBatchSettled(alias, false, this._normalizeError(error));
+            this._onFgBatchSettled(alias, false, this._settleError(error));
             throw error;
           },
         );
       }
 
-      this._claim(this._typeRegistry._key(ctor, alias), ctor, alias, claimer);
+      const key = this._typeRegistry._key(ctor, alias);
+
+      claimedKeys.push(key);
+      this._claim(key, ctor, alias, claimer);
 
       return this._residency._loadSingleAsset(ctor, alias, asset).then(
         resource => {
@@ -1123,7 +1141,7 @@ export class Loader {
         },
         error => {
           notifyFn?.(false);
-          this._onFgBatchSettled(alias, false, this._normalizeError(error));
+          this._onFgBatchSettled(alias, false, this._settleError(error));
           throw error;
         },
       );
@@ -1131,7 +1149,7 @@ export class Loader {
 
     const promise = Promise.all(itemPromises).then(() => buildResult(results));
 
-    const queue = new LoadingQueue<T>(promise, items.length);
+    const queue = new LoadingQueue<T>(promise, items.length, () => this._cancelClaims(claimer, claimedKeys));
     notifyFn = queue._notifyItem.bind(queue);
 
     return queue;
@@ -1144,11 +1162,17 @@ export class Loader {
    * fetch is already driven by `_adopt`; each item's promise is simply the
    * leaf's own readiness promise (`leaf.loaded` — `Promise<this>` for a resource
    * handle, `Promise<T>` for an `AssetRef`). No `_claim` here: adoption already
-   * claimed each key. `buildResult` shapes the resolved values into the return.
+   * claimed each key — `claimer` is carried only so {@link LoadingQueue.cancel}
+   * can drop those very claims again. `buildResult` shapes the resolved values
+   * into the return.
    * @internal
    */
-  private _createAdoptedQueue<T>(entries: Array<[string, object]>, buildResult: (results: Map<string, unknown>) => T): LoadingQueue<T> {
+  private _createAdoptedQueue<T>(claimer: symbol, entries: Array<[string, object]>, buildResult: (results: Map<string, unknown>) => T): LoadingQueue<T> {
     const results = new Map<string, unknown>();
+    // Adoption registered every leaf under its residency key, so the reverse
+    // lookup is the honest source for what this queue claimed — the Loader does
+    // not re-derive the keys the residency just resolved.
+    const claimedKeys = entries.map(([, leaf]) => this._residency._getHandleKey(leaf)).filter((key): key is string => key !== undefined);
     let notifyFn: ((success: boolean) => void) | null = null;
 
     const itemPromises = entries.map(([alias, leaf]) => {
@@ -1164,7 +1188,7 @@ export class Loader {
         },
         error => {
           notifyFn?.(false);
-          this._onFgBatchSettled(alias, false, this._normalizeError(error));
+          this._onFgBatchSettled(alias, false, this._settleError(error));
           throw error;
         },
       );
@@ -1172,10 +1196,22 @@ export class Loader {
 
     const promise = Promise.all(itemPromises).then(() => buildResult(results));
 
-    const queue = new LoadingQueue<T>(promise, entries.length);
+    const queue = new LoadingQueue<T>(promise, entries.length, () => this._cancelClaims(claimer, claimedKeys));
     notifyFn = queue._notifyItem.bind(queue);
 
     return queue;
+  }
+
+  /**
+   * Back {@link LoadingQueue.cancel}: drop the claims this load registered
+   * under its own scope. Whether that actually stops a download is decided one
+   * level down — the residency aborts the in-flight fetch only once the key has
+   * no claim scope left, so a sibling scene loading the same asset keeps it.
+   */
+  private _cancelClaims(claimer: symbol, keys: readonly string[]): void {
+    for (const key of keys) {
+      this._release(key, claimer);
+    }
   }
 
   // -----------------------------------------------------------------------
@@ -1213,5 +1249,15 @@ export class Loader {
 
   private _normalizeError(error: unknown): Error {
     return error instanceof Error ? error : new Error(String(error));
+  }
+
+  /**
+   * The error a settling batch item should REPORT, or `undefined` for a
+   * cancellation. A cancelled load still settles the batch (so `onLoadProgress`
+   * and `onLoadComplete` stay in lockstep with what was started), but it is not
+   * a failure and must not reach {@link onLoadError} — the caller asked for it.
+   */
+  private _settleError(error: unknown): Error | undefined {
+    return isAbortError(error) ? undefined : this._normalizeError(error);
   }
 }

--- a/src/assets/LoadingQueue.ts
+++ b/src/assets/LoadingQueue.ts
@@ -22,15 +22,18 @@ export interface LoadingProgress {
  * with `Promise.all([queue1, queue2])` without wrapping.
  *
  * Progress is updated as individual items complete via {@link _notifyItem}.
+ * A load that is no longer wanted can be dropped with {@link cancel}.
  */
 export class LoadingQueue<T> implements PromiseLike<T> {
   public readonly onProgress: Signal<[LoadingProgress]>;
 
   private _progress: LoadingProgress;
   private readonly _promise: Promise<T>;
+  private readonly _onCancel: (() => void) | undefined;
+  private _cancelled = false;
 
   /** @internal */
-  public constructor(promise: Promise<T>, count: number) {
+  public constructor(promise: Promise<T>, count: number, onCancel?: () => void) {
     this.onProgress = new Signal<[LoadingProgress]>();
     this._progress = {
       total: count,
@@ -39,10 +42,40 @@ export class LoadingQueue<T> implements PromiseLike<T> {
       failed: 0,
     };
     this._promise = promise;
+    this._onCancel = onCancel;
   }
 
   public get progress(): LoadingProgress {
     return this._progress;
+  }
+
+  /** Whether {@link cancel} has been called on this queue. */
+  public get cancelled(): boolean {
+    return this._cancelled;
+  }
+
+  /**
+   * Gives up on this load: drops the claims it registered and, once no other
+   * claim scope still wants the same asset, aborts the in-flight network
+   * request behind it. Idempotent.
+   *
+   * This is a claim-level operation, so the underlying fetch survives as long as
+   * anyone else needs it — a second scene loading the same texture keeps it
+   * downloading, and only the last cancellation actually stops the request. The
+   * queue then rejects with the platform's `AbortError`; a cancelled load is
+   * deliberately NOT reported through `Loader.onError`, since nothing failed.
+   *
+   * Cancelling a load whose assets are already resident behaves like
+   * `Loader.release(...)` for the keys this call claimed: the result is no
+   * longer wanted, so it is freed at refcount 0.
+   */
+  public cancel(): void {
+    if (this._cancelled) {
+      return;
+    }
+
+    this._cancelled = true;
+    this._onCancel?.();
   }
 
   /** @internal Called by Loader after each item settles. */

--- a/src/assets/SharedAbort.ts
+++ b/src/assets/SharedAbort.ts
@@ -1,0 +1,91 @@
+/**
+ * One abortable operation shared by N named holders.
+ *
+ * The asset pipeline deduplicates loads: several consumers asking for the same
+ * asset attach to a single in-flight fetch. Cancellation therefore cannot be a
+ * plain "abort the controller" — the fetch must keep running for as long as ANY
+ * holder still needs its result, and only be aborted once the last one leaves.
+ *
+ * Holders are identified by string (the residency key of whoever joined), so
+ * joining twice under the same name is idempotent and a stale release can never
+ * drop someone else's interest. {@link release} reports whether that particular
+ * departure was the one that aborted the operation.
+ *
+ * Once the operation itself has settled, {@link settle} disarms the handle: a
+ * later release can no longer abort a fetch whose result already arrived.
+ * @internal
+ */
+export class SharedAbort {
+  private readonly _controller = new AbortController();
+  private readonly _holders = new Set<string>();
+  private _settled = false;
+
+  public constructor(holder: string) {
+    this._holders.add(holder);
+  }
+
+  /** The signal to hand to `fetch(url, { signal })` (and to any decode step that honors one). */
+  public get signal(): AbortSignal {
+    return this._controller.signal;
+  }
+
+  /** Whether the shared operation has already been aborted. */
+  public get aborted(): boolean {
+    return this._controller.signal.aborted;
+  }
+
+  /** How many holders currently need this operation's result. */
+  public get holders(): number {
+    return this._holders.size;
+  }
+
+  /** Join as a holder — the operation cannot be aborted while this holder stays. Idempotent. */
+  public retain(holder: string): void {
+    if (this._settled) {
+      return;
+    }
+
+    this._holders.add(holder);
+  }
+
+  /**
+   * Leave as a holder. Returns `true` only when this departure emptied the
+   * holder set and therefore aborted the operation, so the caller can drop its
+   * bookkeeping for a handle that is now spent.
+   */
+  public release(holder: string): boolean {
+    if (!this._holders.delete(holder) || this._holders.size > 0 || this._settled) {
+      return false;
+    }
+
+    this._controller.abort();
+
+    return true;
+  }
+
+  /** Abort unconditionally, whatever holders remain (teardown of the owning loader). */
+  public abort(): void {
+    this._holders.clear();
+
+    if (!this._settled) {
+      this._controller.abort();
+    }
+  }
+
+  /** The shared operation settled: its result is in, so no later release may abort it. */
+  public settle(): void {
+    this._settled = true;
+    this._holders.clear();
+  }
+}
+
+/**
+ * Whether `error` is the rejection a cancelled `fetch` (or any other
+ * `AbortSignal`-aware step) produces. Matches on `name` rather than on
+ * `instanceof DOMException` so a polyfilled or wrapped abort error is still
+ * recognized as a cancellation rather than reported as a load failure.
+ * @internal
+ */
+export function isAbortError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && (error as { name?: unknown }).name === 'AbortError';
+}

--- a/test/assets/load-cancellation.test.ts
+++ b/test/assets/load-cancellation.test.ts
@@ -1,0 +1,218 @@
+import { Assets } from '#assets/Assets';
+import { coreAssetBindings } from '#assets/coreAssetBindings';
+import { Loader } from '#assets/Loader';
+import type { Application } from '#core/Application';
+import { SceneLoader } from '#core/scene/SceneLoader';
+import { materializeAssetBindings } from '#extensions/materialize';
+import { Texture } from '#rendering/texture/Texture';
+
+/** Loader with all core asset bindings (mirrors createCoreLoader in loader-seamless.test.ts). */
+function createCoreLoader(): Loader {
+  const loader = new Loader();
+  materializeAssetBindings(loader, coreAssetBindings);
+  return loader;
+}
+
+interface PendingFetch {
+  readonly url: string;
+  readonly signal: AbortSignal | undefined;
+  settle(): void;
+}
+
+/**
+ * Replaces `fetch` with one that never settles on its own: every call is
+ * captured so a test can inspect the `AbortSignal` it was handed and settle it
+ * explicitly. Rejects exactly like the platform does when its signal aborts.
+ */
+function mockPendingFetch(): PendingFetch[] {
+  const calls: PendingFetch[] = [];
+
+  global.fetch = vi.fn(
+    async (input: unknown, init?: RequestInit): Promise<Response> =>
+      new Promise<Response>((resolve, reject) => {
+        const signal = init?.signal ?? undefined;
+        const response = {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          arrayBuffer: async () => new ArrayBuffer(8),
+        } as unknown as Response;
+
+        signal?.addEventListener('abort', () => {
+          reject(signal.reason as Error);
+        });
+
+        calls.push({ url: String(input), signal, settle: () => resolve(response) });
+      }),
+  ) as unknown as typeof fetch;
+
+  return calls;
+}
+
+/** Lets every pending microtask queued by the loader pipeline run. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
+  }
+}
+
+const originalFetch = global.fetch;
+
+describe('asset load cancellation', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async () => ({ width: 16, height: 16 })),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    global.fetch = originalFetch;
+  });
+
+  test('cancelling a load aborts the underlying fetch', async () => {
+    const calls = mockPendingFetch();
+    const loader = createCoreLoader();
+
+    const queue = loader.load('ship.png');
+    await flush();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.signal).toBeInstanceOf(AbortSignal);
+    expect(calls[0]?.signal?.aborted).toBe(false);
+
+    queue.cancel();
+
+    expect(calls[0]?.signal?.aborted).toBe(true);
+    await expect(queue).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  test('a cancelled load does not dispatch onError', async () => {
+    mockPendingFetch();
+    const loader = createCoreLoader();
+    const errors: Error[] = [];
+
+    loader.onError.add((_type, _alias, error) => errors.push(error));
+
+    const queue = loader.load('ship.png');
+    await flush();
+
+    queue.cancel();
+    await expect(queue).rejects.toMatchObject({ name: 'AbortError' });
+    await flush();
+
+    expect(errors).toEqual([]);
+  });
+
+  test('a shared fetch survives one consumer cancelling and aborts only when the last leaves', async () => {
+    const calls = mockPendingFetch();
+    const loader = createCoreLoader();
+    const app = { loader } as unknown as Application;
+
+    const sceneA = new SceneLoader(app);
+    const sceneB = new SceneLoader(app);
+
+    const queueA = sceneA.load('shared.png');
+    const queueB = sceneB.load('shared.png');
+    await flush();
+
+    // Both consumers deduped onto ONE in-flight fetch.
+    expect(calls).toHaveLength(1);
+
+    queueA.cancel();
+    expect(calls[0]?.signal?.aborted).toBe(false);
+
+    queueB.cancel();
+    expect(calls[0]?.signal?.aborted).toBe(true);
+
+    await expect(queueA).rejects.toMatchObject({ name: 'AbortError' });
+    await expect(queueB).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  test('two aliases sharing one identity-deduped fetch abort only when both release', async () => {
+    const calls = mockPendingFetch();
+    const loader = createCoreLoader();
+
+    const queue = loader.load({ a: 'same.png', b: 'same.png' } as never);
+    await flush();
+
+    expect(calls).toHaveLength(1);
+
+    loader.release(Texture, 'a');
+    expect(calls[0]?.signal?.aborted).toBe(false);
+
+    loader.release(Texture, 'b');
+    expect(calls[0]?.signal?.aborted).toBe(true);
+
+    await expect(queue).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  test('SceneLoader.destroy() aborts its scope outstanding loads', async () => {
+    const calls = mockPendingFetch();
+    const loader = createCoreLoader();
+    const app = { loader } as unknown as Application;
+    const sceneLoader = new SceneLoader(app);
+
+    const queue = sceneLoader.load('level.png');
+    await flush();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.signal?.aborted).toBe(false);
+
+    sceneLoader.destroy();
+
+    expect(calls[0]?.signal?.aborted).toBe(true);
+    await expect(queue).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  test('SceneLoader.destroy() leaves a fetch the app loader still claims running', async () => {
+    const calls = mockPendingFetch();
+    const loader = createCoreLoader();
+    const app = { loader } as unknown as Application;
+    const sceneLoader = new SceneLoader(app);
+
+    const appQueue = loader.load('kept.png');
+    const sceneQueue = sceneLoader.load('kept.png');
+    await flush();
+
+    expect(calls).toHaveLength(1);
+
+    sceneLoader.destroy();
+    expect(calls[0]?.signal?.aborted).toBe(false);
+
+    calls[0]?.settle();
+
+    await expect(appQueue).resolves.toBeInstanceOf(Texture);
+    await expect(sceneQueue).resolves.toBeInstanceOf(Texture);
+  });
+
+  test('cancelling an adopted catalog load aborts every fetch it started', async () => {
+    const calls = mockPendingFetch();
+    const loader = createCoreLoader();
+
+    const queue = loader.load(Assets.from({ hero: 'hero.png', tiles: 'tiles.png' }));
+    await flush();
+
+    expect(calls).toHaveLength(2);
+    expect(calls.every(call => call.signal?.aborted === false)).toBe(true);
+
+    queue.cancel();
+
+    expect(calls.every(call => call.signal?.aborted === true)).toBe(true);
+    await expect(queue).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  test('a load nobody cancels is unaffected: no abort, resolves normally', async () => {
+    const calls = mockPendingFetch();
+    const loader = createCoreLoader();
+
+    const queue = loader.load('plain.png');
+    await flush();
+
+    calls[0]?.settle();
+
+    await expect(queue).resolves.toBeInstanceOf(Texture);
+    expect(calls[0]?.signal?.aborted).toBe(false);
+  });
+});

--- a/test/assets/loader.test.ts
+++ b/test/assets/loader.test.ts
@@ -187,7 +187,9 @@ describe('Loader', () => {
     mockFetch();
     await loader.load('demo.txt');
 
-    expect(global.fetch).toHaveBeenCalledWith('/demo.txt', fetchOptions);
+    // The loader adds the load's cancellation signal on top of the configured
+    // options; every configured field must still ride along untouched.
+    expect(global.fetch).toHaveBeenCalledWith('/demo.txt', { ...fetchOptions, signal: expect.any(AbortSignal) });
   });
 
   test('load() deduplicates concurrent requests for the same alias', async () => {
@@ -1182,7 +1184,7 @@ describe('basePath / fetchOptions property accessors', () => {
 
     await loader.load('demo.txt');
 
-    expect(global.fetch).toHaveBeenCalledWith('/demo.txt', { mode: 'no-cors' });
+    expect(global.fetch).toHaveBeenCalledWith('/demo.txt', { mode: 'no-cors', signal: expect.any(AbortSignal) });
   });
 });
 


### PR DESCRIPTION
Fixes HI-12 from the independent architecture review: scene navigation could drop asset claims but never stop the work behind them. `AbortSignal` appeared nowhere on the network path, so a fast sequence of scene changes accumulated concurrent downloads that kept running after every consumer had gone away.

Loads are now abortable end to end: `AssetDecoder` threads a native `AbortSignal` into `fetch(url, { signal })` and exposes it on `AssetLoaderContext`, so a `bindAsset` handler can honour it in its own fetching/decoding work. `LoadingQueue.cancel()` exposes this to callers.

The interesting half is deciding *when* to abort. The refcount that answers it already existed: a key's claim scopes are exactly the set of consumers waiting for its payload, so refcount 0 — the eviction path — is the abort condition. Where eviction previously found nothing resident to free, there is now an in-flight fetch to cancel instead. A consequence worth noting: `SceneLoader.destroy()` aborts its scope's outstanding loads with **no wiring of its own** — releasing the scope releases its claims, and whatever key that empties gets cancelled, while a key another scope still holds keeps downloading.

The second dedup keyspace (several aliases riding one identity-deduped request, each holding its own claim) does need real counting — the new internal `SharedAbort` gives both keyspaces one primitive: named holders join and leave, only the last departure aborts, and settling disarms it so a release arriving after the result can't cancel a finished fetch.

A cancelled load rejects with the platform `AbortError` but is deliberately **not** reported through `onError`/`onLoadError` — nothing failed, and an abort can only fire once the last claim is gone, so no consumer can be surprised by someone else's cancellation. Handles and refs are still failed so awaiters settle rather than stranding `.loaded` in `loading` forever.