### PR TITLE
feat(particles): add a ribbon render mode

### DIFF
--- a/packages/exojs-particles/src/public.ts
+++ b/packages/exojs-particles/src/public.ts
@@ -12,4 +12,6 @@ export { ParticleSystem } from './ParticleSystem';
 export { ParticleMaterial } from './renderModes/ParticleMaterial';
 export { ParticleRenderMode } from './renderModes/ParticleRenderMode';
 export { QuadParticles } from './renderModes/QuadParticles';
+export type { RibbonParticlesOptions } from './renderModes/RibbonParticles';
+export { RibbonParticles } from './renderModes/RibbonParticles';
 export type { Extension, RendererBinding } from '@codexo/exojs/extensions';

--- a/packages/exojs-particles/src/renderModes/RibbonParticles.ts
+++ b/packages/exojs-particles/src/renderModes/RibbonParticles.ts
@@ -1,0 +1,299 @@
+import type { Material } from '@codexo/exojs';
+import { Geometry, ShaderSource } from '@codexo/exojs';
+
+import type { ParticleSystem } from '#ParticleSystem';
+
+import fragmentSource from './glsl/ribbon.frag';
+import vertexSource from './glsl/ribbon.vert';
+import { ParticleMaterial } from './ParticleMaterial';
+import { ParticleRenderMode } from './ParticleRenderMode';
+
+const vertexStrideBytes = 20;
+const wordsPerVertex = vertexStrideBytes / Float32Array.BYTES_PER_ELEMENT;
+const defaultWidth = 1;
+
+/** Construction options for {@link RibbonParticles}. */
+export interface RibbonParticlesOptions {
+  /**
+   * Width of the strip in system-local units, before per-particle scaling.
+   * The half-width actually emitted is `width * scaleX[i] / 2`.
+   *
+   * @default 1
+   */
+  readonly width?: number;
+}
+
+/**
+ * WGSL counterpart of `glsl/ribbon.vert` + `glsl/ribbon.frag`. Vertex and
+ * fragment entry points share one source per WGSL convention, and the
+ * per-vertex attributes bind by `@location`, matching the declaration order and
+ * byte offsets of {@link RibbonParticles.geometry}.
+ *
+ * The uniform struct is the one the WebGPU particle renderer writes for every
+ * mode, so `localBounds` and `uvBounds` are declared but unused here: the strip
+ * carries its own final positions and UVs, and only the projection, the system
+ * transform and the premultiply flag are read.
+ */
+export const ribbonParticleWgsl = `
+struct ProjectionUniforms {
+    projection: mat4x4<f32>,
+    translation: mat4x4<f32>,
+    flags: vec4<f32>,
+    localBounds: vec4<f32>,    // quadMin.xy, quadSize.xy — unused by this mode
+    uvBounds: vec4<f32>,       // uvMin.xy, uvMax.xy — unused by this mode
+};
+
+@group(0) @binding(0)
+var<uniform> uniforms: ProjectionUniforms;
+
+@group(1) @binding(0)
+var particleTexture: texture_2d<f32>;
+
+@group(1) @binding(1)
+var particleSampler: sampler;
+
+// Per-vertex attributes (two vertices per particle, 20 bytes each).
+struct VertexInput {
+    @location(0) position: vec2<f32>,         // strip vertex in system-local space
+    @location(1) texcoord: vec2<f32>,         // u along the strip, v across it
+    @location(2) color: vec4<f32>,
+};
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) texcoord: vec2<f32>,
+    @location(1) color: vec4<f32>,
+};
+
+@vertex
+fn vertexMain(input: VertexInput) -> VertexOutput {
+    var output: VertexOutput;
+
+    // The strip is already expanded on the CPU — each vertex carries its final
+    // system-local position, so there is no per-particle transform to rebuild here.
+    output.position = uniforms.projection * uniforms.translation * vec4<f32>(input.position, 0.0, 1.0);
+    output.texcoord = input.texcoord;
+    output.color = vec4(input.color.rgb * input.color.a, input.color.a);
+
+    return output;
+}
+
+@fragment
+fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+    let sample = textureSample(particleTexture, particleSampler, input.texcoord);
+    let premultipliedSample = select(sample, vec4(sample.rgb * sample.a, sample.a), uniforms.flags.x > 0.5);
+
+    return premultipliedSample * input.color;
+}
+`;
+
+/**
+ * A connected triangle strip through the system's particles: one ribbon per
+ * system, drawn as a single non-instanced draw.
+ *
+ * Every particle contributes two vertices, offset either side of the path
+ * running through its neighbours, so the whole live range becomes one continuous
+ * band — the shape a sword arc, a projectile streak or a smoke plume wants,
+ * where a quad-per-particle would show as a dotted line.
+ *
+ * Layout of the per-vertex buffer {@link build} fills (20 bytes, 3 attributes):
+ *
+ * ```
+ *   a_position   f32x2  (offset  0,  8 bytes)  strip vertex (system-local)
+ *   a_texcoord   f32x2  (offset  8,  8 bytes)  u along the strip, v across it
+ *   a_color      u8x4   (offset 16,  4 bytes)  RGBA tint, normalised
+ * ```
+ *
+ * **No ribbon-specific styling parameters.** Half-width comes from the
+ * particle's `scaleX` and the tint from its `color`, so the existing update
+ * modules already produce the expected look: `ScaleOverLifetime` tapers the
+ * tail, `ColorOverLifetime` gradients along the streak, and
+ * `AlphaFadeOverLifetime` fades it out. {@link RibbonParticlesOptions.width}
+ * only sets the base the scale multiplies.
+ *
+ * **The strip is built on the CPU**, so this mode is not GPU-eligible and a
+ * system using it stays on the CPU simulation path (observable through
+ * `ParticleSystem.gpuMode`). That is what guarantees the builder reads valid
+ * positions in emission order: CPU-mode slots are dense and compaction copies
+ * survivors forward stably, which is exactly the ordering a connected strip
+ * needs.
+ *
+ * @example
+ * const trail = new ParticleSystem(sparkTexture, {
+ *     capacity: 64,
+ *     render: new RibbonParticles({ width: 12 }),
+ * });
+ *
+ * trail.addUpdateModule(new ScaleOverLifetime(1, 0)); // tapers to a point
+ */
+export class RibbonParticles extends ParticleRenderMode {
+  public readonly instanced = false;
+
+  /**
+   * Floats spanned by one vertex. Exposed so callers reading {@link data} can
+   * step through it without hard-coding the stride.
+   */
+  public readonly floatsPerVertex = wordsPerVertex;
+
+  /**
+   * A strip has no fixed vertex count — the draw covers whatever {@link build}
+   * emitted this frame — so the geometry describes only the layout and carries
+   * an empty placeholder. Non-indexed by construction: the strip's own vertex
+   * order is its topology, and an indexed geometry would pin the draw to a fixed
+   * index count.
+   */
+  public readonly geometry = new Geometry({
+    attributes: [
+      { name: 'a_position', size: 2, type: 'f32', normalized: false, offset: 0 },
+      { name: 'a_texcoord', size: 2, type: 'f32', normalized: false, offset: 8 },
+      { name: 'a_color', size: 4, type: 'u8', normalized: true, offset: 16 },
+    ],
+    vertexData: new ArrayBuffer(0),
+    stride: vertexStrideBytes,
+    topology: 'triangle-strip',
+    usage: 'stream',
+  });
+
+  private readonly _width: number;
+
+  private _material: ParticleMaterial | null = null;
+  private _float32 = new Float32Array(this.data);
+  private _uint32 = new Uint32Array(this.data);
+
+  public constructor(options: RibbonParticlesOptions = {}) {
+    super();
+
+    this._width = options.width ?? defaultWidth;
+  }
+
+  /**
+   * Built on first read rather than in the constructor: a system may be
+   * simulated without ever being drawn, and the shader pair is only needed
+   * once a backend actually compiles it.
+   */
+  public get material(): Material {
+    this._material ??= new ParticleMaterial({
+      shader: new ShaderSource({
+        glsl: { vertex: vertexSource, fragment: fragmentSource },
+        wgsl: ribbonParticleWgsl,
+      }),
+    });
+
+    return this._material;
+  }
+
+  public build(system: ParticleSystem): void {
+    const limit = system.liveCount;
+
+    // A strip needs a segment, and a segment needs two particles.
+    if (limit < 2) {
+      this._setCount(0);
+
+      return;
+    }
+
+    const { posX, posY, scaleX, color } = system;
+
+    // UVs run along the strip by arc length rather than by particle index, so
+    // unevenly spaced particles do not stretch the texture unevenly. That needs
+    // the total up front, hence the separate pass.
+    let totalLength = 0;
+
+    for (let i = 1; i < limit; i++) {
+      totalLength += Math.sqrt((posX[i]! - posX[i - 1]!) ** 2 + (posY[i]! - posY[i - 1]!) ** 2);
+    }
+
+    // Every particle sits on the same spot: no path, no direction, nothing to
+    // expand a strip around.
+    if (totalLength === 0) {
+      this._setCount(0);
+
+      return;
+    }
+
+    // Must precede the view reads below: growing swaps in fresh typed-array
+    // views over a new backing buffer.
+    this._ensureCapacity(limit * 2 * vertexStrideBytes);
+
+    const f32 = this._float32;
+    const u32 = this._uint32;
+    const width = this._width;
+
+    let vertexCount = 0;
+    let travelled = 0;
+    let previousDirectionX = 0;
+    let previousDirectionY = 0;
+    let hasPreviousDirection = false;
+
+    for (let i = 0; i < limit; i++) {
+      if (i > 0) {
+        travelled += Math.sqrt((posX[i]! - posX[i - 1]!) ** 2 + (posY[i]! - posY[i - 1]!) ** 2);
+      }
+
+      // Central difference through the neighbours, clamped to a one-sided
+      // difference at the two ends of the strip.
+      const before = i === 0 ? 0 : i - 1;
+      const after = i === limit - 1 ? i : i + 1;
+
+      let directionX = posX[after]! - posX[before]!;
+      let directionY = posY[after]! - posY[before]!;
+
+      const length = Math.sqrt(directionX ** 2 + directionY ** 2);
+
+      if (length > 0) {
+        directionX /= length;
+        directionY /= length;
+        previousDirectionX = directionX;
+        previousDirectionY = directionY;
+        hasPreviousDirection = true;
+      } else if (hasPreviousDirection) {
+        // Coincident neighbours leave no direction to expand around; carrying
+        // the last one keeps the strip continuous instead of collapsing it.
+        directionX = previousDirectionX;
+        directionY = previousDirectionY;
+      } else {
+        // Head of the strip with nothing to inherit — this particle cannot be
+        // placed, so it contributes no pair.
+        continue;
+      }
+
+      const halfWidth = (width * scaleX[i]!) / 2;
+      // The direction rotated 90°, scaled to the half-width in one step.
+      const offsetX = -directionY * halfWidth;
+      const offsetY = directionX * halfWidth;
+      const u = travelled / totalLength;
+      const packedColor = color[i]!;
+
+      let offset = vertexCount * wordsPerVertex;
+
+      f32[offset + 0] = posX[i]! - offsetX;
+      f32[offset + 1] = posY[i]! - offsetY;
+      f32[offset + 2] = u;
+      f32[offset + 3] = 0;
+      u32[offset + 4] = packedColor;
+
+      offset += wordsPerVertex;
+
+      f32[offset + 0] = posX[i]! + offsetX;
+      f32[offset + 1] = posY[i]! + offsetY;
+      f32[offset + 2] = u;
+      f32[offset + 3] = 1;
+      u32[offset + 4] = packedColor;
+
+      vertexCount += 2;
+    }
+
+    this._setCount(vertexCount);
+  }
+
+  public override destroy(): void {
+    this._material?.destroy();
+    this._material = null;
+    this.geometry.destroy();
+  }
+
+  protected override _onBufferGrown(data: ArrayBuffer): void {
+    this._float32 = new Float32Array(data);
+    this._uint32 = new Uint32Array(data);
+  }
+}

