### PR TITLE
feat: manual render texture pool trim, per-tile collision geometry

### DIFF
--- a/examples/shared/physics-tilemap.js
+++ b/examples/shared/physics-tilemap.js
@@ -1,6 +1,6 @@
 // Auto-generated from physics-tilemap.ts — edit the .ts source, not this file.
 // Shared example recipe: build static physics colliders from a Tiled object
-// layer.
+// layer, or from a tile layer's per-tile collision geometry.
 //
 // This module is the integration seam between two intentionally decoupled
 // packages: `@codexo/exojs-tilemap` (data-only object layers) and
@@ -11,19 +11,27 @@
 // legitimate. Copy it into your own project and adapt as needed; it is a
 // recipe, not engine API.
 //
-// It walks an `ObjectLayer`, maps each geometry kind to the closest convex
-// physics shape, and adds one static `PhysicsBody` per object to the world:
+// `buildCollidersFromObjectLayer` walks an `ObjectLayer`, maps each geometry
+// kind to the closest convex physics shape, and adds one static `PhysicsBody`
+// per object to the world:
 //
 //   - Rectangle → `BoxShape`            (centred on the object's centre)
 //   - Polygon   → `PolygonShape`        (convex; concave inputs are skipped)
 //   - Ellipse   → `CircleShape`         (radius = the larger semi-axis)
 //   - Point / Polyline / Tile           (no closed area → skipped)
 //
+// `buildCollidersFromTileLayer` does the same for the per-tile collision shapes
+// authored on tileset tiles. The hard part — walking the tile grid, applying
+// tile transforms and layer offsets, and merging adjacent whole-cell boxes into
+// as few rectangles as possible — lives in `@codexo/exojs-tilemap`'s
+// `buildTileCollisionGeometry`; all that is left here is the same short
+// geometry → shape loop.
+//
 // Object coordinates are in object-layer pixel space with +Y down, matching the
 // engine's screen space, so positions map straight through. Rotation (Tiled
 // degrees, clockwise) is converted to radians on the body.
 import { BoxShape, CircleShape, PhysicsBody, PolygonShape, } from '@codexo/exojs-physics';
-import { ObjectKind } from '@codexo/exojs-tilemap';
+import { buildTileCollisionGeometry, ObjectKind, } from '@codexo/exojs-tilemap';
 const DEGREES_TO_RADIANS = Math.PI / 180;
 /**
  * Build a static {@link PhysicsBody} (one box / polygon / circle collider) for
@@ -41,14 +49,14 @@ export function buildCollidersFromObjectLayer(world, layer, options = {}) {
         if (!accept(object)) {
             continue;
         }
-        const placement = shapeForObject(object);
+        const placement = shapeForGeometry(object, object.name || String(object.id));
         if (placement === null) {
             continue;
         }
         const body = new PhysicsBody({
             type: 'static',
             position: { x: placement.x, y: placement.y },
-            angle: object.rotation * DEGREES_TO_RADIANS,
+            angle: placement.angle,
             colliders: [
                 {
                     shape: placement.shape,
@@ -64,64 +72,107 @@ export function buildCollidersFromObjectLayer(world, layer, options = {}) {
     return built;
 }
 /**
- * Map one object to a convex shape + body position, or `null` when the object
- * has no closed area (point / polyline / tile) or is a degenerate / non-convex
- * polygon. The body is positioned at the object's geometric centre so the
- * shape, which is centred on the collider origin, lines up with the object.
+ * Build static colliders from a tile layer's per-tile collision shapes — the
+ * `objectgroup` Tiled lets you draw on a tileset tile.
+ *
+ * All the geometry work is done by `buildTileCollisionGeometry` in
+ * `@codexo/exojs-tilemap`: it walks the tile grid, applies each tile's
+ * flip/rotation transform plus the tileset and layer pixel offsets, and merges
+ * adjacent whole-cell boxes into as few rectangles as it can — so a solid
+ * region becomes a handful of wide bodies instead of one body per tile. This
+ * function only turns that geometry into bodies, with the same kind → shape
+ * mapping as {@link buildCollidersFromObjectLayer}.
+ *
+ * Pass `region` to scope the build to part of the layer (a streamed chunk, the
+ * tiles around the player) instead of the whole map.
  */
-function shapeForObject(object) {
-    switch (object.kind) {
+export function buildCollidersFromTileLayer(world, layer, options = {}) {
+    const geometry = buildTileCollisionGeometry(layer, {
+        ...(options.region !== undefined && { region: options.region }),
+        ...(options.merge !== undefined && { merge: options.merge }),
+        ...(options.accept !== undefined && { accept: options.accept }),
+    });
+    const built = [];
+    const add = (placement, source) => {
+        if (placement === null) {
+            return;
+        }
+        const body = new PhysicsBody({
+            type: 'static',
+            position: { x: placement.x, y: placement.y },
+            angle: placement.angle,
+            colliders: [
+                {
+                    shape: placement.shape,
+                    friction: options.friction ?? 0.6,
+                    restitution: options.restitution ?? 0,
+                    filter: options.filter,
+                },
+            ],
+        });
+        world.add(body);
+        built.push({ source, body });
+    };
+    for (const rect of geometry.rects) {
+        // A merged rectangle is axis-aligned by construction, so the body needs
+        // no angle — just the box centred on the run.
+        add({
+            shape: new BoxShape(rect.width, rect.height),
+            x: rect.x + rect.width / 2,
+            y: rect.y + rect.height / 2,
+            angle: 0,
+        }, { kind: 'rect', rect });
+    }
+    for (const shape of geometry.shapes) {
+        add(shapeForGeometry(shape, shape.source.name || `tile ${shape.tx},${shape.ty}`), { kind: 'shape', shape });
+    }
+    return built;
+}
+/**
+ * Map one piece of collision geometry to a convex shape + body placement, or
+ * `null` when it has no closed area (point / polyline / tile) or is a
+ * degenerate / non-convex polygon. Boxes and circles are positioned at the
+ * geometry's centre, since a physics shape is centred on its collider origin.
+ */
+function shapeForGeometry(geometry, label) {
+    const angle = geometry.rotation * DEGREES_TO_RADIANS;
+    switch (geometry.kind) {
         case ObjectKind.Rectangle: {
-            if (object.width <= 0 || object.height <= 0) {
+            if (geometry.width <= 0 || geometry.height <= 0) {
                 return null;
             }
             // The body sits at the rectangle's centre; the box is centred on it.
             // Rotation pivots about the object origin in Tiled, so rotate the
             // centre offset (w/2, h/2) by the object's angle around that origin.
-            const angle = object.rotation * DEGREES_TO_RADIANS;
-            const cos = Math.cos(angle);
-            const sin = Math.sin(angle);
-            const halfWidth = object.width / 2;
-            const halfHeight = object.height / 2;
-            return {
-                shape: new BoxShape(object.width, object.height),
-                x: object.x + (cos * halfWidth - sin * halfHeight),
-                y: object.y + (sin * halfWidth + cos * halfHeight),
-            };
+            const centre = rotateOffset(geometry, angle);
+            return { shape: new BoxShape(geometry.width, geometry.height), x: centre.x, y: centre.y, angle };
         }
         case ObjectKind.Ellipse: {
             // No native ellipse collider — approximate with a circle whose radius
             // is the larger semi-axis (a conservative, fully-covering bound).
-            const radius = Math.max(object.width, object.height) / 2;
+            const radius = Math.max(geometry.width, geometry.height) / 2;
             if (radius <= 0) {
                 return null;
             }
-            const angle = object.rotation * DEGREES_TO_RADIANS;
-            const cos = Math.cos(angle);
-            const sin = Math.sin(angle);
-            const halfWidth = object.width / 2;
-            const halfHeight = object.height / 2;
-            return {
-                shape: new CircleShape(radius),
-                x: object.x + (cos * halfWidth - sin * halfHeight),
-                y: object.y + (sin * halfWidth + cos * halfHeight),
-            };
+            const centre = rotateOffset(geometry, angle);
+            return { shape: new CircleShape(radius), x: centre.x, y: centre.y, angle };
         }
         case ObjectKind.Polygon: {
-            if (object.points.length < 3) {
+            const points = geometry.points ?? [];
+            if (points.length < 3) {
                 return null;
             }
             try {
                 // Polygon points are relative to the object origin; the body
                 // carries the world origin + rotation, so the shape keeps the
                 // local points and we place the body at the object origin.
-                const shape = new PolygonShape(object.points.map(point => ({ x: point.x, y: point.y })));
-                return { shape, x: object.x, y: object.y };
+                const shape = new PolygonShape(points.map(point => ({ x: point.x, y: point.y })));
+                return { shape, x: geometry.x, y: geometry.y, angle };
             }
             catch (error) {
                 // PolygonShape throws on non-convex / degenerate input — there is
                 // no automatic convex decomposition. Skip and let the author know.
-                warn(`physics-tilemap: skipped non-convex/degenerate polygon "${object.name || object.id}": ${describeError(error)}`);
+                warn(`physics-tilemap: skipped non-convex/degenerate polygon "${label}": ${describeError(error)}`);
                 return null;
             }
         }
@@ -129,6 +180,17 @@ function shapeForObject(object) {
             // Point, polyline and tile objects have no closed collision area.
             return null;
     }
+}
+/** The centre of an axis-aligned box rotated about its top-left origin. */
+function rotateOffset(geometry, angle) {
+    const cos = Math.cos(angle);
+    const sin = Math.sin(angle);
+    const halfWidth = geometry.width / 2;
+    const halfHeight = geometry.height / 2;
+    return {
+        x: geometry.x + (cos * halfWidth - sin * halfHeight),
+        y: geometry.y + (sin * halfWidth + cos * halfHeight),
+    };
 }
 function describeError(error) {
     return error instanceof Error ? error.message : String(error);

--- a/examples/shared/physics-tilemap.ts
+++ b/examples/shared/physics-tilemap.ts
@@ -1,5 +1,5 @@
 // Shared example recipe: build static physics colliders from a Tiled object
-// layer.
+// layer, or from a tile layer's per-tile collision geometry.
 //
 // This module is the integration seam between two intentionally decoupled
 // packages: `@codexo/exojs-tilemap` (data-only object layers) and
@@ -10,13 +10,21 @@
 // legitimate. Copy it into your own project and adapt as needed; it is a
 // recipe, not engine API.
 //
-// It walks an `ObjectLayer`, maps each geometry kind to the closest convex
-// physics shape, and adds one static `PhysicsBody` per object to the world:
+// `buildCollidersFromObjectLayer` walks an `ObjectLayer`, maps each geometry
+// kind to the closest convex physics shape, and adds one static `PhysicsBody`
+// per object to the world:
 //
 //   - Rectangle → `BoxShape`            (centred on the object's centre)
 //   - Polygon   → `PolygonShape`        (convex; concave inputs are skipped)
 //   - Ellipse   → `CircleShape`         (radius = the larger semi-axis)
 //   - Point / Polyline / Tile           (no closed area → skipped)
+//
+// `buildCollidersFromTileLayer` does the same for the per-tile collision shapes
+// authored on tileset tiles. The hard part — walking the tile grid, applying
+// tile transforms and layer offsets, and merging adjacent whole-cell boxes into
+// as few rectangles as possible — lives in `@codexo/exojs-tilemap`'s
+// `buildTileCollisionGeometry`; all that is left here is the same short
+// geometry → shape loop.
 //
 // Object coordinates are in object-layer pixel space with +Y down, matching the
 // engine's screen space, so positions map straight through. Rotation (Tiled
@@ -31,7 +39,17 @@ import {
     type PhysicsWorld,
     PolygonShape,
 } from '@codexo/exojs-physics';
-import { ObjectKind, type ObjectLayer, type TileMapObject } from '@codexo/exojs-tilemap';
+import {
+    buildTileCollisionGeometry,
+    ObjectKind,
+    type ObjectLayer,
+    type ObjectPoint,
+    type TileCollisionOptions,
+    type TileCollisionRect,
+    type TileCollisionShape,
+    type TileLayer,
+    type TileMapObject,
+} from '@codexo/exojs-tilemap';
 
 const DEGREES_TO_RADIANS = Math.PI / 180;
 
@@ -81,7 +99,7 @@ export function buildCollidersFromObjectLayer(
             continue;
         }
 
-        const placement = shapeForObject(object);
+        const placement = shapeForGeometry(object, object.name || String(object.id));
 
         if (placement === null) {
             continue;
@@ -90,7 +108,7 @@ export function buildCollidersFromObjectLayer(
         const body = new PhysicsBody({
             type: 'static',
             position: { x: placement.x, y: placement.y },
-            angle: object.rotation * DEGREES_TO_RADIANS,
+            angle: placement.angle,
             colliders: [
                 {
                     shape: placement.shape,
@@ -108,66 +126,175 @@ export function buildCollidersFromObjectLayer(
     return built;
 }
 
-/** A shape plus the world position its origin should be placed at. */
+/**
+ * Options for {@link buildCollidersFromTileLayer}. Combines the collider
+ * material settings above with the tilemap package's geometry options (region
+ * scoping, merge toggle, per-shape filter).
+ */
+export interface TileLayerColliderOptions extends TileCollisionOptions {
+    /** Coulomb friction for every generated collider. Default `0.6`. */
+    friction?: number;
+    /** Restitution / bounciness in `[0, 1]` for every generated collider. Default `0`. */
+    restitution?: number;
+    /** Category/mask/group collision filter shared by every generated collider. */
+    filter?: Partial<CollisionFilter>;
+}
+
+/**
+ * What a tile-layer collider was built from: either a merged whole-cell
+ * rectangle (which spans many tiles and has no single source object) or one
+ * pass-through per-tile shape.
+ */
+export type TileLayerColliderSource =
+    | { readonly kind: 'rect'; readonly rect: TileCollisionRect }
+    | { readonly kind: 'shape'; readonly shape: TileCollisionShape };
+
+/** A single static body produced from tile collision geometry. */
+export interface TileLayerCollider {
+    /** The geometry the body was built from. */
+    readonly source: TileLayerColliderSource;
+    /** The static body added to the world. */
+    readonly body: PhysicsBody;
+}
+
+/**
+ * Build static colliders from a tile layer's per-tile collision shapes — the
+ * `objectgroup` Tiled lets you draw on a tileset tile.
+ *
+ * All the geometry work is done by `buildTileCollisionGeometry` in
+ * `@codexo/exojs-tilemap`: it walks the tile grid, applies each tile's
+ * flip/rotation transform plus the tileset and layer pixel offsets, and merges
+ * adjacent whole-cell boxes into as few rectangles as it can — so a solid
+ * region becomes a handful of wide bodies instead of one body per tile. This
+ * function only turns that geometry into bodies, with the same kind → shape
+ * mapping as {@link buildCollidersFromObjectLayer}.
+ *
+ * Pass `region` to scope the build to part of the layer (a streamed chunk, the
+ * tiles around the player) instead of the whole map.
+ */
+export function buildCollidersFromTileLayer(
+    world: PhysicsWorld,
+    layer: TileLayer,
+    options: TileLayerColliderOptions = {},
+): Array<TileLayerCollider> {
+    const geometry = buildTileCollisionGeometry(layer, {
+        ...(options.region !== undefined && { region: options.region }),
+        ...(options.merge !== undefined && { merge: options.merge }),
+        ...(options.accept !== undefined && { accept: options.accept }),
+    });
+    const built: Array<TileLayerCollider> = [];
+
+    const add = (placement: ShapePlacement | null, source: TileLayerColliderSource): void => {
+        if (placement === null) {
+            return;
+        }
+
+        const body = new PhysicsBody({
+            type: 'static',
+            position: { x: placement.x, y: placement.y },
+            angle: placement.angle,
+            colliders: [
+                {
+                    shape: placement.shape,
+                    friction: options.friction ?? 0.6,
+                    restitution: options.restitution ?? 0,
+                    filter: options.filter,
+                },
+            ],
+        });
+
+        world.add(body);
+        built.push({ source, body });
+    };
+
+    for (const rect of geometry.rects) {
+        // A merged rectangle is axis-aligned by construction, so the body needs
+        // no angle — just the box centred on the run.
+        add(
+            {
+                shape: new BoxShape(rect.width, rect.height),
+                x: rect.x + rect.width / 2,
+                y: rect.y + rect.height / 2,
+                angle: 0,
+            },
+            { kind: 'rect', rect },
+        );
+    }
+
+    for (const shape of geometry.shapes) {
+        add(
+            shapeForGeometry(shape, shape.source.name || `tile ${shape.tx},${shape.ty}`),
+            { kind: 'shape', shape },
+        );
+    }
+
+    return built;
+}
+
+/** A shape plus the world position and angle its origin should be placed at. */
 interface ShapePlacement {
     readonly shape: AnyShape;
     readonly x: number;
     readonly y: number;
+    readonly angle: number;
 }
 
 /**
- * Map one object to a convex shape + body position, or `null` when the object
- * has no closed area (point / polyline / tile) or is a degenerate / non-convex
- * polygon. The body is positioned at the object's geometric centre so the
- * shape, which is centred on the collider origin, lines up with the object.
+ * The subset of fields both an object-layer {@link TileMapObject} and a
+ * per-tile {@link TileCollisionShape} share — enough to pick a physics shape.
+ * Both types are structurally assignable to it, so one mapping serves both.
  */
-function shapeForObject(object: TileMapObject): ShapePlacement | null {
-    switch (object.kind) {
+interface CollisionGeometry {
+    readonly kind: ObjectKind;
+    readonly x: number;
+    readonly y: number;
+    readonly width: number;
+    readonly height: number;
+    readonly rotation: number;
+    readonly points?: readonly ObjectPoint[];
+}
+
+/**
+ * Map one piece of collision geometry to a convex shape + body placement, or
+ * `null` when it has no closed area (point / polyline / tile) or is a
+ * degenerate / non-convex polygon. Boxes and circles are positioned at the
+ * geometry's centre, since a physics shape is centred on its collider origin.
+ */
+function shapeForGeometry(geometry: CollisionGeometry, label: string): ShapePlacement | null {
+    const angle = geometry.rotation * DEGREES_TO_RADIANS;
+
+    switch (geometry.kind) {
         case ObjectKind.Rectangle: {
-            if (object.width <= 0 || object.height <= 0) {
+            if (geometry.width <= 0 || geometry.height <= 0) {
                 return null;
             }
 
             // The body sits at the rectangle's centre; the box is centred on it.
             // Rotation pivots about the object origin in Tiled, so rotate the
             // centre offset (w/2, h/2) by the object's angle around that origin.
-            const angle = object.rotation * DEGREES_TO_RADIANS;
-            const cos = Math.cos(angle);
-            const sin = Math.sin(angle);
-            const halfWidth = object.width / 2;
-            const halfHeight = object.height / 2;
+            const centre = rotateOffset(geometry, angle);
 
-            return {
-                shape: new BoxShape(object.width, object.height),
-                x: object.x + (cos * halfWidth - sin * halfHeight),
-                y: object.y + (sin * halfWidth + cos * halfHeight),
-            };
+            return { shape: new BoxShape(geometry.width, geometry.height), x: centre.x, y: centre.y, angle };
         }
 
         case ObjectKind.Ellipse: {
             // No native ellipse collider — approximate with a circle whose radius
             // is the larger semi-axis (a conservative, fully-covering bound).
-            const radius = Math.max(object.width, object.height) / 2;
+            const radius = Math.max(geometry.width, geometry.height) / 2;
 
             if (radius <= 0) {
                 return null;
             }
 
-            const angle = object.rotation * DEGREES_TO_RADIANS;
-            const cos = Math.cos(angle);
-            const sin = Math.sin(angle);
-            const halfWidth = object.width / 2;
-            const halfHeight = object.height / 2;
+            const centre = rotateOffset(geometry, angle);
 
-            return {
-                shape: new CircleShape(radius),
-                x: object.x + (cos * halfWidth - sin * halfHeight),
-                y: object.y + (sin * halfWidth + cos * halfHeight),
-            };
+            return { shape: new CircleShape(radius), x: centre.x, y: centre.y, angle };
         }
 
         case ObjectKind.Polygon: {
-            if (object.points.length < 3) {
+            const points = geometry.points ?? [];
+
+            if (points.length < 3) {
                 return null;
             }
 
@@ -175,13 +302,13 @@ function shapeForObject(object: TileMapObject): ShapePlacement | null {
                 // Polygon points are relative to the object origin; the body
                 // carries the world origin + rotation, so the shape keeps the
                 // local points and we place the body at the object origin.
-                const shape = new PolygonShape(object.points.map(point => ({ x: point.x, y: point.y })));
+                const shape = new PolygonShape(points.map(point => ({ x: point.x, y: point.y })));
 
-                return { shape, x: object.x, y: object.y };
+                return { shape, x: geometry.x, y: geometry.y, angle };
             } catch (error) {
                 // PolygonShape throws on non-convex / degenerate input — there is
                 // no automatic convex decomposition. Skip and let the author know.
-                warn(`physics-tilemap: skipped non-convex/degenerate polygon "${object.name || object.id}": ${describeError(error)}`);
+                warn(`physics-tilemap: skipped non-convex/degenerate polygon "${label}": ${describeError(error)}`);
 
                 return null;
             }
@@ -191,6 +318,19 @@ function shapeForObject(object: TileMapObject): ShapePlacement | null {
             // Point, polyline and tile objects have no closed collision area.
             return null;
     }
+}
+
+/** The centre of an axis-aligned box rotated about its top-left origin. */
+function rotateOffset(geometry: CollisionGeometry, angle: number): ObjectPoint {
+    const cos = Math.cos(angle);
+    const sin = Math.sin(angle);
+    const halfWidth = geometry.width / 2;
+    const halfHeight = geometry.height / 2;
+
+    return {
+        x: geometry.x + (cos * halfWidth - sin * halfHeight),
+        y: geometry.y + (sin * halfWidth + cos * halfHeight),
+    };
 }
 
 function describeError(error: unknown): string {

--- a/packages/exojs-tilemap/src/public.ts
+++ b/packages/exojs-tilemap/src/public.ts
@@ -76,6 +76,17 @@ export {
 } from './types';
 // Per-tile animation driver (RPG-Maker-style): advances only animated cells.
 export { TileAnimator } from './TileAnimator';
+// Per-tile collision: layer-space geometry from TileDefinition.collision,
+// with whole-cell boxes greedily merged. Physics-agnostic — plain geometry.
+export type {
+  TileCollisionGeometry,
+  TileCollisionOptions,
+  TileCollisionRect,
+  TileCollisionShape,
+  TileCollisionShapeKind,
+  TileRegion,
+} from './tileCollision';
+export { buildTileCollisionGeometry } from './tileCollision';
 // Chunk streaming: loads/unloads TileLayer chunks from a View's position via a ChunkSource provider.
 export type { ChunkStreamerOptions } from './ChunkStreamer';
 export { ChunkStreamer } from './ChunkStreamer';

--- a/packages/exojs-tilemap/src/tileCollision.ts
+++ b/packages/exojs-tilemap/src/tileCollision.ts
@@ -1,0 +1,595 @@
+import type { ObjectPoint, TileMapObject } from './ObjectLayer';
+import { ObjectKind } from './ObjectLayer';
+import type { TileLayer } from './TileLayer';
+import type { TileSet } from './TileSet';
+import type { TileTransform } from './types';
+
+/**
+ * The geometry kinds a {@link TileCollisionShape} can carry. Tile (GID) and
+ * text objects describe no collision area and are never emitted, so they are
+ * excluded from the union.
+ * @advanced
+ */
+export type TileCollisionShapeKind =
+  | typeof ObjectKind.Rectangle
+  | typeof ObjectKind.Ellipse
+  | typeof ObjectKind.Polygon
+  | typeof ObjectKind.Polyline
+  | typeof ObjectKind.Point;
+
+/**
+ * A half-open tile-coordinate rectangle covering
+ * `[x, x + width)` × `[y, y + height)`.
+ *
+ * Used to scope {@link buildTileCollisionGeometry} to part of a layer — a
+ * streamed chunk, the tiles around the player, a hand-picked room — instead of
+ * always rebuilding the whole map.
+ * @advanced
+ */
+export interface TileRegion {
+  /** Leftmost tile column (inclusive). */
+  readonly x: number;
+  /** Topmost tile row (inclusive). */
+  readonly y: number;
+  /** Width in tiles. */
+  readonly width: number;
+  /** Height in tiles. */
+  readonly height: number;
+}
+
+/**
+ * An axis-aligned collision rectangle in tile-layer pixel space (+Y down),
+ * covering one or more whole tile cells.
+ *
+ * Rectangles are synthesized geometry, not source objects: a merged run has no
+ * single originating object, so it carries no object `id`/`name`/`properties` —
+ * only the `type` string shared by every shape merged into it. Anything that
+ * does not exactly cover whole cells stays a {@link TileCollisionShape}, which
+ * does keep its source object.
+ * @advanced
+ */
+export interface TileCollisionRect {
+  /** Left edge in layer pixel space. */
+  readonly x: number;
+  /** Top edge in layer pixel space. */
+  readonly y: number;
+  /** Width in pixels (a whole number of tile cells). */
+  readonly width: number;
+  /** Height in pixels (a whole number of tile cells). */
+  readonly height: number;
+  /** Class/type string shared by every source shape merged into this rectangle. */
+  readonly type: string;
+}
+
+/**
+ * A per-tile collision shape placed in tile-layer pixel space (+Y down).
+ *
+ * Emitted for every collision shape that does not exactly cover a whole tile
+ * cell: partial boxes, ellipses, polygons, polylines, points, and rotated
+ * geometry. Shapes are never merged with one another.
+ * @advanced
+ */
+export interface TileCollisionShape {
+  /** Geometry discriminant. */
+  readonly kind: TileCollisionShapeKind;
+  /** X of the shape origin in layer pixel space. */
+  readonly x: number;
+  /** Y of the shape origin in layer pixel space. */
+  readonly y: number;
+  /** Bounding width in px (`0` for polygons, polylines and points). */
+  readonly width: number;
+  /** Bounding height in px (`0` for polygons, polylines and points). */
+  readonly height: number;
+  /**
+   * Rotation in degrees, clockwise, about `(x, y)`, normalised to `[0, 360)`.
+   * Always `0` for polygons and polylines — their rotation is baked into
+   * {@link points}.
+   */
+  readonly rotation: number;
+  /** Polygon/polyline vertices relative to `(x, y)`; absent for other kinds. */
+  readonly points?: readonly ObjectPoint[];
+  /** Tile column the shape came from. */
+  readonly tx: number;
+  /** Tile row the shape came from. */
+  readonly ty: number;
+  /** The tile-local source object, for `name`/`type`/`properties` lookups. */
+  readonly source: TileMapObject;
+}
+
+/**
+ * Collision geometry extracted from a tile layer: whole-cell boxes merged into
+ * as few {@link TileCollisionRect}s as a greedy pass can manage, plus every
+ * other shape passed through individually.
+ * @advanced
+ */
+export interface TileCollisionGeometry {
+  /** Merged whole-cell rectangles, in row-major order. */
+  readonly rects: readonly TileCollisionRect[];
+  /** Non-whole-cell shapes, in the order their tiles were walked. */
+  readonly shapes: readonly TileCollisionShape[];
+}
+
+/**
+ * Options for {@link buildTileCollisionGeometry}.
+ * @advanced
+ */
+export interface TileCollisionOptions {
+  /**
+   * Tile-coordinate region to walk. Defaults to the bounding box of the
+   * layer's currently loaded chunks, so an unbounded (streamed) layer works
+   * without the caller computing anything.
+   */
+  readonly region?: TileRegion;
+  /**
+   * Merge adjacent whole-cell boxes that share a `type` into larger
+   * rectangles. Default `true`. With `false`, every whole-cell box becomes its
+   * own single-cell rectangle.
+   */
+  readonly merge?: boolean;
+  /**
+   * Drop source shapes before any geometry is built (e.g. by a custom
+   * property). Return `true` to keep a shape. Default keeps all of them.
+   */
+  readonly accept?: (object: TileMapObject, tx: number, ty: number) => boolean;
+}
+
+const DEGREES_TO_RADIANS = Math.PI / 180;
+
+/** Normalise degrees into `[0, 360)`. */
+function normaliseDegrees(degrees: number): number {
+  const wrapped = degrees % 360;
+
+  return wrapped < 0 ? wrapped + 360 : wrapped;
+}
+
+/**
+ * Cosine of an angle in degrees, exact on the quadrant multiples.
+ * `Math.cos(Math.PI / 2)` is `6.1e-17`, not `0`; tile transforms produce those
+ * quadrant angles constantly, and the whole-cell test below compares
+ * coordinates exactly, so the noise has to stay out of the arithmetic.
+ */
+function cosDegrees(degrees: number): number {
+  const angle = normaliseDegrees(degrees);
+
+  if (angle === 0) return 1;
+  if (angle === 90 || angle === 270) return 0;
+  if (angle === 180) return -1;
+
+  return Math.cos(angle * DEGREES_TO_RADIANS);
+}
+
+/** Sine of an angle in degrees, exact on the quadrant multiples. */
+function sinDegrees(degrees: number): number {
+  const angle = normaliseDegrees(degrees);
+
+  if (angle === 0 || angle === 180) return 0;
+  if (angle === 90) return 1;
+  if (angle === 270) return -1;
+
+  return Math.sin(angle * DEGREES_TO_RADIANS);
+}
+
+/** `true` when the transform mirrors (an odd number of reflections). */
+function isMirrored(transform: TileTransform): boolean {
+  const flags = (transform.flipX ? 1 : 0) + (transform.flipY ? 1 : 0) + (transform.diagonal ? 1 : 0);
+
+  return flags % 2 === 1;
+}
+
+/**
+ * Rotation in degrees contributed by a non-mirroring transform. Only the four
+ * even-parity transforms are rotations: identity, `flipX+flipY` (180°),
+ * `diagonal+flipX` (90°) and `diagonal+flipY` (270°).
+ */
+function transformRotation(transform: TileTransform): number {
+  if (transform.diagonal) {
+    return transform.flipX ? 90 : 270;
+  }
+
+  return transform.flipX ? 180 : 0;
+}
+
+/**
+ * Map a point from tile-local pixel space into the transformed tile-local
+ * space of a placed tile. The diagonal flip (a transpose of the axes, which
+ * also swaps the box dimensions) is applied first, then the axis mirrors —
+ * the same order the renderer's orientation code implies.
+ */
+function mapLocalPoint(
+  px: number,
+  py: number,
+  boxWidth: number,
+  boxHeight: number,
+  transform: TileTransform,
+): ObjectPoint {
+  let x = px;
+  let y = py;
+  let width = boxWidth;
+  let height = boxHeight;
+
+  if (transform.diagonal) {
+    const swapped = x;
+
+    x = y;
+    y = swapped;
+    width = boxHeight;
+    height = boxWidth;
+  }
+
+  if (transform.flipX) x = width - x;
+  if (transform.flipY) y = height - y;
+
+  return { x, y };
+}
+
+/**
+ * Layer-space position of a placed tile's top-left image corner. Mirrors the
+ * renderer's placement (see `chunkGeometry`): the tileset's draw offset shifts
+ * every tile, and a tile taller than the layer's cell is bottom-aligned within
+ * it, so collision geometry lands exactly where the tile is drawn.
+ */
+function tileAnchor(layer: TileLayer, tileset: TileSet, tx: number, ty: number): ObjectPoint {
+  return {
+    x: tx * layer.tileWidth + layer.offsetX + tileset.offsetX,
+    y: ty * layer.tileHeight + layer.offsetY + layer.tileHeight - tileset.tileHeight + tileset.offsetY,
+  };
+}
+
+/** A shape in layer pixel space, before it is classified as cell or shape. */
+interface PlacedShape {
+  readonly kind: TileCollisionShapeKind;
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+  readonly rotation: number;
+  readonly points?: readonly ObjectPoint[];
+}
+
+/**
+ * Place one tile-local collision object into layer pixel space, applying the
+ * tile's flip/rotation transform, the tileset draw offset and the layer offset.
+ * Returns `null` for kinds that carry no collision geometry.
+ */
+function placeShape(
+  object: TileMapObject,
+  layer: TileLayer,
+  tileset: TileSet,
+  transform: TileTransform,
+  tx: number,
+  ty: number,
+): PlacedShape | null {
+  if (object.kind === ObjectKind.Tile || object.kind === ObjectKind.Text) {
+    return null;
+  }
+
+  const anchor = tileAnchor(layer, tileset, tx, ty);
+  const boxWidth = tileset.tileWidth;
+  const boxHeight = tileset.tileHeight;
+  const mirrored = isMirrored(transform);
+  const sourceCos = cosDegrees(object.rotation);
+  const sourceSin = sinDegrees(object.rotation);
+
+  if (object.kind === ObjectKind.Polygon || object.kind === ObjectKind.Polyline) {
+    // Rotation is baked into the vertices: the source rotation pivots about the
+    // object origin, and the tile transform may mirror the whole tile, so an
+    // origin-plus-angle form would need a second angle convention. Absolute
+    // vertices are exact under both.
+    const origin = mapLocalPoint(object.x, object.y, boxWidth, boxHeight, transform);
+    const originX = anchor.x + origin.x;
+    const originY = anchor.y + origin.y;
+    const points = object.points.map(point => {
+      const localX = object.x + (sourceCos * point.x - sourceSin * point.y);
+      const localY = object.y + (sourceSin * point.x + sourceCos * point.y);
+      const mapped = mapLocalPoint(localX, localY, boxWidth, boxHeight, transform);
+
+      return { x: anchor.x + mapped.x - originX, y: anchor.y + mapped.y - originY };
+    });
+
+    return {
+      kind: object.kind,
+      x: originX,
+      y: originY,
+      width: 0,
+      height: 0,
+      rotation: 0,
+      // A mirror reverses the winding order; reversing the vertices restores
+      // the source orientation, which convex-hull/polygon consumers rely on.
+      points: mirrored ? points.reverse() : points,
+    };
+  }
+
+  if (object.kind === ObjectKind.Point) {
+    const mapped = mapLocalPoint(object.x, object.y, boxWidth, boxHeight, transform);
+
+    return {
+      kind: ObjectKind.Point,
+      x: anchor.x + mapped.x,
+      y: anchor.y + mapped.y,
+      width: 0,
+      height: 0,
+      rotation: 0,
+    };
+  }
+
+  // Rectangles and ellipses are symmetric about their centre, so placing the
+  // centre and re-deriving the origin handles every transform uniformly.
+  const halfWidth = object.width / 2;
+  const halfHeight = object.height / 2;
+  const centreLocalX = object.x + (sourceCos * halfWidth - sourceSin * halfHeight);
+  const centreLocalY = object.y + (sourceSin * halfWidth + sourceCos * halfHeight);
+  const centre = mapLocalPoint(centreLocalX, centreLocalY, boxWidth, boxHeight, transform);
+  const centreX = anchor.x + centre.x;
+  const centreY = anchor.y + centre.y;
+
+  // Conjugating a rotation by a mirror negates it; a non-mirroring transform is
+  // itself a rotation and simply adds. Only a mirror can swap the local axes,
+  // and then only when the diagonal flip is part of it.
+  const rotation = normaliseDegrees(mirrored ? -object.rotation : object.rotation + transformRotation(transform));
+  const swapAxes = mirrored && transform.diagonal;
+  const width = swapAxes ? object.height : object.width;
+  const height = swapAxes ? object.width : object.height;
+
+  if (rotation % 90 === 0) {
+    // Quadrant-aligned geometry is axis-aligned; re-express it without a
+    // rotation so whole-cell boxes on rotated tiles stay mergeable.
+    const axisWidth = rotation % 180 === 0 ? width : height;
+    const axisHeight = rotation % 180 === 0 ? height : width;
+
+    return {
+      kind: object.kind,
+      x: centreX - axisWidth / 2,
+      y: centreY - axisHeight / 2,
+      width: axisWidth,
+      height: axisHeight,
+      rotation: 0,
+    };
+  }
+
+  const cos = cosDegrees(rotation);
+  const sin = sinDegrees(rotation);
+
+  return {
+    kind: object.kind,
+    x: centreX - (cos * (width / 2) - sin * (height / 2)),
+    y: centreY - (sin * (width / 2) + cos * (height / 2)),
+    width,
+    height,
+    rotation,
+  };
+}
+
+/** The tile-coordinate bounding box of the layer's loaded chunks, or `null`. */
+function loadedTileRegion(layer: TileLayer): TileRegion | null {
+  let minTx = Number.POSITIVE_INFINITY;
+  let minTy = Number.POSITIVE_INFINITY;
+  let maxTx = Number.NEGATIVE_INFINITY;
+  let maxTy = Number.NEGATIVE_INFINITY;
+
+  for (const chunk of layer.loadedChunks()) {
+    const startTx = chunk.cx * layer.chunkWidth;
+    const startTy = chunk.cy * layer.chunkHeight;
+
+    minTx = Math.min(minTx, startTx);
+    minTy = Math.min(minTy, startTy);
+    maxTx = Math.max(maxTx, startTx + chunk.width - 1);
+    maxTy = Math.max(maxTy, startTy + chunk.height - 1);
+  }
+
+  if (!Number.isFinite(minTx) || !Number.isFinite(minTy)) {
+    return null;
+  }
+
+  return { x: minTx, y: minTy, width: maxTx - minTx + 1, height: maxTy - minTy + 1 };
+}
+
+/** Key of a claimed cell in the occupancy grid. */
+function cellKey(tx: number, ty: number): string {
+  return `${tx},${ty}`;
+}
+
+/**
+ * `true` when a placed shape is an axis-aligned rectangle covering exactly the
+ * tile cell at `(cellX, cellY)` — the only geometry the merging pass handles.
+ */
+function coversWholeCell(placed: PlacedShape, layer: TileLayer, cellX: number, cellY: number): boolean {
+  return (
+    placed.kind === ObjectKind.Rectangle &&
+    placed.rotation === 0 &&
+    placed.x === cellX &&
+    placed.y === cellY &&
+    placed.width === layer.tileWidth &&
+    placed.height === layer.tileHeight
+  );
+}
+
+/** One single-cell rectangle per claimed cell, for `merge: false`. */
+function unmergedCells(cells: ReadonlyMap<string, string>, layer: TileLayer): TileCollisionRect[] {
+  const rects: TileCollisionRect[] = [];
+
+  for (const [key, type] of cells) {
+    const [tx, ty] = key.split(',').map(Number) as [number, number];
+
+    rects.push({
+      x: tx * layer.tileWidth + layer.offsetX,
+      y: ty * layer.tileHeight + layer.offsetY,
+      width: layer.tileWidth,
+      height: layer.tileHeight,
+      type,
+    });
+  }
+
+  return rects;
+}
+
+/**
+ * Greedy rectangle merging over the claimed cells: walk row-major, grow each
+ * unconsumed cell as far right as the type key allows, then as far down as a
+ * full row of that width allows, and consume the block. Deliberately the plain
+ * textbook pass — it is linear in the number of cells and always produces a
+ * valid, non-overlapping cover, which matters more here than minimality.
+ */
+function mergeCells(
+  cells: ReadonlyMap<string, string>,
+  region: TileRegion,
+  layer: TileLayer,
+): TileCollisionRect[] {
+  const consumed = new Set<string>();
+  const rects: TileCollisionRect[] = [];
+  const endTx = region.x + region.width;
+  const endTy = region.y + region.height;
+
+  for (let ty = region.y; ty < endTy; ty++) {
+    for (let tx = region.x; tx < endTx; tx++) {
+      const key = cells.get(cellKey(tx, ty));
+
+      if (key === undefined || consumed.has(cellKey(tx, ty))) {
+        continue;
+      }
+
+      let width = 1;
+
+      while (
+        tx + width < endTx &&
+        cells.get(cellKey(tx + width, ty)) === key &&
+        !consumed.has(cellKey(tx + width, ty))
+      ) {
+        width++;
+      }
+
+      let height = 1;
+
+      growDown: while (ty + height < endTy) {
+        for (let column = 0; column < width; column++) {
+          const candidate = cellKey(tx + column, ty + height);
+
+          if (cells.get(candidate) !== key || consumed.has(candidate)) {
+            break growDown;
+          }
+        }
+
+        height++;
+      }
+
+      for (let row = 0; row < height; row++) {
+        for (let column = 0; column < width; column++) {
+          consumed.add(cellKey(tx + column, ty + row));
+        }
+      }
+
+      rects.push({
+        x: tx * layer.tileWidth + layer.offsetX,
+        y: ty * layer.tileHeight + layer.offsetY,
+        width: width * layer.tileWidth,
+        height: height * layer.tileHeight,
+        type: key,
+      });
+    }
+  }
+
+  return rects;
+}
+
+/**
+ * Extract collision geometry from a tile layer's per-tile
+ * {@link import('./types').TileDefinition.collision} shapes.
+ *
+ * Every placed tile in `region` is resolved back to its tileset definition, and
+ * each collision shape is transformed from tile-local pixel space into layer
+ * pixel space (+Y down) — applying the tile's flip/rotation transform, the
+ * tileset draw offset, and the layer's pixel offset, so the geometry lands
+ * exactly where the tile is drawn.
+ *
+ * Shapes that end up covering exactly one whole tile cell are collected into an
+ * occupancy grid and merged into as few {@link TileCollisionRect}s as a greedy
+ * pass manages — a 200×200 solid region becomes one rectangle instead of 40 000.
+ * Cells only merge with neighbours whose source object carries the same `type`
+ * string, so a `water` run never fuses into an adjacent `solid` run. Everything
+ * else (partial boxes, ellipses, polygons, polylines, points, rotated geometry)
+ * passes through individually as a {@link TileCollisionShape}.
+ *
+ * This package has no physics dependency and builds no bodies: the result is
+ * plain geometry. Turning it into colliders is a short loop in application code.
+ *
+ * @param layer - The layer to walk.
+ * @param options - Region scoping, merge toggle, and a source-shape filter.
+ * @returns Merged rectangles plus pass-through shapes; both empty when the
+ *          region holds no tile carrying collision data.
+ *
+ * @example
+ * ```ts
+ * const { rects, shapes } = buildTileCollisionGeometry(layer);
+ *
+ * for (const rect of rects) {
+ *   world.add(makeStaticBox(rect.x, rect.y, rect.width, rect.height));
+ * }
+ * ```
+ * @advanced
+ */
+export function buildTileCollisionGeometry(
+  layer: TileLayer,
+  options: TileCollisionOptions = {},
+): TileCollisionGeometry {
+  const region = options.region ?? loadedTileRegion(layer);
+
+  if (region === null || region.width <= 0 || region.height <= 0) {
+    return { rects: [], shapes: [] };
+  }
+
+  const accept = options.accept;
+  const cells = new Map<string, string>();
+  const shapes: TileCollisionShape[] = [];
+
+  for (const { tx, ty, tile } of layer.tilesInRect(region.x, region.y, region.width, region.height)) {
+    const definition = tile.tileset.getTileDefinition(tile.localTileId);
+
+    if (definition?.collision === undefined) {
+      continue;
+    }
+
+    const cellX = tx * layer.tileWidth + layer.offsetX;
+    const cellY = ty * layer.tileHeight + layer.offsetY;
+
+    for (const object of definition.collision) {
+      if (accept !== undefined && !accept(object, tx, ty)) {
+        continue;
+      }
+
+      const placed = placeShape(object, layer, tile.tileset, tile.transform, tx, ty);
+
+      if (placed === null) {
+        continue;
+      }
+
+      const key = cellKey(tx, ty);
+
+      // A second whole-cell box on the same tile cannot claim the cell twice;
+      // it falls through to the shape list so no geometry is silently dropped.
+      if (coversWholeCell(placed, layer, cellX, cellY) && !cells.has(key)) {
+        cells.set(key, object.type);
+        continue;
+      }
+
+      shapes.push({
+        kind: placed.kind,
+        x: placed.x,
+        y: placed.y,
+        width: placed.width,
+        height: placed.height,
+        rotation: placed.rotation,
+        ...(placed.points !== undefined && { points: placed.points }),
+        tx,
+        ty,
+        source: object,
+      });
+    }
+  }
+
+  if (cells.size === 0) {
+    return { rects: [], shapes };
+  }
+
+  const rects = options.merge === false ? unmergedCells(cells, layer) : mergeCells(cells, region, layer);
+
+  return { rects, shapes };
+}

--- a/packages/exojs-tilemap/test/tileCollision.test.ts
+++ b/packages/exojs-tilemap/test/tileCollision.test.ts
@@ -1,0 +1,463 @@
+import { TextureRegion } from '@codexo/exojs';
+import { type Texture } from '@codexo/exojs';
+import { describe, expect, it } from 'vitest';
+
+import { ObjectKind, type TileMapObject } from '../src/ObjectLayer';
+import { buildTileCollisionGeometry } from '../src/tileCollision';
+import { TileLayer } from '../src/TileLayer';
+import { TileSet } from '../src/TileSet';
+import type { TileDefinition, TileTransform } from '../src/types';
+import { TILE_TRANSFORM_IDENTITY } from '../src/types';
+
+// ── Test helpers ──────────────────────────────────────────────────────────
+
+function fakeTexture(): Texture {
+  return {
+    destroyed: false,
+    destroy: () => {},
+    height: 512,
+    label: 'test',
+    uid: 0,
+    width: 512,
+  } as unknown as Texture;
+}
+
+function fakeRegion(): TextureRegion {
+  return new TextureRegion(fakeTexture(), { height: 512, width: 512, x: 0, y: 0 });
+}
+
+/** A tile-local collision shape, defaulting to a full 16×16 tile rectangle. */
+function shape(overrides: Partial<TileMapObject> = {}): TileMapObject {
+  return {
+    kind: ObjectKind.Rectangle,
+    id: 1,
+    name: '',
+    type: 'solid',
+    x: 0,
+    y: 0,
+    width: 16,
+    height: 16,
+    rotation: 0,
+    visible: true,
+    properties: {},
+    ...overrides,
+  } as TileMapObject;
+}
+
+interface TileSetSetup {
+  readonly tileWidth?: number;
+  readonly tileHeight?: number;
+  readonly offsetX?: number;
+  readonly offsetY?: number;
+}
+
+function makeTileset(
+  collisionByTile: Record<number, readonly TileMapObject[]>,
+  setup: TileSetSetup = {},
+): TileSet {
+  const tileset = new TileSet({
+    name: 'ts',
+    texture: fakeRegion(),
+    tileWidth: setup.tileWidth ?? 16,
+    tileHeight: setup.tileHeight ?? 16,
+    tileCount: 16,
+    columns: 4,
+    offsetX: setup.offsetX ?? 0,
+    offsetY: setup.offsetY ?? 0,
+  });
+  const definitions: TileDefinition[] = Object.entries(collisionByTile).map(([id, collision]) => ({
+    localTileId: Number(id),
+    collision,
+  }));
+  tileset._setDefinitions(definitions);
+
+  return tileset;
+}
+
+interface LayerSetup {
+  readonly offsetX?: number;
+  readonly offsetY?: number;
+}
+
+function makeLayer(tileset: TileSet, setup: LayerSetup = {}): TileLayer {
+  return new TileLayer({
+    id: 1,
+    name: 'ground',
+    width: 8,
+    height: 8,
+    tileWidth: 16,
+    tileHeight: 16,
+    tilesets: [tileset],
+    offsetX: setup.offsetX ?? 0,
+    offsetY: setup.offsetY ?? 0,
+  });
+}
+
+function place(
+  layer: TileLayer,
+  tileset: TileSet,
+  tx: number,
+  ty: number,
+  localTileId = 0,
+  transform: TileTransform = TILE_TRANSFORM_IDENTITY,
+): void {
+  layer.setTileAt(tx, ty, { tileset, localTileId, transform });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('buildTileCollisionGeometry — per-tile shapes', () => {
+  it('places a partial tile-local rectangle at its exact layer-space position', () => {
+    // A 8×4 box at tile-local (4, 8) on the tile at column 2, row 3.
+    const tileset = makeTileset({ 0: [shape({ x: 4, y: 8, width: 8, height: 4 })] });
+    const layer = makeLayer(tileset);
+    place(layer, tileset, 2, 3);
+
+    const geometry = buildTileCollisionGeometry(layer);
+
+    expect(geometry.rects).toEqual([]);
+    expect(geometry.shapes).toHaveLength(1);
+    expect(geometry.shapes[0]).toMatchObject({
+      kind: ObjectKind.Rectangle,
+      x: 2 * 16 + 4,
+      y: 3 * 16 + 8,
+      width: 8,
+      height: 4,
+      rotation: 0,
+      tx: 2,
+      ty: 3,
+    });
+  });
+
+  it('keeps the source object reachable on every emitted shape', () => {
+    const source = shape({ x: 2, y: 2, width: 4, height: 4, type: 'ladder', name: 'rung' });
+    const tileset = makeTileset({ 0: [source] });
+    const layer = makeLayer(tileset);
+    place(layer, tileset, 0, 0);
+
+    const geometry = buildTileCollisionGeometry(layer);
+
+    expect(geometry.shapes[0]!.source).toBe(source);
+    expect(geometry.shapes[0]!.source.type).toBe('ladder');
+  });
+
+  it('passes a polygon through unmerged with correct layer-space coordinates', () => {
+    const polygon = shape({
+      kind: ObjectKind.Polygon,
+      x: 2,
+      y: 3,
+      width: 0,
+      height: 0,
+      points: [
+        { x: 0, y: 0 },
+        { x: 8, y: 0 },
+        { x: 0, y: 8 },
+      ],
+    });
+    const tileset = makeTileset({ 0: [polygon] });
+    const layer = makeLayer(tileset);
+    place(layer, tileset, 1, 1);
+
+    const geometry = buildTileCollisionGeometry(layer);
+
+    expect(geometry.rects).toEqual([]);
+    expect(geometry.shapes).toHaveLength(1);
+    expect(geometry.shapes[0]).toMatchObject({
+      kind: ObjectKind.Polygon,
+      x: 16 + 2,
+      y: 16 + 3,
+      rotation: 0,
+    });
+    expect(geometry.shapes[0]!.points).toEqual([
+      { x: 0, y: 0 },
+      { x: 8, y: 0 },
+      { x: 0, y: 8 },
+    ]);
+  });
+
+  it('passes an ellipse through unmerged with correct layer-space coordinates', () => {
+    const tileset = makeTileset({
+      0: [shape({ kind: ObjectKind.Ellipse, x: 0, y: 4, width: 16, height: 8 })],
+    });
+    const layer = makeLayer(tileset);
+    place(layer, tileset, 3, 0);
+
+    const geometry = buildTileCollisionGeometry(layer);
+
+    expect(geometry.rects).toEqual([]);
+    expect(geometry.shapes).toHaveLength(1);
+    expect(geometry.shapes[0]).toMatchObject({
+      kind: ObjectKind.Ellipse,
+      x: 48,
+      y: 4,
+      width: 16,
+      height: 8,
+    });
+  });
+
+  it('never merges non-rectangular geometry, however many identical tiles carry it', () => {
+    const tileset = makeTileset({
+      0: [
+        shape({
+          kind: ObjectKind.Polygon,
+          x: 0,
+          y: 0,
+          width: 0,
+          height: 0,
+          points: [
+            { x: 0, y: 16 },
+            { x: 16, y: 16 },
+            { x: 16, y: 0 },
+          ],
+        }),
+      ],
+    });
+    const layer = makeLayer(tileset);
+
+    for (let tx = 0; tx < 4; tx++) {
+      place(layer, tileset, tx, 0);
+    }
+
+    const geometry = buildTileCollisionGeometry(layer);
+
+    expect(geometry.rects).toEqual([]);
+    expect(geometry.shapes).toHaveLength(4);
+    expect(geometry.shapes.map(entry => entry.x)).toEqual([0, 16, 32, 48]);
+  });
+});
+
+describe('buildTileCollisionGeometry — merging', () => {
+  it('merges a 4×1 run of full-tile boxes into a single rectangle', () => {
+    const tileset = makeTileset({ 0: [shape()] });
+    const layer = makeLayer(tileset);
+
+    for (let tx = 0; tx < 4; tx++) {
+      place(layer, tileset, tx, 0);
+    }
+
+    const geometry = buildTileCollisionGeometry(layer);
+
+    expect(geometry.shapes).toEqual([]);
+    expect(geometry.rects).toHaveLength(1);
+    expect(geometry.rects[0]).toEqual({ x: 0, y: 0, width: 64, height: 16, type: 'solid' });
+  });
+
+  it('emits one rectangle per tile when merging is disabled', () => {
+    const tileset = makeTileset({ 0: [shape()] });
+    const layer = makeLayer(tileset);
+
+    for (let tx = 0; tx < 4; tx++) {
+      place(layer, tileset, tx, 0);
+    }
+
+    expect(buildTileCollisionGeometry(layer, { merge: false }).rects).toHaveLength(4);
+  });
+
+  it('merges a solid 3×3 block into a single rectangle', () => {
+    const tileset = makeTileset({ 0: [shape()] });
+    const layer = makeLayer(tileset);
+
+    for (let ty = 0; ty < 3; ty++) {
+      for (let tx = 0; tx < 3; tx++) {
+        place(layer, tileset, tx, ty);
+      }
+    }
+
+    const geometry = buildTileCollisionGeometry(layer);
+
+    expect(geometry.rects).toHaveLength(1);
+    expect(geometry.rects[0]).toEqual({ x: 0, y: 0, width: 48, height: 48, type: 'solid' });
+  });
+
+  it('does not merge across a gap', () => {
+    const tileset = makeTileset({ 0: [shape()] });
+    const layer = makeLayer(tileset);
+    place(layer, tileset, 0, 0);
+    place(layer, tileset, 1, 0);
+    place(layer, tileset, 3, 0);
+
+    const geometry = buildTileCollisionGeometry(layer);
+
+    expect(geometry.rects).toEqual([
+      { x: 0, y: 0, width: 32, height: 16, type: 'solid' },
+      { x: 48, y: 0, width: 16, height: 16, type: 'solid' },
+    ]);
+  });
+
+  it('does not merge tiles whose collision shapes carry different type strings', () => {
+    const tileset = makeTileset({
+      0: [shape({ type: 'solid' })],
+      1: [shape({ type: 'water' })],
+    });
+    const layer = makeLayer(tileset);
+    place(layer, tileset, 0, 0, 0);
+    place(layer, tileset, 1, 0, 1);
+
+    const geometry = buildTileCollisionGeometry(layer);
+
+    expect(geometry.rects).toHaveLength(2);
+    expect(geometry.rects.map(rect => rect.type)).toEqual(['solid', 'water']);
+  });
+});
+
+describe('buildTileCollisionGeometry — offsets and transforms', () => {
+  it('applies the layer pixel offset to merged rectangles', () => {
+    const tileset = makeTileset({ 0: [shape()] });
+    const layer = makeLayer(tileset, { offsetX: 100, offsetY: -40 });
+    place(layer, tileset, 1, 2);
+
+    const geometry = buildTileCollisionGeometry(layer);
+
+    expect(geometry.rects[0]).toEqual({ x: 116, y: -8, width: 16, height: 16, type: 'solid' });
+  });
+
+  it('applies the layer pixel offset to pass-through shapes', () => {
+    const tileset = makeTileset({ 0: [shape({ x: 4, y: 4, width: 8, height: 8 })] });
+    const layer = makeLayer(tileset, { offsetX: 100, offsetY: -40 });
+    place(layer, tileset, 1, 2);
+
+    const geometry = buildTileCollisionGeometry(layer);
+
+    expect(geometry.shapes[0]).toMatchObject({ x: 120, y: -4, width: 8, height: 8 });
+  });
+
+  it('applies the tileset draw offset, matching the rendered tile position', () => {
+    const tileset = makeTileset(
+      { 0: [shape({ x: 0, y: 0, width: 8, height: 8 })] },
+      { offsetX: 3, offsetY: -5 },
+    );
+    const layer = makeLayer(tileset);
+    place(layer, tileset, 1, 1);
+
+    const geometry = buildTileCollisionGeometry(layer);
+
+    expect(geometry.shapes[0]).toMatchObject({ x: 16 + 3, y: 16 - 5 });
+  });
+
+  it('mirrors a tile-local box on a horizontally flipped tile', () => {
+    // A 4-wide box hugging the tile's left edge mirrors to its right edge.
+    const tileset = makeTileset({ 0: [shape({ x: 0, y: 0, width: 4, height: 16 })] });
+    const layer = makeLayer(tileset);
+    place(layer, tileset, 0, 0, 0, { flipX: true, flipY: false, diagonal: false });
+
+    const geometry = buildTileCollisionGeometry(layer);
+
+    expect(geometry.shapes[0]).toMatchObject({ x: 12, y: 0, width: 4, height: 16, rotation: 0 });
+  });
+
+  it('mirrors a tile-local box on a vertically flipped tile', () => {
+    const tileset = makeTileset({ 0: [shape({ x: 0, y: 0, width: 16, height: 4 })] });
+    const layer = makeLayer(tileset);
+    place(layer, tileset, 0, 0, 0, { flipX: false, flipY: true, diagonal: false });
+
+    const geometry = buildTileCollisionGeometry(layer);
+
+    expect(geometry.shapes[0]).toMatchObject({ x: 0, y: 12, width: 16, height: 4, rotation: 0 });
+  });
+
+  it('transposes a tile-local box on a diagonally flipped tile', () => {
+    const tileset = makeTileset({ 0: [shape({ x: 0, y: 0, width: 16, height: 4 })] });
+    const layer = makeLayer(tileset);
+    place(layer, tileset, 0, 0, 0, { flipX: false, flipY: false, diagonal: true });
+
+    const geometry = buildTileCollisionGeometry(layer);
+
+    expect(geometry.shapes[0]).toMatchObject({ x: 0, y: 0, width: 4, height: 16, rotation: 0 });
+  });
+
+  it('still merges a full-tile box on a rotated (diagonal + flipX) tile', () => {
+    const tileset = makeTileset({ 0: [shape()] });
+    const layer = makeLayer(tileset);
+    place(layer, tileset, 0, 0, 0, { flipX: true, flipY: false, diagonal: true });
+    place(layer, tileset, 1, 0, 0, { flipX: true, flipY: false, diagonal: true });
+
+    const geometry = buildTileCollisionGeometry(layer);
+
+    expect(geometry.shapes).toEqual([]);
+    expect(geometry.rects).toEqual([{ x: 0, y: 0, width: 32, height: 16, type: 'solid' }]);
+  });
+
+  it('mirrors polygon points and preserves their winding on a flipped tile', () => {
+    const polygon = shape({
+      kind: ObjectKind.Polygon,
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      points: [
+        { x: 0, y: 0 },
+        { x: 8, y: 0 },
+        { x: 0, y: 8 },
+      ],
+    });
+    const tileset = makeTileset({ 0: [polygon] });
+    const layer = makeLayer(tileset);
+    place(layer, tileset, 0, 0, 0, { flipX: true, flipY: false, diagonal: false });
+
+    const geometry = buildTileCollisionGeometry(layer);
+
+    // Origin mirrors from local x = 0 to x = 16; the points mirror around it and
+    // reverse order so the polygon keeps its original winding.
+    expect(geometry.shapes[0]).toMatchObject({ x: 16, y: 0 });
+    expect(geometry.shapes[0]!.points).toEqual([
+      { x: 0, y: 8 },
+      { x: -8, y: 0 },
+      { x: 0, y: 0 },
+    ]);
+  });
+});
+
+describe('buildTileCollisionGeometry — scoping and empty inputs', () => {
+  it('returns an empty result for a layer with no tiles at all', () => {
+    const tileset = makeTileset({ 0: [shape()] });
+    const layer = makeLayer(tileset);
+
+    expect(buildTileCollisionGeometry(layer)).toEqual({ rects: [], shapes: [] });
+  });
+
+  it('returns an empty result when no placed tile carries collision data', () => {
+    const tileset = makeTileset({ 5: [shape()] });
+    const layer = makeLayer(tileset);
+    place(layer, tileset, 0, 0, 0);
+    place(layer, tileset, 1, 0, 1);
+
+    expect(buildTileCollisionGeometry(layer)).toEqual({ rects: [], shapes: [] });
+  });
+
+  it('restricts the walk to an explicit tile region', () => {
+    const tileset = makeTileset({ 0: [shape()] });
+    const layer = makeLayer(tileset);
+
+    for (let tx = 0; tx < 6; tx++) {
+      place(layer, tileset, tx, 0);
+    }
+
+    const geometry = buildTileCollisionGeometry(layer, {
+      region: { x: 2, y: 0, width: 2, height: 1 },
+    });
+
+    expect(geometry.rects).toEqual([{ x: 32, y: 0, width: 32, height: 16, type: 'solid' }]);
+  });
+
+  it('honours an accept predicate that drops source shapes before merging', () => {
+    const tileset = makeTileset({
+      0: [shape({ type: 'solid' })],
+      1: [shape({ type: 'decoration' })],
+    });
+    const layer = makeLayer(tileset);
+    place(layer, tileset, 0, 0, 0);
+    place(layer, tileset, 1, 0, 1);
+
+    const geometry = buildTileCollisionGeometry(layer, {
+      accept: object => object.type === 'solid',
+    });
+
+    expect(geometry.rects).toEqual([{ x: 0, y: 0, width: 16, height: 16, type: 'solid' }]);
+  });
+
+  it('is reachable from the package barrel', async () => {
+    const barrel = await import('../src/index');
+
+    expect(typeof barrel.buildTileCollisionGeometry).toBe('function');
+  });
+});

--- a/site/src/content/api/tile-collision-geometry.json
+++ b/site/src/content/api/tile-collision-geometry.json
@@ -1,0 +1,116 @@
+{
+  "title": "TileCollisionGeometry",
+  "description": "Collision geometry extracted from a tile layer: whole-cell boxes merged into as few TileCollisionRects as a greedy pass can manage, plus every other shape passed through individually.",
+  "symbol": "TileCollisionGeometry",
+  "kind": "interface",
+  "subsystem": "tilemap",
+  "importPath": "@codexo/exojs-tilemap",
+  "tier": "advanced",
+  "memberCount": 2,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 2,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Collision geometry extracted from a tile layer: whole-cell boxes merged into as few TileCollisionRects as a greedy pass can manage, plus every other shape passed through individually."
+      ],
+      "importLine": "import { TileCollisionGeometry } from '@codexo/exojs-tilemap'",
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "rects",
+          "signature": "rects: readonly TileCollisionRect[]",
+          "signatureTokens": [
+            {
+              "text": "rects",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TileCollisionRect",
+              "kind": "type"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Merged whole-cell rectangles, in row-major order."
+        },
+        {
+          "name": "shapes",
+          "signature": "shapes: readonly TileCollisionShape[]",
+          "signatureTokens": [
+            {
+              "text": "shapes",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TileCollisionShape",
+              "kind": "type"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Non-whole-cell shapes, in the order their tiles were walked."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "packages/exojs-tilemap/src/tileCollision.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/tileCollision.ts"
+      }
+    }
+  ],
+  "sourcePath": "packages/exojs-tilemap/src/tileCollision.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/tileCollision.ts"
+}

--- a/site/src/content/api/tile-collision-options.json
+++ b/site/src/content/api/tile-collision-options.json
@@ -1,0 +1,177 @@
+{
+  "title": "TileCollisionOptions",
+  "description": "Options for buildTileCollisionGeometry.",
+  "symbol": "TileCollisionOptions",
+  "kind": "interface",
+  "subsystem": "tilemap",
+  "importPath": "@codexo/exojs-tilemap",
+  "tier": "advanced",
+  "memberCount": 3,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 3,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Options for buildTileCollisionGeometry."
+      ],
+      "importLine": "import { TileCollisionOptions } from '@codexo/exojs-tilemap'",
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "accept",
+          "signature": "accept?: (object: TileMapObject, tx: number, ty: number) => boolean",
+          "signatureTokens": [
+            {
+              "text": "accept",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "object",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TileMapObject",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "tx",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ty",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ") => ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Drop source shapes before any geometry is built (e.g. by a custom property). Return true to keep a shape. Default keeps all of them."
+        },
+        {
+          "name": "merge",
+          "signature": "merge?: boolean",
+          "signatureTokens": [
+            {
+              "text": "merge",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Merge adjacent whole-cell boxes that share a type into larger rectangles. Default true. With false, every whole-cell box becomes its own single-cell rectangle."
+        },
+        {
+          "name": "region",
+          "signature": "region?: TileRegion",
+          "signatureTokens": [
+            {
+              "text": "region",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TileRegion",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Tile-coordinate region to walk. Defaults to the bounding box of the layer's currently loaded chunks, so an unbounded (streamed) layer works without the caller computing anything."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "packages/exojs-tilemap/src/tileCollision.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/tileCollision.ts"
+      }
+    }
+  ],
+  "sourcePath": "packages/exojs-tilemap/src/tileCollision.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/tileCollision.ts"
+}

--- a/site/src/content/api/tile-collision-rect.json
+++ b/site/src/content/api/tile-collision-rect.json
@@ -1,0 +1,156 @@
+{
+  "title": "TileCollisionRect",
+  "description": "An axis-aligned collision rectangle in tile-layer pixel space (+Y down), covering one or more whole tile cells. Rectangles are synthesized geometry, not source objects: a merged run has no single originating object, so it carries no object `id`/`name`/`properties` — only the `type` string shared by every shape merged into it. Anything that does not exactly cover whole cells stays a TileCollisionShape, which does keep its source object.",
+  "symbol": "TileCollisionRect",
+  "kind": "interface",
+  "subsystem": "tilemap",
+  "importPath": "@codexo/exojs-tilemap",
+  "tier": "advanced",
+  "memberCount": 5,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 5,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "An axis-aligned collision rectangle in tile-layer pixel space (+Y down), covering one or more whole tile cells.",
+        "Rectangles are synthesized geometry, not source objects: a merged run has no single originating object, so it carries no object `id`/`name`/`properties` — only the `type` string shared by every shape merged into it. Anything that does not exactly cover whole cells stays a TileCollisionShape, which does keep its source object."
+      ],
+      "importLine": "import { TileCollisionRect } from '@codexo/exojs-tilemap'",
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "height",
+          "signature": "height: number",
+          "signatureTokens": [
+            {
+              "text": "height",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Height in pixels (a whole number of tile cells)."
+        },
+        {
+          "name": "type",
+          "signature": "type: string",
+          "signatureTokens": [
+            {
+              "text": "type",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Class/type string shared by every source shape merged into this rectangle."
+        },
+        {
+          "name": "width",
+          "signature": "width: number",
+          "signatureTokens": [
+            {
+              "text": "width",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Width in pixels (a whole number of tile cells)."
+        },
+        {
+          "name": "x",
+          "signature": "x: number",
+          "signatureTokens": [
+            {
+              "text": "x",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Left edge in layer pixel space."
+        },
+        {
+          "name": "y",
+          "signature": "y: number",
+          "signatureTokens": [
+            {
+              "text": "y",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Top edge in layer pixel space."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "packages/exojs-tilemap/src/tileCollision.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/tileCollision.ts"
+      }
+    }
+  ],
+  "sourcePath": "packages/exojs-tilemap/src/tileCollision.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/tileCollision.ts"
+}

--- a/site/src/content/api/tile-collision-shape-kind.json
+++ b/site/src/content/api/tile-collision-shape-kind.json
@@ -1,0 +1,135 @@
+{
+  "title": "TileCollisionShapeKind",
+  "description": "The geometry kinds a TileCollisionShape can carry. Tile (GID) and text objects describe no collision area and are never emitted, so they are excluded from the union.",
+  "symbol": "TileCollisionShapeKind",
+  "kind": "type",
+  "subsystem": "tilemap",
+  "importPath": "@codexo/exojs-tilemap",
+  "tier": "advanced",
+  "memberCount": 0,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 0,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "The geometry kinds a TileCollisionShape can carry. Tile (GID) and text objects describe no collision area and are never emitted, so they are excluded from the union."
+      ],
+      "importLine": "import { TileCollisionShapeKind } from '@codexo/exojs-tilemap'",
+      "sourceLink": null
+    },
+    {
+      "id": "definition",
+      "title": "Definition",
+      "members": [
+        {
+          "name": "TileCollisionShapeKind",
+          "signature": "typeof ObjectKind.Rectangle | typeof ObjectKind.Ellipse | typeof ObjectKind.Polygon | typeof ObjectKind.Polyline | typeof ObjectKind.Point",
+          "signatureTokens": [
+            {
+              "text": "typeof",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ObjectKind.Rectangle",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "typeof",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ObjectKind.Ellipse",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "typeof",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ObjectKind.Polygon",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "typeof",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ObjectKind.Polyline",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "typeof",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ObjectKind.Point",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "packages/exojs-tilemap/src/tileCollision.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/tileCollision.ts"
+      }
+    }
+  ],
+  "sourcePath": "packages/exojs-tilemap/src/tileCollision.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/tileCollision.ts"
+}

--- a/site/src/content/api/tile-collision-shape.json
+++ b/site/src/content/api/tile-collision-shape.json
@@ -1,0 +1,277 @@
+{
+  "title": "TileCollisionShape",
+  "description": "A per-tile collision shape placed in tile-layer pixel space (+Y down). Emitted for every collision shape that does not exactly cover a whole tile cell: partial boxes, ellipses, polygons, polylines, points, and rotated geometry. Shapes are never merged with one another.",
+  "symbol": "TileCollisionShape",
+  "kind": "interface",
+  "subsystem": "tilemap",
+  "importPath": "@codexo/exojs-tilemap",
+  "tier": "advanced",
+  "memberCount": 10,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 10,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "A per-tile collision shape placed in tile-layer pixel space (+Y down).",
+        "Emitted for every collision shape that does not exactly cover a whole tile cell: partial boxes, ellipses, polygons, polylines, points, and rotated geometry. Shapes are never merged with one another."
+      ],
+      "importLine": "import { TileCollisionShape } from '@codexo/exojs-tilemap'",
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "height",
+          "signature": "height: number",
+          "signatureTokens": [
+            {
+              "text": "height",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Bounding height in px (0 for polygons, polylines and points)."
+        },
+        {
+          "name": "kind",
+          "signature": "kind: TileCollisionShapeKind",
+          "signatureTokens": [
+            {
+              "text": "kind",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TileCollisionShapeKind",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Geometry discriminant."
+        },
+        {
+          "name": "points",
+          "signature": "points?: readonly ObjectPoint[]",
+          "signatureTokens": [
+            {
+              "text": "points",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ObjectPoint",
+              "kind": "type"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Polygon/polyline vertices relative to (x, y); absent for other kinds."
+        },
+        {
+          "name": "rotation",
+          "signature": "rotation: number",
+          "signatureTokens": [
+            {
+              "text": "rotation",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Rotation in degrees, clockwise, about (x, y), normalised to [0, 360). Always 0 for polygons and polylines — their rotation is baked into points."
+        },
+        {
+          "name": "source",
+          "signature": "source: TileMapObject",
+          "signatureTokens": [
+            {
+              "text": "source",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TileMapObject",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "The tile-local source object, for name/type/properties lookups."
+        },
+        {
+          "name": "tx",
+          "signature": "tx: number",
+          "signatureTokens": [
+            {
+              "text": "tx",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Tile column the shape came from."
+        },
+        {
+          "name": "ty",
+          "signature": "ty: number",
+          "signatureTokens": [
+            {
+              "text": "ty",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Tile row the shape came from."
+        },
+        {
+          "name": "width",
+          "signature": "width: number",
+          "signatureTokens": [
+            {
+              "text": "width",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Bounding width in px (0 for polygons, polylines and points)."
+        },
+        {
+          "name": "x",
+          "signature": "x: number",
+          "signatureTokens": [
+            {
+              "text": "x",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "X of the shape origin in layer pixel space."
+        },
+        {
+          "name": "y",
+          "signature": "y: number",
+          "signatureTokens": [
+            {
+              "text": "y",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Y of the shape origin in layer pixel space."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "packages/exojs-tilemap/src/tileCollision.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/tileCollision.ts"
+      }
+    }
+  ],
+  "sourcePath": "packages/exojs-tilemap/src/tileCollision.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/tileCollision.ts"
+}

--- a/site/src/content/api/tile-region.json
+++ b/site/src/content/api/tile-region.json
@@ -1,0 +1,135 @@
+{
+  "title": "TileRegion",
+  "description": "A half-open tile-coordinate rectangle covering `[x, x + width)` × `[y, y + height)`. Used to scope buildTileCollisionGeometry to part of a layer — a streamed chunk, the tiles around the player, a hand-picked room — instead of always rebuilding the whole map.",
+  "symbol": "TileRegion",
+  "kind": "interface",
+  "subsystem": "tilemap",
+  "importPath": "@codexo/exojs-tilemap",
+  "tier": "advanced",
+  "memberCount": 4,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 4,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "A half-open tile-coordinate rectangle covering `[x, x + width)` × `[y, y + height)`.",
+        "Used to scope buildTileCollisionGeometry to part of a layer — a streamed chunk, the tiles around the player, a hand-picked room — instead of always rebuilding the whole map."
+      ],
+      "importLine": "import { TileRegion } from '@codexo/exojs-tilemap'",
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "height",
+          "signature": "height: number",
+          "signatureTokens": [
+            {
+              "text": "height",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Height in tiles."
+        },
+        {
+          "name": "width",
+          "signature": "width: number",
+          "signatureTokens": [
+            {
+              "text": "width",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Width in tiles."
+        },
+        {
+          "name": "x",
+          "signature": "x: number",
+          "signatureTokens": [
+            {
+              "text": "x",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Leftmost tile column (inclusive)."
+        },
+        {
+          "name": "y",
+          "signature": "y: number",
+          "signatureTokens": [
+            {
+              "text": "y",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Topmost tile row (inclusive)."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "packages/exojs-tilemap/src/tileCollision.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/tileCollision.ts"
+      }
+    }
+  ],
+  "sourcePath": "packages/exojs-tilemap/src/tileCollision.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-tilemap/src/tileCollision.ts"
+}

--- a/site/src/content/api/tilemap-functions.json
+++ b/site/src/content/api/tilemap-functions.json
@@ -6,10 +6,10 @@
   "subsystem": "tilemap",
   "importPath": "@codexo/exojs-tilemap",
   "tier": "stable",
-  "memberCount": 10,
+  "memberCount": 11,
   "counts": {
     "constructors": 0,
-    "methods": 8,
+    "methods": 9,
     "properties": 2,
     "events": 0
   },
@@ -120,6 +120,74 @@
           ],
           "returnType": "void",
           "description": "Apply Wang autotiling to layer using wangSet. Iterates every cell in the layer. For each cell that belongs to the Wang group, computes a neighbor bitmask and looks up the correct local tile ID from WangSet.blobMap. The layer is mutated in place; cells whose computed bitmask has no mapping in the blobMap are left unchanged. The function performs two passes (snapshot then write) so neighbor tests always reflect the pre-call state regardless of processing order. **Group membership.** With no matchFn, a cell belongs to the group when its tilesetIndex matches WangSet.tilesetIndex and its localTileId is a member of the set. Membership covers every variant the set can produce, so re-running autoTile (or refreshCell) on already-autotiled data is stable. Paint with a tile ID that is a member (a blobMap value, or one listed in WangSetOptions.members). **Blob mode bitmask (bit positions):**  1 | 2 | 4 8 | -- | 16 32 | 64 | 128  Diagonal bits (1, 4, 32, 128) are only set when both adjacent cardinals are also set (the \"corner dependency\" rule that reduces 256 raw combinations to 47 valid blob states). **Edge mode bitmask (bit positions):** Top=1, Right=2, Bottom=4, Left=8."
+        },
+        {
+          "name": "buildTileCollisionGeometry",
+          "signature": "buildTileCollisionGeometry(layer: TileLayer, options: TileCollisionOptions): TileCollisionGeometry",
+          "signatureTokens": [
+            {
+              "text": "buildTileCollisionGeometry",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "layer",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TileLayer",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "options",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TileCollisionOptions",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TileCollisionGeometry",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "layer",
+              "type": "TileLayer",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "TileCollisionOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "TileCollisionGeometry",
+          "description": "Extract collision geometry from a tile layer's per-tile import('./types').TileDefinition.collision shapes. Every placed tile in region is resolved back to its tileset definition, and each collision shape is transformed from tile-local pixel space into layer pixel space (+Y down) — applying the tile's flip/rotation transform, the tileset draw offset, and the layer's pixel offset, so the geometry lands exactly where the tile is drawn. Shapes that end up covering exactly one whole tile cell are collected into an occupancy grid and merged into as few TileCollisionRects as a greedy pass manages — a 200×200 solid region becomes one rectangle instead of 40 000. Cells only merge with neighbours whose source object carries the same type string, so a water run never fuses into an adjacent solid run. Everything else (partial boxes, ellipses, polygons, polylines, points, rotated geometry) passes through individually as a TileCollisionShape. This package has no physics dependency and builds no bodies: the result is plain geometry. Turning it into colliders is a short loop in application code."
         },
         {
           "name": "createSampledChunkSource",

--- a/src/rendering/RenderBackend.ts
+++ b/src/rendering/RenderBackend.ts
@@ -116,6 +116,24 @@ export interface RenderBackend {
   releaseRenderTexture(texture: RenderTexture): this;
 
   /**
+   * Destroy every render texture currently sitting in the backend's reuse
+   * pool and empty it, freeing the VRAM they hold. The pool itself keeps
+   * working afterwards — {@link acquireRenderTexture} /
+   * {@link releaseRenderTexture} behave exactly as before, they just start
+   * from empty and re-allocate whatever intermediates are asked for next.
+   *
+   * This is a manual, opt-in operation, not something the engine calls on
+   * your behalf. It trades pooled VRAM for a burst of re-allocation the next
+   * time those sizes are needed, so call it at a point where you actually
+   * want that trade: a memory-pressure signal from the platform, a long idle
+   * pause, or tearing down a level whose filter/mask intermediates won't
+   * recur at the same sizes. Do not call it on every scene change — that
+   * would defeat the pool and reintroduce the allocation churn it exists to
+   * avoid.
+   */
+  trimRenderTexturePool(): this;
+
+  /**
    * Composite `content` onto the active render target with each output
    * pixel's alpha multiplied by the corresponding sample of
    * `mask.alpha`. The mask is stretched-fit over the target rectangle

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -867,6 +867,12 @@ export class WebGl2Backend implements RenderBackend {
     return this;
   }
 
+  public trimRenderTexturePool(): this {
+    this._renderTexturePool.destroy();
+
+    return this;
+  }
+
   public setView(view: View | null): this {
     // Only flush the open batch when the view actually changes. The unconditional
     // flush forced one draw call per render() call (each render() re-applies the

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -765,6 +765,12 @@ export class WebGpuBackend implements RenderBackend {
     return this;
   }
 
+  public trimRenderTexturePool(): this {
+    this._renderTexturePool.destroy();
+
+    return this;
+  }
+
   public setView(view: View | null): this {
     // Only flush the open batch when the view actually changes. The unconditional
     // flush forced one draw call per render() call (each render() re-applies the

--- a/test/rendering/render-texture-pool.test.ts
+++ b/test/rendering/render-texture-pool.test.ts
@@ -114,6 +114,28 @@ describe('RenderTexturePool', () => {
 
     orphaned.destroy();
   });
+
+  test('destroy leaves the pool usable for further acquire/release', () => {
+    const pool = new RenderTexturePool();
+    const first = new RenderTexture(64, 64);
+
+    pool.release(first);
+    pool.destroy();
+
+    expect(pool.size).toBe(0);
+    expect(pool.bytes).toBe(0);
+
+    // Acquiring after destroy() must never hand back the destroyed entry.
+    const reacquired = pool.acquire(64, 64);
+
+    expect(reacquired).not.toBe(first);
+    expect(reacquired.destroyed).toBe(false);
+
+    pool.release(reacquired);
+
+    expect(pool.size).toBe(1);
+    expect(pool.acquire(64, 64)).toBe(reacquired);
+  });
 });
 
 describe('WebGl2Backend render texture pool', () => {
@@ -145,6 +167,29 @@ describe('WebGl2Backend render texture pool', () => {
 
     backend.destroy();
   });
+
+  test('trimRenderTexturePool() destroys pooled entries and leaves the pool usable', () => {
+    const backend = createFakeWebGl2Backend();
+    const pooled = backend.acquireRenderTexture(32, 32);
+
+    backend.releaseRenderTexture(pooled);
+    backend.trimRenderTexturePool();
+
+    expect(pooled.destroyed).toBe(true);
+
+    // The backend keeps working normally afterwards: a fresh acquire never
+    // returns the trimmed-out entry, and releasing repopulates the pool.
+    const reacquired = backend.acquireRenderTexture(32, 32);
+
+    expect(reacquired).not.toBe(pooled);
+    expect(reacquired.destroyed).toBe(false);
+
+    backend.releaseRenderTexture(reacquired);
+
+    expect(backend.acquireRenderTexture(32, 32)).toBe(reacquired);
+
+    backend.destroy();
+  });
 });
 
 describe('WebGpuBackend render texture pool', () => {
@@ -169,6 +214,27 @@ describe('WebGpuBackend render texture pool', () => {
 
     expect(reacquired.destroyed).toBe(false);
     expect(live).toContain(reacquired);
+
+    backend.destroy();
+  });
+
+  test('trimRenderTexturePool() destroys pooled entries and leaves the pool usable', async () => {
+    const backend = await createMockBackend(createMockWebGpuEnvironment());
+    const pooled = backend.acquireRenderTexture(32, 32);
+
+    backend.releaseRenderTexture(pooled);
+    backend.trimRenderTexturePool();
+
+    expect(pooled.destroyed).toBe(true);
+
+    const reacquired = backend.acquireRenderTexture(32, 32);
+
+    expect(reacquired).not.toBe(pooled);
+    expect(reacquired.destroyed).toBe(false);
+
+    backend.releaseRenderTexture(reacquired);
+
+    expect(backend.acquireRenderTexture(32, 32)).toBe(reacquired);
 
     backend.destroy();
   });

--- a/test/site/physics-tilemap-bridge.test.ts
+++ b/test/site/physics-tilemap-bridge.test.ts
@@ -1,8 +1,9 @@
+import { type Texture, TextureRegion } from '@codexo/exojs';
 import { BoxShape, CircleShape, PhysicsBody, PhysicsWorld, PolygonShape } from '@codexo/exojs-physics';
-import { ObjectKind, ObjectLayer, type TileMapObject } from '@codexo/exojs-tilemap';
+import { ObjectKind, ObjectLayer, TILE_TRANSFORM_IDENTITY, TileLayer, type TileMapObject, TileSet } from '@codexo/exojs-tilemap';
 import { describe, expect, it, vi } from 'vitest';
 
-import { buildCollidersFromObjectLayer } from '../../examples/shared/physics-tilemap';
+import { buildCollidersFromObjectLayer, buildCollidersFromTileLayer } from '../../examples/shared/physics-tilemap';
 
 // The example physics↔tilemap bridge recipe (examples/shared/physics-tilemap.ts)
 // is the only place that depends on BOTH @codexo/exojs-tilemap and
@@ -186,6 +187,167 @@ describe('buildCollidersFromObjectLayer', () => {
     // The box bottom should rest on the floor top (y ≈ 400): centre ≈ 380.
     expect(box.y).toBeGreaterThan(360);
     expect(box.y).toBeLessThan(400);
+    expect(Math.hypot(box.linearVelocityX, box.linearVelocityY)).toBeLessThan(5);
+  });
+});
+
+// ── Per-tile collision ────────────────────────────────────────────────────
+
+function fakeRegion(): TextureRegion {
+  const texture = {
+    destroyed: false,
+    destroy: () => {},
+    height: 512,
+    label: 'test',
+    uid: 0,
+    width: 512,
+  } as unknown as Texture;
+
+  return new TextureRegion(texture, { height: 512, width: 512, x: 0, y: 0 });
+}
+
+/** A tileset whose tile 0 carries `collision`, plus a 16px layer using it. */
+function tileLayerWith(collision: readonly TileMapObject[]): { layer: TileLayer; tileset: TileSet } {
+  const tileset = new TileSet({
+    name: 'ts',
+    texture: fakeRegion(),
+    tileWidth: 16,
+    tileHeight: 16,
+    tileCount: 16,
+    columns: 4,
+  });
+
+  tileset._setDefinitions([{ localTileId: 0, collision }]);
+
+  const layer = new TileLayer({
+    id: 1,
+    name: 'ground',
+    width: 16,
+    height: 16,
+    tileWidth: 16,
+    tileHeight: 16,
+    tilesets: [tileset],
+  });
+
+  return { layer, tileset };
+}
+
+function fill(layer: TileLayer, tileset: TileSet, fromTx: number, toTx: number, ty: number): void {
+  for (let tx = fromTx; tx <= toTx; tx++) {
+    layer.setTileAt(tx, ty, { tileset, localTileId: 0, transform: TILE_TRANSFORM_IDENTITY });
+  }
+}
+
+describe('buildCollidersFromTileLayer', () => {
+  it('collapses a run of full-tile collision boxes into a single wide body', () => {
+    const world = new PhysicsWorld();
+    const { layer, tileset } = tileLayerWith([rectangle(1, 0, 0, 16, 16)]);
+
+    fill(layer, tileset, 0, 3, 5);
+
+    const built = buildCollidersFromTileLayer(world, layer);
+
+    // Four tiles, one merged body — the whole point of the merging pass.
+    expect(built).toHaveLength(1);
+    expect(built[0].source.kind).toBe('rect');
+
+    const { body } = built[0];
+
+    expect(body.type).toBe('static');
+    expect(body.colliders[0].shape).toBeInstanceOf(BoxShape);
+    expect(body.x).toBeCloseTo(32);
+    expect(body.y).toBeCloseTo(88);
+    expect(world.bodies).toContain(body);
+  });
+
+  it('builds one body per tile for non-rectangular per-tile geometry', () => {
+    const world = new PhysicsWorld();
+    const slope: TileMapObject = {
+      ...base,
+      kind: ObjectKind.Polygon,
+      id: 1,
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      points: [
+        { x: 0, y: 16 },
+        { x: 16, y: 16 },
+        { x: 16, y: 0 },
+      ],
+    };
+    const { layer, tileset } = tileLayerWith([slope]);
+
+    fill(layer, tileset, 0, 2, 0);
+
+    const built = buildCollidersFromTileLayer(world, layer);
+
+    expect(built).toHaveLength(3);
+
+    for (const collider of built) {
+      expect(collider.source.kind).toBe('shape');
+      expect(collider.body.colliders[0].shape).toBeInstanceOf(PolygonShape);
+    }
+
+    expect(built.map(collider => collider.body.x)).toEqual([0, 16, 32]);
+  });
+
+  it('scopes the build to an explicit tile region', () => {
+    const world = new PhysicsWorld();
+    const { layer, tileset } = tileLayerWith([rectangle(1, 0, 0, 16, 16)]);
+
+    fill(layer, tileset, 0, 7, 0);
+
+    const built = buildCollidersFromTileLayer(world, layer, { region: { x: 2, y: 0, width: 2, height: 1 } });
+
+    expect(built).toHaveLength(1);
+    expect(built[0].body.x).toBeCloseTo(48);
+  });
+
+  it('forwards friction, restitution and filter onto every generated collider', () => {
+    const world = new PhysicsWorld();
+    const { layer, tileset } = tileLayerWith([rectangle(1, 0, 0, 16, 16)]);
+
+    fill(layer, tileset, 0, 1, 0);
+
+    const built = buildCollidersFromTileLayer(world, layer, {
+      friction: 0.9,
+      restitution: 0.3,
+      filter: { category: 0b10 },
+      merge: false,
+    });
+
+    expect(built).toHaveLength(2);
+
+    for (const { body } of built) {
+      expect(body.colliders[0].friction).toBeCloseTo(0.9);
+      expect(body.colliders[0].restitution).toBeCloseTo(0.3);
+      expect(body.colliders[0].filter.category).toBe(0b10);
+    }
+  });
+
+  it('produces a solid tile floor a dynamic body lands on (integration)', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+    const { layer, tileset } = tileLayerWith([rectangle(1, 0, 0, 16, 16)]);
+
+    // A 16-tile floor whose top edge sits at y = 160 (tile row 10).
+    fill(layer, tileset, 0, 15, 10);
+    buildCollidersFromTileLayer(world, layer, { friction: 0.6 });
+
+    const box = world.add(
+      new PhysicsBody({
+        type: 'dynamic',
+        position: { x: 120, y: 40 },
+        colliders: [{ shape: new BoxShape(16, 16), density: 1 }],
+      }),
+    );
+
+    for (let frame = 0; frame < 180; frame++) {
+      world.step(1 / 60);
+    }
+
+    expect(box.y).toBeGreaterThan(140);
+    expect(box.y).toBeLessThan(160);
     expect(Math.hypot(box.linearVelocityX, box.linearVelocityY)).toBeLessThan(5);
   });
 });


### PR DESCRIPTION
Two independent items from the architecture review, bundled since they touch disjoint files.

**HI-11 (remainder) — `trimRenderTexturePool()`.** The pool's count cap, byte cap and LRU eviction already shipped; what remained was only a manual escape hatch. Scope was deliberately narrowed after quantifying the actual exposure: the caps already bound the worst case at 64MB and already handle the "animating filter bounds churn out size classes" pathology, so no age-based eviction and no automatic trim-on-scene-change were added — an automatic trim would be actively counterproductive, throwing away intermediates two scenes share and immediately re-allocating them. This is just the public, opt-in trim for a real memory-pressure moment (mobile being the plausible case). It lives on `RenderBackend` alongside `acquireRenderTexture`/`releaseRenderTexture` and delegates to the pool's existing teardown.

**HI-18 — per-tile collision geometry.** `TileDefinition.collision` was parsed, frozen and stored, and then read by nothing in the entire repo; the only physics bridge handled object layers alone. The work splits unevenly, and the halves belong in different places: the hard half (collect per-tile geometry, apply tile/layer/tileset offsets and flip transforms, merge adjacent full-tile boxes via greedy meshing) has **no physics dependency at all** and now lives in `@codexo/exojs-tilemap` as `buildTileCollisionGeometry()` — the deliberate tilemap↔physics decoupling stays intact (`package.json` unchanged, no physics import). The trivial half — turning shapes into `PhysicsBody`/`BoxShape` — remains a recipe, with `examples/shared/physics-tilemap.ts` extended (not replaced) to cover per-tile collision alongside its existing object-layer path. Optional `region` scoping makes it usable per-chunk without building a streaming system.