--- a/packages/exojs-particles/src/renderModes/glsl/ribbon.frag
+++ b/packages/exojs-particles/src/renderModes/glsl/ribbon.frag
@@ -1,0 +1,15 @@
+#version 300 es
+precision lowp float;
+
+uniform sampler2D u_texture;
+
+// UVs need full precision on mobile GLES (the lowp default would quantise
+// them); the color varying stays lowp for 8-bit output.
+in highp vec2 v_texcoord;
+in vec4 v_color;
+
+layout(location = 0) out vec4 fragColor;
+
+void main(void) {
+    fragColor = texture(u_texture, v_texcoord) * v_color;
+}

--- a/packages/exojs-particles/src/renderModes/glsl/ribbon.vert
+++ b/packages/exojs-particles/src/renderModes/glsl/ribbon.vert
@@ -1,0 +1,22 @@
+#version 300 es
+precision highp float;
+
+// Per-vertex attributes (two vertices per particle, 20 bytes each).
+layout(location = 0) in vec2 a_position;         // strip vertex in system-local space
+layout(location = 1) in vec2 a_texcoord;         // u along the strip, v across it
+layout(location = 2) in vec4 a_color;            // RGBA tint of the particle this pair came from
+
+uniform mat3 u_projection;
+uniform mat3 u_systemTransform;
+
+out vec2 v_texcoord;
+out vec4 v_color;
+
+void main(void) {
+    // The strip is already expanded on the CPU — each vertex carries its final
+    // system-local position, so there is no per-particle transform to rebuild here.
+    gl_Position = vec4((u_projection * u_systemTransform * vec3(a_position, 1.0)).xy, 0.0, 1.0);
+
+    v_texcoord = a_texcoord;
+    v_color = vec4(a_color.rgb * a_color.a, a_color.a);
+}

--- a/packages/exojs-particles/test/render-mode-ribbon.test.ts
+++ b/packages/exojs-particles/test/render-mode-ribbon.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+
+import { ParticleSystem } from '../src/ParticleSystem';
+import { RibbonParticles } from '../src/renderModes/RibbonParticles';
+
+const spawnChain = (system: ParticleSystem, count: number): void => {
+  for (let i = 0; i < count; i++) {
+    const slot = system.spawn();
+
+    system.posX[slot] = i * 10;
+    system.posY[slot] = 0;
+    system.scaleX[slot] = 1;
+    system.scaleY[slot] = 1;
+    system.lifetime[slot] = 5;
+  }
+};
+
+describe('RibbonParticles', () => {
+  it('declares a non-instanced, CPU-only triangle-strip mode', () => {
+    const mode = new RibbonParticles();
+
+    expect(mode.instanced).toBe(false);
+    expect(mode.gpuEligible).toBe(false);
+    expect(mode.geometry.topology).toBe('triangle-strip');
+  });
+
+  it('emits two vertices per particle', () => {
+    const system = new ParticleSystem({ capacity: 16 });
+    const mode = new RibbonParticles({ width: 4 });
+
+    spawnChain(system, 5);
+    mode.build(system);
+
+    expect(mode.count).toBe(10);
+  });
+
+  it('emits nothing below two live particles', () => {
+    const system = new ParticleSystem({ capacity: 16 });
+    const mode = new RibbonParticles();
+
+    spawnChain(system, 1);
+    mode.build(system);
+
+    expect(mode.count).toBe(0);
+  });
+
+  it('offsets the two vertices by half-width around the path', () => {
+    const system = new ParticleSystem({ capacity: 16 });
+    const mode = new RibbonParticles({ width: 4 });
+
+    spawnChain(system, 2);
+    mode.build(system);
+
+    const floats = new Float32Array(mode.data);
+    // Path runs along +X, so the pair straddles it in Y by half of width * scaleX.
+    expect(floats[1]).toBeCloseTo(-2);
+    expect(floats[1 + mode.floatsPerVertex]).toBeCloseTo(2);
+  });
+
+  it('runs the strip UV by accumulated path length rather than by index', () => {
+    const system = new ParticleSystem({ capacity: 16 });
+    const mode = new RibbonParticles();
+
+    spawnChain(system, 3);
+    // Uneven spacing: 10 units to the second particle, 90 to the third.
+    system.posX[2] = 100;
+
+    mode.build(system);
+
+    const floats = new Float32Array(mode.data);
+    const u = (particle: number): number => floats[particle * 2 * mode.floatsPerVertex + 2]!;
+
+    expect(u(0)).toBeCloseTo(0);
+    expect(u(1)).toBeCloseTo(0.1);
+    expect(u(2)).toBeCloseTo(1);
+  });
+
+  it('runs the strip UV across the two sides of a pair', () => {
+    const system = new ParticleSystem({ capacity: 16 });
+    const mode = new RibbonParticles();
+
+    spawnChain(system, 2);
+    mode.build(system);
+
+    const floats = new Float32Array(mode.data);
+
+    expect(floats[3]).toBe(0);
+    expect(floats[3 + mode.floatsPerVertex]).toBe(1);
+  });
+
+  it('copies the particle colour to both vertices of its pair', () => {
+    const system = new ParticleSystem({ capacity: 16 });
+    const mode = new RibbonParticles();
+
+    spawnChain(system, 2);
+    system.color[0] = 0xff0000ff;
+    system.color[1] = 0xff00ff00;
+
+    mode.build(system);
+
+    const words = new Uint32Array(mode.data);
+
+    expect(words[4]).toBe(0xff0000ff);
+    expect(words[4 + mode.floatsPerVertex]).toBe(0xff0000ff);
+    expect(words[4 + 2 * mode.floatsPerVertex]).toBe(0xff00ff00);
+    expect(words[4 + 3 * mode.floatsPerVertex]).toBe(0xff00ff00);
+  });
+
+  it('tapers the half-width with the particle scale', () => {
+    const system = new ParticleSystem({ capacity: 16 });
+    const mode = new RibbonParticles({ width: 4 });
+
+    spawnChain(system, 2);
+    system.scaleX[1] = 0.5;
+
+    mode.build(system);
+
+    const floats = new Float32Array(mode.data);
+
+    expect(floats[1]).toBeCloseTo(-2);
+    expect(floats[1 + 2 * mode.floatsPerVertex]).toBeCloseTo(-1);
+  });
+
+  it('skips a leading particle whose neighbour is coincident with it', () => {
+    const system = new ParticleSystem({ capacity: 16 });
+    const mode = new RibbonParticles();
+
+    spawnChain(system, 3);
+    // The first two particles share a position, so the head has no direction
+    // and no previous one to inherit.
+    system.posX[1] = 0;
+
+    mode.build(system);
+
+    expect(mode.count).toBe(4);
+  });
+
+  it('forces the system onto the CPU path', () => {
+    const system = new ParticleSystem({ capacity: 16, render: new RibbonParticles() });
+
+    expect(system.gpuMode).toBe(false);
+  });
+});

--- a/site/src/content/api/ribbon-particles-options.json
+++ b/site/src/content/api/ribbon-particles-options.json
@@ -1,0 +1,75 @@
+{
+  "title": "RibbonParticlesOptions",
+  "description": "Construction options for RibbonParticles.",
+  "symbol": "RibbonParticlesOptions",
+  "kind": "interface",
+  "subsystem": "particles",
+  "importPath": "@codexo/exojs-particles",
+  "tier": "stable",
+  "memberCount": 1,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 1,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Construction options for RibbonParticles."
+      ],
+      "importLine": "import { RibbonParticlesOptions } from '@codexo/exojs-particles'",
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "width",
+          "signature": "width?: number",
+          "signatureTokens": [
+            {
+              "text": "width",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Width of the strip in system-local units, before per-particle scaling. The half-width actually emitted is width * scaleX[i] / 2."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "packages/exojs-particles/src/renderModes/RibbonParticles.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/renderModes/RibbonParticles.ts"
+      }
+    }
+  ],
+  "sourcePath": "packages/exojs-particles/src/renderModes/RibbonParticles.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/renderModes/RibbonParticles.ts"
+}

--- a/site/src/content/api/ribbon-particles.json
+++ b/site/src/content/api/ribbon-particles.json
@@ -1,0 +1,484 @@
+{
+  "title": "RibbonParticles",
+  "description": "A connected triangle strip through the system's particles: one ribbon per system, drawn as a single non-instanced draw. Every particle contributes two vertices, offset either side of the path running through its neighbours, so the whole live range becomes one continuous band — the shape a sword arc, a projectile streak or a smoke plume wants, where a quad-per-particle would show as a dotted line. Layout of the per-vertex buffer build fills (20 bytes, 3 attributes): ``` a_position f32x2 (offset 0, 8 bytes) strip vertex (system-local) a_texcoord f32x2 (offset 8, 8 bytes) u along the strip, v across it a_color u8x4 (offset 16, 4 bytes) RGBA tint, normalised ``` **No ribbon-specific styling parameters.** Half-width comes from the particle's `scaleX` and the tint from its `color`, so the existing update modules already produce the expected look: `ScaleOverLifetime` tapers the tail, `ColorOverLifetime` gradients along the streak, and `AlphaFadeOverLifetime` fades it out. RibbonParticlesOptions.width only sets the base the scale multiplies. **The strip is built on the CPU**, so this mode is not GPU-eligible and a system using it stays on the CPU simulation path (observable through `ParticleSystem.gpuMode`). That is what guarantees the builder reads valid positions in emission order: CPU-mode slots are dense and compaction copies survivors forward stably, which is exactly the ordering a connected strip needs.",
+  "symbol": "RibbonParticles",
+  "kind": "class",
+  "subsystem": "particles",
+  "importPath": "@codexo/exojs-particles",
+  "tier": "stable",
+  "memberCount": 13,
+  "counts": {
+    "constructors": 1,
+    "methods": 5,
+    "properties": 7,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "A connected triangle strip through the system's particles: one ribbon per system, drawn as a single non-instanced draw.",
+        "Every particle contributes two vertices, offset either side of the path running through its neighbours, so the whole live range becomes one continuous band — the shape a sword arc, a projectile streak or a smoke plume wants, where a quad-per-particle would show as a dotted line.",
+        "Layout of the per-vertex buffer build fills (20 bytes, 3 attributes):",
+        "``` a_position f32x2 (offset 0, 8 bytes) strip vertex (system-local) a_texcoord f32x2 (offset 8, 8 bytes) u along the strip, v across it a_color u8x4 (offset 16, 4 bytes) RGBA tint, normalised ```",
+        "**No ribbon-specific styling parameters.** Half-width comes from the particle's `scaleX` and the tint from its `color`, so the existing update modules already produce the expected look: `ScaleOverLifetime` tapers the tail, `ColorOverLifetime` gradients along the streak, and `AlphaFadeOverLifetime` fades it out. RibbonParticlesOptions.width only sets the base the scale multiplies.",
+        "**The strip is built on the CPU**, so this mode is not GPU-eligible and a system using it stays on the CPU simulation path (observable through `ParticleSystem.gpuMode`). That is what guarantees the builder reads valid positions in emission order: CPU-mode slots are dense and compaction copies survivors forward stably, which is exactly the ordering a connected strip needs."
+      ],
+      "importLine": "import { RibbonParticles } from '@codexo/exojs-particles'",
+      "sourceLink": null
+    },
+    {
+      "id": "constructors",
+      "title": "Constructors",
+      "members": [
+        {
+          "name": "new",
+          "signature": "new(options: RibbonParticlesOptions): RibbonParticles",
+          "signatureTokens": [
+            {
+              "text": "new",
+              "kind": "keyword"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "options",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "RibbonParticlesOptions",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "RibbonParticles",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "options",
+              "type": "RibbonParticlesOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "RibbonParticles",
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "methods",
+      "title": "Methods",
+      "members": [
+        {
+          "name": "_ensureCapacity",
+          "signature": "_ensureCapacity(byteLength: number): void",
+          "signatureTokens": [
+            {
+              "text": "_ensureCapacity",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "byteLength",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "byteLength",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Grow the scratch buffer to hold at least byteLength. Grow-only: a shrinking particle count reuses the larger buffer rather than reallocating, matching the renderers' existing buffer policy."
+        },
+        {
+          "name": "_onBufferGrown",
+          "signature": "_onBufferGrown(data: ArrayBuffer): void",
+          "signatureTokens": [
+            {
+              "text": "_onBufferGrown",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "data",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ArrayBuffer",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "data",
+              "type": "ArrayBuffer",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Re-create typed-array views after _ensureCapacity reallocates."
+        },
+        {
+          "name": "_setCount",
+          "signature": "_setCount(count: number): void",
+          "signatureTokens": [
+            {
+              "text": "_setCount",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "count",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "count",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Record the element count produced by a build."
+        },
+        {
+          "name": "build",
+          "signature": "build(system: ParticleSystem): void",
+          "signatureTokens": [
+            {
+              "text": "build",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "system",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ParticleSystem",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "system",
+              "type": "ParticleSystem",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Fill the scratch buffer from system's current SoA state."
+        },
+        {
+          "name": "destroy",
+          "signature": "destroy(): void",
+          "signatureTokens": [
+            {
+              "text": "destroy",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "void",
+          "description": "Optional cleanup, called from ParticleSystem.destroy."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "floatsPerVertex",
+          "signature": "floatsPerVertex: number",
+          "signatureTokens": [
+            {
+              "text": "floatsPerVertex",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Floats spanned by one vertex. Exposed so callers reading data can step through it without hard-coding the stride."
+        },
+        {
+          "name": "geometry",
+          "signature": "geometry: Geometry",
+          "signatureTokens": [
+            {
+              "text": "geometry",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "A strip has no fixed vertex count — the draw covers whatever build emitted this frame — so the geometry describes only the layout and carries an empty placeholder. Non-indexed by construction: the strip's own vertex order is its topology, and an indexed geometry would pin the draw to a fixed index count."
+        },
+        {
+          "name": "gpuEligible",
+          "signature": "gpuEligible: boolean",
+          "signatureTokens": [
+            {
+              "text": "gpuEligible",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Whether this mode can run while the system is in GPU compute mode. Mirrors UpdateModule.wgsl(): a mode that cannot forces the whole system onto the CPU path, silently and observably via ParticleSystem.gpuMode. A GPU-eligible mode's layout must match what the compute pipeline emits into gpuState.instanceBuffer — today that is QuadParticles's layout, and it is the only GPU-eligible mode."
+        },
+        {
+          "name": "instanced",
+          "signature": "instanced: false",
+          "signatureTokens": [
+            {
+              "text": "instanced",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "false",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Draw model. true issues an instanced draw against geometry; false a plain draw over the built vertex buffer. Declared here because Geometry carries topology but has no instancing concept."
+        },
+        {
+          "name": "count",
+          "signature": "count: number",
+          "signatureTokens": [
+            {
+              "text": "count",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Element count of the draw call this mode's last build produced. Draw-model relative: instance count when instanced, vertex count otherwise. Do not assume one meaning."
+        },
+        {
+          "name": "data",
+          "signature": "data: ArrayBuffer",
+          "signatureTokens": [
+            {
+              "text": "data",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ArrayBuffer",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "The buffer the renderer uploads. Valid until the next build."
+        },
+        {
+          "name": "material",
+          "signature": "material: Material",
+          "signatureTokens": [
+            {
+              "text": "material",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Material",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Shader pair plus uniforms/textures for this mode."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "packages/exojs-particles/src/renderModes/RibbonParticles.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/renderModes/RibbonParticles.ts"
+      }
+    }
+  ],
+  "sourcePath": "packages/exojs-particles/src/renderModes/RibbonParticles.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/renderModes/RibbonParticles.ts"
+}

--- a/test/rendering/_particleGlslMocks.ts
+++ b/test/rendering/_particleGlslMocks.ts
@@ -23,3 +23,9 @@ vi.mock('../../packages/exojs-particles/src/renderers/glsl/particle.frag', async
 vi.mock('../../packages/exojs-particles/src/renderers/glsl/particle.vert', async () => ({
   default: (await import('../../packages/exojs-particles/src/renderers/glsl/particle.vert?raw')).default,
 }));
+vi.mock('../../packages/exojs-particles/src/renderModes/glsl/ribbon.frag', async () => ({
+  default: (await import('../../packages/exojs-particles/src/renderModes/glsl/ribbon.frag?raw')).default,
+}));
+vi.mock('../../packages/exojs-particles/src/renderModes/glsl/ribbon.vert', async () => ({
+  default: (await import('../../packages/exojs-particles/src/renderModes/glsl/ribbon.vert?raw')).default,
+}));

--- a/test/rendering/browser/_glslMocks.ts
+++ b/test/rendering/browser/_glslMocks.ts
@@ -52,3 +52,9 @@ vi.mock('../../../packages/exojs-particles/src/renderers/glsl/particle.frag', as
 vi.mock('../../../packages/exojs-particles/src/renderers/glsl/particle.vert', async () => ({
   default: (await import('../../../packages/exojs-particles/src/renderers/glsl/particle.vert?raw')).default,
 }));
+vi.mock('../../../packages/exojs-particles/src/renderModes/glsl/ribbon.frag', async () => ({
+  default: (await import('../../../packages/exojs-particles/src/renderModes/glsl/ribbon.frag?raw')).default,
+}));
+vi.mock('../../../packages/exojs-particles/src/renderModes/glsl/ribbon.vert', async () => ({
+  default: (await import('../../../packages/exojs-particles/src/renderModes/glsl/ribbon.vert?raw')).default,
+}));

--- a/test/rendering/browser/webgl2-particles.test.ts
+++ b/test/rendering/browser/webgl2-particles.test.ts
@@ -24,7 +24,7 @@ import type { RenderNode } from '#rendering/RenderNode';
 import { Texture } from '#rendering/texture/Texture';
 import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
 
-import { particlesExtension, ParticleSystem } from '../../../packages/exojs-particles/src/index';
+import { particlesExtension, ParticleSystem, RibbonParticles } from '../../../packages/exojs-particles/src/index';
 import { readWebGl2Pixel } from './_backendSetup';
 import { wireCoreRenderers } from './_coreRenderers';
 import { expectPixelNear } from './_pixels';
@@ -228,6 +228,93 @@ describe('WebGL2 ParticleSystem — solid color', () => {
 
       expectPixelNear(readWebGl2Pixel(backend, 32, 32), [0, 255, 0, 255]);
       expectPixelNear(readWebGl2Pixel(backend, 4, 4), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});
+
+describe('WebGL2 ParticleSystem — ribbon', () => {
+  test('a chain of particles renders as one connected band', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ffffff', 16, 16);
+    const root = new Container();
+    // The ribbon mode ships its own shader pair, which only a real backend ever
+    // compiles — a broken one draws nothing and fails the interior assertions
+    // below rather than passing silently in the node lanes.
+    const system = new ParticleSystem(texture, { capacity: 8, render: new RibbonParticles({ width: 12 }) });
+
+    try {
+      // Three particles on a horizontal line, system-local. The strip expands
+      // ±6px around it, so at (32, 32) it covers x 16..48, y 26..38.
+      for (const x of [-16, 0, 16]) {
+        const slot = system.spawn();
+
+        system.posX[slot] = x;
+        system.posY[slot] = 0;
+        system.scaleX[slot] = 1;
+        system.scaleY[slot] = 1;
+        system.color[slot] = new Color(0, 255, 0).toRgba();
+        system.lifetime[slot] = 1;
+      }
+
+      system.setPosition(32, 32);
+      root.addChild(system);
+
+      render(backend, root);
+
+      // Along the band: both ends and the middle are filled, which a
+      // strip-that-drew-only-one-segment would not satisfy.
+      expectPixelNear(readWebGl2Pixel(backend, 20, 32), [0, 255, 0, 255]);
+      expectPixelNear(readWebGl2Pixel(backend, 32, 32), [0, 255, 0, 255]);
+      expectPixelNear(readWebGl2Pixel(backend, 44, 32), [0, 255, 0, 255]);
+      // Across it: the band is a band, not the whole column.
+      expectPixelNear(readWebGl2Pixel(backend, 32, 12), [0, 0, 0, 255]);
+      expectPixelNear(readWebGl2Pixel(backend, 32, 52), [0, 0, 0, 255]);
+      // Past the ends of the path, and a safely empty corner.
+      expectPixelNear(readWebGl2Pixel(backend, 58, 32), [0, 0, 0, 255]);
+      expectPixelNear(readWebGl2Pixel(backend, 4, 4), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('the strip tapers with the per-particle scale', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ffffff', 16, 16);
+    const root = new Container();
+    const system = new ParticleSystem(texture, { capacity: 8, render: new RibbonParticles({ width: 20 }) });
+
+    try {
+      // Half-width runs from 10px at the head down to 1px at the tail, which is
+      // what `ScaleOverLifetime` drives in a real scene.
+      const scales = [1, 0.1];
+
+      for (let i = 0; i < scales.length; i++) {
+        const slot = system.spawn();
+
+        system.posX[slot] = i === 0 ? -16 : 16;
+        system.posY[slot] = 0;
+        system.scaleX[slot] = scales[i]!;
+        system.scaleY[slot] = 1;
+        system.color[slot] = new Color(0, 255, 0).toRgba();
+        system.lifetime[slot] = 1;
+      }
+
+      system.setPosition(32, 32);
+      root.addChild(system);
+
+      render(backend, root);
+
+      // Wide end: 8px off the centre line is still inside the band.
+      expectPixelNear(readWebGl2Pixel(backend, 17, 25), [0, 255, 0, 255]);
+      // Narrow end: the same offset is outside it, while the centre is not.
+      expectPixelNear(readWebGl2Pixel(backend, 47, 25), [0, 0, 0, 255]);
+      expectPixelNear(readWebGl2Pixel(backend, 47, 32), [0, 255, 0, 255]);
     } finally {
       root.destroy();
       texture.destroy();

--- a/test/rendering/browser/webgl2-shader-compile.test.ts
+++ b/test/rendering/browser/webgl2-shader-compile.test.ts
@@ -41,14 +41,16 @@ const shaders: readonly ShaderEntry[] = Object.entries(shaderModules)
 const sourceByName: Record<string, string> = Object.fromEntries(shaders.map(entry => [entry.name, entry.source]));
 
 // Vertex/fragment pairs as wired up by the renderer sources; `text.vert` is
-// shared across all three text-fragment variants and `particle.*` comes from
-// the particles package's render mode. Every file the globs pick up must appear
-// here (guarded below) so a dead `.vert`/`.frag` cannot sit in the folder being
-// compiled-but-never-linked — it has to be wired or removed.
+// shared across all three text-fragment variants, while `particle.*` and
+// `ribbon.*` come from the particles package's two render modes. Every file the
+// globs pick up must appear here (guarded below) so a dead `.vert`/`.frag`
+// cannot sit in the folder being compiled-but-never-linked — it has to be wired
+// or removed.
 const programPairs: ReadonlyArray<readonly [string, string]> = [
   ['sprite.vert', 'sprite.frag'],
   ['mesh.vert', 'mesh.frag'],
   ['particle.vert', 'particle.frag'],
+  ['ribbon.vert', 'ribbon.frag'],
   ['text.vert', 'text-color.frag'],
   ['text.vert', 'text-sdf.frag'],
   ['text.vert', 'text-msdf.frag'],

--- a/test/rendering/browser/webgpu-particles.test.ts
+++ b/test/rendering/browser/webgpu-particles.test.ts
@@ -34,7 +34,7 @@ import type { RenderNode } from '#rendering/RenderNode';
 import { Texture } from '#rendering/texture/Texture';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
-import { particlesExtension, ParticleSystem } from '../../../packages/exojs-particles/src/index';
+import { particlesExtension, ParticleSystem, RibbonParticles } from '../../../packages/exojs-particles/src/index';
 import { readWebGpuPixels } from './_backendSetup';
 import { wireCoreRenderers } from './_coreRenderers';
 import { expectPixelNear } from './_pixels';
@@ -197,6 +197,59 @@ describe('WebGPU ParticleSystem — solid color', () => {
       const readPixel = readWebGpuPixels(backend, canvasSize);
 
       expectPixelNear(readPixel(32, 32), [0, 255, 0, 255]);
+      expectPixelNear(readPixel(4, 4), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});
+
+describe('WebGPU ParticleSystem — ribbon', () => {
+  test('a chain of particles renders as one connected band', async ctx => {
+    const backend = await setupBackend();
+
+    const texture = createSolidTexture('#ffffff');
+    const root = new Container();
+    // The ribbon mode ships its own WGSL, which only a real device ever
+    // compiles — a broken module draws nothing and fails the interior
+    // assertions below rather than passing silently in the node lanes.
+    const system = new ParticleSystem(texture, { capacity: 8, render: new RibbonParticles({ width: 12 }) });
+
+    try {
+      // Three particles on a horizontal line, system-local. The strip expands
+      // ±6px around it, so at (32, 32) it covers x 16..48, y 26..38.
+      for (const x of [-16, 0, 16]) {
+        const slot = system.spawn();
+
+        system.posX[slot] = x;
+        system.posY[slot] = 0;
+        system.scaleX[slot] = 1;
+        system.scaleY[slot] = 1;
+        system.color[slot] = new Color(0, 255, 0).toRgba();
+        system.lifetime[slot] = 1;
+      }
+
+      system.setPosition(32, 32);
+      root.addChild(system);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      const readPixel = readWebGpuPixels(backend, canvasSize);
+
+      // Along the band: both ends and the middle are filled, which a
+      // strip-that-drew-only-one-segment would not satisfy.
+      expectPixelNear(readPixel(20, 32), [0, 255, 0, 255]);
+      expectPixelNear(readPixel(32, 32), [0, 255, 0, 255]);
+      expectPixelNear(readPixel(44, 32), [0, 255, 0, 255]);
+      // Across it: the band is a band, not the whole column.
+      expectPixelNear(readPixel(32, 12), [0, 0, 0, 255]);
+      expectPixelNear(readPixel(32, 52), [0, 0, 0, 255]);
+      // Past the ends of the path, and a safely empty corner.
+      expectPixelNear(readPixel(58, 32), [0, 0, 0, 255]);
       expectPixelNear(readPixel(4, 4), [0, 0, 0, 255]);
     } finally {
       root.destroy();


### PR DESCRIPTION
The second render mode on the seam merged in #488, and the first that is not a quad — proof that the seam actually carries a non-quad primitive rather than merely allowing one on paper.

`RibbonParticles` turns the live particle range into **one connected triangle strip**: two vertices per particle, offset either side of the path through its neighbours. It is non-instanced, non-indexed and not GPU-eligible, which keeps it inside the seam's documented limits and holds the system on the CPU path — where slot order equals emission order, which is exactly what a strip needs.

**No renderer changes were required.** Both executors already handled non-instanced triangle-strip and the non-indexed draw path, as the seam work intended.

**The part worth looking at:** the ribbon introduces *no* ribbon-specific styling parameters. Half-width is routed through `scaleX` and the tint comes from the packed colour, so the existing modules compose onto it directly — `ScaleOverLifetime` tapers the band, `ColorOverLifetime` gradients along the streak, `AlphaFadeOverLifetime` fades the tail, `Drag`/`Turbulence` make it drift. The strip UV runs by accumulated path length rather than by index, so uneven particle spacing does not stretch the texture.

v1 is deliberately one ribbon per system, with no grouping key — a sword arc, a projectile streak and a smoke plume are naturally one system each. A grouping channel (the route to per-particle trails, and how Unreal's Niagara holds several ribbons in one system) is purely additive later.

**Verification.** 10 unit tests plus real-GL and real-WebGPU browser specs that render a chain and read the band back — a brand-new shader pair is completely unexercised by the node lanes, so those were mandatory rather than optional. One spec asserts three separated points along the band (a mode drawing only one segment fails) plus background above, below and past the end; another drives `scaleX` 1 → 0.1 and pins the taper in real pixels. Both were empirically confirmed to have teeth by breaking `gl_Position` / `output.position` and watching them fail.

One test file was edited: `webgl2-shader-compile.test.ts` requires every globbed shader file to appear in its program-pair registry ("wire it up or delete it"). Adding the ribbon pair is that registry's intended extension point, and it gives the new shaders free real-driver compile+link coverage.

Note: `ribbon.frag` is currently byte-identical to `particle.frag`. Kept separate deliberately — the seam gives each mode its own shader pair, and sharing would couple the ribbon to the quad shader's future uniforms.